### PR TITLE
improve: skip Gateway migration preflight without legacy state

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { note } from "../../../packages/terminal-core/src/note.js";
+import { requireNodeSqlite } from "../../infra/node-sqlite.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { formatCliCommand } from "../command-format.js";
 import { ensureConfigReady, testApi } from "./config-guard.js";
@@ -124,8 +125,54 @@ describe("ensureConfigReady", () => {
     fs.writeFileSync(markerPath, "{}");
   }
 
+  function writePluginStateKvMarker(root: string, pluginId: string, namespace: string): void {
+    const dbPath = path.join(root, ".openclaw", "state", "openclaw.sqlite");
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        CREATE TABLE plugin_state_entries (
+          plugin_id TEXT NOT NULL,
+          namespace TEXT NOT NULL,
+          entry_key TEXT NOT NULL,
+          value_json TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          expires_at INTEGER,
+          PRIMARY KEY (plugin_id, namespace, entry_key)
+        );
+      `);
+      db.prepare(
+        `INSERT INTO plugin_state_entries (
+          plugin_id, namespace, entry_key, value_json, created_at, expires_at
+        ) VALUES (?, ?, 'entry-1', '{"version":1}', 1, NULL)`,
+      ).run(pluginId, namespace);
+    } finally {
+      db.close();
+    }
+  }
+
+  function writeWorkboardLegacyKvMarker(root: string): void {
+    writePluginStateKvMarker(root, "workboard", "workboard.cards");
+  }
+
+  function writeMSTeamsLearningMarker(
+    storeDir: string,
+    fileName = "bXN0ZWFtczp1c2VyMQ.learnings.json",
+  ): void {
+    fs.mkdirSync(storeDir, { recursive: true });
+    fs.writeFileSync(path.join(storeDir, fileName), JSON.stringify(["Prefer concise answers"]));
+  }
+
   beforeEach(() => {
-    envSnapshot = captureEnv(["HOME", "OPENCLAW_HOME", "OPENCLAW_STATE_DIR"]);
+    envSnapshot = captureEnv([
+      "HOME",
+      "OPENCLAW_HOME",
+      "OPENCLAW_PROFILE",
+      "OPENCLAW_DEBUG_PROXY_DB_PATH",
+      "OPENCLAW_STATE_DIR",
+      "OPENCLAW_WORKSPACE_DIR",
+    ]);
     vi.clearAllMocks();
     resetConfigGuardStateForTests();
     for (const root of tempRoots.splice(0)) {
@@ -164,6 +211,11 @@ describe("ensureConfigReady", () => {
       expectedDoctorCalls: 0,
     },
     {
+      name: "skips doctor flow for gateway run without legacy state",
+      commandPath: ["gateway", "run"],
+      expectedDoctorCalls: 0,
+    },
+    {
       name: "runs doctor flow for commands that may mutate state without legacy state",
       commandPath: ["message"],
       expectedDoctorCalls: 1,
@@ -192,6 +244,791 @@ describe("ensureConfigReady", () => {
       invalidConfigNote: false,
     });
   });
+
+  it("runs doctor flow for gateway run when lightweight startup detection finds legacy state", async () => {
+    const root = useTempOpenClawHome();
+    writeLegacyTaskSidecarMarker(root);
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("skips doctor flow for gateway run when debug proxy db points at shared state", async () => {
+    const root = useTempOpenClawHome();
+    const sharedStateDb = path.join(root, ".openclaw", "state", "openclaw.sqlite");
+    fs.mkdirSync(path.dirname(sharedStateDb), { recursive: true });
+    fs.writeFileSync(sharedStateDb, "");
+    setTestEnvValue("OPENCLAW_DEBUG_PROXY_DB_PATH", sharedStateDb);
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("skips doctor flow for gateway run when only the current canonical agents directory exists", async () => {
+    const root = useTempOpenClawHome();
+    fs.mkdirSync(path.join(root, ".openclaw", "agents", "main", "sessions"), { recursive: true });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("skips doctor flow for gateway run when configured custom session store has no legacy state", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, "custom-sessions.json");
+    fs.writeFileSync(storePath, JSON.stringify({}));
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { session: { store: storePath } },
+      runtimeConfig: { session: { store: storePath } },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("runs doctor flow for gateway run when the canonical session store has legacy keys", async () => {
+    const root = useTempOpenClawHome();
+    writeStateMarker(root, "agents/main/sessions/sessions.json");
+    const storePath = path.join(root, ".openclaw", "agents", "main", "sessions", "sessions.json");
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        main: { sessionId: "abc", updatedAt: 1 },
+      }),
+    );
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when the canonical session store is JSON5 with legacy keys", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, ".openclaw", "agents", "main", "sessions", "sessions.json");
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(
+      storePath,
+      "{\n  // operator-edited legacy store\n  main: { sessionId: 'abc', updatedAt: 1 }\n}\n",
+    );
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when a non-default discovered session store has legacy keys", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, ".openclaw", "agents", "work", "sessions", "sessions.json");
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(storePath, JSON.stringify({ main: { sessionId: "abc", updatedAt: 1 } }));
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when Telegram session sidecars exist", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, ".openclaw", "agents", "main", "sessions", "sessions.json");
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(storePath, "{}");
+    fs.writeFileSync(`${storePath}.telegram-messages.json`, JSON.stringify({ version: 1 }));
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when Telegram sidecars exist without sessions json", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, ".openclaw", "agents", "main", "sessions", "sessions.json");
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(`${storePath}.telegram-sent-messages.json`, JSON.stringify({ version: 1 }));
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when Telegram named-account sidecars exist", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, ".openclaw", "agents", "ops", "sessions", "sessions.json");
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(`${storePath}.telegram-topic-names.json`, JSON.stringify({ version: 1 }));
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { channels: { telegram: { accounts: { ops: {} } } } },
+      runtimeConfig: { channels: { telegram: { accounts: { ops: {} } } } },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when canonical session entries contain ACP metadata", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, ".openclaw", "agents", "main", "sessions", "sessions.json");
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "abc",
+          updatedAt: 1,
+          acp: { threadId: "thread-1", provider: "fixture" },
+        },
+      }),
+    );
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when global scope makes agent main key legacy", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, ".openclaw", "agents", "main", "sessions", "sessions.json");
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": { sessionId: "abc", updatedAt: 1 },
+      }),
+    );
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { session: { scope: "global" } },
+      runtimeConfig: { session: { scope: "global" } },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("skips doctor flow for gateway run when current sessionFile path is already valid", async () => {
+    const root = useTempOpenClawHome();
+    const sessionsDir = path.join(root, ".openclaw", "agents", "main", "sessions");
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const transcriptPath = path.join(sessionsDir, "abc.jsonl");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(transcriptPath, JSON.stringify({ type: "session", id: "abc" }) + "\n");
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": { sessionId: "abc", updatedAt: 1, sessionFile: transcriptPath },
+      }),
+    );
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("runs doctor flow for gateway run when a shared session store has a later agent legacy key", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, "shared-sessions.json");
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:work:main": { sessionId: "abc", updatedAt: 1 },
+      }),
+    );
+    const snapshot = {
+      ...makeSnapshot(),
+      config: {
+        session: { store: storePath, scope: "global" },
+        agents: { list: [{ id: "main" }, { id: "work" }] },
+      },
+      runtimeConfig: {
+        session: { store: storePath, scope: "global" },
+        agents: { list: [{ id: "main" }, { id: "work" }] },
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("skips doctor flow for gateway run when shared session store has current cross-agent keys", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, "shared-sessions.json");
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": { sessionId: "abc", updatedAt: 1 },
+      }),
+    );
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { session: { store: storePath }, agents: { list: [{ id: "main" }, { id: "work" }] } },
+      runtimeConfig: {
+        session: { store: storePath },
+        agents: { list: [{ id: "main" }, { id: "work" }] },
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("runs doctor flow for gateway run when shared non-main store has orphan main keys", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, "shared-sessions.json");
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": { sessionId: "abc", updatedAt: 1 },
+      }),
+    );
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { session: { store: storePath }, agents: { list: [{ id: "work" }] } },
+      runtimeConfig: { session: { store: storePath }, agents: { list: [{ id: "work" }] } },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when shared work-ops store has orphan main keys", async () => {
+    const root = useTempOpenClawHome();
+    const storePath = path.join(root, "shared-sessions.json");
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": { sessionId: "abc", updatedAt: 1 },
+      }),
+    );
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { session: { store: storePath }, agents: { list: [{ id: "work" }, { id: "ops" }] } },
+      runtimeConfig: {
+        session: { store: storePath },
+        agents: { list: [{ id: "work" }, { id: "ops" }] },
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it.each([
+    ["legacy delivery queue", "delivery-queue/pending.json"],
+    ["plugin-owned active memory state", "plugins/active-memory/session-toggles.json"],
+    ["plugin-owned phone control state", "plugins/phone-control/armed.json"],
+    ["ACPX process leases", "acpx/process-leases.json"],
+    ["ACPX gateway instance", "gateway-instance-id"],
+    ["Device Pair notify state", "device-pair-notify.json"],
+    ["Matrix state", "matrix/default/storage-meta.json"],
+    ["Nostr state", "nostr/bus-state-default.json"],
+    ["MSTeams conversations", "msteams-conversations.json"],
+  ])("runs doctor flow for gateway run when %s exists", async (_label, relativePath) => {
+    const root = useTempOpenClawHome();
+    writeStateMarker(root, relativePath);
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("detects MSTeams feedback-learning files in configured session store paths", () => {
+    const root = useTempOpenClawHome();
+    const storeTemplate = path.join(root, "stores", "{agentId}", "sessions");
+    writeMSTeamsLearningMarker(path.join(root, "stores", "work", "sessions"));
+
+    expect(
+      testApi.hasMSTeamsFeedbackLearningLegacyStateForTests({
+        session: { store: storeTemplate },
+        agents: { list: [{ id: "work" }] },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects MSTeams feedback-learning files when the configured store path itself ends in json", () => {
+    const root = useTempOpenClawHome();
+    const storeTemplate = path.join(root, "stores", "{agentId}", "sessions.json");
+    writeMSTeamsLearningMarker(path.join(root, "stores", "work", "sessions.json"));
+
+    expect(
+      testApi.hasMSTeamsFeedbackLearningLegacyStateForTests({
+        session: { store: storeTemplate },
+        agents: { list: [{ id: "work" }] },
+      }),
+    ).toBe(true);
+  });
+
+  it("normalizes agent ids when detecting MSTeams feedback-learning files", () => {
+    const root = useTempOpenClawHome();
+    const storeTemplate = path.join(root, "stores", "{agentId}", "sessions");
+    writeMSTeamsLearningMarker(path.join(root, "stores", "sales-team", "sessions"));
+
+    expect(
+      testApi.hasMSTeamsFeedbackLearningLegacyStateForTests({
+        session: { store: storeTemplate },
+        agents: { list: [{ id: "Sales Team" }] },
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores sibling MSTeams feedback-learning files when the configured store is a json file", () => {
+    const root = useTempOpenClawHome();
+    const storeDir = path.join(root, "stores", "main");
+    writeMSTeamsLearningMarker(storeDir);
+
+    expect(
+      testApi.hasMSTeamsFeedbackLearningLegacyStateForTests({
+        session: { store: path.join(root, "stores", "{agentId}", "sessions.json") },
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores archived MSTeams feedback-learning files in session store paths", () => {
+    const root = useTempOpenClawHome();
+    const storeDir = path.join(root, "stores", "main", "sessions");
+    writeMSTeamsLearningMarker(storeDir, "bXN0ZWFtczp1c2VyMQ.learnings.json.migrated");
+
+    expect(
+      testApi.hasMSTeamsFeedbackLearningLegacyStateForTests({
+        session: { store: path.join(root, "stores", "{agentId}", "sessions") },
+      }),
+    ).toBe(false);
+  });
+
+  it("runs doctor flow for gateway run when MSTeams feedback-learning legacy files exist", async () => {
+    const root = useTempOpenClawHome();
+    const storeTemplate = path.join(root, "stores", "{agentId}", "sessions");
+    writeMSTeamsLearningMarker(path.join(root, "stores", "work", "sessions"));
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { session: { store: storeTemplate }, agents: { list: [{ id: "work" }] } },
+      runtimeConfig: { session: { store: storeTemplate }, agents: { list: [{ id: "work" }] } },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when configured Memory Core workspace state exists", async () => {
+    const root = useTempOpenClawHome();
+    const workspace = path.join(root, "custom-workspace");
+    const markerPath = path.join(workspace, "memory", ".dreams", "daily-ingestion.json");
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, "{}");
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { agents: { defaults: { workspace } } },
+      runtimeConfig: { agents: { defaults: { workspace } } },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when canonicalized agent workspace has Memory Core state", async () => {
+    const root = useTempOpenClawHome();
+    const markerPath = path.join(
+      root,
+      ".openclaw",
+      "workspace-sales-team",
+      "memory",
+      ".dreams",
+      "daily-ingestion.json",
+    );
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, "{}");
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { agents: { list: [{ id: "main", default: true }, { id: "Sales Team" }] } },
+      runtimeConfig: { agents: { list: [{ id: "main", default: true }, { id: "Sales Team" }] } },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when mixed-case profile workspace has Memory Core state", async () => {
+    const root = useTempOpenClawHome();
+    setTestEnvValue("OPENCLAW_PROFILE", "Work");
+    const markerPath = path.join(
+      root,
+      ".openclaw",
+      "workspace-Work",
+      "memory",
+      ".dreams",
+      "phase-signals.json",
+    );
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, "{}");
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when OPENCLAW_WORKSPACE_DIR has Memory Core state", async () => {
+    const root = useTempOpenClawHome();
+    const workspace = path.join(root, "env-workspace");
+    setTestEnvValue("OPENCLAW_WORKSPACE_DIR", workspace);
+    const markerPath = path.join(workspace, "memory", ".dreams", "session-ingestion.json");
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, "{}");
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when a derived agent workspace has Memory Core state", async () => {
+    const root = useTempOpenClawHome();
+    const stateDir = path.join(root, "custom-state");
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    const markerPath = path.join(
+      stateDir,
+      "workspace-main",
+      "memory",
+      ".dreams",
+      "short-term-recall.json",
+    );
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, "{}");
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { agents: { list: [{ id: "main" }, { id: "ops", default: true }] } },
+      runtimeConfig: { agents: { list: [{ id: "main" }, { id: "ops", default: true }] } },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when configured Memory Wiki vault state exists", async () => {
+    const root = useTempOpenClawHome();
+    const vault = path.join(root, "wiki-vault");
+    const markerPath = path.join(vault, ".openclaw-wiki", "source-sync.json");
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, "{}");
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { plugins: { entries: { "memory-wiki": { config: { vault: { path: vault } } } } } },
+      runtimeConfig: {
+        plugins: { entries: { "memory-wiki": { config: { vault: { path: vault } } } } },
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when OS-home default Memory Wiki vault state exists", async () => {
+    const openclawHome = useTempOpenClawHome();
+    const osHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-guard-wiki-home-"));
+    tempRoots.push(osHome);
+    setTestEnvValue("HOME", osHome);
+    expect(openclawHome).not.toBe(osHome);
+    const markerPath = path.join(
+      osHome,
+      ".openclaw",
+      "wiki",
+      "main",
+      ".openclaw-wiki",
+      "source-sync.json",
+    );
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, "{}");
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when configured tilde Voice Call store exists under OS home", async () => {
+    const openclawHome = useTempOpenClawHome();
+    const osHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-guard-voice-home-"));
+    tempRoots.push(osHome);
+    setTestEnvValue("HOME", osHome);
+    expect(openclawHome).not.toBe(osHome);
+    const markerPath = path.join(osHome, "voice-calls", "calls.jsonl");
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, "{}\n");
+    const snapshot = {
+      ...makeSnapshot(),
+      config: {
+        plugins: {
+          entries: {
+            "voice-call": {
+              config: { store: "~/voice-calls" },
+            },
+          },
+        },
+      },
+      runtimeConfig: {
+        plugins: {
+          entries: {
+            "voice-call": {
+              config: { store: "~/voice-calls" },
+            },
+          },
+        },
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when configured Voice Call legacy store exists", async () => {
+    const root = useTempOpenClawHome();
+    const store = path.join(root, "custom-voice-calls");
+    fs.mkdirSync(store, { recursive: true });
+    fs.writeFileSync(path.join(store, "calls.jsonl"), "{}\n");
+    const snapshot = {
+      ...makeSnapshot(),
+      config: {
+        plugins: {
+          entries: {
+            "@openclaw/voice-call": {
+              config: { store },
+            },
+          },
+        },
+      },
+      runtimeConfig: {
+        plugins: {
+          entries: {
+            "@openclaw/voice-call": {
+              config: { store },
+            },
+          },
+        },
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({
+      snapshot,
+      baseConfig: {},
+    });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when OS-home Voice Call legacy store exists", async () => {
+    const openclawHome = useTempOpenClawHome();
+    const osHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-guard-os-home-"));
+    tempRoots.push(osHome);
+    setTestEnvValue("HOME", osHome);
+    expect(openclawHome).not.toBe(osHome);
+    const markerPath = path.join(osHome, ".openclaw", "voice-calls", "calls.jsonl");
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, "{}\n");
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("skips doctor flow for gateway run when Voice Call file exists only under OPENCLAW_HOME", async () => {
+    const openclawHome = useTempOpenClawHome();
+    const osHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-guard-os-home-empty-"));
+    tempRoots.push(osHome);
+    setTestEnvValue("HOME", osHome);
+    expect(openclawHome).not.toBe(osHome);
+    writeStateMarker(openclawHome, "voice-calls/calls.jsonl");
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("runs doctor flow for gateway run when Workboard legacy plugin KV exists", async () => {
+    const root = useTempOpenClawHome();
+    writeWorkboardLegacyKvMarker(root);
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when Telegram legacy plugin KV exists", async () => {
+    const root = useTempOpenClawHome();
+    writePluginStateKvMarker(root, "telegram", "telegram.message-dispatch-dedupe");
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("skips doctor flow for gateway run when only current plugin KV exists", async () => {
+    const root = useTempOpenClawHome();
+    writePluginStateKvMarker(root, "demo-plugin", "current-state");
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["plugin", "plugins/active-memory/session-toggles.json.migrated"],
+    ["Matrix", "matrix/default/storage-meta.json.migrated"],
+    ["Nostr", "nostr/bus-state-default.json.migrated"],
+  ])(
+    "skips doctor flow for gateway run when %s migration source is already archived",
+    async (_label, relativePath) => {
+      const root = useTempOpenClawHome();
+      writeStateMarker(root, relativePath);
+
+      await runEnsureConfigReady(["gateway", "run"]);
+
+      expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("runs doctor flow when lightweight startup detection finds a pending SQLite archive", async () => {
     const root = useTempOpenClawHome();
@@ -278,6 +1115,45 @@ describe("ensureConfigReady", () => {
     await runEnsureConfigReady(["status"]);
 
     expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["legacy cron jobs", "cron/jobs.json"],
+    ["legacy cron state", "cron/jobs-state.json"],
+    ["legacy cron run log", "cron/runs/job-1.jsonl"],
+  ])("runs doctor flow for gateway run when default %s exists", async (_label, relativePath) => {
+    const root = useTempOpenClawHome();
+    writeStateMarker(root, relativePath);
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+  });
+
+  it("runs doctor flow for gateway run when configured cron legacy store exists", async () => {
+    const root = useTempOpenClawHome();
+    const store = path.join(root, "custom-cron", "jobs.json");
+    fs.mkdirSync(path.dirname(store), { recursive: true });
+    fs.writeFileSync(store, "{}");
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { cron: { store } },
+      runtimeConfig: { cron: { store } },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({ snapshot, baseConfig: {} });
+
+    await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
   });
 
   it("runs doctor flow for read-only commands with configured custom session stores", async () => {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -5,9 +5,21 @@ import path from "node:path";
 import { withSuppressedNotes } from "../../../packages/terminal-core/src/note.js";
 import { readConfigFileSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import { resolveLegacyStateDirs, resolveOAuthDir, resolveStateDir } from "../../config/paths.js";
+import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session.js";
+import { resolveAllAgentSessionStoreTargetsSync } from "../../config/sessions/targets.js";
 import type { ConfigFileSnapshot } from "../../config/types.js";
-import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  resolveHomeRelativePath,
+  resolveRequiredHomeDir,
+  resolveRequiredOsHomeDir,
+} from "../../infra/home-dir.js";
+import { readSessionStoreJson5 } from "../../infra/state-migrations.fs.js";
+import type { OpenKeyedStoreOptions } from "../../plugin-state/plugin-state-store.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/account-id.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
+import { normalizeSessionKeyPreservingOpaquePeerIds } from "../../sessions/session-key-utils.js";
 import { shouldMigrateStateFromPath } from "../argv.js";
 
 const ALLOWED_INVALID_COMMANDS = new Set(["doctor", "logs", "health", "help", "status"]);
@@ -47,6 +59,19 @@ function dirHasFile(dir: string, predicate: (name: string) => boolean): boolean 
     return fs
       .readdirSync(dir, { withFileTypes: true })
       .some((entry) => entry.isFile() && predicate(entry.name));
+  } catch {
+    return false;
+  }
+}
+
+function dirHasDescendantFile(dir: string, predicate: (name: string) => boolean): boolean {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true }).some((entry) => {
+      if (entry.isFile()) {
+        return predicate(entry.name);
+      }
+      return entry.isDirectory() && dirHasDescendantFile(path.join(dir, entry.name), predicate);
+    });
   } catch {
     return false;
   }
@@ -98,6 +123,175 @@ function hasBundledChannelLegacyStateMigrationInputs(stateDir: string, oauthDir:
   return dirHasFile(oauthDir, isLegacyWhatsAppAuthFile);
 }
 
+function hasLegacyDeliveryQueueMigrationInput(stateDir: string): boolean {
+  const queueDirs = ["delivery-queue", "session-delivery-queue"].map((dirName) =>
+    path.join(stateDir, dirName),
+  );
+  return queueDirs.some(
+    (queueDir) =>
+      dirHasFile(queueDir, (name) => name.endsWith(".json") || name.endsWith(".delivered")) ||
+      dirHasFile(path.join(queueDir, "failed"), (name) => name.endsWith(".json")),
+  );
+}
+
+function hasLegacyDebugProxyCaptureInput(stateDir: string): boolean {
+  const sourcePath =
+    process.env.OPENCLAW_DEBUG_PROXY_DB_PATH?.trim() ||
+    path.join(stateDir, "debug-proxy", "capture.sqlite");
+  if (path.resolve(sourcePath) === path.resolve(path.join(stateDir, "state", "openclaw.sqlite"))) {
+    return false;
+  }
+  const blobDir =
+    process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR?.trim() ||
+    path.join(stateDir, "debug-proxy", "blobs");
+  return (
+    fileOrDirExists(sourcePath) ||
+    (fileOrDirExists(`${sourcePath}.migrated`) &&
+      (["-shm", "-wal", "-journal"].some((suffix) => fileOrDirExists(`${sourcePath}${suffix}`)) ||
+        fileOrDirExists(blobDir)))
+  );
+}
+
+function hasLegacyStateJsonMigrationInput(stateDir: string): boolean {
+  return [
+    path.join(stateDir, "settings", "voicewake.json"),
+    path.join(stateDir, "settings", "voicewake-routing.json"),
+    path.join(stateDir, "update-check.json"),
+    path.join(stateDir, "logs", "config-health.json"),
+    path.join(stateDir, "bindings", "current-conversations.json"),
+  ].some(fileOrDirExists);
+}
+
+function resolveConfigDirForStartupDetection(): string {
+  const stateOverride = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (stateOverride) {
+    return resolveConfiguredPath(stateOverride);
+  }
+  const configPath = process.env.OPENCLAW_CONFIG_PATH?.trim();
+  if (configPath) {
+    return path.dirname(resolveConfiguredPath(configPath));
+  }
+  return path.join(resolveRequiredHomeDir(process.env, os.homedir), ".openclaw");
+}
+
+function resolveCronStorePathForStartupDetection(store?: unknown): string {
+  const rawStore = typeof store === "string" ? store.trim() : "";
+  if (rawStore) {
+    return resolveConfiguredPath(rawStore);
+  }
+  return path.join(resolveConfigDirForStartupDetection(), "cron", "jobs.json");
+}
+
+function resolveLegacyCronStatePath(storePath: string): string {
+  return storePath.endsWith(".json")
+    ? storePath.replace(/\.json$/, "-state.json")
+    : `${storePath}-state.json`;
+}
+
+function hasLegacyCronMigrationInputForStore(storePath: string): boolean {
+  return (
+    fileOrDirExists(storePath) ||
+    fileOrDirExists(resolveLegacyCronStatePath(storePath)) ||
+    dirHasFile(path.join(path.dirname(storePath), "runs"), (name) => name.endsWith(".jsonl"))
+  );
+}
+
+async function hasSharedStateDatabaseLegacyMigrationInput(stateDir: string): Promise<boolean> {
+  const stateDbPath = path.join(stateDir, "state", "openclaw.sqlite");
+  if (!fileOrDirExists(stateDbPath)) {
+    return false;
+  }
+  try {
+    const [{ requireNodeSqlite }, { detectOpenClawStateDatabaseSchemaMigrations }] =
+      await Promise.all([
+        import("../../infra/node-sqlite.js"),
+        import("../../state/openclaw-state-db.js"),
+      ]);
+    if (
+      detectOpenClawStateDatabaseSchemaMigrations({
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      }).length > 0
+    ) {
+      return true;
+    }
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(stateDbPath, { readOnly: true });
+    try {
+      const hasPluginStateTable = db
+        .prepare(
+          "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'plugin_state_entries'",
+        )
+        .get();
+      if (!hasPluginStateTable) {
+        return false;
+      }
+      return Boolean(
+        db
+          .prepare(
+            `SELECT 1
+               FROM plugin_state_entries
+              WHERE (plugin_id = 'workboard'
+                     AND namespace IN (
+                       'workboard.cards',
+                       'workboard.boards',
+                       'workboard.notify',
+                       'workboard.attachments'
+                     ))
+                 OR (plugin_id = 'telegram'
+                     AND namespace = 'telegram.message-dispatch-dedupe')
+              LIMIT 1`,
+          )
+          .get(),
+      );
+    } finally {
+      db.close();
+    }
+  } catch {
+    // If the cheap schema/KV probe cannot run, keep the conservative behavior
+    // and let the doctor preflight own the user-facing migration/error path.
+    return true;
+  }
+}
+
+function hasMatrixLegacyStateMigrationInput(stateDir: string): boolean {
+  const matrixLegacyFilenames = new Set([
+    "storage-meta.json",
+    "bot-storage.json",
+    "recovery-key.json",
+    "crypto-idb-snapshot.json",
+    "legacy-crypto-migration.json",
+  ]);
+  return dirHasDescendantFile(path.join(stateDir, "matrix"), (name) =>
+    matrixLegacyFilenames.has(name),
+  );
+}
+
+function hasNostrLegacyStateMigrationInput(stateDir: string): boolean {
+  return dirHasFile(
+    path.join(stateDir, "nostr"),
+    (name) =>
+      (name.startsWith("bus-state-") || name.startsWith("profile-state-")) &&
+      name.endsWith(".json"),
+  );
+}
+
+function hasShippedPluginLegacyStateMigrationInput(stateDir: string): boolean {
+  const osHomeDir = resolveRequiredOsHomeDir(process.env, os.homedir);
+  return (
+    fileOrDirExists(path.join(stateDir, "plugins", "active-memory", "session-toggles.json")) ||
+    fileOrDirExists(path.join(stateDir, "plugins", "phone-control", "armed.json")) ||
+    fileOrDirExists(path.join(stateDir, "gateway-instance-id")) ||
+    fileOrDirExists(path.join(stateDir, "device-pair-notify.json")) ||
+    dirHasFile(path.join(stateDir, "acpx"), (name) => name.endsWith(".json")) ||
+    hasMatrixLegacyStateMigrationInput(stateDir) ||
+    hasNostrLegacyStateMigrationInput(stateDir) ||
+    ["msteams-conversations.json", "msteams-polls.json", "msteams-sso-tokens.json"].some((name) =>
+      fileOrDirExists(path.join(stateDir, name)),
+    ) ||
+    fileOrDirExists(path.join(osHomeDir, ".openclaw", "voice-calls", "calls.jsonl"))
+  );
+}
+
 function hasLegacyExecApprovalsMigrationInput(stateDir: string): boolean {
   if (!process.env.OPENCLAW_STATE_DIR?.trim()) {
     return false;
@@ -119,7 +313,7 @@ function hasPendingSqliteSidecarArchive(sourcePath: string): boolean {
   );
 }
 
-function hasLegacyStateMigrationInputs(): boolean {
+async function hasLegacyStateMigrationInputs(): Promise<boolean> {
   // Only run migration prompts when old state actually exists in known legacy locations.
   const stateDir = resolveStateDir(process.env, os.homedir);
   const oauthDir = resolveOAuthDir(process.env, stateDir);
@@ -139,7 +333,6 @@ function hasLegacyStateMigrationInputs(): boolean {
   return (
     [
       path.join(stateDir, "agent"),
-      path.join(stateDir, "agents"),
       path.join(stateDir, "plugins", "installs.json"),
       path.join(stateDir, "sessions"),
     ].some(fileOrDirExists) ||
@@ -147,7 +340,20 @@ function hasLegacyStateMigrationInputs(): boolean {
       (sourcePath) => fileOrDirExists(sourcePath) || hasPendingSqliteSidecarArchive(sourcePath),
     ) ||
     hasBundledChannelLegacyStateMigrationInputs(stateDir, oauthDir) ||
-    hasLegacyExecApprovalsMigrationInput(stateDir)
+    hasLegacyDeliveryQueueMigrationInput(stateDir) ||
+    hasLegacyDebugProxyCaptureInput(stateDir) ||
+    hasLegacyStateJsonMigrationInput(stateDir) ||
+    hasLegacyCronMigrationInputForStore(resolveCronStorePathForStartupDetection()) ||
+    hasShippedPluginLegacyStateMigrationInput(stateDir) ||
+    fileOrDirExists(
+      path.join(
+        resolveRequiredHomeDir(process.env, os.homedir),
+        ".openclaw",
+        "plugin-binding-approvals.json",
+      ),
+    ) ||
+    hasLegacyExecApprovalsMigrationInput(stateDir) ||
+    (await hasSharedStateDatabaseLegacyMigrationInput(stateDir))
   );
 }
 
@@ -157,6 +363,7 @@ function shouldRunStateMigrationOnlyWithLegacyInputs(commandPath: string[]): boo
   return (
     commandName === "agent" ||
     commandName === "status" ||
+    (commandName === "gateway" && (subcommandName === undefined || subcommandName === "run")) ||
     (commandName === "tasks" &&
       (subcommandName === undefined || ALLOWED_INVALID_TASK_SUBCOMMANDS.has(subcommandName)))
   );
@@ -168,6 +375,522 @@ function snapshotHasConfiguredSessionStore(
   const cfg = snapshot.runtimeConfig ?? snapshot.config;
   const store = cfg?.session?.store;
   return typeof store === "string" && store.trim().length > 0;
+}
+
+function readSessionStoreObjectForStartupDetection(
+  storePath: string,
+): Record<string, Record<string, unknown>> | null {
+  const parsed = readSessionStoreJson5(storePath);
+  return parsed.ok ? (parsed.store as Record<string, Record<string, unknown>>) : null;
+}
+
+function canonicalizeSessionKeyForStartupDetection(params: {
+  cfg: unknown;
+  agentId: string;
+  key: string;
+  skipCrossAgentRemap?: boolean;
+}): string {
+  const raw = params.key.trim();
+  if (!raw) {
+    return raw;
+  }
+  const rawLower = raw.toLowerCase();
+  const normalized = normalizeSessionKeyPreservingOpaquePeerIds(raw);
+  if (rawLower === "global" || rawLower === "unknown") {
+    return rawLower;
+  }
+  const session = objectRecord(objectRecord(params.cfg)?.session);
+  const mainKey = typeof session?.mainKey === "string" ? session.mainKey : undefined;
+  const scope = session?.scope === "global" ? "global" : undefined;
+  if (params.skipCrossAgentRemap) {
+    const parsed = parseAgentSessionKey(raw);
+    if (parsed && normalizeAgentId(parsed.agentId) !== params.agentId) {
+      return normalized;
+    }
+    if (params.agentId !== "main" && (rawLower === "main" || rawLower === (mainKey ?? "main"))) {
+      return rawLower;
+    }
+  }
+  const canonicalMain = canonicalizeMainSessionAlias({
+    cfg: { session: { scope, mainKey } },
+    agentId: params.agentId,
+    sessionKey: raw,
+  });
+  if (canonicalMain !== raw) {
+    return canonicalMain.toLowerCase();
+  }
+  if (rawLower.startsWith("agent:")) {
+    return normalized;
+  }
+  if (rawLower.startsWith("subagent:")) {
+    const rest = raw.slice("subagent:".length);
+    return `agent:${params.agentId}:subagent:${rest}`.toLowerCase();
+  }
+  if (rawLower.startsWith("group:") || rawLower.startsWith("channel:")) {
+    return `agent:${params.agentId}:unknown:${raw}`.toLowerCase();
+  }
+  return normalizeSessionKeyPreservingOpaquePeerIds(`agent:${params.agentId}:${raw}`);
+}
+
+function hasLegacySessionKeyForStartupDetection(params: {
+  cfg: unknown;
+  agentId: string;
+  key: string;
+  skipCrossAgentRemap?: boolean;
+}): boolean {
+  return canonicalizeSessionKeyForStartupDetection(params) !== params.key;
+}
+
+function hasAcpSessionMetadataForStartupDetection(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return false;
+  }
+  return Boolean((entry as { acp?: unknown }).acp);
+}
+
+function listDirEntriesForStartupDetection(dir: string): fs.Dirent[] {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function hasStaleSessionFileForStartupDetection(params: {
+  entry: unknown;
+  legacyDir: string;
+  targetDir: string;
+}): boolean {
+  if (!params.entry || typeof params.entry !== "object" || Array.isArray(params.entry)) {
+    return false;
+  }
+  const entry = params.entry as { sessionFile?: unknown; sessionId?: unknown };
+  const rawSessionFile = entry.sessionFile;
+  if (typeof rawSessionFile !== "string" || !rawSessionFile.trim()) {
+    return false;
+  }
+  const legacySessionFile = path.isAbsolute(rawSessionFile)
+    ? path.resolve(rawSessionFile)
+    : path.resolve(params.legacyDir, rawSessionFile);
+  const relative = path.relative(path.resolve(params.legacyDir), legacySessionFile);
+  if (
+    relative.startsWith("..") ||
+    path.isAbsolute(relative) ||
+    fileOrDirExists(legacySessionFile)
+  ) {
+    return false;
+  }
+  const legacyBackupHasTranscript = listDirEntriesForStartupDetection(
+    path.dirname(params.legacyDir),
+  ).some(
+    (dirent) =>
+      dirent.isDirectory() &&
+      dirent.name.startsWith(`${path.basename(params.legacyDir)}.legacy-`) &&
+      fileOrDirExists(
+        path.join(path.dirname(params.legacyDir), dirent.name, path.basename(legacySessionFile)),
+      ),
+  );
+  if (legacyBackupHasTranscript) {
+    return false;
+  }
+  const parsed = path.parse(path.basename(legacySessionFile));
+  const hasCollisionRename = listDirEntriesForStartupDetection(params.targetDir).some(
+    (dirent) =>
+      dirent.isFile() &&
+      dirent.name.startsWith(`${parsed.name}.legacy-`) &&
+      dirent.name.endsWith(parsed.ext),
+  );
+  if (hasCollisionRename) {
+    return false;
+  }
+  const targetSessionFile = path.join(params.targetDir, path.basename(legacySessionFile));
+  if (!fileOrDirExists(targetSessionFile) || typeof entry.sessionId !== "string") {
+    return false;
+  }
+  try {
+    const fd = fs.openSync(targetSessionFile, "r");
+    let firstLine: string | undefined;
+    try {
+      const buffer = Buffer.alloc(8192);
+      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+      if (bytesRead > 0) {
+        const chunk = buffer.subarray(0, bytesRead).toString("utf8");
+        const newline = chunk.indexOf("\n");
+        firstLine = newline >= 0 ? chunk.slice(0, newline) : chunk;
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+    const header = firstLine ? (JSON.parse(firstLine) as unknown) : undefined;
+    if (!header || typeof header !== "object" || Array.isArray(header)) {
+      return false;
+    }
+    if ((header as { type?: unknown }).type === "session") {
+      return (header as { id?: unknown }).id === entry.sessionId;
+    }
+    const canonicalFileName =
+      path.basename(entry.sessionId) === entry.sessionId ? `${entry.sessionId}.jsonl` : undefined;
+    return canonicalFileName === path.basename(targetSessionFile);
+  } catch {
+    return false;
+  }
+}
+
+function snapshotHasCanonicalSessionMigrationState(
+  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
+): boolean {
+  const cfg = (objectRecord(snapshot.runtimeConfig ?? snapshot.config) ?? {}) as OpenClawConfig;
+  const session = objectRecord(objectRecord(cfg)?.session);
+  const configuredStore =
+    typeof session?.store === "string" && session.store.trim() ? session.store : undefined;
+  const targets = new Map<string, { agentId: string; storePath: string }>();
+  for (const target of resolveAllAgentSessionStoreTargetsSync(cfg, { env: process.env })) {
+    targets.set(`${target.storePath}\0${target.agentId}`, target);
+  }
+  for (const agentId of listConfiguredAgentIdsForSessionMigrationDetection(cfg)) {
+    const storePath = resolveSessionStorePathForStartupDetection(configuredStore, agentId);
+    targets.set(`${storePath}\0${agentId}`, { agentId, storePath });
+  }
+  const agentIdsByStorePath = new Map<string, Set<string>>();
+  for (const target of targets.values()) {
+    const ids = agentIdsByStorePath.get(target.storePath) ?? new Set<string>();
+    ids.add(target.agentId);
+    agentIdsByStorePath.set(target.storePath, ids);
+  }
+  const shouldSkipCrossAgentRemap = (storePath: string) => {
+    const ids = agentIdsByStorePath.get(storePath);
+    return (ids?.size ?? 0) > 1 && ids?.has("main") === true;
+  };
+  return [...targets.values()].some((target) => {
+    const store = readSessionStoreObjectForStartupDetection(target.storePath);
+    if (!store) {
+      return false;
+    }
+    const targetDir = path.dirname(target.storePath);
+    const legacyDir = path.join(resolveStateDir(process.env, os.homedir), "sessions");
+    return Object.entries(store).some(
+      ([key, entry]) =>
+        hasLegacySessionKeyForStartupDetection({
+          cfg,
+          agentId: target.agentId,
+          key,
+          skipCrossAgentRemap: shouldSkipCrossAgentRemap(target.storePath),
+        }) ||
+        hasAcpSessionMetadataForStartupDetection(entry) ||
+        hasStaleSessionFileForStartupDetection({ entry, legacyDir, targetDir }),
+    );
+  });
+}
+
+function snapshotHasConfiguredCronLegacyState(
+  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
+): boolean {
+  const cfg = snapshot.runtimeConfig ?? snapshot.config;
+  const cron = objectRecord(cfg?.cron);
+  return hasLegacyCronMigrationInputForStore(resolveCronStorePathForStartupDetection(cron?.store));
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function normalizeSessionAgentIdForDetection(value: unknown): string {
+  return normalizeAgentId(typeof value === "string" ? value : undefined);
+}
+
+function listAgentIdsForSessionStoreDetection(cfg: unknown): string[] {
+  const ids = new Set<string>(["main"]);
+  for (const id of listConfiguredAgentIdsForSessionMigrationDetection(cfg)) {
+    ids.add(id);
+  }
+  return [...ids];
+}
+
+function listConfiguredAgentIdsForSessionMigrationDetection(cfg: unknown): string[] {
+  const agents = objectRecord(objectRecord(cfg)?.agents);
+  const list = Array.isArray(agents?.list) ? agents.list : [];
+  if (list.length === 0) {
+    return ["main"];
+  }
+  const ids = new Set<string>();
+  for (const entry of list) {
+    const record = objectRecord(entry);
+    const id = normalizeSessionAgentIdForDetection(record?.id);
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return [...ids];
+}
+
+function resolveSessionStorePathForStartupDetection(store: string | undefined, agentId: string) {
+  const normalizedAgentId = normalizeSessionAgentIdForDetection(agentId);
+  if (!store) {
+    return path.join(
+      resolveStateDir(process.env, os.homedir),
+      "agents",
+      normalizedAgentId,
+      "sessions",
+      "sessions.json",
+    );
+  }
+  const expanded = store.includes("{agentId}")
+    ? store.replaceAll("{agentId}", normalizedAgentId)
+    : store;
+  return resolveHomeRelativePath(expanded, { env: process.env, homedir: os.homedir });
+}
+
+function listMSTeamsFeedbackLearningScanDirs(storePath: string): string[] {
+  return [path.resolve(storePath)];
+}
+
+function hasMSTeamsFeedbackLearningLegacyState(cfg: unknown): boolean {
+  const session = objectRecord(objectRecord(cfg)?.session);
+  const store =
+    typeof session?.store === "string" && session.store.trim() ? session.store : undefined;
+  return listAgentIdsForSessionStoreDetection(cfg).some((agentId) =>
+    listMSTeamsFeedbackLearningScanDirs(
+      resolveSessionStorePathForStartupDetection(store, agentId),
+    ).some((dir) => dirHasFile(dir, (name) => name.endsWith(".learnings.json"))),
+  );
+}
+
+function listTelegramAccountIdsForStartupDetection(cfg: unknown): string[] {
+  const ids = new Set<string>([DEFAULT_ACCOUNT_ID]);
+  const root = objectRecord(cfg);
+  const channels = objectRecord(root?.channels);
+  const telegram = objectRecord(channels?.telegram);
+  const accounts = objectRecord(telegram?.accounts);
+  for (const id of Object.keys(accounts ?? {})) {
+    ids.add(normalizeAccountId(id));
+  }
+  const bindings = Array.isArray(root?.bindings) ? root.bindings : [];
+  for (const binding of bindings) {
+    const record = objectRecord(binding);
+    const match = objectRecord(record?.match);
+    if (typeof match?.channel !== "string" || match.channel.trim().toLowerCase() !== "telegram") {
+      continue;
+    }
+    if (typeof match.accountId === "string" && match.accountId.trim() && match.accountId !== "*") {
+      ids.add(normalizeAccountId(match.accountId));
+    }
+  }
+  return [...ids];
+}
+
+function hasTelegramSidecarForStorePath(storePath: string): boolean {
+  if (
+    [
+      `${storePath}.telegram-messages.json`,
+      `${storePath}.telegram-sent-messages.json`,
+      `${storePath}.telegram-topic-names.json`,
+    ].some(fileOrDirExists)
+  ) {
+    return true;
+  }
+  const basename = path.basename(storePath);
+  return dirHasFile(
+    path.dirname(storePath),
+    (name) => name.startsWith(`${basename}.telegram-message-dispatch-`) && name.endsWith(".json"),
+  );
+}
+
+function hasTelegramSessionSidecarLegacyState(cfg: unknown): boolean {
+  const normalizedCfg = (objectRecord(cfg) ?? {}) as OpenClawConfig;
+  const session = objectRecord(objectRecord(cfg)?.session);
+  const configuredStore =
+    typeof session?.store === "string" && session.store.trim() ? session.store : undefined;
+  const storePaths = new Set<string>();
+  for (const target of resolveAllAgentSessionStoreTargetsSync(normalizedCfg, {
+    env: process.env,
+  })) {
+    storePaths.add(target.storePath);
+  }
+  for (const agentId of listAgentIdsForSessionStoreDetection(cfg)) {
+    storePaths.add(resolveSessionStorePathForStartupDetection(configuredStore, agentId));
+  }
+  for (const accountId of listTelegramAccountIdsForStartupDetection(cfg)) {
+    storePaths.add(resolveSessionStorePathForStartupDetection(configuredStore, accountId));
+  }
+  return [...storePaths].some(hasTelegramSidecarForStorePath);
+}
+
+function readPluginConfigObject(cfg: unknown, pluginId: string): Record<string, unknown> | null {
+  const root = objectRecord(cfg);
+  const plugins = objectRecord(root?.plugins);
+  const entries = objectRecord(plugins?.entries);
+  const entry = objectRecord(entries?.[pluginId]);
+  return objectRecord(entry?.config);
+}
+
+function resolveConfiguredPath(input: string): string {
+  return resolveHomeRelativePath(input, { env: process.env, homedir: os.homedir });
+}
+
+function normalizeAgentIdForWorkspace(value: unknown): string {
+  return normalizeAgentId(typeof value === "string" ? value : undefined);
+}
+
+function listAgentEntriesForWorkspace(cfg: unknown): Record<string, unknown>[] {
+  const agents = objectRecord(objectRecord(cfg)?.agents);
+  const list = Array.isArray(agents?.list) ? agents.list : [];
+  return list.flatMap((entry) => {
+    const record = objectRecord(entry);
+    return record ? [record] : [];
+  });
+}
+
+function resolveDefaultAgentIdForWorkspace(cfg: unknown): string {
+  const entries = listAgentEntriesForWorkspace(cfg);
+  const defaultEntry = entries.find((entry) => entry.default === true) ?? entries[0];
+  return normalizeAgentIdForWorkspace(defaultEntry?.id);
+}
+
+function resolveDefaultWorkspaceDirForEnv(): string {
+  const workspaceDir = process.env.OPENCLAW_WORKSPACE_DIR?.trim();
+  if (workspaceDir) {
+    return path.resolve(workspaceDir);
+  }
+  const homeDir = resolveRequiredHomeDir(process.env, os.homedir);
+  const profile = process.env.OPENCLAW_PROFILE?.trim();
+  return profile && profile.toLowerCase() !== "default"
+    ? path.join(homeDir, ".openclaw", `workspace-${profile}`)
+    : path.join(homeDir, ".openclaw", "workspace");
+}
+
+function resolveAgentWorkspaceDirForSnapshot(cfg: unknown, agentId: string): string {
+  const id = normalizeAgentIdForWorkspace(agentId);
+  const entries = listAgentEntriesForWorkspace(cfg);
+  const entry = entries.find((candidate) => normalizeAgentIdForWorkspace(candidate.id) === id);
+  if (typeof entry?.workspace === "string" && entry.workspace.trim().length > 0) {
+    return resolveConfiguredPath(entry.workspace);
+  }
+  const defaults = objectRecord(objectRecord(cfg)?.agents)?.defaults;
+  const defaultWorkspace = objectRecord(defaults)?.workspace;
+  const defaultAgentId = resolveDefaultAgentIdForWorkspace(cfg);
+  if (typeof defaultWorkspace === "string" && defaultWorkspace.trim().length > 0) {
+    const resolvedDefault = resolveConfiguredPath(defaultWorkspace);
+    return id === defaultAgentId ? resolvedDefault : path.join(resolvedDefault, id);
+  }
+  return id === defaultAgentId
+    ? resolveDefaultWorkspaceDirForEnv()
+    : path.join(resolveStateDir(process.env, os.homedir), `workspace-${id}`);
+}
+
+function listConfiguredAgentWorkspaceDirs(cfg: unknown): string[] {
+  const entries = listAgentEntriesForWorkspace(cfg);
+  const ids =
+    entries.length > 0
+      ? [...new Set(entries.map((entry) => normalizeAgentIdForWorkspace(entry.id)))]
+      : [resolveDefaultAgentIdForWorkspace(cfg)];
+  return [...new Set(ids.map((id) => resolveAgentWorkspaceDirForSnapshot(cfg, id)))];
+}
+
+function hasMemoryCoreLegacyWorkspaceState(cfg: unknown): boolean {
+  const relativePaths = [
+    path.join("memory", ".dreams", "daily-ingestion.json"),
+    path.join("memory", ".dreams", "session-ingestion.json"),
+    path.join("memory", ".dreams", "short-term-recall.json"),
+    path.join("memory", ".dreams", "phase-signals.json"),
+  ];
+  return listConfiguredAgentWorkspaceDirs(cfg).some((workspaceDir) =>
+    relativePaths.some((relativePath) => fileOrDirExists(path.join(workspaceDir, relativePath))),
+  );
+}
+
+function resolveVoiceCallStorePath(rawPath: string): string {
+  const trimmed = rawPath.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("~")) {
+    return path.resolve(
+      trimmed.replace(/^~(?=$|[\\/])/, resolveRequiredOsHomeDir(process.env, os.homedir)),
+    );
+  }
+  return path.resolve(trimmed);
+}
+
+function resolveMemoryWikiVaultPath(rawPath: string): string {
+  const trimmed = rawPath.trim();
+  if (trimmed === "~") {
+    return resolveRequiredOsHomeDir(process.env, os.homedir);
+  }
+  if (trimmed.startsWith("~/")) {
+    return path.join(resolveRequiredOsHomeDir(process.env, os.homedir), trimmed.slice(2));
+  }
+  return trimmed;
+}
+
+function hasMemoryWikiLegacyVaultState(cfg: unknown): boolean {
+  const config = readPluginConfigObject(cfg, "memory-wiki");
+  const vault = objectRecord(config?.vault);
+  const rawVaultPath =
+    typeof vault?.path === "string" && vault.path.trim().length > 0
+      ? vault.path
+      : path.join(resolveRequiredOsHomeDir(process.env, os.homedir), ".openclaw", "wiki", "main");
+  const vaultRoot = resolveMemoryWikiVaultPath(rawVaultPath);
+  return (
+    fileOrDirExists(path.join(vaultRoot, ".openclaw-wiki", "source-sync.json")) ||
+    dirHasFile(path.join(vaultRoot, ".openclaw-wiki", "import-runs"), (name) =>
+      name.endsWith(".json"),
+    )
+  );
+}
+
+function snapshotHasConfiguredPluginLegacyState(
+  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
+): boolean {
+  const cfg = snapshot.runtimeConfig ?? snapshot.config;
+  for (const pluginId of ["voice-call", "@openclaw/voice-call"]) {
+    const store = readPluginConfigObject(cfg, pluginId)?.store;
+    if (typeof store === "string" && store.trim().length > 0) {
+      if (fileOrDirExists(path.join(resolveVoiceCallStorePath(store), "calls.jsonl"))) {
+        return true;
+      }
+    }
+  }
+  return (
+    hasMSTeamsFeedbackLearningLegacyState(cfg) ||
+    hasTelegramSessionSidecarLegacyState(cfg) ||
+    hasMemoryCoreLegacyWorkspaceState(cfg) ||
+    hasMemoryWikiLegacyVaultState(cfg)
+  );
+}
+
+async function snapshotHasPluginDoctorLegacyState(
+  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
+): Promise<boolean> {
+  const cfg = (objectRecord(snapshot.runtimeConfig ?? snapshot.config) ?? {}) as OpenClawConfig;
+  const [{ createPluginStateKeyedStore }, { listPluginDoctorStateMigrationEntries }] =
+    await Promise.all([
+      import("../../plugin-state/plugin-state-store.js"),
+      import("../../plugins/doctor-contract-registry.js"),
+    ]);
+  const stateDir = resolveStateDir(process.env, os.homedir);
+  const oauthDir = resolveOAuthDir(process.env, stateDir);
+  for (const entry of listPluginDoctorStateMigrationEntries({ config: cfg, env: process.env })) {
+    const detected = await entry.migration.detectLegacyState({
+      config: cfg,
+      env: process.env,
+      stateDir,
+      oauthDir,
+      context: {
+        openPluginStateKeyedStore<T>(options: OpenKeyedStoreOptions) {
+          return createPluginStateKeyedStore<T>(entry.pluginId, {
+            ...options,
+            env: options.env ?? process.env,
+          });
+        },
+      },
+    });
+    if (detected?.preview.length) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function getConfigSnapshot() {
@@ -216,11 +939,13 @@ export async function ensureConfigReady(params: {
   if (
     !didRunDoctorConfigFlow &&
     shouldConsiderStateMigration &&
-    (!requiresLegacyStateInput || hasLegacyStateMigrationInputs())
+    (!requiresLegacyStateInput || (await hasLegacyStateMigrationInputs()))
   ) {
     preflightSnapshot = await runStateMigrationPreflight();
   }
 
+  const commandName = commandPath[0];
+  const subcommandName = commandPath[1];
   let snapshot = preflightSnapshot ?? (await getConfigSnapshot());
   if (
     !preflightSnapshot &&
@@ -228,13 +953,15 @@ export async function ensureConfigReady(params: {
     shouldConsiderStateMigration &&
     requiresLegacyStateInput &&
     snapshot.valid &&
-    snapshotHasConfiguredSessionStore(snapshot)
+    (snapshotHasCanonicalSessionMigrationState(snapshot) ||
+      (commandName !== "gateway" && snapshotHasConfiguredSessionStore(snapshot)) ||
+      snapshotHasConfiguredCronLegacyState(snapshot) ||
+      snapshotHasConfiguredPluginLegacyState(snapshot) ||
+      (await snapshotHasPluginDoctorLegacyState(snapshot)))
   ) {
     preflightSnapshot = await runStateMigrationPreflight();
     snapshot = preflightSnapshot;
   }
-  const commandName = commandPath[0];
-  const subcommandName = commandPath[1];
   const isBareGatewayForegroundRun =
     commandName === "gateway" && (subcommandName === undefined || subcommandName.trim() === "");
   const isReadOnlyTaskStateCommand =
@@ -314,5 +1041,6 @@ export async function ensureConfigReady(params: {
 
 export const testApi = {
   resetConfigGuardStateForTests,
+  hasMSTeamsFeedbackLearningLegacyStateForTests: hasMSTeamsFeedbackLearningLegacyState,
 };
 export { testApi as __test__ };


### PR DESCRIPTION
## What Problem This Solves

`openclaw gateway run` paid doctor startup preflight work even when no legacy state was present. Earlier versions of this PR skipped too aggressively; the current version keeps the skip only after checking the legacy inputs that the doctor migration path can still handle.

## Why This Change Was Made

This change gates the Gateway foreground startup doctor migration preflight behind legacy-input detection, matching the existing read-only-command intent while preserving automatic migration for known legacy sources.

The detector now covers or delegates to:

- core legacy state directories, sidecars, pending SQLite archives, delivery queues, debug-proxy, config-health/update/current-conversation state, cron legacy stores/run logs, and exec approvals
- canonical and configured session stores, including JSON5 stores, non-default/retired agent stores, ACP metadata, stale migrated session-file repairs, and shared-store cross-agent orphan-key behavior
- bundled channel legacy state sidecars, including Telegram sidecars without `sessions.json`, named-account Telegram sidecars, and configured/default account paths
- shipped plugin doctor migration sources (Active Memory, Phone Control, ACPX, Device Pair, Matrix, Nostr, MSTeams, Voice Call, Memory Core, Memory Wiki, Workboard, Telegram)
- generic installed plugin `doctor-contract-api` state migrations by invoking their public `detectLegacyState` contract after config load
- conservative fallback when the shared-state SQLite probe cannot run

It also avoids persistent false positives from already-archived `*.migrated` plugin sources, normal current plugin-state rows, current canonical agent directories, current custom session stores, current shared debug-proxy SQLite DBs, and unmigratable Voice Call files under `OPENCLAW_HOME` when the Voice Call default is OS-home based.

## User Impact

Gateway startup still runs doctor preflight when legacy/migratable state exists. On no-legacy startup, the reviewed patch keeps a meaningful Gateway-ready improvement, though smaller than the initial draft because the final version preserves generic plugin doctor migration detection.

Latest benchmark artifact:

- `.artifacts/gateway-startup-upstream/final-reviewed-gateway-startup.json`
- log: `.artifacts/gateway-startup-upstream/final-reviewed-gateway-startup.log`

P50 Gateway-ready deltas vs the original `origin/main` baseline artifact `.artifacts/gateway-startup-upstream/20260623T215700Z-main-baseline/gateway-startup.json`:

| case | baseline p50 ready ms | reviewed candidate p50 ready ms | delta |
|---|---:|---:|---:|
| default | 3380.7 | 3104.4 | -276.3ms (-8.2%) |
| skipChannels | 3087.7 | 2482.2 | -605.5ms (-19.6%) |
| oneInternalHook | 3060.8 | 2463.9 | -596.9ms (-19.5%) |
| allInternalHooks | 3056.5 | 2468.0 | -588.5ms (-19.3%) |
| fiftyPlugins | 3291.8 | 2692.4 | -599.4ms (-18.2%) |
| fiftyStartupLazyPlugins | 3170.3 | 2496.9 | -673.4ms (-21.2%) |

## Evidence

Passed locally on the reviewed head `0149e9d9c1`:

- `pnpm test src/cli/program/config-guard.test.ts`
  - 88 tests passed
- `pnpm test extensions/msteams/doctor-contract-api.test.ts`
  - 5 tests passed
- `OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD=1 pnpm tsgo:core`
- `pnpm build:docker`
- `codex review --base origin/main`
  - result: `No discrete correctness issues were identified in the changed config-guard migration detection paths or adjacent migration contracts reviewed.`
- `pnpm test:startup:gateway --runs 5 --warmup 1 --output .artifacts/gateway-startup-upstream/final-reviewed-gateway-startup.json`

Earlier full-suite caveat still applies:

- Full `pnpm test` was run before the review-fix loop and failed in unrelated shards outside this patch's two changed files. Failures included provider catalog expectations, timing/process tests, backup late-SQLite tests, security scan allowlist tests, and script resolver tests. The failure log is `.artifacts/gateway-startup-upstream/pnpm-test-gateway-preflight-final.log`.
