### PR TITLE
fix(codex): deliver generated images from remote app-server

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -18,6 +18,7 @@ import {
   resetGlobalHookRunner,
 } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CodexAppServerEventProjector,
@@ -741,6 +742,47 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(result.toolMediaUrls).toHaveLength(1);
     expect(result.toolMediaUrls?.[0]).not.toBe(savedPath);
+  });
+
+  it("prefers gateway-managed image media when the typed event arrives first", async () => {
+    await withTempDir("openclaw-codex-media-state-", async (stateDir) => {
+      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+      const projector = await createProjector();
+      const savedPath = "/home/dev-user/.codex/generated_images/session-1/ig_123.png";
+
+      await projector.handleNotification(
+        forCurrentTurn("item/completed", {
+          item: {
+            type: "imageGeneration",
+            id: "ig_123",
+            status: "completed",
+            revisedPrompt: "A tiny blue square",
+            result: tinyPngBase64,
+            savedPath,
+          },
+        }),
+      );
+      await projector.handleNotification(
+        forCurrentTurn("rawResponseItem/completed", {
+          item: {
+            type: "image_generation_call",
+            id: "ig_123",
+            status: "generating",
+            result: tinyPngBase64,
+          },
+        }),
+      );
+
+      const result = projector.buildResult(buildEmptyToolTelemetry());
+      const mediaUrl = result.toolMediaUrls?.[0];
+
+      expect(result.toolMediaUrls).toHaveLength(1);
+      expect(mediaUrl).not.toBe(savedPath);
+      expect(mediaUrl).toContain(`${path.sep}media${path.sep}tool-image-generation${path.sep}`);
+      await expect(fs.readFile(mediaUrl ?? "")).resolves.toEqual(
+        Buffer.from(tinyPngBase64, "base64"),
+      );
+    });
   });
 
   it("preserves distinct raw image-generation items with identical image bytes", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -188,7 +188,6 @@ export class CodexAppServerEventProjector {
   private readonly toolTrajectoryItemsById = new Map<string, CodexThreadItem>();
   private readonly transcriptToolProgressCallIds = new Set<string>();
   private lastNativeToolError: EmbeddedRunAttemptResult["lastToolError"];
-  private readonly nativeGeneratedMediaUrls = new Set<string>();
   private readonly nativeGeneratedMediaItemIds = new Set<string>();
   private readonly nativeGeneratedMediaUrlsByItemId = new Map<string, string>();
   private readonly diagnosticToolStartedAtByItem = new Map<string, number>();
@@ -1028,6 +1027,9 @@ export class CodexAppServerEventProjector {
       this.recordNativeGeneratedMediaUrl({
         itemId,
         mediaUrl: saved.path,
+        // The typed savedPath may belong to a remote app-server host. Always
+        // prefer the copy persisted into this gateway's managed media root.
+        replaceExisting: true,
       });
     } catch (error) {
       embeddedAgentLog.warn("codex app-server raw image generation result save failed", {
@@ -1037,13 +1039,19 @@ export class CodexAppServerEventProjector {
     }
   }
 
-  private recordNativeGeneratedMediaUrl(params: { itemId: string; mediaUrl: string }): void {
-    if (this.nativeGeneratedMediaUrlsByItemId.has(params.itemId)) {
+  private recordNativeGeneratedMediaUrl(params: {
+    itemId: string;
+    mediaUrl: string;
+    replaceExisting?: boolean;
+  }): void {
+    if (
+      this.nativeGeneratedMediaUrlsByItemId.has(params.itemId) &&
+      params.replaceExisting !== true
+    ) {
       this.nativeGeneratedMediaItemIds.add(params.itemId);
       return;
     }
     this.nativeGeneratedMediaUrlsByItemId.set(params.itemId, params.mediaUrl);
-    this.nativeGeneratedMediaUrls.add(params.mediaUrl);
     this.nativeGeneratedMediaItemIds.add(params.itemId);
   }
 
@@ -1052,7 +1060,7 @@ export class CodexAppServerEventProjector {
       toolTelemetry.toolMediaUrls?.map((url) => url.trim()).filter(Boolean) ?? [],
     );
     if ((toolTelemetry.messagingToolSentMediaUrls?.length ?? 0) === 0) {
-      for (const mediaUrl of this.nativeGeneratedMediaUrls) {
+      for (const mediaUrl of this.nativeGeneratedMediaUrlsByItemId.values()) {
         mediaUrls.add(mediaUrl);
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users generating images through a remote Codex app-server could receive `Media failed` even though image generation succeeded. The typed image-completion event can arrive before the raw image response and leave the gateway pointing at the app-server host's local path.

## Why This Change Was Made

The event projector now treats the copy persisted in the gateway's managed media root as authoritative for each generated-image item. That managed path replaces an earlier typed `savedPath`, while a later typed event cannot overwrite it, so delivery no longer depends on notification ordering.

## User Impact

Generated images are attached successfully when Codex runs on a remote host, instead of falling back to a text-only reply with `Media failed`.

## Evidence

- Reproduced the failure with a typed completion carrying a remote `~/.codex/generated_images/...` path followed by the raw image response.
- Added a regression test for that exact typed-first notification order.
- Verified against the current Codex app-server protocol: typed image completion precedes the raw response item and both carry the same item ID.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/event-projector.test.ts` — 98 passed.
- `node_modules/oxfmt/bin/oxfmt --check extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts` — passed.
- `git diff --check` — passed.
- Codex review found no correctness issues.
- AI-assisted: implementation and validation performed with Codex; I reviewed the resulting behavior and understand the change.