### PR TITLE
refactor(gateway): add alias mutation accessor

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -154,6 +154,7 @@ export const migratedSessionAccessorWriteFiles = new Set([
   "src/auto-reply/reply/session-usage.ts",
   "src/commands/tasks.ts",
   "src/config/sessions/cleanup-service.ts",
+  "src/gateway/server-node-events.ts",
   "src/plugins/host-hook-cleanup.ts",
   "src/plugins/host-hook-state.ts",
   "src/tui/embedded-backend.ts",
@@ -555,6 +556,7 @@ export async function main() {
     "src/auto-reply",
     "src/commands",
     "src/config/sessions",
+    "src/gateway",
     "src/plugins",
     "src/tui",
   ]);

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -11,8 +11,10 @@ export * from "./sessions/lifecycle.js";
 export * from "./sessions/paths.js";
 export * from "./sessions/reset.js";
 export {
+  canonicalizeSessionEntryAliases,
   deleteSessionEntryLifecycle,
   resetSessionEntryLifecycle,
+  type CanonicalizeSessionEntryAliasesResult,
   type DeleteSessionEntryLifecycleParams,
   type DeleteSessionEntryLifecycleResult,
   type ResetSessionEntryLifecycleParams,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -11,6 +11,7 @@ import {
   appendTranscriptEvent,
   applySessionEntryLifecycleMutation,
   applySessionPatchProjection,
+  canonicalizeSessionEntryAliases,
   cleanupSessionLifecycleArtifacts,
   createSessionEntryWithTranscript,
   listSessionEntries,
@@ -157,6 +158,67 @@ describe("session accessor file-backed seam", () => {
 
     expect(result).toBeNull();
     expect(fs.existsSync(storePath)).toBe(false);
+  });
+
+  it("canonicalizes alias rows and patches the canonical entry in one accessor write", async () => {
+    const now = Date.now();
+    fs.writeFileSync(transcriptPath, '{"type":"session","id":"sess-fresh"}\n', "utf-8");
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:main": {
+            label: "canonical-stale",
+            sessionFile: transcriptPath,
+            sessionId: "sess-stale",
+            updatedAt: now,
+          },
+          main: {
+            label: "legacy-fresh",
+            sessionFile: transcriptPath,
+            sessionId: "sess-fresh",
+            updatedAt: now + 1,
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+    );
+
+    const result = await canonicalizeSessionEntryAliases({
+      storePath,
+      target: {
+        canonicalKey: "agent:main:main",
+        storeKeys: ["agent:main:main", "main"],
+      },
+      update: (entry) => {
+        if (entry) {
+          entry.sessionId = "mutated-callback-copy";
+        }
+        return {
+          lastChannel: "telegram",
+          updatedAt: now + 2,
+        };
+      },
+    });
+
+    expect(result).toEqual({
+      canonicalKey: "agent:main:main",
+      entry: expect.objectContaining({
+        label: "legacy-fresh",
+        lastChannel: "telegram",
+        sessionId: "sess-fresh",
+        updatedAt: now + 2,
+      }),
+    });
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(persisted["agent:main:main"]).toMatchObject({
+      label: "legacy-fresh",
+      lastChannel: "telegram",
+      sessionId: "sess-fresh",
+      updatedAt: now + 2,
+    });
+    expect(persisted.main).toBeUndefined();
   });
 
   it("purges deleted-agent entries from the current locked store", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -509,6 +509,11 @@ export type DeleteSessionEntryLifecycleParams = {
   target: SessionLifecycleStoreTarget;
 };
 
+export type CanonicalizeSessionEntryAliasesResult = {
+  canonicalKey: string;
+  entry?: SessionEntry;
+};
+
 export { clearPluginOwnedSessionState };
 
 function isStorePathTemplate(store?: string): boolean {
@@ -799,6 +804,87 @@ export async function patchSessionEntryWithKey(
     takeCacheOwnership: options.takeCacheOwnership,
     update,
   });
+}
+
+/**
+ * Promotes the freshest alias row to the canonical key, prunes legacy aliases,
+ * and optionally patches the canonical entry under one accessor operation.
+ */
+export async function canonicalizeSessionEntryAliases(params: {
+  storePath: string;
+  target: SessionLifecycleStoreTarget;
+  update?: (
+    entry: SessionEntry | undefined,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
+}): Promise<CanonicalizeSessionEntryAliasesResult> {
+  return await updateSessionStore(params.storePath, async (store) => {
+    const targetKeys = normalizeTargetStoreKeys(params.target);
+    const freshest = resolveFreshestTargetEntry(store, targetKeys);
+    if (freshest) {
+      const current = store[params.target.canonicalKey];
+      if (!current || (freshest.entry.updatedAt ?? 0) > (current.updatedAt ?? 0)) {
+        store[params.target.canonicalKey] = freshest.entry;
+      }
+    }
+
+    const currentEntry = store[params.target.canonicalKey];
+    const patch = params.update ? await params.update(cloneOptionalEntry(currentEntry)) : null;
+    if (patch) {
+      store[params.target.canonicalKey] = {
+        ...currentEntry,
+        ...patch,
+      } as SessionEntry;
+    }
+
+    for (const key of targetKeys) {
+      if (key !== params.target.canonicalKey) {
+        delete store[key];
+      }
+    }
+    const entry = cloneOptionalEntry(store[params.target.canonicalKey]);
+    return {
+      canonicalKey: params.target.canonicalKey,
+      ...(entry ? { entry } : {}),
+    };
+  });
+}
+
+// Normalizes caller-supplied alias sets while always preserving the canonical key.
+function normalizeTargetStoreKeys(target: SessionLifecycleStoreTarget): string[] {
+  const keys = new Set<string>();
+  const remember = (value: string) => {
+    const trimmed = value.trim();
+    if (trimmed) {
+      keys.add(trimmed);
+    }
+  };
+  remember(target.canonicalKey);
+  for (const key of target.storeKeys) {
+    remember(key);
+  }
+  return [...keys];
+}
+
+// Selects the row that current JSON-store alias migration would promote.
+function resolveFreshestTargetEntry(
+  store: Record<string, SessionEntry>,
+  targetKeys: readonly string[],
+): { key: string; entry: SessionEntry } | undefined {
+  let freshest: { key: string; entry: SessionEntry } | undefined;
+  for (const key of targetKeys) {
+    const entry = store[key];
+    if (!entry) {
+      continue;
+    }
+    if (!freshest || (entry.updatedAt ?? 0) > (freshest.entry.updatedAt ?? 0)) {
+      freshest = { key, entry };
+    }
+  }
+  return freshest;
+}
+
+function cloneOptionalEntry(entry: SessionEntry | undefined): SessionEntry | undefined {
+  return entry ? structuredClone(entry) : undefined;
 }
 
 /**

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -34,6 +34,7 @@ vi.mock("./session-utils.js", () => ({
     store: {},
     entry: undefined,
     canonicalKey: "session-1",
+    storeKeys: ["session-1"],
     legacyKey: undefined,
   })),
 }));
@@ -60,14 +61,17 @@ describe("agent event handler", () => {
       showAlerts: true,
       useIndicator: true,
     });
-    vi.mocked(loadSessionEntry).mockReset().mockReturnValue({
-      cfg: {},
-      storePath: "/tmp/sessions.json",
-      store: {},
-      entry: undefined,
-      canonicalKey: "session-1",
-      legacyKey: undefined,
-    });
+    vi.mocked(loadSessionEntry)
+      .mockReset()
+      .mockReturnValue({
+        cfg: {},
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: undefined,
+        canonicalKey: "session-1",
+        storeKeys: ["session-1"],
+        legacyKey: undefined,
+      });
     vi.mocked(loadGatewaySessionRow).mockReset().mockReturnValue(null);
     persistGatewaySessionLifecycleEventMock.mockReset().mockResolvedValue(undefined);
     resetAgentRunContextForTest();
@@ -1493,6 +1497,7 @@ describe("agent event handler", () => {
       store: {},
       entry: { sessionId: "session-1", verboseLevel: "on", updatedAt: 1_500 },
       canonicalKey: "session-1",
+      storeKeys: ["session-1"],
       legacyKey: undefined,
     });
 
@@ -1531,6 +1536,7 @@ describe("agent event handler", () => {
       store: {},
       entry: { sessionId: "session-1", verboseLevel: "off", updatedAt: 1_500 },
       canonicalKey: "session-1",
+      storeKeys: ["session-1"],
       legacyKey: undefined,
     });
 
@@ -2102,6 +2108,7 @@ describe("agent event handler", () => {
         ],
       },
       canonicalKey: "session-recovery",
+      storeKeys: ["session-recovery"],
       legacyKey: undefined,
     });
     const {
@@ -2170,6 +2177,7 @@ describe("agent event handler", () => {
         ],
       },
       canonicalKey: "session-recovery",
+      storeKeys: ["session-recovery"],
       legacyKey: undefined,
     });
     const markTrackedRunTerminalPersisted = vi.fn();
@@ -2260,6 +2268,7 @@ describe("agent event handler", () => {
         restartRecoveryRuns,
       },
       canonicalKey: "session-recovery",
+      storeKeys: ["session-recovery"],
       legacyKey: undefined,
     });
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
@@ -2330,6 +2339,7 @@ describe("agent event handler", () => {
         restartRecoveryRuns,
       },
       canonicalKey: "session-recovery",
+      storeKeys: ["session-recovery"],
       legacyKey: undefined,
     });
     let currentRow = {
@@ -2419,6 +2429,7 @@ describe("agent event handler", () => {
         status: "running",
       },
       canonicalKey: "session-recovery",
+      storeKeys: ["session-recovery"],
       legacyKey: undefined,
     });
     let currentRow = {
@@ -2541,6 +2552,7 @@ describe("agent event handler", () => {
         ],
       },
       canonicalKey: "session-recovery",
+      storeKeys: ["session-recovery"],
       legacyKey: undefined,
     });
     registerAgentRunContext("shared-run", {
@@ -2633,6 +2645,7 @@ describe("agent event handler", () => {
         ],
       },
       canonicalKey: "session-recovery",
+      storeKeys: ["session-recovery"],
       legacyKey: undefined,
     });
     resetAgentRunContextForTest();

--- a/src/gateway/server-node-events.runtime.ts
+++ b/src/gateway/server-node-events.runtime.ts
@@ -8,7 +8,7 @@ export { sendDurableMessageBatch } from "../channels/message/runtime.js";
 export { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 export { agentCommandFromIngress } from "../commands/agent.js";
 export { getRuntimeConfig } from "../config/io.js";
-export { updateSessionStore } from "../config/sessions.js";
+export { canonicalizeSessionEntryAliases } from "../config/sessions.js";
 export { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 export { requestHeartbeat } from "../infra/heartbeat-wake.js";
 export { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
@@ -22,7 +22,6 @@ export { parseMessageWithAttachments, resolveChatAttachmentMaxBytes } from "./ch
 export { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
 export {
   loadSessionEntry,
-  migrateAndPruneGatewaySessionStoreKey,
   resolveGatewayModelSupportsImages,
   resolveSessionModelRef,
 } from "./session-utils.js";

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -40,6 +40,7 @@ const buildSessionLookup = (
     parentSessionKey: entry.parentSessionKey,
   },
   canonicalKey: sessionKey,
+  storeKeys: [sessionKey],
   legacyKey: undefined,
 });
 
@@ -84,13 +85,7 @@ const runtimeMocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(() => ({ session: { mainKey: "agent:main:main" } })),
   loadOrCreateDeviceIdentity: loadOrCreateDeviceIdentityMock,
   loadSessionEntry: vi.fn((sessionKey: string) => buildSessionLookup(sessionKey)),
-  migrateAndPruneGatewaySessionStoreKey: vi.fn(
-    ({ key, store }: { key: string; store: Record<string, unknown> }) => ({
-      target: { canonicalKey: key, storeKeys: [key] },
-      primaryKey: key,
-      entry: store[key],
-    }),
-  ),
+  canonicalizeSessionEntryAliases: vi.fn(),
   normalizeChannelId: normalizeChannelIdMock,
   normalizeMainKey: vi.fn((key?: string | null) => key?.trim() || "agent:main:main"),
   normalizeRpcAttachmentsToChatAttachments: vi.fn((attachments?: unknown[]) => attachments ?? []),
@@ -135,7 +130,6 @@ const runtimeMocks = vi.hoisted(() => ({
       ? { ...wakeOptions, sessionKey: sessionKey as string }
       : wakeOptions;
   }),
-  updateSessionStore: vi.fn(),
 }));
 
 vi.mock("./server-node-events.runtime.js", () => runtimeMocks);
@@ -159,7 +153,7 @@ const enqueueSystemEventMock = runtimeMocks.enqueueSystemEvent;
 const requestHeartbeatMock = runtimeMocks.requestHeartbeat;
 const loadConfigMock = runtimeMocks.getRuntimeConfig;
 const agentCommandMock = runtimeMocks.agentCommandFromIngress;
-const updateSessionStoreMock = runtimeMocks.updateSessionStore;
+const canonicalizeSessionEntryAliasesMock = runtimeMocks.canonicalizeSessionEntryAliases;
 const loadSessionEntryMock = runtimeMocks.loadSessionEntry;
 const registerApnsRegistrationVi = runtimeMocks.registerApnsRegistration;
 const normalizeChannelIdVi = runtimeMocks.normalizeChannelId;
@@ -773,10 +767,11 @@ describe("node exec events", () => {
 describe("voice transcript events", () => {
   beforeEach(() => {
     agentCommandMock.mockClear();
-    updateSessionStoreMock.mockClear();
+    canonicalizeSessionEntryAliasesMock.mockClear();
     agentCommandMock.mockResolvedValue({ status: "ok" } as never);
-    updateSessionStoreMock.mockImplementation(async (_storePath, update) => {
-      update({});
+    canonicalizeSessionEntryAliasesMock.mockImplementation(async ({ target, update }) => {
+      const entry = update ? await update(undefined) : undefined;
+      return { canonicalKey: target.canonicalKey, entry };
     });
   });
 
@@ -801,7 +796,7 @@ describe("voice transcript events", () => {
 
     expect(agentCommandMock).toHaveBeenCalledTimes(1);
     expect(addChatRun).toHaveBeenCalledTimes(1);
-    expect(updateSessionStoreMock).toHaveBeenCalledTimes(1);
+    expect(canonicalizeSessionEntryAliasesMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not dedupe identical text when source event IDs differ", async () => {
@@ -825,7 +820,7 @@ describe("voice transcript events", () => {
     });
 
     expect(agentCommandMock).toHaveBeenCalledTimes(2);
-    expect(updateSessionStoreMock).toHaveBeenCalledTimes(2);
+    expect(canonicalizeSessionEntryAliasesMock).toHaveBeenCalledTimes(2);
   });
 
   it("forwards transcript with voice provenance", async () => {
@@ -868,7 +863,7 @@ describe("voice transcript events", () => {
     const warn = vi.fn();
     const ctx = buildCtx();
     ctx.logGateway = { warn };
-    updateSessionStoreMock.mockRejectedValueOnce(new Error("disk down"));
+    canonicalizeSessionEntryAliasesMock.mockRejectedValueOnce(new Error("disk down"));
 
     await handleNodeEvent(ctx, "node-v3", {
       event: "voice.transcript",
@@ -900,23 +895,24 @@ describe("voice transcript events", () => {
       }),
     );
 
-    let updatedStore: Record<string, unknown> | undefined;
-    updateSessionStoreMock.mockImplementationOnce(async (_storePath, update) => {
-      const store = {
-        "voice-preserve-session": {
-          sessionId: "sess-preserve",
-          updatedAt: 10,
-          label: "existing label",
-          spawnedBy: "agent:main:parent",
-          parentSessionKey: "agent:main:parent",
-          lastChannel: "discord",
-          lastTo: "thread-1",
-          lastAccountId: "acct-1",
-          lastThreadId: 42,
-        },
+    let updatedEntry: Record<string, unknown> | undefined;
+    canonicalizeSessionEntryAliasesMock.mockImplementationOnce(async ({ target, update }) => {
+      const existing = {
+        sessionId: "sess-preserve",
+        updatedAt: 10,
+        label: "existing label",
+        spawnedBy: "agent:main:parent",
+        parentSessionKey: "agent:main:parent",
+        lastChannel: "discord",
+        lastTo: "thread-1",
+        lastAccountId: "acct-1",
+        lastThreadId: 42,
       };
-      update(store);
-      updatedStore = structuredClone(store);
+      updatedEntry = {
+        ...existing,
+        ...(update ? await update(existing) : {}),
+      };
+      return { canonicalKey: target.canonicalKey, entry: updatedEntry };
     });
 
     await handleNodeEvent(ctx, "node-v4", {
@@ -928,7 +924,7 @@ describe("voice transcript events", () => {
     });
     await Promise.resolve();
 
-    expectFields(updatedStore?.["voice-preserve-session"], {
+    expectFields(updatedEntry, {
       sessionId: "sess-preserve",
       label: "existing label",
       spawnedBy: "agent:main:parent",
@@ -1136,7 +1132,7 @@ describe("agent request events", () => {
   beforeEach(() => {
     agentCommandMock.mockClear();
     parseMessageWithAttachmentsMock.mockReset();
-    updateSessionStoreMock.mockClear();
+    canonicalizeSessionEntryAliasesMock.mockClear();
     loadSessionEntryMock.mockClear();
     normalizeChannelIdVi.mockClear();
     normalizeChannelIdVi.mockImplementation((channel?: string | null) => channel ?? null);
@@ -1147,8 +1143,9 @@ describe("agent request events", () => {
       offloadedRefs: [],
     });
     agentCommandMock.mockResolvedValue({ status: "ok" } as never);
-    updateSessionStoreMock.mockImplementation(async (_storePath, update) => {
-      update({});
+    canonicalizeSessionEntryAliasesMock.mockImplementation(async ({ target, update }) => {
+      const entry = update ? await update(undefined) : undefined;
+      return { canonicalKey: target.canonicalKey, entry };
     });
     loadSessionEntryMock.mockImplementation((sessionKey: string) => buildSessionLookup(sessionKey));
   });

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -31,7 +31,6 @@ import {
   getRuntimeConfig,
   loadOrCreateDeviceIdentity,
   loadSessionEntry,
-  migrateAndPruneGatewaySessionStoreKey,
   normalizeChannelId,
   normalizeMainKey,
   normalizeRpcAttachmentsToChatAttachments,
@@ -45,7 +44,7 @@ import {
   resolveSessionModelRef,
   sanitizeInboundSystemTags,
   sendDurableMessageBatch,
-  updateSessionStore,
+  canonicalizeSessionEntryAliases,
 } from "./server-node-events.runtime.js";
 
 const MAX_EXEC_EVENT_OUTPUT_CHARS = 180;
@@ -255,10 +254,9 @@ function compactNotificationEventText(raw: string) {
 type LoadedSessionEntry = ReturnType<typeof loadSessionEntry>;
 
 async function touchSessionStore(params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
   storePath: LoadedSessionEntry["storePath"];
   canonicalKey: LoadedSessionEntry["canonicalKey"];
+  storeKeys: LoadedSessionEntry["storeKeys"];
   entry: LoadedSessionEntry["entry"];
   sessionId: string;
   now: number;
@@ -267,14 +265,14 @@ async function touchSessionStore(params: {
   if (!storePath) {
     return;
   }
-  await updateSessionStore(storePath, (store) => {
-    const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
-      cfg: params.cfg,
-      key: params.sessionKey,
-      store,
-    });
-    store[primaryKey] = {
-      ...store[primaryKey],
+  await canonicalizeSessionEntryAliases({
+    storePath,
+    target: {
+      canonicalKey: params.canonicalKey,
+      storeKeys: params.storeKeys,
+    },
+    update: (entry) => ({
+      ...entry,
       sessionId: params.sessionId,
       updatedAt: params.now,
       thinkingLevel: params.entry?.thinkingLevel,
@@ -287,25 +285,23 @@ async function touchSessionStore(params: {
       lastTo: params.entry?.lastTo,
       lastAccountId: params.entry?.lastAccountId,
       lastThreadId: params.entry?.lastThreadId,
-    };
+    }),
   });
 }
 
 function queueSessionStoreTouch(params: {
   ctx: NodeEventContext;
-  cfg: OpenClawConfig;
-  sessionKey: string;
   storePath: LoadedSessionEntry["storePath"];
   canonicalKey: LoadedSessionEntry["canonicalKey"];
+  storeKeys: LoadedSessionEntry["storeKeys"];
   entry: LoadedSessionEntry["entry"];
   sessionId: string;
   now: number;
 }) {
   void touchSessionStore({
-    cfg: params.cfg,
-    sessionKey: params.sessionKey,
     storePath: params.storePath,
     canonicalKey: params.canonicalKey,
+    storeKeys: params.storeKeys,
     entry: params.entry,
     sessionId: params.sessionId,
     now: params.now,
@@ -403,7 +399,7 @@ export const handleNodeEvent = async (
       const cfg = getRuntimeConfig();
       const rawMainKey = normalizeMainKey(cfg.session?.mainKey);
       const sessionKey = sessionKeyRaw.length > 0 ? sessionKeyRaw : rawMainKey;
-      const { storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
+      const { storePath, entry, canonicalKey, storeKeys } = loadSessionEntry(sessionKey);
       const now = Date.now();
       const fingerprint = resolveVoiceTranscriptFingerprint(obj, text);
       if (shouldDropDuplicateVoiceTranscript({ sessionKey: canonicalKey, fingerprint, now })) {
@@ -412,10 +408,9 @@ export const handleNodeEvent = async (
       const sessionId = entry?.sessionId ?? randomUUID();
       queueSessionStoreTouch({
         ctx,
-        cfg,
-        sessionKey,
         storePath,
         canonicalKey,
+        storeKeys,
         entry,
         sessionId,
         now,
@@ -479,7 +474,7 @@ export const handleNodeEvent = async (
       const sessionKeyRaw = (link?.sessionKey ?? "").trim();
       const sessionKey = sessionKeyRaw.length > 0 ? sessionKeyRaw : `node-${nodeId}`;
       const cfg = getRuntimeConfig();
-      const { storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
+      const { storePath, entry, canonicalKey, storeKeys } = loadSessionEntry(sessionKey);
 
       let message = (link?.message ?? "").trim();
       const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(
@@ -552,7 +547,14 @@ export const handleNodeEvent = async (
 
       const now = Date.now();
       const sessionId = entry?.sessionId ?? randomUUID();
-      await touchSessionStore({ cfg, sessionKey, storePath, canonicalKey, entry, sessionId, now });
+      await touchSessionStore({
+        storePath,
+        canonicalKey,
+        storeKeys,
+        entry,
+        sessionId,
+        now,
+      });
 
       if (deliverRequested && (!channel || !to)) {
         const entryChannel =

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -62,6 +62,7 @@ const mocks = vi.hoisted(() => {
         store: {},
         storePath: "/tmp/sessions.json",
         canonicalKey: "agent:main:main",
+        storeKeys: ["agent:main:main"],
         legacyKey: undefined,
       }),
     ),
@@ -402,6 +403,7 @@ describe("scheduleRestartSentinelWake", () => {
       store: {},
       storePath: "/tmp/sessions.json",
       canonicalKey: "agent:main:main",
+      storeKeys: ["agent:main:main"],
       legacyKey: undefined,
     });
     mocks.deliveryContextFromSession.mockReset();
@@ -678,6 +680,7 @@ describe("scheduleRestartSentinelWake", () => {
       store: {},
       storePath: "/tmp/sessions.json",
       canonicalKey: "agent:main:main",
+      storeKeys: ["agent:main:main"],
       legacyKey: undefined,
     });
 
@@ -718,6 +721,7 @@ describe("scheduleRestartSentinelWake", () => {
       store: {},
       storePath: "/tmp/sessions.json",
       canonicalKey: "agent:main:main",
+      storeKeys: ["agent:main:main"],
       legacyKey: undefined,
     };
     const replacementEntry: LoadedSessionEntry = {
@@ -731,6 +735,7 @@ describe("scheduleRestartSentinelWake", () => {
       store: {},
       storePath: "/tmp/sessions.json",
       canonicalKey: "agent:main:main",
+      storeKeys: ["agent:main:main"],
       legacyKey: undefined,
     };
     mocks.readRestartSentinel.mockResolvedValue({
@@ -806,6 +811,7 @@ describe("scheduleRestartSentinelWake", () => {
       store: {},
       storePath: "/tmp/sessions.json",
       canonicalKey: "agent:main:main",
+      storeKeys: ["agent:main:main"],
       legacyKey: undefined,
     });
 
@@ -853,6 +859,7 @@ describe("scheduleRestartSentinelWake", () => {
       store: {},
       storePath: "/tmp/sessions.json",
       canonicalKey: "agent:main:group",
+      storeKeys: ["agent:main:group"],
       legacyKey: undefined,
     });
     mocks.resolveOutboundTarget.mockReturnValue({ ok: true as const, to: "telegram:-1001" });
@@ -897,6 +904,7 @@ describe("scheduleRestartSentinelWake", () => {
       store: {},
       storePath: "/tmp/sessions.json",
       canonicalKey: "agent:main:telegram:group:-1003826723328:topic:13757",
+      storeKeys: ["agent:main:telegram:group:-1003826723328:topic:13757"],
       legacyKey: undefined,
     });
     mocks.deliveryContextFromSession.mockReturnValue({
@@ -1512,6 +1520,7 @@ describe("scheduleRestartSentinelWake", () => {
         store: {},
         storePath: "/tmp/sessions.json",
         canonicalKey: "agent:main:matrix:channel:!lowercased:example.org:thread:$thread-event",
+        storeKeys: ["agent:main:matrix:channel:!lowercased:example.org:thread:$thread-event"],
         legacyKey: undefined,
       })
       .mockReturnValueOnce({
@@ -1525,6 +1534,7 @@ describe("scheduleRestartSentinelWake", () => {
         store: {},
         storePath: "/tmp/sessions.json",
         canonicalKey: "agent:main:matrix:channel:!lowercased:example.org",
+        storeKeys: ["agent:main:matrix:channel:!lowercased:example.org"],
         legacyKey: undefined,
       });
     mocks.deliveryContextFromSession

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1021,6 +1021,7 @@ export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; 
     store,
     entry: freshestMatch?.entry,
     canonicalKey: target.canonicalKey,
+    storeKeys: target.storeKeys,
     legacyKey,
   };
 }

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -5,9 +5,8 @@ import { ErrorCodes } from "../../packages/gateway-protocol/src/index.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 
 const hoisted = vi.hoisted(() => ({
-  updateSessionStoreMock: vi.fn(),
+  canonicalizeSessionEntryAliasesMock: vi.fn(),
   listSessionsFromStoreMock: vi.fn(),
-  migrateAndPruneGatewaySessionStoreKeyMock: vi.fn(),
   resolveGatewaySessionStoreTargetWithStoreMock: vi.fn(),
   loadCombinedSessionStoreForGatewayMock: vi.fn(),
   listAgentIdsMock: vi.fn(),
@@ -28,7 +27,7 @@ vi.mock("../config/sessions.js", async () => {
     await vi.importActual<typeof import("../config/sessions.js")>("../config/sessions.js");
   return {
     ...actual,
-    updateSessionStore: hoisted.updateSessionStoreMock,
+    canonicalizeSessionEntryAliases: hoisted.canonicalizeSessionEntryAliasesMock,
   };
 });
 
@@ -37,7 +36,6 @@ vi.mock("./session-utils.js", async () => {
   return {
     ...actual,
     listSessionsFromStore: hoisted.listSessionsFromStoreMock,
-    migrateAndPruneGatewaySessionStoreKey: hoisted.migrateAndPruneGatewaySessionStoreKeyMock,
     resolveGatewaySessionStoreTargetWithStore:
       hoisted.resolveGatewaySessionStoreTargetWithStoreMock,
     loadCombinedSessionStoreForGateway: hoisted.loadCombinedSessionStoreForGatewayMock,
@@ -68,9 +66,8 @@ describe("resolveSessionKeyFromResolveParams", () => {
   };
 
   beforeEach(() => {
-    hoisted.updateSessionStoreMock.mockReset();
+    hoisted.canonicalizeSessionEntryAliasesMock.mockReset();
     hoisted.listSessionsFromStoreMock.mockReset();
-    hoisted.migrateAndPruneGatewaySessionStoreKeyMock.mockReset();
     hoisted.resolveGatewaySessionStoreTargetWithStoreMock.mockReset();
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReset();
     hoisted.listAgentIdsMock.mockReset();
@@ -83,12 +80,11 @@ describe("resolveSessionKeyFromResolveParams", () => {
       storePath,
       store: targetStore,
     }));
-    hoisted.migrateAndPruneGatewaySessionStoreKeyMock.mockReturnValue({ primaryKey: canonicalKey });
-    hoisted.updateSessionStoreMock.mockImplementation(
-      async (_path: string, updater: (store: Record<string, SessionEntry>) => void) => {
-        updater(targetStore);
-      },
-    );
+    hoisted.canonicalizeSessionEntryAliasesMock.mockImplementation(async () => {
+      targetStore[canonicalKey] = targetStore[legacyKey] ?? targetStore[canonicalKey];
+      delete targetStore[legacyKey];
+      return { canonicalKey, entry: targetStore[canonicalKey] };
+    });
   });
 
   it("hides canonical keys that fail the spawnedBy visibility filter", async () => {
@@ -140,10 +136,14 @@ describe("resolveSessionKeyFromResolveParams", () => {
 
     await expectResolveToCanonicalKey({ key: canonicalKey, spawnedBy: "controller-1" });
 
-    expect(hoisted.updateSessionStoreMock).toHaveBeenCalledTimes(1);
-    const updateSessionStoreCall = hoisted.updateSessionStoreMock.mock.calls[0];
-    expect(updateSessionStoreCall?.[0]).toBe(storePath);
-    expect(typeof updateSessionStoreCall?.[1]).toBe("function");
+    expect(hoisted.canonicalizeSessionEntryAliasesMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.canonicalizeSessionEntryAliasesMock).toHaveBeenCalledWith({
+      storePath,
+      target: {
+        canonicalKey,
+        storeKeys: [canonicalKey, legacyKey],
+      },
+    });
   });
 
   it("does not let allowMissing mask a deleted-agent error", async () => {

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -7,7 +7,7 @@ import {
   errorShape,
   type SessionsResolveParams,
 } from "../../packages/gateway-protocol/src/index.js";
-import { updateSessionStore, type SessionEntry } from "../config/sessions.js";
+import { canonicalizeSessionEntryAliases, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSessionIdMatchSelection } from "../sessions/session-id-resolution.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
@@ -15,7 +15,6 @@ import {
   filterAndSortSessionEntries,
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
-  migrateAndPruneGatewaySessionStoreKey,
   resolveDeletedAgentIdFromSessionKey,
   resolveGatewaySessionStoreTargetWithStore,
 } from "./session-utils.js";
@@ -158,11 +157,12 @@ export async function resolveSessionKeyFromResolveParams(params: {
     if (!legacyKey) {
       return noSessionFoundResult({ p, message: `No session found: ${key}` });
     }
-    await updateSessionStore(target.storePath, (s) => {
-      const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({ cfg, key, store: s });
-      if (!s[primaryKey] && s[legacyKey]) {
-        s[primaryKey] = s[legacyKey];
-      }
+    await canonicalizeSessionEntryAliases({
+      storePath: target.storePath,
+      target: {
+        canonicalKey: target.canonicalKey,
+        storeKeys: target.storeKeys,
+      },
     });
     const refreshedTarget = resolveGatewaySessionStoreTargetWithStore({
       cfg,

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -112,6 +112,7 @@ describe("session accessor boundary guard", () => {
         "src/auto-reply/reply/session-usage.ts",
         "src/commands/tasks.ts",
         "src/config/sessions/cleanup-service.ts",
+        "src/gateway/server-node-events.ts",
         "src/plugins/host-hook-cleanup.ts",
         "src/plugins/host-hook-state.ts",
         "src/tui/embedded-backend.ts",


### PR DESCRIPTION
## What Problem This Solves

Path 3 needs gateway session alias mutation to move behind a narrow session accessor before sessions/transcripts can become SQLite-backed. `src/gateway/server-node-events.ts` and `src/gateway/sessions-resolve.ts` still touched gateway session-store alias migration directly, which kept whole-store mutation behavior visible at the gateway boundary.

## Why This Change Was Made

This change gives the gateway one narrow accessor operation for canonicalizing/pruning legacy gateway session aliases while reading or updating the canonical session entry. That keeps the current legacy alias behavior intact while preparing the call sites for the SQLite-era session/transcript store boundary tracked by #88838.

## User Impact

No intended user-facing behavior change. Legacy gateway session aliases still resolve to canonical keys, stale aliases are pruned, and node-originated session touches still update the canonical session entry.

## Evidence

- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/gateway/sessions-resolve.test.ts src/gateway/server-node-events.test.ts test/scripts/check-session-accessor-boundary.test.ts` passed before commit.
- `node scripts/check-session-accessor-boundary.mjs` passed before commit.
- `node scripts/run-oxlint.mjs src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/gateway/server-node-events.ts src/gateway/server-node-events.test.ts src/gateway/sessions-resolve.ts src/gateway/sessions-resolve.test.ts scripts/check-session-accessor-boundary.mjs test/scripts/check-session-accessor-boundary.test.ts` passed before commit.
- Autoreview clean before commit; thermonuclear review clean after commit.
- Rebase/conflict refresh onto `upstream/main` at `9512294e8f6` produced head `98aea3dfcaf2`; post-rebase proof passed: `node scripts/check-session-accessor-boundary.mjs`, focused `node scripts/run-vitest.mjs ...`, and `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`.
- CI attribution follow-up for `check-test-types` on `98aea3dfcaf2`: job `83083755100` failed with TS2741 missing `storeKeys` in `src/gateway/server-chat.agent-events.test.ts` and `src/gateway/server-restart-sentinel.test.ts`. This was PR-attributable mock drift from the new `loadSessionEntry` return shape; fixed in `da371d7ecad` by adding `storeKeys` to those gateway test doubles. Post-fix proof passed: core and extension `scripts/run-tsgo.mjs` test configs, `node scripts/check-session-accessor-boundary.mjs`, focused `node scripts/run-vitest.mjs ...`, and autoreview clean.

## Real behavior proof

**Behavior addressed**

Gateway session alias mutation now goes through the session accessor boundary for the touched Path 3 slice:

- `sessions.resolve` canonicalizes/prunes a legacy gateway alias before returning the canonical key.
- `server-node-events` no longer calls the old whole-store migration helper directly; focused tests cover canonical touch/update behavior through the new accessor.
- The ratchet guard tracks the migrated gateway files so direct whole-store mutation does not come back unnoticed.

**Real environment tested**

- Live local OpenClaw gateway on loopback port `18789`.
- Live proof branch/head: `josh/path3-gateway-alias-mutation-accessor` at `ace76c2f422b9c2ada83bf680b184bb5be1a6a87`.
- Conflict-resolution refresh: rebased/pushed head `98aea3dfcaf2f6c85e7f1e31cd1f1697cabc3017` onto `upstream/main` at `9512294e8f6`; the only manual conflict was additive in `src/config/sessions/session-accessor.test.ts` and kept both current-main abort-target tests and this PR's alias-canonicalization test.
- Saved healthy checkout before/after proof: `3f74951260a23c759e4d1b2525f9826ddd6344e3`.
- `openclaw --version` on proof checkout reported `OpenClaw 2026.6.9 (ace76c2)`.
- `/readyz` and `/healthz` were clean after proof-checkout restart and again after restoring the saved checkout.

**Exact steps or command run after this patch**

1. Confirmed no running tasks and no queued system events before live mutation proof:
   - `pnpm openclaw tasks list --status running --json` -> `count: 0`.
   - `pnpm openclaw gateway call status --json` -> `tasks.byStatus.running: 0`, `queuedSystemEvents: []`.
2. Captured reversible live state under `/tmp/path3-alias-proof.lfPQ7p`, including saved `HEAD`, LaunchAgent plist, config, and sessions-store copy.
3. Detached live checkout to `ace76c2f422b9c2ada83bf680b184bb5be1a6a87`, ran `pnpm build`, then `pnpm openclaw gateway restart`.
4. Verified proof checkout runtime:
   - `pnpm openclaw --version` -> `OpenClaw 2026.6.9 (ace76c2)`.
   - `pnpm openclaw gateway status --deep --require-rpc` -> runtime running, read probe ok, admin-capable.
   - `curl -fsS http://127.0.0.1:18789/readyz && curl -fsS http://127.0.0.1:18789/healthz` -> `ready: true`, `healthz: {"ok":true,"status":"live"}` after startup settled.
5. Seeded synthetic legacy aliases in the live `main` session store:
   - `path3-proof-alias-1782256178`
   - `path3-proof-rpc-1782256215`
6. Exercised gateway alias resolution:
   - `pnpm openclaw gateway call sessions.resolve --json --params '{"key":"path3-proof-alias-1782256178"}'` returned `{"ok":true,"key":"agent:main:path3-proof-alias-1782256178"}`.
   - Direct gateway RPC client call against the running service for `sessions.resolve` with `path3-proof-rpc-1782256215` returned `{"ok":true,"key":"agent:main:path3-proof-rpc-1782256215"}` without the CLI startup migration prelude.
7. Verified persisted state after live calls:
   - Both synthetic legacy keys were absent.
   - Both canonical `agent:main:` keys were present.
   - The canonical entries preserved the seeded `sessionId` and label.
8. Ran focused proof on the proof checkout:
   - `node scripts/run-vitest.mjs src/gateway/sessions-resolve.test.ts src/gateway/server-node-events.test.ts src/config/sessions/session-accessor.test.ts test/scripts/check-session-accessor-boundary.test.ts` -> 8 files passed, 183 tests passed.
   - `node scripts/check-session-accessor-boundary.mjs` -> `session accessor boundary guard passed.`
   - `rg -n "migrateAndPruneGatewaySessionStoreKey|updateSessionStore|loadMutableSessionStore|sessionStore" src/gateway/server-node-events.ts src/gateway/sessions-resolve.ts` -> no matches.
9. Cleaned up only the synthetic proof rows/transcripts; verified no synthetic legacy/canonical keys or transcript files remained.
10. Restored live checkout to `3f74951260a23c759e4d1b2525f9826ddd6344e3`, ran `pnpm build`, then `pnpm openclaw gateway restart`.
11. Verified restored runtime:
    - `pnpm openclaw --version` -> `OpenClaw 2026.6.9 (3f74951)`.
    - `/readyz` -> `ready: true`, no degraded event-loop reasons.
    - `/healthz` -> `{"ok":true,"status":"live"}`.
    - `pnpm openclaw gateway status --deep --require-rpc` -> runtime running, read probe ok, admin-capable.

**Evidence after fix**

- `sessions.resolve` returned canonical keys for synthetic legacy aliases through the live gateway.
- The persisted session store had canonical entries and no legacy aliases after resolution.
- Focused tests covered both changed gateway files plus the new accessor.
- The accessor-boundary ratchet passed and includes the migrated gateway files.
- The direct grep for old whole-store mutation helper names in `src/gateway/server-node-events.ts` and `src/gateway/sessions-resolve.ts` returned no matches.

**Observed result after fix**

Legacy aliases are pruned and resolved to canonical `agent:main:` keys, while canonical session entry data is preserved. The live local service was restored to the saved healthy checkout after proof.

**What was not tested**

- I did not rerun the live gateway proof after the rebase-only conflict refresh; focused tests, boundary guard, and autoreview passed on rebased head `98aea3dfcaf2`.
- I did not exercise a live `node.event` from a paired node-role client. The public `gateway call` helper connects as an operator, and `node.event` is correctly role-gated to node clients. The `server-node-events.ts` mutation behavior is covered here by focused gateway tests plus the accessor-boundary guard.
- I did not run broad CI locally; this slice used focused Path 3 proof only.

Related: #88838



