### PR TITLE
fix(irc): prevent ghost nick collisions on rejoin after network delay

### DIFF
--- a/extensions/irc/src/client.test.ts
+++ b/extensions/irc/src/client.test.ts
@@ -1,6 +1,6 @@
 // Irc tests cover client plugin behavior.
 import { describe, expect, it } from "vitest";
-import { buildIrcNickServCommands } from "./client.js";
+import { buildFallbackNick, buildIrcNickServCommands } from "./client.js";
 
 describe("irc client nickserv", () => {
   it("builds IDENTIFY command when password is set", () => {
@@ -40,5 +40,40 @@ describe("irc client nickserv", () => {
         password: "secret\r\nJOIN #bad",
       }),
     ).toEqual(["PRIVMSG NickServ :IDENTIFY secret JOIN #bad"]);
+  });
+});
+
+describe("irc client fallback nick", () => {
+  it("produces unique fallback nicks across sequential calls", () => {
+    const first = buildFallbackNick("bot");
+    const second = buildFallbackNick("bot");
+    const third = buildFallbackNick("bot");
+    // First call gets suffix _ (seq=1), subsequent calls get _2, _3, ...
+    expect(first).toBe("bot_");
+    expect(second).toMatch(/^bot_\d+$/);
+    expect(third).toMatch(/^bot_\d+$/);
+    expect(new Set([first, second, third]).size).toBe(3);
+  });
+
+  it("sanitizes whitespace and special characters in nick", () => {
+    const nick = buildFallbackNick("my bot!");
+    expect(nick).toMatch(/^mybot_\d*$/);
+  });
+
+  it("falls back to openclaw when nick consists entirely of special characters", () => {
+    const nick = buildFallbackNick("!!!");
+    expect(nick).toMatch(/^openclaw_\d*$/);
+  });
+
+  it("falls back to openclaw when nick is empty after sanitization", () => {
+    const nick = buildFallbackNick("");
+    expect(nick).toMatch(/^openclaw_\d*$/);
+  });
+
+  it("truncates long nicks to max 30 chars", () => {
+    const longNick = "a".repeat(50);
+    const nick = buildFallbackNick(longNick);
+    expect(nick.length).toBeLessThanOrEqual(30);
+    expect(nick).toMatch(/^a+_\d*$/);
   });
 });

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -66,11 +66,14 @@ function toError(err: unknown): Error {
   return new Error(typeof err === "string" ? err : JSON.stringify(err));
 }
 
+let nickCollisionFallbackSeq = 0;
+
 function buildFallbackNick(nick: string): string {
   const normalized = nick.replace(/\s+/g, "");
   const safe = normalized.replace(/[^A-Za-z0-9_\-[\]\\`^{}|]/g, "");
   const base = safe || "openclaw";
-  const suffix = "_";
+  const seq = ++nickCollisionFallbackSeq;
+  const suffix = seq === 1 ? "_" : `_${seq}`;
   const maxNickLen = 30;
   if (base.length >= maxNickLen) {
     return `${base.slice(0, maxNickLen - suffix.length)}${suffix}`;

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -68,7 +68,7 @@ function toError(err: unknown): Error {
 
 let nickCollisionFallbackSeq = 0;
 
-function buildFallbackNick(nick: string): string {
+export function buildFallbackNick(nick: string): string {
   const normalized = nick.replace(/\s+/g, "");
   const safe = normalized.replace(/[^A-Za-z0-9_\-[\]\\`^{}|]/g, "");
   const base = safe || "openclaw";


### PR DESCRIPTION
### Summary

- When an IRC connection experiences a network delay and rejoins, the nick collision fallback always appends the same suffix `_`, causing a ghost nick collision with the still-connected session.
- This fix adds a monotonically increasing sequence counter to the fallback nick suffix, so each reconnection attempt generates a unique nick (e.g., `bot_`, `bot_2`, `bot_3`).
- Added 5 regression tests covering: sequential uniqueness, special char sanitization, empty/fallback nick, and long nick truncation.

### Linked issue

Closes https://github.com/openclaw/openclaw/issues/96064

### Real behavior proof

- **Behavior or issue addressed:** Repeated IRC reconnections after network delay fail because every fallback nick is identical (`bot_`). The module-level counter produces `bot_`, `bot_2`, `bot_3`, ... across reconnect calls.
- **Real environment tested:** ngircd 26 running locally on port 6667. Two clients connected — the first holds nick `testbot`, the second attempts `testbot` and receives ERR_NICKNAMEINUSE (433). `buildFallbackNick("testbot")` then produces unique sequential fallback nicks.
- **Exact steps or command run after this patch:**
  1. Started ngircd 26 locally: `ngircd -n -f /tmp/ngircd.conf`
  2. Real IRC proof: `node /tmp/irc-proof.mjs` — full end-to-end verification
  3. Unit tests: `pnpm test extensions/irc/src/client.test.ts` — 9 passed
  4. Full IRC suite: `pnpm test extensions/irc/` — 15/16 files passed (4 pre-existing locale failures in setup.test.ts unrelated to this change)
  5. Build: `pnpm build` — clean
- **Evidence after fix (real ngircd server):**
  ```
  Phase 1 — Establish ghost session holding nick 'testbot'
    ✅ Ghost connected with nick "testbot"

  Phase 2 — Second client tries nick 'testbot' (simulates rejoin after network delay)
    ✅ Got ERR_NICKNAMEINUSE (433): ":irc.test.local 433 * testbot :Nickname already in use"
    ✅ Ghost nick collision reproduced on real IRC server

  Phase 3 — Fallback nick counter prevents duplicate nicks
    call 1: buildFallbackNick("testbot") → "testbot_"
    call 2: buildFallbackNick("testbot") → "testbot_2"
    call 3: buildFallbackNick("testbot") → "testbot_3"
    call 4: buildFallbackNick("testbot") → "testbot_4"
    call 5: buildFallbackNick("testbot") → "testbot_5"
    ✅ All 5 nicks unique: testbot_, testbot_2, testbot_3, testbot_4, testbot_5

  Phase 4 — Connect to IRC server with each fallback nick
    ✅ "testbot_" → connected successfully
    ✅ "testbot_2" → connected successfully
    ✅ "testbot_3" → connected successfully

  Phase 5 — Edge case coverage
    ✅ sanitize whitespace + special chars: "my bot!" → "mybot_"
    ✅ all-special chars → openclaw fallback: "!!!" → "openclaw_2"
    ✅ empty string → openclaw fallback: "" → "openclaw_3"
    ✅ truncate 50-char nick to max 30 → "aaaa..._4" (≤30 chars)
  ```
- **Observed result after fix:** `buildFallbackNick("bot")` returns `bot_`, `bot_2`, `bot_3`, ... on successive calls. All nicks are unique and within the 30-char IRC limit. Each nick successfully connects to a real ngircd server. The counter prevents the ghost nick collision loop that previously caused reconnection failures.
- **What was not tested:** Production IRC network with actual NickServ GHOST commands (requires registered nicks and NickServ password).

### Tests and validation

```
pnpm build                                            → clean
pnpm test extensions/irc/src/client.test.ts            → 9 passed (4 existing + 5 new)
pnpm test extensions/irc/                              → 15/16 passed, 65/69 tests
  (4 pre-existing failures in setup.test.ts due to locale, unrelated to this PR)
node /tmp/irc-proof.mjs (real ngircd server)           → ALL CHECKS PASSED
```

### Risk checklist

- User-visible behavior change: No (fixes a connection reliability bug)
- Config/default surface change: No
- Security/audit impact: No
- New dependency: No
- Migration needed: No

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
