### PR TITLE
fix: make LinkedIn cron invitation reads resilient

### DIFF
--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -26,6 +26,7 @@ const BROWSER_ACT_KINDS = [
   "resize",
   "wait",
   "evaluate",
+  "readPageState",
   "close",
 ] as const;
 
@@ -98,6 +99,8 @@ const BrowserActSchema = Type.Object({
   loadState: Type.Optional(Type.String()),
   textGone: Type.Optional(Type.String()),
   timeoutMs: optionalPositiveIntegerSchema(),
+  stateKind: Type.Optional(stringEnum(["page", "linkedin_invitations"] as const)),
+  maxChars: optionalNonNegativeIntegerSchema(),
   // evaluate
   fn: Type.Optional(Type.String()),
 });

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -187,6 +187,8 @@ const LEGACY_BROWSER_ACT_REQUEST_KEYS = [
   "selector",
   "url",
   "loadState",
+  "stateKind",
+  "maxChars",
   "fn",
   "timeoutMs",
 ] as const;

--- a/extensions/browser/src/browser/client-actions.types.ts
+++ b/extensions/browser/src/browser/client-actions.types.ts
@@ -96,6 +96,13 @@ export type BrowserActRequest =
       timeoutMs?: number;
     }
   | { kind: "evaluate"; fn: string; ref?: string; targetId?: string; timeoutMs?: number }
+  | {
+      kind: "readPageState";
+      selector?: string;
+      stateKind?: "page" | "linkedin_invitations";
+      targetId?: string;
+      maxChars?: number;
+    }
   | { kind: "close"; targetId?: string }
   | {
       kind: "batch";

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -40,7 +40,11 @@ import {
   requireRefOrSelector,
   toAIFriendlyError,
 } from "./pw-tools-core.shared.js";
-import { closePageViaPlaywright, resizeViewportViaPlaywright } from "./pw-tools-core.snapshot.js";
+import {
+  closePageViaPlaywright,
+  readPageStateViaPlaywright,
+  resizeViewportViaPlaywright,
+} from "./pw-tools-core.snapshot.js";
 import {
   ANNOTATION_MAX_LABELS_DEFAULT,
   type AnnotationItem,
@@ -1667,6 +1671,15 @@ async function executeSingleAction(
         timeoutMs: action.timeoutMs,
         signal,
       });
+    case "readPageState":
+      return await readPageStateViaPlaywright({
+        cdpUrl,
+        targetId: effectiveTargetId,
+        ssrfPolicy,
+        kind: action.stateKind,
+        selector: action.selector,
+        maxChars: action.maxChars,
+      });
     case "close":
       await closePageViaPlaywright({
         cdpUrl,
@@ -1736,7 +1749,7 @@ export async function executeActViaPlaywright(opts: {
       0,
       dialogAbort.signal,
     );
-    if (opts.action.kind === "evaluate") {
+    if (opts.action.kind === "evaluate" || opts.action.kind === "readPageState") {
       return { result };
     }
     return {};

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -236,6 +236,45 @@ describe("pw-tools-core aria snapshot storage", () => {
     expect(page.setViewportSize).not.toHaveBeenCalled();
   });
 
+  it("reads LinkedIn invitation state without unsafe body innerText evaluation", async () => {
+    const locatorEvaluate = vi.fn(async (fn: (el: { textContent: string }) => unknown) =>
+      fn({
+        textContent: "Manage invitations Received No new invitations All (0) People you may know",
+      }),
+    );
+    const locator = vi.fn(() => ({
+      first: () => ({ evaluate: locatorEvaluate }),
+    }));
+    const page = {
+      url: vi.fn(() => "https://www.linkedin.com/mynetwork/invitation-manager/"),
+      title: vi.fn(async () => "Invitations | LinkedIn"),
+      locator,
+      evaluate: vi.fn(async () => {
+        throw new Error("unsafe body innerText evaluation failed");
+      }),
+    };
+    getPageForTargetId.mockResolvedValue(page);
+
+    const mod = await import("./pw-tools-core.snapshot.js");
+    const result = await mod.readPageStateViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      kind: "linkedin_invitations",
+    });
+
+    expect(result).toEqual({
+      kind: "linkedin_invitations",
+      state: "empty",
+      url: "https://www.linkedin.com/mynetwork/invitation-manager/",
+      title: "Invitations | LinkedIn",
+      text: "Manage invitations Received No new invitations All (0) People you may know",
+      cards: [],
+    });
+    expect(page.evaluate).not.toHaveBeenCalled();
+    expect(locator).toHaveBeenCalledWith("main, [role='main'], body");
+    expect(locatorEvaluate).toHaveBeenCalled();
+  });
+
   it("stores role fallback metadata when backend markers are unavailable", async () => {
     const page = { id: "page-1" };
     const mod = await import("./pw-tools-core.snapshot.js");

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -89,6 +89,156 @@ async function collectSnapshotUrls(page: Page): Promise<SnapshotUrlEntry[]> {
   return Array.isArray(urls) ? urls : [];
 }
 
+export type PageStateKind = "page" | "linkedin_invitations";
+
+export type PageStateReadResult = {
+  kind: PageStateKind;
+  state: "auth_required" | "empty" | "cards_found" | "unknown";
+  url: string;
+  title: string;
+  text: string;
+  cards?: Array<{ name: string; profileUrl?: string; message?: string }>;
+};
+
+function normalizeExtractedText(value: unknown, maxChars: number): string {
+  const text = typeof value === "string" ? value : "";
+  return text.replace(/\s+/g, " ").trim().slice(0, maxChars);
+}
+
+function classifyLinkedInInvitationState(params: {
+  url: string;
+  title: string;
+  text: string;
+  cards: Array<{ name: string; profileUrl?: string; message?: string }>;
+}): PageStateReadResult["state"] {
+  const haystack = `${params.url}\n${params.title}\n${params.text}`.toLowerCase();
+  if (
+    haystack.includes("/uas/login") ||
+    haystack.includes("/login") ||
+    haystack.includes("/checkpoint/") ||
+    haystack.includes("linkedin login") ||
+    haystack.includes("sign in | linkedin") ||
+    haystack.includes("join linkedin") ||
+    haystack.includes("sign in to linkedin")
+  ) {
+    return "auth_required";
+  }
+  if (params.cards.length > 0) {
+    return "cards_found";
+  }
+  if (
+    /\ball\s*\(0\)/i.test(params.text) ||
+    /no new invitations/i.test(params.text) ||
+    /no pending invitations/i.test(params.text)
+  ) {
+    return "empty";
+  }
+  return "unknown";
+}
+
+async function collectLinkedInInvitationCards(
+  page: Page,
+  maxChars: number,
+): Promise<Array<{ name: string; profileUrl?: string; message?: string }>> {
+  const cardSelector = [
+    "li.invitation-card",
+    "div.invitation-card",
+    "[data-view-name*='invitation']",
+    "[class*='invitation-card']",
+  ].join(", ");
+  const locator = page.locator(cardSelector);
+  const maybeEvaluateAll = (locator as unknown as { evaluateAll?: unknown }).evaluateAll;
+  if (typeof maybeEvaluateAll !== "function") {
+    return [];
+  }
+  const cards = await (
+    maybeEvaluateAll as (
+      fn: (
+        elements: Element[],
+        maxChars: number,
+      ) => Array<{
+        name: string;
+        profileUrl?: string;
+        message?: string;
+      }>,
+      arg: number,
+    ) => Promise<Array<{ name: string; profileUrl?: string; message?: string }>>
+  )((elements, textLimit) => {
+    return elements
+      .map((element) => {
+        const link = element.querySelector<HTMLAnchorElement>("a[href*='/in/']");
+        const name = (
+          link?.textContent ||
+          element.querySelector("[aria-label]")?.getAttribute("aria-label") ||
+          ""
+        )
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 160);
+        const message =
+          element
+            .querySelector("[class*='message'], [data-test-invitation-message]")
+            ?.textContent?.replace(/\s+/g, " ")
+            .trim()
+            .slice(0, textLimit) || undefined;
+        return {
+          name,
+          ...(link?.href ? { profileUrl: link.href } : {}),
+          ...(message ? { message } : {}),
+        };
+      })
+      .filter((card) => card.name);
+  }, maxChars);
+  return Array.isArray(cards) ? cards : [];
+}
+
+/** Reads bounded page state without relying on unsafe whole-body innerText eval. */
+export async function readPageStateViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  kind?: PageStateKind;
+  selector?: string;
+  maxChars?: number;
+  ssrfPolicy?: SsrFPolicy;
+}): Promise<PageStateReadResult> {
+  const kind = opts.kind === "linkedin_invitations" ? opts.kind : "page";
+  const maxChars = resolveIntegerOption(opts.maxChars, 12_000, { min: 0, max: 100_000 });
+  const page = await prepareSnapshotPageViaPlaywright({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
+  const url = page.url();
+  const title = await page.title().catch(() => "");
+  const selector =
+    normalizeOptionalString(opts.selector) ??
+    (kind === "linkedin_invitations" ? "main, [role='main'], body" : "body");
+  const text = await page
+    .locator(selector)
+    .first()
+    .evaluate((element, limit) => (element.textContent || "").slice(0, limit), maxChars)
+    .then((value) => normalizeExtractedText(value, maxChars))
+    .catch(() => "");
+  const cards =
+    kind === "linkedin_invitations"
+      ? await collectLinkedInInvitationCards(page, maxChars).catch(() => [])
+      : [];
+  const state =
+    kind === "linkedin_invitations"
+      ? classifyLinkedInInvitationState({ url, title, text, cards })
+      : text
+        ? "unknown"
+        : "empty";
+  return {
+    kind,
+    state,
+    url,
+    title,
+    text,
+    ...(kind === "linkedin_invitations" ? { cards } : {}),
+  };
+}
+
 function buildStoredAriaRefs(
   nodes: AriaSnapshotNode[],
   markedRefs: Set<string>,

--- a/extensions/browser/src/browser/routes/agent.act.normalize.ts
+++ b/extensions/browser/src/browser/routes/agent.act.normalize.ts
@@ -377,6 +377,23 @@ export function normalizeActRequest(
         ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       };
     }
+    case "readPageState": {
+      const selector = toStringOrEmpty(body.selector) || undefined;
+      const rawStateKind = toStringOrEmpty(body.stateKind);
+      const stateKind =
+        rawStateKind === "linkedin_invitations" || rawStateKind === "page"
+          ? rawStateKind
+          : undefined;
+      const targetId = toStringOrEmpty(body.targetId) || undefined;
+      const maxChars = readActionNonNegativeInteger(body, "maxChars");
+      return {
+        kind,
+        ...(selector ? { selector } : {}),
+        ...(stateKind ? { stateKind } : {}),
+        ...(targetId ? { targetId } : {}),
+        ...(maxChars !== undefined ? { maxChars } : {}),
+      };
+    }
     case "close": {
       const targetId = toStringOrEmpty(body.targetId) || undefined;
       return {

--- a/extensions/browser/src/browser/routes/agent.act.shared.ts
+++ b/extensions/browser/src/browser/routes/agent.act.shared.ts
@@ -15,6 +15,7 @@ const ACT_KINDS = [
   "hover",
   "scrollIntoView",
   "press",
+  "readPageState",
   "resize",
   "select",
   "type",

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -200,10 +200,10 @@ function buildExistingSessionWaitPredicate(params: {
 }): string | null {
   const checks: string[] = [];
   if (params.text) {
-    checks.push(`Boolean(document.body?.innerText?.includes(${JSON.stringify(params.text)}))`);
+    checks.push(`Boolean(document.body?.textContent?.includes(${JSON.stringify(params.text)}))`);
   }
   if (params.textGone) {
-    checks.push(`!document.body?.innerText?.includes(${JSON.stringify(params.textGone)})`);
+    checks.push(`!document.body?.textContent?.includes(${JSON.stringify(params.textGone)})`);
   }
   if (params.selector) {
     checks.push(`Boolean(document.querySelector(${JSON.stringify(params.selector)}))`);
@@ -348,6 +348,8 @@ function getExistingSessionUnsupportedMessage(action: BrowserActRequest): string
         : null;
     case "evaluate":
       return action.timeoutMs !== undefined ? EXISTING_SESSION_LIMITS.act.evaluateTimeout : null;
+    case "readPageState":
+      return EXISTING_SESSION_LIMITS.act.readPageState;
     case "batch":
       return EXISTING_SESSION_LIMITS.act.batch;
     case "resize":
@@ -644,6 +646,13 @@ export function registerBrowserAgentActRoutes(
                 });
                 return await jsonOk({ result });
               }
+              case "readPageState":
+                return jsonActError(
+                  res,
+                  501,
+                  ACT_ERROR_CODES.unsupportedForExistingSession,
+                  EXISTING_SESSION_LIMITS.act.readPageState,
+                );
               case "close":
                 await closeChromeMcpTab(profileName, tab.targetId, profileCtx.profile);
                 return await jsonOk();
@@ -688,6 +697,7 @@ export function registerBrowserAgentActRoutes(
                 { resolveCurrentTarget: true },
               );
             case "evaluate":
+            case "readPageState":
               return await jsonOk({ result: result.result }, { resolveCurrentTarget: true });
             case "click":
             case "clickCoords":

--- a/extensions/browser/src/browser/routes/existing-session-limits.ts
+++ b/extensions/browser/src/browser/routes/existing-session-limits.ts
@@ -28,6 +28,8 @@ export const EXISTING_SESSION_LIMITS = {
     fillTimeout: "existing-session fill does not support timeoutMs overrides.",
     waitNetworkIdle: "existing-session wait does not support loadState=networkidle yet.",
     evaluateTimeout: "existing-session evaluate does not support timeoutMs overrides.",
+    readPageState:
+      "existing-session readPageState is not supported yet; use snapshot for existing-session profiles.",
     batch: "existing-session batch is not supported yet; send actions individually.",
   },
   hooks: {


### PR DESCRIPTION
## What Problem This Solves
The LinkedIn Connection Request Management cron relied on an improvised mcporter/Playwright page-body scrape. The failing run used `playwright.browser_run_code_unsafe` to read `document.body.innerText`, and that harness/tool call failed instead of returning a structured LinkedIn invitation/auth/empty state.

This PR adds a stable page-state read path so LinkedIn invitation capture can use scoped `textContent`, URL/title auth-wall checks, and explicit structured states instead of unsafe whole-body eval.

## Fix
- Add `readPageState` as a stable browser action backed by scoped `textContent` extraction instead of whole-body unsafe eval.
- Add a `linkedin_invitations` page-state kind that returns explicit `auth_required`, `empty`, `cards_found`, or `unknown` state plus bounded invitation card data.
- Switch wait text checks from `body.innerText` to `body.textContent`.

## Sibling occurrences
Grep checked `browser_run_code_unsafe`, `document.body.innerText`, and `body?.innerText` under `extensions/browser`, `src`, `test`, and `scripts`.
Remaining occurrences are deferred because they are test fixtures intentionally exercising the generic `evaluate` action:
- `extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts`
- `extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts`
- `extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts`

## Evidence
RED: in pristine `origin/main` test-only worktree, adding the regression test failed with:
`TS2339: Property 'readPageStateViaPlaywright' does not exist`.

GREEN:
- `pnpm vitest run extensions/browser/src/browser/pw-tools-core.snapshot.test.ts -t "reads LinkedIn invitation state without unsafe body innerText evaluation" --reporter=dot`
- `pnpm vitest run extensions/browser/src/browser/pw-tools-core.snapshot.test.ts --reporter=dot`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- `pnpm lint:extensions`
- `pnpm exec oxfmt --check <10 changed browser files>`

Quality gate note: full `pnpm format:check` currently fails on existing repo-wide baseline formatting issues across unrelated files; the changed files pass `oxfmt --check`.

Cron verification: local/gateway cron payload for job `7d78077c-dfa7-40bb-8785-d09db1e5b316` was updated to use:
`python3 ~/.openclaw/.claude/skills/linkedin-connection-manager/scripts/process_connection_requests.py --json --limit 25`

Manual processor run returned structured empty output: 0 pending invitations.
Manual cron run after the live payload update completed `ok` with run id `manual:7d78077c-dfa7-40bb-8785-d09db1e5b316:1782258439954:3`, duration 78.9s, and no `browser_run_code_unsafe` diagnostic in the latest run record.
