### PR TITLE
fix(exec): gate versioned inline interpreters

### DIFF
--- a/src/infra/command-analysis/inline-eval.test.ts
+++ b/src/infra/command-analysis/inline-eval.test.ts
@@ -70,6 +70,7 @@ describe("exec inline eval detection", () => {
     expect(detectInterpreterInlineEvalArgv(["node", "script.js"])).toBeNull();
     expect(detectInterpreterInlineEvalArgv(["php", "-F", "filter.php"])).toBeNull();
     expect(detectInterpreterInlineEvalArgv(["Rscript", "script.R"])).toBeNull();
+    expect(detectInterpreterInlineEvalArgv(["r2", "-e", "bin.cache=true", "program"])).toBeNull();
     expect(detectInterpreterInlineEvalArgv(["awk", "-f", "script.awk", "data.csv"])).toBeNull();
     expect(detectInterpreterInlineEvalArgv(["find", ".", "-name", "*.ts"])).toBeNull();
     expect(detectInterpreterInlineEvalArgv(["xargs", "-0"])).toBeNull();
@@ -90,6 +91,7 @@ describe("exec inline eval detection", () => {
     expect(isInterpreterLikeAllowlistPattern("pypy3.10")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("**/node")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("Rscript")).toBe(true);
+    expect(isInterpreterLikeAllowlistPattern("r2")).toBe(false);
     expect(isInterpreterLikeAllowlistPattern("/usr/bin/awk")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("**/gawk")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("/usr/bin/mawk")).toBe(true);

--- a/src/infra/command-analysis/inline-eval.test.ts
+++ b/src/infra/command-analysis/inline-eval.test.ts
@@ -18,8 +18,15 @@ function expectInlineEvalDescription(hit: InterpreterInlineEvalHit | null, expec
 describe("exec inline eval detection", () => {
   it.each([
     { argv: ["python3", "-c", "print('hi')"], expected: "python3 -c" },
+    { argv: ["python3.13", "-c", "print('hi')"], expected: "python3.13 -c" },
+    { argv: ["/usr/bin/pypy3.10", "-c", "print('hi')"], expected: "pypy3.10 -c" },
     { argv: ["/usr/bin/node", "--eval", "console.log('hi')"], expected: "node --eval" },
     { argv: ["perl", "-E", "say 1"], expected: "perl -e" },
+    { argv: ["php", "-B", "system('id');"], expected: "php -B" },
+    { argv: ["php", "-E", "system('id');"], expected: "php -E" },
+    { argv: ["php", "-R", "system('id');"], expected: "php -R" },
+    { argv: ["Rscript", "-e", "system('id')"], expected: "rscript -e" },
+    { argv: ["R", "--exec", "system('id')"], expected: "r --exec" },
     { argv: ["osascript", "-e", "beep"], expected: "osascript -e" },
     { argv: ["awk", "BEGIN { print 1 }"], expected: "awk inline program" },
     { argv: ["gawk", "-F", ",", "{print $1}", "data.csv"], expected: "gawk inline program" },
@@ -60,7 +67,10 @@ describe("exec inline eval detection", () => {
 
   it("ignores normal script execution", () => {
     expect(detectInterpreterInlineEvalArgv(["python3", "script.py"])).toBeNull();
+    expect(detectInterpreterInlineEvalArgv(["python3.13", "script.py"])).toBeNull();
     expect(detectInterpreterInlineEvalArgv(["node", "script.js"])).toBeNull();
+    expect(detectInterpreterInlineEvalArgv(["php", "-F", "filter.php"])).toBeNull();
+    expect(detectInterpreterInlineEvalArgv(["Rscript", "script.R"])).toBeNull();
     expect(detectInterpreterInlineEvalArgv(["awk", "-f", "script.awk", "data.csv"])).toBeNull();
     expect(detectInterpreterInlineEvalArgv(["find", ".", "-name", "*.ts"])).toBeNull();
     expect(detectInterpreterInlineEvalArgv(["xargs", "-0"])).toBeNull();
@@ -76,7 +86,11 @@ describe("exec inline eval detection", () => {
 
   it("matches interpreter-like allowlist patterns", () => {
     expect(isInterpreterLikeAllowlistPattern("/usr/bin/python3")).toBe(true);
+    expect(isInterpreterLikeAllowlistPattern("/usr/bin/python3.13")).toBe(true);
+    expect(isInterpreterLikeAllowlistPattern("python3.*")).toBe(true);
+    expect(isInterpreterLikeAllowlistPattern("pypy3.10")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("**/node")).toBe(true);
+    expect(isInterpreterLikeAllowlistPattern("Rscript")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("/usr/bin/awk")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("**/gawk")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("/usr/bin/mawk")).toBe(true);

--- a/src/infra/command-analysis/inline-eval.test.ts
+++ b/src/infra/command-analysis/inline-eval.test.ts
@@ -26,7 +26,6 @@ describe("exec inline eval detection", () => {
     { argv: ["php", "-E", "system('id');"], expected: "php -E" },
     { argv: ["php", "-R", "system('id');"], expected: "php -R" },
     { argv: ["Rscript", "-e", "system('id')"], expected: "rscript -e" },
-    { argv: ["R", "--exec", "system('id')"], expected: "r --exec" },
     { argv: ["osascript", "-e", "beep"], expected: "osascript -e" },
     { argv: ["awk", "BEGIN { print 1 }"], expected: "awk inline program" },
     { argv: ["gawk", "-F", ",", "{print $1}", "data.csv"], expected: "gawk inline program" },

--- a/src/infra/command-analysis/inline-eval.ts
+++ b/src/infra/command-analysis/inline-eval.ts
@@ -58,7 +58,7 @@ const FLAG_INTERPRETER_INLINE_EVAL_SPECS: readonly InterpreterFlagSpec[] = [
       ["-R", "-R"],
     ]),
   },
-  { names: ["r", "rscript"], exactFlags: new Set(["-e", "--exec"]) },
+  { names: ["r", "rscript"], exactFlags: new Set(["-e"]) },
   { names: ["lua"], exactFlags: new Set(["-e"]) },
   { names: ["osascript"], exactFlags: new Set(["-e"]) },
   {

--- a/src/infra/command-analysis/inline-eval.ts
+++ b/src/infra/command-analysis/inline-eval.ts
@@ -34,6 +34,8 @@ type PositionalInterpreterSpec = {
   flag: "<command>" | "<program>";
 };
 
+const VERSION_SUFFIX_PATTERN = /-?\d+(?:\.\d+)*$/;
+
 const FLAG_INTERPRETER_INLINE_EVAL_SPECS: readonly InterpreterFlagSpec[] = [
   { names: ["python", "python2", "python3", "pypy", "pypy3"], exactFlags: new Set(["-c"]) },
   {
@@ -47,7 +49,16 @@ const FLAG_INTERPRETER_INLINE_EVAL_SPECS: readonly InterpreterFlagSpec[] = [
   },
   { names: ["ruby"], exactFlags: new Set(["-e"]) },
   { names: ["perl"], exactFlags: new Set(["-e", "-E"]) },
-  { names: ["php"], exactFlags: new Set(["-r"]) },
+  {
+    names: ["php"],
+    exactFlags: new Set(["-r"]),
+    rawExactFlags: new Map([
+      ["-B", "-B"],
+      ["-E", "-E"],
+      ["-R", "-R"],
+    ]),
+  },
+  { names: ["r", "rscript"], exactFlags: new Set(["-e", "--exec"]) },
   { names: ["lua"], exactFlags: new Set(["-e"]) },
   { names: ["osascript"], exactFlags: new Set(["-e"]) },
   {
@@ -154,10 +165,26 @@ const INTERPRETER_ALLOWLIST_NAMES = new Set(
   ),
 );
 
+function stripInterpreterVersionSuffix(value: string): string {
+  const stripped = value.replace(VERSION_SUFFIX_PATTERN, "");
+  return stripped.length > 0 ? stripped : value;
+}
+
+function interpreterNameVariants(value: string): readonly string[] {
+  const stripped = stripInterpreterVersionSuffix(value);
+  return stripped === value ? [value] : [value, stripped];
+}
+
+function specNamesInclude(names: readonly string[], normalizedExecutable: string): boolean {
+  return interpreterNameVariants(normalizedExecutable).some((candidate) =>
+    names.includes(candidate),
+  );
+}
+
 function findInterpreterSpec(executable: string): InterpreterFlagSpec | null {
   const normalized = normalizeExecutableToken(executable);
   for (const spec of FLAG_INTERPRETER_INLINE_EVAL_SPECS) {
-    if (spec.names.includes(normalized)) {
+    if (specNamesInclude(spec.names, normalized)) {
       return spec;
     }
   }
@@ -167,7 +194,7 @@ function findInterpreterSpec(executable: string): InterpreterFlagSpec | null {
 function findPositionalInterpreterSpec(executable: string): PositionalInterpreterSpec | null {
   const normalized = normalizeExecutableToken(executable);
   for (const spec of POSITIONAL_INTERPRETER_INLINE_EVAL_SPECS) {
-    if (spec.names.includes(normalized)) {
+    if (specNamesInclude(spec.names, normalized)) {
       return spec;
     }
   }
@@ -299,11 +326,17 @@ export function isInterpreterLikeAllowlistPattern(pattern: string | undefined | 
     return false;
   }
   const normalized = normalizeExecutableToken(trimmed);
-  if (INTERPRETER_ALLOWLIST_NAMES.has(normalized)) {
+  if (
+    interpreterNameVariants(normalized).some((candidate) =>
+      INTERPRETER_ALLOWLIST_NAMES.has(candidate),
+    )
+  ) {
     return true;
   }
   const basename = trimmed.replace(/\\/g, "/").split("/").pop() ?? trimmed;
   const withoutExe = basename.endsWith(".exe") ? basename.slice(0, -4) : basename;
-  const strippedWildcards = withoutExe.replace(/[*?[\]{}()]/g, "");
-  return INTERPRETER_ALLOWLIST_NAMES.has(strippedWildcards);
+  const strippedWildcards = withoutExe.replace(/[*?[\]{}()]/g, "").replace(/[.-]+$/, "");
+  return interpreterNameVariants(strippedWildcards).some((candidate) =>
+    INTERPRETER_ALLOWLIST_NAMES.has(candidate),
+  );
 }

--- a/src/infra/command-analysis/inline-eval.ts
+++ b/src/infra/command-analysis/inline-eval.ts
@@ -172,7 +172,9 @@ function stripInterpreterVersionSuffix(value: string): string {
 
 function interpreterNameVariants(value: string): readonly string[] {
   const stripped = stripInterpreterVersionSuffix(value);
-  return stripped === value ? [value] : [value, stripped];
+  // Do not synthesize one-letter interpreter names: commands like r2 can use
+  // their own eval flags and must not be mistaken for R inline execution.
+  return stripped === value || stripped.length < 2 ? [value] : [value, stripped];
 }
 
 function specNamesInclude(names: readonly string[], normalizedExecutable: string): boolean {

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -1601,6 +1601,10 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         command: ["python3", "-c", "print('hi')"],
         expected: "python3 -c requires explicit approval in strictInlineEval mode",
       },
+      {
+        command: ["python3.13", "-c", "print('hi')"],
+        expected: "python3.13 -c requires explicit approval in strictInlineEval mode",
+      },
     ] as const;
     setRuntimeConfigSnapshot({
       tools: {
@@ -1672,7 +1676,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           const tempDir = createFixtureDir("openclaw-inline-eval-bin-");
           const executablePath = createTempExecutable({
             dir: tempDir,
-            name: "python3",
+            name: "python3.13",
           });
           const { runCommand, sendInvokeResult } = await runSystemInvoke({
             preferMacAppExecHost: false,


### PR DESCRIPTION
## Summary

Tightens strict inline-eval approval detection so additional interpreter forms cannot bypass the existing approval guard when interpreter executables are otherwise allowlisted.

## Changes

- Matches version-suffixed Python and PyPy executable names when resolving inline-eval interpreter specs.
- Adds PHP inline-code flags `-B`, `-E`, and `-R`, and R/Rscript `-e` to the detector table.
- Applies the same interpreter matching to allowlist-pattern recognition so allow-always persistence remains suppressed for these interpreter targets.
- Adds focused detector and handler-level regression coverage.
- Removes the unsupported `R --exec` detector case after upstream/R CLI contract review.

## Validation

- `node scripts/run-vitest.mjs src/infra/command-analysis/inline-eval.test.ts src/node-host/invoke-system-run.test.ts` — 2 files, 65 tests passed.
- `./node_modules/.bin/oxfmt --check --threads=1 src/infra/command-analysis/inline-eval.ts src/infra/command-analysis/inline-eval.test.ts src/node-host/invoke-system-run.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.
- Terminal production-handler proof: direct `handleSystemRunInvoke` run with `strictInlineEval=true` showed `python3.13 -c` denied before execution (`runCommandCalls: 0`, `SYSTEM_RUN_DENIED: approval required ... strictInlineEval mode`) and an explicit `allow-always` approval ran once without persisting an allowlist entry (`persistedAllowlistEntries: 0`).

## Notes

Security-sensitive report details are tracked privately. `CHANGELOG.md` was not updated.
