### PR TITLE
fix(discord): download attachments at receipt time, not after the run queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Discord queued attachments:** download direct and forwarded media during authorized receipt-time preflight so expiring CDN URLs cannot lose attachments behind a busy run queue. (#96183, #96165) Thanks @ZacharyYW.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Discord queued attachments:** download direct and forwarded signed CDN attachments during authorized receipt preflight so busy-run queues cannot outlive Discord URL expiry, while dropping repeat-bot traffic before media I/O. (#96183, #96165) Thanks @ZacharyYW.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Discord queued attachments:** download direct and forwarded media during authorized receipt-time preflight so expiring CDN URLs cannot lose attachments behind a busy run queue. (#96183, #96165) Thanks @ZacharyYW.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Discord queued attachments:** download direct and forwarded signed CDN attachments during authorized receipt preflight so busy-run queues cannot outlive Discord URL expiry, while dropping repeat-bot traffic before media I/O. (#96183, #96165) Thanks @ZacharyYW.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/extensions/discord/src/monitor/inbound-job.test.ts
+++ b/extensions/discord/src/monitor/inbound-job.test.ts
@@ -72,6 +72,13 @@ describe("buildDiscordInboundJob", () => {
         },
         ownerId: "user-1",
       },
+      preparedMedia: [
+        {
+          path: "/tmp/openclaw-discord-test/photo.png",
+          contentType: "image/png",
+          placeholder: "<media:image>",
+        },
+      ],
     });
 
     const job = buildDiscordInboundJob(ctx);
@@ -95,6 +102,7 @@ describe("buildDiscordInboundJob", () => {
       ownerId: "user-1",
     });
     const serializedPayload = jsonRoundTrip(job.payload);
+    expect(serializedPayload.preparedMedia).toEqual(ctx.preparedMedia);
     expect(serializedPayload.threadChannel).toEqual({
       id: "thread-1",
       name: "codex",

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -569,6 +569,47 @@ describe("preflightDiscordMessage", () => {
     expect(preflight.preflightAudioTranscript).toBe("hello openclaw from dm audio");
   });
 
+  it("downloads attachments during preflight, before the message reaches the run queue", async () => {
+    // Regression for #96165: Discord CDN attachment URLs expire. Downloading
+    // must happen at receipt time (preflight), not after a possible run-queue
+    // delay, or queued messages lose their media.
+    const result = await runDmPreflight({
+      channelId: "dm-channel-image-1",
+      message: createDiscordMessage({
+        id: "m-dm-image-1",
+        channelId: "dm-channel-image-1",
+        content: "look at this",
+        attachments: [
+          {
+            id: "att-dm-image-1",
+            url: "https://cdn.discordapp.com/attachments/1/photo.png?ex=expired",
+            content_type: "image/png",
+            filename: "photo.png",
+          },
+        ],
+        author: {
+          id: "user-1",
+          bot: false,
+          username: "alice",
+        },
+      }),
+      discordConfig: {
+        dmPolicy: "open",
+      } as DiscordConfig,
+    });
+
+    expect(saveRemoteMediaMock).toHaveBeenCalledTimes(1);
+    const preflight = expectPreflightResult(result);
+    expect(preflight.preflightMediaList).toEqual([
+      {
+        path: "/tmp/openclaw-discord-test/photo.png",
+        contentType: "image/png",
+        placeholder: "<media:image>",
+      },
+    ]);
+    expect(preflight.preflightForwardedMediaList).toEqual([]);
+  });
+
   it("keeps no-guild messages direct when channel lookup is unavailable", async () => {
     const result = await runUnresolvedDmPreflight({
       cfg: {

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -694,7 +694,7 @@ describe("preflightDiscordMessage", () => {
     ).toBe("default");
   });
 
-  it("passes bot-loop protection facts for accepted bot-authored Discord messages (#58789)", async () => {
+  it("suppresses repeated bot messages before downloading attachments (#58789)", async () => {
     const channelId = "channel-bot-loop";
     const guildId = "guild-bot-loop";
     const senderBotId = "relay-bot-1";
@@ -715,7 +715,7 @@ describe("preflightDiscordMessage", () => {
           allowBots: true,
           botLoopProtection: {
             enabled: true,
-            maxEventsPerWindow: 3,
+            maxEventsPerWindow: 1,
             cooldownSeconds: 60,
           },
         } as DiscordConfig,
@@ -729,58 +729,77 @@ describe("preflightDiscordMessage", () => {
       }),
     );
 
-    expect(expectPreflightResult(result).botLoopProtection).toEqual({
-      scopeId: "default",
-      conversationId: channelId,
-      senderId: senderBotId,
-      receiverId: "openclaw-bot",
-      config: {
-        enabled: true,
-        maxEventsPerWindow: 3,
-        cooldownSeconds: 60,
-      },
-      defaultsConfig: undefined,
-      defaultEnabled: true,
-      nowMs: Date.parse(messageTimestamp),
+    expect(result).not.toBeNull();
+
+    const repeatedMessage = createDiscordMessage({
+      id: "m-loop-2",
+      channelId,
+      content: "more chatter <@openclaw-bot>",
+      mentionedUsers: [{ id: "openclaw-bot" }],
+      attachments: [
+        {
+          id: "att-loop",
+          url: "https://cdn.discordapp.com/attachments/1/loop.png",
+          content_type: "image/png",
+          filename: "loop.png",
+        },
+      ],
+      author: { id: senderBotId, bot: true, username: "Relay" },
+      timestamp: "2026-05-13T05:00:00.001Z",
     });
+
+    expect(
+      await runGuildPreflight({
+        channelId,
+        guildId,
+        message: repeatedMessage,
+        discordConfig: {
+          allowBots: true,
+          botLoopProtection: {
+            enabled: true,
+            maxEventsPerWindow: 1,
+            cooldownSeconds: 60,
+          },
+        } as DiscordConfig,
+      }),
+    ).toBeNull();
+    expect(saveRemoteMediaMock).not.toHaveBeenCalled();
   });
 
   it("passes generic channel defaults for Discord bot loop budgets", async () => {
     const channelId = "channel-bot-loop-defaults";
     const guildId = "guild-bot-loop-defaults";
     const discordConfig = { allowBots: true } as DiscordConfig;
-    const message = createDiscordMessage({
-      id: "m-loop-default-1",
-      channelId,
-      content: "relay <@openclaw-bot>",
-      mentionedUsers: [{ id: "openclaw-bot" }],
-      author: { id: "relay-bot-defaults", bot: true, username: "Relay" },
-    });
-    const result = await runGuildPreflight({
-      channelId,
-      guildId,
-      message,
-      discordConfig,
-      cfg: {
-        ...DEFAULT_PREFLIGHT_CFG,
-        channels: {
-          defaults: {
-            botLoopProtection: {
-              maxEventsPerWindow: 1,
-              cooldownSeconds: 60,
+    const runBotMessage = async (id: string) =>
+      await runGuildPreflight({
+        channelId,
+        guildId,
+        message: createDiscordMessage({
+          id,
+          channelId,
+          content: "relay <@openclaw-bot>",
+          mentionedUsers: [{ id: "openclaw-bot" }],
+          author: { id: "relay-bot-defaults", bot: true, username: "Relay" },
+        }),
+        discordConfig,
+        cfg: {
+          ...DEFAULT_PREFLIGHT_CFG,
+          channels: {
+            defaults: {
+              botLoopProtection: {
+                maxEventsPerWindow: 1,
+                cooldownSeconds: 60,
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    expect(expectPreflightResult(result).botLoopProtection?.defaultsConfig).toEqual({
-      maxEventsPerWindow: 1,
-      cooldownSeconds: 60,
-    });
+    expect(await runBotMessage("m-loop-default-1")).not.toBeNull();
+    expect(await runBotMessage("m-loop-default-2")).toBeNull();
   });
 
-  it("does not prepare loop-guard facts for bot messages that later preflight gates drop (#58789)", async () => {
+  it("does not count bot messages that earlier preflight gates drop (#58789)", async () => {
     const channelId = "channel-bot-loop-dropped";
     const guildId = "guild-bot-loop-dropped";
     const senderBotId = "relay-bot-dropped";

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -600,14 +600,13 @@ describe("preflightDiscordMessage", () => {
 
     expect(saveRemoteMediaMock).toHaveBeenCalledTimes(1);
     const preflight = expectPreflightResult(result);
-    expect(preflight.preflightMediaList).toEqual([
+    expect(preflight.preparedMedia).toEqual([
       {
         path: "/tmp/openclaw-discord-test/photo.png",
         contentType: "image/png",
         placeholder: "<media:image>",
       },
     ]);
-    expect(preflight.preflightForwardedMediaList).toEqual([]);
   });
 
   it("keeps no-guild messages direct when channel lookup is unavailable", async () => {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -64,9 +64,14 @@ import {
   resolveDiscordChannelInfo,
   resolveDiscordMessageChannelId,
   resolveDiscordMessageText,
+  resolveForwardedMediaList,
   resolveMediaList,
 } from "./message-utils.js";
 import { resolveDiscordSenderIdentity, resolveDiscordWebhookId } from "./sender-identity.js";
+import {
+  DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
+  DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
+} from "./timeouts.js";
 
 export type {
   DiscordMessagePreflightContext,
@@ -769,6 +774,32 @@ export async function preflightDiscordMessage(
         }
       : undefined;
 
+  // Discord CDN attachment URLs expire; download now (receipt time) instead
+  // of after the run queue, which may delay processing past the URL TTL.
+  const mediaResolveOptions = {
+    fetchImpl: params.discordRestFetch,
+    ssrfPolicy: params.cfg.browser?.ssrfPolicy,
+    readIdleTimeoutMs: DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
+    totalTimeoutMs: DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
+    abortSignal: params.abortSignal,
+  };
+  const preflightMediaList = await resolveMediaList(
+    message,
+    params.mediaMaxBytes,
+    mediaResolveOptions,
+  );
+  if (isPreflightAborted(params.abortSignal)) {
+    return null;
+  }
+  const preflightForwardedMediaList = await resolveForwardedMediaList(
+    message,
+    params.mediaMaxBytes,
+    mediaResolveOptions,
+  );
+  if (isPreflightAborted(params.abortSignal)) {
+    return null;
+  }
+
   logDebug(
     `[discord-preflight] success: route=${effectiveRoute.agentId} sessionKey=${effectiveRoute.sessionKey}`,
   );
@@ -791,6 +822,8 @@ export async function preflightDiscordMessage(
     baseText,
     messageText,
     ...(preflightTranscript !== undefined ? { preflightAudioTranscript: preflightTranscript } : {}),
+    preflightMediaList,
+    preflightForwardedMediaList,
     wasMentioned,
     route: effectiveRoute,
     threadBinding,

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -5,6 +5,7 @@ import {
   buildMentionRegexes,
   classifyChannelInboundEvent,
   logInboundDrop,
+  recordChannelBotPairLoopAndCheckSuppression,
   resolveInboundMentionDecision,
   resolveUnmentionedGroupInboundPolicy,
   recordDroppedChannelInboundHistory,
@@ -773,6 +774,15 @@ export async function preflightDiscordMessage(
           nowMs: resolveTimestampMs(message.timestamp),
         }
       : undefined;
+  if (botLoopProtection) {
+    const botLoopResult = recordChannelBotPairLoopAndCheckSuppression(botLoopProtection);
+    if (botLoopResult.suppressed) {
+      logVerbose(
+        `discord: bot-to-bot loop detected before media download, suppressing for ${Math.max(0, Math.ceil((botLoopResult.cooldownUntilMs - Date.now()) / 1000))}s`,
+      );
+      return null;
+    }
+  }
 
   // Discord CDN attachment URLs expire; download now (receipt time) instead
   // of after the run queue, which may delay processing past the URL TTL.
@@ -850,6 +860,5 @@ export async function preflightDiscordMessage(
     inboundEventKind,
     canDetectMention,
     historyEntry,
-    botLoopProtection,
   });
 }

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -783,7 +783,11 @@ export async function preflightDiscordMessage(
     totalTimeoutMs: DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
     abortSignal: params.abortSignal,
   };
-  const preflightMediaList = await resolveMediaList(
+  const preparedMedia = await resolveMediaList(message, params.mediaMaxBytes, mediaResolveOptions);
+  if (isPreflightAborted(params.abortSignal)) {
+    return null;
+  }
+  const forwardedMedia = await resolveForwardedMediaList(
     message,
     params.mediaMaxBytes,
     mediaResolveOptions,
@@ -791,14 +795,7 @@ export async function preflightDiscordMessage(
   if (isPreflightAborted(params.abortSignal)) {
     return null;
   }
-  const preflightForwardedMediaList = await resolveForwardedMediaList(
-    message,
-    params.mediaMaxBytes,
-    mediaResolveOptions,
-  );
-  if (isPreflightAborted(params.abortSignal)) {
-    return null;
-  }
+  preparedMedia.push(...forwardedMedia);
 
   logDebug(
     `[discord-preflight] success: route=${effectiveRoute.agentId} sessionKey=${effectiveRoute.sessionKey}`,
@@ -822,8 +819,7 @@ export async function preflightDiscordMessage(
     baseText,
     messageText,
     ...(preflightTranscript !== undefined ? { preflightAudioTranscript: preflightTranscript } : {}),
-    preflightMediaList,
-    preflightForwardedMediaList,
+    preparedMedia,
     wasMentioned,
     route: effectiveRoute,
     threadBinding,

--- a/extensions/discord/src/monitor/message-handler.preflight.types.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.types.ts
@@ -7,7 +7,7 @@ import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import type { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import type { ChannelType, Client, User } from "../internal/discord.js";
 import type { DiscordChannelConfigResolved, DiscordGuildEntryResolved } from "./allow-list.js";
-import type { DiscordChannelInfo } from "./message-utils.js";
+import type { DiscordChannelInfo, DiscordMediaInfo } from "./message-utils.js";
 import type { DiscordThreadBindingLookup } from "./reply-delivery.js";
 import type { DiscordReplyTypingFeedback } from "./reply-typing-feedback.js";
 import type { DiscordSenderIdentity } from "./sender-identity.js";
@@ -60,6 +60,10 @@ export type DiscordMessagePreflightContext = DiscordMessagePreflightSharedFields
   baseText: string;
   messageText: string;
   preflightAudioTranscript?: string;
+  // Fetched at receipt time, before the run queue may delay processing, so
+  // Discord's expiring CDN attachment URLs are still valid when downloaded.
+  preflightMediaList?: DiscordMediaInfo[];
+  preflightForwardedMediaList?: DiscordMediaInfo[];
   wasMentioned: boolean;
 
   route: ReturnType<typeof resolveAgentRoute>;

--- a/extensions/discord/src/monitor/message-handler.preflight.types.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.types.ts
@@ -60,10 +60,9 @@ export type DiscordMessagePreflightContext = DiscordMessagePreflightSharedFields
   baseText: string;
   messageText: string;
   preflightAudioTranscript?: string;
-  // Fetched at receipt time, before the run queue may delay processing, so
-  // Discord's expiring CDN attachment URLs are still valid when downloaded.
-  preflightMediaList?: DiscordMediaInfo[];
-  preflightForwardedMediaList?: DiscordMediaInfo[];
+  // Keep one required receipt-time snapshot: queued processing must never
+  // fall back to Discord's expiring attachment URLs.
+  preparedMedia: DiscordMediaInfo[];
   wasMentioned: boolean;
 
   route: ReturnType<typeof resolveAgentRoute>;

--- a/extensions/discord/src/monitor/message-handler.preflight.types.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.types.ts
@@ -1,6 +1,5 @@
 // Discord type declarations define plugin contracts.
 import type { InboundEventKind } from "openclaw/plugin-sdk/channel-inbound";
-import type { ChannelBotLoopProtectionFacts } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig, ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import type { SessionBindingRecord } from "openclaw/plugin-sdk/conversation-runtime";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
@@ -103,7 +102,6 @@ export type DiscordMessagePreflightContext = DiscordMessagePreflightSharedFields
   threadBindings: DiscordThreadBindingLookup;
   replyTypingFeedback?: DiscordReplyTypingFeedback;
   discordRestFetch?: typeof fetch;
-  botLoopProtection?: ChannelBotLoopProtectionFacts;
 };
 
 export type DiscordMessagePreflightParams = DiscordMessagePreflightSharedFields & {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1,9 +1,5 @@
 // Discord tests cover message handler.process plugin behavior.
 import { DEFAULT_EMOJIS, DEFAULT_TIMING } from "openclaw/plugin-sdk/channel-feedback";
-import {
-  recordChannelBotPairLoopAndCheckSuppression,
-  type ChannelBotLoopProtectionFacts,
-} from "openclaw/plugin-sdk/channel-inbound";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import * as runtimeEnvModule from "openclaw/plugin-sdk/runtime-env";
@@ -754,55 +750,6 @@ function expectFreshFinalText(text: string) {
 }
 
 describe("processDiscordMessage ack reactions", () => {
-  it("drops bot-loop-suppressed messages before Discord side effects", async () => {
-    const botLoopProtection: ChannelBotLoopProtectionFacts = {
-      scopeId: "discord-process-side-effect-test",
-      conversationId: "c-loop-side-effects",
-      senderId: "bot-a",
-      receiverId: "bot-b",
-      config: {
-        maxEventsPerWindow: 1,
-        windowSeconds: 60,
-        cooldownSeconds: 60,
-      },
-      defaultEnabled: true,
-      nowMs: 10_000,
-    };
-    expect(recordChannelBotPairLoopAndCheckSuppression(botLoopProtection)).toEqual({
-      suppressed: false,
-    });
-    const observer = { onReplyPlanResolved: vi.fn() };
-    const ctx = await createAutomaticSourceDeliveryContext({
-      messageChannelId: botLoopProtection.conversationId,
-      message: {
-        id: "m-loop-side-effects",
-        channelId: botLoopProtection.conversationId,
-        timestamp: new Date().toISOString(),
-        attachments: [
-          {
-            id: "att-loop",
-            url: "https://cdn.discordapp.test/loop.png",
-            contentType: "image/png",
-            filename: "loop.png",
-            size: 16,
-          },
-        ],
-      },
-      botLoopProtection: {
-        ...botLoopProtection,
-        nowMs: 10_001,
-      },
-    });
-
-    await processDiscordMessage(ctx, observer);
-
-    expect(observer.onReplyPlanResolved).not.toHaveBeenCalled();
-    expect(createDiscordRestClientSpy).not.toHaveBeenCalled();
-    expect(sendMocks.reactMessageDiscord).not.toHaveBeenCalled();
-    expect(recordInboundSession).not.toHaveBeenCalled();
-    expect(dispatchInboundMessage).not.toHaveBeenCalled();
-  });
-
   it("skips ack reactions for group-mentions when mentions are not required", async () => {
     const ctx = await createBaseContext({
       shouldRequireMention: false,

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1323,12 +1323,6 @@ describe("processDiscordMessage ack reactions", () => {
 
 describe("processDiscordMessage session routing", () => {
   it("carries preflight audio transcript into dispatch context and marks media transcribed", async () => {
-    const fetchImpl = vi.fn(
-      async () =>
-        new Response(new Uint8Array([1, 2, 3, 4]), {
-          headers: { "content-type": "audio/ogg" },
-        }),
-    );
     const ctx = await createBaseContext({
       message: {
         id: "m-audio-preflight",
@@ -1347,8 +1341,13 @@ describe("processDiscordMessage session routing", () => {
       baseText: "<media:audio>",
       messageText: "<media:audio>",
       preflightAudioTranscript: "hello from discord voice",
-      discordRestFetch: fetchImpl,
-      mediaMaxBytes: 1024 * 1024,
+      preparedMedia: [
+        {
+          path: "/tmp/openclaw-discord-test/voice.ogg",
+          contentType: "audio/ogg",
+          placeholder: "<media:audio>",
+        },
+      ],
     });
 
     await runProcessDiscordMessage(ctx);
@@ -1361,7 +1360,7 @@ describe("processDiscordMessage session routing", () => {
     });
   });
 
-  it("reuses preflight-resolved media instead of re-downloading after the run queue", async () => {
+  it("uses prepared media instead of re-downloading after the run queue", async () => {
     // Regression for #96165: Discord CDN attachment URLs expire, so process
     // must not re-fetch attachments preflight already downloaded at receipt
     // time. A throwing fetchImpl here proves no re-fetch happens.
@@ -1385,16 +1384,14 @@ describe("processDiscordMessage session routing", () => {
       },
       baseText: "look",
       messageText: "look",
-      preflightMediaList: [
+      preparedMedia: [
         {
           path: "/tmp/openclaw-discord-test/photo.png",
           contentType: "image/png",
           placeholder: "<media:image>",
         },
       ],
-      preflightForwardedMediaList: [],
       discordRestFetch: fetchImpl,
-      mediaMaxBytes: 1024 * 1024,
     });
 
     await runProcessDiscordMessage(ctx);

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1361,6 +1361,52 @@ describe("processDiscordMessage session routing", () => {
     });
   });
 
+  it("reuses preflight-resolved media instead of re-downloading after the run queue", async () => {
+    // Regression for #96165: Discord CDN attachment URLs expire, so process
+    // must not re-fetch attachments preflight already downloaded at receipt
+    // time. A throwing fetchImpl here proves no re-fetch happens.
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("attachment should not be re-fetched after preflight downloaded it");
+    });
+    const ctx = await createBaseContext({
+      message: {
+        id: "m-preflight-media",
+        channelId: "c1",
+        content: "look",
+        timestamp: new Date().toISOString(),
+        attachments: [
+          {
+            id: "att-preflight-media",
+            url: "https://cdn.discordapp.com/attachments/1/photo.png?ex=expired",
+            content_type: "image/png",
+            filename: "photo.png",
+          },
+        ],
+      },
+      baseText: "look",
+      messageText: "look",
+      preflightMediaList: [
+        {
+          path: "/tmp/openclaw-discord-test/photo.png",
+          contentType: "image/png",
+          placeholder: "<media:image>",
+        },
+      ],
+      preflightForwardedMediaList: [],
+      discordRestFetch: fetchImpl,
+      mediaMaxBytes: 1024 * 1024,
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expectRecordFields(requireRecord(getLastDispatchCtx(), "dispatch context"), {
+      MediaPath: "/tmp/openclaw-discord-test/photo.png",
+      MediaType: "image/png",
+      MediaPaths: ["/tmp/openclaw-discord-test/photo.png"],
+    });
+  });
+
   it("does not attach referenced reply media when reply context is hidden", async () => {
     const fetchImpl = vi.fn(async () => {
       throw new Error("hidden reply media should not be fetched");

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -59,7 +59,11 @@ import {
 import { buildDiscordMessageProcessContext } from "./message-handler.context.js";
 import { createDiscordDraftPreviewController } from "./message-handler.draft-preview.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
-import { resolveForwardedMediaList, resolveMediaList } from "./message-utils.js";
+import {
+  resolveForwardedMediaList,
+  resolveMediaList,
+  type DiscordMediaInfo,
+} from "./message-utils.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
 import { sanitizeDiscordFrontChannelReplyPayloads } from "./reply-safety.js";
 import { createDiscordReplyTypingFeedback } from "./reply-typing-feedback.js";
@@ -183,6 +187,8 @@ async function processDiscordMessageInner(
     abortSignal,
     botLoopProtection,
     replyTypingFeedback,
+    preflightMediaList,
+    preflightForwardedMediaList,
   } = ctx;
   if (isProcessAborted(abortSignal)) {
     return;
@@ -197,27 +203,39 @@ async function processDiscordMessageInner(
     }
   }
 
-  const ssrfPolicy = cfg.browser?.ssrfPolicy;
-  const mediaResolveOptions = {
-    fetchImpl: discordRestFetch,
-    ssrfPolicy,
-    readIdleTimeoutMs: DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
-    totalTimeoutMs: DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
-    abortSignal,
-  };
-  const mediaList = await resolveMediaList(message, mediaMaxBytes, mediaResolveOptions);
+  // Discord CDN attachment URLs expire; preflight already downloaded these
+  // at message-receipt time, before this run could be delayed by the queue.
+  // Contexts built outside preflightDiscordMessage (e.g. tests) fall back to
+  // resolving now.
+  let mediaList: DiscordMediaInfo[];
+  if (preflightMediaList && preflightForwardedMediaList) {
+    mediaList = [...preflightMediaList, ...preflightForwardedMediaList];
+  } else {
+    const ssrfPolicy = cfg.browser?.ssrfPolicy;
+    const mediaResolveOptions = {
+      fetchImpl: discordRestFetch,
+      ssrfPolicy,
+      readIdleTimeoutMs: DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
+      totalTimeoutMs: DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
+      abortSignal,
+    };
+    mediaList = await resolveMediaList(message, mediaMaxBytes, mediaResolveOptions);
+    if (isProcessAborted(abortSignal)) {
+      return;
+    }
+    const forwardedMediaList = await resolveForwardedMediaList(
+      message,
+      mediaMaxBytes,
+      mediaResolveOptions,
+    );
+    if (isProcessAborted(abortSignal)) {
+      return;
+    }
+    mediaList.push(...forwardedMediaList);
+  }
   if (isProcessAborted(abortSignal)) {
     return;
   }
-  const forwardedMediaList = await resolveForwardedMediaList(
-    message,
-    mediaMaxBytes,
-    mediaResolveOptions,
-  );
-  if (isProcessAborted(abortSignal)) {
-    return;
-  }
-  mediaList.push(...forwardedMediaList);
   const text = messageText;
   if (!text) {
     logVerbose("discord: drop message " + message.id + " (empty content)");

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -59,18 +59,9 @@ import {
 import { buildDiscordMessageProcessContext } from "./message-handler.context.js";
 import { createDiscordDraftPreviewController } from "./message-handler.draft-preview.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
-import {
-  resolveForwardedMediaList,
-  resolveMediaList,
-  type DiscordMediaInfo,
-} from "./message-utils.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
 import { sanitizeDiscordFrontChannelReplyPayloads } from "./reply-safety.js";
 import { createDiscordReplyTypingFeedback } from "./reply-typing-feedback.js";
-import {
-  DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
-  DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
-} from "./timeouts.js";
 
 const loadReplyRuntime = createLazyRuntimeModule(() => import("openclaw/plugin-sdk/reply-runtime"));
 const TARGETED_ONLY_ALLOWED_MENTIONS = {
@@ -166,7 +157,6 @@ async function processDiscordMessageInner(
     runtime,
     guildHistories,
     historyLimit,
-    mediaMaxBytes,
     textLimit,
     replyToMode,
     ackReactionScope,
@@ -183,12 +173,10 @@ async function processDiscordMessageInner(
     channelConfig,
     threadBindings,
     route,
-    discordRestFetch,
     abortSignal,
     botLoopProtection,
     replyTypingFeedback,
-    preflightMediaList,
-    preflightForwardedMediaList,
+    preparedMedia: mediaList,
   } = ctx;
   if (isProcessAborted(abortSignal)) {
     return;
@@ -203,39 +191,6 @@ async function processDiscordMessageInner(
     }
   }
 
-  // Discord CDN attachment URLs expire; preflight already downloaded these
-  // at message-receipt time, before this run could be delayed by the queue.
-  // Contexts built outside preflightDiscordMessage (e.g. tests) fall back to
-  // resolving now.
-  let mediaList: DiscordMediaInfo[];
-  if (preflightMediaList && preflightForwardedMediaList) {
-    mediaList = [...preflightMediaList, ...preflightForwardedMediaList];
-  } else {
-    const ssrfPolicy = cfg.browser?.ssrfPolicy;
-    const mediaResolveOptions = {
-      fetchImpl: discordRestFetch,
-      ssrfPolicy,
-      readIdleTimeoutMs: DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
-      totalTimeoutMs: DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
-      abortSignal,
-    };
-    mediaList = await resolveMediaList(message, mediaMaxBytes, mediaResolveOptions);
-    if (isProcessAborted(abortSignal)) {
-      return;
-    }
-    const forwardedMediaList = await resolveForwardedMediaList(
-      message,
-      mediaMaxBytes,
-      mediaResolveOptions,
-    );
-    if (isProcessAborted(abortSignal)) {
-      return;
-    }
-    mediaList.push(...forwardedMediaList);
-  }
-  if (isProcessAborted(abortSignal)) {
-    return;
-  }
   const text = messageText;
   if (!text) {
     logVerbose("discord: drop message " + message.id + " (empty content)");

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -11,7 +11,6 @@ import {
 import {
   dispatchChannelInboundReply,
   hasFinalInboundReplyDispatch,
-  recordChannelBotPairLoopAndCheckSuppression,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
   createChannelMessageReplyPipeline,
@@ -174,23 +173,12 @@ async function processDiscordMessageInner(
     threadBindings,
     route,
     abortSignal,
-    botLoopProtection,
     replyTypingFeedback,
     preparedMedia: mediaList,
   } = ctx;
   if (isProcessAborted(abortSignal)) {
     return;
   }
-  if (botLoopProtection) {
-    const botLoopResult = recordChannelBotPairLoopAndCheckSuppression(botLoopProtection);
-    if (botLoopResult.suppressed) {
-      logVerbose(
-        `discord: bot-to-bot loop detected before dispatch setup, suppressing for ${Math.max(0, Math.ceil((botLoopResult.cooldownUntilMs - Date.now()) / 1000))}s`,
-      );
-      return;
-    }
-  }
-
   const text = messageText;
   if (!text) {
     logVerbose("discord: drop message " + message.id + " (empty content)");

--- a/extensions/discord/src/monitor/message-handler.test-harness.ts
+++ b/extensions/discord/src/monitor/message-handler.test-harness.ts
@@ -47,6 +47,7 @@ export async function createBaseDiscordMessageContext(
     commandAuthorized: true,
     baseText: "hi",
     messageText: "hi",
+    preparedMedia: [],
     wasMentioned: false,
     shouldRequireMention: true,
     canDetectMention: true,


### PR DESCRIPTION
## What Problem This Solves

Discord messages with attachments can wait in the inbound run queue while OpenClaw processes an earlier request. Discord attachment CDN URLs are signed and expire at the fixed `ex` timestamp, so downloading only after dequeue can silently lose the media before the agent sees it.

## Why This Change Was Made

Authorized Discord preflight now resolves direct and forwarded attachments at receipt time, combines them into one required `preparedMedia` array, and serializes that immutable snapshot into the queued inbound job. Processing consumes only the prepared array; the delayed download path, process-time fallback, and duplicate timeout plumbing are removed.

Bot-loop suppression also runs before CDN I/O. Messages rejected as repeated bot traffic therefore perform no media download and never enter the run queue.

This matches Discord's documented [signed attachment CDN URL](https://docs.discord.com/developers/reference#signed-attachment-cdn-urls) contract and keeps volatile transport work at the receipt boundary.

## User Impact

Discord image, file, video, and forwarded attachments sent while OpenClaw is busy are downloaded immediately and remain available when the queued message eventually runs. Text-only messages and existing attachment authorization, size, SSRF, and timeout protections are unchanged.

## Evidence

- Focused Discord monitor regression suite on maintained implementation head `695599f0f1f3f23d53867d955ef4875a1aefc81e`: 169/169 passed. Subsequent rebases only incorporated unrelated `main` changes.
- `corepack pnpm build` passed on that implementation tree on the dedicated QA host.
- Live Discord busy-queue proof with a real signed CDN PNG: while A2 remained in a 60-second tool run, B2's attachment was written locally 178 ms after receipt. A2 replied at 19:40:08 UTC; queued B2 then consumed the prepared image and replied at 19:40:16 UTC.
- Regression coverage includes direct and forwarded preflight media, queued job serialization, process consumption without re-fetch, and repeat-bot suppression before download.
- Fresh full-branch autoreview after the ordering fix: no actionable findings.
- `oxfmt` and `git diff --check`: clean.

Fixes #96165
