### PR TITLE
fix: force UTF-8 encoding for PowerShell exec output on Windows

### DIFF
--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -50,7 +50,7 @@ describe("getShellConfig", () => {
   });
 
   if (isWin) {
-    it("uses PowerShell on Windows", () => {
+    it("uses PowerShell on Windows with UTF-8 encoding init", () => {
       const { shell, args } = getShellConfig();
       const normalized = shell.toLowerCase();
       if (normalized.includes("powershell")) {
@@ -58,7 +58,13 @@ describe("getShellConfig", () => {
       } else {
         expect(normalized).toContain("pwsh");
       }
-      expect(args).toEqual(["-NoProfile", "-NonInteractive", "-Command"]);
+      expect(args[0]).toBe("-NoProfile");
+      expect(args[1]).toBe("-NonInteractive");
+      expect(args[2]).toBe("-Command");
+      // 4th arg is the UTF-8 + error-suppression init script
+      expect(args[3]).toContain("OutputEncoding");
+      expect(args[3]).toContain("UTF8");
+      expect(args[3]).toContain("SilentlyContinue");
     });
     return;
   }

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -106,9 +106,19 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
     // directly to the console via WriteConsole API, bypassing stdout pipes.
     // When Node.js spawns cmd.exe with piped stdio, these utilities produce no output.
     // PowerShell properly captures and redirects their output to stdout.
+    //
+    // Force UTF-8 output encoding so accented characters (áéíóúñ), CJK, and other
+    // non-ASCII text renders correctly regardless of the system locale.
+    // SilentlyContinue prevents PowerShell from wrapping stderr in noisy ErrorRecord objects.
+    const poweshellInit = [
+      "[Console]::OutputEncoding=[Text.Encoding]::UTF8",
+      "[Console]::InputEncoding=[Text.Encoding]::UTF8",
+      "$OutputEncoding=[Text.Encoding]::UTF8",
+      "$ErrorActionPreference='SilentlyContinue'"
+    ].join(";") + ";";
     return {
       shell: resolvePowerShellPath(),
-      args: ["-NoProfile", "-NonInteractive", "-Command"],
+      args: ["-NoProfile", "-NonInteractive", "-Command", poweshellInit],
     };
   }
 


### PR DESCRIPTION
## Problem

PowerShell defaults to the system console encoding (e.g. Windows-1252 on Spanish/Portuguese systems) when spawned via OpenClaw's exec tool. This causes:
- **Accented characters** (áéíóúñ, ç, ã) render as garbled
- **Non-ASCII text** (CJK, Cyrillic, etc.) corrupted
- **PowerShell stderr** wrapped in noisy ErrorRecord objects

## Root cause

`getShellConfig()` in `shell-utils.ts` constructs:

    powershell.exe -NoProfile -NonInteractive -Command "user command"

Without forcing `[Console]::OutputEncoding = UTF8`, PowerShell uses the system locale encoding (e.g. Windows-1252). `decodeWindowsBufferWithFallback()` already tries UTF-8 first, but the raw output IS NOT UTF-8.

## Fix

Add a PowerShell init snippet as an extra argument after `-Command`:

    [Console]::OutputEncoding=[Text.Encoding]::UTF8;
    [Console]::InputEncoding=[Text.Encoding]::UTF8;
    $OutputEncoding=[Text.Encoding]::UTF8;
    $ErrorActionPreference='SilentlyContinue';

The final argv becomes:

    powershell.exe -NoProfile -NonInteractive -Command "init" "user command"

PowerShell concatenates all remaining args after `-Command`, so the init runs before every user command.

## Files changed

- `src/agents/shell-utils.ts` — Add UTF-8 + error suppression init
- `src/agents/shell-utils.test.ts` — Update test expectations

## Related

- Closes #30640 (and variants for non-Chinese locales)
- Also fixes the PowerShell ErrorRecord noise issue
