### PR TITLE
Guard overflow recovery retries

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -439,6 +439,56 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.error).toBeUndefined();
   });
 
+  it("blocks instead of retrying when compaction reports context still over budget", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: makeOverflowError(
+          "Context overflow: prompt too large for the model (precheck).",
+        ),
+        promptErrorSource: "precheck",
+        preflightRecovery: { route: "compact_only" },
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "anthropic",
+          model: "test-model",
+          route: "compact_only",
+          shouldCompact: true,
+          estimatedPromptTokens: 220_000,
+          contextTokenBudget: 200_000,
+          promptBudgetBeforeReserve: 180_000,
+          reserveTokens: 20_000,
+          effectiveReserveTokens: 20_000,
+          remainingPromptBudgetTokens: 0,
+          overflowTokens: 40_000,
+          toolResultReducibleChars: 0,
+          messageCount: 14,
+          unwindowedMessageCount: 14,
+          sessionId: "test-session",
+        },
+      }),
+    );
+
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted session",
+        firstKeptEntryId: "entry-5",
+        tokensBefore: 230_000,
+        tokensAfter: 190_000,
+      }),
+    );
+
+    const result = await runEmbeddedAgent(baseParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta.error?.kind).toBe("context_overflow");
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expectLogIncludes(mockedLog.warn, "post-compaction budget check failed");
+    expectLogExcludes(mockedLog.info, "auto-compaction succeeded");
+  });
+
   it("retries compaction up to 3 times before giving up", async () => {
     const overflowError = makeOverflowError();
 

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -223,6 +223,43 @@ function isNoRealConversationCompactionNoop(params: {
   );
 }
 
+function resolvePostRecoveryBudgetOverflow(params: {
+  contextBudgetStatus?: EmbeddedAgentMeta["contextBudgetStatus"];
+  tokensAfter?: number;
+  recoveryAction: string;
+  provider: string;
+  modelId: string;
+  sessionKey?: string;
+  sessionId?: string;
+  sessionFile?: string;
+}): { message: string } | undefined {
+  const { contextBudgetStatus } = params;
+  if (
+    !contextBudgetStatus ||
+    typeof params.tokensAfter !== "number" ||
+    !Number.isFinite(params.tokensAfter)
+  ) {
+    return undefined;
+  }
+  const tokensAfter = Math.max(0, Math.ceil(params.tokensAfter));
+  const promptBudgetBeforeReserve = Math.max(
+    1,
+    Math.floor(contextBudgetStatus.promptBudgetBeforeReserve),
+  );
+  if (tokensAfter <= promptBudgetBeforeReserve) {
+    return undefined;
+  }
+  const overflowTokens = Math.max(1, tokensAfter - promptBudgetBeforeReserve);
+  return {
+    message:
+      `${params.recoveryAction} left context over budget; ` +
+      `tokensAfter=${tokensAfter} promptBudgetBeforeReserve=${promptBudgetBeforeReserve} ` +
+      `overflowTokens=${overflowTokens} provider=${params.provider}/${params.modelId} ` +
+      `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"} ` +
+      `sessionFile=${params.sessionFile ?? "unknown"}`,
+  };
+}
+
 async function resetNoRealConversationTokenSnapshot(params: {
   config?: RunEmbeddedAgentParams["config"];
   sessionKey?: string;
@@ -2041,6 +2078,49 @@ export async function runEmbeddedAgent(
             );
             const isCompactionFailure = isCompactionFailureError(errorText);
             const hadAttemptLevelCompaction = attemptCompactionCount > 0;
+            const returnBlockedOverflowResult = (params: {
+              kind: "compaction_failure" | "context_overflow";
+              errorMessage: string;
+              logMessage: string;
+            }): EmbeddedAgentRunResult => {
+              const overflowRecoveryText =
+                "Context overflow: prompt too large for the model. " +
+                "Try /reset (or /new) to start a fresh session, or use a larger-context model.";
+              log.warn(params.logMessage);
+              attempt.setTerminalLifecycleMeta?.({
+                replayInvalid: resolveReplayInvalidForAttempt(),
+                livenessState: "blocked",
+              });
+              return {
+                payloads: [
+                  {
+                    text: overflowRecoveryText,
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: buildErrorAgentMeta({
+                    sessionId: sessionIdUsed,
+                    sessionFile: activeSessionFile,
+                    provider,
+                    model: model.id,
+                    contextTokens: ctxInfo.tokens,
+                    usageAccumulator,
+                    lastRunPromptUsage,
+                    lastAssistant: sessionLastAssistant,
+                    lastTurnTotal,
+                  }),
+                  systemPromptReport: attempt.systemPromptReport,
+                  finalAssistantVisibleText: overflowRecoveryText,
+                  finalAssistantRawText: overflowRecoveryText,
+                  finalPromptText: attempt.finalPromptText,
+                  replayInvalid: resolveReplayInvalidForAttempt(),
+                  livenessState: "blocked",
+                  error: { kind: params.kind, message: params.errorMessage },
+                },
+              };
+            };
             // If this attempt already compacted (SDK auto-compaction), avoid immediately
             // running another explicit compaction for the same overflow trigger.
             if (
@@ -2222,6 +2302,45 @@ export async function runEmbeddedAgent(
                       `[context-overflow-precheck] post-compaction tool-result truncation did not help for ` +
                         `${provider}/${modelId}: ${truncResult.reason ?? "unknown"}`,
                     );
+                    const postRecoveryOverflow = resolvePostRecoveryBudgetOverflow({
+                      contextBudgetStatus: attempt.contextBudgetStatus ?? lastContextBudgetStatus,
+                      tokensAfter: compactResult.result?.tokensAfter,
+                      recoveryAction: "post-compaction recovery",
+                      provider,
+                      modelId,
+                      sessionKey: params.sessionKey,
+                      sessionId: params.sessionId,
+                      sessionFile: activeSessionFile,
+                    });
+                    if (postRecoveryOverflow) {
+                      return returnBlockedOverflowResult({
+                        kind: "context_overflow",
+                        errorMessage: `${errorText}; ${postRecoveryOverflow.message}`,
+                        logMessage:
+                          `[context-overflow-recovery] post-compaction budget check failed; ` +
+                          postRecoveryOverflow.message,
+                      });
+                    }
+                  }
+                } else {
+                  const postRecoveryOverflow = resolvePostRecoveryBudgetOverflow({
+                    contextBudgetStatus: attempt.contextBudgetStatus ?? lastContextBudgetStatus,
+                    tokensAfter: compactResult.result?.tokensAfter,
+                    recoveryAction: "auto-compaction recovery",
+                    provider,
+                    modelId,
+                    sessionKey: params.sessionKey,
+                    sessionId: params.sessionId,
+                    sessionFile: activeSessionFile,
+                  });
+                  if (postRecoveryOverflow) {
+                    return returnBlockedOverflowResult({
+                      kind: "context_overflow",
+                      errorMessage: `${errorText}; ${postRecoveryOverflow.message}`,
+                      logMessage:
+                        `[context-overflow-recovery] post-compaction budget check failed; ` +
+                        postRecoveryOverflow.message,
+                    });
                   }
                 }
                 autoCompactionCount += 1;
@@ -2300,46 +2419,13 @@ export async function runEmbeddedAgent(
               );
             }
             const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
-            const overflowRecoveryText =
-              "Context overflow: prompt too large for the model. " +
-              "Try /reset (or /new) to start a fresh session, or use a larger-context model.";
-            log.warn(
-              `[context-overflow-recovery] exhausted provider overflow recovery for ${provider}/${modelId}; ` +
+            return returnBlockedOverflowResult({
+              kind,
+              errorMessage: errorText,
+              logMessage:
+                `[context-overflow-recovery] exhausted provider overflow recovery for ${provider}/${modelId}; ` +
                 `livenessState=blocked suggestedAction=reset_or_new kind=${kind}`,
-            );
-            attempt.setTerminalLifecycleMeta?.({
-              replayInvalid: resolveReplayInvalidForAttempt(),
-              livenessState: "blocked",
             });
-            return {
-              payloads: [
-                {
-                  text: overflowRecoveryText,
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta: buildErrorAgentMeta({
-                  sessionId: sessionIdUsed,
-                  sessionFile: activeSessionFile,
-                  provider,
-                  model: model.id,
-                  contextTokens: ctxInfo.tokens,
-                  usageAccumulator,
-                  lastRunPromptUsage,
-                  lastAssistant: sessionLastAssistant,
-                  lastTurnTotal,
-                }),
-                systemPromptReport: attempt.systemPromptReport,
-                finalAssistantVisibleText: overflowRecoveryText,
-                finalAssistantRawText: overflowRecoveryText,
-                finalPromptText: attempt.finalPromptText,
-                replayInvalid: resolveReplayInvalidForAttempt(),
-                livenessState: "blocked",
-                error: { kind, message: errorText },
-              },
-            };
           }
 
           if (promptErrorSource === "hook:before_agent_run" && !aborted) {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -626,6 +626,21 @@ describe("buildContextOverflowRecoveryText", () => {
     expect(text).not.toContain("reset our conversation");
   });
 
+  it("omits operator config advice for external preserved-session copy", () => {
+    const text = buildContextOverflowRecoveryText({
+      preserveSessionMapping: true,
+      includeOperatorHint: false,
+      cfg: {},
+      primaryProvider: "openrouter",
+      primaryModel: "qwen3.6-plus",
+    });
+
+    expect(text).toContain("kept this conversation mapped to the current session");
+    expect(text).toContain("The conversation history is still available");
+    expect(text).not.toContain("reserveTokensFloor");
+    expect(text).not.toContain("agents.defaults.compaction");
+  });
+
   it("falls back to session entry model when runtimeProvider is not provided", () => {
     const text = buildContextOverflowRecoveryText({
       cfg: {
@@ -5348,7 +5363,9 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toContain("kept this conversation mapped to the current session");
-      expect(result.payload.text).toContain("reserveTokensFloor");
+      expect(result.payload.text).toContain("The conversation history is still available");
+      expect(result.payload.text).not.toContain("reserveTokensFloor");
+      expect(result.payload.text).not.toContain("agents.defaults.compaction");
       expectRecordFields(requireRecord(getReplyPayloadMetadata(result.payload), "reply metadata"), {
         deliverDespiteSourceReplySuppression: true,
       });
@@ -5391,7 +5408,9 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toContain("kept this conversation mapped to the current session");
-      expect(result.payload.text).toContain("reserveTokensFloor");
+      expect(result.payload.text).toContain("The conversation history is still available");
+      expect(result.payload.text).not.toContain("reserveTokensFloor");
+      expect(result.payload.text).not.toContain("agents.defaults.compaction");
       expectRecordFields(requireRecord(getReplyPayloadMetadata(result.payload), "reply metadata"), {
         deliverDespiteSourceReplySuppression: true,
       });
@@ -5434,8 +5453,9 @@ describe("runAgentTurnWithFallback", () => {
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
-      expect(result.payload.text).toContain("reserveTokensFloor");
-      expect(result.payload.text).toContain("20000");
+      expect(result.payload.text).toContain("The conversation history is still available");
+      expect(result.payload.text).not.toContain("reserveTokensFloor");
+      expect(result.payload.text).not.toContain("agents.defaults.compaction");
       expect(result.payload.text).not.toContain("100000");
     }
   });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -955,6 +955,13 @@ function buildContextOverflowResetHint(contextWindowTokens: number | undefined):
   );
 }
 
+function buildContextOverflowExternalHint(): string {
+  return (
+    "\n\nThe conversation history is still available. If this keeps happening, start a new " +
+    "session after saving any important context."
+  );
+}
+
 type ModelRefLike = {
   provider: string;
   model: string;
@@ -1133,6 +1140,7 @@ function resolveHeartbeatBleedHint(params: {
 export function buildContextOverflowRecoveryText(params: {
   duringCompaction?: boolean;
   preserveSessionMapping?: boolean;
+  includeOperatorHint?: boolean;
   cfg: FollowupRun["run"]["config"];
   agentId?: string;
   primaryProvider?: string;
@@ -1142,10 +1150,13 @@ export function buildContextOverflowRecoveryText(params: {
   activeSessionEntry?: SessionEntry;
 }): string {
   const prefix = params.preserveSessionMapping
-    ? "⚠️ Auto-compaction could not recover this turn. I kept this conversation mapped to the current session. Please try again, use /compact, or use /new to start a fresh session."
+    ? "⚠️ This conversation is too large to continue cleanly. I kept this conversation mapped to the current session. Please try again, use /compact, or use /new to start a fresh session."
     : params.duringCompaction
       ? "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again."
       : "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.";
+  if (params.includeOperatorHint === false) {
+    return prefix + buildContextOverflowExternalHint();
+  }
   const primaryContextWindow = resolveContextWindowForCompactionHint({
     cfg: params.cfg,
     primaryProvider: params.primaryProvider,
@@ -2603,6 +2614,7 @@ export async function runAgentTurnWithFallback(params: {
           payload: markAgentRunFailureReplyPayload({
             text: buildContextOverflowRecoveryText({
               preserveSessionMapping: true,
+              includeOperatorHint: false,
               cfg: runtimeConfig,
               agentId: params.followupRun.run.agentId,
               primaryProvider: params.followupRun.run.provider,
@@ -2742,6 +2754,7 @@ export async function runAgentTurnWithFallback(params: {
             text: buildContextOverflowRecoveryText({
               duringCompaction: true,
               preserveSessionMapping: true,
+              includeOperatorHint: false,
               cfg: runtimeConfig,
               agentId: params.followupRun.run.agentId,
               primaryProvider: params.followupRun.run.provider,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -2201,8 +2201,10 @@ describe("runReplyAgent typing (heartbeat)", () => {
     if (!payload) {
       throw new Error("expected payload");
     }
-    expect(payload.text).toContain("Auto-compaction could not recover this turn");
-    expect(payload.text).toContain("reserveTokensFloor");
+    expect(payload.text).toContain("This conversation is too large to continue cleanly");
+    expect(payload.text).toContain("The conversation history is still available");
+    expect(payload.text).not.toContain("reserveTokensFloor");
+    expect(payload.text).not.toContain("agents.defaults.compaction");
     expect(payload.text).toContain("/new");
   });
 
@@ -2224,8 +2226,10 @@ describe("runReplyAgent typing (heartbeat)", () => {
     if (!payload) {
       throw new Error("expected payload");
     }
-    expect(payload.text).toContain("Auto-compaction could not recover this turn");
-    expect(payload.text).toContain("reserveTokensFloor");
+    expect(payload.text).toContain("This conversation is too large to continue cleanly");
+    expect(payload.text).toContain("The conversation history is still available");
+    expect(payload.text).not.toContain("reserveTokensFloor");
+    expect(payload.text).not.toContain("agents.defaults.compaction");
     expect(payload.text).toContain("/new");
   });
 


### PR DESCRIPTION
## What Problem This Solves

Overflow recovery could retry an already over-budget transcript after compaction/truncation, which caused long tool-loop or voice-note sessions to keep failing and sometimes expose internal recovery/config guidance to customer channels.

## Summary

- Stop overflow recovery from retrying the model when compaction reports the transcript is still above the reserve-aware prompt budget.
- Keep the existing blocked-overflow result shape, but add a post-compaction budget diagnostic for logs.
- Replace customer-facing preserved-session overflow fallback copy so external chats do not expose internal config keys such as `agents.defaults.compaction.reserveTokensFloor`.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.overflow-compaction.test.ts`
- `PATH="/Users/natannobrechaves/.npm/_npx/e32453d063f7b9f9/node_modules/.bin:$PATH" pnpm lint:core`
- `PATH="/Users/natannobrechaves/.npm/_npx/e32453d063f7b9f9/node_modules/.bin:$PATH" pnpm tsgo:prod`
- `PATH="/Users/natannobrechaves/.npm/_npx/e32453d063f7b9f9/node_modules/.bin:$PATH" pnpm check:test-types`
- `PATH="/Users/natannobrechaves/.npm/_npx/e32453d063f7b9f9/node_modules/.bin:$PATH" pnpm build:plugin-sdk:strict-smoke`
- `git diff --check`

## Production Readiness

Risk tier: Medium

Summary: Runtime overflow recovery now fails closed when compaction still leaves the prompt over budget, and external fallback text no longer leaks operator config advice.

Production/customer impact: Affects the context-overflow failure path for agent replies. Normal successful replies and channel delivery mechanics are unchanged.

Validation: Targeted runner, reply fallback, e2e reply, type, lint, and plugin boundary checks above exercise the retry guard and the customer-visible fallback text.

Rollback/disable path: Revert this commit. No migration or data backfill is required.

Observability after deploy: Watch logs for `[context-overflow-recovery] post-compaction budget check failed` and for reduced customer-facing fallback messages containing internal config names.

Security/data/secrets/external-send impact: No new secrets, auth, permissions, persistence, customer-data access, or external-send paths. Existing failure replies may still be emitted, but their text is less internal.

Reviewer notes: Base is `release/2026.5.28` to match the release line used by downstream fleet builds.
