### PR TITLE
fix: models status auth, browser local-file nav, codex workspace app-server, tui empty sessions

### DIFF
--- a/extensions/browser/src/browser/cdp.test.ts
+++ b/extensions/browser/src/browser/cdp.test.ts
@@ -22,6 +22,8 @@ import {
 } from "./errors.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 
+const TEST_WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
+
 describe("cdp", () => {
   let httpServer: ReturnType<typeof createServer> | null = null;
   let wsServer: WebSocketServer | null = null;
@@ -212,7 +214,7 @@ describe("cdp", () => {
   });
 
   it("honors configured WebSocket handshake timeouts when creating a target", async () => {
-    wsServer = new WebSocketServer({ noServer: true });
+    wsServer = new WebSocketServer({ noServer: true, maxPayload: TEST_WS_MAX_PAYLOAD_BYTES });
     httpServer = createServer();
     const heldSockets: Duplex[] = [];
     httpServer.on("upgrade", (_req, socket) => {
@@ -454,7 +456,7 @@ describe("cdp", () => {
       res.statusCode = 404;
       res.end("not found");
     });
-    const wss = new WebSocketServer({ noServer: true });
+    const wss = new WebSocketServer({ noServer: true, maxPayload: TEST_WS_MAX_PAYLOAD_BYTES });
     server.on("upgrade", (req, socket, head) => {
       wss.handleUpgrade(req, socket, head, (ws) => {
         wss.emit("connection", ws, req);

--- a/extensions/browser/src/browser/cdp.test.ts
+++ b/extensions/browser/src/browser/cdp.test.ts
@@ -327,13 +327,13 @@ describe("cdp", () => {
     }
   });
 
-  it("blocks unsupported non-network navigation URLs", async () => {
+  it("blocks unsupported active-content navigation URLs", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     try {
       await expect(
         createTargetViaCdp({
           cdpUrl: "http://127.0.0.1:9222",
-          url: "file:///etc/passwd",
+          url: "data:text/html,<h1>owned</h1>",
         }),
       ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
       expect(fetchSpy).not.toHaveBeenCalled();

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -188,11 +188,13 @@ export type CdpActionTimeouts = {
 export async function createTargetViaCdp(opts: {
   cdpUrl: string;
   url: string;
+  allowLocalFileNavigation?: boolean;
   ssrfPolicy?: SsrFPolicy;
   timeouts?: CdpActionTimeouts;
 }): Promise<{ targetId: string }> {
   await assertBrowserNavigationAllowed({
     url: opts.url,
+    allowLocalFileNavigation: opts.allowLocalFileNavigation,
     ...withBrowserNavigationPolicy(opts.ssrfPolicy),
   });
 

--- a/extensions/browser/src/browser/navigation-guard.test.ts
+++ b/extensions/browser/src/browser/navigation-guard.test.ts
@@ -50,12 +50,48 @@ describe("browser navigation guard", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("allows file URLs in the local unshackled runtime", async () => {
+  it("blocks file URLs unless local file navigation is explicitly allowed", async () => {
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "file:///tmp/openclaw-report.txt",
+      }),
+    ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
+  });
+
+  it("allows inert local file URLs when explicitly allowed", async () => {
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "file:///tmp/openclaw-report.txt",
+        allowLocalFileNavigation: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("allows localhost local file URLs when explicitly allowed", async () => {
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "file://localhost/tmp/openclaw-report.txt",
+        allowLocalFileNavigation: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("blocks remote-host file URLs even when local file navigation is explicitly allowed", async () => {
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "file://server/share/openclaw-report.txt",
+        allowLocalFileNavigation: true,
+      }),
+    ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
+  });
+
+  it("blocks active local file documents even when local file navigation is explicitly allowed", async () => {
     await expect(
       assertBrowserNavigationAllowed({
         url: "file:///tmp/openclaw-report.html",
+        allowLocalFileNavigation: true,
       }),
-    ).resolves.toBeUndefined();
+    ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
   });
 
   it("blocks data URLs", async () => {
@@ -270,6 +306,22 @@ describe("browser navigation guard", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("validates final file URLs after navigation", async () => {
+    await expect(
+      assertBrowserNavigationResultAllowed({
+        url: "file:///tmp/openclaw-report.txt",
+        allowLocalFileNavigation: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      assertBrowserNavigationResultAllowed({
+        url: "file:///tmp/openclaw-report.html",
+        allowLocalFileNavigation: true,
+      }),
+    ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
+  });
+
   it("blocks final hostname URLs in strict mode after navigation", async () => {
     await expect(
       assertBrowserNavigationResultAllowed({
@@ -324,6 +376,39 @@ describe("browser navigation guard", () => {
         lookupFn,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("allows an explicit inert local file as the initial navigation request", async () => {
+    const finalRequest = {
+      url: () => "file:///tmp/openclaw-report.txt",
+      redirectedFrom: () => null,
+    };
+
+    await expect(
+      assertBrowserNavigationRedirectChainAllowed({
+        request: finalRequest,
+        initialUrl: "file:///tmp/openclaw-report.txt",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("blocks redirects from network URLs into local files", async () => {
+    const lookupFn = createLookupFn("93.184.216.34");
+    const finalRequest = {
+      url: () => "file:///tmp/openclaw-report.txt",
+      redirectedFrom: () => ({
+        url: () => "https://public.example/start",
+        redirectedFrom: () => null,
+      }),
+    };
+
+    await expect(
+      assertBrowserNavigationRedirectChainAllowed({
+        request: finalRequest,
+        initialUrl: "https://public.example/start",
+        lookupFn,
+      }),
+    ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
   });
 
   it("requires redirect-hop inspection only in explicit strict mode", () => {

--- a/extensions/browser/src/browser/navigation-guard.test.ts
+++ b/extensions/browser/src/browser/navigation-guard.test.ts
@@ -50,12 +50,12 @@ describe("browser navigation guard", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("blocks file URLs", async () => {
+  it("allows file URLs in the local unshackled runtime", async () => {
     await expect(
       assertBrowserNavigationAllowed({
-        url: "file:///etc/passwd",
+        url: "file:///tmp/openclaw-report.html",
       }),
-    ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
+    ).resolves.toBeUndefined();
   });
 
   it("blocks data URLs", async () => {

--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -15,20 +15,59 @@ import { matchesHostnameAllowlist, normalizeHostname } from "../sdk-security-run
 
 const NETWORK_NAVIGATION_PROTOCOLS = new Set(["http:", "https:"]);
 const SAFE_NON_NETWORK_URLS = new Set(["about:blank"]);
-const LOCAL_FILE_NAVIGATION_PROTOCOLS = new Set(["file:"]);
+const LOCAL_FILE_NAVIGATION_HOSTNAMES = new Set(["", "localhost"]);
+const INERT_LOCAL_FILE_NAVIGATION_EXTENSIONS = new Set([
+  ".csv",
+  ".gif",
+  ".jpeg",
+  ".jpg",
+  ".json",
+  ".jsonl",
+  ".log",
+  ".markdown",
+  ".md",
+  ".png",
+  ".txt",
+  ".tsv",
+  ".webp",
+]);
 
-function isAllowedNonNetworkNavigationUrl(parsed: URL): boolean {
-  // Kennedy's local unshackled runtime already grants agents filesystem read
-  // access; blocking file:// in the browser only forces brittle localhost
-  // workarounds for local reports. Keep active-content protocols blocked, but
-  // allow explicit local file navigation.
-  return (
-    SAFE_NON_NETWORK_URLS.has(parsed.href) || LOCAL_FILE_NAVIGATION_PROTOCOLS.has(parsed.protocol)
+function isAllowedLocalFileNavigationUrl(parsed: URL): boolean {
+  if (parsed.protocol !== "file:") {
+    return false;
+  }
+  if (!LOCAL_FILE_NAVIGATION_HOSTNAMES.has(normalizeHostname(parsed.hostname))) {
+    return false;
+  }
+  const pathname = parsed.pathname.toLowerCase();
+  return Array.from(INERT_LOCAL_FILE_NAVIGATION_EXTENSIONS).some((extension) =>
+    pathname.endsWith(extension),
   );
+}
+
+function isAllowedNonNetworkNavigationUrl(
+  parsed: URL,
+  opts?: { allowLocalFileNavigation?: boolean },
+): boolean {
+  if (SAFE_NON_NETWORK_URLS.has(parsed.href)) {
+    return true;
+  }
+  return opts?.allowLocalFileNavigation === true && isAllowedLocalFileNavigationUrl(parsed);
 }
 
 function normalizeNavigationUrl(url: string): string {
   return url.trim();
+}
+
+/** Return true when two navigation URL strings resolve to the same browser target. */
+export function isSameBrowserNavigationUrl(left: string, right: string): boolean {
+  try {
+    return (
+      new URL(normalizeNavigationUrl(left)).href === new URL(normalizeNavigationUrl(right)).href
+    );
+  } catch {
+    return false;
+  }
 }
 
 /** Raised when a browser navigation URL fails syntax or policy validation. */
@@ -43,6 +82,7 @@ export class InvalidBrowserNavigationUrlError extends Error {
 export type BrowserNavigationPolicyOptions = {
   ssrfPolicy?: SsrFPolicy;
   browserProxyMode?: BrowserNavigationProxyMode;
+  allowLocalFileNavigation?: boolean;
 };
 
 /** Describes whether the browser itself is routing page traffic through a proxy. */
@@ -126,7 +166,11 @@ export async function assertBrowserNavigationAllowed(
   }
 
   if (!NETWORK_NAVIGATION_PROTOCOLS.has(parsed.protocol)) {
-    if (isAllowedNonNetworkNavigationUrl(parsed)) {
+    if (
+      isAllowedNonNetworkNavigationUrl(parsed, {
+        allowLocalFileNavigation: opts.allowLocalFileNavigation,
+      })
+    ) {
       return;
     }
     throw new InvalidBrowserNavigationUrlError(
@@ -192,7 +236,8 @@ export async function assertBrowserNavigationResultAllowed(
   }
   if (
     NETWORK_NAVIGATION_PROTOCOLS.has(parsed.protocol) ||
-    isAllowedNonNetworkNavigationUrl(parsed)
+    SAFE_NON_NETWORK_URLS.has(parsed.href) ||
+    parsed.protocol === "file:"
   ) {
     await assertBrowserNavigationAllowed(opts);
   }
@@ -202,6 +247,7 @@ export async function assertBrowserNavigationResultAllowed(
 export async function assertBrowserNavigationRedirectChainAllowed(
   opts: {
     request?: BrowserNavigationRequestLike | null;
+    initialUrl?: string;
     lookupFn?: LookupFn;
   } & BrowserNavigationPolicyOptions,
 ): Promise<void> {
@@ -211,12 +257,14 @@ export async function assertBrowserNavigationRedirectChainAllowed(
     chain.push(current.url());
     current = current.redirectedFrom();
   }
-  for (const url of chain.toReversed()) {
+  for (const [index, url] of chain.toReversed().entries()) {
     await assertBrowserNavigationAllowed({
       url,
       lookupFn: opts.lookupFn,
       ssrfPolicy: opts.ssrfPolicy,
       browserProxyMode: opts.browserProxyMode,
+      allowLocalFileNavigation:
+        index === 0 && opts.initialUrl ? isSameBrowserNavigationUrl(url, opts.initialUrl) : false,
     });
   }
 }

--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -15,10 +15,16 @@ import { matchesHostnameAllowlist, normalizeHostname } from "../sdk-security-run
 
 const NETWORK_NAVIGATION_PROTOCOLS = new Set(["http:", "https:"]);
 const SAFE_NON_NETWORK_URLS = new Set(["about:blank"]);
+const LOCAL_FILE_NAVIGATION_PROTOCOLS = new Set(["file:"]);
 
 function isAllowedNonNetworkNavigationUrl(parsed: URL): boolean {
-  // Keep non-network navigation explicit; about:blank is the only allowed bootstrap URL.
-  return SAFE_NON_NETWORK_URLS.has(parsed.href);
+  // Kennedy's local unshackled runtime already grants agents filesystem read
+  // access; blocking file:// in the browser only forces brittle localhost
+  // workarounds for local reports. Keep active-content protocols blocked, but
+  // allow explicit local file navigation.
+  return (
+    SAFE_NON_NETWORK_URLS.has(parsed.href) || LOCAL_FILE_NAVIGATION_PROTOCOLS.has(parsed.protocol)
+  );
 }
 
 function normalizeNavigationUrl(url: string): string {

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -200,12 +200,12 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
 
     const created = await createPageViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
-      url: "file:///tmp/openclaw-report.html",
+      url: "file:///tmp/openclaw-report.txt",
     });
 
     expect(created.targetId).toBe("TARGET_1");
     expect(pageGoto).toHaveBeenCalledWith(
-      "file:///tmp/openclaw-report.html",
+      "file:///tmp/openclaw-report.txt",
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
   });

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -195,17 +195,19 @@ afterEach(async () => {
 });
 
 describe("pw-session createPageViaPlaywright navigation guard", () => {
-  it("blocks unsupported non-network URLs", async () => {
+  it("allows local file URLs", async () => {
     const { pageGoto } = installBrowserMocks();
 
-    await expect(
-      createPageViaPlaywright({
-        cdpUrl: "http://127.0.0.1:18792",
-        url: "file:///etc/passwd",
-      }),
-    ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
+    const created = await createPageViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      url: "file:///tmp/openclaw-report.html",
+    });
 
-    expect(pageGoto).not.toHaveBeenCalled();
+    expect(created.targetId).toBe("TARGET_1");
+    expect(pageGoto).toHaveBeenCalledWith(
+      "file:///tmp/openclaw-report.html",
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
   });
 
   it("allows about:blank without network navigation", async () => {
@@ -380,7 +382,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
       pageGoto,
       getRouteHandler,
       mainFrame,
-      hopUrl: "file:///etc/passwd",
+      hopUrl: "data:text/html,<h1>owned</h1>",
     });
 
     await expect(

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -44,6 +44,7 @@ import {
   assertBrowserNavigationResultAllowed,
   type BrowserNavigationPolicyOptions,
   InvalidBrowserNavigationUrlError,
+  isSameBrowserNavigationUrl,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
 import { writeViaSiblingTempPath } from "./output-atomic.js";
@@ -1304,6 +1305,7 @@ export async function assertPageNavigationCompletedSafely(
     cdpUrl: string;
     page: Page;
     response: Response | null;
+    initialUrl?: string;
     targetId?: string;
   } & BrowserNavigationPolicyOptions,
 ): Promise<void> {
@@ -1313,10 +1315,15 @@ export async function assertPageNavigationCompletedSafely(
   try {
     await assertBrowserNavigationRedirectChainAllowed({
       request: opts.response?.request(),
+      initialUrl: opts.initialUrl,
       ...navigationPolicy,
     });
+    const finalUrl = opts.page.url();
     await assertBrowserNavigationResultAllowed({
-      url: opts.page.url(),
+      url: finalUrl,
+      allowLocalFileNavigation: opts.initialUrl
+        ? isSameBrowserNavigationUrl(finalUrl, opts.initialUrl)
+        : false,
       ...navigationPolicy,
     });
   } catch (err) {
@@ -1373,6 +1380,7 @@ export async function gotoPageWithNavigationGuard(
     try {
       await assertBrowserNavigationAllowed({
         url: request.url(),
+        allowLocalFileNavigation: isTopLevel && isSameBrowserNavigationUrl(request.url(), opts.url),
         ...navigationPolicy,
       });
     } catch (err) {
@@ -1757,6 +1765,7 @@ export async function createPageViaPlaywright(
     });
     await assertBrowserNavigationAllowed({
       url: targetUrl,
+      allowLocalFileNavigation: true,
       ...navigationPolicy,
     });
     let response: Response | null = null;
@@ -1782,6 +1791,7 @@ export async function createPageViaPlaywright(
         cdpUrl: opts.cdpUrl,
         page,
         response,
+        initialUrl: targetUrl,
         ssrfPolicy: opts.ssrfPolicy,
         browserProxyMode: opts.browserProxyMode,
         targetId: createdTargetId ?? undefined,

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -2,7 +2,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import "../test-support/browser-security.mock.js";
-import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import {
   getPwToolsCoreSessionMocks,
   installPwToolsCoreTestHooks,
@@ -32,22 +31,25 @@ describe("pw-tools-core.snapshot navigate guard", () => {
     vi.unstubAllEnvs();
   });
 
-  it("blocks unsupported non-network URLs before page lookup", async () => {
+  it("allows local file URLs", async () => {
     const goto = vi.fn(async () => {});
     setPwToolsCoreCurrentPage({
       goto,
-      url: vi.fn(() => "about:blank"),
+      url: vi.fn(() => "file:///tmp/openclaw-report.html"),
     });
 
     await expect(
       mod.navigateViaPlaywright({
         cdpUrl: "http://127.0.0.1:18792",
-        url: "file:///etc/passwd",
+        url: "file:///tmp/openclaw-report.html",
       }),
-    ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
+    ).resolves.toBeDefined();
 
-    expect(getPwToolsCoreSessionMocks().getPageForTargetId).not.toHaveBeenCalled();
-    expect(goto).not.toHaveBeenCalled();
+    expect(getPwToolsCoreSessionMocks().getPageForTargetId).toHaveBeenCalled();
+    expect(goto).toHaveBeenCalledWith(
+      "file:///tmp/openclaw-report.html",
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
   });
 
   it("navigates valid network URLs with clamped timeout", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -35,19 +35,19 @@ describe("pw-tools-core.snapshot navigate guard", () => {
     const goto = vi.fn(async () => {});
     setPwToolsCoreCurrentPage({
       goto,
-      url: vi.fn(() => "file:///tmp/openclaw-report.html"),
+      url: vi.fn(() => "file:///tmp/openclaw-report.txt"),
     });
 
     await expect(
       mod.navigateViaPlaywright({
         cdpUrl: "http://127.0.0.1:18792",
-        url: "file:///tmp/openclaw-report.html",
+        url: "file:///tmp/openclaw-report.txt",
       }),
     ).resolves.toBeDefined();
 
     expect(getPwToolsCoreSessionMocks().getPageForTargetId).toHaveBeenCalled();
     expect(goto).toHaveBeenCalledWith(
-      "file:///tmp/openclaw-report.html",
+      "file:///tmp/openclaw-report.txt",
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
   });
@@ -78,6 +78,7 @@ describe("pw-tools-core.snapshot navigate guard", () => {
     });
     expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
       cdpUrl: "http://127.0.0.1:18792",
+      initialUrl: "https://example.com",
       page,
       response: null,
       ssrfPolicy: { allowPrivateNetwork: true },

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -406,6 +406,7 @@ export async function navigateViaPlaywright(opts: {
   }
   await assertBrowserNavigationAllowed({
     url,
+    allowLocalFileNavigation: true,
     ...withBrowserNavigationPolicy(opts.ssrfPolicy, {
       browserProxyMode: opts.browserProxyMode,
     }),
@@ -447,6 +448,7 @@ export async function navigateViaPlaywright(opts: {
       cdpUrl: opts.cdpUrl,
       page,
       response,
+      initialUrl: url,
       ssrfPolicy: opts.ssrfPolicy,
       browserProxyMode: opts.browserProxyMode,
       targetId: opts.targetId,

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -23,6 +23,7 @@ import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "../constants.js";
 import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationResultAllowed,
+  isSameBrowserNavigationUrl,
 } from "../navigation-guard.js";
 import { getBrowserProfileCapabilities } from "../profile-capabilities.js";
 import type { AnnotationItem } from "../screenshot-annotate.js";
@@ -331,14 +332,22 @@ export function registerBrowserAgentSnapshotRoutes(
         run: async ({ profileCtx, tab, cdpUrl }) => {
           if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
             const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
-            await assertBrowserNavigationAllowed({ url, ...ssrfPolicyOpts });
+            await assertBrowserNavigationAllowed({
+              url,
+              allowLocalFileNavigation: true,
+              ...ssrfPolicyOpts,
+            });
             const result = await navigateChromeMcpPage({
               profileName: profileCtx.profile.name,
               profile: profileCtx.profile,
               targetId: tab.targetId,
               url,
             });
-            await assertBrowserNavigationResultAllowed({ url: result.url, ...ssrfPolicyOpts });
+            await assertBrowserNavigationResultAllowed({
+              url: result.url,
+              allowLocalFileNavigation: isSameBrowserNavigationUrl(result.url, url),
+              ...ssrfPolicyOpts,
+            });
             return res.json({ ok: true, targetId: tab.targetId, ...result });
           }
           const pw = await requirePwAi(res, "navigate");

--- a/extensions/browser/src/browser/routes/tabs.ts
+++ b/extensions/browser/src/browser/routes/tabs.ts
@@ -238,6 +238,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
         run: async (profileCtx) => {
           await assertBrowserNavigationAllowed({
             url,
+            allowLocalFileNavigation: true,
             ...browserNavigationPolicyForProfile(ctx, profileCtx),
           });
           await profileCtx.ensureBrowserAvailable();

--- a/extensions/browser/src/browser/server-context.tab-ops.ts
+++ b/extensions/browser/src/browser/server-context.tab-ops.ts
@@ -20,6 +20,7 @@ import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationResultAllowed,
   InvalidBrowserNavigationUrlError,
+  isSameBrowserNavigationUrl,
   requiresInspectableBrowserNavigationRedirectsForUrl,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
@@ -298,12 +299,20 @@ export function createProfileTabOps({
     const ssrfPolicyOpts = getNavigationPolicy();
 
     if (capabilities.usesChromeMcp) {
-      await assertBrowserNavigationAllowed({ url, ...ssrfPolicyOpts });
+      await assertBrowserNavigationAllowed({
+        url,
+        allowLocalFileNavigation: true,
+        ...ssrfPolicyOpts,
+      });
       const { openChromeMcpTab } = await getChromeMcpModule();
       const page = await openChromeMcpTab(profile.name, url, profile);
       const profileState = getProfileState();
       profileState.lastTargetId = page.targetId;
-      await assertBrowserNavigationResultAllowed({ url: page.url, ...ssrfPolicyOpts });
+      await assertBrowserNavigationResultAllowed({
+        url: page.url,
+        allowLocalFileNavigation: isSameBrowserNavigationUrl(page.url, url),
+        ...ssrfPolicyOpts,
+      });
       return assignTabAlias({ profileState, tab: page, label: opts?.label });
     }
 
@@ -338,11 +347,16 @@ export function createProfileTabOps({
       );
     }
 
-    await assertBrowserNavigationAllowed({ url, ...ssrfPolicyOpts });
+    await assertBrowserNavigationAllowed({
+      url,
+      allowLocalFileNavigation: true,
+      ...ssrfPolicyOpts,
+    });
     const cdpActionTimeouts = getRemoteCdpActionTimeouts();
     const createTargetOpts: Parameters<typeof createTargetViaCdp>[0] = {
       cdpUrl: profile.cdpUrl,
       url,
+      allowLocalFileNavigation: true,
       ssrfPolicy: getCdpControlPolicy(),
     };
     if (cdpActionTimeouts) {
@@ -360,7 +374,11 @@ export function createProfileTabOps({
         const tabs = await listTabs().catch(() => [] as BrowserTab[]);
         const found = tabs.find((t) => t.targetId === createdViaCdp);
         if (found) {
-          await assertBrowserNavigationResultAllowed({ url: found.url, ...ssrfPolicyOpts });
+          await assertBrowserNavigationResultAllowed({
+            url: found.url,
+            allowLocalFileNavigation: isSameBrowserNavigationUrl(found.url, url),
+            ...ssrfPolicyOpts,
+          });
           triggerManagedTabLimit(found.targetId);
           return assignTabAlias({ profileState, tab: found, label: opts?.label });
         }

--- a/extensions/browser/src/browser/server-context.tab-selection-state.test.ts
+++ b/extensions/browser/src/browser/server-context.tab-selection-state.test.ts
@@ -6,7 +6,6 @@ import "./server-context.chrome-test-harness.js";
 import { CDP_JSON_NEW_TIMEOUT_MS } from "./cdp-timeouts.js";
 import * as cdpHelpersModule from "./cdp.helpers.js";
 import * as cdpModule from "./cdp.js";
-import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import {
   createTestBrowserRouteContext,
   makeManagedTabsWithNew,
@@ -349,9 +348,25 @@ describe("browser server-context tab selection state", () => {
     expect(opened.targetId).toBe("NEW");
   });
 
-  it("blocks unsupported non-network URLs before any HTTP tab-open fallback", async () => {
-    const fetchMock = vi.fn(async () => {
-      throw new Error("unexpected fetch");
+  it("allows local file URLs through the tab-open path", async () => {
+    vi.spyOn(cdpModule, "createTargetViaCdp").mockResolvedValue({ targetId: "FILE" });
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const value = String(url);
+      if (value.includes("/json/list")) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: "FILE",
+              title: "Local Report",
+              url: "file:///tmp/openclaw-report.html",
+              webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/FILE",
+              type: "page",
+            },
+          ],
+        } as unknown as Response;
+      }
+      throw new Error(`unexpected fetch: ${value}`);
     });
 
     global.fetch = withBrowserFetchPreconnect(fetchMock);
@@ -359,10 +374,11 @@ describe("browser server-context tab selection state", () => {
     const ctx = createTestBrowserRouteContext({ getState: () => state });
     const openclaw = ctx.forProfile("openclaw");
 
-    await expect(openclaw.openTab("file:///etc/passwd")).rejects.toBeInstanceOf(
-      InvalidBrowserNavigationUrlError,
-    );
-    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(openclaw.openTab("file:///tmp/openclaw-report.html")).resolves.toMatchObject({
+      targetId: "FILE",
+      url: "file:///tmp/openclaw-report.html",
+    });
+    expect(fetchCallUrls(fetchMock)).toEqual(["http://127.0.0.1:18800/json/list"]);
   });
 
   it("uses the loopback CDP control policy for /json/new fallback requests", async () => {

--- a/extensions/browser/src/browser/server-context.tab-selection-state.test.ts
+++ b/extensions/browser/src/browser/server-context.tab-selection-state.test.ts
@@ -134,6 +134,7 @@ describe("browser server-context tab selection state", () => {
     expect(createTargetViaCdp).toHaveBeenCalledWith({
       cdpUrl: "http://127.0.0.1:18800",
       url: "http://127.0.0.1:8080",
+      allowLocalFileNavigation: true,
       ssrfPolicy: undefined,
     });
   });
@@ -178,6 +179,7 @@ describe("browser server-context tab selection state", () => {
     expect(createTargetViaCdp).toHaveBeenCalledWith({
       cdpUrl: "http://127.0.0.1:18800",
       url: "about:blank",
+      allowLocalFileNavigation: true,
       ssrfPolicy: undefined,
     });
   });
@@ -237,6 +239,7 @@ describe("browser server-context tab selection state", () => {
     expect(createTargetViaCdp).toHaveBeenCalledWith({
       cdpUrl: "http://127.0.0.1:18800",
       url: "about:blank",
+      allowLocalFileNavigation: true,
       ssrfPolicy: undefined,
     });
   });
@@ -359,7 +362,7 @@ describe("browser server-context tab selection state", () => {
             {
               id: "FILE",
               title: "Local Report",
-              url: "file:///tmp/openclaw-report.html",
+              url: "file:///tmp/openclaw-report.txt",
               webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/FILE",
               type: "page",
             },
@@ -374,9 +377,9 @@ describe("browser server-context tab selection state", () => {
     const ctx = createTestBrowserRouteContext({ getState: () => state });
     const openclaw = ctx.forProfile("openclaw");
 
-    await expect(openclaw.openTab("file:///tmp/openclaw-report.html")).resolves.toMatchObject({
+    await expect(openclaw.openTab("file:///tmp/openclaw-report.txt")).resolves.toMatchObject({
       targetId: "FILE",
-      url: "file:///tmp/openclaw-report.html",
+      url: "file:///tmp/openclaw-report.txt",
     });
     expect(fetchCallUrls(fetchMock)).toEqual(["http://127.0.0.1:18800/json/list"]);
   });

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -10,6 +10,7 @@ import {
   CODEX_PLUGINS_CONFIG_KEYS,
   canUseCodexModelBackedApprovalsReviewerForModel,
   codexAppServerStartOptionsKey,
+  codexSandboxPolicyForTurn,
   fingerprintCodexAppServerNetworkProxyConfigPatch,
   readCodexPluginConfig,
   resolveCodexAppServerRuntimeOptions,
@@ -69,6 +70,23 @@ function expectUiHintLabel(manifest: { uiHints: Record<string, unknown> }, key: 
 }
 
 describe("Codex app-server config", () => {
+  it("keeps workspace-write filesystem-scoped while allowing network egress", () => {
+    expect(codexSandboxPolicyForTurn("workspace-write", "/workspace")).toEqual({
+      type: "workspaceWrite",
+      writableRoots: ["/workspace"],
+      networkAccess: true,
+      excludeTmpdirEnvVar: false,
+      excludeSlashTmp: false,
+    });
+  });
+
+  it("keeps read-only sandbox network-denied", () => {
+    expect(codexSandboxPolicyForTurn("read-only", "/workspace")).toEqual({
+      type: "readOnly",
+      networkAccess: false,
+    });
+  });
+
   it("only auto-approves app-server approvals for full yolo runtime policy", () => {
     expect(
       shouldAutoApproveCodexAppServerApprovals({

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -903,7 +903,11 @@ export function codexSandboxPolicyForTurn(
   return {
     type: "workspaceWrite",
     writableRoots: [cwd],
-    networkAccess: false,
+    // Workspace-write keeps filesystem writes scoped to the task workspace. Keep
+    // network available so local agents can perform normal development tasks
+    // (git fetch/clone, package metadata checks, API health probes) without
+    // falling back to danger-full-access.
+    networkAccess: true,
     excludeTmpdirEnvVar: false,
     excludeSlashTmp: false,
   };

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -15,13 +15,15 @@ import {
   DEFAULT_OAUTH_WARN_MS,
   formatRemainingShort,
 } from "../../agents/auth-health.js";
+import { OPENAI_CODEX_DEFAULT_PROFILE_ID } from "../../agents/auth-profiles/constants.js";
 import { evaluateStoredCredentialEligibility } from "../../agents/auth-profiles/credential-state.js";
+import { externalCliDiscoveryForConfigStatus } from "../../agents/auth-profiles/external-cli-discovery.js";
 import {
   resolveAuthProfileEligibility,
   resolveAuthProfileOrder,
 } from "../../agents/auth-profiles/order.js";
 import { resolveAuthStorePathForDisplay } from "../../agents/auth-profiles/paths.js";
-import { ensureAuthProfileStoreWithoutExternalProfiles as ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
+import { ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
 import {
@@ -331,14 +333,8 @@ export async function modelsStatusCommand(
     }, {});
     const allowed = Object.keys(cfg.agents?.defaults?.models ?? {});
 
-    const store = ensureAuthProfileStore(agentDir);
     const modelsPath = path.join(agentDir, "models.json");
 
-    const providersFromStore = new Set(
-      Object.values(store.profiles)
-        .map((profile) => normalizeProviderId(profile.provider))
-        .filter((p): p is string => Boolean(p)),
-    );
     const providersFromConfig = new Set(
       Object.keys(cfg.models?.providers ?? {})
         .map((p) => (typeof p === "string" ? normalizeProviderId(p) : ""))
@@ -446,6 +442,55 @@ export async function modelsStatusCommand(
       })
       .filter((usage): usage is NonNullable<typeof usage> => Boolean(usage));
 
+    const codexProvider = normalizeProviderId(OPENAI_PROVIDER_ID);
+    const codexProviderAlias = aliasMap[codexProvider] ?? codexProvider;
+    const codexRuntimeAuthUsages = providerUses.filter(
+      (usage) =>
+        usage.allowCodexRuntimeFallback &&
+        openAIProviderUsesCodexRuntimeByDefault({ provider: usage.provider, config: cfg }),
+    );
+    const configExternalCliDiscovery = externalCliDiscoveryForConfigStatus({ cfg });
+    const externalCliProviderIds = new Set<string>();
+    const externalCliProfileIds = new Set<string>();
+    if (configExternalCliDiscovery.mode === "scoped") {
+      for (const providerId of configExternalCliDiscovery.providerIds ?? []) {
+        externalCliProviderIds.add(providerId);
+      }
+      for (const profileId of configExternalCliDiscovery.profileIds ?? []) {
+        externalCliProfileIds.add(profileId);
+      }
+    }
+    for (const usage of providerUses) {
+      externalCliProviderIds.add(usage.provider);
+      externalCliProviderIds.add(resolveProviderIdForAuth(usage.provider, envLookupParams));
+    }
+    if (codexRuntimeAuthUsages.length > 0) {
+      externalCliProviderIds.add(codexProvider);
+      externalCliProviderIds.add(codexProviderAlias);
+      externalCliProviderIds.add("codex");
+      externalCliProviderIds.add("codex-cli");
+      externalCliProviderIds.add("codex-app-server");
+      externalCliProfileIds.add(OPENAI_CODEX_DEFAULT_PROFILE_ID);
+    }
+    const store = ensureAuthProfileStore(agentDir, {
+      readOnly: true,
+      allowKeychainPrompt: false,
+      externalCli:
+        externalCliProviderIds.size > 0 || externalCliProfileIds.size > 0
+          ? {
+              mode: "scoped",
+              allowKeychainPrompt: false,
+              config: cfg,
+              providerIds: externalCliProviderIds,
+              profileIds: externalCliProfileIds,
+            }
+          : configExternalCliDiscovery,
+    });
+    const providersFromStore = new Set(
+      Object.values(store.profiles)
+        .map((profile) => normalizeProviderId(profile.provider))
+        .filter((p): p is string => Boolean(p)),
+    );
     const providers = Array.from(
       new Set([
         ...providersFromStore,
@@ -460,13 +505,6 @@ export async function modelsStatusCommand(
       .toSorted((a, b) => a.localeCompare(b));
     const syntheticProvidersToProbe = new Set(
       providers.map((provider) => normalizeProviderId(provider)),
-    );
-    const codexProvider = normalizeProviderId(OPENAI_PROVIDER_ID);
-    const codexProviderAlias = aliasMap[codexProvider] ?? codexProvider;
-    const codexRuntimeAuthUsages = providerUses.filter(
-      (usage) =>
-        usage.allowCodexRuntimeFallback &&
-        openAIProviderUsesCodexRuntimeByDefault({ provider: usage.provider, config: cfg }),
     );
     if (codexRuntimeAuthUsages.length > 0) {
       syntheticProvidersToProbe.add(codexProvider);

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -460,9 +460,9 @@ export async function modelsStatusCommand(
         externalCliProfileIds.add(profileId);
       }
     }
-    for (const usage of providerUses) {
-      externalCliProviderIds.add(usage.provider);
-      externalCliProviderIds.add(resolveProviderIdForAuth(usage.provider, envLookupParams));
+    for (const usage of cliRuntimeAuthUsages) {
+      externalCliProviderIds.add(usage.runtime);
+      externalCliProviderIds.add(resolveProviderIdForAuth(usage.runtime, envLookupParams));
     }
     if (codexRuntimeAuthUsages.length > 0) {
       externalCliProviderIds.add(codexProvider);

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -145,6 +145,11 @@ const mocks = vi.hoisted(() => {
     loadProviderUsageSummary: vi.fn().mockResolvedValue(undefined),
     resolveRuntimeSyntheticAuthProviderRefs: vi.fn().mockReturnValue([]),
     resolveProviderSyntheticAuthWithPlugin: vi.fn().mockReturnValue(undefined),
+    externalCliDiscoveryForConfigStatus: vi.fn().mockReturnValue({
+      mode: "scoped",
+      providerIds: ["openai"],
+      profileIds: ["openai:codex-cli"],
+    }),
   };
 });
 
@@ -177,6 +182,9 @@ vi.mock("../../agents/auth-profiles/profiles.js", () => ({
 vi.mock("../../agents/auth-profiles/store.js", () => ({
   ensureAuthProfileStore: mocks.ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles: mocks.ensureAuthProfileStore,
+}));
+vi.mock("../../agents/auth-profiles/external-cli-discovery.js", () => ({
+  externalCliDiscoveryForConfigStatus: mocks.externalCliDiscoveryForConfigStatus,
 }));
 vi.mock("../../agents/auth-profiles/usage.js", () => ({
   resolveProfileUnusableUntilForDisplay: mocks.resolveProfileUnusableUntilForDisplay,
@@ -390,6 +398,15 @@ describe("modelsStatusCommand auth overview", () => {
     expect(payload.defaultModel).toBe("anthropic/claude-opus-4-6");
     expect(payload.configPath).toBe("/tmp/openclaw-dev/openclaw.json");
     expect(payload.auth.storePath).toBe("/tmp/openclaw-agent/auth-profiles.json");
+    expect(mocks.externalCliDiscoveryForConfigStatus).toHaveBeenCalled();
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith(
+      "/tmp/openclaw-agent",
+      expect.objectContaining({
+        readOnly: true,
+        allowKeychainPrompt: false,
+        externalCli: expect.objectContaining({ mode: "scoped" }),
+      }),
+    );
     expect(payload.auth.shellEnvFallback.enabled).toBe(true);
     expect(payload.auth.shellEnvFallback.appliedKeys).toContain("OPENAI_API_KEY");
     expect(payload.auth.missingProvidersInUse).toStrictEqual([]);
@@ -437,7 +454,14 @@ describe("modelsStatusCommand auth overview", () => {
     });
 
     expect(mocks.resolveAgentDir).not.toHaveBeenCalled();
-    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-isolated-agent");
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith(
+      "/tmp/openclaw-isolated-agent",
+      expect.objectContaining({
+        readOnly: true,
+        allowKeychainPrompt: false,
+        externalCli: expect.objectContaining({ mode: "scoped" }),
+      }),
+    );
     const payload = parseFirstJsonLog(localRuntime);
     expect(payload.agentDir).toBe("/tmp/openclaw-isolated-agent");
     expect(payload.auth.storePath).toBe("/tmp/openclaw-isolated-agent/auth-profiles.json");
@@ -457,7 +481,14 @@ describe("modelsStatusCommand auth overview", () => {
     );
 
     expect(mocks.resolveAgentDir).not.toHaveBeenCalled();
-    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-legacy-agent");
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith(
+      "/tmp/openclaw-legacy-agent",
+      expect.objectContaining({
+        readOnly: true,
+        allowKeychainPrompt: false,
+        externalCli: expect.objectContaining({ mode: "scoped" }),
+      }),
+    );
     const payload = parseFirstJsonLog(localRuntime);
     expect(payload.agentDir).toBe("/tmp/openclaw-legacy-agent");
   });
@@ -524,8 +555,23 @@ describe("modelsStatusCommand auth overview", () => {
     );
 
     try {
+      const storeCallStart = mocks.ensureAuthProfileStore.mock.calls.length;
       await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
       const payload = parseFirstJsonLog(localRuntime);
+      const storeOptions = mocks.ensureAuthProfileStore.mock.calls.find(
+        ([agentDir], index) => index >= storeCallStart && agentDir === "/tmp/openclaw-agent",
+      )?.[1] as
+        | {
+            externalCli?: {
+              providerIds?: Iterable<string>;
+              profileIds?: Iterable<string>;
+            };
+          }
+        | undefined;
+      expect([...(storeOptions?.externalCli?.providerIds ?? [])]).toEqual(
+        expect.arrayContaining(["openai", "codex", "codex-cli", "codex-app-server"]),
+      );
+      expect([...(storeOptions?.externalCli?.profileIds ?? [])]).toContain("openai:default");
       expect(payload.auth.missingProvidersInUse).toStrictEqual([]);
       expect(localRuntime.exit).not.toHaveBeenCalledWith(1);
     } finally {

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -589,6 +589,83 @@ describe("modelsStatusCommand auth overview", () => {
     }
   });
 
+  it("does not apply Codex CLI auth discovery to custom OpenAI-compatible providers", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    const originalExternalCliImpl =
+      mocks.externalCliDiscoveryForConfigStatus.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5", fallbacks: [] },
+          models: { "openai/gpt-5.5": {} },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://proxy.example.test/v1",
+          },
+        },
+      },
+      env: { shellEnv: { enabled: false } },
+    });
+    mocks.store.profiles = {};
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+    mocks.externalCliDiscoveryForConfigStatus.mockReturnValue({
+      mode: "none",
+      allowKeychainPrompt: false,
+    });
+
+    try {
+      const storeCallStart = mocks.ensureAuthProfileStore.mock.calls.length;
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = parseFirstJsonLog(localRuntime);
+      const storeOptions = mocks.ensureAuthProfileStore.mock.calls.find(
+        ([agentDir], index) => index >= storeCallStart && agentDir === "/tmp/openclaw-agent",
+      )?.[1] as
+        | {
+            externalCli?: {
+              mode?: string;
+              providerIds?: Iterable<string>;
+              profileIds?: Iterable<string>;
+            };
+          }
+        | undefined;
+      const providerIds = [...(storeOptions?.externalCli?.providerIds ?? [])];
+      const profileIds = [...(storeOptions?.externalCli?.profileIds ?? [])];
+      expect(storeOptions?.externalCli?.mode).toBe("none");
+      expect(providerIds).toEqual([]);
+      expect(profileIds).toEqual([]);
+      expect(payload.auth.runtimeAuthRoutes).toEqual([]);
+      expect(payload.auth.missingProvidersInUse).toStrictEqual(["openai"]);
+      expect(localRuntime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+      if (originalExternalCliImpl) {
+        mocks.externalCliDiscoveryForConfigStatus.mockImplementation(originalExternalCliImpl);
+      } else {
+        mocks.externalCliDiscoveryForConfigStatus.mockReturnValue({
+          mode: "scoped",
+          providerIds: ["openai"],
+          profileIds: ["openai:codex-cli"],
+        });
+      }
+    }
+  });
+
   it("keeps delegated OAuth marker display separate from runtime route usability", async () => {
     const localRuntime = createRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1314,6 +1314,37 @@ describe("tui session actions", () => {
     expect(state.sessionInfo.thinkingLevel).toBe("medium");
   });
 
+  it("does not remember a generated TUI session before it exists in persisted history", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 0,
+      defaults: {},
+      sessions: [],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      messages: [],
+    });
+    const rememberSessionKey = vi.fn();
+    const state = createBaseState({
+      currentSessionKey: "agent:main:tui-new-empty",
+    });
+
+    const { loadHistory: runLoadHistory } = createTestSessionActions({
+      client: {
+        listSessions,
+        loadHistory,
+      } as unknown as TuiBackend,
+      state,
+      rememberSessionKey,
+    });
+
+    await runLoadHistory();
+
+    expect(state.currentSessionId).toBeNull();
+    expect(rememberSessionKey).not.toHaveBeenCalled();
+  });
+
   it("loads selected-agent global history with the selected agent id", async () => {
     const loadHistory = vi.fn().mockResolvedValue({
       sessionId: "session-work-global",

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -550,7 +550,9 @@ export function createSessionActions(context: SessionActionContext) {
           `runtime prewarm failed: ${record.runtimePluginsPrewarm.error ?? "unknown"}`,
         );
       }
-      void rememberSessionKey?.(state.currentSessionKey);
+      if (state.currentSessionId || (record.messages?.length ?? 0) > 0) {
+        void rememberSessionKey?.(state.currentSessionKey);
+      }
     } catch (err) {
       chatLog.addSystem(`history failed: ${String(err)}`);
     }


### PR DESCRIPTION
## What Problem This Solves

Four independent, test-backed bugfixes from local use. Each commit is self-contained; happy to split into separate PRs if preferred.

1. **fix(tui): avoid remembering empty generated sessions** — stops TUI persisting empty generated sessions; adds regression test.
2. **fix(codex): keep workspace app-server network available** — keeps workspace codex app-server network available so spawned/delegated runs do not lose connectivity mid-turn; adds app-server/config test.
3. **fix(browser): allow explicit safe local file navigation** — allows local report navigation without reopening browser SSRF paths. Repair update restricts `file:` navigation to explicit top-level hostless/localhost targets with inert extensions only; remote/UNC file URLs, active local documents, redirects, and subframe/file pivots remain blocked.
4. **fix(models): honor Codex CLI auth in status without widening custom providers** — models status honors Codex CLI auth for the Codex runtime while keeping custom OpenAI-compatible providers on their own auth path.

This repair also addresses PR review/CI findings:

- Adds `maxPayload` to `noServer` WebSocket test servers flagged by OpenGrep.
- Adds regression coverage proving Codex CLI auth discovery is not applied to custom OpenAI-compatible providers.
- Replaces the previous broad browser `file:` allow with a narrower opt-in policy for explicit inert local files.

## Evidence

Local validation on repair commit `f11a5e79a8`:

- `pnpm exec vitest run extensions/browser/src/browser/navigation-guard.test.ts extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts extensions/browser/src/browser/server-context.tab-selection-state.test.ts extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts extensions/browser/src/browser/cdp.test.ts src/commands/models/list.status.test.ts` — 7 files passed, 158 tests passed.
- `pnpm exec vitest run src/commands/models/list.status.test.ts` — 1 file passed, 34 tests passed after tightening the custom-provider assertion.
- `pnpm exec oxfmt --check --threads=1 $(git diff --name-only -- '*.ts')` — all 14 changed TypeScript files used the correct format before commit.
- `git diff --check` — passed.
- `pnpm tsgo:core:test` — passed.
- `pnpm tsgo:extensions:test` — passed.
- `pnpm lint:core` — passed.
- `pnpm lint:extensions` — passed.

Notes:

- No generated files or unrelated local worktree changes were staged into the repair commit.
- GitHub Actions will be watched after the repaired branch is pushed.
