### PR TITLE
fix(agents): run heartbeat_prompt_contribution on harness prompt builds

### DIFF
--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { resetGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../../plugins/hooks.test-helpers.js";
 import { resolveAgentHarnessBeforePromptBuildResult } from "./prompt-compaction-hook-helpers.js";
 
 afterEach(() => {
@@ -62,5 +66,44 @@ describe("resolveAgentHarnessBeforePromptBuildResult", () => {
       developerInstructions: "base instructions",
       promptInputRange: { start: 17, end: 17 },
     });
+  });
+
+  it("runs heartbeat_prompt_contribution on a heartbeat turn and prepends its contribution", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "heartbeat_prompt_contribution",
+          handler: () => ({ prependContext: "Run the base-heartbeat skill." }),
+        },
+      ]),
+    );
+
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "Read HEARTBEAT.md.",
+      developerInstructions: "base instructions",
+      messages: [],
+      ctx: { trigger: "heartbeat", agentId: "agent-1", sessionKey: "session-1" },
+    });
+
+    expect(result.prompt).toBe("Run the base-heartbeat skill.\n\nRead HEARTBEAT.md.");
+    // The heartbeat contribution affects only the prompt, not developer instructions.
+    expect(result.developerInstructions).toBe("base instructions");
+  });
+
+  it("skips heartbeat_prompt_contribution off a heartbeat turn", async () => {
+    const handler = vi.fn(() => ({ prependContext: "should not appear" }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "heartbeat_prompt_contribution", handler }]),
+    );
+
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "hello",
+      developerInstructions: "base instructions",
+      messages: [],
+      ctx: { trigger: "user", agentId: "agent-1", sessionKey: "session-1" },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.prompt).toBe("hello");
   });
 });

--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -90,6 +90,47 @@ describe("resolveAgentHarnessBeforePromptBuildResult", () => {
     expect(result.developerInstructions).toBe("base instructions");
   });
 
+  it("runs heartbeat contributions before other prompt-build hooks", async () => {
+    const calls: string[] = [];
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "heartbeat_prompt_contribution",
+          handler: () => {
+            calls.push("heartbeat");
+            return { prependContext: "heartbeat context" };
+          },
+        },
+        {
+          hookName: "before_prompt_build",
+          handler: () => {
+            calls.push("before_prompt_build");
+            return { prependContext: "prompt context" };
+          },
+        },
+        {
+          hookName: "before_agent_start",
+          handler: () => {
+            calls.push("before_agent_start");
+            return { prependContext: "agent-start context" };
+          },
+        },
+      ]),
+    );
+
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "hello",
+      developerInstructions: "base instructions",
+      messages: [],
+      ctx: { trigger: "heartbeat", agentId: "agent-1", sessionKey: "session-1" },
+    });
+
+    expect(calls).toEqual(["heartbeat", "before_prompt_build", "before_agent_start"]);
+    expect(result.prompt).toBe(
+      "heartbeat context\n\nprompt context\n\nagent-start context\n\nhello",
+    );
+  });
+
   it("skips heartbeat_prompt_contribution off a heartbeat turn", async () => {
     const handler = vi.fn(() => ({ prependContext: "should not appear" }));
     initializeGlobalHookRunner(

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -35,8 +35,16 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
 }): Promise<AgentHarnessPromptBuildResult> {
   const hookRunner = getGlobalHookRunner();
   const hasPrecomputedBeforeAgentStartResult = "beforeAgentStartResult" in params;
+  // heartbeat_prompt_contribution fires only on heartbeat turns. Harness runtimes
+  // (e.g. the Codex app-server) build the prompt through this helper rather than
+  // the embedded runner's resolvePromptBuildHookResult, so the hook must run from
+  // here too — otherwise it never fires on those runtimes.
+  const isHeartbeatTurn = params.ctx.trigger === "heartbeat";
+  const hasHeartbeatContribution =
+    isHeartbeatTurn && Boolean(hookRunner?.hasHooks("heartbeat_prompt_contribution"));
   if (
     !hasPrecomputedBeforeAgentStartResult &&
+    !hasHeartbeatContribution &&
     !hookRunner?.hasHooks("before_prompt_build") &&
     !hookRunner?.hasHooks("before_agent_start")
   ) {
@@ -73,16 +81,38 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
         })
       : undefined;
 
+  // heartbeat_prompt_contribution runs only on heartbeat turns. Mirrors the
+  // embedded runner (resolvePromptBuildHookResult): the contribution is merged
+  // ahead of the before_prompt_build / before_agent_start contributions.
+  const heartbeatResult =
+    hasHeartbeatContribution && hookRunner
+      ? await hookRunner
+          .runHeartbeatPromptContribution(
+            {
+              sessionKey: params.ctx.sessionKey,
+              agentId: params.ctx.agentId,
+              heartbeatName: "heartbeat",
+            },
+            hookCtx,
+          )
+          .catch((error: unknown) => {
+            log.warn(`heartbeat_prompt_contribution hook failed: ${String(error)}`);
+            return undefined;
+          })
+      : undefined;
+
   const systemPrompt = resolvePromptBuildSystemPrompt({
     developerInstructions: params.developerInstructions,
     promptBuildResult,
     beforeAgentStartResult,
   });
   const promptPrefix = joinPresentTextSegments([
+    heartbeatResult?.prependContext,
     promptBuildResult?.prependContext,
     beforeAgentStartResult?.prependContext,
   ]);
   const promptSuffix = joinPresentTextSegments([
+    heartbeatResult?.appendContext,
     promptBuildResult?.appendContext,
     beforeAgentStartResult?.appendContext,
   ]);

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -60,6 +60,25 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
     messages: params.messages,
   };
 
+  // Match the embedded runner's lifecycle order: heartbeat contributions are
+  // collected before prompt-build hooks so hook side effects stay deterministic.
+  const heartbeatResult =
+    hasHeartbeatContribution && hookRunner
+      ? await hookRunner
+          .runHeartbeatPromptContribution(
+            {
+              sessionKey: params.ctx.sessionKey,
+              agentId: params.ctx.agentId,
+              heartbeatName: "heartbeat",
+            },
+            hookCtx,
+          )
+          .catch((error: unknown) => {
+            log.warn(`heartbeat_prompt_contribution hook failed: ${String(error)}`);
+            return undefined;
+          })
+      : undefined;
+
   // Support the newer before_prompt_build hook plus the deprecated
   // before_agent_start hook during the prompt-build migration window.
   const promptBuildResult = hookRunner?.hasHooks("before_prompt_build")
@@ -79,26 +98,6 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
           );
           return undefined;
         })
-      : undefined;
-
-  // heartbeat_prompt_contribution runs only on heartbeat turns. Mirrors the
-  // embedded runner (resolvePromptBuildHookResult): the contribution is merged
-  // ahead of the before_prompt_build / before_agent_start contributions.
-  const heartbeatResult =
-    hasHeartbeatContribution && hookRunner
-      ? await hookRunner
-          .runHeartbeatPromptContribution(
-            {
-              sessionKey: params.ctx.sessionKey,
-              agentId: params.ctx.agentId,
-              heartbeatName: "heartbeat",
-            },
-            hookCtx,
-          )
-          .catch((error: unknown) => {
-            log.warn(`heartbeat_prompt_contribution hook failed: ${String(error)}`);
-            return undefined;
-          })
       : undefined;
 
   const systemPrompt = resolvePromptBuildSystemPrompt({


### PR DESCRIPTION
## What Problem This Solves

Plugins that contribute heartbeat context through the documented `heartbeat_prompt_contribution` hook get **nothing** on heartbeat turns when the agent runs on a harness runtime (e.g. the Codex / gpt-5.5 app-server). Those runtimes assemble the prompt via `resolveAgentHarnessBeforePromptBuildResult` (`src/agents/harness/prompt-compaction-hook-helpers.ts`), which runs `before_prompt_build` and `before_agent_start` but **never invokes `heartbeat_prompt_contribution`** — so the hook silently no-ops there, even though it works on the embedded-runner path (`resolvePromptBuildHookResult`).

## Why This Change Was Made

The two prompt-build paths have drifted. The embedded runner invokes `heartbeat_prompt_contribution` (gated on `trigger === "heartbeat"`) and merges its contribution; the harness helper does not. This brings the harness path in line so the documented hook fires on every runtime.

`appendContext` from `before_prompt_build` / `before_agent_start` is already honored by the harness helper, so boot-style append contributions already reach the model — only the heartbeat hook was missing.

Scope: this PR fixes the heartbeat hook specifically. Two other contributions the embedded path runs (`agent_turn_prepare` and exactly-once queued injections) are also absent from the harness path; those are left out here (the queued-injection draining has exactly-once semantics that deserve their own change) and can be a follow-up.

## User Impact

- Plugins using `heartbeat_prompt_contribution` now have their contribution reach the model on harness runtimes (Codex/gpt-5.5), matching the embedded path.
- No change on non-heartbeat turns (gated on `trigger === "heartbeat"`), and none for plugins that don't use the hook.

## Evidence

- New unit tests in `prompt-compaction-hook-helpers.test.ts`: the hook runs and prepends its contribution on a heartbeat turn, and is skipped off a heartbeat turn (asserts the handler isn't even called). `node scripts/run-vitest.mjs src/agents/harness/prompt-compaction-hook-helpers.test.ts` → **5 passed**.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` clean; `oxfmt --check` clean on the touched files.
- Consumption path confirmed: the helper's returned `prompt` flows into `codexTurnPromptText` in `extensions/codex/src/app-server/run-attempt.ts`, i.e. the contribution reaches the model turn. The change is harness-level (which hooks run during prompt build) and does not touch the Codex protocol.
- Ordering: the heartbeat contribution is merged ahead of the `before_prompt_build` / `before_agent_start` contributions, matching the embedded path so cross-plugin priority ordering is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
