### PR TITLE
fix(macos): drop Textual from chat packaging

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -65,15 +65,6 @@
       }
     },
     {
-      "identity" : "swift-concurrency-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
-      "state" : {
-        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
-        "version" : "1.3.2"
-      }
-    },
-    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -107,24 +98,6 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "swiftui-math",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/swiftui-math",
-      "state" : {
-        "revision" : "0b5c2cfaaec8d6193db206f675048eeb5ce95f71",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "textual",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/textual",
-      "state" : {
-        "revision" : "5b06b811c0f5313b6b84bbef98c635a630638c38",
-        "version" : "0.3.1"
       }
     }
   ],

--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -65,6 +65,15 @@
       }
     },
     {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
         .package(url: "https://github.com/steipete/Peekaboo.git", exact: "3.5.2"),
+        .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../swabble"),
     ],
@@ -54,6 +55,7 @@ let package = Package(
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "PeekabooBridge", package: "Peekaboo"),
                 .product(name: "PeekabooAutomationKit", package: "Peekaboo"),
+                .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
             ],
             exclude: [
                 "Resources/Info.plist",

--- a/apps/shared/OpenClawKit/Package.swift
+++ b/apps/shared/OpenClawKit/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/steipete/ElevenLabsKit", exact: "0.1.1"),
-        .package(url: "https://github.com/gonzalezreal/textual", exact: "0.3.1"),
     ],
     targets: [
         .target(
@@ -45,10 +44,6 @@ let package = Package(
             name: "OpenClawChatUI",
             dependencies: [
                 "OpenClawKit",
-                .product(
-                    name: "Textual",
-                    package: "textual",
-                    condition: .when(platforms: [.macOS, .iOS])),
             ],
             path: "Sources/OpenClawChatUI",
             swiftSettings: [

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -1,5 +1,5 @@
+import Foundation
 import SwiftUI
-import Textual
 
 public enum ChatMarkdownVariant: String, CaseIterable, Sendable {
     case standard
@@ -22,46 +22,28 @@ struct ChatMarkdownRenderer: View {
     var body: some View {
         let processed = ChatMarkdownPreprocessor.preprocess(markdown: self.text)
         VStack(alignment: .leading, spacing: 10) {
-            StructuredText(markdown: processed.cleaned)
-                .modifier(ChatMarkdownStyle(
-                    variant: self.variant,
-                    context: self.context,
-                    font: self.font,
-                    textColor: self.textColor))
+            Text(self.markdownText(processed.cleaned))
+                .font(self.font)
+                .foregroundStyle(self.textColor)
+                .tint(self.linkColor)
+                .textSelection(.enabled)
+                .lineSpacing(self.variant == .compact ? 2 : 4)
 
             if !processed.images.isEmpty {
                 InlineImageList(images: processed.images)
             }
         }
     }
-}
 
-private struct ChatMarkdownStyle: ViewModifier {
-    let variant: ChatMarkdownVariant
-    let context: ChatMarkdownRenderer.Context
-    let font: Font
-    let textColor: Color
-
-    func body(content: Content) -> some View {
-        Group {
-            if self.variant == .compact {
-                content.textual.structuredTextStyle(.default)
-            } else {
-                content.textual.structuredTextStyle(.gitHub)
-            }
-        }
-        .font(self.font)
-        .foregroundStyle(self.textColor)
-        .textual.inlineStyle(self.inlineStyle)
-        .textual.textSelection(.enabled)
+    private var linkColor: Color {
+        self.context == .user ? self.textColor : OpenClawChatTheme.accent
     }
 
-    private var inlineStyle: InlineStyle {
-        let linkColor: Color = self.context == .user ? self.textColor : OpenClawChatTheme.accent
-        let codeScale: CGFloat = self.variant == .compact ? 0.85 : 0.9
-        return InlineStyle()
-            .code(.monospaced, .fontScale(codeScale))
-            .link(.foregroundColor(linkColor))
+    private func markdownText(_ markdown: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .full,
+            failurePolicy: .returnPartiallyParsedIfPossible)
+        return (try? AttributedString(markdown: markdown, options: options)) ?? AttributedString(markdown)
     }
 }
 

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -304,33 +304,6 @@ else
   exit 1
 fi
 
-echo "📦 Copying Textual resources"
-TEXTUAL_BUNDLE_DIR="$(build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG"
-TEXTUAL_BUNDLE=""
-for candidate in \
-  "$TEXTUAL_BUNDLE_DIR/textual_Textual.bundle" \
-  "$TEXTUAL_BUNDLE_DIR/Textual_Textual.bundle"
-do
-  if [ -d "$candidate" ]; then
-    TEXTUAL_BUNDLE="$candidate"
-    break
-  fi
-done
-if [ -z "$TEXTUAL_BUNDLE" ]; then
-  TEXTUAL_BUNDLE="$(find "$BUILD_ROOT" -type d \( -name "textual_Textual.bundle" -o -name "Textual_Textual.bundle" \) -print -quit)"
-fi
-if [ -n "$TEXTUAL_BUNDLE" ] && [ -d "$TEXTUAL_BUNDLE" ]; then
-  rm -rf "$APP_ROOT/Contents/Resources/$(basename "$TEXTUAL_BUNDLE")"
-  cp -R "$TEXTUAL_BUNDLE" "$APP_ROOT/Contents/Resources/"
-else
-  if [[ "${ALLOW_MISSING_TEXTUAL_BUNDLE:-0}" == "1" ]]; then
-    echo "WARN: Textual resource bundle not found (continuing due to ALLOW_MISSING_TEXTUAL_BUNDLE=1)" >&2
-  else
-    echo "ERROR: Textual resource bundle not found. Set ALLOW_MISSING_TEXTUAL_BUNDLE=1 to bypass." >&2
-    exit 1
-  fi
-fi
-
 running_packaged_app_pids() {
   command -v pgrep >/dev/null 2>&1 || return 0
   local app_binary="$APP_ROOT/Contents/MacOS/OpenClaw"

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -387,13 +387,15 @@ describe("package-mac-app plist stamping", () => {
       script.indexOf(
         'OPENCLAWKIT_BUNDLE="$(build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG/OpenClawKit_OpenClawKit.bundle"',
       ),
-      script.indexOf('echo "📦 Copying Textual resources"'),
+      script.indexOf("running_packaged_app_pids()"),
     );
 
     expect(openClawKitBlock).toContain("ERROR: OpenClawKit resource bundle not found");
     expect(openClawKitBlock).toContain("exit 1");
     expect(openClawKitBlock).not.toContain("WARN:");
     expect(openClawKitBlock).not.toContain("continuing");
+    expect(script).not.toContain("Textual resource bundle");
+    expect(script).not.toContain("ALLOW_MISSING_TEXTUAL_BUNDLE");
   });
 
   it("does not mask required Info.plist stamp failures", () => {


### PR DESCRIPTION
## Summary
- replace the shared chat markdown renderer's Textual dependency with native `AttributedString(markdown:)` rendering
- remove Textual / swiftui-math from OpenClawKit and macOS SwiftPM resolution
- remove the obsolete Textual resource bundle requirement from mac packaging and keep the package script test pinned to that behavior
- declare `swift-concurrency-extras` directly for the macOS app because `OpenClaw` imports `ConcurrencyExtras`

## Verification
- `git diff --check origin/main...HEAD`
- Testbox changed gate on rebased head `d583acd29bbe9276c7b523beea900c1f356b6179`: `tbx_01kvvfz00hfd0hgakfmy0785nb`, label `openclaw-check-changed-rebased-macos-textual-d583`, passed
- Autoreview on rebased branch: clean, no accepted/actionable findings
- GitHub CI on pre-rebase SHA `223f5f509513df019e21dce189bdcf27f313ad25`: https://github.com/openclaw/openclaw/actions/runs/28065115671 passed, including `macos-swift` and `macos-node`

## Proof gap
- Direct AWS `pnpm mac:package` repro is still blocked by runner availability/toolchain, not by this patch. `run_8b5953683de7` reached JS/UI build, then failed on AWS `mac2.metal` because default Swift was 6.0.3 while `apps/macos` requires Swift tools 6.2.0. The M4 host that previously reproduced the Textual macro failure is currently unavailable/pending.
