### PR TITLE
feat(agents): configured agent env reaches spawned subprocesses

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1051,6 +1051,7 @@ for provider examples and precedence.
         reasoningDefault: "on", // per-agent reasoning visibility override
         fastModeDefault: false, // per-agent fast mode override
         params: { cacheRetention: "none" }, // overrides matching defaults.models params by key
+        env: { OPENCLAW_AGENT_ENV: "enabled" }, // child-process env overrides for this agent
         tts: {
           providers: {
             elevenlabs: { speakerVoiceId: "EXAVITQu4vr4xnSDxMaL" },
@@ -1092,6 +1093,7 @@ for provider examples and precedence.
 - `model`: string form sets a strict per-agent primary with no model fallback; object form `{ primary }` is also strict unless you add `fallbacks`. Use `{ primary, fallbacks: [...] }` to opt that agent into fallback, or `{ primary, fallbacks: [] }` to make strict behavior explicit. Cron jobs that only override `primary` still inherit default fallbacks unless you set `fallbacks: []`.
 - `utilityModel`: optional per-agent override for short internal tasks such as generated session and thread titles. Falls back to `agents.defaults.utilityModel`, then this agent's primary model.
 - `params`: per-agent stream params merged over the selected model entry in `agents.defaults.models`. Use this for agent-specific overrides like `cacheRetention`, `temperature`, or `maxTokens` without duplicating the whole model catalog.
+- `env`: optional per-agent environment variables injected only into child processes spawned for that agent: CLI backends, `exec`, ACP/ACPX sessions, and stdio MCP servers. Accepted keys override inherited Gateway process env at those child-process boundaries. The host env security policy filters `PATH`, loader/search-path/shell-hook keys, and credential-control variables; stdio MCP server `env` values are merged after `agents.list[].env`, so a server-local value can override the inherited per-agent value for that MCP process. Values are literal strings, so do not commit long-lived secrets here; keep them in the Gateway service environment or use the MCP server SecretInput flow when the secret is specific to a stdio MCP server (see [MCP server environment variables](/gateway/secrets#mcp-server-environment-variables)).
 - `tts`: optional per-agent text-to-speech overrides. The block deep-merges over `messages.tts`, so keep shared provider credentials and fallback policy in `messages.tts` and set only persona-specific values such as provider, voice, model, style, or auto mode here.
 - `skills`: optional per-agent skill allowlist. If omitted, the agent inherits `agents.defaults.skills` when set; an explicit list replaces defaults instead of merging, and `[]` means no skills.
 - `thinkingDefault`: optional per-agent default thinking level (`off | minimal | low | medium | high | xhigh | adaptive | max`). Overrides `agents.defaults.thinkingDefault` for this agent when no per-message or session override is set. The selected provider/model profile controls which values are valid; for Google Gemini, `adaptive` keeps provider-owned dynamic thinking (`thinkingLevel` omitted on Gemini 3/3.1, `thinkingBudget: -1` on Gemini 2.5).

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { RequestedModelUnsupportedError } from "acpx/runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AcpRuntimeError,
@@ -26,6 +25,12 @@ const CODEX_ACP_WRAPPER_COMMAND_WITH_LEASE = `${CODEX_ACP_WRAPPER_COMMAND} ${OPE
 const LOCAL_NODE_MODULES_CODEX_COMMAND = `node "${path.resolve(
   "node_modules/@zed-industries/codex-acp/bin/codex-acp.js",
 )}"`;
+
+function makeRequestedModelUnsupportedError(message: string): Error {
+  const error = new Error(message);
+  error.name = "RequestedModelUnsupportedError";
+  return error;
+}
 
 function makeRuntime(
   baseStore: TestSessionStore,
@@ -325,6 +330,47 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       mode: "persistent",
       model: "gpt-5.4",
       sessionOptions: { model: "gpt-5.4" },
+    });
+  });
+
+  it("passes OpenClaw env through ACPX session options", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      agentRegistry: {
+        resolve: (agentName: string) => (agentName === "codex" ? CODEX_ACP_COMMAND : agentName),
+        list: () => ["codex", "openclaw"],
+      },
+    });
+    const ensure = vi.spyOn(delegate, "ensureSession").mockResolvedValue({
+      sessionKey: "agent:codex:acp:test-env",
+      backend: "acpx",
+      runtimeSessionName: "codex",
+    });
+
+    await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:test-env",
+      agent: "codex",
+      mode: "persistent",
+      env: {
+        OPENCLAW_AGENT_ENV: "visible-to-acpx",
+      },
+    });
+
+    expect(readFirstEnsureSessionInput(ensure)).toEqual({
+      sessionKey: "agent:codex:acp:test-env",
+      agent: "codex",
+      mode: "persistent",
+      env: {
+        OPENCLAW_AGENT_ENV: "visible-to-acpx",
+      },
+      sessionOptions: {
+        env: {
+          OPENCLAW_AGENT_ENV: "visible-to-acpx",
+        },
+      },
     });
   });
 
@@ -826,9 +872,8 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     const ensure = vi
       .spyOn(delegate, "ensureSession")
       .mockRejectedValueOnce(
-        new RequestedModelUnsupportedError(
+        makeRequestedModelUnsupportedError(
           "Cannot apply --model: the ACP agent did not advertise model support",
-          "missing-capability",
         ),
       )
       .mockResolvedValueOnce({
@@ -868,9 +913,8 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     const ensure = vi
       .spyOn(delegate, "ensureSession")
       .mockRejectedValueOnce(
-        new RequestedModelUnsupportedError(
+        makeRequestedModelUnsupportedError(
           "Cannot apply --model: the ACP agent did not advertise that model",
-          "unadvertised-model",
         ),
       );
 
@@ -1508,6 +1552,67 @@ describe("AcpxRuntime fresh reset wrapper", () => {
 
     expect(resolvedCommands).toEqual([CODEX_ACP_WRAPPER_COMMAND]);
     expect(leaseStore.store.save).not.toHaveBeenCalled();
+  });
+
+  it("starts a fresh persistent ACPX session when effective env changes", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        name: "agent:codex:acp:binding:test",
+        acpxRecordId: "record-1",
+        acpSessionId: "session-1",
+        agentCommand: CODEX_ACP_WRAPPER_COMMAND,
+        cwd: "/tmp",
+        closed: false,
+        acpx: {
+          session_options: {
+            env: {
+              OPENCLAW_AGENT_ENV: "old-value",
+            },
+          },
+        },
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    const recordsLoadedByDelegate: unknown[] = [];
+    const ensure = vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
+      recordsLoadedByDelegate.push(await wrappedStore.load(input.sessionKey));
+      return {
+        sessionKey: "agent:codex:acp:binding:test",
+        backend: "acpx",
+        runtimeSessionName: "agent:codex:acp:binding:test",
+      };
+    });
+
+    await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:binding:test",
+      agent: "codex",
+      mode: "persistent",
+      env: {
+        OPENCLAW_AGENT_ENV: "new-value",
+      },
+    });
+
+    expect(leaseStore.store.save).toHaveBeenCalledOnce();
+    expect(recordsLoadedByDelegate).toEqual([undefined]);
+    expect(readFirstEnsureSessionInput(ensure)).toMatchObject({
+      sessionKey: "agent:codex:acp:binding:test",
+      sessionOptions: {
+        env: {
+          OPENCLAW_AGENT_ENV: "new-value",
+        },
+      },
+    });
   });
 
   it("merges sidecar lease ids into loaded ACPX session records", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -13,7 +13,6 @@ import {
   createFileSessionStore,
   decodeAcpxRuntimeHandleState,
   encodeAcpxRuntimeHandleState,
-  isRequestedModelUnsupportedError,
   type AcpAgentRegistry,
   type AcpRuntimeDoctorReport,
   type AcpRuntimeEvent,
@@ -65,6 +64,11 @@ const OPENCLAW_TOOLS_MCP_AGENT_SESSION_KEY_ENV = "OPENCLAW_TOOLS_MCP_AGENT_SESSI
 
 type ResetAwareSessionStore = AcpSessionStore & {
   markFresh: (sessionKey: string) => void;
+};
+
+type StablePersistentSessionReuseDecision = {
+  canReuse: boolean;
+  requiresFreshRecord: boolean;
 };
 
 type OpenClawLeaseSessionMetadata = {
@@ -179,6 +183,45 @@ function readRecordResetOnNextEnsure(record: unknown): boolean {
     return false;
   }
   return (acpx as { reset_on_next_ensure?: unknown }).reset_on_next_ensure === true;
+}
+
+function normalizeSessionEnv(value: unknown): Record<string, string> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .toSorted(([left], [right]) => left.localeCompare(right));
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function readRecordSessionEnv(record: unknown): Record<string, string> | undefined {
+  if (typeof record !== "object" || record === null) {
+    return undefined;
+  }
+  const { acpx } = record as { acpx?: unknown };
+  if (typeof acpx !== "object" || acpx === null) {
+    return undefined;
+  }
+  const { session_options: sessionOptions } = acpx as { session_options?: unknown };
+  if (typeof sessionOptions !== "object" || sessionOptions === null) {
+    return undefined;
+  }
+  return normalizeSessionEnv((sessionOptions as { env?: unknown }).env);
+}
+
+function sessionEnvMatches(left: unknown, right: unknown): boolean {
+  return (
+    JSON.stringify(normalizeSessionEnv(left) ?? {}) ===
+    JSON.stringify(normalizeSessionEnv(right) ?? {})
+  );
+}
+
+function readRuntimeEnsureSessionEnv(
+  input: OpenClawRuntimeEnsureInput,
+): Record<string, string> | undefined {
+  const existingOptions = (input as { sessionOptions?: SessionAgentOptions }).sessionOptions;
+  return normalizeSessionEnv(input.env ?? existingOptions?.env);
 }
 
 function readRecordAgentPid(record: unknown): number | undefined {
@@ -585,15 +628,30 @@ function normalizeClaudeAcpModelOverride(rawModel: string | undefined): string |
 function withAcpxSessionOptions(input: OpenClawRuntimeEnsureInput): AcpxDelegateEnsureInput {
   const existingOptions = (input as { sessionOptions?: SessionAgentOptions }).sessionOptions;
   const model = input.model?.trim() || existingOptions?.model;
-  const sessionOptions = model ? { ...existingOptions, model } : existingOptions;
+  const env = input.env ?? existingOptions?.env;
+  const sessionOptions = {
+    ...existingOptions,
+    ...(model ? { model } : {}),
+    ...(env ? { env } : {}),
+  };
   return {
     ...input,
-    ...(sessionOptions ? { sessionOptions } : {}),
+    ...(Object.keys(sessionOptions).length > 0 ? { sessionOptions } : {}),
   } as AcpxDelegateEnsureInput;
 }
 
 function isAcpModelCapabilityMissingError(error: unknown): boolean {
-  return isRequestedModelUnsupportedError(error) && error.reason === "missing-capability";
+  if (!(error instanceof Error) || error.name !== "RequestedModelUnsupportedError") {
+    return false;
+  }
+  const reason = (error as { reason?: unknown }).reason;
+  if (reason === "missing-capability") {
+    return true;
+  }
+  if (reason) {
+    return false;
+  }
+  return error.message.includes("did not advertise model support");
 }
 
 // ACPX owns the distinction between missing model capability and an invalid model id.
@@ -889,32 +947,39 @@ export class AcpxRuntime implements AcpRuntime {
     });
   }
 
-  private async canReuseStablePersistentSession(params: {
+  private async resolveStablePersistentSessionReuse(params: {
     sessionKey: string;
     mode: Parameters<AcpRuntime["ensureSession"]>[0]["mode"];
     cwd: string | undefined;
     command: string | undefined;
     resumeSessionId: string | undefined;
-  }): Promise<boolean> {
+    env: Record<string, string> | undefined;
+  }): Promise<StablePersistentSessionReuseDecision> {
     if (params.mode !== "persistent" || !params.command) {
-      return false;
+      return { canReuse: false, requiresFreshRecord: false };
     }
     const existing = await this.sessionStore.load(params.sessionKey);
     if (!existing || readRecordResetOnNextEnsure(existing)) {
-      return false;
+      return { canReuse: false, requiresFreshRecord: false };
     }
     const recordCwd = readRecordCwd(existing);
     if (!recordCwd || resolvePath(recordCwd) !== resolvePath(params.cwd?.trim() || this.cwd)) {
-      return false;
+      return { canReuse: false, requiresFreshRecord: false };
     }
     if (readRecordAgentCommand(existing) !== params.command) {
-      return false;
+      return { canReuse: false, requiresFreshRecord: false };
+    }
+    if (!sessionEnvMatches(readRecordSessionEnv(existing), params.env)) {
+      return { canReuse: false, requiresFreshRecord: true };
     }
     const existingSessionId =
       typeof existing === "object" && existing !== null
         ? (existing as { acpSessionId?: unknown }).acpSessionId
         : undefined;
-    return !params.resumeSessionId || existingSessionId === params.resumeSessionId;
+    return {
+      canReuse: !params.resumeSessionId || existingSessionId === params.resumeSessionId,
+      requiresFreshRecord: false,
+    };
   }
 
   private async runWithLaunchLease<T>(params: {
@@ -1090,13 +1155,18 @@ export class AcpxRuntime implements AcpRuntime {
       codexModelOverride && command
         ? appendCodexAcpConfigOverrides(command, codexModelOverride)
         : command;
-    const shouldStartWithLease = !(await this.canReuseStablePersistentSession({
+    const reuseDecision = await this.resolveStablePersistentSessionReuse({
       sessionKey: input.sessionKey,
       mode: input.mode,
       cwd: input.cwd,
       command: stableLaunchCommand,
       resumeSessionId: input.resumeSessionId,
-    }));
+      env: readRuntimeEnsureSessionEnv(ensureInput),
+    });
+    if (reuseDecision.requiresFreshRecord) {
+      this.sessionStore.markFresh(input.sessionKey);
+    }
+    const shouldStartWithLease = !reuseDecision.canReuse;
 
     if (!codexModelOverride) {
       return await this.runWithLaunchLease({

--- a/src/acp/control-plane/manager.initialize-session.test.ts
+++ b/src/acp/control-plane/manager.initialize-session.test.ts
@@ -100,6 +100,95 @@ describe("AcpSessionManager initializeSession", () => {
     });
   });
 
+  it("passes configured agent env into ACP runtime initialization", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.upsertAcpSessionMetaMock.mockResolvedValue({
+      sessionKey: "agent:codex:acp:session-agent-env",
+      storeSessionKey: "agent:codex:acp:session-agent-env",
+      acp: readySessionMeta(),
+    });
+    const cfg = {
+      ...baseCfg,
+      agents: {
+        list: [
+          {
+            id: "codex",
+            env: {
+              OPENCLAW_AGENT_ENV: "visible-to-acp",
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const manager = new AcpSessionManager();
+    await manager.initializeSession({
+      cfg,
+      sessionKey: "agent:codex:acp:session-agent-env",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    expectRecordFields(mockCallArg(runtimeState.ensureSession), {
+      sessionKey: "agent:codex:acp:session-agent-env",
+      env: {
+        OPENCLAW_AGENT_ENV: "visible-to-acp",
+      },
+    });
+  });
+
+  it("uses the configured agent owner env when ACP initialization targets a harness agent", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.upsertAcpSessionMetaMock.mockResolvedValue({
+      sessionKey: "agent:reviewer:acp:binding:discord:default:agent-env",
+      storeSessionKey: "agent:reviewer:acp:binding:discord:default:agent-env",
+      acp: readySessionMeta({ agent: "codex" }),
+    });
+    const cfg = {
+      ...baseCfg,
+      agents: {
+        list: [
+          {
+            id: "reviewer",
+            env: {
+              OPENCLAW_AGENT_ENV: "visible-to-owner",
+            },
+            runtime: {
+              type: "acp",
+              acp: {
+                agent: "codex",
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const manager = new AcpSessionManager();
+    await manager.initializeSession({
+      cfg,
+      sessionKey: "agent:reviewer:acp:binding:discord:default:agent-env",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    expectRecordFields(mockCallArg(runtimeState.ensureSession), {
+      sessionKey: "agent:reviewer:acp:binding:discord:default:agent-env",
+      agent: "codex",
+      env: {
+        OPENCLAW_AGENT_ENV: "visible-to-owner",
+      },
+    });
+  });
+
   it("preserves runtimeOptions cwd when initializeSession cwd is omitted", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.initialize-session.ts
+++ b/src/acp/control-plane/manager.initialize-session.ts
@@ -4,9 +4,11 @@ import {
   mergeSessionIdentity,
 } from "@openclaw/acp-core/runtime/session-identity";
 import type { AcpRuntime, AcpRuntimeHandle } from "@openclaw/acp-core/runtime/types";
+import { resolveAgentConfig } from "../../agents/agent-scope-config.js";
 import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
+import { sanitizeHostEnvOverrides } from "../../infra/host-env-security.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { AcpRuntimeError, withAcpRuntimeErrorBoundary } from "../runtime/errors.js";
 import type { ManagerRuntimeHandleCache } from "./manager.runtime-handle-cache.js";
@@ -17,6 +19,7 @@ import type {
   SessionEntry,
   WriteManagerSessionMeta,
 } from "./manager.types.js";
+import { resolveAcpAgentFromSessionKey } from "./manager.utils.js";
 import {
   normalizeRuntimeOptions,
   normalizeText,
@@ -40,6 +43,11 @@ export async function runManagerInitializeSession(params: {
   const backend = params.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
   const runtime = backend.runtime;
   const agent = normalizeAgentId(input.agent);
+  const agentEnvOwner = resolveAcpAgentFromSessionKey(sessionKey, agent);
+  const agentEnv = sanitizeHostEnvOverrides({
+    overrides: resolveAgentConfig(input.cfg, agentEnvOwner)?.env,
+    blockPathOverrides: true,
+  });
   const initialRuntimeOptions = validateRuntimeOptionPatch({
     ...input.runtimeOptions,
     ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
@@ -60,6 +68,7 @@ export async function runManagerInitializeSession(params: {
         resumeSessionId: input.resumeSessionId,
         ...(requestedModel ? { model: requestedModel } : {}),
         ...(requestedThinking ? { thinking: requestedThinking } : {}),
+        ...(agentEnv ? { env: agentEnv } : {}),
         cwd: requestedCwd,
       }),
     fallbackCode: "ACP_SESSION_INIT_FAILED",

--- a/src/acp/control-plane/manager.runtime-handle-ensure.ts
+++ b/src/acp/control-plane/manager.runtime-handle-ensure.ts
@@ -9,9 +9,11 @@ import {
   resolveSessionIdentityFromMeta,
 } from "@openclaw/acp-core/runtime/session-identity";
 import type { AcpRuntime, AcpRuntimeHandle } from "@openclaw/acp-core/runtime/types";
+import { resolveAgentConfig } from "../../agents/agent-scope-config.js";
 import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
+import { sanitizeHostEnvOverrides } from "../../infra/host-env-security.js";
 import { toAcpRuntimeError, withAcpRuntimeErrorBoundary } from "../runtime/errors.js";
 import type { ManagerRuntimeHandleCache } from "./manager.runtime-handle-cache.js";
 import type {
@@ -45,6 +47,11 @@ export async function ensureManagerRuntimeHandle(params: {
   const model = normalizeText(runtimeOptions.model);
   const thinking = normalizeText(runtimeOptions.thinking);
   const configuredBackend = (params.meta.backend || params.cfg.acp?.backend || "").trim();
+  const agentEnvOwner = resolveAcpAgentFromSessionKey(params.sessionKey, agent);
+  const agentEnv = sanitizeHostEnvOverrides({
+    overrides: resolveAgentConfig(params.cfg, agentEnvOwner)?.env,
+    blockPathOverrides: true,
+  });
   const configSignature = resolveRuntimeConfigCacheKey(params.cfg);
   const cached = params.runtimeHandles.get(params.sessionKey);
   if (cached) {
@@ -108,6 +115,7 @@ export async function ensureManagerRuntimeHandle(params: {
           ...(resumeSessionId ? { resumeSessionId } : {}),
           ...(model ? { model } : {}),
           ...(thinking ? { thinking } : {}),
+          ...(agentEnv ? { env: agentEnv } : {}),
           cwd,
         }),
       fallbackCode: "ACP_SESSION_INIT_FAILED",

--- a/src/acp/control-plane/manager.runtime-handles.test.ts
+++ b/src/acp/control-plane/manager.runtime-handles.test.ts
@@ -374,6 +374,105 @@ describe("AcpSessionManager runtime handles", () => {
     });
   });
 
+  it("passes configured agent env into ACP runtime re-ensure after restart", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    const sessionKey = "agent:codex:acp:binding:demo-binding:default:agent-env-restart";
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const key = (paramsUnknown as { sessionKey?: string }).sessionKey ?? sessionKey;
+      return {
+        sessionKey: key,
+        storeSessionKey: key,
+        acp: readySessionMeta({ agent: "codex" }),
+      };
+    });
+    const cfg = {
+      ...baseCfg,
+      agents: {
+        list: [
+          {
+            id: "codex",
+            env: {
+              OPENCLAW_AGENT_ENV: "visible-after-restart",
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg,
+      sessionKey,
+      text: "after restart",
+      mode: "prompt",
+      requestId: "r-binding-restart-agent-env",
+    });
+
+    expectRecordFields(mockCallArg(runtimeState.ensureSession), {
+      sessionKey,
+      env: {
+        OPENCLAW_AGENT_ENV: "visible-after-restart",
+      },
+    });
+  });
+
+  it("uses the configured agent owner env when ACP runtime re-ensure targets a harness agent", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    const sessionKey = "agent:reviewer:acp:binding:discord:default:agent-env-restart";
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const key = (paramsUnknown as { sessionKey?: string }).sessionKey ?? sessionKey;
+      return {
+        sessionKey: key,
+        storeSessionKey: key,
+        acp: readySessionMeta({ agent: "codex" }),
+      };
+    });
+    const cfg = {
+      ...baseCfg,
+      agents: {
+        list: [
+          {
+            id: "reviewer",
+            env: {
+              OPENCLAW_AGENT_ENV: "visible-after-owner-restart",
+            },
+            runtime: {
+              type: "acp",
+              acp: {
+                agent: "codex",
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg,
+      sessionKey,
+      text: "after restart",
+      mode: "prompt",
+      requestId: "r-binding-restart-owner-agent-env",
+    });
+
+    expectRecordFields(mockCallArg(runtimeState.ensureSession), {
+      sessionKey,
+      agent: "codex",
+      env: {
+        OPENCLAW_AGENT_ENV: "visible-after-owner-restart",
+      },
+    });
+  });
+
   it("passes persisted model runtime options into ensureSession after restart", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1116,6 +1116,93 @@ describe("spawnAcpDirect", () => {
     });
   });
 
+  it("rejects configured runtime=acp aliases that are not allowed as configured owners", async () => {
+    replaceSpawnConfig({
+      ...createDefaultSpawnConfig(),
+      agents: {
+        list: [
+          {
+            id: "codex-acp",
+            env: {
+              OPENCLAW_AGENT_ENV: "visible-to-owner",
+            },
+            runtime: {
+              type: "acp",
+              acp: { agent: "codex" },
+            },
+          },
+        ],
+        defaults: {
+          subagents: {
+            allowAgents: ["codex"],
+            maxSpawnDepth: 2,
+          },
+        },
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex-acp",
+      },
+      {
+        ...createRequesterContext(),
+        agentSessionKey: "agent:main:subagent:parent",
+      },
+    );
+
+    const failed = expectFailedSpawn(result, "forbidden");
+    expect(failed.errorCode).toBe("subagent_policy");
+    expect(failed.error).toContain("agentId is not allowed for sessions_spawn");
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("uses configured runtime=acp agent id as the ACP session owner", async () => {
+    replaceSpawnConfig({
+      ...createDefaultSpawnConfig(),
+      agents: {
+        list: [
+          {
+            id: "codex-acp",
+            env: {
+              OPENCLAW_AGENT_ENV: "visible-to-owner",
+            },
+            runtime: {
+              type: "acp",
+              acp: { agent: "codex" },
+            },
+          },
+        ],
+        defaults: {
+          subagents: {
+            allowAgents: ["codex-acp"],
+            maxSpawnDepth: 2,
+          },
+        },
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex-acp",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted.childSessionKey).toMatch(/^agent:codex-acp:acp:/);
+    const initInput = expectInitializeSessionFields({
+      agent: "codex",
+      sessionKey: accepted.childSessionKey,
+    });
+    expect(initInput.sessionKey).toMatch(/^agent:codex-acp:acp:/);
+    expect(findAgentGatewayCall()?.params?.sessionKey).toBe(accepted.childSessionKey);
+  });
+
   it("uses configured runtime=acp agent primary model as an ACP startup model", async () => {
     replaceSpawnConfig({
       ...createDefaultSpawnConfig(),
@@ -1357,7 +1444,7 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params).not.toHaveProperty("attachments");
   });
 
-  it("maps OpenClaw ACP runtime agent aliases to their configured harness id", async () => {
+  it("maps OpenClaw ACP runtime agent aliases to their configured harness id and session owner", async () => {
     replaceSpawnConfig({
       ...createDefaultSpawnConfig(),
       agents: {
@@ -1393,7 +1480,7 @@ describe("spawnAcpDirect", () => {
 
     expectAcceptedSpawn(result);
     const initInput = expectInitializeSessionFields({ agent: "codex" });
-    expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
+    expect(initInput.sessionKey).toMatch(/^agent:reviewer:acp:/);
   });
 
   it("inherits subagent envelope fields onto ACP children", async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -823,6 +823,7 @@ function resolveAcpSubagentEnvelopeState(params: {
   requesterSessionKey?: string;
   requesterAgentId: string;
   targetAgentId: string;
+  policyTargetAgentId?: string;
   requestedAgentId?: string;
   subagentStore?: SessionCapabilityStore;
 }): AcpSubagentEnvelopeState {
@@ -875,7 +876,7 @@ function resolveAcpSubagentEnvelopeState(params: {
 
   const targetPolicy = resolveSubagentTargetPolicy({
     requesterAgentId: params.requesterAgentId,
-    targetAgentId: params.targetAgentId,
+    targetAgentId: params.policyTargetAgentId ?? params.targetAgentId,
     requestedAgentId: params.requestedAgentId,
     allowAgents:
       resolveAgentConfig(params.cfg, params.requesterAgentId)?.subagents?.allowAgents ??
@@ -955,7 +956,7 @@ function sessionEntryIsOwnedByRequester(params: {
 
 function validateAcpResumeSessionOwnership(params: {
   cfg: OpenClawConfig;
-  targetAgentId: string;
+  sessionOwnerAgentId: string;
   requesterSessionKey?: string;
   resumeSessionId?: string;
 }): { ok: true } | { ok: false; error: string } {
@@ -971,9 +972,12 @@ function validateAcpResumeSessionOwnership(params: {
     };
   }
 
-  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: params.sessionOwnerAgentId,
+  });
   for (const { sessionKey, entry } of listSessionEntries({ storePath, clone: false })) {
     const acp = readAcpSessionMeta({ sessionKey, cfg: params.cfg });
+
     if (!sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)) {
       continue;
     }
@@ -1065,12 +1069,15 @@ async function initializeAcpSpawnRuntime(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   targetAgentId: string;
+  sessionOwnerAgentId: string;
   runtimeMode: AcpRuntimeSessionMode;
   resumeSessionId?: string;
   runtimeOptions?: AcpSpawnRuntimeOptions;
   cwd?: string;
 }): Promise<AcpSpawnInitializedRuntime> {
-  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: params.sessionOwnerAgentId,
+  });
   let sessionEntry = loadSessionEntry({
     storePath,
     sessionKey: params.sessionKey,
@@ -1083,7 +1090,7 @@ async function initializeAcpSpawnRuntime(params: {
       sessionKey: params.sessionKey,
       storePath,
       sessionEntry,
-      agentId: params.targetAgentId,
+      agentId: params.sessionOwnerAgentId,
       stage: "spawn",
     });
   }
@@ -1115,6 +1122,7 @@ async function bindPreparedAcpThread(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   targetAgentId: string;
+  sessionOwnerAgentId: string;
   label?: string;
   preparedBinding: PreparedAcpThreadBinding;
   initializedRuntime: AcpSpawnInitializedRuntime;
@@ -1180,7 +1188,7 @@ async function bindPreparedAcpThread(params: {
         sessionKey: params.sessionKey,
         storePath: params.initializedRuntime.storePath,
         sessionEntry,
-        agentId: params.targetAgentId,
+        agentId: params.sessionOwnerAgentId,
         threadId: boundThreadId,
         stage: "thread-bind",
       });
@@ -1359,6 +1367,7 @@ export async function spawnAcpDirect(
     });
   }
   const targetAgentId = targetAgentResult.agentId;
+  const sessionOwnerAgentId = targetAgentResult.configAgentId ?? targetAgentId;
   const agentPolicyError = resolveAcpAgentPolicyError(cfg, targetAgentId);
   if (agentPolicyError) {
     return createAcpSpawnFailure({
@@ -1383,6 +1392,7 @@ export async function spawnAcpDirect(
     requesterSessionKey: requesterInternalKey,
     requesterAgentId,
     targetAgentId,
+    policyTargetAgentId: sessionOwnerAgentId,
     requestedAgentId: params.agentId,
     subagentStore,
   });
@@ -1395,7 +1405,7 @@ export async function spawnAcpDirect(
   }
   const resumeAuthorization = validateAcpResumeSessionOwnership({
     cfg,
-    targetAgentId,
+    sessionOwnerAgentId,
     requesterSessionKey: requesterInternalKey,
     resumeSessionId: params.resumeSessionId,
   });
@@ -1428,11 +1438,11 @@ export async function spawnAcpDirect(
     requester: requesterState,
   });
 
-  const sessionKey = `agent:${targetAgentId}:acp:${crypto.randomUUID()}`;
+  const sessionKey = `agent:${sessionOwnerAgentId}:acp:${crypto.randomUUID()}`;
   const runtimeMode = resolveAcpSessionMode(spawnMode);
   const resolvedCwd = resolveSpawnedWorkspaceInheritance({
     config: cfg,
-    targetAgentId,
+    targetAgentId: sessionOwnerAgentId,
     requesterSessionKey: ctx.agentSessionKey,
     explicitWorkspaceDir: params.cwd,
   });
@@ -1491,6 +1501,7 @@ export async function spawnAcpDirect(
       cfg,
       sessionKey,
       targetAgentId,
+      sessionOwnerAgentId,
       runtimeMode,
       resumeSessionId: params.resumeSessionId,
       runtimeOptions: runtimeOptionsResult.runtimeOptions,
@@ -1503,6 +1514,7 @@ export async function spawnAcpDirect(
         cfg,
         sessionKey,
         targetAgentId,
+        sessionOwnerAgentId,
         label: params.label,
         preparedBinding,
         initializedRuntime: initializedSession,

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -2627,7 +2627,7 @@ async function handle(message) {
     };
     if (await isFirstConnect()) {
       log("slow first initialize");
-      setTimeout(() => send(response), 600);
+      setTimeout(() => send(response), 2500);
     } else {
       log("fast retry initialize");
       send(response);
@@ -2682,7 +2682,7 @@ process.on("SIGINT", shutdown);`,
               slow: {
                 command: process.execPath,
                 args: [slowServerPath],
-                connectionTimeoutMs: 150,
+                connectionTimeoutMs: 1_000,
               },
             },
           },

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -346,6 +346,121 @@ afterEach(async () => {
 });
 
 describe("session MCP runtime", () => {
+  it("resolves inherited stdio MCP env from trusted agent owner before raw session key", async () => {
+    const tempDir = makeTempDir(tempDirs, "bundle-mcp-trusted-owner-env-");
+    const serverPath = path.join(tempDir, "env-server.mjs");
+    const logPath = path.join(tempDir, "server.log");
+
+    await writeExecutable(
+      serverPath,
+      `#!/usr/bin/env node
+import fs from "node:fs/promises";
+
+const logPath = ${JSON.stringify(logPath)};
+let buffer = "";
+function log(line) {
+  void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
+}
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+function handle(message) {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  if (message.method === "initialize") {
+    log("env " + String(process.env.OPENCLAW_AGENT_ENV ?? "null"));
+    log("ld " + String(process.env.LD_PRELOAD ?? "null"));
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+        capabilities: { tools: {} },
+        serverInfo: { name: "env-owner", version: "1.0.0" },
+      },
+    });
+    return;
+  }
+  if (message.method === "tools/list") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        tools: [{ name: "env_tool", inputSchema: { type: "object", properties: {} } }],
+      },
+    });
+  }
+}
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) {
+      return;
+    }
+    const line = buffer.slice(0, newline).replace(/\\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (line.trim()) {
+      handle(JSON.parse(line));
+    }
+  }
+});
+process.stdin.on("end", () => process.exit(0));
+process.on("SIGTERM", () => process.exit(0));
+process.on("SIGINT", () => process.exit(0));`,
+    );
+
+    const runtimeParams: Parameters<typeof getOrCreateSessionMcpRuntime>[0] & { agentId: string } =
+      {
+        sessionId: "session-trusted-owner-env",
+        sessionKey: "main:abc",
+        agentId: "reviewer",
+        workspaceDir: "/workspace",
+        cfg: {
+          agents: {
+            list: [
+              {
+                id: "main",
+                env: {
+                  OPENCLAW_AGENT_ENV: "wrong-main-env",
+                },
+              },
+              {
+                id: "reviewer",
+                env: {
+                  OPENCLAW_AGENT_ENV: "visible-reviewer-env",
+                  LD_PRELOAD: "/blocked-loader",
+                },
+              },
+            ],
+          },
+          mcp: {
+            servers: {
+              envProbe: {
+                command: process.execPath,
+                args: [serverPath],
+              },
+            },
+          },
+        },
+      };
+
+    const runtime = await getOrCreateSessionMcpRuntime(runtimeParams);
+    try {
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools.map((tool) => tool.toolName)).toEqual(["env_tool"]);
+      const logText = await fs.readFile(logPath, "utf8");
+      expect(logText).toContain("env visible-reviewer-env");
+      expect(logText).not.toContain("wrong-main-env");
+      expect(logText).toContain("ld null");
+      expect(logText).not.toContain("/blocked-loader");
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
   it("accepts draft-2020-12 tool output schemas from external MCP catalogs", () => {
     const validator = createBundleMcpJsonSchemaValidator().getValidator<{
       format: string;

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -16,8 +16,10 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { Compile } from "typebox/compile";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { toErrorObject } from "../infra/errors.js";
+import { sanitizeHostEnvOverrides } from "../infra/host-env-security.js";
 import { logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
   findJsonSchemaShapeError,
@@ -34,6 +36,7 @@ import type {
   SessionMcpRuntime,
   SessionMcpRuntimeManager,
 } from "./agent-bundle-mcp-types.js";
+import { resolveAgentConfig } from "./agent-scope-config.js";
 import { loadEmbeddedAgentMcpConfig } from "./embedded-agent-mcp.js";
 import { isMcpConfigRecord } from "./mcp-config-shared.js";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
@@ -454,20 +457,42 @@ async function disposeSession(session: BundleMcpSession) {
   }
 }
 
-function createCatalogFingerprint(servers: Record<string, unknown>): string {
+function createCatalogFingerprint(
+  servers: Record<string, unknown>,
+  inheritedEnv?: Record<string, string>,
+): string {
   // Session MCP fingerprints only invalidate in-memory runtime catalogs.
   // Algorithm changes can cause one cache miss, but no persisted state migration.
-  return crypto.createHash("sha256").update(JSON.stringify(servers)).digest("hex");
+  return crypto.createHash("sha256").update(JSON.stringify({ servers, inheritedEnv })).digest("hex");
+}
+
+function resolveSessionMcpInheritedEnv(params: {
+  cfg?: OpenClawConfig;
+  sessionKey?: string;
+  agentId?: string;
+}): Record<string, string> | undefined {
+  if (!params.cfg) {
+    return undefined;
+  }
+  const agentId = params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey);
+  const env = resolveAgentConfig(params.cfg, agentId)?.env;
+  return sanitizeHostEnvOverrides({
+    overrides: env,
+    blockPathOverrides: true,
+  });
 }
 
 function loadSessionMcpConfig(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  sessionKey?: string;
+  agentId?: string;
   logDiagnostics?: boolean;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): {
   loaded: LoadedMcpConfig;
   fingerprint: string;
+  inheritedEnv?: Record<string, string>;
 } {
   const loaded = loadEmbeddedAgentMcpConfig({
     workspaceDir: params.workspaceDir,
@@ -479,9 +504,15 @@ function loadSessionMcpConfig(params: {
       logWarn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
     }
   }
+  const inheritedEnv = resolveSessionMcpInheritedEnv({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+  });
   return {
     loaded,
-    fingerprint: createCatalogFingerprint(loaded.mcpServers),
+    fingerprint: createCatalogFingerprint(loaded.mcpServers, inheritedEnv),
+    ...(inheritedEnv ? { inheritedEnv } : {}),
   };
 }
 
@@ -492,11 +523,15 @@ function loadSessionMcpConfig(params: {
 export function resolveSessionMcpConfigSummary(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  sessionKey?: string;
+  agentId?: string;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): { fingerprint: string; serverNames: string[] } {
   const { loaded, fingerprint } = loadSessionMcpConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
     logDiagnostics: false,
     manifestRegistry: params.manifestRegistry,
   });
@@ -521,13 +556,20 @@ function resolveSessionMcpRuntimeIdleTtlMs(cfg?: OpenClawConfig): number {
 export function createSessionMcpRuntime(params: {
   sessionId: string;
   sessionKey?: string;
+  agentId?: string;
   workspaceDir: string;
   cfg?: OpenClawConfig;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): SessionMcpRuntime {
-  const { loaded, fingerprint: configFingerprint } = loadSessionMcpConfig({
+  const {
+    loaded,
+    fingerprint: configFingerprint,
+    inheritedEnv,
+  } = loadSessionMcpConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
     logDiagnostics: true,
     manifestRegistry: params.manifestRegistry,
   });
@@ -655,7 +697,7 @@ export function createSessionMcpRuntime(params: {
         }> = [];
         for (const [serverName, rawServer] of Object.entries(loaded.mcpServers)) {
           failIfDisposed();
-          const resolved = resolveMcpTransport(serverName, rawServer);
+          const resolved = resolveMcpTransport(serverName, rawServer, { inheritedEnv });
           if (!resolved) {
             continue;
           }
@@ -1122,6 +1164,8 @@ function createSessionMcpRuntimeManager(
       const { fingerprint: nextFingerprint } = loadSessionMcpConfig({
         workspaceDir: params.workspaceDir,
         cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        agentId: params.agentId,
         logDiagnostics: false,
       });
       const existing = runtimesBySessionId.get(params.sessionId);
@@ -1156,6 +1200,7 @@ function createSessionMcpRuntimeManager(
         createRuntime({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
+          agentId: params.agentId,
           workspaceDir: params.workspaceDir,
           cfg: params.cfg,
           configFingerprint: nextFingerprint,
@@ -1239,6 +1284,7 @@ export function getSessionMcpRuntimeManager(): SessionMcpRuntimeManager {
 export async function getOrCreateSessionMcpRuntime(params: {
   sessionId: string;
   sessionKey?: string;
+  agentId?: string;
   workspaceDir: string;
   cfg?: OpenClawConfig;
 }): Promise<SessionMcpRuntime> {

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -90,6 +90,7 @@ export type SessionMcpRuntimeManager = {
   getOrCreate: (params: {
     sessionId: string;
     sessionKey?: string;
+    agentId?: string;
     workspaceDir: string;
     cfg?: OpenClawConfig;
   }) => Promise<SessionMcpRuntime>;

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -19,6 +19,7 @@ export type ResolvedAgentConfig = {
   name?: string;
   workspace?: string;
   agentDir?: string;
+  env?: AgentEntry["env"];
   model?: AgentEntry["model"];
   utilityModel?: AgentEntry["utilityModel"];
   thinkingDefault?: AgentEntry["thinkingDefault"];
@@ -125,6 +126,7 @@ export function resolveAgentConfig(
     name: readStringValue(entry.name),
     workspace: readStringValue(entry.workspace),
     agentDir: readStringValue(entry.agentDir),
+    env: entry.env ? { ...entry.env } : undefined,
     model:
       typeof entry.model === "string" || (entry.model && typeof entry.model === "object")
         ? entry.model

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -79,6 +79,37 @@ describe("resolveAgentConfig", () => {
     });
   });
 
+  it("returns per-agent env for the resolved agent only", () => {
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            env: {
+              OPENCLAW_AGENT_ENV: "main-only",
+              GIT_AUTHOR_EMAIL: "main@example.com",
+            },
+          },
+          {
+            id: "worker",
+            env: {
+              OPENCLAW_AGENT_ENV: "worker-only",
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveAgentConfig(cfg, "main") as
+      | ({ env?: Record<string, string> } & NonNullable<ReturnType<typeof resolveAgentConfig>>)
+      | undefined;
+
+    expect(result?.env).toEqual({
+      OPENCLAW_AGENT_ENV: "main-only",
+      GIT_AUTHOR_EMAIL: "main@example.com",
+    });
+  });
+
   it("prefers per-agent verbose defaults over global defaults", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -4,6 +4,7 @@
  * exec host without leaking unsafe overrides.
  */
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import { OPENCLAW_CLI_ENV_VALUE } from "../infra/openclaw-exec-env.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -164,6 +165,50 @@ describe("exec resolve_exec_env hook wiring", () => {
     expect(mocks.spawnInputs[0]?.env?.[CHANNEL_CONTEXT_ENV_KEY]).toBe(
       mocks.gatewayParams[0]?.env[CHANNEL_CONTEXT_ENV_KEY],
     );
+  });
+
+  it("merges configured agent env into gateway exec subprocesses", async () => {
+    const tool = createExecTool({
+      host: "auto",
+      security: "full",
+      ask: "off",
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+      config: {
+        agents: {
+          list: [
+            {
+              id: "main",
+              env: {
+                AGENT_SAFE: "agent",
+                EXISTING: "agent",
+                NODE_OPTIONS: "--require ./malicious.js",
+              },
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    await tool.execute("call-agent-env", {
+      command: "echo ok",
+      env: { EXISTING: "request" },
+      yieldMs: 120_000,
+    });
+
+    expect(mocks.gatewayParams[0]?.requestedEnv).toMatchObject({
+      AGENT_SAFE: "agent",
+      EXISTING: "request",
+    });
+    expect(mocks.gatewayParams[0]?.env).toMatchObject({
+      AGENT_SAFE: "agent",
+      EXISTING: "request",
+    });
+    expect(mocks.gatewayParams[0]?.env).not.toHaveProperty("NODE_OPTIONS");
+    expect(mocks.spawnInputs[0]?.env).toMatchObject({
+      AGENT_SAFE: "agent",
+      EXISTING: "request",
+    });
   });
 
   it("merges filtered plugin env into gateway execution and approval-visible requested env", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -33,6 +33,7 @@ import {
   isDangerousHostEnvOverrideVarName,
   isDangerousHostEnvVarName,
   normalizeHostOverrideEnvVarKey,
+  sanitizeHostEnvOverrides,
   sanitizeHostExecEnvWithDiagnostics,
 } from "../infra/host-env-security.js";
 import { OPENCLAW_CLI_ENV_VAR } from "../infra/openclaw-exec-env.js";
@@ -52,6 +53,7 @@ import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
 import { splitShellArgs } from "../utils/shell-argv.js";
+import { resolveAgentConfig } from "./agent-scope-config.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
 import { stripMalformedXmlArgValueSuffixFromKeys } from "./agent-tools.params.js";
 import { markBackgrounded } from "./bash-process-registry.js";
@@ -1780,11 +1782,24 @@ export function createExecTool(
         const inheritedBaseEnv = coerceEnv(process.env);
         const resolvedExecEnvState = getResolvedExecEnvPreparedState(params);
         const channelContextEnv = buildChannelContextEnv(defaults?.channelContext);
+        const agentEnv =
+          defaults?.config && agentId
+            ? sanitizeHostEnvOverrides({
+                overrides: resolveAgentConfig(defaults.config, agentId)?.env,
+                blockPathOverrides: true,
+              })
+            : undefined;
         const requestedEnv: Record<string, string> | undefined =
+          agentEnv !== undefined ||
           params.env !== undefined ||
           resolvedExecEnvState?.pluginEnv !== undefined ||
           channelContextEnv !== undefined
-            ? { ...params.env, ...resolvedExecEnvState?.pluginEnv, ...channelContextEnv }
+            ? {
+                ...agentEnv,
+                ...params.env,
+                ...resolvedExecEnvState?.pluginEnv,
+                ...channelContextEnv,
+              }
             : undefined;
         const hostEnvResult =
           host === "sandbox"

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -659,6 +659,36 @@ describe("runCliAgent spawn path", () => {
     );
   });
 
+  it("passes configured per-agent env to the spawned CLI process", async () => {
+    mockSuccessfulCliRun();
+
+    await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "codex-cli",
+        model: "gpt-5.5",
+        runId: "run-agent-env",
+        agentId: "main",
+        config: {
+          agents: {
+            list: [
+              {
+                id: "main",
+                env: {
+                  OPENCLAW_AGENT_ENV: "visible-to-cli",
+                  NODE_OPTIONS: "--require ./malicious.js",
+                },
+              },
+            ],
+          },
+        } as unknown as PreparedCliRunContext["params"]["config"],
+      }),
+    );
+
+    const input = mockCallArg(supervisorSpawnMock) as { env?: Record<string, string> };
+    expect(input.env?.OPENCLAW_AGENT_ENV).toBe("visible-to-cli");
+    expect(input.env?.NODE_OPTIONS).toBeUndefined();
+  });
+
   it("passes OpenClaw skills to Claude as a session plugin", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-skills-"));
     const skillDir = path.join(workspaceDir, "skills", "weather");

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -26,11 +26,12 @@ import {
   scopedHeartbeatWakeOptionsForPolicy,
 } from "../../infra/event-session-routing.js";
 import { requestHeartbeat as requestHeartbeatImpl } from "../../infra/heartbeat-wake.js";
-import { sanitizeHostExecEnv } from "../../infra/host-env-security.js";
+import { sanitizeHostEnvOverrides, sanitizeHostExecEnv } from "../../infra/host-env-security.js";
 import { shouldUseInternalSourceReplySink } from "../../infra/outbound/internal-source-reply.js";
 import { enqueueSystemEvent as enqueueSystemEventImpl } from "../../infra/system-events.js";
 import { getProcessSupervisor as getProcessSupervisorImpl } from "../../process/supervisor/index.js";
 import { applySkillEnvOverridesFromSnapshot } from "../../skills/runtime/env-overrides.js";
+import { resolveAgentConfig } from "../agent-scope-config.js";
 import { appendBootstrapPromptWarning } from "../bootstrap-budget.js";
 import {
   createCliJsonlStreamingParser,
@@ -892,8 +893,16 @@ export async function executePreparedCliRun(
             }
             delete next[key];
           }
+          const agentEnv = context.params.agentId
+            ? sanitizeHostEnvOverrides({
+                overrides: resolveAgentConfig(context.params.config ?? {}, context.params.agentId)
+                  ?.env,
+                blockPathOverrides: true,
+              })
+            : undefined;
           const backendEnv = {
             ...backend.env,
+            ...agentEnv,
             ...context.preparedBackend.env,
           };
           if (Object.keys(backendEnv).length > 0) {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1628,6 +1628,7 @@ export async function runEmbeddedAttempt(
       ? await getOrCreateSessionMcpRuntime({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
+          agentId: sessionAgentId,
           workspaceDir: effectiveWorkspace,
           cfg: params.config,
         })

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -126,6 +126,50 @@ describe("resolveMcpTransportConfig", () => {
     });
   });
 
+  it("merges inherited agent env into stdio config before server env", () => {
+    const resolveWithInheritedEnv = resolveMcpTransportConfig as (
+      serverName: string,
+      rawServer: unknown,
+      options?: { inheritedEnv?: Record<string, string> },
+    ) => ReturnType<typeof resolveMcpTransportConfig>;
+
+    const resolved = resolveWithInheritedEnv(
+      "probe",
+      {
+        command: "node",
+        env: {
+          OPENCLAW_AGENT_ENV: "server-wins",
+          SERVER_ONLY: "server",
+        },
+      },
+      {
+        inheritedEnv: {
+          OPENCLAW_AGENT_ENV: "agent",
+          AGENT_ONLY: "agent",
+          NODE_OPTIONS: "--require=./evil.js",
+          PATH: "/tmp/agent-bin",
+        },
+      },
+    );
+
+    expect(resolved).toEqual({
+      kind: "stdio",
+      transportType: "stdio",
+      command: "node",
+      args: undefined,
+      env: {
+        OPENCLAW_AGENT_ENV: "server-wins",
+        AGENT_ONLY: "agent",
+        SERVER_ONLY: "server",
+      },
+      cwd: undefined,
+      description: "node",
+      connectionTimeoutMs: 30_000,
+      requestTimeoutMs: 60_000,
+      supportsParallelToolCalls: false,
+    });
+  });
+
   it("sanitizes config-controlled names in stdio env warnings", () => {
     resolveMcpTransportConfig("probe\nWARN forged\u001b[31m", {
       command: "node",

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -4,6 +4,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveOpenClawMcpTransportAlias } from "../config/mcp-config-normalize.js";
+import { sanitizeHostEnvOverrides } from "../infra/host-env-security.js";
 import { logWarn } from "../logger.js";
 import { readTrimmedStringAlias } from "../utils/string-readers.js";
 import {
@@ -49,14 +50,22 @@ type ResolvedHttpMcpTransportConfig = ResolvedBaseMcpTransportConfig & {
 
 type ResolvedMcpTransportConfig = ResolvedStdioMcpTransportConfig | ResolvedHttpMcpTransportConfig;
 
+type ResolveMcpTransportConfigOptions = {
+  inheritedEnv?: Record<string, string>;
+};
+
 const DEFAULT_CONNECTION_TIMEOUT_MS = 30_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 function getPositiveNumber(rawServer: unknown, keys: readonly string[]): number | undefined {
-  if (!rawServer || typeof rawServer !== "object") {
+  if (!isRecord(rawServer)) {
     return undefined;
   }
-  const record = rawServer as Record<string, unknown>;
+  const record = rawServer;
   for (const key of keys) {
     const value = record[key];
     if (typeof value === "number" && Number.isFinite(value) && value > 0) {
@@ -113,8 +122,7 @@ function getStringField(rawServer: unknown, keys: readonly string[]): string | u
 
 function getRequestedTransport(rawServer: unknown): string {
   if (
-    !rawServer ||
-    typeof rawServer !== "object" ||
+    !isRecord(rawServer) ||
     typeof (rawServer as { transport?: unknown }).transport !== "string"
   ) {
     return "";
@@ -123,14 +131,31 @@ function getRequestedTransport(rawServer: unknown): string {
 }
 
 function getRequestedTransportAlias(rawServer: unknown): HttpMcpTransportType | "" {
-  if (
-    !rawServer ||
-    typeof rawServer !== "object" ||
-    typeof (rawServer as { type?: unknown }).type !== "string"
-  ) {
+  if (!isRecord(rawServer) || typeof (rawServer as { type?: unknown }).type !== "string") {
     return "";
   }
   return resolveOpenClawMcpTransportAlias((rawServer as { type?: string }).type) ?? "";
+}
+
+function withInheritedStdioEnv(
+  rawServer: unknown,
+  inheritedEnv: Record<string, string> | undefined,
+): unknown {
+  const safeInheritedEnv = sanitizeHostEnvOverrides({
+    overrides: inheritedEnv,
+    blockPathOverrides: true,
+  });
+  if (!safeInheritedEnv || Object.keys(safeInheritedEnv).length === 0 || !isRecord(rawServer)) {
+    return rawServer;
+  }
+  const serverEnv = isRecord(rawServer.env) ? rawServer.env : undefined;
+  return {
+    ...rawServer,
+    env: {
+      ...safeInheritedEnv,
+      ...serverEnv,
+    },
+  };
 }
 
 function resolveHttpTransportConfig(
@@ -159,13 +184,10 @@ function resolveHttpTransportConfig(
     transportType: launch.config.transportType,
     url: launch.config.url,
     headers: launch.config.headers,
-    ...(rawServer &&
-    typeof rawServer === "object" &&
-    (rawServer as { auth?: unknown }).auth === "oauth"
+    ...(isRecord(rawServer) && (rawServer as { auth?: unknown }).auth === "oauth"
       ? { auth: "oauth" as const }
       : {}),
-    ...(rawServer &&
-    typeof rawServer === "object" &&
+    ...(isRecord(rawServer) &&
     (rawServer as { oauth?: unknown }).oauth &&
     typeof (rawServer as { oauth?: unknown }).oauth === "object" &&
     !Array.isArray((rawServer as { oauth?: unknown }).oauth)
@@ -193,12 +215,14 @@ function resolveHttpTransportConfig(
 export function resolveMcpTransportConfig(
   serverName: string,
   rawServer: unknown,
+  options?: ResolveMcpTransportConfigOptions,
 ): ResolvedMcpTransportConfig | null {
   const logServerName = sanitizeForLog(serverName);
   const requestedTransport = getRequestedTransport(rawServer);
   const requestedTransportAlias = requestedTransport ? "" : getRequestedTransportAlias(rawServer);
   const effectiveTransport = requestedTransport || requestedTransportAlias;
-  const stdioLaunch = resolveStdioMcpServerLaunchConfig(rawServer, {
+  const stdioRawServer = withInheritedStdioEnv(rawServer, options?.inheritedEnv);
+  const stdioLaunch = resolveStdioMcpServerLaunchConfig(stdioRawServer, {
     onDroppedEnv: (key) => {
       logWarn(
         `bundle-mcp: server "${logServerName}": env "${sanitizeForLog(key)}" is blocked for stdio startup safety and was ignored.`,

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -21,6 +21,10 @@ import { createMcpOAuthClientProvider } from "./mcp-oauth.js";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 import { resolveMcpTransportConfig } from "./mcp-transport-config.js";
 
+type ResolveMcpTransportOptions = {
+  inheritedEnv?: Record<string, string>;
+};
+
 type ResolvedMcpTransport = {
   transport: Transport;
   description: string;
@@ -89,8 +93,9 @@ function buildSseEventSourceFetch(
 export function resolveMcpTransport(
   serverName: string,
   rawServer: unknown,
+  options?: ResolveMcpTransportOptions,
 ): ResolvedMcpTransport | null {
-  const resolved = resolveMcpTransportConfig(serverName, rawServer);
+  const resolved = resolveMcpTransportConfig(serverName, rawServer, options);
   if (!resolved) {
     return null;
   }

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -412,6 +412,46 @@ describe("redactConfigSnapshot", () => {
     );
   });
 
+  it("redacts per-agent env values from config snapshots", () => {
+    const hints = buildConfigSchema().uiHints;
+    const raw = `{
+  agents: {
+    list: [
+      {
+        id: "reviewer",
+        env: {
+          OPENCLAW_AGENT_ENV: "plain-agent-env-value",
+        },
+      },
+    ],
+  },
+}`;
+    const snapshot = makeSnapshot(
+      {
+        agents: {
+          list: [
+            {
+              id: "reviewer",
+              env: {
+                OPENCLAW_AGENT_ENV: "plain-agent-env-value",
+              },
+            },
+          ],
+        },
+      },
+      raw,
+    );
+
+    const result = redactConfigSnapshot(snapshot, hints);
+    const agents = result.config.agents as { list: Array<{ env: Record<string, string> }> };
+    expect(agents.list[0]?.env.OPENCLAW_AGENT_ENV).toBe(REDACTED_SENTINEL);
+    expect(result.raw).toContain(REDACTED_SENTINEL);
+    expect(result.raw).not.toContain("plain-agent-env-value");
+
+    const restored = restoreRedactedValues(result.config, snapshot.config, hints);
+    expect(restored.agents.list[0]?.env.OPENCLAW_AGENT_ENV).toBe("plain-agent-env-value");
+  });
+
   it("redacts install policy env values from config snapshots", () => {
     const hints = buildConfigSchema().uiHints;
     const raw = `{

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -303,6 +303,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Default max characters retained from AGENTS.md during post-compaction context refresh injection. Lower this to make compaction recovery cheaper, or raise it for agents that depend on longer startup guidance.",
   "agents.list":
     "Explicit list of configured agents with IDs and optional overrides for model, tools, identity, and workspace. Keep IDs stable over time so bindings, approvals, and session routing remain deterministic.",
+  "agents.list[].env":
+    "Optional per-agent environment variables injected into that agent's spawned CLI, exec, ACP, and stdio MCP subprocesses. Accepted keys override inherited process env only at child-process boundaries; blocked loader, shell-hook, credential-control, and PATH-style keys are filtered by the host env security policy. Values must be literal strings, so keep long-lived secrets in your external secret/env manager and reference them through that managed runtime environment instead of committing plaintext credentials.",
   "agents.list[].skillsLimits":
     "Optional per-agent overrides for skills subsystem budgets. Use this when an agent needs a different skills prompt budget without introducing a second generic context-limits path.",
   "agents.list[].skillsLimits.maxSkillsPromptChars":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -103,6 +103,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.contextLimits.toolResultMaxChars": "Default Tool Result Max Chars",
   "agents.defaults.contextLimits.postCompactionMaxChars": "Default Post-compaction Max Chars",
   "agents.list": "Agent List",
+  "agents.list[].env": "Agent Environment Variables",
   "agents.list[].skillsLimits": "Agent Skills Limits",
   "agents.list[].skillsLimits.maxSkillsPromptChars": "Agent Skills Prompt Max Chars",
   "agents.list[].contextLimits": "Agent Context Limits",

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -86,6 +86,7 @@ export type AgentConfig = {
   description?: string;
   workspace?: string;
   agentDir?: string;
+  env?: Record<string, string>;
   model?: AgentModelConfig;
   /** Optional per-agent model for short internal tasks such as generated session titles. */
   utilityModel?: string;

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -74,6 +74,27 @@ describe("agent defaults schema", () => {
     );
   });
 
+  it("accepts per-agent env string maps", () => {
+    expectSchemaSuccess(
+      AgentEntrySchema.safeParse({
+        id: "ops",
+        env: {
+          GIT_AUTHOR_EMAIL: "ops@example.com",
+          OPENCLAW_AGENT_ENV: "enabled",
+        },
+      }),
+    );
+    expectSchemaFailurePath(
+      AgentEntrySchema.safeParse({
+        id: "ops",
+        env: {
+          PORT: 3000,
+        },
+      }),
+      "env.PORT",
+    );
+  });
+
   it("accepts videoGenerationModel", () => {
     expectSchemaSuccess(
       AgentDefaultsSchema.safeParse({

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -1038,6 +1038,7 @@ export const AgentEntrySchema = z
     description: z.string().optional(),
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
+    env: z.record(z.string(), z.string()).optional(),
     model: AgentModelSchema.optional(),
     utilityModel: z.string().optional(),
     models: z.record(z.string(), AgentModelRuntimeEntrySchema).optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -1038,7 +1038,7 @@ export const AgentEntrySchema = z
     description: z.string().optional(),
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
-    env: z.record(z.string(), z.string()).optional(),
+    env: z.record(z.string(), z.string().register(sensitive)).optional(),
     model: AgentModelSchema.optional(),
     utilityModel: z.string().optional(),
     models: z.record(z.string(), AgentModelRuntimeEntrySchema).optional(),

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -286,6 +286,56 @@ describe("tools.effective handler", () => {
     expectInvalidResponse(respond, 'unknown session key "missing-session"');
   });
 
+  it("passes the trusted session agent to MCP config summary", async () => {
+    runtimeMocks.resolveSessionAgentId.mockReturnValueOnce("reviewer");
+    runtimeMocks.resolveAgentWorkspaceDir.mockReturnValueOnce("/tmp/workspace-reviewer");
+    runtimeMocks.loadSessionEntry.mockReturnValueOnce({
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", env: { OPENCLAW_AGENT_ENV: "wrong-main-env" } },
+            { id: "reviewer", env: { OPENCLAW_AGENT_ENV: "visible-reviewer-env" } },
+          ],
+        },
+      },
+      canonicalKey: "agent:reviewer:telegram:acct:thread",
+      entry: {
+        sessionId: "session-reviewer",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastAccountId: "acct-1",
+        lastThreadId: "thread-2",
+        lastTo: "channel-1",
+        groupId: "group-4",
+        groupChannel: "#ops",
+        space: "workspace-5",
+        chatType: "group",
+        modelProvider: "openai",
+        model: "gpt-4.1",
+        spawnedBy: "agent:reviewer:telegram:group:parent-group",
+        spawnedWorkspaceDir: undefined,
+      },
+    });
+
+    const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
+    await invoke();
+
+    expect(firstRespondCall(respond)?.[0]).toBe(true);
+    expect(runtimeMocks.resolveSessionMcpConfigSummary).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace-reviewer",
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", env: { OPENCLAW_AGENT_ENV: "wrong-main-env" } },
+            { id: "reviewer", env: { OPENCLAW_AGENT_ENV: "visible-reviewer-env" } },
+          ],
+        },
+      },
+      sessionKey: "main:abc",
+      agentId: "reviewer",
+    });
+  });
+
   it("returns the read-only effective runtime inventory without MCP startup", async () => {
     const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
     await invoke();
@@ -500,6 +550,31 @@ describe("tools.effective handler", () => {
     expect(runtimeMocks.resolveSessionMcpConfigSummary).toHaveBeenCalledWith({
       workspaceDir: "/tmp/sandbox-copy",
       cfg: {},
+      sessionKey: "main:abc",
+      agentId: "main",
+    });
+  });
+
+  it("uses the session MCP env fingerprint when projecting warm agent env catalogs", async () => {
+    const mcpTool = makeMcpTool();
+    const catalog = makeMcpCatalog();
+    runtimeMocks.resolveSessionMcpConfigSummary.mockImplementationOnce(
+      ({ sessionKey } = { sessionKey: undefined }) => ({
+        fingerprint: sessionKey === "main:abc" ? "mcp:env:main" : "mcp:env-less",
+        serverNames: ["reproProbe"],
+      }),
+    );
+    mockWarmMcpRuntime(catalog, {
+      configFingerprint: "mcp:env:main",
+    });
+    runtimeMocks.buildBundleMcpToolsFromCatalog.mockReturnValueOnce([mcpTool]);
+
+    const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
+    await invoke();
+
+    expectPayloadGroupIds(respond, ["core", "mcp"]);
+    expect(firstRespondCall(respond)?.[1]).not.toMatchObject({
+      notices: [expect.objectContaining({ id: "mcp-stale-catalog" })],
     });
   });
 

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -132,6 +132,8 @@ function buildMcpConfigSummaryCacheKey(params: {
     config: params.context.runtimeConfigCacheKey,
     pluginRegistry: params.context.pluginRegistryVersion,
     workspaceDir: params.workspaceDir,
+    sessionKey: params.context.sessionKey,
+    agentId: params.context.agentId,
   });
 }
 
@@ -157,6 +159,8 @@ function resolveCachedSessionMcpConfigSummary(params: {
   const summary = resolveSessionMcpConfigSummary({
     workspaceDir: params.workspaceDir,
     cfg: params.context.cfg,
+    sessionKey: params.context.sessionKey,
+    agentId: params.context.agentId,
   });
   mcpConfigSummaryCache.set(key, summary);
   trimMcpConfigSummaryCache();

--- a/src/infra/host-env-security.ts
+++ b/src/infra/host-env-security.ts
@@ -303,6 +303,16 @@ export function inspectHostExecEnvOverrides(params?: {
   };
 }
 
+export function sanitizeHostEnvOverrides(params?: {
+  overrides?: Record<string, string> | null;
+  blockPathOverrides?: boolean;
+}): Record<string, string> | undefined {
+  const result = sanitizeHostEnvOverridesWithDiagnostics(params);
+  return result.acceptedOverrides && Object.keys(result.acceptedOverrides).length > 0
+    ? result.acceptedOverrides
+    : undefined;
+}
+
 export function sanitizeHostExecEnv(params?: {
   baseEnv?: Record<string, string | undefined>;
   overrides?: Record<string, string> | null;


### PR DESCRIPTION
Related: #93425

## What Problem This Solves

Resolves a problem where operators configuring `agents.list[].env` could not rely on that per-agent environment reaching the real subprocess boundary for the configured OpenClaw agent. The gap was most visible when a configured ACP owner such as `reviewer` or `codex-acp` wrapped the shared `codex` harness agent: env lookup, session ownership, MCP inherited env, and ACPX persistent session reuse could follow the harness/raw session identity instead of the configured owner.

## Why This Change Was Made

This wires the public `agents.list[].env` contract through the configured-owner source of truth while keeping the ACP harness id as the runtime adapter target. Env lookup, ACP initialization/re-ensure, spawned ACP session keys, subagent allowlist authorization, stdio MCP inherited env, tools-effective fingerprinting, and ACPX persistent-session freshness now use the same configured owner/env boundary.

Security and compatibility boundaries are intentionally unchanged: env injection remains opt-in, host env sanitization still blocks loader/search-path/PATH-style overrides, server-local stdio MCP env keeps precedence for that MCP process, no metadata migration is introduced, `SessionAcpMeta.agent` semantics are not changed, and no new secret provider or ACP protocol shape is added. Because this is a public config surface, `agents.list[].env` values are also marked sensitive for config schema hints/snapshot redaction.

## User Impact

Operators can configure one `agents.list[].env` entry and expect allowed values to reach that agent's real spawned CLI/`exec`, ACP/ACPX, and stdio MCP subprocess paths, including configured ACP wrappers around a shared harness agent. Blocked env overrides stay filtered, and subagent access still requires the configured owner to be explicitly allowed.

## Evidence

Fresh validation after the docs-map repair on the current rescue branch:

- `pnpm docs:map:check` — failed before the repair with `docs/docs_map.md is out of date`; passed after regenerating the docs map.
- `pnpm check:docs` — passed formatting, markdown lint, MDX, i18n glossary, link audit, and docs-map checks.
- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts src/gateway/server-methods/tools-effective.test.ts` — passed 48 gateway tests and 42 agent MCP runtime tests.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec.resolve-env-hook.test.ts` — passed 22 exec/env-hook tests.
- `corepack pnpm exec node scripts/run-vitest.mjs run --config test/vitest/vitest.acp.config.ts src/acp/control-plane/manager.initialize-session.test.ts src/acp/control-plane/manager.runtime-handles.test.ts --maxWorkers=1` — passed 6 ACP manager tests.
- `corepack pnpm exec node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/acp-spawn.test.ts --maxWorkers=1` — passed 68 ACP spawn tests.
- `node scripts/run-vitest.mjs extensions/acpx/src/runtime.test.ts` — passed 55 ACPX runtime tests.
- `node scripts/run-vitest.mjs src/config/redact-snapshot.test.ts src/config/schema.hints.test.ts` — passed 55 config redaction/schema hint tests, including a regression that redacts generic `agents.list[].env.OPENCLAW_AGENT_ENV` values and restores them locally.
- `git diff --check origin/main..HEAD` — passed.
- `corepack pnpm tsgo:core:test` — passed after refreshing workspace links with `corepack pnpm install --frozen-lockfile`.
- `pnpm lint --threads=8` — passed.
- `node scripts/run-bundled-extension-oxlint.mjs` — passed.

Real subprocess proof used production `createExecTool`/gateway exec to spawn a child process. The configured allowed value reached the child process, while blocked overrides did not leak:

```text
Warning: background execution is disabled; running synchronously.

{"OPENCLAW_AGENT_ENV":"visible-to-real-child","LD_PRELOAD":null,"PATH":"[local path redacted]"}
```

The focused regressions cover the configured-owner/harness-agent split, persisted ACP re-ensure, `sessions_spawn` owner identity, owner-based subagent allowlists, stdio MCP inherited env and fingerprinting, and ACPX stale env refresh. During the rebase onto current `origin/main`, the new MCP timeout-retire regression was also kept behaviorally equivalent but made tolerant of slower child-process startup; the full MCP runtime/tools suite now passes.

Not tested: no external provider-backed live ACP service was invoked. ACP behavior is validated at the OpenClaw ACP manager/spawn subprocess boundary, and the real child-process smoke covers the production exec subprocess env boundary requested by review.
