### PR TITLE
fix: tool progress clears after embedded tool completion

### DIFF
--- a/src/agents/embedded-agent-runner.extensions.test.ts
+++ b/src/agents/embedded-agent-runner.extensions.test.ts
@@ -225,6 +225,51 @@ describe("buildEmbeddedExtensionFactories", () => {
     });
   });
 
+  it("clears live terminal presentation on errored results with no pending entry", async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    const onToolOutcome = vi.fn();
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+      runId: "run-terminal-missing-pending-error",
+      onToolOutcome,
+    });
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+
+    const result = await handlers.get("tool_result")?.(
+      {
+        toolName: "web_fetch",
+        toolCallId: "call-terminal-missing-pending-error",
+        input: { url: "https://example.com" },
+        content: [{ type: "text", text: "boom" }],
+        details: { status: 500 },
+        isError: true,
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "boom" }],
+      details: { status: 500 },
+      isError: true,
+    });
+    expect(onToolOutcome).toHaveBeenLastCalledWith({
+      toolName: "web_fetch",
+      argsHash: "",
+      resultHash: "",
+      terminalPresentation: undefined,
+      presentationOnly: true,
+    });
+  });
+
   it("clears terminal presentation when middleware blocks the result", async () => {
     const registry = createEmptyPluginRegistry();
     registry.agentToolResultMiddlewares.push({

--- a/src/agents/embedded-agent-runner.extensions.test.ts
+++ b/src/agents/embedded-agent-runner.extensions.test.ts
@@ -182,6 +182,49 @@ describe("buildEmbeddedExtensionFactories", () => {
     ).toEqual({ url: "https://approved.example" });
   });
 
+  it("clears live terminal presentation when the pending entry is missing", async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    const onToolOutcome = vi.fn();
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+      runId: "run-terminal-missing-pending",
+      onToolOutcome,
+    });
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+
+    const result = await handlers.get("tool_result")?.(
+      {
+        toolName: "web_fetch",
+        toolCallId: "call-terminal-missing-pending",
+        input: { url: "https://example.com" },
+        content: [{ type: "text", text: "raw output" }],
+        details: { status: 200 },
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "raw output" }],
+      details: { status: 200 },
+    });
+    expect(onToolOutcome).toHaveBeenLastCalledWith({
+      toolName: "web_fetch",
+      argsHash: "",
+      resultHash: "",
+      terminalPresentation: undefined,
+      presentationOnly: true,
+    });
+  });
+
   it("clears terminal presentation when middleware blocks the result", async () => {
     const registry = createEmptyPluginRegistry();
     registry.agentToolResultMiddlewares.push({

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -15,6 +15,7 @@ import { resolveEffectiveCompactionMode } from "../agent-settings.js";
 import {
   finalizeToolTerminalPresentation,
   peekAdjustedParamsForToolCall,
+  type ToolOutcomeObserver,
 } from "../agent-tools.before-tool-call.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
@@ -53,6 +54,7 @@ function snapshotToolSendReceipt(details: unknown): unknown {
 function buildAgentToolResultMiddlewareFactory(
   sessionManager: SessionManager,
   runId?: string,
+  onToolOutcome?: ToolOutcomeObserver,
 ): ExtensionFactory {
   const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" });
   return (agent) => {
@@ -104,6 +106,8 @@ function buildAgentToolResultMiddlewareFactory(
           runId,
           result,
           isError,
+          observer: onToolOutcome,
+          toolName: event.toolName,
         });
       }
       return {
@@ -179,6 +183,7 @@ export function buildEmbeddedExtensionFactories(params: {
   modelId: string;
   model: ProviderRuntimeModel | undefined;
   runId?: string;
+  onToolOutcome?: ToolOutcomeObserver;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveEffectiveCompactionMode(params.cfg) === "safeguard") {
@@ -212,6 +217,12 @@ export function buildEmbeddedExtensionFactories(params: {
   if (pruningFactory) {
     factories.push(pruningFactory);
   }
-  factories.push(buildAgentToolResultMiddlewareFactory(params.sessionManager, params.runId));
+  factories.push(
+    buildAgentToolResultMiddlewareFactory(
+      params.sessionManager,
+      params.runId,
+      params.onToolOutcome,
+    ),
+  );
   return factories;
 }

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -101,6 +101,10 @@ function buildAgentToolResultMiddlewareFactory(
         isAcceptedSessionSpawn &&
         (event.isError === true || inputHadErrorStatus || isToolResultError(result));
       if (eventToolCallId) {
+        // Pass the live observer + toolName so a missing pending entry still emits a
+        // presentation-only clear (retiring stale channel progress), matching the Codex
+        // dynamic-tool path. When a pending entry exists, finalize keeps using its own
+        // recorded observer/tool, so these only act as the no-pending fallback.
         finalizeToolTerminalPresentation({
           toolCallId: eventToolCallId,
           runId,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2729,6 +2729,7 @@ export async function runEmbeddedAttempt(
         modelId: params.modelId,
         model: params.model,
         runId: params.runId,
+        onToolOutcome: params.onToolOutcome,
       });
       const resourceLoader = createEmbeddedAgentResourceLoader({
         cwd: effectiveCwd,


### PR DESCRIPTION
Closes #96207

## What Problem This Solves

Fixes an issue where users could see tool-call progress messages remain visible after a successful embedded tool completed when the terminal-presentation pending entry was no longer available.

## Why This Change Was Made

The embedded runner now threads its live tool outcome observer into tool-result finalization, matching the direct Codex dynamic-tool path. That lets successful completions still emit a presentation-only clear when the pending lookup misses, without changing the existing pending-entry terminal-presentation rendering path.

Duplicate-work check: issue #96207 is open and no superseding PR was found. Related open PR #92517 is Discord-only and failed/error-progress-specific; it does not touch the embedded-runner success path fixed here.

AI-assisted: yes. This change and PR text were prepared with Codex assistance and reviewed with the repo-local autoreview gate.

## User Impact

Channel-visible tool progress should retire after the final tool result is processed instead of leaving a stale progress card or draft state behind.

## Evidence

Real behavior proof:

- Behavior addressed: successful embedded tool completions can leave stale tool progress visible when the pending terminal-presentation entry is missing.
- Real environment tested: local OpenClaw source checkout on branch `codex/96207-tool-progress-retire`, Node v24.16.0.
- Exact steps or command run after this patch: `/Users/harjothk/.nvm/versions/node/v24.16.0/bin/node scripts/run-vitest.mjs src/agents/embedded-agent-runner.extensions.test.ts`.
- Evidence after fix: the focused test file passed with 10 tests, including the new regression that a successful `tool_result` with no pending entry emits `presentationOnly: true` and `terminalPresentation: undefined` through `onToolOutcome`.
- Observed result after fix: the embedded result bridge sends the clear notification needed for live channel progress retirement even when finalization cannot recover the pending terminal-presentation record.
- What was not tested: no live Telegram or Discord run was executed locally; broader repository checks are left to GitHub CI.

Additional validation:

- `git diff --check`
- `/Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 .agents/skills/autoreview/scripts/autoreview --mode local`
- `PATH=/Users/harjothk/.nvm/versions/node/v24.16.0/bin:$PATH /Users/harjothk/.nvm/versions/node/v24.16.0/bin/node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-runner/extensions.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner.extensions.test.ts`
