### PR TITLE
fix: keep successful cron runs ok after non-terminal tool errors

### DIFF
--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -50,6 +50,40 @@ describe("resolveCronPayloadOutcome", () => {
     ]);
   });
 
+  it("lets preferred final assistant text recover a failed bash tool result", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        {
+          name: "bash",
+          toolName: "bash",
+          text: '{\n  "status": "failed",\n  "exitCode": 1,\n  "durationMs": 0\n}',
+          isError: true,
+          details: {
+            status: "failed",
+            exitCode: 1,
+            aggregated:
+              'pgrep -af "project_data_quality|check_hygiene|create_task.py|audit_projects|check_mountain_quality" failed',
+          },
+        },
+      ],
+      finalAssistantVisibleText:
+        "Daily data-quality sweep completed. Findings existed, so not `HEARTBEAT_OK`.",
+      preferFinalAssistantVisibleText: true,
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.embeddedRunError).toBeUndefined();
+    expect(result.summary).toBe(
+      "Daily data-quality sweep completed. Findings existed, so not `HEARTBEAT_OK`.",
+    );
+    expect(result.outputText).toBe(
+      "Daily data-quality sweep completed. Findings existed, so not `HEARTBEAT_OK`.",
+    );
+    expect(result.deliveryPayloads).toEqual([
+      { text: "Daily data-quality sweep completed. Findings existed, so not `HEARTBEAT_OK`." },
+    ]);
+  });
+
   it("treats transient error payloads as non-fatal when a later success exists", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -10,7 +10,11 @@ import { shouldSkipHeartbeatOnlyDelivery } from "../heartbeat-policy.js";
 type DeliveryPayload = Pick<
   ReplyPayload,
   "text" | "mediaUrl" | "mediaUrls" | "presentation" | "interactive" | "channelData" | "isError"
->;
+> & {
+  name?: string;
+  toolName?: string;
+  details?: unknown;
+};
 
 /** Normalized cron run payload state used for summaries, delivery, and failure classification. */
 export type CronPayloadOutcome = {
@@ -217,6 +221,46 @@ function isCronToolWarning(text: string | undefined): boolean {
   return normalizeOptionalString(text)?.startsWith("⚠️ 🛠️ ") === true;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function normalizeToolName(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function hasFailedToolDetails(details: unknown): boolean {
+  if (!isRecord(details)) {
+    return false;
+  }
+  const status = typeof details.status === "string" ? details.status : undefined;
+  const exitCode = typeof details.exitCode === "number" ? details.exitCode : undefined;
+  return status === "failed" || (exitCode !== undefined && exitCode !== 0);
+}
+
+function hasFailedToolResultText(text: string | undefined): boolean {
+  const normalized = normalizeOptionalString(text);
+  if (!normalized) {
+    return false;
+  }
+  try {
+    return hasFailedToolDetails(JSON.parse(normalized));
+  } catch {
+    return false;
+  }
+}
+
+function isFailedToolResultPayload(payload: DeliveryPayload | undefined): boolean {
+  if (!payload || payload.isError !== true) {
+    return false;
+  }
+  const toolName = normalizeToolName(payload.toolName) ?? normalizeToolName(payload.name);
+  if (!toolName) {
+    return false;
+  }
+  return hasFailedToolDetails(payload.details) || hasFailedToolResultText(payload.text);
+}
+
 function isNonTerminalToolErrorWarning(payload: object | undefined): boolean {
   return Boolean(payload && getReplyPayloadMetadata(payload)?.nonTerminalToolErrorWarning);
 }
@@ -293,7 +337,9 @@ export function resolveCronPayloadOutcome(params: {
     normalizedFinalAssistantVisibleText !== undefined &&
     !hasStructuredDeliveryPayloads &&
     errorPayloads.length > 0 &&
-    errorPayloads.every((payload) => isCronToolWarning(payload?.text));
+    errorPayloads.every(
+      (payload) => isCronToolWarning(payload?.text) || isFailedToolResultPayload(payload),
+    );
   // Structured error payloads are fatal unless later successful output or a
   // known non-terminal warning proves the agent recovered.
   const hasFatalStructuredErrorPayload =


### PR DESCRIPTION
## What Problem This Solves
OpenClaw isolated cron outcome classification treated a failed tool payload as fatal even when the final assistant response reported successful completion. In the Daily Data Quality run, all review tasks refreshed successfully, then `pgrep -af "project_data_quality|check_hygiene|create_task.py|audit_projects|check_mountain_quality"` returned 1 because no matching processes remained. The scheduler recorded that probe miss as the cron `error`.

This keeps successful isolated cron final responses as `ok` when failed tool payloads are recovered tool-result failures, while preserving those failures in warning diagnostics. Fatal structured errors, run-level errors, aborts, timeouts, delivery failures, and explicit failure signals still produce `error`.

## Evidence
Source evidence: `/Users/aaroneden/.openclaw/agents/main/sessions/0cbf5dcb-4073-4bf9-9715-73310d42306e.jsonl`; compiled package locations `dist/isolated-agent-m1TKi5F0.js:841-859` and `dist/run-diagnostics-B2g3j-A0.js:159-187`.

New regression: `resolveCronPayloadOutcome > lets preferred final assistant text recover a failed bash tool result`.

RED: `node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts -- src/cron/isolated-agent.helpers.test.ts src/cron/run-diagnostics.test.ts` failed on the new test before the fix with `expected true to be false` for `hasFatalErrorPayload`.

GREEN: same command passes: 2 files, 39 tests.

Quality gates:
- `pnpm tsgo:core` passed.
- `pnpm format:check src/cron/isolated-agent/helpers.ts src/cron/isolated-agent.helpers.test.ts` passed.

## Sibling occurrences
`rg -n "hasFatalErrorPayload|hasFatalStructuredErrorPayload|createCronRunDiagnosticsFromAgentResult|finalStatus: \\\"ok\\\"" src test packages extensions -S` found the cron runtime call site, the cron helper classifier, run diagnostics, and mocked runtime tests. No second independent production status classifier was found.

## Notes
`pnpm test:unit -- ...` starts the full `test:unit:fast` suite before the requested files in this repo; that broad preflight showed unrelated existing failures in `src/node-host/invoke-system-run-plan.test.ts`, `src/crestodian/operations.test.ts`, `src/plugin-sdk/memory-host-events.test.ts`, and `src/skills/security/workspace-audit.test.ts`, so I stopped it and used the dedicated cron config for the narrow regression.