### PR TITLE
fix(whatsapp): quote current follow-up in durable replies

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -743,8 +743,13 @@ describe("whatsapp inbound dispatch", () => {
       expectedReplyToId: "trigger-message",
     },
     {
-      name: "blocks durable fallback without a final payload reply target",
+      name: "quotes the current user follow-up without falling back to the quoted bot message",
       payload: { text: "final payload" },
+      expectedReplyToId: "trigger-message",
+    },
+    {
+      name: "preserves explicit null reply targets",
+      payload: { text: "final payload", replyToId: null },
       expectedReplyToId: null,
     },
   ] satisfies Array<{

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -111,6 +111,10 @@ function whatsAppReplyDeliveryVisibilityFromDurableResult(result: {
   return whatsAppReplyDeliveryVisibility(result.visibleReplySent === true);
 }
 
+function readTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
 function markWhatsAppReplyDeliveryErrorVisibleAfterFlush(
   error: unknown,
   flushResult: WhatsAppMediaOnlyFlushResult,
@@ -139,6 +143,29 @@ function logWhatsAppReplyDeliveryError(params: {
     },
     "auto-reply delivery failed",
   );
+}
+
+function resolveWhatsAppDurableReplyToId(params: {
+  context: Record<string, unknown>;
+  info: ReplyDeliveryInfo;
+  msg: AdmittedWebInboundMessage;
+  payload: DeliverableWhatsAppOutboundPayload<ReplyPayload>;
+}): string | null {
+  if (params.payload.replyToId === null) {
+    return null;
+  }
+  const explicitPayloadReplyToId = readTrimmedString(params.payload.replyToId);
+  if (explicitPayloadReplyToId) {
+    return explicitPayloadReplyToId;
+  }
+  const hasVisibleInboundReplyTarget =
+    Boolean(readTrimmedString(params.context.ReplyToId)) ||
+    Boolean(readTrimmedString(params.context.ReplyToIdFull));
+  const currentInboundMessageId = readTrimmedString(params.msg.event.id);
+  if (params.info.kind === "final" && hasVisibleInboundReplyTarget && currentInboundMessageId) {
+    return currentInboundMessageId;
+  }
+  return null;
 }
 
 function resolveWhatsAppDisableBlockStreaming(cfg: ReturnType<LoadConfigFn>): boolean | undefined {
@@ -691,7 +718,12 @@ export async function dispatchWhatsAppBufferedReply(params: {
               payload: normalizedDeliveryPayload,
               info,
               to: conversationId,
-              replyToId: normalizedDeliveryPayload.replyToId ?? null,
+              replyToId: resolveWhatsAppDurableReplyToId({
+                context: params.context,
+                info,
+                msg: params.msg,
+                payload: normalizedDeliveryPayload,
+              }),
               formatting: {
                 textLimit,
                 tableMode,


### PR DESCRIPTION
## What Problem This Solves

WhatsApp durable final replies no longer quote the wrong bot message during reply-to-bot wakeups, but after #95914 they quoted nothing in that scenario. The desired behavior is to quote the current user follow-up message while still preventing durable delivery from falling back to the older quoted bot message.

## Why This Change Was Made

The WhatsApp inbound dispatcher now resolves the durable reply target explicitly before calling the shared durable delivery path:

- explicit payload `replyToId` wins
- explicit payload `replyToId: null` remains a no-reply sentinel
- reply-to-bot wakeups use the current inbound WhatsApp message id
- ordinary final replies still pass `null` so core durable delivery cannot fall back to `ctxPayload.ReplyToId`

The focused test contract now names the wakeup behavior directly and keeps a regression row for explicit `null`.

## User Impact

Users replying to a prior OpenClaw WhatsApp response now get the assistant's durable final reply threaded to their current follow-up message instead of seeing no quote or the older bot message quoted.

## Evidence

- `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts` - 53 tests passed
- `pnpm exec oxfmt --check extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts` - formatting clean
- `pnpm tsgo:extensions` - typecheck clean
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the WhatsApp durable final-reply change. Intended behavior: explicit payload replyToId wins, explicit null stays no-reply, reply-to-bot wakeups quote the current inbound user message id, and other final replies still pass null to block fallback to ctx ReplyToId."` - clean, no accepted/actionable findings
