### PR TITLE
fix(gateway): cap auth limiter entries

### DIFF
--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -22,6 +22,7 @@ describe("auth rate limiter", () => {
       lockoutMs: number;
       exemptLoopback: boolean;
       pruneIntervalMs: number;
+      maxEntries: number;
     }>,
   ) {
     limiter = createAuthRateLimiter({
@@ -157,6 +158,87 @@ describe("auth rate limiter", () => {
     // A different IP should be unaffected.
     expect(limiter.check("10.0.0.11").allowed).toBe(true);
     expect(limiter.check("10.0.0.11").remaining).toBe(2);
+  });
+
+  it("caps unique client entries under flood", () => {
+    createLimiter({ maxEntries: 3, pruneIntervalMs: 0 });
+
+    limiter.recordFailure("10.0.1.1");
+    limiter.recordFailure("10.0.1.2");
+    limiter.recordFailure("10.0.1.3");
+    limiter.recordFailure("10.0.1.4");
+
+    expect(limiter.size()).toBe(3);
+    expect(limiter.check("10.0.1.1").remaining).toBe(2);
+    expect(limiter.check("10.0.1.4").remaining).toBe(1);
+  });
+
+  it("preserves locked entries when flood eviction runs", () => {
+    createLimiter({ maxEntries: 3, pruneIntervalMs: 0 });
+
+    limiter.recordFailure("10.0.2.1");
+    limiter.recordFailure("10.0.2.1");
+    expect(limiter.check("10.0.2.1").allowed).toBe(false);
+    limiter.recordFailure("10.0.2.2");
+    limiter.recordFailure("10.0.2.3");
+
+    limiter.recordFailure("10.0.2.4");
+
+    expect(limiter.size()).toBe(3);
+    expect(limiter.check("10.0.2.1").allowed).toBe(false);
+    expect(limiter.check("10.0.2.2").remaining).toBe(2);
+    expect(limiter.check("10.0.2.4").remaining).toBe(1);
+  });
+
+  it("fails closed when every tracked entry is locked", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({
+        maxAttempts: 1,
+        windowMs: 60_000,
+        lockoutMs: 60_000,
+        maxEntries: 2,
+        pruneIntervalMs: 0,
+      });
+
+      limiter.recordFailure("10.0.3.1");
+      limiter.recordFailure("10.0.3.2");
+      limiter.recordFailure("10.0.3.3");
+
+      expect(limiter.size()).toBe(2);
+      expect(limiter.check("10.0.3.1").allowed).toBe(false);
+      expect(limiter.check("10.0.3.2").allowed).toBe(false);
+      const overflowResult = limiter.check("10.0.3.3");
+      expect(overflowResult.allowed).toBe(false);
+      expect(overflowResult.retryAfterMs).toBeGreaterThan(0);
+
+      vi.advanceTimersByTime(60_001);
+      expect(limiter.check("10.0.3.3").allowed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { value: 0, expectedSize: 1 },
+    { value: -2, expectedSize: 1 },
+    { value: 1.9, expectedSize: 1 },
+    { value: 2.9, expectedSize: 2 },
+    { value: Number.NaN, expectedSize: 2 },
+    { value: Number.POSITIVE_INFINITY, expectedSize: 2 },
+  ])("normalizes maxEntries value $value", ({ value, expectedSize }) => {
+    limiter = createAuthRateLimiter({
+      maxAttempts: 2,
+      windowMs: 60_000,
+      lockoutMs: 60_000,
+      maxEntries: value,
+      pruneIntervalMs: 0,
+    });
+
+    limiter.recordFailure("10.0.4.1");
+    limiter.recordFailure("10.0.4.2");
+
+    expect(limiter.size()).toBe(expectedSize);
   });
 
   it("treats ipv4 and ipv4-mapped ipv6 forms as the same client", () => {

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -8,15 +8,15 @@
  *
  * Design decisions:
  * - Pure in-memory Map – no external dependencies; suitable for a single
- *   gateway process.  The Map is periodically pruned to avoid unbounded
- *   growth.
+ *   gateway process. The Map is periodically pruned and capped to avoid
+ *   unbounded growth.
  * - Loopback addresses (127.0.0.1 / ::1) are exempt by default so that local
  *   CLI sessions are never locked out.
  * - The module is side-effect-free: callers create an instance via
  *   {@link createAuthRateLimiter} and pass it where needed.
  */
 
-import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
+import { resolveIntegerOption, resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { isLoopbackAddress, resolveClientIp } from "./net.js";
 
 // ---------------------------------------------------------------------------
@@ -34,6 +34,8 @@ export interface RateLimitConfig {
   exemptLoopback?: boolean;
   /** Background prune interval in milliseconds; set <= 0 to disable auto-prune.  @default 60_000 */
   pruneIntervalMs?: number;
+  /** Maximum tracked client identities before old unlocked entries are evicted.  @default 10_000 */
+  maxEntries?: number;
 }
 
 export const AUTH_RATE_LIMIT_SCOPE_DEFAULT = "default";
@@ -96,6 +98,7 @@ const DEFAULT_MAX_ATTEMPTS = 10;
 const DEFAULT_WINDOW_MS = 60_000; // 1 minute
 const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
 const PRUNE_INTERVAL_MS = 60_000; // prune stale entries every minute
+const DEFAULT_MAX_ENTRIES = 10_000;
 
 // ---------------------------------------------------------------------------
 // Implementation
@@ -137,8 +140,10 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
   const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS, 0);
   const exemptLoopback = config?.exemptLoopback ?? true;
   const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);
+  const maxEntries = resolveIntegerOption(config?.maxEntries, DEFAULT_MAX_ENTRIES, { min: 1 });
 
   const entries = new Map<string, RateLimitEntry>();
+  let overflowLockedUntil: number | undefined;
 
   // Periodic cleanup to avoid unbounded map growth.
   const pruneTimer = pruneIntervalMs > 0 ? setInterval(() => prune(), pruneIntervalMs) : null;
@@ -187,6 +192,10 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
     const entry = entries.get(key);
 
     if (!entry) {
+      const overflowLock = checkOverflowLock(now);
+      if (overflowLock) {
+        return overflowLock;
+      }
       return { allowed: true, remaining: maxAttempts, retryAfterMs: 0 };
     }
 
@@ -220,6 +229,10 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
     let entry = entries.get(key);
 
     if (!entry) {
+      if (!enforceMaxEntries(now)) {
+        overflowLockedUntil = Math.max(overflowLockedUntil ?? 0, now + lockoutMs);
+        return;
+      }
       entry = { attempts: [] };
       entries.set(key, entry);
     }
@@ -242,8 +255,7 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
     entries.delete(key);
   }
 
-  function prune(): void {
-    const now = Date.now();
+  function pruneExpiredEntries(now: number): void {
     for (const [key, entry] of entries) {
       // If locked out, keep the entry until the lockout expires.
       if (entry.lockedUntil && now < entry.lockedUntil) {
@@ -256,6 +268,52 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
     }
   }
 
+  function checkOverflowLock(now: number): RateLimitCheckResult | undefined {
+    if (!overflowLockedUntil) {
+      return undefined;
+    }
+    if (now >= overflowLockedUntil) {
+      overflowLockedUntil = undefined;
+      return undefined;
+    }
+    if (entries.size >= maxEntries) {
+      pruneExpiredEntries(now);
+    }
+    if (entries.size < maxEntries) {
+      overflowLockedUntil = undefined;
+      return undefined;
+    }
+    return {
+      allowed: false,
+      remaining: 0,
+      retryAfterMs: overflowLockedUntil - now,
+    };
+  }
+
+  function enforceMaxEntries(now: number): boolean {
+    if (entries.size < maxEntries) {
+      return true;
+    }
+
+    pruneExpiredEntries(now);
+    if (entries.size < maxEntries) {
+      return true;
+    }
+
+    // Preserve active lockouts so a flood cannot evict the attacker's own block.
+    for (const [entryKey, entry] of entries) {
+      if (!entry.lockedUntil || now >= entry.lockedUntil) {
+        entries.delete(entryKey);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function prune(): void {
+    pruneExpiredEntries(Date.now());
+  }
+
   function size(): number {
     return entries.size;
   }
@@ -265,6 +323,7 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
       clearInterval(pruneTimer);
     }
     entries.clear();
+    overflowLockedUntil = undefined;
   }
 
   return { check, recordFailure, reset, size, prune, dispose };


### PR DESCRIPTION
## Summary

Caps the Gateway auth rate limiter's tracked client entries so failed-auth bookkeeping cannot grow without bound between prune sweeps.

## Changes

- Adds a normalized internal `maxEntries` option with a default cap of 10,000 tracked identities.
- Prunes expired entries before eviction, evicts the oldest unlocked entry when at capacity, and preserves active lockouts.
- Fails closed with a temporary overflow lock when every tracked entry is actively locked, avoiding a fail-open saturated-table path.
- Adds focused Gateway auth limiter tests for flood capping, lockout-preserving eviction, saturated overflow behavior, and numeric normalization.

## Validation

- `corepack pnpm exec oxfmt --check --threads=1 src/gateway/auth-rate-limit.ts src/gateway/auth-rate-limit.test.ts`
- `node scripts/run-vitest.mjs src/gateway/auth-rate-limit.test.ts` (4 files, 136 tests)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean)

## Notes

- Closes openclaw/openclaw#77986.
- AI-assisted.
- `CHANGELOG.md` was not updated.
