### PR TITLE
fix(gateway): remote SSH gateway rejects plaintext before SSH tunnel connects

### DIFF
--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -352,6 +352,7 @@ type AssembledConnect = {
 
 type FingerprintCheckingClientOptions = Omit<ClientOptions, "checkServerIdentity"> & {
   checkServerIdentity?: (servername: string, cert: CertMeta) => Error | undefined;
+  servername?: string;
 };
 
 const DEFAULT_GATEWAY_CLIENT_URL = "ws://127.0.0.1:18789";
@@ -453,6 +454,7 @@ export type GatewayClientOptions = {
   minProtocol?: number;
   maxProtocol?: number;
   tlsFingerprint?: string;
+  tlsServerName?: string;
   onEvent?: (evt: EventFrame) => void;
   onHelloOk?: (hello: HelloOk) => void;
   onConnectError?: (err: Error) => void;
@@ -640,6 +642,10 @@ export class GatewayClient {
       maxPayload: 25 * 1024 * 1024,
       ...(this.opts.origin ? { origin: this.opts.origin } : {}),
     };
+    const tlsServerName = normalizeOptionalString(this.opts.tlsServerName);
+    if (url.startsWith("wss://") && tlsServerName) {
+      wsOptions.servername = tlsServerName;
+    }
     if (url.startsWith("wss://") && this.opts.tlsFingerprint) {
       wsOptions.rejectUnauthorized = false;
       wsOptions.checkServerIdentity = (_hostValue: string, cert: CertMeta) => {

--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type GatewayClientCallbacks = {
   onEvent?: (evt: { event: string; payload?: unknown }) => void;
+  onStop?: () => void | Promise<void>;
   onHelloOk?: () => void;
   onConnectError?: (err: Error) => void;
   onClose?: (code: number, reason: string) => void;
@@ -16,10 +17,17 @@ type ResolveGatewayClientBootstrap = (params: unknown) => Promise<{
   url: string;
   urlSource: string;
   auth: GatewayClientAuth;
+  sshTunnel?: {
+    stop: () => void | Promise<void>;
+    exited?: Promise<unknown>;
+  };
+  tlsServerName?: string;
 }>;
 type GatewayClientOptions = GatewayClientCallbacks &
   GatewayClientAuth & {
     caps?: string[];
+    stopWhen?: Promise<unknown>;
+    tlsServerName?: string;
     url?: string;
   };
 type MockAcpStream = {
@@ -30,9 +38,12 @@ type MockAcpStream = {
 const mockState = vi.hoisted(() => ({
   acpProtocolVersion: 1,
   acpInputMessages: [] as unknown[],
+  ndJsonStreamError: null as Error | null,
   gateways: [] as MockGatewayClient[],
   gatewayAuth: [] as GatewayClientAuth[],
   gatewayOptions: [] as GatewayClientOptions[],
+  gatewayConstructorError: null as Error | null,
+  gatewayStopAndWait: vi.fn(),
   agentSideConnectionCtor: vi.fn(),
   agentHandleGatewayEvent: vi.fn(async (_evt: unknown) => {}),
   agentStart: vi.fn(),
@@ -54,12 +65,25 @@ const mockState = vi.hoisted(() => ({
       password: undefined,
     },
   })),
+  startGatewayClientWhenEventLoopReady: vi.fn(async (client: { start: () => void }) => {
+    client.start();
+    return {
+      ready: true,
+      elapsedMs: 0,
+      maxDriftMs: 0,
+      checks: 2,
+      aborted: false,
+    };
+  }),
 }));
 
 class MockGatewayClient {
   private callbacks: GatewayClientCallbacks;
 
   constructor(opts: GatewayClientOptions) {
+    if (mockState.gatewayConstructorError) {
+      throw mockState.gatewayConstructorError;
+    }
     this.callbacks = opts;
     mockState.gatewayOptions.push(opts);
     mockState.gatewayAuth.push({ token: opts.token, password: opts.password });
@@ -69,14 +93,17 @@ class MockGatewayClient {
   start(): void {}
 
   stop(): void {
+    void this.callbacks.onStop?.();
     this.callbacks.onClose?.(1000, "gateway stopped");
   }
 
   async stopAndWait(): Promise<void> {
+    mockState.gatewayStopAndWait();
     if (mockState.gatewayStopDeferred) {
       await mockState.gatewayStopDeferred.promise;
     }
-    this.stop();
+    await this.callbacks.onStop?.();
+    this.callbacks.onClose?.(1000, "gateway stopped");
   }
 
   emitHello(): void {
@@ -103,17 +130,22 @@ vi.mock("@agentclientprotocol/sdk", () => ({
     factory({});
   },
   PROTOCOL_VERSION: mockState.acpProtocolVersion,
-  ndJsonStream: vi.fn(() => ({
-    writable: new WritableStream(),
-    readable: new ReadableStream({
-      start(controller) {
-        for (const message of mockState.acpInputMessages) {
-          controller.enqueue(message);
-        }
-        controller.close();
-      },
-    }),
-  })),
+  ndJsonStream: vi.fn(() => {
+    if (mockState.ndJsonStreamError) {
+      throw mockState.ndJsonStreamError;
+    }
+    return {
+      writable: new WritableStream(),
+      readable: new ReadableStream({
+        start(controller) {
+          for (const message of mockState.acpInputMessages) {
+            controller.enqueue(message);
+          }
+          controller.close();
+        },
+      }),
+    };
+  }),
 }));
 
 vi.mock("../config/config.js", () => {
@@ -155,16 +187,8 @@ vi.mock("../gateway/client.js", () => ({
 }));
 
 vi.mock("../gateway/client-start-readiness.js", () => ({
-  startGatewayClientWhenEventLoopReady: vi.fn(async (client: MockGatewayClient) => {
-    client.start();
-    return {
-      ready: true,
-      elapsedMs: 0,
-      maxDriftMs: 0,
-      checks: 2,
-      aborted: false,
-    };
-  }),
+  startGatewayClientWhenEventLoopReady: (client: MockGatewayClient) =>
+    mockState.startGatewayClientWhenEventLoopReady(client),
 }));
 
 vi.mock("../infra/is-main.js", () => ({
@@ -314,9 +338,12 @@ describe("serveAcpGateway startup", () => {
 
   beforeEach(async () => {
     mockState.acpInputMessages.length = 0;
+    mockState.ndJsonStreamError = null;
     mockState.gateways.length = 0;
     mockState.gatewayAuth.length = 0;
     mockState.gatewayOptions.length = 0;
+    mockState.gatewayConstructorError = null;
+    mockState.gatewayStopAndWait.mockReset();
     mockState.agentSideConnectionCtor.mockReset();
     mockState.agentHandleGatewayEvent.mockReset();
     mockState.agentStart.mockReset();
@@ -339,6 +366,19 @@ describe("serveAcpGateway startup", () => {
         password: undefined,
       },
     });
+    mockState.startGatewayClientWhenEventLoopReady.mockReset();
+    mockState.startGatewayClientWhenEventLoopReady.mockImplementation(
+      async (client: { start: () => void }) => {
+        client.start();
+        return {
+          ready: true,
+          elapsedMs: 0,
+          maxDriftMs: 0,
+          checks: 2,
+          aborted: false,
+        };
+      },
+    );
   });
 
   it("waits for gateway hello before creating AgentSideConnection", async () => {
@@ -433,6 +473,22 @@ describe("serveAcpGateway startup", () => {
   });
 
   it("rejects startup when gateway connect fails before hello", async () => {
+    let resolveTunnelStop!: () => void;
+    const sshTunnelStop = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTunnelStop = resolve;
+        }),
+    );
+    mockState.resolveGatewayClientBootstrap.mockResolvedValue({
+      url: "ws://127.0.0.1:19091",
+      urlSource: "config gateway.remote.url via ssh tunnel",
+      auth: {
+        token: undefined,
+        password: undefined,
+      },
+      sshTunnel: { stop: sshTunnelStop },
+    });
     const onceSpy = vi
       .spyOn(process, "once")
       .mockImplementation(
@@ -440,12 +496,34 @@ describe("serveAcpGateway startup", () => {
       );
 
     try {
-      const servePromise = serveAcpGateway({});
+      let settled = false;
+      const servePromise = serveAcpGateway({}).then(
+        () => {
+          settled = true;
+          return null;
+        },
+        (error: unknown) => {
+          settled = true;
+          return error;
+        },
+      );
       await Promise.resolve();
 
       const gateway = getMockGateway();
       gateway.emitConnectError("connect failed");
-      await expect(servePromise).rejects.toThrow("connect failed");
+      await vi.waitFor(() => {
+        expect(mockState.gatewayStopAndWait).toHaveBeenCalledTimes(1);
+      });
+      expect(sshTunnelStop).toHaveBeenCalledTimes(1);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(settled).toBe(false);
+
+      resolveTunnelStop();
+      const error = await servePromise;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("connect failed");
       expect(mockState.agentSideConnectionCtor).not.toHaveBeenCalled();
     } finally {
       onceSpy.mockRestore();
@@ -522,6 +600,123 @@ describe("serveAcpGateway startup", () => {
 
       await emitHelloAndWaitForAgentSideConnection();
       await stopServeWithSigint(signalHandlers, servePromise);
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("stops bootstrap SSH tunnel during ACP shutdown", async () => {
+    const sshTunnelStop = vi.fn(async () => undefined);
+    mockState.resolveGatewayClientBootstrap.mockResolvedValue({
+      url: "ws://127.0.0.1:19091",
+      urlSource: "config gateway.remote.url via ssh tunnel",
+      auth: {
+        token: undefined,
+        password: undefined,
+      },
+      sshTunnel: { stop: sshTunnelStop },
+    });
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await emitHelloAndWaitForAgentSideConnection();
+      await stopServeWithSigint(signalHandlers, servePromise);
+
+      expect(sshTunnelStop).toHaveBeenCalledTimes(1);
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("stops bootstrap SSH tunnel when ACP GatewayClient construction fails", async () => {
+    const sshTunnelStop = vi.fn(async () => undefined);
+    mockState.gatewayConstructorError = new Error("device identity unavailable");
+    mockState.resolveGatewayClientBootstrap.mockResolvedValue({
+      url: "ws://127.0.0.1:19091",
+      urlSource: "config gateway.remote.url via ssh tunnel",
+      auth: {
+        token: undefined,
+        password: undefined,
+      },
+      sshTunnel: { stop: sshTunnelStop },
+    });
+    const onceSpy = vi
+      .spyOn(process, "once")
+      .mockImplementation(
+        ((_signal: NodeJS.Signals, _handler: () => void) => process) as typeof process.once,
+      );
+
+    try {
+      await expect(serveAcpGateway({})).rejects.toThrow("device identity unavailable");
+
+      expect(mockState.gateways).toHaveLength(0);
+      expect(sshTunnelStop).toHaveBeenCalledTimes(1);
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("stops bootstrap SSH tunnel when ACP gateway readiness startup fails", async () => {
+    const sshTunnelStop = vi.fn(async () => undefined);
+    mockState.startGatewayClientWhenEventLoopReady.mockRejectedValueOnce(
+      new Error("gateway event loop failed"),
+    );
+    mockState.resolveGatewayClientBootstrap.mockResolvedValue({
+      url: "ws://127.0.0.1:19091",
+      urlSource: "config gateway.remote.url via ssh tunnel",
+      auth: {
+        token: undefined,
+        password: undefined,
+      },
+      sshTunnel: { stop: sshTunnelStop },
+    });
+    const onceSpy = vi
+      .spyOn(process, "once")
+      .mockImplementation(
+        ((_signal: NodeJS.Signals, _handler: () => void) => process) as typeof process.once,
+      );
+
+    try {
+      await expect(serveAcpGateway({})).rejects.toThrow("gateway event loop failed");
+
+      expect(sshTunnelStop).toHaveBeenCalledTimes(1);
+      expect(mockState.agentSideConnectionCtor).not.toHaveBeenCalled();
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("stops the GatewayClient when ACP stream setup fails after gateway readiness", async () => {
+    const sshTunnelStop = vi.fn(async () => undefined);
+    mockState.ndJsonStreamError = new Error("stdio stream unavailable");
+    mockState.resolveGatewayClientBootstrap.mockResolvedValue({
+      url: "ws://127.0.0.1:19091",
+      urlSource: "config gateway.remote.url via ssh tunnel",
+      auth: {
+        token: undefined,
+        password: undefined,
+      },
+      sshTunnel: { stop: sshTunnelStop },
+    });
+    const onceSpy = vi
+      .spyOn(process, "once")
+      .mockImplementation(
+        ((_signal: NodeJS.Signals, _handler: () => void) => process) as typeof process.once,
+      );
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await vi.waitFor(() => {
+        expect(mockState.gateways).toHaveLength(1);
+      });
+      getMockGateway().emitHello();
+
+      await expect(servePromise).rejects.toThrow("stdio stream unavailable");
+
+      expect(mockState.gatewayStopAndWait).toHaveBeenCalledTimes(1);
+      expect(sshTunnelStop).toHaveBeenCalledTimes(1);
+      expect(mockState.agentSideConnectionCtor).not.toHaveBeenCalled();
     } finally {
       onceSpy.mockRestore();
     }

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -89,44 +89,53 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     }
   };
 
-  const gateway = new GatewayClient({
-    url: bootstrap.url,
-    token: bootstrap.auth.token,
-    password: bootstrap.auth.password,
-    preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs,
-    clientName: GATEWAY_CLIENT_NAMES.CLI,
-    clientDisplayName: "ACP",
-    clientVersion: "acp",
-    mode: GATEWAY_CLIENT_MODES.CLI,
-    caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
-    onEvent: (evt) => {
-      if (stopped) {
-        return;
-      }
-      // Gateway delivery stays non-blocking, but translator failures must not
-      // escape this callback as unhandled process rejections.
-      void agent?.handleGatewayEvent(evt).catch((err: unknown) => {
-        process.stderr.write(`openclaw acp: gateway event ${evt.event} failed\n`);
-        if (opts.verbose) {
-          process.stderr.write(`openclaw acp: gateway event ${evt.event} error: ${String(err)}\n`);
+  let gateway: GatewayClient;
+  try {
+    gateway = new GatewayClient({
+      url: bootstrap.url,
+      token: bootstrap.auth.token,
+      password: bootstrap.auth.password,
+      onStop: () => bootstrap.sshTunnel?.stop(),
+      ...(bootstrap.sshTunnel?.exited ? { stopWhen: bootstrap.sshTunnel.exited } : {}),
+      ...(bootstrap.tlsServerName ? { tlsServerName: bootstrap.tlsServerName } : {}),
+      preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs,
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      clientDisplayName: "ACP",
+      clientVersion: "acp",
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
+      onEvent: (evt) => {
+        if (stopped) {
+          return;
         }
-      });
-    },
-    onHelloOk: () => {
-      resolveGatewayReady();
-      agent?.handleGatewayReconnect();
-    },
-    onConnectError: (err) => {
-      rejectGatewayReady(err);
-    },
-    onClose: (code, reason) => {
-      if (stopped) {
-        return;
-      }
-      rejectGatewayReady(new Error(`gateway closed before ready (${code}): ${reason}`));
-      agent?.handleGatewayDisconnect(`${code}: ${reason}`);
-    },
-  });
+        // Gateway delivery stays non-blocking, but translator failures must not
+        // escape this callback as unhandled process rejections.
+        void agent?.handleGatewayEvent(evt).catch((err: unknown) => {
+          process.stderr.write(`openclaw acp: gateway event ${evt.event} failed\n`);
+          if (opts.verbose) {
+            process.stderr.write(`openclaw acp: gateway event ${evt.event} error: ${String(err)}\n`);
+          }
+        });
+      },
+      onHelloOk: () => {
+        resolveGatewayReady();
+        agent?.handleGatewayReconnect();
+      },
+      onConnectError: (err) => {
+        rejectGatewayReady(err);
+      },
+      onClose: (code, reason) => {
+        if (stopped) {
+          return;
+        }
+        rejectGatewayReady(new Error(`gateway closed before ready (${code}): ${reason}`));
+        agent?.handleGatewayDisconnect(`${code}: ${reason}`);
+      },
+    });
+  } catch (error) {
+    await bootstrap.sshTunnel?.stop().catch(() => undefined);
+    throw error;
+  }
 
   const shutdown = async () => {
     if (stopped) {
@@ -157,59 +166,72 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     void shutdown();
   });
 
+  const stopGatewayAfterStartupFailure = async () => {
+    if (!stopped) {
+      stopped = true;
+      resolveGatewayReady();
+      await gateway.stopAndWait().catch(() => undefined);
+      onClosed();
+    }
+  };
+
   // Start gateway first and wait for hello before accepting ACP requests.
-  const readiness = await startGatewayClientWhenEventLoopReady(gateway, {
-    clientOptions: { preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs },
-  });
-  if (!readiness.ready) {
-    rejectGatewayReady(new Error("gateway event loop readiness timeout"));
-  }
-  await gatewayReady.catch(async (err: unknown) => {
-    await shutdown();
+  try {
+    const readiness = await startGatewayClientWhenEventLoopReady(gateway, {
+      clientOptions: { preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs },
+    });
+    if (!readiness.ready) {
+      rejectGatewayReady(new Error("gateway event loop readiness timeout"));
+    }
+    await gatewayReady;
+  } catch (err) {
+    await stopGatewayAfterStartupFailure();
     throw err;
-  });
+  }
   if (stopped) {
     return closed;
   }
 
-  const input = Writable.toWeb(process.stdout);
-  const output = Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>;
-  const stream = ndJsonStream(input, output);
-  const readable = stream.readable.pipeThrough(
-    new TransformStream<AcpStreamMessage, AcpStreamMessage>({
-      transform(message, controller) {
-        controller.enqueue(normalizeAcpInitializeProtocolVersion(message));
-      },
-    }),
-  );
-  startupWork = migrateFileAcpEventLedgerToSqlite({
-    filePath: resolveDefaultAcpEventLedgerPath(process.env),
-    archiveSource: true,
-  });
   try {
-    await startupWork;
+    const input = Writable.toWeb(process.stdout);
+    const output = Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>;
+    const stream = ndJsonStream(input, output);
+    const readable = stream.readable.pipeThrough(
+      new TransformStream<AcpStreamMessage, AcpStreamMessage>({
+        transform(message, controller) {
+          controller.enqueue(normalizeAcpInitializeProtocolVersion(message));
+        },
+      }),
+    );
+    startupWork = migrateFileAcpEventLedgerToSqlite({
+      filePath: resolveDefaultAcpEventLedgerPath(process.env),
+      archiveSource: true,
+    });
+    try {
+      await startupWork;
+    } finally {
+      startupWork = null;
+    }
+    if (stopped) {
+      return closed;
+    }
+    const eventLedger = createSqliteAcpEventLedger();
+
+    void new AgentSideConnection(
+      (conn: AgentSideConnection) => {
+        agent = new AcpGatewayAgent(conn, gateway, { ...opts, eventLedger });
+        agent.start();
+        return agent;
+      },
+      { ...stream, readable },
+    );
   } catch (err) {
     if (stopped) {
       return closed;
     }
     await shutdown();
     throw err;
-  } finally {
-    startupWork = null;
   }
-  if (stopped) {
-    return closed;
-  }
-  const eventLedger = createSqliteAcpEventLedger();
-
-  void new AgentSideConnection(
-    (conn: AgentSideConnection) => {
-      agent = new AcpGatewayAgent(conn, gateway, { ...opts, eventLedger });
-      agent.start();
-      return agent;
-    },
-    { ...stream, readable },
-  );
 
   return closed;
 }

--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -52,6 +52,7 @@ export async function probeGatewayStatus(opts: {
   password?: string;
   config?: OpenClawConfig;
   tlsFingerprint?: string;
+  tlsServerName?: string;
   timeoutMs: number;
   preauthHandshakeTimeoutMs?: number;
   json?: boolean;
@@ -77,6 +78,7 @@ export async function probeGatewayStatus(opts: {
             password: opts.password,
           },
           tlsFingerprint: opts.tlsFingerprint,
+          ...(opts.tlsServerName ? { tlsServerName: opts.tlsServerName } : {}),
           ...(opts.preauthHandshakeTimeoutMs !== undefined
             ? { preauthHandshakeTimeoutMs: opts.preauthHandshakeTimeoutMs }
             : {}),
@@ -96,6 +98,7 @@ export async function probeGatewayStatus(opts: {
             token: opts.token,
             password: opts.password,
             tlsFingerprint: opts.tlsFingerprint,
+            ...(opts.tlsServerName ? { tlsServerName: opts.tlsServerName } : {}),
             ...(allowRpcConfigCredentials && opts.config ? { config: opts.config } : {}),
             method: "status",
             timeoutMs: opts.timeoutMs,

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -109,21 +109,26 @@ export async function checkGatewayHealth(params: {
   } catch (err) {
     if (isGatewayHealthAuthUnavailableError(err)) {
       const probeDetails = await buildGatewayProbeConnectionDetails({ config: params.cfg });
-      const probe = await probeGatewayStatus({
-        url: probeDetails.url,
-        timeoutMs,
-        tlsFingerprint: probeDetails.tlsFingerprint,
-        preauthHandshakeTimeoutMs: probeDetails.preauthHandshakeTimeoutMs,
-        config: params.cfg,
-        json: true,
-      });
-      if (gatewayProbeResultSawGateway(probe)) {
-        note(
-          GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
-          GATEWAY_HEALTH_CREDENTIALS_REQUIRED_TITLE,
-        );
-        healthOk = true;
-        return { healthOk, authenticated: false };
+      try {
+        const probe = await probeGatewayStatus({
+          url: probeDetails.url,
+          timeoutMs,
+          tlsFingerprint: probeDetails.tlsFingerprint,
+          ...(probeDetails.tlsServerName ? { tlsServerName: probeDetails.tlsServerName } : {}),
+          preauthHandshakeTimeoutMs: probeDetails.preauthHandshakeTimeoutMs,
+          config: params.cfg,
+          json: true,
+        });
+        if (gatewayProbeResultSawGateway(probe)) {
+          note(
+            GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
+            GATEWAY_HEALTH_CREDENTIALS_REQUIRED_TITLE,
+          );
+          healthOk = true;
+          return { healthOk, authenticated: false };
+        }
+      } finally {
+        await Promise.resolve(probeDetails.sshTunnel?.stop()).catch(() => undefined);
       }
     }
     const message = String(err);

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -75,14 +75,23 @@ const buildGatewayConnectionDetailsMock = vi.fn(() => ({
   message: TEST_GATEWAY_MESSAGE,
   url: TEST_GATEWAY_URL,
 }));
-const buildGatewayProbeConnectionDetailsMock = vi.fn(() => ({
-  message: TEST_GATEWAY_MESSAGE,
-  preauthHandshakeTimeoutMs: 4321,
-  tlsFingerprint: TEST_TLS_FINGERPRINT,
-  url: TEST_GATEWAY_URL,
-}));
+const buildGatewayProbeConnectionDetailsMock = vi.fn(
+  (): {
+    message: string;
+    preauthHandshakeTimeoutMs: number;
+    tlsFingerprint: string;
+    url: string;
+    sshTunnel?: { stop: () => void | Promise<void> };
+  } => ({
+    message: TEST_GATEWAY_MESSAGE,
+    preauthHandshakeTimeoutMs: 4321,
+    tlsFingerprint: TEST_TLS_FINGERPRINT,
+    url: TEST_GATEWAY_URL,
+  }),
+);
 const formatGatewayTransportErrorJsonMock = vi.fn();
 const probeGatewayStatusMock = vi.fn();
+const probeSshTunnelStopMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => callGatewayMock(...args),
   buildGatewayConnectionDetails: (...args: [unknown, ...unknown[]]) =>
@@ -149,6 +158,7 @@ describe("healthCommand", () => {
     isGatewayCredentialsRequiredErrorMock.mockReturnValue(false);
     isGatewaySecretRefUnavailableErrorMock.mockReturnValue(false);
     probeGatewayStatusMock.mockReset();
+    probeSshTunnelStopMock.mockReset();
   });
 
   it("outputs JSON from gateway", async () => {
@@ -399,6 +409,13 @@ describe("healthCommand", () => {
     const error = new Error("gateway.auth.password is unavailable");
     callGatewayMock.mockRejectedValueOnce(error);
     isGatewaySecretRefUnavailableErrorMock.mockReturnValueOnce(true);
+    buildGatewayProbeConnectionDetailsMock.mockReturnValueOnce({
+      message: TEST_GATEWAY_MESSAGE,
+      preauthHandshakeTimeoutMs: 4321,
+      tlsFingerprint: TEST_TLS_FINGERPRINT,
+      url: TEST_GATEWAY_URL,
+      sshTunnel: { stop: probeSshTunnelStopMock },
+    });
     probeGatewayStatusMock.mockResolvedValueOnce({
       ok: false,
       kind: "connect",
@@ -423,6 +440,7 @@ describe("healthCommand", () => {
       [GATEWAY_HEALTH_REACHABLE_LINE],
       [GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE],
     ]);
+    expect(probeSshTunnelStopMock).toHaveBeenCalledTimes(1);
     expect(runtime.error).not.toHaveBeenCalled();
   });
 

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -97,29 +97,34 @@ export async function emitReachableGatewayAuthDiagnostic(params: {
     password: params.password,
     localPortOverride: params.localPortOverride,
   });
-  const probe = await probeGatewayStatus({
-    url: details.url,
-    token: params.token,
-    password: params.password,
-    tlsFingerprint: details.tlsFingerprint,
-    preauthHandshakeTimeoutMs: details.preauthHandshakeTimeoutMs,
-    timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-    config: params.config,
-    json: params.json,
-  });
-  if (!gatewayProbeResultSawGateway(probe)) {
-    return false;
-  }
-  const diagnostic = buildCredentialsRequiredHealthDiagnostic();
-  if (params.json) {
-    writeRuntimeJson(params.runtime, diagnostic);
+  try {
+    const probe = await probeGatewayStatus({
+      url: details.url,
+      token: params.token,
+      password: params.password,
+      tlsFingerprint: details.tlsFingerprint,
+      ...(details.tlsServerName ? { tlsServerName: details.tlsServerName } : {}),
+      preauthHandshakeTimeoutMs: details.preauthHandshakeTimeoutMs,
+      timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      config: params.config,
+      json: params.json,
+    });
+    if (!gatewayProbeResultSawGateway(probe)) {
+      return false;
+    }
+    const diagnostic = buildCredentialsRequiredHealthDiagnostic();
+    if (params.json) {
+      writeRuntimeJson(params.runtime, diagnostic);
+      params.runtime.exit(1);
+      return true;
+    }
+    params.runtime.log(GATEWAY_HEALTH_REACHABLE_LINE);
+    params.runtime.log(diagnostic.error.message);
     params.runtime.exit(1);
     return true;
+  } finally {
+    await Promise.resolve(details.sshTunnel?.stop()).catch(() => undefined);
   }
-  params.runtime.log(GATEWAY_HEALTH_REACHABLE_LINE);
-  params.runtime.log(diagnostic.error.message);
-  params.runtime.exit(1);
-  return true;
 }
 
 const loadConfigRuntime = async () => await import("../config/config.js");

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -90,31 +90,36 @@ export async function collectGatewayHealthFindings(
     ];
   }
 
-  const probe = await probeGatewayStatus({
-    url: probeDetails.url,
-    timeoutMs: 3000,
-    tlsFingerprint: probeDetails.tlsFingerprint,
-    preauthHandshakeTimeoutMs: probeDetails.preauthHandshakeTimeoutMs,
-    config: ctx.cfg,
-    json: true,
-  });
-  if (gatewayProbeResultSawGateway(probe)) {
-    return [];
+  try {
+    const probe = await probeGatewayStatus({
+      url: probeDetails.url,
+      timeoutMs: 3000,
+      tlsFingerprint: probeDetails.tlsFingerprint,
+      ...(probeDetails.tlsServerName ? { tlsServerName: probeDetails.tlsServerName } : {}),
+      preauthHandshakeTimeoutMs: probeDetails.preauthHandshakeTimeoutMs,
+      config: ctx.cfg,
+      json: true,
+    });
+    if (gatewayProbeResultSawGateway(probe)) {
+      return [];
+    }
+    const mode = ctx.cfg.gateway?.mode === "remote" ? "remote" : "local";
+    return [
+      {
+        checkId: "core/doctor/gateway-health",
+        severity: "warning",
+        message: `Gateway is not reachable: ${probe.error ?? "status probe failed"}`,
+        path: mode === "remote" ? "gateway.remote.url" : "gateway.mode",
+        target: formatGatewayHealthTarget(probeDetails.url),
+        fixHint:
+          mode === "remote"
+            ? "Verify the remote Gateway URL, network path, TLS settings, and credentials."
+            : "Start the Gateway service or run `openclaw doctor --fix` for service repair prompts.",
+      },
+    ];
+  } finally {
+    await Promise.resolve(probeDetails.sshTunnel?.stop()).catch(() => undefined);
   }
-  const mode = ctx.cfg.gateway?.mode === "remote" ? "remote" : "local";
-  return [
-    {
-      checkId: "core/doctor/gateway-health",
-      severity: "warning",
-      message: `Gateway is not reachable: ${probe.error ?? "status probe failed"}`,
-      path: mode === "remote" ? "gateway.remote.url" : "gateway.mode",
-      target: formatGatewayHealthTarget(probeDetails.url),
-      fixHint:
-        mode === "remote"
-          ? "Verify the remote Gateway URL, network path, TLS settings, and credentials."
-          : "Start the Gateway service or run `openclaw doctor --fix` for service repair prompts.",
-    },
-  ];
 }
 
 function gatewayRuntimeStatus(runtime: GatewayServiceRuntime | undefined): string | undefined {

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -29,6 +29,8 @@ const deviceIdentityState = vi.hoisted(() => ({
 const loadDeviceAuthTokenMock = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => DeviceAuthEntry | null>(() => null),
 );
+const startSshPortForwardMock = vi.hoisted(() => vi.fn());
+const stopSshTunnelMock = vi.hoisted(() => vi.fn());
 
 const eventLoopReadyState = vi.hoisted(() => ({
   calls: [] as Array<{ maxWaitMs?: number } | undefined>,
@@ -67,6 +69,7 @@ let lastClientOptions: {
   token?: string;
   password?: string;
   tlsFingerprint?: string;
+  tlsServerName?: string;
   preauthHandshakeTimeoutMs?: number;
   clientName?: string;
   clientDisplayName?: string;
@@ -204,6 +207,10 @@ vi.mock("./event-loop-ready.js", () => ({
   }),
 }));
 
+vi.mock("../infra/ssh-tunnel.js", () => ({
+  startSshPortForward: (...args: unknown[]) => startSshPortForwardMock(...args),
+}));
+
 const {
   testing,
   buildGatewayConnectionDetails,
@@ -294,6 +301,8 @@ function resetGatewayCallMocks() {
     resolveGatewayPort: resolveGatewayPortForTests,
   });
   deviceIdentityState.throwOnLoad = false;
+  startSshPortForwardMock.mockReset();
+  stopSshTunnelMock.mockReset();
   loadDeviceAuthTokenMock.mockReset();
   loadDeviceAuthTokenMock.mockReturnValue({
     token: "paired-device-token",
@@ -430,6 +439,124 @@ describe("callGateway url resolution", () => {
 
     expect(lastClientOptions?.url).toBe("wss://override.example/ws");
     expect(lastClientOptions?.token).toBe("explicit-token");
+  });
+
+  it("opens an SSH tunnel for configured remote call paths", async () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://remote.example.com:18789",
+          transport: "ssh",
+          sshTarget: "user@gateway.example",
+          sshIdentity: "~/.ssh/id_ed25519",
+          token: "remote-token",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    startSshPortForwardMock.mockResolvedValue({
+      parsedTarget: { user: "user", host: "gateway.example", port: 22 },
+      localPort: 19091,
+      remotePort: 18789,
+      pid: 1234,
+      stderr: [],
+      stop: stopSshTunnelMock,
+    });
+
+    await callGateway({ method: "health" });
+
+    expect(startSshPortForwardMock).toHaveBeenCalledWith({
+      target: "user@gateway.example",
+      identity: "~/.ssh/id_ed25519",
+      localPortPreferred: 18789,
+      remotePort: 18789,
+      timeoutMs: expect.any(Number),
+    });
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:19091");
+    expect(lastClientOptions?.token).toBe("remote-token");
+    expect(lastClientOptions?.deviceIdentity).toEqual(deviceIdentityState.value);
+    expect(stopSshTunnelMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the remote TLS server name for configured wss SSH tunnels", async () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example.com:9443/ws",
+          transport: "ssh",
+          sshTarget: "user@gateway.example",
+          token: "remote-token",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    startSshPortForwardMock.mockResolvedValue({
+      parsedTarget: { user: "user", host: "gateway.example", port: 22 },
+      localPort: 19091,
+      remotePort: 18789,
+      pid: 1234,
+      stderr: [],
+      stop: stopSshTunnelMock,
+    });
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.url).toBe("wss://127.0.0.1:19091/ws");
+    expect(lastClientOptions?.tlsServerName).toBe("gateway.example.com");
+    expect(stopSshTunnelMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses externally managed SSH tunnel URLs when sshTarget is absent", async () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://127.0.0.1:18789",
+          transport: "ssh",
+          token: "remote-token",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+
+    await callGateway({ method: "health" });
+
+    expect(startSshPortForwardMock).not.toHaveBeenCalled();
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18789");
+    expect(lastClientOptions?.token).toBe("remote-token");
+  });
+
+  it("stops configured SSH tunnels when auth validation fails before connecting", async () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://remote.example.com:18789",
+          transport: "ssh",
+          sshTarget: "user@gateway.example",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    loadDeviceAuthTokenMock.mockReturnValue(null);
+    startSshPortForwardMock.mockResolvedValue({
+      parsedTarget: { user: "user", host: "gateway.example", port: 22 },
+      localPort: 19091,
+      remotePort: 18789,
+      pid: 1234,
+      stderr: [],
+      stop: stopSshTunnelMock,
+    });
+
+    await expect(callGateway({ method: "sessions.list" })).rejects.toThrow(
+      "requires credentials before opening a websocket",
+    );
+
+    expect(startSshPortForwardMock).toHaveBeenCalledTimes(1);
+    expect(stopSshTunnelMock).toHaveBeenCalledTimes(1);
+    expect(lastClientOptions).toBeNull();
   });
 
   it("skips config loading when explicit url and token are provided", async () => {
@@ -1160,6 +1287,61 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.preauthHandshakeTimeoutMs).toBe(4321);
   });
 
+  it("keeps externally managed SSH tunnel probe URLs when sshTarget is absent", async () => {
+    const config = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://127.0.0.1:18789",
+          transport: "ssh",
+        },
+      },
+    } satisfies OpenClawConfig;
+    resolveGatewayPort.mockReturnValue(18789);
+
+    const details = await buildGatewayProbeConnectionDetails({ config });
+
+    expect(startSshPortForwardMock).not.toHaveBeenCalled();
+    expect(details.url).toBe("ws://127.0.0.1:18789");
+    expect(details.urlSource).toBe("config gateway.remote.url");
+  });
+
+  it("opens configured SSH tunnels for probe details", async () => {
+    const config = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://remote.example.com:18789",
+          transport: "ssh",
+          sshTarget: "user@gateway.example",
+        },
+      },
+    } satisfies OpenClawConfig;
+    resolveGatewayPort.mockReturnValue(18789);
+    startSshPortForwardMock.mockResolvedValue({
+      parsedTarget: { user: "user", host: "gateway.example", port: 22 },
+      localPort: 19091,
+      remotePort: 18789,
+      pid: 1234,
+      stderr: [],
+      stop: stopSshTunnelMock,
+    });
+
+    const details = await buildGatewayProbeConnectionDetails({ config });
+
+    expect(startSshPortForwardMock).toHaveBeenCalledWith({
+      target: "user@gateway.example",
+      identity: undefined,
+      localPortPreferred: 18789,
+      remotePort: 18789,
+      timeoutMs: expect.any(Number),
+    });
+    expect(details.url).toBe("ws://127.0.0.1:19091");
+    expect(details.urlSource).toBe("config gateway.remote.url via ssh tunnel");
+    await details.sshTunnel?.stop();
+    expect(stopSshTunnelMock).toHaveBeenCalledTimes(1);
+  });
+
   it("lets probe details local port override bypass gateway env URL and port", async () => {
     const config = {
       gateway: {
@@ -1377,6 +1559,165 @@ describe("buildGatewayConnectionDetails", () => {
     expect((thrown as Error).message).toContain("wss://");
     expect((thrown as Error).message).toContain("Tailscale Serve/Funnel");
     expect((thrown as Error).message).toContain("openclaw doctor --fix");
+  });
+
+  it("rejects plaintext ws remote URLs by default when SSH transport has sshTarget", () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        remote: {
+          url: "ws://remote.example.com:18789",
+          transport: "ssh",
+          sshTarget: "user@gateway.example",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+
+    expect(() => buildGatewayConnectionDetails()).toThrow("SECURITY ERROR");
+  });
+
+  it("allows plaintext ws remote URLs when the caller opts into owning the SSH tunnel", () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        remote: {
+          url: "ws://remote.example.com:18789",
+          transport: "ssh",
+          sshTarget: "user@gateway.example",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+
+    const details = buildGatewayConnectionDetails({ allowConfiguredSshTransport: true });
+
+    expect(details.url).toBe("ws://remote.example.com:18789");
+    expect(details.urlSource).toBe("config gateway.remote.url");
+  });
+
+  it("allows plaintext ws remote URLs for the default SSH transport when the caller owns the tunnel", () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        remote: {
+          url: "ws://remote.example.com:18789",
+          sshTarget: "user@gateway.example",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+
+    const details = buildGatewayConnectionDetails({ allowConfiguredSshTransport: true });
+
+    expect(details.url).toBe("ws://remote.example.com:18789");
+    expect(details.urlSource).toBe("config gateway.remote.url");
+  });
+
+  it.each(["not a url", "mailto:gateway"])(
+    "rejects invalid configured SSH remote URLs when the caller owns the tunnel (%s)",
+    (url) => {
+      getRuntimeConfig.mockReturnValue({
+        gateway: {
+          mode: "remote",
+          bind: "loopback",
+          remote: {
+            url,
+            transport: "ssh",
+            sshTarget: "user@gateway.example",
+          },
+        },
+      });
+      resolveGatewayPort.mockReturnValue(18789);
+
+      expect(() => buildGatewayConnectionDetails({ allowConfiguredSshTransport: true })).toThrow(
+        "SECURITY ERROR",
+      );
+    },
+  );
+
+  it("rejects plaintext CLI URL overrides when configured SSH allowance is enabled", () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        remote: {
+          url: "ws://127.0.0.1:18789",
+          transport: "ssh",
+          sshTarget: "user@gateway.example",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+
+    expect(() =>
+      buildGatewayConnectionDetails({
+        url: "ws://remote.example.com:18789",
+        allowConfiguredSshTransport: true,
+      }),
+    ).toThrow("Source: cli --url");
+  });
+
+  it("rejects plaintext env URL overrides when configured SSH allowance is enabled", () => {
+    try {
+      setTestEnvValue("OPENCLAW_GATEWAY_URL", "ws://remote.example.com:18789");
+      getRuntimeConfig.mockReturnValue({
+        gateway: {
+          mode: "remote",
+          bind: "loopback",
+          remote: {
+            url: "ws://127.0.0.1:18789",
+            transport: "ssh",
+            sshTarget: "user@gateway.example",
+          },
+        },
+      });
+      resolveGatewayPort.mockReturnValue(18789);
+
+      expect(() => buildGatewayConnectionDetails({ allowConfiguredSshTransport: true })).toThrow(
+        "Source: env OPENCLAW_GATEWAY_URL",
+      );
+    } finally {
+      deleteTestEnvValue("OPENCLAW_GATEWAY_URL");
+    }
+  });
+
+  it("rejects plaintext direct transport URLs when configured SSH allowance is enabled", () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        remote: {
+          url: "ws://remote.example.com:18789",
+          transport: "direct",
+          sshTarget: "user@gateway.example",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+
+    expect(() => buildGatewayConnectionDetails({ allowConfiguredSshTransport: true })).toThrow(
+      "Source: config gateway.remote.url",
+    );
+  });
+
+  it("rejects plaintext ws remote URLs when SSH transport has no sshTarget", () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        remote: {
+          url: "ws://remote.example.com:18789",
+          transport: "ssh",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+
+    expect(() => buildGatewayConnectionDetails()).toThrow("SECURITY ERROR");
   });
 
   it("redacts credential-bearing target URLs from insecure ws:// errors", () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -59,6 +59,11 @@ import {
   resolveLeastPrivilegeOperatorScopesForMethod,
   type OperatorScope,
 } from "./method-scopes.js";
+import {
+  applyGatewaySshTunnelConnectionDetails,
+  startGatewayRemoteSshTunnel,
+  type GatewaySshTunnelConnection,
+} from "./ssh-transport.js";
 export type { GatewayConnectionDetails };
 
 export type GatewayRequestFunction = <T = Record<string, unknown>>(
@@ -72,6 +77,7 @@ type CallGatewayBaseOptions = {
   token?: string;
   password?: string;
   tlsFingerprint?: string;
+  tlsServerName?: string;
   config?: OpenClawConfig;
   method: string;
   params?: unknown;
@@ -219,7 +225,9 @@ export type GatewayClientRequestErrorJson = {
 
 export type GatewayProbeConnectionDetails = GatewayConnectionDetails & {
   tlsFingerprint?: string;
+  tlsServerName?: string;
   preauthHandshakeTimeoutMs?: number;
+  sshTunnel?: GatewaySshTunnelConnection["tunnel"];
 };
 
 function firstGatewayErrorLine(message: string): string {
@@ -430,6 +438,7 @@ export function buildGatewayConnectionDetails(
     urlSource?: "cli" | "env";
     ignoreEnvUrlOverride?: boolean;
     localPortOverride?: number;
+    allowConfiguredSshTransport?: boolean;
   } = {},
 ): GatewayConnectionDetails {
   return buildGatewayConnectionDetailsWithResolvers(options, {
@@ -488,7 +497,11 @@ function shouldOmitDeviceIdentityForGatewayCall(params: {
   token?: string;
   password?: string;
   allowAuthNone?: boolean;
+  tunneledRemote?: boolean;
 }): boolean {
+  if (params.tunneledRemote === true) {
+    return false;
+  }
   const mode = params.opts.mode ?? GATEWAY_CLIENT_MODES.CLI;
   const clientName = params.opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI;
   // Inactive ambient credentials must not turn an auth-none CLI call device-less.
@@ -510,7 +523,18 @@ function shouldOmitDeviceIdentityForGatewayCall(params: {
   return isLocalBackendSharedAuth || isLocalCliSharedAuth;
 }
 
-function resolveDeviceIdentityForGatewayCall(): DeviceIdentity | null {
+function resolveDeviceIdentityForGatewayCall(params: {
+  opts: CallGatewayBaseOptions;
+  url: string;
+  authMode: ReturnType<typeof resolveGatewayAuth>["mode"];
+  token?: string;
+  password?: string;
+  allowAuthNone?: boolean;
+  tunneledRemote?: boolean;
+}): DeviceIdentity | null {
+  if (shouldOmitDeviceIdentityForGatewayCall(params)) {
+    return null;
+  }
   try {
     return gatewayCallDeps.loadOrCreateDeviceIdentity();
   } catch {
@@ -908,6 +932,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
   token?: string;
   password?: string;
   tlsFingerprint?: string;
+  tlsServerName?: string;
   preauthHandshakeTimeoutMs?: number;
   timeoutMs: number | null;
   startupTimeoutMs: number;
@@ -923,6 +948,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
     token,
     password,
     tlsFingerprint,
+    tlsServerName,
     preauthHandshakeTimeoutMs,
     timeoutMs,
     startupTimeoutMs,
@@ -1003,6 +1029,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       token,
       password,
       tlsFingerprint,
+      ...(tlsServerName ? { tlsServerName } : {}),
       preauthHandshakeTimeoutMs,
       instanceId: opts.instanceId ?? randomUUID(),
       clientName: opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
@@ -1161,85 +1188,113 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     configPath: context.configPath,
   });
   ensureRemoteModeUrlConfigured(context);
-  const connectionDetails = buildGatewayConnectionDetails({
+  let connectionDetails = buildGatewayConnectionDetails({
     config: context.config,
     url: context.urlOverride,
     urlSource: context.urlOverrideSource,
     ignoreEnvUrlOverride: opts.localPortOverride !== undefined,
     localPortOverride: opts.localPortOverride,
+    allowConfiguredSshTransport: true,
     ...(opts.configPath ? { configPath: opts.configPath } : {}),
   });
-  const url = connectionDetails.url;
-  const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
-  const token = useStoredDeviceAuth ? undefined : resolvedCredentials.token;
-  const password = useStoredDeviceAuth ? undefined : resolvedCredentials.password;
-  const authMode = resolveGatewayCallAuth(context.config).mode;
-  const allowAuthNone = opts.requireLocalBackendSharedAuth === true && authMode === "none";
-  const omitDeviceIdentity = shouldOmitDeviceIdentityForGatewayCall({
-    opts,
-    url,
-    authMode,
-    token,
-    password,
-    allowAuthNone,
+  const connectionDetailsBeforeSsh = connectionDetails;
+  const ssh = await startGatewayRemoteSshTunnel({
+    config: context.config,
+    url: connectionDetails.url,
+    urlSource: connectionDetails.urlSource,
   });
-  if (opts.requireLocalBackendSharedAuth && !omitDeviceIdentity) {
-    throw new GatewayLocalBackendSharedAuthUnavailableError(
-      "local backend shared auth requires a loopback gateway with token/password credentials or auth mode none",
-    );
-  }
-  const deviceIdentity =
-    opts.deviceIdentity === undefined
-      ? omitDeviceIdentity
-        ? null
-        : resolveDeviceIdentityForGatewayCall()
-      : opts.deviceIdentity;
-  if (useStoredDeviceAuth) {
-    const storedAuth = loadStoredOperatorDeviceAuthToken(deviceIdentity);
-    if (!storedAuth?.token) {
-      throw new GatewayCredentialsRequiredError({
-        method: opts.method,
-        configPath: context.configPath,
+  try {
+    if (ssh) {
+      connectionDetails = applyGatewaySshTunnelConnectionDetails({
+        details: connectionDetails,
+        ssh,
       });
     }
-    if (
-      Array.isArray(opts.requiredStoredDeviceAuthScopes) &&
-      !roleScopesAllow({
-        role: "operator",
-        requestedScopes: opts.requiredStoredDeviceAuthScopes,
-        allowedScopes: storedAuth.scopes,
-      })
-    ) {
-      throw new GatewayStoredDeviceAuthUnavailableError(
-        "stored device auth does not grant the required operator scopes",
+    const url = connectionDetails.url;
+    const deviceIdentityUrl = ssh ? connectionDetailsBeforeSsh.url : url;
+    const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
+    const token = useStoredDeviceAuth ? undefined : resolvedCredentials.token;
+    const password = useStoredDeviceAuth ? undefined : resolvedCredentials.password;
+    const authMode = resolveGatewayCallAuth(context.config).mode;
+    const allowAuthNone = opts.requireLocalBackendSharedAuth === true && authMode === "none";
+    const omitDeviceIdentity = shouldOmitDeviceIdentityForGatewayCall({
+      opts,
+      url: deviceIdentityUrl,
+      authMode,
+      token,
+      password,
+      allowAuthNone,
+      tunneledRemote: Boolean(ssh),
+    });
+    if (opts.requireLocalBackendSharedAuth && !omitDeviceIdentity) {
+      throw new GatewayLocalBackendSharedAuthUnavailableError(
+        "local backend shared auth requires a loopback gateway with token/password credentials or auth mode none",
       );
     }
+    const deviceIdentity =
+      opts.deviceIdentity === undefined
+        ? omitDeviceIdentity
+          ? null
+          : resolveDeviceIdentityForGatewayCall({
+              opts,
+              url: deviceIdentityUrl,
+              authMode,
+              token,
+              password,
+              allowAuthNone,
+              tunneledRemote: Boolean(ssh),
+            })
+        : opts.deviceIdentity;
+    if (useStoredDeviceAuth) {
+      const storedAuth = loadStoredOperatorDeviceAuthToken(deviceIdentity);
+      if (!storedAuth?.token) {
+        throw new GatewayCredentialsRequiredError({
+          method: opts.method,
+          configPath: context.configPath,
+        });
+      }
+      if (
+        Array.isArray(opts.requiredStoredDeviceAuthScopes) &&
+        !roleScopesAllow({
+          role: "operator",
+          requestedScopes: opts.requiredStoredDeviceAuthScopes,
+          allowedScopes: storedAuth.scopes,
+        })
+      ) {
+        throw new GatewayStoredDeviceAuthUnavailableError(
+          "stored device auth does not grant the required operator scopes",
+        );
+      }
+    }
+    ensureGatewayCallCanAuthenticate({
+      opts,
+      context,
+      token,
+      password,
+      deviceIdentity,
+    });
+    return await executeGatewayRequestWithScopes<T>({
+      opts,
+      scopes: useStoredDeviceAuth ? undefined : scopes,
+      url,
+      token,
+      password,
+      tlsFingerprint,
+      tlsServerName: opts.tlsServerName ?? ssh?.tlsServerName,
+      preauthHandshakeTimeoutMs: context.config.gateway?.handshakeTimeoutMs,
+      timeoutMs,
+      startupTimeoutMs,
+      safeTimerTimeoutMs,
+      connectionDetails,
+      deviceIdentity,
+      surfaceGatewayClientRequestErrors:
+        useStoredDeviceAuth ||
+        opts.requireLocalBackendSharedAuth === true ||
+        Boolean(opts.agentRuntimeIdentityToken),
+    });
+  } finally {
+    await ssh?.tunnel.stop();
   }
-  ensureGatewayCallCanAuthenticate({
-    opts,
-    context,
-    token,
-    password,
-    deviceIdentity,
-  });
-  return await executeGatewayRequestWithScopes<T>({
-    opts,
-    scopes: useStoredDeviceAuth ? undefined : scopes,
-    url,
-    token,
-    password,
-    tlsFingerprint,
-    preauthHandshakeTimeoutMs: context.config.gateway?.handshakeTimeoutMs,
-    timeoutMs,
-    startupTimeoutMs,
-    safeTimerTimeoutMs,
-    connectionDetails,
-    deviceIdentity,
-    surfaceGatewayClientRequestErrors:
-      useStoredDeviceAuth ||
-      opts.requireLocalBackendSharedAuth === true ||
-      Boolean(opts.agentRuntimeIdentityToken),
-  });
 }
 
 export async function buildGatewayProbeConnectionDetails(
@@ -1254,26 +1309,46 @@ export async function buildGatewayProbeConnectionDetails(
   } satisfies CallGatewayBaseOptions;
   const context = await resolveGatewayCallContext(callOpts);
   ensureRemoteModeUrlConfigured(context);
-  const connectionDetails = buildGatewayConnectionDetails({
-    config: context.config,
-    url: context.urlOverride,
-    urlSource: context.urlOverrideSource,
-    ignoreEnvUrlOverride: opts.localPortOverride !== undefined,
-    localPortOverride: opts.localPortOverride,
-    ...(opts.configPath ? { configPath: opts.configPath } : {}),
-  });
-  const tlsFingerprint = await resolveGatewayTlsFingerprint({
-    opts: callOpts,
-    context,
-    url: connectionDetails.url,
-  });
-  return {
-    ...connectionDetails,
-    ...(tlsFingerprint ? { tlsFingerprint } : {}),
-    ...(context.config.gateway?.handshakeTimeoutMs
-      ? { preauthHandshakeTimeoutMs: context.config.gateway.handshakeTimeoutMs }
-      : {}),
-  };
+  let ssh: GatewaySshTunnelConnection | null = null;
+  try {
+    let connectionDetails = buildGatewayConnectionDetails({
+      config: context.config,
+      url: context.urlOverride,
+      urlSource: context.urlOverrideSource,
+      ignoreEnvUrlOverride: opts.localPortOverride !== undefined,
+      localPortOverride: opts.localPortOverride,
+      allowConfiguredSshTransport: true,
+      ...(opts.configPath ? { configPath: opts.configPath } : {}),
+    });
+    ssh = await startGatewayRemoteSshTunnel({
+      config: context.config,
+      url: connectionDetails.url,
+      urlSource: connectionDetails.urlSource,
+    });
+    if (ssh) {
+      connectionDetails = applyGatewaySshTunnelConnectionDetails({
+        details: connectionDetails,
+        ssh,
+      });
+    }
+    const tlsFingerprint = await resolveGatewayTlsFingerprint({
+      opts: callOpts,
+      context,
+      url: connectionDetails.url,
+    });
+    return {
+      ...connectionDetails,
+      ...(tlsFingerprint ? { tlsFingerprint } : {}),
+      ...(ssh?.tlsServerName ? { tlsServerName: ssh.tlsServerName } : {}),
+      ...(ssh ? { sshTunnel: ssh.tunnel } : {}),
+      ...(context.config.gateway?.handshakeTimeoutMs
+        ? { preauthHandshakeTimeoutMs: context.config.gateway.handshakeTimeoutMs }
+        : {}),
+    };
+  } catch (err) {
+    await Promise.resolve(ssh?.tunnel.stop()).catch(() => undefined);
+    throw err;
+  }
 }
 
 export async function callGatewayCli<T = Record<string, unknown>>(

--- a/src/gateway/client-bootstrap.test.ts
+++ b/src/gateway/client-bootstrap.test.ts
@@ -8,6 +8,8 @@ type AuthResolutionParams = Parameters<typeof resolveGatewayConnectionAuth>[0];
 const mockState = vi.hoisted(() => ({
   buildGatewayConnectionDetails: vi.fn(),
   resolveGatewayConnectionAuth: vi.fn(),
+  startSshPortForward: vi.fn(),
+  stopSshTunnel: vi.fn(),
 }));
 
 vi.mock("./connection-details.js", () => ({
@@ -18,6 +20,10 @@ vi.mock("./connection-details.js", () => ({
 vi.mock("./connection-auth.js", () => ({
   resolveGatewayConnectionAuth: (...args: unknown[]) =>
     mockState.resolveGatewayConnectionAuth(...args),
+}));
+
+vi.mock("../infra/ssh-tunnel.js", () => ({
+  startSshPortForward: (...args: unknown[]) => mockState.startSshPortForward(...args),
 }));
 
 const { resolveGatewayClientBootstrap, resolveGatewayUrlOverrideSource } =
@@ -49,6 +55,8 @@ describe("resolveGatewayClientBootstrap", () => {
   beforeEach(() => {
     mockState.buildGatewayConnectionDetails.mockReset();
     mockState.resolveGatewayConnectionAuth.mockReset();
+    mockState.startSshPortForward.mockReset();
+    mockState.stopSshTunnel.mockReset();
     mockState.resolveGatewayConnectionAuth.mockResolvedValue({
       token: undefined,
       password: undefined,
@@ -97,6 +105,122 @@ describe("resolveGatewayClientBootstrap", () => {
       urlOverride: undefined,
       urlOverrideSource: undefined,
     });
+  });
+
+  it("opens an SSH tunnel and returns the local tunnel URL for configured SSH transport", async () => {
+    mockState.buildGatewayConnectionDetails.mockReturnValue({
+      url: "ws://remote.example.com:18789",
+      urlSource: "config gateway.remote.url",
+    });
+    mockState.startSshPortForward.mockResolvedValue({
+      parsedTarget: { user: "user", host: "gateway.example", port: 22 },
+      localPort: 19091,
+      remotePort: 18789,
+      pid: 1234,
+      stderr: [],
+      stop: mockState.stopSshTunnel,
+    });
+
+    const result = await resolveGatewayClientBootstrap({
+      config: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "ws://remote.example.com:18789",
+            transport: "ssh",
+            sshTarget: "user@gateway.example",
+            sshIdentity: "~/.ssh/id_ed25519",
+          },
+        },
+      } as never,
+      env: process.env,
+    });
+
+    expect(mockState.startSshPortForward).toHaveBeenCalledWith({
+      target: "user@gateway.example",
+      identity: "~/.ssh/id_ed25519",
+      localPortPreferred: 18789,
+      remotePort: 18789,
+      timeoutMs: expect.any(Number),
+    });
+    expect(result.url).toBe("ws://127.0.0.1:19091");
+    expect(result.urlSource).toBe("config gateway.remote.url via ssh tunnel");
+    await result.sshTunnel?.stop();
+    expect(mockState.stopSshTunnel).toHaveBeenCalledTimes(1);
+    expectLastAuthResolutionParams({
+      urlOverride: undefined,
+      urlOverrideSource: undefined,
+    });
+  });
+
+  it("opens an SSH tunnel when remote transport is omitted", async () => {
+    mockState.buildGatewayConnectionDetails.mockReturnValue({
+      url: "ws://remote.example.com:18789",
+      urlSource: "config gateway.remote.url",
+    });
+    mockState.startSshPortForward.mockResolvedValue({
+      parsedTarget: { user: "user", host: "gateway.example", port: 22 },
+      localPort: 19091,
+      remotePort: 18789,
+      pid: 1234,
+      stderr: [],
+      stop: mockState.stopSshTunnel,
+    });
+
+    const result = await resolveGatewayClientBootstrap({
+      config: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "ws://remote.example.com:18789",
+            sshTarget: "user@gateway.example",
+          },
+        },
+      } as never,
+      env: process.env,
+    });
+
+    expect(mockState.startSshPortForward).toHaveBeenCalledWith({
+      target: "user@gateway.example",
+      identity: undefined,
+      localPortPreferred: 18789,
+      remotePort: 18789,
+      timeoutMs: expect.any(Number),
+    });
+    expect(result.url).toBe("ws://127.0.0.1:19091");
+    expect(result.urlSource).toBe("config gateway.remote.url via ssh tunnel");
+  });
+
+  it("keeps loopback remote URLs with omitted transport on the existing local tunnel", async () => {
+    mockState.buildGatewayConnectionDetails.mockReturnValue({
+      url: "ws://127.0.0.1:18789",
+      urlSource: "config gateway.remote.url",
+    });
+    mockState.startSshPortForward.mockResolvedValue({
+      parsedTarget: { user: "user", host: "gateway.example", port: 22 },
+      localPort: 19091,
+      remotePort: 18789,
+      pid: 1234,
+      stderr: [],
+      stop: mockState.stopSshTunnel,
+    });
+
+    const result = await resolveGatewayClientBootstrap({
+      config: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "ws://127.0.0.1:18789",
+            sshTarget: "user@gateway.example",
+          },
+        },
+      } as never,
+      env: process.env,
+    });
+
+    expect(mockState.startSshPortForward).not.toHaveBeenCalled();
+    expect(result.url).toBe("ws://127.0.0.1:18789");
+    expect(result.urlSource).toBe("config gateway.remote.url");
   });
 
   it("carries configured preauth handshake timeout for GatewayClient callers", async () => {

--- a/src/gateway/client-bootstrap.ts
+++ b/src/gateway/client-bootstrap.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveGatewayConnectionAuth } from "./connection-auth.js";
 import { buildGatewayConnectionDetailsWithResolvers } from "./connection-details.js";
 import type { ExplicitGatewayAuth } from "./credentials.js";
+import { startGatewayRemoteSshTunnel, type GatewaySshTunnelConnection } from "./ssh-transport.js";
 
 /**
  * Maps connection-detail source labels to the override kinds that affect auth fallback.
@@ -30,6 +31,8 @@ export async function resolveGatewayClientBootstrap(params: {
   url: string;
   urlSource: string;
   preauthHandshakeTimeoutMs?: number;
+  tlsServerName?: string;
+  sshTunnel?: GatewaySshTunnelConnection["tunnel"];
   auth: {
     token?: string;
     password?: string;
@@ -38,6 +41,7 @@ export async function resolveGatewayClientBootstrap(params: {
   const connection = buildGatewayConnectionDetailsWithResolvers({
     config: params.config,
     url: params.gatewayUrl,
+    allowConfiguredSshTransport: true,
   });
   const urlOverrideSource = resolveGatewayUrlOverrideSource(connection.urlSource);
   // Only direct CLI/env URL overrides should constrain token/password fallback. Config-derived
@@ -49,10 +53,17 @@ export async function resolveGatewayClientBootstrap(params: {
     urlOverride: urlOverrideSource ? connection.url : undefined,
     urlOverrideSource,
   });
-  return {
+  const ssh = await startGatewayRemoteSshTunnel({
+    config: params.config,
     url: connection.url,
     urlSource: connection.urlSource,
+  });
+  return {
+    url: ssh?.url ?? connection.url,
+    urlSource: ssh?.urlSource ?? connection.urlSource,
     preauthHandshakeTimeoutMs: params.config.gateway?.handshakeTimeoutMs,
+    ...(ssh?.tlsServerName ? { tlsServerName: ssh.tlsServerName } : {}),
+    sshTunnel: ssh?.tunnel,
     auth,
   };
 }

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -354,6 +354,30 @@ describe("GatewayClient security checks", () => {
     client.stop();
   });
 
+  it("stops when an external connection dependency exits", async () => {
+    let resolveStopWhen!: () => void;
+    const stopWhen = new Promise<void>((resolve) => {
+      resolveStopWhen = resolve;
+    });
+    const onStop = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      stopWhen,
+      onStop,
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    resolveStopWhen();
+
+    await vi.waitFor(() => {
+      expect(ws.closeCalls).toBe(1);
+    });
+    expect(onStop).toHaveBeenCalledTimes(1);
+    expect(wsInstances).toHaveLength(1);
+  });
+
   it("does not treat hostnames starting with 127 as loopback", () => {
     const onConnectError = vi.fn();
     const client = new GatewayClient({
@@ -1080,6 +1104,20 @@ describe("GatewayClient close handling", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("runs onStop once when the client is stopped", async () => {
+    const onStop = vi.fn(async () => undefined);
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onStop,
+    });
+
+    client.start();
+    await client.stopAndWait();
+    client.stop();
+
+    expect(onStop).toHaveBeenCalledTimes(1);
   });
 
   it("does not clear persisted device auth when explicit shared token is provided", () => {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -152,6 +152,9 @@ export type GatewayClientOptions = {
   minProtocol?: number;
   maxProtocol?: number;
   tlsFingerprint?: string;
+  tlsServerName?: string;
+  onStop?: () => void | Promise<void>;
+  stopWhen?: Promise<unknown>;
   onEvent?: (evt: EventFrame) => void;
   onHelloOk?: (hello: HelloOk) => void;
   onConnectError?: (err: Error) => void;
@@ -200,15 +203,32 @@ export function resolveGatewayClientConnectChallengeTimeoutMs(
 
 export class GatewayClient {
   #client: BaseGatewayClient;
+  #onStop?: () => void | Promise<void>;
+  #onStopPromise?: Promise<void>;
 
   constructor(opts: GatewayClientOptions) {
+    const { onStop, stopWhen, ...clientOptions } = opts;
+    this.#onStop = onStop;
     // Inject host deps here so the reusable package stays decoupled from
     // OpenClaw device identity, token storage, proxy routing, and logging.
     this.#client = new BaseGatewayClient({
-      ...opts,
-      clientVersion: opts.clientVersion ?? VERSION,
-      hostDeps: createOpenClawGatewayClientHostDeps(opts.hostDeps),
+      ...clientOptions,
+      clientVersion: clientOptions.clientVersion ?? VERSION,
+      hostDeps: createOpenClawGatewayClientHostDeps(clientOptions.hostDeps),
     });
+    void stopWhen?.then(
+      () => this.stop(),
+      () => this.stop(),
+    );
+  }
+
+  #runOnStop(): Promise<void> {
+    if (!this.#onStopPromise) {
+      this.#onStopPromise = Promise.resolve()
+        .then(() => this.#onStop?.())
+        .then(() => undefined);
+    }
+    return this.#onStopPromise;
   }
 
   start(): void {
@@ -217,10 +237,15 @@ export class GatewayClient {
 
   stop(): void {
     this.#client.stop();
+    void this.#runOnStop().catch(() => undefined);
   }
 
-  stopAndWait(opts?: { timeoutMs?: number }): Promise<void> {
-    return this.#client.stopAndWait(opts);
+  async stopAndWait(opts?: { timeoutMs?: number }): Promise<void> {
+    try {
+      await this.#client.stopAndWait(opts);
+    } finally {
+      await this.#runOnStop();
+    }
   }
 
   request<T = Record<string, unknown>>(

--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -3,7 +3,8 @@ import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensit
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveConfigPath, resolveGatewayPort } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { isSecureWebSocketUrl } from "./net.js";
+import { isGatewayWebSocketUrl, isSecureWebSocketUrl } from "./net.js";
+import { isGatewayRemoteSshTransport } from "./ssh-transport-config.js";
 
 /** Resolved gateway target plus redacted display text for diagnostics. */
 export type GatewayConnectionDetails = {
@@ -29,6 +30,7 @@ export function buildGatewayConnectionDetailsWithResolvers(
     urlSource?: "cli" | "env";
     ignoreEnvUrlOverride?: boolean;
     localPortOverride?: number;
+    allowConfiguredSshTransport?: boolean;
   } = {},
   resolvers: GatewayConnectionDetailResolvers = {},
 ): GatewayConnectionDetails {
@@ -74,7 +76,14 @@ export function buildGatewayConnectionDetailsWithResolvers(
     : undefined;
 
   const allowPrivateWs = process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1";
-  if (!isSecureWebSocketUrl(url, { allowPrivateWs })) {
+  const usesConfiguredSshTransport =
+    options.allowConfiguredSshTransport === true &&
+    !urlOverride &&
+    remoteUrl !== undefined &&
+    isGatewayWebSocketUrl(remoteUrl) &&
+    isGatewayRemoteSshTransport(remote) &&
+    Boolean(normalizeOptionalString(remote?.sshTarget));
+  if (!usesConfiguredSshTransport && !isSecureWebSocketUrl(url, { allowPrivateWs })) {
     throw new Error(
       [
         `SECURITY ERROR: Gateway URL "${displayUrl}" uses plaintext ws:// to a non-loopback address.`,

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -472,6 +472,16 @@ function parseHostForAddressChecks(
  * All other ws:// URLs are considered insecure because both credentials
  * AND chat/conversation data would be exposed to network interception.
  */
+export function isGatewayWebSocketUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  return Boolean(parsed.hostname) && ["ws:", "wss:"].includes(parsed.protocol);
+}
+
 export function isSecureWebSocketUrl(
   url: string,
   opts?: {

--- a/src/gateway/operator-approvals-client.test.ts
+++ b/src/gateway/operator-approvals-client.test.ts
@@ -7,6 +7,7 @@ const clientState = vi.hoisted(() => ({
   startMode: "hello" as "hello" | "close",
   close: { code: 1008, reason: "pairing required" },
   requestSpy: vi.fn(),
+  constructError: null as Error | null,
   stopSpy: vi.fn(),
   stopAndWaitSpy: vi.fn(async () => undefined),
 }));
@@ -15,12 +16,17 @@ const bootstrapState = vi.hoisted(() => ({
   url: "ws://127.0.0.1:18789",
   urlSource: "local loopback",
   auth: { token: "secret" as string | undefined, password: undefined as string | undefined },
+  sshTunnelStop: vi.fn(async () => undefined),
+  sshTunnelExited: Promise.resolve(),
 }));
 
 class MockGatewayClient {
   private readonly opts: Record<string, unknown>;
 
   constructor(opts: Record<string, unknown>) {
+    if (clientState.constructError) {
+      throw clientState.constructError;
+    }
     this.opts = opts;
     clientState.options = opts;
   }
@@ -49,10 +55,18 @@ class MockGatewayClient {
 
   stop(): void {
     clientState.stopSpy();
+    const onStop = this.opts.onStop;
+    if (typeof onStop === "function") {
+      void onStop();
+    }
   }
 
   async stopAndWait(): Promise<void> {
     await clientState.stopAndWaitSpy();
+    const onStop = this.opts.onStop;
+    if (typeof onStop === "function") {
+      await onStop();
+    }
   }
 }
 
@@ -61,6 +75,7 @@ vi.mock("./client-bootstrap.js", () => ({
     url: bootstrapState.url,
     urlSource: bootstrapState.urlSource,
     auth: bootstrapState.auth,
+    sshTunnel: { stop: bootstrapState.sshTunnelStop, exited: bootstrapState.sshTunnelExited },
   })),
 }));
 
@@ -97,11 +112,37 @@ describe("withOperatorApprovalsGatewayClient", () => {
     clientState.startMode = "hello";
     clientState.close = { code: 1008, reason: "pairing required" };
     clientState.requestSpy.mockReset().mockResolvedValue(undefined);
+    clientState.constructError = null;
     clientState.stopSpy.mockReset();
     clientState.stopAndWaitSpy.mockReset().mockResolvedValue(undefined);
     bootstrapState.url = "ws://127.0.0.1:18789";
     bootstrapState.urlSource = "local loopback";
     bootstrapState.auth = { token: "secret", password: undefined };
+    bootstrapState.sshTunnelStop.mockReset().mockResolvedValue(undefined);
+    bootstrapState.sshTunnelExited = Promise.resolve();
+  });
+
+  it("stops bootstrap SSH tunnel when the approval client closes", async () => {
+    await runOperatorApprovalsGatewayClient();
+
+    expect(bootstrapState.sshTunnelStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the approval GatewayClient when the bootstrap SSH tunnel exits", async () => {
+    await runOperatorApprovalsGatewayClient();
+
+    expect(clientState.options?.stopWhen).toBe(bootstrapState.sshTunnelExited);
+  });
+
+  it("stops bootstrap SSH tunnel when approval GatewayClient construction fails", async () => {
+    clientState.constructError = new Error("device identity unavailable");
+
+    await expect(runOperatorApprovalsGatewayClient()).rejects.toThrow(
+      "device identity unavailable",
+    );
+
+    expect(clientState.options).toBeNull();
+    expect(bootstrapState.sshTunnelStop).toHaveBeenCalledTimes(1);
   });
 
   it("waits for hello before running the callback and stops cleanly", async () => {

--- a/src/gateway/operator-approvals-client.ts
+++ b/src/gateway/operator-approvals-client.ts
@@ -45,29 +45,37 @@ export async function createOperatorApprovalsGatewayClient(
   });
   const sendsApprovalRuntimeToken = shouldSendApprovalRuntimeToken(bootstrap.urlSource);
 
-  return new GatewayClient({
-    url: bootstrap.url,
-    token: bootstrap.auth.token,
-    password: bootstrap.auth.password,
-    ...(sendsApprovalRuntimeToken
-      ? { approvalRuntimeToken: getOperatorApprovalRuntimeToken() }
-      : {}),
-    preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs,
-    clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-    clientDisplayName: params.clientDisplayName,
-    mode: GATEWAY_CLIENT_MODES.BACKEND,
-    scopes: ["operator.approvals"],
-    deviceIdentity: shouldOmitApprovalRuntimeDeviceIdentity({
-      sendsApprovalRuntimeToken,
-    })
-      ? null
-      : undefined,
-    onEvent: params.onEvent,
-    onHelloOk: params.onHelloOk,
-    onConnectError: params.onConnectError,
-    onReconnectPaused: params.onReconnectPaused,
-    onClose: params.onClose,
-  });
+  try {
+    return new GatewayClient({
+      url: bootstrap.url,
+      token: bootstrap.auth.token,
+      password: bootstrap.auth.password,
+      onStop: () => bootstrap.sshTunnel?.stop(),
+      ...(bootstrap.sshTunnel?.exited ? { stopWhen: bootstrap.sshTunnel.exited } : {}),
+      ...(bootstrap.tlsServerName ? { tlsServerName: bootstrap.tlsServerName } : {}),
+      ...(sendsApprovalRuntimeToken
+        ? { approvalRuntimeToken: getOperatorApprovalRuntimeToken() }
+        : {}),
+      preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs,
+      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientDisplayName: params.clientDisplayName,
+      mode: GATEWAY_CLIENT_MODES.BACKEND,
+      scopes: ["operator.approvals"],
+      deviceIdentity: shouldOmitApprovalRuntimeDeviceIdentity({
+        sendsApprovalRuntimeToken,
+      })
+        ? null
+        : undefined,
+      onEvent: params.onEvent,
+      onHelloOk: params.onHelloOk,
+      onConnectError: params.onConnectError,
+      onReconnectPaused: params.onReconnectPaused,
+      onClose: params.onClose,
+    });
+  } catch (error) {
+    await bootstrap.sshTunnel?.stop().catch(() => undefined);
+    throw error;
+  }
 }
 
 /** Run a callback with a started operator-approvals Gateway client and close it after. */

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -235,6 +235,7 @@ export async function probeGateway(opts: {
   includeDetails?: boolean;
   detailLevel?: "none" | "presence" | "full";
   tlsFingerprint?: string;
+  tlsServerName?: string;
   env?: NodeJS.ProcessEnv;
 }): Promise<GatewayProbeResult> {
   const startedAt = Date.now();
@@ -365,6 +366,7 @@ export async function probeGateway(opts: {
       token: opts.auth?.token,
       password: opts.auth?.password,
       tlsFingerprint: opts.tlsFingerprint,
+      ...(opts.tlsServerName ? { tlsServerName: opts.tlsServerName } : {}),
       preauthHandshakeTimeoutMs: opts.preauthHandshakeTimeoutMs,
       env: opts.env,
       scopes: [READ_SCOPE],

--- a/src/gateway/ssh-transport-config.ts
+++ b/src/gateway/ssh-transport-config.ts
@@ -1,0 +1,5 @@
+export function isGatewayRemoteSshTransport(
+  remote: { transport?: "ssh" | "direct" } | undefined,
+): boolean {
+  return Boolean(remote) && remote?.transport !== "direct";
+}

--- a/src/gateway/ssh-transport.test.ts
+++ b/src/gateway/ssh-transport.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_GATEWAY_PORT } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SshTunnel } from "../infra/ssh-tunnel.js";
+import {
+  applyGatewaySshTunnelConnectionDetails,
+  startGatewayRemoteSshTunnel,
+} from "./ssh-transport.js";
+
+const mocks = vi.hoisted(() => ({
+  startSshPortForward: vi.fn(),
+}));
+
+vi.mock("../infra/ssh-tunnel.js", () => ({
+  startSshPortForward: mocks.startSshPortForward,
+}));
+
+describe("startGatewayRemoteSshTunnel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.startSshPortForward.mockResolvedValue({
+      parsedTarget: { user: "user", host: "gateway.example", port: 22 },
+      localPort: 19089,
+      remotePort: DEFAULT_GATEWAY_PORT,
+      pid: null,
+      stderr: [],
+      stop: vi.fn(async () => undefined),
+    } satisfies SshTunnel);
+  });
+
+  it("defaults the remote SSH port to the gateway default when only the local tunnel URL has a port", async () => {
+    const config = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://127.0.0.1:19089",
+          transport: "ssh",
+          sshTarget: "user@gateway.example",
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await startGatewayRemoteSshTunnel({
+      config,
+      url: "ws://127.0.0.1:19089",
+      urlSource: "config gateway.remote.url",
+    });
+
+    expect(mocks.startSshPortForward).toHaveBeenCalledWith({
+      target: "user@gateway.example",
+      identity: undefined,
+      localPortPreferred: 19089,
+      remotePort: DEFAULT_GATEWAY_PORT,
+      timeoutMs: 5000,
+    });
+    expect(result?.url).toBe("ws://127.0.0.1:19089");
+  });
+
+  it("ignores configured remote SSH ports outside the valid TCP range", async () => {
+    const config = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://127.0.0.1:19089",
+          transport: "ssh",
+          remotePort: 70_000,
+          sshTarget: "user@gateway.example",
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    await startGatewayRemoteSshTunnel({
+      config,
+      url: "ws://127.0.0.1:19089",
+      urlSource: "config gateway.remote.url",
+    });
+
+    expect(mocks.startSshPortForward).toHaveBeenCalledWith(
+      expect.objectContaining({ remotePort: DEFAULT_GATEWAY_PORT }),
+    );
+  });
+
+  it("preserves the configured URL path when rewriting to a local tunnel", async () => {
+    const config = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://remote.example.com:18789/ws",
+          transport: "ssh",
+          sshTarget: "user@gateway.example",
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await startGatewayRemoteSshTunnel({
+      config,
+      url: "ws://remote.example.com:18789/ws",
+      urlSource: "config gateway.remote.url",
+    });
+
+    expect(result?.url).toBe("ws://127.0.0.1:19089/ws");
+  });
+
+  it.each(["not a url", "https://remote.example.com:18789"])(
+    "rejects invalid configured URLs before starting an SSH tunnel (%s)",
+    async (url) => {
+      const config = {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url,
+            transport: "ssh",
+            sshTarget: "user@gateway.example",
+          },
+        },
+      } satisfies OpenClawConfig;
+
+      await expect(
+        startGatewayRemoteSshTunnel({
+          config,
+          url,
+          urlSource: "config gateway.remote.url",
+        }),
+      ).rejects.toThrow("Invalid Gateway URL");
+      expect(mocks.startSshPortForward).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps configured target details separate from temporary SSH tunnel URLs", () => {
+    const result = applyGatewaySshTunnelConnectionDetails({
+      details: {
+        url: "ws://remote.example.com:18789",
+        urlSource: "config gateway.remote.url",
+        message: [
+          "Gateway target: ws://remote.example.com:18789",
+          "Source: config gateway.remote.url",
+          "Config: /tmp/openclaw.json",
+        ].join("\n"),
+      },
+      ssh: {
+        url: "ws://127.0.0.1:19091",
+        urlSource: "config gateway.remote.url via ssh tunnel",
+        tunnel: {
+          parsedTarget: { user: "user", host: "gateway.example", port: 22 },
+          localPort: 19091,
+          remotePort: DEFAULT_GATEWAY_PORT,
+          pid: 1234,
+          stderr: [],
+          stop: vi.fn(async () => undefined),
+        },
+      },
+    });
+
+    expect(result.url).toBe("ws://127.0.0.1:19091");
+    expect(result.message).toContain("Gateway target: ws://remote.example.com:18789");
+    expect(result.message).toContain("Source: config gateway.remote.url");
+    expect(result.message).toContain("Transport: configured SSH tunnel");
+    expect(result.message).not.toContain("ws://127.0.0.1:19091");
+  });
+});

--- a/src/gateway/ssh-transport.test.ts
+++ b/src/gateway/ssh-transport.test.ts
@@ -56,6 +56,30 @@ describe("startGatewayRemoteSshTunnel", () => {
     expect(result?.url).toBe("ws://127.0.0.1:19089");
   });
 
+  it("passes configured OpenSSH host-key policy to managed tunnels", async () => {
+    const config = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://127.0.0.1:19089",
+          transport: "ssh",
+          sshTarget: "user@gateway.example",
+          sshHostKeyPolicy: "openssh",
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    await startGatewayRemoteSshTunnel({
+      config,
+      url: "ws://127.0.0.1:19089",
+      urlSource: "config gateway.remote.url",
+    });
+
+    expect(mocks.startSshPortForward).toHaveBeenCalledWith(
+      expect.objectContaining({ hostKeyPolicy: "openssh" }),
+    );
+  });
+
   it("ignores configured remote SSH ports outside the valid TCP range", async () => {
     const config = {
       gateway: {

--- a/src/gateway/ssh-transport.ts
+++ b/src/gateway/ssh-transport.ts
@@ -1,0 +1,154 @@
+import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { DEFAULT_GATEWAY_PORT, resolveGatewayPort } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { startSshPortForward, type SshTunnel } from "../infra/ssh-tunnel.js";
+import type { GatewayConnectionDetails } from "./connection-details.js";
+import { isGatewayWebSocketUrl } from "./net.js";
+import { isGatewayRemoteSshTransport } from "./ssh-transport-config.js";
+
+export type GatewaySshTunnelConnection = {
+  url: string;
+  urlSource: string;
+  tunnel: SshTunnel;
+  tlsServerName?: string;
+};
+
+const DEFAULT_SSH_TUNNEL_TIMEOUT_MS = 5_000;
+
+function parseGatewayTunnelUrl(rawUrl: string): URL {
+  if (!isGatewayWebSocketUrl(rawUrl)) {
+    throw new Error(
+      `Invalid Gateway URL for configured SSH transport: ${redactSensitiveUrlLikeString(rawUrl)}`,
+    );
+  }
+  return new URL(rawUrl);
+}
+
+function parseExplicitUrlPort(url: URL): number | undefined {
+  const port = Number(url.port);
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : undefined;
+}
+
+function resolveRemoteSshPort(config: OpenClawConfig): number {
+  const remotePort = config.gateway?.remote?.remotePort;
+  return typeof remotePort === "number" &&
+    Number.isInteger(remotePort) &&
+    remotePort > 0 &&
+    remotePort <= 65535
+    ? remotePort
+    : DEFAULT_GATEWAY_PORT;
+}
+
+function rewriteGatewayUrlToLocalTunnel(url: URL, rawUrl: string, localPort: number): string {
+  const suffix =
+    url.pathname === "/" && !rawUrl.includes("/", rawUrl.indexOf("//") + 2)
+      ? `${url.search}${url.hash}`
+      : `${url.pathname}${url.search}${url.hash}`;
+  return `${url.protocol}//127.0.0.1:${localPort}${suffix}`;
+}
+
+function resolveGatewayTunnelTlsServerName(url: URL): string | undefined {
+  if (url.protocol !== "wss:") {
+    return undefined;
+  }
+  const hostname = normalizeOptionalString(url.hostname);
+  if (!hostname) {
+    return undefined;
+  }
+  return hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+}
+
+function isLoopbackTunnelUrl(rawUrl: string): boolean {
+  try {
+    const hostname = new URL(rawUrl).hostname.toLowerCase();
+    const unbracketed =
+      hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+    return unbracketed === "localhost" || isLoopbackIpAddress(unbracketed);
+  } catch {
+    return false;
+  }
+}
+
+function shouldStartConfiguredSshTunnel(params: {
+  config: OpenClawConfig;
+  url: string;
+  urlSource: string;
+}): boolean {
+  const remote = params.config.gateway?.remote;
+  if (
+    params.config.gateway?.mode !== "remote" ||
+    !remote ||
+    params.urlSource !== "config gateway.remote.url" ||
+    !isGatewayRemoteSshTransport(remote)
+  ) {
+    return false;
+  }
+  return remote.transport === "ssh" || !isLoopbackTunnelUrl(params.url);
+}
+
+export async function startGatewayRemoteSshTunnel(params: {
+  config: OpenClawConfig;
+  url: string;
+  urlSource: string;
+}): Promise<GatewaySshTunnelConnection | null> {
+  if (!shouldStartConfiguredSshTunnel(params)) {
+    return null;
+  }
+
+  const remote = params.config.gateway?.remote;
+  const target = normalizeOptionalString(remote?.sshTarget);
+  if (!target) {
+    return null;
+  }
+
+  const parsedUrl = parseGatewayTunnelUrl(params.url);
+  const localPortPreferred = parseExplicitUrlPort(parsedUrl) ?? resolveGatewayPort(params.config);
+  const remotePort = resolveRemoteSshPort(params.config);
+  const identity = normalizeOptionalString(remote?.sshIdentity);
+  const tunnel = await startSshPortForward({
+    target,
+    identity,
+    localPortPreferred,
+    remotePort,
+    timeoutMs: DEFAULT_SSH_TUNNEL_TIMEOUT_MS,
+  });
+  const tlsServerName = resolveGatewayTunnelTlsServerName(parsedUrl);
+
+  return {
+    url: rewriteGatewayUrlToLocalTunnel(parsedUrl, params.url, tunnel.localPort),
+    urlSource: `${params.urlSource} via ssh tunnel`,
+    tunnel,
+    ...(tlsServerName ? { tlsServerName } : {}),
+  };
+}
+
+export function applyGatewaySshTunnelConnectionDetails(params: {
+  details: GatewayConnectionDetails;
+  ssh: GatewaySshTunnelConnection;
+}): GatewayConnectionDetails {
+  const detailLines = params.details.message
+    .split("\n")
+    .filter(
+      (line) =>
+        !line.startsWith("Gateway target:") &&
+        !line.startsWith("Source:") &&
+        !line.startsWith("Transport:"),
+    );
+  const message = [
+    `Gateway target: ${redactSensitiveUrlLikeString(params.details.url)}`,
+    `Source: ${params.details.urlSource}`,
+    "Transport: configured SSH tunnel",
+    ...detailLines,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return {
+    ...params.details,
+    url: params.ssh.url,
+    urlSource: params.ssh.urlSource,
+    message,
+  };
+}

--- a/src/gateway/ssh-transport.ts
+++ b/src/gateway/ssh-transport.ts
@@ -110,6 +110,7 @@ export async function startGatewayRemoteSshTunnel(params: {
   const tunnel = await startSshPortForward({
     target,
     identity,
+    hostKeyPolicy: remote?.sshHostKeyPolicy,
     localPortPreferred,
     remotePort,
     timeoutMs: DEFAULT_SSH_TUNNEL_TIMEOUT_MS,

--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -184,6 +184,25 @@ describe("startSshPortForward", () => {
     expect(mocks.ensurePortAvailable).toHaveBeenCalledWith(43210, "127.0.0.1");
   });
 
+  it("delegates host-key checking to OpenSSH config when requested", async () => {
+    mocks.ensurePortAvailable.mockResolvedValueOnce();
+    spawnFakeSshListening();
+
+    const tunnel = await startSshPortForward({
+      target: "me@example.com:2222",
+      localPortPreferred: 43210,
+      remotePort: 18789,
+      timeoutMs: 1000,
+      hostKeyPolicy: "openssh",
+    });
+    const args = mocks.spawn.mock.calls[0]?.[1] as string[];
+
+    expect(args).not.toContain("StrictHostKeyChecking=yes");
+    expect(args).not.toContain("UpdateHostKeys=yes");
+
+    await tunnel.stop();
+  });
+
   it("falls back to an ephemeral port when the preferred port is in use", async () => {
     // ensurePortAvailable raises the domain PortInUseError (no errno `code`),
     // which the catch must treat as "busy" and route to pickEphemeralPort.

--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -108,6 +108,66 @@ describe("startSshPortForward", () => {
     });
   }
 
+  function spawnFakeSshStartupError(error: Error) {
+    mocks.spawn.mockImplementation(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        killed: boolean;
+        pid?: number;
+        stderr: EventEmitter & { setEncoding: (enc: string) => void };
+        kill: (signal?: string) => boolean;
+      };
+      child.killed = false;
+      const stderr = new EventEmitter() as EventEmitter & { setEncoding: (enc: string) => void };
+      stderr.setEncoding = () => {};
+      child.stderr = stderr;
+      child.kill = (signal?: string) => {
+        child.killed = true;
+        queueMicrotask(() => child.emit("exit", null, signal ?? null));
+        return true;
+      };
+      queueMicrotask(() => child.emit("error", error));
+      return child;
+    });
+  }
+
+  it.runIf(process.platform !== "win32")(
+    "uses the trusted POSIX ssh binary instead of PATH lookup",
+    async () => {
+      mocks.ensurePortAvailable.mockResolvedValueOnce();
+      spawnFakeSshListening();
+
+      const tunnel = await startSshPortForward({
+        target: "me@example.com:2222",
+        localPortPreferred: 43210,
+        remotePort: 18789,
+        timeoutMs: 1000,
+      });
+
+      expect(mocks.spawn).toHaveBeenCalledWith(
+        "/usr/bin/ssh",
+        expect.arrayContaining(["-L", `127.0.0.1:${tunnel.localPort}:127.0.0.1:18789`]),
+        expect.anything(),
+      );
+
+      await tunnel.stop();
+    },
+  );
+
+  it("rejects when the ssh process cannot be spawned", async () => {
+    const startupError = Object.assign(new Error("spawn ssh ENOENT"), { code: "ENOENT" });
+    mocks.ensurePortAvailable.mockResolvedValueOnce();
+    spawnFakeSshStartupError(startupError);
+
+    await expect(
+      startSshPortForward({
+        target: "me@example.com:2222",
+        localPortPreferred: 43210,
+        remotePort: 18789,
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow("spawn ssh ENOENT");
+  });
+
   it("scopes the preferred-port preflight to the IPv4 loopback interface", async () => {
     const sentinel = new Error("stop before spawning ssh");
     mocks.ensurePortAvailable.mockRejectedValueOnce(sentinel);
@@ -157,7 +217,7 @@ describe("startSshPortForward", () => {
     expect(tunnel.localPort).not.toBe(preferredPort);
     expect(tunnel.localPort).toBeGreaterThan(0);
     expect(mocks.spawn).toHaveBeenCalledWith(
-      "/usr/bin/ssh",
+      process.platform === "win32" ? "ssh" : "/usr/bin/ssh",
       expect.arrayContaining(["-L", `127.0.0.1:${tunnel.localPort}:127.0.0.1:18789`]),
       expect.anything(),
     );

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -34,6 +34,8 @@ export type SshTunnel = {
   stop: () => Promise<void>;
 };
 
+export type SshHostKeyPolicy = "strict" | "openssh";
+
 // Reject hosts that would corrupt the SSH HostName field or enable argument
 // injection: a leading '-' becomes an ssh option, and a stray leading/trailing
 // ':' (e.g. sliced from "host::22") produces an invalid HostName.
@@ -126,6 +128,7 @@ async function waitForLocalListener(port: number, timeoutMs: number): Promise<vo
 export async function startSshPortForward(opts: {
   target: string;
   identity?: string;
+  hostKeyPolicy?: SshHostKeyPolicy;
   localPortPreferred: number;
   remotePort: number;
   timeoutMs: number;
@@ -158,16 +161,15 @@ export async function startSshPortForward(opts: {
     "-o",
     "BatchMode=yes",
     "-o",
-    "StrictHostKeyChecking=yes",
-    "-o",
-    "UpdateHostKeys=yes",
-    "-o",
     "ConnectTimeout=5",
     "-o",
     "ServerAliveInterval=15",
     "-o",
     "ServerAliveCountMax=3",
   ];
+  if (opts.hostKeyPolicy !== "openssh") {
+    args.push("-o", "StrictHostKeyChecking=yes", "-o", "UpdateHostKeys=yes");
+  }
   if (opts.identity?.trim()) {
     args.push("-i", opts.identity.trim());
   }

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -3,13 +3,25 @@ import { spawn } from "node:child_process";
 import net from "node:net";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { formatErrorMessage, isErrno } from "./errors.js";
+import { resolveExecutable } from "./executable-path.js";
 import { parseStrictPositiveInteger } from "./parse-finite-number.js";
 import { ensurePortAvailable, PortInUseError } from "./ports.js";
+
+const POSIX_SSH_BINARY = "/usr/bin/ssh";
+
+function resolveSshExecutable(): string {
+  return process.platform === "win32" ? resolveExecutable("ssh") : POSIX_SSH_BINARY;
+}
 
 export type SshParsedTarget = {
   user?: string;
   host: string;
   port: number;
+};
+
+export type SshTunnelExit = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
 };
 
 export type SshTunnel = {
@@ -18,6 +30,7 @@ export type SshTunnel = {
   remotePort: number;
   pid: number | null;
   stderr: string[];
+  exited?: Promise<SshTunnelExit>;
   stop: () => Promise<void>;
 };
 
@@ -162,7 +175,7 @@ export async function startSshPortForward(opts: {
   args.push("--", userHost);
 
   const stderr: string[] = [];
-  const child = spawn("/usr/bin/ssh", args, {
+  const child = spawn(resolveSshExecutable(), args, {
     stdio: ["ignore", "ignore", "pipe"],
   });
   const stderrStream = child.stderr;
@@ -174,34 +187,56 @@ export async function startSshPortForward(opts: {
     const lines = normalizeStringEntries(String(chunk).split("\n"));
     stderr.push(...lines);
   });
+  const exited = new Promise<SshTunnelExit>((resolve) => {
+    child.once("exit", (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
 
   const stop = async () => {
-    if (child.killed || !child.kill("SIGTERM")) {
+    if (
+      child.killed ||
+      child.exitCode !== null ||
+      child.signalCode !== null ||
+      typeof child.pid !== "number"
+    ) {
       return;
     }
-    await new Promise<void>((resolve) => {
-      const t = setTimeout(() => {
-        try {
-          child.kill("SIGKILL");
-        } finally {
+    let signaled: boolean;
+    try {
+      signaled = child.kill("SIGTERM");
+    } catch {
+      return;
+    }
+    if (!signaled) {
+      return;
+    }
+    await Promise.race([
+      exited.then(() => undefined),
+      new Promise<void>((resolve) => {
+        const t = setTimeout(() => {
+          try {
+            child.kill("SIGKILL");
+          } finally {
+            resolve();
+          }
+        }, 1500);
+        void exited.then(() => {
+          clearTimeout(t);
           resolve();
-        }
-      }, 1500);
-      child.once("exit", () => {
-        clearTimeout(t);
-        resolve();
-      });
-    });
+        });
+      }),
+    ]);
   };
 
   try {
     await Promise.race([
       waitForLocalListener(localPort, Math.max(250, opts.timeoutMs)),
       new Promise<void>((_, reject) => {
-        child.once("error", (err) => reject(err));
-        child.once("exit", (code, signal) => {
-          reject(new Error(`ssh exited (${code ?? "null"}${signal ? `/${signal}` : ""})`));
-        });
+        child.once("error", reject);
+      }),
+      exited.then(({ code, signal }) => {
+        throw new Error(`ssh exited (${code ?? "null"}${signal ? `/${signal}` : ""})`);
       }),
     ]);
   } catch (err) {
@@ -216,6 +251,7 @@ export async function startSshPortForward(opts: {
     remotePort: opts.remotePort,
     pid: typeof child.pid === "number" ? child.pid : null,
     stderr,
+    exited,
     stop,
   };
 }

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -194,12 +194,9 @@ export async function startSshPortForward(opts: {
   });
 
   const stop = async () => {
-    if (
-      child.killed ||
-      child.exitCode !== null ||
-      child.signalCode !== null ||
-      typeof child.pid !== "number"
-    ) {
+    const hasSpawnedProcess = typeof child.pid === "number";
+    const hasExited = child.exitCode !== null || child.signalCode !== null;
+    if (child.killed || (hasSpawnedProcess && hasExited)) {
       return;
     }
     let signaled: boolean;

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -195,7 +195,7 @@ export async function startSshPortForward(opts: {
 
   const stop = async () => {
     const hasSpawnedProcess = typeof child.pid === "number";
-    const hasExited = child.exitCode !== null || child.signalCode !== null;
+    const hasExited = child.exitCode != null || child.signalCode != null;
     if (child.killed || (hasSpawnedProcess && hasExited)) {
       return;
     }

--- a/src/mcp/channel-bridge.test.ts
+++ b/src/mcp/channel-bridge.test.ts
@@ -8,10 +8,92 @@ const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 const SWEEP_INTERVAL_MS = 5 * ONE_MINUTE_MS;
 const APPROVAL_DEFAULT_TTL_MS = 30 * ONE_MINUTE_MS;
 
+const gatewayClientState = vi.hoisted(() => ({
+  options: null as Record<string, unknown> | null,
+  stopAndWait: vi.fn(async () => undefined),
+  sshTunnelStop: vi.fn(async () => undefined),
+  constructError: null as Error | null,
+  bootstrapPromise: null as Promise<Record<string, unknown>> | null,
+  readinessResult: {
+    ready: true,
+    elapsedMs: 0,
+    maxDriftMs: 0,
+    checks: 1,
+    aborted: false,
+  },
+}));
+
+vi.mock("../gateway/client-bootstrap.js", () => ({
+  resolveGatewayClientBootstrap: vi.fn(
+    () =>
+      gatewayClientState.bootstrapPromise ??
+      Promise.resolve({
+        url: "ws://127.0.0.1:19091",
+        urlSource: "config gateway.remote.url via ssh tunnel",
+        auth: { token: undefined, password: undefined },
+        sshTunnel: { stop: gatewayClientState.sshTunnelStop },
+      }),
+  ),
+}));
+
+vi.mock("../gateway/client.js", () => ({
+  GatewayClient: class {
+    private readonly opts: Record<string, unknown>;
+
+    constructor(opts: Record<string, unknown>) {
+      if (gatewayClientState.constructError) {
+        throw gatewayClientState.constructError;
+      }
+      this.opts = opts;
+      gatewayClientState.options = opts;
+    }
+
+    start(): void {
+      const onHelloOk = this.opts.onHelloOk;
+      if (typeof onHelloOk === "function") {
+        void Promise.resolve().then(() => onHelloOk());
+      }
+    }
+
+    async stopAndWait(): Promise<void> {
+      await gatewayClientState.stopAndWait();
+      const onStop = this.opts.onStop;
+      if (typeof onStop === "function") {
+        await onStop();
+      }
+    }
+
+    async request<T = Record<string, unknown>>(): Promise<T> {
+      return {} as T;
+    }
+  },
+}));
+
+vi.mock("../gateway/client-start-readiness.js", () => ({
+  startGatewayClientWhenEventLoopReady: vi.fn(async (client: { start: () => void }) => {
+    if (gatewayClientState.readinessResult.ready) {
+      client.start();
+    }
+    return gatewayClientState.readinessResult;
+  }),
+}));
+
+vi.mock("../gateway/method-scopes.js", () => ({
+  APPROVALS_SCOPE: "approvals",
+  READ_SCOPE: "read",
+  WRITE_SCOPE: "write",
+}));
+
+vi.mock("../../packages/gateway-protocol/src/client-info.js", () => ({
+  GATEWAY_CLIENT_MODES: { CLI: "cli" },
+  GATEWAY_CLIENT_NAMES: { CLI: "cli" },
+}));
+
 // Test view that exposes the private map/timer fields and the methods we
 // exercise. Defined as a standalone shape (not an intersection with the class)
 // because mixing public/private constituents collapses to `never` under tsgo.
 type BridgeInternals = {
+  start: () => Promise<void>;
   queue: QueueEvent[];
   pendingClaudePermissions: Map<string, unknown>;
   pendingApprovals: Map<string, unknown>;
@@ -126,6 +208,18 @@ describe("OpenClawChannelBridge — pendingClaudePermissions / pendingApprovals 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
+    gatewayClientState.options = null;
+    gatewayClientState.stopAndWait.mockReset().mockResolvedValue(undefined);
+    gatewayClientState.sshTunnelStop.mockReset().mockResolvedValue(undefined);
+    gatewayClientState.constructError = null;
+    gatewayClientState.bootstrapPromise = null;
+    gatewayClientState.readinessResult = {
+      ready: true,
+      elapsedMs: 0,
+      maxDriftMs: 0,
+      checks: 1,
+      aborted: false,
+    };
   });
 
   afterEach(async () => {
@@ -260,6 +354,67 @@ describe("OpenClawChannelBridge — pendingClaudePermissions / pendingApprovals 
     expect(bridge.pendingApprovals.size).toBe(0);
     expect(bridge.pendingSweepInterval).toBeNull();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("close() stops the bootstrap SSH tunnel after Gateway startup", async () => {
+    const bridge = makeBridge();
+
+    await bridge.start();
+    await bridge.close();
+
+    expect(gatewayClientState.stopAndWait).toHaveBeenCalledTimes(1);
+    expect(gatewayClientState.sshTunnelStop).toHaveBeenCalledTimes(1);
+  });
+
+  test("close() stops a bootstrap SSH tunnel when shutdown wins startup", async () => {
+    let resolveBootstrap: (value: Record<string, unknown>) => void = () => undefined;
+    gatewayClientState.bootstrapPromise = new Promise((resolve) => {
+      resolveBootstrap = resolve;
+    });
+    const bridge = makeBridge();
+
+    const startPromise = bridge.start();
+    await bridge.close();
+    gatewayClientState.sshTunnelStop.mockRejectedValueOnce(new Error("stop failed"));
+    resolveBootstrap({
+      url: "ws://127.0.0.1:19091",
+      urlSource: "config gateway.remote.url via ssh tunnel",
+      auth: { token: undefined, password: undefined },
+      sshTunnel: { stop: gatewayClientState.sshTunnelStop },
+    });
+    await startPromise;
+
+    expect(gatewayClientState.options).toBeNull();
+    expect(gatewayClientState.stopAndWait).not.toHaveBeenCalled();
+    expect(gatewayClientState.sshTunnelStop).toHaveBeenCalledTimes(1);
+  });
+
+  test("start() stops the bootstrap SSH tunnel when Gateway readiness fails", async () => {
+    gatewayClientState.readinessResult = {
+      ready: false,
+      elapsedMs: 250,
+      maxDriftMs: 250,
+      checks: 1,
+      aborted: false,
+    };
+    const bridge = makeBridge();
+
+    await expect(bridge.start()).rejects.toThrow("gateway event loop readiness timeout");
+
+    expect(gatewayClientState.options).not.toBeNull();
+    expect(gatewayClientState.stopAndWait).toHaveBeenCalledTimes(1);
+    expect(gatewayClientState.sshTunnelStop).toHaveBeenCalledTimes(1);
+  });
+
+  test("start() stops the bootstrap SSH tunnel when GatewayClient construction fails", async () => {
+    gatewayClientState.constructError = new Error("device identity unavailable");
+    const bridge = makeBridge();
+
+    await expect(bridge.start()).rejects.toThrow("device identity unavailable");
+
+    expect(gatewayClientState.options).toBeNull();
+    expect(gatewayClientState.stopAndWait).not.toHaveBeenCalled();
+    expect(gatewayClientState.sshTunnelStop).toHaveBeenCalledTimes(1);
   });
 
   test("handleClaudePermissionRequest is a no-op after close(), preventing post-close accumulation", async () => {

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -132,50 +132,66 @@ export class OpenClawChannelBridge {
       env: process.env,
     });
     if (this.closed) {
+      await bootstrap.sshTunnel?.stop().catch(() => undefined);
       this.resolveReadyOnce();
       return;
     }
 
-    this.gateway = new GatewayClientCtor({
-      url: bootstrap.url,
-      token: bootstrap.auth.token,
-      password: bootstrap.auth.password,
-      preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs,
-      clientName: GATEWAY_CLIENT_NAMES.CLI,
-      clientDisplayName: "OpenClaw MCP",
-      clientVersion: VERSION,
-      mode: GATEWAY_CLIENT_MODES.CLI,
-      scopes: [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
-      requestTimeoutMs: 180_000,
-      onEvent: (event) => {
-        void this.dispatchGatewayEvent(event);
-      },
-      onHelloOk: () => {
-        this.retryingInitialConnect = false;
-        void this.handleHelloOk();
-      },
-      onConnectError: (error) => {
-        const normalizedError = error instanceof Error ? error : new Error(String(error));
-        if (shouldRetryInitialMcpGatewayConnect(normalizedError)) {
-          this.retryingInitialConnect = true;
-          return;
-        }
-        this.rejectReadyOnce(normalizedError);
-      },
-      onClose: (code, reason) => {
-        if (!this.ready && !this.closed && !this.retryingInitialConnect) {
-          this.rejectReadyOnce(new Error(`gateway closed before ready (${code}): ${reason}`));
-        }
-        this.retryingInitialConnect = false;
-      },
-    });
-    const readiness = await startGatewayClientWhenEventLoopReady(this.gateway, {
-      clientOptions: { preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs },
-    });
-    if (!readiness.ready) {
-      this.rejectReadyOnce(new Error("gateway event loop readiness timeout"));
+    try {
+      this.gateway = new GatewayClientCtor({
+        url: bootstrap.url,
+        token: bootstrap.auth.token,
+        password: bootstrap.auth.password,
+        onStop: () => bootstrap.sshTunnel?.stop(),
+        ...(bootstrap.sshTunnel?.exited ? { stopWhen: bootstrap.sshTunnel.exited } : {}),
+        ...(bootstrap.tlsServerName ? { tlsServerName: bootstrap.tlsServerName } : {}),
+        preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs,
+        clientName: GATEWAY_CLIENT_NAMES.CLI,
+        clientDisplayName: "OpenClaw MCP",
+        clientVersion: VERSION,
+        mode: GATEWAY_CLIENT_MODES.CLI,
+        scopes: [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
+        requestTimeoutMs: 180_000,
+        onEvent: (event) => {
+          void this.dispatchGatewayEvent(event);
+        },
+        onHelloOk: () => {
+          this.retryingInitialConnect = false;
+          void this.handleHelloOk();
+        },
+        onConnectError: (error) => {
+          const normalizedError = error instanceof Error ? error : new Error(String(error));
+          if (shouldRetryInitialMcpGatewayConnect(normalizedError)) {
+            this.retryingInitialConnect = true;
+            return;
+          }
+          this.rejectReadyOnce(normalizedError);
+        },
+        onClose: (code, reason) => {
+          if (!this.ready && !this.closed && !this.retryingInitialConnect) {
+            this.rejectReadyOnce(new Error(`gateway closed before ready (${code}): ${reason}`));
+          }
+          this.retryingInitialConnect = false;
+        },
+      });
+    } catch (error) {
+      await bootstrap.sshTunnel?.stop().catch(() => undefined);
+      throw error;
     }
-    await this.readyPromise;
+    try {
+      const readiness = await startGatewayClientWhenEventLoopReady(this.gateway, {
+        clientOptions: { preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs },
+      });
+      if (!readiness.ready) {
+        this.rejectReadyOnce(new Error("gateway event loop readiness timeout"));
+      }
+      await this.readyPromise;
+    } catch (error) {
+      const gateway = this.gateway;
+      this.gateway = null;
+      await gateway?.stopAndWait().catch(() => undefined);
+      throw error;
+    }
   }
 
   /** Wait until the bridge has subscribed to Gateway session events. */


### PR DESCRIPTION
Closes #26250

## What Problem This Solves

Fixes an issue where users configuring a remote Gateway with SSH transport could be rejected by the plaintext `ws://` security check before OpenClaw had a chance to establish the configured SSH tunnel.

The affected workflow is the documented remote Gateway setup using `gateway.mode: "remote"`, `gateway.remote.url`, and `gateway.remote.sshTarget`. In that setup, the configured Gateway URL may point at the remote endpoint, while the runtime connection is expected to go through an OpenClaw-managed local SSH-forwarded endpoint.

This update also addresses the review risks around that tunnel ownership boundary:

- Remote SSH Gateway calls keep their `deviceIdentity` after the runtime URL is rewritten to `127.0.0.1:<localPort>`, so remote calls are not misclassified as direct local backend calls.
- Configured `wss://` SSH tunnels preserve the original remote hostname as the TLS server name when connecting through the loopback tunnel.
- Configured `sshHostKeyPolicy: "openssh"` continues to delegate host-key behavior to the effective OpenSSH config instead of forcing strict overrides in the new core-managed tunnel path.
- Existing externally managed local tunnel configs are preserved when `gateway.remote.url` is already loopback and `gateway.remote.transport` is omitted.
- Long-lived ACP, MCP, and operator-approval Gateway clients stop when their managed SSH tunnel exits, instead of reconnecting forever to a dead loopback port.
- ACP startup failures after Gateway readiness now clean up the `GatewayClient` and its SSH tunnel.
- The common Gateway probe builder supports configured SSH transport, and health/doctor/core health probe callers stop the returned tunnel in `finally` cleanup.

## Why This Change Was Made

The fix keeps the plaintext safety check strict for direct connections, CLI/env URL overrides, malformed URLs, non-websocket URLs, and SSH configs without `sshTarget`, while allowing only config-derived remote Gateway SSH transport to enter the managed tunnel path before the raw remote URL is rejected.

The shipped boundary is intentionally narrow:

- `transport: "direct"` remains the explicit opt-out from managed SSH behavior.
- Explicit `transport: "ssh"` keeps the managed SSH tunnel behavior.
- Omitted `transport` with a non-loopback configured remote Gateway URL and `sshTarget` can use the managed SSH default.
- Omitted `transport` with an already-loopback configured remote Gateway URL and `sshTarget` stays on the existing local tunnel and does not spawn a second OpenClaw-owned SSH process.
- The SSH allowance only applies after the configured remote URL parses as an accepted Gateway `ws:` or `wss:` URL.
- The tunnel rewrite no longer controls whether a remote call can omit `deviceIdentity`; that decision uses the pre-tunnel remote URL and knows when the connection is tunneled.
- `wss://` over SSH uses the original configured hostname for the WebSocket TLS `servername`, while existing fingerprint-pinning behavior remains intact.
- `sshHostKeyPolicy` keeps the shipped semantics: strict remains the default, while `"openssh"` omits OpenClaw strict host-key overrides and delegates to the effective OpenSSH config.
- Managed SSH tunnels expose an exit signal; long-lived Gateway clients use it as a stop condition so reconnects do not target a stale loopback URL after the SSH process exits.
- Probe callers that receive an owned SSH tunnel from the common probe builder are responsible for stopping it; one-shot calls and bootstrap clients keep their existing lifecycle ownership.

What this does not change:

- No schema, migration, wire protocol, or new transport protocol is introduced.
- The SSH remote forwarding contract is not redefined: `gateway.remote.url` is not repurposed as the SSH remote forwarding port, and the remote side still targets the SSH host loopback Gateway endpoint.
- This PR does not claim a product-wide rewrite of every Gateway-adjacent surface. `health`, `doctor`, and core health checks are covered through the common probe path; `gateway status` keeps its existing separate tunnel lifecycle; TUI, security-audit, logs, devices, and Crestodian-style surfaces are not broadened here unless they already use the fixed call/bootstrap helpers.

Maintainers should still explicitly accept these scoped behavior decisions before merge:

- Non-loopback configs with `gateway.remote.sshTarget` and omitted or SSH transport can spawn an OpenClaw-owned SSH process before connecting.
- The plaintext guard exception is limited to config-owned managed SSH Gateway URLs, not CLI/env overrides or direct transport.
- Gateway call/bootstrap, ACP, MCP, and operator approval startup now depend on SSH binary availability, credentials, host-key readiness, and local tunnel startup when the config selects managed SSH transport.

## User Impact

Users following the configured SSH remote Gateway path can connect through the managed tunnel instead of seeing an early plaintext `ws://` rejection. Explicit unsafe plaintext remotes still fail closed unless they are owned by the configured SSH tunnel path, so credentials and chat data remain protected from accidental direct plaintext network use.

The follow-up fixes also protect correctness, compatibility, and cleanup on the remote SSH path:

- Remote SSH calls retain device identity for audit/scope attribution.
- `wss://` SSH tunnels can validate against the configured remote hostname instead of the temporary loopback host.
- Existing configs that set `sshHostKeyPolicy: "openssh"` keep delegating host-key behavior to OpenSSH instead of being upgraded into strict host-key overrides by the core-managed tunnel path.
- Users who already maintain their own local tunnel with a loopback `gateway.remote.url`, an `sshTarget`, and omitted `transport` do not get a second SSH process started unexpectedly.
- ACP/MCP/operator-approval clients stop when the managed SSH process exits, preventing a reconnect loop against a dead local port.
- ACP startup no longer leaves a ready Gateway client or SSH tunnel running when later stream/ledger setup fails.
- Health and doctor preauth probes can use the same configured SSH remote as the main Gateway path and clean up their temporary tunnel.

The main compatibility point is the managed SSH behavior for non-loopback `sshTarget` configs. That is intentional for the documented SSH remote setup, while already-loopback omitted-transport configs keep their existing externally managed tunnel behavior.

## Evidence

Reviewer concerns addressed in this update:

- Existing loopback URL + omitted transport configs no longer spawn a new managed SSH process; remaining non-loopback managed SSH behavior is disclosed above as the maintainer decision boundary.
- The plaintext guard remains fail-closed for direct, CLI/env override, malformed, non-websocket, and missing-`sshTarget` paths; only config-derived managed SSH Gateway URLs get the pre-tunnel allowance.
- SSH binary/credentials/host-key/local tunnel startup dependencies are disclosed as the managed SSH operational boundary, and the shipped `sshHostKeyPolicy: "openssh"` compatibility path is preserved.
- The common probe path now covers health/doctor/core health checks; remaining sibling surfaces are scoped above instead of claimed as fully rewritten.
- The requested focused Gateway, ACP, MCP, SSH infra, health/doctor, and doctor-core validation passed for the substantive SSH/Gateway behavior; after syncing with current `main`, the conflict-touched ACP startup, Gateway call, SSH tunnel, and MCP bridge tests were rerun.

Post-sync validation recorded for the current PR diff:

```text
pnpm test -- src/acp/server.startup.test.ts

Test Files  1 passed (1)
Tests       23 passed (23)
```

```text
pnpm test -- src/gateway/ssh-transport.test.ts src/infra/ssh-tunnel.test.ts

Test Files  4 passed (4)
Tests       28 passed (28)

Test Files  1 passed (1)
Tests       12 passed (12)
```

```text
pnpm test -- src/gateway/call.test.ts src/infra/ssh-tunnel.test.ts src/mcp/channel-bridge.test.ts

Test Files  1 passed (1)
Tests       22 passed (22)

Test Files  4 passed (4)
Tests       532 passed (532)

Test Files  1 passed (1)
Tests       12 passed (12)
```

```text
git diff --check

Validation result: pass, exit_code=0
```

The earlier focused behavior proof below is still the issue-specific runtime evidence for the configured SSH transport path. Broad local `tsgo:core` / `tsgo:core:test` runs after syncing are not claimed as passing evidence here because they currently fail before this PR path on generated UI package resolution and existing Node `StatsFs` test-shape errors.

Real environment tested: a real OpenClaw CLI process, a foreground OpenClaw Gateway process, and an isolated local OpenSSH daemon with strict host-key checking, public-key auth, token auth, and `ssh -L` direct-tcpip forwarding. This proves the configured SSH transport boundary; it is not claimed as a hosted WSS certificate integration test.

```text
Configured remote URL: ws://203.0.113.10:34829
SSH target: 127.0.0.1:42069
Remote Gateway port: 35601
Local tunnel preferred port: 34829
configured SSH gateway call exit: 0
explicit --url override exit: 1
sshd accepted publickey: True
sshd observed direct-tcpip forwarding to Gateway: True
leftover OpenClaw ssh forward process: none
```

```text
Configured SSH health response:
ok: true
JSON keys included: agents, channelLabels, channelOrder, channels, defaultAgentId, durationMs, eventLoop, heartbeatSeconds, modelPricing, ok, plugins, sessions, ts
```

```text
Explicit --url override safety probe:
Gateway call failed: Error: SECURITY ERROR: Gateway URL "ws://203.0.113.10:34829" uses plaintext ws:// to a non-loopback address.
Both credentials and chat data would be exposed to network interception.
Source: cli --url
Fix: Use wss:// for remote gateway URLs.
```

The `wss://` TLS server-name behavior is covered by focused regression proof that the loopback runtime URL carries `tlsServerName: "gateway.example.com"`; no real hosted WSS certificate proof is claimed here. Intermediate wrong-config/no-test runs and intentional RED runs are not claimed as passing evidence.
