### PR TITLE
refactor: use accessor-backed transcript corpus for memory

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -5,9 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   buildSessionEntry,
-  listSessionFilesForAgent,
-  loadSessionTranscriptClassificationForAgent,
-  normalizeSessionTranscriptPathForComparison,
+  listSessionTranscriptCorpusEntriesForAgent,
   parseUsageCountedSessionIdFromFileName,
   sessionPathForFile,
 } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
@@ -848,25 +846,16 @@ async function collectSessionIngestionBatches(params: {
     sessionPath: string;
   }> = [];
   for (const agentId of agentIds) {
-    const files = await listSessionFilesForAgent(agentId);
-    const transcriptClassification =
-      files.length > 0
-        ? loadSessionTranscriptClassificationForAgent(agentId)
-        : {
-            dreamingNarrativeTranscriptPaths: new Set<string>(),
-            cronRunTranscriptPaths: new Set<string>(),
-          };
-    for (const absolutePath of files) {
+    for (const entry of await listSessionTranscriptCorpusEntriesForAgent(agentId)) {
+      const absolutePath = entry.sessionFile;
       if (isCheckpointSessionTranscriptPath(absolutePath)) {
         continue;
       }
-      const normalizedPath = normalizeSessionTranscriptPathForComparison(absolutePath);
       sessionFiles.push({
         agentId,
         absolutePath,
-        generatedByDreamingNarrative:
-          transcriptClassification.dreamingNarrativeTranscriptPaths.has(normalizedPath),
-        generatedByCronRun: transcriptClassification.cronRunTranscriptPaths.has(normalizedPath),
+        generatedByDreamingNarrative: entry.generatedByDreamingNarrative === true,
+        generatedByCronRun: entry.generatedByCronRun === true,
         sessionPath: sessionPathForFile(absolutePath),
       });
     }

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { emitSessionTranscriptUpdate } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { clearConfigCache, clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/config-runtime";
 import {
   resolveSessionTranscriptsDirForAgent,
   type OpenClawConfig,
@@ -15,6 +14,10 @@ import type {
   MemorySyncParams,
   MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { emitSessionTranscriptUpdate } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/config-runtime";
 import {
   resolveSessionTranscriptsDirForAgent,
   type OpenClawConfig,
@@ -102,6 +103,7 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
 
   readonly syncCalls: SyncParams[] = [];
   readonly indexedPaths: string[] = [];
+  readonly indexedContents: string[] = [];
 
   constructor(sourceRows: SourceStateRow[]) {
     super();
@@ -137,6 +139,35 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
 
   getPendingSessionFiles(): string[] {
     return Array.from(this.sessionPendingFiles);
+  }
+
+  addPendingSessionTarget(target: NonNullable<MemorySyncParams["sessions"]>[number]): void {
+    this.sessionPendingTargets.set(
+      [target.agentId ?? "", target.sessionId, target.sessionKey ?? ""].join("\0"),
+      target,
+    );
+  }
+
+  async processPendingSessionDeltas(): Promise<void> {
+    await (
+      this as unknown as {
+        processSessionDeltaBatch: () => Promise<void>;
+      }
+    ).processSessionDeltaBatch();
+  }
+
+  async combineTargetSessionFilesForTest(params: {
+    sessions?: MemorySyncParams["sessions"];
+    sessionFiles?: string[];
+  }): Promise<Set<string> | null> {
+    return await (
+      this as unknown as {
+        combineTargetSessionFiles: (params: {
+          sessions?: MemorySyncParams["sessions"];
+          sessionFiles?: string[];
+        }) => Promise<Set<string> | null>;
+      }
+    ).combineTargetSessionFiles(params);
   }
 
   isSessionsDirty(): boolean {
@@ -184,9 +215,10 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
 
   protected async indexFile(
     entry: MemoryIndexEntry,
-    _options: { source: MemorySource; content?: string },
+    options: { source: MemorySource; content?: string },
   ): Promise<void> {
     this.indexedPaths.push(entry.path);
+    this.indexedContents.push(options.content ?? "");
   }
 }
 
@@ -202,6 +234,8 @@ describe("session startup catch-up", () => {
     vi.clearAllTimers();
     vi.useRealTimers();
     vi.unstubAllEnvs();
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
     await fs.rm(stateDir, { recursive: true, force: true });
   });
 
@@ -396,6 +430,147 @@ describe("session startup catch-up", () => {
     expect(harness.indexedPaths).toEqual([]);
   });
 
+  it("resolves identity-targeted delta sync through a custom session store", async () => {
+    const storeDir = path.join(stateDir, "custom-sessions");
+    const sessionFile = path.join(storeDir, "custom-thread.jsonl");
+    const storePath = path.join(storeDir, "sessions.json");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.mkdir(storeDir, { recursive: true });
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "custom store target" },
+      }) + "\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:chat:custom": {
+          sessionFile: "custom-thread.jsonl",
+          sessionId: "custom-thread",
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(configPath, JSON.stringify({ session: { store: storePath } }), "utf-8");
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    const harness = new SessionStartupCatchupHarness([]);
+    (harness as unknown as { settings: ResolvedMemorySearchConfig }).settings.sync.sessions = {
+      deltaBytes: 1,
+      deltaMessages: 1,
+      postCompactionForce: true,
+    };
+    harness.addPendingSessionTarget({
+      agentId: "main",
+      sessionId: "custom-thread",
+      sessionKey: "agent:main:chat:custom",
+    });
+
+    await harness.processPendingSessionDeltas();
+    await Promise.resolve();
+
+    expect(harness.getDirtySessionFiles()).toEqual([sessionFile]);
+    expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+  });
+
+  it("keeps explicit custom-store session file targets at the sync gate", async () => {
+    const storeDir = path.join(stateDir, "custom-sessions");
+    const sessionFile = path.join(storeDir, "explicit-target.jsonl");
+    const storePath = path.join(storeDir, "sessions.json");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.mkdir(storeDir, { recursive: true });
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "explicit target" },
+      }) + "\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:chat:explicit-target": {
+          sessionFile: "explicit-target.jsonl",
+          sessionId: "explicit-target",
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(configPath, JSON.stringify({ session: { store: storePath } }), "utf-8");
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    const harness = new SessionStartupCatchupHarness([]);
+
+    await expect(
+      harness.combineTargetSessionFilesForTest({ sessionFiles: [sessionFile] }),
+    ).resolves.toEqual(new Set([sessionFile]));
+  });
+
+  it("preserves generated-session classification during targeted custom-store indexing", async () => {
+    const storeDir = path.join(stateDir, "custom-sessions");
+    const sessionFile = path.join(storeDir, "cron-thread.jsonl");
+    const otherSessionFile = path.join(storeDir, "other-thread.jsonl");
+    const storePath = path.join(storeDir, "sessions.json");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.mkdir(storeDir, { recursive: true });
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "Internal cron output that must stay out." },
+      }) + "\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      otherSessionFile,
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "Other custom-store content" },
+      }) + "\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:cron:job-1:run:run-1": {
+          sessionFile: "cron-thread.jsonl",
+          sessionId: "cron-thread",
+        },
+        "agent:main:chat:other": {
+          sessionFile: "other-thread.jsonl",
+          sessionId: "other-thread",
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(configPath, JSON.stringify({ session: { store: storePath } }), "utf-8");
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    const harness = new SessionStartupCatchupHarness([]);
+
+    await (
+      harness as unknown as {
+        syncSessionFiles: (params: {
+          needsFullReindex: boolean;
+          targetSessionFiles: string[];
+        }) => Promise<void>;
+      }
+    ).syncSessionFiles({
+      needsFullReindex: false,
+      targetSessionFiles: [sessionFile],
+    });
+
+    expect(harness.indexedPaths).toEqual(["sessions/cron-thread.jsonl"]);
+    expect(harness.indexedContents).toEqual([""]);
+  });
+
   it("queues transcript update identity without requiring a session file", async () => {
     vi.useFakeTimers();
     const harness = new SessionStartupCatchupHarness([]);
@@ -452,6 +627,49 @@ describe("session startup catch-up", () => {
     });
 
     expect(harness.getPendingSessionFiles()).toEqual([session.filePath]);
+    expect(harness.getPendingSessionTargets()).toEqual([]);
+    harness.stopTranscriptListener();
+  });
+
+  it("queues file-only transcript updates from a custom session store", async () => {
+    vi.useFakeTimers();
+    const storeDir = path.join(stateDir, "custom-sessions");
+    const sessionFile = path.join(storeDir, "custom-update.jsonl");
+    const storePath = path.join(storeDir, "sessions.json");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.mkdir(storeDir, { recursive: true });
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "custom update" },
+      }) + "\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:chat:custom-update": {
+          sessionFile: "custom-update.jsonl",
+          sessionId: "custom-update",
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(configPath, JSON.stringify({ session: { store: storePath } }), "utf-8");
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    const harness = new SessionStartupCatchupHarness([]);
+    harness.startTranscriptListener();
+
+    emitSessionTranscriptUpdate({
+      sessionFile,
+      sessionKey: "agent:main:chat:custom-update",
+    });
+    await Promise.resolve();
+
+    expect(harness.getPendingSessionFiles()).toEqual([sessionFile]);
     expect(harness.getPendingSessionTargets()).toEqual([]);
     harness.stopTranscriptListener();
   });

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -21,9 +21,11 @@ import {
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
   listSessionFilesForAgent,
+  listSessionTranscriptCorpusEntriesForAgent,
   parseCanonicalSessionSyncTargetFromPath,
   resolveSessionFileForSyncTarget,
   sessionPathForFile,
+  type SessionTranscriptCorpusEntry,
 } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import {
   buildFileEntry,
@@ -1467,8 +1469,22 @@ export abstract class MemoryManagerSyncOps {
       const target = this.resolveSessionTranscriptUpdateSyncTarget(update);
       if (target) {
         this.scheduleSessionDirty(target);
+        return;
+      }
+      if (sessionFile) {
+        void this.scheduleCorpusSessionFileDirty(sessionFile).catch((err: unknown) => {
+          log.warn(`memory session corpus update failed: ${String(err)}`);
+        });
       }
     });
+  }
+
+  private async scheduleCorpusSessionFileDirty(sessionFile: string): Promise<void> {
+    const resolvedSessionFile = path.resolve(sessionFile);
+    const corpusEntries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId);
+    if (corpusEntries.some((entry) => path.resolve(entry.sessionFile) === resolvedSessionFile)) {
+      this.scheduleSessionDirty(resolvedSessionFile);
+    }
   }
 
   protected ensureSessionStartupCatchup(): void {
@@ -1563,7 +1579,7 @@ export abstract class MemoryManagerSyncOps {
     const pendingTargets = Array.from(this.sessionPendingTargets.values());
     this.sessionPendingFiles.clear();
     this.sessionPendingTargets.clear();
-    pending.push(...Array.from(this.resolveSessionFilesForSyncTargets(pendingTargets)));
+    pending.push(...Array.from(await this.resolveSessionFilesForSyncTargets(pendingTargets)));
     let shouldSync = false;
     for (const sessionFile of pending) {
       // Usage-counted session archives (`.jsonl.reset.<iso>` and
@@ -1773,11 +1789,15 @@ export abstract class MemoryManagerSyncOps {
     };
   }
 
-  private normalizeTargetSessionFiles(sessionFiles?: string[]): Set<string> | null {
+  private normalizeTargetSessionFiles(
+    sessionFiles?: string[],
+    corpusEntries: readonly SessionTranscriptCorpusEntry[] = [],
+  ): Set<string> | null {
     if (!sessionFiles || sessionFiles.length === 0) {
       return null;
     }
     const normalized = new Set<string>();
+    const corpusPaths = new Set(corpusEntries.map((entry) => path.resolve(entry.sessionFile)));
     for (const sessionFile of sessionFiles) {
       const trimmed = sessionFile.trim();
       if (!trimmed) {
@@ -1788,6 +1808,10 @@ export abstract class MemoryManagerSyncOps {
         this.isSessionFileForAgent(resolved) &&
         parseCanonicalSessionSyncTargetFromPath(resolved)
       ) {
+        normalized.add(resolved);
+        continue;
+      }
+      if (corpusPaths.has(resolved)) {
         normalized.add(resolved);
       }
     }
@@ -1818,11 +1842,36 @@ export abstract class MemoryManagerSyncOps {
     return normalized.size > 0 ? normalized : null;
   }
 
-  private resolveSessionFilesForSyncTargets(
+  private async resolveSessionFilesForSyncTargets(
     sessions?: Iterable<MemorySessionSyncTarget> | null,
-  ): Set<string> {
+    knownCorpusEntries?: readonly SessionTranscriptCorpusEntry[],
+  ): Promise<Set<string>> {
     const files = new Set<string>();
-    for (const session of sessions ?? []) {
+    const targets = Array.from(sessions ?? []);
+    if (targets.length === 0) {
+      return files;
+    }
+    const corpusEntries =
+      knownCorpusEntries ?? (await listSessionTranscriptCorpusEntriesForAgent(this.agentId));
+    for (const session of targets) {
+      const sessionKey = session.sessionKey?.trim();
+      let matchedCorpusEntry = false;
+      for (const entry of corpusEntries) {
+        if (normalizeAgentId(entry.agentId) !== normalizeAgentId(this.agentId)) {
+          continue;
+        }
+        if (entry.sessionId !== session.sessionId) {
+          continue;
+        }
+        if (sessionKey && entry.sessionKey !== sessionKey) {
+          continue;
+        }
+        files.add(path.resolve(entry.sessionFile));
+        matchedCorpusEntry = true;
+      }
+      if (matchedCorpusEntry) {
+        continue;
+      }
       const resolved = resolveSessionFileForSyncTarget(session, this.agentId);
       if (!resolved || normalizeAgentId(resolved.agentId) !== normalizeAgentId(this.agentId)) {
         continue;
@@ -1838,16 +1887,18 @@ export abstract class MemoryManagerSyncOps {
     return files;
   }
 
-  private combineTargetSessionFiles(params: {
+  private async combineTargetSessionFiles(params: {
     sessions?: MemorySessionSyncTarget[];
     sessionFiles?: string[];
-  }): Set<string> | null {
+  }): Promise<Set<string> | null> {
     const files = new Set<string>();
-    for (const file of this.normalizeTargetSessionFiles(params.sessionFiles) ?? []) {
+    const corpusEntries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId);
+    for (const file of this.normalizeTargetSessionFiles(params.sessionFiles, corpusEntries) ?? []) {
       files.add(file);
     }
-    for (const file of this.resolveSessionFilesForSyncTargets(
+    for (const file of await this.resolveSessionFilesForSyncTargets(
       this.normalizeTargetSessions(params.sessions)?.values(),
+      corpusEntries,
     )) {
       files.add(file);
     }
@@ -2062,12 +2113,16 @@ export abstract class MemoryManagerSyncOps {
         ? this.db.prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
         : null;
 
+    const corpusEntries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId);
     const targetSessionFiles = params.needsFullReindex
       ? null
-      : this.normalizeTargetSessionFiles(params.targetSessionFiles);
+      : this.normalizeTargetSessionFiles(params.targetSessionFiles, corpusEntries);
+    const corpusEntryByPath = new Map<string, SessionTranscriptCorpusEntry>(
+      corpusEntries.map((entry) => [entry.sessionFile, entry]),
+    );
     const files = targetSessionFiles
       ? Array.from(targetSessionFiles)
-      : await listSessionFilesForAgent(this.agentId);
+      : corpusEntries.map((entry) => entry.sessionFile);
     const sessionPlan = resolveMemorySessionSyncPlan({
       needsFullReindex: params.needsFullReindex,
       files,
@@ -2163,7 +2218,17 @@ export abstract class MemoryManagerSyncOps {
                   }
                   return null;
                 }
-                const entry = await buildSessionEntry(absPath);
+                const corpusEntry = corpusEntryByPath.get(absPath);
+                const entry = await buildSessionEntry(
+                  absPath,
+                  corpusEntry
+                    ? {
+                        generatedByDreamingNarrative:
+                          corpusEntry.generatedByDreamingNarrative === true,
+                        generatedByCronRun: corpusEntry.generatedByCronRun === true,
+                      }
+                    : undefined,
+                );
                 if (!entry) {
                   if (params.progress) {
                     params.progress.completed += 1;
@@ -2233,7 +2298,16 @@ export abstract class MemoryManagerSyncOps {
           }
           return;
         }
-        const entry = await buildSessionEntry(absPath);
+        const corpusEntry = corpusEntryByPath.get(absPath);
+        const entry = await buildSessionEntry(
+          absPath,
+          corpusEntry
+            ? {
+                generatedByDreamingNarrative: corpusEntry.generatedByDreamingNarrative === true,
+                generatedByCronRun: corpusEntry.generatedByCronRun === true,
+              }
+            : undefined,
+        );
         if (!entry) {
           if (params.progress) {
             params.progress.completed += 1;
@@ -2344,7 +2418,7 @@ export abstract class MemoryManagerSyncOps {
     }
     const vectorReady = await this.ensureVectorReady();
     const meta = this.readMeta();
-    const targetSessionFiles = this.combineTargetSessionFiles({
+    const targetSessionFiles = await this.combineTargetSessionFiles({
       sessions: params?.sessions,
       sessionFiles: params?.sessionFiles,
     });

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -34,6 +34,7 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-qmd", () => {
     isSessionArchiveArtifactName: (fileName: string) => /\.jsonl\.(reset|deleted)\./.test(fileName),
     isUsageCountedSessionTranscriptFileName: (fileName: string) => fileName.endsWith(".jsonl"),
     listSessionFilesForAgent: vi.fn(async () => []),
+    listSessionTranscriptCorpusEntriesForAgent: vi.fn(async () => []),
     parseCanonicalSessionSyncTargetFromPath: (filePath: string) => ({
       agentId: "main",
       sessionId: basename(filePath).replace(/\.jsonl$/, ""),

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -25,13 +25,14 @@ import {
   deriveQmdScopeChatType,
   isSessionArchiveArtifactName,
   isQmdScopeAllowed,
-  listSessionFilesForAgent,
+  listSessionTranscriptCorpusEntriesForAgent,
   parseQmdQueryJson,
   resolveSessionIdentityForTranscriptFile,
   resolveCliSpawnInvocation,
   runCliCommand,
   type QmdQueryResult,
   type SessionFileEntry,
+  type SessionTranscriptCorpusEntry,
 } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import {
   buildMemoryReadResult,
@@ -2541,15 +2542,19 @@ export class QmdMemoryManager implements MemorySearchManager {
     const exportDir = this.sessionExporter.dir;
     await fs.mkdir(exportDir, { recursive: true });
     const exportRoot = await root(exportDir);
-    const files = await listSessionFilesForAgent(this.agentId);
+    const corpusEntries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId);
     const keep = new Set<string>();
     const tracked = new Set<string>();
     const artifactMappings: QmdSessionArtifactMapping[] = [];
     const cutoff = this.sessionExporter.retentionMs
       ? Date.now() - this.sessionExporter.retentionMs
       : null;
-    for (const sessionFile of files) {
-      const entry = await buildSessionEntry(sessionFile);
+    for (const corpusEntry of corpusEntries) {
+      const sessionFile = corpusEntry.sessionFile;
+      const entry = await buildSessionEntry(sessionFile, {
+        generatedByDreamingNarrative: corpusEntry.generatedByDreamingNarrative === true,
+        generatedByCronRun: corpusEntry.generatedByCronRun === true,
+      });
       if (!entry) {
         continue;
       }
@@ -2559,7 +2564,12 @@ export class QmdMemoryManager implements MemorySearchManager {
       const targetName = `${path.basename(sessionFile, ".jsonl")}.md`;
       const target = path.join(exportDir, targetName);
       tracked.add(sessionFile);
-      const identity = this.buildSessionArtifactMapping(sessionFile, targetName, target);
+      const identity = this.buildSessionArtifactMapping(
+        sessionFile,
+        targetName,
+        target,
+        corpusEntry,
+      );
       if (identity) {
         artifactMappings.push(identity);
       }
@@ -2602,11 +2612,12 @@ export class QmdMemoryManager implements MemorySearchManager {
     sessionFile: string,
     artifactPath: string,
     target: string,
+    corpusEntry?: SessionTranscriptCorpusEntry,
   ): QmdSessionArtifactMapping | null {
     if (!this.sessionExporter) {
       return null;
     }
-    const identity = resolveSessionIdentityForTranscriptFile(sessionFile);
+    const identity = corpusEntry ?? resolveSessionIdentityForTranscriptFile(sessionFile);
     if (!identity?.agentId) {
       return null;
     }

--- a/packages/memory-host-sdk/src/engine-qmd.ts
+++ b/packages/memory-host-sdk/src/engine-qmd.ts
@@ -4,6 +4,7 @@ export { extractKeywords, isQueryStopWordToken } from "./host/query-expansion.js
 export {
   buildSessionEntry,
   listSessionFilesForAgent,
+  listSessionTranscriptCorpusEntriesForAgent,
   loadDreamingNarrativeTranscriptPathSetForAgent,
   loadSessionTranscriptClassificationForAgent,
   normalizeSessionTranscriptPathForComparison,
@@ -16,6 +17,7 @@ export {
   type ResolvedSessionTranscriptIdentity,
   type SessionFileEntry,
   type SessionTranscriptClassification,
+  type SessionTranscriptCorpusEntry,
 } from "./host/session-files.js";
 export {
   isSessionArchiveArtifactName,

--- a/packages/memory-host-sdk/src/host/openclaw-runtime-session.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-session.ts
@@ -1,6 +1,10 @@
 // Narrow session/runtime facade re-exported for memory transcript helpers.
 
 export {
+  canonicalizeMainSessionAlias,
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+  getRuntimeConfig,
   HEARTBEAT_PROMPT,
   HEARTBEAT_TOKEN,
   SILENT_REPLY_TOKEN,
@@ -12,9 +16,14 @@ export {
   isSessionArchiveArtifactName,
   isSilentReplyPayloadText,
   isUsageCountedSessionTranscriptFileName,
+  listSessionEntries,
   onSessionTranscriptUpdate,
   parseUsageCountedSessionIdFromFileName,
+  resolveSessionFilePath,
+  resolveStorePath,
+  resolveSessionAgentId,
   resolveSessionTranscriptsDirForAgent,
   stripInboundMetadata,
   stripInternalRuntimeContext,
+  type SessionEntry,
 } from "./openclaw-runtime.js";

--- a/packages/memory-host-sdk/src/host/openclaw-runtime.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime.ts
@@ -42,6 +42,8 @@ export { parseDurationMs } from "../../../../src/cli/parse-duration.js";
 export { withProgress, withProgressTotals } from "../../../../src/cli/progress.js";
 export { parseNonNegativeByteSize } from "../../../../src/config/byte-size.js";
 export {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
   getRuntimeConfig,
   /** @deprecated Use getRuntimeConfig(), or pass the already loaded config through the call path. */
   loadConfig,
@@ -54,7 +56,14 @@ export {
   isUsageCountedSessionTranscriptFileName,
   parseUsageCountedSessionIdFromFileName,
 } from "../../../../src/config/sessions/artifacts.js";
+export { canonicalizeMainSessionAlias } from "../../../../src/config/sessions/main-session.js";
 export { resolveSessionTranscriptsDirForAgent } from "../../../../src/config/sessions/paths.js";
+export {
+  listSessionEntries,
+  resolveSessionFilePath,
+  resolveStorePath,
+} from "../../../../src/plugin-sdk/session-store-runtime.js";
+export type { SessionEntry } from "../../../../src/config/sessions/types.js";
 export type { SessionSendPolicyConfig } from "../../../../src/config/types.base.js";
 export type {
   MemoryBackend,

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -3,9 +3,12 @@ import fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "./openclaw-runtime-session.js";
 import {
   buildSessionEntry,
   listSessionFilesForAgent,
+  listSessionTranscriptCorpusEntriesForAgent,
+  loadSessionTranscriptClassificationForAgent,
   parseCanonicalSessionSyncTargetFromPath,
   resolveSessionIdentityForTranscriptFile,
   resolveSessionFileForSyncTarget,
@@ -14,13 +17,19 @@ import {
 } from "./session-files.js";
 
 function captureStateDirEnv() {
-  const value = process.env.OPENCLAW_STATE_DIR;
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  const configPath = process.env.OPENCLAW_CONFIG_PATH;
   return {
     restore() {
-      if (value === undefined) {
+      if (stateDir === undefined) {
         Reflect.deleteProperty(process.env, "OPENCLAW_STATE_DIR");
       } else {
-        Reflect.set(process.env, "OPENCLAW_STATE_DIR", value);
+        Reflect.set(process.env, "OPENCLAW_STATE_DIR", stateDir);
+      }
+      if (configPath === undefined) {
+        Reflect.deleteProperty(process.env, "OPENCLAW_CONFIG_PATH");
+      } else {
+        Reflect.set(process.env, "OPENCLAW_CONFIG_PATH", configPath);
       }
     },
   };
@@ -44,11 +53,15 @@ beforeEach(() => {
   fsSync.mkdirSync(tmpDir, { recursive: true });
   envSnapshot = captureStateDirEnv();
   Reflect.set(process.env, "OPENCLAW_STATE_DIR", tmpDir);
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
 });
 
 afterEach(() => {
   envSnapshot?.restore();
   envSnapshot = undefined;
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
 });
 
 function requireSessionEntry(entry: SessionFileEntry | null): SessionFileEntry {
@@ -84,6 +97,381 @@ describe("listSessionFilesForAgent", () => {
     expect(files.map((filePath) => path.basename(filePath)).toSorted()).toEqual(
       included.toSorted(),
     );
+  });
+});
+
+describe("listSessionTranscriptCorpusEntriesForAgent", () => {
+  it("lists active session entries with accessor-backed identity and classification", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(path.join(sessionsDir, "narrative.jsonl"), "");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:dreaming-narrative-run-1": {
+          sessionFile: "narrative.jsonl",
+          sessionId: "narrative",
+        },
+      }),
+    );
+
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([
+      {
+        agentId: "main",
+        artifactKind: "active-session",
+        generatedByDreamingNarrative: true,
+        sessionFile: path.join(sessionsDir, "narrative.jsonl"),
+        sessionId: "narrative",
+        sessionKey: "agent:main:dreaming-narrative-run-1",
+      },
+    ]);
+  });
+
+  it("keeps archive artifacts in the corpus and inherits active session classification", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    const activePath = path.join(sessionsDir, "cron-run.jsonl");
+    const archivePath = path.join(sessionsDir, "cron-run.jsonl.deleted.2026-02-16T22-27-33.000Z");
+    fsSync.writeFileSync(activePath, "");
+    fsSync.writeFileSync(archivePath, "");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:cron:job-1:run:run-1": {
+          sessionFile: "cron-run.jsonl",
+          sessionId: "cron-run",
+        },
+      }),
+    );
+
+    const classification = loadSessionTranscriptClassificationForAgent("main");
+
+    expect(classification.cronRunTranscriptPaths).toEqual(
+      new Set([activePath, archivePath].map((filePath) => path.resolve(filePath))),
+    );
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toContainEqual({
+      agentId: "main",
+      artifactKind: "archive-artifact",
+      generatedByCronRun: true,
+      sessionFile: archivePath,
+      sessionId: "cron-run",
+    });
+  });
+
+  it("keeps archive classification when the active transcript is missing", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    const archivePath = path.join(sessionsDir, "cron-run.jsonl.reset.2026-02-16T22-26-33.000Z");
+    fsSync.writeFileSync(archivePath, "");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:cron:job-1:run:run-1": {
+          sessionFile: "cron-run.jsonl",
+          sessionId: "cron-run",
+        },
+      }),
+    );
+
+    const expectedArchivePath = archivePath;
+    const classification = loadSessionTranscriptClassificationForAgent("main");
+
+    expect(classification.cronRunTranscriptPaths).toEqual(new Set([expectedArchivePath]));
+    await expect(listSessionFilesForAgent("main")).resolves.toEqual([expectedArchivePath]);
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([
+      {
+        agentId: "main",
+        artifactKind: "archive-artifact",
+        generatedByCronRun: true,
+        sessionFile: expectedArchivePath,
+        sessionId: "cron-run",
+      },
+    ]);
+  });
+
+  it("omits active session entries whose transcript files are missing", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:missing": {
+          sessionFile: "missing.jsonl",
+          sessionId: "missing",
+        },
+      }),
+    );
+
+    await expect(listSessionFilesForAgent("main")).resolves.toEqual([]);
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([]);
+  });
+
+  it("omits active session entries whose transcript path is a symlink", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    const targetPath = path.join(tmpDir, "external.jsonl");
+    const symlinkPath = path.join(sessionsDir, "linked.jsonl");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(targetPath, "");
+    fsSync.symlinkSync(targetPath, symlinkPath);
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:linked": {
+          sessionFile: "linked.jsonl",
+          sessionId: "linked",
+        },
+      }),
+    );
+
+    await expect(listSessionFilesForAgent("main")).resolves.toEqual([]);
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([]);
+  });
+
+  it("rejects session ids that would escape the sessions directory", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(path.join(tmpDir, "secret.jsonl"), "");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:escape": {
+          sessionId: "../secret",
+        },
+      }),
+    );
+
+    await expect(listSessionFilesForAgent("main")).resolves.toEqual([]);
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([]);
+  });
+
+  it("does not classify a fallback transcript when explicit sessionFile is invalid", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    const sessionFile = path.join(sessionsDir, "active.jsonl");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(sessionFile, "");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:cron:job-1:run:run-1": {
+          sessionFile: "../old.jsonl",
+          sessionId: "active",
+        },
+      }),
+    );
+
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([
+      {
+        agentId: "main",
+        artifactKind: "orphan-file-artifact",
+        sessionFile,
+        sessionId: "active",
+      },
+    ]);
+  });
+
+  it("rejects relative sessionFile values that escape through nested segments", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    const secretPath = path.join(tmpDir, "agents", "main", "secret.jsonl");
+    fsSync.mkdirSync(path.join(sessionsDir, "sub"), { recursive: true });
+    fsSync.writeFileSync(secretPath, "");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:escape-file": {
+          sessionFile: "sub/../../secret.jsonl",
+          sessionId: "secret",
+        },
+      }),
+    );
+
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([]);
+  });
+
+  it("rejects absolute transcript paths owned by another agent", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    const otherSessionsDir = path.join(tmpDir, "agents", "ops", "sessions");
+    const otherSessionFile = path.join(otherSessionsDir, "private.jsonl");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.mkdirSync(otherSessionsDir, { recursive: true });
+    fsSync.writeFileSync(otherSessionFile, "");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:cross-agent": {
+          sessionFile: otherSessionFile,
+          sessionId: "private",
+        },
+      }),
+    );
+
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([]);
+  });
+
+  it("falls back to transcript filename identity when an active row lacks sessionId", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "active-thread-456.jsonl");
+    fsSync.writeFileSync(sessionFile, "");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:thread-456": {
+          sessionFile: "active-thread-456.jsonl",
+        },
+      }),
+    );
+
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([
+      {
+        agentId: "main",
+        artifactKind: "active-session",
+        sessionFile,
+        sessionId: "active-thread-456",
+        sessionKey: "agent:main:chat:thread-456",
+      },
+    ]);
+  });
+
+  it("lists only the requested agent's active transcripts from a shared custom store", async () => {
+    const sessionsDir = path.join(tmpDir, "custom-sessions");
+    const sessionFile = path.join(sessionsDir, "custom-thread.jsonl");
+    const otherSessionFile = path.join(sessionsDir, "ops-thread.jsonl");
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const configPath = path.join(tmpDir, "openclaw.json");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(sessionFile, "");
+    fsSync.writeFileSync(otherSessionFile, "");
+    fsSync.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:chat:custom": {
+          sessionFile: "custom-thread.jsonl",
+          sessionId: "custom-thread",
+        },
+        "agent:ops:chat:custom": {
+          sessionFile: "ops-thread.jsonl",
+          sessionId: "ops-thread",
+        },
+      }),
+    );
+    fsSync.writeFileSync(configPath, JSON.stringify({ session: { store: storePath } }));
+    Reflect.set(process.env, "OPENCLAW_CONFIG_PATH", configPath);
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+
+    await expect(listSessionFilesForAgent("main")).resolves.toEqual([sessionFile]);
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([
+      {
+        agentId: "main",
+        artifactKind: "active-session",
+        sessionFile,
+        sessionId: "custom-thread",
+        sessionKey: "agent:main:chat:custom",
+      },
+    ]);
+    await expect(listSessionFilesForAgent("ops")).resolves.toEqual([otherSessionFile]);
+  });
+
+  it("keeps unowned archives from an agent-owned fixed session store", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    const archivePath = path.join(sessionsDir, "retained.jsonl.deleted.2026-02-16T22-27-33.000Z");
+    const configPath = path.join(tmpDir, "openclaw.json");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(archivePath, "");
+    fsSync.writeFileSync(path.join(sessionsDir, "sessions.json"), "{}");
+    fsSync.writeFileSync(
+      configPath,
+      JSON.stringify({ session: { store: path.join(sessionsDir, "sessions.json") } }),
+    );
+    Reflect.set(process.env, "OPENCLAW_CONFIG_PATH", configPath);
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+
+    await expect(listSessionFilesForAgent("main")).resolves.toEqual([archivePath]);
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([
+      {
+        agentId: "main",
+        artifactKind: "archive-artifact",
+        sessionFile: archivePath,
+        sessionId: "retained",
+      },
+    ]);
+  });
+
+  it("resolves absolute transcript paths from a fixed custom store", async () => {
+    const storeDir = path.join(tmpDir, "custom-sessions");
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    const sessionFile = path.join(sessionsDir, "absolute-thread.jsonl");
+    const archivePath = path.join(
+      sessionsDir,
+      "absolute-thread.jsonl.deleted.2026-02-16T22-27-33.000Z",
+    );
+    const storePath = path.join(storeDir, "sessions.json");
+    const configPath = path.join(tmpDir, "openclaw.json");
+    fsSync.mkdirSync(storeDir, { recursive: true });
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(sessionFile, "");
+    fsSync.writeFileSync(archivePath, "");
+    fsSync.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:chat:absolute": {
+          sessionFile,
+          sessionId: "absolute-thread",
+        },
+      }),
+    );
+    fsSync.writeFileSync(configPath, JSON.stringify({ session: { store: storePath } }));
+    Reflect.set(process.env, "OPENCLAW_CONFIG_PATH", configPath);
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+
+    await expect(listSessionFilesForAgent("main")).resolves.toEqual([sessionFile, archivePath]);
+  });
+
+  it("keeps legacy session keys in non-main per-agent stores", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "ops", "sessions");
+    const sessionFile = path.join(sessionsDir, "legacy-thread.jsonl");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(sessionFile, "");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "slack:workspace:thread": {
+          sessionFile: "legacy-thread.jsonl",
+          sessionId: "legacy-thread",
+        },
+      }),
+    );
+
+    await expect(listSessionFilesForAgent("ops")).resolves.toEqual([sessionFile]);
+    await expect(listSessionFilesForAgent("main")).resolves.toEqual([]);
+  });
+
+  it("keeps legacy main aliases in a renamed default agent store", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "ops", "sessions");
+    const sessionFile = path.join(sessionsDir, "legacy-main.jsonl");
+    const configPath = path.join(tmpDir, "openclaw.json");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(sessionFile, "");
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:main": {
+          sessionFile: "legacy-main.jsonl",
+          sessionId: "legacy-main",
+        },
+      }),
+    );
+    fsSync.writeFileSync(
+      configPath,
+      JSON.stringify({ agents: { list: [{ id: "ops", default: true }] } }),
+    );
+    Reflect.set(process.env, "OPENCLAW_CONFIG_PATH", configPath);
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+
+    await expect(listSessionFilesForAgent("ops")).resolves.toEqual([sessionFile]);
   });
 });
 

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -6,10 +6,8 @@ import { readRegularFile, statRegularFile } from "./fs-utils.js";
 import { hashText } from "./hash.js";
 import { createSubsystemLogger, redactSensitiveText } from "./openclaw-runtime-io.js";
 import {
-  getRuntimeConfig,
   HEARTBEAT_PROMPT,
   HEARTBEAT_TOKEN,
-  canonicalizeMainSessionAlias,
   hasInterSessionUserProvenance,
   isCompactionCheckpointTranscriptFileName,
   isCronRunSessionKey,
@@ -18,18 +16,24 @@ import {
   isSessionArchiveArtifactName,
   isSilentReplyPayloadText,
   isUsageCountedSessionTranscriptFileName,
-  listSessionEntries,
   parseUsageCountedSessionIdFromFileName,
-  resolveSessionFilePath,
-  resolveStorePath,
-  resolveSessionAgentId,
   resolveSessionTranscriptsDirForAgent,
   stripInboundMetadata,
   stripInternalRuntimeContext,
-  type SessionEntry,
 } from "./openclaw-runtime-session.js";
 import { retryTransientMemoryRead } from "./read-retry.js";
+import {
+  listSessionTranscriptCorpusEntriesForAgent,
+  listSessionTranscriptCorpusEntriesForAgentSync,
+  type SessionTranscriptCorpusEntry,
+} from "./session-transcript-corpus.js";
 import type { MemorySessionSyncTarget } from "./types.js";
+
+export {
+  listSessionTranscriptCorpusEntriesForAgent,
+  type SessionTranscriptCorpusArtifactKind,
+  type SessionTranscriptCorpusEntry,
+} from "./session-transcript-corpus.js";
 
 const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
 // Keep the historical one-line-per-message export shape for normal turns, but
@@ -72,23 +76,6 @@ export type SessionTranscriptClassification = {
   cronRunTranscriptPaths: ReadonlySet<string>;
 };
 
-export type SessionTranscriptCorpusArtifactKind =
-  | "active-session"
-  | "archive-artifact"
-  | "orphan-file-artifact";
-
-export type SessionTranscriptCorpusEntry = {
-  agentId: string;
-  sessionFile: string;
-  sessionId: string;
-  artifactKind: SessionTranscriptCorpusArtifactKind;
-  sessionKey?: string;
-  /** True when this transcript belongs to an internal dreaming narrative run. */
-  generatedByDreamingNarrative?: boolean;
-  /** True when this transcript belongs to an isolated cron run session. */
-  generatedByCronRun?: boolean;
-};
-
 export type ResolvedMemorySessionSyncTarget = {
   agentId: string;
   sessionFile: string;
@@ -104,11 +91,6 @@ export type ResolvedSessionTranscriptIdentity = {
 type SessionTranscriptStoreEntry = {
   sessionFile?: unknown;
   sessionId?: unknown;
-};
-
-type SessionEntrySummary = {
-  sessionKey: string;
-  entry: SessionEntry;
 };
 
 function shouldSkipTranscriptFileForDreaming(absPath: string): boolean {
@@ -209,10 +191,6 @@ function isDreamingNarrativeSessionStoreKey(sessionKey: string): boolean {
   return sessionSegment.startsWith(DREAMING_NARRATIVE_RUN_PREFIX);
 }
 
-function isDreamingNarrativeSessionKeyLike(value: unknown): boolean {
-  return typeof value === "string" && isDreamingNarrativeSessionStoreKey(value);
-}
-
 function hasCronRunSessionKey(value: unknown): boolean {
   return typeof value === "string" && isCronRunSessionKey(value);
 }
@@ -242,26 +220,8 @@ function normalizeComparablePath(pathname: string): string {
   return process.platform === "win32" ? resolved.toLowerCase() : resolved;
 }
 
-function normalizeRealComparablePath(pathname: string): string {
-  try {
-    return normalizeComparablePath(fsSync.realpathSync(pathname));
-  } catch {
-    try {
-      return normalizeComparablePath(
-        path.join(fsSync.realpathSync(path.dirname(pathname)), path.basename(pathname)),
-      );
-    } catch {
-      return normalizeComparablePath(pathname);
-    }
-  }
-}
-
 export function normalizeSessionTranscriptPathForComparison(pathname: string): string {
   return normalizeComparablePath(pathname);
-}
-
-function rememberArtifactDir(dirs: Map<string, string>, dir: string): void {
-  dirs.set(normalizeRealComparablePath(dir), dir);
 }
 
 function resolveSessionStoreTranscriptPath(
@@ -286,74 +246,6 @@ function resolveSessionStoreTranscriptResolvedPath(
   return null;
 }
 
-function resolveSessionStoreTranscriptCorpusPath(
-  agentId: string,
-  sessionsDir: string,
-  entry: { sessionFile?: unknown; sessionId?: unknown } | undefined,
-): string | null {
-  const sessionFile =
-    typeof entry?.sessionFile === "string" && entry.sessionFile.trim().length > 0
-      ? entry.sessionFile.trim()
-      : undefined;
-  const sessionId =
-    typeof entry?.sessionId === "string" && entry.sessionId.trim().length > 0
-      ? entry.sessionId.trim()
-      : sessionFile
-        ? parseUsageCountedSessionIdFromFileName(path.basename(sessionFile))
-        : null;
-  if (!sessionId) {
-    return null;
-  }
-  try {
-    if (!sessionFile) {
-      return resolveSessionFilePath(sessionId, undefined, { agentId, sessionsDir });
-    }
-    const resolved = resolveSessionFilePath(
-      sessionId,
-      { sessionFile },
-      {
-        agentId,
-        sessionsDir,
-      },
-    );
-    if (!path.isAbsolute(sessionFile)) {
-      const candidate = path.resolve(sessionsDir, sessionFile);
-      if (
-        normalizeComparablePath(path.dirname(candidate)) !== normalizeComparablePath(sessionsDir)
-      ) {
-        return null;
-      }
-      return normalizeRealComparablePath(resolved) === normalizeRealComparablePath(candidate)
-        ? candidate
-        : null;
-    }
-    const pathAgentId = extractAgentIdFromSessionPath(sessionFile);
-    if (pathAgentId && normalizeAgentId(pathAgentId) !== normalizeAgentId(agentId)) {
-      return null;
-    }
-    return normalizeRealComparablePath(resolved) === normalizeRealComparablePath(sessionFile)
-      ? sessionFile
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-function classifySessionEntry(
-  sessionKey: string,
-  entry: SessionEntry,
-): {
-  generatedByDreamingNarrative: boolean;
-  generatedByCronRun: boolean;
-} {
-  return {
-    generatedByDreamingNarrative:
-      isDreamingNarrativeSessionStoreKey(sessionKey) ||
-      isDreamingNarrativeSessionKeyLike(entry.spawnedBy),
-    generatedByCronRun: isCronRunSessionKey(sessionKey) || hasCronRunSessionKey(entry.spawnedBy),
-  };
-}
-
 function extractAgentIdFromSessionsDir(sessionsDir: string): string | null {
   const parts = path.normalize(path.resolve(sessionsDir)).split(path.sep).filter(Boolean);
   const sessionsIndex = parts.length - 1;
@@ -372,214 +264,6 @@ function isCanonicalSessionsDirForAgent(sessionsDir: string, agentId: string): b
     normalizeComparablePath(sessionsDir) ===
     normalizeComparablePath(resolveSessionTranscriptsDirForAgent(agentId))
   );
-}
-
-function isRegularSessionTranscriptFile(absPath: string): boolean {
-  try {
-    return fsSync.lstatSync(absPath).isFile();
-  } catch {
-    return false;
-  }
-}
-
-function toSessionStoreCorpusEntry(
-  agentId: string,
-  sessionsDir: string,
-  summary: SessionEntrySummary,
-): SessionTranscriptCorpusEntry | null {
-  const sessionFile = resolveSessionStoreTranscriptCorpusPath(agentId, sessionsDir, summary.entry);
-  if (!sessionFile || !isUsageCountedSessionTranscriptFileName(path.basename(sessionFile))) {
-    return null;
-  }
-  const sessionId =
-    typeof summary.entry.sessionId === "string" && summary.entry.sessionId.trim()
-      ? summary.entry.sessionId.trim()
-      : parseUsageCountedSessionIdFromFileName(path.basename(sessionFile));
-  if (!sessionId) {
-    return null;
-  }
-  const sessionKey = summary.sessionKey.trim();
-  const classification = classifySessionEntry(summary.sessionKey, summary.entry);
-  return {
-    agentId,
-    artifactKind: "active-session",
-    sessionFile,
-    sessionId,
-    ...(sessionKey ? { sessionKey } : {}),
-    ...(classification.generatedByDreamingNarrative ? { generatedByDreamingNarrative: true } : {}),
-    ...(classification.generatedByCronRun ? { generatedByCronRun: true } : {}),
-  };
-}
-
-function listSessionTranscriptArtifactFiles(sessionsDir: string): string[] {
-  try {
-    return fsSync
-      .readdirSync(sessionsDir, { withFileTypes: true })
-      .filter((entry) => entry.isFile())
-      .map((entry) => entry.name)
-      .filter((name) => isUsageCountedSessionTranscriptFileName(name))
-      .map((name) => path.join(sessionsDir, name));
-  } catch {
-    return [];
-  }
-}
-
-function classifyTranscriptArtifact(
-  artifactPath: string,
-  activeEntriesByPath: ReadonlyMap<string, SessionTranscriptCorpusEntry>,
-): {
-  generatedByDreamingNarrative: boolean;
-  generatedByCronRun: boolean;
-} {
-  const directEntry = activeEntriesByPath.get(normalizeRealComparablePath(artifactPath));
-  if (directEntry) {
-    return {
-      generatedByDreamingNarrative: directEntry.generatedByDreamingNarrative === true,
-      generatedByCronRun: directEntry.generatedByCronRun === true,
-    };
-  }
-  const sessionsDir = path.dirname(artifactPath);
-  const primarySessionId = parseUsageCountedSessionIdFromFileName(path.basename(artifactPath));
-  const primaryEntry =
-    primarySessionId && isSessionArchiveArtifactName(path.basename(artifactPath))
-      ? activeEntriesByPath.get(
-          normalizeRealComparablePath(path.join(sessionsDir, `${primarySessionId}.jsonl`)),
-        )
-      : undefined;
-  return {
-    generatedByDreamingNarrative: primaryEntry?.generatedByDreamingNarrative === true,
-    generatedByCronRun: primaryEntry?.generatedByCronRun === true,
-  };
-}
-
-function toArtifactCorpusEntry(
-  agentId: string,
-  artifactPath: string,
-  activeEntriesByPath: ReadonlyMap<string, SessionTranscriptCorpusEntry>,
-): SessionTranscriptCorpusEntry | null {
-  const sessionId = parseUsageCountedSessionIdFromFileName(path.basename(artifactPath));
-  if (!sessionId) {
-    return null;
-  }
-  const artifactKind = isSessionArchiveArtifactName(path.basename(artifactPath))
-    ? "archive-artifact"
-    : "orphan-file-artifact";
-  const classification = classifyTranscriptArtifact(artifactPath, activeEntriesByPath);
-  return {
-    agentId,
-    artifactKind,
-    sessionFile: artifactPath,
-    sessionId,
-    ...(classification.generatedByDreamingNarrative ? { generatedByDreamingNarrative: true } : {}),
-    ...(classification.generatedByCronRun ? { generatedByCronRun: true } : {}),
-  };
-}
-
-function listSessionTranscriptCorpusEntriesForAgentSync(
-  agentId: string,
-): SessionTranscriptCorpusEntry[] {
-  const normalizedAgentId = normalizeAgentId(agentId);
-  const cfg = getRuntimeConfig();
-  const configuredStore = cfg.session?.store;
-  const storePath = resolveStorePath(configuredStore, {
-    agentId: normalizedAgentId,
-  });
-  const sessionsDir = path.dirname(storePath);
-  const fixedStoreOwnerAgentId = extractAgentIdFromSessionsDir(sessionsDir);
-  const isAgentOwnedFixedStore =
-    fixedStoreOwnerAgentId !== null &&
-    normalizeAgentId(fixedStoreOwnerAgentId) === normalizedAgentId;
-  const isSharedFixedStore =
-    typeof configuredStore === "string" &&
-    configuredStore.trim().length > 0 &&
-    !configuredStore.includes("{agentId}") &&
-    !isAgentOwnedFixedStore;
-  const activeEntriesByPath = new Map<string, SessionTranscriptCorpusEntry>();
-  const activeEntryOwnersByPath = new Map<string, string>();
-  const artifactDirsByPath = new Map<string, string>();
-  rememberArtifactDir(artifactDirsByPath, sessionsDir);
-  for (const summary of listSessionEntries({
-    agentId: normalizedAgentId,
-    hydrateSkillPromptRefs: false,
-    storePath,
-  })) {
-    const sessionKey = isSharedFixedStore
-      ? summary.sessionKey
-      : canonicalizeMainSessionAlias({
-          cfg,
-          agentId: normalizedAgentId,
-          sessionKey: summary.sessionKey,
-        });
-    const ownerAgentId = resolveSessionAgentId({
-      config: cfg,
-      sessionKey,
-      ...(isSharedFixedStore ? {} : { fallbackAgentId: normalizedAgentId }),
-    });
-    const entry = toSessionStoreCorpusEntry(ownerAgentId, sessionsDir, summary);
-    if (!entry) {
-      continue;
-    }
-    const normalizedEntryPath = normalizeRealComparablePath(entry.sessionFile);
-    activeEntryOwnersByPath.set(normalizedEntryPath, ownerAgentId);
-    rememberArtifactDir(artifactDirsByPath, path.dirname(entry.sessionFile));
-    if (ownerAgentId === normalizedAgentId) {
-      activeEntriesByPath.set(normalizedEntryPath, entry);
-    }
-  }
-  const includeUnownedArtifacts = !isSharedFixedStore;
-  const corpusEntries = [...activeEntriesByPath.values()].filter((entry) =>
-    isRegularSessionTranscriptFile(entry.sessionFile),
-  );
-  const scannedArtifactPaths = new Set<string>();
-  for (const artifactDir of artifactDirsByPath.values()) {
-    for (const artifactPath of listSessionTranscriptArtifactFiles(artifactDir)) {
-      const normalizedArtifactPath = normalizeRealComparablePath(artifactPath);
-      if (scannedArtifactPaths.has(normalizedArtifactPath)) {
-        continue;
-      }
-      scannedArtifactPaths.add(normalizedArtifactPath);
-      if (activeEntriesByPath.has(normalizedArtifactPath)) {
-        continue;
-      }
-      const artifactOwner = activeEntryOwnersByPath.get(normalizedArtifactPath);
-      if (artifactOwner) {
-        continue;
-      }
-      const primarySessionId = parseUsageCountedSessionIdFromFileName(path.basename(artifactPath));
-      const primaryOwner =
-        primarySessionId && isSessionArchiveArtifactName(path.basename(artifactPath))
-          ? activeEntryOwnersByPath.get(
-              normalizeRealComparablePath(
-                path.join(path.dirname(artifactPath), `${primarySessionId}.jsonl`),
-              ),
-            )
-          : undefined;
-      if (primaryOwner && primaryOwner !== normalizedAgentId) {
-        continue;
-      }
-      if (!primaryOwner && !includeUnownedArtifacts) {
-        continue;
-      }
-      const entry = toArtifactCorpusEntry(normalizedAgentId, artifactPath, activeEntriesByPath);
-      if (entry) {
-        corpusEntries.push(entry);
-      }
-    }
-  }
-  return corpusEntries;
-}
-
-/**
- * Lists transcript corpus entries for QMD/memory indexing.
- *
- * Active sessions come from the session accessor seam; retained reset/delete
- * transcript artifacts remain explicit file artifacts until core owns archive
- * artifact enumeration.
- */
-export async function listSessionTranscriptCorpusEntriesForAgent(
-  agentId: string,
-): Promise<SessionTranscriptCorpusEntry[]> {
-  return listSessionTranscriptCorpusEntriesForAgentSync(agentId);
 }
 
 export function loadSessionTranscriptClassificationForSessionsDir(

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -1,14 +1,15 @@
 // Memory Host SDK module implements session files behavior.
 import fsSync from "node:fs";
-import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeAgentId } from "./config-utils.js";
 import { readRegularFile, statRegularFile } from "./fs-utils.js";
 import { hashText } from "./hash.js";
 import { createSubsystemLogger, redactSensitiveText } from "./openclaw-runtime-io.js";
 import {
+  getRuntimeConfig,
   HEARTBEAT_PROMPT,
   HEARTBEAT_TOKEN,
+  canonicalizeMainSessionAlias,
   hasInterSessionUserProvenance,
   isCompactionCheckpointTranscriptFileName,
   isCronRunSessionKey,
@@ -17,10 +18,15 @@ import {
   isSessionArchiveArtifactName,
   isSilentReplyPayloadText,
   isUsageCountedSessionTranscriptFileName,
+  listSessionEntries,
   parseUsageCountedSessionIdFromFileName,
+  resolveSessionFilePath,
+  resolveStorePath,
+  resolveSessionAgentId,
   resolveSessionTranscriptsDirForAgent,
   stripInboundMetadata,
   stripInternalRuntimeContext,
+  type SessionEntry,
 } from "./openclaw-runtime-session.js";
 import { retryTransientMemoryRead } from "./read-retry.js";
 import type { MemorySessionSyncTarget } from "./types.js";
@@ -66,6 +72,23 @@ export type SessionTranscriptClassification = {
   cronRunTranscriptPaths: ReadonlySet<string>;
 };
 
+export type SessionTranscriptCorpusArtifactKind =
+  | "active-session"
+  | "archive-artifact"
+  | "orphan-file-artifact";
+
+export type SessionTranscriptCorpusEntry = {
+  agentId: string;
+  sessionFile: string;
+  sessionId: string;
+  artifactKind: SessionTranscriptCorpusArtifactKind;
+  sessionKey?: string;
+  /** True when this transcript belongs to an internal dreaming narrative run. */
+  generatedByDreamingNarrative?: boolean;
+  /** True when this transcript belongs to an isolated cron run session. */
+  generatedByCronRun?: boolean;
+};
+
 export type ResolvedMemorySessionSyncTarget = {
   agentId: string;
   sessionFile: string;
@@ -81,6 +104,11 @@ export type ResolvedSessionTranscriptIdentity = {
 type SessionTranscriptStoreEntry = {
   sessionFile?: unknown;
   sessionId?: unknown;
+};
+
+type SessionEntrySummary = {
+  sessionKey: string;
+  entry: SessionEntry;
 };
 
 function shouldSkipTranscriptFileForDreaming(absPath: string): boolean {
@@ -181,6 +209,10 @@ function isDreamingNarrativeSessionStoreKey(sessionKey: string): boolean {
   return sessionSegment.startsWith(DREAMING_NARRATIVE_RUN_PREFIX);
 }
 
+function isDreamingNarrativeSessionKeyLike(value: unknown): boolean {
+  return typeof value === "string" && isDreamingNarrativeSessionStoreKey(value);
+}
+
 function hasCronRunSessionKey(value: unknown): boolean {
   return typeof value === "string" && isCronRunSessionKey(value);
 }
@@ -210,8 +242,26 @@ function normalizeComparablePath(pathname: string): string {
   return process.platform === "win32" ? resolved.toLowerCase() : resolved;
 }
 
+function normalizeRealComparablePath(pathname: string): string {
+  try {
+    return normalizeComparablePath(fsSync.realpathSync(pathname));
+  } catch {
+    try {
+      return normalizeComparablePath(
+        path.join(fsSync.realpathSync(path.dirname(pathname)), path.basename(pathname)),
+      );
+    } catch {
+      return normalizeComparablePath(pathname);
+    }
+  }
+}
+
 export function normalizeSessionTranscriptPathForComparison(pathname: string): string {
   return normalizeComparablePath(pathname);
+}
+
+function rememberArtifactDir(dirs: Map<string, string>, dir: string): void {
+  dirs.set(normalizeRealComparablePath(dir), dir);
 }
 
 function resolveSessionStoreTranscriptPath(
@@ -236,9 +286,311 @@ function resolveSessionStoreTranscriptResolvedPath(
   return null;
 }
 
+function resolveSessionStoreTranscriptCorpusPath(
+  agentId: string,
+  sessionsDir: string,
+  entry: { sessionFile?: unknown; sessionId?: unknown } | undefined,
+): string | null {
+  const sessionFile =
+    typeof entry?.sessionFile === "string" && entry.sessionFile.trim().length > 0
+      ? entry.sessionFile.trim()
+      : undefined;
+  const sessionId =
+    typeof entry?.sessionId === "string" && entry.sessionId.trim().length > 0
+      ? entry.sessionId.trim()
+      : sessionFile
+        ? parseUsageCountedSessionIdFromFileName(path.basename(sessionFile))
+        : null;
+  if (!sessionId) {
+    return null;
+  }
+  try {
+    if (!sessionFile) {
+      return resolveSessionFilePath(sessionId, undefined, { agentId, sessionsDir });
+    }
+    const resolved = resolveSessionFilePath(
+      sessionId,
+      { sessionFile },
+      {
+        agentId,
+        sessionsDir,
+      },
+    );
+    if (!path.isAbsolute(sessionFile)) {
+      const candidate = path.resolve(sessionsDir, sessionFile);
+      if (
+        normalizeComparablePath(path.dirname(candidate)) !== normalizeComparablePath(sessionsDir)
+      ) {
+        return null;
+      }
+      return normalizeRealComparablePath(resolved) === normalizeRealComparablePath(candidate)
+        ? candidate
+        : null;
+    }
+    const pathAgentId = extractAgentIdFromSessionPath(sessionFile);
+    if (pathAgentId && normalizeAgentId(pathAgentId) !== normalizeAgentId(agentId)) {
+      return null;
+    }
+    return normalizeRealComparablePath(resolved) === normalizeRealComparablePath(sessionFile)
+      ? sessionFile
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function classifySessionEntry(
+  sessionKey: string,
+  entry: SessionEntry,
+): {
+  generatedByDreamingNarrative: boolean;
+  generatedByCronRun: boolean;
+} {
+  return {
+    generatedByDreamingNarrative:
+      isDreamingNarrativeSessionStoreKey(sessionKey) ||
+      isDreamingNarrativeSessionKeyLike(entry.spawnedBy),
+    generatedByCronRun: isCronRunSessionKey(sessionKey) || hasCronRunSessionKey(entry.spawnedBy),
+  };
+}
+
+function extractAgentIdFromSessionsDir(sessionsDir: string): string | null {
+  const parts = path.normalize(path.resolve(sessionsDir)).split(path.sep).filter(Boolean);
+  const sessionsIndex = parts.length - 1;
+  if (
+    parts[sessionsIndex] !== "sessions" ||
+    sessionsIndex < 2 ||
+    parts[sessionsIndex - 2] !== "agents"
+  ) {
+    return null;
+  }
+  return parts[sessionsIndex - 1] || null;
+}
+
+function isCanonicalSessionsDirForAgent(sessionsDir: string, agentId: string): boolean {
+  return (
+    normalizeComparablePath(sessionsDir) ===
+    normalizeComparablePath(resolveSessionTranscriptsDirForAgent(agentId))
+  );
+}
+
+function isRegularSessionTranscriptFile(absPath: string): boolean {
+  try {
+    return fsSync.lstatSync(absPath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function toSessionStoreCorpusEntry(
+  agentId: string,
+  sessionsDir: string,
+  summary: SessionEntrySummary,
+): SessionTranscriptCorpusEntry | null {
+  const sessionFile = resolveSessionStoreTranscriptCorpusPath(agentId, sessionsDir, summary.entry);
+  if (!sessionFile || !isUsageCountedSessionTranscriptFileName(path.basename(sessionFile))) {
+    return null;
+  }
+  const sessionId =
+    typeof summary.entry.sessionId === "string" && summary.entry.sessionId.trim()
+      ? summary.entry.sessionId.trim()
+      : parseUsageCountedSessionIdFromFileName(path.basename(sessionFile));
+  if (!sessionId) {
+    return null;
+  }
+  const sessionKey = summary.sessionKey.trim();
+  const classification = classifySessionEntry(summary.sessionKey, summary.entry);
+  return {
+    agentId,
+    artifactKind: "active-session",
+    sessionFile,
+    sessionId,
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(classification.generatedByDreamingNarrative ? { generatedByDreamingNarrative: true } : {}),
+    ...(classification.generatedByCronRun ? { generatedByCronRun: true } : {}),
+  };
+}
+
+function listSessionTranscriptArtifactFiles(sessionsDir: string): string[] {
+  try {
+    return fsSync
+      .readdirSync(sessionsDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .filter((name) => isUsageCountedSessionTranscriptFileName(name))
+      .map((name) => path.join(sessionsDir, name));
+  } catch {
+    return [];
+  }
+}
+
+function classifyTranscriptArtifact(
+  artifactPath: string,
+  activeEntriesByPath: ReadonlyMap<string, SessionTranscriptCorpusEntry>,
+): {
+  generatedByDreamingNarrative: boolean;
+  generatedByCronRun: boolean;
+} {
+  const directEntry = activeEntriesByPath.get(normalizeRealComparablePath(artifactPath));
+  if (directEntry) {
+    return {
+      generatedByDreamingNarrative: directEntry.generatedByDreamingNarrative === true,
+      generatedByCronRun: directEntry.generatedByCronRun === true,
+    };
+  }
+  const sessionsDir = path.dirname(artifactPath);
+  const primarySessionId = parseUsageCountedSessionIdFromFileName(path.basename(artifactPath));
+  const primaryEntry =
+    primarySessionId && isSessionArchiveArtifactName(path.basename(artifactPath))
+      ? activeEntriesByPath.get(
+          normalizeRealComparablePath(path.join(sessionsDir, `${primarySessionId}.jsonl`)),
+        )
+      : undefined;
+  return {
+    generatedByDreamingNarrative: primaryEntry?.generatedByDreamingNarrative === true,
+    generatedByCronRun: primaryEntry?.generatedByCronRun === true,
+  };
+}
+
+function toArtifactCorpusEntry(
+  agentId: string,
+  artifactPath: string,
+  activeEntriesByPath: ReadonlyMap<string, SessionTranscriptCorpusEntry>,
+): SessionTranscriptCorpusEntry | null {
+  const sessionId = parseUsageCountedSessionIdFromFileName(path.basename(artifactPath));
+  if (!sessionId) {
+    return null;
+  }
+  const artifactKind = isSessionArchiveArtifactName(path.basename(artifactPath))
+    ? "archive-artifact"
+    : "orphan-file-artifact";
+  const classification = classifyTranscriptArtifact(artifactPath, activeEntriesByPath);
+  return {
+    agentId,
+    artifactKind,
+    sessionFile: artifactPath,
+    sessionId,
+    ...(classification.generatedByDreamingNarrative ? { generatedByDreamingNarrative: true } : {}),
+    ...(classification.generatedByCronRun ? { generatedByCronRun: true } : {}),
+  };
+}
+
+function listSessionTranscriptCorpusEntriesForAgentSync(
+  agentId: string,
+): SessionTranscriptCorpusEntry[] {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  const cfg = getRuntimeConfig();
+  const configuredStore = cfg.session?.store;
+  const storePath = resolveStorePath(configuredStore, {
+    agentId: normalizedAgentId,
+  });
+  const sessionsDir = path.dirname(storePath);
+  const fixedStoreOwnerAgentId = extractAgentIdFromSessionsDir(sessionsDir);
+  const isAgentOwnedFixedStore =
+    fixedStoreOwnerAgentId !== null &&
+    normalizeAgentId(fixedStoreOwnerAgentId) === normalizedAgentId;
+  const isSharedFixedStore =
+    typeof configuredStore === "string" &&
+    configuredStore.trim().length > 0 &&
+    !configuredStore.includes("{agentId}") &&
+    !isAgentOwnedFixedStore;
+  const activeEntriesByPath = new Map<string, SessionTranscriptCorpusEntry>();
+  const activeEntryOwnersByPath = new Map<string, string>();
+  const artifactDirsByPath = new Map<string, string>();
+  rememberArtifactDir(artifactDirsByPath, sessionsDir);
+  for (const summary of listSessionEntries({
+    agentId: normalizedAgentId,
+    hydrateSkillPromptRefs: false,
+    storePath,
+  })) {
+    const sessionKey = isSharedFixedStore
+      ? summary.sessionKey
+      : canonicalizeMainSessionAlias({
+          cfg,
+          agentId: normalizedAgentId,
+          sessionKey: summary.sessionKey,
+        });
+    const ownerAgentId = resolveSessionAgentId({
+      config: cfg,
+      sessionKey,
+      ...(isSharedFixedStore ? {} : { fallbackAgentId: normalizedAgentId }),
+    });
+    const entry = toSessionStoreCorpusEntry(ownerAgentId, sessionsDir, summary);
+    if (!entry) {
+      continue;
+    }
+    const normalizedEntryPath = normalizeRealComparablePath(entry.sessionFile);
+    activeEntryOwnersByPath.set(normalizedEntryPath, ownerAgentId);
+    rememberArtifactDir(artifactDirsByPath, path.dirname(entry.sessionFile));
+    if (ownerAgentId === normalizedAgentId) {
+      activeEntriesByPath.set(normalizedEntryPath, entry);
+    }
+  }
+  const includeUnownedArtifacts = !isSharedFixedStore;
+  const corpusEntries = [...activeEntriesByPath.values()].filter((entry) =>
+    isRegularSessionTranscriptFile(entry.sessionFile),
+  );
+  const scannedArtifactPaths = new Set<string>();
+  for (const artifactDir of artifactDirsByPath.values()) {
+    for (const artifactPath of listSessionTranscriptArtifactFiles(artifactDir)) {
+      const normalizedArtifactPath = normalizeRealComparablePath(artifactPath);
+      if (scannedArtifactPaths.has(normalizedArtifactPath)) {
+        continue;
+      }
+      scannedArtifactPaths.add(normalizedArtifactPath);
+      if (activeEntriesByPath.has(normalizedArtifactPath)) {
+        continue;
+      }
+      const artifactOwner = activeEntryOwnersByPath.get(normalizedArtifactPath);
+      if (artifactOwner) {
+        continue;
+      }
+      const primarySessionId = parseUsageCountedSessionIdFromFileName(path.basename(artifactPath));
+      const primaryOwner =
+        primarySessionId && isSessionArchiveArtifactName(path.basename(artifactPath))
+          ? activeEntryOwnersByPath.get(
+              normalizeRealComparablePath(
+                path.join(path.dirname(artifactPath), `${primarySessionId}.jsonl`),
+              ),
+            )
+          : undefined;
+      if (primaryOwner && primaryOwner !== normalizedAgentId) {
+        continue;
+      }
+      if (!primaryOwner && !includeUnownedArtifacts) {
+        continue;
+      }
+      const entry = toArtifactCorpusEntry(normalizedAgentId, artifactPath, activeEntriesByPath);
+      if (entry) {
+        corpusEntries.push(entry);
+      }
+    }
+  }
+  return corpusEntries;
+}
+
+/**
+ * Lists transcript corpus entries for QMD/memory indexing.
+ *
+ * Active sessions come from the session accessor seam; retained reset/delete
+ * transcript artifacts remain explicit file artifacts until core owns archive
+ * artifact enumeration.
+ */
+export async function listSessionTranscriptCorpusEntriesForAgent(
+  agentId: string,
+): Promise<SessionTranscriptCorpusEntry[]> {
+  return listSessionTranscriptCorpusEntriesForAgentSync(agentId);
+}
+
 export function loadSessionTranscriptClassificationForSessionsDir(
   sessionsDir: string,
 ): SessionTranscriptClassification {
+  const agentId = extractAgentIdFromSessionsDir(sessionsDir);
+  if (agentId && isCanonicalSessionsDirForAgent(sessionsDir, agentId)) {
+    return classifySessionTranscriptCorpusEntries(
+      listSessionTranscriptCorpusEntriesForAgentSync(agentId),
+    );
+  }
   const storePath = path.join(sessionsDir, "sessions.json");
   const store = readSessionTranscriptClassificationStore(storePath);
   const dreamingTranscriptPaths = new Set<string>();
@@ -275,6 +627,26 @@ function readSessionTranscriptClassificationStore(
   }
 }
 
+function classifySessionTranscriptCorpusEntries(
+  corpusEntries: readonly SessionTranscriptCorpusEntry[],
+): SessionTranscriptClassification {
+  const dreamingTranscriptPaths = new Set<string>();
+  const cronRunTranscriptPaths = new Set<string>();
+  for (const entry of corpusEntries) {
+    const normalizedPath = normalizeComparablePath(entry.sessionFile);
+    if (entry.generatedByDreamingNarrative) {
+      dreamingTranscriptPaths.add(normalizedPath);
+    }
+    if (entry.generatedByCronRun) {
+      cronRunTranscriptPaths.add(normalizedPath);
+    }
+  }
+  return {
+    dreamingNarrativeTranscriptPaths: dreamingTranscriptPaths,
+    cronRunTranscriptPaths,
+  };
+}
+
 function findSessionTranscriptStoreEntryBySessionId(
   store: Record<string, SessionTranscriptStoreEntry>,
   sessionId: string,
@@ -293,8 +665,8 @@ export function loadDreamingNarrativeTranscriptPathSetForAgent(
 export function loadSessionTranscriptClassificationForAgent(
   agentId: string,
 ): SessionTranscriptClassification {
-  return loadSessionTranscriptClassificationForSessionsDir(
-    resolveSessionTranscriptsDirForAgent(agentId),
+  return classifySessionTranscriptCorpusEntries(
+    listSessionTranscriptCorpusEntriesForAgentSync(agentId),
   );
 }
 
@@ -322,17 +694,9 @@ function classifySessionTranscriptFromSessionStore(absPath: string): {
 }
 
 export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {
-  const dir = resolveSessionTranscriptsDirForAgent(agentId);
-  try {
-    const entries = await fs.readdir(dir, { withFileTypes: true });
-    return entries
-      .filter((entry) => entry.isFile())
-      .map((entry) => entry.name)
-      .filter((name) => isUsageCountedSessionTranscriptFileName(name))
-      .map((name) => path.join(dir, name));
-  } catch {
-    return [];
-  }
+  return (await listSessionTranscriptCorpusEntriesForAgent(agentId)).map(
+    (entry) => entry.sessionFile,
+  );
 }
 
 function extractAgentIdFromSessionPath(absPath: string): string | null {

--- a/packages/memory-host-sdk/src/host/session-transcript-corpus.ts
+++ b/packages/memory-host-sdk/src/host/session-transcript-corpus.ts
@@ -1,0 +1,384 @@
+// Accessor-backed transcript corpus discovery for memory/QMD session indexing.
+import fsSync from "node:fs";
+import path from "node:path";
+import { normalizeAgentId } from "./config-utils.js";
+import {
+  canonicalizeMainSessionAlias,
+  getRuntimeConfig,
+  isCronRunSessionKey,
+  isSessionArchiveArtifactName,
+  isUsageCountedSessionTranscriptFileName,
+  listSessionEntries,
+  parseUsageCountedSessionIdFromFileName,
+  resolveSessionAgentId,
+  resolveSessionFilePath,
+  resolveStorePath,
+  type SessionEntry,
+} from "./openclaw-runtime-session.js";
+
+const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
+
+export type SessionTranscriptCorpusArtifactKind =
+  | "active-session"
+  | "archive-artifact"
+  | "orphan-file-artifact";
+
+export type SessionTranscriptCorpusEntry = {
+  agentId: string;
+  sessionFile: string;
+  sessionId: string;
+  artifactKind: SessionTranscriptCorpusArtifactKind;
+  sessionKey?: string;
+  /** True when this transcript belongs to an internal dreaming narrative run. */
+  generatedByDreamingNarrative?: boolean;
+  /** True when this transcript belongs to an isolated cron run session. */
+  generatedByCronRun?: boolean;
+};
+
+type SessionEntrySummary = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
+function isDreamingNarrativeSessionStoreKey(sessionKey: string): boolean {
+  const trimmed = sessionKey.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const firstSeparator = trimmed.indexOf(":");
+  if (firstSeparator < 0) {
+    return trimmed.startsWith(DREAMING_NARRATIVE_RUN_PREFIX);
+  }
+  const secondSeparator = trimmed.indexOf(":", firstSeparator + 1);
+  const sessionSegment = secondSeparator < 0 ? trimmed : trimmed.slice(secondSeparator + 1);
+  return sessionSegment.startsWith(DREAMING_NARRATIVE_RUN_PREFIX);
+}
+
+function isDreamingNarrativeSessionKeyLike(value: unknown): boolean {
+  return typeof value === "string" && isDreamingNarrativeSessionStoreKey(value);
+}
+
+function hasCronRunSessionKey(value: unknown): boolean {
+  return typeof value === "string" && isCronRunSessionKey(value);
+}
+
+function normalizeComparablePath(pathname: string): string {
+  const resolved = path.resolve(pathname);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function normalizeRealComparablePath(pathname: string): string {
+  try {
+    return normalizeComparablePath(fsSync.realpathSync(pathname));
+  } catch {
+    try {
+      return normalizeComparablePath(
+        path.join(fsSync.realpathSync(path.dirname(pathname)), path.basename(pathname)),
+      );
+    } catch {
+      return normalizeComparablePath(pathname);
+    }
+  }
+}
+
+function rememberArtifactDir(dirs: Map<string, string>, dir: string): void {
+  dirs.set(normalizeRealComparablePath(dir), dir);
+}
+
+function extractAgentIdFromSessionPath(absPath: string): string | null {
+  const parts = path.normalize(path.resolve(absPath)).split(path.sep).filter(Boolean);
+  const sessionsIndex = parts.lastIndexOf("sessions");
+  if (sessionsIndex < 2 || parts[sessionsIndex - 2] !== "agents") {
+    return null;
+  }
+  return parts[sessionsIndex - 1] || null;
+}
+
+function extractAgentIdFromSessionsDir(sessionsDir: string): string | null {
+  const parts = path.normalize(path.resolve(sessionsDir)).split(path.sep).filter(Boolean);
+  const sessionsIndex = parts.length - 1;
+  if (
+    parts[sessionsIndex] !== "sessions" ||
+    sessionsIndex < 2 ||
+    parts[sessionsIndex - 2] !== "agents"
+  ) {
+    return null;
+  }
+  return parts[sessionsIndex - 1] || null;
+}
+
+function resolveSessionStoreTranscriptCorpusPath(
+  agentId: string,
+  sessionsDir: string,
+  entry: { sessionFile?: unknown; sessionId?: unknown } | undefined,
+): string | null {
+  const sessionFile =
+    typeof entry?.sessionFile === "string" && entry.sessionFile.trim().length > 0
+      ? entry.sessionFile.trim()
+      : undefined;
+  const sessionId =
+    typeof entry?.sessionId === "string" && entry.sessionId.trim().length > 0
+      ? entry.sessionId.trim()
+      : sessionFile
+        ? parseUsageCountedSessionIdFromFileName(path.basename(sessionFile))
+        : null;
+  if (!sessionId) {
+    return null;
+  }
+  try {
+    if (!sessionFile) {
+      return resolveSessionFilePath(sessionId, undefined, { agentId, sessionsDir });
+    }
+    const resolved = resolveSessionFilePath(
+      sessionId,
+      { sessionFile },
+      {
+        agentId,
+        sessionsDir,
+      },
+    );
+    if (!path.isAbsolute(sessionFile)) {
+      const candidate = path.resolve(sessionsDir, sessionFile);
+      if (
+        normalizeComparablePath(path.dirname(candidate)) !== normalizeComparablePath(sessionsDir)
+      ) {
+        return null;
+      }
+      return normalizeRealComparablePath(resolved) === normalizeRealComparablePath(candidate)
+        ? candidate
+        : null;
+    }
+    const pathAgentId = extractAgentIdFromSessionPath(sessionFile);
+    if (pathAgentId && normalizeAgentId(pathAgentId) !== normalizeAgentId(agentId)) {
+      return null;
+    }
+    return normalizeRealComparablePath(resolved) === normalizeRealComparablePath(sessionFile)
+      ? sessionFile
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function classifySessionEntry(
+  sessionKey: string,
+  entry: SessionEntry,
+): {
+  generatedByDreamingNarrative: boolean;
+  generatedByCronRun: boolean;
+} {
+  return {
+    generatedByDreamingNarrative:
+      isDreamingNarrativeSessionStoreKey(sessionKey) ||
+      isDreamingNarrativeSessionKeyLike(entry.spawnedBy),
+    generatedByCronRun: isCronRunSessionKey(sessionKey) || hasCronRunSessionKey(entry.spawnedBy),
+  };
+}
+
+function isRegularSessionTranscriptFile(absPath: string): boolean {
+  try {
+    return fsSync.lstatSync(absPath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function toSessionStoreCorpusEntry(
+  agentId: string,
+  sessionsDir: string,
+  summary: SessionEntrySummary,
+): SessionTranscriptCorpusEntry | null {
+  const sessionFile = resolveSessionStoreTranscriptCorpusPath(agentId, sessionsDir, summary.entry);
+  if (!sessionFile || !isUsageCountedSessionTranscriptFileName(path.basename(sessionFile))) {
+    return null;
+  }
+  const sessionId =
+    typeof summary.entry.sessionId === "string" && summary.entry.sessionId.trim()
+      ? summary.entry.sessionId.trim()
+      : parseUsageCountedSessionIdFromFileName(path.basename(sessionFile));
+  if (!sessionId) {
+    return null;
+  }
+  const sessionKey = summary.sessionKey.trim();
+  const classification = classifySessionEntry(summary.sessionKey, summary.entry);
+  return {
+    agentId,
+    artifactKind: "active-session",
+    sessionFile,
+    sessionId,
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(classification.generatedByDreamingNarrative ? { generatedByDreamingNarrative: true } : {}),
+    ...(classification.generatedByCronRun ? { generatedByCronRun: true } : {}),
+  };
+}
+
+function listSessionTranscriptArtifactFiles(sessionsDir: string): string[] {
+  try {
+    return fsSync
+      .readdirSync(sessionsDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .filter((name) => isUsageCountedSessionTranscriptFileName(name))
+      .map((name) => path.join(sessionsDir, name));
+  } catch {
+    return [];
+  }
+}
+
+function classifyTranscriptArtifact(
+  artifactPath: string,
+  activeEntriesByPath: ReadonlyMap<string, SessionTranscriptCorpusEntry>,
+): {
+  generatedByDreamingNarrative: boolean;
+  generatedByCronRun: boolean;
+} {
+  const directEntry = activeEntriesByPath.get(normalizeRealComparablePath(artifactPath));
+  if (directEntry) {
+    return {
+      generatedByDreamingNarrative: directEntry.generatedByDreamingNarrative === true,
+      generatedByCronRun: directEntry.generatedByCronRun === true,
+    };
+  }
+  const sessionsDir = path.dirname(artifactPath);
+  const primarySessionId = parseUsageCountedSessionIdFromFileName(path.basename(artifactPath));
+  const primaryEntry =
+    primarySessionId && isSessionArchiveArtifactName(path.basename(artifactPath))
+      ? activeEntriesByPath.get(
+          normalizeRealComparablePath(path.join(sessionsDir, `${primarySessionId}.jsonl`)),
+        )
+      : undefined;
+  return {
+    generatedByDreamingNarrative: primaryEntry?.generatedByDreamingNarrative === true,
+    generatedByCronRun: primaryEntry?.generatedByCronRun === true,
+  };
+}
+
+function toArtifactCorpusEntry(
+  agentId: string,
+  artifactPath: string,
+  activeEntriesByPath: ReadonlyMap<string, SessionTranscriptCorpusEntry>,
+): SessionTranscriptCorpusEntry | null {
+  const sessionId = parseUsageCountedSessionIdFromFileName(path.basename(artifactPath));
+  if (!sessionId) {
+    return null;
+  }
+  const artifactKind = isSessionArchiveArtifactName(path.basename(artifactPath))
+    ? "archive-artifact"
+    : "orphan-file-artifact";
+  const classification = classifyTranscriptArtifact(artifactPath, activeEntriesByPath);
+  return {
+    agentId,
+    artifactKind,
+    sessionFile: artifactPath,
+    sessionId,
+    ...(classification.generatedByDreamingNarrative ? { generatedByDreamingNarrative: true } : {}),
+    ...(classification.generatedByCronRun ? { generatedByCronRun: true } : {}),
+  };
+}
+
+export function listSessionTranscriptCorpusEntriesForAgentSync(
+  agentId: string,
+): SessionTranscriptCorpusEntry[] {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  const cfg = getRuntimeConfig();
+  const configuredStore = cfg.session?.store;
+  const storePath = resolveStorePath(configuredStore, {
+    agentId: normalizedAgentId,
+  });
+  const sessionsDir = path.dirname(storePath);
+  const fixedStoreOwnerAgentId = extractAgentIdFromSessionsDir(sessionsDir);
+  const isAgentOwnedFixedStore =
+    fixedStoreOwnerAgentId !== null &&
+    normalizeAgentId(fixedStoreOwnerAgentId) === normalizedAgentId;
+  const isSharedFixedStore =
+    typeof configuredStore === "string" &&
+    configuredStore.trim().length > 0 &&
+    !configuredStore.includes("{agentId}") &&
+    !isAgentOwnedFixedStore;
+  const activeEntriesByPath = new Map<string, SessionTranscriptCorpusEntry>();
+  const activeEntryOwnersByPath = new Map<string, string>();
+  const artifactDirsByPath = new Map<string, string>();
+  rememberArtifactDir(artifactDirsByPath, sessionsDir);
+  for (const summary of listSessionEntries({
+    agentId: normalizedAgentId,
+    hydrateSkillPromptRefs: false,
+    storePath,
+  })) {
+    const sessionKey = isSharedFixedStore
+      ? summary.sessionKey
+      : canonicalizeMainSessionAlias({
+          cfg,
+          agentId: normalizedAgentId,
+          sessionKey: summary.sessionKey,
+        });
+    const ownerAgentId = resolveSessionAgentId({
+      config: cfg,
+      sessionKey,
+      ...(isSharedFixedStore ? {} : { fallbackAgentId: normalizedAgentId }),
+    });
+    const entry = toSessionStoreCorpusEntry(ownerAgentId, sessionsDir, summary);
+    if (!entry) {
+      continue;
+    }
+    const normalizedEntryPath = normalizeRealComparablePath(entry.sessionFile);
+    activeEntryOwnersByPath.set(normalizedEntryPath, ownerAgentId);
+    rememberArtifactDir(artifactDirsByPath, path.dirname(entry.sessionFile));
+    if (ownerAgentId === normalizedAgentId) {
+      activeEntriesByPath.set(normalizedEntryPath, entry);
+    }
+  }
+  const includeUnownedArtifacts = !isSharedFixedStore;
+  const corpusEntries = [...activeEntriesByPath.values()].filter((entry) =>
+    isRegularSessionTranscriptFile(entry.sessionFile),
+  );
+  const scannedArtifactPaths = new Set<string>();
+  for (const artifactDir of artifactDirsByPath.values()) {
+    for (const artifactPath of listSessionTranscriptArtifactFiles(artifactDir)) {
+      const normalizedArtifactPath = normalizeRealComparablePath(artifactPath);
+      if (scannedArtifactPaths.has(normalizedArtifactPath)) {
+        continue;
+      }
+      scannedArtifactPaths.add(normalizedArtifactPath);
+      if (activeEntriesByPath.has(normalizedArtifactPath)) {
+        continue;
+      }
+      const artifactOwner = activeEntryOwnersByPath.get(normalizedArtifactPath);
+      if (artifactOwner) {
+        continue;
+      }
+      const primarySessionId = parseUsageCountedSessionIdFromFileName(path.basename(artifactPath));
+      const primaryOwner =
+        primarySessionId && isSessionArchiveArtifactName(path.basename(artifactPath))
+          ? activeEntryOwnersByPath.get(
+              normalizeRealComparablePath(
+                path.join(path.dirname(artifactPath), `${primarySessionId}.jsonl`),
+              ),
+            )
+          : undefined;
+      if (primaryOwner && primaryOwner !== normalizedAgentId) {
+        continue;
+      }
+      if (!primaryOwner && !includeUnownedArtifacts) {
+        continue;
+      }
+      const entry = toArtifactCorpusEntry(normalizedAgentId, artifactPath, activeEntriesByPath);
+      if (entry) {
+        corpusEntries.push(entry);
+      }
+    }
+  }
+  return corpusEntries;
+}
+
+/**
+ * Lists transcript corpus entries for QMD/memory indexing.
+ *
+ * Active sessions come from the session accessor seam; retained reset/delete
+ * transcript artifacts remain explicit file artifacts until core owns archive
+ * artifact enumeration.
+ */
+export async function listSessionTranscriptCorpusEntriesForAgent(
+  agentId: string,
+): Promise<SessionTranscriptCorpusEntry[]> {
+  return listSessionTranscriptCorpusEntriesForAgentSync(agentId);
+}

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -73,6 +73,7 @@ export const allowedSessionStoreRuntimeFileBackedCompatExports = new Set([
 ]);
 
 export const migratedSessionAccessorFiles = new Set([
+  "packages/memory-host-sdk/src/host/session-files.ts",
   "src/agents/embedded-agent-runner/compaction-successor-transcript.ts",
   "src/agents/embedded-agent-runner/run/attempt.ts",
   "src/agents/embedded-agent-runner/tool-result-truncation.ts",
@@ -166,6 +167,23 @@ export const migratedSessionLifecycleCleanupFiles = new Set([
   "src/config/sessions/cleanup-service.ts",
   "src/cron/session-reaper.ts",
   "src/infra/heartbeat-runner.ts",
+]);
+
+export const migratedMemoryHostSessionCorpusFiles = new Set([
+  "packages/memory-host-sdk/src/host/session-files.ts",
+]);
+
+const memoryHostSessionCorpusFunctionNames = new Set([
+  "listSessionTranscriptCorpusEntriesForAgentSync",
+  "listSessionTranscriptCorpusEntriesForAgent",
+  "loadDreamingNarrativeTranscriptPathSetForAgent",
+  "loadSessionTranscriptClassificationForAgent",
+  "listSessionFilesForAgent",
+]);
+
+const legacyMemoryHostSessionCorpusNames = new Set([
+  "loadSessionTranscriptClassificationForSessionsDir",
+  "readSessionTranscriptClassificationStore",
 ]);
 
 function normalizeRelativePath(filePath) {
@@ -423,9 +441,67 @@ export function findSessionLifecycleCleanupBoundaryViolations(content, fileName 
   );
 }
 
+function declarationName(node) {
+  if (ts.isFunctionDeclaration(node) && node.name) {
+    return node.name.text;
+  }
+  if (!ts.isVariableStatement(node)) {
+    return null;
+  }
+  const declaration = node.declarationList.declarations[0];
+  return declaration && ts.isIdentifier(declaration.name) ? declaration.name.text : null;
+}
+
+function functionBodyForDeclaration(node) {
+  if (ts.isFunctionDeclaration(node)) {
+    return node.body ?? null;
+  }
+  if (!ts.isVariableStatement(node)) {
+    return null;
+  }
+  const declaration = node.declarationList.declarations[0];
+  const initializer = declaration?.initializer;
+  if (initializer && (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer))) {
+    return initializer.body;
+  }
+  return null;
+}
+
+export function findMemoryHostSessionCorpusBoundaryViolations(content, fileName = "source.ts") {
+  const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
+  const violations = [];
+
+  const visitCorpusBody = (node) => {
+    if (ts.isCallExpression(node)) {
+      const calleeName = propertyAccessName(node.expression);
+      if (calleeName && legacyMemoryHostSessionCorpusNames.has(calleeName)) {
+        violations.push({
+          line: toLine(sourceFile, node.expression),
+          reason: `calls legacy memory-host session corpus helper "${calleeName}"`,
+        });
+      }
+    }
+    ts.forEachChild(node, visitCorpusBody);
+  };
+
+  for (const statement of sourceFile.statements) {
+    const name = declarationName(statement);
+    if (!name || !memoryHostSessionCorpusFunctionNames.has(name)) {
+      continue;
+    }
+    const body = functionBodyForDeclaration(statement);
+    if (body) {
+      visitCorpusBody(body);
+    }
+  }
+
+  return violations;
+}
+
 export async function main() {
   const repoRoot = resolveRepoRoot(import.meta.url);
   const readSourceRoots = resolveSourceRoots(repoRoot, [
+    "packages/memory-host-sdk/src/host",
     "extensions/discord/src/monitor",
     "extensions/telegram/src",
     "src/agents",
@@ -506,6 +582,15 @@ export async function main() {
       ),
     findViolations: findSessionLifecycleCleanupBoundaryViolations,
   });
+  const memoryHostSessionCorpusViolations = await collectFileViolations({
+    repoRoot,
+    sourceRoots: resolveSourceRoots(repoRoot, ["packages/memory-host-sdk/src/host"]),
+    skipFile: (filePath) =>
+      !migratedMemoryHostSessionCorpusFiles.has(
+        normalizeRelativePath(path.relative(repoRoot, filePath)),
+      ),
+    findViolations: findMemoryHostSessionCorpusBoundaryViolations,
+  });
   const sessionStoreRuntimePath = path.join(repoRoot, "src/plugin-sdk/session-store-runtime.ts");
   const sessionStoreRuntimeCompatViolations =
     findSessionStoreRuntimeFileBackedCompatExportViolations(
@@ -521,6 +606,7 @@ export async function main() {
     ...sessionCreateLifecycleViolations,
     ...manualCompactTrimViolations,
     ...lifecycleCleanupViolations,
+    ...memoryHostSessionCorpusViolations,
     ...sessionStoreRuntimeCompatViolations,
   ];
 

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -171,6 +171,7 @@ export const migratedSessionLifecycleCleanupFiles = new Set([
 
 export const migratedMemoryHostSessionCorpusFiles = new Set([
   "packages/memory-host-sdk/src/host/session-files.ts",
+  "packages/memory-host-sdk/src/host/session-transcript-corpus.ts",
 ]);
 
 const memoryHostSessionCorpusFunctionNames = new Set([
@@ -467,32 +468,55 @@ function functionBodyForDeclaration(node) {
   return null;
 }
 
+function collectTopLevelFunctionBodies(sourceFile) {
+  const bodies = new Map();
+  for (const statement of sourceFile.statements) {
+    const name = declarationName(statement);
+    const body = functionBodyForDeclaration(statement);
+    if (name && body) {
+      bodies.set(name, body);
+    }
+  }
+  return bodies;
+}
+
 export function findMemoryHostSessionCorpusBoundaryViolations(content, fileName = "source.ts") {
   const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
+  const functionBodies = collectTopLevelFunctionBodies(sourceFile);
+  const visitedFunctions = new Set();
+  const violationKeys = new Set();
   const violations = [];
 
   const visitCorpusBody = (node) => {
     if (ts.isCallExpression(node)) {
       const calleeName = propertyAccessName(node.expression);
       if (calleeName && legacyMemoryHostSessionCorpusNames.has(calleeName)) {
-        violations.push({
-          line: toLine(sourceFile, node.expression),
-          reason: `calls legacy memory-host session corpus helper "${calleeName}"`,
-        });
+        const line = toLine(sourceFile, node.expression);
+        const reason = `calls legacy memory-host session corpus helper "${calleeName}"`;
+        const key = `${line}:${reason}`;
+        if (!violationKeys.has(key)) {
+          violationKeys.add(key);
+          violations.push({ line, reason });
+        }
+      }
+      if (calleeName && ts.isIdentifier(unwrapExpression(node.expression))) {
+        const localBody = functionBodies.get(calleeName);
+        if (localBody && !visitedFunctions.has(calleeName)) {
+          visitedFunctions.add(calleeName);
+          visitCorpusBody(localBody);
+        }
       }
     }
     ts.forEachChild(node, visitCorpusBody);
   };
 
-  for (const statement of sourceFile.statements) {
-    const name = declarationName(statement);
-    if (!name || !memoryHostSessionCorpusFunctionNames.has(name)) {
+  for (const name of memoryHostSessionCorpusFunctionNames) {
+    const body = functionBodies.get(name);
+    if (!body || visitedFunctions.has(name)) {
       continue;
     }
-    const body = functionBodyForDeclaration(statement);
-    if (body) {
-      visitCorpusBody(body);
-    }
+    visitedFunctions.add(name);
+    visitCorpusBody(body);
   }
 
   return violations;

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -202,8 +202,8 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10369),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5201),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10371),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5202),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3247,

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -141,7 +141,10 @@ describe("session accessor boundary guard", () => {
 
   it("ratchets only memory-host session corpus files migrated to accessor entries", () => {
     expect(migratedMemoryHostSessionCorpusFiles).toEqual(
-      new Set(["packages/memory-host-sdk/src/host/session-files.ts"]),
+      new Set([
+        "packages/memory-host-sdk/src/host/session-files.ts",
+        "packages/memory-host-sdk/src/host/session-transcript-corpus.ts",
+      ]),
     );
   });
 
@@ -282,6 +285,25 @@ describe("session accessor boundary guard", () => {
       },
       {
         line: 6,
+        reason:
+          'calls legacy memory-host session corpus helper "readSessionTranscriptClassificationStore"',
+      },
+    ]);
+  });
+
+  it("follows memory-host corpus helper calls when checking legacy access", () => {
+    expect(
+      findMemoryHostSessionCorpusBoundaryViolations(`
+        function loadViaHelper() {
+          return readSessionTranscriptClassificationStore("sessions.json");
+        }
+        function listSessionTranscriptCorpusEntriesForAgentSync(agentId) {
+          return loadViaHelper(agentId);
+        }
+      `),
+    ).toEqual([
+      {
+        line: 3,
         reason:
           'calls legacy memory-host session corpus helper "readSessionTranscriptClassificationStore"',
       },

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -3,6 +3,7 @@ import {
   allowedSessionStoreRuntimeFileBackedCompatExports,
   collectSessionStoreRuntimeFileBackedCompatExports,
   findGatewaySessionCreateLifecycleViolations,
+  findMemoryHostSessionCorpusBoundaryViolations,
   findSessionAccessorBoundaryViolations,
   findSessionCompactManualTrimBoundaryViolations,
   findSessionAccessorWriteBoundaryViolations,
@@ -10,6 +11,7 @@ import {
   findSessionStoreRuntimeFileBackedCompatExportViolations,
   findTranscriptWriterBoundaryViolations,
   migratedBundledPluginSessionAccessorFiles,
+  migratedMemoryHostSessionCorpusFiles,
   migratedSessionLifecycleCleanupFiles,
   migratedSessionCompactManualTrimFiles,
   migratedSessionAccessorFiles,
@@ -21,6 +23,7 @@ describe("session accessor boundary guard", () => {
   it("ratchets only the files migrated by the session accessor slices", () => {
     expect(migratedSessionAccessorFiles).toEqual(
       new Set([
+        "packages/memory-host-sdk/src/host/session-files.ts",
         "src/agents/embedded-agent-runner/compaction-successor-transcript.ts",
         "src/agents/embedded-agent-runner/run/attempt.ts",
         "src/agents/embedded-agent-runner/tool-result-truncation.ts",
@@ -133,6 +136,12 @@ describe("session accessor boundary guard", () => {
         "src/cron/session-reaper.ts",
         "src/infra/heartbeat-runner.ts",
       ]),
+    );
+  });
+
+  it("ratchets only memory-host session corpus files migrated to accessor entries", () => {
+    expect(migratedMemoryHostSessionCorpusFiles).toEqual(
+      new Set(["packages/memory-host-sdk/src/host/session-files.ts"]),
     );
   });
 
@@ -251,6 +260,43 @@ describe("session accessor boundary guard", () => {
       findSessionAccessorBoundaryViolations(`
         import { listSessionEntries } from "../config/sessions/session-accessor.js";
         listSessionEntries({ storePath });
+      `),
+    ).toEqual([]);
+  });
+
+  it("flags legacy memory-host corpus classification calls in migrated entrypoints", () => {
+    expect(
+      findMemoryHostSessionCorpusBoundaryViolations(`
+        function listSessionTranscriptCorpusEntriesForAgentSync(agentId) {
+          return loadSessionTranscriptClassificationForSessionsDir(resolveSessionTranscriptsDirForAgent(agentId));
+        }
+        export async function listSessionFilesForAgent(agentId) {
+          return readSessionTranscriptClassificationStore("sessions.json");
+        }
+      `),
+    ).toEqual([
+      {
+        line: 3,
+        reason:
+          'calls legacy memory-host session corpus helper "loadSessionTranscriptClassificationForSessionsDir"',
+      },
+      {
+        line: 6,
+        reason:
+          'calls legacy memory-host session corpus helper "readSessionTranscriptClassificationStore"',
+      },
+    ]);
+  });
+
+  it("allows memory-host corpus entrypoints to use the accessor-backed corpus helper", () => {
+    expect(
+      findMemoryHostSessionCorpusBoundaryViolations(`
+        function listSessionTranscriptCorpusEntriesForAgentSync(agentId) {
+          return listSessionEntries({ agentId });
+        }
+        export async function listSessionFilesForAgent(agentId) {
+          return (await listSessionTranscriptCorpusEntriesForAgent(agentId)).map((entry) => entry.sessionFile);
+        }
       `),
     ).toEqual([]);
   });


### PR DESCRIPTION
## What Problem This Solves

Refs #88838.

Memory dreaming, QMD export, and memory session sync need the session identity and ownership model from the 3.1b session accessor migration. This PR adds a transcript corpus helper that reads active session entries through the session accessor seam, then gives memory callers one entry shape with path, session id, session key, agent owner, artifact kind, and generated-session flags. The CI ratchet covers the migrated memory corpus surface so future memory changes use that helper.

## Why This Change Was Made

PR #93187 changed transcript and session-file behavior in memory paths that sat outside the previous session-accessor guards. Active sessions already have canonical identity through `listSessionEntries`. Retained reset/delete transcripts are file-backed artifacts because core does not expose archive enumeration through the session accessor. The corpus helper combines those inputs at the SDK boundary and keeps ownership and classification decisions out of dreaming and QMD call sites.

## User Impact

There are no user-facing command changes. Memory dreaming, QMD session export, full session indexing, targeted session sync, and live transcript-update catchup keep active, reset, and deleted transcript coverage. The corpus respects configured `session.store` paths, shared-store agent ownership, legacy default-agent aliases, generated dreaming/cron classification, malformed metadata rejection, symlink rejection, and cross-agent transcript boundaries.

## Changes

- Add a dedicated memory transcript corpus module.
- Read active transcripts from session accessor entries.
- Represent retained reset/delete transcript files as corpus artifacts.
- Move dreaming, QMD export, and memory sync to corpus entries.
- Carry generated dreaming/cron classification through corpus entries.
- Keep `listSessionFilesForAgent` as a corpus wrapper.
- Ratchet migrated corpus entrypoints and helper calls.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-sync-yield.test.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts packages/memory-host-sdk/src/host/session-files.test.ts test/scripts/check-session-accessor-boundary.test.ts src/plugins/contracts/extension-package-project-boundaries.test.ts`
  - Proves corpus enumeration, retained archives, custom/shared session stores, targeted custom-store delta sync, explicit custom-store file targets, live file-only custom-store updates, generated-session classification, cross-agent rejection, symlink rejection, ratchet tests, and plugin boundary contract.
- `node scripts/check-deprecated-api-usage.mjs && node scripts/check-session-accessor-boundary.mjs && node scripts/check-session-transcript-reader-boundary.mjs && node --import tsx scripts/check-no-monolithic-plugin-sdk-entry-imports.ts`
  - Confirms deprecated API, accessor/transcript-reader ratchets, and plugin SDK subpath guards pass with the memory-host corpus coverage.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.packages.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-packages.tsbuildinfo`
  - Confirms the package test TypeScript gate accepts the split corpus module and exports.
- `node scripts/plugin-sdk-surface-report.mjs --check`
  - Confirms the SDK surface budget matches this PR's public export change.
- `git diff --check`
  - Confirms the final patch has no whitespace errors.
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Clean on `830f26aa35b` with no accepted/actionable findings.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":17,"user":8,"assistant":8,"toolCalls":679,"toolOutputsDropped":678,"web":0,"redactions":1,"omittedUnsafe":0,"rawEntries":427}

[user]
See openclaw issue 88838. Then, look at this PR: [https://github.com/openclaw/openclaw/pull/93187/changes#diff-f8127e9fb45694361617e52f7d50b5339da6cd30daa7c413f86edace7ae8b1f9](https://github.com/openclaw/openclaw/pull/93187/changes#diff-f8127e9fb45694361617e52f7d50b5339da6cd30daa7c413f86edace7ae8b1f9)

93187 seems to do a lot of work with transcript and session files. Should it be CI-gated by the ratchet that ensures session and transcript files are not used? Did we already ratchet the places it's being used?

[assistant]
I’ll treat this as OpenClaw maintainer review, so I’m going to inspect the live issue/PR state and the repository ratchet rather than reasoning from the diff URL alone. I’ll also do a light memory check for prior context around issue 88838 before making a verdict.

The memory hit is directly relevant: issue 88838 is the Path 3 session/transcript SQLite migration tracker, and prior work kept the “no session/transcript file use” ratchet slice-specific. I’m checking the live PR against current source now, including whether this PR touches code covered by that ratchet or a still-unratcheted surface.

The local checkout is clean but it is a long-lived fork state (`main` is thousands of commits ahead of `origin/main`), so I’m not pulling in this working tree. I’ll use live `gh` plus explicit `upstream/main`/PR refs for source comparison.

PR 93187 is not part of the Path 3 tracker queue; it fixes issue 90313 in Dreaming/memory-host SDK, but it touches the same transcript/session-file neighborhood. The key question is whether its touched file-backed SDK helper is still an allowed compatibility boundary or whether this PR should add that file to the existing accessor-boundary ratchet.

I’ve fetched `upstream/main` and PR 93187 into remote refs only; no branch switch or local edits. The PR currently touches `extensions/memory-core`, `packages/memory-host-sdk`, SDK facade exports, and the SDK surface report test/script.

The existing guard is not a broad textual ban on `sessionFile`; it is a targeted boundary script with explicit migrated-file sets. I’m reading those sets and the violation patterns now to see whether `packages/memory-host-sdk/src/host/session-files.ts` is already covered.

One important detail: PR 93187’s own head is not on the Path 3 queue, and GitHub’s PR diff is small, but `upstream/main` has moved since the branch base. I’m checking the ratchet from current `upstream/main`, because that is what CI and maintainer policy should be measured against.

Current `upstream/main` already has the session-accessor boundary guard, and its unit test deliberately asserts that the guard is narrow. The guard source roots are `src/**` plus only the migrated Discord/Telegram plugin files; they do not scan `packages/memory-host-sdk` or `extensions/memory-core`.

CI does have a dedicated `check-session-accessor-boundary` matrix job, and package.json wires it as `lint:tmp:session-accessor-boundary`. The question is scope: that job only fails for configured migrated surfaces, not for every remaining transcript/session file reader in the repo.

Short answer: **no, PR 93187 is not currently gated by the Path 3 session/transcript ratchets, and we have not ratcheted the `memory-host-sdk` / Dreaming file surfaces it touches.**

What I found:

- Issue #88838 is the Path 3 tracker for migrating session/transcript runtime state behind accessors and then SQLite.
- Current `upstream/main` already has CI jobs for:
  - `check-session-accessor-boundary`
  - `check-session-transcript-reader-boundary`
- Those guards are intentionally narrow. Their tests literally assert “ratchets only the files migrated by this slice.”
- The accessor guard scans `src/agents`, `src/auto-reply`, `src/commands`, `src/config/sessions`, `src/cron`, `src/gateway`, `src/infra`, `src/tui`, plus three specific Discord/Telegram plugin files.
- The transcript-reader guard scans only `src/agents`, `src/gateway`, `src/status`, and `src/tui`.
- PR 93187 touches `extensions/memory-core/src/dreaming-phases.ts` and `packages/memory-host-sdk/src/host/session-files.ts`; neither is in those ratchet source roots or migrated-file sets.

So: **the existing ratchets would not catch this PR’s continued direct `sessions.json` / transcript-file enumeration.** `packages/memory-host-sdk/src/host/session-files.ts` still reads `sessions.json`, resolves `sessionFile`, and does `fs.readdir` over transcript dirs on current `main`.

My verdict: don’t bolt this PR onto the existing Path 3 ratchet unless we are ready to migrate the memory/QMD/Dreaming surface now. PR 93187 is changing an existing file-backed compatibility surface for Dreaming ingestion; it is not newly moving a migrated core runtime file back to raw file access. If we want to enforce “memory-host SDK/Dreaming must not read transcript/session files directly,” that should be a **new dedicated ratchet slice** or part of the planned memory/QMD identity migration, not an incidental requirement on this bugfix PR.

Commands run:

```text
git status -sb
- Clean, but local main is long-lived and ahead of origin/main; I did not pull.

gh issue view 88838 --repo openclaw/openclaw ...
- Confirmed #88838 is the open Path 3 SQLite/accessor tracker.

gh pr view 93187 --repo openclaw/openclaw ...
- Confirmed PR 93187 fixes #90313 and touches memory-core, memory-host-sdk, SDK exports, and surface-report files.

git fetch upstream main
git fetch upstream pull/93187/head:refs/remotes/upstream/pr/93187
- Fetched current upstream/main and PR head without switching branches.

git show upstream/main:scripts/check-session-accessor-boundary.mjs
git show upstream/main:scripts/check-session-transcript-reader-boundary.mjs
- Verified both guards are narrow file-list/source-root ratchets.

git grep -n "check-session-accessor-boundary" upstream/main -- .github package.json test scripts
git grep -n "check-session-transcript-reader-boundary" upstream/main -- .github package.json test scripts
- Verified CI and package scripts wire both checks.

git show upstream/main:packages/memory-host-sdk/src/host/session-files.ts | rg ...
- Confirmed current main still reads sessions.json, resolves sessionFile, and lists transcript files in memory-host-sdk.
```

Full refs:
https://github.com/openclaw/openclaw/issues/88838  
https://github.com/openclaw/openclaw/pull/93187

[user]
So is this an example of a part of the interface where our 3.1b migration has missed a set of interfaces that need migrating?

[assistant]
Yes. I’d call it a **missed or still-unfinished 3.1b interface set**, not a problem introduced by PR 93187.

93187 is touching an existing memory/Dreaming SDK surface that still treats transcript files and `sessions.json` as the interface:

- `listSessionFilesForAgent(agentId)`
- `loadSessionTranscriptClassificationForAgent(agentId)`
- `loadSessionTranscriptClassificationForSessionsDir(sessionsDir)`
- `buildSessionEntry(sessionFile)`
- exported through `openclaw/plugin-sdk/memory-core-host-engine-qmd`
- consumed by `extensions/memory-core/src/dreaming-phases.ts`, QMD, and memory sync paths

That means this part of the plugin/memory interface still has file-backed concepts baked into the public-ish helper shape. The existing 3.1b ratchets covered many core/gateway/agent/channel/runtime paths, but not the memory-host SDK / Dreaming ingestion boundary.

I would track this as a separate 3.1b follow-up: migrate the memory/QMD/Dreaming transcript corpus interface to session/transcript identity or accessor-shaped APIs, then add a narrow ratchet covering those files. I would not block 93187 solely on the current ratchet, because that ratchet intentionally does not cover this surface yet.

So the answer is: **yes, this is evidence that the 3.1b migration still has an unratcheted interface family in memory-host/Dreaming/QMD.** It should be explicitly planned before the SQLite flip, or explicitly marked as a temporary public compatibility surface with a deprecation/removal plan.

[user]
Are you familiar with the 3.1b migration and understand what needs to be modified about this interface? And are you sure we don’t have an existing open or that covers this?

[assistant]
I understand the interface shape from the previous pass, but I’m going to verify the live tracker/PR set before claiming it’s uncovered. I’ll search the Path 3 issue, open PRs, and related GitHub text for the concrete helper names instead of relying on memory.

The memory summary now has a note from the previous turn, but I’m treating that as a hypothesis. I’m checking live GitHub/gitcrawl for open work that already owns this exact interface family: the helper names, memory-host SDK, Dreaming, QMD, and the Path 3 active queue.

The live tracker changed since yesterday: #89912 is now marked merged, #95030/#95087 are marked done, and the active Path 3 queue is #89518, #90439, #89911, #89178, #90437, #90438. I’m checking whether any of those actually name or modify `listSessionFilesForAgent` / `loadSessionTranscriptClassification*`, not just adjacent “memory/QMD identity” work.

The strongest candidate was #95087, because it explicitly combined memory session sync identity and QMD artifact identity. It did land, but its own scope notes/tests show it kept compatibility in `packages/memory-host-sdk/src/host/session-files.ts`; it did not remove `listSessionFilesForAgent` or the classification helper.

Yes. I’m familiar with the 3.1b shape, and I understand what needs to change here.

The interface that still smells wrong is the memory-host/Dreaming/QMD transcript corpus API. It currently asks for and returns file concepts:

- `listSessionFilesForAgent(agentId)`
- `loadSessionTranscriptClassificationForAgent(agentId)`
- `loadSessionTranscriptClassificationForSessionsDir(sessionsDir)`
- `buildSessionEntry(sessionFile)`
- `sessionPathForFile(absolutePath)`

Those are exported through `packages/memory-host-sdk/src/engine-qmd.ts` and then through `src/plugin-sdk/memory-core-host-engine-qmd.ts`, so `extensions/memory-core/src/dreaming-phases.ts` consumes a file-list API instead of a session/transcript identity API.

What should change: Dreaming/QMD should consume a storage-neutral session transcript corpus interface: session identity, target identity, archive/primary status, cron/dreaming classification, and transcript/event reader access should come from the session/transcript seam. Filename/path parsing should be compatibility only, not the primary interface. Archives should be explicit metadata, not inferred by `.jsonl.deleted.*` / `.jsonl.reset.*` naming at the consumer.

I checked live state. There is **broad coverage** in #88838: the tracker explicitly lists `packages/memory-host-sdk/*`, plugin runtime/SDK, memory/QMD, and bundled plugin consumers as part of the 3.1b direct-call inventory. But I do **not** see an existing open PR or issue that specifically owns this exact remaining interface.

Important distinctions:

- #95087 already landed and covered memory/QMD session identity mapping, but it deliberately kept deprecated/file-compatible session behavior. Current `upstream/main` still exports and uses `listSessionFilesForAgent`, `loadSessionTranscriptClassificationForAgent`, and `buildSessionEntry(sessionFile)`.
- #89518 is about Codex/Copilot transcript mirrors. It runs memory-host tests as proof, but does not migrate this interface.
- #89911 is bundled Discord/Telegram transcript target lookups, not Dreaming/QMD corpus enumeration.
- #90439 is embedded run/session target work, not this memory-host SDK surface.
- `gh search` and `gitcrawl` did not find an open issue/PR for the exact helper names or “memory-core-host-engine-qmd” beyond #93187 itself.

So the precise answer is: **#88838 covers this as the umbrella, but there does not appear to be a dedicated open PR or sub-issue for this exact missed memory-host/Dreaming/QMD interface.** I’d add it to the active queue or open a focused 3.1b follow-up before the SQLite flip.

Commands run:

```text
gitcrawl search openclaw/openclaw --query "listSessionFilesForAgent loadSessionTranscriptClassificationForAgent memory-host-sdk Dreaming QMD Path 3"
- Only surfaced #93187 for this exact interface cluster.

gitcrawl neighbors openclaw/openclaw --number 88838 --limit 20
- Showed adjacent Path 3 work: #90439, #89178, #89203, #89904, #89581, etc.

gh issue view 88838 --repo openclaw/openclaw ...
- Confirmed current active queue and that #95087/#89912 have landed.

gh search prs/issues --repo openclaw/openclaw --state open --match title,body/comments ...
- No open exact matches for listSessionFilesForAgent, loadSessionTranscriptClassification*, memory-core-host-engine-qmd, or Dreaming session corpus.

gh pr view 89518 / 89911 / 90439 / 95087 / 89912 / 89203 ...
- Confirmed nearby PR scopes; none owns this exact remaining interface.

git fetch upstream main
- Updated upstream/main to current.

git show upstream/main:packages/memory-host-sdk/src/host/session-files.ts | rg ...
git show upstream/main:extensions/memory-core/src/dreaming-phases.ts | rg ...
git show upstream/main:packages/memory-host-sdk/src/engine-qmd.ts
git show upstream/main:src/plugin-sdk/memory-core-host-engine-qmd.ts
- Confirmed current main still exposes and consumes the file-backed memory-host/Dreaming/QMD helpers.
```

https://github.com/openclaw/openclaw/issues/88838  
https://github.com/openclaw/openclaw/pull/93187

[user]
To take a stab at the follow up slice yourself? Does it require changes to the accessor seam, or is it sufficient to just use it here?

[assistant]
I’ll take a narrow implementation pass. First I’m going to get off `main`, inspect the current accessor/session transcript APIs, and then decide whether the clean slice is “consume existing seam” or “add one small accessor method.”

The checkout is currently detached rather than on `main`, so I’m going to create a scoped branch from current `upstream/main` before editing. Since this is a narrow exploratory slice, I’ll avoid a worktree and keep the diff limited to memory-host SDK plus its focused tests unless the existing seam is missing a small required primitive.

I’m on `josh/refactor-memory-qmd-corpus-seam` tracking current `upstream/main`. Next I’m reading the actual accessor/runtime APIs and the memory-host caller surface to find the smallest useful migration point.

The existing accessor does have entry listing and transcript read/write primitives, but not a ready-made “memory corpus entries for agent” operation. I’m checking whether the memory-host SDK can use `listSessionEntries` directly through a public SDK facade, which would avoid adding a new accessor method.

The clean path looks like “use the seam via the existing plugin SDK runtime facade” for session entries, not expand `session-accessor.ts`. The missing piece is local to `memory-host-sdk`: build corpus candidates from `listSessionEntries()` instead of parsing `sessions.json` directly, while keeping explicit file resolution as a deprecated file-backed adapter until SQLite exists.

The package boundary confirms `packages/memory-host-sdk` is allowed to depend on core only through designated bridge files. So the right implementation is probably: add/extend a bridge export in `openclaw-runtime-session.ts`, then have `session-files.ts` call that bridge instead of reading `sessions.json` itself. That’s still “use existing accessor seam,” not “expand `session-accessor.ts`.”

One caveat showed up: `listSessionEntries()` alone is not enough, because `listSessionFilesForAgent()` intentionally includes reset/deleted archive transcripts for QMD/memory_search. Active session entries do not enumerate those archive artifacts. That means a real slice needs either a small transcript-corpus accessor helper or it must leave archive listing as a file-backed compatibility tail. I’m looking for existing artifact scan helpers before adding anything.

I’m going to implement a storage-neutral corpus entry layer inside `session-files.ts`: active entries come from the accessor-backed `listSessionEntries`, while archive/orphan transcript artifacts remain a named file-backed compatibility source. That avoids expanding `session-accessor.ts` while making the caller-facing memory/QMD interface identity-first.

I’ll continue from the branch I created and keep this as a narrow follow-up slice: first prove whether existing accessor APIs can feed this caller, then patch only the memory-host/QMD corpus interface if that holds.

The accessor seam already exposes `listSessionEntries`, so this looks like a caller-side migration rather than a seam redesign. The one wrinkle is archive/orphan transcript artifacts: current QMD tests expect those to remain indexed, so I’m keeping that as explicit corpus artifact handling instead of pretending active sessions cover it.

I’m going to patch the SDK bridge first, then make the corpus helper use accessor entries for active sessions and the transcript directory only for retained archive artifacts. That answers the interface question directly: no new accessor method unless we decide archive artifact enumeration itself belongs in core later.

I found current main still has some older sync-target helpers that are path/file compatibility APIs. I’m not going to uproot those in this slice; I’m moving the QMD corpus/listing and classification path onto the accessor-backed entry list, which is the surface PR 93187 was leaning on.

Before editing: I’m adding one exported corpus helper in `session-files.ts`, plus a bridge export for `listSessionEntries`. Existing deprecated sync-target functions will remain intact because they’re separate compatibility APIs and need a dedicated pass if we want them fully SQLite-shaped.

The patch is in place. I’m going to run the focused test file first, then fix any type/format fallout in the touched files only.

The focused test passes. The repo doesn’t have `format:files`, so I’m checking the available formatting scripts before running anything broader than necessary.

The diff is larger than I want for a small slice, mostly helper scaffolding in one file. I’m formatting the touched files now, then I’ll look for a way to trim the helper shape without losing the archive behavior.

Formatting completed cleanly. I’m rerunning the focused test and a targeted type/lint check if there’s a lightweight one available for these files.

The focused test and whitespace check pass. I’m doing one more source read over the formatted diff because the production LOC growth is non-trivial for a refactor slice; if there’s obvious excess, I’ll trim it before broader checks.

I removed an unused import and tightened active entries to canonical transcript dirs, so accessor-backed entries cannot pull arbitrary paths into the corpus. Running the same focused checks again.

The focused checks still pass. Next I’m looking for the narrowest TypeScript/lint lane; the bridge export change is the part most likely to fail declaration/type rules.

For validation, the relevant narrow lanes are plugin SDK declarations and package test types. I’ll run them sequentially to avoid TS cache races.

The plugin SDK declaration build passed after waiting on another local heavy-check lock. I’m running the package test type lane now, then I’ll decide whether a small lint/boundary guard is warranted.

I noticed the bridge export made `SessionStoreEntrySummary` a new public plugin-SDK type just to satisfy an internal caller. That’s unnecessary surface area, so I’m trimming it back to an internal local shape instead of changing the plugin SDK API.

The file had already been formatted after the export change, so I’m applying the trim against the current text.

That removes the accidental public SDK type export while keeping the memory-host bridge narrow. I’m formatting and rerunning the relevant checks.

Focused runtime tests still pass. I’m rerunning the declaration and package-type lanes after the API trim.

The declaration and package type checks are clean. Since this is specifically about the Path 3 guard surface, I’m also running the existing session accessor/transcript reader ratchets to confirm this slice doesn’t trip them.

The existing Path 3 guards pass. I’m running the package-boundary test that owns memory-host core bridge exceptions, because this change deliberately uses that bridge.

The bridge-boundary test passes too. I’m checking the final diff and status now, then I’ll summarize what changed and answer the seam question plainly.

The final diff is scoped to memory-host session files and its runtime bridge. I’m doing one caller scan so I can tell you exactly what surface this changes.

Took the slice on `josh/refactor-memory-qmd-corpus-seam`.

Verdict: this does **not** require changing the accessor seam for the active-session part. The existing `listSessionEntries` seam is enough there. It is **not** sufficient to only use active accessor entries, because QMD/memory indexing still intentionally includes retained reset/deleted transcript artifacts that are not active sessions. I handled that by making `packages/memory-host-sdk/src/host/session-files.ts` build a transcript corpus from accessor-backed active sessions plus explicit file-backed archive/orphan artifacts.

Changed:
- `packages/memory-host-sdk/src/host/openclaw-runtime.ts`
- `packages/memory-host-sdk/src/host/openclaw-runtime-session.ts`
- `packages/memory-host-sdk/src/host/session-files.ts`
- `packages/memory-host-sdk/src/host/session-files.test.ts`

The old `listSessionFilesForAgent` API now delegates to the new corpus helper, so existing QMD/dreaming callers move through the migrated interface without needing call-site churn. I left older sync-target compatibility helpers alone; those are a separate file/path compatibility pass, not necessary for this follow-up.

`::git-create-branch{cwd="[LOCAL_PATH]" branch="josh/refactor-memory-qmd-corpus-seam"}`

Validation:
```text
git switch -c josh/refactor-memory-qmd-corpus-seam upstream/main
# Created the working branch.

pnpm exec oxfmt --write --threads=1 ...
# Formatted the touched files.

node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts
# Passed: 1 file, 23 tests.

pnpm build:plugin-sdk:dts
# Passed.

pnpm tsgo:test:packages
# Passed.

node scripts/check-session-accessor-boundary.mjs
node scripts/check-session-transcript-reader-boundary.mjs
# Both ratchets passed.

node scripts/run-vitest.mjs src/plugins/contracts/extension-package-project-boundaries.test.ts
# Passed: 1 file, 8 tests.
```

Note: branch status currently shows `[behind 5]` relative to `upstream/main`; I did not rebase because the worktree is now dirty with this slice.

[user]
Has the ci ratchet been extended accordingly?

[assistant]
I have not extended the ratchet yet. I’m going to check the existing guard structure first, then add the narrow memory-host/QMD corpus surface if it fits the current ratchet pattern.

The current CI jobs already run the two session ratchets, but the ratchet files still have their original narrow migrated-file lists. I’m reading the rest of the guard scripts now and then I’ll extend the list with the files this slice actually migrated.

The existing accessor ratchet catches legacy session-store helper names, not raw `sessions.json` string reads. For this slice, I’m going to extend it with an explicit memory-host corpus guard so the migrated helper can’t regress back to direct whole-store classification or directory-only listing.

I found tests for the accessor guard, so I’ll update both the guard and its unit coverage rather than just adding a path. The guard will be specific to `packages/memory-host-sdk/src/host/session-files.ts` and the newly migrated corpus API.

I’m extending the accessor ratchet in two layers: include `session-files.ts` in the migrated file set, and add a memory-host corpus sub-guard that protects the migrated QMD entrypoints from calling the legacy `sessions.json` classification path.

The guard script is patched. I’m updating its unit test to lock the new ratchet entry and prove the memory-host corpus sub-guard catches legacy classification calls.

The ratchet test now covers the new migrated surface. I’m formatting and running the guard plus the guard’s unit test.

The extended accessor ratchet passes and its tests pass. I’m rerunning the earlier focused checks that are affected by the added guard files, then I’ll give you the exact status.

The runtime-focused test, both ratchets, and whitespace check are clean. I’m checking the final diff so I can answer with the actual files changed and the remaining caveat, if any.

Yes, now it has been extended.

I added `packages/memory-host-sdk/src/host/session-files.ts` to the session accessor ratchet and added a memory-host-specific sub-guard in `scripts/check-session-accessor-boundary.mjs`. That guard protects the migrated QMD/memory corpus entrypoints from regressing back to the legacy `sessions.json` classification path via `loadSessionTranscriptClassificationForSessionsDir` or `readSessionTranscriptClassificationStore`.

I also added unit coverage in `test/scripts/check-session-accessor-boundary.test.ts` so the ratchet list and the new violation detector are locked.

Validation run:
```text
pnpm exec oxfmt --write --threads=1 scripts/check-session-accessor-boundary.mjs test/scripts/check-session-accessor-boundary.test.ts
# Formatted guard + tests.

node scripts/check-session-accessor-boundary.mjs
# session accessor boundary guard passed.

node scripts/run-vitest.mjs test/scripts/check-session-accessor-boundary.test.ts
# Passed: 1 file, 27 tests.

node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts
# Passed: 1 file, 23 tests.

node scripts/check-session-transcript-reader-boundary.mjs
# session transcript reader boundary guard passed.

git diff --check -- ...
# No whitespace errors.
```

Caveat: this extends the existing accessor ratchet for the migrated memory-host corpus surface. It does not globally ban all file-backed archive enumeration, because this slice still intentionally keeps reset/deleted transcript artifacts in the QMD corpus until core owns an archive-artifact enumeration seam.

[user]
Open a PR and link it to the issue tracker.

[assistant]
I’ll turn this into a normal contributor PR: run the required local review, commit only this slice, push the branch, then open the PR with a tracker link to #88838.

I’ve loaded the PR, transcript, and autoreview workflows. Next I’m going to verify the branch state/remotes and run the required autoreview before committing.

The branch has only the intended six changed files, and `gh` is authenticated as `jalehman` against `openclaw/openclaw`. I’m fetching latest `upstream/main`, then autoreviewing the dirty local diff before I commit.

Autoreview is still running after the fetch updated `upstream/main`. I’m letting the helper finish; it can take a while on a branch diff.

The review helper is healthy and has emitted its 60s heartbeat. I’m continuing to wait; no code changes until it returns.

Still waiting on the Codex review subprocess; no failure output yet.

Autoreview is at the 120s heartbeat and still running normally. I’ll continue polling rather than interrupting it.

No new output yet; the review process is still active.

The review helper is still progressing, now at 180s. I’m continuing to wait for the structured result.

Another heartbeat at 240s; still healthy.

Autoreview came back clean with no actionable findings. I’m checking the repo’s PR template/instructions, then I’ll commit this slice and rebase onto the freshly fetched `upstream/main`.

The repo PR template is the current `What Problem This Solves` / `Evidence` format. I’m committing the six intended files now, then I’ll rebase and rerun the focused checks if the rebase changes anything.

The commit is created. I’m rebasing it onto current `upstream/main` now, then I’ll rerun the focused checks on the rebased branch.

The rebase completed cleanly. I’m rerunning the focused tests, ratchets, types, and autoreview on the rebased commit before pushing.

The rebased checks are clean. I’m running the required post-rebase autoreview on the committed diff now.

The post-rebase autoreview is running; I’ll wait for its structured result before pushing.

Autoreview is healthy at the 60s heartbeat.

Still waiting on the review subprocess; no findings output yet.

The review helper is at the 120s heartbeat and still progressing.

No new output yet; continuing to wait for the clean/finding result.

Autoreview is still healthy at 180s.

The post-rebase autoreview found a real regression: active session entries could be returned even when the transcript file no longer exists, which would stop stale memory rows from being pruned. I’m fixing that by filtering active corpus entries to existing regular transcript files and adding a regression test.

The missing-file filter and regression test are in. I’m formatting, rerunning focused checks, amending the commit, and then I’ll rerun autoreview.

The regression test passes and the accessor guard still passes. I’m amending the commit with the fix, then I’ll run the full focused check set again.

The commit is amended. I’m rerunning the complete focused validation set now.

Focused validation is clean, but `upstream/main` moved again while we were working. I’m fetching/rebasing once more before the final autoreview and push.

The second rebase was clean. I’m doing the final autoreview on the current HEAD now.

Final autoreview is running on the rebased HEAD; waiting for the structured result.

Autoreview heartbeat at 60s; still healthy.

Still waiting on the final review.

Autoreview is at the 120s heartbeat and still running.

No findings output yet; continuing to wait.

Autoreview found another real compatibility edge: a valid `sessionFile` row can lack normalized `sessionId`, and the new accessor-backed path must not throw. I’ll add a parsed-filename fallback and a regression test, then rerun the same loop.

The sessionId fallback is patched with a regression test. I’m formatting and running the focused test file now.

The focused session-files tests pass with the new fallback. I’m amending the commit and rerunning the final validation set.

Commit amended again. I’m running the complete focused checks before one final autoreview pass.

All focused checks are clean again. I’m running the final autoreview pass; if it comes back clean, I’ll push and create the PR.

Final autoreview is running.

Still waiting on the final review output.

Final review is at the 120s heartbeat and still progressing.

No result yet; continuing to wait.

Autoreview found a custom `session.store` mismatch: accessor entries can come from the configured store path while my corpus code still used the default agent sessions dir. I’m reading the session store path helpers so the corpus uses the same directory as the accessor.

The correct fix is to derive the corpus store path with `resolveStorePath(getRuntimeConfig().session?.store, { agentId })` and pass that same `storePath` into `listSessionEntries`, so active entries and artifact scanning use the same configured directory. I’m patching that and adding custom-store coverage.

For tests, I’m going to use the existing config cache reset helpers so the custom `session.store` is actually loaded by `getRuntimeConfig`. I’ll keep those imports test-only; production still goes through the bridge.

The package-boundary contract excludes `*.test.ts`, so the test can import config reset helpers directly. I’m applying the custom-store fix now.

I’m adding `getRuntimeConfig` and `resolveStorePath` to the existing memory-host runtime session bridge, then making the corpus code derive `sessionsDir` from that resolved store path.

The import order shifted, so I’m applying the custom-store patch against the current formatted file.

I’m also updating the test env snapshot to include `OPENCLAW_CONFIG_PATH`, so the custom-store test does not leak config state into later cases.

Part of the previous patch already landed in one file, so I’m re-reading the exact current lines and applying the remaining changes in smaller patches.

The current checkout view shows the earlier corpus edits are not in the working tree view I expected, so I’m checking the exact diff/commit state before applying anything else.

I caught a branch problem before editing: the checkout is currently on `main`, not the PR branch. I’m switching back to `josh/refactor-memory-qmd-corpus-seam` now and will continue there only.

Back on the PR branch. I’m applying the custom-store fix there now.

The PR branch has the expected corpus changes. I’m patching the store-path derivation and test scaffolding now.

The custom-store fix is in. I’m formatting and running the session-files test first because that directly exercises the new config behavior.

The targeted test passes with the custom-store case. `pnpm exec` did a workspace install/postinstall before formatting, so I’m checking the tracked diff before amending to ensure only intended source/test files changed.

Only intended files changed. I’m rerunning the full focused check set, then I’ll amend and autoreview again.

The boundary test caught the direct core import in the memory-host test. I’m removing that by avoiding config cache manipulation from the package test; instead I’ll make the production code resolve config fresh enough for this path without test-only core imports, or move the reset behind the existing bridge if needed.

Rather than importing core config directly from the package test, I’m exposing the reset helpers through the existing memory-host bridge and importing that bridge in the test. That keeps the boundary test meaningful.

The test now uses the existing bridge. I’m formatting and rerunning the full focused validation set.

The cleanest product code remains pinned runtime config; I don’t want to make QMD reread config on every sync just to simplify a test. I’m going to remove the test-only bridge import and instead cover the custom-store path through an optional internal store-path parameter on the corpus helper, so production still uses runtime config while the test proves the directory logic.

A smaller option works: expose the reset helpers through `openclaw-runtime-session.ts` and import that facade in the test. That keeps tests away from core and avoids adding the test file to the bridge allowlist.

The test now imports only the session facade. I’m formatting and rerunning the full focused checks again.

All focused checks are clean now, including the package boundary test. I’m amending the commit with the custom-store fix.

The commit is amended. I’m checking whether `upstream/main` moved, then I’ll run final autoreview again.

`upstream/main` moved again, and the rebase was clean. I’m doing one final fast validation pass plus autoreview on the current HEAD.

The final focused checks are clean on the latest base. Running final autoreview now.

Final autoreview is running again.

Autoreview heartbeat at 60s; waiting for the result.

Still waiting on the final review subprocess.

Autoreview is at 120s and still healthy.

No output yet; I’m continuing to wait.

Final autoreview is still progressing at 180s.

Still no final result, continuing to wait.

The helper is healthy at 240s.

Final review found a real shared-store ownership bug: fixed `session.store` paths can contain multiple agents, and the corpus loop was stamping every row with the requested agent. I’m adding an owner filter before corpus entries are built.

I’m filtering shared fixed-store rows by `resolveAgentIdFromSessionKey(sessionKey)` before building corpus entries, and extending the custom-store test with a second agent row to prove it doesn’t cross-index.

The ownership filter and shared-store regression test are in. I’m formatting and running the focused checks again.

The failure is useful: after filtering active rows, directory artifact scanning still treated the other agent’s active transcript as an orphan file. I’m making artifact scanning ownership-aware too: skip files that are active for any other agent, and avoid unowned artifacts in shared fixed stores.

The artifact scan now knows about all active owners in the shared store. I’m rerunning the focused tests and checks.

The ownership-aware artifact scan passes the focused suite. I’m amending the commit and then running autoreview again.

Only the intended files are dirty. Amending now.

The commit is amended. I’m running autoreview again on the updated HEAD.

Autoreview is running again on the amended commit.

Autoreview heartbeat at 60s.

Still waiting on the review result.

Autoreview is still healthy at 120s.

Autoreview is at 180s and still progressing.

Still waiting for final review output.

Autoreview caught the legacy-key fallback case. I’m changing owner resolution to use the requested/store agent as fallback for unscoped keys, so non-main per-agent stores keep their legacy-key transcripts.

I’m using `resolveSessionAgentId` with the requested agent as fallback only for agent-scoped stores. For shared fixed stores, unscoped keys stay with the config default so they don’t get attributed to every agent.

The legacy-key fallback fix is patched with a non-main per-agent-store regression test. I’m running the focused checks again.

The legacy-key fix passes the focused checks. I’m amending the commit and running autoreview again.

The commit is amended; autoreview is running on that amended HEAD.

Autoreview is healthy at 120s.

No final output yet; continuing to wait.

Autoreview is still progressing at 180s.

Still waiting on the final review result.

I’m going to pick up at the last gate: confirm the final autoreview result, then push the branch and create the PR with a `Refs #88838` link in the body. After that I’ll verify the PR metadata so the issue tracker link is real, not just assumed.

The previous autoreview process no longer exists after compaction, so I’m rerunning the final commit review instead of trusting the interrupted output. I’ll also check the branch/worktree state before doing any GitHub write.

The branch is clean and one commit ahead of `upstream/main`. The commit-level autoreview is running now; I’ll wait for that to finish before pushing.

Autoreview is still working through the commit. I’m letting it finish because this branch has already had useful review catches, and I don’t want to open the PR on an unverified last amend.

No output yet beyond the review heartbeat. Once this comes back clean I’ll do the short post-review checks, then push and create the PR.

Autoreview found a real regression: when an active transcript file is missing, we were also dropping the accessor row metadata needed to classify reset/deleted archive artifacts. I’m going to fix that by separating “active file exists” from “session metadata exists,” then rerun the focused tests and autoreview.

The failing path is localized in corpus entry construction and archive classification. I’m going to make the active metadata map include accessor rows even when the live transcript file is gone, while keeping `listSessionFilesForAgent` from returning missing active files.

I’m editing the helper now: the accessor row will produce a canonical entry for classification, but only entries whose transcript file exists will be emitted as active corpus files. That keeps missing live files out of the corpus without losing archive metadata.

I’m adding the missing regression test beside the existing archive classification tests, specifically for the case where only the reset/deleted artifact exists and the accessor row still identifies the session.

The code and regression test are in place. I’m formatting the touched files and rerunning the narrow validation set before amending the branch commit.

The new test exposed that classification intentionally only returns existing files now; the important invariant is the archive gets cron classification without reintroducing the missing active transcript into the corpus. I’m tightening the assertion to that behavior.

The focused tests pass with the new regression case. I’m checking the diff, then I’ll amend the existing branch commit and rerun the non-test gates plus autoreview.

The fix is amended into the single branch commit. I’m rerunning the boundary ratchets, type gates, diff check, and then the final commit autoreview.

The ratchets, diff whitespace check, and package type gates are green. I’m starting the final autoreview now; this is the last quality gate before push/PR.

Autoreview is running on the amended commit. The local proof is already green; I’m waiting on the reviewer result before touching GitHub.

Still no review result beyond the heartbeat. I’ll keep waiting; the earlier review passes were catching edge cases, so this is worth letting finish.

Autoreview found another concrete fixed-store regression: any explicit `session.store` was treated as shared, so agent-owned fixed stores could lose unowned reset/deleted archives. I’m going to classify fixed stores under `agents/<agent>/sessions` as agent-owned and add coverage for that exact case.

The ownership fix is small: an explicit fixed store beneath the requested agent’s canonical sessions directory is no longer treated as shared. I’m adding a regression test so that reset/deleted archives still appear for that configuration.

The second regression test is in place. I’m formatting and rerunning the same focused suite before amending again.

The test is still failing: with that config shape the runtime is not resolving the fixed store to the path I expected. I’m checking the config/store resolver now and will align the test and fix to the actual contract rather than guessing.

The resolver source confirms the config value itself is valid, so the failing test points at runtime config loading in this package test setup rather than path syntax. I’m checking the loaded config shape/reset behavior before changing product logic further.

The archive filename and resolver contract are fine, so I’m reading the actual corpus listing path next. The failure likely comes from how unowned artifacts are filtered after the fixed-store ownership decision, not from the filesystem scan itself.

The first debug probe only failed because the TS runner rejected top-level `await`; no repo state changed. I’m rerunning it wrapped in an async function to inspect the actual runtime values.

The probe confirms the corpus path is returning empty despite the file being present. I’m now printing the resolver and artifact predicate inputs directly; that will tell whether the issue is config ownership or the filename filter.

The resolver and filename predicates are correct, so the remaining mismatch is inside the ownership check. I’m reading the current formatted block and will adjust the ownership extraction if it’s using the wrong `sessions` segment.

Found it: I fixed the shared-store classifier but left the later unowned-artifact flag using the old raw condition. I’m wiring that flag to the computed `isSharedFixedStore` value.

The focused tests are green again, including both archive-regression cases. I’ll amend this into the branch commit and run the full local gate set one more time.

The ratchets, diff check, and type gates are green after the fixed-store correction. I’m rerunning final autoreview now.

Autoreview is running on the latest amended commit. If this pass is clean, I’ll go straight to transcript check, push, and PR creation.

Still waiting on autoreview. Local gates remain green; I’m not moving to GitHub until the reviewer returns clean or actionable findings are handled.

The review is still in progress at the two-minute heartbeat. I’ll continue polling; there’s no unfinished shell work besides this review process.

Still just heartbeat output. I’ll give it another poll; if it returns findings, I’ll patch them before opening anything.

Autoreview found a third compatibility edge: persisted absolute `sessionFile` paths that the session resolver supports can live outside the custom store directory. I’m going to switch corpus resolution to the existing session-file path resolver contract instead of hard-coding “same directory as store.”

I’m going to use the existing `resolveSessionFilePath` helper through the memory-host facade and scan artifact directories reached by accessor rows, not only the store directory. That keeps the accessor contract intact for absolute transcript paths and still lets the owner map filter shared stores.

The facade export is added. Now I’m updating the corpus helper to delegate path resolution and to scan any accessor-reached transcript directories for retained artifacts.

The helper has a couple of older call sites that still need the simple “store directory plus entry” behavior. I’ll add the accessor-contract resolver for corpus use without breaking those older classification/sync helpers.

I’m applying this in small patches: first the import/export and resolver helper, then the corpus loop.

The corpus resolver now delegates to `resolveSessionFilePath`. Next I’m updating the artifact scan to include directories discovered from accessor rows and dedupe scanned files.

I’m adding coverage for a fixed custom store whose row points at an absolute canonical transcript path outside the store directory, including its retained archive.

The resolver-contract test is in place. I’m formatting and running the focused tests again; this should catch both the absolute active path and its archive scan.

The test failures are from `resolveSessionFilePath` realpathing macOS `/var` to `/private/var`, which also made artifact scans see duplicates. I’m keeping the resolver as the validator for absolute paths, but preserving the original persisted path spelling when it resolves to the same file.

I’m tightening the relative-path branch as well so it still goes through the resolver contract and cannot accidentally accept a path escape.

The path spelling and containment behavior are adjusted. I’m rerunning the focused suite now.

Two failures remain. One is only `/var` versus `/private/var` normalization in the classification set; the other shows absolute-path archive scanning is still blocked under a shared fixed store. I’m probing that second path because it’s behavioral.

The archive skip is a real bug in my scan loop: primary-owner lookup was still joining against the store directory instead of the artifact’s own directory. I’m fixing that now.

The remaining classification assertion needs to account for the runtime’s canonicalized directory spelling on macOS. I’m updating that expected path using `realpathSync`, which is portable and matches the existing file.

I’m formatting and rerunning the focused suite again after the owner-path fix and normalized assertion.

That duplicate is the same `/var` versus `/private/var` directory being scanned twice. I’m changing the internal corpus maps and scan dedupe to use real-path comparison while preserving the emitted path spelling from the chosen scan directory.

The last patch left one bad `Map.get` call shape; I’m cleaning that up and applying real-path keys consistently in the owner/active maps and scan set.

The map keys are consistent now. I’m formatting and rerunning the focused tests.

Only the test expectation remains: this path is emitted in canonical realpath form for the default store when the active file is absent. I’m making the test assert that explicitly.

The formatted assertion spans lines now; I’m applying the expectation update against the current file shape.

I’m rerunning the focused suite after the expectation fix.

The focused suite is green with the absolute-path regression covered. I’m amending this final fix into the branch commit and rerunning the ratchets/type gates.

The commit is amended. I’m running the non-test gates and whitespace check again before the final autoreview pass.

The local gates are green after the absolute-path fix. I’m starting final autoreview again; this has to come back clean before the PR.

Autoreview is running on the latest commit. The earlier findings were all concrete edge cases, so I’m continuing to wait rather than bypass it.

Still waiting on the review process. Once it returns clean, the remaining work is mechanical: transcript check, push, PR create, and PR verification.

No result yet beyond heartbeats. I’m continuing to poll; there are no parallel edits happening while the reviewer runs.

The review is still at heartbeat only. I’ll wait for completion and then either patch any finding or move to PR creation.

Autoreview found an API-shape problem rather than another path bug: `listSessionFilesForAgent()` throws away the new corpus metadata, so callers that build entries by path can lose cron/dreaming classification for custom stores. I’m checking the callers now and will thread corpus entries where needed instead of widening the old path-only API.

The affected callers are the QMD manager, sync ops, and dreaming phases under `extensions/memory-core`, plus the SDK engine wrapper. I’m reading those call sites now and will keep the fix narrow: switch the indexing/enqueue paths to corpus entries where metadata matters.

I need the scoped extension guide before editing those plugin files, then I’ll thread the existing metadata through the two indexing paths that currently call `buildSessionEntry` by path.

I’m adding the corpus entry export to the SDK engine barrel, then I’ll update the three metadata-sensitive call sites to use corpus entries and pass generated-session flags into `buildSessionEntry`.

First caller: dreaming ingestion. It already has a local session-file metadata shape, so I’m replacing the separate file list plus classification lookup with the corpus entries directly.

Next caller: QMD export. I’m using corpus entries for both `buildSessionEntry` classification options and artif

...[transcript truncated to 50000 chars]
````

</details>
<!-- agent-transcript:end -->





