### PR TITLE
fix: stop Claude tool heartbeats from hiding stuck sessions

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1970,7 +1970,7 @@ ${JSON.stringify({
     expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
   });
 
-  it("reports Claude live stream progress and keeps native tools fresh while they are running", async () => {
+  it("reports Claude live stream progress without treating active tool heartbeats as progress", async () => {
     vi.useFakeTimers({
       toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"],
     });
@@ -2069,14 +2069,12 @@ ${JSON.stringify({
 
       await vi.advanceTimersByTimeAsync(10_000);
       await waitForDiagnosticEventsDrained();
-      expect(
-        getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:diagnostics" })
-          .lastProgressReason,
-      ).toBe("cli_live:tool_running");
-      expect(
-        getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:diagnostics" })
-          .lastProgressAgeMs,
-      ).toBeLessThan(100);
+      expect(diagnosticEvents).toContain("run.progress");
+      const snapshotAfterToolHeartbeat = getDiagnosticSessionActivitySnapshot({
+        sessionKey: "agent:main:diagnostics",
+      });
+      expect(snapshotAfterToolHeartbeat.lastProgressReason).toBe("cli_live:tool_started");
+      expect(snapshotAfterToolHeartbeat.lastProgressAgeMs).toBeGreaterThanOrEqual(10_000);
 
       stdoutListener?.(
         [

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -271,9 +271,17 @@ function recordRunProgress(event: DiagnosticRunProgressActivityEvent): void {
   markDiagnosticRunProgress(event);
 }
 
+function isPassiveRunProgressReason(reason: string): boolean {
+  return reason === "cli_live:tool_running";
+}
+
 export function markDiagnosticRunProgress(params: DiagnosticRunProgressActivityEvent): void {
-  const activity = resolveSessionActivity({ ...params, create: true });
+  const passiveProgress = isPassiveRunProgressReason(params.reason);
+  const activity = resolveSessionActivity({ ...params, create: !passiveProgress });
   if (!activity) {
+    return;
+  }
+  if (passiveProgress) {
     return;
   }
   touchSessionActivity(activity, params.reason);

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -276,14 +276,14 @@ function isPassiveRunProgressReason(reason: string): boolean {
 }
 
 export function markDiagnosticRunProgress(params: DiagnosticRunProgressActivityEvent): void {
-  const passiveProgress = isPassiveRunProgressReason(params.reason);
-  const activity = resolveSessionActivity({ ...params, create: !passiveProgress });
-  if (!activity) {
+  // Claude live active-tool heartbeats are observability ticks, not work progress.
+  // Refreshing the session clock (or even creating activity) here can hide wedged
+  // CLI tools from stall detection.
+  if (isPassiveRunProgressReason(params.reason)) {
     return;
   }
-  if (passiveProgress) {
-    // Claude live active-tool heartbeats are observability ticks, not work progress.
-    // Refreshing the session clock here can hide wedged CLI tools from stall detection.
+  const activity = resolveSessionActivity({ ...params, create: true });
+  if (!activity) {
     return;
   }
   touchSessionActivity(activity, params.reason);

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -282,6 +282,8 @@ export function markDiagnosticRunProgress(params: DiagnosticRunProgressActivityE
     return;
   }
   if (passiveProgress) {
+    // Claude live active-tool heartbeats are observability ticks, not work progress.
+    // Refreshing the session clock here can hide wedged CLI tools from stall detection.
     return;
   }
   touchSessionActivity(activity, params.reason);

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -604,6 +604,31 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("does not refresh progress age for Claude live active-tool heartbeats", () => {
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+    markDiagnosticRunProgressForTest({
+      sessionId: "s1",
+      sessionKey: "main",
+      reason: "cli_live:tool_started",
+    });
+
+    vi.advanceTimersByTime(10_000);
+    markDiagnosticRunProgressForTest({
+      sessionId: "s1",
+      sessionKey: "main",
+      reason: "cli_live:tool_running",
+    });
+
+    expectRecordFields(
+      getDiagnosticSessionActivitySnapshot({ sessionId: "s1", sessionKey: "main" }),
+      {
+        hasActiveEmbeddedRun: true,
+        lastProgressAgeMs: 10_000,
+        lastProgressReason: "cli_live:tool_started",
+      },
+    );
+  });
+
   it("aborts and drains embedded runs after an extended no-progress stall", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();


### PR DESCRIPTION
Closes #96168

## What Problem This Solves

Fixes an issue where Claude CLI live-session runs could keep a wedged native tool looking fresh when the backend emitted active-tool heartbeat progress. If the CLI emitted `tool_use` but never emitted the matching `tool_result`, OpenClaw's diagnostic stuck-session detection could see recent progress and delay surfacing or recovering the blocked work.

## Why This Change Was Made

`cli_live:tool_running` is now treated as passive diagnostic progress: the heartbeat event is still emitted for observability, but it no longer creates or refreshes diagnostic session activity. Real progress, including tool start/result and run result events, still updates the activity clock.

This keeps the fix at the diagnostic activity boundary, avoids changing Claude CLI runtime behavior, and does not add config or a new timeout policy. Blast radius is limited to diagnostic run-activity bookkeeping and the existing Claude live-session regression harness.

## User Impact

Wedged Claude CLI live-session turns with an active tool that never returns a `tool_result` can age normally in stuck-session detection instead of being kept fresh by a synthetic heartbeat.

Because the synthetic heartbeat no longer masks tool age, Claude live native-tool calls now follow the **same** stall/abort policy already applied to model calls and embedded runs: a tool with no real intermediate progress is surfaced as a stalled (`blocked_tool_call`) session past the warn threshold (default 2 min) and becomes auto-recovery/abort-eligible past the abort threshold (default 6 min, configurable via `diagnostics.stuckSessionAbortMs`). Previously such tools were shielded from stall detection indefinitely. Tools that stream real intermediate output keep refreshing the activity clock exactly as before, so normal long-running work is unaffected.

## Evidence

AI-assisted disclosure: This PR was prepared with Codex assistance; I reviewed the change and validation.

Behavior addressed
Claude live active-tool heartbeat events still emit `run.progress`, but no longer refresh diagnostic session "last real progress" state.

Real environment tested
Local OpenClaw checkout on current `origin/main` SHA `c24d266b2d0943a2376ae9ac87a2fd8e200920e1`, using the production Claude live runner path up to the subprocess boundary, diagnostic event bus, timer heartbeat, and session activity snapshot.

Exact steps or command run after this patch
`node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts -t "reports Claude live stream progress without treating active tool heartbeats as progress"`

Evidence after fix
Focused run passed: `Test Files 2 passed (2)`, `Tests 2 passed | 118 skipped (120)`.

Supplemental validation:
- `node scripts/run-vitest.mjs src/logging/diagnostic-session-attention.test.ts` - passed, `1 file`, `11 tests`
- `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts -t "does not refresh progress age for Claude live active-tool heartbeats"` - passed, `1 test | 72 skipped`
- `node scripts/run-oxlint.mjs src/logging/diagnostic-run-activity.ts src/agents/cli-runner.spawn.test.ts` - passed
- `git diff --check` - passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings reported

Observed result after fix
After a simulated Claude `tool_use` starts an active tool, the 10s heartbeat still produces `run.progress`, but `lastProgressReason` remains `cli_live:tool_started` and `lastProgressAgeMs >= 10000`. The heartbeat no longer masks a wedged tool as fresh progress.

What was not tested
No live Claude account/API call or actual Claude CLI binary invocation. The proof uses the repo's deterministic live-runner harness because the bug boundary is the JSONL stream, heartbeat timer, and diagnostic activity bookkeeping.

