### PR TITLE
feat: expose requester origin to tool policy hooks

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-ebb0ae07e4d6f6ea1faccba7604c9da71a5401b3aa2bc3618963e1e44a8dbcce  plugin-sdk-api-baseline.json
-9b7aee16d91c6a1b042a7d7e6f92a77b3e234337cc5fcf5a797de05fa9e9a02e  plugin-sdk-api-baseline.jsonl
+212b76ef72779add8f18be4848e143e61b6ae42a1c7daeefdc42d91e0a1152e9  plugin-sdk-api-baseline.json
+976179e09e9e46a9b9259bd20ca1cafc8883c8e281a099a9aaa5fceab3c2983b  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -186,8 +186,12 @@ file.
 - optional `event.runId`
 - optional `event.toolCallId`
 - context fields such as `ctx.agentId`, `ctx.sessionKey`, `ctx.sessionId`,
-  `ctx.runId`, `ctx.jobId` (set on cron-driven runs), `ctx.toolKind`,
-  `ctx.toolInputKind`, and diagnostic `ctx.trace`
+  `ctx.runId`, `ctx.jobId` (set on cron-driven runs), `ctx.trigger`,
+  `ctx.toolKind`, `ctx.toolInputKind`, and diagnostic `ctx.trace`
+- for channel-originated calls, origin fields such as `ctx.channel`,
+  `ctx.messageProvider`, `ctx.channelId`, `ctx.chatId`, `ctx.senderId`, and
+  extensible `ctx.channelContext` sender/chat metadata. These use the same
+  identity semantics described below for agent hook contexts.
 
 It can return:
 

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -12,7 +12,11 @@ import {
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { buildApprovalResponse, handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
+import {
+  buildApprovalResponse,
+  handleCodexAppServerApprovalRequest as handleCodexAppServerApprovalRequestImpl,
+} from "./approval-bridge.js";
+import { buildCodexToolHookRunContext } from "./tool-hook-context.js";
 
 vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>()),
@@ -41,6 +45,20 @@ const mockResolveNativeHookRelayDeferredToolApproval = vi.mocked(
 );
 const mockReviewExecRequestWithConfiguredModel = vi.mocked(reviewExecRequestWithConfiguredModel);
 const mockRunBeforeToolCallHook = vi.mocked(runBeforeToolCallHook);
+
+type ApprovalRequestParams = Parameters<typeof handleCodexAppServerApprovalRequestImpl>[0];
+
+function handleCodexAppServerApprovalRequest(
+  params: Omit<ApprovalRequestParams, "toolHookContext"> & {
+    toolHookContext?: ApprovalRequestParams["toolHookContext"];
+  },
+) {
+  return handleCodexAppServerApprovalRequestImpl({
+    ...params,
+    toolHookContext:
+      params.toolHookContext ?? buildCodexToolHookRunContext({ attempt: params.paramsForRun }),
+  });
+}
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -243,6 +261,8 @@ describe("Codex app-server approval bridge", () => {
       ctx: {
         agentId: "main",
         sessionKey: "agent:main:session-1",
+        messageProvider: "telegram",
+        channel: "telegram",
         channelId: "chat-1",
       },
     });
@@ -1164,11 +1184,18 @@ describe("Codex app-server approval bridge", () => {
     });
   });
 
-  it("normalizes prefixed channel targets for OpenClaw tool policy context", async () => {
+  it("uses the caller-resolved hook context for approval fallback policy", async () => {
     const params = createParams();
-    params.messageChannel = "telegram";
-    params.messageProvider = "telegram";
-    params.currentChannelId = "telegram:-100123";
+    params.agentId = "raw-agent";
+    params.sessionId = "raw-session";
+    params.sessionKey = "agent:raw:session";
+    params.runId = "raw-run";
+    params.messageChannel = "discord";
+    params.messageProvider = "discord";
+    params.currentChannelId = "discord:raw-target";
+    params.jobId = "raw-job";
+    params.senderId = "raw-user";
+    params.chatId = "raw-chat";
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-prefixed", status: "accepted" })
       .mockResolvedValueOnce({ id: "plugin:approval-prefixed", decision: "allow-once" });
@@ -1182,6 +1209,27 @@ describe("Codex app-server approval bridge", () => {
         command: "pnpm test extensions/codex/src/app-server",
       },
       paramsForRun: params,
+      toolHookContext: {
+        agentId: "resolved-agent",
+        sessionId: "resolved-session",
+        sessionKey: "agent:resolved:session",
+        runId: "resolved-run",
+        jobId: "resolved-job",
+        trigger: "user",
+        messageProvider: "telegram-voice",
+        channel: "telegram",
+        channelId: "-100123",
+        chatId: "native-chat-1",
+        senderId: "user-1",
+        channelContext: {
+          sender: {
+            id: "user-1",
+            displayName: "Ada",
+            providerUserId: "provider-user-1",
+          },
+          chat: { id: "native-chat-1", providerThreadKey: "thread-key-1" },
+        },
+      },
       threadId: "thread-1",
       turnId: "turn-1",
     });
@@ -1189,11 +1237,29 @@ describe("Codex app-server approval bridge", () => {
     expect(mockRunBeforeToolCallHook).toHaveBeenCalledWith(
       expect.objectContaining({
         ctx: expect.objectContaining({
+          agentId: "resolved-agent",
+          sessionId: "resolved-session",
+          sessionKey: "agent:resolved:session",
+          runId: "resolved-run",
+          jobId: "resolved-job",
+          trigger: "user",
+          messageProvider: "telegram-voice",
+          channel: "telegram",
           channelId: "-100123",
+          chatId: "native-chat-1",
+          senderId: "user-1",
+          channelContext: {
+            sender: {
+              id: "user-1",
+              displayName: "Ada",
+              providerUserId: "provider-user-1",
+            },
+            chat: { id: "native-chat-1", providerThreadKey: "thread-key-1" },
+          },
         }),
       }),
     );
-    expect(gatewayRequestPayload().turnSourceTo).toBe("telegram:-100123");
+    expect(gatewayRequestPayload().turnSourceTo).toBe("discord:raw-target");
   });
 
   it("denies command approvals before prompting when OpenClaw tool policy blocks", async () => {

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -8,7 +8,6 @@ import {
  */
 import {
   type AgentApprovalEventData,
-  buildAgentHookContextChannelFields,
   formatApprovalDisplayPath,
   hasNativeHookRelayInvocation,
   invokeNativeHookRelay,
@@ -17,6 +16,7 @@ import {
   type NativeHookRelayProcessResponse,
   type NativeHookRelayRegistrationHandle,
   runBeforeToolCallHook,
+  type ToolHookRunContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeTrimmedStringList } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -75,6 +75,7 @@ export async function handleCodexAppServerApprovalRequest(params: {
   method: string;
   requestParams: JsonValue | undefined;
   paramsForRun: EmbeddedRunAttemptParams;
+  toolHookContext: ToolHookRunContext;
   threadId: string;
   turnId: string;
   nativeHookRelay?: Pick<
@@ -106,6 +107,7 @@ export async function handleCodexAppServerApprovalRequest(params: {
       method: params.method,
       requestParams,
       paramsForRun: params.paramsForRun,
+      toolHookContext: params.toolHookContext,
       context,
       nativeHookRelay: params.nativeHookRelay,
       signal: params.signal,
@@ -619,6 +621,7 @@ async function runOpenClawToolPolicyForApprovalRequest(params: {
   method: string;
   requestParams: JsonObject | undefined;
   paramsForRun: EmbeddedRunAttemptParams;
+  toolHookContext: ToolHookRunContext;
   context: ApprovalContext;
   nativeHookRelay?: Pick<
     NativeHookRelayRegistrationHandle,
@@ -652,13 +655,6 @@ async function runOpenClawToolPolicyForApprovalRequest(params: {
   if (nativeRelayOutcome?.handled) {
     return { outcome: "no-decision" };
   }
-  const hookChannelId = buildAgentHookContextChannelFields({
-    sessionKey: params.paramsForRun.sessionKey,
-    messageChannel: params.paramsForRun.messageChannel,
-    messageProvider: params.paramsForRun.messageProvider,
-    currentChannelId: params.paramsForRun.currentChannelId,
-    messageTo: params.paramsForRun.messageTo,
-  }).channelId;
   const outcome = await runBeforeToolCallHook({
     toolName: policyRequest.toolName,
     params: policyRequest.params,
@@ -666,13 +662,9 @@ async function runOpenClawToolPolicyForApprovalRequest(params: {
     approvalMode: "request",
     signal: params.signal,
     ctx: {
-      ...(params.paramsForRun.agentId ? { agentId: params.paramsForRun.agentId } : {}),
+      ...params.toolHookContext,
       ...(params.paramsForRun.config ? { config: params.paramsForRun.config } : {}),
       ...(cwd ? { cwd } : {}),
-      ...(params.paramsForRun.sessionKey ? { sessionKey: params.paramsForRun.sessionKey } : {}),
-      ...(params.paramsForRun.sessionId ? { sessionId: params.paramsForRun.sessionId } : {}),
-      ...(params.paramsForRun.runId ? { runId: params.paramsForRun.runId } : {}),
-      ...(hookChannelId ? { channelId: hookChannelId } : {}),
     },
   });
   if (outcome.blocked) {

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -944,8 +944,16 @@ describe("Codex app-server dynamic tool build", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
-    params.currentChannelId = "D123";
+    params.messageChannel = "discord";
+    params.messageProvider = "discord-voice";
+    params.currentChannelId = "discord:D123";
     params.currentMessagingTarget = "user:U123";
+    params.chatId = "chat-123";
+    params.senderId = "user-123";
+    params.channelContext = {
+      sender: { id: "user-123" },
+      chat: { id: "chat-123" },
+    };
     params.runtimePlan = createCodexRuntimePlanFixture();
     const factoryOptions: unknown[] = [];
     setOpenClawCodingToolsFactoryForTests((options) => {
@@ -956,9 +964,19 @@ describe("Codex app-server dynamic tool build", () => {
     await buildDynamicToolsForTest(params, workspaceDir, { sandbox: null as never });
 
     expect(factoryOptions[0]).toMatchObject({
-      currentChannelId: "D123",
+      messageChannel: "discord",
+      messageProvider: "discord",
+      toolPolicyMessageProvider: "discord-voice",
+      currentChannelId: "discord:D123",
       currentMessagingTarget: "user:U123",
+      chatId: "chat-123",
+      senderId: "user-123",
+      hookChannelContext: {
+        sender: { id: "user-123" },
+        chat: { id: "chat-123" },
+      },
     });
+    expect((factoryOptions[0] as { channelContext?: unknown }).channelContext).toBeUndefined();
   });
 
   it("passes the approval reviewer device into Codex dynamic tools", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -125,7 +125,7 @@ export function resolveCodexAppServerHookChannelId(
     messageChannel: params.messageChannel,
     messageProvider: params.messageProvider,
     currentChannelId: params.currentChannelId,
-    messageTo: params.messageTo,
+    messageTo: params.currentMessagingTarget ?? params.messageTo,
   }).channelId;
 }
 
@@ -239,6 +239,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
       elevated: params.bashElevated,
     },
     sandbox: input.sandbox,
+    messageChannel: params.messageChannel,
     messageProvider: resolveCodexMessageToolProvider(params),
     toolPolicyMessageProvider: params.messageProvider ?? params.messageChannel,
     agentAccountId: params.agentAccountId,
@@ -249,6 +250,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     groupSpace: params.groupSpace,
     spawnedBy: params.spawnedBy,
     senderId: params.senderId,
+    hookChannelContext: params.channelContext,
     senderName: params.senderName,
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
@@ -290,6 +292,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     ),
     suppressManagedWebSearch: false,
     currentChannelId: params.currentChannelId,
+    chatId: params.chatId,
     currentMessagingTarget: params.currentMessagingTarget,
     hookChannelId: resolveCodexAppServerHookChannelId(params, input.sandboxSessionKey),
     currentThreadTs: params.currentThreadTs,

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -1846,6 +1846,17 @@ describe("createCodexDynamicToolBridge", () => {
         sessionId: "session-1",
         sessionKey: "agent:agent-1:session-1",
         runId: "run-1",
+        jobId: "job-1",
+        trigger: "user",
+        messageProvider: "discord-voice",
+        channel: "discord",
+        chatId: "channel-1",
+        senderId: "user-1",
+        channelId: "channel-1",
+        channelContext: {
+          sender: { id: "user-1", displayName: "Ada" },
+          chat: { id: "channel-1" },
+        },
       },
     });
 
@@ -1949,6 +1960,17 @@ describe("createCodexDynamicToolBridge", () => {
         sessionId: "session-1",
         sessionKey: "agent:agent-1:session-1",
         runId: "run-1",
+        jobId: "job-1",
+        trigger: "user",
+        messageProvider: "discord-voice",
+        channel: "discord",
+        chatId: "channel-1",
+        senderId: "user-1",
+        channelId: "channel-1",
+        channelContext: {
+          sender: { id: "user-1", displayName: "Ada" },
+          chat: { id: "channel-1" },
+        },
       },
     });
 
@@ -1975,6 +1997,17 @@ describe("createCodexDynamicToolBridge", () => {
       sessionId: "session-1",
       sessionKey: "agent:agent-1:session-1",
       runId: "run-1",
+      jobId: "job-1",
+      trigger: "user",
+      messageProvider: "discord-voice",
+      channel: "discord",
+      chatId: "channel-1",
+      senderId: "user-1",
+      channelId: "channel-1",
+      channelContext: {
+        sender: { id: "user-1", displayName: "Ada" },
+        chat: { id: "channel-1" },
+      },
       toolCallId: "call-1",
     });
     expectExecuteCall(execute, { callId: "call-1", args: { command: "pwd", mode: "safe" } });
@@ -1997,6 +2030,17 @@ describe("createCodexDynamicToolBridge", () => {
       sessionId: "session-1",
       sessionKey: "agent:agent-1:session-1",
       runId: "run-1",
+      jobId: "job-1",
+      trigger: "user",
+      messageProvider: "discord-voice",
+      channel: "discord",
+      chatId: "channel-1",
+      senderId: "user-1",
+      channelId: "channel-1",
+      channelContext: {
+        sender: { id: "user-1", displayName: "Ada" },
+        chat: { id: "channel-1" },
+      },
       toolCallId: "call-1",
     });
   });

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -32,6 +32,7 @@ import {
   type HeartbeatToolResponse,
   type MessagingToolSend,
   type MessagingToolSourceReplyPayload,
+  type ToolHookRunContext,
   wrapToolWithBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
@@ -53,13 +54,8 @@ import type {
   JsonValue,
 } from "./protocol.js";
 
-type CodexDynamicToolHookContext = {
-  agentId?: string;
+type CodexDynamicToolHookContext = ToolHookRunContext & {
   config?: EmbeddedRunAttemptParams["config"];
-  sessionId?: string;
-  sessionKey?: string;
-  runId?: string;
-  channelId?: string;
   currentChannelProvider?: string;
   currentChannelId?: string;
   currentMessagingTarget?: string;
@@ -70,7 +66,7 @@ type CodexDynamicToolHookContext = {
   allocateToolOutcomeOrdinal?: EmbeddedRunAttemptParams["allocateToolOutcomeOrdinal"];
 };
 
-type CodexToolResultHookContext = Omit<CodexDynamicToolHookContext, "config">;
+type CodexToolResultHookContext = ToolHookRunContext;
 
 type ProjectedCodexDynamicTool = {
   tool: AnyAgentTool;
@@ -310,11 +306,7 @@ export function createCodexDynamicToolBridge(params: {
         void runAgentHarnessAfterToolCallHook({
           toolName,
           toolCallId: call.callId,
-          runId: toolResultHookContext.runId,
-          agentId: toolResultHookContext.agentId,
-          sessionId: toolResultHookContext.sessionId,
-          sessionKey: toolResultHookContext.sessionKey,
-          channelId: toolResultHookContext.channelId,
+          ...toolResultHookContext,
           startArgs: executedArgs,
           result,
           startedAt,
@@ -407,11 +399,7 @@ export function createCodexDynamicToolBridge(params: {
         void runAgentHarnessAfterToolCallHook({
           toolName,
           toolCallId: call.callId,
-          runId: toolResultHookContext.runId,
-          agentId: toolResultHookContext.agentId,
-          sessionId: toolResultHookContext.sessionId,
-          sessionKey: toolResultHookContext.sessionKey,
-          channelId: toolResultHookContext.channelId,
+          ...toolResultHookContext,
           startArgs: executedArgs,
           error: errorMessage,
           startedAt,
@@ -702,13 +690,35 @@ function dedupeQuarantinedDynamicTools(
 function toToolResultHookContext(
   ctx: CodexDynamicToolHookContext | undefined,
 ): CodexToolResultHookContext {
-  const { agentId, sessionId, sessionKey, runId, channelId } = ctx ?? {};
+  const {
+    agentId,
+    sessionId,
+    sessionKey,
+    runId,
+    jobId,
+    trace,
+    trigger,
+    messageProvider,
+    channel,
+    chatId,
+    senderId,
+    channelId,
+    channelContext,
+  } = ctx ?? {};
   return {
     ...(agentId && { agentId }),
     ...(sessionId && { sessionId }),
     ...(sessionKey && { sessionKey }),
     ...(runId && { runId }),
+    ...(jobId && { jobId }),
+    ...(trace && { trace }),
+    ...(trigger && { trigger }),
+    ...(messageProvider && { messageProvider }),
+    ...(channel && { channel }),
+    ...(chatId && { chatId }),
+    ...(senderId && { senderId }),
     ...(channelId && { channelId }),
+    ...(channelContext && { channelContext }),
   };
 }
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -2587,15 +2587,36 @@ describe("CodexAppServerEventProjector", () => {
     });
   });
 
-  it("emits after_tool_call observations for Codex-native tool item completions", async () => {
+  it("keeps resolved hook identity authoritative for Codex-native tool completions", async () => {
     const afterToolCall = vi.fn();
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "after_tool_call", handler: afterToolCall }]),
     );
-    const projector = await createProjector({
+    const projectorParams = {
       ...(await createParams()),
-      agentId: "main",
-      sessionKey: "agent:main:session-1",
+      agentId: "raw-agent",
+      sessionId: "raw-session",
+      sessionKey: "agent:raw:session-1",
+      runId: "raw-run",
+    };
+    const projector = await createProjector(projectorParams, {
+      toolHookContext: {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        runId: "run-1",
+        jobId: "job-1",
+        trigger: "user",
+        messageProvider: "discord-voice",
+        channel: "discord",
+        chatId: "channel-1",
+        senderId: "user-1",
+        channelId: "channel-1",
+        channelContext: {
+          sender: { id: "user-1" },
+          chat: { id: "channel-1" },
+        },
+      },
     });
 
     await projector.handleNotification(
@@ -2652,6 +2673,17 @@ describe("CodexAppServerEventProjector", () => {
     expect(context.sessionId).toBe("session-1");
     expect(context.sessionKey).toBe("agent:main:session-1");
     expect(context.runId).toBe("run-1");
+    expect(context.jobId).toBe("job-1");
+    expect(context.trigger).toBe("user");
+    expect(context.messageProvider).toBe("discord-voice");
+    expect(context.channel).toBe("discord");
+    expect(context.chatId).toBe("channel-1");
+    expect(context.senderId).toBe("user-1");
+    expect(context.channelId).toBe("channel-1");
+    expect(context.channelContext).toEqual({
+      sender: { id: "user-1" },
+      chat: { id: "channel-1" },
+    });
     expect(context.toolName).toBe("bash");
     expect(context.toolCallId).toBe("cmd-observed");
   });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -18,6 +18,7 @@ import {
   type HeartbeatToolResponse,
   type MessagingToolSend,
   type MessagingToolSourceReplyPayload,
+  type ToolHookRunContext,
   type ToolProgressDetailMode,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
@@ -65,6 +66,7 @@ export type CodexAppServerToolTelemetry = {
 
 export type CodexAppServerEventProjectorOptions = {
   nativePostToolUseRelayEnabled?: boolean;
+  toolHookContext?: ToolHookRunContext;
   onNativeToolResultRecorded?: () => void | Promise<void>;
   trajectoryRecorder?: CodexTrajectoryRecorder | null;
 };
@@ -1374,6 +1376,9 @@ export class CodexAppServerEventProjector {
       agentId: this.params.agentId,
       sessionId: this.params.sessionId,
       sessionKey: this.params.sessionKey,
+      // The attempt boundary resolves aliases and sandbox session identity once.
+      // Keep that canonical snapshot authoritative over optional raw projector params.
+      ...this.options.toolHookContext,
       startArgs: itemToolArgs(item) ?? {},
       ...(result !== undefined ? { result } : {}),
       ...(error ? { error } : {}),

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -8,6 +8,7 @@ import {
   type EmbeddedRunAttemptParams,
   type NativeHookRelayEvent,
   type NativeHookRelayRegistrationHandle,
+  type ToolHookRunContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   addTimerTimeoutGraceMs,
@@ -121,6 +122,7 @@ export function createCodexNativeHookRelay(params: {
   config: EmbeddedRunAttemptParams["config"];
   runId: string;
   channelId?: string;
+  toolHookContext?: ToolHookRunContext;
   attemptTimeoutMs: number;
   startupTimeoutMs: number;
   turnStartTimeoutMs: number;
@@ -146,6 +148,7 @@ export function createCodexNativeHookRelay(params: {
     ...(params.config ? { config: params.config } : {}),
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),
+    ...(params.toolHookContext ? { toolHookContext: params.toolHookContext } : {}),
     allowedEvents: params.events,
     ttlMs: resolveCodexNativeHookRelayTtlMs({
       explicitTtlMs: params.options?.ttlMs,

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -1,9 +1,6 @@
 // Codex tests cover run attemptynamic tools plugin behavior.
 import path from "node:path";
-import {
-  onAgentEvent,
-  type AgentEventPayload,
-} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { onAgentEvent, type AgentEventPayload } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   emitTrustedDiagnosticEvent,
   onInternalDiagnosticEvent,
@@ -607,6 +604,21 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
     } finally {
       unsubscribeDiagnostics();
     }
+  });
+
+  it("prefers the current messaging target for hook channel fallback", () => {
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.messageChannel = "telegram";
+    params.messageProvider = "telegram";
+    params.messageTo = "telegram:stale-target";
+    params.currentMessagingTarget = "telegram:current-target";
+
+    expect(testing.resolveCodexAppServerHookChannelId(params, "agent:main:session-1")).toBe(
+      "current-target",
+    );
   });
 
   it("passes normalized channel context to app-server dynamic tool result hooks", async () => {

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -30,9 +30,7 @@ const DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
   web_search: "disabled",
 });
 
-function writeCodexAppServerBinding(
-  ...args: Parameters<typeof writeRawCodexAppServerBinding>
-) {
+function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppServerBinding>) {
   const [sessionFile, binding, lookup] = args;
   return writeRawCodexAppServerBinding(
     sessionFile,
@@ -95,7 +93,15 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const harness = createStartedThreadHarness();
     const params = createParams(sessionFile, workspaceDir);
     params.messageChannel = "discord";
+    params.messageProvider = "discord-voice";
     params.currentChannelId = "channel:target";
+    params.trigger = "user";
+    params.senderId = "user-1";
+    params.chatId = "native-target";
+    params.channelContext = {
+      sender: { id: "user-1", providerUserId: "discord-user-1" },
+      chat: { id: "native-target", guildId: "guild-1" },
+    };
 
     const run = runCodexAppServerAttempt(params, {
       nativeHookRelay: {
@@ -135,6 +141,22 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       autoApprove: true,
+      toolHookContext: {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        runId: "run-1",
+        trigger: "user",
+        messageProvider: "discord-voice",
+        channel: "discord",
+        channelId: "target",
+        chatId: "native-target",
+        senderId: "user-1",
+        channelContext: {
+          sender: { id: "user-1", providerUserId: "discord-user-1" },
+          chat: { id: "native-target", guildId: "guild-1" },
+        },
+      },
     });
     expect(approvalArgs?.nativeHookRelay).toMatchObject({
       relayId,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -38,6 +38,7 @@ import {
   type EmbeddedRunAttemptResult,
   type NativeHookRelayEvent,
   type NativeHookRelayRegistrationHandle,
+  type ToolHookRunContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import {
@@ -248,6 +249,7 @@ import {
   type CodexAppServerThreadLifecycleBinding,
   type CodexContextEngineThreadBootstrapProjection,
 } from "./thread-lifecycle.js";
+import { buildCodexToolHookRunContext } from "./tool-hook-context.js";
 import {
   inferCodexDynamicToolMeta,
   resolveCodexToolProgressDetailMode,
@@ -717,6 +719,14 @@ export async function runCodexAppServerAttempt(
     });
   }
   const hookChannelId = resolveCodexAppServerHookChannelId(params, sandboxSessionKey);
+  const toolHookRunContext = buildCodexToolHookRunContext({
+    attempt: params,
+    agentId: sessionAgentId,
+    sessionId: params.sessionId,
+    sessionKey: sandboxSessionKey,
+    runId: params.runId,
+    channelId: hookChannelId,
+  });
   preDynamicStartupStages.mark("context-engine-support");
   const preDynamicSummary = preDynamicStartupStages.snapshot();
   if (shouldWarnCodexDynamicToolBuildStageSummary(preDynamicSummary)) {
@@ -832,12 +842,8 @@ export async function runCodexAppServerAttempt(
     }),
     directToolNames: resolveCodexDynamicToolDirectNames(params),
     hookContext: {
-      agentId: sessionAgentId,
+      ...toolHookRunContext,
       config: params.config,
-      sessionId: params.sessionId,
-      sessionKey: sandboxSessionKey,
-      runId: params.runId,
-      channelId: hookChannelId,
       currentChannelProvider: resolveCodexMessageToolProvider(params),
       currentChannelId: params.currentChannelId,
       currentMessagingTarget: params.currentMessagingTarget,
@@ -1444,6 +1450,7 @@ export async function runCodexAppServerAttempt(
       config: params.config,
       runId: params.runId,
       channelId: hookChannelId,
+      toolHookContext: toolHookRunContext,
       attemptTimeoutMs: params.timeoutMs,
       startupTimeoutMs,
       turnStartTimeoutMs: params.timeoutMs,
@@ -2150,6 +2157,7 @@ export async function runCodexAppServerAttempt(
             method: request.method,
             params: request.params,
             paramsForRun: params,
+            toolHookContext: toolHookRunContext,
             threadId: thread.threadId,
             turnId,
             nativeHookRelay,
@@ -2761,6 +2769,7 @@ export async function runCodexAppServerAttempt(
       nativePostToolUseRelayEnabled:
         nativeHookRelay?.allowedEvents.includes("post_tool_use") === true &&
         nativeHookRelay.shouldRelayEvent("post_tool_use"),
+      toolHookContext: toolHookRunContext,
       trajectoryRecorder,
       onNativeToolResultRecorded: maybeAnnounceFastModeAutoOff,
     },
@@ -3430,6 +3439,7 @@ function handleApprovalRequest(params: {
   method: string;
   params: JsonValue | undefined;
   paramsForRun: EmbeddedRunAttemptParams;
+  toolHookContext: ToolHookRunContext;
   threadId: string;
   turnId: string;
   nativeHookRelay?: NativeHookRelayRegistrationHandle;
@@ -3443,6 +3453,7 @@ function handleApprovalRequest(params: {
     method: params.method,
     requestParams: params.params,
     paramsForRun: params.paramsForRun,
+    toolHookContext: params.toolHookContext,
     threadId: params.threadId,
     turnId: params.turnId,
     nativeHookRelay: params.nativeHookRelay,

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -861,9 +861,12 @@ describe("runCodexAppServerSideQuestion", () => {
         ).toMatchObject({
           agentId: "main",
           sessionId: "session-1",
-          sessionKey: "agent:main:session-1",
+          sessionKey: "agent:main:runtime-policy",
           runId: "run-side-1",
           channelId: "voice-room",
+          toolHookContext: {
+            sessionKey: "agent:main:runtime-policy",
+          },
           allowedEvents: ["pre_tool_use", "post_tool_use", "before_agent_finalize"],
         });
         return threadResult("side-thread");
@@ -889,6 +892,7 @@ describe("runCodexAppServerSideQuestion", () => {
       runCodexAppServerSideQuestion(
         sideParams({
           sessionKey: "agent:main:session-1",
+          sandboxSessionKey: "agent:main:runtime-policy",
           messageChannel: "discord",
           messageProvider: "discord-voice",
           currentChannelId: "discord:voice-room",
@@ -971,6 +975,7 @@ describe("runCodexAppServerSideQuestion", () => {
       runCodexAppServerSideQuestion(
         sideParams({
           sessionKey: "agent:main:session-1",
+          sandboxSessionKey: "agent:main:runtime-policy",
           messageChannel: "discord",
           messageProvider: "discord-voice",
           opts: { runId: "run-side-approval" },
@@ -988,6 +993,7 @@ describe("runCodexAppServerSideQuestion", () => {
           threadId?: string;
           turnId?: string;
           paramsForRun?: { messageChannel?: string; messageProvider?: string };
+          toolHookContext?: { sessionKey?: string };
           nativeHookRelay?: { relayId?: string; allowedEvents?: readonly string[] };
         }
       | undefined;
@@ -1006,6 +1012,9 @@ describe("runCodexAppServerSideQuestion", () => {
       paramsForRun: {
         messageChannel: "discord",
         messageProvider: "discord-voice",
+      },
+      toolHookContext: {
+        sessionKey: "agent:main:runtime-policy",
       },
     });
     expect(approvalArgs?.nativeHookRelay).toMatchObject({
@@ -1482,6 +1491,14 @@ describe("runCodexAppServerSideQuestion", () => {
   });
 
   it("bridges side-thread dynamic tool requests to OpenClaw tools", async () => {
+    const beforeToolCall = vi.fn();
+    const afterToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "before_tool_call", handler: beforeToolCall },
+        { hookName: "after_tool_call", handler: afterToolCall },
+      ]),
+    );
     const client = createFakeClient();
     let toolResponse: unknown;
     client.request.mockImplementation(async (method: string) => {
@@ -1527,6 +1544,13 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(toolArguments).toEqual({ topic: "AGENTS.md" });
     expect(toolSignal).toBeInstanceOf(AbortSignal);
     expect(toolOptions).toBeUndefined();
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(mockCall(beforeToolCall)[1]).toMatchObject({ sessionKey: "session-1" });
+    await vi.waitFor(() => expect(afterToolCall).toHaveBeenCalledTimes(1));
+    expect(mockCall(afterToolCall)[1]).toMatchObject({ sessionKey: "session-1" });
+    expect(createOpenClawCodingToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: "session-1" }),
+    );
     expect(toolResponse).toEqual({
       success: true,
       contentItems: [{ type: "inputText", text: "tool output" }],
@@ -1610,14 +1634,29 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(activeDiagnosticToolKeys(diagnosticEvents)).toEqual(new Set());
   });
 
-  it("normalizes hook channel ids for side-thread dynamic tool requests", async () => {
+  it("preserves requester identity while normalizing side-thread hook channels", async () => {
+    const afterToolCall = vi.fn();
     const beforeToolCall = vi.fn((...args: unknown[]) => {
-      const context = args[1] as { channelId?: string };
-      expect(context.channelId).toBe("voice-room");
+      const context = args[1] as Record<string, unknown>;
+      expect(context).toMatchObject({
+        sessionKey: "agent:main:runtime-policy",
+        messageProvider: "discord-voice",
+        channel: "discord",
+        channelId: "voice-room",
+        chatId: "native-voice-chat",
+        senderId: "sender-1",
+        channelContext: {
+          sender: { id: "sender-1", providerUserId: "discord-user-1" },
+          chat: { id: "native-voice-chat", guildId: "guild-1" },
+        },
+      });
       return undefined;
     });
     initializeGlobalHookRunner(
-      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+      createMockPluginRegistry([
+        { hookName: "before_tool_call", handler: beforeToolCall },
+        { hookName: "after_tool_call", handler: afterToolCall },
+      ]),
     );
     const client = createFakeClient();
     client.request.mockImplementation(async (method: string) => {
@@ -1657,17 +1696,48 @@ describe("runCodexAppServerSideQuestion", () => {
     await expect(
       runCodexAppServerSideQuestion(
         sideParams({
+          sessionKey: "agent:main:conversation",
+          sandboxSessionKey: "agent:main:runtime-policy",
           messageChannel: "discord",
           messageProvider: "discord-voice",
           currentChannelId: "discord:voice-room",
+          chatId: "native-voice-chat",
+          senderId: "sender-1",
+          channelContext: {
+            sender: { id: "sender-1", providerUserId: "discord-user-1" },
+            chat: { id: "native-voice-chat", guildId: "guild-1" },
+          },
         }),
       ),
     ).resolves.toEqual({ text: "Tool answer." });
 
     expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(afterToolCall).toHaveBeenCalledTimes(1));
+    expect(mockCall(afterToolCall)[1]).toMatchObject({
+      sessionKey: "agent:main:runtime-policy",
+      messageProvider: "discord-voice",
+      channel: "discord",
+      channelId: "voice-room",
+      chatId: "native-voice-chat",
+    });
     expect(createOpenClawCodingToolsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ hookChannelId: "voice-room" }),
+      expect.objectContaining({
+        sessionKey: "agent:main:runtime-policy",
+        runSessionKey: "agent:main:conversation",
+        messageChannel: "discord",
+        messageProvider: "discord",
+        toolPolicyMessageProvider: "discord-voice",
+        hookChannelId: "voice-room",
+        chatId: "native-voice-chat",
+        hookChannelContext: {
+          sender: { id: "sender-1", providerUserId: "discord-user-1" },
+          chat: { id: "native-voice-chat", guildId: "guild-1" },
+        },
+      }),
     );
+    expect(
+      (mockCall(createOpenClawCodingToolsMock)[0] as { channelContext?: unknown }).channelContext,
+    ).toBeUndefined();
     expect(toolExecuteMock).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -1,6 +1,5 @@
 // Codex plugin module implements side question behavior.
 import {
-  buildAgentHookContextChannelFields,
   embeddedAgentLog,
   formatErrorMessage,
   resolveAgentDir,
@@ -16,6 +15,7 @@ import {
   type EmbeddedRunAttemptParams,
   type NativeHookRelayEvent,
   type NativeHookRelayRegistrationHandle,
+  type ToolHookRunContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { loadExecApprovals } from "openclaw/plugin-sdk/exec-approvals-runtime";
 import { resolveCodexAppServerForModelProvider } from "./app-server-policy.js";
@@ -89,6 +89,7 @@ import {
   resolveCodexBindingModelProviderFallback,
   resolveReasoningEffort,
 } from "./thread-lifecycle.js";
+import { buildCodexToolHookRunContext } from "./tool-hook-context.js";
 import { filterToolsForVisionInputs } from "./vision-tools.js";
 import {
   resolveCodexWebSearchPlan,
@@ -206,9 +207,21 @@ export async function runCodexAppServerSideQuestion(
   });
   const cwd = binding.cwd || params.workspaceDir || process.cwd();
   const sideRunParams = buildSideRunAttemptParams(params, { cwd, authProfileId });
+  const toolHookSessionKey =
+    sideRunParams.sandboxSessionKey?.trim() ||
+    sideRunParams.sessionKey?.trim() ||
+    sideRunParams.sessionId ||
+    sessionAgentId;
+  const toolHookRunContext = buildCodexToolHookRunContext({
+    attempt: sideRunParams,
+    agentId: sessionAgentId,
+    sessionId: sideRunParams.sessionId,
+    sessionKey: toolHookSessionKey,
+    runId: sideRunParams.runId,
+  });
   const nativeExecutionBlock = resolveCodexNativeExecutionBlock({
     config: sideRunParams.config,
-    sessionKey: sideRunParams.sandboxSessionKey?.trim() || sideRunParams.sessionKey,
+    sessionKey: toolHookSessionKey,
     sessionId: sideRunParams.sessionId,
     surface: "/btw side-question mode",
   });
@@ -287,6 +300,7 @@ export async function runCodexAppServerSideQuestion(
       nativeToolSurfaceEnabled,
       nativeProviderWebSearchSupport,
       signal: runAbortController.signal,
+      toolHookContext: toolHookRunContext,
     });
     removeRequestHandler = client.addRequestHandler(async (request) => {
       if (request.method === "account/chatgptAuthTokens/refresh") {
@@ -319,19 +333,20 @@ export async function runCodexAppServerSideQuestion(
           method: request.method,
           requestParams: request.params,
           paramsForRun: sideRunParams,
+          toolHookContext: toolHookRunContext,
           threadId: childThreadId,
           turnId,
           nativeHookRelay,
-	          execPolicy,
-	          execReviewerAgentId: sessionAgentId,
-	          internalExecAutoReview: modelScopedAppServer.approvalsReviewer === "user",
-	          autoApprove: shouldAutoApproveCodexAppServerApprovals({
-	            approvalPolicy,
-	            networkProxy: modelScopedAppServer.networkProxy,
-	            sandbox,
-	          }),
-	          signal: runAbortController.signal,
-	        });
+          execPolicy,
+          execReviewerAgentId: sessionAgentId,
+          internalExecAutoReview: modelScopedAppServer.approvalsReviewer === "user",
+          autoApprove: shouldAutoApproveCodexAppServerApprovals({
+            approvalPolicy,
+            networkProxy: modelScopedAppServer.networkProxy,
+            sandbox,
+          }),
+          signal: runAbortController.signal,
+        });
       }
       if (request.method !== "item/tool/call") {
         return undefined;
@@ -388,15 +403,11 @@ export async function runCodexAppServerSideQuestion(
           events: nativeHookRelayEvents,
           agentId: sessionAgentId,
           sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
+          sessionKey: toolHookRunContext.sessionKey,
           config: params.cfg,
           runId: sideRunParams.runId,
-          channelId: buildAgentHookContextChannelFields({
-            sessionKey: params.sessionKey,
-            messageChannel: params.messageChannel,
-            messageProvider: params.messageProvider,
-            currentChannelId: params.currentChannelId,
-          }).channelId,
+          channelId: toolHookRunContext.channelId,
+          toolHookContext: toolHookRunContext,
           requestTimeoutMs: appServer.requestTimeoutMs,
           completionTimeoutMs: Math.max(
             appServer.turnCompletionIdleTimeoutMs,
@@ -419,12 +430,12 @@ export async function runCodexAppServerSideQuestion(
       nativeCodeModeEnabled: nativeToolSurfaceEnabled,
       nativeCodeModeOnlyEnabled: appServer.codeModeOnly,
     });
-	    const threadConfig =
-	      mergeCodexThreadConfigs(
-	        nativeHookRelayConfig,
-	        runtimeThreadConfig,
-	        modelScopedAppServer.networkProxy?.configPatch,
-	      ) ?? runtimeThreadConfig;
+    const threadConfig =
+      mergeCodexThreadConfigs(
+        nativeHookRelayConfig,
+        runtimeThreadConfig,
+        modelScopedAppServer.networkProxy?.configPatch,
+      ) ?? runtimeThreadConfig;
     const forkResponse = assertCodexThreadForkResponse(
       await forkCodexSideThread(
         client,
@@ -436,7 +447,7 @@ export async function runCodexAppServerSideQuestion(
           cwd,
           approvalPolicy,
           approvalsReviewer: modelScopedAppServer.approvalsReviewer,
-	          ...(modelScopedAppServer.networkProxy ? {} : { sandbox }),
+          ...(modelScopedAppServer.networkProxy ? {} : { sandbox }),
           ...(serviceTier ? { serviceTier } : {}),
           config: threadConfig,
           developerInstructions: SIDE_DEVELOPER_INSTRUCTIONS,
@@ -542,6 +553,7 @@ function registerCodexSideNativeHookRelay(params: {
   config: EmbeddedRunAttemptParams["config"];
   runId: string;
   channelId?: string;
+  toolHookContext?: ToolHookRunContext;
   requestTimeoutMs: number;
   completionTimeoutMs: number;
   signal: AbortSignal;
@@ -557,6 +569,7 @@ function registerCodexSideNativeHookRelay(params: {
     ...(params.config ? { config: params.config } : {}),
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),
+    ...(params.toolHookContext ? { toolHookContext: params.toolHookContext } : {}),
     allowedEvents: params.events,
     ttlMs: resolveCodexSideNativeHookRelayTtlMs({
       explicitTtlMs: params.options.ttlMs,
@@ -596,6 +609,7 @@ function buildSideRunAttemptParams(
     provider: params.provider,
     modelId: params.model,
     model: params.runtimeModel ?? ({ id: params.model, provider: params.provider } as never),
+    trigger: "user" as const,
     sessionId: params.sessionId,
     sessionFile: params.sessionFile,
     sessionKey: params.sessionKey,
@@ -616,6 +630,8 @@ function buildSideRunAttemptParams(
     ...(params.senderUsername !== undefined ? { senderUsername: params.senderUsername } : {}),
     ...(params.senderE164 !== undefined ? { senderE164: params.senderE164 } : {}),
     ...(params.senderIsOwner !== undefined ? { senderIsOwner: params.senderIsOwner } : {}),
+    ...(params.chatId ? { chatId: params.chatId } : {}),
+    ...(params.channelContext ? { channelContext: params.channelContext } : {}),
     ...(params.currentChannelId ? { currentChannelId: params.currentChannelId } : {}),
     ...(params.toolsAllow ? { toolsAllow: params.toolsAllow } : {}),
     workspaceDir: options.cwd,
@@ -647,6 +663,7 @@ async function createCodexSideToolBridge(input: {
   nativeToolSurfaceEnabled: boolean;
   nativeProviderWebSearchSupport: CodexNativeWebSearchSupport;
   signal: AbortSignal;
+  toolHookContext: ToolHookRunContext;
 }): Promise<{ toolBridge: CodexDynamicToolBridge; webSearchPlan: CodexWebSearchPlan }> {
   const runtimeModel =
     input.params.runtimeModel ??
@@ -657,10 +674,7 @@ async function createCodexSideToolBridge(input: {
     const createOpenClawCodingTools = (await import("openclaw/plugin-sdk/agent-harness"))
       .createOpenClawCodingTools;
     const sandboxSessionKey =
-      input.params.sandboxSessionKey?.trim() ||
-      input.params.sessionKey?.trim() ||
-      input.params.sessionId ||
-      input.sessionAgentId;
+      input.toolHookContext.sessionKey || input.params.sessionId || input.sessionAgentId;
     const sandbox = await resolveSandboxContext({
       config: input.params.cfg,
       sessionKey: sandboxSessionKey,
@@ -696,6 +710,9 @@ async function createCodexSideToolBridge(input: {
         workspaceDir: input.cwd,
       }),
       suppressManagedWebSearch: false,
+      trigger: input.toolHookContext.trigger,
+      jobId: input.toolHookContext.jobId,
+      messageChannel: input.params.messageChannel,
       ...(input.params.messageProvider || input.params.messageChannel
         ? {
             messageProvider: messageToolProvider,
@@ -715,6 +732,8 @@ async function createCodexSideToolBridge(input: {
       ...(input.params.memberRoleIds ? { memberRoleIds: input.params.memberRoleIds } : {}),
       ...(input.params.spawnedBy !== undefined ? { spawnedBy: input.params.spawnedBy } : {}),
       ...(input.params.senderId !== undefined ? { senderId: input.params.senderId } : {}),
+      chatId: input.toolHookContext.chatId,
+      hookChannelContext: input.toolHookContext.channelContext,
       ...(input.params.senderName !== undefined ? { senderName: input.params.senderName } : {}),
       ...(input.params.senderUsername !== undefined
         ? { senderUsername: input.params.senderUsername }
@@ -724,12 +743,7 @@ async function createCodexSideToolBridge(input: {
         ? { senderIsOwner: input.params.senderIsOwner }
         : {}),
       ...(input.params.currentChannelId ? { currentChannelId: input.params.currentChannelId } : {}),
-      hookChannelId: buildAgentHookContextChannelFields({
-        sessionKey: input.params.sessionKey,
-        messageChannel: input.params.messageChannel,
-        messageProvider: input.params.messageProvider,
-        currentChannelId: input.params.currentChannelId,
-      }).channelId,
+      hookChannelId: input.toolHookContext.channelId,
       sandbox,
       emitBeforeToolCallDiagnostics: false,
       modelHasVision: runtimeModel.input?.includes("image") ?? false,
@@ -757,25 +771,15 @@ async function createCodexSideToolBridge(input: {
         })
       : requestedWebSearchPlan;
   const exposedTools = tools.filter((tool) => tool.name !== "web_search");
-  const hookChannelFields = buildAgentHookContextChannelFields({
-    sessionKey: input.params.sessionKey,
-    messageChannel: input.params.messageChannel,
-    messageProvider: input.params.messageProvider,
-    currentChannelId: input.params.currentChannelId,
-  });
   return {
     toolBridge: createCodexDynamicToolBridge({
       tools: exposedTools,
       signal: input.signal,
       loading: resolveCodexDynamicToolsLoading(input.pluginConfig),
       hookContext: {
-        agentId: input.sessionAgentId,
+        ...input.toolHookContext,
         config: input.params.cfg,
-        sessionId: input.params.sessionId,
-        sessionKey: input.params.sessionKey,
-        runId: input.params.opts?.runId ?? `codex-btw:${input.params.sessionId}`,
         currentChannelProvider: messageToolProvider,
-        ...hookChannelFields,
       },
     }),
     webSearchPlan,

--- a/extensions/codex/src/app-server/tool-hook-context.ts
+++ b/extensions/codex/src/app-server/tool-hook-context.ts
@@ -1,0 +1,41 @@
+/** Builds one canonical requester-origin snapshot for Codex tool hook paths. */
+import {
+  buildAgentHookContextOriginFields,
+  type EmbeddedRunAttemptParams,
+  type ToolHookRunContext,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+
+/** Build the plain run metadata shared by Codex before/after tool hook owners. */
+export function buildCodexToolHookRunContext(params: {
+  attempt: EmbeddedRunAttemptParams;
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  runId?: string;
+  channelId?: string;
+}): ToolHookRunContext {
+  const attempt = params.attempt;
+  const agentId = params.agentId ?? attempt.agentId;
+  const sessionKey = params.sessionKey ?? attempt.sessionKey;
+  const sessionId = params.sessionId ?? attempt.sessionId;
+  const runId = params.runId ?? attempt.runId;
+  return {
+    ...(agentId ? { agentId } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(runId ? { runId } : {}),
+    ...(attempt.jobId ? { jobId: attempt.jobId } : {}),
+    ...(attempt.trigger ? { trigger: attempt.trigger } : {}),
+    ...buildAgentHookContextOriginFields({
+      sessionKey,
+      messageChannel: attempt.messageChannel,
+      messageProvider: attempt.messageProvider ?? attempt.messageChannel,
+      currentChannelId: params.channelId ?? attempt.currentChannelId,
+      messageTo: attempt.currentMessagingTarget ?? attempt.messageTo,
+      trigger: attempt.trigger,
+      senderId: attempt.senderId,
+      chatId: attempt.chatId,
+      channelContext: attempt.channelContext,
+    }),
+  };
+}

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -340,7 +340,22 @@ describe("runCopilotAttempt", () => {
       return { sdkTools: [], sourceTools: [] };
     });
 
-    await runCopilotAttempt(makeParams(), {
+    const params = makeParams();
+    Object.assign(params, {
+      jobId: "job-1",
+      trigger: "user",
+      messageChannel: "slack",
+      messageProvider: "slack-voice",
+      currentChannelId: "C123",
+      chatId: "C123",
+      senderId: "U123",
+      channelContext: {
+        sender: { id: "U123", displayName: "Ada" },
+        chat: { id: "C123" },
+      },
+    });
+
+    await runCopilotAttempt(params, {
       createToolBridge,
       pool: makeFakePool(sdk),
     });
@@ -387,7 +402,21 @@ describe("runCopilotAttempt", () => {
         toolCallId: "tool-call-1",
         toolName: "read",
       }),
-      expect.objectContaining({ agentId: "agent-1", sessionId: "session-1" }),
+      expect.objectContaining({
+        agentId: "agent-1",
+        sessionId: "session-1",
+        jobId: "job-1",
+        trigger: "user",
+        messageProvider: "slack-voice",
+        channel: "slack",
+        chatId: "C123",
+        senderId: "U123",
+        channelId: "C123",
+        channelContext: {
+          sender: { id: "U123", displayName: "Ada" },
+          chat: { id: "C123" },
+        },
+      }),
     );
   });
 
@@ -1285,6 +1314,32 @@ describe("runCopilotAttempt", () => {
       ((sdk.createSession.mock.calls[0] as unknown[] | undefined)![0] as { tools?: unknown[] })
         .tools,
     ).toBe(sdkTools);
+  });
+
+  it("passes the session-resolved agent id to the tool bridge", async () => {
+    const sdk = makeFakeSdk();
+    const pool = makeFakePool(sdk);
+    const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+
+    await runCopilotAttempt(
+      makeParams({
+        agentId: undefined,
+        sessionKey: "agent:beta:main",
+        config: {
+          agents: {
+            list: [{ id: "main" }, { id: "beta" }],
+          },
+        } as never,
+      }),
+      { createToolBridge, pool },
+    );
+
+    expect(createToolBridge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "beta",
+        sessionKey: "agent:beta:main",
+      }),
+    );
   });
 
   it("F6: sessionRef is populated after createSession so the tool bridge's onYield can abort the live SDK session", async () => {

--- a/extensions/copilot/src/attempt.ts
+++ b/extensions/copilot/src/attempt.ts
@@ -9,6 +9,7 @@ import type {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   buildAgentHookContextChannelFields,
+  buildAgentHookContextOriginFields,
   detectAndLoadAgentHarnessPromptImages,
   getModelProviderRequestTransport,
   resolveAgentHarnessBeforePromptBuildResult,
@@ -409,6 +410,25 @@ export async function runCopilotAttempt(
     ...hookContextWindowFields,
     ...buildAgentHookContextChannelFields(input),
   };
+  const toolHookRunContext = {
+    runId: input.runId,
+    jobId: input.jobId,
+    agentId: sessionAgentId,
+    sessionKey: sandboxSessionKey,
+    sessionId: input.sessionId,
+    trigger: input.trigger,
+    ...buildAgentHookContextOriginFields({
+      sessionKey: sandboxSessionKey,
+      messageChannel: input.messageChannel,
+      messageProvider: input.messageProvider ?? input.messageChannel,
+      currentChannelId: input.currentChannelId,
+      messageTo: input.currentMessagingTarget ?? input.messageTo,
+      trigger: input.trigger,
+      senderId: input.senderId,
+      chatId: input.chatId,
+      channelContext: input.channelContext,
+    }),
+  };
   const finishAttempt = (result: AgentHarnessAttemptResult) =>
     finalizeCopilotAttempt(input, result, hookContext, attemptStartedAt, now);
 
@@ -626,7 +646,7 @@ export async function runCopilotAttempt(
         allowModelTools: poolAcquire.provider.mode === "byok",
         modelProvider: modelRef.provider,
         modelId: modelRef.id,
-        agentId: readString(params.agentId) ?? "copilot",
+        agentId: sessionAgentId,
         sessionId: readString(input.sessionId) ?? "copilot-session",
         sessionKey: readString((input as { sessionKey?: unknown }).sessionKey),
         agentDir: readString(input.agentDir),
@@ -652,11 +672,7 @@ export async function runCopilotAttempt(
           runAgentHarnessAfterToolCallHook({
             toolName,
             toolCallId,
-            runId: input.runId,
-            agentId: sessionAgentId,
-            sessionId: input.sessionId,
-            sessionKey: sandboxSessionKey,
-            channelId: hookContext.channelId,
+            ...toolHookRunContext,
             startArgs: args,
             ...(result !== undefined ? { result } : {}),
             ...(error ? { error } : {}),

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -1,11 +1,17 @@
 // Copilot tests cover tool bridge plugin behavior.
 import type { Tool as SdkTool, ToolInvocation, ToolResultObject } from "@github/copilot-sdk";
 import type { AnyAgentTool, SandboxContext } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createCopilotToolBridge,
   convertOpenClawToolToSdkTool,
   supportsModelTools,
+  testing,
 } from "./tool-bridge.js";
 
 type FakeTool = AnyAgentTool & {
@@ -77,6 +83,7 @@ function runSdkTool(tool: SdkTool, args: unknown, invocation = makeInvocation())
 }
 
 afterEach(() => {
+  resetGlobalHookRunner();
   vi.restoreAllMocks();
 });
 
@@ -309,6 +316,79 @@ describe("createCopilotToolBridge", () => {
     expect(result.sdkTools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
   });
 
+  it("runs requester-aware policy before code-mode exec controls", async () => {
+    const beforeToolCall = vi.fn(() => ({
+      block: true,
+      blockReason: "blocked before code-mode execution",
+    }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const createOpenClawCodingTools = vi.fn(async () => [makeTool({ name: "read" })]);
+
+    const result = await createCopilotToolBridge({
+      agentId: "agent-1",
+      attemptParams: {
+        config: { tools: { codeMode: true } },
+        runId: "run-code-mode",
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        jobId: "job-1",
+        trigger: "user",
+        messageChannel: "slack",
+        messageProvider: "slack-voice",
+        currentChannelId: "slack:C123",
+        senderId: "U123",
+        channelContext: { sender: { id: "U123", displayName: "Ada" } },
+      } as never,
+      createOpenClawCodingTools,
+      modelId: "gpt-4o",
+      modelProvider: "github-copilot",
+      sessionId: "session-1",
+    });
+    const exec = result.sdkTools.find((tool) => tool.name === "exec");
+    if (!exec) {
+      throw new Error("missing code-mode exec control");
+    }
+
+    await runSdkTool(
+      exec,
+      { code: "return 1;" },
+      makeInvocation({ toolCallId: "code-call-1", toolName: "exec" }),
+    );
+
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(beforeToolCall).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { code: "return 1;", command: "return 1;" },
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        runId: "run-code-mode",
+        toolCallId: "code-call-1",
+      },
+      {
+        toolName: "exec",
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        agentId: "agent-1",
+        sessionKey: "agent:main:main",
+        sessionId: "session-1",
+        runId: "run-code-mode",
+        jobId: "job-1",
+        trigger: "user",
+        messageProvider: "slack-voice",
+        channel: "slack",
+        senderId: "U123",
+        toolCallId: "code-call-1",
+        channelId: "C123",
+        channelContext: {
+          sender: { id: "U123", displayName: "Ada" },
+        },
+      },
+    );
+  });
+
   it("keeps code-mode controls visible when a narrow allowlist is active", async () => {
     const createOpenClawCodingTools = vi.fn(async () => [
       makeTool({ name: "fake_hidden" }),
@@ -443,7 +523,13 @@ describe("createCopilotToolBridge", () => {
           currentMessagingTarget: "user:U123",
           currentThreadTs: "1700000000.000100",
           currentMessageId: "M-1",
-          messageProvider: "slack",
+          messageChannel: "slack",
+          messageProvider: "slack-voice",
+          chatId: "chat-1",
+          channelContext: {
+            sender: { id: "sender-1", displayName: "Ada" },
+            chat: { id: "chat-1", kind: "channel" },
+          },
           messageTo: "U-1",
           messageThreadId: "1700000000.000100",
           replyToMode: "first",
@@ -477,7 +563,13 @@ describe("createCopilotToolBridge", () => {
         currentMessagingTarget: "user:U123",
         currentThreadTs: "1700000000.000100",
         currentMessageId: "M-1",
-        messageProvider: "slack",
+        messageChannel: "slack",
+        messageProvider: "slack-voice",
+        chatId: "chat-1",
+        hookChannelContext: {
+          sender: { id: "sender-1", displayName: "Ada" },
+          chat: { id: "chat-1", kind: "channel" },
+        },
         messageTo: "U-1",
         messageThreadId: "1700000000.000100",
         replyToMode: "first",
@@ -485,6 +577,7 @@ describe("createCopilotToolBridge", () => {
         forceMessageTool: true,
         enableHeartbeatTool: true,
       });
+      expect(opts.channelContext).toBeUndefined();
     });
 
     it("falls back messageProvider to attemptParams.messageChannel when messageProvider is absent (codex parity)", async () => {
@@ -500,6 +593,63 @@ describe("createCopilotToolBridge", () => {
       });
 
       expect(getOpts().messageProvider).toBe("telegram");
+    });
+
+    it("uses messageTo when currentMessagingTarget is absent in tool hook routing", () => {
+      const context = testing.buildCopilotToolHookContext({
+        agentId: "agent-1",
+        messageChannel: "slack",
+        messageProvider: "slack",
+        messageTo: "user:U-only",
+        trigger: "user",
+      });
+
+      expect(context).toMatchObject({
+        channel: "slack",
+        messageProvider: "slack",
+        channelId: "U-only",
+        turnSourceChannel: "slack",
+        turnSourceTo: "user:U-only",
+      });
+      expect(context.chatId).toBeUndefined();
+      expect(context.channelContext).toBeUndefined();
+    });
+
+    it("resolves per-agent loop detection overrides for generated code-mode controls", () => {
+      const context = testing.buildCopilotToolHookContext({
+        agentId: "agent-1",
+        config: {
+          tools: {
+            loopDetection: {
+              enabled: true,
+              warningThreshold: 7,
+              detectors: { genericRepeat: true },
+              postCompactionGuard: { windowSize: 4 },
+            },
+          },
+          agents: {
+            list: [
+              {
+                id: "agent-1",
+                tools: {
+                  loopDetection: {
+                    enabled: false,
+                    detectors: { pingPong: false },
+                    postCompactionGuard: { windowSize: 2 },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      expect(context.loopDetection).toEqual({
+        enabled: false,
+        warningThreshold: 7,
+        detectors: { genericRepeat: true, pingPong: false },
+        postCompactionGuard: { windowSize: 2 },
+      });
     });
 
     it("forwards authProfileStore, runId, config, and run hooks (onToolOutcome) from attemptParams", async () => {

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -7,15 +7,19 @@ import type {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   applyEmbeddedAttemptToolsAllow,
+  buildAgentHookContextOriginFields,
   buildEmbeddedAttemptToolRunContext,
   extractToolErrorMessage,
   getPluginToolMeta,
   isSubagentSessionKey,
+  isToolWrappedWithBeforeToolCallHook,
   isToolResultError,
   resolveAttemptSpawnWorkspaceDir,
   resolveEmbeddedAttemptToolConstructionPlan,
   resolveModelAuthMode,
+  resolveToolLoopDetectionConfig,
   sanitizeToolResult,
+  wrapToolWithBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { createAgentHarnessToolSurfaceRuntime } from "openclaw/plugin-sdk/agent-harness-tool-runtime";
 
@@ -144,6 +148,7 @@ export interface CopilotToolBridge {
 export const SUPPORTED_TOOL_PROVIDERS: ReadonlySet<string> = new Set(["github-copilot"]);
 const BASE_COPILOT_CODING_TOOL_NAMES = new Set(["edit", "read", "write"]);
 const SHELL_COPILOT_CODING_TOOL_NAMES = new Set(["apply_patch", "exec", "process"]);
+const CODE_MODE_CONTROL_TOOL_NAMES = new Set(["exec", "wait"]);
 
 export function supportsModelTools(modelProvider: string): boolean {
   return SUPPORTED_TOOL_PROVIDERS.has(modelProvider);
@@ -210,6 +215,7 @@ export async function createCopilotToolBridge(
     },
     toolSurfaceRuntime,
   );
+  const toolHookContext = buildCopilotToolHookContext(toolOptions);
 
   let sourceTools: unknown;
   try {
@@ -231,9 +237,18 @@ export async function createCopilotToolBridge(
     sourceTools as AnyAgentTool[],
     toolSurfaceRuntime.runtimeToolAllowlist,
   );
-  const compactedTools = toolSurfaceRuntime.compactTools(allowedSourceTools);
+  const compactedTools = toolSurfaceRuntime.compactTools(allowedSourceTools, {
+    hookContext: toolHookContext,
+  });
+  const hookedCompactedTools = compactedTools.tools.map((tool) =>
+    !toolSurfaceRuntime.codeModeControlsEnabled ||
+    !CODE_MODE_CONTROL_TOOL_NAMES.has(tool.name) ||
+    isToolWrappedWithBeforeToolCallHook(tool)
+      ? tool
+      : wrapToolWithBeforeToolCallHook(tool, toolHookContext),
+  );
   const plannedTools = filterCopilotToolsForConstructionPlan(
-    compactedTools.tools,
+    hookedCompactedTools,
     effectiveToolPlan.codingToolConstructionPlan,
     { preserveToolNames: toolSurfaceRuntime.runtimeToolAllowlist },
   );
@@ -263,6 +278,51 @@ export async function createCopilotToolBridge(
     sourceTools: filteredTools,
   };
 }
+
+function buildCopilotToolHookContext(toolOptions: OpenClawCodingToolsOptions) {
+  const turnSourceChannel = toolOptions.messageChannel ?? toolOptions.messageProvider;
+  const messageTo = toolOptions.currentMessagingTarget ?? toolOptions.messageTo;
+  const turnSourceTo = messageTo ?? toolOptions.currentChannelId;
+  return {
+    agentId: toolOptions.agentId,
+    config: toolOptions.config,
+    cwd: toolOptions.cwd,
+    workspaceDir: toolOptions.workspaceDir,
+    sessionKey: toolOptions.sessionKey,
+    sessionId: toolOptions.sessionId,
+    runId: toolOptions.runId,
+    jobId: toolOptions.jobId,
+    trace: toolOptions.trace,
+    trigger: toolOptions.trigger,
+    ...buildAgentHookContextOriginFields({
+      sessionKey: toolOptions.sessionKey,
+      messageChannel: toolOptions.messageChannel,
+      messageProvider: toolOptions.toolPolicyMessageProvider ?? toolOptions.messageProvider,
+      currentChannelId: toolOptions.hookChannelId ?? toolOptions.currentChannelId,
+      messageTo,
+      trigger: toolOptions.trigger,
+      senderId: toolOptions.senderId,
+      chatId: toolOptions.chatId,
+      channelContext: toolOptions.hookChannelContext ?? toolOptions.channelContext,
+    }),
+    ...(turnSourceChannel ? { turnSourceChannel } : {}),
+    ...(turnSourceTo ? { turnSourceTo } : {}),
+    ...(toolOptions.agentAccountId ? { turnSourceAccountId: toolOptions.agentAccountId } : {}),
+    ...(toolOptions.currentThreadTs ? { turnSourceThreadId: toolOptions.currentThreadTs } : {}),
+    loopDetection: resolveToolLoopDetectionConfig({
+      cfg: toolOptions.config,
+      agentId: toolOptions.agentId,
+    }),
+    onToolOutcome: toolOptions.onToolOutcome,
+    allocateToolOutcomeOrdinal: toolOptions.allocateToolOutcomeOrdinal,
+  };
+}
+
+/** Test-only access to requester-context construction. */
+export const testing = {
+  buildCopilotToolHookContext: (toolOptions: unknown): Record<string, unknown> =>
+    buildCopilotToolHookContext(toolOptions as OpenClawCodingToolsOptions),
+};
 
 /**
  * Builds the full `createOpenClawCodingTools` options bag mirroring the
@@ -350,7 +410,9 @@ function buildOpenClawCodingToolsOptions(
       ...a.execOverrides,
       elevated: a.bashElevated,
     },
+    messageChannel: a.messageChannel,
     messageProvider: a.messageProvider ?? a.messageChannel,
+    toolPolicyMessageProvider: a.messageProvider ?? a.messageChannel,
     agentAccountId: a.agentAccountId,
     messageTo: a.messageTo,
     messageThreadId: a.messageThreadId,
@@ -360,6 +422,7 @@ function buildOpenClawCodingToolsOptions(
     memberRoleIds: a.memberRoleIds,
     spawnedBy: a.spawnedBy,
     senderId: a.senderId,
+    hookChannelContext: a.channelContext,
     senderName: a.senderName,
     senderUsername: a.senderUsername,
     senderE164: a.senderE164,
@@ -395,6 +458,7 @@ function buildOpenClawCodingToolsOptions(
       workspaceDir,
     }),
     currentChannelId: a.currentChannelId,
+    chatId: a.chatId,
     currentMessagingTarget: a.currentMessagingTarget,
     currentThreadTs: a.currentThreadTs,
     currentMessageId: a.currentMessageId,

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -33,6 +33,13 @@ import { markCodeModeControlTool } from "./code-mode-control-tools.js";
 import { CODE_MODE_EXEC_TOOL_NAME, createCodeModeTools } from "./code-mode.js";
 import { splitSdkTools } from "./embedded-agent-runner.js";
 import type { ExtensionContext } from "./sessions/index.js";
+import {
+  addClientToolsToToolSearchCatalog,
+  applyToolSearchCatalog,
+  clearToolSearchCatalog,
+  createToolSearchTools,
+  TOOL_CALL_RAW_TOOL_NAME,
+} from "./tool-search.js";
 import { setToolTerminalPresentation } from "./tool-terminal-presentation.js";
 
 type BeforeToolCallHandlerMock = ReturnType<typeof vi.fn>;
@@ -1198,6 +1205,143 @@ describe("before_tool_call hook integration for client tools", () => {
       value: "ok",
       extra: true,
     });
+  });
+
+  it("preserves requester origin context on adapted client tools", async () => {
+    const beforeToolCallHook = installBeforeToolCallHook();
+    const [tool] = toClientToolDefinitions(
+      [
+        {
+          type: "function",
+          function: {
+            name: "client_tool",
+            description: "Client tool",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+      undefined,
+      {
+        agentId: "main",
+        sessionKey: "agent:main:client",
+        sessionId: "session-client",
+        runId: "run-client",
+        jobId: "job-client",
+        trigger: "user",
+        messageProvider: "slack-voice",
+        channel: "slack",
+        chatId: "C123",
+        senderId: "U123",
+        channelId: "C123",
+        channelContext: {
+          sender: { id: "U123", displayName: "Ada" },
+          chat: { id: "C123" },
+        },
+      },
+    );
+    const extensionContext = {} as Parameters<typeof tool.execute>[4];
+
+    await tool.execute("client-call-context", {}, undefined, undefined, extensionContext);
+
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "client_tool",
+        params: {},
+        runId: "run-client",
+        toolCallId: "client-call-context",
+      },
+      {
+        toolName: "client_tool",
+        agentId: "main",
+        sessionKey: "agent:main:client",
+        sessionId: "session-client",
+        runId: "run-client",
+        jobId: "job-client",
+        trigger: "user",
+        messageProvider: "slack-voice",
+        channel: "slack",
+        chatId: "C123",
+        senderId: "U123",
+        toolCallId: "client-call-context",
+        channelId: "C123",
+        channelContext: {
+          sender: { id: "U123", displayName: "Ada" },
+          chat: { id: "C123" },
+        },
+      },
+    );
+  });
+
+  it("preserves requester origin context when a client tool is cataloged", async () => {
+    const beforeToolCallHook = installBeforeToolCallHook();
+    const onClientToolCall = vi.fn();
+    const sessionId = "session-client-catalog";
+    const config = { tools: { toolSearch: { enabled: true, mode: "tools" } } } as never;
+    const [clientTool] = toClientToolDefinitions(
+      [
+        {
+          type: "function",
+          function: {
+            name: "client_tool",
+            description: "Client tool",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+      onClientToolCall,
+      {
+        agentId: "main",
+        sessionKey: "agent:main:client",
+        sessionId,
+        runId: "run-client-catalog",
+        jobId: "job-client",
+        trigger: "user",
+        messageProvider: "slack-voice",
+        channel: "slack",
+        chatId: "C123",
+        senderId: "U123",
+        channelId: "C123",
+        channelContext: {
+          sender: { id: "U123", displayName: "Ada" },
+          chat: { id: "C123" },
+        },
+      },
+    );
+    if (!clientTool) {
+      throw new Error("missing client tool definition");
+    }
+    const controls = createToolSearchTools({ config, sessionId });
+    applyToolSearchCatalog({ tools: controls, config, sessionId });
+    addClientToolsToToolSearchCatalog({ tools: [clientTool], config, sessionId });
+    const toolCall = controls.find((tool) => tool.name === TOOL_CALL_RAW_TOOL_NAME);
+    if (!toolCall) {
+      throw new Error("missing tool_call control");
+    }
+
+    try {
+      await toolCall.execute("catalog-parent", {
+        id: "client:client:client_tool",
+        args: { value: "cataloged" },
+      });
+
+      expect(beforeToolCallHook).toHaveBeenCalledTimes(1);
+      expect(beforeToolCallHook.mock.calls[0]?.[1]).toMatchObject({
+        jobId: "job-client",
+        trigger: "user",
+        messageProvider: "slack-voice",
+        channel: "slack",
+        chatId: "C123",
+        senderId: "U123",
+        channelId: "C123",
+        channelContext: {
+          sender: { id: "U123", displayName: "Ada" },
+          chat: { id: "C123" },
+        },
+      });
+      expect(onClientToolCall).toHaveBeenCalledWith("client_tool", { value: "cataloged" });
+    } finally {
+      clearToolSearchCatalog({ sessionId });
+    }
   });
 
   it("preserves client tool source order when hooks resolve out of order", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -37,6 +37,7 @@ import {
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { redactToolDetail } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { buildAgentHookContextIdentityFields } from "../plugins/hook-agent-context.js";
 import { getGlobalHookRunnerRegistry } from "../plugins/hook-runner-global-state.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { deriveToolParams } from "../plugins/host-tool-param-parsers.js";
@@ -50,8 +51,10 @@ import {
   PluginApprovalResolutions,
   type PluginApprovalResolution,
   type PluginHookBeforeToolCallResult,
+  type PluginHookChannelContext,
   type PluginHookToolInputKind,
   type PluginHookToolKind,
+  type PluginHookToolContext,
 } from "../plugins/types.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import {
@@ -110,8 +113,15 @@ export type HookContext = {
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
   runId?: string;
+  jobId?: string;
   trace?: DiagnosticTraceContext;
+  trigger?: string;
+  messageProvider?: string;
+  channel?: string;
+  chatId?: string;
+  senderId?: string;
   channelId?: string;
+  channelContext?: PluginHookChannelContext;
   /** Originating channel for approval delivery routing; mirrors exec approval turn-source fields. */
   turnSourceChannel?: string;
   turnSourceTo?: string;
@@ -132,6 +142,24 @@ export type HookContext = {
     bridge: SandboxFsBridge;
   };
 };
+
+/** Plain run-owned metadata that can safely be projected onto tool hook contexts. */
+export type ToolHookRunContext = Pick<
+  HookContext,
+  | "agentId"
+  | "sessionKey"
+  | "sessionId"
+  | "runId"
+  | "jobId"
+  | "trace"
+  | "trigger"
+  | "messageProvider"
+  | "channel"
+  | "chatId"
+  | "senderId"
+  | "channelId"
+  | "channelContext"
+>;
 
 type HookBlockedKind = "veto" | "failure";
 type HookBlockedReason = "plugin-before-tool-call" | "plugin-approval" | "tool-loop";
@@ -209,6 +237,38 @@ export function getBeforeToolCallPolicyDiagnosticState(): BeforeToolCallPolicyDi
 export function hasBeforeToolCallPolicy(): boolean {
   const state = getBeforeToolCallPolicyDiagnosticState();
   return state.hasBeforeToolCallHook || state.trustedToolPolicies.length > 0;
+}
+
+/** Project the internal tool runtime context onto the public plugin hook contract. */
+export function buildPluginHookToolContext(args: {
+  toolName: string;
+  toolKind?: PluginHookToolKind;
+  toolInputKind?: PluginHookToolInputKind;
+  toolCallId?: string;
+  ctx?: ToolHookRunContext;
+}): PluginHookToolContext {
+  return {
+    toolName: args.toolName,
+    ...(args.toolKind && { toolKind: args.toolKind }),
+    ...(args.toolInputKind && { toolInputKind: args.toolInputKind }),
+    ...(args.ctx?.agentId && { agentId: args.ctx.agentId }),
+    ...(args.ctx?.sessionKey && { sessionKey: args.ctx.sessionKey }),
+    ...(args.ctx?.sessionId && { sessionId: args.ctx.sessionId }),
+    ...(args.ctx?.runId && { runId: args.ctx.runId }),
+    ...(args.ctx?.jobId && { jobId: args.ctx.jobId }),
+    ...(args.ctx?.trace && { trace: freezeDiagnosticTraceContext(args.ctx.trace) }),
+    ...(args.ctx?.trigger && { trigger: args.ctx.trigger }),
+    ...(args.ctx?.messageProvider && { messageProvider: args.ctx.messageProvider }),
+    ...(args.ctx?.channel && { channel: args.ctx.channel }),
+    ...(args.toolCallId && { toolCallId: args.toolCallId }),
+    ...(args.ctx?.channelId && { channelId: args.ctx.channelId }),
+    ...buildAgentHookContextIdentityFields({
+      trigger: args.ctx?.trigger,
+      senderId: args.ctx?.senderId,
+      chatId: args.ctx?.chatId,
+      channelContext: args.ctx?.channelContext,
+    }),
+  };
 }
 
 const log = createSubsystemLogger("agents/tools");
@@ -1143,17 +1203,13 @@ export async function runBeforeToolCallHook(args: {
       ...(args.toolKind && { toolKind: args.toolKind }),
       ...(args.toolInputKind && { toolInputKind: args.toolInputKind }),
     };
-    const buildToolContext = (identity: typeof toolIdentity) => ({
-      toolName,
-      ...identity,
-      ...(args.ctx?.agentId && { agentId: args.ctx.agentId }),
-      ...(args.ctx?.sessionKey && { sessionKey: args.ctx.sessionKey }),
-      ...(args.ctx?.sessionId && { sessionId: args.ctx.sessionId }),
-      ...(args.ctx?.runId && { runId: args.ctx.runId }),
-      ...(args.ctx?.trace && { trace: freezeDiagnosticTraceContext(args.ctx.trace) }),
-      ...(args.toolCallId && { toolCallId: args.toolCallId }),
-      ...(args.ctx?.channelId && { channelId: args.ctx.channelId }),
-    });
+    const buildToolContext = (identity: typeof toolIdentity) =>
+      buildPluginHookToolContext({
+        toolName,
+        ...identity,
+        ...(args.toolCallId && { toolCallId: args.toolCallId }),
+        ...(args.ctx ? { ctx: args.ctx } : {}),
+      });
     const toolContext = buildToolContext(toolIdentity);
     const trustedPolicyResult = shouldRunTrustedPolicies
       ? await runTrustedToolPolicies(

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -201,7 +201,7 @@ describe("createOpenClawCodingTools", () => {
     expect(names.has("tool_call")).toBe(false);
   });
 
-  it("passes explicit hook channel ids to wrapped tool hooks", async () => {
+  it("passes requester origin context to wrapped tool hooks", async () => {
     const beforeToolCall = vi.fn();
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
@@ -210,15 +210,36 @@ describe("createOpenClawCodingTools", () => {
     await fs.writeFile(path.join(tmpDir, "note.txt"), "hello");
     const tools = createOpenClawCodingTools({
       workspaceDir: tmpDir,
-      currentChannelId: "telegram:-100123",
-      hookChannelId: "-100123",
+      messageChannel: "telegram",
+      messageProvider: "telegram",
+      toolPolicyMessageProvider: "telegram-voice",
+      messageTo: "telegram:-100123",
+      senderId: "speaker-1",
+      trigger: "user",
+      jobId: "job-1",
+      hookChannelContext: {
+        sender: { id: "transport-speaker" },
+        chat: { id: "transport-chat" },
+      },
     });
     const readTool = requireTool(tools, "read");
     await requireToolExecute(readTool)("tool-hook-channel", { path: "note.txt" });
 
     expect(beforeToolCall).toHaveBeenCalledTimes(1);
     expect(beforeToolCall.mock.calls[0]?.[1]).toEqual(
-      expect.objectContaining({ channelId: "-100123" }),
+      expect.objectContaining({
+        channel: "telegram",
+        messageProvider: "telegram-voice",
+        channelId: "-100123",
+        chatId: "transport-chat",
+        senderId: "speaker-1",
+        trigger: "user",
+        jobId: "job-1",
+        channelContext: {
+          sender: { id: "speaker-1" },
+          chat: { id: "transport-chat" },
+        },
+      }),
     );
   });
 

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -19,6 +19,7 @@ import { resolveEventSessionRoutingPolicy } from "../infra/event-session-routing
 import { applyExecPolicyLayer } from "../infra/exec-policy.js";
 import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
 import { logWarn } from "../logger.js";
+import { buildAgentHookContextOriginFields } from "../plugins/hook-agent-context.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
@@ -470,8 +471,12 @@ export function createOpenClawCodingTools(options?: {
   currentMessagingTarget?: string;
   /** Normalized conversation id exposed to tool hooks. Defaults to currentChannelId. */
   hookChannelId?: string;
+  /** Transport-native conversation id exposed to tool hooks when available. */
+  chatId?: string;
   /** Channel-owned sender/chat metadata exposed to subprocess environments. */
   channelContext?: PluginHookChannelContext;
+  /** Channel-owned sender/chat metadata exposed only to plugin tool hooks. */
+  hookChannelContext?: PluginHookChannelContext;
   /** Current thread timestamp for auto-threading (Slack). */
   currentThreadTs?: string;
   /** Current inbound message id for action fallbacks (e.g. Telegram react). */
@@ -1187,7 +1192,8 @@ export function createOpenClawCodingTools(options?: {
   );
   options?.recordToolPrepStage?.("schema-normalization");
   const turnSourceChannel = options?.messageChannel ?? options?.messageProvider;
-  const turnSourceTo = options?.currentMessagingTarget ?? options?.currentChannelId;
+  const turnSourceTo =
+    options?.currentMessagingTarget ?? options?.messageTo ?? options?.currentChannelId;
   const hookContext = {
     agentId,
     ...(options?.config ? { config: options.config } : {}),
@@ -1200,7 +1206,19 @@ export function createOpenClawCodingTools(options?: {
     sessionKey: options?.sessionKey,
     sessionId: options?.sessionId,
     runId: options?.runId,
-    channelId: options?.hookChannelId ?? options?.currentChannelId,
+    jobId: options?.jobId,
+    trigger: options?.trigger,
+    ...buildAgentHookContextOriginFields({
+      sessionKey: options?.sessionKey,
+      messageChannel: options?.messageChannel,
+      messageProvider: options?.toolPolicyMessageProvider ?? options?.messageProvider,
+      currentChannelId: options?.hookChannelId ?? options?.currentChannelId,
+      messageTo: options?.currentMessagingTarget ?? options?.messageTo,
+      trigger: options?.trigger,
+      senderId: options?.senderId,
+      chatId: options?.chatId,
+      channelContext: options?.hookChannelContext ?? options?.channelContext,
+    }),
     ...(turnSourceChannel ? { turnSourceChannel } : {}),
     ...(turnSourceTo ? { turnSourceTo } : {}),
     ...(options?.agentAccountId ? { turnSourceAccountId: options.agentAccountId } : {}),

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -629,6 +629,11 @@ describe("runBtwSideQuestion", () => {
       senderName: "Rosita",
       senderUsername: "rosita",
       senderE164: "+15550001",
+      chatId: "native-chat-1",
+      channelContext: {
+        sender: { id: "sender-1", providerUserId: "provider-user-1" },
+        chat: { id: "native-chat-1", providerThreadKey: "thread-key-1" },
+      },
     });
 
     expect(result).toEqual({ text: "Codex side answer." });
@@ -653,6 +658,11 @@ describe("runBtwSideQuestion", () => {
           senderName?: string;
           senderUsername?: string;
           senderE164?: string;
+          chatId?: string;
+          channelContext?: {
+            sender?: Record<string, unknown>;
+            chat?: Record<string, unknown>;
+          };
           toolsAllow?: string[];
         },
       ]
@@ -675,6 +685,11 @@ describe("runBtwSideQuestion", () => {
       senderName: "Rosita",
       senderUsername: "rosita",
       senderE164: "+15550001",
+      chatId: "native-chat-1",
+      channelContext: {
+        sender: { id: "sender-1", providerUserId: "provider-user-1" },
+        chat: { id: "native-chat-1", providerThreadKey: "thread-key-1" },
+      },
     });
     expect(
       (mockArg(codexSideQuestionMock, 0, 0) as { sessionFile?: string }).sessionFile,

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -18,6 +18,7 @@ import type {
   Model,
   TextContent,
 } from "../llm/types.js";
+import type { PluginHookChannelContext } from "../plugins/hook-types.js";
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.js";
 import { discoverAuthStorage, discoverModels } from "./agent-model-discovery.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
@@ -388,6 +389,8 @@ type RunBtwSideQuestionParams = {
   senderUsername?: string | null;
   senderE164?: string | null;
   senderIsOwner?: boolean;
+  chatId?: string;
+  channelContext?: PluginHookChannelContext;
   currentChannelId?: string;
 };
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -52,6 +52,7 @@ import { getCurrentPluginMetadataSnapshot } from "../../../plugins/current-plugi
 import {
   buildAgentHookContextChannelFields,
   buildAgentHookContextIdentityFields,
+  buildAgentHookContextOriginFields,
 } from "../../../plugins/hook-agent-context.js";
 import { resolveBlockMessage } from "../../../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
@@ -1241,6 +1242,7 @@ export async function runEmbeddedAttempt(
       toolConstructionPlan.constructTools ||
       toolSearchControlsEnabledForRun ||
       codeModeControlsEnabledForRun;
+    const toolPolicyMessageProvider = resolveAttemptToolPolicyMessageProvider(params);
     let toolSearchCatalogExecutor: ToolSearchCatalogToolExecutor | undefined;
     toolSearchCatalogRef =
       toolSearchControlsEnabledForRun || codeModeControlsEnabledForRun
@@ -1261,7 +1263,7 @@ export async function runEmbeddedAttempt(
               elevated: params.bashElevated,
             },
             sandbox,
-            messageProvider: resolveAttemptToolPolicyMessageProvider(params),
+            messageProvider: toolPolicyMessageProvider,
             agentAccountId: params.agentAccountId,
             messageTo: params.messageTo,
             messageThreadId: params.messageThreadId,
@@ -1314,6 +1316,7 @@ export async function runEmbeddedAttempt(
             }),
             currentChannelId: params.currentChannelId,
             currentMessagingTarget: params.currentMessagingTarget,
+            chatId: params.chatId,
             currentThreadTs: params.currentThreadTs,
             currentMessageId: params.currentMessageId,
             currentInboundAudio: params.currentInboundAudio,
@@ -1661,7 +1664,19 @@ export async function runEmbeddedAttempt(
       sessionKey: sandboxSessionKey,
       sessionId: params.sessionId,
       runId: params.runId,
-      channelId: params.currentChannelId,
+      jobId: params.jobId,
+      trigger: params.trigger,
+      ...buildAgentHookContextOriginFields({
+        sessionKey: sandboxSessionKey,
+        messageChannel: params.messageChannel,
+        messageProvider: toolPolicyMessageProvider,
+        currentChannelId: params.currentChannelId,
+        messageTo: params.currentMessagingTarget ?? params.messageTo,
+        trigger: params.trigger,
+        senderId: params.senderId,
+        chatId: params.chatId,
+        channelContext: params.channelContext,
+      }),
       trace: runTrace,
       loopDetection: resolveToolLoopDetectionConfig({
         cfg: params.config,
@@ -2421,14 +2436,9 @@ export async function runEmbeddedAttempt(
               },
             },
             {
-              agentId: sessionAgentId,
-              sessionKey: sandboxSessionKey,
+              ...catalogToolHookContext,
               config: toolSearchRuntimeConfig,
-              sessionId: params.sessionId,
-              runId: params.runId,
               loopDetection: clientToolLoopDetection,
-              onToolOutcome: params.onToolOutcome,
-              allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,
             },
           )
         : [];
@@ -3555,6 +3565,7 @@ export async function runEmbeddedAttempt(
           messageChannel: runtimeChannel,
           initialReplayState: params.initialReplayState,
           hookRunner: getGlobalHookRunner() ?? undefined,
+          toolHookContext: catalogToolHookContext,
           verboseLevel: params.verboseLevel,
           reasoningMode: params.reasoningLevel ?? "off",
           thinkingLevel: params.thinkLevel,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -34,6 +34,7 @@ import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { normalizeAcceptedSessionSpawnResult } from "./accepted-session-spawn.js";
+import { buildPluginHookToolContext } from "./agent-tools.before-tool-call.js";
 import {
   consumeAdjustedParamsForToolCall,
   consumePreExecutionBlockedToolCall,
@@ -1573,14 +1574,20 @@ export async function handleToolExecutionEnd(
       durationMs,
     };
     void hookRunnerAfter
-      .runAfterToolCall(hookEvent, {
-        toolName,
-        agentId: ctx.params.agentId,
-        sessionKey: ctx.params.sessionKey,
-        sessionId: ctx.params.sessionId,
-        runId,
-        toolCallId,
-      })
+      .runAfterToolCall(
+        hookEvent,
+        buildPluginHookToolContext({
+          toolName,
+          toolCallId,
+          ctx: {
+            ...ctx.params.toolHookContext,
+            ...(ctx.params.agentId ? { agentId: ctx.params.agentId } : {}),
+            ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+            ...(ctx.params.sessionId ? { sessionId: ctx.params.sessionId } : {}),
+            runId,
+          },
+        }),
+      )
       .catch((err: unknown) => {
         ctx.log.warn(`after_tool_call hook failed: tool=${toolName} error=${String(err)}`);
       });

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -272,6 +272,7 @@ export type EmbeddedAgentSubscribeContext = {
 type ToolHandlerParams = Pick<
   SubscribeEmbeddedAgentSessionParams,
   | "runId"
+  | "toolHookContext"
   | "onBlockReplyFlush"
   | "onAgentEvent"
   | "onToolStreamBoundary"

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -10,6 +10,7 @@ import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookRunner } from "../plugins/hooks.js";
+import type { ToolHookRunContext } from "./agent-tools.before-tool-call.js";
 import type { BlockReplyPayload } from "./embedded-agent-payloads.js";
 import type { EmbeddedRunReplayState } from "./embedded-agent-runner/replay-state.js";
 import type {
@@ -35,6 +36,8 @@ export type SubscribeEmbeddedAgentSessionParams = {
   messageChannel?: string;
   initialReplayState?: EmbeddedRunReplayState;
   hookRunner?: HookRunner;
+  /** Internal run context projected onto before/after tool hook contracts. */
+  toolHookContext?: ToolHookRunContext;
   verboseLevel?: VerboseLevel;
   reasoningMode?: ReasoningLevel;
   thinkingLevel?: ThinkLevel;

--- a/src/agents/harness/hook-helpers.ts
+++ b/src/agents/harness/hook-helpers.ts
@@ -6,25 +6,26 @@
  */
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { consumeAdjustedParamsForToolCall } from "../agent-tools.before-tool-call.js";
+import {
+  buildPluginHookToolContext,
+  consumeAdjustedParamsForToolCall,
+  type ToolHookRunContext,
+} from "../agent-tools.before-tool-call.js";
 import type { AgentMessage } from "../runtime/index.js";
 
 const log = createSubsystemLogger("agents/harness");
 
 /** Runs best-effort after-tool-call hooks for a completed tool invocation. */
-export async function runAgentHarnessAfterToolCallHook(params: {
-  toolName: string;
-  toolCallId: string;
-  runId?: string;
-  agentId?: string;
-  sessionId?: string;
-  sessionKey?: string;
-  channelId?: string;
-  startArgs: Record<string, unknown>;
-  result?: unknown;
-  error?: string;
-  startedAt?: number;
-}): Promise<void> {
+export async function runAgentHarnessAfterToolCallHook(
+  params: ToolHookRunContext & {
+    toolName: string;
+    toolCallId: string;
+    startArgs: Record<string, unknown>;
+    result?: unknown;
+    error?: string;
+    startedAt?: number;
+  },
+): Promise<void> {
   const adjustedArgs = consumeAdjustedParamsForToolCall(params.toolCallId, params.runId);
   // Hooks should see adjusted tool params when before_tool_call rewrote them.
   const resolvedArgs =
@@ -47,15 +48,11 @@ export async function runAgentHarnessAfterToolCallHook(params: {
         ...(params.error ? { error: params.error } : {}),
         ...(params.startedAt != null ? { durationMs: Date.now() - params.startedAt } : {}),
       },
-      {
+      buildPluginHookToolContext({
         toolName: params.toolName,
-        ...(params.agentId ? { agentId: params.agentId } : {}),
-        ...(params.sessionId ? { sessionId: params.sessionId } : {}),
-        ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-        ...(params.runId ? { runId: params.runId } : {}),
-        ...(params.channelId ? { channelId: params.channelId } : {}),
         toolCallId: params.toolCallId,
-      },
+        ctx: params,
+      }),
     );
   } catch (error) {
     log.warn(`after_tool_call hook failed: tool=${params.toolName} error=${String(error)}`);

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -1637,6 +1637,19 @@ describe("native hook relay registry", () => {
       sessionKey: "agent:main:session-1",
       runId: "run-1",
       channelId: "telegram",
+      toolHookContext: {
+        jobId: "job-1",
+        trigger: "user",
+        messageProvider: "telegram-voice",
+        channel: "telegram",
+        chatId: "chat-1",
+        senderId: "user-1",
+        channelId: "telegram",
+        channelContext: {
+          sender: { id: "user-1" },
+          chat: { id: "chat-1" },
+        },
+      },
     });
 
     const response = await invokeNativeHookRelay({
@@ -1674,7 +1687,17 @@ describe("native hook relay registry", () => {
       sessionId: "session-1",
       sessionKey: "agent:main:session-1",
       runId: "run-1",
+      jobId: "job-1",
+      trigger: "user",
+      messageProvider: "telegram-voice",
+      channel: "telegram",
+      chatId: "chat-1",
+      senderId: "user-1",
       channelId: "telegram",
+      channelContext: {
+        sender: { id: "user-1" },
+        chat: { id: "chat-1" },
+      },
       toolName: "exec",
       toolCallId: "native-call-1",
     });
@@ -1695,6 +1718,19 @@ describe("native hook relay registry", () => {
       sessionKey: "agent:main:session-1",
       runId: "run-1",
       channelId: "telegram",
+      toolHookContext: {
+        jobId: "job-1",
+        trigger: "user",
+        messageProvider: "telegram-voice",
+        channel: "telegram",
+        chatId: "chat-1",
+        senderId: "user-1",
+        channelId: "telegram",
+        channelContext: {
+          sender: { id: "user-1" },
+          chat: { id: "chat-1" },
+        },
+      },
     });
 
     const response = await invokeNativeHookRelay({
@@ -2243,6 +2279,19 @@ describe("native hook relay registry", () => {
       sessionKey: "agent:main:session-1",
       runId: "run-1",
       channelId: "telegram",
+      toolHookContext: {
+        jobId: "job-1",
+        trigger: "user",
+        messageProvider: "telegram-voice",
+        channel: "telegram",
+        chatId: "chat-1",
+        senderId: "user-1",
+        channelId: "telegram",
+        channelContext: {
+          sender: { id: "user-1" },
+          chat: { id: "chat-1" },
+        },
+      },
     });
 
     const response = await invokeNativeHookRelay({
@@ -2273,7 +2322,17 @@ describe("native hook relay registry", () => {
       sessionId: "session-1",
       sessionKey: "agent:main:session-1",
       runId: "run-1",
+      jobId: "job-1",
+      trigger: "user",
+      messageProvider: "telegram-voice",
+      channel: "telegram",
+      chatId: "chat-1",
+      senderId: "user-1",
       channelId: "telegram",
+      channelContext: {
+        sender: { id: "user-1" },
+        chat: { id: "chat-1" },
+      },
       toolName: "exec",
       toolCallId: "native-call-1",
     });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -37,6 +37,7 @@ import {
   requestDeferredPluginToolApproval,
   runBeforeToolCallHook,
   type DeferredPluginToolApproval,
+  type ToolHookRunContext,
 } from "../agent-tools.before-tool-call.js";
 import { stableStringify } from "../stable-stringify.js";
 import { resolveToolLoopDetectionConfig } from "../tool-loop-detection-config.js";
@@ -104,6 +105,7 @@ export type NativeHookRelayRegistration = {
   config?: OpenClawConfig;
   runId: string;
   channelId?: string;
+  toolHookContext?: ToolHookRunContext;
   allowedEvents: readonly NativeHookRelayEvent[];
   expiresAtMs: number;
   signal?: AbortSignal;
@@ -131,6 +133,7 @@ export type RegisterNativeHookRelayParams = {
   config?: OpenClawConfig;
   runId: string;
   channelId?: string;
+  toolHookContext?: ToolHookRunContext;
   allowedEvents?: readonly NativeHookRelayEvent[];
   ttlMs?: number;
   command?: NativeHookRelayCommandOptions;
@@ -435,6 +438,7 @@ export function registerNativeHookRelay(
     ...(params.config ? { config: params.config } : {}),
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),
+    ...(params.toolHookContext ? { toolHookContext: params.toolHookContext } : {}),
     allowedEvents,
     expiresAtMs,
     ...(params.signal ? { signal: params.signal } : {}),
@@ -1398,6 +1402,7 @@ async function runNativeHookRelayPreToolUse(params: {
     ...(approvalMode === "report" ? { approvalMode: "defer" } : {}),
     signal: params.registration.signal,
     ctx: {
+      ...params.registration.toolHookContext,
       ...(params.registration.agentId ? { agentId: params.registration.agentId } : {}),
       sessionId: params.registration.sessionId,
       ...(params.registration.sessionKey ? { sessionKey: params.registration.sessionKey } : {}),
@@ -1447,6 +1452,7 @@ async function runNativeHookRelayPostToolUse(params: {
   await runAgentHarnessAfterToolCallHook({
     toolName,
     toolCallId,
+    ...params.registration.toolHookContext,
     runId: params.registration.runId,
     ...(params.registration.agentId ? { agentId: params.registration.agentId } : {}),
     sessionId: params.registration.sessionId,

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -65,6 +65,8 @@ export type AgentHarnessSideQuestionParams = {
   senderUsername?: string | null;
   senderE164?: string | null;
   senderIsOwner?: boolean;
+  chatId?: string;
+  channelContext?: import("../../plugins/hook-types.js").PluginHookChannelContext;
   currentChannelId?: string;
   toolsAllow?: string[];
   authProfileId?: string;

--- a/src/agents/tool-loop-detection-config.ts
+++ b/src/agents/tool-loop-detection-config.ts
@@ -5,7 +5,7 @@
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveAgentConfig } from "./agent-scope-config.js";
 
 /** Resolves effective tool loop-detection config by overlaying agent settings on globals. */
 export function resolveToolLoopDetectionConfig(params: {

--- a/src/auto-reply/reply/commands-btw.test.ts
+++ b/src/auto-reply/reply/commands-btw.test.ts
@@ -130,6 +130,12 @@ describe("handleBtwCommand", () => {
     params.ctx.SenderUsername = "rosita";
     params.ctx.SenderE164 = "+15550001";
     params.ctx.MessageThreadId = "thread-1";
+    params.ctx.NativeChannelId = "native-chat-1";
+    params.ctx.ChatId = "legacy-chat";
+    params.ctx.ChannelContext = {
+      sender: { id: "sender-1", providerUserId: "provider-user-1" },
+      chat: { id: "native-chat-1", providerThreadKey: "thread-key-1" },
+    };
     params.agentDir = "/tmp/agent";
     params.sessionEntry = {
       sessionId: "session-1",
@@ -161,6 +167,11 @@ describe("handleBtwCommand", () => {
       senderUsername: "rosita",
       senderE164: "+15550001",
       senderIsOwner: true,
+      chatId: "native-chat-1",
+      channelContext: {
+        sender: { id: "sender-1", providerUserId: "provider-user-1" },
+        chat: { id: "native-chat-1", providerThreadKey: "thread-key-1" },
+      },
     });
     expect(String(runnerArgs.agentDir)).toContain("/agents/main/agent");
     expect(result).toEqual({

--- a/src/auto-reply/reply/commands-btw.ts
+++ b/src/auto-reply/reply/commands-btw.ts
@@ -1,4 +1,5 @@
 /** Handles /btw side-question commands against the active session context. */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { runBtwSideQuestion } from "../../agents/btw.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
@@ -57,6 +58,12 @@ export const handleBtwCommand: CommandHandler = async (params, allowTextCommands
     await params.typing?.startTypingLoop();
     const currentChannelId =
       params.ctx.OriginatingTo?.trim() || params.command.to || params.command.channelId;
+    const chatId =
+      normalizeOptionalString(params.ctx.NativeChannelId) ??
+      normalizeOptionalString(params.ctx.ChatId) ??
+      normalizeOptionalString(params.rootCtx?.NativeChannelId) ??
+      normalizeOptionalString(params.rootCtx?.ChatId);
+    const channelContext = params.ctx.ChannelContext ?? params.rootCtx?.ChannelContext;
     const groupId = resolveGroupSessionKey(params.ctx)?.id ?? targetSessionEntry.groupId;
     const reply = await runBtwSideQuestion({
       cfg: params.cfg,
@@ -109,6 +116,8 @@ export const handleBtwCommand: CommandHandler = async (params, allowTextCommands
       ...(params.ctx.SenderUsername ? { senderUsername: params.ctx.SenderUsername } : {}),
       ...(params.ctx.SenderE164 ? { senderE164: params.ctx.SenderE164 } : {}),
       senderIsOwner: params.command.senderIsOwner,
+      ...(chatId ? { chatId } : {}),
+      ...(channelContext ? { channelContext } : {}),
       ...(currentChannelId ? { currentChannelId } : {}),
     });
     return {

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -47,6 +47,16 @@ type BeforeToolCallHookInput = {
     agentId?: string;
     config?: unknown;
     sessionKey?: string;
+    sessionId?: string;
+    messageProvider?: string;
+    channel?: string;
+    channelId?: string;
+    chatId?: string;
+    senderId?: string;
+    channelContext?: {
+      sender?: { id?: string };
+      chat?: { id?: string };
+    };
   };
   signal?: unknown;
 };
@@ -1437,6 +1447,37 @@ describe("mcp loopback server", () => {
     expect(hookInput.signal).toBeInstanceOf(AbortSignal);
     expect(execute).not.toHaveBeenCalled();
     expectMcpResultText(payload, "blocked by hook", true);
+  });
+
+  it("passes canonical prefixed channel origin into loopback before-tool hooks", async () => {
+    const execute = vi.fn<MockGatewayTool["execute"]>(async () => ({
+      content: [{ type: "text", text: "EXECUTED" }],
+    }));
+    mockScopedTools([makeMessageTool({ execute })]);
+    const { runtime } = await startLoopbackServerForTest();
+
+    const response = await sendLoopbackToolCall({
+      token: runtime.ownerToken,
+      name: "message",
+      args: { body: "hello" },
+      headers: {
+        "x-session-key": "agent:main:main",
+        "x-openclaw-session-id": "session-origin-1",
+        "x-openclaw-message-channel": "telegram",
+        "x-openclaw-current-channel-id": "telegram:chat123",
+      },
+    });
+
+    expectMcpResultText(await readOkMcpPayload(response), "EXECUTED", false);
+    expect(getBeforeToolCallHookInput(0).ctx).toEqual({
+      agentId: "main",
+      config: { session: { mainKey: "main" } },
+      sessionKey: "agent:main:main",
+      sessionId: "session-origin-1",
+      messageProvider: "telegram",
+      channel: "telegram",
+      channelId: "chat123",
+    });
   });
 
   it("forwards the request abort signal to loopback tool execution", async () => {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -11,6 +11,7 @@ import { getRuntimeConfig } from "../config/io.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logDebug, logWarn } from "../logger.js";
+import { buildAgentHookContextOriginFields } from "../plugins/hook-agent-context.js";
 import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
 import {
   clearActiveMcpLoopbackRuntimeByOwnerToken,
@@ -273,6 +274,12 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
                 agentId: scopedTools.agentId,
                 config: cfg,
                 sessionKey: requestContext.sessionKey,
+                ...(requestContext.sessionId ? { sessionId: requestContext.sessionId } : {}),
+                ...buildAgentHookContextOriginFields({
+                  sessionKey: requestContext.sessionKey,
+                  messageProvider: requestContext.messageProvider,
+                  currentChannelId: requestContext.currentChannelId,
+                }),
               },
               signal: requestAbort.signal,
               onToolCallPrepared: cliCaptureHandle

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -684,6 +684,7 @@ describe("POST /tools/invoke", () => {
       port: sharedPort,
       headers: {
         ...gatewayAuthHeaders(),
+        "x-openclaw-message-channel": "telegram",
         "x-openclaw-message-to": "channel:24514",
         "x-openclaw-thread-id": "thread-24514",
       },
@@ -696,6 +697,14 @@ describe("POST /tools/invoke", () => {
       agentTo: "channel:24514",
       agentThreadId: "thread-24514",
     });
+    expect(firstHookCallArg().ctx).toMatchObject({
+      messageProvider: "telegram",
+      channel: "telegram",
+      channelId: "24514",
+    });
+    expect(firstHookCallArg().ctx?.senderId).toBeUndefined();
+    expect(firstHookCallArg().ctx?.chatId).toBeUndefined();
+    expect(firstHookCallArg().ctx?.channelContext).toBeUndefined();
   });
 
   it("propagates owner-only HTTP denies into spawned session inheritance", async () => {

--- a/src/gateway/tools-invoke-shared.ts
+++ b/src/gateway/tools-invoke-shared.ts
@@ -13,6 +13,7 @@ import { resolveMainSessionKey } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import { isTestDefaultMemorySlotDisabled } from "../plugins/config-state.js";
+import { buildAgentHookContextOriginFields } from "../plugins/hook-agent-context.js";
 import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { canonicalizeSessionKeyForAgent } from "./session-store-key.js";
@@ -257,6 +258,12 @@ export async function invokeGatewayTool(params: {
         agentId,
         config: params.cfg,
         sessionKey,
+        ...buildAgentHookContextOriginFields({
+          sessionKey,
+          messageChannel: params.messageChannel,
+          messageProvider: params.messageChannel,
+          messageTo: params.agentTo,
+        }),
         loopDetection: resolveToolLoopDetectionConfig({ cfg: params.cfg, agentId }),
       },
       approvalMode: params.approvalMode,

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -108,11 +108,16 @@ export type {
   NativeHookRelayProvider,
   NativeHookRelayRegistrationHandle,
 } from "../agents/harness/native-hook-relay.js";
+export type { ToolHookRunContext } from "../agents/agent-tools.before-tool-call.js";
 
 export { VERSION as OPENCLAW_VERSION } from "../version.js";
 export { formatErrorMessage } from "../infra/errors.js";
 export { formatApprovalDisplayPath } from "../infra/approval-display-paths.js";
-export { buildAgentHookContextChannelFields } from "../plugins/hook-agent-context.js";
+export {
+  buildAgentHookContextChannelFields,
+  buildAgentHookContextOriginFields,
+} from "../plugins/hook-agent-context.js";
+export { resolveToolLoopDetectionConfig } from "../agents/tool-loop-detection-config.js";
 export { emitAgentEvent, onAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
 export { runAgentCleanupStep } from "../agents/run-cleanup-timeout.js";
 export { log as embeddedAgentLog } from "../agents/embedded-agent-runner/logger.js";

--- a/src/plugins/hook-agent-context.test.ts
+++ b/src/plugins/hook-agent-context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildAgentHookContextChannelFields,
   buildAgentHookContextIdentityFields,
+  buildAgentHookContextOriginFields,
   resolveAgentHookChannelId,
 } from "./hook-agent-context.js";
 
@@ -133,5 +134,65 @@ describe("buildAgentHookContextIdentityFields", () => {
         chatId: "chat-1",
       }),
     ).toEqual({});
+  });
+});
+
+describe("buildAgentHookContextOriginFields", () => {
+  it("infers a canonical channel while preserving native chat identity", () => {
+    expect(
+      buildAgentHookContextOriginFields({
+        sessionKey: "agent:main:main",
+        messageProvider: "discord-voice",
+        currentChannelId: "discord:1472750640760623226",
+        trigger: "user",
+        channelContext: {
+          sender: { id: "user-123" },
+          chat: { id: "native-chat-1" },
+        },
+      }),
+    ).toEqual({
+      channel: "discord",
+      messageProvider: "discord-voice",
+      channelId: "1472750640760623226",
+      chatId: "native-chat-1",
+      senderId: "user-123",
+      channelContext: {
+        sender: { id: "user-123" },
+        chat: { id: "native-chat-1" },
+      },
+    });
+  });
+
+  it("does not infer native chat identity from a routing target", () => {
+    expect(
+      buildAgentHookContextOriginFields({
+        messageChannel: "telegram",
+        messageProvider: "telegram",
+        currentChannelId: "telegram:-100123:topic:7",
+        trigger: "user",
+      }),
+    ).toEqual({
+      channel: "telegram",
+      messageProvider: "telegram",
+      channelId: "-100123:topic:7",
+    });
+  });
+
+  it("keeps routing fields but omits requester identity for system triggers", () => {
+    expect(
+      buildAgentHookContextOriginFields({
+        messageChannel: "telegram",
+        messageProvider: "telegram",
+        currentChannelId: "telegram:-100123",
+        trigger: "cron",
+        senderId: "stale-user",
+        chatId: "stale-chat",
+        channelContext: { sender: { id: "stale-user" }, chat: { id: "stale-chat" } },
+      }),
+    ).toEqual({
+      channel: "telegram",
+      messageProvider: "telegram",
+      channelId: "-100123",
+    });
   });
 });

--- a/src/plugins/hook-agent-context.ts
+++ b/src/plugins/hook-agent-context.ts
@@ -38,18 +38,48 @@ function stripConversationPrefix(
   return text;
 }
 
+function inferNarrowProviderChannel(params: {
+  messageProvider?: string | null;
+  currentChannelId?: string | null;
+  messageTo?: string | null;
+}): string | undefined {
+  const providerKey = normalizeKey(normalizeOptionalString(params.messageProvider));
+  if (!providerKey) {
+    return undefined;
+  }
+  for (const value of [params.currentChannelId, params.messageTo]) {
+    const text = normalizeOptionalString(value);
+    const separatorIndex = text?.indexOf(":") ?? -1;
+    if (!text || separatorIndex <= 0) {
+      continue;
+    }
+    const prefix = normalizeOptionalString(text.slice(0, separatorIndex));
+    const prefixKey = normalizeKey(prefix);
+    if (prefix && providerKey.startsWith(`${prefixKey}-`)) {
+      return prefix;
+    }
+  }
+  return undefined;
+}
+
 function resolveAgentHookChannel(params: {
   messageChannel?: string | null;
   messageProvider?: string | null;
+  currentChannelId?: string | null;
+  messageTo?: string | null;
 }): string | undefined {
   const messageChannel = normalizeOptionalString(params.messageChannel);
   const provider = normalizeOptionalString(params.messageProvider);
+  const inferredProviderChannel = inferNarrowProviderChannel(params);
   if (!messageChannel) {
-    return provider;
+    return inferredProviderChannel ?? provider;
   }
 
   const separatorIndex = messageChannel.indexOf(":");
   if (separatorIndex === -1) {
+    if (inferredProviderChannel && normalizeKey(messageChannel) === normalizeKey(provider)) {
+      return inferredProviderChannel;
+    }
     return messageChannel;
   }
 
@@ -61,7 +91,7 @@ function resolveAgentHookChannel(params: {
     TARGET_PREFIXES.has(normalizeKey(prefix)) ||
     normalizeKey(prefix) === normalizeKey(provider)
   ) {
-    return provider;
+    return inferredProviderChannel ?? provider;
   }
   return prefix;
 }
@@ -76,14 +106,19 @@ export function resolveAgentHookChannelId(params: {
 }): string | undefined {
   const provider = normalizeOptionalString(params.messageProvider);
   const messageChannel = normalizeOptionalString(params.messageChannel);
+  const channel = resolveAgentHookChannel(params);
   const parsed = parseRawSessionConversationRef(params.sessionKey);
   if (parsed?.rawId) {
     return parsed.rawId;
   }
 
   const metadataChannel =
-    stripConversationPrefix(params.currentChannelId ?? undefined, provider, messageChannel) ??
-    stripConversationPrefix(params.messageTo ?? undefined, provider, messageChannel);
+    stripConversationPrefix(
+      params.currentChannelId ?? undefined,
+      provider,
+      messageChannel,
+      channel,
+    ) ?? stripConversationPrefix(params.messageTo ?? undefined, provider, messageChannel, channel);
   if (metadataChannel && normalizeKey(metadataChannel) !== normalizeKey(provider)) {
     return metadataChannel;
   }
@@ -154,5 +189,40 @@ export function buildAgentHookContextIdentityFields(params: {
     ...(senderId ? { senderId } : {}),
     ...(chatId ? { chatId } : {}),
     ...(channelContext ? { channelContext } : {}),
+  };
+}
+
+/** Builds canonical channel and requester fields shared by agent and tool hooks. */
+export function buildAgentHookContextOriginFields(params: {
+  sessionKey?: string | null;
+  messageChannel?: string | null;
+  messageProvider?: string | null;
+  currentChannelId?: string | null;
+  messageTo?: string | null;
+  trigger?: string | null;
+  senderId?: string | null;
+  chatId?: string | null;
+  channelContext?: PluginHookChannelContext;
+}): Pick<
+  PluginHookAgentContext,
+  "channel" | "messageProvider" | "channelId" | "chatId" | "senderId" | "channelContext"
+> {
+  const channelFields = buildAgentHookContextChannelFields({
+    sessionKey: params.sessionKey,
+    messageChannel: params.messageChannel,
+    messageProvider: params.messageProvider,
+    currentChannelId: params.currentChannelId,
+    messageTo: params.messageTo,
+  });
+  return {
+    ...(channelFields.channel ? { channel: channelFields.channel } : {}),
+    ...(channelFields.messageProvider ? { messageProvider: channelFields.messageProvider } : {}),
+    ...(channelFields.channelId ? { channelId: channelFields.channelId } : {}),
+    ...buildAgentHookContextIdentityFields({
+      trigger: params.trigger,
+      senderId: params.senderId ?? params.channelContext?.sender?.id,
+      chatId: params.chatId ?? params.channelContext?.chat?.id,
+      channelContext: params.channelContext,
+    }),
   };
 }

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -609,12 +609,22 @@ export type PluginHookReplyPayloadSendingResult = {
 export type PluginHookToolKind = "code_mode_exec";
 export type PluginHookToolInputKind = "javascript" | "typescript";
 
-export type PluginHookToolContext = {
-  agentId?: string;
-  sessionKey?: string;
-  sessionId?: string;
-  runId?: string;
-  trace?: DiagnosticTraceContext;
+export type PluginHookToolContext = Pick<
+  PluginHookAgentContext,
+  | "agentId"
+  | "sessionKey"
+  | "sessionId"
+  | "runId"
+  | "jobId"
+  | "trace"
+  | "trigger"
+  | "messageProvider"
+  | "channel"
+  | "chatId"
+  | "senderId"
+  | "channelId"
+  | "channelContext"
+> & {
   toolName: string;
   /** Host-authoritative discriminator for tools that intentionally share names. */
   toolKind?: PluginHookToolKind;
@@ -622,7 +632,6 @@ export type PluginHookToolContext = {
   toolInputKind?: PluginHookToolInputKind;
   toolCallId?: string;
   getSessionExtension?: (namespace: string) => PluginJsonValue | undefined;
-  channelId?: string;
 };
 
 export type PluginHookBeforeToolCallEvent = {

--- a/src/plugins/wired-hooks-after-tool-call.e2e.test.ts
+++ b/src/plugins/wired-hooks-after-tool-call.e2e.test.ts
@@ -29,6 +29,19 @@ function createToolHandlerCtx(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  toolHookContext?: {
+    jobId?: string;
+    trigger?: string;
+    messageProvider?: string;
+    channel?: string;
+    chatId?: string;
+    senderId?: string;
+    channelId?: string;
+    channelContext?: {
+      sender?: { id?: string; displayName?: string };
+      chat?: { id?: string };
+    };
+  };
   onBlockReplyFlush?: unknown;
 }) {
   return {
@@ -38,6 +51,7 @@ function createToolHandlerCtx(params: {
       agentId: params.agentId,
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
+      toolHookContext: params.toolHookContext,
       onBlockReplyFlush: params.onBlockReplyFlush,
     },
     hookRunner: hookMocks.runner,
@@ -74,7 +88,15 @@ function getAfterToolCallCall(index = 0) {
           sessionKey?: string;
           sessionId?: string;
           runId?: string;
+          jobId?: string;
+          trigger?: string;
+          messageProvider?: string;
+          channel?: string;
+          chatId?: string;
+          senderId?: string;
           toolCallId?: string;
+          channelId?: string;
+          channelContext?: unknown;
         }
       | undefined,
   };
@@ -126,6 +148,19 @@ describe("after_tool_call hook wiring", () => {
       agentId: "main",
       sessionKey: "test-session",
       sessionId: "test-ephemeral-session",
+      toolHookContext: {
+        jobId: "job-1",
+        trigger: "user",
+        messageProvider: "slack-voice",
+        channel: "slack",
+        chatId: "C123",
+        senderId: "U123",
+        channelId: "C123",
+        channelContext: {
+          sender: { id: "U123", displayName: "Ada" },
+          chat: { id: "C123" },
+        },
+      },
     });
 
     await handleToolExecutionStart(
@@ -166,6 +201,17 @@ describe("after_tool_call hook wiring", () => {
         sessionKey: "test-session",
         sessionId: "test-ephemeral-session",
         runId: "test-run-1",
+        jobId: "job-1",
+        trigger: "user",
+        messageProvider: "slack-voice",
+        channel: "slack",
+        chatId: "C123",
+        senderId: "U123",
+        channelId: "C123",
+        channelContext: {
+          sender: { id: "U123", displayName: "Ada" },
+          chat: { id: "C123" },
+        },
         toolCallId: "wired-hook-call-1",
       },
     });


### PR DESCRIPTION
Related: #50291

## What Problem This Solves

Resolves a problem where tool-policy hooks could not reliably identify the requester and originating channel across OpenClaw runtimes. Channel- and sender-scoped enterprise policies could therefore receive incomplete or inconsistent context, especially for cataloged tools, Copilot, Codex native tools, side questions, and direct gateway invocation paths.

## Why This Change Was Made

OpenClaw now builds one canonical, allowlisted requester-origin snapshot and carries it through before/after tool hooks across embedded, Copilot, Codex, native-relay, and gateway paths. Native chat identity remains distinct from routing targets, non-user triggers omit requester identity, and hook-only channel metadata is kept out of shell subprocess defaults.

## User Impact

Plugin authors and operators can consistently enforce sender-, channel-, job-, and trigger-aware tool policies without runtime-specific gaps. Existing tool execution behavior and subprocess metadata boundaries remain unchanged.

## Evidence

- 18 focused test files / 900 tests passed across core, Copilot, Codex, gateway, native relay, `/btw`, and end-to-end hook paths.
- Core TypeScript check passed.
- Oxfmt, Oxlint, and `git diff --check` passed.
- Plugin SDK API baseline check passed.
- Docs MDX and 5,464-link audit passed with zero broken links.
- Final Codex autoreview: clean, no accepted/actionable findings.
