### PR TITLE
refactor: route plugin host hook state through accessor

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -109,6 +109,7 @@ export const migratedSessionAccessorFiles = new Set([
   "src/infra/outbound/message-action-tts.ts",
   "src/agents/tools/embedded-gateway-stub.ts",
   "src/agents/tools/sessions-list-tool.ts",
+  "src/plugins/host-hook-state.ts",
   "src/status/status-message.ts",
   "src/tui/embedded-backend.ts",
 ]);
@@ -147,6 +148,7 @@ export const migratedSessionAccessorWriteFiles = new Set([
   "src/commands/tasks.ts",
   "src/config/sessions/cleanup-service.ts",
   "src/plugins/host-hook-cleanup.ts",
+  "src/plugins/host-hook-state.ts",
   "src/tui/embedded-backend.ts",
 ]);
 
@@ -535,6 +537,7 @@ export async function main() {
     "src/cron",
     "src/gateway",
     "src/infra",
+    "src/plugins",
     "src/tui",
   ]);
   const writeSourceRoots = resolveSourceRoots(repoRoot, [

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -23,10 +23,12 @@ import {
   publishTranscriptUpdate,
   readSessionUpdatedAt,
   replaceSessionEntry,
+  resolveSessionEntryAccessTarget,
   resolveSessionTranscriptReadTarget,
   resolveSessionTranscriptRuntimeReadTarget,
   resolveSessionTranscriptRuntimeTarget,
   trimSessionTranscriptForManualCompact,
+  updateResolvedSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
@@ -446,6 +448,88 @@ describe("session accessor file-backed seam", () => {
         sessionId: "legacy-session",
       }),
     });
+  });
+
+  it("updates the freshest matching session entry across discovered agent stores", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const cfg = {
+      session: {
+        mainKey: "main",
+        store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+      },
+      agents: { list: [{ id: "retired-agent", default: true }] },
+    } satisfies OpenClawConfig;
+    const configuredStorePath = path.join(
+      stateDir,
+      "agents",
+      "retired-agent",
+      "sessions",
+      "sessions.json",
+    );
+    const discoveredStorePath = path.join(
+      stateDir,
+      "agents",
+      "Retired Agent",
+      "sessions",
+      "sessions.json",
+    );
+    fs.mkdirSync(path.dirname(configuredStorePath), { recursive: true });
+    fs.mkdirSync(path.dirname(discoveredStorePath), { recursive: true });
+    fs.writeFileSync(
+      configuredStorePath,
+      JSON.stringify({
+        "agent:retired-agent:main": { sessionId: "configured", updatedAt: 10 },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      discoveredStorePath,
+      JSON.stringify({
+        "agent:retired-agent:main": { sessionId: "discovered", updatedAt: 20 },
+      }),
+      "utf8",
+    );
+
+    const resolved = resolveSessionEntryAccessTarget({
+      cfg,
+      env,
+      sessionKey: "agent:retired-agent:main",
+    });
+
+    expect(resolved.entry?.sessionId).toBe("discovered");
+
+    const updated = await updateResolvedSessionEntry(
+      {
+        cfg,
+        env,
+        sessionKey: "agent:retired-agent:main",
+      },
+      (entry, context) => {
+        expect(context.canonicalKey).toBe("agent:retired-agent:main");
+        expect(context.storeKey).toBe("agent:retired-agent:main");
+        entry.model = "gpt-5.5";
+        entry.updatedAt = Date.now();
+        return entry.sessionId;
+      },
+    );
+
+    expect(updated).toMatchObject({
+      found: true,
+      canonicalKey: "agent:retired-agent:main",
+      result: "discovered",
+    });
+    expect(loadSessionStore(configuredStorePath)["agent:retired-agent:main"]).toMatchObject({
+      sessionId: "configured",
+      updatedAt: 10,
+    });
+    expect(Object.values(loadSessionStore(discoveredStorePath))).toContainEqual(
+      expect.objectContaining({
+        model: "gpt-5.5",
+        sessionId: "discovered",
+        updatedAt: expect.any(Number),
+      }),
+    );
   });
 
   it("applies restart recovery replacements without exposing mutable store rows", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -144,13 +144,15 @@ export type ResolvedSessionEntryAccessTarget = {
   agentId: string;
   /** Canonical session key returned to callers even when an alias row won. */
   canonicalKey: string;
-  /** Freshest matching entry, if any, from the selected backing store. */
+  /** Freshest matching entry, if any. */
   entry?: SessionEntry;
   /** Original caller-supplied key after trimming. */
   requestedKey: string;
   /** Persisted key for the selected row. */
   storeKey: string;
-  /** Current file-backed store path; future backends keep this detail internal. */
+};
+
+type ResolvedSessionEntryStoreTarget = ResolvedSessionEntryAccessTarget & {
   storePath: string;
 };
 
@@ -554,6 +556,19 @@ function findFreshestSessionEntryMatch(
 export function resolveSessionEntryAccessTarget(
   scope: LogicalSessionAccessScope,
 ): ResolvedSessionEntryAccessTarget {
+  const target = resolveSessionEntryStoreTarget(scope);
+  return {
+    agentId: target.agentId,
+    canonicalKey: target.canonicalKey,
+    entry: target.entry,
+    requestedKey: target.requestedKey,
+    storeKey: target.storeKey,
+  };
+}
+
+function resolveSessionEntryStoreTarget(
+  scope: LogicalSessionAccessScope,
+): ResolvedSessionEntryStoreTarget {
   const requestedKey = scope.sessionKey.trim();
   const canonicalKey = resolveSessionStoreKey({ cfg: scope.cfg, sessionKey: requestedKey });
   const agentId = resolveSessionStoreAgentId(scope.cfg, canonicalKey);
@@ -574,7 +589,7 @@ export function resolveSessionEntryAccessTarget(
   };
   let selectedStorePath = fallback.storePath;
   let selectedMatch = findFreshestSessionEntryMatch(
-    listSessionEntries({ storePath: fallback.storePath, clone: false }),
+    listSessionEntries({ storePath: fallback.storePath }),
     scanTargets,
   );
   for (let index = 1; index < candidates.length; index += 1) {
@@ -583,7 +598,7 @@ export function resolveSessionEntryAccessTarget(
       continue;
     }
     const match = findFreshestSessionEntryMatch(
-      listSessionEntries({ storePath: candidate.storePath, clone: false }),
+      listSessionEntries({ storePath: candidate.storePath }),
       scanTargets,
     );
     if (
@@ -612,7 +627,7 @@ export async function updateResolvedSessionEntry<T>(
   scope: LogicalSessionAccessScope,
   update: (entry: SessionEntry, context: ResolvedSessionEntryUpdateContext) => Promise<T> | T,
 ): Promise<ResolvedSessionEntryUpdateResult<T>> {
-  const target = resolveSessionEntryAccessTarget(scope);
+  const target = resolveSessionEntryStoreTarget(scope);
   if (!target.entry) {
     return { canonicalKey: target.canonicalKey, found: false };
   }
@@ -621,9 +636,12 @@ export async function updateResolvedSessionEntry<T>(
     if (!entry) {
       return { canonicalKey: target.canonicalKey, found: false };
     }
-    const context = {
-      ...target,
+    const context: ResolvedSessionEntryUpdateContext = {
+      agentId: target.agentId,
+      canonicalKey: target.canonicalKey,
       entry,
+      requestedKey: target.requestedKey,
+      storeKey: target.storeKey,
     };
     const result = await update(entry, context);
     return {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -6,6 +6,10 @@ import {
   acquireSessionWriteLock,
   resolveSessionWriteLockOptions,
 } from "../../agents/session-write-lock.js";
+import {
+  resolveSessionStoreAgentId,
+  resolveSessionStoreKey,
+} from "../../gateway/session-store-key.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
@@ -18,6 +22,7 @@ import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import { extractGeneratedTranscriptSessionId } from "./generated-transcript-session-id.js";
+import { resolveAgentMainSessionKey } from "./main-session.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
@@ -68,6 +73,7 @@ import {
   type SessionLifecycleArtifactCleanupResult,
   type SessionLifecycleStoreTarget,
 } from "./store.js";
+import { resolveAllAgentSessionStoreTargetsSync, type SessionStoreTarget } from "./targets.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import {
   type AppendSessionTranscriptMessageParams,
@@ -123,6 +129,48 @@ export type SessionAccessScope = {
   /** Explicit store path for callers that already resolved the owning store. */
   storePath?: string;
 };
+
+export type LogicalSessionAccessScope = {
+  /** Runtime config whose session store rules define the logical session owner. */
+  cfg: OpenClawConfig;
+  /** Environment override used when resolving configured/discovered agent stores. */
+  env?: NodeJS.ProcessEnv;
+  /** Canonical or alias session key for the logical entry being read or written. */
+  sessionKey: string;
+};
+
+export type ResolvedSessionEntryAccessTarget = {
+  /** Agent owner inferred from the canonical session key. */
+  agentId: string;
+  /** Canonical session key returned to callers even when an alias row won. */
+  canonicalKey: string;
+  /** Freshest matching entry, if any, from the selected backing store. */
+  entry?: SessionEntry;
+  /** Original caller-supplied key after trimming. */
+  requestedKey: string;
+  /** Persisted key for the selected row. */
+  storeKey: string;
+  /** Current file-backed store path; future backends keep this detail internal. */
+  storePath: string;
+};
+
+export type ResolvedSessionEntryUpdateContext = Omit<ResolvedSessionEntryAccessTarget, "entry"> & {
+  /** Mutable entry inside the storage operation. */
+  entry: SessionEntry;
+};
+
+export type ResolvedSessionEntryUpdateResult<T> =
+  | {
+      canonicalKey: string;
+      found: false;
+    }
+  | {
+      canonicalKey: string;
+      entry: SessionEntry;
+      found: true;
+      result: T;
+      storeKey: string;
+    };
 
 export type SessionTranscriptAccessScope = Omit<SessionAccessScope, "sessionKey"> & {
   /** Explicit transcript file path; bypasses store lookup when already known. */
@@ -427,6 +475,166 @@ export type DeleteSessionEntryLifecycleParams = {
 };
 
 export { clearPluginOwnedSessionState };
+
+function isStorePathTemplate(store?: string): boolean {
+  return typeof store === "string" && store.includes("{agentId}");
+}
+
+function resolveLogicalSessionStoreCandidates(params: {
+  agentId: string;
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): SessionStoreTarget[] {
+  const storeConfig = params.cfg.session?.store;
+  const defaultTarget = {
+    agentId: params.agentId,
+    storePath: resolveStorePath(storeConfig, { agentId: params.agentId, env: params.env }),
+  };
+  if (!isStorePathTemplate(storeConfig)) {
+    return [defaultTarget];
+  }
+  const targets = new Map<string, SessionStoreTarget>();
+  targets.set(defaultTarget.storePath, defaultTarget);
+  for (const target of resolveAllAgentSessionStoreTargetsSync(params.cfg, { env: params.env })) {
+    if (target.agentId === params.agentId) {
+      targets.set(target.storePath, target);
+    }
+  }
+  return [...targets.values()];
+}
+
+function buildLogicalSessionEntryCandidateKeys(params: {
+  agentId: string;
+  canonicalKey: string;
+  cfg: OpenClawConfig;
+  requestedKey: string;
+}): string[] {
+  const targets = new Set<string>();
+  if (params.canonicalKey) {
+    targets.add(params.canonicalKey);
+  }
+  if (params.requestedKey && params.requestedKey !== params.canonicalKey) {
+    targets.add(params.requestedKey);
+  }
+  if (params.canonicalKey === "global" || params.canonicalKey === "unknown") {
+    return [...targets];
+  }
+  const agentMainKey = resolveAgentMainSessionKey({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+  if (params.canonicalKey === agentMainKey) {
+    targets.add(`agent:${params.agentId}:main`);
+  }
+  return [...targets];
+}
+
+function findFreshestSessionEntryMatch(
+  entries: SessionEntrySummary[],
+  candidateKeys: readonly string[],
+): SessionEntrySummary | undefined {
+  let freshest: SessionEntrySummary | undefined;
+  for (const candidate of candidateKeys) {
+    const trimmed = candidate.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const match = entries.find((entry) => entry.sessionKey === trimmed);
+    if (match && (!freshest || (match.entry.updatedAt ?? 0) >= (freshest.entry.updatedAt ?? 0))) {
+      freshest = match;
+    }
+  }
+  return freshest;
+}
+
+/**
+ * Resolves a logical session key to the freshest matching entry across the
+ * configured store and discovered same-agent stores.
+ */
+export function resolveSessionEntryAccessTarget(
+  scope: LogicalSessionAccessScope,
+): ResolvedSessionEntryAccessTarget {
+  const requestedKey = scope.sessionKey.trim();
+  const canonicalKey = resolveSessionStoreKey({ cfg: scope.cfg, sessionKey: requestedKey });
+  const agentId = resolveSessionStoreAgentId(scope.cfg, canonicalKey);
+  const scanTargets = buildLogicalSessionEntryCandidateKeys({
+    agentId,
+    canonicalKey,
+    cfg: scope.cfg,
+    requestedKey,
+  });
+  const candidates = resolveLogicalSessionStoreCandidates({
+    agentId,
+    cfg: scope.cfg,
+    env: scope.env,
+  });
+  const fallback = candidates[0] ?? {
+    agentId,
+    storePath: resolveStorePath(scope.cfg.session?.store, { agentId, env: scope.env }),
+  };
+  let selectedStorePath = fallback.storePath;
+  let selectedMatch = findFreshestSessionEntryMatch(
+    listSessionEntries({ storePath: fallback.storePath, clone: false }),
+    scanTargets,
+  );
+  for (let index = 1; index < candidates.length; index += 1) {
+    const candidate = candidates[index];
+    if (!candidate) {
+      continue;
+    }
+    const match = findFreshestSessionEntryMatch(
+      listSessionEntries({ storePath: candidate.storePath, clone: false }),
+      scanTargets,
+    );
+    if (
+      match &&
+      (!selectedMatch || (match.entry.updatedAt ?? 0) >= (selectedMatch.entry.updatedAt ?? 0))
+    ) {
+      selectedStorePath = candidate.storePath;
+      selectedMatch = match;
+    }
+  }
+  return {
+    agentId,
+    canonicalKey,
+    entry: selectedMatch?.entry,
+    requestedKey,
+    storeKey: selectedMatch?.sessionKey ?? canonicalKey,
+    storePath: selectedStorePath,
+  };
+}
+
+/**
+ * Mutates the freshest matching logical session entry without exposing the
+ * backing store map to callers.
+ */
+export async function updateResolvedSessionEntry<T>(
+  scope: LogicalSessionAccessScope,
+  update: (entry: SessionEntry, context: ResolvedSessionEntryUpdateContext) => Promise<T> | T,
+): Promise<ResolvedSessionEntryUpdateResult<T>> {
+  const target = resolveSessionEntryAccessTarget(scope);
+  if (!target.entry) {
+    return { canonicalKey: target.canonicalKey, found: false };
+  }
+  return await updateSessionStore(target.storePath, async (store) => {
+    const entry = store[target.storeKey];
+    if (!entry) {
+      return { canonicalKey: target.canonicalKey, found: false };
+    }
+    const context = {
+      ...target,
+      entry,
+    };
+    const result = await update(entry, context);
+    return {
+      canonicalKey: target.canonicalKey,
+      entry: structuredClone(entry),
+      found: true,
+      result,
+      storeKey: target.storeKey,
+    };
+  });
+}
 
 /** Returns the entry for a canonical or alias session key, if one exists. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {

--- a/src/plugins/host-hook-state.ts
+++ b/src/plugins/host-hook-state.ts
@@ -1,18 +1,12 @@
 // Tracks host hook state and scheduled turn identifiers.
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { loadSessionStore, updateSessionStore, type SessionEntry } from "../config/sessions.js";
-import { resolveAgentMainSessionKey } from "../config/sessions/main-session.js";
-import { resolveStorePath } from "../config/sessions/paths.js";
+import type { SessionEntry } from "../config/sessions.js";
 import {
-  resolveAllAgentSessionStoreTargetsSync,
-  type SessionStoreTarget,
-} from "../config/sessions/targets.js";
+  resolveSessionEntryAccessTarget,
+  updateResolvedSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  resolveSessionStoreAgentId,
-  resolveSessionStoreKey,
-} from "../gateway/session-store-key.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 export { clearPluginOwnedSessionState } from "./host-hook-cleanup.js";
 import {
@@ -34,10 +28,6 @@ const PROJECTION_FAILED = Symbol("plugin-session-extension-projection-failed");
 const MAX_PLUGIN_NEXT_TURN_INJECTION_TEXT_LENGTH = 32 * 1024;
 const MAX_PLUGIN_NEXT_TURN_INJECTION_IDEMPOTENCY_KEY_LENGTH = 512;
 const MAX_PLUGIN_NEXT_TURN_INJECTIONS_PER_SESSION = 32;
-
-function isStorePathTemplate(store?: string): boolean {
-  return typeof store === "string" && store.includes("{agentId}");
-}
 
 function normalizeNamespace(value: string): string {
   return value.trim();
@@ -78,112 +68,6 @@ function isExpired(entry: unknown, now: number) {
     return true;
   }
   return typeof entry.ttlMs === "number" && entry.ttlMs >= 0 && now - entry.createdAt > entry.ttlMs;
-}
-
-function findFreshestStoreMatch(
-  store: Record<string, SessionEntry>,
-  ...candidates: string[]
-): { entry: SessionEntry; key: string } | undefined {
-  let freshest: { entry: SessionEntry; key: string } | undefined;
-  for (const candidate of candidates) {
-    const trimmed = normalizeOptionalString(candidate) ?? "";
-    if (!trimmed) {
-      continue;
-    }
-    const exact = store[trimmed];
-    if (exact && (!freshest || (exact.updatedAt ?? 0) >= (freshest.entry.updatedAt ?? 0))) {
-      freshest = { entry: exact, key: trimmed };
-    }
-  }
-  return freshest;
-}
-
-function resolveSessionStoreCandidates(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-}): SessionStoreTarget[] {
-  const storeConfig = params.cfg.session?.store;
-  const defaultTarget = {
-    agentId: params.agentId,
-    storePath: resolveStorePath(storeConfig, { agentId: params.agentId }),
-  };
-  if (!isStorePathTemplate(storeConfig)) {
-    return [defaultTarget];
-  }
-  const targets = new Map<string, SessionStoreTarget>();
-  targets.set(defaultTarget.storePath, defaultTarget);
-  for (const target of resolveAllAgentSessionStoreTargetsSync(params.cfg)) {
-    if (target.agentId === params.agentId) {
-      targets.set(target.storePath, target);
-    }
-  }
-  return [...targets.values()];
-}
-
-function buildSessionStoreScanTargets(params: {
-  cfg: OpenClawConfig;
-  key: string;
-  canonicalKey: string;
-  agentId: string;
-}): string[] {
-  const targets = new Set<string>();
-  if (params.canonicalKey) {
-    targets.add(params.canonicalKey);
-  }
-  if (params.key && params.key !== params.canonicalKey) {
-    targets.add(params.key);
-  }
-  if (params.canonicalKey === "global" || params.canonicalKey === "unknown") {
-    return [...targets];
-  }
-  const agentMainKey = resolveAgentMainSessionKey({
-    cfg: params.cfg,
-    agentId: params.agentId,
-  });
-  if (params.canonicalKey === agentMainKey) {
-    targets.add(`agent:${params.agentId}:main`);
-  }
-  return [...targets];
-}
-
-function loadPluginHostHookSessionEntry(params: { cfg: OpenClawConfig; sessionKey: string }): {
-  storePath: string;
-  entry?: SessionEntry;
-  canonicalKey: string;
-  storeKey: string;
-} {
-  const key = normalizeOptionalString(params.sessionKey) ?? "";
-  const cfg = params.cfg;
-  const canonicalKey = resolveSessionStoreKey({ cfg, sessionKey: key });
-  const agentId = resolveSessionStoreAgentId(cfg, canonicalKey);
-  const scanTargets = buildSessionStoreScanTargets({ cfg, key, canonicalKey, agentId });
-  const candidates = resolveSessionStoreCandidates({ cfg, agentId });
-  const fallback = candidates[0] ?? {
-    agentId,
-    storePath: resolveStorePath(cfg.session?.store, { agentId }),
-  };
-  let selectedStorePath = fallback.storePath;
-  let selectedMatch = findFreshestStoreMatch(loadSessionStore(fallback.storePath), ...scanTargets);
-  for (let index = 1; index < candidates.length; index += 1) {
-    const candidate = candidates[index];
-    if (!candidate) {
-      continue;
-    }
-    const match = findFreshestStoreMatch(loadSessionStore(candidate.storePath), ...scanTargets);
-    if (
-      match &&
-      (!selectedMatch || (match.entry.updatedAt ?? 0) >= (selectedMatch.entry.updatedAt ?? 0))
-    ) {
-      selectedStorePath = candidate.storePath;
-      selectedMatch = match;
-    }
-  }
-  return {
-    storePath: selectedStorePath,
-    entry: selectedMatch?.entry,
-    canonicalKey,
-    storeKey: selectedMatch?.key ?? canonicalKey,
-  };
 }
 
 function isPluginPromptInjectionEnabled(cfg: OpenClawConfig, pluginId: string): boolean {
@@ -258,11 +142,6 @@ export async function enqueuePluginNextTurnInjection(params: {
   ) {
     return { enqueued: false, id: "", sessionKey };
   }
-  const loaded = loadPluginHostHookSessionEntry({ cfg: params.cfg, sessionKey });
-  if (!loaded.entry) {
-    return { enqueued: false, id: "", sessionKey };
-  }
-  const canonicalKey = loaded.canonicalKey ?? sessionKey;
   const now = params.now ?? Date.now();
   const record = toPluginNextTurnInjectionRecord({
     pluginId: params.pluginId,
@@ -270,13 +149,9 @@ export async function enqueuePluginNextTurnInjection(params: {
     injection: { ...params.injection, sessionKey, text },
     now,
   });
-  let enqueued = false;
-  let resultId = record.id;
-  await updateSessionStore(loaded.storePath, (store) => {
-    const entry = store[loaded.storeKey];
-    if (!entry) {
-      return;
-    }
+  const updated = await updateResolvedSessionEntry({ cfg: params.cfg, sessionKey }, (entry) => {
+    let enqueued = false;
+    let resultId = record.id;
     const injections = { ...entry.pluginNextTurnInjections };
     // Guard against malformed/hand-edited persisted state — a non-array value
     // here would crash the spread/filter and break the whole session's enqueue.
@@ -291,19 +166,23 @@ export async function enqueuePluginNextTurnInjection(params: {
       resultId = duplicate.id;
       injections[params.pluginId] = existing;
       entry.pluginNextTurnInjections = injections;
-      return;
+      return { enqueued, id: resultId };
     }
     if (existing.length >= MAX_PLUGIN_NEXT_TURN_INJECTIONS_PER_SESSION) {
       injections[params.pluginId] = existing;
       entry.pluginNextTurnInjections = injections;
-      return;
+      return { enqueued, id: resultId };
     }
     injections[params.pluginId] = [...existing, record];
     entry.pluginNextTurnInjections = injections;
     entry.updatedAt = now;
     enqueued = true;
+    return { enqueued, id: resultId };
   });
-  return { enqueued, id: resultId, sessionKey: canonicalKey };
+  if (!updated.found) {
+    return { enqueued: false, id: "", sessionKey };
+  }
+  return { ...updated.result, sessionKey: updated.canonicalKey };
 }
 
 export async function drainPluginNextTurnInjections(params: {
@@ -315,23 +194,22 @@ export async function drainPluginNextTurnInjections(params: {
   if (!sessionKey) {
     return [];
   }
-  const loaded = loadPluginHostHookSessionEntry({ cfg: params.cfg, sessionKey });
-  if (!loaded.entry) {
+  const target = resolveSessionEntryAccessTarget({ cfg: params.cfg, sessionKey });
+  if (!target.entry) {
     return [];
   }
-  // Avoid the locked re-save in updateSessionStore when there is nothing queued.
+  // Avoid a locked session-entry rewrite when there is nothing queued.
   // Drain runs once per prompt build; the common case is no injections, so a
   // pre-flight read keeps prompt-build off the session-store write path.
   // (Concurrently-enqueued injections during this gap land on the next turn.)
   if (
-    !loaded.entry.pluginNextTurnInjections ||
-    Object.keys(loaded.entry.pluginNextTurnInjections).length === 0
+    !target.entry.pluginNextTurnInjections ||
+    Object.keys(target.entry.pluginNextTurnInjections).length === 0
   ) {
     return [];
   }
   const now = params.now ?? Date.now();
-  return await updateSessionStore(loaded.storePath, (store) => {
-    const entry = store[loaded.storeKey];
+  const updated = await updateResolvedSessionEntry({ cfg: params.cfg, sessionKey }, (entry) => {
     if (!entry?.pluginNextTurnInjections) {
       return [];
     }
@@ -364,6 +242,7 @@ export async function drainPluginNextTurnInjections(params: {
     }
     return drained;
   });
+  return updated.found ? updated.result : [];
 }
 
 export async function drainPluginNextTurnInjectionContext(params: {
@@ -388,8 +267,8 @@ export function getPluginSessionExtensionStateSync(params: {
   if (!pluginId || !sessionKey) {
     return undefined;
   }
-  const loaded = loadPluginHostHookSessionEntry({ cfg: params.cfg, sessionKey });
-  const value = loaded.entry?.pluginExtensions?.[pluginId] as
+  const target = resolveSessionEntryAccessTarget({ cfg: params.cfg, sessionKey });
+  const value = target.entry?.pluginExtensions?.[pluginId] as
     | Record<string, PluginJsonValue>
     | undefined;
   return value ? (copyJsonValue(value) as Record<string, PluginJsonValue>) : undefined;
@@ -425,11 +304,6 @@ export async function patchPluginSessionExtension(params: {
   if (!registration) {
     return { ok: false, error: `unknown plugin session extension: ${pluginId}/${namespace}` };
   }
-  const loaded = loadPluginHostHookSessionEntry({ cfg: params.cfg, sessionKey: params.sessionKey });
-  if (!loaded.entry) {
-    return { ok: false, error: `unknown session key: ${params.sessionKey}` };
-  }
-  const canonicalKey = loaded.canonicalKey ?? params.sessionKey;
   // Promote the projected value into a top-level SessionEntry slot when the
   // extension opted in via `sessionEntrySlotKey`. The slot is a read-only
   // mirror: writes still go through patchSessionExtension; the host overwrites
@@ -442,67 +316,69 @@ export async function patchPluginSessionExtension(params: {
     );
   }
   const slotKey = normalizedSlotKey?.ok === true ? normalizedSlotKey.key : undefined;
-  const nextValue = await updateSessionStore(loaded.storePath, (store) => {
-    const entry = store[loaded.storeKey];
-    if (!entry) {
-      return undefined;
-    }
-    const entryRecord = entry as Record<string, unknown>;
-    const pluginExtensions = { ...entry.pluginExtensions };
-    const pluginState = { ...pluginExtensions[pluginId] };
-    if (params.unset === true) {
-      delete pluginState[namespace];
-    } else {
-      pluginState[namespace] = copyJsonValue(nextPluginValue);
-    }
-    if (Object.keys(pluginState).length > 0) {
-      pluginExtensions[pluginId] = pluginState;
-    } else {
-      delete pluginExtensions[pluginId];
-    }
-    if (Object.keys(pluginExtensions).length > 0) {
-      entry.pluginExtensions = pluginExtensions;
-    } else {
-      delete entry.pluginExtensions;
-    }
-    const storedSlotKeys = { ...entry.pluginExtensionSlotKeys };
-    const pluginSlotKeys = { ...storedSlotKeys[pluginId] };
-    const previousSlotKey = normalizeSessionEntrySlotKey(pluginSlotKeys[namespace]);
-    if (previousSlotKey.ok && previousSlotKey.key !== slotKey) {
-      delete entryRecord[previousSlotKey.key];
-    }
-    if (slotKey && params.unset !== true) {
-      pluginSlotKeys[namespace] = slotKey;
-    } else {
-      delete pluginSlotKeys[namespace];
-    }
-    if (Object.keys(pluginSlotKeys).length > 0) {
-      storedSlotKeys[pluginId] = pluginSlotKeys;
-    } else {
-      delete storedSlotKeys[pluginId];
-    }
-    if (Object.keys(storedSlotKeys).length > 0) {
-      entry.pluginExtensionSlotKeys = storedSlotKeys;
-    } else {
-      delete entry.pluginExtensionSlotKeys;
-    }
-    if (slotKey) {
-      const projected = projectSessionExtensionValueForSlot({
-        registration,
-        sessionKey: canonicalKey,
-        sessionId: entry.sessionId,
-        nextValue: params.unset === true ? undefined : nextPluginValue,
-      });
-      if (projected === undefined) {
-        delete entryRecord[slotKey];
+  const updated = await updateResolvedSessionEntry(
+    { cfg: params.cfg, sessionKey: params.sessionKey },
+    (entry, context) => {
+      const entryRecord = entry as Record<string, unknown>;
+      const pluginExtensions = { ...entry.pluginExtensions };
+      const pluginState = { ...pluginExtensions[pluginId] };
+      if (params.unset === true) {
+        delete pluginState[namespace];
       } else {
-        entryRecord[slotKey] = projected;
+        pluginState[namespace] = copyJsonValue(nextPluginValue);
       }
-    }
-    entry.updatedAt = Date.now();
-    return pluginState[namespace] as PluginJsonValue | undefined;
-  });
-  return { ok: true, key: canonicalKey, value: nextValue };
+      if (Object.keys(pluginState).length > 0) {
+        pluginExtensions[pluginId] = pluginState;
+      } else {
+        delete pluginExtensions[pluginId];
+      }
+      if (Object.keys(pluginExtensions).length > 0) {
+        entry.pluginExtensions = pluginExtensions;
+      } else {
+        delete entry.pluginExtensions;
+      }
+      const storedSlotKeys = { ...entry.pluginExtensionSlotKeys };
+      const pluginSlotKeys = { ...storedSlotKeys[pluginId] };
+      const previousSlotKey = normalizeSessionEntrySlotKey(pluginSlotKeys[namespace]);
+      if (previousSlotKey.ok && previousSlotKey.key !== slotKey) {
+        delete entryRecord[previousSlotKey.key];
+      }
+      if (slotKey && params.unset !== true) {
+        pluginSlotKeys[namespace] = slotKey;
+      } else {
+        delete pluginSlotKeys[namespace];
+      }
+      if (Object.keys(pluginSlotKeys).length > 0) {
+        storedSlotKeys[pluginId] = pluginSlotKeys;
+      } else {
+        delete storedSlotKeys[pluginId];
+      }
+      if (Object.keys(storedSlotKeys).length > 0) {
+        entry.pluginExtensionSlotKeys = storedSlotKeys;
+      } else {
+        delete entry.pluginExtensionSlotKeys;
+      }
+      if (slotKey) {
+        const projected = projectSessionExtensionValueForSlot({
+          registration,
+          sessionKey: context.canonicalKey,
+          sessionId: entry.sessionId,
+          nextValue: params.unset === true ? undefined : nextPluginValue,
+        });
+        if (projected === undefined) {
+          delete entryRecord[slotKey];
+        } else {
+          entryRecord[slotKey] = projected;
+        }
+      }
+      entry.updatedAt = Date.now();
+      return pluginState[namespace] as PluginJsonValue | undefined;
+    },
+  );
+  if (!updated.found) {
+    return { ok: false, error: `unknown session key: ${params.sessionKey}` };
+  }
+  return { ok: true, key: updated.canonicalKey, value: updated.result };
 }
 
 /**

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -59,6 +59,7 @@ describe("session accessor boundary guard", () => {
         "src/infra/outbound/message-action-tts.ts",
         "src/agents/tools/embedded-gateway-stub.ts",
         "src/agents/tools/sessions-list-tool.ts",
+        "src/plugins/host-hook-state.ts",
         "src/status/status-message.ts",
         "src/tui/embedded-backend.ts",
       ]),
@@ -105,6 +106,7 @@ describe("session accessor boundary guard", () => {
         "src/commands/tasks.ts",
         "src/config/sessions/cleanup-service.ts",
         "src/plugins/host-hook-cleanup.ts",
+        "src/plugins/host-hook-state.ts",
         "src/tui/embedded-backend.ts",
       ]),
     );


### PR DESCRIPTION
## What Problem This Solves

This PR moves the plugin host hook-state persistence surface off direct session-store file access and onto the internal session accessor seam tracked by #88838. The migrated surface is `src/plugins/host-hook-state.ts`, covering plugin-owned session extension patches and queued next-turn injection state without introducing a second runtime persistence path.

## Why This Change Was Made

Path 3 needs plugin host session state to stop depending on file-store helpers before the session metadata backend can flip to SQLite. Keeping this slice narrow lets the future SQLite implementation replace the accessor internals without plugin host code scanning or mutating whole JSON session stores directly.

## User Impact

No user-facing behavior change is intended. Existing plugin session extension and next-turn injection behavior remains file-backed today, with the storage-specific lookup/update details moved behind the session accessor boundary.

## Evidence

- Focused Vitest: `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/plugins/contracts/host-hooks.contract.test.ts test/scripts/check-session-accessor-boundary.test.ts` passed 3 shards / 134 tests at `8e0385d`.
- Boundary guard: `node scripts/check-session-accessor-boundary.mjs` passed.
- Touched-file lint: `node scripts/run-oxlint.mjs src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/plugins/host-hook-state.ts test/scripts/check-session-accessor-boundary.test.ts scripts/check-session-accessor-boundary.mjs` passed.
- Import cycles: `pnpm check:import-cycles` passed with 0 runtime value cycles.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` reported no accepted/actionable findings.

## Real behavior proof

Behavior addressed: plugin host session extension persistence now resolves and updates session entries through the session accessor seam while preserving the existing gateway-visible `sessions.pluginPatch` behavior.

Real environment tested: local live gateway from `/Users/phaedrus/Projects/clawdbot`, branch SHA `8e0385d9e5762f9f249d3da49d2ce08fdc997801`, OpenClaw `2026.6.9 (8e0385d)`, loopback gateway on port `18789`.

Exact steps or command run after this patch:

```bash
pnpm openclaw tasks list --status running --json
pnpm openclaw gateway status
pnpm build
pnpm openclaw gateway restart
pnpm openclaw --version
curl -fsS http://127.0.0.1:18789/readyz
curl -fsS http://127.0.0.1:18789/healthz

# Temporary local proof plugin registered one session extension:
# pluginId=path3-proof-hook-state namespace=workflow sessionEntrySlotKey=path3ProofHookState
pnpm openclaw plugins inspect path3-proof-hook-state --runtime --json

pnpm openclaw gateway call sessions.create --json --params \
  '{"key":"agent:main:path3-proof-hook-state-20260623130512","label":"Path 3 hook-state proof 20260623130512"}'
pnpm openclaw gateway call sessions.pluginPatch --json --params \
  '{"key":"agent:main:path3-proof-hook-state-20260623130512","pluginId":"path3-proof-hook-state","namespace":"workflow","value":{"status":"queued","proof":"path3-host-hook-state"}}'

node - <<'NODE'
const fs = require('fs');
const key = 'agent:main:path3-proof-hook-state-20260623130512';
const store = JSON.parse(fs.readFileSync(process.env.HOME + '/.openclaw/agents/main/sessions/sessions.json', 'utf8'));
const entry = store[key];
console.log(JSON.stringify({
  key,
  persisted: Boolean(entry),
  pluginExtension: entry?.pluginExtensions?.['path3-proof-hook-state']?.workflow,
  promotedSlot: entry?.path3ProofHookState,
  hasStorePathLeak: Object.prototype.hasOwnProperty.call(entry ?? {}, 'storePath'),
}, null, 2));
NODE

pnpm openclaw gateway call sessions.delete --json --params \
  '{"key":"agent:main:path3-proof-hook-state-20260623130512","deleteTranscript":true}'
```

Evidence after fix: `sessions.pluginPatch` returned `ok: true`; the persisted session entry contained `pluginExtensions.path3-proof-hook-state.workflow = { status: "queued", proof: "path3-host-hook-state" }`, the promoted `path3ProofHookState` slot matched the same value, and `hasStorePathLeak` was `false`. Cleanup deleted the proof session and archived its temporary transcript. The temporary proof plugin/config was removed afterward, and the live gateway was restored on `upstream/main` `fcedd37067ec7e5f6b7a1d35d2f68481622fa4b6` with `/readyz` and `/healthz` healthy.

Observed result after fix: plugin-owned hook state persisted through the real gateway command path and was readable from the canonical session store without exposing file-store internals in the stored entry.

What was not tested: the future SQLite backend flip, doctor/import migration behavior, third-party SDK compatibility, and a live agent turn draining queued next-turn injections. Those remain separate Path 3 follow-up boundaries under #88838; this PR stays on the file-backed accessor seam and does not add fallback readers, JSON/SQLite dual reads, or a second persistence path.
