### PR TITLE
Doctor: expose plugin registry findings

### DIFF
--- a/src/commands/doctor-plugin-registry.test.ts
+++ b/src/commands/doctor-plugin-registry.test.ts
@@ -7,12 +7,18 @@ import type { PluginCandidate } from "../plugins/discovery.js";
 import { resolvePluginNpmProjectDir } from "../plugins/install-paths.js";
 import {
   readPersistedInstalledPluginIndex,
+  resolveInstalledPluginIndexStorePath,
   writePersistedInstalledPluginIndex,
 } from "../plugins/installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
 import { markRetainedManagedNpmInstall } from "../plugins/managed-npm-retention.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
-import { maybeRepairPluginRegistryState } from "./doctor-plugin-registry.js";
+import {
+  detectPluginRegistryHealthIssues,
+  maybeRepairPluginRegistryState,
+  pluginRegistryIssueToHealthFinding,
+  pluginRegistryIssueToRepairEffect,
+} from "./doctor-plugin-registry.js";
 import { DISABLE_PLUGIN_REGISTRY_MIGRATION_ENV } from "./doctor/shared/plugin-registry-migration.js";
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
@@ -291,6 +297,151 @@ function expectedPluginIndexRecord(params: {
 }
 
 describe("maybeRepairPluginRegistryState", () => {
+  it("maps missing plugin registry state to a structured finding and dry-run effect", async () => {
+    const stateDir = makeTempDir();
+    const registryPath = resolveInstalledPluginIndexStorePath({ stateDir });
+
+    const [issue] = await detectPluginRegistryHealthIssues({
+      stateDir,
+      env: hermeticEnv(),
+      config: {},
+      prompter: { shouldRepair: false },
+    });
+
+    expect(issue).toEqual({
+      kind: "registry-missing-or-stale",
+      path: registryPath,
+    });
+    expect(pluginRegistryIssueToHealthFinding(issue)).toMatchObject({
+      checkId: "core/doctor/plugin-registry",
+      severity: "warning",
+      path: registryPath,
+      fixHint: "Run `openclaw doctor --fix` to rebuild the plugin registry from enabled plugins.",
+    });
+    expect(pluginRegistryIssueToRepairEffect(issue)).toEqual({
+      kind: "state",
+      action: "would-rebuild-plugin-registry",
+      target: registryPath,
+      dryRunSafe: false,
+    });
+  });
+
+  it("maps stale managed npm bundled plugin shadows to structured findings", async () => {
+    const stateDir = makeTempDir();
+    const bundledDir = path.join(stateDir, "bundled", "google-meet");
+    fs.mkdirSync(bundledDir, { recursive: true });
+    const managed = createManagedNpmPlugin({
+      stateDir,
+      id: "google-meet",
+      packageName: "@openclaw/google-meet",
+      version: "2026.5.2",
+    });
+    await writePersistedInstalledPluginIndex(createCurrentIndex(), { stateDir });
+
+    const issues = await detectPluginRegistryHealthIssues({
+      stateDir,
+      candidates: [
+        createBundledCandidate({
+          rootDir: bundledDir,
+          id: "google-meet",
+          packageName: "@openclaw/google-meet",
+          version: "2026.5.3",
+        }),
+      ],
+      env: hermeticEnv(),
+      config: {
+        plugins: {
+          allow: ["google-meet"],
+          entries: {
+            "google-meet": {
+              enabled: true,
+              config: {},
+            },
+          },
+        },
+      },
+      prompter: { shouldRepair: false },
+    });
+
+    const staleIssue = issues.find((issue) => issue.kind === "stale-managed-npm-bundled-plugin");
+    expect(staleIssue).toMatchObject({
+      kind: "stale-managed-npm-bundled-plugin",
+      pluginId: "google-meet",
+      packageName: "@openclaw/google-meet",
+      packageDir: managed.packageDir,
+      version: "2026.5.2",
+    });
+    expect(pluginRegistryIssueToHealthFinding(staleIssue!)).toMatchObject({
+      checkId: "core/doctor/plugin-registry",
+      severity: "warning",
+      path: managed.packageDir,
+      target: "google-meet",
+    });
+    expect(pluginRegistryIssueToRepairEffect(staleIssue!)).toEqual({
+      kind: "package",
+      action: "would-remove-stale-managed-npm-bundled-plugin",
+      target: managed.packageDir,
+      dryRunSafe: false,
+    });
+  });
+
+  it("maps stale local bundled install records to structured findings", async () => {
+    const stateDir = makeTempDir();
+    const bundledDir = path.join(stateDir, "current", "dist", "extensions", "discord");
+    const staleDir = path.join(stateDir, "old-checkout", "dist", "extensions", "discord");
+    fs.mkdirSync(bundledDir, { recursive: true });
+    fs.mkdirSync(staleDir, { recursive: true });
+    createCandidate(staleDir, "discord");
+    await writePersistedInstalledPluginIndex(
+      createCurrentIndexWithPathRecord({
+        pluginId: "discord",
+        installPath: staleDir,
+        version: "2026.5.4-beta.3",
+      }),
+      { stateDir },
+    );
+
+    const issues = await detectPluginRegistryHealthIssues({
+      stateDir,
+      candidates: [
+        createBundledCandidate({
+          rootDir: bundledDir,
+          id: "discord",
+          packageName: "@openclaw/discord",
+          version: "2026.5.20-beta.1",
+        }),
+      ],
+      env: hermeticEnv(),
+      config: {
+        plugins: {
+          allow: ["discord"],
+          entries: {
+            discord: {
+              enabled: true,
+              config: {},
+            },
+          },
+        },
+      },
+      prompter: { shouldRepair: false },
+    });
+
+    const staleIssue = issues.find(
+      (issue) => issue.kind === "stale-local-bundled-plugin-install-record",
+    );
+    expect(staleIssue).toEqual({
+      kind: "stale-local-bundled-plugin-install-record",
+      pluginId: "discord",
+      stalePath: staleDir,
+    });
+    expect(pluginRegistryIssueToHealthFinding(staleIssue!)).toMatchObject({
+      checkId: "core/doctor/plugin-registry",
+      severity: "warning",
+      path: staleDir,
+      target: "discord",
+    });
+  });
+
   it("refreshes an existing registry during repair", async () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "plugins", "demo");

--- a/src/commands/doctor-plugin-registry.ts
+++ b/src/commands/doctor-plugin-registry.ts
@@ -513,6 +513,7 @@ export function pluginRegistryIssueToHealthFinding(
         fixHint: "Run `openclaw doctor --fix` to relink managed npm plugin packages.",
       };
   }
+  return assertNeverPluginRegistryIssue(issue);
 }
 
 export function pluginRegistryIssueToRepairEffect(
@@ -548,6 +549,13 @@ export function pluginRegistryIssueToRepairEffect(
         dryRunSafe: false,
       };
   }
+  return assertNeverPluginRegistryIssue(issue);
+}
+
+function assertNeverPluginRegistryIssue(issue: never): never {
+  throw new Error(
+    `Unhandled plugin registry issue kind: ${String((issue as { kind?: unknown }).kind)}`,
+  );
 }
 
 /**

--- a/src/commands/doctor-plugin-registry.ts
+++ b/src/commands/doctor-plugin-registry.ts
@@ -5,6 +5,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import { saveJsonFile } from "../infra/json-file.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
 import type { BundledPluginSource } from "../plugins/bundled-sources.js";
@@ -18,6 +19,7 @@ import { hasRetainedManagedNpmInstallMarker } from "../plugins/managed-npm-reten
 import { listManagedPluginNpmRootsSync } from "../plugins/npm-project-roots.js";
 import {
   auditOpenClawPeerDependenciesInManagedNpmRoot,
+  type OpenClawPeerLinkAuditIssue,
   relinkOpenClawPeerDependenciesInManagedNpmRoot,
 } from "../plugins/plugin-peer-link.js";
 import { refreshPluginRegistry } from "../plugins/plugin-registry.js";
@@ -33,6 +35,8 @@ import {
   preflightPluginRegistryInstallMigration,
   type PluginRegistryInstallMigrationParams,
 } from "./doctor/shared/plugin-registry-migration.js";
+
+const PLUGIN_REGISTRY_CHECK_ID = "core/doctor/plugin-registry";
 
 type PluginRegistryDoctorRepairParams = Omit<PluginRegistryInstallMigrationParams, "config"> &
   InstalledPluginIndexRecordStoreOptions & {
@@ -52,6 +56,31 @@ type PluginRegistryDoctorNoteLogger = {
   info: (message: string) => void;
   warn: (message: string) => void;
 };
+
+export type PluginRegistryHealthIssue =
+  | {
+      kind: "registry-missing-or-stale";
+      path: string;
+    }
+  | {
+      kind: "stale-managed-npm-bundled-plugin";
+      pluginId: string;
+      packageName: string;
+      packageDir: string;
+      npmRoot: string;
+      version?: string;
+    }
+  | {
+      kind: "stale-local-bundled-plugin-install-record";
+      pluginId: string;
+      stalePath: string;
+    }
+  | {
+      kind: "managed-npm-openclaw-peer-link";
+      packageName: string;
+      packageDir: string;
+      reason: string;
+    };
 
 function readJsonObject(filePath: string): Record<string, unknown> | null {
   const parsed = tryReadJsonSync(filePath);
@@ -388,6 +417,137 @@ async function loadInstallRecordsWithoutPluginIds(
     delete records[pluginId];
   }
   return records;
+}
+
+async function listManagedNpmOpenClawPeerLinkIssues(
+  params: PluginRegistryDoctorRepairParams,
+): Promise<OpenClawPeerLinkAuditIssue[]> {
+  const audits = await Promise.all(
+    listManagedPluginNpmRoots(params).map((npmRoot) =>
+      auditOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot }),
+    ),
+  );
+  return audits.flatMap((audit) => audit.issues);
+}
+
+export async function detectPluginRegistryHealthIssues(
+  params: PluginRegistryDoctorRepairParams,
+): Promise<PluginRegistryHealthIssue[]> {
+  const preflight = preflightPluginRegistryInstallMigration(params);
+  const issues: PluginRegistryHealthIssue[] = [];
+  if (preflight.action === "migrate") {
+    issues.push({
+      kind: "registry-missing-or-stale",
+      path: preflight.filePath,
+    });
+  }
+  for (const plugin of listStaleManagedNpmBundledPlugins(params)) {
+    issues.push({
+      kind: "stale-managed-npm-bundled-plugin",
+      pluginId: plugin.pluginId,
+      packageName: plugin.packageName,
+      packageDir: plugin.packageDir,
+      npmRoot: plugin.npmRoot,
+      ...(plugin.version ? { version: plugin.version } : {}),
+    });
+  }
+  for (const record of await listStaleLocalBundledPluginInstallRecordShadows(params)) {
+    issues.push({
+      kind: "stale-local-bundled-plugin-install-record",
+      pluginId: record.pluginId,
+      stalePath: record.stalePath,
+    });
+  }
+  for (const issue of await listManagedNpmOpenClawPeerLinkIssues(params)) {
+    issues.push({
+      kind: "managed-npm-openclaw-peer-link",
+      packageName: issue.packageName,
+      packageDir: issue.packageDir,
+      reason: issue.reason,
+    });
+  }
+  return issues;
+}
+
+export function pluginRegistryIssueToHealthFinding(
+  issue: PluginRegistryHealthIssue,
+): HealthFinding {
+  switch (issue.kind) {
+    case "registry-missing-or-stale":
+      return {
+        checkId: PLUGIN_REGISTRY_CHECK_ID,
+        severity: "warning",
+        message: "Persisted plugin registry is missing or stale.",
+        path: issue.path,
+        fixHint: "Run `openclaw doctor --fix` to rebuild the plugin registry from enabled plugins.",
+      };
+    case "stale-managed-npm-bundled-plugin":
+      return {
+        checkId: PLUGIN_REGISTRY_CHECK_ID,
+        severity: "warning",
+        message: `Managed npm package ${issue.packageName}${
+          issue.version ? `@${issue.version}` : ""
+        } shadows bundled plugin ${issue.pluginId}.`,
+        path: issue.packageDir,
+        target: issue.pluginId,
+        fixHint:
+          "Run `openclaw doctor --fix` to remove stale managed npm packages and rebuild the plugin registry.",
+      };
+    case "stale-local-bundled-plugin-install-record":
+      return {
+        checkId: PLUGIN_REGISTRY_CHECK_ID,
+        severity: "warning",
+        message: `Local install record for bundled plugin ${issue.pluginId} points at a stale path.`,
+        path: issue.stalePath,
+        target: issue.pluginId,
+        fixHint:
+          "Run `openclaw doctor --fix` to remove stale local install records and rebuild the plugin registry.",
+      };
+    case "managed-npm-openclaw-peer-link":
+      return {
+        checkId: PLUGIN_REGISTRY_CHECK_ID,
+        severity: "warning",
+        message: `Managed npm package ${issue.packageName} has a broken OpenClaw peer link: ${issue.reason}.`,
+        path: issue.packageDir,
+        target: issue.packageName,
+        fixHint: "Run `openclaw doctor --fix` to relink managed npm plugin packages.",
+      };
+  }
+}
+
+export function pluginRegistryIssueToRepairEffect(
+  issue: PluginRegistryHealthIssue,
+): HealthRepairEffect {
+  switch (issue.kind) {
+    case "registry-missing-or-stale":
+      return {
+        kind: "state",
+        action: "would-rebuild-plugin-registry",
+        target: issue.path,
+        dryRunSafe: false,
+      };
+    case "stale-managed-npm-bundled-plugin":
+      return {
+        kind: "package",
+        action: "would-remove-stale-managed-npm-bundled-plugin",
+        target: issue.packageDir,
+        dryRunSafe: false,
+      };
+    case "stale-local-bundled-plugin-install-record":
+      return {
+        kind: "state",
+        action: "would-remove-stale-local-bundled-plugin-install-record",
+        target: issue.pluginId,
+        dryRunSafe: false,
+      };
+    case "managed-npm-openclaw-peer-link":
+      return {
+        kind: "package",
+        action: "would-relink-managed-npm-openclaw-peer",
+        target: issue.packageDir,
+        dryRunSafe: false,
+      };
+  }
 }
 
 /**

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1051,6 +1051,7 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/config-audit-scrub");
     expect(contributionIds).toContain("core/doctor/session-transcripts");
     expect(contributionIds).toContain("core/doctor/session-snapshots");
+    expect(contributionIds).toContain("core/doctor/plugin-registry");
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1266,6 +1266,42 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:plugin-registry",
       label: "Plugin registry",
+      healthChecks: {
+        id: "core/doctor/plugin-registry",
+        description: "Plugin registry migration, stale shadow, and peer-link issues are findings.",
+        defaultEnabled: false,
+        async detect(ctx) {
+          const { detectPluginRegistryHealthIssues, pluginRegistryIssueToHealthFinding } =
+            await import("../commands/doctor-plugin-registry.js");
+          return (
+            await detectPluginRegistryHealthIssues({
+              config: ctx.cfg,
+              env: process.env,
+              prompter: { shouldRepair: false },
+            })
+          ).map(pluginRegistryIssueToHealthFinding);
+        },
+        async repair(ctx) {
+          const { detectPluginRegistryHealthIssues, pluginRegistryIssueToRepairEffect } =
+            await import("../commands/doctor-plugin-registry.js");
+          const effects = (
+            await detectPluginRegistryHealthIssues({
+              config: ctx.cfg,
+              env: process.env,
+              prompter: { shouldRepair: false },
+            })
+          ).map(pluginRegistryIssueToRepairEffect);
+          if (ctx.dryRun === true) {
+            return { status: "repaired", changes: [], effects };
+          }
+          return {
+            status: "skipped",
+            reason: "legacy doctor plugin registry contribution owns registry repairs",
+            changes: [],
+            effects,
+          };
+        },
+      },
       run: runPluginRegistryHealth,
     }),
     createDoctorHealthContribution({


### PR DESCRIPTION
## Summary
- add structured `core/doctor/plugin-registry` findings for missing/stale registry state, stale managed npm bundled plugin shadows, stale local bundled install records, and managed npm OpenClaw peer-link issues
- expose dry-run repair effects for those findings while keeping real mutation in the existing plugin registry doctor repair path
- register the plugin registry contribution in doctor health check ordering
- add an exhaustive fallback for plugin-registry finding/effect mappers so CI lint can prove they always return or throw

## Contract
- No public SDK, plugin, or config contract changes.
- Default `doctor --lint` skips this check because it is `defaultEnabled: false`.
- Explicit `--only core/doctor/plugin-registry` or `--all` can surface the finding.
- This does not include configured plugin install backfill; that remains a separate slice.

## Validation
- `node scripts/run-vitest.mjs run src/commands/doctor-plugin-registry.test.ts src/flows/doctor-health-contributions.test.ts --reporter=dot` (64 passed)
- `pnpm exec oxfmt --check src/commands/doctor-plugin-registry.ts src/commands/doctor-plugin-registry.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `pnpm exec oxlint src/commands/doctor-plugin-registry.ts src/commands/doctor-plugin-registry.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `pnpm tsgo:core`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `git diff --check origin/main...HEAD`
- Maintainer prepare local gate: `pnpm build` passed; `pnpm check` failed only on the npm shrinkwrap guard, and `pnpm deps:shrinkwrap:check` reproduces the same stale `npm-shrinkwrap.json` failure on latest `origin/main`, outside this PR's touched surface.

## Source CLI Proof
- Head: `cf4399955e2ddc8a38f5bb0f34bed4c6afc54749`
- Setup: isolated temp `OPENCLAW_STATE_DIR` and empty config `{}`.
- Command: `node scripts/run-node.mjs doctor --lint --json --only core/doctor/plugin-registry`
- Result: exit code `1`, `ok: false`, `checksRun: 1`, `checksSkipped: 28`.
- Redacted JSON finding:

```json
{
  "checkId": "core/doctor/plugin-registry",
  "severity": "warning",
  "message": "Persisted plugin registry is missing or stale.",
  "path": "<temp-state>/state/openclaw.sqlite",
  "fixHint": "Run `openclaw doctor --fix` to rebuild the plugin registry from enabled plugins."
}
```

No dry-run preview consumer is included in this slice; real mutation remains in the existing plugin registry doctor repair path.