### PR TITLE
fix(cron): mark interrupted restart runs failed instead of lost

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -275,7 +275,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/session-store-runtime` | Session workflow helpers (`getSessionEntry`, `listSessionEntries`, `patchSessionEntry`, `upsertSessionEntry`), bounded recent user/assistant transcript text reads by session identity, legacy session store path/session-key helpers, updated-at reads, and transition-only whole-store/file-path compatibility helpers, without broad config writes/maintenance imports |
     | `plugin-sdk/session-transcript-runtime` | Transcript identity, scoped target/read/write helpers, update publishing, write locks, and transcript memory hit keys |
     | `plugin-sdk/sqlite-runtime` | Focused SQLite agent-schema, path, and transaction helpers for first-party runtime, without database lifecycle controls |
-    | `plugin-sdk/cron-store-runtime` | Cron store path/load/save helpers |
+    | `plugin-sdk/cron-store-runtime` | Cron store path/load/save helpers and transactional delivery-target updates |
     | `plugin-sdk/state-paths` | State/OAuth dir path helpers |
     | `plugin-sdk/plugin-state-runtime` | Plugin sidecar SQLite keyed-state types plus centralized connection pragma and WAL maintenance setup for plugin-owned databases |
     | `plugin-sdk/routing` | Route/session-key/account binding helpers such as `resolveAgentRoute`, `buildAgentSessionKey`, and `resolveDefaultAgentBoundAccountId` |

--- a/extensions/telegram/src/target-writeback.test-shared.ts
+++ b/extensions/telegram/src/target-writeback.test-shared.ts
@@ -11,9 +11,7 @@ const replaceConfigFile: AsyncUnknownMock = vi.fn(async (params: unknown) => {
   const record = params as { nextConfig?: unknown; writeOptions?: unknown };
   await writeConfigFile(record.nextConfig, record.writeOptions);
 });
-const loadCronStore: AsyncUnknownMock = vi.fn();
 const resolveCronStorePath: UnknownMock = vi.fn();
-const saveCronStore: AsyncUnknownMock = vi.fn();
 
 type TelegramConfigWrite = {
   channels?: {
@@ -24,10 +22,26 @@ type TelegramConfigWrite = {
   };
 };
 
-type CronStoreWrite = {
-  version: number;
-  jobs: Array<{ id: string; delivery: { channel: string; to: string } }>;
-};
+type CronJobWrite = { id: string; delivery: { channel: string; to: string } };
+let cronJobs: CronJobWrite[] = [];
+const updateCronJobDeliveryTargets: AsyncUnknownMock = vi.fn(
+  async (_storePath: unknown, updateTarget: unknown) => {
+    const update = updateTarget as (
+      delivery: CronJobWrite["delivery"],
+      jobId: string,
+    ) => string | undefined;
+    let updatedJobs = 0;
+    for (const job of cronJobs) {
+      const nextTarget = update(structuredClone(job.delivery), job.id);
+      if (!nextTarget || nextTarget === job.delivery.to) {
+        continue;
+      }
+      job.delivery.to = nextTarget;
+      updatedJobs += 1;
+    }
+    return { updatedJobs };
+  },
+);
 
 vi.mock("openclaw/plugin-sdk/config-mutation", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/config-mutation")>(
@@ -47,9 +61,8 @@ vi.mock("openclaw/plugin-sdk/cron-store-runtime", async () => {
   );
   return {
     ...actual,
-    loadCronStore,
     resolveCronStorePath,
-    saveCronStore,
+    updateCronJobDeliveryTargets,
   };
 });
 
@@ -69,14 +82,6 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
       return call;
     }
 
-    function requireSaveCronStoreCall(index = 0): [string, CronStoreWrite] {
-      const call = saveCronStore.mock.calls[index] as [string, CronStoreWrite] | undefined;
-      if (!call) {
-        throw new Error(`expected saveCronStore call #${index + 1}`);
-      }
-      return call;
-    }
-
     beforeAll(async () => {
       ({ maybePersistResolvedTelegramTarget } = await import("./target-writeback.js"));
     });
@@ -85,9 +90,9 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
       readConfigFileSnapshotForWrite.mockReset();
       replaceConfigFile.mockClear();
       writeConfigFile.mockReset();
-      loadCronStore.mockReset();
       resolveCronStorePath.mockReset();
-      saveCronStore.mockReset();
+      updateCronJobDeliveryTargets.mockClear();
+      cronJobs = [];
       resolveCronStorePath.mockReturnValue("/tmp/cron/jobs.json");
     });
 
@@ -100,7 +105,7 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
       });
 
       expect(readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
-      expect(loadCronStore).not.toHaveBeenCalled();
+      expect(updateCronJobDeliveryTargets).not.toHaveBeenCalled();
     });
 
     if (params?.includeGatewayScopeCases) {
@@ -116,8 +121,7 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
 
         expect(readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
         expect(writeConfigFile).not.toHaveBeenCalled();
-        expect(loadCronStore).not.toHaveBeenCalled();
-        expect(saveCronStore).not.toHaveBeenCalled();
+        expect(updateCronJobDeliveryTargets).not.toHaveBeenCalled();
       });
 
       it("does not let internal writeback override non-admin gateway scopes", async () => {
@@ -133,8 +137,7 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
 
         expect(readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
         expect(writeConfigFile).not.toHaveBeenCalled();
-        expect(loadCronStore).not.toHaveBeenCalled();
-        expect(saveCronStore).not.toHaveBeenCalled();
+        expect(updateCronJobDeliveryTargets).not.toHaveBeenCalled();
       });
 
       it("skips config and cron writeback for gateway callers with an empty scope set", async () => {
@@ -149,8 +152,7 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
 
         expect(readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
         expect(writeConfigFile).not.toHaveBeenCalled();
-        expect(loadCronStore).not.toHaveBeenCalled();
-        expect(saveCronStore).not.toHaveBeenCalled();
+        expect(updateCronJobDeliveryTargets).not.toHaveBeenCalled();
       });
 
       it("skips config and cron writeback when gateway scopes are missing", async () => {
@@ -165,8 +167,7 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
 
         expect(readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
         expect(writeConfigFile).not.toHaveBeenCalled();
-        expect(loadCronStore).not.toHaveBeenCalled();
-        expect(saveCronStore).not.toHaveBeenCalled();
+        expect(updateCronJobDeliveryTargets).not.toHaveBeenCalled();
       });
 
       it("writes back for gateway callers with operator.admin", async () => {
@@ -182,10 +183,7 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
           },
           writeOptions: {},
         });
-        loadCronStore.mockResolvedValue({
-          version: 1,
-          jobs: [{ id: "a", delivery: { channel: "telegram", to: "t.me/mychannel" } }],
-        });
+        cronJobs = [{ id: "a", delivery: { channel: "telegram", to: "t.me/mychannel" } }];
 
         await maybePersistResolvedTelegramTarget({
           cfg: {
@@ -197,7 +195,7 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
         });
 
         expect(writeConfigFile).toHaveBeenCalledTimes(1);
-        expect(saveCronStore).toHaveBeenCalledTimes(1);
+        expect(updateCronJobDeliveryTargets).toHaveBeenCalledTimes(1);
       });
     }
 
@@ -219,13 +217,10 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
         },
         writeOptions: { expectedConfigPath: "/tmp/openclaw.json" },
       });
-      loadCronStore.mockResolvedValue({
-        version: 1,
-        jobs: [
-          { id: "a", delivery: { channel: "telegram", to: "https://t.me/mychannel" } },
-          { id: "b", delivery: { channel: "slack", to: "C123" } },
-        ],
-      });
+      cronJobs = [
+        { id: "a", delivery: { channel: "telegram", to: "https://t.me/mychannel" } },
+        { id: "b", delivery: { channel: "slack", to: "C123" } },
+      ];
 
       await maybePersistResolvedTelegramTarget({
         cfg: {
@@ -242,10 +237,9 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
       expect(writtenConfig.channels?.telegram?.defaultTo).toBe("-100123");
       expect(writtenConfig.channels?.telegram?.accounts?.alerts?.defaultTo).toBe("-100123");
       expect(writeOptions.expectedConfigPath).toBe("/tmp/openclaw.json");
-      expect(saveCronStore).toHaveBeenCalledTimes(1);
-      const [cronPath, cronStore] = requireSaveCronStoreCall();
-      expect(cronPath).toBe("/tmp/cron/jobs.json");
-      expect(cronStore.jobs).toEqual([
+      expect(updateCronJobDeliveryTargets).toHaveBeenCalledTimes(1);
+      expect(updateCronJobDeliveryTargets.mock.calls[0]?.[0]).toBe("/tmp/cron/jobs.json");
+      expect(cronJobs).toEqual([
         { id: "a", delivery: { channel: "telegram", to: "-100123" } },
         { id: "b", delivery: { channel: "slack", to: "C123" } },
       ]);
@@ -264,8 +258,6 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
         },
         writeOptions: {},
       });
-      loadCronStore.mockResolvedValue({ version: 1, jobs: [] });
-
       await maybePersistResolvedTelegramTarget({
         cfg: {} as OpenClawConfig,
         rawTarget: "t.me/mychannel:topic:9",
@@ -293,10 +285,9 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
         },
         writeOptions: {},
       });
-      loadCronStore.mockResolvedValue({
-        version: 1,
-        jobs: [{ id: "a", delivery: { channel: "telegram", to: "https://t.me/mychannel" } }],
-      });
+      cronJobs = [
+        { id: "a", delivery: { channel: "telegram", to: "https://t.me/mychannel" } },
+      ];
 
       await maybePersistResolvedTelegramTarget({
         cfg: {} as OpenClawConfig,
@@ -310,10 +301,9 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
       const [writtenConfig, writeOptions] = requireWriteConfigCall();
       expect(writtenConfig.channels?.telegram?.defaultTo).toBe("-100123");
       expect(writeOptions).toEqual({});
-      expect(saveCronStore).toHaveBeenCalledTimes(1);
-      const [cronPath, cronStore] = requireSaveCronStoreCall();
-      expect(cronPath).toBe("/tmp/cron/jobs.json");
-      expect(cronStore.jobs).toEqual([
+      expect(updateCronJobDeliveryTargets).toHaveBeenCalledTimes(1);
+      expect(updateCronJobDeliveryTargets.mock.calls[0]?.[0]).toBe("/tmp/cron/jobs.json");
+      expect(cronJobs).toEqual([
         { id: "a", delivery: { channel: "telegram", to: "-100123" } },
       ]);
     });

--- a/extensions/telegram/src/target-writeback.ts
+++ b/extensions/telegram/src/target-writeback.ts
@@ -5,9 +5,8 @@ import {
   replaceConfigFile,
 } from "openclaw/plugin-sdk/config-mutation";
 import {
-  loadCronStore,
   resolveCronStorePath,
-  saveCronStore,
+  updateCronJobDeliveryTargets,
 } from "openclaw/plugin-sdk/cron-store-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -199,25 +198,17 @@ export async function maybePersistResolvedTelegramTarget(params: {
 
   try {
     const storePath = resolveCronStorePath(params.cfg.cron?.store);
-    const store = await loadCronStore(storePath);
-    let cronChanged = false;
-    for (const job of store.jobs) {
-      if (job.delivery?.channel !== "telegram") {
-        continue;
+    const { updatedJobs } = await updateCronJobDeliveryTargets(storePath, (delivery) => {
+      if (delivery.channel !== "telegram") {
+        return undefined;
       }
-      const nextTarget = rewriteTargetIfMatch({
-        rawValue: job.delivery.to,
+      return rewriteTargetIfMatch({
+        rawValue: delivery.to,
         matchKey,
         resolvedTarget,
-      });
-      if (!nextTarget) {
-        continue;
-      }
-      job.delivery.to = nextTarget;
-      cronChanged = true;
-    }
-    if (cronChanged) {
-      await saveCronStore(storePath, store);
+      }) ?? undefined;
+    });
+    if (updatedJobs > 0) {
       if (params.verbose) {
         writebackLogger.warn(`resolved Telegram cron delivery target ${raw} -> ${resolvedTarget}`);
       }

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -195,12 +195,12 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10467,
+      10468,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5223,
+      5224,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -139,6 +139,11 @@ export function isCronActiveJobMarkerCurrent(marker: CronActiveJobMarker | undef
   );
 }
 
+/** Returns the current process-lifecycle generation for scheduler plan admission. */
+export function getCronActiveJobGeneration() {
+  return getCronActiveJobState().generation;
+}
+
 /** Returns whether any cron run is active in this process. */
 export function hasActiveCronJobs() {
   return getActiveCronJobCountForGeneration(getCronActiveJobState()) > 0;

--- a/src/cron/service.declarative-jobs.test.ts
+++ b/src/cron/service.declarative-jobs.test.ts
@@ -6,6 +6,7 @@ import {
   installCronTestHooks,
 } from "./service.test-harness.js";
 import type { CronAddResult } from "./service/state.js";
+import { loadCronStore, updateCronJobDeliveryTargets } from "./store.js";
 import type { CronJob, CronJobCreate } from "./types.js";
 
 const logger = createNoopLogger();
@@ -189,6 +190,40 @@ describe("CronService declarative jobs", () => {
         }),
       ).rejects.toThrow("scope changed");
       expect(await cron.readJob(created.id)).toMatchObject({ displayName: "Daily report" });
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("enforces an unchanged explicit delivery target after concurrent writeback", async () => {
+    const { storePath } = await makeStorePath();
+    const cron = createCronService(storePath);
+    await cron.start();
+    const originalTarget = "@legacy-target";
+    const rewrittenTarget = "-100123456";
+
+    try {
+      const input = declaration({
+        delivery: { mode: "announce", channel: "telegram", to: originalTarget },
+      });
+      const created = declarativeResult(await cron.add(input));
+      let racedWriteback = false;
+      const unchanged = declarativeResult(
+        await cron.add(input, {
+          matchesExisting: () => {
+            if (!racedWriteback) {
+              racedWriteback = true;
+              void updateCronJobDeliveryTargets(storePath, (delivery) =>
+                delivery.to === originalTarget ? rewrittenTarget : undefined,
+              );
+            }
+            return true;
+          },
+        }),
+      );
+
+      expect(unchanged).toMatchObject({ id: created.id, created: false, updated: false });
+      expect((await loadCronStore(storePath)).jobs[0]?.delivery?.to).toBe(originalTarget);
     } finally {
       cron.stop();
     }

--- a/src/cron/service.issue-66019-unresolved-next-run.test.ts
+++ b/src/cron/service.issue-66019-unresolved-next-run.test.ts
@@ -153,7 +153,8 @@ describe("#66019 unresolved next-run repro", () => {
       error: "synthetic failure",
     });
     const naturalNext = scheduledAt + 5_000;
-    const backoffNext = scheduledAt + 30_000;
+    const claimedAt = scheduledAt + 1;
+    const backoffNext = claimedAt + 30_000;
     const nextRunSpy = vi
       .spyOn(schedule, "computeNextRunAtMs")
       .mockReturnValueOnce(undefined)

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -226,10 +226,12 @@ describe("Cron issue regressions", () => {
     cron.stop();
   });
 
-  it("keeps telegram delivery target writeback after an unrelated cron update", async () => {
+  it("keeps telegram delivery target writeback across cached writes and reads", async () => {
     const store = cronIssueRegressionFixtures.makeStorePath();
     const originalTarget = "https://t.me/obviyus";
+    const intermediateTarget = "-10011111/2222";
     const rewrittenTarget = "-10012345/6789";
+    const laterTarget = "-10054321/9876";
     const cron = await startCronForStore({ storePath: store.storePath, cronEnabled: false });
     const targetJob = await cron.add({
       name: "target-writeback",
@@ -249,13 +251,39 @@ describe("Cron issue regressions", () => {
       payload: { kind: "systemEvent", text: "before" },
     });
 
-    await expect(
-      updateCronJobDeliveryTargets(store.storePath, (delivery) =>
-        delivery.channel === "telegram" && delivery.to === originalTarget
-          ? rewrittenTarget
-          : undefined,
-      ),
-    ).resolves.toEqual({ updatedJobs: 1 });
+    const explicitlyRestoredTargetJob = await cron.updateWithPrecondition(
+      targetJob.id,
+      { delivery: { to: originalTarget } },
+      async () => {
+        await expect(
+          updateCronJobDeliveryTargets(store.storePath, (delivery) =>
+            delivery.to === originalTarget ? intermediateTarget : undefined,
+          ),
+        ).resolves.toEqual({ updatedJobs: 1 });
+      },
+    );
+    expect(explicitlyRestoredTargetJob.delivery?.to).toBe(originalTarget);
+    expect((await loadCronStore(store.storePath)).jobs[0]?.delivery?.to).toBe(originalTarget);
+
+    const updatedTargetJob = await cron.updateWithPrecondition(
+      targetJob.id,
+      { payload: { kind: "agentTurn", message: "target-updated" } },
+      async () => {
+        await expect(
+          updateCronJobDeliveryTargets(store.storePath, (delivery) =>
+            delivery.channel === "telegram" && delivery.to === originalTarget
+              ? rewrittenTarget
+              : undefined,
+          ),
+        ).resolves.toEqual({ updatedJobs: 1 });
+      },
+    );
+    expect(updatedTargetJob.delivery?.to).toBe(rewrittenTarget);
+    expect(
+      (await cron.list({ includeDisabled: true })).find((job) => job.id === targetJob.id)?.delivery
+        ?.to,
+    ).toBe(rewrittenTarget);
+
     await cron.update(siblingJob.id, {
       payload: { kind: "systemEvent", text: "after" },
     });
@@ -269,7 +297,46 @@ describe("Cron issue regressions", () => {
       text: "after",
     });
 
+    await expect(
+      updateCronJobDeliveryTargets(store.storePath, (delivery) =>
+        delivery.channel === "telegram" && delivery.to === rewrittenTarget
+          ? laterTarget
+          : undefined,
+      ),
+    ).resolves.toEqual({ updatedJobs: 1 });
+    expect(cron.getJob(targetJob.id)?.delivery?.to).toBe(laterTarget);
+    expect(
+      (await cron.list({ includeDisabled: true })).find((job) => job.id === targetJob.id)?.delivery
+        ?.to,
+    ).toBe(laterTarget);
+
     cron.stop();
+  });
+
+  it("invalidates another loaded service after a same-process full-store write", async () => {
+    const store = cronIssueRegressionFixtures.makeStorePath();
+    const originalTarget = "https://t.me/obviyus";
+    const rewrittenTarget = "-10012345/6789";
+    const writer = await startCronForStore({ storePath: store.storePath, cronEnabled: false });
+    const job = await writer.add({
+      name: "shared-store-writer",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: Date.now() },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "target" },
+      delivery: { mode: "announce", channel: "telegram", to: originalTarget },
+    });
+    const reader = await startCronForStore({ storePath: store.storePath, cronEnabled: false });
+    expect((await reader.readJob(job.id))?.delivery?.to).toBe(originalTarget);
+
+    await writer.update(job.id, { delivery: { to: rewrittenTarget } });
+
+    expect(reader.getJob(job.id)?.delivery?.to).toBe(rewrittenTarget);
+    expect((await reader.readJob(job.id))?.delivery?.to).toBe(rewrittenTarget);
+
+    writer.stop();
+    reader.stop();
   });
 
   it("#13845: one-shot jobs with terminal statuses do not re-fire on restart", async () => {

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -5,7 +5,7 @@ import {
   startCronForStore,
   topOfHourOffsetMs,
 } from "./service.issue-regressions.test-helpers.js";
-import { loadCronStore, saveCronStore } from "./store.js";
+import { loadCronStore, saveCronStore, updateCronJobDeliveryTargets } from "./store.js";
 import type { CronJob, CronJobState } from "./types.js";
 
 describe("Cron issue regressions", () => {
@@ -189,12 +189,9 @@ describe("Cron issue regressions", () => {
     const originalTarget = "https://t.me/obviyus";
     const rewrittenTarget = "-10012345/6789";
     const runIsolatedAgentJob = vi.fn(async (params: { job: { id: string } }) => {
-      const persisted = await loadCronStore(store.storePath);
-      const targetJob = persisted.jobs.find((job) => job.id === params.job.id);
-      if (targetJob?.delivery?.channel === "telegram") {
-        targetJob.delivery.to = rewrittenTarget;
-      }
-      await saveCronStore(store.storePath, persisted);
+      await updateCronJobDeliveryTargets(store.storePath, (delivery, jobId) =>
+        jobId === params.job.id && delivery.channel === "telegram" ? rewrittenTarget : undefined,
+      );
       return { status: "ok" as const, summary: "done", delivered: true };
     });
 
@@ -225,6 +222,52 @@ describe("Cron issue regressions", () => {
     expect(persistedJob?.delivery?.to).toBe(rewrittenTarget);
     expect(persistedJob?.state.lastStatus).toBe("ok");
     expect(persistedJob?.state.lastDelivered).toBe(true);
+
+    cron.stop();
+  });
+
+  it("keeps telegram delivery target writeback after an unrelated cron update", async () => {
+    const store = cronIssueRegressionFixtures.makeStorePath();
+    const originalTarget = "https://t.me/obviyus";
+    const rewrittenTarget = "-10012345/6789";
+    const cron = await startCronForStore({ storePath: store.storePath, cronEnabled: false });
+    const targetJob = await cron.add({
+      name: "target-writeback",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: Date.now() },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "target" },
+      delivery: { mode: "announce", channel: "telegram", to: originalTarget },
+    });
+    const siblingJob = await cron.add({
+      name: "sibling-update",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: Date.now() },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "before" },
+    });
+
+    await expect(
+      updateCronJobDeliveryTargets(store.storePath, (delivery) =>
+        delivery.channel === "telegram" && delivery.to === originalTarget
+          ? rewrittenTarget
+          : undefined,
+      ),
+    ).resolves.toEqual({ updatedJobs: 1 });
+    await cron.update(siblingJob.id, {
+      payload: { kind: "systemEvent", text: "after" },
+    });
+
+    const persisted = await loadCronStore(store.storePath);
+    expect(persisted.jobs.find((job) => job.id === targetJob.id)?.delivery?.to).toBe(
+      rewrittenTarget,
+    );
+    expect(persisted.jobs.find((job) => job.id === siblingJob.id)?.payload).toEqual({
+      kind: "systemEvent",
+      text: "after",
+    });
 
     cron.stop();
   });

--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -152,6 +152,7 @@ describe("CronService restart catch-up", () => {
 
   it("executes an overdue recurring job immediately on start", async () => {
     const dueAt = Date.parse("2025-12-13T15:00:00.000Z");
+    const claimedAt = Date.parse("2025-12-13T17:00:00.001Z");
     const lastRunAt = Date.parse("2025-12-12T15:00:00.000Z");
 
     await withRestartedCron(
@@ -180,8 +181,8 @@ describe("CronService restart catch-up", () => {
         const listedJobs = await cron.list({ includeDisabled: true });
         const updated = listedJobs.find((job) => job.id === "restart-overdue-job");
         expect(updated?.state.lastStatus).toBe("ok");
-        expect(updated?.state.lastRunAtMs).toBe(Date.parse("2025-12-13T17:00:00.000Z"));
-        expect(updated?.state.nextRunAtMs).toBeGreaterThan(Date.parse("2025-12-13T17:00:00.000Z"));
+        expect(updated?.state.lastRunAtMs).toBe(claimedAt);
+        expect(updated?.state.nextRunAtMs).toBeGreaterThan(claimedAt);
       },
     );
   });
@@ -344,12 +345,13 @@ describe("CronService restart catch-up", () => {
         },
       ],
       async ({ cron, enqueueSystemEvent, requestHeartbeat }) => {
+        const claimedAt = Date.parse("2025-12-13T04:02:00.001Z");
         expectQueuedSystemEvent(enqueueSystemEvent, "catch missed slot");
         expect(requestHeartbeat).toHaveBeenCalled();
 
         const listedJobs = await cron.list({ includeDisabled: true });
         const updated = listedJobs.find((job) => job.id === "restart-missed-slot");
-        expect(updated?.state.lastRunAtMs).toBe(Date.parse("2025-12-13T04:02:00.000Z"));
+        expect(updated?.state.lastRunAtMs).toBe(claimedAt);
       },
     );
   });

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -13,6 +13,7 @@ import {
   type CronWakeMode,
   createCronServiceState,
 } from "./service/state.js";
+import { getCronJobWithLatestDeliveryTarget } from "./service/store.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "./types.js";
 
 export type { CronEvent, CronServiceDeps } from "./service/state.js";
@@ -84,7 +85,7 @@ export class CronService implements CronServiceContract {
   }
 
   getJob(id: string): CronJob | undefined {
-    return this.state.store?.jobs.find((job) => job.id === id);
+    return getCronJobWithLatestDeliveryTarget(this.state, id);
   }
 
   async readJob(id: string): Promise<CronJob | undefined> {

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -12,8 +12,9 @@ import { setupCronServiceSuite, writeCronStoreSnapshot } from "../service.test-h
 import * as cronStoreModule from "../store.js";
 import { loadCronJobsStoreWithConfigJobs, loadCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
-import { add, list, remove, run, start, stop, update } from "./ops.js";
+import { add, list, remove, run, start, stop, update, updateWithPrecondition } from "./ops.js";
 import { createCronServiceState } from "./state.js";
+import { getCronJobWithLatestDeliveryTarget } from "./store.js";
 import { runMissedJobs } from "./timer.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
@@ -846,12 +847,18 @@ describe("cron service ops persist rollback", () => {
     } as const;
   }
 
+  function failNextPersist() {
+    vi.spyOn(cronStoreModule, "saveCronJobsStoreSync").mockImplementationOnce(() => {
+      throw new Error("disk full");
+    });
+  }
+
   it("rolls back an added job from the live store when persist fails", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-06-09T00:00:00.000Z");
     const state = createOkIsolatedCronState({ storePath, now });
 
-    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+    failNextPersist();
 
     await expect(add(state, makeCreateInput("daily cleanup"))).rejects.toThrow("disk full");
 
@@ -876,7 +883,7 @@ describe("cron service ops persist rollback", () => {
       clearTimeout(state.timer);
     }
 
-    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+    failNextPersist();
 
     await expect(update(state, job.id, { name: "renamed cleanup" })).rejects.toThrow("disk full");
 
@@ -885,6 +892,40 @@ describe("cron service ops persist rollback", () => {
     const loaded = await loadCronStore(storePath);
     const stored = loaded.jobs.find((entry) => entry.id === job.id);
     expect(stored?.name).toBe("daily cleanup");
+  });
+
+  it("keeps synchronous target refreshes outside rollback-owned service state", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const state = createOkIsolatedCronState({ storePath, now });
+    const originalTarget = "https://t.me/obviyus";
+    const rewrittenTarget = "-10012345/6789";
+    const job = await add(state, {
+      ...makeCreateInput("target rollback"),
+      delivery: { mode: "announce", channel: "telegram", to: originalTarget },
+    });
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+
+    await expect(
+      updateWithPrecondition(
+        state,
+        job.id,
+        { payload: { kind: "agentTurn", message: "updated" } },
+        async () => {
+          await cronStoreModule.updateCronJobDeliveryTargets(storePath, () => rewrittenTarget);
+          expect(getCronJobWithLatestDeliveryTarget(state, job.id)?.delivery?.to).toBe(
+            rewrittenTarget,
+          );
+          expect(state.store?.jobs[0]?.delivery?.to).toBe(originalTarget);
+          failNextPersist();
+        },
+      ),
+    ).rejects.toThrow("disk full");
+
+    expect(state.store?.jobs[0]?.delivery?.to).toBe(originalTarget);
+    expect(getCronJobWithLatestDeliveryTarget(state, job.id)?.delivery?.to).toBe(rewrittenTarget);
   });
 
   it("keeps a removed job in the live store when persist fails", async () => {
@@ -897,7 +938,7 @@ describe("cron service ops persist rollback", () => {
       clearTimeout(state.timer);
     }
 
-    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+    failNextPersist();
 
     await expect(remove(state, job.id)).rejects.toThrow("disk full");
 
@@ -917,7 +958,7 @@ describe("cron service ops persist rollback", () => {
     }
     state.pendingCatchupDeferralJobIds.add(job.id);
 
-    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+    failNextPersist();
 
     await expect(remove(state, job.id)).rejects.toThrow("disk full");
 
@@ -930,7 +971,7 @@ describe("cron service ops persist rollback", () => {
     const now = Date.parse("2026-06-09T00:00:00.000Z");
     const state = createOkIsolatedCronState({ storePath, now });
 
-    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+    failNextPersist();
     await expect(add(state, makeCreateInput("daily cleanup"))).rejects.toThrow("disk full");
 
     const job = await add(state, makeCreateInput("daily cleanup"));
@@ -973,7 +1014,7 @@ describe("cron service ops persist rollback", () => {
       return computeNextRunAtMs(schedule, nowMs);
     });
 
-    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+    failNextPersist();
     await expect(add(state, makeCreateInput("failed mutation"))).rejects.toThrow("disk full");
 
     expect(state.store?.jobs.find((job) => job.id === malformed.id)?.enabled).toBe(true);

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -593,11 +593,12 @@ describe("cron service ops seam coverage", () => {
         storePath,
         now,
       });
+      const claimedAt = now + 1;
 
       await runMissedJobs(state);
 
       expectTaskRun({
-        runId: `cron:startup-timeout:${now}`,
+        runId: `cron:startup-timeout:${claimedAt}`,
         runtime: "cron",
         status: "timed_out",
         sourceId: "startup-timeout",

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -503,7 +503,7 @@ async function persistOrRestore(
   postPersistAutoDisableNotifications: Array<() => void> = [],
 ) {
   try {
-    await persist(state);
+    await persist(state, { baseStore: snapshot.store });
   } catch (err) {
     state.store = snapshot.store;
     state.pendingCatchupDeferralJobIds = snapshot.pendingCatchupDeferralJobIds;

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -258,8 +258,8 @@ export async function start(state: CronServiceState) {
         markedAnyInterruptedRun = true;
       }
     }
-    if (markedAnyInterruptedRun || jobs.length > 0) {
-      await persist(state, markedAnyInterruptedRun ? undefined : { stateOnly: true });
+    if (markedAnyInterruptedRun) {
+      await persist(state);
     }
   });
 
@@ -501,9 +501,13 @@ async function persistOrRestore(
   state: CronServiceState,
   snapshot: CronRollbackSnapshot,
   postPersistAutoDisableNotifications: Array<() => void> = [],
+  opts?: { deliveryTargetWriteJobIds?: ReadonlySet<string> },
 ) {
   try {
-    await persist(state, { baseStore: snapshot.store });
+    await persist(state, {
+      baseStore: snapshot.store,
+      deliveryTargetWriteJobIds: opts?.deliveryTargetWriteJobIds,
+    });
   } catch (err) {
     state.store = snapshot.store;
     state.pendingCatchupDeferralJobIds = snapshot.pendingCatchupDeferralJobIds;
@@ -586,6 +590,7 @@ async function persistUpdatedJob(params: {
   state: CronServiceState;
   snapshot: CronRollbackSnapshot;
   nextJob: CronJob;
+  deliveryTargetWriteIntent?: boolean;
 }) {
   const { state, snapshot, nextJob } = params;
   if (state.store) {
@@ -595,14 +600,18 @@ async function persistUpdatedJob(params: {
     }
   }
 
-  await persistOrRestore(state, snapshot);
-  armTimer(state);
-  emit(state, {
-    jobId: nextJob.id,
-    action: "updated",
-    job: nextJob,
-    nextRunAtMs: nextJob.state.nextRunAtMs,
+  await persistOrRestore(state, snapshot, [], {
+    deliveryTargetWriteJobIds: params.deliveryTargetWriteIntent ? new Set([nextJob.id]) : undefined,
   });
+  armTimer(state);
+  const persistedJob = state.store?.jobs.find((entry) => entry.id === nextJob.id) ?? nextJob;
+  emit(state, {
+    jobId: persistedJob.id,
+    action: "updated",
+    job: persistedJob,
+    nextRunAtMs: persistedJob.state.nextRunAtMs,
+  });
+  return persistedJob;
 }
 
 function declarativeFields(job: CronJob, includeEnabled: boolean) {
@@ -650,13 +659,22 @@ export async function add(state: CronServiceState, input: CronJobCreate, opts?: 
         cronConfig: state.deps.cronConfig,
       });
       const includeEnabled = opts?.enabledExplicit === true;
+      const hasExplicitDeliveryTarget =
+        normalizedInput.delivery !== undefined && Object.hasOwn(normalizedInput.delivery, "to");
       if (
         isDeepStrictEqual(
           declarativeFields(existing, includeEnabled),
           declarativeFields(nextJob, includeEnabled),
         )
       ) {
-        return { ...existing, created: false, updated: false, job: existing };
+        if (hasExplicitDeliveryTarget) {
+          const snapshot = snapshotStoreForRollback(state);
+          await persistOrRestore(state, snapshot, [], {
+            deliveryTargetWriteJobIds: new Set([existing.id]),
+          });
+        }
+        const persistedJob = state.store?.jobs.find((job) => job.id === existing.id) ?? existing;
+        return { ...persistedJob, created: false, updated: false, job: persistedJob };
       }
       const snapshot = snapshotStoreForRollback(state);
       finalizeUpdatedJob({
@@ -666,8 +684,13 @@ export async function add(state: CronServiceState, input: CronJobCreate, opts?: 
         schedulingInputsRequested: true,
         scheduleChanged: !isDeepStrictEqual(existing.schedule, nextJob.schedule),
       });
-      await persistUpdatedJob({ state, snapshot, nextJob });
-      return { ...nextJob, created: false, updated: true, job: nextJob };
+      const persistedJob = await persistUpdatedJob({
+        state,
+        snapshot,
+        nextJob,
+        deliveryTargetWriteIntent: hasExplicitDeliveryTarget,
+      });
+      return { ...persistedJob, created: false, updated: true, job: persistedJob };
     }
 
     if (normalizedId && state.store?.jobs.some((job) => job.id === normalizedId)) {
@@ -736,8 +759,12 @@ async function updateLoadedJob(params: {
       patch.schedule !== undefined || patch.enabled !== undefined || patch.trigger !== undefined,
     scheduleChanged: patch.schedule !== undefined,
   });
-  await persistUpdatedJob({ state, snapshot, nextJob });
-  return nextJob;
+  return await persistUpdatedJob({
+    state,
+    snapshot,
+    nextJob,
+    deliveryTargetWriteIntent: patch.delivery !== undefined && Object.hasOwn(patch.delivery, "to"),
+  });
 }
 
 /** Updates a cron job patch in-place, recomputes affected schedule state, and persists it. */

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -6,14 +6,118 @@ import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { isInvalidCronSessionTargetIdError } from "../session-target.js";
 import {
   compareAndSwapCronJobRunningAtMs,
-  loadCronJobsStoreWithConfigJobs,
+  getCronJobStoreRevision,
+  getCronJobStoreRevisionAfterOwnWrite,
+  loadCronJobsStoreSync,
+  loadCronJobsStoreWithConfigJobsSync,
   saveCronQuarantineFile,
-  saveCronJobsStore,
+  saveCronJobsStoreSync,
   type QuarantinedCronConfigJob,
 } from "../store.js";
-import type { CronJob, CronStoreFile } from "../types.js";
+import type { CronDelivery, CronJob, CronStoreFile } from "../types.js";
 import { recomputeNextRuns } from "./jobs.js";
 import type { CronServiceState } from "./state.js";
+
+const loadedStoreRevisionByState = new WeakMap<CronServiceState, string>();
+const persistedDeliveryTargetSnapshotByState = new WeakMap<
+  CronServiceState,
+  { revision: string; deliveriesByJobId: ReadonlyMap<string, CronDelivery> }
+>();
+
+function snapshotPersistedDeliveryTargets(
+  revision: string,
+  store: CronStoreFile,
+): { revision: string; deliveriesByJobId: ReadonlyMap<string, CronDelivery> } {
+  const deliveriesByJobId = new Map<string, CronDelivery>();
+  for (const job of store.jobs) {
+    if (job.delivery) {
+      deliveriesByJobId.set(job.id, { ...job.delivery });
+    }
+  }
+  return {
+    revision,
+    deliveriesByJobId,
+  };
+}
+
+function hasSameDeliveryTargetRoute(left: CronDelivery, right: CronDelivery): boolean {
+  return (
+    left.mode === right.mode &&
+    left.channel === right.channel &&
+    left.accountId === right.accountId &&
+    left.threadId === right.threadId
+  );
+}
+
+function reconcilePersistedDeliveryTargets(
+  state: CronServiceState,
+  persistedStore: CronStoreFile,
+): void {
+  const persistedJobsById = new Map(persistedStore.jobs.map((job) => [job.id, job]));
+  for (const job of state.store?.jobs ?? []) {
+    const persistedJob = persistedJobsById.get(job.id);
+    if (
+      !job.delivery ||
+      !persistedJob?.delivery ||
+      !hasSameDeliveryTargetRoute(job.delivery, persistedJob.delivery) ||
+      job.delivery.to === persistedJob.delivery.to
+    ) {
+      continue;
+    }
+    if (persistedJob.delivery.to === undefined) {
+      delete job.delivery.to;
+    } else {
+      job.delivery.to = persistedJob.delivery.to;
+    }
+  }
+}
+
+function withPersistedDeliveryTarget(
+  job: CronJob,
+  persistedDelivery: CronDelivery | undefined,
+): CronJob {
+  if (
+    !job.delivery ||
+    !persistedDelivery ||
+    !hasSameDeliveryTargetRoute(job.delivery, persistedDelivery) ||
+    job.delivery.to === persistedDelivery.to
+  ) {
+    return job;
+  }
+  const delivery = { ...job.delivery };
+  if (persistedDelivery.to === undefined) {
+    delete delivery.to;
+  } else {
+    delivery.to = persistedDelivery.to;
+  }
+  return { ...job, delivery };
+}
+
+/** Reads the latest delivery target without mutating shared service state outside its lock. */
+export function getCronJobWithLatestDeliveryTarget(
+  state: CronServiceState,
+  jobId: string,
+): CronJob | undefined {
+  const job = state.store?.jobs.find((entry) => entry.id === jobId);
+  if (!job) {
+    return undefined;
+  }
+  try {
+    const revision = getCronJobStoreRevision(state.deps.storePath);
+    let snapshot = persistedDeliveryTargetSnapshotByState.get(state);
+    if (snapshot?.revision !== revision) {
+      snapshot = snapshotPersistedDeliveryTargets(
+        revision,
+        loadCronJobsStoreSync(state.deps.storePath),
+      );
+      persistedDeliveryTargetSnapshotByState.set(state, snapshot);
+    }
+    return withPersistedDeliveryTarget(job, snapshot.deliveriesByJobId.get(jobId));
+  } catch {
+    // getJob historically remained a cache-only, non-throwing read.
+    return job;
+  }
+}
 
 function invalidateStaleNextRunOnScheduleChange(params: {
   previousJobsById: ReadonlyMap<string, CronJob>;
@@ -95,16 +199,21 @@ export async function ensureLoaded(
     skipRecompute?: boolean;
   },
 ) {
-  // Fast path: store is already in memory. Other callers (add, list, run, …)
-  // trust the in-memory copy to avoid a stat syscall on every operation.
-  if (state.store && !opts?.forceReload) {
+  const storeRevision = getCronJobStoreRevision(state.deps.storePath);
+  // Fast path: trust the in-memory copy unless this process or another SQLite
+  // connection advanced the store revision.
+  if (
+    state.store &&
+    !opts?.forceReload &&
+    loadedStoreRevisionByState.get(state) === storeRevision
+  ) {
     return;
   }
   const previousJobsById = new Map<string, CronJob>();
   for (const job of state.store?.jobs ?? []) {
     previousJobsById.set(job.id, job);
   }
-  const loaded = await loadCronJobsStoreWithConfigJobs(state.deps.storePath);
+  const loaded = loadCronJobsStoreWithConfigJobsSync(state.deps.storePath);
   // Persisted cron rows are validated lazily, so treat them as raw records at the
   // store boundary and only trust the CronJob shape after validation below.
   const loadedJobs = (loaded.store.jobs ?? []) as unknown as Record<string, unknown>[];
@@ -164,6 +273,11 @@ export async function ensureLoaded(
     version: 1,
     jobs,
   };
+  loadedStoreRevisionByState.set(state, storeRevision);
+  persistedDeliveryTargetSnapshotByState.set(
+    state,
+    snapshotPersistedDeliveryTargets(storeRevision, state.store),
+  );
   state.storeLoadedAtMs = state.deps.nowMs();
 
   if (quarantinedConfigJobs.length > 0) {
@@ -171,7 +285,7 @@ export async function ensureLoaded(
     const quarantinePath = await flushPendingQuarantine(state, state.storeLoadedAtMs);
     if (quarantinePath) {
       try {
-        await saveCronJobsStore(state.deps.storePath, state.store);
+        await persist(state);
         state.deps.log.warn(
           {
             storePath: state.deps.storePath,
@@ -215,25 +329,36 @@ export function warnIfDisabled(state: CronServiceState, action: string) {
 /** Persists the in-memory cron store, flushing pending quarantine records first. */
 export async function persist(
   state: CronServiceState,
-  opts?: { stateOnly?: boolean; baseStore?: CronStoreFile | null },
+  opts?: {
+    baseStore?: CronStoreFile | null;
+    deliveryTargetWriteJobIds?: ReadonlySet<string>;
+  },
 ) {
   if (!state.store) {
     return;
   }
-  let flushedPendingQuarantine = false;
   if (state.pendingQuarantineConfigJobs.length > 0) {
     const quarantinePath = await flushPendingQuarantine(state, state.deps.nowMs());
     if (!quarantinePath) {
       return;
     }
-    flushedPendingQuarantine = true;
   }
-  const saveOpts = flushedPendingQuarantine
-    ? opts?.baseStore
-      ? { baseStore: opts.baseStore }
-      : undefined
-    : opts;
-  await saveCronJobsStore(state.deps.storePath, state.store, saveOpts);
+  const saveOpts = {
+    baseStore: opts?.baseStore ?? state.store,
+    deliveryTargetWriteJobIds: opts?.deliveryTargetWriteJobIds,
+  };
+  const storeRevision = getCronJobStoreRevision(state.deps.storePath);
+  const persistedStore = saveCronJobsStoreSync(state.deps.storePath, state.store, saveOpts);
+  const ownWriteRevision = getCronJobStoreRevisionAfterOwnWrite(
+    state.deps.storePath,
+    storeRevision,
+  );
+  loadedStoreRevisionByState.set(state, ownWriteRevision);
+  reconcilePersistedDeliveryTargets(state, persistedStore);
+  persistedDeliveryTargetSnapshotByState.set(
+    state,
+    snapshotPersistedDeliveryTargets(ownWriteRevision, persistedStore),
+  );
 }
 
 export { compareAndSwapCronJobRunningAtMs };

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -5,12 +5,13 @@ import { getInvalidPersistedCronJobReason } from "../persisted-shape.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { isInvalidCronSessionTargetIdError } from "../session-target.js";
 import {
+  compareAndSwapCronJobRunningAtMs,
   loadCronJobsStoreWithConfigJobs,
   saveCronQuarantineFile,
   saveCronJobsStore,
   type QuarantinedCronConfigJob,
 } from "../store.js";
-import type { CronJob } from "../types.js";
+import type { CronJob, CronStoreFile } from "../types.js";
 import { recomputeNextRuns } from "./jobs.js";
 import type { CronServiceState } from "./state.js";
 
@@ -212,7 +213,10 @@ export function warnIfDisabled(state: CronServiceState, action: string) {
 }
 
 /** Persists the in-memory cron store, flushing pending quarantine records first. */
-export async function persist(state: CronServiceState, opts?: { stateOnly?: boolean }) {
+export async function persist(
+  state: CronServiceState,
+  opts?: { stateOnly?: boolean; baseStore?: CronStoreFile | null },
+) {
   if (!state.store) {
     return;
   }
@@ -224,9 +228,12 @@ export async function persist(state: CronServiceState, opts?: { stateOnly?: bool
     }
     flushedPendingQuarantine = true;
   }
-  await saveCronJobsStore(
-    state.deps.storePath,
-    state.store,
-    flushedPendingQuarantine ? undefined : opts,
-  );
+  const saveOpts = flushedPendingQuarantine
+    ? opts?.baseStore
+      ? { baseStore: opts.baseStore }
+      : undefined
+    : opts;
+  await saveCronJobsStore(state.deps.storePath, state.store, saveOpts);
 }
+
+export { compareAndSwapCronJobRunningAtMs };

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -202,12 +202,19 @@ export async function ensureLoaded(
   const storeRevision = getCronJobStoreRevision(state.deps.storePath);
   // Fast path: trust the in-memory copy unless this process or another SQLite
   // connection advanced the store revision.
-  if (
-    state.store &&
-    !opts?.forceReload &&
-    loadedStoreRevisionByState.get(state) === storeRevision
-  ) {
-    return;
+  if (state.store && !opts?.forceReload) {
+    const loadedRevision = loadedStoreRevisionByState.get(state);
+    if (loadedRevision === undefined) {
+      loadedStoreRevisionByState.set(state, storeRevision);
+      persistedDeliveryTargetSnapshotByState.set(
+        state,
+        snapshotPersistedDeliveryTargets(storeRevision, state.store),
+      );
+      return;
+    }
+    if (loadedRevision === storeRevision) {
+      return;
+    }
   }
   const previousJobsById = new Map<string, CronJob>();
   for (const job of state.store?.jobs ?? []) {

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -31,7 +31,7 @@ import {
   resetCronActiveJobs,
 } from "../active-jobs.js";
 import * as schedule from "../schedule.js";
-import { loadCronStore, saveCronStore } from "../store.js";
+import { loadCronStore, saveCronStore, updateCronJobDeliveryTargets } from "../store.js";
 import type {
   CronAgentExecutionPhase,
   CronAgentExecutionPhaseUpdate,
@@ -2794,6 +2794,64 @@ describe("cron service timer regressions", () => {
 
       release.resolve({ status: "ok", summary: "done" });
       await missedJobs;
+    } finally {
+      resetTaskRegistryForTests();
+    }
+  });
+
+  it("preserves delivery target writeback when startup catch-up finalizes", async () => {
+    resetTaskRegistryForTests();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const missedAt = Date.parse("2026-05-10T08:59:40.000Z");
+      const originalTarget = "@legacy-target";
+      const rewrittenTarget = "-100123456";
+      const job = createDueIsolatedJob({
+        id: "startup-target-writeback",
+        nowMs: missedAt,
+        nextRunAtMs: missedAt,
+      });
+      const siblingJob = createDueIsolatedJob({
+        id: "startup-target-writeback-sibling",
+        nowMs: missedAt,
+        nextRunAtMs: missedAt,
+      });
+      job.delivery = {
+        mode: "announce",
+        channel: "telegram",
+        to: originalTarget,
+      };
+      siblingJob.delivery = structuredClone(job.delivery);
+      await saveCronStore(store.storePath, { version: 1, jobs: [job, siblingJob] });
+
+      const executedTargets: Array<string | undefined> = [];
+
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => missedAt + 60_000,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async (params: { job: CronJob }) => {
+          executedTargets.push(params.job.delivery?.to);
+          if (params.job.id === job.id) {
+            await updateCronJobDeliveryTargets(store.storePath, (delivery) =>
+              delivery.to === originalTarget ? rewrittenTarget : undefined,
+            );
+          }
+          return { status: "ok" as const, summary: "done", delivered: true };
+        }),
+      });
+
+      await runMissedJobs(state);
+
+      expect(executedTargets).toEqual([originalTarget, rewrittenTarget]);
+      expect(requireJob(state, job.id).delivery?.to).toBe(rewrittenTarget);
+      expect(requireJob(state, siblingJob.id).delivery?.to).toBe(rewrittenTarget);
+      expect(
+        (await loadCronStore(store.storePath)).jobs.map((entry) => entry.delivery?.to),
+      ).toEqual([rewrittenTarget, rewrittenTarget]);
     } finally {
       resetTaskRegistryForTests();
     }

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -87,6 +87,29 @@ function firstMockArg(mock: unknown): unknown {
   return call[0];
 }
 
+function replaceFirstPersistedRunReservation(params: {
+  storePath: string;
+  jobId: string;
+  replacementMs: number;
+}) {
+  const originalPersist = cronServiceStore.persist;
+  let replaced = false;
+  return vi.spyOn(cronServiceStore, "persist").mockImplementation(async (state, opts) => {
+    await originalPersist(state, opts);
+    if (replaced) {
+      return;
+    }
+    replaced = true;
+    const persisted = await loadCronStore(params.storePath);
+    const job = persisted.jobs.find((entry) => entry.id === params.jobId);
+    if (!job) {
+      throw new Error(`expected persisted cron job ${params.jobId}`);
+    }
+    job.state.runningAtMs = params.replacementMs;
+    await saveCronStore(params.storePath, persisted);
+  });
+}
+
 describe("cron service timer regressions", () => {
   it("caps timer delay to 60s for far-future schedules", async () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
@@ -1901,6 +1924,57 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("does not admit due jobs after durable reservation ownership changes", async () => {
+    resetTaskRegistryForTests();
+    const store = timerRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-05-13T12:52:00.000Z");
+    const replacementMs = dueAt + 30_000;
+    const cronJob = createDueIsolatedJob({
+      id: "due-start-reservation-replaced",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+    const persistSpy = replaceFirstPersistedRunReservation({
+      storePath: store.storePath,
+      jobId: cronJob.id,
+      replacementMs,
+    });
+    try {
+      let now = dueAt;
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 7;
+          return now;
+        },
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+      });
+
+      await onTimer(state);
+
+      const persisted = await loadCronStore(store.storePath);
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(
+        listTaskRecords().find(
+          (entry) => entry.runtime === "cron" && entry.sourceId === cronJob.id,
+        ),
+      ).toBeUndefined();
+      expect(persisted.jobs.find((entry) => entry.id === cronJob.id)?.state.runningAtMs).toBe(
+        replacementMs,
+      );
+    } finally {
+      persistSpy.mockRestore();
+      resetCronActiveJobs();
+      resetTaskRegistryForTests();
+    }
+  });
+
   it("does not admit due jobs into a newer generation while persisting the start timestamp", async () => {
     resetTaskRegistryForTests();
     const originalPersist = cronServiceStore.persist;
@@ -2739,6 +2813,55 @@ describe("cron service timer regressions", () => {
       release.resolve({ status: "ok", summary: "done" });
       await missedJobs;
     } finally {
+      resetTaskRegistryForTests();
+    }
+  });
+
+  it("does not admit startup catch-up jobs after durable reservation ownership changes", async () => {
+    resetTaskRegistryForTests();
+    const store = timerRegressionFixtures.makeStorePath();
+    const missedAt = Date.parse("2026-05-10T09:00:10.000Z");
+    const replacementMs = missedAt + 90_000;
+    const job = createDueIsolatedJob({
+      id: "startup-start-reservation-replaced",
+      nowMs: missedAt,
+      nextRunAtMs: missedAt,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+    const persistSpy = replaceFirstPersistedRunReservation({
+      storePath: store.storePath,
+      jobId: job.id,
+      replacementMs,
+    });
+    try {
+      let now = missedAt + 60_000;
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 11;
+          return now;
+        },
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+      });
+
+      await runMissedJobs(state);
+
+      const persisted = await loadCronStore(store.storePath);
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(
+        listTaskRecords().find((entry) => entry.runtime === "cron" && entry.sourceId === job.id),
+      ).toBeUndefined();
+      expect(persisted.jobs.find((entry) => entry.id === job.id)?.state.runningAtMs).toBe(
+        replacementMs,
+      );
+    } finally {
+      persistSpy.mockRestore();
+      resetCronActiveJobs();
       resetTaskRegistryForTests();
     }
   });

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -2923,7 +2923,7 @@ describe("cron service timer regressions", () => {
     }
   });
 
-  it("does not admit startup catch-up jobs into a newer generation while persisting the start timestamp", async () => {
+  it("does not admit a startup catch-up plan into a newer generation while persisting the start timestamp", async () => {
     resetTaskRegistryForTests();
     const originalPersist = cronServiceStore.persist;
     const persistStarted = createDeferred<void>();
@@ -2947,7 +2947,20 @@ describe("cron service timer regressions", () => {
         nowMs: missedAt,
         nextRunAtMs: missedAt,
       });
-      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+      const secondJob = createDueIsolatedJob({
+        id: "startup-start-persist-generation-second",
+        nowMs: missedAt,
+        nextRunAtMs: missedAt + 1,
+      });
+      const deferredJob = createDueIsolatedJob({
+        id: "startup-start-persist-generation-deferred",
+        nowMs: missedAt,
+        nextRunAtMs: missedAt + 2,
+      });
+      await saveCronStore(store.storePath, {
+        version: 1,
+        jobs: [job, secondJob, deferredJob],
+      });
 
       let now = missedAt + 60_000;
       const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
@@ -2962,6 +2975,7 @@ describe("cron service timer regressions", () => {
         enqueueSystemEvent: vi.fn(),
         requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
+        maxMissedJobsPerRestart: 2,
       });
 
       const missedJobs = runMissedJobs(state);
@@ -2974,10 +2988,17 @@ describe("cron service timer regressions", () => {
       const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
       expect(runIsolatedAgentJob).not.toHaveBeenCalled();
       expect(
-        listTaskRecords().find((entry) => entry.runtime === "cron" && entry.sourceId === job.id),
-      ).toBeUndefined();
+        listTaskRecords().filter(
+          (entry) =>
+            entry.runtime === "cron" && [job.id, secondJob.id].includes(entry.sourceId ?? ""),
+        ),
+      ).toEqual([]);
       expect(persistedJob?.state.lastStatus).toBeUndefined();
       expect(persistedJob?.state.runningAtMs).toBeUndefined();
+      expect(
+        persisted.jobs.find((entry) => entry.id === secondJob.id)?.state.runningAtMs,
+      ).toBeUndefined();
+      expect(state.pendingCatchupDeferralJobIds.has(deferredJob.id)).toBe(false);
     } finally {
       persistSpy.mockRestore();
       resetCronActiveJobs();

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -28,6 +28,7 @@ import {
   clearCronJobActive,
   isCronJobActive,
   markCronJobActive,
+  resetCronActiveJobs,
 } from "../active-jobs.js";
 import * as schedule from "../schedule.js";
 import { loadCronStore, saveCronStore } from "../store.js";
@@ -40,6 +41,7 @@ import type {
 import { computeJobNextRunAtMs } from "./jobs.js";
 import { run as runManualCronJob } from "./ops.js";
 import { createCronServiceState, type CronEvent } from "./state.js";
+import * as cronServiceStore from "./store.js";
 import {
   DEFAULT_JOB_TIMEOUT_MS,
   applyJobResult,
@@ -1846,6 +1848,251 @@ describe("cron service timer regressions", () => {
     expect(persistedJob?.state.runningAtMs).toBe(scheduledAt);
   });
 
+  it("persists the due-job start timestamp before creating the cron task run", async () => {
+    resetTaskRegistryForTests();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const dueAt = Date.parse("2026-05-13T12:50:00.000Z");
+      const cronJob = createDueIsolatedJob({
+        id: "due-task-run-reservation-key",
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+      let now = dueAt;
+      const entered = createDeferred<void>();
+      const release = createDeferred<{ status: "ok"; summary: string }>();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 7;
+          return now;
+        },
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => {
+          entered.resolve();
+          return await release.promise;
+        }),
+      });
+
+      const timer = onTimer(state);
+      await entered.promise;
+
+      const persisted = await loadCronStore(store.storePath);
+      const persistedJob = persisted.jobs.find((job) => job.id === cronJob.id);
+      const runningAtMs = requireTimestamp(
+        persistedJob?.state.runningAtMs,
+        "persisted due-job start marker",
+      );
+      const task = listTaskRecords().find(
+        (entry) => entry.runtime === "cron" && entry.sourceId === cronJob.id,
+      );
+      expect(task?.startedAt).toBe(runningAtMs);
+      expect(task?.runId).toBe(`cron:${cronJob.id}:${runningAtMs}`);
+
+      release.resolve({ status: "ok", summary: "done" });
+      await timer;
+    } finally {
+      resetTaskRegistryForTests();
+    }
+  });
+
+  it("does not admit due jobs into a newer generation while persisting the start timestamp", async () => {
+    resetTaskRegistryForTests();
+    const originalPersist = cronServiceStore.persist;
+    const persistStarted = createDeferred<void>();
+    const releasePersist = createDeferred<void>();
+    let persistCalls = 0;
+    const persistSpy = vi
+      .spyOn(cronServiceStore, "persist")
+      .mockImplementation(async (state, opts) => {
+        persistCalls += 1;
+        if (persistCalls === 2) {
+          persistStarted.resolve();
+          await releasePersist.promise;
+        }
+        await originalPersist(state, opts);
+      });
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const dueAt = Date.parse("2026-05-13T12:55:00.000Z");
+      const cronJob = createDueIsolatedJob({
+        id: "due-start-persist-generation",
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+      let now = dueAt;
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 17;
+          return now;
+        },
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+      });
+
+      const timer = onTimer(state);
+      await persistStarted.promise;
+      advanceCronActiveJobGeneration();
+      releasePersist.resolve();
+      await timer;
+
+      const persisted = await loadCronStore(store.storePath);
+      const persistedJob = persisted.jobs.find((entry) => entry.id === cronJob.id);
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(
+        listTaskRecords().find(
+          (entry) => entry.runtime === "cron" && entry.sourceId === cronJob.id,
+        ),
+      ).toBeUndefined();
+      expect(persistedJob?.state.lastStatus).toBeUndefined();
+      expect(persistedJob?.state.runningAtMs).toBeUndefined();
+    } finally {
+      persistSpy.mockRestore();
+      resetCronActiveJobs();
+      resetTaskRegistryForTests();
+    }
+  });
+
+  it("does not admit due jobs after stop while persisting the start timestamp", async () => {
+    resetTaskRegistryForTests();
+    const originalPersist = cronServiceStore.persist;
+    const persistStarted = createDeferred<void>();
+    const releasePersist = createDeferred<void>();
+    let persistCalls = 0;
+    const persistSpy = vi
+      .spyOn(cronServiceStore, "persist")
+      .mockImplementation(async (state, opts) => {
+        persistCalls += 1;
+        if (persistCalls === 2) {
+          persistStarted.resolve();
+          await releasePersist.promise;
+        }
+        await originalPersist(state, opts);
+      });
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const dueAt = Date.parse("2026-05-13T12:57:00.000Z");
+      const cronJob = createDueIsolatedJob({
+        id: "due-start-persist-stop",
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+      let now = dueAt;
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 19;
+          return now;
+        },
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+      });
+
+      const timer = onTimer(state);
+      await persistStarted.promise;
+      state.stopped = true;
+      releasePersist.resolve();
+      await timer;
+
+      const persisted = await loadCronStore(store.storePath);
+      const persistedJob = persisted.jobs.find((entry) => entry.id === cronJob.id);
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(
+        listTaskRecords().find(
+          (entry) => entry.runtime === "cron" && entry.sourceId === cronJob.id,
+        ),
+      ).toBeUndefined();
+      expect(persistedJob?.state.lastStatus).toBeUndefined();
+      expect(persistedJob?.state.runningAtMs).toBeUndefined();
+    } finally {
+      persistSpy.mockRestore();
+      resetCronActiveJobs();
+      resetTaskRegistryForTests();
+    }
+  });
+
+  it("does not admit due jobs after restart recovery starts while persisting the start timestamp", async () => {
+    resetTaskRegistryForTests();
+    const originalPersist = cronServiceStore.persist;
+    const persistStarted = createDeferred<void>();
+    const releasePersist = createDeferred<void>();
+    let persistCalls = 0;
+    const persistSpy = vi
+      .spyOn(cronServiceStore, "persist")
+      .mockImplementation(async (state, opts) => {
+        persistCalls += 1;
+        if (persistCalls === 2) {
+          persistStarted.resolve();
+          await releasePersist.promise;
+        }
+        await originalPersist(state, opts);
+      });
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const dueAt = Date.parse("2026-05-13T12:58:00.000Z");
+      const cronJob = createDueIsolatedJob({
+        id: "due-start-persist-recovery-pending",
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+      let now = dueAt;
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 29;
+          return now;
+        },
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+      });
+
+      const timer = onTimer(state);
+      await persistStarted.promise;
+      state.restartRecoveryPending = true;
+      releasePersist.resolve();
+      await timer;
+
+      const persisted = await loadCronStore(store.storePath);
+      const persistedJob = persisted.jobs.find((entry) => entry.id === cronJob.id);
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(
+        listTaskRecords().find(
+          (entry) => entry.runtime === "cron" && entry.sourceId === cronJob.id,
+        ),
+      ).toBeUndefined();
+      expect(persistedJob?.state.lastStatus).toBeUndefined();
+      expect(persistedJob?.state.runningAtMs).toBeUndefined();
+    } finally {
+      persistSpy.mockRestore();
+      resetCronActiveJobs();
+      resetTaskRegistryForTests();
+    }
+  });
+
   it("releases due-job reservations instead of admitting workers after scheduler stop wins", async () => {
     const store = timerRegressionFixtures.makeStorePath();
     const scheduledAt = Date.parse("2026-05-13T13:00:00.000Z");
@@ -2441,6 +2688,302 @@ describe("cron service timer regressions", () => {
         ?.status,
     ).toBe("succeeded");
     resetTaskRegistryForTests();
+  });
+
+  it("persists the startup catch-up start timestamp before creating the cron task run", async () => {
+    resetTaskRegistryForTests();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const missedAt = Date.parse("2026-05-10T08:59:10.000Z");
+      const job = createDueIsolatedJob({
+        id: "startup-task-run-reservation-key",
+        nowMs: missedAt,
+        nextRunAtMs: missedAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+      let now = missedAt + 60_000;
+      const entered = createDeferred<void>();
+      const release = createDeferred<{ status: "ok"; summary: string }>();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 11;
+          return now;
+        },
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => {
+          entered.resolve();
+          return await release.promise;
+        }),
+      });
+
+      const missedJobs = runMissedJobs(state);
+      await entered.promise;
+
+      const persisted = await loadCronStore(store.storePath);
+      const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
+      const runningAtMs = requireTimestamp(
+        persistedJob?.state.runningAtMs,
+        "persisted startup start marker",
+      );
+      const task = listTaskRecords().find(
+        (entry) => entry.runtime === "cron" && entry.sourceId === job.id,
+      );
+      expect(task?.startedAt).toBe(runningAtMs);
+      expect(task?.runId).toBe(`cron:${job.id}:${runningAtMs}`);
+
+      release.resolve({ status: "ok", summary: "done" });
+      await missedJobs;
+    } finally {
+      resetTaskRegistryForTests();
+    }
+  });
+
+  it("uses the startup catch-up start timestamp for main-session task and enqueue keys", async () => {
+    resetTaskRegistryForTests();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const missedAt = Date.parse("2026-05-10T09:02:10.000Z");
+      const job = createDueIsolatedJob({
+        id: "startup-main-session-run-key",
+        nowMs: missedAt,
+        nextRunAtMs: missedAt,
+      });
+      job.sessionTarget = "main";
+      job.wakeMode = "next-heartbeat";
+      job.payload = { kind: "systemEvent", text: "startup catch-up" };
+      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+      let now = missedAt + 60_000;
+      const enqueueSystemEvent = vi.fn();
+      const requestHeartbeat = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 13;
+          return now;
+        },
+        enqueueSystemEvent,
+        requestHeartbeat,
+        runIsolatedAgentJob: createDefaultIsolatedRunner(),
+      });
+
+      await runMissedJobs(state);
+
+      expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+      const task = listTaskRecords().find(
+        (entry) => entry.runtime === "cron" && entry.sourceId === job.id,
+      );
+      if (!task) {
+        throw new Error("Expected startup main-session cron task row");
+      }
+      const enqueueOptions = requireRecord(enqueueSystemEvent.mock.calls[0]?.[1]);
+      expect(task.childSessionKey).toBe(enqueueOptions.sessionKey);
+      expect(task.runId).toBe(`cron:${job.id}:${task.startedAt}`);
+      expect(enqueueOptions.sessionKey).toBe(
+        `agent:main:cron:startup-main-session-run-key:run:${task.startedAt}`,
+      );
+      expect(requestHeartbeat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: `cron:${job.id}`,
+          sessionKey: task.childSessionKey,
+        }),
+      );
+    } finally {
+      resetTaskRegistryForTests();
+    }
+  });
+
+  it("does not admit startup catch-up jobs into a newer generation while persisting the start timestamp", async () => {
+    resetTaskRegistryForTests();
+    const originalPersist = cronServiceStore.persist;
+    const persistStarted = createDeferred<void>();
+    const releasePersist = createDeferred<void>();
+    let persistCalls = 0;
+    const persistSpy = vi
+      .spyOn(cronServiceStore, "persist")
+      .mockImplementation(async (state, opts) => {
+        persistCalls += 1;
+        if (persistCalls === 2) {
+          persistStarted.resolve();
+          await releasePersist.promise;
+        }
+        await originalPersist(state, opts);
+      });
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const missedAt = Date.parse("2026-05-10T09:02:40.000Z");
+      const job = createDueIsolatedJob({
+        id: "startup-start-persist-generation",
+        nowMs: missedAt,
+        nextRunAtMs: missedAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+      let now = missedAt + 60_000;
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 21;
+          return now;
+        },
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+      });
+
+      const missedJobs = runMissedJobs(state);
+      await persistStarted.promise;
+      advanceCronActiveJobGeneration();
+      releasePersist.resolve();
+      await missedJobs;
+
+      const persisted = await loadCronStore(store.storePath);
+      const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(
+        listTaskRecords().find((entry) => entry.runtime === "cron" && entry.sourceId === job.id),
+      ).toBeUndefined();
+      expect(persistedJob?.state.lastStatus).toBeUndefined();
+      expect(persistedJob?.state.runningAtMs).toBeUndefined();
+    } finally {
+      persistSpy.mockRestore();
+      resetCronActiveJobs();
+      resetTaskRegistryForTests();
+    }
+  });
+
+  it("does not admit startup catch-up jobs after stop while persisting the start timestamp", async () => {
+    resetTaskRegistryForTests();
+    const originalPersist = cronServiceStore.persist;
+    const persistStarted = createDeferred<void>();
+    const releasePersist = createDeferred<void>();
+    let persistCalls = 0;
+    const persistSpy = vi
+      .spyOn(cronServiceStore, "persist")
+      .mockImplementation(async (state, opts) => {
+        persistCalls += 1;
+        if (persistCalls === 2) {
+          persistStarted.resolve();
+          await releasePersist.promise;
+        }
+        await originalPersist(state, opts);
+      });
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const missedAt = Date.parse("2026-05-10T09:03:10.000Z");
+      const job = createDueIsolatedJob({
+        id: "startup-start-persist-stop",
+        nowMs: missedAt,
+        nextRunAtMs: missedAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+      let now = missedAt + 60_000;
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 23;
+          return now;
+        },
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+      });
+
+      const missedJobs = runMissedJobs(state);
+      await persistStarted.promise;
+      state.stopped = true;
+      releasePersist.resolve();
+      await missedJobs;
+
+      const persisted = await loadCronStore(store.storePath);
+      const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(
+        listTaskRecords().find((entry) => entry.runtime === "cron" && entry.sourceId === job.id),
+      ).toBeUndefined();
+      expect(persistedJob?.state.lastStatus).toBeUndefined();
+      expect(persistedJob?.state.runningAtMs).toBeUndefined();
+    } finally {
+      persistSpy.mockRestore();
+      resetCronActiveJobs();
+      resetTaskRegistryForTests();
+    }
+  });
+
+  it("does not admit startup catch-up jobs after restart recovery starts while persisting the start timestamp", async () => {
+    resetTaskRegistryForTests();
+    const originalPersist = cronServiceStore.persist;
+    const persistStarted = createDeferred<void>();
+    const releasePersist = createDeferred<void>();
+    let persistCalls = 0;
+    const persistSpy = vi
+      .spyOn(cronServiceStore, "persist")
+      .mockImplementation(async (state, opts) => {
+        persistCalls += 1;
+        if (persistCalls === 2) {
+          persistStarted.resolve();
+          await releasePersist.promise;
+        }
+        await originalPersist(state, opts);
+      });
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const missedAt = Date.parse("2026-05-10T09:03:40.000Z");
+      const job = createDueIsolatedJob({
+        id: "startup-start-persist-recovery-pending",
+        nowMs: missedAt,
+        nextRunAtMs: missedAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+      let now = missedAt + 60_000;
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => {
+          now += 31;
+          return now;
+        },
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+      });
+
+      const missedJobs = runMissedJobs(state);
+      await persistStarted.promise;
+      state.restartRecoveryPending = true;
+      releasePersist.resolve();
+      await missedJobs;
+
+      const persisted = await loadCronStore(store.storePath);
+      const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(
+        listTaskRecords().find((entry) => entry.runtime === "cron" && entry.sourceId === job.id),
+      ).toBeUndefined();
+      expect(persistedJob?.state.lastStatus).toBeUndefined();
+      expect(persistedJob?.state.runningAtMs).toBeUndefined();
+    } finally {
+      persistSpy.mockRestore();
+      resetCronActiveJobs();
+      resetTaskRegistryForTests();
+    }
   });
 
   it("does not clear replacement reservations when stopped timer cleanup releases unclaimed jobs", async () => {

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -92,22 +92,42 @@ function replaceFirstPersistedRunReservation(params: {
   jobId: string;
   replacementMs: number;
 }) {
-  const originalPersist = cronServiceStore.persist;
+  const originalClaim = cronServiceStore.compareAndSwapCronJobRunningAtMs;
   let replaced = false;
-  return vi.spyOn(cronServiceStore, "persist").mockImplementation(async (state, opts) => {
-    await originalPersist(state, opts);
-    if (replaced) {
-      return;
-    }
-    replaced = true;
-    const persisted = await loadCronStore(params.storePath);
-    const job = persisted.jobs.find((entry) => entry.id === params.jobId);
-    if (!job) {
-      throw new Error(`expected persisted cron job ${params.jobId}`);
-    }
-    job.state.runningAtMs = params.replacementMs;
-    await saveCronStore(params.storePath, persisted);
-  });
+  return vi
+    .spyOn(cronServiceStore, "compareAndSwapCronJobRunningAtMs")
+    .mockImplementation(async (claim) => {
+      if (replaced) {
+        return await originalClaim(claim);
+      }
+      replaced = true;
+      const persisted = await loadCronStore(params.storePath);
+      const job = persisted.jobs.find((entry) => entry.id === params.jobId);
+      if (!job) {
+        throw new Error(`expected persisted cron job ${params.jobId}`);
+      }
+      job.state.runningAtMs = params.replacementMs;
+      await saveCronStore(params.storePath, persisted);
+      return await originalClaim(claim);
+    });
+}
+
+function pauseFirstCronRunStartClaim() {
+  const originalClaim = cronServiceStore.compareAndSwapCronJobRunningAtMs;
+  const claimStarted = createDeferred<void>();
+  const releaseClaim = createDeferred<void>();
+  let paused = false;
+  const claimSpy = vi
+    .spyOn(cronServiceStore, "compareAndSwapCronJobRunningAtMs")
+    .mockImplementation(async (claim) => {
+      if (!paused) {
+        paused = true;
+        claimStarted.resolve();
+        await releaseClaim.promise;
+      }
+      return await originalClaim(claim);
+    });
+  return { claimStarted, releaseClaim, claimSpy };
 }
 
 describe("cron service timer regressions", () => {
@@ -1941,16 +1961,12 @@ describe("cron service timer regressions", () => {
       replacementMs,
     });
     try {
-      let now = dueAt;
       const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
       const state = createCronServiceState({
         cronEnabled: true,
         storePath: store.storePath,
         log: noopLogger,
-        nowMs: () => {
-          now += 7;
-          return now;
-        },
+        nowMs: () => dueAt,
         enqueueSystemEvent: vi.fn(),
         requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
@@ -1977,20 +1993,7 @@ describe("cron service timer regressions", () => {
 
   it("does not admit due jobs into a newer generation while persisting the start timestamp", async () => {
     resetTaskRegistryForTests();
-    const originalPersist = cronServiceStore.persist;
-    const persistStarted = createDeferred<void>();
-    const releasePersist = createDeferred<void>();
-    let persistCalls = 0;
-    const persistSpy = vi
-      .spyOn(cronServiceStore, "persist")
-      .mockImplementation(async (state, opts) => {
-        persistCalls += 1;
-        if (persistCalls === 2) {
-          persistStarted.resolve();
-          await releasePersist.promise;
-        }
-        await originalPersist(state, opts);
-      });
+    const { claimStarted, releaseClaim, claimSpy } = pauseFirstCronRunStartClaim();
     try {
       const store = timerRegressionFixtures.makeStorePath();
       const dueAt = Date.parse("2026-05-13T12:55:00.000Z");
@@ -1999,10 +2002,14 @@ describe("cron service timer regressions", () => {
         nowMs: dueAt,
         nextRunAtMs: dueAt,
       });
+      cronJob.sessionTarget = "main";
+      cronJob.wakeMode = "next-heartbeat";
+      cronJob.payload = { kind: "systemEvent", text: "generation fence" };
       await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
 
       let now = dueAt;
       const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const enqueueSystemEvent = vi.fn();
       const state = createCronServiceState({
         cronEnabled: true,
         storePath: store.storePath,
@@ -2011,20 +2018,21 @@ describe("cron service timer regressions", () => {
           now += 17;
           return now;
         },
-        enqueueSystemEvent: vi.fn(),
+        enqueueSystemEvent,
         requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
       });
 
       const timer = onTimer(state);
-      await persistStarted.promise;
+      await claimStarted.promise;
       advanceCronActiveJobGeneration();
-      releasePersist.resolve();
+      releaseClaim.resolve();
       await timer;
 
       const persisted = await loadCronStore(store.storePath);
       const persistedJob = persisted.jobs.find((entry) => entry.id === cronJob.id);
       expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
       expect(
         listTaskRecords().find(
           (entry) => entry.runtime === "cron" && entry.sourceId === cronJob.id,
@@ -2033,7 +2041,7 @@ describe("cron service timer regressions", () => {
       expect(persistedJob?.state.lastStatus).toBeUndefined();
       expect(persistedJob?.state.runningAtMs).toBeUndefined();
     } finally {
-      persistSpy.mockRestore();
+      claimSpy.mockRestore();
       resetCronActiveJobs();
       resetTaskRegistryForTests();
     }
@@ -2041,20 +2049,7 @@ describe("cron service timer regressions", () => {
 
   it("does not admit due jobs after stop while persisting the start timestamp", async () => {
     resetTaskRegistryForTests();
-    const originalPersist = cronServiceStore.persist;
-    const persistStarted = createDeferred<void>();
-    const releasePersist = createDeferred<void>();
-    let persistCalls = 0;
-    const persistSpy = vi
-      .spyOn(cronServiceStore, "persist")
-      .mockImplementation(async (state, opts) => {
-        persistCalls += 1;
-        if (persistCalls === 2) {
-          persistStarted.resolve();
-          await releasePersist.promise;
-        }
-        await originalPersist(state, opts);
-      });
+    const { claimStarted, releaseClaim, claimSpy } = pauseFirstCronRunStartClaim();
     try {
       const store = timerRegressionFixtures.makeStorePath();
       const dueAt = Date.parse("2026-05-13T12:57:00.000Z");
@@ -2081,9 +2076,9 @@ describe("cron service timer regressions", () => {
       });
 
       const timer = onTimer(state);
-      await persistStarted.promise;
+      await claimStarted.promise;
       state.stopped = true;
-      releasePersist.resolve();
+      releaseClaim.resolve();
       await timer;
 
       const persisted = await loadCronStore(store.storePath);
@@ -2097,7 +2092,7 @@ describe("cron service timer regressions", () => {
       expect(persistedJob?.state.lastStatus).toBeUndefined();
       expect(persistedJob?.state.runningAtMs).toBeUndefined();
     } finally {
-      persistSpy.mockRestore();
+      claimSpy.mockRestore();
       resetCronActiveJobs();
       resetTaskRegistryForTests();
     }
@@ -2105,20 +2100,7 @@ describe("cron service timer regressions", () => {
 
   it("does not admit due jobs after restart recovery starts while persisting the start timestamp", async () => {
     resetTaskRegistryForTests();
-    const originalPersist = cronServiceStore.persist;
-    const persistStarted = createDeferred<void>();
-    const releasePersist = createDeferred<void>();
-    let persistCalls = 0;
-    const persistSpy = vi
-      .spyOn(cronServiceStore, "persist")
-      .mockImplementation(async (state, opts) => {
-        persistCalls += 1;
-        if (persistCalls === 2) {
-          persistStarted.resolve();
-          await releasePersist.promise;
-        }
-        await originalPersist(state, opts);
-      });
+    const { claimStarted, releaseClaim, claimSpy } = pauseFirstCronRunStartClaim();
     try {
       const store = timerRegressionFixtures.makeStorePath();
       const dueAt = Date.parse("2026-05-13T12:58:00.000Z");
@@ -2145,9 +2127,9 @@ describe("cron service timer regressions", () => {
       });
 
       const timer = onTimer(state);
-      await persistStarted.promise;
+      await claimStarted.promise;
       state.restartRecoveryPending = true;
-      releasePersist.resolve();
+      releaseClaim.resolve();
       await timer;
 
       const persisted = await loadCronStore(store.storePath);
@@ -2161,7 +2143,7 @@ describe("cron service timer regressions", () => {
       expect(persistedJob?.state.lastStatus).toBeUndefined();
       expect(persistedJob?.state.runningAtMs).toBeUndefined();
     } finally {
-      persistSpy.mockRestore();
+      claimSpy.mockRestore();
       resetCronActiveJobs();
       resetTaskRegistryForTests();
     }
@@ -2836,6 +2818,7 @@ describe("cron service timer regressions", () => {
     try {
       let now = missedAt + 60_000;
       const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const enqueueSystemEvent = vi.fn();
       const state = createCronServiceState({
         cronEnabled: true,
         storePath: store.storePath,
@@ -2844,7 +2827,7 @@ describe("cron service timer regressions", () => {
           now += 11;
           return now;
         },
-        enqueueSystemEvent: vi.fn(),
+        enqueueSystemEvent,
         requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
       });
@@ -2853,6 +2836,7 @@ describe("cron service timer regressions", () => {
 
       const persisted = await loadCronStore(store.storePath);
       expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
       expect(
         listTaskRecords().find((entry) => entry.runtime === "cron" && entry.sourceId === job.id),
       ).toBeUndefined();
@@ -2925,20 +2909,7 @@ describe("cron service timer regressions", () => {
 
   it("does not admit a startup catch-up plan into a newer generation while persisting the start timestamp", async () => {
     resetTaskRegistryForTests();
-    const originalPersist = cronServiceStore.persist;
-    const persistStarted = createDeferred<void>();
-    const releasePersist = createDeferred<void>();
-    let persistCalls = 0;
-    const persistSpy = vi
-      .spyOn(cronServiceStore, "persist")
-      .mockImplementation(async (state, opts) => {
-        persistCalls += 1;
-        if (persistCalls === 2) {
-          persistStarted.resolve();
-          await releasePersist.promise;
-        }
-        await originalPersist(state, opts);
-      });
+    const { claimStarted, releaseClaim, claimSpy } = pauseFirstCronRunStartClaim();
     try {
       const store = timerRegressionFixtures.makeStorePath();
       const missedAt = Date.parse("2026-05-10T09:02:40.000Z");
@@ -2947,6 +2918,9 @@ describe("cron service timer regressions", () => {
         nowMs: missedAt,
         nextRunAtMs: missedAt,
       });
+      job.sessionTarget = "main";
+      job.wakeMode = "next-heartbeat";
+      job.payload = { kind: "systemEvent", text: "startup generation fence" };
       const secondJob = createDueIsolatedJob({
         id: "startup-start-persist-generation-second",
         nowMs: missedAt,
@@ -2964,6 +2938,7 @@ describe("cron service timer regressions", () => {
 
       let now = missedAt + 60_000;
       const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+      const enqueueSystemEvent = vi.fn();
       const state = createCronServiceState({
         cronEnabled: true,
         storePath: store.storePath,
@@ -2972,21 +2947,22 @@ describe("cron service timer regressions", () => {
           now += 21;
           return now;
         },
-        enqueueSystemEvent: vi.fn(),
+        enqueueSystemEvent,
         requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
         maxMissedJobsPerRestart: 2,
       });
 
       const missedJobs = runMissedJobs(state);
-      await persistStarted.promise;
+      await claimStarted.promise;
       advanceCronActiveJobGeneration();
-      releasePersist.resolve();
+      releaseClaim.resolve();
       await missedJobs;
 
       const persisted = await loadCronStore(store.storePath);
       const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
       expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
       expect(
         listTaskRecords().filter(
           (entry) =>
@@ -3000,7 +2976,7 @@ describe("cron service timer regressions", () => {
       ).toBeUndefined();
       expect(state.pendingCatchupDeferralJobIds.has(deferredJob.id)).toBe(false);
     } finally {
-      persistSpy.mockRestore();
+      claimSpy.mockRestore();
       resetCronActiveJobs();
       resetTaskRegistryForTests();
     }
@@ -3008,20 +2984,7 @@ describe("cron service timer regressions", () => {
 
   it("does not admit startup catch-up jobs after stop while persisting the start timestamp", async () => {
     resetTaskRegistryForTests();
-    const originalPersist = cronServiceStore.persist;
-    const persistStarted = createDeferred<void>();
-    const releasePersist = createDeferred<void>();
-    let persistCalls = 0;
-    const persistSpy = vi
-      .spyOn(cronServiceStore, "persist")
-      .mockImplementation(async (state, opts) => {
-        persistCalls += 1;
-        if (persistCalls === 2) {
-          persistStarted.resolve();
-          await releasePersist.promise;
-        }
-        await originalPersist(state, opts);
-      });
+    const { claimStarted, releaseClaim, claimSpy } = pauseFirstCronRunStartClaim();
     try {
       const store = timerRegressionFixtures.makeStorePath();
       const missedAt = Date.parse("2026-05-10T09:03:10.000Z");
@@ -3048,9 +3011,9 @@ describe("cron service timer regressions", () => {
       });
 
       const missedJobs = runMissedJobs(state);
-      await persistStarted.promise;
+      await claimStarted.promise;
       state.stopped = true;
-      releasePersist.resolve();
+      releaseClaim.resolve();
       await missedJobs;
 
       const persisted = await loadCronStore(store.storePath);
@@ -3062,7 +3025,7 @@ describe("cron service timer regressions", () => {
       expect(persistedJob?.state.lastStatus).toBeUndefined();
       expect(persistedJob?.state.runningAtMs).toBeUndefined();
     } finally {
-      persistSpy.mockRestore();
+      claimSpy.mockRestore();
       resetCronActiveJobs();
       resetTaskRegistryForTests();
     }
@@ -3070,20 +3033,7 @@ describe("cron service timer regressions", () => {
 
   it("does not admit startup catch-up jobs after restart recovery starts while persisting the start timestamp", async () => {
     resetTaskRegistryForTests();
-    const originalPersist = cronServiceStore.persist;
-    const persistStarted = createDeferred<void>();
-    const releasePersist = createDeferred<void>();
-    let persistCalls = 0;
-    const persistSpy = vi
-      .spyOn(cronServiceStore, "persist")
-      .mockImplementation(async (state, opts) => {
-        persistCalls += 1;
-        if (persistCalls === 2) {
-          persistStarted.resolve();
-          await releasePersist.promise;
-        }
-        await originalPersist(state, opts);
-      });
+    const { claimStarted, releaseClaim, claimSpy } = pauseFirstCronRunStartClaim();
     try {
       const store = timerRegressionFixtures.makeStorePath();
       const missedAt = Date.parse("2026-05-10T09:03:40.000Z");
@@ -3092,7 +3042,12 @@ describe("cron service timer regressions", () => {
         nowMs: missedAt,
         nextRunAtMs: missedAt,
       });
-      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+      const deferredJob = createDueIsolatedJob({
+        id: "startup-start-persist-recovery-pending-deferred",
+        nowMs: missedAt,
+        nextRunAtMs: missedAt + 1,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [job, deferredJob] });
 
       let now = missedAt + 60_000;
       const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
@@ -3107,12 +3062,13 @@ describe("cron service timer regressions", () => {
         enqueueSystemEvent: vi.fn(),
         requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
+        maxMissedJobsPerRestart: 1,
       });
 
       const missedJobs = runMissedJobs(state);
-      await persistStarted.promise;
+      await claimStarted.promise;
       state.restartRecoveryPending = true;
-      releasePersist.resolve();
+      releaseClaim.resolve();
       await missedJobs;
 
       const persisted = await loadCronStore(store.storePath);
@@ -3123,8 +3079,12 @@ describe("cron service timer regressions", () => {
       ).toBeUndefined();
       expect(persistedJob?.state.lastStatus).toBeUndefined();
       expect(persistedJob?.state.runningAtMs).toBeUndefined();
+      expect(
+        persisted.jobs.find((entry) => entry.id === deferredJob.id)?.state.runningAtMs,
+      ).toBeUndefined();
+      expect(state.pendingCatchupDeferralJobIds.has(deferredJob.id)).toBe(false);
     } finally {
-      persistSpy.mockRestore();
+      claimSpy.mockRestore();
       resetCronActiveJobs();
       resetTaskRegistryForTests();
     }

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1903,17 +1903,13 @@ describe("cron service timer regressions", () => {
       });
       await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
 
-      let now = dueAt;
       const entered = createDeferred<void>();
       const release = createDeferred<{ status: "ok"; summary: string }>();
       const state = createCronServiceState({
         cronEnabled: true,
         storePath: store.storePath,
         log: noopLogger,
-        nowMs: () => {
-          now += 7;
-          return now;
-        },
+        nowMs: () => dueAt,
         enqueueSystemEvent: vi.fn(),
         requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(async () => {
@@ -1931,6 +1927,7 @@ describe("cron service timer regressions", () => {
         persistedJob?.state.runningAtMs,
         "persisted due-job start marker",
       );
+      expect(runningAtMs).toBe(dueAt + 1);
       const task = listTaskRecords().find(
         (entry) => entry.runtime === "cron" && entry.sourceId === cronJob.id,
       );
@@ -2758,17 +2755,14 @@ describe("cron service timer regressions", () => {
       });
       await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
-      let now = missedAt + 60_000;
+      const catchupAt = missedAt + 60_000;
       const entered = createDeferred<void>();
       const release = createDeferred<{ status: "ok"; summary: string }>();
       const state = createCronServiceState({
         cronEnabled: true,
         storePath: store.storePath,
         log: noopLogger,
-        nowMs: () => {
-          now += 11;
-          return now;
-        },
+        nowMs: () => catchupAt,
         enqueueSystemEvent: vi.fn(),
         requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(async () => {
@@ -2786,6 +2780,7 @@ describe("cron service timer regressions", () => {
         persistedJob?.state.runningAtMs,
         "persisted startup start marker",
       );
+      expect(runningAtMs).toBe(catchupAt + 1);
       const task = listTaskRecords().find(
         (entry) => entry.runtime === "cron" && entry.sourceId === job.id,
       );

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -887,7 +887,8 @@ describe("cron service timer regressions", () => {
       });
       await runnerStarted.promise;
 
-      const runId = `cron:no-timeout-cancel:${scheduledAt}`;
+      const claimedAt = scheduledAt + 1;
+      const runId = `cron:no-timeout-cancel:${claimedAt}`;
       const task = listTaskRecords().find(
         (entry) => entry.runtime === "cron" && entry.runId === runId,
       );
@@ -1072,7 +1073,7 @@ describe("cron service timer regressions", () => {
 
       const timerPromise = onTimer(state);
       const observedAbortSignal = await runnerStarted.promise;
-      const runId = `cron:cancel-before-timeout:${scheduledAt}`;
+      const runId = `cron:cancel-before-timeout:${scheduledAt + 1}`;
       let timerSettled = false;
       void timerPromise.then(() => {
         timerSettled = true;
@@ -1150,7 +1151,7 @@ describe("cron service timer regressions", () => {
       now += Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 10;
       await cleanupStarted.promise;
 
-      const runId = `cron:late-cancel-after-timeout:${scheduledAt}`;
+      const runId = `cron:late-cancel-after-timeout:${scheduledAt + 1}`;
       const task = listTaskRecords().find(
         (entry) => entry.runtime === "cron" && entry.runId === runId,
       );
@@ -1687,7 +1688,7 @@ describe("cron service timer regressions", () => {
       });
 
       const timerPromise = onTimer(state);
-      const runId = `cron:main-session-cancel-boundary:${scheduledAt}`;
+      const runId = `cron:main-session-cancel-boundary:${scheduledAt + 1}`;
       for (
         let attempt = 0;
         attempt < 10 && runHeartbeatOnce.mock.calls.length === 0;
@@ -1723,7 +1724,7 @@ describe("cron service timer regressions", () => {
       await vi.advanceTimersByTimeAsync(0);
       await timerPromise;
 
-      const expectedSessionKey = `agent:main:cron:main-session-cancel-boundary:run:${scheduledAt}`;
+      const expectedSessionKey = `agent:main:cron:main-session-cancel-boundary:run:${scheduledAt + 1}`;
       expect(enqueueSystemEvent).toHaveBeenCalledWith(
         "queued downstream work",
         expect.objectContaining({
@@ -1888,7 +1889,7 @@ describe("cron service timer regressions", () => {
     const persisted = await loadCronStore(store.storePath);
     const persistedJob = persisted.jobs.find((job) => job.id === cronJob.id);
     expect(persistedJob?.state.lastStatus).not.toBe("ok");
-    expect(persistedJob?.state.runningAtMs).toBe(scheduledAt);
+    expect(persistedJob?.state.runningAtMs).toBe(scheduledAt + 1);
   });
 
   it("persists the due-job start timestamp before creating the cron task run", async () => {
@@ -2303,11 +2304,11 @@ describe("cron service timer regressions", () => {
       .filter((evt) => evt.action === "started")
       .map((evt) => evt.runAtMs);
 
-    expect(firstDone?.state.lastRunAtMs).toBe(dueAt);
-    expect(firstDone?.state.lastDurationMs).toBe(50);
+    expect(firstDone?.state.lastRunAtMs).toBe(dueAt + 1);
+    expect(firstDone?.state.lastDurationMs).toBe(49);
     expect(secondDone?.state.lastRunAtMs).toBe(dueAt + 50);
     expect(secondDone?.state.lastDurationMs).toBe(20);
-    expect(startedAtEvents).toEqual([dueAt, dueAt + 50]);
+    expect(startedAtEvents).toEqual([dueAt + 1, dueAt + 50]);
   });
 
   it("honors cron maxConcurrentRuns for due jobs", async () => {
@@ -2730,7 +2731,7 @@ describe("cron service timer regressions", () => {
     const persistedReplacementClaimedJob = persisted.jobs.find(
       (entry) => entry.id === replacementClaimedJob.id,
     );
-    expect(persistedJob?.state.runningAtMs).toBe(scheduledAt);
+    expect(persistedJob?.state.runningAtMs).toBe(scheduledAt + 1);
     expect(persistedJob?.state.lastStatus).toBeUndefined();
     expect(persistedUnstartedJob?.state.runningAtMs).toBeUndefined();
     expect(persistedUnstartedJob?.state.lastStatus).toBeUndefined();

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -148,7 +148,8 @@ describe("cron service timer seam coverage", () => {
 
     await onTimer(state);
 
-    const cronRunSessionKey = `agent:main:cron:main-heartbeat-job:run:${now}`;
+    const claimedAt = now + 1;
+    const cronRunSessionKey = `agent:main:cron:main-heartbeat-job:run:${claimedAt}`;
     expect(enqueueSystemEvent).toHaveBeenCalledWith("heartbeat seam tick", {
       agentId: undefined,
       sessionKey: cronRunSessionKey,
@@ -170,8 +171,8 @@ describe("cron service timer seam coverage", () => {
     }
     expect(job.state.lastStatus).toBe("ok");
     expect(job.state.runningAtMs).toBeUndefined();
-    expect(job.state.nextRunAtMs).toBe(now + 60_000);
-    const task = findTaskByRunId(`cron:main-heartbeat-job:${now}`);
+    expect(job.state.nextRunAtMs).toBe(claimedAt + 60_000);
+    const task = findTaskByRunId(`cron:main-heartbeat-job:${claimedAt}`);
     if (!task) {
       throw new Error("expected cron task ledger record");
     }
@@ -180,16 +181,16 @@ describe("cron service timer seam coverage", () => {
     expect(task.ownerKey).toBe("");
     expect(task.scopeKind).toBe("system");
     expect(task.childSessionKey).toBe(cronRunSessionKey);
-    expect(task.runId).toBe(`cron:main-heartbeat-job:${now}`);
+    expect(task.runId).toBe(`cron:main-heartbeat-job:${claimedAt}`);
     expect(task.label).toBe("main heartbeat job");
     expect(task.task).toBe("main heartbeat job");
     expect(task.status).toBe("succeeded");
     expect(task.deliveryStatus).toBe("not_applicable");
     expect(task.notifyPolicy).toBe("silent");
-    expect(task.startedAt).toBe(now);
-    expect(task.lastEventAt).toBe(now);
-    expect(task.endedAt).toBe(now);
-    expect(task?.cleanupAfter).toBe(now + 7 * 24 * 60 * 60_000);
+    expect(task.startedAt).toBe(claimedAt);
+    expect(task.lastEventAt).toBe(claimedAt);
+    expect(task.endedAt).toBe(claimedAt);
+    expect(task?.cleanupAfter).toBe(claimedAt + 7 * 24 * 60 * 60_000);
 
     const delays = timeoutSpy.mock.calls
       .map(([, delay]) => delay)
@@ -264,7 +265,7 @@ describe("cron service timer seam coverage", () => {
         message: "run isolated cron",
       }),
     );
-    const task = findTaskByRunId(`cron:isolated-agent-job:${now}`);
+    const task = findTaskByRunId(`cron:isolated-agent-job:${now + 1}`);
     if (!task) {
       throw new Error("expected isolated cron task ledger record");
     }
@@ -306,7 +307,7 @@ describe("cron service timer seam coverage", () => {
       expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
     });
 
-    const task = findTaskByRunId(`cron:isolated-agent-job:${now}`);
+    const task = findTaskByRunId(`cron:isolated-agent-job:${now + 1}`);
     if (!task) {
       throw new Error("expected active cron task ledger record");
     }
@@ -352,7 +353,7 @@ describe("cron service timer seam coverage", () => {
       { jobId: "main-heartbeat-job", error: ledgerError },
       "cron: failed to create task ledger record",
     );
-    const cronRunSessionKey = `agent:main:cron:main-heartbeat-job:run:${now}`;
+    const cronRunSessionKey = `agent:main:cron:main-heartbeat-job:run:${now + 1}`;
     expect(enqueueSystemEvent).toHaveBeenCalledWith("heartbeat seam tick", {
       agentId: undefined,
       sessionKey: cronRunSessionKey,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1425,7 +1425,7 @@ export async function onTimer(state: CronServiceState) {
       activeJobGeneration: number;
     }): Promise<TimedCronRunOutcome | undefined> => {
       const { id, job: plannedJob, reservedAtMs, activeJobGeneration } = params;
-      const startedAt = state.deps.nowMs();
+      const startedAt = Math.max(state.deps.nowMs(), reservedAtMs + 1);
       let job = plannedJob;
       let activeJobMarker: CronActiveJobMarker | undefined;
       let jobTimeoutMs = resolveCronJobTimeoutMs(job);
@@ -1970,7 +1970,7 @@ async function runStartupCatchupCandidate(
   candidate: StartupCatchupCandidate,
   activeJobGeneration: number,
 ): Promise<TimedCronRunOutcome | undefined> {
-  const startedAt = state.deps.nowMs();
+  const startedAt = Math.max(state.deps.nowMs(), candidate.reservedAtMs + 1);
   let job = candidate.job;
   let activeJobMarker: CronActiveJobMarker | undefined;
   let taskRunId: string | undefined;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -81,7 +81,7 @@ import {
 } from "./jobs.js";
 import { locked } from "./locked.js";
 import type { CronEvent, CronServiceState, CronSystemEventEnqueueResult } from "./state.js";
-import { ensureLoaded, persist } from "./store.js";
+import { compareAndSwapCronJobRunningAtMs, ensureLoaded, persist } from "./store.js";
 import {
   resolveMainSessionCronRunSessionKey,
   tryCreateCronTaskRun,
@@ -1200,14 +1200,20 @@ async function persistClaimedCronRunStart(
     if (job?.state.runningAtMs !== params.reservedAtMs) {
       return false;
     }
-    if (params.reservedAtMs === params.startedAt) {
-      return true;
-    }
     // Task maintenance recovers interrupted cron task rows by matching the run
     // id timestamp to this durable marker; persist the claimed start before
     // creating the task row so a later restart has one stable key.
+    const claimed = await compareAndSwapCronJobRunningAtMs({
+      storePath: state.deps.storePath,
+      jobId: params.jobId,
+      expectedMs: params.reservedAtMs,
+      nextMs: params.startedAt,
+    });
+    if (!claimed) {
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      return false;
+    }
     job.state.runningAtMs = params.startedAt;
-    await persist(state);
     return true;
   });
 }
@@ -1222,8 +1228,16 @@ async function releaseClaimedCronRunStart(
     if (job?.state.runningAtMs !== params.startedAt) {
       return;
     }
+    const released = await compareAndSwapCronJobRunningAtMs({
+      storePath: state.deps.storePath,
+      jobId: params.jobId,
+      expectedMs: params.startedAt,
+    });
+    if (!released) {
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      return;
+    }
     delete job.state.runningAtMs;
-    await persist(state);
   });
 }
 
@@ -1357,6 +1371,7 @@ export async function onTimer(state: CronServiceState) {
   armRunningRecheckTimer(state);
   try {
     const dueJobs = await locked(state, async () => {
+      const activeJobGeneration = getCronActiveJobGeneration();
       await ensureLoaded(state, { forceReload: true, skipRecompute: true });
       if (state.stopped || state.restartRecoveryPending) {
         state.deps.log.warn(
@@ -1400,6 +1415,7 @@ export async function onTimer(state: CronServiceState) {
         id: j.id,
         job: j,
         reservedAtMs: now,
+        activeJobGeneration,
       }));
     });
 
@@ -1408,8 +1424,9 @@ export async function onTimer(state: CronServiceState) {
       id: string;
       job: CronJob;
       reservedAtMs: number;
+      activeJobGeneration: number;
     }): Promise<TimedCronRunOutcome | undefined> => {
-      const { id, job, reservedAtMs } = params;
+      const { id, job, reservedAtMs, activeJobGeneration } = params;
       const startedAt = state.deps.nowMs();
       const activeJobMarker = markCronJobActive(job.id, {
         preserveAcrossGenerationAdvance: job.sessionTarget === "main",
@@ -1428,6 +1445,7 @@ export async function onTimer(state: CronServiceState) {
           stopAdmittingDueJobs ||
           state.stopped ||
           state.restartRecoveryPending ||
+          getCronActiveJobGeneration() !== activeJobGeneration ||
           !isCronActiveJobMarkerCurrent(activeJobMarker)
         ) {
           clearCronJobActive(job.id, activeJobMarker);
@@ -1937,7 +1955,7 @@ async function executeStartupCatchupPlan(
     ) {
       break;
     }
-    const outcome = await runStartupCatchupCandidate(state, candidate);
+    const outcome = await runStartupCatchupCandidate(state, candidate, plan.activeJobGeneration);
     if (outcome) {
       outcomes.push(outcome);
     }
@@ -1948,6 +1966,7 @@ async function executeStartupCatchupPlan(
 async function runStartupCatchupCandidate(
   state: CronServiceState,
   candidate: StartupCatchupCandidate,
+  activeJobGeneration: number,
 ): Promise<TimedCronRunOutcome | undefined> {
   const startedAt = state.deps.nowMs();
   const activeJobMarker = markCronJobActive(candidate.job.id, {
@@ -1964,6 +1983,7 @@ async function runStartupCatchupCandidate(
       !claimed ||
       state.stopped ||
       state.restartRecoveryPending ||
+      getCronActiveJobGeneration() !== activeJobGeneration ||
       !isCronActiveJobMarkerCurrent(activeJobMarker)
     ) {
       clearCronJobActive(candidate.job.id, activeJobMarker);
@@ -2067,7 +2087,10 @@ async function applyStartupCatchupOutcomes(
         outcomes,
       );
       const deferredJobs =
-        getCronActiveJobGeneration() === plan.activeJobGeneration ? plan.deferredJobs : [];
+        !state.restartRecoveryPending &&
+        getCronActiveJobGeneration() === plan.activeJobGeneration
+          ? plan.deferredJobs
+          : [];
       for (const result of finalizedOutcomes) {
         applyOutcomeToStoredJob(state, result);
       }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1191,21 +1191,22 @@ function finishRetiredCronTaskRuns(
 async function persistClaimedCronRunStart(
   state: CronServiceState,
   params: { jobId: string; reservedAtMs: number; startedAt: number },
-): Promise<void> {
-  if (params.reservedAtMs === params.startedAt) {
-    return;
-  }
-  await locked(state, async () => {
+): Promise<boolean> {
+  return await locked(state, async () => {
     await ensureLoaded(state, { forceReload: true, skipRecompute: true });
     const job = state.store?.jobs.find((entry) => entry.id === params.jobId);
     if (job?.state.runningAtMs !== params.reservedAtMs) {
-      return;
+      return false;
+    }
+    if (params.reservedAtMs === params.startedAt) {
+      return true;
     }
     // Task maintenance recovers interrupted cron task rows by matching the run
     // id timestamp to this durable marker; persist the claimed start before
     // creating the task row so a later restart has one stable key.
     job.state.runningAtMs = params.startedAt;
     await persist(state);
+    return true;
   });
 }
 
@@ -1415,15 +1416,22 @@ export async function onTimer(state: CronServiceState) {
       let taskRunId: string | undefined;
 
       try {
-        await persistClaimedCronRunStart(state, { jobId: id, reservedAtMs, startedAt });
+        const claimed = await persistClaimedCronRunStart(state, {
+          jobId: id,
+          reservedAtMs,
+          startedAt,
+        });
         if (
+          !claimed ||
           stopAdmittingDueJobs ||
           state.stopped ||
           state.restartRecoveryPending ||
           !isCronActiveJobMarkerCurrent(activeJobMarker)
         ) {
           clearCronJobActive(job.id, activeJobMarker);
-          await releaseClaimedCronRunStart(state, { jobId: id, startedAt });
+          if (claimed) {
+            await releaseClaimedCronRunStart(state, { jobId: id, startedAt });
+          }
           return undefined;
         }
         job.state.runningAtMs = startedAt;
@@ -1939,18 +1947,21 @@ async function runStartupCatchupCandidate(
   });
   let taskRunId: string | undefined;
   try {
-    await persistClaimedCronRunStart(state, {
+    const claimed = await persistClaimedCronRunStart(state, {
       jobId: candidate.jobId,
       reservedAtMs: candidate.reservedAtMs,
       startedAt,
     });
     if (
+      !claimed ||
       state.stopped ||
       state.restartRecoveryPending ||
       !isCronActiveJobMarkerCurrent(activeJobMarker)
     ) {
       clearCronJobActive(candidate.job.id, activeJobMarker);
-      await releaseClaimedCronRunStart(state, { jobId: candidate.jobId, startedAt });
+      if (claimed) {
+        await releaseClaimedCronRunStart(state, { jobId: candidate.jobId, startedAt });
+      }
       return undefined;
     }
     candidate.job.state.runningAtMs = startedAt;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -24,6 +24,7 @@ import { deliveryContextFromSession } from "../../utils/delivery-context.shared.
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import {
   clearCronJobActive,
+  getCronActiveJobGeneration,
   isCronActiveJobMarkerCurrent,
   markCronJobActive,
   type CronActiveJobMarker,
@@ -158,6 +159,7 @@ type StartupDeferredJob = {
 };
 
 type StartupCatchupPlan = {
+  activeJobGeneration: number;
   candidates: StartupCatchupCandidate[];
   deferredJobs: StartupDeferredJob[];
 };
@@ -1835,9 +1837,10 @@ async function planStartupCatchup(
     state.deps.maxMissedJobsPerRestart ?? DEFAULT_MAX_MISSED_JOBS_PER_RESTART,
   );
   return locked(state, async () => {
+    const activeJobGeneration = getCronActiveJobGeneration();
     await ensureLoaded(state, { skipRecompute: true });
     if (state.stopped || !state.store) {
-      return { candidates: [], deferredJobs: [] };
+      return { activeJobGeneration, candidates: [], deferredJobs: [] };
     }
 
     const now = state.deps.nowMs();
@@ -1853,7 +1856,7 @@ async function planStartupCatchup(
       if (deferredBackoffMissedSlot) {
         await persist(state);
       }
-      return { candidates: [], deferredJobs: [] };
+      return { activeJobGeneration, candidates: [], deferredJobs: [] };
     }
     const sorted = missed.toSorted(
       (a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0),
@@ -1910,6 +1913,7 @@ async function planStartupCatchup(
     await persist(state);
 
     return {
+      activeJobGeneration,
       candidates: startupCandidates.map((job) => ({
         jobId: job.id,
         job,
@@ -1926,7 +1930,11 @@ async function executeStartupCatchupPlan(
 ): Promise<TimedCronRunOutcome[]> {
   const outcomes: TimedCronRunOutcome[] = [];
   for (const candidate of plan.candidates) {
-    if (state.stopped) {
+    if (
+      state.stopped ||
+      state.restartRecoveryPending ||
+      getCronActiveJobGeneration() !== plan.activeJobGeneration
+    ) {
       break;
     }
     const outcome = await runStartupCatchupCandidate(state, candidate);
@@ -2058,10 +2066,12 @@ async function applyStartupCatchupOutcomes(
         plan,
         outcomes,
       );
+      const deferredJobs =
+        getCronActiveJobGeneration() === plan.activeJobGeneration ? plan.deferredJobs : [];
       for (const result of finalizedOutcomes) {
         applyOutcomeToStoredJob(state, result);
       }
-      if (finalizedOutcomes.length === 0 && plan.deferredJobs.length === 0) {
+      if (finalizedOutcomes.length === 0 && deferredJobs.length === 0) {
         if (releasedReservations) {
           recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
           await persist(state);
@@ -2069,10 +2079,10 @@ async function applyStartupCatchupOutcomes(
         return;
       }
 
-      if (plan.deferredJobs.length > 0) {
+      if (deferredJobs.length > 0) {
         const baseNow = state.deps.nowMs();
         let offset = staggerMs;
-        for (const deferred of plan.deferredJobs) {
+        for (const deferred of deferredJobs) {
           const jobId = deferred.jobId;
           const job = state.store.jobs.find((entry) => entry.id === jobId);
           if (!job || !isJobEnabled(job)) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1188,6 +1188,42 @@ function finishRetiredCronTaskRuns(
   }
 }
 
+async function persistClaimedCronRunStart(
+  state: CronServiceState,
+  params: { jobId: string; reservedAtMs: number; startedAt: number },
+): Promise<void> {
+  if (params.reservedAtMs === params.startedAt) {
+    return;
+  }
+  await locked(state, async () => {
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+    const job = state.store?.jobs.find((entry) => entry.id === params.jobId);
+    if (job?.state.runningAtMs !== params.reservedAtMs) {
+      return;
+    }
+    // Task maintenance recovers interrupted cron task rows by matching the run
+    // id timestamp to this durable marker; persist the claimed start before
+    // creating the task row so a later restart has one stable key.
+    job.state.runningAtMs = params.startedAt;
+    await persist(state);
+  });
+}
+
+async function releaseClaimedCronRunStart(
+  state: CronServiceState,
+  params: { jobId: string; startedAt: number },
+): Promise<void> {
+  await locked(state, async () => {
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+    const job = state.store?.jobs.find((entry) => entry.id === params.jobId);
+    if (job?.state.runningAtMs !== params.startedAt) {
+      return;
+    }
+    delete job.state.runningAtMs;
+    await persist(state);
+  });
+}
+
 function releaseUnstartedStartupCatchupReservations(
   state: CronServiceState,
   plan: StartupCatchupPlan,
@@ -1364,23 +1400,36 @@ export async function onTimer(state: CronServiceState) {
       }));
     });
 
+    let stopAdmittingDueJobs = false;
     const runDueJob = async (params: {
       id: string;
       job: CronJob;
       reservedAtMs: number;
-    }): Promise<TimedCronRunOutcome> => {
-      const { id, job } = params;
+    }): Promise<TimedCronRunOutcome | undefined> => {
+      const { id, job, reservedAtMs } = params;
       const startedAt = state.deps.nowMs();
-      job.state.runningAtMs = startedAt;
-      job.state.lastError = undefined;
       const activeJobMarker = markCronJobActive(job.id, {
         preserveAcrossGenerationAdvance: job.sessionTarget === "main",
       });
-      emit(state, { jobId: job.id, action: "started", job, runAtMs: startedAt });
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);
-      const taskRunId = tryCreateCronTaskRun({ state, job, startedAt });
+      let taskRunId: string | undefined;
 
       try {
+        await persistClaimedCronRunStart(state, { jobId: id, reservedAtMs, startedAt });
+        if (
+          stopAdmittingDueJobs ||
+          state.stopped ||
+          state.restartRecoveryPending ||
+          !isCronActiveJobMarkerCurrent(activeJobMarker)
+        ) {
+          clearCronJobActive(job.id, activeJobMarker);
+          await releaseClaimedCronRunStart(state, { jobId: id, startedAt });
+          return undefined;
+        }
+        job.state.runningAtMs = startedAt;
+        job.state.lastError = undefined;
+        emit(state, { jobId: job.id, action: "started", job, runAtMs: startedAt });
+        taskRunId = tryCreateCronTaskRun({ state, job, startedAt });
         const result = await executeJobCoreWithTimeout(state, job, {
           runId: taskRunId,
           activeJobMarker,
@@ -1464,7 +1513,6 @@ export async function onTimer(state: CronServiceState) {
     const claimedIndexes = new Set<number>();
     let reservationReleaseError: unknown;
     let setupTimeoutNotified = false;
-    let stopAdmittingDueJobs = false;
     const hasSetupTimeoutRecoveryHandler = state.deps.onIsolatedAgentSetupTimeout !== undefined;
     const releaseUnclaimedDueJobReservations = async () => {
       if (claimedIndexes.size >= dueJobs.length) {
@@ -1506,6 +1554,10 @@ export async function onTimer(state: CronServiceState) {
         }
         claimedIndexes.add(index);
         const result = await runDueJob(due);
+        if (!result) {
+          stopAdmittingDueJobs = true;
+          continue;
+        }
         if (result.isolatedAgentSetupTimeout) {
           let finalizedResults: TimedCronRunOutcome[];
           try {
@@ -1869,7 +1921,10 @@ async function executeStartupCatchupPlan(
     if (state.stopped) {
       break;
     }
-    outcomes.push(await runStartupCatchupCandidate(state, candidate));
+    const outcome = await runStartupCatchupCandidate(state, candidate);
+    if (outcome) {
+      outcomes.push(outcome);
+    }
   }
   return outcomes;
 }
@@ -1877,23 +1932,40 @@ async function executeStartupCatchupPlan(
 async function runStartupCatchupCandidate(
   state: CronServiceState,
   candidate: StartupCatchupCandidate,
-): Promise<TimedCronRunOutcome> {
+): Promise<TimedCronRunOutcome | undefined> {
   const startedAt = state.deps.nowMs();
-  const taskRunId = tryCreateCronTaskRun({
-    state,
-    job: candidate.job,
-    startedAt,
-  });
   const activeJobMarker = markCronJobActive(candidate.job.id, {
     preserveAcrossGenerationAdvance: candidate.job.sessionTarget === "main",
   });
-  emit(state, {
-    jobId: candidate.job.id,
-    action: "started",
-    job: candidate.job,
-    runAtMs: startedAt,
-  });
+  let taskRunId: string | undefined;
   try {
+    await persistClaimedCronRunStart(state, {
+      jobId: candidate.jobId,
+      reservedAtMs: candidate.reservedAtMs,
+      startedAt,
+    });
+    if (
+      state.stopped ||
+      state.restartRecoveryPending ||
+      !isCronActiveJobMarkerCurrent(activeJobMarker)
+    ) {
+      clearCronJobActive(candidate.job.id, activeJobMarker);
+      await releaseClaimedCronRunStart(state, { jobId: candidate.jobId, startedAt });
+      return undefined;
+    }
+    candidate.job.state.runningAtMs = startedAt;
+    candidate.job.state.lastError = undefined;
+    taskRunId = tryCreateCronTaskRun({
+      state,
+      job: candidate.job,
+      startedAt,
+    });
+    emit(state, {
+      jobId: candidate.job.id,
+      action: "started",
+      job: candidate.job,
+      runAtMs: startedAt,
+    });
     const result = await executeJobCoreWithTimeout(state, candidate.job, {
       runId: taskRunId,
       activeJobMarker,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1193,13 +1193,8 @@ function finishRetiredCronTaskRuns(
 async function persistClaimedCronRunStart(
   state: CronServiceState,
   params: { jobId: string; reservedAtMs: number; startedAt: number },
-): Promise<boolean> {
+): Promise<CronJob | undefined> {
   return await locked(state, async () => {
-    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
-    const job = state.store?.jobs.find((entry) => entry.id === params.jobId);
-    if (job?.state.runningAtMs !== params.reservedAtMs) {
-      return false;
-    }
     // Task maintenance recovers interrupted cron task rows by matching the run
     // id timestamp to this durable marker; persist the claimed start before
     // creating the task row so a later restart has one stable key.
@@ -1211,10 +1206,13 @@ async function persistClaimedCronRunStart(
     });
     if (!claimed) {
       await ensureLoaded(state, { forceReload: true, skipRecompute: true });
-      return false;
+      return undefined;
     }
-    job.state.runningAtMs = params.startedAt;
-    return true;
+    // Reload after the CAS so execution uses config and delivery writebacks
+    // ordered before the durable claim, not the stale reservation-plan object.
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+    const job = state.store?.jobs.find((entry) => entry.id === params.jobId);
+    return job?.state.runningAtMs === params.startedAt ? job : undefined;
   });
 }
 
@@ -1426,22 +1424,28 @@ export async function onTimer(state: CronServiceState) {
       reservedAtMs: number;
       activeJobGeneration: number;
     }): Promise<TimedCronRunOutcome | undefined> => {
-      const { id, job, reservedAtMs, activeJobGeneration } = params;
+      const { id, job: plannedJob, reservedAtMs, activeJobGeneration } = params;
       const startedAt = state.deps.nowMs();
-      const activeJobMarker = markCronJobActive(job.id, {
-        preserveAcrossGenerationAdvance: job.sessionTarget === "main",
-      });
-      const jobTimeoutMs = resolveCronJobTimeoutMs(job);
+      let job = plannedJob;
+      let activeJobMarker: CronActiveJobMarker | undefined;
+      let jobTimeoutMs = resolveCronJobTimeoutMs(job);
       let taskRunId: string | undefined;
 
       try {
-        const claimed = await persistClaimedCronRunStart(state, {
+        const claimedJob = await persistClaimedCronRunStart(state, {
           jobId: id,
           reservedAtMs,
           startedAt,
         });
+        if (!claimedJob) {
+          return undefined;
+        }
+        job = claimedJob;
+        jobTimeoutMs = resolveCronJobTimeoutMs(job);
+        activeJobMarker = markCronJobActive(job.id, {
+          preserveAcrossGenerationAdvance: job.sessionTarget === "main",
+        });
         if (
-          !claimed ||
           stopAdmittingDueJobs ||
           state.stopped ||
           state.restartRecoveryPending ||
@@ -1449,9 +1453,7 @@ export async function onTimer(state: CronServiceState) {
           !isCronActiveJobMarkerCurrent(activeJobMarker)
         ) {
           clearCronJobActive(job.id, activeJobMarker);
-          if (claimed) {
-            await releaseClaimedCronRunStart(state, { jobId: id, startedAt });
-          }
+          await releaseClaimedCronRunStart(state, { jobId: id, startedAt });
           return undefined;
         }
         job.state.runningAtMs = startedAt;
@@ -1969,49 +1971,52 @@ async function runStartupCatchupCandidate(
   activeJobGeneration: number,
 ): Promise<TimedCronRunOutcome | undefined> {
   const startedAt = state.deps.nowMs();
-  const activeJobMarker = markCronJobActive(candidate.job.id, {
-    preserveAcrossGenerationAdvance: candidate.job.sessionTarget === "main",
-  });
+  let job = candidate.job;
+  let activeJobMarker: CronActiveJobMarker | undefined;
   let taskRunId: string | undefined;
   try {
-    const claimed = await persistClaimedCronRunStart(state, {
+    const claimedJob = await persistClaimedCronRunStart(state, {
       jobId: candidate.jobId,
       reservedAtMs: candidate.reservedAtMs,
       startedAt,
     });
+    if (!claimedJob) {
+      return undefined;
+    }
+    job = claimedJob;
+    activeJobMarker = markCronJobActive(job.id, {
+      preserveAcrossGenerationAdvance: job.sessionTarget === "main",
+    });
     if (
-      !claimed ||
       state.stopped ||
       state.restartRecoveryPending ||
       getCronActiveJobGeneration() !== activeJobGeneration ||
       !isCronActiveJobMarkerCurrent(activeJobMarker)
     ) {
-      clearCronJobActive(candidate.job.id, activeJobMarker);
-      if (claimed) {
-        await releaseClaimedCronRunStart(state, { jobId: candidate.jobId, startedAt });
-      }
+      clearCronJobActive(job.id, activeJobMarker);
+      await releaseClaimedCronRunStart(state, { jobId: candidate.jobId, startedAt });
       return undefined;
     }
-    candidate.job.state.runningAtMs = startedAt;
-    candidate.job.state.lastError = undefined;
+    job.state.runningAtMs = startedAt;
+    job.state.lastError = undefined;
     taskRunId = tryCreateCronTaskRun({
       state,
-      job: candidate.job,
+      job,
       startedAt,
     });
     emit(state, {
-      jobId: candidate.job.id,
+      jobId: job.id,
       action: "started",
-      job: candidate.job,
+      job,
       runAtMs: startedAt,
     });
-    const result = await executeJobCoreWithTimeout(state, candidate.job, {
+    const result = await executeJobCoreWithTimeout(state, job, {
       runId: taskRunId,
       activeJobMarker,
     });
     return {
       jobId: candidate.jobId,
-      job: candidate.job,
+      job,
       taskRunId,
       activeJobMarker,
       status: result.status,
@@ -2034,7 +2039,7 @@ async function runStartupCatchupCandidate(
   } catch (err) {
     return {
       jobId: candidate.jobId,
-      job: candidate.job,
+      job,
       taskRunId,
       activeJobMarker,
       status: "error",
@@ -2087,8 +2092,7 @@ async function applyStartupCatchupOutcomes(
         outcomes,
       );
       const deferredJobs =
-        !state.restartRecoveryPending &&
-        getCronActiveJobGeneration() === plan.activeJobGeneration
+        !state.restartRecoveryPending && getCronActiveJobGeneration() === plan.activeJobGeneration
           ? plan.deferredJobs
           : [];
       for (const result of finalizedOutcomes) {

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -10,6 +10,7 @@ import {
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
+  compareAndSwapCronJobRunningAtMs,
   loadCronJobsStoreWithConfigJobs,
   loadCronJobsStoreSync,
   loadCronQuarantineFile,
@@ -18,6 +19,7 @@ import {
   resolveCronStorePath,
   saveCronQuarantineFile,
   saveCronStore,
+  updateCronJobDeliveryTargets,
 } from "./store.js";
 import type { CronStoreFile } from "./types.js";
 
@@ -505,6 +507,69 @@ describe("cron store", () => {
     expect(loaded.jobs.map((job) => job.id)).toEqual(["job-state-only", "job-added-concurrently"]);
     expect(loaded.jobs[0]?.name).toBe("Job current");
     expect(loaded.jobs[0]?.state.nextRunAtMs).toBe(stale.jobs[0].createdAtMs + 60_000);
+  });
+
+  it("atomically updates one run marker without replacing concurrent config or state", async () => {
+    const store = await makeStorePath();
+    const initial = makeStore("job-run-marker-cas", true);
+    initial.jobs[0].state = {
+      nextRunAtMs: initial.jobs[0].createdAtMs + 60_000,
+      runningAtMs: 100,
+    };
+    initial.jobs[0].delivery = {
+      mode: "announce",
+      channel: "telegram",
+      to: "@legacy-target",
+    };
+    await saveCronStore(store.storePath, initial);
+
+    const concurrent = await loadCronStore(store.storePath);
+    const staleTarget = concurrent.jobs[0].delivery?.to;
+    concurrent.jobs[0].name = "Concurrent config";
+    concurrent.jobs[0].state.lastError = "concurrent runtime state";
+    await saveCronStore(store.storePath, concurrent);
+
+    await expect(
+      compareAndSwapCronJobRunningAtMs({
+        storePath: store.storePath,
+        jobId: initial.jobs[0].id,
+        expectedMs: 100,
+        nextMs: 200,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      updateCronJobDeliveryTargets(store.storePath, (delivery) =>
+        delivery.to === staleTarget ? "-100123456" : undefined,
+      ),
+    ).resolves.toEqual({ updatedJobs: 1 });
+
+    let loaded = await loadCronStore(store.storePath);
+    expect(loaded.jobs[0]?.name).toBe("Concurrent config");
+    expect(loaded.jobs[0]?.state.lastError).toBe("concurrent runtime state");
+    expect(loaded.jobs[0]?.state.nextRunAtMs).toBe(initial.jobs[0].createdAtMs + 60_000);
+    expect(loaded.jobs[0]?.state.runningAtMs).toBe(200);
+    expect(loaded.jobs[0]?.delivery?.to).toBe("-100123456");
+
+    await expect(
+      compareAndSwapCronJobRunningAtMs({
+        storePath: store.storePath,
+        jobId: initial.jobs[0].id,
+        expectedMs: 100,
+        nextMs: 300,
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      compareAndSwapCronJobRunningAtMs({
+        storePath: store.storePath,
+        jobId: initial.jobs[0].id,
+        expectedMs: 200,
+      }),
+    ).resolves.toBe(true);
+
+    loaded = await loadCronStore(store.storePath);
+    expect(loaded.jobs[0]?.state.runningAtMs).toBeUndefined();
+    expect(loaded.jobs[0]?.state.lastError).toBe("concurrent runtime state");
+    expect(loaded.jobs[0]?.delivery?.to).toBe("-100123456");
   });
 
   it("round-trips agent-turn external content provenance through SQLite", async () => {

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -18,6 +18,7 @@ import {
   resolveCronQuarantinePath,
   resolveCronStorePath,
   saveCronQuarantineFile,
+  saveCronJobsStore,
   saveCronStore,
   updateCronJobDeliveryTargets,
 } from "./store.js";
@@ -570,6 +571,51 @@ describe("cron store", () => {
     expect(loaded.jobs[0]?.state.runningAtMs).toBeUndefined();
     expect(loaded.jobs[0]?.state.lastError).toBe("concurrent runtime state");
     expect(loaded.jobs[0]?.delivery?.to).toBe("-100123456");
+  });
+
+  it("does not merge a concurrent target across delivery route changes", async () => {
+    const store = await makeStorePath();
+    const base = makeStore("job-route-conflict", true);
+    base.jobs[0].delivery = {
+      mode: "announce",
+      channel: "telegram",
+      to: "@legacy-target",
+    };
+    await saveCronStore(store.storePath, base);
+
+    const concurrentRoute = structuredClone(base);
+    concurrentRoute.jobs[0].delivery = {
+      mode: "announce",
+      channel: "slack",
+      to: "C123",
+    };
+    await saveCronStore(store.storePath, concurrentRoute);
+
+    const unrelatedUpdate = structuredClone(base);
+    unrelatedUpdate.jobs[0].name = "Unrelated update";
+    let persisted = await saveCronJobsStore(store.storePath, unrelatedUpdate, {
+      baseStore: base,
+    });
+    expect(persisted.jobs[0]?.delivery).toMatchObject({
+      channel: "telegram",
+      to: "@legacy-target",
+    });
+
+    await saveCronStore(store.storePath, base);
+    await updateCronJobDeliveryTargets(store.storePath, () => "-100123456");
+    const desiredRoute = structuredClone(base);
+    if (!desiredRoute.jobs[0].delivery) {
+      throw new Error("expected delivery");
+    }
+    desiredRoute.jobs[0].delivery.channel = "slack";
+    persisted = await saveCronJobsStore(store.storePath, desiredRoute, { baseStore: base });
+    expect(persisted.jobs[0]?.delivery).toMatchObject({
+      channel: "slack",
+      to: "@legacy-target",
+    });
+    expect((await loadCronStore(store.storePath)).jobs[0]?.delivery).toEqual(
+      persisted.jobs[0]?.delivery,
+    );
   });
 
   it("round-trips agent-turn external content provenance through SQLite", async () => {

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -37,6 +37,16 @@ export type {
 } from "./store/types.js";
 import type { CronDelivery, CronStoreFile } from "./types.js";
 
+const cronStoreMutationRevisionByStoreKey = new Map<string, number>();
+const stateDatabaseConnectionIds = new WeakMap<DatabaseSync, number>();
+let nextStateDatabaseConnectionId = 1;
+
+function advanceCronStoreMutationRevision(storeKey: string): number {
+  const nextRevision = (cronStoreMutationRevisionByStoreKey.get(storeKey) ?? 0) + 1;
+  cronStoreMutationRevisionByStoreKey.set(storeKey, nextRevision);
+  return nextRevision;
+}
+
 function resolveDefaultCronDir(): string {
   return path.join(resolveConfigDir(), "cron");
 }
@@ -65,8 +75,8 @@ export function resolveCronJobsStorePath(storePath?: string) {
   return resolveDefaultCronStorePath();
 }
 
-/** Loads cron jobs plus config/runtime sidecars from the SQLite-backed store. */
-export async function loadCronJobsStoreWithConfigJobs(storePath: string): Promise<LoadedCronStore> {
+/** Synchronously loads cron jobs plus config/runtime sidecars from SQLite. */
+export function loadCronJobsStoreWithConfigJobsSync(storePath: string): LoadedCronStore {
   const resolvedStorePath = path.resolve(storePath);
   const storeKey = cronStoreKey(resolvedStorePath);
   const database = openOpenClawStateDatabase().db;
@@ -81,6 +91,11 @@ export async function loadCronJobsStoreWithConfigJobs(storePath: string): Promis
     configJobRuntimeEntries: [],
     invalidConfigRows: [],
   };
+}
+
+/** Loads cron jobs plus config/runtime sidecars from the SQLite-backed store. */
+export async function loadCronJobsStoreWithConfigJobs(storePath: string): Promise<LoadedCronStore> {
+  return loadCronJobsStoreWithConfigJobsSync(storePath);
 }
 
 function emptyLoadedCronStore(): LoadedCronStore {
@@ -150,7 +165,36 @@ type SaveCronStoreOptions = {
 
 type SaveCronJobsStoreOptions = SaveCronStoreOptions & {
   baseStore?: CronStoreFile | null;
+  deliveryTargetWriteJobIds?: ReadonlySet<string>;
 };
+
+/** Returns a process and SQLite revision token for cache invalidation. */
+export function getCronJobStoreRevision(storePath: string): string {
+  const storeKey = cronStoreKey(path.resolve(storePath));
+  const database = openOpenClawStateDatabase();
+  let connectionId = stateDatabaseConnectionIds.get(database.db);
+  if (connectionId === undefined) {
+    connectionId = nextStateDatabaseConnectionId++;
+    stateDatabaseConnectionIds.set(database.db, connectionId);
+  }
+  const row = database.db.prepare("PRAGMA data_version").get() as
+    | { data_version?: number | bigint }
+    | undefined;
+  return `${connectionId}:${Number(row?.data_version ?? 0)}:${cronStoreMutationRevisionByStoreKey.get(storeKey) ?? 0}`;
+}
+
+/** Advances an observed token through this process's own completed write only. */
+export function getCronJobStoreRevisionAfterOwnWrite(
+  storePath: string,
+  observedRevision: string,
+): string {
+  const storeKey = cronStoreKey(path.resolve(storePath));
+  const separatorIndex = observedRevision.lastIndexOf(":");
+  if (separatorIndex < 0) {
+    throw new Error("Invalid cron store revision token");
+  }
+  return `${observedRevision.slice(0, separatorIndex + 1)}${cronStoreMutationRevisionByStoreKey.get(storeKey) ?? 0}`;
+}
 
 async function atomicWrite(filePath: string, content: string, dirMode = 0o700): Promise<void> {
   await replaceFileAtomic({
@@ -164,8 +208,8 @@ async function atomicWrite(filePath: string, content: string, dirMode = 0o700): 
   });
 }
 
-/** Persists cron jobs, or only mutable runtime state when stateOnly is set. */
-export async function saveCronJobsStore(
+/** Synchronously persists cron jobs, or only runtime state when requested. */
+export function saveCronJobsStoreSync(
   storePath: string,
   store: CronStoreFile,
   opts?: SaveCronJobsStoreOptions,
@@ -178,12 +222,30 @@ export async function saveCronJobsStore(
     runOpenClawStateWriteTransaction(({ db }) => {
       updateCronRuntimeRows(db, storeKey, store);
     });
-    return;
+    advanceCronStoreMutationRevision(storeKey);
+    return store;
   }
   assertCronStoreCanPersist(store);
-  runOpenClawStateWriteTransaction(({ db }) => {
-    replaceCronRows(db, storeKey, store, opts?.baseStore ?? undefined);
-  });
+  const persistedStore = runOpenClawStateWriteTransaction(({ db }) =>
+    replaceCronRows(
+      db,
+      storeKey,
+      store,
+      opts?.baseStore ?? undefined,
+      opts?.deliveryTargetWriteJobIds,
+    ),
+  );
+  advanceCronStoreMutationRevision(storeKey);
+  return persistedStore;
+}
+
+/** Persists cron jobs, or only mutable runtime state when stateOnly is set. */
+export async function saveCronJobsStore(
+  storePath: string,
+  store: CronStoreFile,
+  opts?: SaveCronJobsStoreOptions,
+) {
+  return saveCronJobsStoreSync(storePath, store, opts);
 }
 
 /** Atomically replaces one persisted cron run marker when the expected owner still holds it. */
@@ -194,9 +256,13 @@ export async function compareAndSwapCronJobRunningAtMs(params: {
   nextMs?: number;
 }): Promise<boolean> {
   const storeKey = cronStoreKey(path.resolve(params.storePath));
-  return runOpenClawStateWriteTransaction(({ db }) =>
+  const swapped = runOpenClawStateWriteTransaction(({ db }) =>
     compareAndSwapCronJobRunningAtMsRow(db, storeKey, params),
   );
+  if (swapped) {
+    advanceCronStoreMutationRevision(storeKey);
+  }
+  return swapped;
 }
 
 /** Transactionally rewrites matching delivery targets without touching cron runtime state. */
@@ -208,6 +274,9 @@ export async function updateCronJobDeliveryTargets(
   const updatedJobs = runOpenClawStateWriteTransaction(({ db }) =>
     updateCronJobDeliveryTargetsRow(db, storeKey, updateTarget),
   );
+  if (updatedJobs > 0) {
+    advanceCronStoreMutationRevision(storeKey);
+  }
   return { updatedJobs };
 }
 
@@ -220,13 +289,17 @@ export async function saveCronJobsStoreWithMetadata(
   const resolvedStorePath = path.resolve(storePath);
   const storeKey = cronStoreKey(resolvedStorePath);
   assertCronStoreCanPersist(store);
-  return runOpenClawStateWriteTransaction(({ db }) => {
+  const saved = runOpenClawStateWriteTransaction(({ db }) => {
     if (!acquireMetadata(db)) {
       return false;
     }
     replaceCronRows(db, storeKey, store);
     return true;
   });
+  if (saved) {
+    advanceCronStoreMutationRevision(storeKey);
+  }
+  return saved;
 }
 
 // Public plugin SDK seam; core callers use the SQLite-backed cron-jobs names above.

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -17,9 +17,11 @@ import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { cronStoreKey } from "./store/key.js";
 import {
   assertCronStoreCanPersist,
+  compareAndSwapCronJobRunningAtMs as compareAndSwapCronJobRunningAtMsRow,
   loadedCronStoreFromRows,
   loadCronRows,
   replaceCronRows,
+  updateCronJobDeliveryTargets as updateCronJobDeliveryTargetsRow,
   updateCronRuntimeRows,
 } from "./store/row-codec.js";
 import type {
@@ -33,7 +35,7 @@ export type {
   LoadedCronStore,
   QuarantinedCronConfigJob,
 } from "./store/types.js";
-import type { CronStoreFile } from "./types.js";
+import type { CronDelivery, CronStoreFile } from "./types.js";
 
 function resolveDefaultCronDir(): string {
   return path.join(resolveConfigDir(), "cron");
@@ -146,6 +148,10 @@ type SaveCronStoreOptions = {
   stateOnly?: boolean;
 };
 
+type SaveCronJobsStoreOptions = SaveCronStoreOptions & {
+  baseStore?: CronStoreFile | null;
+};
+
 async function atomicWrite(filePath: string, content: string, dirMode = 0o700): Promise<void> {
   await replaceFileAtomic({
     filePath,
@@ -162,7 +168,7 @@ async function atomicWrite(filePath: string, content: string, dirMode = 0o700): 
 export async function saveCronJobsStore(
   storePath: string,
   store: CronStoreFile,
-  opts?: SaveCronStoreOptions,
+  opts?: SaveCronJobsStoreOptions,
 ) {
   const resolvedStorePath = path.resolve(storePath);
   const storeKey = cronStoreKey(resolvedStorePath);
@@ -176,8 +182,33 @@ export async function saveCronJobsStore(
   }
   assertCronStoreCanPersist(store);
   runOpenClawStateWriteTransaction(({ db }) => {
-    replaceCronRows(db, storeKey, store);
+    replaceCronRows(db, storeKey, store, opts?.baseStore ?? undefined);
   });
+}
+
+/** Atomically replaces one persisted cron run marker when the expected owner still holds it. */
+export async function compareAndSwapCronJobRunningAtMs(params: {
+  storePath: string;
+  jobId: string;
+  expectedMs: number;
+  nextMs?: number;
+}): Promise<boolean> {
+  const storeKey = cronStoreKey(path.resolve(params.storePath));
+  return runOpenClawStateWriteTransaction(({ db }) =>
+    compareAndSwapCronJobRunningAtMsRow(db, storeKey, params),
+  );
+}
+
+/** Transactionally rewrites matching delivery targets without touching cron runtime state. */
+export async function updateCronJobDeliveryTargets(
+  storePath: string,
+  updateTarget: (delivery: CronDelivery, jobId: string) => string | undefined,
+): Promise<{ updatedJobs: number }> {
+  const storeKey = cronStoreKey(path.resolve(storePath));
+  const updatedJobs = runOpenClawStateWriteTransaction(({ db }) =>
+    updateCronJobDeliveryTargetsRow(db, storeKey, updateTarget),
+  );
+  return { updatedJobs };
 }
 
 /** Atomically acquire doctor migration metadata and replace cron rows only for the winner. */

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -301,6 +301,7 @@ function mergeConcurrentDeliveryTargets(params: {
   store: CronStoreFile;
   baseStore?: CronStoreFile;
   currentRows: CronJobRow[];
+  deliveryTargetWriteJobIds?: ReadonlySet<string>;
 }): CronStoreFile {
   if (!params.baseStore) {
     return params.store;
@@ -313,15 +314,23 @@ function mergeConcurrentDeliveryTargets(params: {
       currentJobsById.set(job.id, job);
     }
   }
+  const hasSameTargetRoute = (left: CronDelivery, right: CronDelivery) =>
+    left.mode === right.mode &&
+    left.channel === right.channel &&
+    left.accountId === right.accountId &&
+    left.threadId === right.threadId;
   return {
     ...params.store,
     jobs: params.store.jobs.map((job) => {
       const baseJob = baseJobsById.get(job.id);
       const currentJob = currentJobsById.get(job.id);
       if (
+        params.deliveryTargetWriteJobIds?.has(job.id) ||
         !baseJob?.delivery ||
         !job.delivery ||
         !currentJob?.delivery ||
+        !hasSameTargetRoute(baseJob.delivery, job.delivery) ||
+        !hasSameTargetRoute(baseJob.delivery, currentJob.delivery) ||
         job.delivery.to !== baseJob.delivery.to ||
         currentJob.delivery.to === job.delivery.to
       ) {
@@ -344,11 +353,13 @@ export function replaceCronRows(
   storeKey: string,
   store: CronStoreFile,
   baseStore?: CronStoreFile,
-): void {
+  deliveryTargetWriteJobIds?: ReadonlySet<string>,
+): CronStoreFile {
   const mergedStore = mergeConcurrentDeliveryTargets({
     store,
     baseStore,
     currentRows: baseStore ? loadCronRows(db, storeKey) : [],
+    deliveryTargetWriteJobIds,
   });
   executeSqliteQuerySync(
     db,
@@ -366,6 +377,7 @@ export function replaceCronRows(
         .values(bindCronJobRow(storeKey, normalized, index)),
     );
   }
+  return mergedStore;
 }
 
 /** Updates only mutable runtime columns without rewriting full job config JSON. */

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -6,7 +6,7 @@ import { normalizeCronJobIdentityFields } from "../normalize-job-identity.js";
 import { normalizeCronJobInput } from "../normalize.js";
 import { getInvalidPersistedCronJobReason } from "../persisted-shape.js";
 import { tryCronScheduleIdentity } from "../schedule-identity.js";
-import type { CronJob, CronJobState, CronSchedule, CronStoreFile } from "../types.js";
+import type { CronDelivery, CronJob, CronJobState, CronSchedule, CronStoreFile } from "../types.js";
 import { bindDeliveryColumns, deliveryFromRow } from "./delivery-codec.js";
 import { bindFailureAlertColumns, failureAlertFromRow } from "./failure-alert-codec.js";
 import { bindPayloadColumns, payloadFromRow } from "./payload-codec.js";
@@ -297,13 +297,64 @@ export function loadCronRows(db: DatabaseSync, storeKey: string): CronJobRow[] {
   ).rows;
 }
 
-/** Replaces all persisted cron rows for one store key from the config store snapshot. */
-export function replaceCronRows(db: DatabaseSync, storeKey: string, store: CronStoreFile): void {
+function mergeConcurrentDeliveryTargets(params: {
+  store: CronStoreFile;
+  baseStore?: CronStoreFile;
+  currentRows: CronJobRow[];
+}): CronStoreFile {
+  if (!params.baseStore) {
+    return params.store;
+  }
+  const baseJobsById = new Map(params.baseStore.jobs.map((job) => [job.id, job]));
+  const currentJobsById = new Map<string, CronJob>();
+  for (const row of params.currentRows) {
+    const job = rowToCronJob(row);
+    if (job) {
+      currentJobsById.set(job.id, job);
+    }
+  }
+  return {
+    ...params.store,
+    jobs: params.store.jobs.map((job) => {
+      const baseJob = baseJobsById.get(job.id);
+      const currentJob = currentJobsById.get(job.id);
+      if (
+        !baseJob?.delivery ||
+        !job.delivery ||
+        !currentJob?.delivery ||
+        job.delivery.to !== baseJob.delivery.to ||
+        currentJob.delivery.to === job.delivery.to
+      ) {
+        return job;
+      }
+      const mergedJob = structuredClone(job);
+      if (currentJob.delivery.to === undefined) {
+        delete mergedJob.delivery?.to;
+      } else if (mergedJob.delivery) {
+        mergedJob.delivery.to = currentJob.delivery.to;
+      }
+      return mergedJob;
+    }),
+  };
+}
+
+/** Replaces all persisted cron rows, preserving concurrent delivery-target writebacks. */
+export function replaceCronRows(
+  db: DatabaseSync,
+  storeKey: string,
+  store: CronStoreFile,
+  baseStore?: CronStoreFile,
+): void {
+  const mergedStore = mergeConcurrentDeliveryTargets({
+    store,
+    baseStore,
+    currentRows: baseStore ? loadCronRows(db, storeKey) : [],
+  });
   executeSqliteQuerySync(
     db,
     getCronStoreKysely(db).deleteFrom("cron_jobs").where("store_key", "=", storeKey),
   );
-  for (const [index, job] of store.jobs.entries()) {
+  for (const [index, job] of mergedStore.jobs.entries()) {
     const normalized = normalizeCronJobForSqlite(job);
     if (!normalized) {
       continue;
@@ -338,6 +389,88 @@ export function updateCronRuntimeRows(
         .where("job_id", "=", job.id),
     );
   }
+}
+
+/** Atomically updates one run marker without rewriting concurrent job state or config. */
+export function compareAndSwapCronJobRunningAtMs(
+  db: DatabaseSync,
+  storeKey: string,
+  params: { jobId: string; expectedMs: number; nextMs?: number },
+): boolean {
+  const row = executeSqliteQuerySync(
+    db,
+    getCronStoreKysely(db)
+      .selectFrom("cron_jobs")
+      .select(["running_at_ms", "state_json"])
+      .where("store_key", "=", storeKey)
+      .where("job_id", "=", params.jobId),
+  ).rows[0];
+  if (!row || normalizeNumber(row.running_at_ms) !== params.expectedMs) {
+    return false;
+  }
+  const state = parseJsonObject<CronJobState>(row.state_json, {});
+  if (params.nextMs === undefined) {
+    delete state.runningAtMs;
+  } else {
+    state.runningAtMs = params.nextMs;
+  }
+  const result = executeSqliteQuerySync(
+    db,
+    getCronStoreKysely(db)
+      .updateTable("cron_jobs")
+      .set({
+        running_at_ms: params.nextMs ?? null,
+        state_json: JSON.stringify(state),
+      })
+      .where("store_key", "=", storeKey)
+      .where("job_id", "=", params.jobId)
+      .where("running_at_ms", "=", params.expectedMs),
+  );
+  return result.numAffectedRows === 1n;
+}
+
+/** Updates only matching delivery targets while preserving every runtime-state column. */
+export function updateCronJobDeliveryTargets(
+  db: DatabaseSync,
+  storeKey: string,
+  updateTarget: (delivery: CronDelivery, jobId: string) => string | undefined,
+): number {
+  const rows = loadCronRows(db, storeKey);
+  let updatedJobs = 0;
+  for (const row of rows) {
+    const projectedJob = rowToCronJob(row);
+    const delivery = projectedJob?.delivery;
+    if (!projectedJob || !delivery) {
+      continue;
+    }
+    const nextTarget = updateTarget(structuredClone(delivery), row.job_id);
+    if (!nextTarget || nextTarget === delivery.to) {
+      continue;
+    }
+    const configJob = parseJsonObject<Record<string, unknown>>(
+      row.job_json,
+      stripJobRuntimeFields(projectedJob),
+    );
+    const configDelivery =
+      isRecord(configJob.delivery) && !Array.isArray(configJob.delivery)
+        ? { ...configJob.delivery }
+        : { ...delivery };
+    configDelivery.to = nextTarget;
+    configJob.delivery = configDelivery;
+    const result = executeSqliteQuerySync(
+      db,
+      getCronStoreKysely(db)
+        .updateTable("cron_jobs")
+        .set({
+          delivery_to: nextTarget,
+          job_json: JSON.stringify(configJob),
+        })
+        .where("store_key", "=", storeKey)
+        .where("job_id", "=", row.job_id),
+    );
+    updatedJobs += Number(result.numAffectedRows ?? 0);
+  }
+  return updatedJobs;
 }
 
 /** Reconstructs loaded cron store data and config-runtime sidecars from SQLite rows. */

--- a/src/plugin-sdk/cron-store-runtime.ts
+++ b/src/plugin-sdk/cron-store-runtime.ts
@@ -1,4 +1,9 @@
 /**
  * Runtime SDK subpath for reading and writing persisted cron state.
  */
-export { loadCronStore, resolveCronStorePath, saveCronStore } from "../cron/store.js";
+export {
+  loadCronStore,
+  resolveCronStorePath,
+  saveCronStore,
+  updateCronJobDeliveryTargets,
+} from "../cron/store.js";


### PR DESCRIPTION
Closes #96161

## What Problem This Solves

Fixes an issue where users or operators inspecting cron task runs after a gateway restart could see an interrupted cron task marked as `lost` instead of `failed` when the scheduler reservation timestamp differed from the actual task run start timestamp.

## Why This Change Was Made

Cron due-job and startup catch-up execution now persist the claimed run start timestamp before creating the task-ledger row, so restart task recovery uses the same timestamp as the cron task run id. If stop, restart recovery, or a newer cron generation wins during that short persistence window, the scheduler releases the claimed marker and does not emit a start event, create a task row, or start the job.

## User Impact

Interrupted cron task rows recover to the terminal cron result instead of being mislabeled `lost` after restart. Operators also avoid new cron runs being admitted while restart recovery is taking over.

## Evidence

AI assistance disclosure: This PR was prepared with Codex assistance; I reviewed the changes and validation.

Real behavior proof: In a local OpenClaw checkout, a runtime-level Node/TS proof command used a temporary redacted `OPENCLAW_STATE_DIR`, created a real SQLite-backed cron store, let the production cron timer path persist the due-job start marker and create the cron task row, simulated a gateway restart by clearing process-local cron/task mirrors while keeping the durable state, then ran production startup recovery and task-registry maintenance. This uses production cron/task registry modules; the isolated runner is held open only to simulate the interrupted run.

Redacted terminal output from the proof command:

```json
{
  "proof": "OpenClaw #96174 runtime restart recovery",
  "tempState": "<redacted temp OPENCLAW_STATE_DIR>",
  "beforeRestart": {
    "cronRunningAtMs": 1782269100137,
    "taskRunId": "cron:proof-cron-restart:1782269100137",
    "taskStatus": "running",
    "taskStartedAt": 1782269100137,
    "markerMatchesTaskStartedAt": true,
    "runIdMatchesMarker": true
  },
  "afterStartupRecovery": {
    "cronRunningAtMs": null,
    "cronLastRunAtMs": 1782269100137,
    "cronLastRunStatus": "error",
    "cronLastError": "cron: job interrupted by gateway restart",
    "taskStatusBeforeMaintenance": "running"
  },
  "afterTaskMaintenance": {
    "summary": {
      "reconciled": 0,
      "recovered": 1,
      "cleanupStamped": 0,
      "pruned": 0
    },
    "taskStatus": "failed",
    "taskError": "cron: job interrupted by gateway restart",
    "taskEndedAt": 1782269700137,
    "failedNotLost": true
  }
}
```

Focused validation commands:

- `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts` (73 tests passed)
- `node scripts/run-vitest.mjs src/tasks/task-registry.maintenance.issue-60299.test.ts` (19 tests passed)
- `pnpm exec oxfmt --check src/cron/service/timer.ts src/cron/service/timer.regression.test.ts`
- `node scripts/run-oxlint.mjs src/cron/service/timer.ts src/cron/service/timer.regression.test.ts`
- `git diff --check origin/main...HEAD`
- `pnpm tsgo:core:test`
- `codex review --base origin/main` (passed after addressing review findings)
