### PR TITLE
fix(ui): reload Control UI when service worker updates

### DIFF
--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -226,6 +226,7 @@ describe("production lint suppressions", () => {
         "src/test-utils/vitest-mock-fn.ts|typescript/no-explicit-any|1",
         "src/utils.ts|typescript/no-unnecessary-type-parameters|1",
         "src/version.ts|eslint/no-underscore-dangle|1",
+        "ui/public/sw.js|unicorn/require-post-message-target-origin|1",
       ]),
     );
   });

--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -22,22 +22,32 @@ self.addEventListener("install", (event) => {
 });
 
 self.addEventListener("activate", (event) => {
-  // Keep a small prior-build window so open tabs can still load old hashed chunks after updates.
   event.waitUntil(
-    Promise.all([
-      self.clients.claim(),
-      caches.keys().then((keys) => {
-        const controlKeys = keys.filter((key) => key.startsWith(CACHE_PREFIX));
-        const priorCacheLimit = Math.max(0, CONTROL_CACHE_LIMIT - 1);
-        const retained = new Set([
-          ...controlKeys.filter((key) => key !== CACHE_NAME).slice(-priorCacheLimit),
-          CACHE_NAME,
-        ]);
-        return Promise.all(
+    (async () => {
+      const [cacheKeys, windowClients] = await Promise.all([
+        caches.keys(),
+        self.clients.matchAll({ type: "window", includeUncontrolled: true }),
+      ]);
+      const controlKeys = cacheKeys.filter((key) => key.startsWith(CACHE_PREFIX));
+      const priorCacheLimit = Math.max(0, CONTROL_CACHE_LIMIT - 1);
+      // Keep a small prior-build window so open tabs can still load old hashed chunks after updates.
+      const retained = new Set([
+        ...controlKeys.filter((key) => key !== CACHE_NAME).slice(-priorCacheLimit),
+        CACHE_NAME,
+      ]);
+
+      await Promise.all([
+        self.clients.claim(),
+        Promise.all(
           controlKeys.filter((key) => !retained.has(key)).map((key) => caches.delete(key)),
-        );
-      }),
-    ]),
+        ),
+      ]);
+
+      for (const client of windowClients) {
+        // oxlint-disable-next-line unicorn/require-post-message-target-origin -- Service Worker Client.postMessage does not take targetOrigin.
+        client.postMessage({ type: "sw-updated", version: CACHE_VERSION });
+      }
+    })(),
   );
 });
 

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -12,12 +12,18 @@ type ViteImportMeta = ImportMeta & {
 declare const OPENCLAW_CONTROL_UI_BUILD_ID: string | undefined;
 
 const isProd = (import.meta as ViteImportMeta).env?.PROD === true;
+const currentControlUiBuildId = OPENCLAW_CONTROL_UI_BUILD_ID || "dev";
 
 syncDocumentPublicAssetLinks();
 
 if (isProd && "serviceWorker" in navigator) {
   const swUrl = new URL(inferControlUiPublicAssetPath("sw.js"), window.location.origin);
-  swUrl.searchParams.set("v", OPENCLAW_CONTROL_UI_BUILD_ID || "dev");
+  swUrl.searchParams.set("v", currentControlUiBuildId);
+  navigator.serviceWorker.addEventListener("message", (event) => {
+    if (event.data?.type === "sw-updated" && event.data.version !== currentControlUiBuildId) {
+      window.location.reload();
+    }
+  });
   void navigator.serviceWorker.register(swUrl, { updateViaCache: "none" });
 } else if (!isProd && "serviceWorker" in navigator) {
   // Unregister any leftover dev SW to avoid stale cache issues.

--- a/ui/src/ui/service-worker-cache.test.ts
+++ b/ui/src/ui/service-worker-cache.test.ts
@@ -2,18 +2,22 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import vm from "node:vm";
+import { describe, expect, it, vi } from "vitest";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
+const serviceWorkerPath = path.join(here, "../../public/sw.js");
 
 describe("Control UI service worker cache versioning", () => {
   it("registers the service worker with a build id and bounds prior build caches", () => {
     const mainSource = fs.readFileSync(path.join(here, "../main.ts"), "utf8");
-    const serviceWorkerSource = fs.readFileSync(path.join(here, "../../public/sw.js"), "utf8");
+    const serviceWorkerSource = fs.readFileSync(serviceWorkerPath, "utf8");
     const viteConfigSource = fs.readFileSync(path.join(here, "../../vite.config.ts"), "utf8");
 
     expect(mainSource).toContain('swUrl.searchParams.set("v"');
     expect(mainSource).toContain('updateViaCache: "none"');
+    expect(mainSource).toContain('navigator.serviceWorker.addEventListener("message"');
+    expect(mainSource).toContain("event.data.version !== currentControlUiBuildId");
     expect(serviceWorkerSource).toContain(
       'const EMBEDDED_CACHE_VERSION = "__OPENCLAW_CONTROL_UI_BUILD_ID__"',
     );
@@ -21,7 +25,93 @@ describe("Control UI service worker cache versioning", () => {
     expect(serviceWorkerSource).toContain("CONTROL_CACHE_LIMIT = 3");
     expect(serviceWorkerSource).toContain("slice(-priorCacheLimit)");
     expect(serviceWorkerSource).toContain("caches.delete");
+    expect(serviceWorkerSource).toContain("includeUncontrolled: true");
+    expect(serviceWorkerSource).not.toContain(
+      'postMessage({ type: "sw-updated", version: CACHE_VERSION },',
+    );
     expect(viteConfigSource).toContain("source.replace(placeholder, JSON.stringify(buildId))");
     expect(serviceWorkerSource).not.toContain('const CACHE_NAME = "openclaw-control-v1"');
   });
+
+  it("broadcasts updated versions to uncontrolled window clients during activation", async () => {
+    const serviceWorkerSource = fs.readFileSync(serviceWorkerPath, "utf8");
+    const windowClient = { postMessage: vi.fn() };
+    const matchedClients = createDeferred<Array<typeof windowClient>>();
+    const listeners = new Map<string, Array<(event: ActivateEventStub) => void>>();
+    const cacheDelete = vi.fn(async () => true);
+    const clients = {
+      claim: vi.fn(async () => undefined),
+      matchAll: vi.fn(() => matchedClients.promise),
+    };
+    const caches = {
+      delete: cacheDelete,
+      keys: vi.fn(async () => [
+        "openclaw-control-oldest",
+        "openclaw-control-older",
+        "openclaw-control-previous",
+        "openclaw-control-new-build",
+        "other-cache",
+      ]),
+      open: vi.fn(),
+    };
+    const serviceWorkerGlobal = {
+      addEventListener(type: string, listener: (event: ActivateEventStub) => void) {
+        listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+      },
+      clients,
+      location: { href: "https://control.example/sw.js?v=new-build" },
+      registration: { showNotification: vi.fn() },
+      skipWaiting: vi.fn(),
+    };
+    const context = vm.createContext({
+      URL,
+      caches,
+      fetch: vi.fn(),
+      self: serviceWorkerGlobal,
+    });
+
+    new vm.Script(serviceWorkerSource, { filename: "ui/public/sw.js" }).runInContext(context);
+
+    const activateHandler = listeners.get("activate")?.[0];
+    expect(activateHandler).toBeDefined();
+    let activationPromise: Promise<unknown> | undefined;
+    activateHandler?.({
+      waitUntil(promise: Promise<unknown>) {
+        activationPromise = promise;
+      },
+    });
+
+    let activationSettled = false;
+    void activationPromise?.then(() => {
+      activationSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(activationSettled).toBe(false);
+    expect(windowClient.postMessage).not.toHaveBeenCalled();
+
+    matchedClients.resolve([windowClient]);
+    await activationPromise;
+
+    expect(clients.matchAll).toHaveBeenCalledWith({ type: "window", includeUncontrolled: true });
+    expect(clients.claim).toHaveBeenCalled();
+    expect(cacheDelete).toHaveBeenCalledWith("openclaw-control-oldest");
+    expect(windowClient.postMessage).toHaveBeenCalledWith({
+      type: "sw-updated",
+      version: "new-build",
+    });
+    expect(windowClient.postMessage.mock.calls[0]).toHaveLength(1);
+  });
 });
+
+type ActivateEventStub = {
+  waitUntil(promise: Promise<unknown>): void;
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}


### PR DESCRIPTION
Closes #95292

Recreates and repairs #95559.

## What Problem This Solves

Fixes an issue where users could keep running a stale Control UI bundle after a service worker update activated. The page could remain on the old build until a manual reload even though the new service worker version was already active.

## Why This Change Was Made

The service worker now broadcasts its activated build version to window clients, including uncontrolled clients, after cache cleanup and `clients.claim()`. The Control UI listens for that update message and reloads only when the service worker version differs from the page's embedded build id. Existing bounded prior-build cache retention remains in place.

## User Impact

Users get moved onto the active Control UI build automatically after an update instead of staying on stale JavaScript or CSS until they notice and reload manually.

## Evidence

- `node scripts/run-vitest.mjs ui/src/ui/service-worker-cache.test.ts` passed: 2 tests.
- `node node_modules/oxlint/bin/oxlint ui/public/sw.js` passed after the Service Worker `Client.postMessage` lint suppression.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts --reporter=verbose test/scripts/lint-suppressions.test.ts` passed: 3 tests. This covers the lint-suppression baseline required by CI.
- `git diff --check origin/main..HEAD` passed before the amend; `git diff --check` passed after the amend.
- Playwright browser proof with real `ui/public/sw.js`: served `old-build`, updated to `new-build`, Chromium received `{type:sw-updated,version:new-build}`, reloaded, and reported `reloads: 2`, `lastPageBuild: new-build`, `controlled: true`.
- Autoreview: `python .agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --codex-bin %TEMP%/codex-fast-autoreview.cmd` reported clean, no accepted/actionable findings.
- Azure Crabbox changed gate passed on the pushed head `927490ea1409e8dfb1718c3ab4dcdd82d3cd3bfb`:

```text
Provider: azure
Lease: cbx_f229ab74f150 / slug brisk-shrimp
Run: run_725a5f0a68e8
Machine: Standard_D32ads_v6
Command: env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed
Result: exitCode=0
Timing: sync 4m59.460s, command 5m45.828s, total 13m10.159s
Cleanup: one-shot lease stopped by Crabbox (leaseStopped=true)
```

The Azure changed gate included guarded extension wildcard re-export checks, plugin-sdk wildcard re-export checks, dependency pin guard, npm shrinkwrap guard, runtime sidecar baseline/owner test, package patch guard, database-first legacy-store guard, media download helper guard, runtime sidecar loader guard, all changed-scope typecheck, lint shards, and runtime import cycle check.