### PR TITLE
fix(matrix): tolerate SAS accept events missing method

### DIFF
--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -44,6 +44,7 @@ import {
   MatrixRecoveryKeyStore,
   isRepairableSecretStorageAccessError,
 } from "./sdk/recovery-key-store.js";
+import { patchMatrixRustCryptoToDeviceCompatibility } from "./sdk/to-device-compat.js";
 import { createMatrixGuardedFetch, type HttpMethod, type QueryParams } from "./sdk/transport.js";
 import type {
   MatrixClientEventMap,
@@ -116,6 +117,7 @@ export type MatrixRoomKeyBackupStatus = {
 
 const MATRIX_STATUS_DIAGNOSTIC_TIMEOUT_MS = 10_000;
 const DEFAULT_MATRIX_LOCAL_TIMEOUT_MS = 60_000;
+let matrixVerificationAcceptCompatWarningEmitted = false;
 
 function resolveMatrixLocalTimeoutMs(raw: number | undefined): number {
   if (typeof raw !== "number" || !Number.isFinite(raw)) {
@@ -820,6 +822,19 @@ export class MatrixClient {
     try {
       await this.client.initRustCrypto({
         cryptoDatabasePrefix: this.cryptoDatabasePrefix,
+      });
+      patchMatrixRustCryptoToDeviceCompatibility({
+        client: this.client,
+        onNormalizedAcceptEvents: (count) => {
+          if (matrixVerificationAcceptCompatWarningEmitted) {
+            return;
+          }
+          matrixVerificationAcceptCompatWarningEmitted = true;
+          LogService.warn(
+            "MatrixClientLite",
+            `Normalized ${count} Matrix SAS verification accept event(s) missing method before Rust crypto preprocessing.`,
+          );
+        },
       });
       this.cryptoInitialized = true;
       throwIfMatrixStartupAborted(abortSignal);

--- a/extensions/matrix/src/matrix/sdk/to-device-compat.test.ts
+++ b/extensions/matrix/src/matrix/sdk/to-device-compat.test.ts
@@ -1,0 +1,108 @@
+// Matrix tests cover to-device compatibility normalization before Rust crypto.
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeMatrixToDeviceEventsForRustCrypto,
+  patchMatrixRustCryptoToDeviceCompatibility,
+} from "./to-device-compat.js";
+
+describe("normalizeMatrixToDeviceEventsForRustCrypto", () => {
+  it("adds the SAS method to Matrix verification accept events when Element omits it", () => {
+    const event = {
+      type: "m.key.verification.accept",
+      sender: "@alice:example.org",
+      content: {
+        transaction_id: "txn-1",
+        commitment: "abc",
+      },
+    };
+    const events = [event];
+
+    const result = normalizeMatrixToDeviceEventsForRustCrypto(events);
+
+    expect(result.normalizedAcceptEvents).toBe(1);
+    expect(result.events).not.toBe(events);
+    expect(result.events).toEqual([
+      {
+        ...event,
+        content: {
+          ...event.content,
+          method: "m.sas.v1",
+        },
+      },
+    ]);
+    expect(event.content).not.toHaveProperty("method");
+  });
+
+  it("leaves existing methods and unrelated to-device events untouched", () => {
+    const acceptWithMethod = {
+      type: "m.key.verification.accept",
+      content: { method: "m.qr_code.show.v1", transaction_id: "txn-1" },
+    };
+    const keyEvent = {
+      type: "m.key.verification.key",
+      content: { transaction_id: "txn-1", key: "abc" },
+    };
+    const events = [acceptWithMethod, keyEvent, "not-an-event"];
+
+    const result = normalizeMatrixToDeviceEventsForRustCrypto(events);
+
+    expect(result.normalizedAcceptEvents).toBe(0);
+    expect(result.events).toBe(events);
+  });
+});
+
+describe("patchMatrixRustCryptoToDeviceCompatibility", () => {
+  it("normalizes events before invoking the original Rust crypto preprocessor", async () => {
+    const onNormalizedAcceptEvents = vi.fn();
+    const original = vi.fn(async function (this: unknown, events: unknown[]) {
+      return [{ message: events[0], encryptionInfo: null }];
+    });
+    const backend = {
+      preprocessToDeviceMessages: original,
+    };
+    patchMatrixRustCryptoToDeviceCompatibility({
+      client: { cryptoBackend: backend },
+      onNormalizedAcceptEvents,
+    });
+
+    const result = await backend.preprocessToDeviceMessages([
+      {
+        type: "m.key.verification.accept",
+        content: { transaction_id: "txn-1" },
+      },
+    ]);
+
+    expect(onNormalizedAcceptEvents).toHaveBeenCalledWith(1);
+    expect(original).toHaveBeenCalledWith([
+      {
+        type: "m.key.verification.accept",
+        content: { transaction_id: "txn-1", method: "m.sas.v1" },
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        message: {
+          type: "m.key.verification.accept",
+          content: { transaction_id: "txn-1", method: "m.sas.v1" },
+        },
+        encryptionInfo: null,
+      },
+    ]);
+  });
+
+  it("patches the Rust crypto preprocessor only once", async () => {
+    const original = vi.fn(async (events: unknown[]) => events);
+    const backend = {
+      preprocessToDeviceMessages: original,
+    };
+    const client = { cryptoBackend: backend };
+
+    patchMatrixRustCryptoToDeviceCompatibility({ client });
+    const patched = backend.preprocessToDeviceMessages;
+    patchMatrixRustCryptoToDeviceCompatibility({ client });
+
+    expect(backend.preprocessToDeviceMessages).toBe(patched);
+    await backend.preprocessToDeviceMessages([]);
+    expect(original).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/matrix/src/matrix/sdk/to-device-compat.test.ts
+++ b/extensions/matrix/src/matrix/sdk/to-device-compat.test.ts
@@ -49,6 +49,37 @@ describe("normalizeMatrixToDeviceEventsForRustCrypto", () => {
     expect(result.normalizedAcceptEvents).toBe(0);
     expect(result.events).toBe(events);
   });
+
+  it("normalizes accept events whose method is blank or non-string", () => {
+    const blankMethod = {
+      type: "m.key.verification.accept",
+      content: { method: "   ", transaction_id: "txn-1" },
+    };
+    const nonStringMethod = {
+      type: "m.key.verification.accept",
+      content: { method: null, transaction_id: "txn-2" },
+    };
+    const events = [blankMethod, nonStringMethod];
+
+    const result = normalizeMatrixToDeviceEventsForRustCrypto(events);
+
+    expect(result.normalizedAcceptEvents).toBe(2);
+    expect(result.events).not.toBe(events);
+    expect(
+      (result.events as Array<{ content: { method: string } }>).map((e) => e.content.method),
+    ).toEqual(["m.sas.v1", "m.sas.v1"]);
+  });
+
+  it("leaves accept events without a content object untouched", () => {
+    const noContent = { type: "m.key.verification.accept" };
+    const events = [noContent];
+
+    const result = normalizeMatrixToDeviceEventsForRustCrypto(events);
+
+    expect(result.normalizedAcceptEvents).toBe(0);
+    expect(result.events).toBe(events);
+    expect(events[0]).not.toHaveProperty("content");
+  });
 });
 
 describe("patchMatrixRustCryptoToDeviceCompatibility", () => {

--- a/extensions/matrix/src/matrix/sdk/to-device-compat.test.ts
+++ b/extensions/matrix/src/matrix/sdk/to-device-compat.test.ts
@@ -1,12 +1,42 @@
 // Matrix tests cover to-device compatibility normalization before Rust crypto.
 import { describe, expect, it, vi } from "vitest";
-import {
-  normalizeMatrixToDeviceEventsForRustCrypto,
-  patchMatrixRustCryptoToDeviceCompatibility,
-} from "./to-device-compat.js";
+import { patchMatrixRustCryptoToDeviceCompatibility } from "./to-device-compat.js";
 
-describe("normalizeMatrixToDeviceEventsForRustCrypto", () => {
-  it("adds the SAS method to Matrix verification accept events when Element omits it", () => {
+/**
+ * Drives normalization through the only production seam: the patched Rust crypto
+ * preprocessor. Returns what the real preprocessor would have received.
+ */
+function preprocessThroughPatchedBackend(events: unknown[]): {
+  seenByRustCrypto: unknown[];
+  normalizedAcceptEvents: number | undefined;
+  run: () => Promise<unknown>;
+} {
+  const captured: { events: unknown[] } = { events: [] };
+  const original = vi.fn(async (received: unknown[]) => {
+    captured.events = received;
+    return received;
+  });
+  const backend = { preprocessToDeviceMessages: original };
+  let normalizedAcceptEvents: number | undefined;
+  patchMatrixRustCryptoToDeviceCompatibility({
+    client: { cryptoBackend: backend },
+    onNormalizedAcceptEvents: (count) => {
+      normalizedAcceptEvents = count;
+    },
+  });
+  return {
+    get seenByRustCrypto() {
+      return captured.events;
+    },
+    get normalizedAcceptEvents() {
+      return normalizedAcceptEvents;
+    },
+    run: () => backend.preprocessToDeviceMessages(events),
+  };
+}
+
+describe("matrix to-device normalization before Rust crypto", () => {
+  it("adds the SAS method to Matrix verification accept events when Element omits it", async () => {
     const event = {
       type: "m.key.verification.accept",
       sender: "@alice:example.org",
@@ -16,12 +46,13 @@ describe("normalizeMatrixToDeviceEventsForRustCrypto", () => {
       },
     };
     const events = [event];
+    const harness = preprocessThroughPatchedBackend(events);
 
-    const result = normalizeMatrixToDeviceEventsForRustCrypto(events);
+    await harness.run();
 
-    expect(result.normalizedAcceptEvents).toBe(1);
-    expect(result.events).not.toBe(events);
-    expect(result.events).toEqual([
+    expect(harness.normalizedAcceptEvents).toBe(1);
+    expect(harness.seenByRustCrypto).not.toBe(events);
+    expect(harness.seenByRustCrypto).toEqual([
       {
         ...event,
         content: {
@@ -30,10 +61,11 @@ describe("normalizeMatrixToDeviceEventsForRustCrypto", () => {
         },
       },
     ]);
+    // The caller's original event object must not be mutated.
     expect(event.content).not.toHaveProperty("method");
   });
 
-  it("leaves existing methods and unrelated to-device events untouched", () => {
+  it("leaves existing methods and unrelated to-device events untouched", async () => {
     const acceptWithMethod = {
       type: "m.key.verification.accept",
       content: { method: "m.qr_code.show.v1", transaction_id: "txn-1" },
@@ -43,14 +75,15 @@ describe("normalizeMatrixToDeviceEventsForRustCrypto", () => {
       content: { transaction_id: "txn-1", key: "abc" },
     };
     const events = [acceptWithMethod, keyEvent, "not-an-event"];
+    const harness = preprocessThroughPatchedBackend(events);
 
-    const result = normalizeMatrixToDeviceEventsForRustCrypto(events);
+    await harness.run();
 
-    expect(result.normalizedAcceptEvents).toBe(0);
-    expect(result.events).toBe(events);
+    expect(harness.normalizedAcceptEvents).toBeUndefined();
+    expect(harness.seenByRustCrypto).toBe(events);
   });
 
-  it("normalizes accept events whose method is blank or non-string", () => {
+  it("normalizes accept events whose method is blank or non-string", async () => {
     const blankMethod = {
       type: "m.key.verification.accept",
       content: { method: "   ", transaction_id: "txn-1" },
@@ -60,24 +93,28 @@ describe("normalizeMatrixToDeviceEventsForRustCrypto", () => {
       content: { method: null, transaction_id: "txn-2" },
     };
     const events = [blankMethod, nonStringMethod];
+    const harness = preprocessThroughPatchedBackend(events);
 
-    const result = normalizeMatrixToDeviceEventsForRustCrypto(events);
+    await harness.run();
 
-    expect(result.normalizedAcceptEvents).toBe(2);
-    expect(result.events).not.toBe(events);
+    expect(harness.normalizedAcceptEvents).toBe(2);
+    expect(harness.seenByRustCrypto).not.toBe(events);
     expect(
-      (result.events as Array<{ content: { method: string } }>).map((e) => e.content.method),
+      (harness.seenByRustCrypto as Array<{ content: { method: string } }>).map(
+        (e) => e.content.method,
+      ),
     ).toEqual(["m.sas.v1", "m.sas.v1"]);
   });
 
-  it("leaves accept events without a content object untouched", () => {
+  it("leaves accept events without a content object untouched", async () => {
     const noContent = { type: "m.key.verification.accept" };
     const events = [noContent];
+    const harness = preprocessThroughPatchedBackend(events);
 
-    const result = normalizeMatrixToDeviceEventsForRustCrypto(events);
+    await harness.run();
 
-    expect(result.normalizedAcceptEvents).toBe(0);
-    expect(result.events).toBe(events);
+    expect(harness.normalizedAcceptEvents).toBeUndefined();
+    expect(harness.seenByRustCrypto).toBe(events);
     expect(events[0]).not.toHaveProperty("content");
   });
 });

--- a/extensions/matrix/src/matrix/sdk/to-device-compat.ts
+++ b/extensions/matrix/src/matrix/sdk/to-device-compat.ts
@@ -48,9 +48,7 @@ function normalizeVerificationAcceptEvent(event: MatrixToDeviceEvent): {
   };
 }
 
-export function normalizeMatrixToDeviceEventsForRustCrypto(
-  events: unknown[],
-): MatrixToDeviceCompatResult {
+function normalizeMatrixToDeviceEventsForRustCrypto(events: unknown[]): MatrixToDeviceCompatResult {
   let normalizedAcceptEvents = 0;
   const normalizedEvents = events.map((event) => {
     if (!isRecord(event)) {

--- a/extensions/matrix/src/matrix/sdk/to-device-compat.ts
+++ b/extensions/matrix/src/matrix/sdk/to-device-compat.ts
@@ -1,0 +1,93 @@
+// Matrix plugin module implements to-device compatibility normalization.
+import { VerificationMethod } from "matrix-js-sdk/lib/types.js";
+
+const KEY_VERIFICATION_ACCEPT_TYPE = "m.key.verification.accept";
+const MATRIX_SAS_VERIFICATION_METHOD = VerificationMethod.Sas;
+const MATRIX_TO_DEVICE_COMPAT_PATCHED = Symbol("openclaw-matrix-to-device-compat-patched");
+
+type MatrixToDeviceEvent = {
+  content?: unknown;
+  type?: unknown;
+  [key: string]: unknown;
+};
+
+type MatrixToDeviceCompatResult = {
+  events: unknown[];
+  normalizedAcceptEvents: number;
+};
+
+type MatrixRustCryptoBackendPreprocessor = {
+  preprocessToDeviceMessages?: (events: unknown[]) => Promise<unknown[]>;
+  [MATRIX_TO_DEVICE_COMPAT_PATCHED]?: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeVerificationAcceptEvent(event: MatrixToDeviceEvent): {
+  event: MatrixToDeviceEvent;
+  normalized: boolean;
+} {
+  if (event.type !== KEY_VERIFICATION_ACCEPT_TYPE || !isRecord(event.content)) {
+    return { event, normalized: false };
+  }
+  const method = event.content.method;
+  if (typeof method === "string" && method.trim().length > 0) {
+    return { event, normalized: false };
+  }
+  return {
+    event: {
+      ...event,
+      content: {
+        ...event.content,
+        method: MATRIX_SAS_VERIFICATION_METHOD,
+      },
+    },
+    normalized: true,
+  };
+}
+
+export function normalizeMatrixToDeviceEventsForRustCrypto(
+  events: unknown[],
+): MatrixToDeviceCompatResult {
+  let normalizedAcceptEvents = 0;
+  const normalizedEvents = events.map((event) => {
+    if (!isRecord(event)) {
+      return event;
+    }
+    const normalized = normalizeVerificationAcceptEvent(event);
+    if (normalized.normalized) {
+      normalizedAcceptEvents += 1;
+    }
+    return normalized.event;
+  });
+  return {
+    events: normalizedAcceptEvents > 0 ? normalizedEvents : events,
+    normalizedAcceptEvents,
+  };
+}
+
+export function patchMatrixRustCryptoToDeviceCompatibility(params: {
+  client: unknown;
+  onNormalizedAcceptEvents?: (count: number) => void;
+}): void {
+  // matrix-js-sdk sends /sync to-device events into Rust crypto before JS MatrixEvent
+  // compatibility hooks run, so Element's missing SAS method must be fixed at this boundary.
+  if (!isRecord(params.client) || !isRecord(params.client.cryptoBackend)) {
+    return;
+  }
+  const backend = params.client.cryptoBackend as MatrixRustCryptoBackendPreprocessor;
+  const original = backend.preprocessToDeviceMessages;
+  if (typeof original !== "function" || backend[MATRIX_TO_DEVICE_COMPAT_PATCHED]) {
+    return;
+  }
+  backend[MATRIX_TO_DEVICE_COMPAT_PATCHED] = true;
+  backend.preprocessToDeviceMessages = async (events) => {
+    const normalized = normalizeMatrixToDeviceEventsForRustCrypto(events);
+    if (normalized.normalizedAcceptEvents > 0) {
+      params.onNormalizedAcceptEvents?.(normalized.normalizedAcceptEvents);
+    }
+    return await original.call(backend, normalized.events);
+  };
+}


### PR DESCRIPTION
Closes #96188

## What Problem This Solves

Fixes an issue where Matrix users could get stuck during SAS verification when Element sends an encrypted `m.key.verification.accept` to-device event without a `method` field. In that shape, matrix-js-sdk's Rust crypto preprocessing rejects the event before the Matrix plugin can continue the verification flow.

## Why This Change Was Made

The Matrix client now installs a narrow compatibility wrapper after `initRustCrypto()` that normalizes only `m.key.verification.accept` to-device events with missing or blank `content.method` to the SAS method (`m.sas.v1`) before Rust crypto preprocesses them. Existing methods, unrelated events, and the original event objects are left untouched.

This is intentionally scoped to the matrix-js-sdk Rust crypto preprocessor boundary because `/sync` to-device events reach Rust crypto before higher-level JS `MatrixEvent` compatibility hooks can run.

## User Impact

Matrix SAS verification with Element can continue instead of stalling on an opaque missing-field crypto error. There are no config, setup, or API changes.

## Evidence

- Rechecked live issue state: #96188 is open, and `gh pr list --repo openclaw/openclaw --state open --search "96188"` returned no superseding open PRs.
- Checked dependency behavior in local `matrix-js-sdk` source: `/sync` to-device events are sent through `cryptoCallbacks.preprocessToDeviceMessages()`, and the Rust crypto backend calls `receiveSyncChanges()` before JS compatibility events are emitted.
- Checked the current Matrix client-server spec for `m.key.verification.accept`; the SAS accept example carries `method: "m.sas.v1"`.
- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk/to-device-compat.test.ts extensions/matrix/src/matrix/sdk/crypto-facade.test.ts extensions/matrix/src/matrix/sdk/verification-manager.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 extensions/matrix/src/matrix/sdk.ts extensions/matrix/src/matrix/sdk/to-device-compat.ts extensions/matrix/src/matrix/sdk/to-device-compat.test.ts`
- `git diff --check`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/matrix/src/matrix/sdk.ts extensions/matrix/src/matrix/sdk/to-device-compat.ts extensions/matrix/src/matrix/sdk/to-device-compat.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` with bundled Python: first run found a private MatrixClient typing issue; fixed by moving the private-field access behind an `unknown` boundary inside the helper; rerun was clean.

Local gap: `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` could not run in this checkout because `@typescript/native-preview-darwin-x64` is missing from local `node_modules`. CI should provide the project typecheck signal.

AI assistance disclosure: This PR was implemented and validated with OpenAI Codex assistance.
