### PR TITLE
refactor: migrate command session persistence to accessor

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -149,6 +149,7 @@ export const migratedSessionAccessorWriteFiles = new Set([
   "src/auto-reply/reply/body.ts",
   "src/auto-reply/reply/commands-acp/lifecycle.ts",
   "src/auto-reply/reply/commands-reset.ts",
+  "src/auto-reply/reply/commands-session-store.ts",
   "src/auto-reply/reply/directive-handling.impl.ts",
   "src/auto-reply/reply/directive-handling.persist.ts",
   "src/auto-reply/reply/dispatch-from-config.runtime.ts",

--- a/src/auto-reply/reply/commands-session-store.test.ts
+++ b/src/auto-reply/reply/commands-session-store.test.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import { persistAbortTargetEntry, persistSessionEntry } from "./commands-session-store.js";
+import type { CommandHandler } from "./commands-types.js";
+
+async function withTempStore<T>(run: (storePath: string) => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-command-session-store-"));
+  try {
+    return await run(path.join(dir, "sessions.json"));
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("commands session store persistence", () => {
+  it("persists a single command session entry through the accessor", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "agent:main:command";
+      const otherKey = "agent:main:other";
+      const entry: SessionEntry = {
+        sessionId: "command-session",
+        updatedAt: 1,
+        model: "gpt-5.5",
+      };
+      const otherEntry: SessionEntry = {
+        sessionId: "other-session",
+        updatedAt: 2,
+      };
+      await saveSessionStore(
+        storePath,
+        {
+          [sessionKey]: { ...entry },
+          [otherKey]: { ...otherEntry },
+        },
+        { skipMaintenance: true },
+      );
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: entry };
+
+      await expect(
+        persistSessionEntry({
+          sessionEntry: entry,
+          sessionStore,
+          sessionKey,
+          storePath,
+        } as Parameters<CommandHandler>[0]),
+      ).resolves.toBe(true);
+
+      const persisted = loadSessionStore(storePath, { skipCache: true });
+      expect(sessionStore[sessionKey]).toBe(entry);
+      expect(entry.updatedAt).not.toBe(1);
+      expect(persisted[sessionKey]).toMatchObject({
+        sessionId: "command-session",
+        model: "gpt-5.5",
+        updatedAt: entry.updatedAt,
+      });
+      expect(persisted[otherKey]).toStrictEqual(otherEntry);
+    });
+  });
+
+  it("falls back to the supplied abort target when the persisted row is missing", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "agent:main:abort-target";
+      const entry: SessionEntry = {
+        sessionId: "abort-session",
+        updatedAt: 1,
+        model: "gpt-5.5",
+      };
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: entry };
+      await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf8");
+
+      await expect(
+        persistAbortTargetEntry({
+          entry,
+          key: sessionKey,
+          sessionStore,
+          storePath,
+          abortCutoff: { messageSid: "42", timestamp: 123 },
+        }),
+      ).resolves.toBe(true);
+
+      const persisted = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(sessionStore[sessionKey]).toBe(entry);
+      expect(entry.abortedLastRun).toBe(true);
+      expect(entry.abortCutoffMessageSid).toBe("42");
+      expect(entry.abortCutoffTimestamp).toBe(123);
+      expect(persisted).toMatchObject({
+        sessionId: "abort-session",
+        model: "gpt-5.5",
+        abortedLastRun: true,
+        abortCutoffMessageSid: "42",
+        abortCutoffTimestamp: 123,
+      });
+    });
+  });
+
+  it("patches the persisted abort target when it already exists", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "agent:main:abort-target";
+      const otherKey = "agent:main:other";
+      const entry: SessionEntry = {
+        sessionId: "memory-session",
+        updatedAt: 1,
+      };
+      const persistedEntry: SessionEntry = {
+        sessionId: "persisted-session",
+        updatedAt: 2,
+        model: "sonnet-4.6",
+      };
+      const otherEntry: SessionEntry = {
+        sessionId: "other-session",
+        updatedAt: 3,
+      };
+      await saveSessionStore(
+        storePath,
+        {
+          [sessionKey]: persistedEntry,
+          [otherKey]: otherEntry,
+        },
+        { skipMaintenance: true },
+      );
+
+      await expect(
+        persistAbortTargetEntry({
+          entry,
+          key: sessionKey,
+          sessionStore: { [sessionKey]: entry },
+          storePath,
+        }),
+      ).resolves.toBe(true);
+
+      const persisted = loadSessionStore(storePath, { skipCache: true });
+      expect(entry.abortedLastRun).toBe(true);
+      expect(persisted[sessionKey]).toMatchObject({
+        sessionId: "persisted-session",
+        model: "sonnet-4.6",
+        abortedLastRun: true,
+      });
+      expect(persisted[otherKey]).toStrictEqual(otherEntry);
+    });
+  });
+});

--- a/src/auto-reply/reply/commands-session-store.test.ts
+++ b/src/auto-reply/reply/commands-session-store.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from "vitest";
 import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { persistAbortTargetEntry, persistSessionEntry } from "./commands-session-store.js";
-import type { CommandHandler } from "./commands-types.js";
 
 async function withTempStore<T>(run: (storePath: string) => Promise<T>): Promise<T> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-command-session-store-"));
@@ -46,7 +45,7 @@ describe("commands session store persistence", () => {
           sessionStore,
           sessionKey,
           storePath,
-        } as Parameters<CommandHandler>[0]),
+        }),
       ).resolves.toBe(true);
 
       const persisted = loadSessionStore(storePath, { skipCache: true });

--- a/src/auto-reply/reply/commands-session-store.ts
+++ b/src/auto-reply/reply/commands-session-store.ts
@@ -1,10 +1,14 @@
 // Shared session-store helpers for command handlers that mutate sessions.
 import { resolveSessionStoreEntry, type SessionEntry } from "../../config/sessions.js";
-import { updateSessionStore } from "../../config/sessions.js";
+import { patchSessionEntry } from "../../config/sessions/session-accessor.js";
 import { applyAbortCutoffToSessionEntry, type AbortCutoff } from "./abort-cutoff.js";
 import type { CommandHandler } from "./commands-types.js";
 
 type CommandParams = Parameters<CommandHandler>[0];
+type PersistSessionEntryParams = Pick<
+  CommandParams,
+  "sessionEntry" | "sessionStore" | "sessionKey" | "storePath"
+>;
 
 /** Resolves a command target entry through canonical and legacy session keys. */
 export function resolveCommandSessionEntryForKey(
@@ -24,25 +28,23 @@ export function resolveCommandSessionEntryForKey(
   };
 }
 
-export async function persistSessionEntry(params: CommandParams): Promise<boolean> {
+export async function persistSessionEntry(params: PersistSessionEntryParams): Promise<boolean> {
   if (!params.sessionEntry || !params.sessionStore || !params.sessionKey) {
     return false;
   }
-  params.sessionEntry.updatedAt = Date.now();
-  params.sessionStore[params.sessionKey] = params.sessionEntry;
+  const sessionEntry = params.sessionEntry;
+  sessionEntry.updatedAt = Date.now();
+  params.sessionStore[params.sessionKey] = sessionEntry;
   if (params.storePath) {
     // Slash commands mutate one known session entry; skipping global session
     // maintenance avoids scanning the whole sessions directory for simple
     // command-only writes.
-    await updateSessionStore(
-      params.storePath,
-      (store) => {
-        store[params.sessionKey] = params.sessionEntry as SessionEntry;
-        return params.sessionEntry as SessionEntry;
-      },
+    await patchSessionEntry(
+      { storePath: params.storePath, sessionKey: params.sessionKey },
+      () => sessionEntry,
       {
-        resolveSingleEntryPersistence: (entry) =>
-          entry ? { sessionKey: params.sessionKey, entry } : null,
+        fallbackEntry: sessionEntry,
+        replaceEntry: true,
         skipMaintenance: true,
       },
     );
@@ -68,22 +70,18 @@ export async function persistAbortTargetEntry(params: {
   sessionStore[key] = entry;
 
   if (storePath) {
-    await updateSessionStore(
-      storePath,
-      (store) => {
-        const nextEntry = store[key] ?? entry;
-        if (!nextEntry) {
-          return undefined;
-        }
+    await patchSessionEntry(
+      { storePath, sessionKey: key },
+      (nextEntry) => {
         nextEntry.abortedLastRun = true;
         applyAbortCutoffToSessionEntry(nextEntry, abortCutoff);
         nextEntry.updatedAt = Date.now();
-        store[key] = nextEntry;
         return nextEntry;
       },
       {
-        resolveSingleEntryPersistence: (updated) =>
-          updated ? { sessionKey: key, entry: updated } : null,
+        fallbackEntry: entry,
+        replaceEntry: true,
+        skipMaintenance: true,
       },
     );
   }

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -107,6 +107,7 @@ describe("session accessor boundary guard", () => {
         "src/auto-reply/reply/body.ts",
         "src/auto-reply/reply/commands-acp/lifecycle.ts",
         "src/auto-reply/reply/commands-reset.ts",
+        "src/auto-reply/reply/commands-session-store.ts",
         "src/auto-reply/reply/directive-handling.impl.ts",
         "src/auto-reply/reply/directive-handling.persist.ts",
         "src/auto-reply/reply/dispatch-from-config.runtime.ts",


### PR DESCRIPTION
## What Problem This Solves

Path 3 session storage migration still had command-session persistence helpers writing through the raw session-store update path. This keeps `commands-session-store.ts` on the old store boundary even though the command handlers only need to patch one known session entry.

## Why This Change Was Made

The command helpers need the session accessor boundary before the SQLite storage flip, while preserving their command-specific behavior: mutate the in-memory entry, touch `updatedAt`, persist one known entry, skip global maintenance, and keep abort-target fallback/upsert behavior when the persisted store does not already contain the target entry.

## User Impact

No user-visible command behavior should change. `/tts chat ...` and `/stop`/abort-trigger session updates continue to update the active in-memory session state and persist the targeted entry only, including abort cutoff metadata where applicable.

## Evidence

- Rebased onto current stack base `josh/path3-agent-autoreply-session-accessor` (`45cc84d9d0b`) so the PR diff is limited to this follow-up slice.
- Focused tests: `node scripts/run-vitest.mjs src/auto-reply/reply/commands-session-store.test.ts src/config/sessions/session-accessor.test.ts test/scripts/check-session-accessor-boundary.test.ts` passed 3 shards / 73 tests.
- Boundary ratchet: `node scripts/check-session-accessor-boundary.mjs` passed.
- Diff hygiene: `git diff --check 45cc84d9d0be607be07d9525eaa9e39b4f651450..HEAD` passed.
- Thermonuclear review: initial review found an in-scope maintainability/type-boundary issue in the command persistence params; fixed by narrowing the helper params, then reran focused proof and autoreview.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base 45cc84d9d0be607be07d9525eaa9e39b4f651450` reported no accepted/actionable findings.
- Live real-behavior proof on `/Users/phaedrus/Projects/clawdbot`: checked out `07b165607393`, clean-built, restarted the LaunchAgent, and ran compiled-handler proof against temporary session stores only. Proof covered `/tts chat off` existing-entry single-row persistence, `/tts chat on` missing persisted-row fallback/upsert, `/stop` existing abort target with cutoff metadata, and `/stop` missing abort target fallback/upsert. The proof used compiled bundle `commands-handlers.runtime-6gUw9eSO.js` and passed.
- Live restore: restored service to saved checkout `3f74951260a23c759e4d1b2525f9826ddd6344e3`, rebuilt, restarted LaunchAgent, verified `/readyz` clean (`ready:true`, `failing:[]`, `eventLoop.degraded:false`), gateway RPC ok, no running tasks, and captured config/plist hashes unchanged.

Follow-up boundaries: this does not add a whole-store accessor, runtime dual-read, fallback reader, or cache workaround. Remaining Path 3 session/transcript migration slices stay tracked under #88838.
