### PR TITLE
fix: let isolated cron setup use the job timeout budget

### DIFF
--- a/src/cron/service/agent-watchdog.test.ts
+++ b/src/cron/service/agent-watchdog.test.ts
@@ -6,6 +6,23 @@ describe("cron agent setup watchdog", () => {
     vi.useRealTimers();
   });
 
+  it("allows setup to continue past 60 seconds when the job timeout budget allows it", async () => {
+    vi.useFakeTimers();
+    const triggerTimeout = vi.fn();
+    const watchdog = createCronAgentWatchdog({
+      deferUntilRunner: true,
+      jobTimeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS * 5,
+      triggerTimeout,
+    });
+
+    watchdog.start();
+
+    await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS + 10_000);
+    watchdog.noteRunnerStarted();
+
+    expect(triggerTimeout).not.toHaveBeenCalled();
+  });
+
   it("does not keep lane-wait suppression after lane admission", async () => {
     vi.useFakeTimers();
     const triggerTimeout = vi.fn();

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -14,6 +14,7 @@ import type { CronServiceState } from "./state.js";
 
 const CRON_TIMEOUT_CLEANUP_GUARD_MS = 20_000;
 export const CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
+const CRON_AGENT_SETUP_WATCHDOG_MAX_MS = 10 * 60_000;
 const CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS = 60_000;
 const CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS = 1_000;
 
@@ -48,6 +49,7 @@ const CRON_AGENT_PHASE_WATCHDOG_STAGE = {
 /** Handle for feeding isolated-agent progress into cron timeout watchdogs. */
 export type CronAgentWatchdog = {
   start: () => void;
+  setupTimeoutMs: () => number;
   noteLaneWait: () => void;
   noteLaneAdmitted: () => void;
   noteRunnerStarted: (info?: CronAgentExecutionStarted) => void;
@@ -69,6 +71,7 @@ export function createCronAgentWatchdog(params: {
   let preExecutionTimeoutId: NodeJS.Timeout | undefined;
   let activeExecution: CronAgentExecutionStarted | undefined;
   let observedLaneWait = false;
+  const setupTimeoutMs = resolveCronAgentSetupWatchdogMs(params.jobTimeoutMs);
 
   const setTimedOut = (reason: string) => {
     if (state === "timed_out" || state === "disposed") {
@@ -142,11 +145,12 @@ export function createCronAgentWatchdog(params: {
           if (state === "waiting_for_runner") {
             setTimedOut(setupTimeoutErrorMessage(activeExecution));
           }
-        }, CRON_AGENT_SETUP_WATCHDOG_MS);
+        }, setupTimeoutMs);
         return;
       }
       startTimeout();
     },
+    setupTimeoutMs: () => setupTimeoutMs,
     noteLaneWait: () => {
       if (state === "waiting_for_runner") {
         observedLaneWait = true;
@@ -221,5 +225,12 @@ function resolveCronAgentPreExecutionWatchdogMs(jobTimeoutMs: number): number {
   return Math.max(
     CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS,
     Math.min(CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS, Math.floor(jobTimeoutMs / 2)),
+  );
+}
+
+export function resolveCronAgentSetupWatchdogMs(jobTimeoutMs: number): number {
+  return Math.max(
+    CRON_AGENT_SETUP_WATCHDOG_MS,
+    Math.min(CRON_AGENT_SETUP_WATCHDOG_MAX_MS, Math.floor(jobTimeoutMs / 2)),
   );
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -46,11 +46,7 @@ import type {
   CronRunStatus,
   CronRunTelemetry,
 } from "../types.js";
-import {
-  cleanupTimedOutCronAgentRun,
-  createCronAgentWatchdog,
-  CRON_AGENT_SETUP_WATCHDOG_MS,
-} from "./agent-watchdog.js";
+import { cleanupTimedOutCronAgentRun, createCronAgentWatchdog } from "./agent-watchdog.js";
 import {
   abortErrorMessage,
   isSetupTimeoutErrorText,
@@ -278,7 +274,7 @@ export async function executeJobCoreWithTimeout(
         job.sessionTarget === "isolated" && isSetupTimeoutErrorText(error) && !observedLaneWait
           ? {
               error,
-              timeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS,
+              timeoutMs: watchdog.setupTimeoutMs(),
               otherCronJobsActiveAtTimeout: false,
             }
           : undefined;


### PR DESCRIPTION
## What Problem This Solves
OpenClaw cron isolated `agentTurn` jobs could fail before the runner ever started because the setup watchdog had a fixed 60-second ceiling, independent of the job's much larger timeout budget. Aaron's live `Route Meeting Transcripts (Daily)` cron (`3549b060-2ab7-440b-aca5-7c8c9871e0d3`) showed this exact failure pattern: repeated runs ended after about 60 seconds with `cron: isolated agent setup timed out before runner start`, no session id, no model/provider, and no token usage.

## Root cause
The isolated cron agent setup watchdog had a hardcoded 60-second ceiling. Installed-code evidence from the failing environment pointed to `server-cron-B_E4z-Px.js:493` (`CRON_AGENT_SETUP_WATCHDOG_MS = 6e4`) plus `server-cron-B_E4z-Px.js:566-569`, where the setup watchdog fired while still waiting for the runner.

## Fix
Derive the isolated-agent setup watchdog from the job timeout with bounded limits: keep the existing 60-second minimum for short jobs, cap setup at 10 minutes, and otherwise allow setup to use half of the job timeout budget. Timeout diagnostics still use `setupTimeoutErrorMessage(...)`, and setup timeout telemetry reports the derived watchdog timeout.

## Sibling occurrences
Searched for `CRON_AGENT_SETUP_WATCHDOG_MS`, `setupTimeoutErrorMessage`, `waiting_for_runner`, and `resolveCronAgentSetupWatchdogMs`. The only cron setup watchdog path is `src/cron/service/agent-watchdog.ts`; it is fixed here. Other hits are tests and retry-hint text, intentionally unchanged.

## Evidence
Added a regression test for an isolated cron `agentTurn` whose runner starts after the previous 60-second setup ceiling but before the job timeout.

- RED on unmodified `origin/main`: `node scripts/test-projects.mjs src/cron/service/agent-watchdog.test.ts` failed with `cron: isolated agent setup timed out before runner start`.
- GREEN after fix: same test passed, 3 tests.
- Cron service suite: `node scripts/test-projects.mjs src/cron/service` passed, 15 files / 151 tests.
- Changed tests: `pnpm test:changed` passed, 2 files / 9 tests.
- Lint/type/check: `pnpm lint` passed; `pnpm check` passed.
- Format: global `pnpm format:check` currently reports unrelated baseline formatting issues across 218 existing files; targeted `pnpm exec oxfmt --check src/cron/service/agent-watchdog.test.ts src/cron/service/agent-watchdog.ts src/cron/service/timer.ts` passed, and `git diff --check origin/main` passed.
- Live recovery proof: patched the same behavior into Aaron's installed OpenClaw bundle, restarted Gateway, and force-ran cron `3549b060-2ab7-440b-aca5-7c8c9871e0d3`; it completed `ok` in 128,683 ms with session `30d3924b-6479-4bf7-a922-d6d6c3e27afd`, model `gpt-5.5`, provider `openai`. Scheduler readback now shows `lastRunStatus=ok`, `lastStatus=ok`, `last_error=null`, and `consecutive_errors=0`.