### PR TITLE
fix(diffs): reset viewer controllers on rehydrate

### DIFF
--- a/extensions/diffs/src/viewer-client.test.ts
+++ b/extensions/diffs/src/viewer-client.test.ts
@@ -172,6 +172,24 @@ describe("hydrateViewer", () => {
     expect(document.documentElement.dataset.openclawDiffsError).toBeUndefined();
     warn.mockRestore();
   });
+
+  it("replaces stale controllers when hydrating the current cards again", async () => {
+    renderCard();
+    const { controllers, hydrateViewer } = await import("./viewer-client.js");
+    controllers.splice(0);
+
+    await hydrateViewer();
+    expect(controllers).toHaveLength(1);
+    const firstController = controllers[0];
+
+    document.body.innerHTML = "";
+    renderCard();
+    await hydrateViewer();
+
+    expect(controllers).toHaveLength(1);
+    expect(controllers[0]).not.toBe(firstController);
+    expect(fileDiffHydrateMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("viewerState initialization", () => {

--- a/extensions/diffs/src/viewer-client.ts
+++ b/extensions/diffs/src/viewer-client.ts
@@ -287,6 +287,9 @@ function syncAllControllers(): void {
 }
 
 export async function hydrateViewer(): Promise<void> {
+  // Rehydration replaces the current DOM card set; do not retain controllers
+  // from a previous render because they can keep stale DOM references alive.
+  controllers.length = 0;
   const cards = await Promise.all(
     getCards().map(async ({ host, payload }) => ({
       host,


### PR DESCRIPTION
Closes #83917
Supersedes #95155

## What Problem This Solves

Fixes an issue where users opening a diffs viewer that hydrates more than once could retain stale diff controllers from the previous card set, so later toolbar actions could apply state to controllers for DOM nodes that are no longer current.

## Why This Change Was Made

`hydrateViewer()` now replaces the module-level controller collection before hydrating the current DOM cards. The regression test models re-hydration as a replacement of the current card, rather than appending a second card while expecting one controller.

## User Impact

Users can re-open or rehydrate a diffs viewer without accumulating stale controller references across hydration cycles. The active controller list now matches the current `.oc-diff-card` set.

## Evidence

### Real behavior proof

Behavior or issue addressed: repeated browser hydration of the diffs viewer after the current diff card is replaced must not leave controllers for stale, disconnected DOM nodes.

Real environment tested: local Docker-backed Crabbox/local-container on this Windows desktop, image `mcr.microsoft.com/playwright:v1.60.0-noble`, provider `local-container`, lease `cbx_ed0c8e197837`, slug `quick-crayfish`, Node `v24.15.0`, pnpm `11.2.2`, Chromium `/ms-playwright/chromium-1223/chrome-linux64/chrome`.

Exact steps or command run after this patch:

```text
C:\Users\marti\.local\bin\crabbox.exe run --provider local-container --local-container-image mcr.microsoft.com/playwright:v1.60.0-noble --no-hydrate --timing-json --script C:\oc-work\.tmp\proof-96138-diffs-browser.sh
```

Evidence after fix: the proof script used OpenClaw's own diffs renderer to create real viewer cards, loaded the real browser bundle in Chromium, called `hydrateViewer()`, replaced the active `.oc-diff-card`, called `hydrateViewer()` again, and inspected the exported runtime controller collection in the page.

```text
CRABBOX_PHASE:proof-origin-main
HEAD is now at 1aa7cafc35 fix(github-copilot): bound model discovery and embeddings JSON response (#96499)
PROOF_RESULT {"refName":"origin-main","first":{"controllerCount":1,"cardCount":1},"second":{"controllerCount":2,"cardCount":1,"oldHostConnected":false,"currentHostIsReplacement":true}}

CRABBOX_PHASE:proof-pr-head
HEAD is now at 91a9516282 fix: reset diff viewer controllers on rehydrate
PROOF_RESULT {"refName":"pr-head","first":{"controllerCount":1,"cardCount":1},"second":{"controllerCount":1,"cardCount":1,"oldHostConnected":false,"currentHostIsReplacement":true}}
```

Observed result after fix: current main reproduces the stale-controller behavior in Chromium by retaining 2 controllers after a single replacement card is hydrated; this PR keeps the active controller collection at 1 for the replacement card while confirming the old host is disconnected and the current host is the replacement.

Supplemental validation from the same Crabbox run:

```text
CRABBOX_PHASE:changed-gate
env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed
Result: exitCode=0
Timing: sync 2m8.194s, command 6m8.427s, total 8m16.716s
Cleanup: one-shot lease stopped by Crabbox (leaseStopped=true)
```

The changed gate included conflict-marker checks, changelog attribution checks, extension wildcard re-export checks, plugin-sdk wildcard re-export checks, duplicate target coverage, dependency pin guard, package patch guard, typecheck extensions, typecheck extension tests, lint extensions, database-first legacy-store guard, media download helper guard, runtime sidecar loader guard, and runtime import cycle check.

Additional focused regression proof:

```text
node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-diffs.config.ts extensions/diffs/src/viewer-client.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests  20 passed (20)
```

What was not tested: this proof does not claim visual toolbar rendering or produce a screen recording; it proves the controller lifecycle bug in real Chromium using renderer-generated diffs viewer cards and the runtime browser bundle. Chromium also emitted the known warning that declarative shadow DOM inserted with `innerHTML` is not parsed; the proof assertions do not depend on that shadow DOM rendering path.
