### PR TITLE
Doctor: expose configured plugin install findings

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -320,6 +320,167 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     }
   });
 
+  it("maps a missing configured plugin install to a structured finding and dry-run effect", async () => {
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "matrix",
+        pluginId: "matrix",
+        meta: { label: "Matrix" },
+        install: {
+          npmSpec: "@openclaw/plugin-matrix@1.2.3",
+          expectedIntegrity: "sha512-test",
+        },
+        trustedSourceLinkedOfficialInstall: true,
+      },
+    ]);
+
+    const {
+      configuredPluginInstallIssueToHealthFinding,
+      configuredPluginInstallIssueToRepairEffect,
+      detectConfiguredPluginInstallHealthIssues,
+    } = await import("./missing-configured-plugin-install.js");
+    const [issue] = await detectConfiguredPluginInstallHealthIssues({
+      cfg: {
+        channels: {
+          matrix: { enabled: true, homeserver: "https://matrix.example.org" },
+        },
+      },
+      env: {},
+    });
+
+    expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(issue).toEqual({
+      kind: "missing-install-record",
+      pluginId: "matrix",
+      installSpec: "@openclaw/plugin-matrix@1.2.3",
+    });
+    expect(configuredPluginInstallIssueToHealthFinding(issue)).toMatchObject({
+      checkId: "core/doctor/configured-plugin-installs",
+      severity: "warning",
+      target: "matrix",
+      fixHint: "Run `openclaw doctor --fix` to install @openclaw/plugin-matrix@1.2.3.",
+    });
+    expect(configuredPluginInstallIssueToRepairEffect(issue)).toEqual({
+      kind: "package",
+      action: "would-install-configured-plugin",
+      target: "matrix",
+      dryRunSafe: false,
+    });
+  });
+
+  it("maps package-update deferrals to structured findings without installing packages", async () => {
+    const missingDiscordPath = path.resolve("/missing/discord");
+    const records = {
+      discord: {
+        source: "npm",
+        spec: "@openclaw/discord",
+        installPath: missingDiscordPath,
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "discord",
+        pluginId: "discord",
+        meta: { label: "Discord" },
+        install: {
+          npmSpec: "@openclaw/discord",
+        },
+      },
+    ]);
+
+    const {
+      configuredPluginInstallIssueToHealthFinding,
+      configuredPluginInstallIssueToRepairEffect,
+      detectConfiguredPluginInstallHealthIssues,
+    } = await import("./missing-configured-plugin-install.js");
+    const [issue] = await detectConfiguredPluginInstallHealthIssues({
+      cfg: {
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+        },
+        channels: {
+          discord: { enabled: true },
+        },
+      },
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
+      },
+    });
+
+    expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(issue).toEqual({
+      kind: "deferred-package-manager-repair",
+      pluginId: "discord",
+      installPath: missingDiscordPath,
+    });
+    expect(configuredPluginInstallIssueToHealthFinding(issue)).toMatchObject({
+      checkId: "core/doctor/configured-plugin-installs",
+      severity: "warning",
+      path: missingDiscordPath,
+      target: "discord",
+    });
+    expect(configuredPluginInstallIssueToRepairEffect(issue)).toEqual({
+      kind: "package",
+      action: "would-defer-configured-plugin-install-repair",
+      target: "discord",
+      dryRunSafe: true,
+    });
+  });
+
+  it("reports one finding when a configured plugin record points at a missing package", async () => {
+    const missingDiscordPath = path.resolve("/missing/discord");
+    const records = {
+      discord: {
+        source: "npm",
+        spec: "@openclaw/discord",
+        installPath: missingDiscordPath,
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "discord",
+        pluginId: "discord",
+        meta: { label: "Discord" },
+        install: {
+          npmSpec: "@openclaw/discord",
+        },
+      },
+    ]);
+
+    const { detectConfiguredPluginInstallHealthIssues } =
+      await import("./missing-configured-plugin-install.js");
+    const issues = await detectConfiguredPluginInstallHealthIssues({
+      cfg: {
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+        },
+        channels: {
+          discord: { enabled: true },
+        },
+      },
+      env: {},
+    });
+
+    expect(issues).toEqual([
+      {
+        kind: "missing-installed-payload",
+        pluginId: "discord",
+        installPath: missingDiscordPath,
+        installSpec: "@openclaw/discord",
+      },
+    ]);
+  });
+
   it("installs a missing configured OpenClaw channel plugin from npm by default", async () => {
     mocks.listChannelPluginCatalogEntries.mockReturnValue([
       {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -1707,6 +1707,7 @@ export function configuredPluginInstallIssueToHealthFinding(
         fixHint: "Rerun `openclaw doctor --fix` after the package update completes.",
       };
   }
+  return assertNeverConfiguredPluginInstallIssue(issue);
 }
 
 export function configuredPluginInstallIssueToRepairEffect(
@@ -1750,6 +1751,13 @@ export function configuredPluginInstallIssueToRepairEffect(
         dryRunSafe: true,
       };
   }
+  return assertNeverConfiguredPluginInstallIssue(issue);
+}
+
+function assertNeverConfiguredPluginInstallIssue(issue: never): never {
+  throw new Error(
+    `Unhandled configured plugin install issue kind: ${String((issue as { kind?: unknown }).kind)}`,
+  );
 }
 
 export type RepairMissingPluginInstallsResult = {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -12,6 +12,7 @@ import {
 import { listRawChannelPluginCatalogEntries } from "../../../channels/plugins/catalog.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
+import type { HealthFinding, HealthRepairEffect } from "../../../flows/health-checks.js";
 import { parseClawHubPluginSpec } from "../../../infra/clawhub-spec.js";
 import {
   compareOpenClawReleaseVersions,
@@ -100,6 +101,7 @@ type BundledPluginPackageDescriptor = {
   packageName?: string;
 };
 
+const CONFIGURED_PLUGIN_INSTALLS_CHECK_ID = "core/doctor/configured-plugin-installs";
 const MISSING_CHANNEL_CONFIG_DESCRIPTOR_DIAGNOSTIC = "without channelConfigs metadata";
 const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
   "extension entry escapes package directory",
@@ -993,6 +995,41 @@ function recordClawHubPackageName(value: string | undefined): string | undefined
 
 type InstallCandidateRepairReason = "stale-version-bound-runtime";
 
+export type ConfiguredPluginInstallHealthIssue =
+  | {
+      kind: "missing-install-record";
+      pluginId: string;
+      installSpec: string;
+    }
+  | {
+      kind: "missing-installed-payload";
+      pluginId: string;
+      installPath?: string;
+      installSpec?: string;
+    }
+  | {
+      kind: "repairable-installed-plugin";
+      pluginId: string;
+      installPath?: string;
+      installSpec?: string;
+    }
+  | {
+      kind: "stale-version-bound-runtime";
+      pluginId: string;
+      installPath?: string;
+      installSpec?: string;
+    }
+  | {
+      kind: "stale-channel-config-descriptor";
+      pluginId: string;
+      installPath?: string;
+    }
+  | {
+      kind: "deferred-package-manager-repair";
+      pluginId: string;
+      installPath?: string;
+    };
+
 function formatInstalledConfiguredPluginChange(params: {
   pluginId: string;
   installSpec: string;
@@ -1311,6 +1348,408 @@ async function adoptExistingNpmPackage(params: {
     notices: [],
     warnings: [],
   };
+}
+
+function resolveCandidateInstallSpec(params: {
+  candidate: DownloadableInstallCandidate;
+  updateChannel: UpdateChannel;
+}): string | undefined {
+  if (params.candidate.defaultChoice !== "npm" && params.candidate.clawhubSpec) {
+    return resolveClawHubInstallSpecsForUpdateChannel({
+      spec: params.candidate.clawhubSpec,
+      updateChannel: params.updateChannel,
+    }).installSpec;
+  }
+  if (params.candidate.npmSpec) {
+    return resolveNpmInstallSpecsForUpdateChannel({
+      spec: params.candidate.npmSpec,
+      updateChannel: params.updateChannel,
+    }).installSpec;
+  }
+  if (params.candidate.clawhubSpec) {
+    return resolveClawHubInstallSpecsForUpdateChannel({
+      spec: params.candidate.clawhubSpec,
+      updateChannel: params.updateChannel,
+    }).installSpec;
+  }
+  return undefined;
+}
+
+function resolveRecordInstallPath(
+  record: PluginInstallRecord | undefined,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const installPath = record?.installPath?.trim();
+  return installPath ? resolveUserPath(installPath, env) : undefined;
+}
+
+function missingRecordedPluginIssueKind(params: {
+  pluginId: string;
+  staleVersionBoundRuntimePluginIds: ReadonlySet<string>;
+  repairablePackageDiagnosticPluginIds: ReadonlySet<string>;
+  staleDescriptorPluginIds: ReadonlySet<string>;
+}):
+  | "missing-installed-payload"
+  | "repairable-installed-plugin"
+  | "stale-channel-config-descriptor"
+  | "stale-version-bound-runtime" {
+  if (params.staleVersionBoundRuntimePluginIds.has(params.pluginId)) {
+    return "stale-version-bound-runtime";
+  }
+  if (params.repairablePackageDiagnosticPluginIds.has(params.pluginId)) {
+    return "repairable-installed-plugin";
+  }
+  if (params.staleDescriptorPluginIds.has(params.pluginId)) {
+    return "stale-channel-config-descriptor";
+  }
+  return "missing-installed-payload";
+}
+
+/** Detect configured plugin installs that Doctor can repair without mutating package state. */
+export async function detectConfiguredPluginInstallHealthIssues(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  baselineRecords?: Record<string, PluginInstallRecord>;
+}): Promise<ConfiguredPluginInstallHealthIssue[]> {
+  const env = params.env ?? process.env;
+  const pluginIds = collectConfiguredPluginIds(params.cfg, env);
+  const channelIds = collectConfiguredChannelIds(params.cfg, env);
+  const blockedPluginIds = collectBlockedPluginIds(params.cfg);
+  const snapshot = loadManifestMetadataSnapshot({
+    config: params.cfg,
+    env,
+  });
+  const currentBundledPlugins = loadInstalledPluginIndex({
+    config: params.cfg,
+    env,
+    installRecords: {},
+  }).plugins.filter((plugin) => plugin.origin === "bundled");
+  const knownIds = new Set([
+    ...snapshot.plugins.map((plugin) => plugin.id),
+    ...currentBundledPlugins.map((plugin) => plugin.pluginId),
+  ]);
+  const configuredChannelOwnerPluginIds = collectEffectiveConfiguredChannelOwnerPluginIds({
+    cfg: params.cfg,
+    env,
+    snapshot,
+    configuredChannelIds: channelIds,
+  });
+  const bundledPluginsById = new Map<string, BundledPluginPackageDescriptor>([
+    ...snapshot.plugins
+      .filter((plugin) => plugin.origin === "bundled")
+      .map((plugin) => [plugin.id, plugin] as const),
+    ...currentBundledPlugins.map(
+      (plugin) =>
+        [
+          plugin.pluginId,
+          {
+            packageName: plugin.packageName,
+          },
+        ] as const,
+    ),
+  ]);
+  const staleDescriptorPluginIds = collectConfiguredPluginIdsWithMissingChannelConfigDescriptors({
+    snapshot,
+    configuredPluginIds: pluginIds,
+    configuredChannelIds: channelIds,
+  });
+  const records = params.baselineRecords ?? (await loadInstalledPluginIndexInstallRecords({ env }));
+  const updateChannel = resolveRegistryUpdateChannel({
+    configChannel: normalizeUpdateChannel(params.cfg.update?.channel),
+    currentVersion: VERSION,
+  });
+  const repairablePackageDiagnosticPluginIds =
+    collectInstalledPluginIdsWithRepairablePackageDiagnostics({
+      snapshot,
+      installRecords: records,
+    });
+  const staleVersionBoundRuntimePluginIds =
+    collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages({
+      snapshot,
+      installRecords: records,
+      configuredPluginIds: pluginIds,
+      updateChannel,
+    });
+  const repairableInstalledPluginIds = new Set([
+    ...repairablePackageDiagnosticPluginIds,
+    ...staleVersionBoundRuntimePluginIds,
+  ]);
+  const officialReplacementInstallCandidates = collectOfficialReplacementInstallCandidates({
+    cfg: params.cfg,
+    env,
+    repairablePluginIds: repairableInstalledPluginIds,
+    configuredPluginIds: pluginIds,
+    configuredChannelIds: channelIds,
+    configuredChannelOwnerPluginIds,
+    blockedPluginIds,
+  });
+  const officialReplacementPluginIds = new Set(officialReplacementInstallCandidates.keys());
+  const deferredPluginIds = new Set<string>();
+  const reportedPluginIds = new Set<string>();
+  const issues: ConfiguredPluginInstallHealthIssue[] = [];
+
+  if (shouldDeferConfiguredPluginInstallRepair(env)) {
+    for (const pluginId of collectUpdateDeferredPluginIds({
+      cfg: params.cfg,
+      env,
+      configuredPluginIds: pluginIds,
+      configuredChannelIds: channelIds,
+      configuredChannelOwnerPluginIds,
+      blockedPluginIds,
+    })) {
+      deferredPluginIds.add(pluginId);
+      const record = records[pluginId];
+      if (!record || !isInstalledRecordMissingOnDisk(record, env)) {
+        continue;
+      }
+      issues.push({
+        kind: "deferred-package-manager-repair",
+        pluginId,
+        ...(resolveRecordInstallPath(record, env)
+          ? { installPath: resolveRecordInstallPath(record, env) }
+          : {}),
+      });
+      reportedPluginIds.add(pluginId);
+    }
+  }
+
+  const missingRecordedPluginIds = Object.keys(records).filter(
+    (pluginId) =>
+      !deferredPluginIds.has(pluginId) &&
+      !officialReplacementPluginIds.has(pluginId) &&
+      !bundledPluginsById.has(pluginId) &&
+      ((pluginIds.has(pluginId) &&
+        (!knownIds.has(pluginId) || isInstalledRecordMissingOnDisk(records[pluginId], env))) ||
+        staleDescriptorPluginIds.has(pluginId) ||
+        repairableInstalledPluginIds.has(pluginId)),
+  );
+
+  for (const pluginId of missingRecordedPluginIds) {
+    const record = records[pluginId];
+    const kind = missingRecordedPluginIssueKind({
+      pluginId,
+      staleVersionBoundRuntimePluginIds,
+      repairablePackageDiagnosticPluginIds,
+      staleDescriptorPluginIds,
+    });
+    const installPath = resolveRecordInstallPath(record, env);
+    if (kind === "stale-channel-config-descriptor") {
+      issues.push({
+        kind,
+        pluginId,
+        ...(installPath ? { installPath } : {}),
+      });
+      reportedPluginIds.add(pluginId);
+      continue;
+    }
+    issues.push({
+      kind,
+      pluginId,
+      ...(installPath ? { installPath } : {}),
+      ...(record?.spec ? { installSpec: record.spec } : {}),
+    });
+    reportedPluginIds.add(pluginId);
+  }
+
+  const missingPluginIds = new Set(
+    [...pluginIds].filter((pluginId) => {
+      if (deferredPluginIds.has(pluginId)) {
+        return false;
+      }
+      const hasRecord = Object.hasOwn(records, pluginId);
+      return (
+        (!knownIds.has(pluginId) && !hasRecord && !bundledPluginsById.has(pluginId)) ||
+        (hasRecord &&
+          !bundledPluginsById.has(pluginId) &&
+          isInstalledRecordMissingOnDisk(records[pluginId], env))
+      );
+    }),
+  );
+  const installCandidatePluginIds = new Set([...missingPluginIds, ...officialReplacementPluginIds]);
+  for (const candidate of collectDownloadableInstallCandidates({
+    cfg: params.cfg,
+    env,
+    missingPluginIds: installCandidatePluginIds,
+    configuredPluginIds: pluginIds,
+    configuredChannelIds: channelIds,
+    configuredChannelOwnerPluginIds,
+    blockedPluginIds:
+      deferredPluginIds.size > 0
+        ? new Set([...blockedPluginIds, ...deferredPluginIds])
+        : blockedPluginIds,
+  })) {
+    if (bundledPluginsById.has(candidate.pluginId)) {
+      continue;
+    }
+    if (reportedPluginIds.has(candidate.pluginId)) {
+      continue;
+    }
+    const shouldReplaceBrokenOfficialInstall = officialReplacementPluginIds.has(candidate.pluginId);
+    if (shouldReplaceBrokenOfficialInstall && !candidate.trustedSourceLinkedOfficialInstall) {
+      continue;
+    }
+    const record = records[candidate.pluginId];
+    if (
+      shouldReplaceBrokenOfficialInstall &&
+      !isTrustedOfficialInstallRecordForCandidate({ record, candidate })
+    ) {
+      continue;
+    }
+    const hasUsableRecord =
+      Object.hasOwn(records, candidate.pluginId) &&
+      !isInstalledRecordMissingOnDisk(records[candidate.pluginId], env);
+    if (
+      !shouldReplaceBrokenOfficialInstall &&
+      knownIds.has(candidate.pluginId) &&
+      hasUsableRecord
+    ) {
+      continue;
+    }
+    if (!shouldReplaceBrokenOfficialInstall && hasUsableRecord) {
+      continue;
+    }
+    const installSpec = resolveCandidateInstallSpec({ candidate, updateChannel });
+    if (shouldReplaceBrokenOfficialInstall) {
+      const installPath = resolveRecordInstallPath(record, env);
+      if (staleVersionBoundRuntimePluginIds.has(candidate.pluginId)) {
+        issues.push({
+          kind: "stale-version-bound-runtime",
+          pluginId: candidate.pluginId,
+          ...(installPath ? { installPath } : {}),
+          ...(installSpec ? { installSpec } : {}),
+        });
+      } else {
+        issues.push({
+          kind: "repairable-installed-plugin",
+          pluginId: candidate.pluginId,
+          ...(installPath ? { installPath } : {}),
+          ...(installSpec ? { installSpec } : {}),
+        });
+      }
+      continue;
+    }
+    if (record) {
+      const installPath = resolveRecordInstallPath(record, env);
+      issues.push({
+        kind: "missing-installed-payload",
+        pluginId: candidate.pluginId,
+        ...(installPath ? { installPath } : {}),
+        ...(installSpec ? { installSpec } : {}),
+      });
+    } else if (installSpec) {
+      issues.push({
+        kind: "missing-install-record",
+        pluginId: candidate.pluginId,
+        installSpec,
+      });
+    }
+  }
+
+  return issues.toSorted((left, right) => left.pluginId.localeCompare(right.pluginId));
+}
+
+export function configuredPluginInstallIssueToHealthFinding(
+  issue: ConfiguredPluginInstallHealthIssue,
+): HealthFinding {
+  const target = issue.pluginId;
+  switch (issue.kind) {
+    case "missing-install-record":
+      return {
+        checkId: CONFIGURED_PLUGIN_INSTALLS_CHECK_ID,
+        severity: "warning",
+        message: `Configured plugin ${issue.pluginId} is not installed.`,
+        target,
+        fixHint: `Run \`openclaw doctor --fix\` to install ${issue.installSpec}.`,
+      };
+    case "missing-installed-payload":
+      return {
+        checkId: CONFIGURED_PLUGIN_INSTALLS_CHECK_ID,
+        severity: "warning",
+        message: `Configured plugin ${issue.pluginId} has an install record but its package payload is missing.`,
+        target,
+        ...(issue.installPath ? { path: issue.installPath } : {}),
+        fixHint: "Run `openclaw doctor --fix` to reinstall the configured plugin package.",
+      };
+    case "repairable-installed-plugin":
+      return {
+        checkId: CONFIGURED_PLUGIN_INSTALLS_CHECK_ID,
+        severity: "warning",
+        message: `Configured plugin ${issue.pluginId} has a repairable package install problem.`,
+        target,
+        ...(issue.installPath ? { path: issue.installPath } : {}),
+        fixHint: "Run `openclaw doctor --fix` to repair the configured plugin package.",
+      };
+    case "stale-version-bound-runtime":
+      return {
+        checkId: CONFIGURED_PLUGIN_INSTALLS_CHECK_ID,
+        severity: "warning",
+        message: `Configured runtime plugin ${issue.pluginId} is older than this OpenClaw version.`,
+        target,
+        ...(issue.installPath ? { path: issue.installPath } : {}),
+        fixHint: "Run `openclaw doctor --fix` to refresh the configured runtime plugin.",
+      };
+    case "stale-channel-config-descriptor":
+      return {
+        checkId: CONFIGURED_PLUGIN_INSTALLS_CHECK_ID,
+        severity: "warning",
+        message: `Configured plugin ${issue.pluginId} has stale channel config metadata.`,
+        target,
+        ...(issue.installPath ? { path: issue.installPath } : {}),
+        fixHint: "Run `openclaw doctor --fix` to repair the configured plugin install metadata.",
+      };
+    case "deferred-package-manager-repair":
+      return {
+        checkId: CONFIGURED_PLUGIN_INSTALLS_CHECK_ID,
+        severity: "warning",
+        message: `Configured plugin ${issue.pluginId} package repair is deferred until the package update finishes.`,
+        target,
+        ...(issue.installPath ? { path: issue.installPath } : {}),
+        fixHint: "Rerun `openclaw doctor --fix` after the package update completes.",
+      };
+  }
+}
+
+export function configuredPluginInstallIssueToRepairEffect(
+  issue: ConfiguredPluginInstallHealthIssue,
+): HealthRepairEffect {
+  switch (issue.kind) {
+    case "missing-install-record":
+      return {
+        kind: "package",
+        action: "would-install-configured-plugin",
+        target: issue.pluginId,
+        dryRunSafe: false,
+      };
+    case "missing-installed-payload":
+      return {
+        kind: "package",
+        action: "would-reinstall-configured-plugin",
+        target: issue.pluginId,
+        dryRunSafe: false,
+      };
+    case "repairable-installed-plugin":
+    case "stale-channel-config-descriptor":
+      return {
+        kind: "package",
+        action: "would-repair-configured-plugin-install",
+        target: issue.pluginId,
+        dryRunSafe: false,
+      };
+    case "stale-version-bound-runtime":
+      return {
+        kind: "package",
+        action: "would-refresh-configured-runtime-plugin",
+        target: issue.pluginId,
+        dryRunSafe: false,
+      };
+    case "deferred-package-manager-repair":
+      return {
+        kind: "package",
+        action: "would-defer-configured-plugin-install-repair",
+        target: issue.pluginId,
+        dryRunSafe: true,
+      };
+  }
 }
 
 export type RepairMissingPluginInstallsResult = {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1052,6 +1052,7 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/session-transcripts");
     expect(contributionIds).toContain("core/doctor/session-snapshots");
     expect(contributionIds).toContain("core/doctor/plugin-registry");
+    expect(contributionIds).toContain("core/doctor/configured-plugin-installs");
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1261,6 +1261,44 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:release-configured-plugin-installs",
       label: "Configured plugin repair",
+      healthChecks: {
+        id: "core/doctor/configured-plugin-installs",
+        description: "Configured plugin install records and package payloads are repairable.",
+        defaultEnabled: false,
+        async detect(ctx) {
+          const {
+            detectConfiguredPluginInstallHealthIssues,
+            configuredPluginInstallIssueToHealthFinding,
+          } = await import("../commands/doctor/shared/missing-configured-plugin-install.js");
+          return (
+            await detectConfiguredPluginInstallHealthIssues({
+              cfg: ctx.cfg,
+              env: process.env,
+            })
+          ).map(configuredPluginInstallIssueToHealthFinding);
+        },
+        async repair(ctx) {
+          const {
+            detectConfiguredPluginInstallHealthIssues,
+            configuredPluginInstallIssueToRepairEffect,
+          } = await import("../commands/doctor/shared/missing-configured-plugin-install.js");
+          const effects = (
+            await detectConfiguredPluginInstallHealthIssues({
+              cfg: ctx.cfg,
+              env: process.env,
+            })
+          ).map(configuredPluginInstallIssueToRepairEffect);
+          if (ctx.dryRun === true) {
+            return { status: "repaired", changes: [], effects };
+          }
+          return {
+            status: "skipped",
+            reason: "legacy doctor configured plugin install repair owns package mutation",
+            changes: [],
+            effects,
+          };
+        },
+      },
       run: runReleaseConfiguredPluginInstallsHealth,
     }),
     createDoctorHealthContribution({


### PR DESCRIPTION
## Summary
- add structured `core/doctor/configured-plugin-installs` findings for configured plugins that are missing install records, missing package payloads, deferred during package update, stale version-bound runtime packages, or repairable package metadata
- expose dry-run package repair effects for those findings
- keep real package install/update mutation in the existing legacy configured plugin install repair path
- register the check as lint-only and default-disabled so it only runs when explicitly selected
- add exhaustive mapper fallbacks after the rebase so lint has a concrete return path for every configured-plugin install issue mapper

## Contract
- No public SDK, plugin, or config contract changes.
- No default Doctor behavior change: `core/doctor/configured-plugin-installs` has `defaultEnabled: false` and is reached through explicit lint selection, e.g. `doctor --lint --only core/doctor/configured-plugin-installs` or `doctor --lint --all`.
- This is split from #96169 so plugin registry findings and configured package install findings can be reviewed independently.

## Validation
- Head: `582502d0fd90a98a6320605beb95fc4ed1243649`
- `node scripts/run-vitest.mjs run src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/flows/doctor-health-contributions.test.ts --reporter=dot` (132 passed)
- `pnpm exec oxfmt --check src/commands/doctor/shared/missing-configured-plugin-install.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `pnpm exec oxlint src/commands/doctor/shared/missing-configured-plugin-install.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `pnpm tsgo:core`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `git diff --check origin/main...HEAD`

## Source Proof
- Focused detector coverage asserts the missing install record, deferred package repair, and missing package payload cases without invoking package install/update mutation.
- Contribution coverage asserts the lint check id is registered as `defaultEnabled: false` and does not enter the default Doctor set.
- A post-rebase isolated CLI sanity run of `doctor --lint --json --only core/doctor/configured-plugin-installs` completed with `ok: true`, `checksRun: 1`, and no findings; current bundled/default state did not recreate the missing external package scenario, so the branch relies on the focused source tests for the failing cases.

No dry-run preview consumer is included in this slice; real package install/update mutation remains in the existing configured plugin install repair path.