### PR TITLE
[codex] Reuse scoped runtime plugin registries

### DIFF
--- a/src/agents/runtime-plugins.registry-reuse.test.ts
+++ b/src/agents/runtime-plugins.registry-reuse.test.ts
@@ -87,4 +87,49 @@ describe("ensureRuntimePluginsLoaded registry reuse", () => {
     });
     expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
+
+  it("reuses the startup registry when the turn workspace differs from gateway activation", () => {
+    const config = { plugins: { allow: ["telegram"] } };
+    const activeRegistry = createRegistryWithPlugin("telegram");
+    activeRegistry.coreGatewayMethodNames = ["sessions.get", "sessions.list"];
+    const startupLoadOptions = {
+      config,
+      activationSourceConfig: config,
+      autoEnabledReasons: {},
+      workspaceDir: "/tmp/gateway-workspace",
+      onlyPluginIds: ["telegram"],
+      coreGatewayMethodNames: ["sessions.get", "sessions.list"],
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+      preferBuiltPluginArtifacts: true,
+    };
+    const { cacheKey } = testing.resolvePluginLoadCacheContext(startupLoadOptions);
+    setActivePluginRegistry(
+      activeRegistry,
+      cacheKey,
+      "gateway-bindable",
+      "/tmp/gateway-workspace",
+      startupLoadOptions.onlyPluginIds,
+    );
+    mocks.getCurrentPluginMetadataSnapshot.mockReturnValue({
+      startup: {
+        pluginIds: ["telegram"],
+      },
+    });
+    mocks.loadOpenClawPlugins.mockImplementation(() => {
+      throw new Error("dispatch should reuse the active gateway startup registry");
+    });
+
+    ensureRuntimePluginsLoaded({
+      config,
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    expect(mocks.getCurrentPluginMetadataSnapshot).toHaveBeenCalledWith({
+      config,
+      workspaceDir: "/tmp/agent-workspace",
+    });
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const hoisted = vi.hoisted(() => ({
   getCurrentPluginMetadataSnapshot: vi.fn(),
   ensureStandaloneRuntimePluginRegistryLoaded: vi.fn(),
+  getLoadedRuntimePluginRegistry: vi.fn(),
   getActivePluginRuntimeSubagentMode: vi.fn<() => "default" | "explicit" | "gateway-bindable">(
     () => "default",
   ),
@@ -16,6 +17,10 @@ vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
 
 vi.mock("../plugins/runtime/standalone-runtime-registry-loader.js", () => ({
   ensureStandaloneRuntimePluginRegistryLoaded: hoisted.ensureStandaloneRuntimePluginRegistryLoaded,
+}));
+
+vi.mock("../plugins/active-runtime-registry.js", () => ({
+  getLoadedRuntimePluginRegistry: hoisted.getLoadedRuntimePluginRegistry,
 }));
 
 vi.mock("../plugins/runtime.js", () => ({
@@ -32,6 +37,8 @@ describe("ensureRuntimePluginsLoaded", () => {
     hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue(undefined);
     hoisted.ensureStandaloneRuntimePluginRegistryLoaded.mockReset();
     hoisted.ensureStandaloneRuntimePluginRegistryLoaded.mockReturnValue(undefined);
+    hoisted.getLoadedRuntimePluginRegistry.mockReset();
+    hoisted.getLoadedRuntimePluginRegistry.mockReturnValue(undefined);
     hoisted.getActivePluginRuntimeSubagentMode.mockReset();
     hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("default");
     hoisted.getActivePluginRegistryWorkspaceDir.mockReset();
@@ -139,6 +146,84 @@ describe("ensureRuntimePluginsLoaded", () => {
         config: {} as never,
         onlyPluginIds: ["telegram"],
         workspaceDir: "/tmp/workspace",
+        forceFullRuntimeForChannelPlugins: true,
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+      },
+    });
+  });
+
+  it("reuses the active startup registry workspace only on a compatible cache hit", () => {
+    hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue({
+      startup: {
+        pluginIds: ["telegram"],
+      },
+    });
+    hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("gateway-bindable");
+    hoisted.getActivePluginRegistryWorkspaceDir.mockReturnValue("/tmp/gateway-workspace");
+    hoisted.getLoadedRuntimePluginRegistry.mockReturnValue({});
+
+    ensureRuntimePluginsLoaded({
+      config: {} as never,
+      workspaceDir: "/tmp/agent-workspace",
+      allowGatewaySubagentBinding: true,
+    });
+
+    expect(hoisted.getCurrentPluginMetadataSnapshot).toHaveBeenCalledWith({
+      config: {} as never,
+      workspaceDir: "/tmp/agent-workspace",
+    });
+    expect(hoisted.getLoadedRuntimePluginRegistry).toHaveBeenCalledWith({
+      requiredPluginIds: ["telegram"],
+      workspaceDir: "/tmp/gateway-workspace",
+      loadOptions: {
+        config: {} as never,
+        onlyPluginIds: ["telegram"],
+        workspaceDir: "/tmp/gateway-workspace",
+        forceFullRuntimeForChannelPlugins: true,
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+      },
+    });
+    expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).not.toHaveBeenCalled();
+  });
+
+  it("loads from the requested workspace when active startup registry reuse misses", () => {
+    hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue({
+      startup: {
+        pluginIds: ["telegram"],
+      },
+    });
+    hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("gateway-bindable");
+    hoisted.getActivePluginRegistryWorkspaceDir.mockReturnValue("/tmp/gateway-workspace");
+
+    ensureRuntimePluginsLoaded({
+      config: {} as never,
+      workspaceDir: "/tmp/agent-workspace",
+      allowGatewaySubagentBinding: true,
+    });
+
+    expect(hoisted.getLoadedRuntimePluginRegistry).toHaveBeenCalledWith({
+      requiredPluginIds: ["telegram"],
+      workspaceDir: "/tmp/gateway-workspace",
+      loadOptions: {
+        config: {} as never,
+        onlyPluginIds: ["telegram"],
+        workspaceDir: "/tmp/gateway-workspace",
+        forceFullRuntimeForChannelPlugins: true,
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+      },
+    });
+    expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
+      requiredPluginIds: ["telegram"],
+      loadOptions: {
+        config: {} as never,
+        onlyPluginIds: ["telegram"],
+        workspaceDir: "/tmp/agent-workspace",
         forceFullRuntimeForChannelPlugins: true,
         runtimeOptions: {
           allowGatewaySubagentBinding: true,

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -5,7 +5,11 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
-import { getActivePluginRuntimeSubagentMode } from "../plugins/runtime.js";
+import {
+  getActivePluginRegistryWorkspaceDir,
+  getActivePluginRuntimeSubagentMode,
+} from "../plugins/runtime.js";
+import { getLoadedRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
 import { ensureStandaloneRuntimePluginRegistryLoaded } from "../plugins/runtime/standalone-runtime-registry-loader.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -52,16 +56,32 @@ export function ensureRuntimePluginsLoaded(params: {
   const allowGatewaySubagentBinding =
     params.allowGatewaySubagentBinding === true ||
     getActivePluginRuntimeSubagentMode() === "gateway-bindable";
+  const baseLoadOptions = {
+    config: params.config,
+    workspaceDir,
+    ...(startupPluginIds === undefined ? {} : { onlyPluginIds: startupPluginIds }),
+    ...(startupPluginIds === undefined ? {} : { forceFullRuntimeForChannelPlugins: true }),
+    runtimeOptions: allowGatewaySubagentBinding
+      ? { allowGatewaySubagentBinding: true }
+      : undefined,
+  };
+  const activeWorkspaceDir =
+    startupPluginIds === undefined ? undefined : getActivePluginRegistryWorkspaceDir();
+  if (activeWorkspaceDir && activeWorkspaceDir !== workspaceDir) {
+    const activeRegistry = getLoadedRuntimePluginRegistry({
+      requiredPluginIds: startupPluginIds,
+      loadOptions: {
+        ...baseLoadOptions,
+        workspaceDir: activeWorkspaceDir,
+      },
+      workspaceDir: activeWorkspaceDir,
+    });
+    if (activeRegistry) {
+      return;
+    }
+  }
   ensureStandaloneRuntimePluginRegistryLoaded({
     requiredPluginIds: startupPluginIds,
-    loadOptions: {
-      config: params.config,
-      workspaceDir,
-      ...(startupPluginIds === undefined ? {} : { onlyPluginIds: startupPluginIds }),
-      ...(startupPluginIds === undefined ? {} : { forceFullRuntimeForChannelPlugins: true }),
-      runtimeOptions: allowGatewaySubagentBinding
-        ? { allowGatewaySubagentBinding: true }
-        : undefined,
-    },
+    loadOptions: baseLoadOptions,
   });
 }

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -665,6 +665,68 @@ describe("getCompatibleActivePluginRegistry", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("reuses a scoped gateway startup registry for compatible provider-hook subset loads", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push(
+      createLoadedPluginRecord("acpx"),
+      createLoadedPluginRecord("telegram"),
+      createLoadedPluginRecord("travel-hub"),
+    );
+    registry.coreGatewayMethodNames = ["sessions.get", "sessions.list"];
+    const config = {
+      plugins: {
+        allow: ["acpx", "telegram", "travel-hub"],
+      },
+    };
+    const startupOptions = {
+      config,
+      activationSourceConfig: config,
+      autoEnabledReasons: {},
+      workspaceDir: "/tmp/workspace-a",
+      onlyPluginIds: ["acpx", "telegram", "travel-hub"],
+      coreGatewayMethodNames: ["sessions.get", "sessions.list"],
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+      preferBuiltPluginArtifacts: true,
+    };
+    const { cacheKey } = testing.resolvePluginLoadCacheContext(startupOptions);
+    setActivePluginRegistry(
+      registry,
+      cacheKey,
+      "gateway-bindable",
+      "/tmp/workspace-a",
+      startupOptions.onlyPluginIds,
+    );
+
+    expect(
+      testing.getCompatibleActivePluginRegistry({
+        config,
+        workspaceDir: "/tmp/workspace-a",
+        onlyPluginIds: ["travel-hub"],
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+      }),
+    ).toBe(registry);
+
+    expect(
+      testing.getCompatibleActivePluginRegistry({
+        config: {
+          plugins: {
+            allow: ["acpx", "telegram", "travel-hub"],
+            load: { paths: ["/tmp/changed.js"] },
+          },
+        },
+        workspaceDir: "/tmp/workspace-a",
+        onlyPluginIds: ["travel-hub"],
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+      }),
+    ).toBeUndefined();
+  });
 });
 
 describe("resolveRuntimePluginRegistry", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -146,6 +146,7 @@ import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./
 import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
+  getActivePluginRegistryPluginIdScope,
   getActivePluginRuntimeSubagentMode,
   recordImportedPluginId,
   setActivePluginRegistry,
@@ -1223,6 +1224,17 @@ function registryContainsPluginScope(
   return onlyPluginIds.every((pluginId) => loadedPluginIds.has(pluginId));
 }
 
+function pluginScopeContainsPluginScope(params: {
+  wider: readonly string[] | null;
+  requested: readonly string[] | undefined;
+}): boolean {
+  if (!params.wider || !params.requested || params.requested.length === 0) {
+    return false;
+  }
+  const wider = new Set(params.wider);
+  return params.requested.every((pluginId) => wider.has(pluginId));
+}
+
 function scopedPluginLoadOptionsMatchWiderActiveCacheKey(
   options: PluginLoadOptions,
   expectedCacheKey: string,
@@ -1232,13 +1244,38 @@ function scopedPluginLoadOptionsMatchWiderActiveCacheKey(
   if (!registryContainsPluginScope(activeRegistry, onlyPluginIds)) {
     return false;
   }
-  return pluginLoadOptionsMatchCacheKey(
-    {
+  const activePluginIdScope = getActivePluginRegistryPluginIdScope();
+  const matchesActiveScopedCacheKey = (candidate: PluginLoadOptions): boolean => {
+    if (pluginLoadOptionsMatchCacheKey(candidate, expectedCacheKey)) {
+      return true;
+    }
+    if (candidate.coreGatewayMethodNames !== undefined) {
+      return false;
+    }
+    return pluginLoadOptionsMatchCacheKey(
+      {
+        ...candidate,
+        coreGatewayMethodNames: activeRegistry.coreGatewayMethodNames ?? [],
+      },
+      expectedCacheKey,
+    );
+  };
+  if (
+    pluginScopeContainsPluginScope({
+      wider: activePluginIdScope,
+      requested: onlyPluginIds,
+    }) &&
+    matchesActiveScopedCacheKey({
       ...options,
-      onlyPluginIds: undefined,
-    },
-    expectedCacheKey,
-  );
+      onlyPluginIds: activePluginIdScope ? [...activePluginIdScope] : undefined,
+    })
+  ) {
+    return true;
+  }
+  return matchesActiveScopedCacheKey({
+    ...options,
+    onlyPluginIds: undefined,
+  });
 }
 
 type PluginRegistrationPlan = {
@@ -1810,11 +1847,12 @@ function activatePluginRegistry(
   cacheKey: string,
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable",
   workspaceDir?: string,
+  pluginIdScope?: readonly string[],
 ): void {
   // Always re-initialize: the global runner resolves hooks from the live
   // registry set (active + pinned surfaces), so activation order and scope
   // cannot drop hooks the way the old preserve-one-runner gate did (#91918).
-  setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
+  setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir, pluginIdScope);
   initializeGlobalHookRunner(registry);
 }
 
@@ -1830,6 +1868,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         `empty-plugin-scope::${resolveRuntimeSubagentMode(options.runtimeOptions)}::${options.workspaceDir ?? ""}`,
         resolveRuntimeSubagentMode(options.runtimeOptions),
         options.workspaceDir,
+        requestedOnlyPluginIds,
       );
     }
     return emptyRegistry;
@@ -1888,6 +1927,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           cached.cacheKey,
           cached.runtimeSubagentMode,
           options.workspaceDir,
+          onlyPluginIds,
         );
       }
       return cached.state.registry;
@@ -2970,7 +3010,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       );
     }
     if (shouldActivate) {
-      activatePluginRegistry(registry, cacheKey, runtimeSubagentMode, options.workspaceDir);
+      activatePluginRegistry(
+        registry,
+        cacheKey,
+        runtimeSubagentMode,
+        options.workspaceDir,
+        onlyPluginIds,
+      );
     }
     return registry;
   } finally {

--- a/src/plugins/runtime-state.ts
+++ b/src/plugins/runtime-state.ts
@@ -21,6 +21,7 @@ export type RegistryState = {
   sessionExtension: RegistrySurfaceState;
   agentEventBridgeUnsubscribe?: (() => void) | undefined;
   key: string | null;
+  pluginIdScope: string[] | null;
   workspaceDir: string | null;
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable";
   importedPluginIds: Set<string>;

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -48,6 +48,7 @@ const state: RegistryState = (() => {
       },
       agentEventBridgeUnsubscribe: undefined,
       key: null,
+      pluginIdScope: null,
       workspaceDir: null,
       runtimeSubagentMode: "default",
       importedPluginIds: new Set<string>(),
@@ -200,6 +201,7 @@ export function setActivePluginRegistry(
   cacheKey?: string,
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable" = "default",
   workspaceDir?: string,
+  pluginIdScope?: readonly string[],
 ) {
   const previousRegistry = asPluginRegistry(state.activeRegistry);
   state.activeRegistry = registry;
@@ -209,6 +211,7 @@ export function setActivePluginRegistry(
   syncTrackedSurface(state.channel, registry, true);
   syncTrackedSurface(state.sessionExtension, registry, true);
   state.key = cacheKey ?? null;
+  state.pluginIdScope = pluginIdScope ? [...pluginIdScope] : null;
   state.workspaceDir = workspaceDir ?? null;
   state.runtimeSubagentMode = runtimeSubagentMode;
   syncPluginAgentEventBridge();
@@ -389,6 +392,10 @@ export function getActivePluginSessionExtensionRegistry(): PluginRegistry | null
 
 export function getActivePluginRegistryKey(): string | null {
   return state.key;
+}
+
+export function getActivePluginRegistryPluginIdScope(): readonly string[] | null {
+  return state.pluginIdScope;
 }
 
 export function getActivePluginRuntimeSubagentMode(): "default" | "explicit" | "gateway-bindable" {

--- a/src/plugins/runtime/standalone-runtime-registry-loader.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.ts
@@ -36,7 +36,13 @@ function installStandaloneRegistry(
 ): void {
   const cacheKey = resolvePluginRegistryLoadCacheKey(params.loadOptions);
   const mode = resolveRuntimeSubagentMode(params.loadOptions);
-  setActivePluginRegistry(registry, cacheKey, mode, params.loadOptions.workspaceDir);
+  setActivePluginRegistry(
+    registry,
+    cacheKey,
+    mode,
+    params.loadOptions.workspaceDir,
+    params.loadOptions.onlyPluginIds,
+  );
   switch (params.surface) {
     case "active":
       break;


### PR DESCRIPTION
## What Problem This Solves

The iMessage/source-reply latency investigation showed repeated runtime plugin registry work on hot paths after gateway startup. The broad investigation branch proved the direction, but it bundled tracing, iMessage monitor changes, Codex/source-reply fixes, provider-hook reuse, and tool lookup reuse.

This PR keeps only the smallest safe runtime-registry reuse piece: startup-scoped runtime plugin loads can reuse the active gateway startup registry when the existing cache-key and plugin-scope compatibility checks prove it is the same effective registry.

Fixes part of #96148.

## Why This Change Was Made

The gateway startup registry already records which plugin ids were loaded for startup-scoped runtime work. Agent turns can request that same startup-scoped set from a turn workspace. Previously, those calls could miss the active gateway registry and rebuild scoped runtime plugin state.

This change tracks the active registry plugin-id scope and lets compatible subset loads reuse the active startup registry. The cross-workspace path is reuse-only: it first checks for a compatible loaded registry and falls back to loading from the caller's original workspace on a miss.

Provider-hook and plugin-tool cross-workspace reuse were intentionally left out of this PR after review because they need stronger compatibility contracts.

## User Impact

For users with many configured plugins, agent turns should avoid some redundant startup-scoped runtime plugin reloads after gateway startup. This is a narrow performance improvement, not the full broad-branch optimization.

The live investigation evidence is on #96148 and the superseded draft #96199. The clean broad-branch matched test showed `20.797s -> 17.529s`, but this PR claims only the smallest safe subset from that work.

Focused live proof on this PR shows the remaining iMessage latency is mostly outside this small change. With cron disabled on commit `a397a64`, startup prewarm loaded `149` runtime plugins in `3980.8ms` (`4022ms` gateway phase) and provider auth prewarm took `2679ms`. A live Omar-to-Lobster iMessage turn then took `20504ms` end-to-end: `20391ms` dispatch, `13583ms` model/main lane. The same turn still loaded provider/runtime plugin sets on the hot path: `1` plugin in `7.0ms`, `9` plugins in `1268.6ms`, `51` plugins in `2281.7ms`, and agent tools `22` plugins in `120.4ms`.

That run also hit `incomplete turn detected`, but this branch does not include the Codex message-tool/source-reply terminal fix from #95942. Treat the incomplete-turn evidence here only as proof that this perf branch was missing that correctness fix, not as evidence against #95942.

Normal Lobster steady-state follow-up also showed the separate provider catalog-hook cache idea was not a real iMessage hot-path win: model catalog work converged after startup and `augmentModelCatalogWithProviderPlugins()` did not repeat per message. That branch has been shelved separately and is not part of this PR.

## Evidence

- `node scripts/run-vitest.mjs src/agents/runtime-plugins.test.ts src/agents/runtime-plugins.registry-reuse.test.ts src/plugins/loader.runtime-registry.test.ts`
- `pnpm tsgo:prod`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review this minimal OpenClaw performance patch after the reuse-only fix. Scope: reuse active gateway startup registries only on a compatible cache hit for startup-scoped runtime plugin loads; fallback loads must use the caller workspace. Provider-hook and plugin-tools cross-workspace reuse are intentionally absent. Focus on cross-workspace safety, cache key correctness, and test coverage for cache miss fallback."`
- Focused live iMessage proof, June 24, 2026, `OPENCLAW_SKIP_CRON=1 OPENCLAW_LOG_LEVEL=debug OPENCLAW_VERBOSE=1 pnpm openclaw gateway`, commit `a397a64`: `20504ms` total message processing, `20391ms` dispatch, `13583ms` model/main lane; remaining hot-path plugin loads were `7.0ms + 1268.6ms + 2281.7ms + 120.4ms`.
- Caveat: the focused live run did not include #95942, so its `incomplete turn detected` log is not a verdict on the Codex source-reply fix.
