### PR TITLE
fix(discord): pass session file to plugin slash commands

### DIFF
--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -18,7 +18,13 @@ import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  getSessionEntry,
+  loadSessionStore,
+  resolveAndPersistSessionFile,
+  resolveSessionStoreEntry,
+  resolveStorePath,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { defineThrowingDiscordChannelGetter } from "../test-support/partial-channel.js";
 import { resolveDiscordNativeInteractionRouteState } from "./native-command-route.js";
@@ -36,6 +42,10 @@ const runtimeModuleMocks = vi.hoisted(() => ({
   dispatchReplyWithDispatcher: vi.fn(),
   resolveDirectStatusReplyForSession: vi.fn(),
   getSessionEntry: vi.fn(),
+  loadSessionStore: vi.fn(),
+  resolveAndPersistSessionFile: vi.fn(),
+  resolveSessionStoreEntry: vi.fn(),
+  resolveStorePath: vi.fn(),
 }));
 
 function createConfig(): OpenClawConfig {
@@ -416,6 +426,10 @@ describe("Discord native plugin command dispatch", () => {
       resolveDiscordNativeInteractionRouteState,
     );
     discordNativeCommandTesting.setGetSessionEntry(getSessionEntry);
+    discordNativeCommandTesting.setLoadSessionStore(loadSessionStore);
+    discordNativeCommandTesting.setResolveAndPersistSessionFile(resolveAndPersistSessionFile);
+    discordNativeCommandTesting.setResolveSessionStoreEntry(resolveSessionStoreEntry);
+    discordNativeCommandTesting.setResolveStorePath(resolveStorePath);
   });
 
   beforeEach(() => {
@@ -441,6 +455,28 @@ describe("Discord native plugin command dispatch", () => {
     });
     runtimeModuleMocks.getSessionEntry.mockReset();
     runtimeModuleMocks.getSessionEntry.mockReturnValue(undefined);
+    runtimeModuleMocks.loadSessionStore.mockReset();
+    runtimeModuleMocks.loadSessionStore.mockReturnValue({});
+    runtimeModuleMocks.resolveAndPersistSessionFile.mockReset();
+    runtimeModuleMocks.resolveAndPersistSessionFile.mockResolvedValue({
+      sessionFile: "/tmp/openclaw-discord-plugin-command-test/session.jsonl",
+      sessionEntry: {
+        sessionId: "discord-session",
+        sessionFile: "/tmp/openclaw-discord-plugin-command-test/session.jsonl",
+        updatedAt: Date.now(),
+      },
+    });
+    runtimeModuleMocks.resolveSessionStoreEntry.mockReset();
+    runtimeModuleMocks.resolveSessionStoreEntry.mockImplementation(
+      ({ store, sessionKey }: { store: Record<string, unknown>; sessionKey: string }) => ({
+        normalizedKey: sessionKey,
+        existing: store[sessionKey],
+      }),
+    );
+    runtimeModuleMocks.resolveStorePath.mockReset();
+    runtimeModuleMocks.resolveStorePath.mockReturnValue(
+      "/tmp/openclaw-discord-plugin-command-test/sessions.json",
+    );
     discordNativeCommandTesting.setMatchPluginCommand(
       runtimeModuleMocks.matchPluginCommand as typeof import("openclaw/plugin-sdk/plugin-runtime").matchPluginCommand,
     );
@@ -463,6 +499,18 @@ describe("Discord native plugin command dispatch", () => {
     );
     discordNativeCommandTesting.setGetSessionEntry(
       runtimeModuleMocks.getSessionEntry as typeof import("openclaw/plugin-sdk/session-store-runtime").getSessionEntry,
+    );
+    discordNativeCommandTesting.setLoadSessionStore(
+      runtimeModuleMocks.loadSessionStore as typeof import("openclaw/plugin-sdk/session-store-runtime").loadSessionStore,
+    );
+    discordNativeCommandTesting.setResolveAndPersistSessionFile(
+      runtimeModuleMocks.resolveAndPersistSessionFile as typeof import("openclaw/plugin-sdk/session-store-runtime").resolveAndPersistSessionFile,
+    );
+    discordNativeCommandTesting.setResolveSessionStoreEntry(
+      runtimeModuleMocks.resolveSessionStoreEntry as typeof import("openclaw/plugin-sdk/session-store-runtime").resolveSessionStoreEntry,
+    );
+    discordNativeCommandTesting.setResolveStorePath(
+      runtimeModuleMocks.resolveStorePath as typeof import("openclaw/plugin-sdk/session-store-runtime").resolveStorePath,
     );
   });
 
@@ -569,6 +617,68 @@ describe("Discord native plugin command dispatch", () => {
         authProfileId: "openai:owner@example.com",
       },
     });
+  });
+
+  it("passes the persisted target session file to Discord plugin commands", async () => {
+    const cfg = {
+      ...createConfig(),
+      session: { store: "/tmp/openclaw-discord-plugin-command-test/sessions.json" },
+    } as OpenClawConfig;
+    const interaction = createInteraction();
+    const sessionKey = "agent:main:discord:dm:owner";
+    const sessionEntry = {
+      sessionId: "discord-session",
+      authProfileOverride: "openai:owner@example.com",
+      updatedAt: Date.now(),
+    };
+    runtimeModuleMocks.getSessionEntry.mockReturnValue(sessionEntry);
+    runtimeModuleMocks.loadSessionStore.mockReturnValue({ [sessionKey]: sessionEntry });
+    runtimeModuleMocks.resolveAndPersistSessionFile.mockResolvedValue({
+      sessionFile: "/tmp/openclaw-discord-plugin-command-test/discord-session.jsonl",
+      sessionEntry: {
+        ...sessionEntry,
+        sessionFile: "/tmp/openclaw-discord-plugin-command-test/discord-session.jsonl",
+      },
+    });
+
+    registerPairPlugin();
+    const command = await createPluginCommand({
+      cfg,
+      name: "pair",
+    });
+    const executeSpy = runtimeModuleMocks.executePluginCommand.mockResolvedValue({
+      text: "paired:now",
+    });
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(
+      Object.assign(interaction, {
+        options: {
+          getString: () => "now",
+          getBoolean: () => null,
+          getFocused: () => "",
+        },
+      }) as unknown,
+    );
+
+    expectPluginCommandExecution({
+      mock: executeSpy,
+      commandName: "pair",
+      expected: {
+        sessionKey,
+        sessionId: "discord-session",
+        sessionFile: "/tmp/openclaw-discord-plugin-command-test/discord-session.jsonl",
+        authProfileId: "openai:owner@example.com",
+      },
+    });
+    expect(runtimeModuleMocks.resolveAndPersistSessionFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "discord-session",
+        sessionKey,
+        storePath: "/tmp/openclaw-discord-plugin-command-test/sessions.json",
+        agentId: "main",
+        sessionsDir: "/tmp/openclaw-discord-plugin-command-test",
+      }),
+    );
   });
 
   it("passes the configured binding agent to plugin-owned Discord command sessions", async () => {

--- a/extensions/discord/src/monitor/native-command.runtime.ts
+++ b/extensions/discord/src/monitor/native-command.runtime.ts
@@ -2,7 +2,13 @@
 import { resolveDirectStatusReplyForSession } from "openclaw/plugin-sdk/command-status-runtime";
 import * as pluginRuntime from "openclaw/plugin-sdk/plugin-runtime";
 import { dispatchReplyWithDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
-import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  getSessionEntry,
+  loadSessionStore,
+  resolveAndPersistSessionFile,
+  resolveSessionStoreEntry,
+  resolveStorePath,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveDiscordNativeInteractionRouteState } from "./native-command-route.js";
 
 export const nativeCommandRuntime = {
@@ -12,6 +18,10 @@ export const nativeCommandRuntime = {
   resolveDirectStatusReplyForSession,
   resolveDiscordNativeInteractionRouteState,
   getSessionEntry,
+  loadSessionStore,
+  resolveAndPersistSessionFile,
+  resolveSessionStoreEntry,
+  resolveStorePath,
 };
 
 export const testing = {
@@ -53,6 +63,30 @@ export const testing = {
   setGetSessionEntry(next: typeof getSessionEntry): typeof getSessionEntry {
     const previous = nativeCommandRuntime.getSessionEntry;
     nativeCommandRuntime.getSessionEntry = next;
+    return previous;
+  },
+  setLoadSessionStore(next: typeof loadSessionStore): typeof loadSessionStore {
+    const previous = nativeCommandRuntime.loadSessionStore;
+    nativeCommandRuntime.loadSessionStore = next;
+    return previous;
+  },
+  setResolveAndPersistSessionFile(
+    next: typeof resolveAndPersistSessionFile,
+  ): typeof resolveAndPersistSessionFile {
+    const previous = nativeCommandRuntime.resolveAndPersistSessionFile;
+    nativeCommandRuntime.resolveAndPersistSessionFile = next;
+    return previous;
+  },
+  setResolveSessionStoreEntry(
+    next: typeof resolveSessionStoreEntry,
+  ): typeof resolveSessionStoreEntry {
+    const previous = nativeCommandRuntime.resolveSessionStoreEntry;
+    nativeCommandRuntime.resolveSessionStoreEntry = next;
+    return previous;
+  },
+  setResolveStorePath(next: typeof resolveStorePath): typeof resolveStorePath {
+    const previous = nativeCommandRuntime.resolveStorePath;
+    nativeCommandRuntime.resolveStorePath = next;
     return previous;
   },
 };

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements native command behavior.
+import path from "node:path";
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
 import { loadModelCatalog } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveNativeCommandSessionTargets } from "openclaw/plugin-sdk/command-auth-native";
@@ -550,6 +551,30 @@ async function dispatchDiscordCommandInteraction(params: {
       agentId: pluginCommandAgentId,
       sessionKey: effectiveRoute.sessionKey,
     });
+    let pluginSessionEntry = targetSessionEntry;
+    let pluginSessionFile: string | undefined;
+    if (targetSessionEntry?.sessionId) {
+      const storePath = nativeCommandRuntime.resolveStorePath(cfg.session?.store, {
+        agentId: pluginCommandAgentId,
+      });
+      const sessionStore = nativeCommandRuntime.loadSessionStore(storePath, { clone: false });
+      const resolvedSessionEntry = nativeCommandRuntime.resolveSessionStoreEntry({
+        store: sessionStore,
+        sessionKey: effectiveRoute.sessionKey,
+      });
+      pluginSessionEntry = resolvedSessionEntry.existing ?? targetSessionEntry;
+      pluginSessionFile = (
+        await nativeCommandRuntime.resolveAndPersistSessionFile({
+          sessionId: pluginSessionEntry.sessionId,
+          sessionKey: resolvedSessionEntry.normalizedKey,
+          sessionStore,
+          storePath,
+          sessionEntry: pluginSessionEntry,
+          agentId: pluginCommandAgentId,
+          sessionsDir: path.dirname(storePath),
+        })
+      ).sessionFile;
+    }
     const pluginReply = await nativeCommandRuntime.executePluginCommand({
       command: pluginMatch.command,
       args: pluginMatch.args,
@@ -560,7 +585,9 @@ async function dispatchDiscordCommandInteraction(params: {
       senderIsOwner: senderIsCommandOwner,
       agentId: pluginCommandAgentId,
       sessionKey: effectiveRoute.sessionKey,
-      authProfileId: targetSessionEntry?.authProfileOverride,
+      sessionId: pluginSessionEntry?.sessionId,
+      sessionFile: pluginSessionFile,
+      authProfileId: pluginSessionEntry?.authProfileOverride,
       commandBody: prompt,
       config: cfg,
       from: isDirectMessage


### PR DESCRIPTION
## What Problem This Solves

Discord native `/codex bind` could fail with `Cannot bind Codex because this command did not include an OpenClaw session file.` even when the slash command was invoked correctly through Discord autocomplete.

## Why This Change Was Made

Codex bind requires `ctx.sessionFile` so it can read and write the app-server binding sidecar beside the OpenClaw transcript. Telegram native plugin dispatch already resolves and passes the persisted session file, but Discord plugin dispatch only passed `sessionKey`/auth metadata.

This updates Discord plugin command dispatch to resolve the target session entry, persist/derive the transcript path when a session exists, and include `sessionId` + `sessionFile` in the plugin command context.

## User Impact

Discord users can bind Codex app-server threads from native slash commands in an existing OpenClaw session, matching Telegram behavior. Other plugin commands without an active target session continue without forcing session-file resolution.

## Evidence

- `pnpm test extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
