### PR TITLE
fix(memory-core): keep live reindex of reset/deleted session archives

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -392,7 +392,9 @@ describe("memory index", () => {
           model: params.model ?? "mock-embed",
           fallback: params.fallback,
           outputDimensionality: params.outputDimensionality,
-          store: { vector: {} },
+          store: {
+            vector: params.vectorEnabled !== undefined ? { enabled: params.vectorEnabled } : {},
+          },
           remote: params.batchEnabled
             ? {
                 batch: { enabled: true },

--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -78,9 +78,6 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
         return;
       }
       const sessionFile = update.sessionFile;
-      if (sessionFile && isSessionArchiveArtifactName(path.basename(sessionFile))) {
-        return;
-      }
       if (sessionFile && this.isSessionFileForAgent(sessionFile)) {
         this.scheduleSessionDirty(sessionFile);
         return;

--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -79,6 +79,9 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
       }
       const sessionFile = update.sessionFile;
       if (sessionFile && this.isSessionFileForAgent(sessionFile)) {
+        if (!isUsageCountedSessionTranscriptFileName(path.basename(sessionFile))) {
+          return;
+        }
         this.scheduleSessionDirty(sessionFile);
         return;
       }

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -142,8 +142,12 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   readonly syncCalls: SyncParams[] = [];
   readonly indexedPaths: string[] = [];
   readonly indexedContents: string[] = [];
+  private pendingSyncWork: Promise<void> = Promise.resolve();
 
-  constructor(sourceRows: SourceStateRow[]) {
+  constructor(
+    sourceRows: SourceStateRow[],
+    private readonly indexSessionUpdates = false,
+  ) {
     super();
     this.sources.add("sessions");
     this.db = {
@@ -192,6 +196,10 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
         processSessionDeltaBatch: () => Promise<void>;
       }
     ).processSessionDeltaBatch();
+  }
+
+  async waitForSessionSync(): Promise<void> {
+    await this.pendingSyncWork;
   }
 
   async combineTargetArchiveFilesForTest(params: {
@@ -247,6 +255,10 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
 
   protected async sync(params?: MemorySyncParams): Promise<void> {
     this.syncCalls.push(params ?? {});
+    this.pendingSyncWork = this.indexSessionUpdates
+      ? this.syncArchiveFiles({ needsFullReindex: false }).then(() => undefined)
+      : Promise.resolve();
+    await this.pendingSyncWork;
   }
 
   protected async withTimeout<T>(
@@ -737,11 +749,11 @@ describe("session startup catch-up", () => {
   });
 
   it.each(["reset", "deleted"] as const)(
-    "schedules a %s archive for live indexing when its update is emitted",
+    "indexes a %s archive through the live listener debounce path",
     async (reason) => {
       vi.useFakeTimers();
       const session = await writeSessionFile(`thread.jsonl.${reason}.2026-06-23T10-00-00.000Z`);
-      const harness = new SessionStartupCatchupHarness([]);
+      const harness = new SessionStartupCatchupHarness([], true);
       harness.startTranscriptListener();
 
       try {
@@ -750,12 +762,61 @@ describe("session startup catch-up", () => {
         expect(harness.getPendingArchiveFiles()).toEqual([session.filePath]);
 
         await vi.advanceTimersByTimeAsync(6000);
+        await harness.waitForSessionSync();
 
         expect(harness.getDirtyArchiveFiles()).toEqual([session.filePath]);
         expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+        expect(harness.indexedPaths).toEqual([
+          `sessions/main/thread.jsonl.${reason}.2026-06-23T10-00-00.000Z`,
+        ]);
+        expect(harness.indexedContents).toEqual(["User: startup catchup"]);
       } finally {
         harness.stopTranscriptListener();
       }
     },
   );
+
+  it.each([
+    "thread.jsonl.bak.2026-06-23T10-00-00.000Z",
+    "thread.trajectory.jsonl",
+    "sessions.json",
+  ])("ignores non-corpus session artifact updates for %s", async (fileName) => {
+    vi.useFakeTimers();
+    const session = await writeSessionFile(fileName);
+    const harness = new SessionStartupCatchupHarness([], true);
+    harness.startTranscriptListener();
+
+    try {
+      emitSessionTranscriptUpdate({ sessionFile: session.filePath });
+      await vi.advanceTimersByTimeAsync(6000);
+      await harness.waitForSessionSync();
+
+      expect(harness.getPendingArchiveFiles()).toEqual([]);
+      expect(harness.getDirtyArchiveFiles()).toEqual([]);
+      expect(harness.syncCalls).toEqual([]);
+      expect(harness.indexedPaths).toEqual([]);
+    } finally {
+      harness.stopTranscriptListener();
+    }
+  });
+
+  it("leaves a missing archive update unindexed", async () => {
+    vi.useFakeTimers();
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    const missingPath = path.join(sessionsDir, "missing.jsonl.reset.2026-06-23T10-00-00.000Z");
+    const harness = new SessionStartupCatchupHarness([], true);
+    harness.startTranscriptListener();
+
+    try {
+      emitSessionTranscriptUpdate({ sessionFile: missingPath });
+      await vi.advanceTimersByTimeAsync(6000);
+      await harness.waitForSessionSync();
+
+      expect(harness.getDirtyArchiveFiles()).toEqual([missingPath]);
+      expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+      expect(harness.indexedPaths).toEqual([]);
+    } finally {
+      harness.stopTranscriptListener();
+    }
+  });
 });

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -735,4 +735,27 @@ describe("session startup catch-up", () => {
     expect(harness.getPendingSessionTargets()).toEqual([]);
     harness.stopTranscriptListener();
   });
+
+  it.each(["reset", "deleted"] as const)(
+    "schedules a %s archive for live indexing when its update is emitted",
+    async (reason) => {
+      vi.useFakeTimers();
+      const session = await writeSessionFile(`thread.jsonl.${reason}.2026-06-23T10-00-00.000Z`);
+      const harness = new SessionStartupCatchupHarness([]);
+      harness.startTranscriptListener();
+
+      try {
+        emitSessionTranscriptUpdate({ sessionFile: session.filePath });
+
+        expect(harness.getPendingArchiveFiles()).toEqual([session.filePath]);
+
+        await vi.advanceTimersByTimeAsync(6000);
+
+        expect(harness.getDirtyArchiveFiles()).toEqual([session.filePath]);
+        expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+      } finally {
+        harness.stopTranscriptListener();
+      }
+    },
+  );
 });

--- a/extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts
+++ b/extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts
@@ -86,6 +86,8 @@ describe("memory legacy migration cleanup", () => {
         );
         INSERT INTO memory_index_chunks_vec VALUES ('chunk-canonical', '[1,0,0]');
         INSERT INTO memory_index_chunks_vec VALUES ('chunk-ownerless', '[0,1,0]');
+        INSERT INTO memory_index_meta (key, value)
+          VALUES ('memory_vector_rebuild_v1', 'clean');
 
         CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
         CREATE TABLE files (
@@ -128,23 +130,27 @@ describe("memory legacy migration cleanup", () => {
       vectorEnabled: boolean;
     }) =>
       ({
-        memory: { backend: "builtin" },
+        memory: {
+          backend: "builtin",
+          search: {
+            provider: params.provider,
+            model: params.provider === "none" ? "" : "text-embedding-3-small",
+            rememberAcrossConversations: false,
+            sources: ["memory"],
+            store: {
+              vector: {
+                enabled: params.vectorEnabled,
+                ...(params.extensionPath ? { extensionPath: params.extensionPath } : {}),
+              },
+            },
+            cache: { enabled: false },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+            query: { hybrid: { enabled: true } },
+          },
+        },
         agents: {
           defaults: {
             workspace: workspaceDir,
-            memorySearch: {
-              provider: params.provider,
-              model: params.provider === "none" ? "" : "text-embedding-3-small",
-              store: {
-                vector: {
-                  enabled: params.vectorEnabled,
-                  ...(params.extensionPath ? { extensionPath: params.extensionPath } : {}),
-                },
-              },
-              cache: { enabled: false },
-              sync: { watch: false, onSessionStart: false, onSearch: false },
-              query: { hybrid: { enabled: true } },
-            },
           },
           list: [{ id: "main", default: true }],
         },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who reset or delete a session could not find the archived conversation through live memory search until the gateway restarted. Reset/deleted transcript archives emit a session update, but memory-core discarded archive-file updates before its existing delta/index scheduling path could process them.

## Why This Change Was Made

The session listener is the live bridge between transcript archive creation and memory indexing. Current `main` returns early for archive paths even though `processSessionDeltaBatch` explicitly handles usage-counted reset/deleted archives and schedules an immediate session sync.

This patch admits only usage-counted session transcript filenames from the current agent's sessions directory. Reset/deleted archives now reach the existing `scheduleSessionDirty` and archive-delta path, while backup, trajectory, metadata, outside-agent, and unrecognized archive artifacts remain rejected or use the existing corpus fallback. The regression coverage lives in the existing session-sync harness and exercises the real listener, five-second debounce, dirty state, sync scheduling, and archive content indexing.

PR #76666 remains separate: it addresses complementary listener-attachment timing rather than this archive-classification regression.

## User Impact

Reset and deleted conversations become eligible for memory indexing while the gateway is still running, instead of remaining invisible until restart or manual reindex. There is no configuration, schema, dependency, or provider-routing change.

## Evidence

Accepted exact head: `4b72c0196855261e38757a47122f09733d86f5ad`.

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts`: 1 file, 21 tests passed.
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts -t 'forces a rebuild after incremental writes while vectors are disabled'`: 1 passed.
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts`: 1 passed.
- `oxfmt --check`, `oxlint`, and `git diff --check` on the touched files: clean.
- Codex autoreview: both the runtime branch diff and the CI repair diff completed clean with no accepted/actionable findings.
- Focused before/after proof from the original regression validation: restoring the archive guard left reset/deleted updates out of the pending queue; this head queues each archive, marks it dirty after the debounce, schedules `{ reason: "session-delta" }`, and indexes the archive content through the existing session sync path.
- Exact-head CI initially exposed two migrated-config fixture failures in the selected memory shard. The test-only repair forwards the canonical `memory.search` configuration, passes the vector-enabled option through the fixture, limits the cleanup fixture to memory sources, and seeds the preexisting vector index as clean. Both failed tests pass locally after the repair.
- Exact-head hosted CI is tracked on this PR and must be green before merge.

What was not tested: no live embedding-provider request or end-to-end `memory_search` query was issued. The focused harness reaches the production listener, debounce, archive selection, and indexing-content path while replacing the final provider write with its existing capture.
