### PR TITLE
Recover non-deliverable terminal sessions before transcript replay

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.non-deliverable-terminal-session.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.non-deliverable-terminal-session.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  archiveNonDeliverableTerminalSessionIfNeeded,
+} from "./attempt.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-non-deliverable-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  return fs
+    .stat(filePath)
+    .then(() => true)
+    .catch(() => false);
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("archiveNonDeliverableTerminalSessionIfNeeded", () => {
+  it("archives a transcript whose latest session end was non-deliverable", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const trajectoryFile = path.join(dir, "session.trajectory.jsonl");
+    await fs.writeFile(sessionFile, '{"type":"session"}\n', "utf8");
+    await fs.writeFile(
+      trajectoryFile,
+      [
+        JSON.stringify({ type: "model.completed" }),
+        "not json",
+        JSON.stringify({
+          type: "session.ended",
+          data: {
+            status: "error",
+            terminalError: "non_deliverable_terminal_turn",
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    const warnings: string[] = [];
+    await expect(
+      archiveNonDeliverableTerminalSessionIfNeeded({
+        sessionFile,
+        sessionId: "session",
+        sessionKey: "agent:main:test",
+        env: {},
+        warn: (message) => warnings.push(message),
+      }),
+    ).resolves.toBe(true);
+
+    expect(await exists(sessionFile)).toBe(false);
+    expect(await exists(trajectoryFile)).toBe(false);
+    expect(await fs.readdir(dir)).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^session\.jsonl\.non-deliverable-\d+\.bak$/),
+        expect.stringMatching(/^session\.trajectory\.jsonl\.non-deliverable-\d+\.bak$/),
+      ]),
+    );
+    expect(warnings.join("\n")).toContain("agent:main:test");
+  });
+
+  it("does not archive when a later session end succeeded", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const trajectoryFile = path.join(dir, "session.trajectory.jsonl");
+    await fs.writeFile(sessionFile, '{"type":"session"}\n', "utf8");
+    await fs.writeFile(
+      trajectoryFile,
+      [
+        JSON.stringify({
+          type: "session.ended",
+          data: {
+            status: "error",
+            terminalError: "non_deliverable_terminal_turn",
+          },
+        }),
+        JSON.stringify({
+          type: "session.ended",
+          data: {
+            status: "success",
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    await expect(
+      archiveNonDeliverableTerminalSessionIfNeeded({
+        sessionFile,
+        sessionId: "session",
+        env: {},
+        warn: () => undefined,
+      }),
+    ).resolves.toBe(false);
+
+    expect(await exists(sessionFile)).toBe(true);
+    expect(await exists(trajectoryFile)).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.non-deliverable-terminal-session.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.non-deliverable-terminal-session.test.ts
@@ -2,9 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  archiveNonDeliverableTerminalSessionIfNeeded,
-} from "./attempt.js";
+import { archiveNonDeliverableTerminalSessionIfNeeded } from "./attempt.js";
 
 const tempDirs: string[] = [];
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -83,6 +83,7 @@ import {
   buildTrajectoryArtifacts,
   buildTrajectoryRunMetadata,
 } from "../../../trajectory/metadata.js";
+import { resolveTrajectoryFilePath } from "../../../trajectory/paths.js";
 import {
   createTrajectoryRuntimeRecorder,
   toTrajectoryToolDefinitions,
@@ -365,6 +366,7 @@ import {
 } from "./attempt-tool-construction-plan.js";
 import { flushEmbeddedAttemptTrajectoryRecorder } from "./attempt-trajectory-flush-cleanup.js";
 import {
+  NON_DELIVERABLE_TERMINAL_TURN_REASON,
   resolveAttemptTrajectoryTerminal,
   resolveTerminalAssistantTexts,
 } from "./attempt-trajectory-status.js";
@@ -832,6 +834,73 @@ async function loadAttemptSessionEntryAfterQuotaMaintenance(params: {
     },
   );
   return updated ?? entry;
+}
+
+export async function archiveNonDeliverableTerminalSessionIfNeeded(params: {
+  sessionFile: string;
+  sessionId: string;
+  sessionKey?: string;
+  env?: NodeJS.ProcessEnv;
+  warn: (message: string) => void;
+}): Promise<boolean> {
+  const trajectoryFile = resolveTrajectoryFilePath({
+    env: params.env,
+    sessionFile: params.sessionFile,
+    sessionId: params.sessionId,
+  });
+  let text: string;
+  try {
+    text = await fs.readFile(trajectoryFile, "utf8");
+  } catch {
+    return false;
+  }
+
+  const lines = text.split("\n").filter((line) => line.trim().length > 0);
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    let event: unknown;
+    try {
+      event = JSON.parse(lines[index]);
+    } catch {
+      continue;
+    }
+    if (!event || typeof event !== "object" || !("type" in event)) {
+      continue;
+    }
+    if (event.type !== "session.ended") {
+      continue;
+    }
+
+    const data = "data" in event ? event.data : undefined;
+    if (
+      !data ||
+      typeof data !== "object" ||
+      !("terminalError" in data) ||
+      data.terminalError !== NON_DELIVERABLE_TERMINAL_TURN_REASON
+    ) {
+      return false;
+    }
+
+    const suffix = `.non-deliverable-${Date.now()}.bak`;
+    const sessionArchive = `${params.sessionFile}${suffix}`;
+    const trajectoryArchive = `${trajectoryFile}${suffix}`;
+    await fs.rename(params.sessionFile, sessionArchive).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    });
+    await fs.rename(trajectoryFile, trajectoryArchive).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    });
+    params.warn(
+      `[session-recovery] archived non-deliverable terminal transcript sessionKey=${
+        params.sessionKey ?? params.sessionId
+      } sessionArchive=${sessionArchive} trajectoryArchive=${trajectoryArchive}`,
+    );
+    return true;
+  }
+  return false;
 }
 
 export async function runEmbeddedAttempt(
@@ -2160,7 +2229,7 @@ export async function runEmbeddedAttempt(
       ) {
         invalidateSessionFileRepairCache(params.sessionFile);
       }
-      const hadSessionFile = await fs
+      let hadSessionFile = await fs
         .stat(params.sessionFile)
         .then(() => true)
         .catch(() => false);
@@ -2177,6 +2246,19 @@ export async function runEmbeddedAttempt(
         params.model.api === "openai-responses" ||
         params.model.api === "azure-openai-responses" ||
         params.model.api === "openai-chatgpt-responses";
+
+      if (hadSessionFile) {
+        const archivedNonDeliverableSession = await archiveNonDeliverableTerminalSessionIfNeeded({
+          env: process.env,
+          sessionFile: params.sessionFile,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          warn: (message) => log.warn(message),
+        });
+        if (archivedNonDeliverableSession) {
+          hadSessionFile = false;
+        }
+      }
 
       await prewarmSessionFile(params.sessionFile);
       const preparedUserTurnMessage = await params.userTurnTranscriptRecorder?.resolveMessage();

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -883,13 +883,13 @@ export async function archiveNonDeliverableTerminalSessionIfNeeded(params: {
     const suffix = `.non-deliverable-${Date.now()}.bak`;
     const sessionArchive = `${params.sessionFile}${suffix}`;
     const trajectoryArchive = `${trajectoryFile}${suffix}`;
-    await fs.rename(params.sessionFile, sessionArchive).catch((error: NodeJS.ErrnoException) => {
-      if (error.code !== "ENOENT") {
+    await fs.rename(params.sessionFile, sessionArchive).catch((error: unknown) => {
+      if (!error || typeof error !== "object" || !("code" in error) || error.code !== "ENOENT") {
         throw error;
       }
     });
-    await fs.rename(trajectoryFile, trajectoryArchive).catch((error: NodeJS.ErrnoException) => {
-      if (error.code !== "ENOENT") {
+    await fs.rename(trajectoryFile, trajectoryArchive).catch((error: unknown) => {
+      if (!error || typeof error !== "object" || !("code" in error) || error.code !== "ENOENT") {
         throw error;
       }
     });


### PR DESCRIPTION
## What Problem This Solves

Old embedded-agent transcripts can end with a trajectory terminal marker of `terminalError=non_deliverable_terminal_turn`. When that transcript is reused on the next turn, the runner may replay the same bad terminal context and continue producing empty/non-deliverable turns instead of recovering. In production this surfaced as an old OpenClaw/Feishu session repeatedly swallowing user turns and telling the user to retry or start `/new`.

## Summary

- Adds a pre-open recovery gate before `prewarmSessionFile()` / `SessionManager.open()`.
- If the latest valid trajectory `session.ended` event has `terminalError=non_deliverable_terminal_turn`, archives the session transcript and trajectory beside the original files with a `.non-deliverable-<timestamp>.bak` suffix.
- Marks `hadSessionFile=false` after recovery so the current turn initializes a clean transcript instead of replaying the bad terminal session.
- Adds focused tests for archiving only when the latest valid `session.ended` is non-deliverable.

## Evidence

- Production hotfix was applied first on an Aliyun OpenClaw runtime for CCY-294, targeting `/opt/business-stack/runtime/node/lib/node_modules/openclaw/dist/selection-kQiC501t.js`.
- The affected production session `4c81e36f-215e-436f-b010-d4d6a41fea45` had a trajectory tail ending in `session.ended` with `terminalError=non_deliverable_terminal_turn`; its transcript, trajectory, and pointer were archived as `.non-deliverable-1782226230499.bak` files.
- After the hotfix, the Aliyun gateway health check returned `{"ok":true,"status":"live"}` and the gateway process was running from the patched runtime.
- A fresh OpenClaw agent smoke using `bailian/qwen3.7-plus` returned `CCY294_QWEN_SMOKE_OK`, confirming the agent path/model/network/key chain remained usable after recovery.
- This PR ports that deployed recovery behavior back to source so future package upgrades do not overwrite the dist hotfix.

## Notes

Direct push to `openclaw/openclaw` was unavailable for the current account (`viewerPermission=READ`), so this was submitted from the `fuhao6539-ship-it/openclaw` fork.