### PR TITLE
fix: run fallback models on upstream provider errors

### DIFF
--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -119,6 +119,7 @@ const ERROR_PATTERNS = {
     "bad gateway",
     "gateway timeout",
     "upstream error",
+    "upstream_error",
     "upstream connect error",
     "connection reset",
     // Chinese provider server error messages

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -282,7 +282,16 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     expect(result).toBeNull();
   });
 
-  it("does not retry non-business transport error payloads", () => {
+  it("classifies transient provider error payloads as fallback-worthy", () => {
+    const errorText = JSON.stringify({
+      error: {
+        message: "Upstream request failed",
+        type: "upstream_error",
+        param: "",
+        code: null,
+      },
+    });
+
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "custom",
       model: "llama-3.1",
@@ -290,7 +299,32 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
         payloads: [
           {
             isError: true,
-            text: "HTTP 500: internal server error",
+            text: errorText,
+          },
+        ],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message: `custom/llama-3.1 ended with a provider error: ${errorText}`,
+      reason: "timeout",
+      code: "embedded_error_payload",
+      rawError: errorText,
+    });
+  });
+
+  it("does not retry schema-rejection error payloads", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "custom",
+      model: "llama-3.1",
+      result: {
+        payloads: [
+          {
+            isError: true,
+            text: "LLM request failed: provider rejected the request schema or tool payload.",
           },
         ],
         meta: {

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -146,11 +146,16 @@ function classifyHarnessResult(params: {
   }
 }
 
-/** Maps provider error payloads to fallback-safe business reasons. */
-function classifyBusinessDenialErrorPayloadReason(
+type EmbeddedErrorPayloadFailoverReason = Extract<
+  FailoverReason,
+  "auth" | "auth_permanent" | "billing" | "overloaded" | "rate_limit" | "server_error" | "timeout"
+>;
+
+/** Maps provider error payloads to fallback-safe reasons. */
+function classifyProviderErrorPayloadReason(
   errorText: string,
   provider: string,
-): Extract<FailoverReason, "auth" | "auth_permanent" | "billing" | "rate_limit"> | null {
+): EmbeddedErrorPayloadFailoverReason | null {
   if (!errorText.trim()) {
     return null;
   }
@@ -159,7 +164,10 @@ function classifyBusinessDenialErrorPayloadReason(
     case "auth":
     case "auth_permanent":
     case "billing":
+    case "overloaded":
     case "rate_limit":
+    case "server_error":
+    case "timeout":
       return failoverReason;
     default:
       return null;
@@ -252,7 +260,7 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     .filter((payload) => payload?.isError === true)
     .map((payload) => (typeof payload.text === "string" ? payload.text : ""))
     .join("\n");
-  const failoverReason = classifyBusinessDenialErrorPayloadReason(errorText, params.provider);
+  const failoverReason = classifyProviderErrorPayloadReason(errorText, params.provider);
   if (failoverReason) {
     return {
       message: `${params.provider}/${params.model} ended with a provider error: ${errorText}`,


### PR DESCRIPTION
Fixes #95519.

## What Problem This Solves

Fixes an issue where users with configured fallback models could still see a primary provider failure instead of trying the next model when the primary provider returned a transient upstream error payload such as `upstream_error` / `LLM request failed`.

## Why This Change Was Made

Embedded agent result fallback already treats auth, billing, and rate-limit error payloads as safe fallback triggers when no user-visible output was delivered. This extends that same guarded path to transient provider failures (`overloaded`, `server_error`, and `timeout`) and teaches the shared matcher the canonical `upstream_error` token, while leaving schema/tool-payload rejections non-retryable.

## User Impact

Users with model fallbacks configured should get an automatic fallback attempt for transient upstream provider failures instead of a failed turn from the first provider. Request-shape errors and already-delivered user-visible output remain unchanged.

## Evidence

Real behavior proof: A local OpenClaw production-classifier/runtime proof command imported the production `classifyEmbeddedAgentRunResultForModelFallback` and `runWithModelFallback` modules, fed the provider error payload shape from #95519, and verified the runtime advanced from the primary model to the configured fallback model. The proof used a temporary redacted `OPENCLAW_STATE_DIR`; no credentials or external provider calls were used.

Redacted terminal output from the proof command:

```text
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=openai/gpt-5.5 candidate=openai/gpt-5.5 reason=timeout providerErrorType=upstream_error next=anthropic/claude-sonnet-4-6 detail=Upstream request failed
[model-fallback/decision] model fallback decision: decision=candidate_succeeded requested=openai/gpt-5.5 candidate=anthropic/claude-sonnet-4-6 reason=unknown next=none
```

```json
{
  "proof": "OpenClaw #96196 production fallback classifier and fallback runtime",
  "tempState": "<redacted temp OPENCLAW_STATE_DIR>",
  "upstreamPayloadText": "{\"error\":{\"message\":\"Upstream request failed\",\"type\":\"upstream_error\",\"param\":\"\",\"code\":null}}",
  "productionClassification": {
    "message": "openai/gpt-5.5 ended with a provider error: {\"error\":{\"message\":\"Upstream request failed\",\"type\":\"upstream_error\",\"param\":\"\",\"code\":null}}",
    "reason": "timeout",
    "code": "embedded_error_payload",
    "rawError": "{\"error\":{\"message\":\"Upstream request failed\",\"type\":\"upstream_error\",\"param\":\"\",\"code\":null}}"
  },
  "schemaRejectionClassification": null,
  "runtime": {
    "outcome": "completed",
    "provider": "anthropic",
    "model": "claude-sonnet-4-6",
    "attempts": [
      {
        "provider": "openai",
        "model": "gpt-5.5",
        "error": "{\"error\":{\"message\":\"Upstream request failed\",\"type\":\"upstream_error\",\"param\":\"\",\"code\":null}}",
        "reason": "timeout",
        "code": "embedded_error_payload"
      }
    ],
    "callSequence": [
      {
        "provider": "openai",
        "model": "gpt-5.5",
        "isFinalFallbackAttempt": false
      },
      {
        "provider": "anthropic",
        "model": "claude-sonnet-4-6",
        "isFinalFallbackAttempt": true
      }
    ],
    "fallbackPayloadText": "fallback model completed the turn"
  },
  "assertions": {
    "upstreamErrorClassifiedAsFallback": true,
    "schemaRejectionNotRetried": true,
    "fallbackAttempted": true,
    "completedWithFallback": true
  }
}
```

Focused validation:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/result-fallback-classifier.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/result-fallback-classifier.test.ts src/agents/outcome-fallback-runtime-contract.test.ts src/agents/model-fallback.test.ts src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts`
- `pnpm exec oxfmt --check src/agents/embedded-agent-helpers/failover-matches.ts src/agents/embedded-agent-runner/result-fallback-classifier.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts`
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-helpers/failover-matches.ts src/agents/embedded-agent-runner/result-fallback-classifier.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts`
- `pnpm tsgo:core:test`
- `git diff --check`
- `codex review --base origin/main` -> no discrete correctness regressions found

AI-assisted contribution disclosure: I used Codex to inspect the fallback/classifier path, implement the patch, run focused validation, produce the production proof above, and prepare this PR. I reviewed the diff and validation output before submission.
