### PR TITLE
fix(memory-wiki): tolerate YAML parse errors in wiki frontmatter

### DIFF
--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -421,4 +421,16 @@ describe("toWikiPageSummary", () => {
       },
     ]);
   });
+
+  it("tolerates frontmatter with YAML parse errors instead of crashing", () => {
+    const page = toWikiPageSummary({
+      absolutePath: "/tmp/wiki/sources/bad-yaml.md",
+      relativePath: "sources/bad-yaml.md",
+      raw: '---\npageType: source\nid: source.bad-yaml\ntitle: Bad YAML\nsourceIds:\n  - **MEMORY.md 第 235 行**:"加特契纳 1783 年才赐予保罗,1770 年保罗才 16 岁"\n---\n\nBody text.\n',
+    });
+    expect(page).not.toBeNull();
+    expect(page?.hasFrontmatter).toBe(true);
+    expect(page?.title).toBe("bad-yaml"); // title falls back to filename when frontmatter is empty
+    expect(page?.sourceIds).toEqual([]);
+  });
 });

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -178,15 +178,19 @@ export function parseWikiMarkdown(content: string): ParsedWikiMarkdown {
   if (!match) {
     return { hasFrontmatter: false, frontmatter: {}, body: content };
   }
-  const parsed = YAML.parse(match[1]) as unknown;
-  return {
-    hasFrontmatter: true,
-    frontmatter:
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : {},
-    body: content.slice(match[0].length),
-  };
+  try {
+    const parsed = YAML.parse(match[1]) as unknown;
+    return {
+      hasFrontmatter: true,
+      frontmatter:
+        parsed && typeof parsed === "object" && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : {},
+      body: content.slice(match[0].length),
+    };
+  } catch {
+    return { hasFrontmatter: true, frontmatter: {}, body: content.slice(match[0].length) };
+  }
 }
 
 export function renderWikiMarkdown(params: {


### PR DESCRIPTION
Fixes #96125

## What Problem This Solves

Fixes an issue where a single wiki page with malformed YAML frontmatter causes `wiki_apply` and `wiki_lint` to fail entirely, even though the file was already written successfully. The `compileMemoryWikiVault` step throws `YAMLParseError` ("Unexpected scalar at node end") when parsing frontmatter containing markdown bold syntax with colons (e.g., `- **MEMORY.md 第 235 行**:"..."`). This creates a single-point-of-failure: one bad file breaks the entire vault.

## Why This Change Was Made

`parseWikiMarkdown` (`extensions/memory-wiki/src/markdown.ts:176`) called `YAML.parse` without any error handling. When a list item in frontmatter contains markdown bold + colon (which YAML interprets as an invalid key-value structure), the parser throws and the error propagates up through `toWikiPageSummary` → `readPageSummaries` → `compileMemoryWikiVault` → `wiki_apply`/`wiki_lint`.

The fix wraps `YAML.parse` in a try-catch: when parsing fails, return an empty `frontmatter` but preserve the `body`. This prevents one bad file from crashing the entire vault compilation, while allowing the page to still be processed (albeit without frontmatter metadata).

## User Impact

Users with wiki pages containing complex markdown in frontmatter (like bold + colon combinations) will no longer see `wiki_apply`/`wiki_lint` crash. The affected page will be processed without its frontmatter metadata, but the rest of the vault compiles normally. Previously, the entire operation would fail with a cryptic YAML parse error.

## Evidence

**Environment**: Linux, Node v22.23.0, pnpm v11.2.2, worktree SHA 2af06042c2

**Before fix** (reproduction with `yaml` package):

```bash
$ node -e "const YAML = require('yaml'); YAML.parse('- **MEMORY.md 第 235 行**:\"加特契纳...\"')"
YAMLParseError: Unexpected scalar at node end at line 1, column 10:

- **MEMORY.md 第 235 行**: "加特契纳..."
         ^
```

**After fix** (new regression test on new code):

```bash
$ pnpm test extensions/memory-wiki/src/markdown.test.ts
Test Files  1 passed (1)
     Tests   8 passed (8)
```

**Lint/format clean**:

```bash
$ npx oxlint@latest extensions/memory-wiki/src/markdown.ts extensions/memory-wiki/src/markdown.test.ts
Found 0 warnings and 0 errors.
$ pnpm format extensions/memory-wiki/src/markdown.ts extensions/memory-wiki/src/markdown.test.ts
Finished in 13ms on 2 files using 1 threads.
```