### PR TITLE
fix: route gateway history through session accessor target

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -96,6 +96,7 @@ export const migratedSessionAccessorFiles = new Set([
   "src/cron/service/timer.ts",
   "src/gateway/session-compaction-checkpoints.ts",
   "src/gateway/session-history-state.ts",
+  "src/gateway/sessions-history-http.ts",
   "src/gateway/session-utils.ts",
   "src/gateway/managed-image-attachments.ts",
   "src/gateway/server-methods/artifacts.ts",

--- a/src/gateway/sessions-history-http.revocation.test.ts
+++ b/src/gateway/sessions-history-http.revocation.test.ts
@@ -24,10 +24,6 @@ vi.mock("../config/config.js", () => ({
   }),
 }));
 
-vi.mock("../config/sessions.js", () => ({
-  loadSessionStore: () => ({ entries: [] }),
-}));
-
 vi.mock("../sessions/transcript-events.js", () => ({
   onInternalSessionTranscriptUpdate: (cb: typeof transcriptUpdateHandler) => {
     transcriptUpdateHandler = cb;
@@ -83,11 +79,12 @@ vi.mock("./http-utils.js", () => ({
 }));
 
 vi.mock("./session-utils.js", () => ({
-  resolveGatewaySessionStoreTarget: () => ({
+  resolveGatewaySessionStoreTargetWithStore: () => ({
     storePath: "/tmp",
     storeKeys: ["agent:main"],
     canonicalKey: "agent:main",
     agentId: "main",
+    store: {},
   }),
   resolveFreshestSessionEntryFromStoreKeys: () => ({
     sessionId: "session-1",

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -6,7 +6,6 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { getRuntimeConfig } from "../config/io.js";
-import { loadSessionStore } from "../config/sessions.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
@@ -38,7 +37,7 @@ import {
 } from "./session-transcript-readers.js";
 import {
   resolveFreshestSessionEntryFromStoreKeys,
-  resolveGatewaySessionStoreTarget,
+  resolveGatewaySessionStoreTargetWithStore,
   resolveSessionTranscriptCandidates,
 } from "./session-utils.js";
 
@@ -129,9 +128,8 @@ export async function handleSessionHistoryHttpRequest(
   }
   const { cfg } = authResult;
 
-  const target = resolveGatewaySessionStoreTarget({ cfg, key: sessionKey });
-  const store = loadSessionStore(target.storePath);
-  const entry = resolveFreshestSessionEntryFromStoreKeys(store, target.storeKeys);
+  const target = resolveGatewaySessionStoreTargetWithStore({ cfg, key: sessionKey });
+  const entry = resolveFreshestSessionEntryFromStoreKeys(target.store, target.storeKeys);
   if (!entry?.sessionId) {
     sendJson(res, 404, {
       ok: false,

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -44,6 +44,7 @@ describe("session accessor boundary guard", () => {
         "src/cron/service/timer.ts",
         "src/gateway/session-compaction-checkpoints.ts",
         "src/gateway/session-history-state.ts",
+        "src/gateway/sessions-history-http.ts",
         "src/gateway/session-utils.ts",
         "src/gateway/managed-image-attachments.ts",
         "src/gateway/server-methods/artifacts.ts",


### PR DESCRIPTION
## What Problem This Solves

Path 3 issue #88838 is moving gateway session/transcript reads behind accessor seams before the SQLite-backed session store lands. The Gateway HTTP session history route still loaded the session store directly before resolving the freshest entry, which left this route outside the accessor boundary ratchet.

## Why This Change Was Made

This keeps the slice narrow: only `src/gateway/sessions-history-http.ts` is migrated. The handler now uses the existing gateway session target accessor that already returns the resolved store, then passes that store into the existing freshest-entry resolver. No new transaction shape, fallback reader, JSON/JSONL compatibility shim, or cache was added.

## User Impact

No behavior change intended. Auth, bounded first-page history reads, cursor reads, SSE behavior, and revocation behavior stay on the existing code paths; the session target/store lookup is routed through the accessor helper so the route is ready for the SQLite-era backing store.

## Changes

- Route HTTP history through accessor target
- Reuse accessor-resolved session store
- Update revocation test mock
- Add boundary ratchet coverage

## Real behavior proof

Target: local LaunchAgent gateway on `127.0.0.1:18789`.

Because the live source checkout had unrelated work in progress, I did not switch that checkout onto this branch. Instead I built this branch, backed up the live generated runtime artifacts, synced the branch-built `dist/` and `dist-runtime/` into the live checkout, restarted the LaunchAgent, exercised the HTTP route, then restored the original live artifacts and restarted again.

Branch artifact loaded for the live route proof:

```bash
pnpm build
# passed; branch build-info commit fe1aa74feae8a6ec51bac8a54e03038ca55081c0

rsync -a "$LIVE_ROOT/dist/" "$BACKUP_ROOT/dist/"
rsync -a "$LIVE_ROOT/dist-runtime/" "$BACKUP_ROOT/dist-runtime/"
rsync -a --delete "$BRANCH_ROOT/dist/" "$LIVE_ROOT/dist/"
rsync -a --delete "$BRANCH_ROOT/dist-runtime/" "$LIVE_ROOT/dist-runtime/"
node "$BRANCH_ROOT/dist/index.js" gateway restart --json
# { "action": "restart", "ok": true, "result": "restarted", ... }
```

Runtime artifact proof for the changed route:

```bash
cat "$LIVE_ROOT/dist/build-info.json"
# { "version": "2026.6.9", "commit": "fe1aa74feae8a6ec51bac8a54e03038ca55081c0", ... }

# Changed route chunk matched the branch-built artifact byte-for-byte.
# sessions-history-http-D2XMKwDQ.js sha256:
# 4fca22bc73b9d857152547e00e249807c7f105ac0e33df40634b0e23a546d437
```

Gateway health after loading the branch artifact:

```bash
curl -fsS http://127.0.0.1:18789/healthz
# {"ok":true,"status":"live"}

curl -fsS http://127.0.0.1:18789/readyz
# {"ready":true,"failing":[],...}
```

Authenticated HTTP history route proof, with the gateway token resolved in-process and not printed:

```bash
GET /sessions/agent%3Amain%3Apath3-proof-89911-4eae4ca/history?limit=1
# status: 200
# sessionKey: agent:main:path3-proof-89911-4eae4ca
# messageCount: 1
# firstMessageRole: assistant
# firstTextChars: 22
```

Cleanup proof:

```bash
rsync -a --delete "$BACKUP_ROOT/dist/" "$LIVE_ROOT/dist/"
rsync -a --delete "$BACKUP_ROOT/dist-runtime/" "$LIVE_ROOT/dist-runtime/"
node "$LIVE_ROOT/dist/index.js" gateway restart --json
# { "action": "restart", "ok": true, "result": "restarted", ... }

curl -fsS http://127.0.0.1:18789/healthz
# {"ok":true,"status":"live"}
```

After the live proof, this branch was rebased once more onto the latest `upstream/main`; the final PR commit is `ce0ebdb73d327fe96e17df354bad1a94b0ed1f34` with the same four-file diff, and the focused guards/tests plus autoreview below were rerun on that exact commit.

## Evidence

```bash
node scripts/check-session-accessor-boundary.mjs
# session accessor boundary guard passed.

node scripts/run-vitest.mjs test/scripts/check-session-accessor-boundary.test.ts
# 1 file passed; 24 tests passed

node scripts/run-vitest.mjs src/gateway/sessions-history-http.test.ts src/gateway/sessions-history-http.revocation.test.ts
# gateway shard: 4 files passed; 12 tests passed
# e2e shard: 1 file passed; 20 tests passed

git diff --check upstream/main...HEAD
# clean

.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
# autoreview clean: no accepted/actionable findings reported
```

Out of scope for this narrow slice: `src/gateway/boot.ts`, `src/gateway/server-node-events.ts`, `src/gateway/sessions-resolve.ts`, and `src/gateway/session-compaction-checkpoints.ts`. Those should be handled as separate Path 3 follow-ups, especially anywhere the correct SQLite-era behavior needs an atomic boundary across session metadata and transcript/snapshot artifacts.
