### PR TITLE
fix(failover): fallback on replay-safe prompt timeouts

### DIFF
--- a/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test.ts
+++ b/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test.ts
@@ -1,0 +1,99 @@
+// Coverage for handing replay-safe plugin-harness prompt timeouts to model fallback.
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  MockedFailoverError,
+  mockedClassifyFailoverReason,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+
+let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
+
+describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+  });
+
+  it("throws FailoverError for replay-safe harness-owned prompt timeouts when model fallbacks are configured", async () => {
+    mockedClassifyFailoverReason.mockReturnValue("timeout");
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        promptError: new Error("LLM request timed out."),
+        promptErrorSource: "prompt",
+      }),
+    );
+
+    const promise = runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-prompt-timeout-fallback",
+      config: makeModelFallbackCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-5.4",
+              fallbacks: ["anthropic/claude-opus-4-6"],
+            },
+          },
+        },
+      }),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
+    await expect(promise).rejects.toThrow("LLM request timed out.");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces replay-invalid prompt timeouts instead of handing them to model fallback", async () => {
+    mockedClassifyFailoverReason.mockReturnValue("timeout");
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        promptError: new Error("LLM request timed out."),
+        promptErrorSource: "prompt",
+        promptTimeoutOutcome: {
+          message: "Harness abandoned the timed-out turn after provider activity.",
+          replayInvalid: true,
+          livenessState: "abandoned",
+        },
+      }),
+    );
+
+    let thrown: unknown;
+    try {
+      await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "openai",
+        model: "gpt-5.4",
+        runId: "run-prompt-timeout-replay-invalid",
+        config: makeModelFallbackCfg({
+          agents: {
+            defaults: {
+              model: {
+                primary: "openai/gpt-5.4",
+                fallbacks: ["anthropic/claude-opus-4-6"],
+              },
+            },
+          },
+        }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).not.toBeInstanceOf(MockedFailoverError);
+    expect(String((thrown as Error | undefined)?.message)).toContain("LLM request timed out.");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3103,6 +3103,12 @@ async function runEmbeddedAgentInternal(
             );
             const promptFailoverFailure =
               promptFailoverReason !== null || isFailoverErrorMessage(errorText, { provider });
+            const promptTimeoutFallbackSafe =
+              promptErrorSource === "prompt" &&
+              promptFailoverReason === "timeout" &&
+              !attempt.codexAppServerFailure &&
+              attempt.promptTimeoutOutcome?.replayInvalid !== true &&
+              attempt.replayMetadata.replaySafe;
             // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
             const failedPromptProfileId = lastProfileId;
             const logPromptFailoverDecision = createFailoverDecisionLogger({
@@ -3134,6 +3140,7 @@ async function runEmbeddedAgentInternal(
               failoverFailure: promptFailoverFailure,
               failoverReason: promptFailoverReason,
               harnessOwnsTransport: pluginHarnessOwnsTransport,
+              promptTimeoutFallbackSafe,
               profileRotated: false,
             });
             if (
@@ -3173,6 +3180,7 @@ async function runEmbeddedAgentInternal(
                 failoverFailure: promptFailoverFailure,
                 failoverReason: promptFailoverReason,
                 harnessOwnsTransport: pluginHarnessOwnsTransport,
+                promptTimeoutFallbackSafe,
                 profileRotated: true,
               });
             }

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -581,6 +581,44 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("falls back on fallback-safe harness-owned prompt timeouts", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "timeout",
+        harnessOwnsTransport: true,
+        promptTimeoutFallbackSafe: true,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "timeout",
+    });
+  });
+
+  it("surfaces fallback-safe harness-owned prompt timeouts when no fallback is configured", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: false,
+        failoverFailure: true,
+        failoverReason: "timeout",
+        harnessOwnsTransport: true,
+        promptTimeoutFallbackSafe: true,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "surface_error",
+      reason: "timeout",
+    });
+  });
+
   it("surfaces error on LLM idle timeout when no fallback is configured and rotation is exhausted", () => {
     expect(
       resolveRunFailoverDecision({

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -50,6 +50,7 @@ type PromptDecisionParams = {
   failoverFailure: boolean;
   failoverReason: FailoverReason | null;
   harnessOwnsTransport?: boolean;
+  promptTimeoutFallbackSafe?: boolean;
   profileRotated: boolean;
 };
 
@@ -179,6 +180,14 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
       };
     }
     if (params.harnessOwnsTransport && params.failoverReason === "timeout") {
+      // Plugin harness lifecycle timeouts must stay inside the harness boundary;
+      // only prompt request timeouts proven replay-safe may enter model fallback.
+      if (params.promptTimeoutFallbackSafe === true && params.fallbackConfigured) {
+        return {
+          action: "fallback_model",
+          reason: "timeout",
+        };
+      }
       return {
         action: "surface_error",
         reason: params.failoverReason,


### PR DESCRIPTION
Closes #95574

Recreates and repairs #95576.

## What Problem This Solves

Fixes an issue where replay-safe prompt-stage provider timeouts could surface as terminal errors even when model fallbacks were configured for the run.

## Why This Change Was Made

The failover policy now allows model fallback for harness-owned timeout errors only when the timeout is from the prompt request, the attempt is replay-safe, the harness has not marked the timeout replay-invalid, and the failure is not a Codex app-server transport failure. Plugin harness lifecycle and abandoned-turn timeouts stay inside the existing surface-error path.

## User Impact

Runs with configured fallback models can recover from safe provider prompt timeouts without replaying abandoned or side-effectful work.

## Evidence

Focused local proof:

```sh
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/failover-policy.test.ts src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test.ts src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
```

Result: passed, 46 tests across 3 files.

```sh
git diff --check origin/main..HEAD
```

Result: passed.

Autoreview initially found a replay-invalid timeout gap; fixed by gating on `attempt.promptTimeoutOutcome?.replayInvalid !== true` and adding a regression test.

Final autoreview:

```sh
python .agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --codex-bin %TEMP%/codex-fast-autoreview.cmd
```

Result: clean, no accepted/actionable findings.

Crabbox/Testbox changed-scope proof:

- Provider/id: Blacksmith Testbox (`provider=blacksmith-testbox`), `tbx_01kvtkmff6an4nytrtbpxctrha`
- Warmup run: https://github.com/openclaw/openclaw/actions/runs/28039342593
- PR head tested: `365bfa1e92eec80256e9f028cc9e7db2095c37ec`
- Base at test time: `d095d98a02b99a8ad0f42f128367b5ae2a99ea5a`

Exact command run on the Testbox after checking out `brokemac79:codex/recreate-95576-failover-timeout`:

```sh
env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed
```

Result: passed, `TESTBOX_EXIT=0`.

Relevant output:

```text
[check:changed] lanes=core, coreTests
[check:changed] src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test.ts: core test
[check:changed] src/agents/embedded-agent-runner/run.ts: core production
[check:changed] src/agents/embedded-agent-runner/run/failover-policy.test.ts: core test
[check:changed] src/agents/embedded-agent-runner/run/failover-policy.ts: core production
PASS direct dependency pin guard: checked 470 directly declared dependency specs across 158 tracked package manifests; 0 violations.
PASS package patch guard: no new pnpm patches; 4 legacy patches allowlisted.
Found 0 warnings and 0 errors.
Finished in 4.4s on 4 files with 242 rules using 1 threads.
Database-first legacy-store guard passed.
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
TESTBOX_EXIT=0
```

Azure Crabbox changed gate also passed on the pushed head `365bfa1e92eec80256e9f028cc9e7db2095c37ec`:

```text
Provider: azure
Lease: cbx_7b3f808c9cbd / slug harbor-barnacle
Run: run_ebe808a9b08d
Machine: Standard_D32ads_v6
Command: env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed
Result: exitCode=0
Timing: sync 5m7.189s, command 5m29.249s, total 12m51.318s
Cleanup: one-shot lease stopped by Crabbox (leaseStopped=true)
```

The Azure changed gate included guarded extension wildcard re-export checks, plugin-sdk wildcard re-export checks, dependency pin guard, npm shrinkwrap guard, runtime sidecar baseline/owner test, package patch guard, database-first legacy-store guard, media download helper guard, runtime sidecar loader guard, all changed-scope typecheck, lint shards, and runtime import cycle check.
### Real behavior proof: prompt-stage timeout fallback

Behavior or issue addressed: after a replay-safe prompt-stage timeout from the primary model, `runWithModelFallback` retries the configured fallback model instead of ending the run with the timeout error.

Real environment tested: Crabbox `provider=local-container` on this Windows desktop, Docker image `mcr.microsoft.com/playwright:v1.60.0-noble`, lease `cbx_667e40085f52`, slug `quick-prawn`, PR head `365bfa1e92eec80256e9f028cc9e7db2095c37ec`.

Exact steps or command run after this patch:

```powershell
C:\Users\marti\.local\bin\crabbox.exe run `
  --provider local-container `
  --local-container-image mcr.microsoft.com/playwright:v1.60.0-noble `
  --no-hydrate `
  --timing-json `
  --script C:\oc-work\lsr911-recreate\95576\.tmp\proof-96142-local-container.sh
```

Evidence after fix: the proof harness uses the production `runWithModelFallback` loop and production `runEmbeddedAgent` path with a registered plugin harness. The primary configured model returns a prompt-stage timeout outcome; the fallback configured model completes.

```text
PROOF_96142_RESULT={"scenario":"prompt-stage timeout handoff to configured model fallback","primary":{"provider":"openai","model":"timeout-primary"},"fallback":{"provider":"openai","model":"fallback-ok"},"promptErrorSource":"prompt","promptTimeoutOutcome":{"message":"Harness observed prompt request timeout before assistant/tool output.","replayInvalid":false,"livenessState":"blocked","providerStarted":true,"timeoutPhase":"prompt"},"replaySafe":true,"result":{"provider":"openai","model":"fallback-ok","outcome":"completed"},"attemptCount":2}
[agent/embedded] embedded run failover decision: runId=proof-96142-handoff stage=prompt decision=fallback_model reason=timeout from=openai/timeout-primary profile=- rawError=LLM request timed out before assistant output.
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=openai/timeout-primary candidate=openai/timeout-primary reason=timeout next=openai/fallback-ok detail=LLM request timed out before assistant output.
[model-fallback/decision] model fallback decision: decision=candidate_succeeded requested=openai/timeout-primary candidate=openai/fallback-ok reason=unknown next=none
```

Observed result after fix: the prompt timeout is classified as prompt-stage and replay-safe, the configured fallback `openai/fallback-ok` is attempted, and the run completes on the fallback model after two attempts.

Supplemental validation:

```text
Crabbox changed gate: env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed
Result: exitCode=0
Timing: sync 2m15.308s, command 13m52.512s, total 16m7.919s
Phases: install 1m12.547s, behavior-proof 15.98s, changed-gate 12m23.327s
Cleanup: one-shot local-container lease stopped by Crabbox
```

Supplemental desktop Ollama proof:

- Environment: Windows desktop local OpenClaw embedded agent, Ollama 0.30.8 on `http://127.0.0.1:11434`, model `qwen3.5:4b`, PR head `365bfa1e92eec80256e9f028cc9e7db2095c37ec`.
- Config shape: default primary `ollama-timeout/qwen3.5:4b` pointed at `http://10.255.255.1:11434` with a 1 second timeout; configured fallback `ollama/qwen3.5:4b` pointed at the local Ollama server with `localModelLean: true` and a 262144-token declared context window.

Exact command run after this patch:

```powershell
$env:OPENCLAW_STATE_DIR = "C:\Users\marti\AppData\Local\Temp\openclaw-96142-ollama-proof-1a1883d5daf84d9cb6ae44833d5b84df"
$env:OPENCLAW_CONFIG_PATH = "C:\oc-work\lsr911-recreate\95576\.tmp\proof-96142-ollama-openclaw.json"
$env:OLLAMA_API_KEY = "ollama-local"
$env:OPENCLAW_SKIP_CHANNELS = "1"
$env:OPENCLAW_DEBUG_MODEL_TRANSPORT = "1"
$env:OPENCLAW_DEBUG_SSE = "events"
$env:OPENCLAW_DEBUG_MODEL_PAYLOAD = "summary"
node scripts/run-node.mjs agent --local --agent main --session-key proof-96142-ollama-live --message "Reply with exactly: proof-ok" --timeout 150 --json
```

Evidence after fix:

```text
[fetch-timeout] fetch timeout after 1000ms (elapsed 1006ms) operation=fetchWithSsrFGuard url=http://10.255.255.1:11434/api/chat
[agent/embedded] embedded run failover decision: runId=b67a0fdf-ccba-4296-9dd8-08dfe02765f1 stage=assistant decision=fallback_model reason=timeout from=ollama-timeout/qwen3.5:4b profile=- rawError=LLM idle timeout (1s): no response from model
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=ollama-timeout/qwen3.5:4b candidate=ollama-timeout/qwen3.5:4b reason=timeout next=ollama/qwen3.5:4b detail=LLM idle timeout (1s): no response from model
[model-fallback/decision] model fallback decision: decision=candidate_succeeded requested=ollama-timeout/qwen3.5:4b candidate=ollama/qwen3.5:4b reason=unknown next=none
```

Observed result after fix:

```json
{
  "payloads": [{ "text": "proof-ok", "mediaUrl": null }],
  "meta": {
    "agentMeta": {
      "provider": "ollama",
      "model": "qwen3.5:4b",
      "contextTokens": 262144,
      "fallbackAttempts": [
        {
          "provider": "ollama-timeout",
          "model": "qwen3.5:4b",
          "error": "LLM idle timeout (1s): no response from model",
          "reason": "timeout",
          "status": 408
        }
      ]
    },
    "finalAssistantVisibleText": "proof-ok"
  }
}
```

Proof limitations or environment constraints: the local-container proof uses a deterministic registered OpenClaw plugin harness. The supplemental desktop proof exercises a real local Ollama server and a real fetch timeout to an unreachable Ollama endpoint from the same Windows host, but it does not prove a remote Crabbox VM can reach this desktop's loopback Ollama service.

What was not tested: live third-party cloud provider auth, an actual external provider outage, and remote Crabbox-to-desktop Ollama tunneling were not exercised.
