### PR TITLE
refactor: guard reply session initialization

### DIFF
--- a/src/auto-reply/reply/body.ts
+++ b/src/auto-reply/reply/body.ts
@@ -2,6 +2,7 @@
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { setAbortMemory } from "./abort-primitives.js";
+import type { ReplySessionEntryHandle } from "./session-entry-handle.js";
 
 const sessionAccessorRuntimeLoader = createLazyImportLoader(
   () => import("../../config/sessions/session-accessor.js"),
@@ -16,6 +17,7 @@ export async function applySessionHints(params: {
   baseBody: string;
   abortedLastRun: boolean;
   sessionEntry?: SessionEntry;
+  sessionEntryHandle?: ReplySessionEntryHandle;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
   storePath?: string;
@@ -28,11 +30,13 @@ export async function applySessionHints(params: {
   if (abortedHint) {
     prefixedBodyBase = `${abortedHint}\n\n${prefixedBodyBase}`;
     // The abort hint is one-shot; clear durable state once it is added.
-    if (params.sessionEntry && params.sessionStore && params.sessionKey) {
+    const sessionEntry = params.sessionEntryHandle?.getCurrent() ?? params.sessionEntry;
+    if (sessionEntry && params.sessionEntryHandle && params.sessionKey) {
       const updatedAt = Date.now();
-      params.sessionEntry.abortedLastRun = false;
-      params.sessionEntry.updatedAt = updatedAt;
-      params.sessionStore[params.sessionKey] = params.sessionEntry;
+      params.sessionEntryHandle.patchCurrent({
+        abortedLastRun: false,
+        updatedAt,
+      });
       if (params.storePath) {
         const sessionKey = params.sessionKey;
         const { patchSessionEntry } = await loadSessionAccessorRuntime();
@@ -45,7 +49,27 @@ export async function applySessionHints(params: {
             abortedLastRun: false,
             updatedAt,
           }),
-          { fallbackEntry: params.sessionEntry },
+          { fallbackEntry: params.sessionEntryHandle.getCurrent() ?? sessionEntry },
+        );
+      }
+    } else if (sessionEntry && params.sessionStore && params.sessionKey) {
+      const updatedAt = Date.now();
+      sessionEntry.abortedLastRun = false;
+      sessionEntry.updatedAt = updatedAt;
+      params.sessionStore[params.sessionKey] = sessionEntry;
+      if (params.storePath) {
+        const sessionKey = params.sessionKey;
+        const { patchSessionEntry } = await loadSessionAccessorRuntime();
+        await patchSessionEntry(
+          {
+            storePath: params.storePath,
+            sessionKey,
+          },
+          () => ({
+            abortedLastRun: false,
+            updatedAt,
+          }),
+          { fallbackEntry: sessionEntry },
         );
       }
     } else if (params.abortKey) {

--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -19,6 +19,7 @@ import { isFormattedGoalContinuationPrompt } from "./commands-goal.js";
 import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import type { CommandContext } from "./commands-types.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
+import { createReplySessionEntryHandle } from "./session-entry-handle.js";
 import type { SessionInitResult } from "./session.js";
 
 const COMPLETE_REPLY_CONFIG_SYMBOL = Symbol.for("openclaw.reply.complete-config");
@@ -284,6 +285,11 @@ export function initFastReplySessionState(params: {
       : {}),
   };
   sessionStore[sessionKey] = sessionEntry;
+  const sessionEntryHandle = createReplySessionEntryHandle({
+    sessionEntry,
+    sessionKey,
+    sessionStore,
+  });
   const sessionCtx: TemplateContext = {
     ...ctx,
     SessionKey: sessionKey,
@@ -294,6 +300,7 @@ export function initFastReplySessionState(params: {
   return {
     sessionCtx,
     sessionEntry,
+    sessionEntryHandle,
     sessionStore,
     sessionKey,
     sessionId,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -100,6 +100,7 @@ import {
 import { resolveReplyToMode } from "./reply-threading.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
+import type { ReplySessionEntryHandle } from "./session-entry-handle.js";
 import { resolveBareSessionResetPromptState } from "./session-reset-prompt.js";
 import { resolveBareResetBootstrapFileAccess } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents } from "./session-system-events.js";
@@ -444,6 +445,7 @@ type RunPreparedReplyParams = {
   resetTriggered: boolean;
   systemSent: boolean;
   sessionEntry?: SessionEntry;
+  sessionEntryHandle?: ReplySessionEntryHandle;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey: string;
   sessionId?: string;
@@ -491,6 +493,7 @@ export async function runPreparedReply(
     sessionId,
     storePath,
     workspaceDir,
+    sessionEntryHandle,
     sessionStore,
   } = params;
   const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
@@ -770,11 +773,13 @@ export async function runPreparedReply(
     baseBody: effectiveBaseBody,
     abortedLastRun,
     sessionEntry,
+    sessionEntryHandle,
     sessionStore,
     sessionKey,
     storePath,
     abortKey: command.abortKey,
   });
+  sessionEntry = sessionEntryHandle?.getCurrent() ?? sessionEntry;
   const isGroupSession = sessionEntry?.chatType === "group" || sessionEntry?.chatType === "channel";
   const isMainSession = !isGroupSession && sessionKey === normalizeMainKey(sessionCfg?.mainKey);
   // Extract first-token think hint from the user body BEFORE prepending system events.
@@ -854,6 +859,7 @@ export async function runPreparedReply(
           const { ensureSkillSnapshot } = await loadSessionUpdatesRuntime();
           return await ensureSkillSnapshot({
             sessionEntry,
+            sessionEntryHandle,
             sessionStore,
             sessionKey,
             storePath,
@@ -865,6 +871,9 @@ export async function runPreparedReply(
           });
         });
   sessionEntry = skillResult.sessionEntry ?? sessionEntry;
+  if (sessionEntry) {
+    sessionEntryHandle?.replaceCurrent(sessionEntry);
+  }
   const skillsSnapshot = skillResult.skillsSnapshot;
   let {
     prefixedCommandBody,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -494,6 +494,7 @@ export async function getReplyFromConfig(
   const {
     sessionCtx,
     sessionEntry,
+    sessionEntryHandle,
     previousSessionEntry,
     sessionStore,
     sessionKey,
@@ -534,6 +535,7 @@ export async function getReplyFromConfig(
         sessionEntry.pendingFinalDeliveryAttemptCount = undefined;
         sessionEntry.pendingFinalDeliveryLastError = undefined;
         sessionEntry.pendingFinalDeliveryContext = undefined;
+        sessionEntryHandle.replaceCurrent(sessionEntry);
         if (sessionKey && sessionStore) {
           sessionStore[sessionKey] = sessionEntry;
         }
@@ -570,6 +572,7 @@ export async function getReplyFromConfig(
       sessionCtx,
       ctx: finalized,
       sessionEntry,
+      sessionEntryHandle,
       sessionStore,
       sessionKey,
       storePath,
@@ -741,6 +744,7 @@ export async function getReplyFromConfig(
         resetTriggered,
         systemSent,
         sessionEntry,
+        sessionEntryHandle,
         sessionStore,
         sessionKey,
         sessionId,

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -184,7 +184,7 @@ export function resolveLastToRaw(params: {
 export function maybeRetireLegacyMainDeliveryRoute(params: {
   sessionCfg: { dmScope?: string } | undefined;
   sessionKey: string;
-  sessionStore: Record<string, SessionEntry>;
+  legacyMain?: SessionEntry;
   agentId: string;
   mainKey: string;
   isGroup: boolean;
@@ -201,7 +201,7 @@ export function maybeRetireLegacyMainDeliveryRoute(params: {
   if (params.sessionKey === canonicalMainSessionKey) {
     return undefined;
   }
-  const legacyMain = params.sessionStore[canonicalMainSessionKey];
+  const legacyMain = params.legacyMain;
   if (!legacyMain) {
     return undefined;
   }

--- a/src/auto-reply/reply/session-entry-handle.ts
+++ b/src/auto-reply/reply/session-entry-handle.ts
@@ -1,0 +1,42 @@
+// Narrow mutable handle for the active reply session entry.
+import type { SessionEntry } from "../../config/sessions.js";
+
+export type ReplySessionEntryHandle = {
+  get(sessionKey: string): SessionEntry | undefined;
+  getCurrent(): SessionEntry | undefined;
+  patchCurrent(patch: Partial<SessionEntry>): SessionEntry | undefined;
+  replaceCurrent(entry: SessionEntry): void;
+  set(sessionKey: string, entry: SessionEntry): void;
+  toCompatSessionStore(): Record<string, SessionEntry>;
+};
+
+export function createReplySessionEntryHandle(params: {
+  sessionEntry: SessionEntry;
+  sessionKey: string;
+  sessionStore?: Record<string, SessionEntry>;
+}): ReplySessionEntryHandle {
+  const entries = params.sessionStore ?? { [params.sessionKey]: params.sessionEntry };
+  let currentEntry = params.sessionEntry;
+  entries[params.sessionKey] = currentEntry;
+
+  return {
+    get: (sessionKey) => entries[sessionKey],
+    getCurrent: () => currentEntry,
+    patchCurrent: (patch) => {
+      currentEntry = { ...currentEntry, ...patch };
+      entries[params.sessionKey] = currentEntry;
+      return currentEntry;
+    },
+    replaceCurrent: (entry) => {
+      currentEntry = entry;
+      entries[params.sessionKey] = entry;
+    },
+    set: (sessionKey, entry) => {
+      entries[sessionKey] = entry;
+      if (sessionKey === params.sessionKey) {
+        currentEntry = entry;
+      }
+    },
+    toCompatSessionStore: () => entries,
+  };
+}

--- a/src/auto-reply/reply/session-parent-fork-prepare.ts
+++ b/src/auto-reply/reply/session-parent-fork-prepare.ts
@@ -1,0 +1,62 @@
+// Prepares parent-context fork metadata for guarded reply session initialization.
+import path from "node:path";
+import type { SessionEntry } from "../../config/sessions.js";
+import { forkSessionFromParent, resolveParentForkDecision } from "./session-fork.js";
+
+export async function prepareReplySessionParentFork(params: {
+  agentId: string;
+  alreadyForked: boolean;
+  parentSessionKey?: string;
+  readEntry: (sessionKey: string) => SessionEntry | undefined;
+  sessionEntry: SessionEntry;
+  sessionKey: string;
+  storePath: string;
+  warn: (message: string) => void;
+}): Promise<SessionEntry> {
+  if (
+    !params.parentSessionKey ||
+    params.parentSessionKey === params.sessionKey ||
+    params.alreadyForked
+  ) {
+    return params.sessionEntry;
+  }
+  const parentEntry = params.readEntry(params.parentSessionKey);
+  if (!parentEntry?.sessionId) {
+    return params.sessionEntry;
+  }
+  const decision = await resolveParentForkDecision({
+    parentEntry,
+    agentId: params.agentId,
+    storePath: params.storePath,
+  });
+  if (decision.status === "skip") {
+    // The parent branch is too large to inherit usefully. Start fresh and
+    // mark as handled so the thread does not retry this decision every turn.
+    params.warn(
+      `skipping parent fork (parent too large): parentKey=${params.parentSessionKey} → sessionKey=${params.sessionKey} ` +
+        `parentTokens=${decision.parentTokens} maxTokens=${decision.maxTokens}`,
+    );
+    return { ...params.sessionEntry, forkedFromParent: true };
+  }
+  const fork = await forkSessionFromParent({
+    parentEntry,
+    agentId: params.agentId,
+    sessionsDir: path.dirname(params.storePath),
+  });
+  if (!fork) {
+    return params.sessionEntry;
+  }
+  params.warn(
+    `forking from parent session: parentKey=${params.parentSessionKey} → sessionKey=${params.sessionKey} ` +
+      `parentTokens=${decision.parentTokens ?? "unknown"}`,
+  );
+  params.warn(`forked session created: file=${fork.sessionFile}`);
+  return {
+    ...params.sessionEntry,
+    sessionId: fork.sessionId,
+    sessionFile: fork.sessionFile,
+    forkedFromParent: true,
+    totalTokens: undefined,
+    totalTokensFresh: false,
+  };
+}

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -18,6 +18,7 @@ import {
   type ModelAliasIndex,
   type ModelDirectiveSelection,
 } from "./model-selection-directive.js";
+import type { ReplySessionEntryHandle } from "./session-entry-handle.js";
 
 /** Result of applying a reset-message model override. */
 type ResetModelResult = {
@@ -109,12 +110,14 @@ function buildSelectionFromExplicit(params: {
 function applySelectionToSession(params: {
   selection: ModelDirectiveSelection;
   sessionEntry?: SessionEntry;
+  sessionEntryHandle?: ReplySessionEntryHandle;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
   storePath?: string;
 }) {
-  const { selection, sessionEntry, sessionStore, sessionKey, storePath } = params;
-  if (!sessionEntry || !sessionStore || !sessionKey) {
+  const { selection, sessionEntryHandle, sessionStore, sessionKey, storePath } = params;
+  const sessionEntry = sessionEntryHandle?.getCurrent() ?? params.sessionEntry;
+  if (!sessionEntry || !sessionKey) {
     return;
   }
   const { updated } = applyModelOverrideToSessionEntry({
@@ -124,7 +127,11 @@ function applySelectionToSession(params: {
   if (!updated) {
     return;
   }
-  sessionStore[sessionKey] = sessionEntry;
+  if (sessionEntryHandle) {
+    sessionEntryHandle.replaceCurrent(sessionEntry);
+  } else if (sessionStore) {
+    sessionStore[sessionKey] = sessionEntry;
+  }
   if (storePath) {
     void import("../../config/sessions/session-accessor.js")
       .then(({ replaceSessionEntry }) =>
@@ -146,6 +153,7 @@ export async function applyResetModelOverride(params: {
   sessionCtx: TemplateContext;
   ctx: MsgContext;
   sessionEntry?: SessionEntry;
+  sessionEntryHandle?: ReplySessionEntryHandle;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
   storePath?: string;
@@ -248,6 +256,7 @@ export async function applyResetModelOverride(params: {
   applySelectionToSession({
     selection,
     sessionEntry: params.sessionEntry,
+    sessionEntryHandle: params.sessionEntryHandle,
     sessionStore: params.sessionStore,
     sessionKey: params.sessionKey,
     storePath: params.storePath,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -3,10 +3,7 @@ import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { canExecRequestNode } from "../../agents/exec-defaults.js";
-import {
-  resolveCompactionSessionFile,
-  type SessionEntry,
-} from "../../config/sessions.js";
+import { resolveCompactionSessionFile, type SessionEntry } from "../../config/sessions.js";
 import { patchSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -19,24 +16,29 @@ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { getRemoteSkillEligibility } from "../../skills/runtime/remote.js";
 import { resolveReusableWorkspaceSkillSnapshot } from "../../skills/runtime/session-snapshot.js";
+import type { ReplySessionEntryHandle } from "./session-entry-handle.js";
 import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./session-hooks.js";
 export { drainFormattedSystemEvents } from "./session-system-events.js";
 export { resetResolvedSkillsCacheForTests } from "../../skills/runtime/session-snapshot.js";
 
 async function persistSessionEntryUpdate(params: {
+  sessionEntryHandle?: ReplySessionEntryHandle;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
   storePath?: string;
   nextEntry: SessionEntry;
 }) {
-  if (!params.sessionStore || !params.sessionKey) {
+  if (params.sessionEntryHandle) {
+    params.sessionEntryHandle.replaceCurrent(params.nextEntry);
+  } else if (params.sessionStore && params.sessionKey) {
+    params.sessionStore[params.sessionKey] = {
+      ...params.sessionStore[params.sessionKey],
+      ...params.nextEntry,
+    };
+  } else {
     return;
   }
-  params.sessionStore[params.sessionKey] = {
-    ...params.sessionStore[params.sessionKey],
-    ...params.nextEntry,
-  };
-  if (!params.storePath) {
+  if (!params.storePath || !params.sessionKey) {
     return;
   }
   await upsertSessionEntry(
@@ -116,6 +118,7 @@ function resolveNonNegativeTokenCount(value: number | undefined): number | undef
 /** Ensures a session entry has the reusable skill snapshot needed for reply runs. */
 export async function ensureSkillSnapshot(params: {
   sessionEntry?: SessionEntry;
+  sessionEntryHandle?: ReplySessionEntryHandle;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
   storePath?: string;
@@ -142,6 +145,7 @@ export async function ensureSkillSnapshot(params: {
 
   const {
     sessionEntry,
+    sessionEntryHandle,
     sessionStore,
     sessionKey,
     storePath,
@@ -152,7 +156,7 @@ export async function ensureSkillSnapshot(params: {
     skillFilter,
   } = params;
 
-  let nextEntry = sessionEntry;
+  let nextEntry = sessionEntryHandle?.getCurrent() ?? sessionEntry;
   let systemSent = sessionEntry?.systemSent ?? false;
   const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
   const remoteEligibility = getRemoteSkillEligibility({
@@ -176,9 +180,10 @@ export async function ensureSkillSnapshot(params: {
   const initialSnapshotState = resolveSnapshot(existingSnapshot);
   const shouldRefreshSnapshot = initialSnapshotState.shouldRefresh;
 
-  if (isFirstTurnInSession && sessionStore && sessionKey) {
+  if (isFirstTurnInSession && (sessionEntryHandle || sessionStore) && sessionKey) {
     const current = nextEntry ??
-      sessionStore[sessionKey] ?? {
+      sessionEntryHandle?.get(sessionKey) ??
+      sessionStore?.[sessionKey] ?? {
         sessionId: sessionId ?? crypto.randomUUID(),
         updatedAt: Date.now(),
       };
@@ -193,7 +198,13 @@ export async function ensureSkillSnapshot(params: {
       systemSent: true,
       skillsSnapshot: skillSnapshot,
     };
-    await persistSessionEntryUpdate({ sessionStore, sessionKey, storePath, nextEntry });
+    await persistSessionEntryUpdate({
+      sessionEntryHandle,
+      sessionStore,
+      sessionKey,
+      storePath,
+      nextEntry,
+    });
     systemSent = true;
   }
 
@@ -208,7 +219,7 @@ export async function ensureSkillSnapshot(params: {
         : resolveSnapshot(nextEntry.skillsSnapshot).snapshot;
   if (
     skillsSnapshot &&
-    sessionStore &&
+    (sessionEntryHandle || sessionStore) &&
     sessionKey &&
     !isFirstTurnInSession &&
     (!nextEntry?.skillsSnapshot || shouldRefreshSnapshot)
@@ -223,7 +234,13 @@ export async function ensureSkillSnapshot(params: {
       updatedAt: Date.now(),
       skillsSnapshot,
     };
-    await persistSessionEntryUpdate({ sessionStore, sessionKey, storePath, nextEntry });
+    await persistSessionEntryUpdate({
+      sessionEntryHandle,
+      sessionStore,
+      sessionKey,
+      storePath,
+      nextEntry,
+    });
   }
 
   return { sessionEntry: nextEntry, skillsSnapshot, systemSent };

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1,7 +1,5 @@
 // Manages reply session records, labels, ids, and route persistence.
 import crypto from "node:crypto";
-import fsp from "node:fs/promises";
-import path from "node:path";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -55,7 +53,11 @@ import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenanc
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookSessionEndReason } from "../../plugins/hook-types.js";
-import { isAcpSessionKey, normalizeMainKey } from "../../routing/session-key.js";
+import {
+  buildAgentMainSessionKey,
+  isAcpSessionKey,
+  normalizeMainKey,
+} from "../../routing/session-key.js";
 import { isInterSessionInputProvenance } from "../../sessions/input-provenance.js";
 import {
   normalizeDeliveryChannelRoute,
@@ -75,8 +77,12 @@ import {
   resolveLastChannelRaw,
   resolveLastToRaw,
 } from "./session-delivery.js";
-import { forkSessionFromParent, resolveParentForkDecision } from "./session-fork.js";
+import {
+  createReplySessionEntryHandle,
+  type ReplySessionEntryHandle,
+} from "./session-entry-handle.js";
 import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./session-hooks.js";
+import { prepareReplySessionParentFork } from "./session-parent-fork-prepare.js";
 import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 
 const log = createSubsystemLogger("session-init");
@@ -156,6 +162,7 @@ export type SessionInitResult = {
   sessionCtx: TemplateContext;
   sessionEntry: SessionEntry;
   previousSessionEntry?: SessionEntry;
+  sessionEntryHandle: ReplySessionEntryHandle;
   sessionStore: Record<string, SessionEntry>;
   sessionKey: string;
   sessionId: string;
@@ -403,7 +410,6 @@ async function initSessionStateAttempt(
     storePath,
     sessionKey,
   });
-  const sessionEntries = initializationSnapshot.sessionEntries;
   if (ingressTimingEnabled) {
     log.info(
       `session-init store-load agent=${agentId} session=${sessionCtxForState.SessionKey ?? "(no-session)"} ` +
@@ -413,7 +419,12 @@ async function initSessionStateAttempt(
   const retiredLegacyMainDelivery = maybeRetireLegacyMainDeliveryRoute({
     sessionCfg,
     sessionKey,
-    sessionStore: sessionEntries,
+    legacyMain: initializationSnapshot.readEntry(
+      buildAgentMainSessionKey({
+        agentId,
+        mainKey,
+      }),
+    ),
     agentId,
     mainKey,
     isGroup,
@@ -762,51 +773,6 @@ async function initSessionStateAttempt(
   }
   const parentSessionKey = normalizeOptionalString(ctx.ParentSessionKey);
   const alreadyForked = sessionEntry.forkedFromParent === true;
-  let inheritedParentContext = false;
-  let preparedForkSessionFile: string | undefined;
-  if (parentSessionKey && parentSessionKey !== sessionKey && !alreadyForked) {
-    const parentEntry = sessionEntries[parentSessionKey];
-    if (parentEntry?.sessionId) {
-      const decision = await resolveParentForkDecision({
-        parentEntry,
-        agentId,
-        storePath,
-      });
-      if (decision.status === "skip") {
-        // The parent branch is too large to inherit usefully. Start fresh and
-        // mark as handled so the thread does not retry this decision every turn.
-        log.warn(
-          `skipping parent fork (parent too large): parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-            `parentTokens=${decision.parentTokens} maxTokens=${decision.maxTokens}`,
-        );
-        sessionEntry = { ...sessionEntry, forkedFromParent: true };
-      } else {
-        const fork = await forkSessionFromParent({
-          parentEntry,
-          agentId,
-          sessionsDir: path.dirname(storePath),
-        });
-        if (fork) {
-          log.warn(
-            `forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-              `parentTokens=${decision.parentTokens ?? "unknown"}`,
-          );
-          sessionId = fork.sessionId;
-          preparedForkSessionFile = fork.sessionFile;
-          sessionEntry = {
-            ...sessionEntry,
-            sessionId: fork.sessionId,
-            sessionFile: fork.sessionFile,
-            forkedFromParent: true,
-            totalTokens: undefined,
-            totalTokensFresh: false,
-          };
-          inheritedParentContext = true;
-          log.warn(`forked session created: file=${fork.sessionFile}`);
-        }
-      }
-    }
-  }
   const threadIdFromSessionKey = parseSessionThreadInfoFast(
     sessionCtxForState.SessionKey ?? sessionKey,
   ).threadId;
@@ -839,8 +805,8 @@ async function initSessionStateAttempt(
     sessionEntry.status = undefined;
     // New empty transcripts have a known zero context. Parent-context forks
     // inherit history without a fresh count, so keep those explicitly unknown.
-    sessionEntry.totalTokens = inheritedParentContext ? undefined : 0;
-    sessionEntry.totalTokensFresh = !inheritedParentContext;
+    sessionEntry.totalTokens = 0;
+    sessionEntry.totalTokensFresh = true;
     sessionEntry.inputTokens = undefined;
     sessionEntry.outputTokens = undefined;
     sessionEntry.estimatedCostUsd = undefined;
@@ -873,6 +839,17 @@ async function initSessionStateAttempt(
         entry: sessionEntry,
         warning,
       }),
+    prepareSessionEntry: async ({ readEntry, sessionEntry: entryToCommit }) =>
+      await prepareReplySessionParentFork({
+        agentId,
+        alreadyForked,
+        parentSessionKey,
+        readEntry,
+        sessionEntry: entryToCommit,
+        sessionKey,
+        storePath,
+        warn: (message) => log.warn(message),
+      }),
     previousEntry: previousSessionEntry,
     retiredEntry: retiredLegacyMainDelivery,
     sessionEntry,
@@ -880,20 +857,19 @@ async function initSessionStateAttempt(
     storePath,
   });
   if (!committed.ok) {
-    if (preparedForkSessionFile) {
-      try {
-        await fsp.unlink(preparedForkSessionFile);
-      } catch {
-        // Best-effort cleanup; retry below will choose the current session state.
-      }
-    }
     if (!staleSnapshotRetried) {
       return await initSessionStateAttempt(params, true);
     }
     throw new Error(`reply session initialization conflicted for ${sessionKey}`);
   }
   sessionEntry = committed.sessionEntry;
+  sessionId = sessionEntry.sessionId;
   const sessionStore = committed.sessionStoreView;
+  const sessionEntryHandle = createReplySessionEntryHandle({
+    sessionEntry,
+    sessionKey,
+    sessionStore,
+  });
   const previousSessionTranscript = committed.previousSessionTranscript;
 
   if (previousSessionEntry?.sessionId) {
@@ -990,6 +966,7 @@ async function initSessionStateAttempt(
   return {
     sessionCtx,
     sessionEntry,
+    sessionEntryHandle,
     previousSessionEntry,
     sessionStore,
     sessionKey,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1,5 +1,6 @@
 // Manages reply session records, labels, ids, and route persistence.
 import crypto from "node:crypto";
+import fsp from "node:fs/promises";
 import path from "node:path";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -30,11 +31,12 @@ import {
   resolveThreadFlag,
   type SessionFreshness,
 } from "../../config/sessions/reset.js";
-import { persistSessionRolloverLifecycle } from "../../config/sessions/session-accessor.js";
-import { resolveAndPersistSessionFile } from "../../config/sessions/session-file.js";
+import {
+  commitReplySessionInitialization,
+  loadReplySessionInitializationSnapshot,
+} from "../../config/sessions/session-accessor.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
-import { loadSessionStore } from "../../config/sessions/store.js";
 import { parseSessionThreadInfoFast } from "../../config/sessions/thread-info.js";
 import {
   DEFAULT_RESET_TRIGGERS,
@@ -73,7 +75,7 @@ import {
   resolveLastChannelRaw,
   resolveLastToRaw,
 } from "./session-delivery.js";
-import { forkSessionEntryFromParent } from "./session-fork.js";
+import { forkSessionFromParent, resolveParentForkDecision } from "./session-fork.js";
 import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./session-hooks.js";
 import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 
@@ -169,6 +171,14 @@ export type SessionInitResult = {
   triggerBodyNormalized: string;
 };
 
+export type InitSessionStateParams = {
+  cfg: OpenClawConfig;
+  commandAuthorized: boolean;
+  ctx: MsgContext;
+  requestedSessionId?: string;
+  resumeRequestedSession?: boolean;
+};
+
 function resolveSessionConversationBindingContext(
   cfg: OpenClawConfig,
   ctx: MsgContext,
@@ -227,13 +237,15 @@ function resolveBoundConversationSessionKey(params: {
   return binding.targetSessionKey;
 }
 
-export async function initSessionState(params: {
-  ctx: MsgContext;
-  cfg: OpenClawConfig;
-  commandAuthorized: boolean;
-  requestedSessionId?: string;
-  resumeRequestedSession?: boolean;
-}): Promise<SessionInitResult> {
+/** Initializes or reuses the reply session state for one inbound turn. */
+export async function initSessionState(params: InitSessionStateParams): Promise<SessionInitResult> {
+  return await initSessionStateAttempt(params, false);
+}
+
+async function initSessionStateAttempt(
+  params: InitSessionStateParams,
+  staleSnapshotRetried: boolean,
+): Promise<SessionInitResult> {
   const { ctx, cfg, commandAuthorized } = params;
   // Heartbeat, cron-event, and exec-event runs should NEVER trigger session
   // resets or conversation binding retargeting. These are automated system
@@ -278,21 +290,6 @@ export async function initSessionState(params: {
   const storePath = resolveStorePath(sessionCfg?.store, { agentId });
   const ingressTimingEnabled = process.env.OPENCLAW_DEBUG_INGRESS_TIMING === "1";
 
-  // CRITICAL: Skip cache to ensure fresh data when resolving session identity.
-  // Stale cache (especially with multiple gateway processes or on Windows where
-  // mtime granularity may miss rapid writes) can cause incorrect sessionId
-  // generation, leading to orphaned transcript files. See #17971.
-  const sessionStoreLoadStartMs = ingressTimingEnabled ? Date.now() : 0;
-  const sessionStore: Record<string, SessionEntry> = loadSessionStore(storePath, {
-    skipCache: true,
-    clone: false,
-  });
-  if (ingressTimingEnabled) {
-    log.info(
-      `session-init store-load agent=${agentId} session=${sessionCtxForState.SessionKey ?? "(no-session)"} ` +
-        `elapsedMs=${Date.now() - sessionStoreLoadStartMs} path=${storePath}`,
-    );
-  }
   let sessionEntry: SessionEntry;
 
   let sessionId: string | undefined;
@@ -392,24 +389,37 @@ export async function initSessionState(params: {
   // Canonicalize so the written key matches what all read paths produce.
   // resolveSessionKey uses DEFAULT_AGENT_ID="main"; the configured default
   // agent may differ, causing key mismatch and orphaned sessions (#29683).
-  const sessionKey: string | undefined = canonicalizeMainSessionAlias({
+  const sessionKey: string = canonicalizeMainSessionAlias({
     cfg,
     agentId,
     sessionKey: resolveSessionKey(sessionScope, sessionCtxForState, mainKey),
   });
+  // CRITICAL: Skip cache to ensure fresh data when resolving session identity.
+  // Stale cache (especially with multiple gateway processes or on Windows where
+  // mtime granularity may miss rapid writes) can cause incorrect sessionId
+  // generation, leading to orphaned transcript files. See #17971.
+  const sessionStoreLoadStartMs = ingressTimingEnabled ? Date.now() : 0;
+  const initializationSnapshot = loadReplySessionInitializationSnapshot({
+    storePath,
+    sessionKey,
+  });
+  const sessionEntries = initializationSnapshot.sessionEntries;
+  if (ingressTimingEnabled) {
+    log.info(
+      `session-init store-load agent=${agentId} session=${sessionCtxForState.SessionKey ?? "(no-session)"} ` +
+        `elapsedMs=${Date.now() - sessionStoreLoadStartMs} path=${storePath}`,
+    );
+  }
   const retiredLegacyMainDelivery = maybeRetireLegacyMainDeliveryRoute({
     sessionCfg,
     sessionKey,
-    sessionStore,
+    sessionStore: sessionEntries,
     agentId,
     mainKey,
     isGroup,
     ctx,
   });
-  if (retiredLegacyMainDelivery) {
-    sessionStore[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
-  }
-  const entry = sessionStore[sessionKey];
+  const entry = initializationSnapshot.currentEntry;
   const now = Date.now();
   const isThread = resolveThreadFlag({
     sessionKey,
@@ -753,39 +763,48 @@ export async function initSessionState(params: {
   const parentSessionKey = normalizeOptionalString(ctx.ParentSessionKey);
   const alreadyForked = sessionEntry.forkedFromParent === true;
   let inheritedParentContext = false;
+  let preparedForkSessionFile: string | undefined;
   if (parentSessionKey && parentSessionKey !== sessionKey && !alreadyForked) {
-    const forked = await forkSessionEntryFromParent({
-      parentSessionKey,
-      sessionKey,
-      storePath,
-      fallbackEntry: sessionEntry,
-      agentId,
-      sessionsDir: path.dirname(storePath),
-      decisionSkipPatch: () => ({ ...sessionEntry, forkedFromParent: true }),
-      patch: () => ({
-        ...sessionEntry,
-        totalTokens: undefined,
-        totalTokensFresh: false,
-      }),
-    });
-    if (forked.status === "skipped" && forked.decision?.status === "skip") {
-      // The parent branch is too large to inherit usefully. Start fresh and
-      // mark as handled so the thread does not retry this decision every turn.
-      log.warn(
-        `skipping parent fork (parent too large): parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-          `parentTokens=${forked.decision.parentTokens} maxTokens=${forked.decision.maxTokens}`,
-      );
-      sessionEntry = forked.sessionEntry;
-    } else if (forked.status === "forked") {
-      log.warn(
-        `forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-          `parentTokens=${forked.decision.parentTokens ?? "unknown"}`,
-      );
-      sessionId = forked.fork.sessionId;
-      sessionEntry = forked.sessionEntry;
-      sessionEntry.forkedFromParent = true;
-      inheritedParentContext = true;
-      log.warn(`forked session created: file=${forked.fork.sessionFile}`);
+    const parentEntry = sessionEntries[parentSessionKey];
+    if (parentEntry?.sessionId) {
+      const decision = await resolveParentForkDecision({
+        parentEntry,
+        agentId,
+        storePath,
+      });
+      if (decision.status === "skip") {
+        // The parent branch is too large to inherit usefully. Start fresh and
+        // mark as handled so the thread does not retry this decision every turn.
+        log.warn(
+          `skipping parent fork (parent too large): parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
+            `parentTokens=${decision.parentTokens} maxTokens=${decision.maxTokens}`,
+        );
+        sessionEntry = { ...sessionEntry, forkedFromParent: true };
+      } else {
+        const fork = await forkSessionFromParent({
+          parentEntry,
+          agentId,
+          sessionsDir: path.dirname(storePath),
+        });
+        if (fork) {
+          log.warn(
+            `forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
+              `parentTokens=${decision.parentTokens ?? "unknown"}`,
+          );
+          sessionId = fork.sessionId;
+          preparedForkSessionFile = fork.sessionFile;
+          sessionEntry = {
+            ...sessionEntry,
+            sessionId: fork.sessionId,
+            sessionFile: fork.sessionFile,
+            forkedFromParent: true,
+            totalTokens: undefined,
+            totalTokensFresh: false,
+          };
+          inheritedParentContext = true;
+          log.warn(`forked session created: file=${fork.sessionFile}`);
+        }
+      }
     }
   }
   const threadIdFromSessionKey = parseSessionThreadInfoFast(
@@ -798,19 +817,6 @@ export async function initSessionState(params: {
         ctx.MessageThreadId ?? threadIdFromSessionKey,
       )
     : undefined;
-  const resolvedSessionFile = await resolveAndPersistSessionFile({
-    sessionId: sessionEntry.sessionId,
-    sessionKey,
-    sessionStore,
-    storePath,
-    sessionEntry,
-    agentId,
-    sessionsDir: path.dirname(storePath),
-    fallbackSessionFile,
-    activeSessionKey: sessionKey,
-    maintenanceConfig,
-  });
-  sessionEntry = resolvedSessionFile.sessionEntry;
   if (isNewSession) {
     sessionEntry.compactionCount = 0;
     sessionEntry.memoryFlushCompactionCount = undefined;
@@ -847,13 +853,12 @@ export async function initSessionState(params: {
     // snapshot through /new; the next turn must rebuild the visible skill list.
     sessionEntry.skillsSnapshot = undefined;
   }
-  // Preserve per-session overrides while resetting compaction state on /new.
-  sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
-
   // Archive old transcript so it doesn't accumulate on disk (#14869).
-  const rollover = await persistSessionRolloverLifecycle({
+  const committed = await commitReplySessionInitialization({
     activeSessionKey: sessionKey,
     agentId,
+    expectedRevision: initializationSnapshot.revision,
+    fallbackSessionFile,
     maintenanceConfig,
     onArchiveError: (error, sourcePath) => {
       log.warn(
@@ -874,9 +879,22 @@ export async function initSessionState(params: {
     sessionKey,
     storePath,
   });
-  sessionEntry = rollover.sessionEntry;
-  sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
-  const previousSessionTranscript = rollover.previousSessionTranscript;
+  if (!committed.ok) {
+    if (preparedForkSessionFile) {
+      try {
+        await fsp.unlink(preparedForkSessionFile);
+      } catch {
+        // Best-effort cleanup; retry below will choose the current session state.
+      }
+    }
+    if (!staleSnapshotRetried) {
+      return await initSessionStateAttempt(params, true);
+    }
+    throw new Error(`reply session initialization conflicted for ${sessionKey}`);
+  }
+  sessionEntry = committed.sessionEntry;
+  const sessionStore = committed.sessionStoreView;
+  const previousSessionTranscript = committed.previousSessionTranscript;
 
   if (previousSessionEntry?.sessionId) {
     await retireSessionMcpRuntime({

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -328,7 +328,7 @@ describe("session accessor file-backed seam", () => {
       expectedRevision: snapshot.revision,
       previousEntry: snapshot.currentEntry,
       sessionEntry: {
-        ...(snapshot.currentEntry ?? {}),
+        ...snapshot.currentEntry,
         sessionFile: snapshot.currentEntry?.sessionFile,
         sessionId: "next-rotation",
         updatedAt: 20,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -309,6 +309,41 @@ describe("session accessor file-backed seam", () => {
     expect(fs.existsSync(previousTranscript)).toBe(false);
   });
 
+  it("does not reuse the previous transcript file when initialization rotates session ids", async () => {
+    const sessionKey = "agent:main:main";
+    const previousTranscript = path.join(tempDir, "previous-rotation.jsonl");
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionFile: previousTranscript,
+        sessionId: "previous-rotation",
+        updatedAt: 10,
+      },
+    );
+
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+    const committed = await commitReplySessionInitialization({
+      activeSessionKey: sessionKey,
+      agentId: "main",
+      expectedRevision: snapshot.revision,
+      previousEntry: snapshot.currentEntry,
+      sessionEntry: {
+        ...(snapshot.currentEntry ?? {}),
+        sessionFile: snapshot.currentEntry?.sessionFile,
+        sessionId: "next-rotation",
+        updatedAt: 20,
+      },
+      sessionKey,
+      storePath,
+    });
+
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) {
+      throw new Error("expected reply session initialization to commit");
+    }
+    expect(path.basename(committed.sessionEntry.sessionFile ?? "")).toBe("next-rotation.jsonl");
+  });
+
   it("rejects stale reply session initialization snapshots without writing", async () => {
     const sessionKey = "agent:main:main";
     await upsertSessionEntry(

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -12,8 +12,10 @@ import {
   applySessionEntryLifecycleMutation,
   applySessionPatchProjection,
   cleanupSessionLifecycleArtifacts,
+  commitReplySessionInitialization,
   createSessionEntryWithTranscript,
   listSessionEntries,
+  loadReplySessionInitializationSnapshot,
   loadSessionEntry,
   markSessionAbortTarget,
   patchSessionEntry,
@@ -256,6 +258,94 @@ describe("session accessor file-backed seam", () => {
     });
     expect(loadSessionEntry(scope)).toBeUndefined();
     expect(loadSessionStore(storePath, { skipCache: true })[scope.sessionKey]).toBeUndefined();
+  });
+
+  it("commits reply session initialization with a guarded snapshot", async () => {
+    const sessionKey = "agent:main:main";
+    const previousTranscript = path.join(tempDir, "previous.jsonl");
+    fs.writeFileSync(
+      previousTranscript,
+      `${JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "previous-session",
+        timestamp: new Date().toISOString(),
+      })}\n`,
+      "utf8",
+    );
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionFile: previousTranscript,
+        sessionId: "previous-session",
+        updatedAt: 10,
+      },
+    );
+
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+    const committed = await commitReplySessionInitialization({
+      activeSessionKey: sessionKey,
+      agentId: "main",
+      expectedRevision: snapshot.revision,
+      previousEntry: snapshot.currentEntry,
+      sessionEntry: {
+        sessionId: "next-session",
+        updatedAt: 20,
+      },
+      sessionKey,
+      storePath,
+    });
+
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) {
+      throw new Error("expected reply session initialization to commit");
+    }
+    expect(path.basename(committed.sessionEntry.sessionFile ?? "")).toBe("next-session.jsonl");
+    expect(committed.sessionStoreView[sessionKey]).toMatchObject({
+      sessionId: "next-session",
+      sessionFile: committed.sessionEntry.sessionFile,
+    });
+    expect(committed.previousSessionTranscript.transcriptArchived).toBe(true);
+    expect(fs.existsSync(previousTranscript)).toBe(false);
+  });
+
+  it("rejects stale reply session initialization snapshots without writing", async () => {
+    const sessionKey = "agent:main:main";
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "first-session",
+        updatedAt: 10,
+      },
+    );
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "second-session",
+        updatedAt: 20,
+      },
+    );
+
+    const committed = await commitReplySessionInitialization({
+      activeSessionKey: sessionKey,
+      agentId: "main",
+      expectedRevision: snapshot.revision,
+      sessionEntry: {
+        sessionId: "stale-session",
+        updatedAt: 30,
+      },
+      sessionKey,
+      storePath,
+    });
+
+    expect(committed).toMatchObject({
+      ok: false,
+      reason: "stale-snapshot",
+    });
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      sessionId: "second-session",
+    });
   });
 
   it("can borrow cached entry objects for read-only hot paths", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -376,8 +376,14 @@ export type SessionLifecycleRolloverResult = {
 
 export type ReplySessionInitializationSnapshot = {
   currentEntry?: SessionEntry;
+  readEntry: (sessionKey: string) => SessionEntry | undefined;
   revision: string;
-  sessionEntries: Record<string, SessionEntry>;
+};
+
+export type ReplySessionInitializationCommitContext = {
+  currentEntry?: SessionEntry;
+  readEntry: (sessionKey: string) => SessionEntry | undefined;
+  sessionEntry: SessionEntry;
 };
 
 export type ReplySessionInitializationCommitResult =
@@ -883,15 +889,23 @@ function createReplySessionInitializationRevision(entry: SessionEntry | undefine
 
 function resolveInitializedReplySessionEntry(params: {
   agentId: string;
+  currentEntry?: SessionEntry;
   fallbackSessionFile?: string;
   sessionEntry: SessionEntry;
   storePath: string;
 }): SessionEntry {
   const fallbackSessionFile = params.fallbackSessionFile?.trim();
+  const currentSessionFile = params.currentEntry?.sessionFile;
+  const inheritedPreviousSessionFile =
+    Boolean(currentSessionFile) &&
+    params.currentEntry?.sessionId !== params.sessionEntry.sessionId &&
+    currentSessionFile === params.sessionEntry.sessionFile;
   const entryForResolve =
-    !params.sessionEntry.sessionFile && fallbackSessionFile
+    fallbackSessionFile && (inheritedPreviousSessionFile || !params.sessionEntry.sessionFile)
       ? { ...params.sessionEntry, sessionFile: fallbackSessionFile }
-      : params.sessionEntry;
+      : inheritedPreviousSessionFile
+        ? { ...params.sessionEntry, sessionFile: undefined }
+        : params.sessionEntry;
   const sessionFile = resolveSessionFilePath(params.sessionEntry.sessionId, entryForResolve, {
     agentId: params.agentId,
     sessionsDir: path.dirname(path.resolve(params.storePath)),
@@ -1281,10 +1295,14 @@ export function loadReplySessionInitializationSnapshot(params: {
   const store = loadSessionStore(params.storePath, { skipCache: true, clone: false });
   const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
   const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
+  const entries = cloneSessionEntries(store);
   return {
     ...(currentEntry ? { currentEntry } : {}),
+    readEntry: (sessionKey) => {
+      const entry = resolveSessionStoreEntry({ store: entries, sessionKey }).existing;
+      return entry ? { ...entry } : undefined;
+    },
     revision: createReplySessionInitializationRevision(currentEntry),
-    sessionEntries: cloneSessionEntries(store),
   };
 }
 
@@ -1301,6 +1319,9 @@ export async function commitReplySessionInitialization(params: {
   maintenanceConfig?: ResolvedSessionMaintenanceConfig;
   onArchiveError?: (error: unknown, sourcePath: string) => void;
   onMaintenanceWarning?: (warning: SessionMaintenanceWarning) => void | Promise<void>;
+  prepareSessionEntry?: (
+    context: ReplySessionInitializationCommitContext,
+  ) => Promise<SessionEntry> | SessionEntry;
   previousEntry?: SessionEntry;
   retiredEntry?: SessionEntryRetirement;
   sessionEntry: SessionEntry;
@@ -1309,7 +1330,7 @@ export async function commitReplySessionInitialization(params: {
 }): Promise<ReplySessionInitializationCommitResult> {
   const committed = await updateSessionStore(
     params.storePath,
-    (store): ReplySessionInitializationCommitResult => {
+    async (store): Promise<ReplySessionInitializationCommitResult> => {
       const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
       const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
       const revision = createReplySessionInitializationRevision(currentEntry);
@@ -1322,10 +1343,22 @@ export async function commitReplySessionInitialization(params: {
         };
       }
 
+      const readEntry = (sessionKey: string) => {
+        const entry = resolveSessionStoreEntry({ store, sessionKey }).existing;
+        return entry ? { ...entry } : undefined;
+      };
+      const preparedSessionEntry = params.prepareSessionEntry
+        ? await params.prepareSessionEntry({
+            ...(currentEntry ? { currentEntry } : {}),
+            readEntry,
+            sessionEntry: params.sessionEntry,
+          })
+        : params.sessionEntry;
       const sessionEntry = resolveInitializedReplySessionEntry({
         agentId: params.agentId,
+        ...(currentEntry ? { currentEntry } : {}),
         fallbackSessionFile: params.fallbackSessionFile,
-        sessionEntry: params.sessionEntry,
+        sessionEntry: preparedSessionEntry,
         storePath: params.storePath,
       });
       store[resolved.normalizedKey] = sessionEntry;

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -374,6 +374,26 @@ export type SessionLifecycleRolloverResult = {
   sessionEntry: SessionEntry;
 };
 
+export type ReplySessionInitializationSnapshot = {
+  currentEntry?: SessionEntry;
+  revision: string;
+  sessionEntries: Record<string, SessionEntry>;
+};
+
+export type ReplySessionInitializationCommitResult =
+  | {
+      ok: true;
+      previousSessionTranscript: SessionLifecycleTranscriptInfo;
+      sessionEntry: SessionEntry;
+      sessionStoreView: Record<string, SessionEntry>;
+    }
+  | {
+      ok: false;
+      currentEntry?: SessionEntry;
+      reason: "stale-snapshot";
+      revision: string;
+    };
+
 type SessionEntryRetirement = {
   entry: SessionEntry;
   key: string;
@@ -857,6 +877,31 @@ function cloneSessionEntries(store: Record<string, SessionEntry>): Record<string
   );
 }
 
+function createReplySessionInitializationRevision(entry: SessionEntry | undefined): string {
+  return JSON.stringify(entry ?? null);
+}
+
+function resolveInitializedReplySessionEntry(params: {
+  agentId: string;
+  fallbackSessionFile?: string;
+  sessionEntry: SessionEntry;
+  storePath: string;
+}): SessionEntry {
+  const fallbackSessionFile = params.fallbackSessionFile?.trim();
+  const entryForResolve =
+    !params.sessionEntry.sessionFile && fallbackSessionFile
+      ? { ...params.sessionEntry, sessionFile: fallbackSessionFile }
+      : params.sessionEntry;
+  const sessionFile = resolveSessionFilePath(params.sessionEntry.sessionId, entryForResolve, {
+    agentId: params.agentId,
+    sessionsDir: path.dirname(path.resolve(params.storePath)),
+  });
+  return {
+    ...params.sessionEntry,
+    sessionFile,
+  };
+}
+
 // File-backed creation resolves the concrete transcript artifact and writes the
 // header before the store mutation is saved; SQLite adapters implement this as
 // the same lifecycle operation without exposing rollback details to callers.
@@ -1225,6 +1270,95 @@ export async function persistSessionRolloverLifecycle(params: {
   return {
     previousSessionTranscript,
     sessionEntry: params.sessionEntry,
+  };
+}
+
+/** Loads the reply-session initialization rows without exposing a mutable store. */
+export function loadReplySessionInitializationSnapshot(params: {
+  storePath: string;
+  sessionKey: string;
+}): ReplySessionInitializationSnapshot {
+  const store = loadSessionStore(params.storePath, { skipCache: true, clone: false });
+  const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
+  const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
+  return {
+    ...(currentEntry ? { currentEntry } : {}),
+    revision: createReplySessionInitializationRevision(currentEntry),
+    sessionEntries: cloneSessionEntries(store),
+  };
+}
+
+/**
+ * Persists one reply-session initialization result and archives the previous
+ * transcript after metadata commits. SQLite adapters map the guarded write to a
+ * transaction and keep archive failure warning-only, matching file storage.
+ */
+export async function commitReplySessionInitialization(params: {
+  activeSessionKey: string;
+  agentId: string;
+  expectedRevision: string;
+  fallbackSessionFile?: string;
+  maintenanceConfig?: ResolvedSessionMaintenanceConfig;
+  onArchiveError?: (error: unknown, sourcePath: string) => void;
+  onMaintenanceWarning?: (warning: SessionMaintenanceWarning) => void | Promise<void>;
+  previousEntry?: SessionEntry;
+  retiredEntry?: SessionEntryRetirement;
+  sessionEntry: SessionEntry;
+  sessionKey: string;
+  storePath: string;
+}): Promise<ReplySessionInitializationCommitResult> {
+  const committed = await updateSessionStore(
+    params.storePath,
+    (store): ReplySessionInitializationCommitResult => {
+      const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
+      const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
+      const revision = createReplySessionInitializationRevision(currentEntry);
+      if (revision !== params.expectedRevision) {
+        return {
+          ok: false,
+          ...(currentEntry ? { currentEntry } : {}),
+          reason: "stale-snapshot",
+          revision,
+        };
+      }
+
+      const sessionEntry = resolveInitializedReplySessionEntry({
+        agentId: params.agentId,
+        fallbackSessionFile: params.fallbackSessionFile,
+        sessionEntry: params.sessionEntry,
+        storePath: params.storePath,
+      });
+      store[resolved.normalizedKey] = sessionEntry;
+      if (params.retiredEntry) {
+        store[params.retiredEntry.key] = params.retiredEntry.entry;
+      }
+      return {
+        ok: true,
+        previousSessionTranscript: {},
+        sessionEntry: { ...(store[resolved.normalizedKey] ?? sessionEntry) },
+        sessionStoreView: cloneSessionEntries(store),
+      };
+    },
+    {
+      activeSessionKey: params.activeSessionKey,
+      maintenanceConfig: params.maintenanceConfig,
+      onWarn: params.onMaintenanceWarning,
+      skipSaveWhenResult: (result) => !result.ok,
+    },
+  );
+  if (!committed.ok) {
+    return committed;
+  }
+
+  const previousSessionTranscript = await archivePreviousSessionTranscript({
+    agentId: params.agentId,
+    onArchiveError: params.onArchiveError,
+    previousEntry: params.previousEntry,
+    storePath: params.storePath,
+  });
+  return {
+    ...committed,
+    previousSessionTranscript,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

This PR closes the remaining direct whole-store mutation around reply session initialization by moving the fresh mutable session load/commit in `src/auto-reply/reply/session.ts` behind storage-owned accessor operations. It is a Path 3.1b file-backed seam-adoption slice for #88838, preparing reply session initialization for the later SQLite-backed session/transcript implementation without flipping storage in this PR.

## Why This Change Was Made

Reply session startup currently has to create or rotate a session entry, bind command/conversation routing fields, initialize transcript state, apply reset/rollover lifecycle behavior, and hand mutable state to downstream reply helpers. A simple `loadSessionEntry` swap is not enough because initialization needs a guarded read/commit boundary, stale-snapshot detection, transcript creation/rotation, parent fork preparation, and continued compatibility for unmigrated SDK/public whole-store surfaces. This PR adds that domain boundary while keeping warning-only archive behavior and the current file-backed store.

## User Impact

Behavior should be unchanged for users: direct Gateway agent replies, auto-reply session resets, model/auth profile persistence, session hints, skill snapshot updates, and transcript initialization continue to work. The product surface affected is reply/session startup for direct and channel-backed agent turns: the moment OpenClaw decides which conversation/session to bind to, which transcript file to use, and which persisted per-session preferences apply before the assistant runs.

## Changes

| File | Change |
| --- | --- |
| `src/config/sessions/session-accessor.ts` | Adds reply initialization snapshot/commit operations with stale revision guard. |
| `src/config/sessions/session-accessor.test.ts` | Covers guarded commit, stale snapshots, and transcript rotation regression. |
| `src/auto-reply/reply/session.ts` | Replaces fresh mutable whole-store initialization with accessor snapshot/commit. |
| `src/auto-reply/reply/session-entry-handle.ts` | Adds scoped current-entry handle for migrated internal consumers. |
| `src/auto-reply/reply/session-parent-fork-prepare.ts` | Moves parent fork preparation behind guarded commit preparation. |
| `src/auto-reply/reply/session-delivery.ts` | Narrows legacy main delivery retirement to the entry it needs. |
| `src/auto-reply/reply/body.ts` | Uses the session-entry handle for session hint persistence. |
| `src/auto-reply/reply/get-reply*.ts` | Carries the handle through prepared reply execution. |
| `src/auto-reply/reply/session-reset-model.ts` | Applies reset model overrides through the current-entry handle. |
| `src/auto-reply/reply/session-updates.ts` | Persists skill snapshot updates through the handle when available. |

## Evidence

Focused post-rebase proof at head `4ba72991c93`:

```bash
node scripts/check-session-accessor-boundary.mjs
node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/auto-reply/reply/session.test.ts src/auto-reply/reply/body.test.ts src/auto-reply/reply/session-updates.lifecycle.test.ts
pnpm tsgo:test:src
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Results:

- Boundary guard passed.
- Runtime-config shard passed: 1 file, 50 tests.
- Auto-reply shard passed: 3 files, 122 tests.
- `pnpm tsgo:test:src` passed.
- `git diff --check` passed.
- Fresh autoreview clean: no accepted/actionable findings; overall patch correct `0.99`.

## CI attribution follow-up

GitHub `check-lint` failed on head `4ba72991c9371bd8a70765046e3921949c553e17` in job `83084957373` with:

```text
/home/runner/_work/openclaw/openclaw/src/config/sessions/session-accessor.test.ts
  331:9  error  Empty fallbacks in spreads are unnecessary  unicorn(no-useless-fallback-in-spread)
✖ 1 problem (1 error, 0 warnings)
```

Attribution: PR-attributable test lint in this PR's new accessor regression test. Fixed by removing the unnecessary `?? {}` fallback in `session-accessor.test.ts`; object spread already ignores nullish values, and this test seeds a current entry before building the replacement entry.

Post-fix proof at head `4d45a9ed9104`:

```bash
node scripts/run-oxlint-shards.mjs --threads=8
node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Results: oxlint shards passed, accessor test shard passed (1 file, 50 tests), diff check passed, and autoreview was clean with no accepted/actionable findings.

## Real behavior proof

Behavior addressed: Reply session initialization creates and persists a fresh direct session entry and transcript through the guarded Path 3.1b accessor path.

Real environment tested: Local live Gateway on OpenClaw 2026.6.9 at feature SHA `9f508e3`, temporarily loaded into the live checkout, then restored afterward. The live proof was gathered before a conflict-free rebase onto current `upstream/main`; focused post-rebase proof above passed at `4ba72991c93`.

Exact steps or command run after this patch:

```bash
git checkout --detach 9f508e3cdcd
pnpm build
pnpm openclaw gateway restart
pnpm openclaw --version
pnpm openclaw gateway status --json --timeout 15000
curl -fsS -i http://127.0.0.1:18789/readyz
curl -fsS -i http://127.0.0.1:18789/healthz
pnpm openclaw gateway call health --json --timeout 15000
pnpm openclaw agent --session-key agent:main:path3-init-live-20260623-9f508e3 --message "Reply exactly: path3 session init live proof 9f508e3" --json --timeout 240
jq '."agent:main:path3-init-live-20260623-9f508e3" | {sessionId, sessionFile, updatedAt, modelProvider, model, abortedLastRun, systemPromptSessionKey: .systemPromptReport.sessionKey, contextBudgetSessionId: .contextBudgetStatus.sessionId}' ~/.openclaw/agents/main/sessions/sessions.json
wc -l ~/.openclaw/agents/main/sessions/005c2e38-0b1f-4345-bcb1-4642d6c52072.jsonl
tail -n 5 ~/.openclaw/agents/main/sessions/005c2e38-0b1f-4345-bcb1-4642d6c52072.jsonl
pnpm openclaw sessions --agent main --json --limit 20
pnpm openclaw sessions cleanup --agent main --dry-run --json
```

Evidence after fix: Gateway restart succeeded; `/readyz` returned HTTP 200 with `ready:true`; `/healthz` returned HTTP 200 with `{"ok":true,"status":"live"}`; `gateway call health` returned `ok:true`. The live agent run completed with run id `df0516e5-44a6-42d4-9d12-0e9c524a5cae`, session id `005c2e38-0b1f-4345-bcb1-4642d6c52072`, and final text `path3 session init live proof 9f508e3`. The session store contains key `agent:main:path3-init-live-20260623-9f508e3` bound to that session id and transcript file; the transcript JSONL exists with 6 lines including the user prompt and assistant reply. `openclaw sessions --agent main --json --limit 20` listed the proof session as the newest direct session.

Observed result after fix: A fresh direct Gateway agent turn initialized reply session state, persisted the session metadata, wrote the transcript, and completed normally through the live managed Gateway.

What was not tested: Future SQLite-backed storage, a real concurrent stale-snapshot conflict race, external channel delivery, SDK/plugin contract migration for public whole-store consumers, and destructive cleanup of unrelated old artifacts.


