### PR TITLE
docs(gateway): document high-memory local Ollama compaction tuning

### DIFF
--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -321,6 +321,48 @@ If the model loads cleanly but full agent turns misbehave, work top-down — con
 
 5. **Past that, the bottleneck is upstream.** If the backend still fails only on larger OpenClaw runs after lean mode and `supportsTools: false`, the remaining issue is usually upstream model or server capacity — context window, GPU memory, kv-cache eviction, or a backend bug. It is not OpenClaw's transport layer at that point.
 
+## High-memory Ollama compaction tuning
+
+On 32 GB or 64 GB+ local machines, especially with Ollama models that expose a
+32k context window, you may want OpenClaw to keep more recent transcript before
+preflight compaction starts. Keep the conservative defaults on low-memory
+machines; lowering the reserve can increase model-server memory pressure and
+make Ollama evict, swap, or terminate the run.
+
+Tune this under `agents.defaults.compaction`, not under `models` or a provider
+block:
+
+```json5
+{
+  agents: {
+    defaults: {
+      compaction: {
+        mode: "safeguard",
+        reserveTokensFloor: 2000,
+        keepRecentTokens: 20000,
+      },
+    },
+  },
+}
+```
+
+The preflight compaction threshold is:
+
+```text
+contextWindow - reserveTokensFloor - memoryFlush.softThresholdTokens
+```
+
+For a 32,768-token Ollama model with `reserveTokensFloor: 2000` and the default
+`memoryFlush.softThresholdTokens: 4000`, OpenClaw starts checking near 26,768
+tokens. Raise `reserveTokensFloor` again for larger models or tighter memory
+headroom; for example, a 32B or 72B model may need more KV-cache room than a 7B
+model on the same machine.
+
+Restart or reload OpenClaw after changing `openclaw.json`, then check verbose
+Gateway logs for `preflightCompaction check` or `memoryFlush check`. The log
+line includes `contextWindow` and `threshold`, so you can confirm OpenClaw is
+using the intended model window and reserve before relying on a long session.
+
 ## Troubleshooting
 
 - Gateway can reach the proxy? `curl http://127.0.0.1:1234/v1/models`.


### PR DESCRIPTION
﻿Fixes #55888

## What Problem This Solves

High-memory local Ollama users have existing compaction knobs that can keep more recent transcript in large-context sessions, but the local models guide did not explain the supported profile, threshold math, or safe verification path. Users had to infer why a 32k context model started memory flush or preflight compaction earlier than expected.

## Why This Change Was Made

This adds a focused docs-only profile to the local models guide for 32 GB / 64 GB+ Ollama setups. It documents the existing `agents.defaults.compaction` keys, explains the `contextWindow - reserveTokensFloor - memoryFlush.softThresholdTokens` threshold calculation, and keeps runtime defaults unchanged for lower-memory machines.

## User Impact

Users running larger local Ollama contexts can now tune compaction intentionally, see the expected 32,768 - 2,000 - 4,000 = 26,768 threshold example, and confirm the effective `contextWindow` and `threshold` in verbose Gateway logs before relying on a long session.

## Evidence

AI-assisted: yes. I used Codex to inspect the issue, source-backed threshold behavior, docs rules, and validation output. I reviewed the final diff and understand the change.

Validation run locally:

```text
git diff --check
# passed

node scripts/docs-list.js
# passed

node scripts/check-docs-mdx.mjs docs README.md
# Docs MDX check passed (684 files, 9324ms).

node scripts/docs-link-audit.mjs
# checked_internal_links=5464, broken_links=0

node scripts/format-docs.mjs --check
# failed on pre-existing docs/reference/templates/CLAUDE.md, not touched by this PR
```

Attempted the requested pnpm docs commands too, but local pnpm ran a dependency status/install path before the scripts and failed on Windows `EPERM` renames inside `node_modules` (`@types/node` / `@lit/context`). The equivalent Node docs scripts above were run directly and passed for the changed docs surface.
