### PR TITLE
fix(cron): keep a due recurring run when an edit re-saves the same schedule

### DIFF
--- a/src/cron/service.update-recompute-drops-due-every.test.ts
+++ b/src/cron/service.update-recompute-drops-due-every.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createCronStoreHarness,
+  createFinishedBarrier,
+  createNoopLogger,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+installCronTestHooks({ logger: noopLogger });
+
+describe("update() must not drop a due every-job's pending run", () => {
+  it("preserves a due every-job nextRunAtMs on an idempotent schedule re-save", async () => {
+    const store = await makeStorePath();
+    const base = Date.parse("2025-12-13T00:00:00.000Z");
+
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      onEvent: finished.onEvent,
+    });
+
+    await cron.start();
+
+    const job = await cron.add({
+      name: "every 10s",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 10_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "tick" },
+    });
+    const jobId = job.id;
+    expect(job.state.nextRunAtMs).toBe(base + 10_000);
+
+    // Fire once so the job carries lastRunAtMs and a real next due slot.
+    vi.setSystemTime(new Date(base + 10_000 + 5));
+    const firstRun = finished.waitForOk(jobId);
+    await vi.runOnlyPendingTimersAsync();
+    await firstRun;
+
+    let current = (await cron.list({ includeDisabled: true })).find((j) => j.id === jobId)!;
+    const lastRunAtMs = current.state.lastRunAtMs!;
+    const dueSlot = current.state.nextRunAtMs!;
+    expect(dueSlot).toBe(lastRunAtMs + 10_000);
+
+    // Advance past the next slot so it is now due, before the timer services it.
+    vi.setSystemTime(new Date(dueSlot + 50));
+    const nowDue = dueSlot + 50;
+
+    // User edits the job and the control UI resubmits the unchanged schedule
+    // (a normal idempotent re-save, e.g. while changing the message). This must
+    // not advance the already-due slot.
+    await cron.update(jobId, { schedule: { kind: "every", everyMs: 10_000 } });
+
+    current = (await cron.list({ includeDisabled: true })).find((j) => j.id === jobId)!;
+    // Correct: the due slot is preserved so the pending run still fires.
+    // Buggy (current main): nextRunAtMs jumps to dueSlot + 10_000 (> nowDue),
+    // silently dropping this slot's run.
+    expect(current.state.lastRunAtMs).toBe(lastRunAtMs);
+    expect(current.state.nextRunAtMs).toBe(dueSlot);
+    expect(current.state.nextRunAtMs).toBeLessThanOrEqual(nowDue);
+    // The cadence anchor must not re-phase to "now" on an idempotent re-save.
+    expect(current.schedule).toMatchObject({ kind: "every", anchorMs: base });
+
+    cron.stop();
+  });
+
+  it("preserves a due cron-job nextRunAtMs on an idempotent schedule re-save", async () => {
+    const store = await makeStorePath();
+    vi.setSystemTime(new Date("2025-12-13T08:59:00.000Z"));
+
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      onEvent: finished.onEvent,
+    });
+
+    await cron.start();
+
+    const job = await cron.add({
+      name: "daily 9am",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 9 * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "report" },
+    });
+    const jobId = job.id;
+    const dueSlot = job.state.nextRunAtMs!;
+
+    // Advance past the 09:00 slot so it is now due, before the timer fires it.
+    vi.setSystemTime(new Date(dueSlot + 50));
+    const nowDue = dueSlot + 50;
+
+    await cron.update(jobId, { schedule: { kind: "cron", expr: "0 9 * * *" } });
+
+    const current = (await cron.list({ includeDisabled: true })).find((j) => j.id === jobId)!;
+    // Correct: the due slot is preserved. Buggy main: nextRunAtMs jumps to the
+    // next day, dropping today's run.
+    expect(current.state.nextRunAtMs).toBe(dueSlot);
+    expect(current.state.nextRunAtMs).toBeLessThanOrEqual(nowDue);
+
+    cron.stop();
+  });
+});

--- a/src/cron/service.update-recompute-drops-due-every.test.ts
+++ b/src/cron/service.update-recompute-drops-due-every.test.ts
@@ -73,6 +73,52 @@ describe("update() must not drop a due every-job's pending run", () => {
     cron.stop();
   });
 
+  it("re-anchors an every-job to the edit time when the interval actually changes", async () => {
+    const store = await makeStorePath();
+    const base = Date.parse("2025-12-13T00:00:00.000Z");
+
+    const finished = createFinishedBarrier();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      onEvent: finished.onEvent,
+    });
+
+    await cron.start();
+
+    const job = await cron.add({
+      name: "every 10s",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 10_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "tick" },
+    });
+    const jobId = job.id;
+    expect(job.schedule).toMatchObject({ kind: "every", anchorMs: base });
+
+    // User edits the interval from 10s to 1h. The control UI omits the internal
+    // anchorMs, so the new cadence must start from the edit time rather than
+    // keeping the old phase; nextRunAtMs is one new interval from now.
+    const editTime = base + 3_000;
+    vi.setSystemTime(new Date(editTime));
+    await cron.update(jobId, { schedule: { kind: "every", everyMs: 3_600_000 } });
+
+    const current = (await cron.list({ includeDisabled: true })).find((j) => j.id === jobId)!;
+    expect(current.schedule).toMatchObject({
+      kind: "every",
+      everyMs: 3_600_000,
+      anchorMs: editTime,
+    });
+    expect(current.state.nextRunAtMs).toBe(editTime + 3_600_000);
+
+    cron.stop();
+  });
+
   it("preserves a due cron-job nextRunAtMs on an idempotent schedule re-save", async () => {
     const store = await makeStorePath();
     vi.setSystemTime(new Date("2025-12-13T08:59:00.000Z"));

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -18,6 +18,7 @@ import {
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import { createCronExecutionId } from "../run-id.js";
+import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
 import { normalizeCronRunErrorText } from "./execution-errors.js";
 import { failureNotificationDeliveryFromJobState } from "./failure-alerts.js";
@@ -524,28 +525,44 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
     if (nextJob.schedule.kind === "every") {
       const anchor = nextJob.schedule.anchorMs;
       if (typeof anchor !== "number" || !Number.isFinite(anchor)) {
-        const patchSchedule = patch.schedule;
+        // Inherit the previous cadence anchor when an `every` re-save omits it
+        // (UIs resubmit the schedule without the internal anchorMs). Without
+        // this the edit re-phases the job to now, shifting every future fire
+        // time and skipping an already-due slot.
+        const previousAnchorMs =
+          job.schedule.kind === "every" &&
+          typeof job.schedule.anchorMs === "number" &&
+          Number.isFinite(job.schedule.anchorMs)
+            ? job.schedule.anchorMs
+            : undefined;
         const fallbackAnchorMs =
-          patchSchedule?.kind === "every"
+          previousAnchorMs ??
+          (patch.schedule?.kind === "every"
             ? now
             : typeof nextJob.createdAtMs === "number" && Number.isFinite(nextJob.createdAtMs)
               ? nextJob.createdAtMs
-              : now;
+              : now);
         nextJob.schedule = {
           ...nextJob.schedule,
           anchorMs: Math.max(0, Math.floor(fallbackAnchorMs)),
         };
       }
     }
+    // Only advance a recurring job's next run when the schedule/enabled inputs
+    // actually changed. An idempotent re-save (same schedule, or re-enabling an
+    // already-enabled job) must preserve a still-due slot, matching the
+    // add/remove maintenance recompute; otherwise the pending run is dropped.
+    const schedulingInputsChanged =
+      (patch.schedule !== undefined || patch.enabled !== undefined) &&
+      !cronSchedulingInputsEqual(job, nextJob);
     const scheduleChanged = patch.schedule !== undefined;
-    const enabledChanged = patch.enabled !== undefined;
 
     if (scheduleChanged && nextJob.schedule.kind === "cron" && !isJobEnabled(nextJob)) {
       computeJobNextRunAtMs({ ...nextJob, enabled: true }, now);
     }
 
     nextJob.updatedAtMs = now;
-    if (scheduleChanged || enabledChanged) {
+    if (schedulingInputsChanged) {
       if (isJobEnabled(nextJob)) {
         nextJob.state.nextRunAtMs = computeJobNextRunAtMs(nextJob, now);
       } else {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -525,12 +525,15 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
     if (nextJob.schedule.kind === "every") {
       const anchor = nextJob.schedule.anchorMs;
       if (typeof anchor !== "number" || !Number.isFinite(anchor)) {
-        // Inherit the previous cadence anchor when an `every` re-save omits it
-        // (UIs resubmit the schedule without the internal anchorMs). Without
-        // this the edit re-phases the job to now, shifting every future fire
-        // time and skipping an already-due slot.
+        // Inherit the previous cadence anchor only for an unchanged-interval
+        // re-save (UIs resubmit the schedule without the internal anchorMs).
+        // Without this an idempotent edit re-phases the job to now, shifting
+        // every future fire time and skipping an already-due slot. A genuine
+        // interval change still anchors to the edit time so the new cadence
+        // starts now, matching the prior update semantics.
         const previousAnchorMs =
           job.schedule.kind === "every" &&
+          job.schedule.everyMs === nextJob.schedule.everyMs &&
           typeof job.schedule.anchorMs === "number" &&
           Number.isFinite(job.schedule.anchorMs)
             ? job.schedule.anchorMs


### PR DESCRIPTION
## What Problem This Solves

Editing a recurring cron job (`every` or `cron`) while one of its slots is already due silently drops that pending run. The control UI and `cron edit` resubmit the job's schedule on save, and any update that carries `schedule` (or `enabled`) advances `state.nextRunAtMs` to the next future slot without executing the slot that was already due. For an hourly job edited a few seconds after its slot came due, that hour's run never fires; for a daily job, that day's run is lost. For `every` jobs the same edit also re-phases the cadence anchor to "now", shifting every future fire time.

Root cause: `add()` and `remove()` were fixed (#94323) to recompute through `recomputeNextRunsForMaintenance`, which preserves a past-due `nextRunAtMs` so the pending run still fires. `update()` was never converted; it advances unconditionally whenever the patch carries a schedule or enabled field, even when the schedule is unchanged.

`src/cron/service/ops.ts` (before):

```ts
const scheduleChanged = patch.schedule !== undefined;
const enabledChanged = patch.enabled !== undefined;
...
if (scheduleChanged || enabledChanged) {
  if (isJobEnabled(nextJob)) {
    nextJob.state.nextRunAtMs = computeJobNextRunAtMs(nextJob, now);
  }
  ...
}
```

`computeJobNextRunAtMs` returns the strictly-future next slot, so a still-due `nextRunAtMs <= now` is overwritten. The `every` anchor backfill compounds it: when a re-save omits the internal `anchorMs`, the backfill mints `anchorMs = now`, re-phasing the cadence.

## Why This Change Was Made

Only advance the next run when the scheduling inputs actually changed, using the existing `cronSchedulingInputsEqual` helper (the same helper `service/store.ts` already uses to decide whether stored timer state is still valid).

For the `every` anchor backfill, inherit the previous cadence anchor only when the interval is unchanged (an idempotent re-save), so the job keeps its existing phase and a due slot survives. A genuine interval change (a different `everyMs`, which UIs also submit without `anchorMs`) still anchors to the edit time, exactly as before, so the new cadence starts now; that edit already counts as a scheduling change and recomputes the next run as it always did.

`src/cron/service/ops.ts` (after):

```ts
const previousAnchorMs =
  job.schedule.kind === "every" &&
  job.schedule.everyMs === nextJob.schedule.everyMs &&
  typeof job.schedule.anchorMs === "number" &&
  Number.isFinite(job.schedule.anchorMs)
    ? job.schedule.anchorMs
    : undefined;
...
const schedulingInputsChanged =
  (patch.schedule !== undefined || patch.enabled !== undefined) &&
  !cronSchedulingInputsEqual(job, nextJob);
...
if (schedulingInputsChanged) {
  if (isJobEnabled(nextJob)) {
    nextJob.state.nextRunAtMs = computeJobNextRunAtMs(nextJob, now);
  }
  ...
}
```

A genuine schedule change (different `everyMs`, `expr`, `tz`, or an enable transition) still recomputes exactly as before, and an `every` interval change still re-anchors to the edit time; only the unchanged re-save now preserves a due slot and its phase. This is the right boundary: the defect is in the cron service `update()` op that owns next-run state for CRUD edits, the sibling load-time path (`service/store.ts invalidateStaleNextRunOnScheduleChange`) already gates on the same identity, and `add()`/`remove()` already preserve due slots via maintenance recompute. The fix brings `update()` to parity and preserves #15905 (genuine edits still recompute).

## User Impact

Recurring cron jobs no longer skip a fire when the user edits them during an already-due slot, and `every` jobs keep their cadence phase across an unchanged re-save instead of drifting to the edit time. A real interval edit still starts the new cadence from the edit time, unchanged from today's behavior. Without this, any save that resubmits the schedule (the normal control-UI behavior) can silently swallow a scheduled run.

## Evidence

Drove the real `CronService.update()` against a real on-disk cron store with an injected clock, on the prior PR head and on the patched tree with identical inputs. The only stub is the isolated-agent job runner (the external execution boundary); the store, schedule math, anchor backfill, and update op are all real.

Two cases, `base = 2025-12-13T00:00:00Z`:
- Case A, genuine interval change: add an `every: 10s` job (anchored at `base`), then at `base+3000` call `update(jobId, { schedule: { kind: "every", everyMs: 3_600_000 } })` (UI omits `anchorMs`).
- Case B, idempotent re-save: add an `every: 10s` job, fire it once, advance the clock 50ms past the next due slot, then call `update(jobId, { schedule: { kind: "every", everyMs: 10000 } })`.

```
# BEFORE (prior PR head, anchor inherited unconditionally)
A interval-change 10s->1h: anchorMs=base+0,    nextRunAtMs=base+3600000   <- keeps OLD phase, edit-time anchoring lost
B idempotent 10s re-save:  anchorMs=base+0,    nextRunAtMs=base+1820005   dueSlotPreserved=true

# AFTER (this patch, identical inputs)
A interval-change 10s->1h: anchorMs=base+3000, nextRunAtMs=base+3603000   <- re-anchored to edit time (prior semantics restored)
B idempotent 10s re-save:  anchorMs=base+0,    nextRunAtMs=base+1820005   dueSlotPreserved=true
```

Case A now re-anchors a real interval change to the edit time (`base+3000`) instead of keeping the old phase, matching the existing update semantics. Case B is unchanged: the due slot's `nextRunAtMs` is retained and the cadence anchor stays at its original phase, so the pending run still fires.

The idempotent-preserve before/after against pristine main is unchanged from the original PR (main advances the due slot `base+1820005 -> base+1830055`; this patch keeps `base+1820005`).

Additional checks: the colocated regression suite now has three cases (`every` idempotent, `every` interval-change re-anchor, `cron` idempotent); the new interval-change test fails on the prior PR head and passes here, and the two preserve-due tests still fail on pristine main and pass with the patch. The add/remove/ops/apply-patch/at-reschedule suites stay green (29 cases across the cron service suites run here). oxlint and oxfmt are clean on the changed files. Not covered: no live gateway or real isolated-agent execution; full project typecheck not run on this box (the one new call mirrors the existing un-cast `cronSchedulingInputsEqual(CronJob, CronJob)` call in `service/store.ts`).
