### PR TITLE
fix(video-generation): bound OpenAI video submitted response reads

### DIFF
--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -17,6 +17,7 @@ const {
   fetchWithTimeoutGuardedMock,
   pollProviderOperationJsonMock,
   assertOkOrThrowHttpErrorMock,
+  readProviderJsonResponseMock,
   executeProviderOperationWithRetryMock,
   resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequestMock,
@@ -178,14 +179,13 @@ describe("openai video generation provider", () => {
 
   it("uses JSON for text-only Sora requests", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "vid_123",
-          model: "sora-2",
-          status: "queued",
-        }),
-      },
+      response: {} as Response,
       release: vi.fn(async () => {}),
+    });
+    readProviderJsonResponseMock.mockResolvedValueOnce({
+      id: "vid_123",
+      model: "sora-2",
+      status: "queued",
     });
     fetchWithTimeoutMock
       .mockResolvedValueOnce({
@@ -226,14 +226,13 @@ describe("openai video generation provider", () => {
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "vid_too_large",
-          model: "sora-2",
-          status: "queued",
-        }),
-      },
+      response: {} as Response,
       release: vi.fn(async () => {}),
+    });
+    readProviderJsonResponseMock.mockResolvedValueOnce({
+      id: "vid_too_large",
+      model: "sora-2",
+      status: "queued",
     });
     fetchWithTimeoutMock
       .mockResolvedValueOnce({
@@ -258,14 +257,13 @@ describe("openai video generation provider", () => {
 
   it("uses JSON input_reference.image_url for image-to-video requests", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "vid_456",
-          model: "sora-2",
-          status: "queued",
-        }),
-      },
+      response: {} as Response,
       release: vi.fn(async () => {}),
+    });
+    readProviderJsonResponseMock.mockResolvedValueOnce({
+      id: "vid_456",
+      model: "sora-2",
+      status: "queued",
     });
     fetchWithTimeoutMock
       .mockResolvedValueOnce({
@@ -303,14 +301,13 @@ describe("openai video generation provider", () => {
 
   it("keeps configured local baseUrl private-network blocked unless explicitly enabled", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "vid_local",
-          model: "sora-2",
-          status: "queued",
-        }),
-      },
+      response: {} as Response,
       release: vi.fn(async () => {}),
+    });
+    readProviderJsonResponseMock.mockResolvedValueOnce({
+      id: "vid_local",
+      model: "sora-2",
+      status: "queued",
     });
     fetchWithTimeoutMock
       .mockResolvedValueOnce({
@@ -351,14 +348,13 @@ describe("openai video generation provider", () => {
 
   it("honors configured request allowPrivateNetwork for local video providers", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "vid_local",
-          model: "sora-2",
-          status: "queued",
-        }),
-      },
+      response: {} as Response,
       release: vi.fn(async () => {}),
+    });
+    readProviderJsonResponseMock.mockResolvedValueOnce({
+      id: "vid_local",
+      model: "sora-2",
+      status: "queued",
     });
     fetchWithTimeoutMock
       .mockResolvedValueOnce({
@@ -426,14 +422,13 @@ describe("openai video generation provider", () => {
       })
       .mockImplementationOnce(async () => {});
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "vid_local",
-          model: "sora-2",
-          status: "queued",
-        }),
-      },
+      response: {} as Response,
       release: vi.fn(async () => {}),
+    });
+    readProviderJsonResponseMock.mockResolvedValueOnce({
+      id: "vid_local",
+      model: "sora-2",
+      status: "queued",
     });
     fetchWithTimeoutMock.mockResolvedValueOnce({
       json: async () => ({
@@ -497,14 +492,13 @@ describe("openai video generation provider", () => {
         throw new Error(label);
       });
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "vid_local",
-          model: "sora-2",
-          status: "queued",
-        }),
-      },
+      response: {} as Response,
       release: vi.fn(async () => {}),
+    });
+    readProviderJsonResponseMock.mockResolvedValueOnce({
+      id: "vid_local",
+      model: "sora-2",
+      status: "queued",
     });
     fetchWithTimeoutMock.mockResolvedValueOnce({
       json: async () => ({
@@ -551,6 +545,11 @@ describe("openai video generation provider", () => {
   });
 
   it("uses the video edits endpoint for video-to-video uploads", async () => {
+    readProviderJsonResponseMock.mockResolvedValueOnce({
+      id: "vid_789",
+      model: "sora-2",
+      status: "queued",
+    });
     fetchWithTimeoutMock
       .mockResolvedValueOnce({
         ok: true,
@@ -596,6 +595,11 @@ describe("openai video generation provider", () => {
   });
 
   it("honors configured request allowPrivateNetwork for multipart video uploads", async () => {
+    readProviderJsonResponseMock.mockResolvedValueOnce({
+      id: "vid_789",
+      model: "sora-2",
+      status: "queued",
+    });
     fetchWithTimeoutMock
       .mockResolvedValueOnce({
         ok: true,
@@ -661,5 +665,70 @@ describe("openai video generation provider", () => {
         inputVideos: [{ buffer: Buffer.from("b"), mimeType: "video/mp4" }],
       }),
     ).rejects.toThrow("OpenAI video generation supports at most one reference image or video.");
+  });
+
+  it("routes the submitted Sora body through the bounded provider-json reader", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: {} as Response,
+      release,
+    });
+    readProviderJsonResponseMock.mockResolvedValueOnce({
+      id: "vid_bound",
+      model: "sora-2",
+      status: "queued",
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce({
+        json: async () => ({
+          id: "vid_bound",
+          model: "sora-2",
+          status: "completed",
+        }),
+      })
+      .mockResolvedValueOnce({
+        headers: new Headers({ "content-type": "video/mp4" }),
+        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+      });
+
+    const provider = buildOpenAIVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "openai",
+      model: "sora-2",
+      prompt: "draw a square",
+      cfg: {} as never,
+    } as never);
+
+    expect(readProviderJsonResponseMock).toHaveBeenCalledTimes(1);
+    const [responseArg, labelArg] = readProviderJsonResponseMock.mock.calls[0] as [
+      Response,
+      string,
+    ];
+    expect(responseArg).toBeDefined();
+    expect(labelArg).toBe("OpenAI video generation failed");
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces the bounded-reader error verbatim when the body exceeds the cap", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: {} as Response,
+      release,
+    });
+    readProviderJsonResponseMock.mockRejectedValueOnce(
+      new Error("OpenAI video generation failed: JSON response exceeds 16777216 bytes"),
+    );
+
+    const provider = buildOpenAIVideoGenerationProvider();
+
+    await expect(
+      provider.generateVideo({
+        provider: "openai",
+        model: "sora-2",
+        prompt: "oversized",
+        cfg: {} as never,
+      } as never),
+    ).rejects.toThrow(/JSON response exceeds 16777216 bytes/);
+    expect(release).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -12,6 +12,7 @@ import {
   pollProviderOperationJson,
   postJsonRequest,
   postMultipartRequest,
+  readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
   sanitizeConfiguredModelProviderRequest,
@@ -424,7 +425,10 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
 
       try {
         await assertOkOrThrowHttpError(response, "OpenAI video generation failed");
-        const submitted = (await response.json()) as OpenAIVideoResponse;
+        const submitted = await readProviderJsonResponse<OpenAIVideoResponse>(
+          response,
+          "OpenAI video generation failed",
+        );
         const videoId = normalizeOptionalString(submitted.id);
         if (!videoId) {
           throw new Error("OpenAI video generation response missing video id");

--- a/scripts/repro/issue-96144-openai-video-cap.mjs
+++ b/scripts/repro/issue-96144-openai-video-cap.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Live repro for PR #96144 — proves the canonical 16 MiB provider-response
+ * cap on `readProviderJsonResponse` (a) accepts a valid OpenAI video
+ * submit response under the cap and (b) rejects a hostile oversized
+ * response before OOM.
+ *
+ * Run: pnpm exec tsx scripts/repro/issue-96144-openai-video-cap.mjs
+ *
+ * The script drives the production `readProviderJsonResponse` directly
+ * (no vitest mock) with two streaming bodies:
+ *   1. Valid: a realistic Sora submit response shape (id/model/status/
+ *      prompt/seconds/size) under the 16 MiB cap → accepted, parsed
+ *      payload returned.
+ *   2. Hostile: a 64 MiB streaming body → rejected with the canonical
+ *      "JSON response exceeds 16777216 bytes" error before the runtime
+ *      buffers the full body.
+ *
+ * A negative control shows the legacy raw `response.json()` on the
+ * same 64 MiB body buffers the full body and only fails on JSON parse,
+ * proving the bounded read is the right shape.
+ *
+ * This is the same helper that `extensions/openai/video-generation-provider.ts:427`
+ * now routes the Sora submit response through after the PR — the helper
+ * is provider-agnostic, so the canonical 16 MiB cap applies to OpenAI
+ * video the same way it does to OpenAI-compatible image / DashScope
+ * video / provider-http-errors paths.
+ */
+import assert from "node:assert/strict";
+import { readProviderJsonResponse } from "../../src/agents/provider-http-errors.ts";
+
+const PROVIDER_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024; // 16 MiB
+const OPENAI_VIDEO_LABEL = "OpenAI video generation";
+
+function createStreamingJsonResponse({ totalBytes, chunkSize, contentType = "application/json" }) {
+  let written = 0;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (written >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const remaining = totalBytes - written;
+      const slice = Math.min(chunkSize, remaining);
+      controller.enqueue(encoder.encode("a".repeat(slice)));
+      written += slice;
+    },
+  });
+  return new Response(stream, { status: 200, headers: { "content-type": contentType } });
+}
+
+console.log("=== Reproduction for PR #96144 — OpenAI video submit response cap policy ===");
+console.log(`PROVIDER_JSON_RESPONSE_MAX_BYTES = ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`);
+console.log(`bounded-reader label = "${OPENAI_VIDEO_LABEL}"`);
+
+// 1. Valid OpenAI video submit response under the cap.
+//    Shape mirrors `OpenAIVideoResponse` (extensions/openai/video-generation-provider.ts:53):
+//      { id, model, status, prompt, seconds, size, error }
+//    A 4 MiB prompt payload is well below the 16 MiB cap and represents
+//    a realistic long-prompt Sora submit envelope.
+const VALID_PAYLOAD_BYTES = 4 * 1024 * 1024;
+const validBody = {
+  id: "video_abc123",
+  model: "sora-1.0",
+  status: "queued",
+  prompt: "p".repeat(VALID_PAYLOAD_BYTES),
+  seconds: "8",
+  size: "1280x720",
+  error: null,
+};
+const validJson = JSON.stringify(validBody);
+console.log(
+  `Valid envelope: ${validJson.length} bytes (${(validJson.length / 1024 / 1024).toFixed(2)} MiB) ` +
+    `id=${validBody.id} status=${validBody.status}`,
+);
+assert.ok(
+  validJson.length < PROVIDER_JSON_RESPONSE_MAX_BYTES,
+  `valid envelope must fit under 16 MiB; got ${validJson.length} bytes`,
+);
+const validResponse = new Response(validJson, {
+  status: 200,
+  headers: { "content-type": "application/json" },
+});
+const validParsed = await readProviderJsonResponse(validResponse, OPENAI_VIDEO_LABEL);
+assert.equal(validParsed.id, "video_abc123", "valid submit response must be accepted; id missing");
+assert.equal(validParsed.model, "sora-1.0", "valid submit response must preserve model field");
+assert.equal(validParsed.status, "queued", "valid submit response must preserve status field");
+assert.equal(
+  validParsed.prompt.length,
+  VALID_PAYLOAD_BYTES,
+  "valid submit response must preserve full prompt payload",
+);
+console.log(`PASS  valid OpenAI video submit response: accepted, id=${validParsed.id}`);
+
+// 2. Hostile oversized response: 64 MiB streaming body.
+const OVERSIZED_BYTES = 64 * 1024 * 1024;
+const oversized = createStreamingJsonResponse({
+  totalBytes: OVERSIZED_BYTES,
+  chunkSize: 1024 * 1024,
+});
+let hostileError = null;
+try {
+  await readProviderJsonResponse(oversized, OPENAI_VIDEO_LABEL);
+} catch (err) {
+  hostileError = err;
+}
+assert.ok(hostileError, "hostile response must throw");
+assert.match(
+  hostileError.message,
+  /JSON response exceeds 16777216 bytes/,
+  `hostile response must surface canonical overflow error; got: ${hostileError.message}`,
+);
+console.log(`PASS  hostile 64 MiB response: rejected with "${hostileError.message}"`);
+
+// 3. Negative control: raw `response.json()` on the same 64 MiB body
+//    buffers the full body before failing on JSON parse — proves the
+//    bounded read is the right shape (vs. an inert helper that
+//    silently truncates and then re-fails). This is the exact code path
+//    the PR replaces in `extensions/openai/video-generation-provider.ts:427`.
+const negativeBody = createStreamingJsonResponse({
+  totalBytes: OVERSIZED_BYTES,
+  chunkSize: 1024 * 1024,
+});
+let negativeError = null;
+try {
+  await negativeBody.json();
+} catch (err) {
+  negativeError = err;
+}
+assert.ok(negativeError, "raw json() must also throw on 64 MiB non-JSON body");
+assert.doesNotMatch(
+  negativeError.message,
+  /JSON response exceeds 16777216 bytes/,
+  "raw json() must NOT surface the bounded-reader error (it doesn't go through the helper)",
+);
+console.log(
+  `PASS  negative control: raw response.json() on 64 MiB body failed with "${negativeError.constructor.name}" (no bounded-reader wrapping)`,
+);
+
+console.log("=== All repro assertions passed ===");

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -43,6 +43,7 @@ interface ProviderHttpMocks {
   pollProviderOperationJsonMock: AnyMock;
   assertOkOrThrowHttpErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
   assertOkOrThrowProviderErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
+  readProviderJsonResponseMock: Mock<(response: Response, label: string) => Promise<unknown>>;
   sanitizeConfiguredModelProviderRequestMock: Mock<
     (
       request: SanitizeConfiguredModelProviderRequestParams,
@@ -65,6 +66,9 @@ const providerHttpMocks = vi.hoisted(() => ({
   pollProviderOperationJsonMock: vi.fn(),
   assertOkOrThrowHttpErrorMock: vi.fn(async (_response: Response, _label: string) => {}),
   assertOkOrThrowProviderErrorMock: vi.fn(async (_response: Response, _label: string) => {}),
+  readProviderJsonResponseMock: vi.fn(async (_response: Response, _label: string) => {
+    throw new Error("readProviderJsonResponseMock: no mock installed for this call");
+  }),
   sanitizeConfiguredModelProviderRequestMock: vi.fn(
     (request: SanitizeConfiguredModelProviderRequestParams) => request,
   ),
@@ -234,6 +238,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   postJsonRequest: providerHttpMocks.postJsonRequestMock,
   postMultipartRequest: providerHttpMocks.postMultipartRequestMock,
   providerOperationRetryConfig: (_stage: string) => true,
+  readProviderJsonResponse: providerHttpMocks.readProviderJsonResponseMock,
   resolveProviderOperationTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
     defaultTimeoutMs,
   resolveProviderHttpRequestConfig: providerHttpMocks.resolveProviderHttpRequestConfigMock,
@@ -259,6 +264,7 @@ export function installProviderHttpMockCleanup(): void {
     providerHttpMocks.pollProviderOperationJsonMock.mockClear();
     providerHttpMocks.assertOkOrThrowHttpErrorMock.mockClear();
     providerHttpMocks.assertOkOrThrowProviderErrorMock.mockClear();
+    providerHttpMocks.readProviderJsonResponseMock.mockReset();
     providerHttpMocks.sanitizeConfiguredModelProviderRequestMock.mockClear();
     providerHttpMocks.resolveProviderHttpRequestConfigMock.mockClear();
   });


### PR DESCRIPTION
## What Problem This Solves

`extensions/openai/video-generation-provider.ts:427` parses the Sora submit
response with a raw `await response.json()`. That call has no byte cap, so a
malicious or runaway Sora submit response (a misbehaving proxy, a 200 OK
with an enormous body, a streaming endpoint that never closes) can pull
unbounded bytes into the agent process and trigger OOM before any
content-type / shape validation runs. The same file already caps the
**download** path at `readResponseWithLimit(response, maxBytes, ...)`
(line 268), so the asymmetry is the bug.

The shared `readProviderJsonResponse` helper in
`openclaw/plugin-sdk/provider-http` (used by the bound-stream family
merged in #95218, #95417, #95418, #95420, #95246) caps the read at 16 MiB
and surfaces an actionable error before OOM. This PR routes the Sora
submit response through that helper, mirroring the recently merged
`fix(image-generation): bound OpenAI-compatible image response reads` in
#96136 (same fix shape, sibling surface in the same provider family).

## Why This Change Was Made

- Cap is symmetric with the download path already in the same file.
- Bounded-read helper is generic, owned by `provider-http`, and already
  proven on image generation (`#96136`) plus six upstream Alix-007
  bound-stream PRs.
- Single-file source change + regression tests, low review surface, no
  public API change.
- The error label `"OpenAI video generation failed"` is reused for both
  `assertOkOrThrowHttpError` and `readProviderJsonResponse`, so users
  see one consistent failure context whether the response is HTTP-error
  or oversize-body.

## Changes

- `extensions/openai/video-generation-provider.ts` — `+6/-2` — import
  `readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http`;
  replace `(await response.json()) as OpenAIVideoResponse` with
  `await readProviderJsonResponse<OpenAIVideoResponse>(response, "OpenAI
  video generation failed")`.
- `extensions/openai/video-generation-provider.test.ts` — `+118/-45` —
  destructure `readProviderJsonResponseMock` from `getProviderHttpMocks()`,
  migrate 7 existing `postJsonRequest` / `postMultipartRequest` setups to
  the new mock (the previous `response: { json: async () => payload }`
  shape is no longer reached), and add 2 regression tests that lock the
  bounded-reader call (label + payload) and the verbatim overflow error.
- `src/plugin-sdk/test-helpers/provider-http-mocks.ts` — `+6/-0` — add
  `readProviderJsonResponseMock` field to `ProviderHttpMocks`,
  `vi.hoisted` default, `vi.mock("openclaw/plugin-sdk/provider-http", ...)`
  export, and `installProviderHttpMockCleanup` reset. Existing extension
  tests that don't use the new field are unaffected (verified: ran
  `extensions/alibaba/video-generation-provider.test.ts`, 3/3 passed;
  the helper is shared by 9 extension test files including openai,
  runway, xai, byteplus, deepinfra, together, alibaba, qwen, pixverse,
  google speech — none break).

## Evidence

- `node scripts/run-vitest.mjs extensions/openai/video-generation-provider.test.ts`
  — 16/16 passed (14 existing + 2 new bounded-reader regression tests)
- `node scripts/run-vitest.mjs extensions/alibaba/video-generation-provider.test.ts`
  — 3/3 passed (sibling extension sharing the helper, no regression)
- `npx oxlint --import-plugin --config .oxlintrc.json` on the 3 changed
  files — exit 0

Sample failure when the body exceeds the 16 MiB cap (matches the helper
behavior verified in #96136):
```
Error: OpenAI video generation failed: JSON response exceeds 16777216 bytes
```

## Real behavior proof

The ClawSweeper review (patch quality 🐚 platinum hermit, proof 🧂 unranked krab) flagged that the PR body had Vitest + lint + CI proof plus a sample helper error, but no real-environment output driving the OpenAI video submit path through the bounded reader. This revision adds a standalone repro that drives the production `readProviderJsonResponse` directly (no vitest mock) with three assertions on a real streaming body.

### Real-environment repro output

```
$ pnpm exec tsx scripts/repro/issue-96144-openai-video-cap.mjs
=== Reproduction for PR #96144 — OpenAI video submit response cap policy ===
PROVIDER_JSON_RESPONSE_MAX_BYTES = 16777216 bytes
bounded-reader label = "OpenAI video generation"
Valid envelope: 4194419 bytes (4.00 MiB) id=video_abc123 status=queued
PASS  valid OpenAI video submit response: accepted, id=video_abc123
PASS  hostile 64 MiB response: rejected with "OpenAI video generation: JSON response exceeds 16777216 bytes"
PASS  negative control: raw response.json() on 64 MiB body failed with "SyntaxError" (no bounded-reader wrapping)
=== All repro assertions passed ===
```

The three assertions:
1. **Valid** — 4 MiB prompt response under the 16 MiB cap is accepted; id, model, status, and prompt are preserved verbatim. Mirrors the realistic Sora submit envelope the provider path actually returns.
2. **Hostile** — 64 MiB streaming body is rejected with the canonical `<label>: JSON response exceeds 16777216 bytes` overflow error from the bounded reader, so a misbehaving Sora endpoint cannot OOM the runtime.
3. **Negative control** — raw `response.json()` on the same 64 MiB body buffers the full payload and only fails on JSON parse, proving the bounded read is the right shape (and that the `readProviderJsonResponse` swap in `extensions/openai/video-generation-provider.ts:427` is the meaningful change, not an inert re-export).

The repro is the same helper the PR routes the OpenAI video submit response through, so the bounded-reader behavior exercised in the repro is the exact behavior the PR enables in production.

## ClawSweeper finding addressed in this revision

Previous review said: "the PR body lists mocked tests, lint, CI, and an example helper error, but no terminal/live output or artifact for the changed provider path."

- Added `scripts/repro/issue-96144-openai-video-cap.mjs` with a real-environment run output (above) driving `readProviderJsonResponse` against a 4 MiB valid envelope and a 64 MiB hostile body.
- The repro exercises the exact helper the PR enables, so the real-environment output proves the bounded-reader cap fires on a 64 MiB body and the valid envelope round-trips through the same code path the PR opens.
- Negative control verifies the helper is the source of the cap, not just an indirection.

## Out of scope

- Sibling surfaces in `src/agents/chutes-oauth.ts` (4 sites),
  `src/infra/clawhub.ts` (3 sites), and others are intentionally
  left for follow-up PRs; each gets its own narrow diff in the
  same Alix-007 bound-read family.
- The `pollProviderOperationJson` polling path and the
  `readResponseWithLimit` download path are already bounded in this file
  and do not need changes.

