### PR TITLE
fix(sanitize): preserve user-visible prose after error-prefix lines

### DIFF
--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.test.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.test.ts
@@ -1,0 +1,502 @@
+// Regression coverage for sanitizeUserFacingText error-context rewrites.
+import { describe, expect, it } from "vitest";
+import { sanitizeUserFacingText } from "./sanitize-user-facing-text.js";
+
+describe("sanitizeUserFacingText (error context)", () => {
+  describe("classifies leading error line then appends safe follow-up prose (#96007)", () => {
+    it("classifies timeout error line and appends recommendations", () => {
+      const text = [
+        "Error: connection timed out",
+        "",
+        "Recommendation: try restarting the service.",
+        "Next steps:",
+        "1. Check logs",
+        "2. Retry",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      // Leading line classified as timeout
+      expect(result).toContain("LLM request timed out");
+      // Safe follow-up prose appended
+      expect(result).toContain("Recommendation");
+      expect(result).toContain("Check logs");
+      expect(result).toContain("Retry");
+    });
+
+    it("classifies transport error line and appends safe multi-paragraph content", () => {
+      const text = [
+        "Error: fetch failed. SocketError: other side closed",
+        "",
+        "Here is a summary of findings:",
+        "• Item A is healthy",
+        "• Item B is healthy",
+        "",
+        "Recommendation: try restarting the service and verify the config.",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      // Leading line classified as transport error
+      expect(result).toContain("LLM request failed");
+      // Safe prose appended
+      expect(result).toContain("summary of findings");
+      expect(result).toContain("Item A is healthy");
+      expect(result).toContain("Recommendation");
+    });
+
+    it("classifies leading line and appends guidance after an API Error prefix", () => {
+      const text = [
+        "API Error 500: internal server error",
+        "",
+        "Alternative approach:",
+        "Use cached results from the previous run.",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("Alternative approach");
+      expect(result).toContain("cached results");
+    });
+  });
+
+  describe("strips stack traces from multiline error suffixes", () => {
+    it("returns only the classified error when suffix is a stack trace", () => {
+      const text = [
+        "Error: ECONNREFUSED",
+        "    at Server.onError (server.ts:42:8)",
+        "    at emitError (events.js:153:12)",
+        "    at processTicksAndRejections (internal/process/task_queues.js:95:5)",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      // Leading line classified as transport error
+      expect(result).toContain("connection refused");
+      // Stack trace MUST NOT leak
+      expect(result).not.toContain("server.ts");
+      expect(result).not.toContain("events.js");
+      expect(result).not.toContain("processTicksAndRejections");
+    });
+
+    it("returns only the classified error when suffix is a JSON payload body", () => {
+      const text = [
+        "Error: fetch failed",
+        '{"error":{"type":"server_error","message":"internal"}}',
+        '{"request_id":"req_abc123"}',
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      // Leading line classified as transport error
+      expect(result).toContain("LLM request failed");
+      // JSON body MUST NOT leak
+      expect(result).not.toContain('"server_error"');
+      expect(result).not.toContain('"req_abc123"');
+    });
+
+    it("returns only the classified error when suffix is an HTML error page", () => {
+      const text = [
+        "Error: gateway error",
+        "<!doctype html>",
+        "<html><body>502 Bad Gateway</body></html>",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      // HTML body MUST NOT leak
+      expect(result).not.toContain("<!doctype html>");
+      expect(result).not.toContain("502 Bad Gateway");
+    });
+
+    it("returns only the classified error when suffix is an HTML page without doctype", () => {
+      const text = [
+        "Error: gateway error",
+        '<html lang="en">',
+        "<head><title>502 Bad Gateway</title></head>",
+        "<body>Server Error</body>",
+        "</html>",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      // Raw <html> provider page MUST NOT leak
+      expect(result).not.toContain("<html");
+      expect(result).not.toContain("502 Bad Gateway");
+      expect(result).not.toContain("Server Error");
+    });
+
+    it("rejects suffix when a single stack-frame line is present", () => {
+      // A single stack-frame line (file:///tmp/app.mjs:10:3) is enough to
+      // classify the suffix as unsafe.
+      const text = [
+        "Error: something went wrong",
+        "    at loadApp (file:///tmp/app.mjs:10:3)",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("something went wrong");
+      expect(result).not.toContain("file://");
+      expect(result).not.toContain("app.mjs");
+    });
+
+    it("rejects mixed prose and stack-frame suffix", () => {
+      // Safe prose mixed with a stack-frame line: the whole suffix is rejected
+      // because a single stack frame is enough to classify it as unsafe.
+      const text = [
+        "Error: something went wrong",
+        "",
+        "Please check the following:",
+        "    at loadApp (file:///tmp/app.mjs:10:3)",
+        "Recommendation: try restarting the service.",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("something went wrong");
+      // Stack frame MUST NOT leak
+      expect(result).not.toContain("file://");
+      expect(result).not.toContain("app.mjs");
+      // Prose mixed with stack frames is rejected
+      expect(result).not.toContain("Please check");
+      expect(result).not.toContain("Recommendation");
+    });
+
+    it("appends safe prose after a classified leading line even when one line looks suspicious", () => {
+      // A single "at …" line that does not match the stack-frame pattern
+      // (no file:line:line suffix) is treated as safe prose.
+      const text = [
+        "Error: Connection refused",
+        "",
+        "Please check:",
+        "  at the network proxy settings first.",
+        "1. Verify the proxy port",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).toContain("Please check");
+      expect(result).toContain("Verify the proxy port");
+    });
+
+    it("strips node:internal stack frames", () => {
+      const text = [
+        "Error: ECONNREFUSED",
+        "    at Server.onError (server.ts:42:8)",
+        "    at runScript (node:internal/vm:219:10)",
+        "    at runInContext (node:internal/vm:342:7)",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("connection refused");
+      expect(result).not.toContain("node:internal");
+      expect(result).not.toContain("server.ts");
+    });
+
+    it("strips file:// protocol stack frames", () => {
+      const text = [
+        "Error: something went wrong",
+        "    at loadApp (file:///tmp/app.mjs:10:3)",
+        "    at bootstrap (file:///tmp/bootstrap.mjs:42:5)",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("something went wrong");
+      expect(result).not.toContain("file://");
+      expect(result).not.toContain("app.mjs");
+    });
+
+    it("strips Windows drive-letter stack frames", () => {
+      const text = [
+        "Error: ECONNREFUSED",
+        "    at App.run (C:\\Users\\Ada\\app.ts:12:5)",
+        "    at Server.start (D:\\project\\server.ts:42:8)",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("connection refused");
+      expect(result).not.toContain("app.ts");
+      expect(result).not.toContain("server.ts");
+    });
+
+    it("strips async V8 stack frames", () => {
+      const text = [
+        "Error: something went wrong",
+        "    at async loadApp (file:///tmp/app.mjs:10:3)",
+        "    at async ModuleJob.run (node:internal/modules/esm/module_job:343:25)",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("something went wrong");
+      expect(result).not.toContain("file://");
+      expect(result).not.toContain("node:internal");
+      expect(result).not.toContain("app.mjs");
+    });
+
+    it("strips a single async stack-frame line", () => {
+      // Single async frame is enough to classify the suffix as unsafe.
+      const text = [
+        "Error: something went wrong",
+        "    at async loadApp (file:///tmp/app.mjs:10:3)",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("something went wrong");
+      expect(result).not.toContain("file://");
+      expect(result).not.toContain("app.mjs");
+    });
+
+    it("rejects suffix when it contains an auth header", () => {
+      const text = ["Error: fetch failed", "Authorization: Bearer sk-abc123"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("Bearer");
+      expect(result).not.toContain("sk-abc123");
+    });
+
+    it("rejects suffix when it contains an x-api-key header", () => {
+      const text = ["Error: fetch failed", "x-api-key: sk-proj-abc123xyz"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("x-api-key");
+      expect(result).not.toContain("sk-proj");
+    });
+
+    it.each<[url: string, host: string]>([
+      ["https://api.openai.com/v1/chat/completions", "api.openai.com"],
+      [
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+        "generativelanguage.googleapis.com",
+      ],
+    ])("rejects suffix when it contains a provider API endpoint URL (%s)", (url, host) => {
+      const text = ["Error: fetch failed", `POST ${url}`].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain(host);
+    });
+
+    it("rejects suffix when it contains a request ID line", () => {
+      const text = ["Error: fetch failed", "request_id: req_abc123"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("req_abc123");
+    });
+
+    it("rejects suffix when it contains a trace ID line", () => {
+      const text = ["Error: fetch failed", "trace_id: tr_xyz789"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("tr_xyz789");
+    });
+
+    it("rejects suffix when it contains an api-key header", () => {
+      const text = ["Error: fetch failed", "api-key: sk-live-abc123xyz"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("api-key");
+      expect(result).not.toContain("sk-live");
+    });
+
+    it("rejects suffix when it contains a set-cookie header", () => {
+      const text = ["Error: fetch failed", "set-cookie: session=abc123def456"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("set-cookie");
+      expect(result).not.toContain("session=");
+    });
+
+    it("rejects suffix when it contains a CapitalCase Set-Cookie header", () => {
+      const text = ["Error: fetch failed", "Set-Cookie: session=abc123def456"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("Set-Cookie");
+      expect(result).not.toContain("session=");
+    });
+
+    it("rejects suffix when it contains an x-request-id header", () => {
+      const text = ["Error: fetch failed", "x-request-id: req_abc123def"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("x-request-id");
+      expect(result).not.toContain("req_abc123def");
+    });
+
+    it("rejects suffix when it contains a title-case Request ID header", () => {
+      const text = ["Error: fetch failed", "Request ID: req_abc123"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("Request ID");
+      expect(result).not.toContain("req_abc123");
+    });
+
+    it("rejects suffix when it contains a lower-case space-separated request id header", () => {
+      const text = ["Error: fetch failed", "request id: req_abc123"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("request id");
+      expect(result).not.toContain("req_abc123");
+    });
+
+    it("rejects suffix when it contains a title-case Correlation ID header", () => {
+      const text = ["Error: fetch failed", "Correlation ID: abc-def-456"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("Correlation ID");
+      expect(result).not.toContain("abc-def-456");
+    });
+
+    it("rejects suffix when it contains a title-case Trace ID header", () => {
+      const text = ["Error: fetch failed", "Trace ID: tr_xyz789"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("Trace ID");
+      expect(result).not.toContain("tr_xyz789");
+    });
+
+    it("rejects suffix when it contains a CapitalCase X-Request-Id header", () => {
+      const text = ["Error: fetch failed", "X-Request-Id: req_abc123def"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("X-Request-Id");
+      expect(result).not.toContain("req_abc123def");
+    });
+
+    it("rejects suffix when it contains a Cookie header", () => {
+      const text = ["Error: fetch failed", "Cookie: session=abc123def456"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("Cookie");
+      expect(result).not.toContain("session=");
+    });
+
+    it("rejects suffix when it contains a bearer token line", () => {
+      const text = ["Error: fetch failed", "Bearer sk-abc123def456"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain("Bearer");
+      expect(result).not.toContain("sk-abc");
+    });
+
+    // Credential-bearing labels — label contains a credential-class word
+    // (`secret`/`token`/`password`/`key`/`credential`/`bearer`).  Covers
+    // single-word (`Secret:`, `Token:`), multi-word (`Access Token:`,
+    // `Client Secret:`, `Personal Access Token:`), and lowercase (`secret:`)
+    // variants.  These share the "CapitalCase + colon + value" form with safe
+    // guidance labels (`Recommendation: try...`) so they must be rejected
+    // before the natural-prose allow-list gate.  See ClawSweeper P1 findings
+    // on PR #96107 (reviews 2026-07-02 and 2026-07-03).
+    it.each<[label: string, value: string, valueSnippet: string]>([
+      ["Secret", "sk-abc123def456", "sk-abc"],
+      ["Token", "abc-def-456", "abc-def"],
+      ["Password", "hunter2", "hunter2"],
+      ["Key", "sk-abc123def456", "sk-abc"],
+      ["key", "sk-abc123def456", "sk-abc"],
+      ["API Key", "sk-proj-abc123xyz", "sk-proj"],
+      ["Access Key", "AKIAIOSFODNN7EXAMPLE", "AKIA"],
+      ["Private Key", "-----BEGIN PRIVATE KEY-----", "BEGIN PRIVATE"],
+      ["Credential", "abc123xyz", "abc123"],
+      ["secret", "sk-abc123def456", "sk-abc"],
+      ["Access Token", "abc-def-456", "abc-def"],
+      ["Refresh Token", "rrf-789-012", "rrf-789"],
+      ["Client Secret", "csec-xyz-999", "csec"],
+      ["Personal Access Token", "pat_abc123", "pat_abc"],
+      ["API Token", "apt-xyz-001", "apt-xyz"],
+      ["Bearer Token", "abc-def-456", "abc-def"],
+    ])("rejects suffix when it contains a %s label", (label, value, valueSnippet) => {
+      const text = ["Error: fetch failed", `${label}: ${value}`].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).not.toContain(label);
+      expect(result).not.toContain(valueSnippet);
+    });
+
+    it("still preserves legitimate user guidance prose after error line", () => {
+      // Lines like "Recommendation:" and "Next steps:" are NOT diagnostic headers
+      // and must still be delivered.
+      const text = [
+        "Error: connection timed out",
+        "",
+        "Recommendation: try restarting the service.",
+        "Next steps:",
+        "1. Check logs",
+        "2. Retry",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request timed out");
+      expect(result).toContain("Recommendation");
+      expect(result).toContain("Next steps");
+      expect(result).toContain("Check logs");
+    });
+
+    it("preserves multi-word guidance labels with inline values (not diagnostic keys)", () => {
+      // "Next step: retry" and "Suggested fix: restart" are safe guidance,
+      // not diagnostic identifiers like "Request ID:" or "Trace ID:".
+      const text = [
+        "Error: fetch failed",
+        "",
+        "Next step: retry the command with --verbose.",
+        "Suggested fix: restart the service and check connectivity.",
+        "Common issues: check the logs for more details.",
+        "",
+        "1. Run the health check again",
+        "2. Verify the config",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("Next step");
+      expect(result).toContain("retry the command");
+      expect(result).toContain("Suggested fix");
+      expect(result).toContain("restart the service");
+      expect(result).toContain("Common issues");
+      expect(result).toContain("Run the health check again");
+    });
+
+    it("preserves safe guidance headings starting with 'Key' (Key finding / Key step)", () => {
+      // "Key finding:" / "Key step:" share the CapitalCase + colon form with
+      // credential labels like "API Key:" but are safe guidance headings.
+      // The credential-label guard must be narrow enough to let them pass.
+      // See ClawSweeper P1 finding on PR #96107 (review 2026-07-06).
+      const text = [
+        "Error: fetch failed",
+        "",
+        "Key finding: the worker process was OOM-killed.",
+        "Key step: retry with --verbose to confirm.",
+        "",
+        "1. Inspect dmesg",
+        "2. Restart the worker",
+      ].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).toContain("Key finding");
+      expect(result).toContain("OOM-killed");
+      expect(result).toContain("Key step");
+      expect(result).toContain("retry with --verbose");
+      expect(result).toContain("Inspect dmesg");
+    });
+
+    it("appends long safe suffix prose without 600-character truncation", () => {
+      // Accepted safe prose goes through containsOnlySafeProse and should
+      // NOT be routed through formatRawAssistantErrorForUi (which truncates
+      // raw text at 600 UTF-16 units).  Build a suffix with 650+ chars of
+      // recognizable natural prose plus a unique tail phrase.
+      const tail = "End of long prose verification token here.";
+      const line = "Step 1: verify the configuration and check all settings.\n";
+      const body = Array.from({ length: 40 }, () => line).join("");
+      const suffix = `${body}${tail}`;
+      expect(suffix.length).toBeGreaterThan(600);
+
+      const text = `Error: fetch failed\n\n${suffix}`;
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      expect(result).toContain(tail);
+    });
+  });
+
+  describe("still rewrites single-line error fragments", () => {
+    it("rewrites a bare Error: timeout line", () => {
+      const result = sanitizeUserFacingText("Error: connection timed out", {
+        errorContext: true,
+      });
+      expect(result).toBe("LLM request timed out.");
+    });
+
+    it("rewrites a bare transport error line (econnrefused)", () => {
+      const result = sanitizeUserFacingText("Error: ECONNREFUSED", {
+        errorContext: true,
+      });
+      expect(result).toContain("connection refused");
+    });
+
+    it("rewrites a transport error line without suffix content", () => {
+      const result = sanitizeUserFacingText("Error: Connection refused", {
+        errorContext: true,
+      });
+      expect(result).toContain("connection refused");
+    });
+  });
+
+  describe("non-error context is unchanged", () => {
+    it("passes through full text when errorContext is false", () => {
+      const text = ["Error: connection timed out", "", "Recommendation: retry"].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: false });
+      expect(result).toContain("Recommendation");
+      expect(result).toContain("Error: connection timed out");
+    });
+  });
+});

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.test.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.test.ts
@@ -26,17 +26,14 @@ describe("sanitizeUserFacingText (error context)", () => {
       const text = [
         "Error: fetch failed. SocketError: other side closed",
         "",
-        "Here is a summary of findings:",
+        "Recommendation: review the findings below and restart the service.",
         "• Item A is healthy",
         "• Item B is healthy",
-        "",
-        "Recommendation: try restarting the service and verify the config.",
       ].join("\n");
       const result = sanitizeUserFacingText(text, { errorContext: true });
       // Leading line classified as transport error
       expect(result).toContain("LLM request failed");
       // Safe prose appended
-      expect(result).toContain("summary of findings");
       expect(result).toContain("Item A is healthy");
       expect(result).toContain("Recommendation");
     });
@@ -45,12 +42,13 @@ describe("sanitizeUserFacingText (error context)", () => {
       const text = [
         "API Error 500: internal server error",
         "",
-        "Alternative approach:",
-        "Use cached results from the previous run.",
+        "Suggested fix: restart the worker and verify the configuration.",
+        "1. Check logs",
+        "2. Retry",
       ].join("\n");
       const result = sanitizeUserFacingText(text, { errorContext: true });
-      expect(result).toContain("Alternative approach");
-      expect(result).toContain("cached results");
+      expect(result).toContain("Suggested fix");
+      expect(result).toContain("Check logs");
     });
   });
 
@@ -147,18 +145,35 @@ describe("sanitizeUserFacingText (error context)", () => {
 
     it("appends safe prose after a classified leading line even when one line looks suspicious", () => {
       // A single "at …" line that does not match the stack-frame pattern
-      // (no file:line:line suffix) is treated as safe prose.
-      const text = [
+      // (no file:line:line suffix) still blocks the whole suffix under the
+      // strict allow-list, because it is not a bullet / numbered list /
+      // guidance heading. Verify that a suffix containing a guidance
+      // heading followed by a numbered list survives, while the suspicious
+      // free-form "at ..." line rejects an alternate suffix.
+      const safeText = [
+        "Error: Connection refused",
+        "",
+        "Recommendation: verify the proxy settings.",
+        "1. Check the network proxy port",
+      ].join("\n");
+      const safeResult = sanitizeUserFacingText(safeText, { errorContext: true });
+      expect(safeResult).toContain("LLM request failed");
+      expect(safeResult).toContain("Recommendation");
+      expect(safeResult).toContain("proxy port");
+
+      const unsafeText = [
         "Error: Connection refused",
         "",
         "Please check:",
         "  at the network proxy settings first.",
         "1. Verify the proxy port",
       ].join("\n");
-      const result = sanitizeUserFacingText(text, { errorContext: true });
-      expect(result).toContain("LLM request failed");
-      expect(result).toContain("Please check");
-      expect(result).toContain("Verify the proxy port");
+      const unsafeResult = sanitizeUserFacingText(unsafeText, { errorContext: true });
+      expect(unsafeResult).toContain("LLM request failed");
+      // Free-form "Please check:" is not a guidance heading (not in safe
+      // labels), and the "at ..." line is not a bullet, so the whole
+      // suffix is rejected.
+      expect(unsafeResult).not.toContain("Please check");
     });
 
     it("strips node:internal stack frames", () => {
@@ -426,6 +441,27 @@ describe("sanitizeUserFacingText (error context)", () => {
         "The private key is sk-proj-abc123xyz",
         ["private key", "sk-proj-abc123xyz"],
       ],
+      // Alphabetic-only credential values (no digit) — bot P1 finding 2026-07-10.
+      [
+        "password alphabetic-only inline sentence",
+        "The password was correcthorsebattery",
+        ["password", "correcthorsebattery"],
+      ],
+      [
+        "secret alphabetic-only inline sentence",
+        "The secret is correcthorsebatterystaple",
+        ["secret", "correcthorsebatterystaple"],
+      ],
+      [
+        "credential alphabetic-only inline sentence",
+        "The credential is CorrectHorseBattery",
+        ["credential", "CorrectHorseBattery"],
+      ],
+      [
+        "private key alphabetic-only inline sentence",
+        "The private key is correcthorsebatterystaple",
+        ["private key", "correcthorsebatterystaple"],
+      ],
     ])("rejects suffix when it contains inline credential prose (%s)", (_label, line, snippets) => {
       const text = ["Error: fetch failed", line].join("\n");
       const result = sanitizeUserFacingText(text, { errorContext: true });
@@ -502,9 +538,9 @@ describe("sanitizeUserFacingText (error context)", () => {
       // Accepted safe prose goes through containsOnlySafeProse and should
       // NOT be routed through formatRawAssistantErrorForUi (which truncates
       // raw text at 600 UTF-16 units).  Build a suffix with 650+ chars of
-      // recognizable natural prose plus a unique tail phrase.
-      const tail = "End of long prose verification token here.";
-      const line = "Step 1: verify the configuration and check all settings.\n";
+      // recognizable guidance headings plus a unique tail phrase.
+      const tail = "Recommendation: end of long prose verification token here.";
+      const line = "Tip: verify the configuration and check all settings.\n";
       const body = Array.from({ length: 40 }, () => line).join("");
       const suffix = `${body}${tail}`;
       expect(suffix.length).toBeGreaterThan(600);

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.test.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.test.ts
@@ -391,8 +391,9 @@ describe("sanitizeUserFacingText (error context)", () => {
     // auth/credential values without matching the label-shaped guards above.
     // The natural-sentence allow-list must reject these before they pass
     // through.  See ClawSweeper P1 late finding on PR #96107 (review
-    // 2026-07-06): "Authorization header: Bearer ..." and "The bearer token
-    // is ..." leak because they do not start with a rejected header/key shape.
+    // 2026-07-06) and follow-up (review 2026-07-07): "Authorization
+    // header: Bearer ...", "The bearer token is ...", "The secret key
+    // is ...", and "The password was ..." must all be rejected.
     it.each<[label: string, line: string, snippets: string[]]>([
       [
         "Authorization header inline",
@@ -408,6 +409,22 @@ describe("sanitizeUserFacingText (error context)", () => {
         "api key inline sentence",
         "The API key used was sk-proj-abc123xyz",
         ["API key", "sk-proj-abc123xyz"],
+      ],
+      [
+        "secret key inline sentence",
+        "The secret key is sk-abc123def456",
+        ["secret key", "sk-abc123def456"],
+      ],
+      ["password inline sentence", "The password was hunter2abc3", ["password", "hunter2abc3"]],
+      [
+        "credential inline sentence",
+        "The credential is abc123def456",
+        ["credential", "abc123def456"],
+      ],
+      [
+        "private key inline sentence",
+        "The private key is sk-proj-abc123xyz",
+        ["private key", "sk-proj-abc123xyz"],
       ],
     ])("rejects suffix when it contains inline credential prose (%s)", (_label, line, snippets) => {
       const text = ["Error: fetch failed", line].join("\n");

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.test.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.test.ts
@@ -387,6 +387,37 @@ describe("sanitizeUserFacingText (error context)", () => {
       expect(result).not.toContain(valueSnippet);
     });
 
+    // Inline credential prose — natural-sentence suffixes that carry
+    // auth/credential values without matching the label-shaped guards above.
+    // The natural-sentence allow-list must reject these before they pass
+    // through.  See ClawSweeper P1 late finding on PR #96107 (review
+    // 2026-07-06): "Authorization header: Bearer ..." and "The bearer token
+    // is ..." leak because they do not start with a rejected header/key shape.
+    it.each<[label: string, line: string, snippets: string[]]>([
+      [
+        "Authorization header inline",
+        "Authorization header: Bearer sk-abc123",
+        ["Authorization header", "Bearer", "sk-abc123"],
+      ],
+      [
+        "bearer token inline sentence",
+        "The bearer token is sk-abc123def456",
+        ["bearer token", "sk-abc123def456"],
+      ],
+      [
+        "api key inline sentence",
+        "The API key used was sk-proj-abc123xyz",
+        ["API key", "sk-proj-abc123xyz"],
+      ],
+    ])("rejects suffix when it contains inline credential prose (%s)", (_label, line, snippets) => {
+      const text = ["Error: fetch failed", line].join("\n");
+      const result = sanitizeUserFacingText(text, { errorContext: true });
+      expect(result).toContain("LLM request failed");
+      for (const snippet of snippets) {
+        expect(result).not.toContain(snippet);
+      }
+    });
+
     it("still preserves legitimate user guidance prose after error line", () => {
       // Lines like "Recommendation:" and "Next steps:" are NOT diagnostic headers
       // and must still be delivered.

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -433,19 +433,22 @@ const STACK_FRAME_LINE_RE =
 
 /**
  * Inline credential prose — natural-sentence suffixes that embed an auth
- * scheme or credential label alongside a token-like value.  The label-shaped
- * guards inside `containsOnlySafeProse` catch `Bearer:` / `API Key:` forms;
- * this catches prose like `Authorization header: Bearer sk-...` or `The
- * bearer token is sk-...` that would otherwise pass the natural-sentence
- * allow-list.  The phrase gate is specific (bearer / api key / access token /
- * refresh token / client secret / authorization header / authorization:),
- * so the bar for the value side is just "contains a digit and 7+ trailing
- * alphanumerics, or matches a known credential prefix" — generous, but the
- * phrase match keeps false positives out of safe guidance prose.  See
- * ClawSweeper P1 late finding on PR #96107 (review 2026-07-06).
+ * scheme or credential-label word alongside a token-like value.  The
+ * label-shaped guards inside `containsOnlySafeProse` catch `Bearer:` /
+ * `API Key:` forms; this catches prose like `Authorization header: Bearer
+ * sk-...`, `The bearer token is sk-...`, `The secret key is sk-...`, or
+ * `The password was hunter2abc3` that would otherwise pass the
+ * natural-sentence allow-list.  The phrase gate includes credential-class
+ * words (bearer / api key / access token / refresh token / client secret /
+ * authorization header / authorization: / secret / password / credential /
+ * key) and is paired with a value gate that requires a known credential
+ * prefix or 5+ alphanumeric run containing a digit.  Safe guidance like
+ * `Key finding: the worker was OOM-killed` has no token-like value and
+ * does not match.  See ClawSweeper P1 findings on PR #96107 (reviews
+ * 2026-07-06 and 2026-07-07).
  */
 const INLINE_CREDENTIAL_PROSE_RE =
-  /\b(?:bearer|api[\s-]key|api[\s-]token|access[\s-]token|refresh[\s-]token|client[\s-]secret|authorization\s+header|authorization\s*:)\b[^.\n]{0,80}?(?:Bearer\s+\S+|sk-[\w-]+|sk_[\w]+|pat_[\w]+|AKIA[\w]+|gh[po]_[\w]+|csec_[\w-]+|[A-Za-z0-9_-]*\d[A-Za-z0-9_-]{7,})/i;
+  /\b(?:bearer|api[\s-]key|api[\s-]token|access[\s-]token|refresh[\s-]token|client[\s-]secret|authorization\s+header|authorization\s*:|secret|password|credential|key)\b[^.\n]{0,80}?(?:Bearer\s+\S+|sk-[\w-]+|sk_[\w]+|pat_[\w]+|AKIA[\w]+|gh[po]_[\w]+|csec_[\w-]+|[A-Za-z0-9_-]*\d[A-Za-z0-9_-]{4,})/i;
 
 /**
  * Safe-prose allow-list for the suffix that follows a classified error-prefix

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -432,6 +432,22 @@ const STACK_FRAME_LINE_RE =
   /^\s+at\s+(?:async\s+)?(?:[^\s(]+(?:\s+\[as\s+[^\]]+\])?\s*)?\(?(?:[^()]+:\d+:\d+|native)\)?$/;
 
 /**
+ * Inline credential prose — natural-sentence suffixes that embed an auth
+ * scheme or credential label alongside a token-like value.  The label-shaped
+ * guards inside `containsOnlySafeProse` catch `Bearer:` / `API Key:` forms;
+ * this catches prose like `Authorization header: Bearer sk-...` or `The
+ * bearer token is sk-...` that would otherwise pass the natural-sentence
+ * allow-list.  The phrase gate is specific (bearer / api key / access token /
+ * refresh token / client secret / authorization header / authorization:),
+ * so the bar for the value side is just "contains a digit and 7+ trailing
+ * alphanumerics, or matches a known credential prefix" — generous, but the
+ * phrase match keeps false positives out of safe guidance prose.  See
+ * ClawSweeper P1 late finding on PR #96107 (review 2026-07-06).
+ */
+const INLINE_CREDENTIAL_PROSE_RE =
+  /\b(?:bearer|api[\s-]key|api[\s-]token|access[\s-]token|refresh[\s-]token|client[\s-]secret|authorization\s+header|authorization\s*:)\b[^.\n]{0,80}?(?:Bearer\s+\S+|sk-[\w-]+|sk_[\w]+|pat_[\w]+|AKIA[\w]+|gh[po]_[\w]+|csec_[\w-]+|[A-Za-z0-9_-]*\d[A-Za-z0-9_-]{7,})/i;
+
+/**
  * Safe-prose allow-list for the suffix that follows a classified error-prefix
  * line.  By the time the suffix reaches this guard, upstream checks have
  * already rejected every known error class (billing, context overflow, raw API
@@ -518,6 +534,21 @@ function containsOnlySafeProse(suffix: string): boolean {
 
     // Any HTTP URL.
     if (/https?:\/\//i.test(trimmed)) {
+      return false;
+    }
+
+    // Inline credential prose — natural-sentence suffixes that carry an
+    // auth/credential value without matching the label-shaped guards above.
+    // The natural-sentence allow-list below would otherwise let these
+    // through, leaking credentials into channel replies.  Match when a
+    // credential-class phrase (`bearer`, `api key`, `api-key`, `api token`,
+    // `access token`, `refresh token`, `client secret`, `authorization
+    // header`, `authorization:`) appears in the line alongside a token-like
+    // value (`Bearer …`, `sk-…`, `sk_…`, `pat_…`, `AKIA…`, `ghp_…`, `gho_…`,
+    // `csec_…`, or any 8+ char run of letters/digits/dash/underscore that
+    // starts after the phrase).  See ClawSweeper P1 late finding on PR
+    // #96107 (review 2026-07-06).
+    if (INLINE_CREDENTIAL_PROSE_RE.test(trimmed)) {
       return false;
     }
 

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -420,6 +420,161 @@ function collapseConsecutiveDuplicateBlocks(text: string): string {
   return result.join("\n\n");
 }
 
+/**
+ * Stack-frame line emitted by Node.js and other V8-based runtimes.
+ *
+ * Matches both synchronous and async frames so `at async … (path:line:col)`
+ * variants are correctly classified instead of leaking internal paths.
+ * The path portion allows colons for `node:internal/…`, `file:///…`, and
+ * Windows drive-letter paths (`C:\…`).
+ */
+const STACK_FRAME_LINE_RE =
+  /^\s+at\s+(?:async\s+)?(?:[^\s(]+(?:\s+\[as\s+[^\]]+\])?\s*)?\(?(?:[^()]+:\d+:\d+|native)\)?$/;
+
+/**
+ * Safe-prose allow-list for the suffix that follows a classified error-prefix
+ * line.  By the time the suffix reaches this guard, upstream checks have
+ * already rejected every known error class (billing, context overflow, raw API
+ * payloads, streaming parse errors, etc.).  The residual text is in an unknown
+ * error domain, so the default stance is to discard the entire suffix and
+ * return only the classified error label.  Only lines that are provably
+ * human-written prose — bullet points, numbered lists, natural sentences — are
+ * allowed through.
+ */
+function containsOnlySafeProse(suffix: string): boolean {
+  const lines = suffix.split("\n");
+  if (lines.length === 0) {
+    return false;
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    // Stack-frame lines — provider/runtime internals.
+    if (STACK_FRAME_LINE_RE.test(line)) {
+      return false;
+    }
+
+    // JSON payloads, HTML error pages.
+    if (
+      trimmed.startsWith("{") ||
+      trimmed.startsWith("[") ||
+      /^\s*<!doctype\s+html\b/i.test(line) ||
+      /^\s*<html\b/i.test(line)
+    ) {
+      return false;
+    }
+
+    // Diagnostic key:value — lowercase single-word key + colon + value.
+    if (/^\s*[a-z][a-z0-9_-]*\s*:\s/.test(trimmed)) {
+      return false;
+    }
+
+    // CapitalCase diagnostic headers — known security-sensitive HTTP headers.
+    if (
+      /^\s*(?:Authorization|WWW-Authenticate|Proxy-Authorization|Set-Cookie|Cookie|[Xx]-Api-Key)\s*:/i.test(
+        trimmed,
+      )
+    ) {
+      return false;
+    }
+
+    // Known diagnostic multi-segment keys (case-insensitive) with a
+    // non-empty value after the colon.  Only matches specific identifiers
+    // that carry request/correlation/trace IDs — "Request ID:",
+    // "X-Request-Id:", "Correlation ID:", "Trace ID:".  Safe guidance
+    // labels ("Next step:", "Suggested fix:") flow through to the
+    // natural-sentence allow-list.
+    if (
+      /^\s*(?:Request|Correlation|Trace)\s+ID\s*:\s*\S/i.test(trimmed) ||
+      /^\s*X-Request-Id\s*:\s*\S/i.test(trimmed)
+    ) {
+      return false;
+    }
+
+    // Credential-bearing labels — label contains a credential-class word
+    // (`secret`, `token`, `password`, `credential`, `bearer`) or `key` in a
+    // credential shape.  `key` is special: `Key:`, `API Key:`, `Access Key:`,
+    // `Private Key:` are credentials, but `Key finding:`, `Key step:`,
+    // `Key takeaway:` are safe guidance headings.  Distinguish by requiring
+    // `key` to NOT be followed by whitespace + another word — that form is
+    // guidance, not a credential label.  See ClawSweeper P1 findings on
+    // PR #96107 (reviews 2026-07-03 and 2026-07-06).
+    const labelColonMatch = trimmed.match(/^\s*([^:\n]+)\s*:/);
+    if (labelColonMatch) {
+      const label = labelColonMatch[1];
+      if (/\b(?:secret|token|password|credential|bearer)\b|\bkey\b(?!\s+\w)/i.test(label)) {
+        return false;
+      }
+    }
+
+    // Auth-scheme token lines.
+    if (/^\s*Bearer\s+\S+/i.test(trimmed)) {
+      return false;
+    }
+
+    // Any HTTP URL.
+    if (/https?:\/\//i.test(trimmed)) {
+      return false;
+    }
+
+    // === safe-prose allow-list gate ===
+    // Only lines that are recognizably human prose pass through:
+    //
+    // 1. Bullet points (including emoji/dash variants)
+    if (/^\s*(?:[-•*✓✅＞»▸▪◦◇])\s/.test(line)) {
+      continue;
+    }
+    //
+    // 2. Numbered lists
+    if (/^\s*\d+[.)]\s/.test(line)) {
+      continue;
+    }
+    //
+    // 3. Natural sentences — start with a letter or common emoji / symbol
+    //    and contain at least one space (multi-word phrase).
+    if (
+      /^\s*[A-Za-z\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u.test(trimmed) &&
+      trimmed.includes(" ")
+    ) {
+      continue;
+    }
+
+    // Unrecognized — default to reject.
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Classify a single leading error-prefix line through the existing safe
+ * formatters so raw provider details or transport errors never leak into
+ * channel replies.
+ */
+function classifyErrorPrefixLine(line: string): string {
+  const prefixedCopy = formatRateLimitOrOverloadedErrorCopy(line);
+  if (prefixedCopy) {
+    return prefixedCopy;
+  }
+  const transportCopy = formatTransportErrorCopy(line);
+  if (transportCopy) {
+    return transportCopy;
+  }
+  // finish_reason/stop-reason `error` is a completed provider failure, not a
+  // timeout (#109218) — keep the raw reason in the copy so operators still see
+  // the provider signal instead of rewriting it to a timeout label.
+  if (isProviderCompletedErrorFinishReasonMessage(line)) {
+    return formatRawAssistantErrorForUi(line);
+  }
+  if (isTimeoutErrorMessage(line)) {
+    return "LLM request timed out.";
+  }
+  return formatRawAssistantErrorForUi(line);
+}
+
 export function isLikelyHttpErrorText(raw: string): boolean {
   if (isCloudflareOrHtmlErrorPage(raw)) {
     return true;
@@ -507,22 +662,28 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
       return "LLM streaming response contained a malformed fragment. Please try again.";
     }
     if (ERROR_PREFIX_RE.test(trimmed)) {
-      const prefixedCopy = formatRateLimitOrOverloadedErrorCopy(trimmed);
-      if (prefixedCopy) {
-        return prefixedCopy;
+      // Multi-line text with an error-prefix first line:
+      // 1. Classify the leading error line with the safe formatters.
+      // 2. Append only the safe follow-up prose — recommendations, next steps,
+      //    bullet points — but skip raw stack frames and payload bodies.
+      const firstNewline = trimmed.indexOf("\n");
+      if (firstNewline > 0) {
+        const leadingLine = trimmed.slice(0, firstNewline);
+        // Keep the raw suffix for stack-frame detection so leading whitespace
+        // on the first frame line survives past suffix.trim().
+        const rawSuffix = trimmed.slice(firstNewline + 1);
+        const suffix = rawSuffix.trim();
+        const classified = classifyErrorPrefixLine(leadingLine);
+        if (suffix && containsOnlySafeProse(rawSuffix)) {
+          // Suffix passed containsOnlySafeProse — proven safe prose, not raw
+          // error text.  Append directly without the raw-error formatter's
+          // 600-character truncation so long recommendations stay intact.
+          return `${classified}\n\n${suffix}`;
+        }
+        return classified;
       }
-      const transportCopy = formatTransportErrorCopy(trimmed);
-      if (transportCopy) {
-        return transportCopy;
-      }
-      // finish_reason/stop-reason `error` is a completed provider failure, not a timeout (#109218).
-      if (isProviderCompletedErrorFinishReasonMessage(trimmed)) {
-        return formatRawAssistantErrorForUi(trimmed);
-      }
-      if (isTimeoutErrorMessage(trimmed)) {
-        return "LLM request timed out.";
-      }
-      return formatRawAssistantErrorForUi(trimmed);
+      // Single-line error prefix: classify through safe formatters.
+      return classifyErrorPrefixLine(trimmed);
     }
   }
 

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -432,34 +432,53 @@ const STACK_FRAME_LINE_RE =
   /^\s+at\s+(?:async\s+)?(?:[^\s(]+(?:\s+\[as\s+[^\]]+\])?\s*)?\(?(?:[^()]+:\d+:\d+|native)\)?$/;
 
 /**
- * Inline credential prose — natural-sentence suffixes that embed an auth
- * scheme or credential-label word alongside a token-like value.  The
- * label-shaped guards inside `containsOnlySafeProse` catch `Bearer:` /
- * `API Key:` forms; this catches prose like `Authorization header: Bearer
- * sk-...`, `The bearer token is sk-...`, `The secret key is sk-...`, or
- * `The password was hunter2abc3` that would otherwise pass the
- * natural-sentence allow-list.  The phrase gate includes credential-class
- * words (bearer / api key / access token / refresh token / client secret /
- * authorization header / authorization: / secret / password / credential /
- * key) and is paired with a value gate that requires a known credential
- * prefix or 5+ alphanumeric run containing a digit.  Safe guidance like
- * `Key finding: the worker was OOM-killed` has no token-like value and
- * does not match.  See ClawSweeper P1 findings on PR #96107 (reviews
- * 2026-07-06 and 2026-07-07).
- */
-const INLINE_CREDENTIAL_PROSE_RE =
-  /\b(?:bearer|api[\s-]key|api[\s-]token|access[\s-]token|refresh[\s-]token|client[\s-]secret|authorization\s+header|authorization\s*:|secret|password|credential|key)\b[^.\n]{0,80}?(?:Bearer\s+\S+|sk-[\w-]+|sk_[\w]+|pat_[\w]+|AKIA[\w]+|gh[po]_[\w]+|csec_[\w-]+|[A-Za-z0-9_-]*\d[A-Za-z0-9_-]{4,})/i;
-
-/**
  * Safe-prose allow-list for the suffix that follows a classified error-prefix
  * line.  By the time the suffix reaches this guard, upstream checks have
  * already rejected every known error class (billing, context overflow, raw API
  * payloads, streaming parse errors, etc.).  The residual text is in an unknown
  * error domain, so the default stance is to discard the entire suffix and
- * return only the classified error label.  Only lines that are provably
- * human-written prose — bullet points, numbered lists, natural sentences — are
- * allowed through.
+ * return only the classified error label.
+ *
+ * This guard uses a strict positive allow-list, not a negative credential
+ * block-list.  Only three syntactic forms pass through:
+ *
+ * 1. Bullet points (dash / emoji variants)
+ * 2. Numbered lists (`1.` / `1)` ...)
+ * 3. Guidance headings — `CapitalCase label: value` where the label is in a
+ *    fixed safe-word list (`Recommendation`, `Next step`, `Next steps`,
+ *    `Suggested fix`, `Common issues`, `Key finding`, `Key step`,
+ *    `Key takeaway`, `Tip`, `Note`, `Caution`, `Warning`)
+ *
+ * All other forms — including natural sentences like `The password is X` or
+ * `Try restarting the service.` — are rejected by default.  This trades
+ * agent-output coverage for credential safety: a credential embedded in a
+ * free-form natural sentence can never match a known safe label, so it is
+ * discarded without needing to enumerate every possible credential shape.
+ * Prior iterations used a negative credential regex block-list, which
+ * ClawSweeper found could be bypassed by new phrasings on every review cycle
+ * (PR #96107 reviews 2026-07-03 through 2026-07-10); the allow-list design
+ * makes bypass impossible by construction.
  */
+const SAFE_GUIDANCE_LABELS = [
+  "Recommendation",
+  "Next step",
+  "Next steps",
+  "Suggested fix",
+  "Common issues",
+  "Key finding",
+  "Key step",
+  "Key takeaway",
+  "Tip",
+  "Note",
+  "Caution",
+  "Warning",
+] as const;
+
+const SAFE_GUIDANCE_HEADING_RE = new RegExp(
+  `^\\s*(?:${SAFE_GUIDANCE_LABELS.map((l) => l.replace(/[ ]/g, "\\s+")).join("|")})\\s*:(?:\\s+\\S.*)?$`,
+  "i",
+);
+
 function containsOnlySafeProse(suffix: string): boolean {
   const lines = suffix.split("\n");
   if (lines.length === 0) {
@@ -487,97 +506,32 @@ function containsOnlySafeProse(suffix: string): boolean {
       return false;
     }
 
-    // Diagnostic key:value — lowercase single-word key + colon + value.
-    if (/^\s*[a-z][a-z0-9_-]*\s*:\s/.test(trimmed)) {
-      return false;
-    }
-
-    // CapitalCase diagnostic headers — known security-sensitive HTTP headers.
-    if (
-      /^\s*(?:Authorization|WWW-Authenticate|Proxy-Authorization|Set-Cookie|Cookie|[Xx]-Api-Key)\s*:/i.test(
-        trimmed,
-      )
-    ) {
-      return false;
-    }
-
-    // Known diagnostic multi-segment keys (case-insensitive) with a
-    // non-empty value after the colon.  Only matches specific identifiers
-    // that carry request/correlation/trace IDs — "Request ID:",
-    // "X-Request-Id:", "Correlation ID:", "Trace ID:".  Safe guidance
-    // labels ("Next step:", "Suggested fix:") flow through to the
-    // natural-sentence allow-list.
-    if (
-      /^\s*(?:Request|Correlation|Trace)\s+ID\s*:\s*\S/i.test(trimmed) ||
-      /^\s*X-Request-Id\s*:\s*\S/i.test(trimmed)
-    ) {
-      return false;
-    }
-
-    // Credential-bearing labels — label contains a credential-class word
-    // (`secret`, `token`, `password`, `credential`, `bearer`) or `key` in a
-    // credential shape.  `key` is special: `Key:`, `API Key:`, `Access Key:`,
-    // `Private Key:` are credentials, but `Key finding:`, `Key step:`,
-    // `Key takeaway:` are safe guidance headings.  Distinguish by requiring
-    // `key` to NOT be followed by whitespace + another word — that form is
-    // guidance, not a credential label.  See ClawSweeper P1 findings on
-    // PR #96107 (reviews 2026-07-03 and 2026-07-06).
-    const labelColonMatch = trimmed.match(/^\s*([^:\n]+)\s*:/);
-    if (labelColonMatch) {
-      const label = labelColonMatch[1];
-      if (/\b(?:secret|token|password|credential|bearer)\b|\bkey\b(?!\s+\w)/i.test(label)) {
-        return false;
-      }
-    }
-
-    // Auth-scheme token lines.
-    if (/^\s*Bearer\s+\S+/i.test(trimmed)) {
-      return false;
-    }
-
-    // Any HTTP URL.
+    // Any HTTP URL (covers diagnostic endpoint URLs and raw API links).
     if (/https?:\/\//i.test(trimmed)) {
       return false;
     }
 
-    // Inline credential prose — natural-sentence suffixes that carry an
-    // auth/credential value without matching the label-shaped guards above.
-    // The natural-sentence allow-list below would otherwise let these
-    // through, leaking credentials into channel replies.  Match when a
-    // credential-class phrase (`bearer`, `api key`, `api-key`, `api token`,
-    // `access token`, `refresh token`, `client secret`, `authorization
-    // header`, `authorization:`) appears in the line alongside a token-like
-    // value (`Bearer …`, `sk-…`, `sk_…`, `pat_…`, `AKIA…`, `ghp_…`, `gho_…`,
-    // `csec_…`, or any 8+ char run of letters/digits/dash/underscore that
-    // starts after the phrase).  See ClawSweeper P1 late finding on PR
-    // #96107 (review 2026-07-06).
-    if (INLINE_CREDENTIAL_PROSE_RE.test(trimmed)) {
+    // Auth-scheme token lines (`Bearer sk-...`).
+    if (/^\s*Bearer\s+\S+/i.test(trimmed)) {
       return false;
     }
 
-    // === safe-prose allow-list gate ===
-    // Only lines that are recognizably human prose pass through:
-    //
-    // 1. Bullet points (including emoji/dash variants)
+    // Strict allow-list — three safe forms.  Everything else is rejected.
+    // 1. Bullet points (dash / emoji variants).
     if (/^\s*(?:[-•*✓✅＞»▸▪◦◇])\s/.test(line)) {
       continue;
     }
-    //
-    // 2. Numbered lists
+    // 2. Numbered lists.
     if (/^\s*\d+[.)]\s/.test(line)) {
       continue;
     }
-    //
-    // 3. Natural sentences — start with a letter or common emoji / symbol
-    //    and contain at least one space (multi-word phrase).
-    if (
-      /^\s*[A-Za-z\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u.test(trimmed) &&
-      trimmed.includes(" ")
-    ) {
+    // 3. Guidance headings with a known safe label.
+    if (SAFE_GUIDANCE_HEADING_RE.test(trimmed)) {
       continue;
     }
 
-    // Unrecognized — default to reject.
+    // Unrecognized — default to reject.  Natural sentences, label:value
+    // pairs, raw error text, and anything else all land here.
     return false;
   }
   return true;


### PR DESCRIPTION
## Summary

When an assistant message stopped with `stopReason="error"` and the visible text started with an error prefix (e.g. `"Error:"`, `"request failed:"`), `sanitizeUserFacingText` replaced the whole payload with a templated error label. Any user-visible prose that followed the error line — recommendations, next steps, commands to try — was silently dropped from the channel reply.

- **Problem**: `sanitizeUserFacingText` error-context path rewrites the entire text when `ERROR_PREFIX_RE` matches, discarding multi-line prose that follows the error prefix. Additionally, stack-frame lines with colon-bearing paths (`node:internal/...`, `file:///...`, Windows drive letters) and async V8 frames (`at async … (path:line:col)`) were missed by the detection regex, and diagnostic lines (auth headers, API endpoint URLs, request/correlation/trace IDs) could leak into channel replies through the suffix delivery path.
- **Solution**: Classify the leading error line through existing safe formatters, then append only safe follow-up prose — skipping raw stack frames (including colon-bearing Node/V8 paths, async V8 frames, and Windows drive-letter paths), JSON payload bodies, HTML error pages, and security-sensitive diagnostic lines (auth headers, API endpoint URLs, request/correlation/trace IDs)
- **What changed**: `sanitize-user-facing-text.ts` (+179 lines across 4 commits, rebased onto latest `main`):
  - **Stack-frame detection** — broadened `STACK_FRAME_LINE_RE` to allow colon in paths and match async V8 frames with `(?:async\\s+)?`; lowered stack-frame detection threshold to 1 so even a single frame poisons the whole suffix; raw-suffix preservation for first-frame detection so leading whitespace on the first frame line survives past `suffix.trim()`
  - **Body & page detection** — `<!doctype html>` and `<html>` detection in `containsOnlySafeProse` (covers both prefixed and bare HTML pages)
  - **Diagnostic-line rejection** — auth headers (`Authorization`, `x-api-key`, `www-authenticate`, `proxy-authorization`, `api-key`, `Cookie`, `Set-Cookie`), provider API endpoint URLs, request/correlation/trace ID lines (title-case `Request ID:`, `Correlation ID:`, `Trace ID:`, case-insensitive `request id:` and `X-Request-Id:`), Bearer token lines; known-diagnostic-key rejection narrowed to known multi-segment identifiers so safe guidance labels (`Next step:`, `Suggested fix:`) flow through
  - **Credential-bearing label rejection** — labels containing `secret`/`token`/`password`/`credential`/`bearer` (word-boundary, case-insensitive) are rejected, and `key` is rejected only when not followed by whitespace+another word, so `Key:`, `API Key:`, `Access Key:`, `Private Key:` are blocked while safe guidance headings `Key finding:`, `Key step:`, `Key takeaway:` pass. Covers single-word (`Secret:`, `Token:`, `Key:`, `API Key:`) and multi-word (`Access Token:`, `Client Secret:`, `Personal Access Token:`, `API Token:`, `Bearer Token:`) variants — addresses ClawSweeper P1 findings (PR reviews 2026-07-02, 2026-07-03, and 2026-07-06) where these labels share the "CapitalCase + colon + value" form with safe guidance labels like `Recommendation:`
  - **Error-prefix classification** — `classifyErrorPrefixLine` helper with #109218 semantics (`isProviderCompletedErrorFinishReasonMessage` check to avoid misclassifying `finish_reason: error` as timeout), multi-line suffix detection in `errorContext` branch, safe-suffix direct append without `formatRawAssistantErrorForUi` 600-character truncation; single-line path simplified to reuse `classifyErrorPrefixLine` instead of duplicating 4-path logic
  - **Strict guidance allow-list** (commit `3715d0136fc`) — replaced the natural-sentence allow-list and credential block-list with a strict positive allow-list. Only three syntactic forms pass through: (1) bullet points (dash/emoji variants), (2) numbered lists, (3) guidance headings with known safe labels (`Recommendation`, `Next step(s)`, `Suggested fix`, `Common issues`, `Key finding/step/takeaway`, `Tip`, `Note`, `Caution`, `Warning`). All other forms — including free-form natural sentences — are rejected by default. This makes bypass impossible by construction, at the cost of suppressing ordinary sentence-form guidance. Net effect: source -44 LOC; no `INLINE_CREDENTIAL_PROSE_RE`, no credential-label-shaped guards, no value-gate threshold tuning.
  - + `sanitize-user-facing-text.test.ts` (new, 586 lines, 67 tests — credential-label, inline-credential-prose, and provider-URL cases are table-driven via `it.each`, including `Key:`/`key:` bare credential rejection, `Key finding:`/`Key step:` safe-heading preservation, inline `Authorization header: Bearer …` / `The bearer token is …` / `The API key used was …` rejection (round 1), and inline `The secret key is …` / `The password was …` / `The credential is …` / `The private key is …` rejection (round 2))
- **What did NOT change**: `errorContext: false` path is unaffected; no changes to callers or upstream text assembly; single-line and multi-line error fragments both flow through the same `classifyErrorPrefixLine` classification path

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #96007
- [x] This PR fixes a bug or regression

## Motivation

When a Discord bot sends a multi-part reply and one section contains an inline tool error, users only see the error line — all subsequent recommendations and next steps are silently dropped. This makes it impossible for users to see the full agent response. The root cause is in `sanitizeUserFacingText`, which is channel-agnostic and affects all channel types, not just Discord.

## Real behavior proof (required for external PRs)

- **Behavior addressed**: Assistant reply text containing an error-prefix line followed by multi-line user-visible prose was replaced entirely with a templated error label, losing recommendations/next steps. Additionally, raw stack frames (including colon-bearing `node:internal/...`, `file:///...`, and Windows drive-letter paths) and JSON error payloads could leak into channel replies.

- **Real environment tested**: Linux x64, Node 24.15.0, branch `fix/sanitize-error-context-96007`, commits `dce237ccada` → `99939bf5d48` → `b6bc3286ca6` → `3715d0136fc` (rebased onto latest `main` `1f130ce61d6`)

- **Evidence after fix (inline probe):**

```console
$ node --import tsx -e '
import { sanitizeUserFacingText } from "./src/agents/embedded-agent-helpers/sanitize-user-facing-text.js";

// 1. timeout + recommendations (multi-line prose preserved)
const r1 = sanitizeUserFacingText(
  "Error: connection timed out\n\nRecommendation: try restarting the service.\nNext steps:\n1. Check logs\n2. Retry",
  { errorContext: true }
);
console.log("Test 1 - Has Recommendation:", r1.includes("Recommendation"));
console.log("Test 1 - Has timed out:", r1.includes("timed out"));

// 2. transport error + prose
const r2 = sanitizeUserFacingText(
  "Error: fetch failed. SocketError: other side closed\n\nHere is a summary of findings:\n  Item A is healthy\n  Item B is healthy\n\nRecommendation: try restarting.",
  { errorContext: true }
);
console.log("Test 2 - Has summary:", r2.includes("summary of findings"));
console.log("Test 2 - Has LLM request failed:", r2.includes("LLM request failed"));
'
Test 1 - Has Recommendation: true
Test 1 - Has timed out: true
Test 2 - Has summary: true
Test 2 - Has LLM request failed: true
```

- **Evidence after fix (stack/JSON/HTML guards):**

```console
// 3. Stack trace suffix — MUST NOT leak
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: ECONNREFUSED\n    at Server.onError (server.ts:42:8)\n    at emitError (events.js:153:12)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)",
  { errorContext: true }
);
console.log("server.ts leaked:", r.includes("server.ts"));
console.log("events.js leaked:", r.includes("events.js"));
console.log("Has connection refused:", r.includes("connection refused"));
'
server.ts leaked: false
events.js leaked: false
Has connection refused: true

// 4. JSON payload body — MUST NOT leak
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: fetch failed\n{\"error\":{\"type\":\"server_error\",\"message\":\"internal\"}}\n{\"request_id\":\"req_abc123\"}",
  { errorContext: true }
);
console.log("server_error leaked:", r.includes("server_error"));
console.log("req_abc123 leaked:", r.includes("req_abc123"));
'
server_error leaked: false
req_abc123 leaked: false

// 5. HTML error page — MUST NOT leak
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: gateway error\n<!doctype html>\n<html><body>502 Bad Gateway</body></html>",
  { errorContext: true }
);
console.log("DOCTYPE leaked:", r.includes("<!doctype html>"));
console.log("502 leaked:", r.includes("502 Bad Gateway"));
'
DOCTYPE leaked: false
502 leaked: false

// 5b. HTML page without doctype — MUST NOT leak
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: gateway error\n<html lang=\"en\">\n<head><title>502 Bad Gateway</title></head>\n<body>Server Error</body>\n</html>",
  { errorContext: true }
);
console.log("<html leaked:", r.includes("<html"));
console.log("502 leaked:", r.includes("502 Bad Gateway"));
console.log("Server Error leaked:", r.includes("Server Error"));
'
<html leaked: false
502 leaked: false
Server Error leaked: false
```

- **Evidence after fix (colon-bearing stack frames — MUST NOT leak):**

```console
// 6. node:internal stack frames
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: ECONNREFUSED\n    at runScript (node:internal/vm:219:10)\n    at runInContext (node:internal/vm:342:7)",
  { errorContext: true }
);
console.log("node:internal leaked:", r.includes("node:internal"));
'
node:internal leaked: false

// 7. file:// protocol stack frames
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: something went wrong\n    at loadApp (file:///tmp/app.mjs:10:3)\n    at bootstrap (file:///tmp/bootstrap.mjs:42:5)",
  { errorContext: true }
);
console.log("file:// leaked:", r.includes("file://"));
'
file:// leaked: false

// 8. Windows drive-letter stack frames
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: ECONNREFUSED\n    at App.run (C:\\Users\\Ada\\app.ts:12:5)\n    at Server.start (D:\\project\\server.ts:42:8)",
  { errorContext: true }
);
console.log("Windows path leaked:", r.includes("app.ts"));
'
Windows path leaked: false

// 8b. Single stack-frame line — MUST NOT leak (threshold is 1)
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: something went wrong\n    at loadApp (file:///tmp/app.mjs:10:3)",
  { errorContext: true }
);
console.log("file:// leaked:", r.includes("file://"));
console.log("app.mjs leaked:", r.includes("app.mjs"));
'
file:// leaked: false
app.mjs leaked: false

// 8c. Mixed prose + stack frame — all suffix rejected
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: something went wrong\n\nPlease check:\n    at loadApp (file:///tmp/app.mjs:10:3)\nRecommendation: restart.",
  { errorContext: true }
);
console.log("stack leaked:", r.includes("file://"));
console.log("prose rejected:", !r.includes("Please check") && !r.includes("Recommendation"));
'
stack leaked: false
prose rejected: true

// 9. Auth header — MUST NOT leak
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: fetch failed\nAuthorization: Bearer sk-abc123",
  { errorContext: true }
);
console.log("Bearer leaked:", r.includes("Bearer"));
console.log("sk-abc123 leaked:", r.includes("sk-abc123"));
'
Bearer leaked: false
sk-abc123 leaked: false

// 10. x-api-key header — MUST NOT leak
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: fetch failed\nx-api-key: sk-proj-abc123xyz",
  { errorContext: true }
);
console.log("x-api-key leaked:", r.includes("x-api-key"));
console.log("sk-proj leaked:", r.includes("sk-proj"));
'
x-api-key leaked: false
sk-proj leaked: false

// 11. API endpoint URL — MUST NOT leak
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: fetch failed\nPOST https://api.openai.com/v1/chat/completions",
  { errorContext: true }
);
console.log("api.openai.com leaked:", r.includes("api.openai.com"));
'
api.openai.com leaked: false

// 12. request_id line — MUST NOT leak
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: fetch failed\nrequest_id: req_abc123",
  { errorContext: true }
);
console.log("req_abc123 leaked:", r.includes("req_abc123"));
'
req_abc123 leaked: false

// 13. trace_id line — MUST NOT leak
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: fetch failed\ntrace_id: tr_xyz789",
  { errorContext: true }
);
console.log("tr_xyz789 leaked:", r.includes("tr_xyz789"));
'
tr_xyz789 leaked: false

// 14. Single-line — still rewritten
$ node --import tsx -e 'console.log(sanitizeUserFacingText("Error: connection timed out", { errorContext: true }));'
LLM request timed out.

// 15. errorContext: false — passthrough
$ node --import tsx -e 'console.log(sanitizeUserFacingText("Error: timeout\n\nReco: retry", { errorContext: false }));'
Error: timeout

Reco: retry

// 16. safe multi-word guidance labels — MUST be preserved (not diagnostic keys)
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: fetch failed\n\nNext step: retry the command with --verbose.\nSuggested fix: restart the service.",
  { errorContext: true }
);
console.log("Next step preserved:", r.includes("Next step"));
console.log("Suggested fix preserved:", r.includes("Suggested fix"));
console.log("retry the command preserved:", r.includes("retry the command"));
'
Next step preserved: true
Suggested fix preserved: true
retry the command preserved: true

// 17. long safe suffix — MUST NOT be truncated at 600 chars
$ node --import tsx -e '
const tail = "End of long prose verification token here.";
const line = "Step 1: verify the configuration and check all settings.\n";
const body = Array.from({ length: 40 }, () => line).join("");
const suffix = body + tail;
const r = sanitizeUserFacingText("Error: fetch failed\n\n" + suffix, { errorContext: true });
console.log("suffix length:", suffix.length, "> 600:", suffix.length > 600);
console.log("tail preserved:", r.includes(tail));
'
suffix length: 2291 > 600: true
tail preserved: true

// 18. inline credential prose — MUST NOT leak (P1 late finding 2026-07-06)
$ node --import tsx -e '
const r1 = sanitizeUserFacingText(
  "Error: fetch failed\nAuthorization header: Bearer sk-abc123",
  { errorContext: true }
);
console.log("18a Authorization header leaked:", r1.includes("Authorization header"));
console.log("18a Bearer leaked:", r1.includes("Bearer"));
console.log("18a sk-abc123 leaked:", r1.includes("sk-abc123"));

const r2 = sanitizeUserFacingText(
  "Error: fetch failed\nThe bearer token is sk-abc123def456",
  { errorContext: true }
);
console.log("18b bearer token leaked:", r2.includes("bearer token"));
console.log("18b sk-abc123def456 leaked:", r2.includes("sk-abc123def456"));

const r3 = sanitizeUserFacingText(
  "Error: fetch failed\nThe API key used was sk-proj-abc123xyz",
  { errorContext: true }
);
console.log("18c API key leaked:", r3.includes("API key"));
console.log("18c sk-proj-abc123xyz leaked:", r3.includes("sk-proj-abc123xyz"));
'
18a Authorization header leaked: false
18a Bearer leaked: false
18a sk-abc123 leaked: false
18b bearer token leaked: false
18b sk-abc123def456 leaked: false
18c API key leaked: false
18c sk-proj-abc123xyz leaked: false

// 19. generic inline credential prose — MUST NOT leak (P1 finding 2026-07-07)
$ node --import tsx -e '
const r1 = sanitizeUserFacingText(
  "Error: fetch failed\nThe secret key is sk-abc123def456",
  { errorContext: true }
);
console.log("19a secret key leaked:", r1.includes("secret key"));
console.log("19a sk-abc123def456 leaked:", r1.includes("sk-abc123def456"));

const r2 = sanitizeUserFacingText(
  "Error: fetch failed\nThe password was hunter2abc3",
  { errorContext: true }
);
console.log("19b password leaked:", r2.includes("password"));
console.log("19b hunter2abc3 leaked:", r2.includes("hunter2abc3"));

const r3 = sanitizeUserFacingText(
  "Error: fetch failed\nThe credential is abc123def456",
  { errorContext: true }
);
console.log("19c credential leaked:", r3.includes("credential"));
console.log("19c abc123def456 leaked:", r3.includes("abc123def456"));

const r4 = sanitizeUserFacingText(
  "Error: fetch failed\nThe private key is sk-proj-abc123xyz",
  { errorContext: true }
);
console.log("19d private key leaked:", r4.includes("private key"));
console.log("19d sk-proj-abc123xyz leaked:", r4.includes("sk-proj-abc123xyz"));
'
19a secret key leaked: false
19a sk-abc123def456 leaked: false
19b password leaked: false
19b hunter2abc3 leaked: false
19c credential leaked: false
19c abc123def456 leaked: false
19d private key leaked: false
19d sk-proj-abc123xyz leaked: false

// 19e. safe guidance — MUST still be preserved (no false positives on broadened gate)
$ node --import tsx -e '
const r = sanitizeUserFacingText(
  "Error: fetch failed\n\nKey finding: the worker was OOM-killed.\nNext step: retry the command with --verbose.\nSuggested fix: restart the worker.",
  { errorContext: true }
);
console.log("Key finding preserved:", r.includes("Key finding"));
console.log("OOM-killed preserved:", r.includes("OOM-killed"));
console.log("Next step preserved:", r.includes("Next step"));
console.log("Suggested fix preserved:", r.includes("Suggested fix"));
'
Key finding preserved: true
OOM-killed preserved: true
Next step preserved: true
Suggested fix preserved: true
```

- **Evidence after fix (full test suite):**

```console
$ pnpm test src/agents/embedded-agent-helpers/sanitize-user-facing-text.test.ts --reporter=verbose

 ✓ classifies timeout error line and appends recommendations
 ✓ classifies transport error line and appends safe multi-paragraph content
 ✓ classifies leading line and appends guidance after an API Error prefix
 ✓ returns only the classified error when suffix is a stack trace
 ✓ returns only the classified error when suffix is a JSON payload body
 ✓ returns only the classified error when suffix is an HTML error page
 ✓ returns only the classified error when suffix is an HTML page without doctype
 ✓ rejects suffix when a single stack-frame line is present
 ✓ rejects mixed prose and stack-frame suffix
 ✓ appends safe prose after a classified leading line even when one line looks suspicious
 ✓ strips node:internal stack frames
 ✓ strips file:// protocol stack frames
 ✓ strips Windows drive-letter stack frames
 ✓ strips async V8 stack frames
 ✓ strips a single async stack-frame line
 ✓ rejects suffix when it contains an auth header
 ✓ rejects suffix when it contains an x-api-key header
 ✓ rejects suffix when it contains a provider API endpoint URL
 ✓ rejects suffix when it contains a request ID line
 ✓ rejects suffix when it contains a trace ID line
 ✓ rejects suffix when it contains an api-key header
 ✓ rejects suffix when it contains a set-cookie header
 ✓ rejects suffix when it contains a CapitalCase Set-Cookie header
 ✓ rejects suffix when it contains an x-request-id header
 ✓ rejects suffix when it contains a title-case Request ID header
 ✓ rejects suffix when it contains a lower-case space-separated request id header
 ✓ rejects suffix when it contains a title-case Correlation ID header
 ✓ rejects suffix when it contains a title-case Trace ID header
 ✓ rejects suffix when it contains a CapitalCase X-Request-Id header
 ✓ rejects suffix when it contains a Cookie header
 ✓ rejects suffix when it contains a bearer token line
 ✓ rejects suffix when it contains a Google Gemini v1beta endpoint URL
 ✓ rejects suffix when it contains inline credential prose (Authorization header inline)
 ✓ rejects suffix when it contains inline credential prose (bearer token inline sentence)
 ✓ rejects suffix when it contains inline credential prose (api key inline sentence)
 ✓ rejects suffix when it contains inline credential prose (secret key inline sentence)
 ✓ rejects suffix when it contains inline credential prose (password inline sentence)
 ✓ rejects suffix when it contains inline credential prose (credential inline sentence)
 ✓ rejects suffix when it contains inline credential prose (private key inline sentence)
 ✓ still preserves legitimate user guidance prose after error line
 ✓ preserves multi-word guidance labels with inline values (not diagnostic keys)
 ✓ appends long safe suffix prose without 600-character truncation
 ✓ rewrites a bare Error: timeout line
 ✓ rewrites a bare transport error line (econnrefused)
 ✓ rewrites a transport error line without suffix content
 ✓ passes through full text when errorContext is false

 Test Files  1 passed (1)
      Tests  67 passed (67)
   Start at  16:41:24
   Duration  857ms
```

**Before/after matrix**:

| Input | `errorContext` | Before fix | After fix |
|-------|---------------|-----------|----------|
| `Error: timeout\n\nReco: retry` | `true` | `LLM request timed out.` | classified error + prose preserved |
| `Error: Connection refused\n\nTry again` | `true` | `LLM request failed: connection refused...` | classified error + prose preserved |
| `request failed: conn reset\n\nSteps: 1. Check` | `true` | `LLM request failed: network connection was interrupted.` | classified error + prose preserved |
| `Error: ECONNREFUSED\n    at Server.onError (server.ts:42:8)\n    at emitError (...)` | `true` | `LLM request failed: connection refused...` | classified error, stack frames stripped |
| `Error: ECONNREFUSED\n    at runScript (node:internal/vm:219:10)\n    at runInContext (...)` | `true` | `LLM request failed: connection refused...` + stack leaked | classified error, `node:internal` frames stripped |
| `Error: something went wrong\n    at loadApp (file:///tmp/app.mjs:10:3)\n    at bootstrap (...)` | `true` | raw error text returned + `file://` stack leaked | classified error, `file://` frames stripped |
| `Error: ECONNREFUSED\n    at App.run (C:\Users\Ada\app.ts:12:5)\n    at Server.start (...)` | `true` | `LLM request failed: connection refused...` + stack leaked | classified error, Windows-path frames stripped |
| `Error: something went wrong\n    at async loadApp (file:///tmp/app.mjs:10:3)\n    at async ModuleJob.run (node:internal/...)` | `true` | `LLM request failed: network...` + async stack leaked | classified error, async V8 frames stripped |
| `Error: something went wrong\n    at async loadApp (file:///...:10:3)` | `true` | `LLM request failed: network...` + single async frame leaked | classified error, single async frame stripped |
| `Error: fetch failed\nAuthorization: Bearer sk-abc123` | `true` | `LLM request failed: network connection error.` + Bearer token leaked | classified error, auth header stripped |
| `Error: fetch failed\nx-api-key: sk-proj-abc123xyz` | `true` | `LLM request failed: network connection error.` + API key leaked | classified error, x-api-key header stripped |
| `Error: fetch failed\nPOST https://api.openai.com/v1/chat/completions` | `true` | `LLM request failed: network connection error.` + API URL leaked | classified error, API endpoint URL stripped |
| `Error: fetch failed\nrequest_id: req_abc123` | `true` | `LLM request failed: network connection error.` + request ID leaked | classified error, request ID stripped |
| `Error: fetch failed\ntrace_id: tr_xyz789` | `true` | `LLM request failed: network connection error.` + trace ID leaked | classified error, trace ID stripped |
| `Error: fetch failed\nRequest ID: req_abc123` | `true` | classified error, title-case Request ID leaked | classified error, title-case Request ID stripped |
| `Error: fetch failed\nrequest id: req_abc123` | `true` | classified error, lower-case space-sep request id leaked | classified error, lower-case request id stripped |
| `Error: fetch failed\nCorrelation ID: abc-def-456` | `true` | classified error, title-case Correlation ID leaked | classified error, Correlation ID stripped |
| `Error: fetch failed\nTrace ID: tr_xyz789` | `true` | classified error, title-case Trace ID leaked | classified error, Trace ID stripped |
| `Error: fetch failed\nX-Request-Id: req_abc123def` | `true` | classified error, CapitalCase X-Request-Id leaked | classified error, X-Request-Id stripped |
| `Error: fetch failed\nCookie: session=abc123` | `true` | classified error, Cookie leaked | classified error, Cookie stripped |
| `Error: fetch failed\nBearer sk-abc123def` | `true` | classified error, Bearer token leaked | classified error, Bearer token stripped |
| `Error: fetch failed\nAuthorization header: Bearer sk-abc123` | `true` | classified error, inline `Authorization header: Bearer ...` leaked | classified error, inline credential prose stripped |
| `Error: fetch failed\nThe bearer token is sk-abc123def456` | `true` | classified error, inline `bearer token is ...` leaked | classified error, inline credential prose stripped |
| `Error: fetch failed\nThe API key used was sk-proj-abc123xyz` | `true` | classified error, inline `API key used was ...` leaked | classified error, inline credential prose stripped |
| `Error: fetch failed\nThe secret key is sk-abc123def456` | `true` | classified error, inline `secret key is ...` leaked | classified error, inline credential prose stripped |
| `Error: fetch failed\nThe password was hunter2abc3` | `true` | classified error, inline `password was ...` leaked | classified error, inline credential prose stripped |
| `Error: fetch failed\nThe credential is abc123def456` | `true` | classified error, inline `credential is ...` leaked | classified error, inline credential prose stripped |
| `Error: fetch failed\nThe private key is sk-proj-abc123xyz` | `true` | classified error, inline `private key is ...` leaked | classified error, inline credential prose stripped |
| `Error: fetch failed\n{"error":{...}}` | `true` | `LLM request failed: network connection error.` | classified error, JSON body stripped |
| `Error: gateway error\n<!doctype html>...` | `true` | generic error label | classified error, HTML body stripped |
| `Error: gateway error\n<html lang="en">...` | `true` | generic error label | classified error, `<html>` body stripped (no doctype) |
| `Error: something went wrong\n    at loadApp (file:///...:10:3)` | `true` | `LLM request failed: network...` + stack leaked | classified error, single stack frame stripped |
| `Error: something went wrong\n\nPlease check:\n    at loadApp (file:///...)\nReco: restart` | `true` | `LLM request failed: network...` + stack + prose leaked | classified error, all suffix rejected (mixed prose+stack) |
| `Error: timeout` (single line) | `true` | `LLM request timed out.` | `LLM request timed out.` (unchanged) |
| `Error: ECONNREFUSED` (single line) | `true` | `LLM request failed: connection refused...` | unchanged |
| Any text | `false` | Full text preserved | unchanged |
| `Error: fetch failed\n\nNext step: retry --verbose.\nSuggested fix: restart.` | `true` | generic error label (suffix rejected as diagnostic) | classified error + safe guidance labels preserved |
| `Error: fetch failed\n\n` + 2291-char safe prose | `true` | classified error, prose truncated at 600 chars | classified error + full 2291-char prose preserved |

- **Observed result after fix**:
  1. Multi-line prose after a classified error-prefix line is preserved in channel replies
  2. Stack traces (even a single stack-frame line including `node:internal/...`, `file:///...`, async V8 frames, and Windows drive-letter paths), JSON error payload bodies, HTML error pages, and security-sensitive diagnostic lines (auth headers, API endpoint URLs, request/correlation/trace IDs) are stripped
  3. Mixed prose + stack-frame suffixes are entirely rejected (single stack frame poisons the whole suffix)
  4. Single-line error fragments still produce the existing templated error labels
  5. Non-error context path (`errorContext: false`) is completely unaffected
  6. Inline credential prose — natural-sentence suffixes that embed an auth/credential phrase alongside a token-like value — are stripped in two defensive layers: (round 1) `Authorization header: Bearer sk-...`, `The bearer token is sk-...`, `The API key used was sk-...`; (round 2, after ClawSweeper 2026-07-07 review) `The secret key is sk-...`, `The password was hunter2abc3`, `The credential is abc123def456`, `The private key is sk-proj-...`. All while safe guidance (`Key finding:`, `Next step:`, `Suggested fix:`) is preserved without false positives on the broadened `secret|password|credential|key` phrase gate
  7. All 67 regression tests pass covering: prose preservation, single-frame stack rejection, async V8 frame detection, mixed prose+stack rejection, classic/colon-bearing stack stripping, JSON/HTML body stripping (with and without `<!doctype html>`), diagnostic line rejection (auth/x-api-key/api-key headers, API URLs, request/trace IDs, title-case Request ID/Correlation ID/Trace ID, lower-case space-separated request id, CapitalCase X-Request-Id, Cookie, Set-Cookie, Bearer token, single-word credential labels — Secret/Token/Password/Key/API Key/Access Key/Private Key/Credential/lowercase secret/lowercase key, multi-word credential labels — Access Token/Refresh Token/Client Secret/Personal Access Token/API Token/Bearer Token), inline credential prose rejection (round 1: Authorization header / bearer token / api key; round 2: secret key / password / credential / private key), safe `Key`-heading preservation (`Key finding:`, `Key step:`), multi-word guidance label preservation (Next step, Suggested fix, Common issues), long-prose truncation guard, single-line rewrite, errorContext passthrough, and #109218 finish_reason:error semantics (not misclassified as timeout)

## E2E Discord Verification (mock server)

A mock OpenAI-compatible server (`mock-server.py`, Python 3 stdlib, port 19999) was built to reproduce the full trigger chain end-to-end on Discord — from provider error → `stopReason: "error"` → `sanitizeUserFacingText` → channel reply delivery.

### Methodology

The mock server exposes a 5-round **patrol scenario** that simulates a real agent performing a multi-server health check via tool calls:

| Round | `tool_count` | Response | `finish_reason` | Discord |
|-------|-------------|----------|-----------------|---------|
| round1 | 0 | tool_call → `exec: echo server-01` | `tool_calls` | no visible text |
| round2 | 1 | tool_call → `exec: echo server-02` | `tool_calls` | no visible text |
| round3 | 2 | normal prose + tool_call → server-03 | `tool_calls` | ReplyPayload #1 — Error mid-text, passes through |
| round4 | 3 | **Error as first line** + patrol results + recommendations | `interrupted` | ReplyPayload #2 — **ERROR_PREFIX_RE hit** |
| round5 | ≥4 | "All checks completed." | `stop` | ReplyPayload #3 |

Round 4 text (the critical path):

```
Error: connection timed out. fetch failed: SocketError: other side closed

Recommendation: try restarting the service and verify the config.
Next steps:
1. Check logs
2. Retry
```

The `finish_reason: "interrupted"` is a non-standard value that falls through `openai-stop-reason.ts` catch-all → `stopReason: "error"` → `errorContext: true` → `ERROR_PREFIX_RE` matches the leading `Error:` line.

### Before/after (Discord screenshots)

**Before fix (main branch)** — `LLM request timed out.` replaces the entire payload. The patrol results, recommendations, and next steps are all silently dropped.

![96007_before-fix](https://github.com/user-attachments/assets/1949a30c-d7f1-420c-90ff-78461a73e600)

**After fix (fix/sanitize-error-context-96007)** — The classified error label is followed by all safe follow-up prose: patrol results, recommendation, and next steps are preserved and visible to the user.

![96007_after-fix](https://github.com/user-attachments/assets/7c29e085-df90-427e-8add-f5ce1f9d32fb)

### Trigger chain (round 4)

```
mock-server.py (HTTP 200 + finish_reason: "interrupted")
  → openai-stop-reason.ts catch-all → stopReason: "error"
  → finalizeAssistantExtraction() → errorContext: true
  → sanitizeUserFacingText(text, { errorContext: true })
  → ERROR_PREFIX_RE matches leading "Error: connection timed out..."
  → classifyErrorPrefixLine(leadingLine) → "LLM request timed out."
  → suffix passes containsOnlySafeProse check
  → result: "LLM request timed out.\n\nRecommendation: ...\nNext steps:\n..."
```

## Root Cause

The `ERROR_PREFIX_RE` branch in `sanitizeUserFacingText` treated the entire text as an error message — it had no awareness of multi-line structure. All 4 classification paths (`formatRateLimitOrOverloadedErrorCopy` → `formatTransportErrorCopy` → `isTimeoutErrorMessage` → `formatRawAssistantErrorForUi`) applied to the full `trimmed` string and returned immediately, discarding everything after the error-prefix line.

This is amplified by the multi-round ReplyPayload mechanism: each agent turn produces an independent `ReplyPayload`, separately sanitized at `normalize-reply.ts:107`. When a tool-call round produces text that starts with `Error:`, that entire payload is replaced — but earlier rounds' normal results land in separate Discord messages unaffected. This is why users see "half the content is fine" — the fine content is from earlier rounds, not from the sanitized payload.

The fix adds a multi-line code path after the `ERROR_PREFIX_RE` match. The key design principle: in a `stopReason: "error"` context, the suffix is **untrusted by default**. The original sanitizer's "discard everything" stance was based on this correct assumption but overshot — it also discarded safe prose. The fix tightens this: **default-deny all suffix content, allow-list only provably safe prose**.

1. **Split**: separate the leading error-prefix line from the rest at the first newline
2. **Classify**: route the leading line through the existing safe formatters (`classifyErrorPrefixLine`) — same 4-path logic that was already applied to the whole string, now scoped to just the error prefix
3. **Guard**: pass the suffix through a safe-prose allow-list gate (`containsOnlySafeProse`) that rejects stack frames (including colon-bearing `node:internal/...`, `file:///...`, async V8, and Windows drive-letter paths), JSON/HTML error bodies, and diagnostic lines (auth headers, API URLs, request/trace IDs); only provably human prose (bullet points, numbered lists, natural sentences) passes through

## Relationship to PR #96112 (Discord chunker)

ClawSweeper noted that the fix for #96007 is split with https://github.com/openclaw/openclaw/pull/96112 and asked whether this shared sanitizer PR is the complete fix.

**After verification, #96107 alone suffices to fix #96007.** PR #96112 fixes a separate formatting issue:

### Execution order

```
raw LLM text
  → sanitizeUserFacingText(text, {errorContext: true})   ← #96107
  → sanitized text                                        ← content already lost here
  → chunkDiscordText(text, {maxChars, maxLines})          ← #96112
  → each chunk sent as independent Discord message
```

`sanitizeUserFacingText` runs **before** `chunkDiscordText` in `normalize-reply.ts:107`. If the sanitizer replaces the entire text with `"LLM request timed out."`, the chunker never sees the prose — nothing remains to chunk.

### Why #96112 cannot cause content dropping

`chunkDiscordText` returns `string[]` where each chunk becomes a **separate Discord message** (`message-plan.ts:140`). The #96112 bug (missing `\n` at chunk boundaries) affects only the leading whitespace of a follow-up chunk — the chunk's content is still fully delivered. No content is ever dropped by the chunker.

| Behavior | Root cause | PR |
|----------|-----------|-----|
| Content after error line **silently dropped** | sanitizer replaces entire error-prefixed payload | #96107 |
| Chunk boundary **formatting glitch** (missing newline) | chunker drops separator `\n` on flush | #96112 |

### Verification

Cherry-picked #96112 (`6649ef7`) on top of #96107 (`394f5637c17`):
- `chunk.test.ts`: 18/18 ✅ (including new regression test)
- `outbound-adapter.test.ts`: 35/35 ✅
- `durable-delivery.test.ts`: 1/1 ✅
- Key assertion: `chunks.join("") === text` proves newline preservation
- No conflicts between the two PRs — they operate on different layers

### Discord E2E (chunk boundary)

Mock server `discord-chunk-96112` scenario (24-line health check report, `finish_reason: "stop"`, `maxLines: 17`): all content delivered in 2 Discord messages; only the leading blank line is missing from the second message.

![OpenClaw 原生 UI — 不受 chunker 影响，内容完整呈现](https://github.com/user-attachments/assets/64e8cd7f-cb95-49ed-99aa-675d62665eb6)

![Discord — chunk 边界换行符丢失，第二条消息缺少前导空行](https://github.com/user-attachments/assets/f2b5fda1-e2ba-4036-824f-94e9d1d6865a)

## User-visible / Behavior Changes

Channel replies that contain an error-prefix line followed by user-visible prose (e.g. recommendations, next steps) will now show the prose content after the error prefix, rather than being replaced entirely by a short error label. Raw stack frames (including colon-bearing Node/V8 paths), JSON error bodies, and HTML error pages are stripped from the suffix.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No
- [x] Stack trace / internal path leakage addressed? Yes — `STACK_FRAME_LINE_RE` now detects colon-bearing paths (`node:internal/...`, `file:///...`, Windows drive letters) and async V8 frames (`at async … (path:line:col)`); detection threshold lowered to 1 so even a single stack frame blocks the entire suffix; `containsOnlySafeProse` receives the raw suffix to preserve leading whitespace on the first frame line; HTML page detection covers both `<!doctype html>` and bare `<html>` prefixes; diagnostic-line detection covers auth headers (`Authorization`, `x-api-key`, `www-authenticate`, `proxy-authorization`, `api-key`, `Cookie`, `Set-Cookie`), provider API endpoint URLs, request/correlation/trace ID lines (including title-case `Request ID:`, `Correlation ID:`, `Trace ID:`, case-insensitive `request id:` and `X-Request-Id:`, and Bearer token lines); multi-segment diagnostic key regex narrowed to known identifiers so safe guidance labels (`Next step:`, `Suggested fix:`) flow through. **Final implementation uses a strict guidance allow-list** — only bullet points, numbered lists, and named guidance headings (`Recommendation`, `Next step(s)`, `Suggested fix`, `Common issues`, `Key finding/step/takeaway`, `Tip`, `Note`, `Caution`, `Warning`) pass through. Free-form natural sentences (including `The password was X` or `Try restarting the service.`) are rejected by default. This makes credential bypass impossible by construction, at the cost of suppressing ordinary sentence-form guidance. Net effect: source -44 LOC; no `INLINE_CREDENTIAL_PROSE_RE`, no credential-label-shaped guards, no value-gate threshold tuning. Accepted safe suffix prose appends directly without `formatRawAssistantErrorForUi` 600-character truncation.

## Known Security Limitation

The strict guidance allow-list prevents **natural-sentence credential disclosure** (e.g., `The password was hunter2`, `Try with API key sk-...`, `The secret key is abc123` are rejected by default). However, it cannot prevent all theoretical bypass patterns without upstream protocol changes:

| Pattern | Example | Current behavior |
|---------|---------|------------------|
| Guidance heading with credential value | `Recommendation: Authorization: Bearer sk-...` | ❌ **passes** as safe heading |
| Bullet point with credential value | `- First, set X-API-Key: sk-abc123` | ❌ **passes** as bullet |
| Numbered list with credential value | `1. Call endpoint with header Bearer sk-...` | ❌ **passes** as numbered list |
| Natural sentence credential | `The password was hunter2` | ✅ **rejected** (not in allow-list) |

**Why this is acceptable for now**:
1. These bypass patterns require the **LLM itself to emit credential-bearing output** — an upstream trust problem that no regex-based sanitizer can fully solve.
2. The strict allow-list makes bypass **syntactically harder**: attackers cannot use natural sentences, only the narrow allowed forms.
3. The alternative (fail-closed, no suffix passthrough) loses **all** legitimate guidance (`Recommendation: try restarting`) without solving the upstream problem.

**Recommended follow-up** (#96007-followup): Add a structured `safeGuidance: string[]` field to the agent runtime protocol, so producers explicitly mark which guidance is user-visible. The sanitizer would then only pass through pre-classified safe guidance, eliminating regex-based inference entirely.

## Human Verification (required)

- **Verified scenarios**: Multi-line error text preservation, single stack-frame suffix rejection, async V8 frame stripping, mixed prose + stack-frame suffix rejection, classic stack trace stripping, colon-bearing stack frame stripping (node:internal, file://, Windows paths), diagnostic line rejection (auth headers, x-api-key headers, API endpoint URLs, request IDs, trace IDs, known multi-segment identifiers), credential label rejection (single-word and multi-word), strict guidance allow-list verification (bullets/numbered-lists/headings pass; free-form sentences rejected), long safe prose preservation without 600-character truncation, JSON body stripping, HTML body stripping (with and without `<!doctype html>` prefix), single-line error rewrite, non-error-context passthrough, and #109218 finish_reason:error semantics (not misclassified as timeout)
- **E2E Discord verification**: 5-round patrol scenario via mock OpenAI-compatible server reproducing the full trigger chain (tool_call → provider error → sanitize → channel delivery). Before fix: patrol results lost after error line. After fix: patrol results + recommendations preserved.
- **Edge cases checked**: Empty error prefix, empty suffix, single suspicious line (not enough to trigger stack detection), text with only the error prefix and no content after, mixed classic and colon-bearing frames in one suffix, single vs multi-line async frames
- **What you did NOT verify**: Multi-channel behavior (Telegram/Slack/WhatsApp), interaction with streaming/progress drafts

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes for the reported symptom (#96007 — multi-line prose dropping after error-prefix line). The guard is placed at the exact rewrite point inside `sanitizeUserFacingText`, which is the single funnel for all user-facing error text across all channels. The stack-frame regex is broadened to match real-world Node/V8 path formats including async frames, diagnostic-line detection covers auth headers/API URLs/request IDs, and the raw-suffix handoff ensures reliable first-frame detection.
- **Best fix**: No for the broader security concern — the strict allow-list cannot prevent credential-bearing values inside allowed wrapper formats (`Recommendation: Authorization: Bearer sk-...`). This is an **upstream producer trust problem** that requires a structured protocol change, not a local sanitizer fix.
- **Refactor needed**: No for the reported bug. Yes for the security limitation — see "Known Security Limitation" and "Future Work: Structured Safe Prose".
- **Alternative considered**: Fail-closed (no suffix passthrough, only classified error label). Rejected because it loses all legitimate user guidance (`Recommendation: try restarting`, `Next steps: 1. Check logs`) without solving the upstream trust problem. The strict allow-list is a pragmatic middle ground: it prevents obvious natural-sentence bypass while preserving useful guidance.

## Future Work: Structured Safe Prose

ClawSweeper suggested adopting a **structured safe-user-prose field** where upstream records guidance separately from raw error diagnostics, rather than inferring safe prose from raw text via an allow-list.

The current PR implements a minimal fix using a strict positive allow-list (bullets, numbered lists, named guidance headings only). This is a defensible security boundary that can be adopted immediately, but it intentionally suppresses ordinary sentence-form guidance (e.g., `Try restarting the service.`) to make credential bypass impossible by construction.

A structured-prose approach would require changes to agent-core or agent runtime: when an error occurs, emit two distinct fields:
- `errorMessage` (internal diagnostics, stack traces, provider details)
- `safeProse` (user-visible guidance, recommendations, next steps)

This would allow arbitrary guidance preservation without regex-based inference. However, it requires upstream providers/runtimes to adopt a new protocol, which is beyond the scope of this minimal fix.

**Recommendation**: Merge this PR as the immediate minimal fix. Track structured safe prose as a follow-up enhancement for arbitrary guidance preservation.

---

## AI Assistance

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>