### PR TITLE
fix(memory-core): clamp widen-fallback kNN k to sqlite-vec 4096 limit

### DIFF
--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -1063,4 +1063,76 @@ describe("searchVector sqlite-vec KNN", () => {
       db.close();
     }
   });
+
+  // ===== Widen-fallback kNN clamp =====
+  //
+  // sqlite-vec hard-caps the KNN `k` parameter at 4096 (v0.1.9: a `k` above the
+  // ceiling raises "k out of range"). When the oversampled first pass returns
+  // fewer rows than `limit` and the vector table is larger than the oversample
+  // window, searchVector widens the re-query to `vectorCount`. On a table with
+  // >4096 vectors that re-query would pass an out-of-range `k` and throw,
+  // killing the whole memory search. The fix clamps the widen `k` to 4096.
+  //
+  // These use a prepare-mock instead of a real >4096-row sqlite-vec table: the
+  // assertion is purely on the `k` argument handed to the widen re-query, and a
+  // mock pins that without the cost (and flakiness) of materializing 4097+
+  // vectors and loading the native extension.
+  function runWidenWithVectorCount(vectorCount: number): Promise<number[]> {
+    const widenRow = {
+      id: "hit",
+      path: "memory/hit.md",
+      start_line: 1,
+      end_line: 1,
+      text: "chunk hit",
+      source: "memory",
+      dist: 0.1,
+    };
+    // `k` is the 3rd positional bind of the KNN query (qBlob, qBlob, k, ...).
+    const knnKValues: number[] = [];
+    const prepare = vi.fn((sql: string) => {
+      if (sql.includes("vec_distance_cosine")) {
+        return {
+          all: (...binds: unknown[]) => {
+            knnKValues.push(binds[2] as number);
+            // First (oversample) pass returns < limit so the widen branch runs;
+            // the widen pass returns a row so the search still resolves.
+            return knnKValues.length === 1 ? [] : [widenRow];
+          },
+        };
+      }
+      if (sql.includes("COUNT(*)")) {
+        // Both COUNTs (matching-chunk count and total vectorCount) resolve to
+        // the full table size here: every chunk matches and is indexed, which
+        // is the scenario that triggers the widen.
+        return { get: () => ({ count: vectorCount }) };
+      }
+      throw new Error(`unexpected SQL: ${sql}`);
+    });
+
+    return searchVector({
+      db: { prepare } as unknown as Parameters<typeof searchVector>[0]["db"],
+      vectorTable: "memory_index_chunks_vec",
+      providerModel: "target-model",
+      queryVec: [1, 0],
+      limit: 2,
+      snippetMaxChars: 200,
+      ensureVectorReady: async () => true,
+      sourceFilterVec: { sql: "", params: [] },
+      sourceFilterChunks: { sql: "", params: [] },
+    }).then(() => knnKValues);
+  }
+
+  it("clamps the widen-fallback kNN k to the sqlite-vec 4096 ceiling", async () => {
+    // 5000 vectors → oversample window is limit*8 = 16, so the widen branch
+    // would ask for k=5000 without the clamp. Assert it is capped at 4096.
+    const kValues = await runWidenWithVectorCount(5000);
+    expect(kValues).toEqual([16, 4096]);
+  });
+
+  it("does not over-clamp a widen below the 4096 ceiling", async () => {
+    // A legitimate widen to 30 (> oversample 16, < 4096) must pass through
+    // untouched, proving the clamp is a ceiling and not a fixed value.
+    const kValues = await runWidenWithVectorCount(30);
+    expect(kValues).toEqual([16, 30]);
+  });
 });

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -999,7 +999,7 @@ describe("searchVector sqlite-vec KNN", () => {
     }
   });
 
-  it("fills the requested limit after model filters prune nearest KNN candidates", async () => {
+  it("falls back when filters hide matches beyond sqlite-vec's KNN cap", async () => {
     const db = new DatabaseSync(":memory:", { allowExtension: true });
     try {
       const loaded = await loadSqliteVecExtension({ db });
@@ -1022,11 +1022,16 @@ describe("searchVector sqlite-vec KNN", () => {
       const insertVector = db.prepare(
         "INSERT INTO memory_index_chunks_vec (id, embedding) VALUES (?, ?)",
       );
-      const addChunk = (params: { id: string; model: string; vector: [number, number] }) => {
+      const addChunk = (params: {
+        id: string;
+        model: string;
+        source: "memory" | "sessions";
+        vector: [number, number];
+      }) => {
         insertChunk.run(
           params.id,
           `memory/${params.id}.md`,
-          "memory",
+          params.source,
           1,
           1,
           params.id,
@@ -1039,13 +1044,27 @@ describe("searchVector sqlite-vec KNN", () => {
       };
 
       for (let i = 0; i < 20; i += 1) {
-        addChunk({ id: `other-${i}`, model: "other-model", vector: [1, i / 1000] });
+        addChunk({
+          id: `other-${i}`,
+          model: "other-model",
+          source: "memory",
+          vector: [1, 0],
+        });
       }
-      addChunk({ id: "target-1", model: "target-model", vector: [0.5, 0.5] });
-      addChunk({ id: "target-2", model: "target-model", vector: [0.4, 0.6] });
-      addChunk({ id: "alias-1", model: "alias-model", vector: [0.45, 0.55] });
+      addChunk({
+        id: "target",
+        model: "target-model",
+        source: "memory",
+        vector: [0.5, 0.5],
+      });
+      addChunk({
+        id: "alias",
+        model: "alias-model",
+        source: "memory",
+        vector: [0.4, 0.6],
+      });
 
-      const results = await searchVector({
+      const belowCapResults = await searchVector({
         db,
         vectorTable: "memory_index_chunks_vec",
         providerModel: "target-model",
@@ -1057,82 +1076,48 @@ describe("searchVector sqlite-vec KNN", () => {
         sourceFilterVec: { sql: "", params: [] },
         sourceFilterChunks: { sql: "", params: [] },
       });
+      expect(belowCapResults.map((row) => row.id)).toEqual(["target", "alias"]);
 
-      expect(results.map((row) => row.id)).toEqual(["target-1", "alias-1"]);
+      db.exec("BEGIN");
+      for (let i = 20; i < 4097; i += 1) {
+        addChunk({
+          id: `other-${i}`,
+          model: "other-model",
+          source: "memory",
+          vector: [1, 0],
+        });
+      }
+      addChunk({
+        id: "wrong-source",
+        model: "target-model",
+        source: "sessions",
+        vector: [0.6, 0.4],
+      });
+      db.exec("COMMIT");
+
+      const overLimitQuery = db.prepare(
+        "SELECT id FROM memory_index_chunks_vec WHERE embedding MATCH ? AND k = ?",
+      );
+      expect(() => overLimitQuery.all(vectorToBlob([1, 0]), 4097)).toThrow(
+        "k value in knn query too large, provided 4097 and the limit is 4096",
+      );
+
+      const results = await searchVector({
+        db,
+        vectorTable: "memory_index_chunks_vec",
+        providerModel: "target-model",
+        providerModelAliases: ["alias-model"],
+        queryVec: [1, 0],
+        limit: 2,
+        snippetMaxChars: 200,
+        ensureVectorReady: async () => true,
+        sourceFilterVec: { sql: " AND c.source IN (?)", params: ["memory"] },
+        sourceFilterChunks: { sql: " AND source IN (?)", params: ["memory"] },
+      });
+
+      expect(results.map((row) => row.id)).toEqual(["target", "alias"]);
     } finally {
       db.close();
     }
-  });
-
-  // ===== Widen-fallback kNN clamp =====
-  //
-  // sqlite-vec hard-caps the KNN `k` parameter at 4096 (v0.1.9: a `k` above the
-  // ceiling raises "k out of range"). When the oversampled first pass returns
-  // fewer rows than `limit` and the vector table is larger than the oversample
-  // window, searchVector widens the re-query to `vectorCount`. On a table with
-  // >4096 vectors that re-query would pass an out-of-range `k` and throw,
-  // killing the whole memory search. The fix clamps the widen `k` to 4096.
-  //
-  // These use a prepare-mock instead of a real >4096-row sqlite-vec table: the
-  // assertion is purely on the `k` argument handed to the widen re-query, and a
-  // mock pins that without the cost (and flakiness) of materializing 4097+
-  // vectors and loading the native extension.
-  function runWidenWithVectorCount(vectorCount: number): Promise<number[]> {
-    const widenRow = {
-      id: "hit",
-      path: "memory/hit.md",
-      start_line: 1,
-      end_line: 1,
-      text: "chunk hit",
-      source: "memory",
-      dist: 0.1,
-    };
-    // `k` is the 3rd positional bind of the KNN query (qBlob, qBlob, k, ...).
-    const knnKValues: number[] = [];
-    const prepare = vi.fn((sql: string) => {
-      if (sql.includes("vec_distance_cosine")) {
-        return {
-          all: (...binds: unknown[]) => {
-            knnKValues.push(binds[2] as number);
-            // First (oversample) pass returns < limit so the widen branch runs;
-            // the widen pass returns a row so the search still resolves.
-            return knnKValues.length === 1 ? [] : [widenRow];
-          },
-        };
-      }
-      if (sql.includes("COUNT(*)")) {
-        // Both COUNTs (matching-chunk count and total vectorCount) resolve to
-        // the full table size here: every chunk matches and is indexed, which
-        // is the scenario that triggers the widen.
-        return { get: () => ({ count: vectorCount }) };
-      }
-      throw new Error(`unexpected SQL: ${sql}`);
-    });
-
-    return searchVector({
-      db: { prepare } as unknown as Parameters<typeof searchVector>[0]["db"],
-      vectorTable: "memory_index_chunks_vec",
-      providerModel: "target-model",
-      queryVec: [1, 0],
-      limit: 2,
-      snippetMaxChars: 200,
-      ensureVectorReady: async () => true,
-      sourceFilterVec: { sql: "", params: [] },
-      sourceFilterChunks: { sql: "", params: [] },
-    }).then(() => knnKValues);
-  }
-
-  it("clamps the widen-fallback kNN k to the sqlite-vec 4096 ceiling", async () => {
-    // 5000 vectors → oversample window is limit*8 = 16, so the widen branch
-    // would ask for k=5000 without the clamp. Assert it is capped at 4096.
-    const kValues = await runWidenWithVectorCount(5000);
-    expect(kValues).toEqual([16, 4096]);
-  });
-
-  it("does not over-clamp a widen below the 4096 ceiling", async () => {
-    // A legitimate widen to 30 (> oversample 16, < 4096) must pass through
-    // untouched, proving the clamp is a ceiling and not a fixed value.
-    const kValues = await runWidenWithVectorCount(30);
-    expect(kValues).toEqual([16, 30]);
   });
 });

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -15,6 +15,8 @@ import { vectorToBlob } from "./vector-blob.js";
 const FTS_QUERY_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
 const SHORT_CJK_TRIGRAM_RE = /[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af\u3131-\u3163]/u;
 const VECTOR_KNN_OVERSAMPLE_FACTOR = 8;
+// sqlite-vec hard-caps kNN `k` at 4096; the widen fallback must not exceed it.
+const MAX_VECTOR_KNN_K = 4096;
 
 // Scan fallback vector rows in bounded batches so large chunk tables (no usable
 // vec0 index) cannot pin the main thread for multi-second windows and starve
@@ -210,7 +212,7 @@ export async function searchVector(params: {
             | undefined,
         );
         if (vectorCount > candidateLimit) {
-          rows = runVectorQuery(vectorCount);
+          rows = runVectorQuery(Math.min(vectorCount, MAX_VECTOR_KNN_K));
         }
       }
     }

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -15,7 +15,7 @@ import { vectorToBlob } from "./vector-blob.js";
 const FTS_QUERY_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
 const SHORT_CJK_TRIGRAM_RE = /[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af\u3131-\u3163]/u;
 const VECTOR_KNN_OVERSAMPLE_FACTOR = 8;
-// sqlite-vec hard-caps kNN `k` at 4096; the widen fallback must not exceed it.
+// sqlite-vec v0.1.9 rejects KNN queries with k above 4096.
 const MAX_VECTOR_KNN_K = 4096;
 
 // Scan fallback vector rows in bounded batches so large chunk tables (no usable
@@ -85,7 +85,7 @@ function buildMatchQueryFromTerms(terms: string[]): string | null {
   return quoted.join(" AND ");
 }
 
-function readCount(row: { count?: number | bigint } | undefined): number {
+function readCount(row: Record<string, unknown> | undefined): number {
   if (typeof row?.count === "bigint") {
     return Number(row.count);
   }
@@ -155,6 +155,16 @@ export async function searchVector(params: {
   }
   const providerModels = resolveProviderModels(params.providerModel, params.providerModelAliases);
   const vectorModelFilter = buildModelFilter("c.model", providerModels);
+  const searchFallback = () =>
+    searchChunksByEmbedding({
+      db: params.db,
+      providerModel: params.providerModel,
+      providerModelAliases: params.providerModelAliases,
+      sourceFilter: params.sourceFilterChunks,
+      queryVec: params.queryVec,
+      limit: params.limit,
+      snippetMaxChars: params.snippetMaxChars,
+    });
   if (await params.ensureVectorReady(params.queryVec.length)) {
     // Use sqlite-vec's native KNN (MATCH ? AND k = ?) for candidate selection,
     // which runs in ~O(log N + k) via the vec0 index, instead of the previous
@@ -193,7 +203,7 @@ export async function searchVector(params: {
         dist: number;
       }>;
 
-    const candidateLimit = params.limit * VECTOR_KNN_OVERSAMPLE_FACTOR;
+    const candidateLimit = Math.min(params.limit * VECTOR_KNN_OVERSAMPLE_FACTOR, MAX_VECTOR_KNN_K);
     let rows = runVectorQuery(candidateLimit);
     if (rows.length < params.limit) {
       const matchingChunkCount = readCount(
@@ -201,18 +211,21 @@ export async function searchVector(params: {
           .prepare(
             `SELECT COUNT(*) AS count FROM memory_index_chunks c WHERE ${vectorModelFilter}${params.sourceFilterVec.sql}`,
           )
-          .get(...providerModels, ...params.sourceFilterVec.params) as
-          | { count?: number | bigint }
-          | undefined,
+          .get(...providerModels, ...params.sourceFilterVec.params),
       );
       if (matchingChunkCount > rows.length) {
         const vectorCount = readCount(
-          params.db.prepare(`SELECT COUNT(*) AS count FROM ${params.vectorTable}`).get() as
-            | { count?: number | bigint }
-            | undefined,
+          params.db.prepare(`SELECT COUNT(*) AS count FROM ${params.vectorTable}`).get(),
         );
-        if (vectorCount > candidateLimit) {
-          rows = runVectorQuery(Math.min(vectorCount, MAX_VECTOR_KNN_K));
+        const widenedLimit = Math.min(vectorCount, MAX_VECTOR_KNN_K);
+        if (widenedLimit > candidateLimit) {
+          rows = runVectorQuery(widenedLimit);
+        }
+        const requiredMatches = Math.min(params.limit, matchingChunkCount);
+        if (vectorCount > MAX_VECTOR_KNN_K && rows.length < requiredMatches) {
+          // Post-KNN model/source filters can hide every eligible row beyond
+          // sqlite-vec's ceiling; the bounded scan preserves filtered recall.
+          return await searchFallback();
         }
       }
     }
@@ -228,15 +241,7 @@ export async function searchVector(params: {
     }));
   }
 
-  return await searchChunksByEmbedding({
-    db: params.db,
-    providerModel: params.providerModel,
-    providerModelAliases: params.providerModelAliases,
-    sourceFilter: params.sourceFilterChunks,
-    queryVec: params.queryVec,
-    limit: params.limit,
-    snippetMaxChars: params.snippetMaxChars,
-  });
+  return await searchFallback();
 }
 
 async function searchChunksByEmbedding(params: {


### PR DESCRIPTION
## What Problem This Solves

Large memory indexes can make `searchVector` widen a sqlite-vec KNN query past
the dependency's hard `k = 4096` ceiling. sqlite-vec v0.1.9 rejects that query,
so vector search fails.

A simple clamp avoids the exception but is not sufficient: model and source
filters can place eligible rows beyond the nearest 4096 candidates, silently
underfilling results.

## Why This Change Was Made

The repaired search path:

- caps every sqlite-vec KNN request at 4096;
- keeps the existing oversampled and widened fast path below that ceiling;
- detects when the capped result still underfills known eligible matches;
- reuses the existing bounded, event-loop-yielding embedding scan to preserve
  provider-model aliases and source filters.

This keeps normal searches on vec0 and pays for a full scan only when the
dependency ceiling prevents complete filtered recall.

## User Impact

Memory search no longer throws when an index grows beyond sqlite-vec's KNN
limit, and eligible model/source-filtered matches beyond the cap remain
discoverable.

## Evidence

- Pinned dependency source: sqlite-vec v0.1.9 defines
  `SQLITE_VEC_VEC0_K_MAX` as 4096.
- Real sqlite-vec regression:
  - proves below-cap widening;
  - asserts the native 4097 rejection;
  - inserts 4097 nearer rows for another model;
  - recovers the target model and alias through the bounded fallback;
  - excludes a matching-model row from the wrong source.
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-search.test.ts`
  passed 22 tests.
- Scoped oxlint, oxfmt, `git diff --check`, and Codex autoreview passed.
