### PR TITLE
fix: bridge ACP metadata to session accessors

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -74,6 +74,8 @@ export const allowedSessionStoreRuntimeFileBackedCompatExports = new Set([
 
 export const migratedSessionAccessorFiles = new Set([
   "packages/memory-host-sdk/src/host/session-files.ts",
+  "src/acp/runtime/session-meta.ts",
+  "src/agents/acp-spawn.ts",
   "src/agents/embedded-agent-runner/compaction-successor-transcript.ts",
   "src/agents/embedded-agent-runner/run/attempt.ts",
   "src/agents/embedded-agent-runner/tool-result-truncation.ts",
@@ -120,6 +122,7 @@ export const migratedBundledPluginSessionAccessorFiles = new Set([
 ]);
 
 export const migratedSessionAccessorWriteFiles = new Set([
+  "src/acp/runtime/session-meta.ts",
   "src/agents/command/attempt-execution.shared.ts",
   "src/agents/command/session-store.ts",
   "src/agents/embedded-agent-runner/run.ts",
@@ -528,6 +531,7 @@ export async function main() {
     "packages/memory-host-sdk/src/host",
     "extensions/discord/src/monitor",
     "extensions/telegram/src",
+    "src/acp",
     "src/agents",
     "src/auto-reply",
     "src/commands",
@@ -538,6 +542,7 @@ export async function main() {
     "src/tui",
   ]);
   const writeSourceRoots = resolveSourceRoots(repoRoot, [
+    "src/acp",
     "src/agents",
     "src/auto-reply",
     "src/commands",

--- a/src/acp/runtime/session-meta.test.ts
+++ b/src/acp/runtime/session-meta.test.ts
@@ -154,9 +154,12 @@ describe("ACP session metadata SQLite store", () => {
       expect(loadSessionStore(storePath)[storeSessionKey]?.acp).toBeUndefined();
       const legacyEmbeddedEntry = loadSessionStore(storePath)[storeSessionKey];
       expect(legacyEmbeddedEntry).toBeDefined();
+      if (!legacyEmbeddedEntry) {
+        throw new Error("expected normalized ACP session entry");
+      }
       await writeSessionStoreForTestAsync(storePath, {
         [storeSessionKey]: {
-          ...legacyEmbeddedEntry!,
+          ...legacyEmbeddedEntry,
           acp: {
             backend: "acpx",
             agent: "codex",
@@ -232,6 +235,57 @@ describe("ACP session metadata SQLite store", () => {
           sessionKey: canonicalSessionKey,
         })?.acp?.runtimeSessionName,
       ).toBe("codex-canonicalized");
+      expect(await listAcpSessionEntries({ cfg, databasePath })).toHaveLength(1);
+    });
+  });
+
+  it("binds ACP metadata to the final accessor-selected entry for alias writes", async () => {
+    await withTempDir({ prefix: "openclaw-acp-meta-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const databasePath = path.join(dir, "state", "openclaw.sqlite");
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const canonicalSessionKey = "agent:codex:acp:alias-runtime";
+      const legacyStoreSessionKey = "agent:CODEX:acp:alias-runtime";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [canonicalSessionKey]: {
+            sessionId: "sess-canonical",
+            updatedAt: 100,
+          },
+          [legacyStoreSessionKey]: {
+            sessionId: "sess-legacy",
+            updatedAt: 150,
+          },
+        }),
+        "utf8",
+      );
+
+      await upsertAcpSessionMeta({
+        cfg,
+        databasePath,
+        sessionKey: legacyStoreSessionKey,
+        now: () => 200,
+        mutate: () => ({
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "codex-alias",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: 123,
+        }),
+      });
+
+      const store = loadSessionStore(storePath);
+      expect(store[legacyStoreSessionKey]).toBeUndefined();
+      expect(store[canonicalSessionKey]?.sessionId).toBe("sess-legacy");
+      expect(
+        readAcpSessionEntry({
+          cfg,
+          databasePath,
+          sessionKey: canonicalSessionKey,
+        })?.acp?.runtimeSessionName,
+      ).toBe("codex-alias");
       expect(await listAcpSessionEntries({ cfg, databasePath })).toHaveLength(1);
     });
   });

--- a/src/acp/runtime/session-meta.test.ts
+++ b/src/acp/runtime/session-meta.test.ts
@@ -152,6 +152,21 @@ describe("ACP session metadata SQLite store", () => {
         })?.acp?.runtimeSessionName,
       ).toBe("codex-normalized");
       expect(loadSessionStore(storePath)[storeSessionKey]?.acp).toBeUndefined();
+      const legacyEmbeddedEntry = loadSessionStore(storePath)[storeSessionKey];
+      expect(legacyEmbeddedEntry).toBeDefined();
+      await writeSessionStoreForTestAsync(storePath, {
+        [storeSessionKey]: {
+          ...legacyEmbeddedEntry!,
+          acp: {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: "legacy-embedded",
+            mode: "persistent",
+            state: "idle",
+            lastActivityAt: 120,
+          },
+        },
+      });
 
       await upsertAcpSessionMeta({
         cfg,
@@ -170,6 +185,54 @@ describe("ACP session metadata SQLite store", () => {
           sessionKey: storeSessionKey,
         })?.acp,
       ).toBeUndefined();
+      expect(loadSessionStore(storePath)[storeSessionKey]?.acp).toBeUndefined();
+    });
+  });
+
+  it("keeps SQLite ACP metadata visible when legacy store keys are canonicalized", async () => {
+    await withTempDir({ prefix: "openclaw-acp-meta-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const databasePath = path.join(dir, "state", "openclaw.sqlite");
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const legacyStoreSessionKey = "agent:CODEX:acp:legacy-runtime";
+      const canonicalSessionKey = "agent:codex:acp:legacy-runtime";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [legacyStoreSessionKey]: {
+            sessionId: "sess-acp",
+            updatedAt: 100,
+          },
+        }),
+        "utf8",
+      );
+
+      await upsertAcpSessionMeta({
+        cfg,
+        databasePath,
+        sessionKey: canonicalSessionKey,
+        now: () => 200,
+        mutate: () => ({
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "codex-canonicalized",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: 123,
+        }),
+      });
+
+      const store = loadSessionStore(storePath);
+      expect(store[legacyStoreSessionKey]).toBeUndefined();
+      expect(store[canonicalSessionKey]?.sessionId).toBe("sess-acp");
+      expect(
+        readAcpSessionEntry({
+          cfg,
+          databasePath,
+          sessionKey: canonicalSessionKey,
+        })?.acp?.runtimeSessionName,
+      ).toBe("codex-canonicalized");
+      expect(await listAcpSessionEntries({ cfg, databasePath })).toHaveLength(1);
     });
   });
 

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -4,7 +4,11 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import type { Insertable, Selectable } from "kysely";
 import { getRuntimeConfig } from "../../config/config.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
-import { loadSessionStore } from "../../config/sessions/store-load.js";
+import {
+  listSessionEntries,
+  patchSessionEntry,
+  type SessionEntrySummary,
+} from "../../config/sessions/session-accessor.js";
 import {
   mergeSessionEntry,
   type AcpSessionRuntimeOptions,
@@ -43,30 +47,24 @@ type AcpSessionsTable = OpenClawStateKyselyDatabase["acp_sessions"];
 type AcpSessionMetaDatabase = Pick<OpenClawStateKyselyDatabase, "acp_sessions">;
 type AcpSessionRow = Selectable<AcpSessionsTable>;
 
-let sessionStoreRuntimePromise:
-  | Promise<typeof import("../../config/sessions/store.runtime.js")>
-  | undefined;
-
-function loadSessionStoreRuntime() {
-  sessionStoreRuntimePromise ??= import("../../config/sessions/store.runtime.js");
-  return sessionStoreRuntimePromise;
-}
-
-function resolveStoreSessionKey(store: Record<string, SessionEntry>, sessionKey: string): string {
+function resolveStoreSessionKey(
+  entries: readonly SessionEntrySummary[],
+  sessionKey: string,
+): string {
   const normalized = sessionKey.trim();
   if (!normalized) {
     return "";
   }
-  if (store[normalized]) {
+  if (entries.some((entry) => entry.sessionKey === normalized)) {
     return normalized;
   }
   const lower = normalizeLowercaseStringOrEmpty(normalized);
-  if (store[lower]) {
+  if (entries.some((entry) => entry.sessionKey === lower)) {
     return lower;
   }
-  for (const key of Object.keys(store)) {
-    if (normalizeLowercaseStringOrEmpty(key) === lower) {
-      return key;
+  for (const entry of entries) {
+    if (normalizeLowercaseStringOrEmpty(entry.sessionKey) === lower) {
+      return entry.sessionKey;
     }
   }
   return lower;
@@ -371,12 +369,13 @@ function readSessionEntryFromStore(params: {
     env: params.env,
   });
   try {
-    const store = loadSessionStore(
+    const entries = listSessionEntries({
       storePath,
-      params.clone === false ? { clone: false } : undefined,
-    );
-    const storeSessionKey = resolveStoreSessionKey(store, params.sessionKey);
-    return { cfg, storePath, storeSessionKey, entry: store[storeSessionKey] };
+      ...(params.clone === false ? { clone: false } : {}),
+    });
+    const storeSessionKey = resolveStoreSessionKey(entries, params.sessionKey);
+    const entry = entries.find((candidate) => candidate.sessionKey === storeSessionKey)?.entry;
+    return { cfg, storePath, storeSessionKey, entry };
   } catch {
     return {
       cfg,
@@ -437,14 +436,19 @@ export async function listAcpSessionEntries(params: {
       cfg,
       env: params.env,
     });
-    let store: Record<string, SessionEntry>;
+    let sessionEntries: SessionEntrySummary[];
     try {
-      store = loadSessionStore(storePath, params.clone === false ? { clone: false } : undefined);
+      sessionEntries = listSessionEntries({
+        storePath,
+        ...(params.clone === false ? { clone: false } : {}),
+      });
     } catch {
       continue;
     }
-    const storeSessionKey = resolveStoreSessionKey(store, sessionKey);
-    const entry = store[storeSessionKey];
+    const storeSessionKey = resolveStoreSessionKey(sessionEntries, sessionKey);
+    const entry = sessionEntries.find(
+      (candidate) => candidate.sessionKey === storeSessionKey,
+    )?.entry;
     if (!entry || !acpSessionRowMatchesEntry(row, entry)) {
       continue;
     }
@@ -548,33 +552,52 @@ export async function upsertAcpSessionMeta(params: {
     if (!entry) {
       return null;
     }
-    const { updateSessionStore } = await loadSessionStoreRuntime();
-    return await updateSessionStore(
-      storeEntry.storePath,
-      (store) => {
-        const storeSessionKey = resolveStoreSessionKey(store, storageSessionKey);
-        const next = { ...(store[storeSessionKey] ?? entry) };
+    return await patchSessionEntry(
+      { storePath: storeEntry.storePath, sessionKey: storageSessionKey },
+      (currentEntry) => {
+        const next = { ...currentEntry };
         delete next.acp;
-        store[storeSessionKey] = next;
         return next;
       },
-      sessionStoreUpdateOptions({ ...params, sessionKey: storageSessionKey }),
+      {
+        ...sessionStoreUpdateOptions({ ...params, sessionKey: storageSessionKey }),
+        replaceEntry: true,
+      },
     );
   }
-  const { updateSessionStore } = await loadSessionStoreRuntime();
-  const persisted = await updateSessionStore(
-    storeEntry.storePath,
-    (store) => {
-      const storeSessionKey = resolveStoreSessionKey(store, storageSessionKey);
-      const next = mergeSessionEntry(store[storeSessionKey], {
+  const persisted = await patchSessionEntry(
+    { storePath: storeEntry.storePath, sessionKey: storageSessionKey },
+    (currentEntry) => {
+      const next = mergeSessionEntry(currentEntry, {
         sessionId: preparedEntry?.sessionId,
         updatedAt,
       });
       delete next.acp;
-      store[storeSessionKey] = next;
       return next;
     },
-    sessionStoreUpdateOptions({ ...params, sessionKey: storageSessionKey }),
+    {
+      ...sessionStoreUpdateOptions({ ...params, sessionKey: storageSessionKey }),
+      fallbackEntry: preparedEntry,
+      replaceEntry: true,
+    },
   );
-  return mergeAcpForReturn(persisted, nextMeta);
+  if (persisted) {
+    const persistedStoreEntry = readSessionEntryFromStore({
+      sessionKey: storageSessionKey,
+      cfg: storeEntry.cfg,
+      env: params.env,
+      clone: false,
+    });
+    if (persistedStoreEntry.entry && persistedStoreEntry.storeSessionKey !== storageSessionKey) {
+      repairAcpSessionMetaKeyForMigration({
+        sessionKey: persistedStoreEntry.storeSessionKey,
+        candidateSessionKeys: [storageSessionKey, sessionKey],
+        entry: persistedStoreEntry.entry,
+        env: params.env,
+        databasePath: params.databasePath,
+        now: params.now,
+      });
+    }
+  }
+  return persisted ? mergeAcpForReturn(persisted, nextMeta) : null;
 }

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -522,33 +522,14 @@ export async function upsertAcpSessionMeta(params: {
         current,
         current ? mergeAcpForReturn(preparedEntry, current) : entry,
       );
-      if (nextMeta === null) {
-        executeSqliteQuerySync(
-          database.db,
-          getAcpSessionKysely(database.db)
-            .deleteFrom("acp_sessions")
-            .where("session_key", "=", storageSessionKey),
-        );
-        return;
-      }
-      if (nextMeta !== undefined) {
-        upsertAcpSessionMetaRow(
-          database.db,
-          bindAcpSessionMeta({
-            sessionKey: storageSessionKey,
-            sessionId: preparedEntry.sessionId,
-            meta: nextMeta,
-            updatedAt,
-          }),
-        );
-      }
     },
     { env: params.env, path: params.databasePath },
   );
-  if (nextMeta === undefined) {
+  const metaToPersist = nextMeta;
+  if (metaToPersist === undefined) {
     return current ? mergeAcpForReturn(entry, current) : (entry ?? null);
   }
-  if (nextMeta === null) {
+  if (metaToPersist === null) {
     const patched = entry
       ? await patchSessionEntryWithKey(
           { storePath: storeEntry.storePath, sessionKey: storageSessionKey },
@@ -586,7 +567,6 @@ export async function upsertAcpSessionMeta(params: {
     { storePath: storeEntry.storePath, sessionKey: storageSessionKey },
     (currentEntry) => {
       const next = mergeSessionEntry(currentEntry, {
-        sessionId: preparedEntry?.sessionId,
         updatedAt,
       });
       delete next.acp;
@@ -601,27 +581,27 @@ export async function upsertAcpSessionMeta(params: {
   if (!persisted) {
     return null;
   }
-  if (persisted.sessionKey !== storageSessionKey) {
-    runOpenClawStateWriteTransaction(
-      (database) => {
-        const currentRow = selectAcpSessionRow(database.db, storageSessionKey);
-        if (!currentRow || !acpSessionRowMatchesEntry(currentRow, persisted.entry)) {
-          return;
-        }
-        upsertAcpSessionMetaRow(database.db, {
-          ...currentRow,
-          session_key: persisted.sessionKey,
-          updated_at: updatedAt,
-        });
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      upsertAcpSessionMetaRow(
+        database.db,
+        bindAcpSessionMeta({
+          sessionKey: persisted.sessionKey,
+          sessionId: persisted.entry.sessionId,
+          meta: metaToPersist,
+          updatedAt,
+        }),
+      );
+      if (persisted.sessionKey !== storageSessionKey) {
         executeSqliteQuerySync(
           database.db,
           getAcpSessionKysely(database.db)
             .deleteFrom("acp_sessions")
             .where("session_key", "=", storageSessionKey),
         );
-      },
-      { env: params.env, path: params.databasePath },
-    );
-  }
-  return mergeAcpForReturn(persisted.entry, nextMeta);
+      }
+    },
+    { env: params.env, path: params.databasePath },
+  );
+  return mergeAcpForReturn(persisted.entry, metaToPersist);
 }

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -6,7 +6,7 @@ import { getRuntimeConfig } from "../../config/config.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
   listSessionEntries,
-  patchSessionEntry,
+  patchSessionEntryWithKey,
   type SessionEntrySummary,
 } from "../../config/sessions/session-accessor.js";
 import {
@@ -549,23 +549,40 @@ export async function upsertAcpSessionMeta(params: {
     return current ? mergeAcpForReturn(entry, current) : (entry ?? null);
   }
   if (nextMeta === null) {
-    if (!entry) {
-      return null;
-    }
-    return await patchSessionEntry(
-      { storePath: storeEntry.storePath, sessionKey: storageSessionKey },
-      (currentEntry) => {
-        const next = { ...currentEntry };
-        delete next.acp;
-        return next;
+    const patched = entry
+      ? await patchSessionEntryWithKey(
+          { storePath: storeEntry.storePath, sessionKey: storageSessionKey },
+          (currentEntry) => {
+            const next = { ...currentEntry };
+            delete next.acp;
+            return next;
+          },
+          {
+            ...sessionStoreUpdateOptions({ ...params, sessionKey: storageSessionKey }),
+            replaceEntry: true,
+          },
+        )
+      : null;
+    runOpenClawStateWriteTransaction(
+      (database) => {
+        const sessionKeysToDelete = new Set([storageSessionKey]);
+        if (patched?.sessionKey) {
+          sessionKeysToDelete.add(patched.sessionKey);
+        }
+        for (const key of sessionKeysToDelete) {
+          executeSqliteQuerySync(
+            database.db,
+            getAcpSessionKysely(database.db)
+              .deleteFrom("acp_sessions")
+              .where("session_key", "=", key),
+          );
+        }
       },
-      {
-        ...sessionStoreUpdateOptions({ ...params, sessionKey: storageSessionKey }),
-        replaceEntry: true,
-      },
+      { env: params.env, path: params.databasePath },
     );
+    return patched?.entry ?? null;
   }
-  const persisted = await patchSessionEntry(
+  const persisted = await patchSessionEntryWithKey(
     { storePath: storeEntry.storePath, sessionKey: storageSessionKey },
     (currentEntry) => {
       const next = mergeSessionEntry(currentEntry, {
@@ -581,23 +598,30 @@ export async function upsertAcpSessionMeta(params: {
       replaceEntry: true,
     },
   );
-  if (persisted) {
-    const persistedStoreEntry = readSessionEntryFromStore({
-      sessionKey: storageSessionKey,
-      cfg: storeEntry.cfg,
-      env: params.env,
-      clone: false,
-    });
-    if (persistedStoreEntry.entry && persistedStoreEntry.storeSessionKey !== storageSessionKey) {
-      repairAcpSessionMetaKeyForMigration({
-        sessionKey: persistedStoreEntry.storeSessionKey,
-        candidateSessionKeys: [storageSessionKey, sessionKey],
-        entry: persistedStoreEntry.entry,
-        env: params.env,
-        databasePath: params.databasePath,
-        now: params.now,
-      });
-    }
+  if (!persisted) {
+    return null;
   }
-  return persisted ? mergeAcpForReturn(persisted, nextMeta) : null;
+  if (persisted.sessionKey !== storageSessionKey) {
+    runOpenClawStateWriteTransaction(
+      (database) => {
+        const currentRow = selectAcpSessionRow(database.db, storageSessionKey);
+        if (!currentRow || !acpSessionRowMatchesEntry(currentRow, persisted.entry)) {
+          return;
+        }
+        upsertAcpSessionMetaRow(database.db, {
+          ...currentRow,
+          session_key: persisted.sessionKey,
+          updated_at: updatedAt,
+        });
+        executeSqliteQuerySync(
+          database.db,
+          getAcpSessionKysely(database.db)
+            .deleteFrom("acp_sessions")
+            .where("session_key", "=", storageSessionKey),
+        );
+      },
+      { env: params.env, path: params.databasePath },
+    );
+  }
+  return mergeAcpForReturn(persisted.entry, nextMeta);
 }

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -134,6 +134,69 @@ vi.mock("../config/sessions/store.js", () => ({
   loadSessionStore: hoisted.loadSessionStoreMock,
 }));
 
+vi.mock("../config/sessions/session-accessor.js", () => {
+  const resolveMockStorePath = (scope: {
+    agentId?: string;
+    env?: NodeJS.ProcessEnv;
+    storePath?: string;
+  }): string =>
+    scope.storePath ??
+    hoisted.resolveStorePathMock(undefined, {
+      agentId: scope.agentId,
+      env: scope.env,
+    });
+  const loadMockEntry = (scope: {
+    agentId?: string;
+    env?: NodeJS.ProcessEnv;
+    sessionKey: string;
+    storePath?: string;
+  }): SessionEntry | undefined => {
+    const store = hoisted.loadSessionStoreMock(resolveMockStorePath(scope)) as Record<
+      string,
+      SessionEntry
+    >;
+    return store[scope.sessionKey];
+  };
+  return {
+    listSessionEntries: (
+      scope: {
+        agentId?: string;
+        env?: NodeJS.ProcessEnv;
+        storePath?: string;
+      } = {},
+    ) => {
+      const store = hoisted.loadSessionStoreMock(resolveMockStorePath(scope)) as Record<
+        string,
+        SessionEntry
+      >;
+      return Object.entries(store).map(([sessionKey, entry]) => ({ sessionKey, entry }));
+    },
+    loadSessionEntry: loadMockEntry,
+    resolveSessionTranscriptRuntimeTarget: async (scope: {
+      agentId: string;
+      sessionId: string;
+      sessionKey: string;
+      storePath?: string;
+      threadId?: string | number;
+    }) => {
+      const store = scope.storePath
+        ? (hoisted.loadSessionStoreMock(scope.storePath) as Record<string, SessionEntry>)
+        : undefined;
+      const resolved = await hoisted.resolveSessionTranscriptFileMock({
+        ...scope,
+        ...(store ? { sessionStore: store } : {}),
+        sessionEntry: loadMockEntry(scope),
+      });
+      return {
+        agentId: scope.agentId,
+        sessionFile: resolved.sessionFile,
+        sessionId: scope.sessionId,
+        sessionKey: scope.sessionKey,
+      };
+    },
+  };
+});
+
 vi.mock("../config/sessions.js", () => ({
   loadSessionStore: hoisted.loadSessionStoreMock,
   resolveStorePath: hoisted.resolveStorePathMock,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -71,6 +71,68 @@ const hoisted = vi.hoisted(() => {
   const countActiveRunsForSessionMock = vi.fn();
   const getSubagentRunByChildSessionKeyMock = vi.fn();
   const listTasksForOwnerKeyMock = vi.fn();
+  const createSessionAccessorMock = () => {
+    const resolveMockStorePath = (scope: {
+      agentId?: string;
+      env?: NodeJS.ProcessEnv;
+      storePath?: string;
+    }): string =>
+      scope.storePath ??
+      resolveStorePathMock(undefined, {
+        agentId: scope.agentId,
+        env: scope.env,
+      });
+    const loadMockEntry = (scope: {
+      agentId?: string;
+      env?: NodeJS.ProcessEnv;
+      sessionKey: string;
+      storePath?: string;
+    }): SessionEntry | undefined => {
+      const store = loadSessionStoreMock(resolveMockStorePath(scope)) as Record<
+        string,
+        SessionEntry
+      >;
+      return store[scope.sessionKey];
+    };
+    return {
+      listSessionEntries: (
+        scope: {
+          agentId?: string;
+          env?: NodeJS.ProcessEnv;
+          storePath?: string;
+        } = {},
+      ) => {
+        const store = loadSessionStoreMock(resolveMockStorePath(scope)) as Record<
+          string,
+          SessionEntry
+        >;
+        return Object.entries(store).map(([sessionKey, entry]) => ({ sessionKey, entry }));
+      },
+      loadSessionEntry: loadMockEntry,
+      resolveSessionTranscriptRuntimeTarget: async (scope: {
+        agentId: string;
+        sessionId: string;
+        sessionKey: string;
+        storePath?: string;
+        threadId?: string | number;
+      }) => {
+        const store = scope.storePath
+          ? (loadSessionStoreMock(scope.storePath) as Record<string, SessionEntry>)
+          : undefined;
+        const resolved = await resolveSessionTranscriptFileMock({
+          ...scope,
+          ...(store ? { sessionStore: store } : {}),
+          sessionEntry: loadMockEntry(scope),
+        });
+        return {
+          agentId: scope.agentId,
+          sessionFile: resolved.sessionFile,
+          sessionId: scope.sessionId,
+          sessionKey: scope.sessionKey,
+        };
+      },
+    };
+  };
   const state = {
     cfg: createDefaultSpawnConfig(),
   };
@@ -98,6 +160,7 @@ const hoisted = vi.hoisted(() => {
     countActiveRunsForSessionMock,
     getSubagentRunByChildSessionKeyMock,
     listTasksForOwnerKeyMock,
+    createSessionAccessorMock,
     state,
   };
 });
@@ -134,68 +197,7 @@ vi.mock("../config/sessions/store.js", () => ({
   loadSessionStore: hoisted.loadSessionStoreMock,
 }));
 
-vi.mock("../config/sessions/session-accessor.js", () => {
-  const resolveMockStorePath = (scope: {
-    agentId?: string;
-    env?: NodeJS.ProcessEnv;
-    storePath?: string;
-  }): string =>
-    scope.storePath ??
-    hoisted.resolveStorePathMock(undefined, {
-      agentId: scope.agentId,
-      env: scope.env,
-    });
-  const loadMockEntry = (scope: {
-    agentId?: string;
-    env?: NodeJS.ProcessEnv;
-    sessionKey: string;
-    storePath?: string;
-  }): SessionEntry | undefined => {
-    const store = hoisted.loadSessionStoreMock(resolveMockStorePath(scope)) as Record<
-      string,
-      SessionEntry
-    >;
-    return store[scope.sessionKey];
-  };
-  return {
-    listSessionEntries: (
-      scope: {
-        agentId?: string;
-        env?: NodeJS.ProcessEnv;
-        storePath?: string;
-      } = {},
-    ) => {
-      const store = hoisted.loadSessionStoreMock(resolveMockStorePath(scope)) as Record<
-        string,
-        SessionEntry
-      >;
-      return Object.entries(store).map(([sessionKey, entry]) => ({ sessionKey, entry }));
-    },
-    loadSessionEntry: loadMockEntry,
-    resolveSessionTranscriptRuntimeTarget: async (scope: {
-      agentId: string;
-      sessionId: string;
-      sessionKey: string;
-      storePath?: string;
-      threadId?: string | number;
-    }) => {
-      const store = scope.storePath
-        ? (hoisted.loadSessionStoreMock(scope.storePath) as Record<string, SessionEntry>)
-        : undefined;
-      const resolved = await hoisted.resolveSessionTranscriptFileMock({
-        ...scope,
-        ...(store ? { sessionStore: store } : {}),
-        sessionEntry: loadMockEntry(scope),
-      });
-      return {
-        agentId: scope.agentId,
-        sessionFile: resolved.sessionFile,
-        sessionId: scope.sessionId,
-        sessionKey: scope.sessionKey,
-      };
-    },
-  };
-});
+vi.mock("../config/sessions/session-accessor.js", () => hoisted.createSessionAccessorMock());
 
 vi.mock("../config/sessions.js", () => ({
   loadSessionStore: hoisted.loadSessionStoreMock,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -47,8 +47,11 @@ import {
 } from "../config/agent-limits.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { loadSessionStore } from "../config/sessions/store.js";
-import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
+import {
+  listSessionEntries,
+  loadSessionEntry,
+  resolveSessionTranscriptRuntimeTarget,
+} from "../config/sessions/session-accessor.js";
 import type { SessionAcpMeta, SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
@@ -268,7 +271,6 @@ type AcpSpawnInitializedRuntime = {
   runtimeCloseHandle: AcpSpawnRuntimeCloseHandle;
   sessionId?: string;
   sessionEntry: SessionEntry | undefined;
-  sessionStore: Record<string, SessionEntry>;
   storePath: string;
 };
 
@@ -445,8 +447,11 @@ function hasSessionLocalHeartbeatRelayRoute(params: {
   const storePath = resolveStorePath(params.cfg.session?.store, {
     agentId: params.requesterAgentId,
   });
-  const sessionStore = loadSessionStore(storePath);
-  const parentEntry = sessionStore[params.parentSessionKey];
+  const parentEntry = loadSessionEntry({
+    storePath,
+    sessionKey: params.parentSessionKey,
+    clone: false,
+  });
   const parentDeliveryContext = deliveryContextFromSession(parentEntry);
   return Boolean(parentDeliveryContext?.channel && parentDeliveryContext.to);
 }
@@ -595,23 +600,26 @@ async function persistAcpSpawnSessionFileBestEffort(params: {
   sessionId: string;
   sessionKey: string;
   sessionEntry: SessionEntry | undefined;
-  sessionStore: Record<string, SessionEntry>;
   storePath: string;
   agentId: string;
   threadId?: string | number;
   stage: "spawn" | "thread-bind";
 }): Promise<SessionEntry | undefined> {
   try {
-    const resolvedSessionFile = await resolveSessionTranscriptFile({
+    const resolvedSessionFile = await resolveSessionTranscriptRuntimeTarget({
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
-      sessionEntry: params.sessionEntry,
-      sessionStore: params.sessionStore,
       storePath: params.storePath,
       agentId: params.agentId,
       threadId: params.threadId,
     });
-    return resolvedSessionFile.sessionEntry;
+    return (
+      loadSessionEntry({
+        storePath: params.storePath,
+        sessionKey: resolvedSessionFile.sessionKey,
+        clone: false,
+      }) ?? params.sessionEntry
+    );
   } catch (error) {
     log.warn(
       `ACP session-file persistence failed during ${params.stage} for ${params.sessionKey}: ${summarizeError(error)}`,
@@ -964,9 +972,8 @@ function validateAcpResumeSessionOwnership(params: {
   }
 
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
-  const sessionStore = loadSessionStore(storePath);
-  for (const [sessionKey, entry] of Object.entries(sessionStore)) {
-    const acp = readAcpSessionMeta({ sessionKey });
+  for (const { sessionKey, entry } of listSessionEntries({ storePath, clone: false })) {
+    const acp = readAcpSessionMeta({ sessionKey, cfg: params.cfg });
     if (!sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)) {
       continue;
     }
@@ -1064,14 +1071,16 @@ async function initializeAcpSpawnRuntime(params: {
   cwd?: string;
 }): Promise<AcpSpawnInitializedRuntime> {
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
-  const sessionStore = loadSessionStore(storePath);
-  let sessionEntry: SessionEntry | undefined = sessionStore[params.sessionKey];
+  let sessionEntry = loadSessionEntry({
+    storePath,
+    sessionKey: params.sessionKey,
+    clone: false,
+  });
   const sessionId = sessionEntry?.sessionId;
   if (sessionId) {
     sessionEntry = await persistAcpSpawnSessionFileBestEffort({
       sessionId,
       sessionKey: params.sessionKey,
-      sessionStore,
       storePath,
       sessionEntry,
       agentId: params.targetAgentId,
@@ -1098,7 +1107,6 @@ async function initializeAcpSpawnRuntime(params: {
     },
     sessionId,
     sessionEntry,
-    sessionStore,
     storePath,
   };
 }
@@ -1170,7 +1178,6 @@ async function bindPreparedAcpThread(params: {
       sessionEntry = await persistAcpSpawnSessionFileBestEffort({
         sessionId: params.initializedRuntime.sessionId,
         sessionKey: params.sessionKey,
-        sessionStore: params.initializedRuntime.sessionStore,
         storePath: params.initializedRuntime.storePath,
         sessionEntry,
         agentId: params.targetAgentId,
@@ -1532,16 +1539,19 @@ export async function spawnAcpDirect(
           childSessionKey: sessionKey,
         })
       : undefined;
+  const parentAgentId = parentSessionKey
+    ? resolveAgentIdFromSessionKey(parentSessionKey)
+    : undefined;
   // Resolve parent session delivery context so system events route to the
   // correct thread/topic instead of falling back to the main DM.
   const parentDeliveryCtx =
     effectiveStreamToParent && parentSessionKey
       ? deliveryContextFromSession(
-          loadSessionStore(
-            resolveStorePath(cfg.session?.store, {
-              agentId: resolveAgentIdFromSessionKey(parentSessionKey),
-            }),
-          )[parentSessionKey],
+          loadSessionEntry({
+            sessionKey: parentSessionKey,
+            ...(parentAgentId ? { agentId: parentAgentId } : {}),
+            clone: false,
+          }),
         )
       : undefined;
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -325,8 +325,14 @@ export type SessionEntryPatchOptions = {
   maintenanceConfig?: ResolvedSessionMaintenanceConfig;
   /** Keep the previous updatedAt value when the patch should not count as activity. */
   preserveActivity?: boolean;
+  /** Throw when best-effort store recovery cannot confirm the requested write. */
+  requireWriteSuccess?: boolean;
   /** Replace the whole entry instead of merging the returned patch. */
   replaceEntry?: boolean;
+  /** Skip prune/cap/rotation maintenance for specialized internal updates. */
+  skipMaintenance?: boolean;
+  /** Let the writer cache retain the updated object without cloning. */
+  takeCacheOwnership?: boolean;
 };
 
 export type SessionEntryPatchContext = {
@@ -509,7 +515,10 @@ export async function patchSessionEntry(
     fallbackEntry: options.fallbackEntry,
     maintenanceConfig: options.maintenanceConfig,
     preserveActivity: options.preserveActivity,
+    requireWriteSuccess: options.requireWriteSuccess,
     replaceEntry: options.replaceEntry,
+    skipMaintenance: options.skipMaintenance,
+    takeCacheOwnership: options.takeCacheOwnership,
     update,
   });
 }

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -44,6 +44,7 @@ import {
   loadSessionStore,
   applySessionEntryPatchProjection as applyFileSessionEntryPatchProjection,
   patchSessionEntry as patchFileSessionEntry,
+  patchSessionEntryWithKey as patchFileSessionEntryWithKey,
   purgeDeletedAgentSessionEntries as purgeFileDeletedAgentSessionEntries,
   readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
@@ -340,6 +341,13 @@ export type SessionEntryPatchContext = {
   existingEntry?: SessionEntry;
 };
 
+export type SessionEntryPatchResult = {
+  /** Exact persisted key for the patched entry after alias normalization. */
+  sessionKey: string;
+  /** Persisted entry returned by the backing store. */
+  entry: SessionEntry;
+};
+
 export type RestartRecoveryLifecycleEntry = {
   /** Exact persisted key for the restart recovery candidate row. */
   sessionKey: string;
@@ -511,6 +519,31 @@ export async function patchSessionEntry(
   options: SessionEntryPatchOptions = {},
 ): Promise<SessionEntry | null> {
   return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: options.fallbackEntry,
+    maintenanceConfig: options.maintenanceConfig,
+    preserveActivity: options.preserveActivity,
+    requireWriteSuccess: options.requireWriteSuccess,
+    replaceEntry: options.replaceEntry,
+    skipMaintenance: options.skipMaintenance,
+    takeCacheOwnership: options.takeCacheOwnership,
+    update,
+  });
+}
+
+/**
+ * Applies an atomic patch and returns the persisted key selected by the backing
+ * store. Use when a caller must keep sidecar state keyed to the final row.
+ */
+export async function patchSessionEntryWithKey(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+    context: SessionEntryPatchContext,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntryPatchResult | null> {
+  return await patchFileSessionEntryWithKey({
     ...scope,
     fallbackEntry: options.fallbackEntry,
     maintenanceConfig: options.maintenanceConfig,

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1758,21 +1758,29 @@ export async function applySessionStoreEntryPatch(params: {
   });
 }
 
+type SessionEntryPatchParams = SessionEntryWorkflowOptions & {
+  sessionKey: string;
+  fallbackEntry?: SessionEntry;
+  preserveActivity?: boolean;
+  requireWriteSuccess?: boolean;
+  replaceEntry?: boolean;
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+  update: (
+    entry: SessionEntry,
+    context: { existingEntry?: SessionEntry },
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
+};
+
 export async function patchSessionEntry(
-  params: SessionEntryWorkflowOptions & {
-    sessionKey: string;
-    fallbackEntry?: SessionEntry;
-    preserveActivity?: boolean;
-    requireWriteSuccess?: boolean;
-    replaceEntry?: boolean;
-    skipMaintenance?: boolean;
-    takeCacheOwnership?: boolean;
-    update: (
-      entry: SessionEntry,
-      context: { existingEntry?: SessionEntry },
-    ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
-  },
+  params: SessionEntryPatchParams,
 ): Promise<SessionEntry | null> {
+  return (await patchSessionEntryWithKey(params))?.entry ?? null;
+}
+
+export async function patchSessionEntryWithKey(
+  params: SessionEntryPatchParams,
+): Promise<{ sessionKey: string; entry: SessionEntry } | null> {
   const storePath = resolveSessionWorkflowStorePath(params);
   return await runExclusiveSessionStoreWrite(storePath, async () => {
     const store = loadMutableSessionStoreForWriter(storePath);
@@ -1785,24 +1793,27 @@ export async function patchSessionEntry(
       existingEntry: resolved.existing ? cloneSessionEntry(resolved.existing) : undefined,
     });
     if (!patch) {
-      return existing;
+      return { sessionKey: resolved.normalizedKey, entry: existing };
     }
     const next = params.replaceEntry
       ? cloneSessionEntry(patch as SessionEntry)
       : params.preserveActivity
         ? mergeSessionEntryPreserveActivity(existing, patch)
         : mergeSessionEntry(existing, patch);
-    return await persistResolvedSessionEntry({
-      storePath,
-      store,
-      resolved,
-      next,
-      maintenanceConfig: params.maintenanceConfig,
-      requireWriteSuccess: params.requireWriteSuccess,
-      skipMaintenance: params.skipMaintenance,
-      takeCacheOwnership: params.takeCacheOwnership ?? true,
-      returnDetached: params.takeCacheOwnership !== true,
-    });
+    return {
+      sessionKey: resolved.normalizedKey,
+      entry: await persistResolvedSessionEntry({
+        storePath,
+        store,
+        resolved,
+        next,
+        maintenanceConfig: params.maintenanceConfig,
+        requireWriteSuccess: params.requireWriteSuccess,
+        skipMaintenance: params.skipMaintenance,
+        takeCacheOwnership: params.takeCacheOwnership ?? true,
+        returnDetached: params.takeCacheOwnership !== true,
+      }),
+    };
   });
 }
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1763,7 +1763,10 @@ export async function patchSessionEntry(
     sessionKey: string;
     fallbackEntry?: SessionEntry;
     preserveActivity?: boolean;
+    requireWriteSuccess?: boolean;
     replaceEntry?: boolean;
+    skipMaintenance?: boolean;
+    takeCacheOwnership?: boolean;
     update: (
       entry: SessionEntry,
       context: { existingEntry?: SessionEntry },
@@ -1795,8 +1798,10 @@ export async function patchSessionEntry(
       resolved,
       next,
       maintenanceConfig: params.maintenanceConfig,
-      takeCacheOwnership: true,
-      returnDetached: true,
+      requireWriteSuccess: params.requireWriteSuccess,
+      skipMaintenance: params.skipMaintenance,
+      takeCacheOwnership: params.takeCacheOwnership ?? true,
+      returnDetached: params.takeCacheOwnership !== true,
     });
   });
 }

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -24,6 +24,8 @@ describe("session accessor boundary guard", () => {
     expect(migratedSessionAccessorFiles).toEqual(
       new Set([
         "packages/memory-host-sdk/src/host/session-files.ts",
+        "src/acp/runtime/session-meta.ts",
+        "src/agents/acp-spawn.ts",
         "src/agents/embedded-agent-runner/compaction-successor-transcript.ts",
         "src/agents/embedded-agent-runner/run/attempt.ts",
         "src/agents/embedded-agent-runner/tool-result-truncation.ts",
@@ -78,6 +80,7 @@ describe("session accessor boundary guard", () => {
   it("ratchets only files migrated to session accessor writes", () => {
     expect(migratedSessionAccessorWriteFiles).toEqual(
       new Set([
+        "src/acp/runtime/session-meta.ts",
         "src/agents/command/attempt-execution.shared.ts",
         "src/agents/command/session-store.ts",
         "src/agents/embedded-agent-runner/run.ts",


### PR DESCRIPTION
## What Problem This Solves

Path 3 issue #88838 is moving session and transcript storage behind accessor seams for the SQLite-backed runtime. ACP metadata still had a narrow direct session-store surface in `src/acp/runtime/session-meta.ts` and `src/agents/acp-spawn.ts`, which made ACP session metadata depend on JSON session entries instead of the session accessor and transcript accessor boundaries.

## Why This Change Was Made

This bridges the ACP metadata slice to the accessor seams without depending on adjacent Path 3 PRs. ACP metadata now keeps the session store responsible for canonical session identity while ACP runtime metadata lives in the SQLite `acp_sessions` table, and spawn cleanup/resolution paths use the existing accessor surface instead of reaching into the session store directly.

## User Impact

No user-visible behavior change is intended. ACP spawn/session metadata continues to work, while JSON session entries no longer carry embedded ACP metadata and the direct-store boundary is ratcheted for this slice.

## Evidence

Focused non-live proof:

- `node scripts/run-vitest.mjs src/acp/runtime/session-meta.test.ts src/agents/acp-spawn.test.ts src/config/sessions/session-accessor.test.ts test/scripts/check-session-accessor-boundary.test.ts` passed: 4 shards, 144 tests.
- `node scripts/check-session-accessor-boundary.mjs` passed.
- `git diff --check upstream/main...HEAD` passed.
- `pnpm tsgo:test:src` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` completed with no accepted/actionable findings.

Real behavior proof on live local OpenClaw:

- Safety preflight: live checkout was clean detached at `3f74951260a`; gateway was running on port 18789; `tasks list --status running --json` reported `count: 0`. Existing queued work was silent deferred context-engine maintenance.
- Loaded proof build: switched live checkout to detached `a947599183354dc10939229f6dee261fc7a0c378`, ran `pnpm build`, restarted the gateway, and verified `OpenClaw 2026.6.9 (a947599)`, `/readyz 200`, and `/healthz 200`.
- Created proof parent session `agent:main:path3-acp-accessor-live` with session id `75b3bcd6-2908-411c-90ef-53e86e34bdf5`.
- Codex ACP spawn path reached the ACP backend but local Codex auth failed with `Authentication required | -32000`; no Codex child session was created.
- Claude ACP spawn was accepted and returned child session `agent:claude:acp:2272869c-7922-4872-9700-e8b4c7fac4ea` / run `d3992b62-3734-4498-a877-3fa204c4eefe`, then local Claude Code access failed because subscription access is disabled for the org.
- Opencode ACP spawn was accepted through the live `sessions_spawn` user path. It created child session `agent:opencode:acp:411e4d91-99a7-492b-8029-f7ac859a9f7f`, session id `21ca9656-432d-4694-a1c9-e69c2765f32f`, and run `9de99265-390d-4fe6-920c-2df378fc535f`.
- Accessor/metadata verification for the opencode child showed:
  - JSON session entry resolved by key and session id, `status: done`, `hasEmbeddedAcp: false`.
  - SQLite `acp_sessions` row existed for the same key/session id with `backend: acpx`, `agent: opencode`, `mode: oneshot`, `state: idle`, and `cwd: /Users/phaedrus/Projects/clawdbot`.
  - Transcript target resolution returned `null` because the opencode one-shot did not produce a final deliverable; this was treated as a proof boundary, not a transcript accessor success claim.
- Cleanup/restoration: cancelled the remaining duplicate opencode ACP task record, deleted the opencode/Claude/proof parent sessions through `sessions.delete`, verified no running ACP tasks and no leftover proof `acp_sessions` rows, switched the live checkout back to `3f74951260a`, rebuilt, restarted the gateway, and verified `OpenClaw 2026.6.9 (3f74951)`, `/readyz 200`, `/healthz 200`, and clean detached live checkout state.

Follow-up boundaries not covered by this PR:

- Future full SQLite session/transcript flip behavior.
- Runtime migrations or doctor repair flows for shipped state.
- Broad ACP adapter auth health; local Codex and Claude adapter auth were environment-blocked during proof.
- A successful ACP transcript target proof with a final adapter deliverable; this slice only proves the metadata/session accessor bridge under the live ACP spawn path.


CI follow-up after initial PR open:

- Attributed failed CI job `check-lint` in workflow `CI` at head `a947599183354dc10939229f6dee261fc7a0c378` to this PR: GitHub Actions log reported `src/acp/runtime/session-meta.test.ts:159:14` `typescript(no-unnecessary-type-assertion)`.
- Fixed the lint failure by replacing the non-null assertion with an explicit guard.
- Addressed fresh branch autoreview finding by binding ACP SQLite metadata after `patchSessionEntryWithKey` returns the final accessor-selected key/session id, avoiding hybrid metadata when canonical and legacy alias entries coexist.
- Added regression coverage for alias writes that collapse to the final accessor-selected session entry.
- New head: `05017e299e9f42a61c209127c01a9914449c9973`.
- Additional proof after the fix: `node scripts/run-oxlint.mjs src/acp/runtime/session-meta.ts src/acp/runtime/session-meta.test.ts`, `pnpm lint --threads=8`, `pnpm tsgo:test:src`, `node scripts/run-vitest.mjs src/acp/runtime/session-meta.test.ts src/agents/acp-spawn.test.ts src/config/sessions/session-accessor.test.ts test/scripts/check-session-accessor-boundary.test.ts`, `node scripts/check-session-accessor-boundary.mjs`, and branch-mode autoreview all passed.
