### PR TITLE
fix(memory-core): migrate dreaming cleanup lifecycle

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -89,6 +89,7 @@ async function expectPathMissing(targetPath: string): Promise<void> {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   resolveGlobalMap<string, unknown>(DREAMS_FILE_LOCKS_KEY).clear();
   resolveGlobalMap<string, unknown>(NARRATIVE_SESSION_LOCKS_KEY).clear();
 });
@@ -1192,6 +1193,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const storePath = path.join(sessionsDir, "sessions.json");
     const orphanPath = path.join(sessionsDir, "orphan.jsonl");
     const livePath = path.join(sessionsDir, "still-live.jsonl");
+    const normalTranscriptPath = path.join(sessionsDir, "normal-user-session.jsonl");
     const updatedAt = Date.now();
     await sessionStoreRuntimeModule.saveSessionStore(
       storePath,
@@ -1208,25 +1210,25 @@ describe("generateAndAppendDreamNarrative", () => {
           sessionId: "still-missing-non-dreaming",
           updatedAt,
         },
+        "agent:main:dreaming-narrative-corrupt-normal": {
+          sessionId: "normal-user-session",
+          updatedAt,
+        },
       },
       { skipMaintenance: true },
     );
     await fs.writeFile(orphanPath, '{"runId":"dreaming-narrative-light-123"}\n', "utf-8");
     await fs.writeFile(livePath, '{"runId":"dreaming-narrative-light-keep"}\n', "utf-8");
+    await fs.writeFile(normalTranscriptPath, '{"runId":"ordinary-user-session"}\n', "utf-8");
     const oldDate = new Date(Date.now() - 600_000);
     await fs.utimes(orphanPath, oldDate, oldDate);
     await fs.utimes(livePath, oldDate, oldDate);
+    await fs.utimes(normalTranscriptPath, oldDate, oldDate);
 
     vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfig").mockReturnValue({
       session: {},
     } as never);
-    vi.spyOn(sessionStoreRuntimeModule, "resolveStorePath").mockImplementation(((
-      _store: string | undefined,
-      { agentId }: { agentId: string },
-    ) => {
-      expect(agentId).toBe("main");
-      return storePath;
-    }) as typeof sessionStoreRuntimeModule.resolveStorePath);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     vi.spyOn(memoryCoreHostRuntimeCoreModule, "resolveStateDir").mockReturnValue(stateDir);
 
     const subagent = createMockSubagent("The repository whispered of forgotten endpoints.");
@@ -1243,11 +1245,13 @@ describe("generateAndAppendDreamNarrative", () => {
       skipCache: true,
     }) as Record<string, unknown>;
     expect(updatedStore).not.toHaveProperty("agent:main:dreaming-narrative-light-1");
+    expect(updatedStore).not.toHaveProperty("agent:main:dreaming-narrative-corrupt-normal");
     expect(updatedStore).toHaveProperty("agent:main:kept-session");
     expect(updatedStore).toHaveProperty("agent:main:telegram:group:dreaming-narrative-room");
     const sessionFiles = await fs.readdir(sessionsDir);
     expect(sessionFiles.filter((file) => file.startsWith("orphan.jsonl.deleted."))).not.toEqual([]);
     expect(sessionFiles).toContain("still-live.jsonl");
+    expect(sessionFiles).toContain("normal-user-session.jsonl");
     expectLogIncludes(logger.info, "dreaming cleanup scrubbed");
   });
 
@@ -1293,13 +1297,7 @@ describe("generateAndAppendDreamNarrative", () => {
     vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfig").mockReturnValue({
       session: {},
     } as never);
-    vi.spyOn(sessionStoreRuntimeModule, "resolveStorePath").mockImplementation(((
-      _store: string | undefined,
-      { agentId }: { agentId: string },
-    ) => {
-      expect(agentId).toBe("main");
-      return storePath;
-    }) as typeof sessionStoreRuntimeModule.resolveStorePath);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     vi.spyOn(memoryCoreHostRuntimeCoreModule, "resolveStateDir").mockReturnValue(stateDir);
 
     const subagent = createMockSubagent("A forgotten endpoint hummed in the dark.");

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -14,12 +14,7 @@ import {
 import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
 import { resolveStateDir } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import { pathExists } from "openclaw/plugin-sdk/security-runtime";
-import {
-  loadSessionStore,
-  resolveStorePath,
-  updateSessionStore,
-} from "openclaw/plugin-sdk/session-store-runtime";
+import { cleanupSessionLifecycleArtifacts } from "openclaw/plugin-sdk/session-store-runtime";
 import { readDreamsFile, resolveDreamsPath, updateDreamsFile } from "./dreaming-dreams-file.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -108,7 +103,6 @@ const NARRATIVE_MESSAGE_SETTLE_DELAYS_MS = [50, 150, 300, 750] as const;
 const DREAMING_SESSION_KEY_PREFIX = "dreaming-narrative-";
 const DREAMING_TRANSCRIPT_RUN_MARKER = '"runId":"dreaming-narrative-';
 const DREAMING_ORPHAN_MIN_AGE_MS = 300_000;
-const SAFE_SESSION_ID_RE = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
 const DIARY_START_MARKER = "<!-- openclaw:dreaming:diary:start -->";
 const DIARY_END_MARKER = "<!-- openclaw:dreaming:diary:end -->";
 const BACKFILL_ENTRY_MARKER = "openclaw:dreaming:backfill-entry";
@@ -776,80 +770,6 @@ export async function appendNarrativeEntry(params: {
 
 // ── Orchestrator ───────────────────────────────────────────────────────
 
-function normalizeComparablePath(pathname: string): string {
-  return process.platform === "win32" ? pathname.toLowerCase() : pathname;
-}
-
-async function normalizeSessionFileForComparison(params: {
-  sessionsDir: string;
-  sessionFile: string;
-}): Promise<string | null> {
-  const trimmed = params.sessionFile.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const resolved = path.isAbsolute(trimmed) ? trimmed : path.resolve(params.sessionsDir, trimmed);
-  try {
-    return normalizeComparablePath(await fs.realpath(resolved));
-  } catch {
-    return normalizeComparablePath(path.resolve(resolved));
-  }
-}
-
-function isDreamingSessionStoreKey(sessionKey: string): boolean {
-  const firstSeparator = sessionKey.indexOf(":");
-  if (firstSeparator < 0) {
-    return sessionKey.startsWith(DREAMING_SESSION_KEY_PREFIX);
-  }
-  const secondSeparator = sessionKey.indexOf(":", firstSeparator + 1);
-  const sessionSegment = secondSeparator < 0 ? sessionKey : sessionKey.slice(secondSeparator + 1);
-  return sessionSegment.startsWith(DREAMING_SESSION_KEY_PREFIX);
-}
-
-// A dreaming store row is reclaimable once its narrative run is finished. The
-// happy path deletes the session in `finally`, but when `deleteSession` throws
-// (e.g. request-scoped subagent runtime) the row is left behind referencing a
-// still-present transcript, so the missing-transcript check alone never reaps
-// it and the session lingers in the sidebar forever (issue #88322). Reclaim a
-// dreaming row when its transcript is missing, or when the transcript has aged
-// past the orphan threshold (a live narrative refreshes its transcript well
-// within that window, so active runs are never reaped).
-async function isReclaimableDreamingStoreEntry(
-  normalizedSessionFile: string | null,
-): Promise<boolean> {
-  if (!normalizedSessionFile || !(await pathExists(normalizedSessionFile))) {
-    return true;
-  }
-  try {
-    const stat = await fs.stat(normalizedSessionFile);
-    return Date.now() - stat.mtimeMs >= DREAMING_ORPHAN_MIN_AGE_MS;
-  } catch {
-    return true;
-  }
-}
-
-async function normalizeSessionEntryPathForComparison(params: {
-  sessionsDir: string;
-  entry: { sessionFile?: string; sessionId?: string } | undefined;
-}): Promise<string | null> {
-  const sessionFile = typeof params.entry?.sessionFile === "string" ? params.entry.sessionFile : "";
-  if (sessionFile) {
-    return normalizeSessionFileForComparison({
-      sessionsDir: params.sessionsDir,
-      sessionFile,
-    });
-  }
-  const sessionId =
-    typeof params.entry?.sessionId === "string" ? params.entry.sessionId.trim() : "";
-  if (!SAFE_SESSION_ID_RE.test(sessionId)) {
-    return null;
-  }
-  return normalizeSessionFileForComparison({
-    sessionsDir: params.sessionsDir,
-    sessionFile: `${sessionId}.jsonl`,
-  });
-}
-
 async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
   const cfg = getRuntimeConfig();
   const agentsDir = path.join(resolveStateDir(), "agents");
@@ -868,111 +788,19 @@ async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
       continue;
     }
 
-    const storePath = resolveStorePath(cfg.session?.store, { agentId: agentEntry.name });
-    const sessionsDir = path.dirname(storePath);
-    let store: Record<string, { sessionFile?: string; sessionId?: string } | undefined>;
     try {
-      store = loadSessionStore(storePath) as Record<
-        string,
-        { sessionFile?: string; sessionId?: string } | undefined
-      >;
+      const result = await cleanupSessionLifecycleArtifacts({
+        agentId: agentEntry.name,
+        archiveRemovedEntryTranscripts: false,
+        sessionStore: cfg.session?.store,
+        sessionKeySegmentPrefix: DREAMING_SESSION_KEY_PREFIX,
+        transcriptContentMarker: DREAMING_TRANSCRIPT_RUN_MARKER,
+        orphanTranscriptMinAgeMs: DREAMING_ORPHAN_MIN_AGE_MS,
+      });
+      prunedEntries += result.removedEntries;
+      archivedOrphans += result.archivedTranscriptArtifacts;
     } catch {
       continue;
-    }
-
-    const referencedSessionFiles = new Set<string>();
-    let needsStoreUpdate = false;
-    for (const [key, entry] of Object.entries(store)) {
-      const normalizedSessionFile = await normalizeSessionEntryPathForComparison({
-        sessionsDir,
-        entry,
-      });
-      if (normalizedSessionFile) {
-        referencedSessionFiles.add(normalizedSessionFile);
-      }
-      if (!isDreamingSessionStoreKey(key)) {
-        continue;
-      }
-      if (await isReclaimableDreamingStoreEntry(normalizedSessionFile)) {
-        needsStoreUpdate = true;
-      }
-    }
-
-    if (needsStoreUpdate) {
-      referencedSessionFiles.clear();
-      prunedEntries += await updateSessionStore(storePath, async (lockedStore) => {
-        let prunedForAgent = 0;
-        for (const [key, entry] of Object.entries(lockedStore)) {
-          const normalizedSessionFile = await normalizeSessionEntryPathForComparison({
-            sessionsDir,
-            entry,
-          });
-          if (!isDreamingSessionStoreKey(key)) {
-            if (normalizedSessionFile) {
-              referencedSessionFiles.add(normalizedSessionFile);
-            }
-            continue;
-          }
-          if (await isReclaimableDreamingStoreEntry(normalizedSessionFile)) {
-            // Drop the row and leave the transcript unreferenced so the orphan
-            // transcript pass below archives the aged-out (or missing) file.
-            delete lockedStore[key];
-            prunedForAgent += 1;
-            continue;
-          }
-          if (normalizedSessionFile) {
-            referencedSessionFiles.add(normalizedSessionFile);
-          }
-        }
-        return prunedForAgent;
-      });
-    }
-
-    let sessionFiles: Dirent[];
-    try {
-      sessionFiles = await fs.readdir(sessionsDir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-
-    for (const fileEntry of sessionFiles) {
-      if (!fileEntry.isFile() || !fileEntry.name.endsWith(".jsonl")) {
-        continue;
-      }
-      const transcriptPath = path.join(sessionsDir, fileEntry.name);
-      const normalizedTranscriptPath =
-        (await normalizeSessionFileForComparison({
-          sessionsDir,
-          sessionFile: fileEntry.name,
-        })) ?? normalizeComparablePath(transcriptPath);
-      if (referencedSessionFiles.has(normalizedTranscriptPath)) {
-        continue;
-      }
-      let stat;
-      try {
-        stat = await fs.stat(transcriptPath);
-      } catch {
-        continue;
-      }
-      if (Date.now() - stat.mtimeMs < DREAMING_ORPHAN_MIN_AGE_MS) {
-        continue;
-      }
-      let content;
-      try {
-        content = await fs.readFile(transcriptPath, "utf-8");
-      } catch {
-        continue;
-      }
-      if (!content.includes(DREAMING_TRANSCRIPT_RUN_MARKER)) {
-        continue;
-      }
-      const archivedPath = `${transcriptPath}.deleted.${Date.now()}`;
-      try {
-        await fs.rename(transcriptPath, archivedPath);
-        archivedOrphans += 1;
-      } catch {
-        // best-effort scrubber
-      }
     }
   }
 

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -118,6 +118,7 @@ export const migratedSessionAccessorFiles = new Set([
 export const migratedBundledPluginSessionAccessorFiles = new Set([
   "extensions/discord/src/monitor/native-command-model-picker-apply.ts",
   "extensions/discord/src/monitor/thread-session-close.ts",
+  "extensions/memory-core/src/dreaming-narrative.ts",
   "extensions/telegram/src/bot-handlers.runtime.ts",
 ]);
 
@@ -530,6 +531,7 @@ export async function main() {
   const readSourceRoots = resolveSourceRoots(repoRoot, [
     "packages/memory-host-sdk/src/host",
     "extensions/discord/src/monitor",
+    "extensions/memory-core/src",
     "extensions/telegram/src",
     "src/agents",
     "src/auto-reply",

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -202,8 +202,8 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10376),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5205),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10377),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5206),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3247,

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -268,6 +268,15 @@ export function resolveSessionTranscriptPath(
   return resolveSessionTranscriptPathInDir(sessionId, resolveAgentSessionsDir(agentId), topicId);
 }
 
+export function resolveExplicitSessionFilePath(
+  sessionFile: string,
+  opts?: SessionFilePathOptions,
+): string {
+  return resolvePathWithinSessionsDir(resolveSessionsDir(opts), sessionFile, {
+    agentId: opts?.agentId,
+  });
+}
+
 export function resolveSessionFilePath(
   sessionId: string,
   entry?: { sessionFile?: string },

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -752,7 +752,9 @@ describe("session accessor file-backed seam", () => {
     );
     expect(fs.existsSync(currentTranscriptPath)).toBe(true);
     expect(
-      fs.readdirSync(lifecycleSessionsDir).filter((file) => file.startsWith(`${staleSessionId}.jsonl.deleted.`)),
+      fs
+        .readdirSync(lifecycleSessionsDir)
+        .filter((file) => file.startsWith(`${staleSessionId}.jsonl.deleted.`)),
     ).toHaveLength(1);
   });
 

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -686,7 +686,7 @@ describe("session accessor file-backed seam", () => {
     const lifecycleStorePath = path.join(lifecycleSessionsDir, "sessions.json");
     const freshTranscriptPath = path.join(lifecycleSessionsDir, "session-file-only.jsonl");
     fs.mkdirSync(lifecycleSessionsDir, { recursive: true });
-    saveSessionStore(
+    await saveSessionStore(
       lifecycleStorePath,
       {
         "agent:main:lifecycle-cleanup-file-only": {
@@ -723,7 +723,7 @@ describe("session accessor file-backed seam", () => {
     const currentTranscriptPath = path.join(lifecycleSessionsDir, `${currentSessionId}.jsonl`);
     const staleTranscriptPath = path.join(lifecycleSessionsDir, `${staleSessionId}.jsonl`);
     fs.mkdirSync(lifecycleSessionsDir, { recursive: true });
-    saveSessionStore(
+    await saveSessionStore(
       lifecycleStorePath,
       {
         "agent:main:lifecycle-cleanup-current": {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -32,7 +32,7 @@ import {
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
-import { loadSessionStore, updateSessionStoreEntry } from "./store.js";
+import { loadSessionStore, saveSessionStore, updateSessionStoreEntry } from "./store.js";
 import { withOwnedSessionTranscriptWrites } from "./transcript-write-context.js";
 import type { SessionEntry } from "./types.js";
 
@@ -678,6 +678,82 @@ describe("session accessor file-backed seam", () => {
     expect(files).toContain("referenced.jsonl");
     expect(fs.existsSync(siblingTranscriptPath)).toBe(true);
     expect(fs.readdirSync(siblingDir)).toEqual(["sibling-lifecycle.jsonl"]);
+  });
+
+  it("preserves fresh lifecycle entries that only have explicit sessionFile metadata", async () => {
+    const nowMs = Date.now();
+    const lifecycleSessionsDir = path.join(tempDir, "state", "agents", "main", "sessions");
+    const lifecycleStorePath = path.join(lifecycleSessionsDir, "sessions.json");
+    const freshTranscriptPath = path.join(lifecycleSessionsDir, "session-file-only.jsonl");
+    fs.mkdirSync(lifecycleSessionsDir, { recursive: true });
+    saveSessionStore(
+      lifecycleStorePath,
+      {
+        "agent:main:lifecycle-cleanup-file-only": {
+          sessionFile: freshTranscriptPath,
+          updatedAt: nowMs,
+        } as SessionEntry,
+      },
+      { skipMaintenance: true },
+    );
+    fs.writeFileSync(freshTranscriptPath, '{"runId":"lifecycle-marker-file-only"}\n', "utf-8");
+
+    const result = await cleanupSessionLifecycleArtifacts({
+      storePath: lifecycleStorePath,
+      sessionKeySegmentPrefix: "lifecycle-cleanup-",
+      transcriptContentMarker: "lifecycle-marker-",
+      orphanTranscriptMinAgeMs: 300_000,
+      nowMs,
+    });
+
+    expect(result).toEqual({ removedEntries: 0, archivedTranscriptArtifacts: 0 });
+    expect(loadSessionStore(lifecycleStorePath, { skipCache: true })).toHaveProperty(
+      "agent:main:lifecycle-cleanup-file-only",
+    );
+    expect(fs.existsSync(freshTranscriptPath)).toBe(true);
+  });
+
+  it("prefers current generated lifecycle transcripts over stale generated sessionFile metadata", async () => {
+    const nowMs = Date.now();
+    const oldDate = new Date(nowMs - 600_000);
+    const currentSessionId = "11111111-1111-4111-8111-111111111111";
+    const staleSessionId = "22222222-2222-4222-8222-222222222222";
+    const lifecycleSessionsDir = path.join(tempDir, "state", "agents", "main", "sessions");
+    const lifecycleStorePath = path.join(lifecycleSessionsDir, "sessions.json");
+    const currentTranscriptPath = path.join(lifecycleSessionsDir, `${currentSessionId}.jsonl`);
+    const staleTranscriptPath = path.join(lifecycleSessionsDir, `${staleSessionId}.jsonl`);
+    fs.mkdirSync(lifecycleSessionsDir, { recursive: true });
+    saveSessionStore(
+      lifecycleStorePath,
+      {
+        "agent:main:lifecycle-cleanup-current": {
+          sessionFile: staleTranscriptPath,
+          sessionId: currentSessionId,
+          updatedAt: nowMs,
+        },
+      },
+      { skipMaintenance: true },
+    );
+    fs.writeFileSync(currentTranscriptPath, '{"runId":"lifecycle-marker-current"}\n', "utf-8");
+    fs.writeFileSync(staleTranscriptPath, '{"runId":"lifecycle-marker-stale"}\n', "utf-8");
+    fs.utimesSync(staleTranscriptPath, oldDate, oldDate);
+
+    const result = await cleanupSessionLifecycleArtifacts({
+      storePath: lifecycleStorePath,
+      sessionKeySegmentPrefix: "lifecycle-cleanup-",
+      transcriptContentMarker: "lifecycle-marker-",
+      orphanTranscriptMinAgeMs: 300_000,
+      nowMs,
+    });
+
+    expect(result).toEqual({ removedEntries: 0, archivedTranscriptArtifacts: 1 });
+    expect(loadSessionStore(lifecycleStorePath, { skipCache: true })).toHaveProperty(
+      "agent:main:lifecycle-cleanup-current",
+    );
+    expect(fs.existsSync(currentTranscriptPath)).toBe(true);
+    expect(
+      fs.readdirSync(lifecycleSessionsDir).filter((file) => file.startsWith(`${staleSessionId}.jsonl.deleted.`)),
+    ).toHaveLength(1);
   });
 
   it("persists reset lifecycle entry changes with transcript replay and cleanup", async () => {

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../config.js";
 import type { SessionConfig } from "../types.base.js";
 import { resolveSessionLifecycleTimestamps } from "./lifecycle.js";
 import {
+  resolveExplicitSessionFilePath,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   resolveSessionTranscriptPathInDir,
@@ -70,6 +71,16 @@ describe("session path safety", () => {
       { sessionsDir },
     );
     expect(resolved).toBe(path.resolve(sessionsDir, "sess-1.jsonl"));
+  });
+
+  it("rejects explicit sessionFile paths without derived fallback", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    expect(() =>
+      resolveExplicitSessionFilePath("/tmp/openclaw/agents/work/not-sessions/abc-123.jsonl", {
+        sessionsDir,
+      }),
+    ).toThrow(/within sessions directory/);
   });
 
   it("ignores multi-store sentinel paths when deriving session file options", () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -26,7 +26,7 @@ import {
 } from "./disk-budget.js";
 import { extractGeneratedTranscriptSessionId } from "./generated-transcript-session-id.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
-import { resolveSessionFilePath, resolveStorePath } from "./paths.js";
+import { resolveExplicitSessionFilePath, resolveSessionFilePath, resolveStorePath } from "./paths.js";
 import {
   ensureSessionStorePromptBlobsForPersistence,
   isSessionSkillPromptBlobReadable,
@@ -760,9 +760,11 @@ function resolveLifecycleTranscriptPath(params: {
   const sessionFile = params.entry?.sessionFile?.trim();
   const generatedSessionId = extractGeneratedTranscriptSessionId(sessionFile);
   if (sessionFile && (!sessionId || !generatedSessionId || generatedSessionId === sessionId)) {
-    return resolveSessionFilePath("session-file-reference", { sessionFile }, {
-      sessionsDir: params.sessionsDir,
-    });
+    try {
+      return resolveExplicitSessionFilePath(sessionFile, { sessionsDir: params.sessionsDir });
+    } catch {
+      return null;
+    }
   }
   if (!sessionId) {
     return null;

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -24,6 +24,7 @@ import {
   pruneUnreferencedSessionArtifacts,
   type SessionUnreferencedArtifactSweepResult,
 } from "./disk-budget.js";
+import { extractGeneratedTranscriptSessionId } from "./generated-transcript-session-id.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
 import { resolveSessionFilePath, resolveStorePath } from "./paths.js";
 import {
@@ -220,6 +221,8 @@ type SessionEntryWorkflowOptions = {
 export type SessionLifecycleArtifactCleanupParams = {
   /** Session store to clean. */
   storePath: string;
+  /** Archive exact transcripts referenced by removed entries before the orphan marker scan. */
+  archiveRemovedEntryTranscripts?: boolean;
   /** Matches the persisted session-key segment after `agent:<id>:`. */
   sessionKeySegmentPrefix: string;
   /** Marker that identifies transcript artifacts owned by this lifecycle. */
@@ -754,11 +757,18 @@ function resolveLifecycleTranscriptPath(params: {
   sessionsDir: string;
 }): string | null {
   const sessionId = params.entry?.sessionId?.trim();
+  const sessionFile = params.entry?.sessionFile?.trim();
+  const generatedSessionId = extractGeneratedTranscriptSessionId(sessionFile);
+  if (sessionFile && (!sessionId || !generatedSessionId || generatedSessionId === sessionId)) {
+    return resolveSessionFilePath("session-file-reference", { sessionFile }, {
+      sessionsDir: params.sessionsDir,
+    });
+  }
   if (!sessionId) {
     return null;
   }
   try {
-    return resolveSessionFilePath(sessionId, params.entry, { sessionsDir: params.sessionsDir });
+    return resolveSessionFilePath(sessionId, undefined, { sessionsDir: params.sessionsDir });
   } catch {
     return null;
   }
@@ -1512,6 +1522,7 @@ export async function cleanupSessionLifecycleArtifacts(
   const sessionsDir = path.dirname(storePath);
   const removedSessionFiles = new Map<string, string | undefined>();
   const removedTranscriptPaths: Array<{ sessionId: string; transcriptPath: string }> = [];
+  const archiveRemovedEntryTranscripts = params.archiveRemovedEntryTranscripts !== false;
   let removedEntries = 0;
   let archivedTranscriptArtifacts = 0;
 
@@ -1530,9 +1541,11 @@ export async function cleanupSessionLifecycleArtifacts(
           orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
         })
       ) {
-        rememberRemovedSessionFile(removedSessionFiles, entry);
-        if (entry.sessionId && transcriptPath && fs.existsSync(transcriptPath)) {
-          removedTranscriptPaths.push({ sessionId: entry.sessionId, transcriptPath });
+        if (archiveRemovedEntryTranscripts) {
+          rememberRemovedSessionFile(removedSessionFiles, entry);
+          if (entry.sessionId && transcriptPath && fs.existsSync(transcriptPath)) {
+            removedTranscriptPaths.push({ sessionId: entry.sessionId, transcriptPath });
+          }
         }
         delete store[sessionKey];
         removedEntries += 1;

--- a/src/plugin-sdk/session-store-runtime.test.ts
+++ b/src/plugin-sdk/session-store-runtime.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as jsonFiles from "../infra/json-files.js";
 import {
+  cleanupSessionLifecycleArtifacts,
   getSessionEntry,
   listSessionEntries,
   patchSessionEntry,
@@ -250,5 +251,48 @@ describe("session-store-runtime compatibility surface", () => {
     } finally {
       writeSpy.mockRestore();
     }
+  });
+
+  it("cleans lifecycle artifacts through the accessor-backed SDK wrapper", async () => {
+    const sessionKey = "agent:main:lifecycle-owned-old";
+    const transcriptPath = path.join(tempDir, "lifecycle-owned-old.jsonl");
+    await saveSessionStore(
+      storePath,
+      {
+        [sessionKey]: {
+          sessionFile: transcriptPath,
+          sessionId: "lifecycle-owned-old",
+          updatedAt: 10,
+        },
+        "agent:main:regular": {
+          sessionId: "regular",
+          updatedAt: 20,
+        },
+      },
+      { skipMaintenance: true },
+    );
+    fs.writeFileSync(transcriptPath, '{"runId":"lifecycle-owned-old"}\n', "utf-8");
+    const oldDate = new Date(Date.now() - 600_000);
+    fs.utimesSync(transcriptPath, oldDate, oldDate);
+
+    await expect(
+      cleanupSessionLifecycleArtifacts({
+        storePath,
+        sessionKeySegmentPrefix: "lifecycle-owned-",
+        transcriptContentMarker: '"runId":"lifecycle-owned-',
+        orphanTranscriptMinAgeMs: 300_000,
+      }),
+    ).resolves.toEqual({
+      archivedTranscriptArtifacts: 1,
+      removedEntries: 1,
+    });
+
+    expect(getSessionEntry({ sessionKey, storePath })).toBeUndefined();
+    expect(getSessionEntry({ sessionKey: "agent:main:regular", storePath })).toMatchObject({
+      sessionId: "regular",
+    });
+    expect(
+      fs.readdirSync(tempDir).filter((file) => file.startsWith("lifecycle-owned-old.jsonl.deleted.")),
+    ).toHaveLength(1);
   });
 });

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -1,6 +1,7 @@
 // Narrow session-store helpers for channel hot paths.
 
 import {
+  cleanupSessionLifecycleArtifacts as cleanupAccessorSessionLifecycleArtifacts,
   listSessionEntries as listAccessorSessionEntries,
   loadSessionEntry,
   patchSessionEntry as patchAccessorSessionEntry,
@@ -9,6 +10,7 @@ import {
   type SessionAccessScope,
   updateSessionEntry,
 } from "../config/sessions/session-accessor.js";
+import { resolveStorePath as resolveSessionStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore as loadSessionStoreImpl } from "../config/sessions/store-load.js";
 import type { ResolvedSessionMaintenanceConfig } from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -58,6 +60,23 @@ type UpdateSessionStoreEntryParams = {
 
 type UpsertSessionEntryParams = SessionStoreReadParams & {
   entry: SessionEntry;
+};
+
+type SessionLifecycleArtifactsCleanupParams = {
+  agentId?: string;
+  archiveRemovedEntryTranscripts?: boolean;
+  env?: NodeJS.ProcessEnv;
+  orphanTranscriptMinAgeMs: number;
+  sessionStore?: string;
+  sessionKeySegmentPrefix: string;
+  storePath?: string;
+  transcriptContentMarker: string;
+  nowMs?: number;
+};
+
+type SessionLifecycleArtifactsCleanupResult = {
+  archivedTranscriptArtifacts: number;
+  removedEntries: number;
 };
 
 function toSessionAccessScope(params: SessionStoreReadParams): SessionAccessScope {
@@ -139,6 +158,26 @@ export async function updateSessionStoreEntry(
 /** Replaces or creates one session entry by agent/session identity. */
 export async function upsertSessionEntry(params: UpsertSessionEntryParams): Promise<void> {
   await replaceSessionEntry(toSessionAccessScope(params), params.entry);
+}
+
+/** Cleans stale lifecycle-owned session entries and orphan transcripts for one agent store. */
+export async function cleanupSessionLifecycleArtifacts(
+  params: SessionLifecycleArtifactsCleanupParams,
+): Promise<SessionLifecycleArtifactsCleanupResult> {
+  const storePath =
+    params.storePath ??
+    resolveSessionStorePath(params.sessionStore, {
+      agentId: params.agentId,
+      env: params.env,
+    });
+  return await cleanupAccessorSessionLifecycleArtifacts({
+    storePath,
+    archiveRemovedEntryTranscripts: params.archiveRemovedEntryTranscripts,
+    sessionKeySegmentPrefix: params.sessionKeySegmentPrefix,
+    transcriptContentMarker: params.transcriptContentMarker,
+    orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+    nowMs: params.nowMs,
+  });
 }
 
 export { resolveSessionStoreEntry } from "../config/sessions/store-entry.js";

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -72,6 +72,7 @@ describe("session accessor boundary guard", () => {
       new Set([
         "extensions/discord/src/monitor/native-command-model-picker-apply.ts",
         "extensions/discord/src/monitor/thread-session-close.ts",
+        "extensions/memory-core/src/dreaming-narrative.ts",
         "extensions/telegram/src/bot-handlers.runtime.ts",
       ]),
     );


### PR DESCRIPTION
Tracker: #88838

## What Problem This Solves

`extensions/memory-core/src/dreaming-narrative.ts` still cleaned stale dreaming sessions by importing direct session-store JSON helpers and mutating the whole store. That kept memory-core on the file-era storage boundary and left Path 3 without a ratchet for this migrated dreaming cleanup surface.

## Why This Change Was Made

Path 3 is moving session metadata and transcripts behind lifecycle/accessor APIs before the SQLite-backed runtime flip. This PR makes dreaming narrative cleanup call the session lifecycle accessor instead of scanning and rewriting the store itself, and fixes the accessor path so explicit session-file entries do not rely on a fake sentinel session id.

## User Impact

No user-facing dreaming behavior is intended to change. Dreaming narrative cleanup still removes stale `dreaming-narrative-*` session entries and handles transcript artifacts, but the storage mutation now goes through the lifecycle boundary that can be backed by SQLite later.

## Evidence

- `node scripts/run-vitest.mjs src/config/sessions/sessions.test.ts src/config/sessions/session-accessor.test.ts src/plugin-sdk/session-store-runtime.test.ts extensions/memory-core/src/dreaming-narrative.test.ts test/scripts/check-session-accessor-boundary.test.ts` passed 4 Vitest shards.
- `node scripts/check-session-accessor-boundary.mjs` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` reported no accepted/actionable findings.
- `pnpm build` passed on the live checkout at `b721ff4` before live gateway proof.

## Real behavior proof

Behavior addressed: session lifecycle cleanup for `dreaming-narrative-*` session targets works through the gateway/accessor lifecycle path used by memory-core cleanup after this PR.

Real environment tested: local live gateway from `/Users/phaedrus/Projects/clawdbot`, OpenClaw `2026.6.9 (b721ff4)`, managed LaunchAgent on loopback port `18789`.

Exact steps or command run after this patch:

```bash
pnpm build
pnpm openclaw --version
pnpm openclaw gateway restart --force --json
curl -fsS http://127.0.0.1:18789/healthz
curl -fsS http://127.0.0.1:18789/readyz
pnpm openclaw gateway call sessions.describe --params '{"key":"agent:main:dreaming-narrative-path3-live-proof-b721ff4e"}' --json
pnpm openclaw gateway call sessions.create --params '{"key":"agent:main:dreaming-narrative-path3-live-proof-b721ff4e","label":"Path 3 dreaming lifecycle live proof"}' --json
pnpm openclaw gateway call sessions.describe --params '{"key":"agent:main:dreaming-narrative-path3-live-proof-b721ff4e"}' --json
test -f /Users/phaedrus/.openclaw/agents/main/sessions/11b6e027-16dd-4632-b37b-c09494a0bb7f.jsonl
pnpm openclaw gateway call sessions.delete --params '{"key":"agent:main:dreaming-narrative-path3-live-proof-b721ff4e","deleteTranscript":true}' --json
pnpm openclaw gateway call sessions.describe --params '{"key":"agent:main:dreaming-narrative-path3-live-proof-b721ff4e"}' --json
test ! -e /Users/phaedrus/.openclaw/agents/main/sessions/11b6e027-16dd-4632-b37b-c09494a0bb7f.jsonl
ls -l /Users/phaedrus/.openclaw/agents/main/sessions/11b6e027-16dd-4632-b37b-c09494a0bb7f.jsonl.deleted.2026-06-23T20-18-55.906Z
git checkout --detach 3f74951260a23c759e4d1b2525f9826ddd6344e3
pnpm build
pnpm openclaw gateway restart --force --json
curl -fsS http://127.0.0.1:18789/readyz
```

Evidence after fix: `sessions.create` returned session id `11b6e027-16dd-4632-b37b-c09494a0bb7f` and persisted `/Users/phaedrus/.openclaw/agents/main/sessions/11b6e027-16dd-4632-b37b-c09494a0bb7f.jsonl`; `sessions.delete` returned `deleted: true` and archived that transcript to `11b6e027-16dd-4632-b37b-c09494a0bb7f.jsonl.deleted.2026-06-23T20-18-55.906Z`; the follow-up `sessions.describe` returned `session: null`, the original transcript path was missing, and the archive path existed.

Observed result after fix: the live gateway accepted, persisted, deleted, and archived a `dreaming-narrative-*` session through the session lifecycle/accessor path without direct session-store access from memory-core.

What was not tested: a full memory dreaming sweep with live model generation, because live memory-core dreaming is currently configured disabled and enabling it would widen proof into unrelated promotion/model behavior; the future SQLite runtime flip and transaction shape; doctor migration; #96162 memory-host/transcript corpus behavior; fallback/dual-read behavior, which this PR intentionally does not add.
