### PR TITLE
fix(memory-wiki): wiki_apply errors when another page has bad frontmatter

### DIFF
--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -430,4 +430,43 @@ describe("lintMemoryWikiVault", () => {
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("### Contradictions");
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("### Open Questions");
   });
+
+  it("reports unparsable frontmatter as a lint issue instead of failing the whole vault (#96125)", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-invalid-frontmatter-",
+    });
+    await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "broken.md"),
+      [
+        "---",
+        "pageType: synthesis",
+        "id: synthesis.broken",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+        "---",
+        "",
+        "# Broken\n",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "healthy.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "synthesis",
+          id: "synthesis.healthy",
+          title: "Healthy",
+          sourceIds: ["source.alpha"],
+        },
+        body: "# Healthy\n",
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(issueCodesForPath(result, "syntheses/broken.md")).toEqual(["invalid-frontmatter"]);
+    expect(issueCodesForPath(result, "syntheses/healthy.md")).not.toContain("invalid-frontmatter");
+  });
 });

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -24,6 +24,7 @@ type MemoryWikiLintIssue = {
   severity: "error" | "warning";
   category: "structure" | "provenance" | "links" | "contradictions" | "open-questions" | "quality";
   code:
+    | "invalid-frontmatter"
     | "missing-id"
     | "duplicate-id"
     | "missing-page-type"
@@ -100,6 +101,20 @@ function collectPageIssues(
   const claimHealth = collectWikiClaimHealth(pages);
 
   for (const page of pages) {
+    if (page.frontmatterError) {
+      issues.push({
+        severity: "error",
+        category: "structure",
+        code: "invalid-frontmatter",
+        path: page.relativePath,
+        message: `Frontmatter failed to parse: ${page.frontmatterError}`,
+      });
+      // Frontmatter-derived fields below are empty as a result of the parse
+      // failure; skip checks that would otherwise pile on misleading
+      // "missing field" issues for the same root cause.
+      continue;
+    }
+
     const requiresStructuredPageMetadata = !isUnmanagedRawSourcePage(
       page,
       managedImportedSourcePagePaths,

--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -421,4 +421,32 @@ describe("toWikiPageSummary", () => {
       },
     ]);
   });
+
+  it("degrades to empty frontmatter instead of throwing on unparsable YAML (#96125)", () => {
+    const raw = [
+      "---",
+      "pageType: synthesis",
+      "id: synthesis.test",
+      "sourceIds:",
+      '  - **MEMORY.md line 235**:"some quoted, value"',
+      "---",
+      "",
+      "# Test\n",
+    ].join("\n");
+
+    const summary = toWikiPageSummary({
+      absolutePath: "/tmp/wiki/syntheses/test.md",
+      relativePath: "syntheses/test.md",
+      raw,
+    });
+    if (!summary) {
+      throw new Error("expected wiki summary");
+    }
+
+    expect(summary.frontmatterError).toBeTruthy();
+    expect(summary.hasFrontmatter).toBe(true);
+    expect(summary.id).toBeUndefined();
+    expect(summary.sourceIds).toEqual([]);
+    expect(summary.title).toBe("Test");
+  });
 });

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -79,6 +79,8 @@ export type WikiPageSummary = {
   kind: WikiPageKind;
   title: string;
   hasFrontmatter: boolean;
+  /** Set when frontmatter YAML failed to parse; frontmatter-derived fields fall back to empty. */
+  frontmatterError?: string;
   id?: string;
   pageType?: string;
   entityType?: string;
@@ -173,19 +175,27 @@ export function createWikiPageFilename(stem: string, extension = ".md"): string 
   return `${capWikiValueWithHash(stem, maxStemBytes, "page")}${normalizedExtension}`;
 }
 
-export function parseWikiMarkdown(content: string): ParsedWikiMarkdown {
+function splitWikiFrontmatterBlock(content: string): { yamlSource: string; body: string } | null {
   const match = content.match(FRONTMATTER_PATTERN);
   if (!match) {
+    return null;
+  }
+  return { yamlSource: match[1] ?? "", body: content.slice(match[0].length) };
+}
+
+export function parseWikiMarkdown(content: string): ParsedWikiMarkdown {
+  const split = splitWikiFrontmatterBlock(content);
+  if (!split) {
     return { hasFrontmatter: false, frontmatter: {}, body: content };
   }
-  const parsed = YAML.parse(match[1]) as unknown;
+  const parsed = YAML.parse(split.yamlSource) as unknown;
   return {
     hasFrontmatter: true,
     frontmatter:
       parsed && typeof parsed === "object" && !Array.isArray(parsed)
         ? (parsed as Record<string, unknown>)
         : {},
-    body: content.slice(match[0].length),
+    body: split.body,
   };
 }
 
@@ -571,7 +581,21 @@ export function toWikiPageSummary(params: {
   if (!kind) {
     return null;
   }
-  const parsed = parseWikiMarkdown(params.raw);
+  // A page with unparsable YAML frontmatter must not crash vault-wide scans
+  // (compile/lint/query) over unrelated pages; degrade to empty frontmatter
+  // and surface the failure via WikiPageSummary.frontmatterError instead.
+  let parsed: ParsedWikiMarkdown;
+  let frontmatterError: string | undefined;
+  try {
+    parsed = parseWikiMarkdown(params.raw);
+  } catch (error) {
+    frontmatterError = error instanceof Error ? error.message : String(error);
+    parsed = {
+      hasFrontmatter: true,
+      frontmatter: {},
+      body: splitWikiFrontmatterBlock(params.raw)?.body ?? params.raw,
+    };
+  }
   const title =
     (typeof parsed.frontmatter.title === "string" && parsed.frontmatter.title.trim()) ||
     extractTitleFromMarkdown(parsed.body) ||
@@ -592,6 +616,7 @@ export function toWikiPageSummary(params: {
     kind,
     title,
     hasFrontmatter: parsed.hasFrontmatter,
+    ...(frontmatterError ? { frontmatterError } : {}),
     id: normalizeOptionalString(parsed.frontmatter.id),
     pageType: normalizeOptionalString(parsed.frontmatter.pageType),
     entityType: normalizeOptionalString(parsed.frontmatter.entityType),


### PR DESCRIPTION
Closes: #96125

## What Problem This Solves

Fixes an issue where `wiki_apply` and `wiki_lint` would report a YAML parse error and look like they failed, even though the requested write or lint had already completed. The error actually came from a completely unrelated page elsewhere in the vault whose frontmatter happened to contain YAML that couldn't be parsed (in the reported case, a `sourceIds` list item with an inline `:` inside bold markdown text, which YAML tried to read as a nested key-value pair).

## Why This Change Was Made

Both tools call `compileMemoryWikiVault()` after their own work to refresh vault-wide indexes, and that recompile reads and parses every page's frontmatter. `toWikiPageSummary()` had no error handling around the YAML parse, so one bad page anywhere in the vault threw and aborted the whole scan. The fix makes `toWikiPageSummary()` catch a frontmatter parse failure for the page it's currently summarizing, fall back to empty frontmatter for that one page, and record the failure on the summary instead of letting it propagate. `wiki_lint` now turns that into a normal `invalid-frontmatter` issue on the offending page instead of crashing. Call sites that parse one specific page they're about to edit (e.g. `applyCreateSynthesisMutation`) are untouched and still throw, since silently treating an edit target's broken frontmatter as empty risks losing that page's existing metadata on write.

## User Impact

`wiki_apply` and `wiki_lint` no longer fail because of an unrelated page somewhere else in the vault. A page with broken frontmatter now shows up as a clear, actionable `invalid-frontmatter` lint finding pointing at that specific file, instead of taking down every wiki operation until someone manually finds and fixes it.

## Evidence

New regression tests reproducing the reported scenario (a `sourceIds` entry with an inline colon inside bold text):

```text
$ node scripts/run-vitest.mjs extensions/memory-wiki/src/markdown.test.ts extensions/memory-wiki/src/lint.test.ts extensions/memory-wiki/src/compile.test.ts extensions/memory-wiki/src/apply.test.ts extensions/memory-wiki/src/query.test.ts extensions/memory-wiki/src/status.test.ts
 Test Files  6 passed (6)
      Tests  78 passed (78)
[test] passed 1 Vitest shard in 7.20s
```

```text
$ pnpm tsgo:extensions
$ pnpm tsgo:extensions:test
```
both clean.

```text
$ pnpm format:check -- extensions/memory-wiki/src/markdown.ts extensions/memory-wiki/src/lint.ts extensions/memory-wiki/src/markdown.test.ts extensions/memory-wiki/src/lint.test.ts
All matched files use the correct format.
```

```text
$ git diff --check
# no output
```