### PR TITLE
fix(gmail): stop watcher when OAuth renewal is invalid

### DIFF
--- a/src/hooks/gmail-ops.test.ts
+++ b/src/hooks/gmail-ops.test.ts
@@ -54,8 +54,9 @@ vi.mock("../infra/executable-path.js", () => ({
 }));
 
 const { runGmailService } = await import("./gmail-ops.js");
+const { GMAIL_WATCH_REAUTH_REASON } = await import("./gmail-watcher-errors.js");
 
-function createGmailConfig(account = "me@example.com") {
+function createGmailConfig(account = "me@example.com", gmail: Record<string, unknown> = {}) {
   return {
     hooks: {
       enabled: true,
@@ -65,6 +66,7 @@ function createGmailConfig(account = "me@example.com") {
         topic: "projects/demo/topics/gmail",
         pushToken: "push-token",
         tailscale: { mode: "off" as const },
+        ...gmail,
       },
     },
   };
@@ -111,6 +113,50 @@ describe("runGmailService", () => {
       expect(mocks.defaultRuntime.error).toHaveBeenCalledWith(
         "gmail watch renew failed: Error: renewal failed",
       );
+    } finally {
+      shutdown?.();
+    }
+  });
+
+  it("stops the foreground serve process when watch renewal needs Gmail re-auth", async () => {
+    vi.useFakeTimers();
+    mocks.getRuntimeConfig.mockReturnValue(
+      createGmailConfig("me@example.com", { renewEveryMinutes: 1 }),
+    );
+    mocks.runCommandWithTimeout
+      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+      .mockResolvedValueOnce({
+        code: 1,
+        stdout: "",
+        stderr: "invalid_grant: Token has been expired or revoked",
+      });
+
+    const child = new EventEmitter();
+    const kill = vi.fn(() => {
+      child.emit("exit", null, "SIGTERM");
+      return true;
+    });
+    mocks.spawn.mockReturnValue(Object.assign(child, { kill, killed: false }));
+
+    const existingSigintListeners = new Set(process.rawListeners("SIGINT"));
+    let shutdown: (() => void) | undefined;
+    try {
+      await runGmailService({});
+      shutdown = process
+        .rawListeners("SIGINT")
+        .find((listener) => !existingSigintListeners.has(listener)) as (() => void) | undefined;
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(kill).toHaveBeenCalledWith("SIGTERM");
+      expect(mocks.defaultRuntime.error).toHaveBeenCalledWith(
+        `${GMAIL_WATCH_REAUTH_REASON}; stopping gmail watcher`,
+      );
+      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(2);
     } finally {
       shutdown?.();
     }

--- a/src/hooks/gmail-ops.ts
+++ b/src/hooks/gmail-ops.ts
@@ -23,6 +23,10 @@ import {
   runGcloud,
 } from "./gmail-setup-utils.js";
 import {
+  classifyGmailWatchStartFailure,
+  type GmailWatchStartAttempt,
+} from "./gmail-watcher-errors.js";
+import {
   buildDefaultHookUrl,
   buildGogWatchServeLogArgs,
   buildGogWatchServeArgs,
@@ -315,17 +319,14 @@ export async function runGmailService(opts: GmailRunOptions) {
     });
   }
 
-  await startGmailWatch(runtimeConfig);
+  const initialWatch = await startGmailWatch(runtimeConfig);
+  if (!initialWatch.ok && initialWatch.terminal) {
+    throw new Error(initialWatch.reason);
+  }
 
   let shuttingDown = false;
   let child = spawnGogServe(runtimeConfig);
-
-  const renewMs = runtimeConfig.renewEveryMinutes * 60_000;
-  const renewTimer = setInterval(() => {
-    void startGmailWatch(runtimeConfig).catch((err: unknown) => {
-      defaultRuntime.error(`gmail watch renew failed: ${String(err)}`);
-    });
-  }, renewMs);
+  let renewTimer: ReturnType<typeof setInterval> | null = null;
 
   const detachSignals = () => {
     process.off("SIGINT", shutdown);
@@ -338,9 +339,28 @@ export async function runGmailService(opts: GmailRunOptions) {
     }
     shuttingDown = true;
     detachSignals();
-    clearInterval(renewTimer);
+    if (renewTimer) {
+      clearInterval(renewTimer);
+      renewTimer = null;
+    }
     child.kill("SIGTERM");
   };
+
+  const renewGmailWatch = async () => {
+    const result = await startGmailWatch(runtimeConfig);
+    if (result.ok || !result.terminal || shuttingDown) {
+      return;
+    }
+    defaultRuntime.error(`${result.reason}; stopping gmail watcher`);
+    shutdown();
+  };
+
+  const renewMs = runtimeConfig.renewEveryMinutes * 60_000;
+  renewTimer = setInterval(() => {
+    void renewGmailWatch().catch((err: unknown) => {
+      defaultRuntime.error(`gmail watch renew failed: ${String(err)}`);
+    });
+  }, renewMs);
 
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
@@ -374,7 +394,7 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig) {
 async function startGmailWatch(
   cfg: Pick<GmailHookRuntimeConfig, "account" | "label" | "topic">,
   fatal = false,
-) {
+): Promise<GmailWatchStartAttempt> {
   const args = [resolveGogExecutable(), ...buildGogWatchStartArgs(cfg)];
   const result = await runCommandWithTimeout(args, { timeoutMs: 120_000 });
   if (result.code !== 0) {
@@ -382,6 +402,9 @@ async function startGmailWatch(
     if (fatal) {
       throw new Error(message);
     }
+    const failure = classifyGmailWatchStartFailure(message);
     defaultRuntime.error(message);
+    return { ok: false, ...failure };
   }
+  return { ok: true };
 }

--- a/src/hooks/gmail-watcher-errors.ts
+++ b/src/hooks/gmail-watcher-errors.ts
@@ -1,7 +1,43 @@
 // Gmail watcher error helpers classify watcher startup and runtime failures.
 const ADDRESS_IN_USE_RE = /address already in use|EADDRINUSE/i;
+const TERMINAL_OAUTH_WATCH_RE =
+  /\binvalid_grant\b|refresh_token_reused|invalid refresh token|expired or revoked|sign(?:ed|ing)? in again/i;
+
+export const GMAIL_WATCH_REAUTH_REASON =
+  "gmail OAuth credentials are invalid; re-authenticate gog for the configured account";
 
 /** Detect watcher startup failures caused by an occupied bind port. */
 export function isAddressInUseError(line: string): boolean {
   return ADDRESS_IN_USE_RE.test(line);
+}
+
+function isTerminalGmailWatchAuthError(line: string): boolean {
+  return TERMINAL_OAUTH_WATCH_RE.test(line);
+}
+
+export type GmailWatchStartFailure = {
+  terminal: boolean;
+  reason: string;
+};
+
+export type GmailWatchStartAttempt =
+  | {
+      ok: true;
+    }
+  | ({
+      ok: false;
+    } & GmailWatchStartFailure);
+
+/** Classify gog watch-start failures without losing transient retry behavior. */
+export function classifyGmailWatchStartFailure(message: string): GmailWatchStartFailure {
+  if (isTerminalGmailWatchAuthError(message)) {
+    return {
+      terminal: true,
+      reason: GMAIL_WATCH_REAUTH_REASON,
+    };
+  }
+  return {
+    terminal: false,
+    reason: message,
+  };
 }

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -240,17 +240,19 @@ describe("startGmailWatcher", () => {
         startGmailWatcher(createGmailConfig("old@example.com", { renewEveryMinutes: 1 })),
       ).resolves.toEqual({ started: true });
       await vi.advanceTimersByTimeAsync(60_000);
-      expect(spawnedChildren[0].kill).toHaveBeenCalledWith("SIGTERM");
+      expect(
+        expectDefined(spawnedChildren[0], "spawnedChildren[0] test invariant").kill,
+      ).toHaveBeenCalledWith("SIGTERM");
 
       await expect(
         startGmailWatcher(createGmailConfig("newer@example.com", { renewEveryMinutes: 1 })),
       ).resolves.toEqual({ started: true });
       expect(spawnedChildren).toHaveLength(2);
 
-      spawnedChildren[0].emit("exit", null, "SIGTERM");
+      spawnedChildren[0]?.emit("exit", null, "SIGTERM");
       await vi.advanceTimersByTimeAsync(0);
 
-      spawnedChildren[1].emit("exit", 1, null);
+      spawnedChildren[1]?.emit("exit", 1, null);
       await vi.advanceTimersByTimeAsync(5000);
 
       expect(spawnedChildren).toHaveLength(3);

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -31,8 +31,9 @@ vi.mock("../process/exec.js", () => ({
 }));
 
 const { startGmailWatcher, stopGmailWatcher } = await import("./gmail-watcher.js");
+const { GMAIL_WATCH_REAUTH_REASON } = await import("./gmail-watcher-errors.js");
 
-function createGmailConfig(account = "me@example.com") {
+function createGmailConfig(account = "me@example.com", gmail: Record<string, unknown> = {}) {
   return {
     hooks: {
       enabled: true,
@@ -41,6 +42,7 @@ function createGmailConfig(account = "me@example.com") {
         account,
         topic: "projects/demo/topics/gmail",
         pushToken: "push-token",
+        ...gmail,
       },
     },
   } as never;
@@ -154,6 +156,108 @@ describe("startGmailWatcher", () => {
       reason: "startup cancelled",
     });
     expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn gog serve when watch start needs Gmail re-auth", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 1,
+      stdout: "",
+      stderr: "invalid_grant: Token has been expired or revoked",
+    });
+
+    await expect(startGmailWatcher(createGmailConfig())).resolves.toEqual({
+      started: false,
+      reason: GMAIL_WATCH_REAUTH_REASON,
+    });
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it("stops gog serve when watch renewal needs Gmail re-auth", async () => {
+    vi.useFakeTimers();
+    try {
+      const child = new EventEmitter();
+      const mockedChild = Object.assign(child, {
+        kill: vi.fn(() => {
+          queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+          return true;
+        }),
+        killed: false,
+      });
+      mocks.spawn.mockReturnValue(mockedChild);
+      mocks.runCommandWithTimeout
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+        .mockResolvedValueOnce({
+          code: 1,
+          stdout: "",
+          stderr: "invalid_grant: Token has been expired or revoked",
+        });
+
+      await expect(
+        startGmailWatcher(createGmailConfig("me@example.com", { renewEveryMinutes: 1 })),
+      ).resolves.toEqual({ started: true });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(mockedChild.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let a stale terminal renewal stop clear newer watcher config", async () => {
+    vi.useFakeTimers();
+    try {
+      const spawnedChildren: Array<EventEmitter & { kill: ReturnType<typeof vi.fn> }> = [];
+      mocks.spawn.mockImplementation(() => {
+        const child = new EventEmitter();
+        const childIndex = spawnedChildren.length;
+        const mockedChild = Object.assign(child, {
+          kill: vi.fn(() => {
+            if (childIndex !== 0) {
+              queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+            }
+            return true;
+          }),
+        });
+        spawnedChildren.push(mockedChild);
+        return mockedChild;
+      });
+      mocks.runCommandWithTimeout
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+        .mockResolvedValueOnce({
+          code: 1,
+          stdout: "",
+          stderr: "invalid_grant: Token has been expired or revoked",
+        })
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
+
+      await expect(
+        startGmailWatcher(createGmailConfig("old@example.com", { renewEveryMinutes: 1 })),
+      ).resolves.toEqual({ started: true });
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(spawnedChildren[0].kill).toHaveBeenCalledWith("SIGTERM");
+
+      await expect(
+        startGmailWatcher(createGmailConfig("newer@example.com", { renewEveryMinutes: 1 })),
+      ).resolves.toEqual({ started: true });
+      expect(spawnedChildren).toHaveLength(2);
+
+      spawnedChildren[0].emit("exit", null, "SIGTERM");
+      await vi.advanceTimersByTimeAsync(0);
+
+      spawnedChildren[1].emit("exit", 1, null);
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(spawnedChildren).toHaveLength(3);
+      expect(mocks.spawn.mock.calls[2]?.[1]).toContain("newer@example.com");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("aborts tailscale setup and does not spawn gog serve when cancelled in flight", async () => {

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -11,7 +11,11 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { hasBinary } from "../skills/loading/config.js";
 import { ensureTailscaleEndpoint } from "./gmail-setup-utils.js";
-import { isAddressInUseError } from "./gmail-watcher-errors.js";
+import {
+  classifyGmailWatchStartFailure,
+  type GmailWatchStartAttempt,
+  isAddressInUseError,
+} from "./gmail-watcher-errors.js";
 import {
   buildGogWatchServeLogArgs,
   buildGogWatchServeArgs,
@@ -43,7 +47,7 @@ function isGogAvailable(): boolean {
 async function startGmailWatch(
   cfg: Pick<GmailHookRuntimeConfig, "account" | "label" | "topic">,
   options: { signal?: AbortSignal } = {},
-): Promise<boolean> {
+): Promise<GmailWatchStartAttempt> {
   const args = [resolveGogExecutable(), ...buildGogWatchStartArgs(cfg)];
   try {
     const result = await runCommandWithTimeout(args, {
@@ -52,14 +56,17 @@ async function startGmailWatch(
     });
     if (result.code !== 0) {
       const message = result.stderr || result.stdout || "gog watch start failed";
+      const failure = classifyGmailWatchStartFailure(message);
       log.error(`watch start failed: ${message}`);
-      return false;
+      return { ok: false, ...failure };
     }
     log.info(`watch started for ${cfg.account}`);
-    return true;
+    return { ok: true };
   } catch (err) {
-    log.error(`watch start error: ${String(err)}`);
-    return false;
+    const message = String(err);
+    const failure = classifyGmailWatchStartFailure(message);
+    log.error(`watch start error: ${message}`);
+    return { ok: false, ...failure };
   }
 }
 
@@ -252,6 +259,16 @@ function createGmailWatcherCancellation(
   };
 }
 
+async function renewGmailWatch(runtimeConfig: GmailHookRuntimeConfig): Promise<void> {
+  const watchStarted = await startGmailWatch(runtimeConfig);
+  if (watchStarted.ok || !watchStarted.terminal || currentConfig !== runtimeConfig) {
+    return;
+  }
+
+  log.error(`${watchStarted.reason}; stopping gmail watcher`);
+  await stopGmailWatcher({ expectedConfig: runtimeConfig });
+}
+
 /**
  * Start the Gmail watcher service.
  * Called automatically by the gateway if hooks.gmail is configured.
@@ -351,7 +368,13 @@ export async function startGmailWatcher(
   if (cancellation.isCancelled()) {
     return cancelledGmailWatcherStart(runtimeConfig);
   }
-  if (!watchStarted) {
+  if (!watchStarted.ok) {
+    if (watchStarted.terminal) {
+      if (currentConfig === runtimeConfig) {
+        currentConfig = null;
+      }
+      return { started: false, reason: watchStarted.reason };
+    }
     log.warn("gmail watch start failed, but continuing with serve");
   }
 
@@ -366,7 +389,7 @@ export async function startGmailWatcher(
     if (shuttingDown) {
       return;
     }
-    void startGmailWatch(runtimeConfig);
+    void renewGmailWatch(runtimeConfig);
   }, renewMs);
 
   log.info(
@@ -376,10 +399,18 @@ export async function startGmailWatcher(
   return { started: true };
 }
 
+type GmailWatcherStopOptions = {
+  expectedConfig?: GmailHookRuntimeConfig;
+};
+
 /**
  * Stop the Gmail watcher service.
  */
-export async function stopGmailWatcher(): Promise<void> {
+export async function stopGmailWatcher(options: GmailWatcherStopOptions = {}): Promise<void> {
+  if (options.expectedConfig && currentConfig !== options.expectedConfig) {
+    return;
+  }
+
   shuttingDown = true;
 
   if (respawnTimeout) {
@@ -398,6 +429,8 @@ export async function stopGmailWatcher(): Promise<void> {
     await settleProcess(proc);
   }
 
-  currentConfig = null;
+  if (!options.expectedConfig || currentConfig === options.expectedConfig) {
+    currentConfig = null;
+  }
   log.info("gmail watcher stopped");
 }


### PR DESCRIPTION
Closes #96088

## What Problem This Solves

Fixes an issue where users running the Gmail watcher could keep a `gog gmail watch serve` process alive after Gmail watch renewal failed with terminal OAuth errors such as `invalid_grant` or revoked credentials. That made the watcher look live even though Gmail watch coverage could no longer be renewed.

## Why This Change Was Made

The Gmail watcher now classifies `gog watch start` failures as retryable or terminal. Retryable watch-start failures keep the existing serve-and-renew behavior, while terminal OAuth failures refuse initial startup or stop the active watcher with a clear re-authentication reason. The same classification is shared by the Gateway auto-start watcher and the foreground `openclaw webhooks gmail run` path.

## User Impact

Operators now get a stopped or non-started Gmail watcher when credentials need re-authentication instead of a stale listener that appears healthy. Transient Gmail watch-start failures still keep the previous retry path.

## Evidence

Red-green regression proof — the branch's own test file run on both sides:

**Green (this branch @ `cf7c797761e`):** `CI=true pnpm test src/hooks/gmail-watcher.test.ts src/hooks/gmail-ops.test.ts`
```
Test Files  2 passed (2)
Tests  14 passed (14)
```

**Red (`origin/main` @ `e43bd3d57bc`, with only the test file copied over):**
```
FAIL  gmail-ops > stops the foreground serve process when watch renewal needs Gmail re-auth
AssertionError: expected "vi.fn()" to be called with arguments: [ 'SIGTERM' ]
FAIL  gmail-watcher > does not spawn gog serve when watch start needs Gmail re-auth
AssertionError: expected { started: true } to deeply equal { started: false, reason: undefined }
FAIL  gmail-watcher > stops gog serve when watch renewal needs Gmail re-auth
FAIL  gmail-watcher > does not let a stale terminal renewal stop clear newer watcher config
-> on main the watcher keeps serving and renewing forever after a terminal OAuth failure; this branch classifies the failure and stops.
```

`CI=true pnpm tsgo:core` is clean on the branch. Rebuilt on current main preserving all upstream behavior in the touched files (their pre-existing tests pass unchanged).
