### PR TITLE
fix(memory): large legacy memory index stalls and restarts instead of finishing

### DIFF
--- a/packages/memory-host-sdk/src/host/memory-schema.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.test.ts
@@ -261,4 +261,49 @@ describe("memory index schema", () => {
       db.close();
     }
   });
+
+  it("keeps legacy tables when an empty-canonical copy loses rows", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      // Legacy meta without a primary key can hold two rows for one key. The
+      // canonical meta PK collapses them, so the cheap empty-canonical row-count
+      // check must detect the shortfall and keep the legacy tables rather than
+      // dropping data — the same fail-closed guarantee as the full anti-join.
+      db.exec(`
+        CREATE TABLE meta (key TEXT, value TEXT NOT NULL);
+        CREATE TABLE files (
+          path TEXT PRIMARY KEY,
+          source TEXT NOT NULL DEFAULT 'memory',
+          hash TEXT NOT NULL,
+          mtime INTEGER NOT NULL,
+          size INTEGER NOT NULL
+        );
+        CREATE TABLE chunks (
+          id TEXT PRIMARY KEY,
+          path TEXT NOT NULL,
+          source TEXT NOT NULL DEFAULT 'memory',
+          start_line INTEGER NOT NULL,
+          end_line INTEGER NOT NULL,
+          hash TEXT NOT NULL,
+          model TEXT NOT NULL,
+          text TEXT NOT NULL,
+          embedding TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        INSERT INTO meta VALUES ('memory_index_meta_v1', 'first');
+        INSERT INTO meta VALUES ('memory_index_meta_v1', 'second');
+      `);
+
+      expect(() =>
+        ensureMemoryIndexSchema({
+          db,
+          cacheEnabled: false,
+          ftsEnabled: false,
+        }),
+      ).toThrow("legacy memory meta rows conflict");
+      expect(db.prepare("SELECT COUNT(*) AS count FROM meta").get()).toEqual({ count: 2 });
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -67,6 +67,46 @@ function assertLegacyRowsCopied(db: DatabaseSync, query: string, tableName: stri
   }
 }
 
+function canonicalTableHasRows(db: DatabaseSync, table: string): boolean {
+  return db.prepare(`SELECT 1 FROM ${table} LIMIT 1`).get() !== undefined;
+}
+
+function tableRowCount(db: DatabaseSync, table: string): number {
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as
+    | { count?: unknown }
+    | undefined;
+  return Number(row?.count ?? 0);
+}
+
+// Verify a legacy table was fully copied before the caller drops it. When the
+// canonical table was empty before the copy, INSERT OR IGNORE from its single
+// legacy source cannot collide, so a row-count match proves every row landed.
+// Only a canonical table that already held rows can hide a key whose value
+// differs from legacy, so the per-row full-tuple anti-join runs only then.
+// Skipping it for the common (empty) case keeps large stores (90k+ chunks,
+// 170k+ cache rows) from spending the whole migration window comparing
+// text/embedding blobs row by row, timing out, and rolling the savepoint back
+// on every interrupt — which left the legacy tables in place and re-ran the
+// migration forever.
+function verifyLegacyRowsCopied(
+  db: DatabaseSync,
+  params: {
+    canonicalPrefilled: boolean;
+    legacyTable: string;
+    canonicalTable: string;
+    conflictQuery: string;
+    label: string;
+  },
+): void {
+  if (params.canonicalPrefilled) {
+    assertLegacyRowsCopied(db, params.conflictQuery, params.label);
+    return;
+  }
+  if (tableRowCount(db, params.canonicalTable) !== tableRowCount(db, params.legacyTable)) {
+    throw new Error(`legacy memory ${params.label} rows conflict with canonical memory index rows`);
+  }
+}
+
 function migrateCanonicalMemoryIndexSourcesPrimaryKey(db: DatabaseSync): void {
   if (
     !tableHasExactColumns(db, MEMORY_INDEX_SOURCES_TABLE, MEMORY_INDEX_SOURCE_COLUMNS) ||
@@ -132,6 +172,9 @@ function migrateLegacyMemoryIndexTables(
 
   db.exec("SAVEPOINT migrate_legacy_memory_index_tables");
   try {
+    const metaPrefilled = canonicalTableHasRows(db, MEMORY_INDEX_META_TABLE);
+    const sourcesPrefilled = canonicalTableHasRows(db, MEMORY_INDEX_SOURCES_TABLE);
+    const chunksPrefilled = canonicalTableHasRows(db, MEMORY_INDEX_CHUNKS_TABLE);
     db.exec(`
       INSERT OR IGNORE INTO ${MEMORY_INDEX_META_TABLE} (key, value)
       SELECT key, value FROM meta;
@@ -145,19 +188,24 @@ function migrateLegacyMemoryIndexTables(
       SELECT id, path, source, start_line, end_line, hash, model, text, embedding, updated_at
       FROM chunks;
     `);
-    assertLegacyRowsCopied(
-      db,
-      `SELECT COUNT(*) AS missing
+    verifyLegacyRowsCopied(db, {
+      canonicalPrefilled: metaPrefilled,
+      legacyTable: "meta",
+      canonicalTable: MEMORY_INDEX_META_TABLE,
+      label: "meta",
+      conflictQuery: `SELECT COUNT(*) AS missing
        FROM meta AS legacy
        WHERE NOT EXISTS (
          SELECT 1 FROM ${MEMORY_INDEX_META_TABLE} AS canonical
          WHERE canonical.key = legacy.key AND canonical.value IS legacy.value
        )`,
-      "meta",
-    );
-    assertLegacyRowsCopied(
-      db,
-      `SELECT COUNT(*) AS missing
+    });
+    verifyLegacyRowsCopied(db, {
+      canonicalPrefilled: sourcesPrefilled,
+      legacyTable: "files",
+      canonicalTable: MEMORY_INDEX_SOURCES_TABLE,
+      label: "files",
+      conflictQuery: `SELECT COUNT(*) AS missing
        FROM files AS legacy
        WHERE NOT EXISTS (
          SELECT 1 FROM ${MEMORY_INDEX_SOURCES_TABLE} AS canonical
@@ -167,11 +215,13 @@ function migrateLegacyMemoryIndexTables(
            AND canonical.mtime IS legacy.mtime
            AND canonical.size IS legacy.size
        )`,
-      "files",
-    );
-    assertLegacyRowsCopied(
-      db,
-      `SELECT COUNT(*) AS missing
+    });
+    verifyLegacyRowsCopied(db, {
+      canonicalPrefilled: chunksPrefilled,
+      legacyTable: "chunks",
+      canonicalTable: MEMORY_INDEX_CHUNKS_TABLE,
+      label: "chunks",
+      conflictQuery: `SELECT COUNT(*) AS missing
        FROM chunks AS legacy
        WHERE NOT EXISTS (
          SELECT 1 FROM ${MEMORY_INDEX_CHUNKS_TABLE} AS canonical
@@ -186,8 +236,7 @@ function migrateLegacyMemoryIndexTables(
            AND canonical.embedding IS legacy.embedding
            AND canonical.updated_at IS legacy.updated_at
        )`,
-      "chunks",
-    );
+    });
     if (
       preservedEmbeddingCacheTable !== "embedding_cache" &&
       tableHasExactColumns(db, "embedding_cache", [
@@ -211,15 +260,21 @@ function migrateLegacyMemoryIndexTables(
           updated_at INTEGER NOT NULL,
           PRIMARY KEY (provider, model, provider_key, hash)
         );
+      `);
+      const cachePrefilled = canonicalTableHasRows(db, MEMORY_EMBEDDING_CACHE_TABLE);
+      db.exec(`
         INSERT OR IGNORE INTO ${MEMORY_EMBEDDING_CACHE_TABLE} (
           provider, model, provider_key, hash, embedding, dims, updated_at
         )
         SELECT provider, model, provider_key, hash, embedding, dims, updated_at
         FROM embedding_cache;
       `);
-      assertLegacyRowsCopied(
-        db,
-        `SELECT COUNT(*) AS missing
+      verifyLegacyRowsCopied(db, {
+        canonicalPrefilled: cachePrefilled,
+        legacyTable: "embedding_cache",
+        canonicalTable: MEMORY_EMBEDDING_CACHE_TABLE,
+        label: "embedding_cache",
+        conflictQuery: `SELECT COUNT(*) AS missing
          FROM embedding_cache AS legacy
          WHERE NOT EXISTS (
            SELECT 1 FROM ${MEMORY_EMBEDDING_CACHE_TABLE} AS canonical
@@ -231,8 +286,7 @@ function migrateLegacyMemoryIndexTables(
              AND canonical.dims IS legacy.dims
              AND canonical.updated_at IS legacy.updated_at
          )`,
-        "embedding_cache",
-      );
+      });
       db.exec("DROP TABLE embedding_cache");
     }
     for (const trigger of LEGACY_MEMORY_INDEX_TRIGGERS) {


### PR DESCRIPTION
_AI-assisted PR (Claude Code). I understand the change and have validated the touched surface; details below._

## What Problem This Solves

Fixes an issue where an agent with a large pre-existing memory index (tens of thousands of chunks / embedding-cache rows) sees `openclaw memory index` appear to hang and vector search never reach `ready` after upgrading to the canonicalized memory schema. The one-time legacy→canonical migration runs inside a single transaction on every memory-store open; on a large store it runs long enough that any interruption (gateway restart, redeploy) rolls it back, leaving the legacy tables in place — so it restarts from scratch on the next open and never finishes.

## Why This Change Was Made

The migration verifies the copy by re-scanning every legacy row with a full-tuple anti-join that byte-compares the large `text`/`embedding` columns it just copied. When the canonical table was empty before the copy, an `INSERT OR IGNORE` from a single legacy source cannot collide, so that check can only ever return zero — it is provably unnecessary work, and it dominates (and outgrows) migration time as the store grows.

This change verifies the empty-canonical case with a row-count match, and keeps the full anti-join only when the canonical table already held rows (the real conflict case that the existing "keeps legacy tables when canonical rows conflict" test guards). What gets migrated, and conflict handling, are unchanged. Scope is intentionally limited to the verification step; relocating the migration out of the hot store-open path entirely is a larger, separate change.

## User Impact

Agents with large legacy memory stores complete the one-time migration far faster and reliably reach `Vector search: ready` after upgrade, instead of looping. No configuration or user action is required, and there is no behavior change for normal-size stores.

## Evidence

Touched surface is `packages/memory-host-sdk/src/host/memory-schema.ts` (+ its test).

- **Unit tests** — `packages/memory-host-sdk/src/host/memory-schema.test.ts` passes 7/7. The existing migrate + conflict-keep tests are unchanged; added one test asserting the new empty-canonical path still fails closed (keeps the legacy tables) when a copy would lose rows.
- **Typecheck / lint / format** — `tsgo:test:packages` clean (0 errors); prod typecheck reports nothing in `memory-host-sdk`; `oxlint` and `oxfmt` clean on the changed files.
- **Benchmark** — file-backed SQLite, canonical rows are exact copies of legacy rows (the migration's real worst case, where every blob comparison must read the full value):

  | rows (chunks + cache) | DB size | copy (`INSERT OR IGNORE`) | old verify (blob anti-join) | new verify (count match) |
  |---|---|---|---|---|
  | 15,000 | 985 MB | 1099 ms | 182 ms | ~0 ms |
  | 40,000 | 2.6 GB | 7649 ms | **4459 ms** | 1 ms |

  The old verification grows super-linearly (≈24× slower for ≈2.7× the rows) and reaches 37% of migration time at 40k rows and climbing; on a ~6 GB / 90k-chunk store it is tens of seconds to minutes, which is what exceeds the interrupt window and drives the restart loop. The new row-count check is constant-time.

- **`codex review`** (local, `--base upstream/main`) — no actionable findings.

Full `pnpm build && pnpm check && pnpm test` is left to CI on this PR; local validation focused on the touched memory-host-sdk surface above.
