### PR TITLE
refactor: route checkpoint mutations through accessor

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -164,6 +164,7 @@ export const migratedSessionAccessorWriteFiles = new Set([
   "src/commands/tasks.ts",
   "src/config/sessions/cleanup-service.ts",
   "src/gateway/server-node-events.ts",
+  "src/gateway/session-compaction-checkpoints.ts",
   "src/plugins/host-hook-cleanup.ts",
   "src/plugins/host-hook-state.ts",
   "src/tui/embedded-backend.ts",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -11,6 +11,7 @@ import {
   appendTranscriptEvent,
   applySessionEntryLifecycleMutation,
   applySessionPatchProjection,
+  branchSessionFromCompactionCheckpoint,
   canonicalizeSessionEntryAliases,
   cleanupSessionLifecycleArtifacts,
   commitReplySessionInitialization,
@@ -28,6 +29,7 @@ import {
   readSessionUpdatedAt,
   replaceSessionEntry,
   resolveSessionEntryAccessTarget,
+  restoreSessionFromCompactionCheckpoint,
   resolveSessionTranscriptReadTarget,
   resolveSessionTranscriptRuntimeReadTarget,
   resolveSessionTranscriptRuntimeTarget,
@@ -885,6 +887,134 @@ describe("session accessor file-backed seam", () => {
       status: "running",
       updatedAt: 20,
     });
+  });
+
+  it("branches checkpoint sessions without exposing mutable store rows", async () => {
+    const sourceSessionId = "11111111-1111-4111-8111-111111111111";
+    const branchSessionId = "22222222-2222-4222-8222-222222222222";
+    const branchPath = path.join(tempDir, "branch.jsonl");
+    const now = Date.now();
+    fs.writeFileSync(transcriptPath, `{"type":"session","id":"${sourceSessionId}"}\n`, "utf8");
+    fs.writeFileSync(branchPath, `{"type":"session","id":"${branchSessionId}"}\n`, "utf8");
+    const checkpoint = {
+      checkpointId: "checkpoint-1",
+      sessionKey: "agent:main:main",
+      sessionId: sourceSessionId,
+      createdAt: now,
+      reason: "manual",
+      preCompaction: {
+        sessionId: sourceSessionId,
+        sessionFile: transcriptPath,
+        leafId: "leaf-1",
+      },
+      postCompaction: { sessionId: "33333333-3333-4333-8333-333333333333" },
+    } satisfies NonNullable<SessionEntry["compactionCheckpoints"]>[number];
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          main: {
+            label: "Main",
+            sessionFile: transcriptPath,
+            sessionId: sourceSessionId,
+            updatedAt: now,
+            compactionCheckpoints: [checkpoint],
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const result = await branchSessionFromCompactionCheckpoint({
+      storePath,
+      sourceKey: "agent:main:main",
+      sourceStoreKey: "main",
+      nextKey: "agent:main:branch",
+      checkpointId: "checkpoint-1",
+      forkTranscriptFromCheckpoint: async (selectedCheckpoint) => {
+        expect(selectedCheckpoint).toEqual(checkpoint);
+        return {
+          status: "created",
+          transcript: {
+            sessionFile: branchPath,
+            sessionId: branchSessionId,
+            totalTokens: 42,
+          },
+        };
+      },
+      buildEntry: ({ currentEntry, forkedTranscript }) => ({
+        ...currentEntry,
+        sessionFile: forkedTranscript.sessionFile,
+        sessionId: forkedTranscript.sessionId,
+        totalTokens: forkedTranscript.totalTokens,
+        updatedAt: now + 1,
+      }),
+    });
+
+    expect(result).toMatchObject({
+      status: "created",
+      key: "agent:main:branch",
+      entry: {
+        sessionFile: branchPath,
+        sessionId: branchSessionId,
+        totalTokens: 42,
+      },
+    });
+    expect(loadSessionStore(storePath)).toEqual({
+      main: expect.objectContaining({ sessionId: sourceSessionId }),
+      "agent:main:branch": expect.objectContaining({
+        sessionFile: branchPath,
+        sessionId: branchSessionId,
+        totalTokens: 42,
+      }),
+    });
+  });
+
+  it("does not persist checkpoint restores when the transcript boundary is missing", async () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:main": {
+            sessionId: "session-1",
+            updatedAt: 10,
+            compactionCheckpoints: [
+              {
+                checkpointId: "checkpoint-1",
+                sessionKey: "agent:main:main",
+                sessionId: "session-1",
+                createdAt: 20,
+                reason: "manual",
+                preCompaction: {
+                  sessionId: "session-1",
+                  leafId: "leaf-1",
+                },
+                postCompaction: { sessionId: "session-2" },
+              },
+            ],
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const before = fs.readFileSync(storePath, "utf8");
+    const result = await restoreSessionFromCompactionCheckpoint({
+      storePath,
+      sessionKey: "agent:main:main",
+      checkpointId: "checkpoint-1",
+      forkTranscriptFromCheckpoint: async () => ({ status: "missing-boundary" }),
+      buildEntry: () => {
+        throw new Error("missing boundary should skip entry replacement");
+      },
+    });
+
+    expect(result).toEqual({ status: "missing-boundary" });
+    expect(fs.readFileSync(storePath, "utf8")).toBe(before);
   });
 
   it("cleans scoped lifecycle entries and unreferenced transcript artifacts", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -98,7 +98,7 @@ import {
   resolveOwnedSessionTranscriptWriteLockRunner,
   withOwnedSessionTranscriptWrites,
 } from "./transcript-write-context.js";
-import type { SessionEntry } from "./types.js";
+import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 
 /**
  * Session access API for callers that need entries or transcripts without
@@ -464,6 +464,81 @@ export type RestartRecoveryLifecycleUpdate<T> = {
   result: T;
   /** Exact rows to replace inside the storage transaction. */
   replacements?: Iterable<RestartRecoveryLifecycleReplacement>;
+};
+
+/** File-backed checkpoint transcript fork produced by the checkpoint storage boundary. */
+export type SessionCompactionCheckpointForkedTranscript = {
+  sessionFile: string;
+  sessionId: string;
+  totalTokens?: number;
+};
+
+/** Result of resolving and copying checkpoint transcript content for branch/restore. */
+export type SessionCompactionCheckpointTranscriptForkResult =
+  | { status: "created"; transcript: SessionCompactionCheckpointForkedTranscript }
+  | { status: "missing-boundary" }
+  | { status: "failed" };
+
+/** Result of applying a checkpoint branch or restore mutation to session storage. */
+export type SessionCompactionCheckpointMutationResult =
+  | {
+      status: "created";
+      key: string;
+      checkpoint: SessionCompactionCheckpoint;
+      entry: SessionEntry;
+    }
+  | { status: "missing-session" }
+  | { status: "missing-checkpoint" }
+  | { status: "missing-boundary" }
+  | { status: "failed" };
+
+export type SessionCompactionCheckpointEntryBuildContext = {
+  /** Checkpoint row selected from the current persisted session entry. */
+  checkpoint: SessionCompactionCheckpoint;
+  /** Persisted entry that owns the selected checkpoint. */
+  currentEntry: SessionEntry;
+  /** Forked transcript identity created from the stored checkpoint boundary. */
+  forkedTranscript: SessionCompactionCheckpointForkedTranscript;
+};
+
+export type SessionCompactionCheckpointTranscriptForker = (
+  checkpoint: SessionCompactionCheckpoint,
+) => Promise<SessionCompactionCheckpointTranscriptForkResult>;
+
+export type SessionCompactionCheckpointEntryBuilder = (
+  context: SessionCompactionCheckpointEntryBuildContext,
+) => Promise<SessionEntry> | SessionEntry;
+
+export type BranchSessionFromCompactionCheckpointParams = {
+  /** Checkpoint id stored on the source session entry. */
+  checkpointId: string;
+  /** Builds the branched session entry from the forked transcript. */
+  buildEntry: SessionCompactionCheckpointEntryBuilder;
+  /** Copies transcript content through the stored checkpoint boundary. */
+  forkTranscriptFromCheckpoint: SessionCompactionCheckpointTranscriptForker;
+  /** Persisted key for the new checkpoint branch. */
+  nextKey: string;
+  /** Canonical key used as the branch parent. */
+  sourceKey: string;
+  /** Actual persisted key to read when a legacy alias still owns the row. */
+  sourceStoreKey?: string;
+  /** Explicit store target for file-backed stores and SQLite migration adapters. */
+  storePath: string;
+};
+
+export type RestoreSessionFromCompactionCheckpointParams = {
+  /** Checkpoint id stored on the current session entry. */
+  checkpointId: string;
+  /** Builds the restored session entry from the forked transcript. */
+  buildEntry: SessionCompactionCheckpointEntryBuilder;
+  /** Copies transcript content through the stored checkpoint boundary. */
+  forkTranscriptFromCheckpoint: SessionCompactionCheckpointTranscriptForker;
+  /** Canonical key to replace with the restored checkpoint state. */
+  sessionKey: string;
+  /** Actual persisted key to read when a legacy alias still owns the row. */
+  sessionStoreKey?: string;
+  /** Explicit store target for file-backed stores and SQLite migration adapters. */
+  storePath: string;
 };
 
 export type SessionEntryCreateWithTranscriptContext = {
@@ -1162,6 +1237,103 @@ function applySessionAbortCutoff(
 ): void {
   entry.abortCutoffMessageSid = cutoff?.messageSid;
   entry.abortCutoffTimestamp = cutoff?.timestamp;
+}
+
+function findSessionCompactionCheckpoint(params: {
+  checkpointId: string;
+  entry: SessionEntry;
+}): SessionCompactionCheckpoint | undefined {
+  const checkpointId = params.checkpointId.trim();
+  if (!checkpointId || !Array.isArray(params.entry.compactionCheckpoints)) {
+    return undefined;
+  }
+  return [...params.entry.compactionCheckpoints]
+    .toSorted((a, b) => b.createdAt - a.createdAt)
+    .find((checkpoint) => checkpoint.checkpointId === checkpointId);
+}
+
+type ApplySessionCompactionCheckpointMutationParams = {
+  buildEntry: SessionCompactionCheckpointEntryBuilder;
+  checkpointId: string;
+  forkTranscriptFromCheckpoint: SessionCompactionCheckpointTranscriptForker;
+  readKey: string;
+  storePath: string;
+  writeKey: string;
+};
+
+async function applySessionCompactionCheckpointMutation(
+  params: ApplySessionCompactionCheckpointMutationParams,
+): Promise<SessionCompactionCheckpointMutationResult> {
+  return await updateSessionStore(
+    params.storePath,
+    async (store) => {
+      const currentEntry = store[params.readKey];
+      if (!currentEntry?.sessionId) {
+        return { status: "missing-session" };
+      }
+      const checkpoint = findSessionCompactionCheckpoint({
+        entry: currentEntry,
+        checkpointId: params.checkpointId,
+      });
+      if (!checkpoint) {
+        return { status: "missing-checkpoint" };
+      }
+      const forkedSession = await params.forkTranscriptFromCheckpoint(checkpoint);
+      if (forkedSession.status !== "created") {
+        return forkedSession;
+      }
+
+      const nextEntry = await params.buildEntry({
+        checkpoint,
+        currentEntry,
+        forkedTranscript: forkedSession.transcript,
+      });
+      store[params.writeKey] = nextEntry;
+      return {
+        status: "created",
+        key: params.writeKey,
+        checkpoint,
+        entry: nextEntry,
+      };
+    },
+    { skipSaveWhenResult: (result) => result.status !== "created" },
+  );
+}
+
+/**
+ * Forks checkpoint transcript content and persists a new branch entry in one
+ * storage-sized mutation. SQLite adapters implement the transcript row copy
+ * and `session_entries.entry_json` insert inside the same write transaction.
+ */
+export async function branchSessionFromCompactionCheckpoint(
+  params: BranchSessionFromCompactionCheckpointParams,
+): Promise<SessionCompactionCheckpointMutationResult> {
+  return await applySessionCompactionCheckpointMutation({
+    buildEntry: params.buildEntry,
+    checkpointId: params.checkpointId,
+    forkTranscriptFromCheckpoint: params.forkTranscriptFromCheckpoint,
+    readKey: params.sourceStoreKey ?? params.sourceKey,
+    storePath: params.storePath,
+    writeKey: params.nextKey,
+  });
+}
+
+/**
+ * Forks checkpoint transcript content and replaces the current entry in one
+ * storage-sized mutation. SQLite adapters implement the transcript row copy
+ * and `session_entries.entry_json` update inside the same write transaction.
+ */
+export async function restoreSessionFromCompactionCheckpoint(
+  params: RestoreSessionFromCompactionCheckpointParams,
+): Promise<SessionCompactionCheckpointMutationResult> {
+  return await applySessionCompactionCheckpointMutation({
+    buildEntry: params.buildEntry,
+    checkpointId: params.checkpointId,
+    forkTranscriptFromCheckpoint: params.forkTranscriptFromCheckpoint,
+    readKey: params.sessionStoreKey ?? params.sessionKey,
+    storePath: params.storePath,
+    writeKey: params.sessionKey,
+  });
 }
 
 /**

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -930,6 +930,37 @@ describe("session-compaction-checkpoints", () => {
     expect(nextStore[MAIN_SESSION_KEY]?.compactionCheckpoints).toBeUndefined();
   });
 
+  test("persist skips malformed session rows without synthesizing a session id", async () => {
+    const { storePath, sessionId, sessionKey, now } = await makeTempSessionStore(
+      "openclaw-checkpoint-malformed-row-",
+    );
+    await writeSessionStore(storePath, sessionKey, {
+      sessionId: "",
+      updatedAt: now,
+    });
+
+    const stored = await persistMainCheckpoint(storePath, {
+      sessionId,
+      snapshot: {
+        sessionId,
+        leafId: "pre-leaf",
+      },
+      postSessionFile: path.join(path.dirname(storePath), "sess.compacted.jsonl"),
+      postLeafId: "post-leaf",
+      createdAt: now,
+    });
+
+    expect(stored).toBeNull();
+    const nextStore = await readSessionStore<{
+      compactionCheckpoints?: unknown[];
+      sessionId?: string;
+    }>(storePath);
+    expect(nextStore[MAIN_SESSION_KEY]).toEqual({
+      sessionId: "",
+      updatedAt: now,
+    });
+  });
+
   test("persist trims retained checkpoint snapshots by total byte budget", async () => {
     const { dir, storePath, sessionId, sessionKey, now } = await makeTempSessionStore(
       "openclaw-checkpoint-byte-trim-",

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -8,7 +8,6 @@ import {
   SessionManager,
   type FileEntry as SessionFileEntry,
 } from "../agents/sessions/session-manager.js";
-import { updateSessionStore } from "../config/sessions.js";
 import type {
   SessionCompactionCheckpoint,
   SessionCompactionCheckpointReason,
@@ -16,6 +15,12 @@ import type {
 } from "../config/sessions.js";
 import { isCompactionCheckpointTranscriptFileName } from "../config/sessions/artifacts.js";
 import { readFileRangeAsync } from "../config/sessions/file-range.js";
+import {
+  branchSessionFromCompactionCheckpoint,
+  restoreSessionFromCompactionCheckpoint,
+  type SessionCompactionCheckpointMutationResult,
+  updateSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { streamSessionTranscriptLines } from "../config/sessions/transcript-stream.js";
 import { scanSessionTranscriptTree } from "../config/sessions/transcript-tree.js";
 import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
@@ -66,17 +71,7 @@ export type CompactionCheckpointTranscriptForkResult =
   | { status: "missing-boundary" }
   | { status: "failed" };
 
-export type CompactionCheckpointSessionMutationResult =
-  | {
-      status: "created";
-      key: string;
-      checkpoint: SessionCompactionCheckpoint;
-      entry: SessionEntry;
-    }
-  | { status: "missing-session" }
-  | { status: "missing-checkpoint" }
-  | { status: "missing-boundary" }
-  | { status: "failed" };
+export type CompactionCheckpointSessionMutationResult = SessionCompactionCheckpointMutationResult;
 
 export type BranchCheckpointSessionParams = {
   storePath: string;
@@ -583,30 +578,19 @@ function cloneCheckpointSessionEntry(params: {
 async function branchCheckpointSessionFromStoredBoundary(
   params: BranchCheckpointSessionParams,
 ): Promise<CompactionCheckpointSessionMutationResult> {
-  return await updateSessionStore(
-    params.storePath,
-    async (store) => {
-      const currentEntry = store[params.sourceStoreKey ?? params.sourceKey];
-      if (!currentEntry?.sessionId) {
-        return { status: "missing-session" };
-      }
-      const checkpoint = getSessionCompactionCheckpoint({
-        entry: currentEntry,
-        checkpointId: params.checkpointId,
-      });
-      if (!checkpoint) {
-        return { status: "missing-checkpoint" };
-      }
-      const forkedSession = await forkCheckpointTranscriptFromStoredBoundary({ checkpoint });
-      if (forkedSession.status !== "created") {
-        return forkedSession;
-      }
-
-      const forkedTranscript = forkedSession.transcript;
+  return await branchSessionFromCompactionCheckpoint({
+    storePath: params.storePath,
+    sourceKey: params.sourceKey,
+    nextKey: params.nextKey,
+    checkpointId: params.checkpointId,
+    ...(params.sourceStoreKey ? { sourceStoreKey: params.sourceStoreKey } : {}),
+    forkTranscriptFromCheckpoint: async (checkpoint) =>
+      await forkCheckpointTranscriptFromStoredBoundary({ checkpoint }),
+    buildEntry: ({ currentEntry, forkedTranscript }) => {
       const label = currentEntry.label?.trim()
         ? `${currentEntry.label.trim()} (checkpoint)`
         : "Checkpoint branch";
-      const nextEntry = cloneCheckpointSessionEntry({
+      return cloneCheckpointSessionEntry({
         currentEntry,
         nextSessionId: forkedTranscript.sessionId,
         nextSessionFile: forkedTranscript.sessionFile,
@@ -614,58 +598,29 @@ async function branchCheckpointSessionFromStoredBoundary(
         parentSessionKey: params.sourceKey,
         totalTokens: forkedTranscript.totalTokens,
       });
-      store[params.nextKey] = nextEntry;
-      return {
-        status: "created",
-        key: params.nextKey,
-        checkpoint,
-        entry: nextEntry,
-      };
     },
-    { skipSaveWhenResult: (result) => result.status !== "created" },
-  );
+  });
 }
 
 async function restoreCheckpointSessionFromStoredBoundary(
   params: RestoreCheckpointSessionParams,
 ): Promise<CompactionCheckpointSessionMutationResult> {
-  return await updateSessionStore(
-    params.storePath,
-    async (store) => {
-      const currentEntry = store[params.sessionStoreKey ?? params.sessionKey];
-      if (!currentEntry?.sessionId) {
-        return { status: "missing-session" };
-      }
-      const checkpoint = getSessionCompactionCheckpoint({
-        entry: currentEntry,
-        checkpointId: params.checkpointId,
-      });
-      if (!checkpoint) {
-        return { status: "missing-checkpoint" };
-      }
-      const restoredSession = await forkCheckpointTranscriptFromStoredBoundary({ checkpoint });
-      if (restoredSession.status !== "created") {
-        return restoredSession;
-      }
-
-      const restoredTranscript = restoredSession.transcript;
-      const nextEntry = cloneCheckpointSessionEntry({
+  return await restoreSessionFromCompactionCheckpoint({
+    storePath: params.storePath,
+    sessionKey: params.sessionKey,
+    checkpointId: params.checkpointId,
+    ...(params.sessionStoreKey ? { sessionStoreKey: params.sessionStoreKey } : {}),
+    forkTranscriptFromCheckpoint: async (checkpoint) =>
+      await forkCheckpointTranscriptFromStoredBoundary({ checkpoint }),
+    buildEntry: ({ currentEntry, forkedTranscript }) =>
+      cloneCheckpointSessionEntry({
         currentEntry,
-        nextSessionId: restoredTranscript.sessionId,
-        nextSessionFile: restoredTranscript.sessionFile,
-        totalTokens: restoredTranscript.totalTokens,
+        nextSessionId: forkedTranscript.sessionId,
+        nextSessionFile: forkedTranscript.sessionFile,
+        totalTokens: forkedTranscript.totalTokens,
         preserveCompactionCheckpoints: true,
-      });
-      store[params.sessionKey] = nextEntry;
-      return {
-        status: "created",
-        key: params.sessionKey,
-        checkpoint,
-        entry: nextEntry,
-      };
-    },
-    { skipSaveWhenResult: (result) => result.status !== "created" },
-  );
+      }),
+  });
 }
 
 /**
@@ -818,31 +773,30 @@ export async function persistSessionCompactionCheckpoint(
     },
   };
 
-  let stored = false;
   let trimmedCheckpoints:
     | {
         kept: SessionCompactionCheckpoint[] | undefined;
         removed: SessionCompactionCheckpoint[];
       }
     | undefined;
-  await updateSessionStore(target.storePath, async (store) => {
-    const existing = store[target.canonicalKey];
-    if (!existing?.sessionId) {
-      return;
-    }
-    const checkpoints = sessionStoreCheckpoints(existing);
-    checkpoints.push(checkpoint);
-    const snapshotBytesByPath = await statCheckpointSnapshotBytes(checkpoints);
-    trimmedCheckpoints = trimSessionCheckpoints(checkpoints, snapshotBytesByPath);
-    store[target.canonicalKey] = {
-      ...existing,
-      updatedAt: Math.max(existing.updatedAt ?? 0, createdAt),
-      compactionCheckpoints: trimmedCheckpoints.kept,
-    };
-    stored = true;
-  });
+  const updatedEntry = await updateSessionEntry(
+    {
+      storePath: target.storePath,
+      sessionKey: target.canonicalKey,
+    },
+    async (existing) => {
+      const checkpoints = sessionStoreCheckpoints(existing);
+      checkpoints.push(checkpoint);
+      const snapshotBytesByPath = await statCheckpointSnapshotBytes(checkpoints);
+      trimmedCheckpoints = trimSessionCheckpoints(checkpoints, snapshotBytesByPath);
+      return {
+        updatedAt: Math.max(existing.updatedAt ?? 0, createdAt),
+        compactionCheckpoints: trimmedCheckpoints.kept,
+      };
+    },
+  );
 
-  if (!stored) {
+  if (!updatedEntry) {
     log.warn("skipping compaction checkpoint persist: session not found", {
       sessionKey: params.sessionKey,
     });

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -779,16 +779,21 @@ export async function persistSessionCompactionCheckpoint(
         removed: SessionCompactionCheckpoint[];
       }
     | undefined;
+  let stored = false;
   const updatedEntry = await updateSessionEntry(
     {
       storePath: target.storePath,
       sessionKey: target.canonicalKey,
     },
     async (existing) => {
+      if (!existing.sessionId) {
+        return null;
+      }
       const checkpoints = sessionStoreCheckpoints(existing);
       checkpoints.push(checkpoint);
       const snapshotBytesByPath = await statCheckpointSnapshotBytes(checkpoints);
       trimmedCheckpoints = trimSessionCheckpoints(checkpoints, snapshotBytesByPath);
+      stored = true;
       return {
         updatedAt: Math.max(existing.updatedAt ?? 0, createdAt),
         compactionCheckpoints: trimmedCheckpoints.kept,
@@ -796,7 +801,7 @@ export async function persistSessionCompactionCheckpoint(
     },
   );
 
-  if (!updatedEntry) {
+  if (!updatedEntry || !stored) {
     log.warn("skipping compaction checkpoint persist: session not found", {
       sessionKey: params.sessionKey,
     });

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -122,6 +122,7 @@ describe("session accessor boundary guard", () => {
         "src/commands/tasks.ts",
         "src/config/sessions/cleanup-service.ts",
         "src/gateway/server-node-events.ts",
+        "src/gateway/session-compaction-checkpoints.ts",
         "src/plugins/host-hook-cleanup.ts",
         "src/plugins/host-hook-state.ts",
         "src/tui/embedded-backend.ts",


### PR DESCRIPTION
## What Problem This Solves

Path 3 is moving session and transcript state toward SQLite-backed storage, but compaction checkpoint branch/restore still had storage mutation logic coupled directly to file-backed store helpers. This PR narrows that boundary so checkpoint branch/restore owns transcript fork/copy plus session-entry metadata mutation as one domain store operation.

## Why This Change Was Made

The future SQLite implementation needs to copy transcript rows and update `session_entries.entry_json` inside one write transaction. Routing the current file-backed implementation through `CompactionCheckpointStore` and session-accessor operations preserves today's behavior while making the intended transaction boundary explicit for the SQLite-backed store.

## User Impact

No user-visible behavior change is intended. Existing compaction checkpoint list/get/branch/restore behavior continues to fork from the stored checkpoint boundary and persist branch/restore session metadata; the change is internal migration preparation for openclaw/openclaw#88838.

## Evidence

- `pnpm lint:tmp:session-accessor-boundary` passed.
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/gateway/session-compaction-checkpoints.test.ts test/scripts/check-session-accessor-boundary.test.ts` passed: 28 unit-fast tests, 64 gateway tests, 49 runtime-config tests.
- `pnpm tsgo:test:src` passed.
- Autoreview clean against `upstream/main`: no accepted/actionable findings.
- Real behavior proof completed on live local gateway from `/Users/phaedrus/Projects/clawdbot` using head `2f40aabd3e5` before the non-live rebase follow-up.
- Non-live mergeability follow-up completed after `upstream/main` advanced to `c70accc86f8`: branch rebased to `4c3d1f83ce0`, local `merge-base HEAD upstream/main` equals `c70accc86f8`, and local `git merge-tree` reports no conflicts.
- Rebase conflicts were limited to accessor ratchet/test overlap from landed Path 3 slices; resolution kept both current-main entries and this compaction checkpoint slice.
- Post-rebase proof passed: `pnpm lint:tmp:session-accessor-boundary`, `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/gateway/session-compaction-checkpoints.test.ts test/scripts/check-session-accessor-boundary.test.ts`, `pnpm tsgo:test:src`, and autoreview against `upstream/main`.

## Real behavior proof

Behavior addressed: compaction checkpoint branch/restore storage boundary, including transcript fork/copy from a stored checkpoint boundary and session-entry metadata persistence through the accessor-backed store operation.

Real environment tested: live local OpenClaw gateway in `/Users/phaedrus/Projects/clawdbot`, loopback gateway on port 18789, agent `main`, synthetic temporary proof session only.

Exact steps or command run after this patch:

```bash
# Preflight and exact build
pnpm openclaw tasks list --status running --json
# -> { "count": 0, "tasks": [] }
git checkout --detach 2f40aabd3e5ab63763691adc2c4c54dbaed01d62
pnpm build
pnpm openclaw gateway restart
pnpm openclaw --version
# -> OpenClaw 2026.6.9 (2f40aab)
curl -fsS http://127.0.0.1:18789/readyz
curl -fsS http://127.0.0.1:18789/healthz

# Synthetic proof fixture, created through SessionManager, not raw JSONL message writes
# source key: agent:main:path3-checkpoint-proof-rebased-20260623164953-30482
# checkpoint: c9b07ac6-eece-4a07-9e9d-dc56193a6cfd
# pre-compaction leaf: 8a38d197
# post-compaction checkpoint leaf: 3d251843

pnpm openclaw gateway call sessions.compaction.list --json \
  --params '{"key":"agent:main:path3-checkpoint-proof-rebased-20260623164953-30482","agentId":"main"}' \
  --timeout 20000

pnpm openclaw gateway call sessions.compaction.branch --json \
  --params '{"key":"agent:main:path3-checkpoint-proof-rebased-20260623164953-30482","checkpointId":"c9b07ac6-eece-4a07-9e9d-dc56193a6cfd","agentId":"main"}' \
  --timeout 20000

pnpm openclaw gateway call sessions.compaction.restore --json \
  --params '{"key":"agent:main:path3-checkpoint-proof-rebased-20260623164953-30482","checkpointId":"c9b07ac6-eece-4a07-9e9d-dc56193a6cfd","agentId":"main"}' \
  --timeout 20000
```

Evidence after fix:

- `sessions.compaction.list` returned `ok: true` with the synthetic checkpoint.
- `sessions.compaction.branch` returned `ok: true`, branch key `agent:main:dashboard:a0d9bba0-926c-42ec-8114-f877bd608359`, branch session id `9ad7d9d2-1f06-4b36-b564-10731e7a7234`, parent session key `agent:main:path3-checkpoint-proof-rebased-20260623164953-30482`, and `totalTokens: 34` / `totalTokensFresh: true`.
- `sessions.compaction.restore` returned `ok: true`, restored session id `fe11b495-db40-4605-a2e6-fa81010475fb`, preserved one checkpoint in the restored entry, and persisted `totalTokens: 34` / `totalTokensFresh: true`.
- Verification script read `sessions.json` and both generated transcript files. The branch and restore transcripts contained `PATH3_CHECKPOINT_SOURCE path3-checkpoint-proof-rebased-20260623164953-30482`, did not contain `PATH3_CHECKPOINT_FUTURE path3-checkpoint-proof-rebased-20260623164953-30482`, and the store entry matched the restored session id/file.
- Cleanup removed the synthetic source key, branch key, and all generated proof transcript files; final scan found no `path3-checkpoint-proof` keys.
- Live service was restored to `main` at `6f2869c296f`, rebuilt, restarted, and `/readyz` settled to `ready: true` with `eventLoop.degraded: false`; `/healthz` returned `{ "ok": true, "status": "live" }`.

Observed result after fix: branch/restore kept the existing file-backed behavior through the real gateway surface while proving the store/accessor mutation boundary persists session-entry metadata and forks transcripts from the stored checkpoint boundary. No synthetic proof sessions or transcript files remained afterward.

What was not tested: SQLite-backed session/transcript storage is not enabled yet, so this proof covers the current file-backed store implementation and the intended transaction/accessor boundary only. Live gateway proof was not rerun after the non-live rebase to `4c3d1f83ce0` because the serialized live lane is assigned to the boot-session mapping thread; exact-head proof for `4c3d1f83ce0` is focused local proof plus clean merge-tree. Fresh CI is running on the rebased head.

