### PR TITLE
chore(acpx): bump bundled client to 0.11.2

### DIFF
--- a/extensions/acpx/npm-shrinkwrap.json
+++ b/extensions/acpx/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.39.0",
         "@zed-industries/codex-acp": "0.15.0",
-        "acpx": "0.11.1",
+        "acpx": "0.11.2",
         "zod": "4.4.3"
       }
     },
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/acpx": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/acpx/-/acpx-0.11.1.tgz",
-      "integrity": "sha512-AfjHUYnuxRpvb1JLjjIZILEbCskIENCTP9Mgc5w0BiaPLmsL2hTg5gbM7sG1EssOkceNLQwgeAuVtbukLz0KFw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/acpx/-/acpx-0.11.2.tgz",
+      "integrity": "sha512-ksTmfJDVqUAJJXsNDamEno03AMZ/aAZzXk/h5nt61VsLc/jcpoDMfCVpErzuYNJjwCd0V6Zm5o6F8OoqxsjQWA==",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.28.1",

--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "0.39.0",
     "@zed-industries/codex-acp": "0.15.0",
-    "acpx": "0.11.1",
+    "acpx": "0.11.2",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,8 +313,8 @@ importers:
         specifier: 0.15.0
         version: 0.15.0
       acpx:
-        specifier: 0.11.1
-        version: 0.11.1
+        specifier: 0.11.2
+        version: 0.11.2
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -4611,8 +4611,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acpx@0.11.1:
-    resolution: {integrity: sha512-AfjHUYnuxRpvb1JLjjIZILEbCskIENCTP9Mgc5w0BiaPLmsL2hTg5gbM7sG1EssOkceNLQwgeAuVtbukLz0KFw==}
+  acpx@0.11.2:
+    resolution: {integrity: sha512-ksTmfJDVqUAJJXsNDamEno03AMZ/aAZzXk/h5nt61VsLc/jcpoDMfCVpErzuYNJjwCd0V6Zm5o6F8OoqxsjQWA==}
     engines: {node: '>=22.13.0'}
     hasBin: true
 
@@ -10656,7 +10656,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  acpx@0.11.1:
+  acpx@0.11.2:
     dependencies:
       '@agentclientprotocol/sdk': 0.28.1(zod@4.4.3)
       commander: 15.0.0


### PR DESCRIPTION
Bump the bundled `acpx` runtime from `0.11.1` to the released `0.11.2`.

This consumes the published token-usage persistence fix from https://github.com/openclaw/acpx/pull/407 and its contract/changelog follow-up from https://github.com/openclaw/acpx/pull/409.

Validation: ACPX extension tests 49/49 and 19/19; lockfile/shrinkwrap integrity updated; autoreview clean.