### PR TITLE
fix(gateway): fail readiness when storage cannot be written

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -22,7 +22,7 @@ import {
   setRuntimeConfigSnapshot,
   type ReadConfigFileSnapshotWithPluginMetadataResult,
 } from "../config/io.js";
-import { isNixMode, normalizeStateDirEnv } from "../config/paths.js";
+import { isNixMode, normalizeStateDirEnv, resolveStateDir } from "../config/paths.js";
 import { applyConfigOverrides } from "../config/runtime-overrides.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -117,6 +117,10 @@ import {
 } from "./server/health-state.js";
 import { resolveHookClientIpConfig } from "./server/hook-client-ip-config.js";
 import { createReadinessChecker } from "./server/readiness.js";
+import {
+  createStorageReadinessChecker,
+  resolveGatewayStorageReadinessRoots,
+} from "./server/storage-readiness.js";
 import { loadGatewayTlsRuntime } from "./server/tls.js";
 import { resolveSharedGatewaySessionGeneration } from "./server/ws-shared-generation.js";
 import { maybeSeedControlUiAllowedOriginsAtStartup } from "./startup-control-ui-origins.js";
@@ -890,6 +894,16 @@ export async function startGatewayServer(
   });
   const deferStartupSidecars = opts.deferStartupSidecars === true;
   const isGatewayStartupPending = () => !startupSidecarsReady && !deferStartupSidecars;
+  const startupStateDir = resolveStateDir();
+  const getStorageReadiness = createStorageReadinessChecker({
+    getWritableRoots: () => {
+      const runtimeConfigLocal = getRuntimeConfig();
+      return resolveGatewayStorageReadinessRoots({
+        config: runtimeConfigLocal,
+        stateDir: startupStateDir,
+      });
+    },
+  });
   const getReadiness = createReadinessChecker({
     channelManager,
     startedAt: serverStartedAt,
@@ -897,6 +911,7 @@ export async function startGatewayServer(
     getStartupPendingReason: () => startupPendingReason,
     getGatewayDraining: isGatewayDraining,
     getEventLoopHealth: readinessEventLoopHealth.snapshot,
+    getStorageReadiness,
     shouldSkipChannelReadiness: () =>
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS),

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -70,6 +70,7 @@ function createReadinessHarness(params: {
   getStartupPendingReason?: Parameters<typeof createReadinessChecker>[0]["getStartupPendingReason"];
   getGatewayDraining?: Parameters<typeof createReadinessChecker>[0]["getGatewayDraining"];
   getEventLoopHealth?: Parameters<typeof createReadinessChecker>[0]["getEventLoopHealth"];
+  getStorageReadiness?: Parameters<typeof createReadinessChecker>[0]["getStorageReadiness"];
   shouldSkipChannelReadiness?: Parameters<
     typeof createReadinessChecker
   >[0]["shouldSkipChannelReadiness"];
@@ -86,6 +87,7 @@ function createReadinessHarness(params: {
       getStartupPendingReason: params.getStartupPendingReason,
       getGatewayDraining: params.getGatewayDraining,
       getEventLoopHealth: params.getEventLoopHealth,
+      getStorageReadiness: params.getStorageReadiness,
       shouldSkipChannelReadiness: params.shouldSkipChannelReadiness,
       cacheTtlMs: params.cacheTtlMs,
     }),
@@ -206,6 +208,36 @@ describe("createReadinessChecker", () => {
       gatewayDraining = false;
       expect(readiness()).toEqual(readySnapshot());
       expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("reports not ready when critical storage is not writable", () => {
+    withReadinessClock(() => {
+      const { manager, readiness } = createReadinessHarness({
+        getStorageReadiness: () => ({
+          ready: false,
+          failing: ["workspace-storage-unwritable"],
+        }),
+        cacheTtlMs: 1_000,
+      });
+
+      expect(readiness()).toEqual(failingSnapshot(["workspace-storage-unwritable"]));
+      expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not let skipped channel readiness mask storage failures", () => {
+    withReadinessClock(() => {
+      const { manager, readiness } = createReadinessHarness({
+        getStorageReadiness: () => ({
+          ready: false,
+          failing: ["workspace-storage-unwritable"],
+        }),
+        shouldSkipChannelReadiness: () => true,
+      });
+
+      expect(readiness()).toEqual(failingSnapshot(["workspace-storage-unwritable"]));
+      expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
     });
   });
 

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -9,6 +9,7 @@ import {
 } from "../channel-health-policy.js";
 import type { ChannelManager } from "../server-channels.js";
 import type { GatewayEventLoopHealth } from "./event-loop-health.js";
+import type { StorageReadinessChecker } from "./storage-readiness.js";
 
 /** Snapshot returned by the gateway readiness probe. */
 export type ReadinessResult = {
@@ -44,6 +45,7 @@ export function createReadinessChecker(deps: {
   getStartupPendingReason?: () => string | undefined;
   getGatewayDraining?: () => boolean;
   getEventLoopHealth?: () => GatewayEventLoopHealth | undefined;
+  getStorageReadiness?: StorageReadinessChecker;
   shouldSkipChannelReadiness?: () => boolean;
   cacheTtlMs?: number;
 }): ReadinessChecker {
@@ -65,6 +67,13 @@ export function createReadinessChecker(deps: {
     if (deps.getGatewayDraining?.()) {
       return withEventLoopHealth(
         { ready: false, failing: ["gateway-draining"], uptimeMs },
+        deps.getEventLoopHealth,
+      );
+    }
+    const storageReadiness = deps.getStorageReadiness?.();
+    if (storageReadiness && !storageReadiness.ready) {
+      return withEventLoopHealth(
+        { ready: false, failing: storageReadiness.failing, uptimeMs },
         deps.getEventLoopHealth,
       );
     }

--- a/src/gateway/server/storage-readiness.test.ts
+++ b/src/gateway/server/storage-readiness.test.ts
@@ -1,0 +1,521 @@
+// Storage readiness tests cover write/fsync/delete probes and TTL recovery.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  createStorageReadinessChecker,
+  resolveGatewayStorageReadinessRoots,
+  STORAGE_READINESS_FAILURE,
+  type WritableProbeFileHandle,
+  type WritableProbeFs,
+} from "./storage-readiness.js";
+
+function createProbeFs(
+  overrides: Partial<WritableProbeFs> = {},
+  handleOverrides: Partial<WritableProbeFileHandle> = {},
+) {
+  const handle = {
+    close: vi.fn(async () => undefined),
+    sync: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+    ...handleOverrides,
+  };
+  const probeFs = {
+    mkdir: vi.fn(async () => undefined),
+    open: vi.fn(async () => handle),
+    unlink: vi.fn(async () => undefined),
+    ...overrides,
+  };
+  return { handle, probeFs };
+}
+
+async function expectPathMissing(target: string) {
+  await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+}
+
+describe("createStorageReadinessChecker", () => {
+  it("probes each distinct writable root with a small fsynced file", async () => {
+    const { handle, probeFs } = createProbeFs();
+    const stateRoot = path.resolve("/state");
+    const workspaceRoot = path.resolve("/workspace");
+    let probeIndex = 0;
+    const checker = createStorageReadinessChecker({
+      getWritableRoots: () => ["/state", "/workspace", "/state"],
+      fs: probeFs as unknown as WritableProbeFs,
+      now: () => 1_000,
+      createProbeFileName: () => `.probe-${++probeIndex}`,
+      autoStart: false,
+    });
+
+    await expect(checker.refresh()).resolves.toEqual({ ready: true, failing: [] });
+    expect(checker()).toEqual({ ready: true, failing: [] });
+    expect(probeFs.mkdir).toHaveBeenNthCalledWith(1, stateRoot, {
+      recursive: true,
+    });
+    expect(probeFs.mkdir).toHaveBeenNthCalledWith(2, workspaceRoot, {
+      recursive: true,
+    });
+    expect(probeFs.open).toHaveBeenNthCalledWith(1, path.join(stateRoot, ".probe-1"), "wx", 0o600);
+    expect(probeFs.open).toHaveBeenNthCalledWith(
+      2,
+      path.join(workspaceRoot, ".probe-2"),
+      "wx",
+      0o600,
+    );
+    expect(handle.writeFile).toHaveBeenCalledTimes(2);
+    expect(handle.sync).toHaveBeenCalledTimes(2);
+    expect(handle.close).toHaveBeenCalledTimes(2);
+    expect(probeFs.unlink).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let one slow root block probes for other roots", async () => {
+    const slowRoot = path.resolve("/slow");
+    const fastRoot = path.resolve("/fast");
+    let releaseSlowRoot: (() => void) | undefined;
+    let probeIndex = 0;
+    const { probeFs } = createProbeFs({
+      mkdir: vi.fn((root: string) => {
+        if (root === slowRoot) {
+          return new Promise<unknown>((resolve) => {
+            releaseSlowRoot = () => resolve(undefined);
+          });
+        }
+        return Promise.resolve(undefined);
+      }),
+    });
+    const checker = createStorageReadinessChecker({
+      getWritableRoots: () => [slowRoot, fastRoot],
+      fs: probeFs as unknown as WritableProbeFs,
+      now: () => 1_000,
+      createProbeFileName: () => `.probe-${++probeIndex}`,
+      autoStart: false,
+    });
+
+    const refresh = checker.refresh();
+    await vi.waitFor(() => {
+      expect(probeFs.mkdir).toHaveBeenCalledTimes(2);
+    });
+    await vi.waitFor(() => {
+      expect(probeFs.open).toHaveBeenCalledTimes(1);
+    });
+    expect(probeFs.open).toHaveBeenCalledWith(path.join(fastRoot, ".probe-2"), "wx", 0o600);
+
+    releaseSlowRoot?.();
+    await expect(refresh).resolves.toEqual({ ready: true, failing: [] });
+    expect(probeFs.open).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not create the new default workspace while probing a pinned legacy state root", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-storage-legacy-"));
+    try {
+      const legacyStateDir = path.join(home, ".clawdbot");
+      const newStateDir = path.join(home, ".openclaw");
+      await fs.mkdir(legacyStateDir, { recursive: true });
+      const env = { HOME: home, USERPROFILE: home, OPENCLAW_HOME: home } as NodeJS.ProcessEnv;
+      const roots = resolveGatewayStorageReadinessRoots({
+        config: {} as OpenClawConfig,
+        stateDir: legacyStateDir,
+        env,
+      });
+
+      expect(roots).toContain(legacyStateDir);
+      expect(roots).toContain(path.join(legacyStateDir, "state"));
+      expect(roots).toContain(path.join(legacyStateDir, "agents", "main", "agent"));
+      expect(roots).toContain(path.join(legacyStateDir, "agents", "main", "sessions"));
+      expect(roots).toContain(home);
+      expect(roots).not.toContain(path.join(newStateDir, "workspace"));
+
+      const checker = createStorageReadinessChecker({
+        getWritableRoots: () => roots,
+        createProbeFileName: () => ".probe",
+        autoStart: false,
+      });
+      await expect(checker.refresh()).resolves.toEqual({ ready: true, failing: [] });
+      await expectPathMissing(newStateDir);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("probes the parent creation path for a missing implicit default workspace", async () => {
+    const home = path.resolve("/home/openclaw");
+    const stateDir = path.resolve("/state");
+    const roots = resolveGatewayStorageReadinessRoots({
+      config: {} as OpenClawConfig,
+      stateDir,
+      env: { HOME: home, USERPROFILE: home } as NodeJS.ProcessEnv,
+      workspaceExists: (workspaceDir) => workspaceDir === home,
+    });
+
+    expect(roots).toContain(home);
+    expect(roots).not.toContain(path.join(home, ".openclaw", "workspace"));
+
+    const accessError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    const { probeFs } = createProbeFs({
+      open: vi.fn(async (probePath: string) => {
+        if (probePath.startsWith(`${home}${path.sep}`)) {
+          throw accessError;
+        }
+        return {
+          close: vi.fn(async () => undefined),
+          sync: vi.fn(async () => undefined),
+          writeFile: vi.fn(async () => undefined),
+        };
+      }),
+    });
+    const checker = createStorageReadinessChecker({
+      getWritableRoots: () => roots,
+      fs: probeFs as unknown as WritableProbeFs,
+      createProbeFileName: () => ".probe",
+      autoStart: false,
+    });
+
+    await expect(checker.refresh()).resolves.toEqual({
+      ready: false,
+      failing: [STORAGE_READINESS_FAILURE],
+    });
+    expect(probeFs.open).toHaveBeenCalledWith(path.join(home, ".probe"), "wx", 0o600);
+  });
+
+  it("probes configured workspaces even when they are missing", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-storage-workspace-"));
+    try {
+      const stateDir = path.join(home, ".clawdbot");
+      const workspaceDir = path.join(home, "configured-workspace");
+      await fs.mkdir(stateDir, { recursive: true });
+      const config = {
+        agents: {
+          list: [{ id: "main", workspace: workspaceDir }],
+        },
+      } as OpenClawConfig;
+      const roots = resolveGatewayStorageReadinessRoots({
+        config,
+        stateDir,
+        env: { HOME: home, USERPROFILE: home, OPENCLAW_HOME: home } as NodeJS.ProcessEnv,
+      });
+
+      expect(roots).toContain(workspaceDir);
+
+      const checker = createStorageReadinessChecker({
+        getWritableRoots: () => roots,
+        createProbeFileName: () => ".probe",
+        autoStart: false,
+      });
+      await expect(checker.refresh()).resolves.toEqual({ ready: true, failing: [] });
+      const workspaceStat = await fs.stat(workspaceDir);
+      expect(workspaceStat.isDirectory()).toBe(true);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("includes configured ACP harness session-store roots", () => {
+    const stateDir = path.resolve("/state");
+    const config = {
+      session: {
+        store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+      },
+      agents: {
+        list: [
+          { id: "ops", default: true },
+          { id: "review", runtime: { type: "acp", acp: { agent: "opencode" } } },
+        ],
+      },
+      acp: {
+        defaultAgent: "claude",
+        allowedAgents: ["gemini", "*"],
+      },
+    } as OpenClawConfig;
+    const roots = resolveGatewayStorageReadinessRoots({
+      config,
+      stateDir,
+      env: { HOME: "/home/openclaw", USERPROFILE: "/home/openclaw" } as NodeJS.ProcessEnv,
+    });
+
+    for (const agentId of ["ops", "review", "opencode", "claude", "gemini"]) {
+      expect(roots).toContain(path.join(stateDir, "agents", agentId, "sessions"));
+    }
+    expect(roots).not.toContain(path.join(stateDir, "agents", "claude", "agent"));
+    expect(roots).not.toContain(path.join(stateDir, "agents", "gemini", "agent"));
+    expect(roots).not.toContain(path.join(stateDir, "agents", "*", "sessions"));
+  });
+
+  it("returns cached readiness while an async refresh is in flight", async () => {
+    let finishWrite: (() => void) | undefined;
+    const { handle, probeFs } = createProbeFs(
+      {},
+      {
+        writeFile: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              finishWrite = resolve;
+            }),
+        ),
+      },
+    );
+    const checker = createStorageReadinessChecker({
+      getWritableRoots: () => ["/state"],
+      fs: probeFs as unknown as WritableProbeFs,
+      now: () => 1_000,
+      createProbeFileName: () => ".probe",
+      autoStart: false,
+    });
+
+    const refresh = checker.refresh();
+    expect(checker()).toEqual({ ready: false, failing: [STORAGE_READINESS_FAILURE] });
+    await vi.waitFor(() => {
+      expect(handle.writeFile).toHaveBeenCalled();
+    });
+    expect(handle.sync).not.toHaveBeenCalled();
+
+    finishWrite?.();
+    await expect(refresh).resolves.toEqual({ ready: true, failing: [] });
+    expect(checker()).toEqual({ ready: true, failing: [] });
+  });
+
+  it("reports storage unavailable and caches the failed probe briefly", async () => {
+    let nowMs = 1_000;
+    const writeError = Object.assign(new Error("no space left"), { code: "ENOSPC" });
+    const { handle, probeFs } = createProbeFs(
+      {},
+      {
+        writeFile: vi.fn(async () => {
+          throw writeError;
+        }),
+      },
+    );
+    const checker = createStorageReadinessChecker({
+      getWritableRoots: () => ["/state"],
+      fs: probeFs as unknown as WritableProbeFs,
+      now: () => nowMs,
+      createProbeFileName: () => ".probe",
+      cacheTtlMs: 1_000,
+      autoStart: false,
+    });
+
+    await expect(checker.refresh()).resolves.toEqual({
+      ready: false,
+      failing: [STORAGE_READINESS_FAILURE],
+    });
+    nowMs += 500;
+    expect(checker()).toEqual({ ready: false, failing: [STORAGE_READINESS_FAILURE] });
+    expect(probeFs.open).toHaveBeenCalledTimes(1);
+
+    nowMs += 501;
+    expect(checker()).toEqual({ ready: false, failing: [STORAGE_READINESS_FAILURE] });
+    await checker.refresh();
+    expect(probeFs.open).toHaveBeenCalledTimes(2);
+    expect(handle.writeFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports storage unavailable when writable root discovery fails", async () => {
+    const { probeFs } = createProbeFs();
+    const checker = createStorageReadinessChecker({
+      getWritableRoots: () => {
+        throw new Error("bad workspace config");
+      },
+      fs: probeFs as unknown as WritableProbeFs,
+      now: () => 1_000,
+      createProbeFileName: () => ".probe",
+      autoStart: false,
+    });
+
+    await expect(checker.refresh()).resolves.toEqual({
+      ready: false,
+      failing: [STORAGE_READINESS_FAILURE],
+    });
+    expect(probeFs.open).not.toHaveBeenCalled();
+  });
+
+  it("does not remove a pre-existing probe path when exclusive create fails", async () => {
+    const stateRoot = path.resolve("/state");
+    const existsError = Object.assign(new Error("exists"), { code: "EEXIST" });
+    const { probeFs } = createProbeFs({
+      open: vi.fn(async () => {
+        throw existsError;
+      }),
+    });
+    const checker = createStorageReadinessChecker({
+      getWritableRoots: () => ["/state"],
+      fs: probeFs as unknown as WritableProbeFs,
+      now: () => 1_000,
+      createProbeFileName: () => ".probe",
+      autoStart: false,
+    });
+
+    await expect(checker.refresh()).resolves.toEqual({
+      ready: false,
+      failing: [STORAGE_READINESS_FAILURE],
+    });
+    expect(probeFs.open).toHaveBeenCalledWith(path.join(stateRoot, ".probe"), "wx", 0o600);
+    expect(probeFs.unlink).not.toHaveBeenCalled();
+  });
+
+  it("recovers once writes succeed after the cache expires", async () => {
+    let nowMs = 1_000;
+    let attempts = 0;
+    const writeError = Object.assign(new Error("read only"), { code: "EROFS" });
+    const { probeFs } = createProbeFs(
+      {},
+      {
+        writeFile: vi.fn(async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw writeError;
+          }
+        }),
+      },
+    );
+    const checker = createStorageReadinessChecker({
+      getWritableRoots: () => ["/state"],
+      fs: probeFs as unknown as WritableProbeFs,
+      now: () => nowMs,
+      createProbeFileName: () => ".probe",
+      cacheTtlMs: 1_000,
+      autoStart: false,
+    });
+
+    await expect(checker.refresh()).resolves.toEqual({
+      ready: false,
+      failing: [STORAGE_READINESS_FAILURE],
+    });
+    nowMs += 1_001;
+    expect(checker()).toEqual({ ready: false, failing: [STORAGE_READINESS_FAILURE] });
+    await checker.refresh();
+    expect(checker()).toEqual({ ready: true, failing: [] });
+  });
+
+  it("treats cleanup failures as not ready", async () => {
+    const unlinkError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    const { probeFs } = createProbeFs({
+      unlink: vi.fn(async () => {
+        throw unlinkError;
+      }),
+    });
+    const checker = createStorageReadinessChecker({
+      getWritableRoots: () => ["/state"],
+      fs: probeFs as unknown as WritableProbeFs,
+      now: () => 1_000,
+      createProbeFileName: () => ".probe",
+      autoStart: false,
+    });
+
+    await expect(checker.refresh()).resolves.toEqual({
+      ready: false,
+      failing: [STORAGE_READINESS_FAILURE],
+    });
+  });
+
+  it("marks storage unavailable when a probe does not finish before the timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      let nowMs = 1_000;
+      let writeAttempts = 0;
+      let finishFirstWrite: (() => void) | undefined;
+      const { probeFs } = createProbeFs(
+        {},
+        {
+          writeFile: vi.fn(() => {
+            writeAttempts += 1;
+            if (writeAttempts > 1) {
+              return Promise.resolve();
+            }
+            return new Promise<void>((resolve) => {
+              finishFirstWrite = resolve;
+            });
+          }),
+        },
+      );
+      const checker = createStorageReadinessChecker({
+        getWritableRoots: () => ["/state"],
+        fs: probeFs as unknown as WritableProbeFs,
+        now: () => nowMs,
+        createProbeFileName: () => ".probe",
+        probeTimeoutMs: 50,
+        timeoutRetryMs: 100,
+        autoStart: false,
+      });
+
+      const refresh = checker.refresh();
+      await vi.advanceTimersByTimeAsync(50);
+      await expect(refresh).resolves.toEqual({
+        ready: false,
+        failing: [STORAGE_READINESS_FAILURE],
+      });
+      expect(checker()).toEqual({ ready: false, failing: [STORAGE_READINESS_FAILURE] });
+
+      nowMs += 99;
+      expect(checker()).toEqual({ ready: false, failing: [STORAGE_READINESS_FAILURE] });
+      expect(probeFs.open).toHaveBeenCalledTimes(1);
+
+      nowMs += 1;
+      await expect(checker.refresh()).resolves.toEqual({ ready: true, failing: [] });
+      expect(probeFs.open).toHaveBeenCalledTimes(2);
+      expect(checker()).toEqual({ ready: true, failing: [] });
+
+      finishFirstWrite?.();
+      for (let i = 0; i < 10; i += 1) {
+        await Promise.resolve();
+      }
+      expect(checker()).toEqual({ ready: true, failing: [] });
+      expect(probeFs.open).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("caps timed-out retry probes while storage calls remain hung", async () => {
+    vi.useFakeTimers();
+    try {
+      let nowMs = 1_000;
+      const { probeFs } = createProbeFs(
+        {},
+        {
+          writeFile: vi.fn(
+            () =>
+              new Promise<void>(() => {
+                // Simulate a filesystem call that never settles.
+              }),
+          ),
+        },
+      );
+      const checker = createStorageReadinessChecker({
+        getWritableRoots: () => ["/state"],
+        fs: probeFs as unknown as WritableProbeFs,
+        now: () => nowMs,
+        createProbeFileName: () => ".probe",
+        probeTimeoutMs: 50,
+        timeoutRetryMs: 100,
+        autoStart: false,
+      });
+
+      const firstRefresh = checker.refresh();
+      await vi.advanceTimersByTimeAsync(50);
+      await expect(firstRefresh).resolves.toEqual({
+        ready: false,
+        failing: [STORAGE_READINESS_FAILURE],
+      });
+      expect(probeFs.open).toHaveBeenCalledTimes(1);
+
+      nowMs += 100;
+      const secondRefresh = checker.refresh();
+      await vi.advanceTimersByTimeAsync(50);
+      await expect(secondRefresh).resolves.toEqual({
+        ready: false,
+        failing: [STORAGE_READINESS_FAILURE],
+      });
+      expect(probeFs.open).toHaveBeenCalledTimes(2);
+
+      nowMs += 100;
+      await expect(checker.refresh()).resolves.toEqual({
+        ready: false,
+        failing: [STORAGE_READINESS_FAILURE],
+      });
+      expect(probeFs.open).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/gateway/server/storage-readiness.ts
+++ b/src/gateway/server/storage-readiness.ts
@@ -1,0 +1,371 @@
+// Gateway storage readiness probes critical writable roots used by state/workspace flows.
+import { randomUUID } from "node:crypto";
+import fs, { existsSync } from "node:fs";
+import path from "node:path";
+import {
+  listAgentIds,
+  resolveAgentConfig,
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../../agents/agent-scope-config.js";
+import { resolveStateDir } from "../../config/paths.js";
+import { resolveStorePath } from "../../config/sessions/paths.js";
+import { listConfiguredSessionStoreAgentIds } from "../../config/sessions/targets.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveOpenClawStateSqliteDir } from "../../state/openclaw-state-db.paths.js";
+
+export const STORAGE_READINESS_FAILURE = "workspace-storage-unwritable";
+
+export type StorageReadinessResult = {
+  ready: boolean;
+  failing: string[];
+};
+
+export type StorageReadinessChecker = () => StorageReadinessResult;
+
+export type RefreshableStorageReadinessChecker = StorageReadinessChecker & {
+  refresh: () => Promise<StorageReadinessResult>;
+};
+
+export type WritableProbeFileHandle = {
+  close: () => Promise<void>;
+  sync: () => Promise<void>;
+  writeFile: (data: string) => Promise<void>;
+};
+
+export type WritableProbeFs = {
+  mkdir: (root: string, options: { recursive: true }) => Promise<unknown>;
+  open: (path: string, flags: "wx", mode: number) => Promise<WritableProbeFileHandle>;
+  unlink: (path: string) => Promise<void>;
+};
+
+type ResolveGatewayStorageReadinessRootsOptions = {
+  config: OpenClawConfig;
+  stateDir?: string;
+  env?: NodeJS.ProcessEnv;
+  workspaceExists?: (workspaceDir: string) => boolean;
+};
+
+const DEFAULT_STORAGE_READINESS_CACHE_TTL_MS = 1_000;
+const DEFAULT_STORAGE_READINESS_PROBE_TIMEOUT_MS = 2_000;
+const DEFAULT_STORAGE_READINESS_TIMEOUT_RETRY_MS = 10_000;
+const MAX_ABANDONED_TIMED_OUT_PROBES = 1;
+const DEFAULT_PROBE_FILE_NAME = ".openclaw-readyz-write-probe";
+const PROBE_PAYLOAD = "openclaw-readyz\n";
+
+function shouldProbeAgentWorkspaceDir(params: {
+  config: OpenClawConfig;
+  agentId: string;
+  env: NodeJS.ProcessEnv;
+  workspaceDir: string;
+  workspaceExists: (workspaceDir: string) => boolean;
+}): boolean {
+  const configuredWorkspace = resolveAgentConfig(params.config, params.agentId)?.workspace?.trim();
+  if (configuredWorkspace) {
+    return true;
+  }
+  if (params.config.agents?.defaults?.workspace?.trim()) {
+    return true;
+  }
+  if (params.env.OPENCLAW_WORKSPACE_DIR?.trim()) {
+    return true;
+  }
+  if (params.agentId !== resolveDefaultAgentId(params.config)) {
+    return true;
+  }
+  return params.workspaceExists(params.workspaceDir);
+}
+
+function resolveWorkspaceCreationProbeRoot(
+  workspaceDir: string,
+  workspaceExists: (workspaceDir: string) => boolean,
+): string | undefined {
+  let candidate = path.dirname(workspaceDir);
+  while (candidate && candidate !== path.dirname(candidate)) {
+    if (workspaceExists(candidate)) {
+      return candidate;
+    }
+    candidate = path.dirname(candidate);
+  }
+  return workspaceExists(candidate) ? candidate : undefined;
+}
+
+export function resolveGatewayStorageReadinessRoots(
+  options: ResolveGatewayStorageReadinessRootsOptions,
+): string[] {
+  const env = options.env ?? process.env;
+  const stateDir = options.stateDir ?? resolveStateDir(env);
+  const pinnedStateEnv: NodeJS.ProcessEnv = { ...env, OPENCLAW_STATE_DIR: stateDir };
+  const workspaceExists = options.workspaceExists ?? existsSync;
+  const roots = [stateDir, resolveOpenClawStateSqliteDir(pinnedStateEnv)];
+
+  for (const agentId of listAgentIds(options.config)) {
+    roots.push(resolveAgentDir(options.config, agentId, pinnedStateEnv));
+    const workspaceDir = resolveAgentWorkspaceDir(options.config, agentId, pinnedStateEnv);
+    if (
+      shouldProbeAgentWorkspaceDir({
+        config: options.config,
+        agentId,
+        env: pinnedStateEnv,
+        workspaceDir,
+        workspaceExists,
+      })
+    ) {
+      roots.push(workspaceDir);
+    } else {
+      const creationProbeRoot = resolveWorkspaceCreationProbeRoot(workspaceDir, workspaceExists);
+      if (creationProbeRoot) {
+        roots.push(creationProbeRoot);
+      }
+    }
+  }
+
+  for (const agentId of listConfiguredSessionStoreAgentIds(options.config)) {
+    roots.push(
+      path.dirname(
+        resolveStorePath(options.config.session?.store, { agentId, env: pinnedStateEnv }),
+      ),
+    );
+  }
+
+  return roots;
+}
+
+/** Create a cached async write probe for critical Gateway storage roots. */
+export function createStorageReadinessChecker(deps: {
+  getWritableRoots: () => readonly string[];
+  cacheTtlMs?: number;
+  fs?: WritableProbeFs;
+  now?: () => number;
+  probeFileName?: string;
+  createProbeFileName?: () => string;
+  probeTimeoutMs?: number;
+  timeoutRetryMs?: number;
+  autoStart?: boolean;
+}): RefreshableStorageReadinessChecker {
+  const fsImpl = deps.fs ?? fs.promises;
+  const now = deps.now ?? Date.now;
+  const probeFileName = deps.probeFileName ?? DEFAULT_PROBE_FILE_NAME;
+  const createProbeFileName =
+    deps.createProbeFileName ?? (() => `${probeFileName}.${process.pid}.${randomUUID()}`);
+  const cacheTtlMs = Math.max(0, deps.cacheTtlMs ?? DEFAULT_STORAGE_READINESS_CACHE_TTL_MS);
+  const probeTimeoutMs = Math.max(
+    1,
+    deps.probeTimeoutMs ?? DEFAULT_STORAGE_READINESS_PROBE_TIMEOUT_MS,
+  );
+  const timeoutRetryMs = Math.max(
+    1,
+    deps.timeoutRetryMs ?? DEFAULT_STORAGE_READINESS_TIMEOUT_RETRY_MS,
+  );
+  let nextRefreshAt = Number.NEGATIVE_INFINITY;
+  let cachedState: StorageReadinessResult = {
+    ready: false,
+    failing: [STORAGE_READINESS_FAILURE],
+  };
+  let refreshGeneration = 0;
+  let abandonedTimedOutProbes = 0;
+  let refreshInFlight: {
+    abandon: () => void;
+    bounded: Promise<StorageReadinessResult>;
+    generation: number;
+    timedOut: boolean;
+  } | null = null;
+
+  const maybeAbandonTimedOutProbe = () => {
+    if (!refreshInFlight?.timedOut || abandonedTimedOutProbes >= MAX_ABANDONED_TIMED_OUT_PROBES) {
+      return;
+    }
+    refreshInFlight.abandon();
+  };
+
+  const applyProbeResult = (generation: number, ready: boolean) => {
+    if (generation !== refreshGeneration) {
+      return;
+    }
+    const checkedAt = now();
+    nextRefreshAt = checkedAt + cacheTtlMs;
+    cachedState = ready
+      ? { ready: true, failing: [] }
+      : { ready: false, failing: [STORAGE_READINESS_FAILURE] };
+  };
+
+  const refresh = async (): Promise<StorageReadinessResult> => {
+    if (refreshInFlight) {
+      return await refreshInFlight.bounded;
+    }
+
+    const generation = ++refreshGeneration;
+    let abandoned = false;
+    const abandon = () => {
+      if (abandoned) {
+        return;
+      }
+      abandoned = true;
+      abandonedTimedOutProbes += 1;
+      if (refreshInFlight?.generation === generation) {
+        refreshInFlight = null;
+      }
+    };
+    const probeTask = (async () => {
+      const ready = await probeWritableRoots({
+        getWritableRoots: deps.getWritableRoots,
+        createProbeFileName,
+        fs: fsImpl,
+      });
+      applyProbeResult(generation, ready);
+    })();
+
+    const bounded = withProbeTimeout({
+      probeTask,
+      timeoutMs: probeTimeoutMs,
+      onTimeout: () => {
+        if (generation !== refreshGeneration) {
+          return;
+        }
+        refreshGeneration += 1;
+        nextRefreshAt = now() + timeoutRetryMs;
+        cachedState = { ready: false, failing: [STORAGE_READINESS_FAILURE] };
+        if (refreshInFlight?.generation === generation) {
+          refreshInFlight.timedOut = true;
+          maybeAbandonTimedOutProbe();
+        }
+      },
+      getCachedState: () => cachedState,
+    });
+    refreshInFlight = { abandon, bounded, generation, timedOut: false };
+    void probeTask.finally(() => {
+      if (abandoned) {
+        abandonedTimedOutProbes -= 1;
+      }
+      if (refreshInFlight?.generation === generation) {
+        refreshInFlight = null;
+      }
+      maybeAbandonTimedOutProbe();
+    });
+
+    return await bounded;
+  };
+
+  const checker = (() => {
+    const checkedAt = now();
+    if (checkedAt >= nextRefreshAt && !refreshInFlight) {
+      void refresh();
+    }
+    return cachedState;
+  }) as RefreshableStorageReadinessChecker;
+  checker.refresh = refresh;
+
+  if (deps.autoStart !== false) {
+    void refresh();
+  }
+
+  return checker;
+}
+
+async function probeWritableRoots(params: {
+  getWritableRoots: () => readonly string[];
+  createProbeFileName: () => string;
+  fs: WritableProbeFs;
+}): Promise<boolean> {
+  let roots: string[];
+  try {
+    roots = getDistinctWritableRoots(params.getWritableRoots);
+  } catch {
+    return false;
+  }
+
+  const results = await Promise.all(
+    roots.map(
+      async (root) => await probeWritableRoot(root, params.createProbeFileName(), params.fs),
+    ),
+  );
+  return results.every(Boolean);
+}
+
+async function withProbeTimeout(params: {
+  probeTask: Promise<void>;
+  timeoutMs: number;
+  onTimeout: () => void;
+  getCachedState: () => StorageReadinessResult;
+}): Promise<StorageReadinessResult> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutTask = new Promise<StorageReadinessResult>((resolve) => {
+    timeoutHandle = setTimeout(() => {
+      params.onTimeout();
+      resolve(params.getCachedState());
+    }, params.timeoutMs);
+    timeoutHandle.unref?.();
+  });
+
+  try {
+    return await Promise.race([params.probeTask.then(() => params.getCachedState()), timeoutTask]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+function getDistinctWritableRoots(getWritableRoots: () => readonly string[]): string[] {
+  const roots = getWritableRoots();
+  const seen = new Set<string>();
+  const distinct: string[] = [];
+  for (const root of roots) {
+    const trimmed = root.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const resolved = path.resolve(trimmed);
+    if (seen.has(resolved)) {
+      continue;
+    }
+    seen.add(resolved);
+    distinct.push(resolved);
+  }
+  return distinct;
+}
+
+async function probeWritableRoot(
+  root: string,
+  probeFileName: string,
+  fsImpl: WritableProbeFs,
+): Promise<boolean> {
+  const probePath = path.join(root, probeFileName);
+  let handle: WritableProbeFileHandle | undefined;
+  let failed = false;
+  let createdProbeFile = false;
+
+  try {
+    await fsImpl.mkdir(root, { recursive: true });
+    handle = await fsImpl.open(probePath, "wx", 0o600);
+    createdProbeFile = true;
+    await handle.writeFile(PROBE_PAYLOAD);
+    await handle.sync();
+  } catch {
+    failed = true;
+  } finally {
+    if (handle) {
+      try {
+        await handle.close();
+      } catch {
+        failed = true;
+      }
+    }
+    if (createdProbeFile) {
+      try {
+        await fsImpl.unlink(probePath);
+      } catch (err) {
+        if (!isMissingFileError(err)) {
+          failed = true;
+        }
+      }
+    }
+  }
+
+  return !failed;
+}
+
+function isMissingFileError(err: unknown): boolean {
+  return typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT";
+}


### PR DESCRIPTION
Closes #96084.

AI-assisted: yes. Codex helped implement and review this change; I ran and checked the validation below, and I understand the storage readiness path being changed.

## What Problem This Solves

Fixes an issue where operators using PVC-backed or otherwise shared Gateway storage could see `/readyz` stay healthy while OpenClaw could no longer write critical state, agent, session, or workspace files, such as when the storage volume is full or no longer writable.

## Why This Change Was Made

Gateway readiness now includes a bounded cached write probe over the startup state directory, state SQLite directory, configured agent directories, configured or existing workspace roots, and configured session-store roots. The probe writes, fsyncs, closes, and removes a unique temporary file, while `/healthz` remains a shallow liveness check.

The implementation pins the startup state directory used by readiness so later environment changes cannot move the probe target, avoids creating the implicit default workspace just to check readiness, and limits timed-out probe buildup while still allowing retry and recovery.

## User Impact

Operators and load balancers can stop routing traffic to a Gateway process when its writable storage is unavailable, while liveness remains green for restart policy decisions. When storage becomes writable again, readiness recovers without restarting the Gateway.

## Evidence

Focused validation:

```text
node scripts/run-vitest.mjs src/gateway/server/readiness.test.ts src/gateway/server/storage-readiness.test.ts src/gateway/server-http.probe.test.ts
PASS 10 files, 146 tests

node scripts/run-oxlint.mjs src/gateway/server.impl.ts src/gateway/server/readiness.ts src/gateway/server/readiness.test.ts src/gateway/server/storage-readiness.ts src/gateway/server/storage-readiness.test.ts
PASS

pnpm exec oxfmt --check src/gateway/server.impl.ts src/gateway/server/readiness.ts src/gateway/server/readiness.test.ts src/gateway/server/storage-readiness.ts src/gateway/server/storage-readiness.test.ts
PASS

git diff --check origin/main...HEAD
PASS

pnpm check:test-types
PASS
```

Local Codex review:

```text
codex review --base origin/main
No discrete, actionable correctness issues were found in the storage readiness changes relative to the base diff.
```

Manual local live Gateway proof with a temporary OpenClaw state directory, channels/providers disabled, and actual HTTP probe requests:

```text
baseline /healthz: 200 {"ok":true,"status":"live"}
baseline /readyz: 200 {"ready":true,"failing":[]}

chmod agent storage root to 0500
/healthz: 200 {"ok":true,"status":"live"}
/readyz: 503 {"ready":false,"failing":["workspace-storage-unwritable"]}

chmod agent storage root back to 0700
/readyz: 200 {"ready":true,"failing":[]}
```

The live proof also independently wrote and fsync'd probe files in all resolved critical roots before changing permissions:

```text
.openclaw
.openclaw/state
.openclaw/agents/main/agent
.openclaw/agents/main/sessions
```
