### PR TITLE
fix(state): open compatible schema-v2 agent auth DBs

### DIFF
--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -357,7 +357,46 @@ describe("openclaw agent database", () => {
     });
   });
 
-  it("refuses to open newer per-agent schema versions", () => {
+  it("opens schema-v2 agent databases when known tables are rollback-compatible", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const database = openOpenClawAgentDatabase({
+      agentId: "worker-1",
+      env,
+    });
+    const databasePath = database.path;
+    closeOpenClawAgentDatabasesForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(databasePath);
+    db.exec(`
+      PRAGMA user_version = 2;
+      UPDATE schema_meta
+      SET schema_version = 2
+      WHERE meta_key = 'primary';
+    `);
+    db.close();
+
+    const reopened = openOpenClawAgentDatabase({
+      agentId: "worker-1",
+      env,
+    });
+    const agentDb = getNodeSqliteKysely<AgentDbTestDatabase>(reopened.db);
+
+    expect(readSqliteNumberPragma(reopened.db, "user_version")).toBe(1);
+    expect(
+      executeSqliteQueryTakeFirstSync(
+        reopened.db,
+        agentDb.selectFrom("schema_meta").select(["role", "schema_version", "agent_id"]),
+      ),
+    ).toEqual({
+      role: "agent",
+      schema_version: 1,
+      agent_id: "worker-1",
+    });
+  });
+
+  it("refuses incompatible schema-v2 agent databases", () => {
     const stateDir = createTempStateDir();
     const databasePath = path.join(
       stateDir,
@@ -378,5 +417,28 @@ describe("openclaw agent database", () => {
         env: { OPENCLAW_STATE_DIR: stateDir },
       }),
     ).toThrow(/newer schema version 2/);
+  });
+
+  it("refuses to open newer per-agent schema versions", () => {
+    const stateDir = createTempStateDir();
+    const databasePath = path.join(
+      stateDir,
+      "agents",
+      "worker-1",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(databasePath);
+    db.exec("PRAGMA user_version = 3;");
+    db.close();
+
+    expect(() =>
+      openOpenClawAgentDatabase({
+        agentId: "worker-1",
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      }),
+    ).toThrow(/newer schema version 3/);
   });
 });

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -35,6 +35,7 @@ export { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
  * OpenClaw state database for discovery and maintenance.
  */
 const OPENCLAW_AGENT_SCHEMA_VERSION = 1;
+const OPENCLAW_AGENT_ROLLBACK_COMPAT_SCHEMA_VERSION = 2;
 const OPENCLAW_AGENT_DB_DIR_MODE = 0o700;
 const OPENCLAW_AGENT_DB_FILE_MODE = 0o600;
 
@@ -70,18 +71,84 @@ type ExistingSchemaMeta = {
   role: string | null;
 };
 
+type RequiredAgentTable = {
+  name: string;
+  columns: readonly string[];
+};
+
+const REQUIRED_ROLLBACK_COMPAT_AGENT_TABLES: readonly RequiredAgentTable[] = [
+  {
+    name: "schema_meta",
+    columns: [
+      "meta_key",
+      "role",
+      "schema_version",
+      "agent_id",
+      "app_version",
+      "created_at",
+      "updated_at",
+    ],
+  },
+  {
+    name: "auth_profile_store",
+    columns: ["store_key", "store_json", "updated_at"],
+  },
+  {
+    name: "auth_profile_state",
+    columns: ["state_key", "state_json", "updated_at"],
+  },
+];
+
+function quoteSqliteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
 function readSqliteUserVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version?: unknown } | undefined;
   return Number(row?.user_version ?? 0);
 }
 
+function readSqliteTableColumns(db: DatabaseSync, table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${quoteSqliteIdentifier(table)})`).all() as Array<{
+    name?: unknown;
+  }>;
+  return new Set(rows.flatMap((row) => (typeof row.name === "string" ? [row.name] : [])));
+}
+
+function hasRequiredColumns(columns: Set<string>, required: readonly string[]): boolean {
+  return required.every((column) => columns.has(column));
+}
+
+function hasRollbackCompatibleAgentSchema(db: DatabaseSync): boolean {
+  for (const table of REQUIRED_ROLLBACK_COMPAT_AGENT_TABLES) {
+    const columns = readSqliteTableColumns(db, table.name);
+    if (table.name === "schema_meta" && columns.size === 0) {
+      return false;
+    }
+    if (columns.size > 0 && !hasRequiredColumns(columns, table.columns)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function assertSupportedAgentSchemaVersion(db: DatabaseSync, pathname: string): void {
   const userVersion = readSqliteUserVersion(db);
-  if (userVersion > OPENCLAW_AGENT_SCHEMA_VERSION) {
-    throw new Error(
-      `OpenClaw agent database ${pathname} uses newer schema version ${userVersion}; this OpenClaw build supports ${OPENCLAW_AGENT_SCHEMA_VERSION}.`,
-    );
+  if (userVersion <= OPENCLAW_AGENT_SCHEMA_VERSION) {
+    return;
   }
+  // Schema 2 was briefly used for additive agent-local cache tables. If the
+  // owner and auth tables remain compatible, doctor can migrate auth JSON and
+  // stamp the DB back to the rollback-safe schema version.
+  if (
+    userVersion <= OPENCLAW_AGENT_ROLLBACK_COMPAT_SCHEMA_VERSION &&
+    hasRollbackCompatibleAgentSchema(db)
+  ) {
+    return;
+  }
+  throw new Error(
+    `OpenClaw agent database ${pathname} uses newer schema version ${userVersion}; this OpenClaw build supports ${OPENCLAW_AGENT_SCHEMA_VERSION}.`,
+  );
 }
 
 function ensureOpenClawAgentDatabasePermissions(


### PR DESCRIPTION
## What Problem This Solves

OpenClaw agent databases were briefly stamped with `PRAGMA user_version = 2`
when the QMD export cache moved into the per-agent SQLite database. That cache
state is derived and rollback-safe, and the schema version was later returned to
1, but existing v2 agent databases could no longer be opened by current builds.

That blocked `openclaw doctor --fix` from importing legacy
`auth-profiles.json` into the canonical per-agent SQLite auth store. In live
heartbeat/cron contexts, that left OpenClaw with a visible legacy auth source
but no usable SQLite `auth_profile_store` row, so Anthropic profile resolution
could fail before a Claude bridge attempt had usable auth.

## Why This Change Was Made

This change treats schema-v2 agent databases as rollback-compatible only when
their known OpenClaw-owned tables still expose the columns required by the
current schema owner:

- `schema_meta`
- `auth_profile_store`
- `auth_profile_state`

Compatible schema-v2 databases can then be opened by the current schema-1 code
path and stamped back to schema version 1. Unknown newer schemas, or schema-v2
databases missing required columns, still fail closed with the existing newer
schema error.

This keeps the compatibility boundary narrow: it does not add runtime JSON auth
fallbacks, and it does not make arbitrary future schemas readable.

## User Impact

Users who ran an intermediate build that stamped per-agent databases as schema
2 can upgrade or roll forward to a current build and still run
`openclaw doctor --fix` successfully. Legacy auth profile JSON can migrate into
SQLite, restoring auth-profile resolution for heartbeat, cron, and other
agent-scoped contexts without manual database edits.

Users with genuinely incompatible future agent DB schemas still get a clear
failure instead of silent corruption or partial reads.

## Evidence

Branch:

- `zeroaltitude:fix/heartbeat-claude-auth-schema-v2`

Focused validation:

```bash
node scripts/run-vitest.mjs src/state/openclaw-agent-db.test.ts src/agents/auth-profiles.sqlite-store.test.ts
pnpm tsgo:core
pnpm tsgo:core:test
```

Live integration validation performed before opening this draft:

- merged into `zeroaltitude/openclaw:integration` at `b32ac5c549`
- rebuilt `~/projects/openclaw` successfully with `pnpm build`
- reran `openclaw doctor --non-interactive --fix`; main/tank auth JSON migrated into SQLite
- verified agent DBs were stamped back to `user_version=1`
- verified live Claude bridge process had `ANTHROPIC_API_KEY` present
- verified post-restart logs showed `claude-bridge: initialized` with no post-rotation `profile=-` or invalid-key failures
