### PR TITLE
fix(tool-search): normalize flattened target-tool args for tool_call

### DIFF
--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -1101,6 +1101,64 @@ describe("Tool Search", () => {
     expect(secondExecuteInput.input).toEqual({ value: "structured" });
     expect(secondExecuteInput.signal).toBe(abortController.signal);
     expect(secondExecuteInput.onUpdate).toBe(onUpdate);
+
+    // Flattened args fallback: local models emit target-tool args at the top level
+    await runtimeCallTool.execute(
+      "call-lifecycle-flattened",
+      {
+        id: "fake_lifecycle",
+        command: "ls -la",
+        timeout_ms: 5000,
+      },
+      abortController.signal,
+      onUpdate,
+    );
+
+    const thirdExecuteInput = mockCall(executeTool, 2)[0] as {
+      tool?: { name?: string };
+      toolName?: string;
+      input?: unknown;
+    };
+    expect(thirdExecuteInput.tool?.name).toBe("fake_lifecycle");
+    expect(thirdExecuteInput.input).toEqual({ command: "ls -la", timeout_ms: 5000 });
+
+    // Explicit args wrapper still takes precedence over flattened keys
+    await runtimeCallTool.execute(
+      "call-lifecycle-explicit-args",
+      {
+        id: "fake_lifecycle",
+        args: { value: "explicit" },
+        command: "should-be-ignored",
+      },
+      abortController.signal,
+      onUpdate,
+    );
+
+    const fourthExecuteInput = mockCall(executeTool, 3)[0] as {
+      tool?: { name?: string };
+      toolName?: string;
+      input?: unknown;
+    };
+    expect(fourthExecuteInput.tool?.name).toBe("fake_lifecycle");
+    expect(fourthExecuteInput.input).toEqual({ value: "explicit" });
+
+    // Bare id with no args produces empty input
+    await runtimeCallTool.execute(
+      "call-lifecycle-bare",
+      {
+        id: "fake_lifecycle",
+      },
+      abortController.signal,
+      onUpdate,
+    );
+
+    const fifthExecuteInput = mockCall(executeTool, 4)[0] as {
+      tool?: { name?: string };
+      toolName?: string;
+      input?: unknown;
+    };
+    expect(fifthExecuteInput.tool?.name).toBe("fake_lifecycle");
+    expect(fifthExecuteInput.input).toEqual({});
   });
 
   it("projects target tool calls after their Tool Search wrapper result", () => {

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -1680,10 +1680,12 @@ function readSearchArgs(args: unknown, config: ToolSearchConfig): { query: strin
 function readCallArgs(args: unknown): { id: string; input: unknown } {
   const params = asToolParamsRecord(args);
   const id = readId(params);
-  return {
-    id,
-    input: params.args ?? params.input ?? {},
-  };
+  const input = params.args ?? params.input;
+  if (input !== undefined) {
+    return { id, input };
+  }
+  const { id: _id, toolId: _toolId, name: _name, ...rest } = params;
+  return { id, input: rest };
 }
 
 function getTelemetry(catalog: ToolSearchCatalogSession) {


### PR DESCRIPTION
Fixes #96115

## What Problem This Solves

Fixes an issue where local models (e.g., vLLM/Qwen) with `agents.defaults.experimental.localModelLean: true` drop target-tool arguments when calling `tool_call` through the compact Tool Search surface. The models emit target-tool parameters (such as `command`, `path`, `task`) flattened at the top level of `tool_call` alongside `id`, rather than nesting them under `args`. This causes the target tool to receive `{}` empty arguments and repeatedly fail with `missing required parameter` errors, creating a sticky failure loop.

## Why This Change Was Made

`readCallArgs` (`src/agents/tool-search.ts:1680`) only checked `params.args` and `params.input`, returning `{}` when neither was present. Local models are less precise at schema compliance than GPT/Claude and tend to place target-tool arguments at the top level next to `id`. The fix adds a flattened fallback without breaking the existing `args` nesting contract: when both `args` and `input` are absent, collect every top-level key except `id` from `params` and pass it as the target tool's `input`.

## User Impact

Users running local models with `localModelLean: true` can now invoke tools correctly without losing arguments. Users who explicitly nest arguments under `args` are unaffected.

## Evidence

**Environment**: Linux, Node v22.23.0, pnpm v11.2.2, worktree SHA 2af06042c2

**Before fix** (new regression test on old code):

```bash
$ pnpm test src/agents/tool-search.test.ts --reporter=verbose

AssertionError: expected {} to deeply equal { command: 'ls -la', timeout_ms: 5000 }
```

**After fix** (new regression test on new code):

```bash
$ pnpm test src/agents/tool-search.test.ts
Test Files  1 passed (1)
     Tests  49 passed (49)
```

**Lint/format clean**:

```bash
$ npx oxlint@latest src/agents/tool-search.ts src/agents/tool-search.test.ts
Found 0 warnings and 0 errors.
$ pnpm format src/agents/tool-search.ts src/agents/tool-search.test.ts
Finished in 27ms on 2 files using 1 threads.
```
