### PR TITLE
fix: handle Telegram reaction count updates

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -793,10 +793,12 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
   <Accordion title="Reaction notifications">
     Telegram reactions arrive as `message_reaction` updates (separate from message payloads).
+    Anonymous aggregate reaction totals arrive as separate `message_reaction_count` updates.
 
     When enabled, OpenClaw enqueues system events like:
 
     - `Telegram reaction added: 👍 by Alice (@alice) on msg 42`
+    - `Telegram reaction counts changed: 👍 x3, 🔥 x2 on msg 42`
 
     Config:
 
@@ -807,11 +809,13 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     - `own` means user reactions to bot-sent messages only (best-effort via sent-message cache).
     - Reaction events still respect Telegram access controls (`dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`); unauthorized senders are dropped.
+    - Telegram only delivers reaction updates when the Bot API can expose them to the bot. In practice, bots must be administrators in the chat, so reactions in 1:1 private DMs may not arrive even when `reactionNotifications` is enabled.
+    - `message_reaction_count` has no actor identity. OpenClaw treats it as a chat-level aggregate event for allowed groups; private chats and sender-only allowlist matches are ignored.
     - Telegram does not provide thread IDs in reaction updates.
       - non-forum groups route to group chat session
       - forum groups route to the group general-topic session (`:topic:1`), not the exact originating topic
 
-    `allowed_updates` for polling/webhook include `message_reaction` automatically.
+    `allowed_updates` for polling/webhook include both `message_reaction` and `message_reaction_count` automatically.
 
   </Accordion>
 

--- a/docs/tools/reactions.md
+++ b/docs/tools/reactions.md
@@ -51,6 +51,8 @@ tool with the `react` action. Reaction behavior varies by channel and transport.
   <Accordion title="Telegram">
     - Empty `emoji` removes the bot's reactions.
     - `remove: true` also removes reactions but still requires a non-empty `emoji` for tool validation.
+    - Inbound reaction notifications depend on Telegram Bot API delivery. Bots generally must be administrators in the chat to receive reaction updates, so 1:1 DM reactions can be unavailable even with `channels.telegram.reactionNotifications` enabled.
+    - Anonymous aggregate reaction-count updates are chat-level events without actor identity, so OpenClaw handles them for allowed groups only.
 
   </Accordion>
 

--- a/extensions/telegram/src/allowed-updates.test.ts
+++ b/extensions/telegram/src/allowed-updates.test.ts
@@ -35,6 +35,10 @@ describe("resolveTelegramAllowedUpdates", () => {
       "chat_boost",
       "removed_chat_boost",
     ]);
-    expect(updates).toEqual([...DEFAULT_TELEGRAM_UPDATE_TYPES, "message_reaction"]);
+    expect(updates).toEqual([
+      ...DEFAULT_TELEGRAM_UPDATE_TYPES,
+      "message_reaction",
+      "message_reaction_count",
+    ]);
   });
 });

--- a/extensions/telegram/src/allowed-updates.ts
+++ b/extensions/telegram/src/allowed-updates.ts
@@ -11,6 +11,9 @@ export function resolveTelegramAllowedUpdates(): ReadonlyArray<TelegramUpdateTyp
   if (!updates.includes("message_reaction")) {
     updates.push("message_reaction");
   }
+  if (!updates.includes("message_reaction_count")) {
+    updates.push("message_reaction_count");
+  }
   if (!updates.includes("channel_post")) {
     updates.push("channel_post");
   }

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,6 +1,6 @@
 // Telegram plugin module implements bot handlers behavior.
 import { randomUUID } from "node:crypto";
-import type { Message, ReactionTypeEmoji } from "grammy/types";
+import type { Message, ReactionCount, ReactionTypeEmoji } from "grammy/types";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-helpers";
 import {
@@ -1613,6 +1613,18 @@ export const registerTelegramHandlers = ({
   type TelegramEventAuthorizationContext = TelegramGroupAllowContext & { dmPolicy: DmPolicy };
   const getChat: TelegramGetChat = bot.api.getChat.bind(bot.api);
 
+  const formatTelegramReactionCount = (reaction: ReactionCount): string => {
+    const total = reaction.total_count;
+    const kind = reaction.type;
+    if (kind.type === "emoji") {
+      return `${kind.emoji} x${total}`;
+    }
+    if (kind.type === "custom_emoji") {
+      return `custom_emoji:${kind.custom_emoji_id} x${total}`;
+    }
+    return `paid x${total}`;
+  };
+
   const TELEGRAM_EVENT_AUTH_RULES: Record<
     TelegramEventAuthorizationMode,
     {
@@ -1968,6 +1980,98 @@ export const registerTelegramHandlers = ({
       }
     } catch (err) {
       runtime.error?.(danger(`telegram reaction handler failed: ${String(err)}`));
+      throw err;
+    }
+  });
+
+  // Handle aggregate anonymous reaction counts. Telegram exposes this as a
+  // separate update type from per-user message_reaction changes.
+  bot.on("message_reaction_count", async (ctx) => {
+    try {
+      const reactionCount = ctx.messageReactionCount;
+      if (!reactionCount) {
+        return;
+      }
+      if (shouldSkipUpdate(ctx)) {
+        return;
+      }
+
+      const chatId = reactionCount.chat.id;
+      const messageId = reactionCount.message_id;
+      const isGroup =
+        reactionCount.chat.type === "group" || reactionCount.chat.type === "supergroup";
+      if (!isGroup) {
+        logVerbose(
+          `telegram: skipped anonymous reaction count on msg ${messageId} in non-group chat ${chatId}`,
+        );
+        return;
+      }
+      const isForum = reactionCount.chat.is_forum === true;
+      const reactionMode = telegramCfg.reactionNotifications ?? "own";
+      if (reactionMode === "off") {
+        return;
+      }
+      if (reactionMode === "own" && !telegramDeps.wasSentByBot(chatId, messageId, cfg)) {
+        logVerbose(
+          `telegram: skipped reaction count on msg ${messageId} in chat ${chatId} (own mode, not sent by bot)`,
+        );
+        return;
+      }
+
+      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
+        chatId,
+        isGroup,
+        isForum,
+      });
+      const groupAccess = evaluateTelegramGroupPolicyAccess({
+        isGroup,
+        chatId,
+        cfg,
+        telegramCfg,
+        topicConfig: eventAuthContext.topicConfig,
+        groupConfig: eventAuthContext.groupConfig,
+        effectiveGroupAllow: eventAuthContext.effectiveGroupAllow,
+        senderId: "",
+        senderUsername: "",
+        resolveGroupPolicy,
+        enforcePolicy: true,
+        useTopicAndGroupOverrides: true,
+        enforceAllowlistAuthorization: true,
+        allowEmptyAllowlistEntries: false,
+        requireSenderForAllowlistAuthorization: false,
+        checkChatAllowlist: true,
+      });
+      if (!groupAccess.allowed) {
+        logVerbose(
+          `Blocked telegram anonymous reaction count in group ${chatId} (${groupAccess.reason})`,
+        );
+        return;
+      }
+
+      const summary =
+        reactionCount.reactions.length > 0
+          ? reactionCount.reactions.map(formatTelegramReactionCount).join(", ")
+          : "none";
+      const resolvedThreadId = isForum
+        ? resolveTelegramForumThreadId({ isForum, messageThreadId: undefined })
+        : undefined;
+      const peerId = buildTelegramGroupPeerId(chatId, resolvedThreadId);
+      const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
+      const route = resolveAgentRoute({
+        cfg: telegramDeps.getRuntimeConfig(),
+        channel: "telegram",
+        accountId,
+        peer: { kind: "group", id: peerId },
+        parentPeer,
+      });
+      const text = `Telegram reaction counts changed: ${summary} on msg ${messageId}`;
+      telegramDeps.enqueueSystemEvent(text, {
+        sessionKey: route.sessionKey,
+        contextKey: `telegram:reaction:count:${chatId}:${messageId}:${reactionCount.date}`,
+      });
+      logVerbose(`telegram: reaction count event enqueued: ${text}`);
+    } catch (err) {
+      runtime.error?.(danger(`telegram reaction count handler failed: ${String(err)}`));
       throw err;
     }
   });

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -4064,6 +4064,178 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("registers message_reaction_count handler", () => {
+    onSpy.mockClear();
+    createTelegramBot({ token: "tok" });
+    const reactionCountHandler = onSpy.mock.calls.find(
+      (call) => call[0] === "message_reaction_count",
+    );
+    expect(reactionCountHandler?.[0]).toBe("message_reaction_count");
+    if (typeof reactionCountHandler?.[1] !== "function") {
+      throw new Error("expected message_reaction_count handler");
+    }
+  });
+
+  it("enqueues system event for anonymous reaction counts", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", groupPolicy: "open", reactionNotifications: "all" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction_count") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 550 },
+      messageReactionCount: {
+        chat: { id: 9999, type: "supergroup" },
+        message_id: 42,
+        date: 1736380800,
+        reactions: [
+          { type: { type: "emoji", emoji: THUMBS_UP_EMOJI }, total_count: 3 },
+          { type: { type: "emoji", emoji: FIRE_EMOJI }, total_count: 2 },
+        ],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+    expect(firstSystemEventArg(0)).toBe(
+      `Telegram reaction counts changed: ${THUMBS_UP_EMOJI} x3, ${FIRE_EMOJI} x2 on msg 42`,
+    );
+    expect(String(systemEventOptions().sessionKey)).toContain("telegram:group:9999");
+    expect(String(systemEventOptions().contextKey)).toContain(
+      "telegram:reaction:count:9999:42:1736380800",
+    );
+  });
+
+  it("routes forum anonymous reaction counts to the general topic", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", groupPolicy: "open", reactionNotifications: "all" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction_count") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 551 },
+      messageReactionCount: {
+        chat: { id: 5678, type: "supergroup", is_forum: true },
+        message_id: 100,
+        date: 1736380801,
+        reactions: [{ type: { type: "emoji", emoji: EYES_EMOJI }, total_count: 1 }],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+    expect(firstSystemEventArg(0)).toBe(
+      `Telegram reaction counts changed: ${EYES_EMOJI} x1 on msg 100`,
+    );
+    expect(String(systemEventOptions().sessionKey)).toContain("telegram:group:5678:topic:1");
+  });
+
+  it("skips anonymous reaction counts in private chats", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction_count") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 552 },
+      messageReactionCount: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        date: 1736380802,
+        reactions: [{ type: { type: "emoji", emoji: THUMBS_UP_EMOJI }, total_count: 1 }],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips anonymous reaction counts in own mode when message is not sent by bot", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    wasSentByBot.mockReturnValue(false);
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", groupPolicy: "open", reactionNotifications: "own" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction_count") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 553 },
+      messageReactionCount: {
+        chat: { id: 9999, type: "supergroup" },
+        message_id: 42,
+        date: 1736380803,
+        reactions: [{ type: { type: "emoji", emoji: THUMBS_UP_EMOJI }, total_count: 1 }],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips anonymous reaction counts in unauthorized allowlist groups", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["12345"],
+          reactionNotifications: "all",
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction_count") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 554 },
+      messageReactionCount: {
+        chat: { id: 9999, type: "supergroup" },
+        message_id: 42,
+        date: 1736380804,
+        reactions: [{ type: { type: "emoji", emoji: THUMBS_UP_EMOJI }, total_count: 1 }],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
   it("enqueues system event for reaction", async () => {
     onSpy.mockClear();
     enqueueSystemEventSpy.mockClear();

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -252,6 +252,14 @@ describe("getTelegramSequentialKey", () => {
       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "please do not do that" }) },
       "telegram:123",
     ],
+    [
+      {
+        update: {
+          message_reaction_count: { chat: { id: -1001234567890 } },
+        },
+      },
+      "telegram:-1001234567890",
+    ],
   ])("resolves key %#", (input, expected) => {
     expect(getTelegramSequentialKey(input)).toBe(expected);
   });

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -39,6 +39,7 @@ type TelegramSequentialKeyContext = {
     edited_channel_post?: Message;
     callback_query?: { message?: Message; data?: string };
     message_reaction?: { chat?: { id?: number } };
+    message_reaction_count?: { chat?: { id?: number } };
   };
 };
 
@@ -102,6 +103,10 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   const reaction = ctx.update?.message_reaction;
   if (reaction?.chat?.id) {
     return `telegram:${reaction.chat.id}`;
+  }
+  const reactionCount = ctx.update?.message_reaction_count;
+  if (reactionCount?.chat?.id) {
+    return `telegram:${reactionCount.chat.id}`;
   }
   const msg =
     ctx.message ??


### PR DESCRIPTION
## Summary
- request Telegram `message_reaction_count` updates alongside `message_reaction`
- add a dedicated `message_reaction_count` handler that emits aggregate reaction-count system events for allowed groups
- route reaction-count updates through the Telegram sequential key and document the actorless aggregate-count semantics

## Why
PR #93731 was closed because it subscribed to `message_reaction_count` updates without a runtime handler. That would let polling/webhook accept count updates and then silently drop them. This patch pairs the subscription with explicit aggregate-count handling, routing, docs, and tests.

## Behavior
- `message_reaction` still handles per-user reaction additions.
- `message_reaction_count` now emits events like `Telegram reaction counts changed: 👍 x3, 🔥 x2 on msg 42`.
- Aggregate count updates have no actor identity, so OpenClaw treats them as chat-level group events. Private chats are skipped, and sender-only allowlists do not authorize anonymous aggregate counts.
- Forum group count updates route to the general-topic session, matching existing reaction routing where Telegram omits thread IDs.

## Tests
- `./node_modules/.bin/vitest run extensions/telegram/src/allowed-updates.test.ts extensions/telegram/src/sequential-key.test.ts extensions/telegram/src/bot.test.ts`
- `./node_modules/.bin/oxfmt --check extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot.test.ts extensions/telegram/src/sequential-key.ts extensions/telegram/src/sequential-key.test.ts`
- `node scripts/format-docs.mjs --check`
- `node scripts/check-telegram-grammy-types-imports.mjs`
- `openclaw infer model run --gateway --model codex/gpt-5.5 ...` returned PASS/no merge blockers on the patch summary

Note: full `pnpm format:check` still reports pre-existing unrelated formatting issues in the upstream tree; post-rebase targeted source formatting was checked directly with local `oxfmt`. Full pnpm post-rebase runs also hit npm registry retry failures while fetching new optional packages, so targeted tests were run through local binaries.