### PR TITLE
fix(failover): classify upstream_error as server_error to trigger model fallback

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.test.ts
+++ b/src/agents/embedded-agent-helpers/errors.test.ts
@@ -98,6 +98,8 @@ describe("formatAssistantErrorText streaming JSON parse classification", () => {
   });
 });
 
+import { classifyFailoverSignal } from "./errors.js";
+
 describe("isLikelyContextOverflowError", () => {
   it("detects Codex promptError wording for a full context window", () => {
     expect(
@@ -105,5 +107,30 @@ describe("isLikelyContextOverflowError", () => {
         "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
       ),
     ).toBe(true);
+  });
+});
+
+describe("classifyFailoverSignal upstream_error", () => {
+  it("classifies upstream_error errorType as server_error for model fallback (regression for #95519)", () => {
+    const classification = classifyFailoverSignal({
+      message: '{"error":{"type":"upstream_error","message":"Upstream request failed"}}',
+      errorType: "upstream_error",
+      code: null as unknown as undefined,
+      provider: "openai",
+    });
+    expect(classification).toEqual({
+      kind: "reason",
+      reason: "server_error",
+    });
+  });
+
+  it("does not classify unhandled error messages as server_error", () => {
+    const classification = classifyFailoverSignal({
+      message: "Some other error",
+      provider: "openai",
+    });
+    // Without errorType, upstream_error, or other recognized patterns,
+    // classification falls through and returns null.
+    expect(classification).toBeNull();
   });
 });

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1176,6 +1176,17 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
           errorType: signal.errorType,
         })
       : null;
+  // upstream_error is a provider-side transient failure (e.g. OpenAI
+  // responses API returns {"error":{"type":"upstream_error"}}).  Classify
+  // it as server_error so model fallback triggers instead of ending the
+  // turn with "LLM request failed." (issue #95519).
+  if (
+    !providerPluginReason &&
+    signal.errorType != null &&
+    normalizeLowercaseStringOrEmpty(signal.errorType) === "upstream_error"
+  ) {
+    return toReasonClassification("server_error");
+  }
   const effectiveMessageClassification = providerPluginReason
     ? toReasonClassification(providerPluginReason)
     : mergeMessageAndDetailClassification(messageClassification, detailClassification);


### PR DESCRIPTION
## Summary

Fixes #95519: When a provider returns `{"error":{"type":"upstream_error","message":"Upstream request failed"}}`, model fallback does not trigger because `classifyFailoverSignal` does not recognize the `upstream_error` errorType. The turn ends with "LLM request failed." instead of trying configured fallback models.

**Fix**: In `classifyFailoverSignal`, classify `errorType === "upstream_error"` as `server_error` before falling through to message-based classification. This triggers model fallback for transient provider-side failures.

## Real behavior proof

- **Behavior or issue addressed:** upstream_error from providers (e.g. OpenAI responses API) does not trigger model fallback
- **Real environment tested:** macOS, Node v22.22.3, latest upstream/main
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs run src/agents/embedded-agent-helpers/errors.test.ts --reporter=verbose
```

- **Evidence after fix (copied live output):**

```
 ✓ classifyFailoverSignal upstream_error > classifies upstream_error errorType as server_error for model fallback (regression for #95519)
 ✓ classifyFailoverSignal upstream_error > does not classify unhandled error messages as server_error
 ...
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

- **Observed result after fix:** `classifyFailoverSignal({errorType: "upstream_error", ...})` returns `{kind: "reason", reason: "server_error"}` — upstream_error is now recognized as a transient failure eligible for model fallback.
- **What was not tested:** Live provider returning upstream_error with configured fallback models. The classification fix is deterministic — once classified as server_error, the existing fallback machinery handles the rest.

## Tests and validation

**Which commands did you run?**
```bash
node scripts/run-vitest.mjs run src/agents/embedded-agent-helpers/errors.test.ts
# 7 passed (1 test file, 2 new tests added)
```

**What regression coverage was added?**
- `"classifies upstream_error errorType as server_error for model fallback (regression for #95519)"` — verifies upstream_error → server_error
- `"does not classify unhandled error messages as server_error"` — verifies no false positives

## Risk checklist

**Did user-visible behavior change?** Yes — upstream_error now triggers model fallback instead of ending the turn immediately.
**Did config, environment, or migration behavior change?** No
**Did security, auth, secrets, network, or tool execution behavior change?** No
**What is the highest-risk area?** Could cause fallback loops if upstream_error is persistent across all models. Mitigation: existing fallback exhaustion logic already handles retry loops.

Closes #95519.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Code <noreply@anthropic.com>