### PR TITLE
fix(crabbox): require Xcode for macOS proof

### DIFF
--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -2593,6 +2593,10 @@ function remoteAwsMacosSwiftBootstrap() {
     'echo "[crabbox] current Swift is $1.$2; select/install Xcode 26.x or use a Blacksmith macOS runner with Xcode_26.1.app." >&2;',
     "return 2;",
     "fi;",
+    'openclaw_xcodebuild_version="$(xcodebuild -version 2>&1)" || { printf "%s\\n" "$openclaw_xcodebuild_version" >&2; echo "[crabbox] OpenClaw macOS app proof requires Xcode 26.x; active developer directory does not provide usable xcodebuild." >&2; return 2; };',
+    'printf "%s\\n" "$openclaw_xcodebuild_version" >&2;',
+    'openclaw_xcode_major="$(printf "%s\\n" "$openclaw_xcodebuild_version" | sed -nE "s/^Xcode ([0-9]+)(\\..*)?$/\\1/p" | head -n 1)";',
+    'if [ "$openclaw_xcode_major" != "26" ]; then echo "[crabbox] OpenClaw macOS app proof requires Xcode 26.x; current xcodebuild is ${openclaw_xcode_major:-unknown}." >&2; return 2; fi;',
     "};",
     "openclaw_crabbox_require_macos_swift_62",
   ].join(" ");

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -1183,6 +1183,8 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
     expect(remoteCommand).toContain("/Applications/Xcode-26*.app");
     expect(remoteCommand).toContain('sudo xcode-select -s "$openclaw_developer"');
     expect(remoteCommand).toContain("OpenClaw macOS app proof requires Swift tools 6.2+");
+    expect(remoteCommand).toContain("xcodebuild -version");
+    expect(remoteCommand).toContain("OpenClaw macOS app proof requires Xcode 26.x");
     expect(remoteCommand).not.toContain("openclaw_crabbox_bootstrap_macos_js");
     expectGroupedShellCommand(
       remoteCommand,
@@ -1204,6 +1206,7 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
     expect(remoteCommand).toContain("pnpm --version >&2");
     expect(remoteCommand).toContain("openclaw_crabbox_require_macos_swift_62");
     expect(remoteCommand).toContain("OpenClaw macOS app proof requires Swift tools 6.2+");
+    expect(remoteCommand).toContain("OpenClaw macOS app proof requires Xcode 26.x");
     expectGroupedShellCommand(remoteCommand, "pnpm mac:package");
   });
 
@@ -2234,6 +2237,7 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
     expect(output.scriptContent).toContain("openclaw_crabbox_require_macos_swift_62");
     expect(output.scriptContent).toContain("openclaw_crabbox_require_macos_swift_62 || exit $?");
     expect(output.scriptContent).toContain("OpenClaw macOS app proof requires Swift tools 6.2+");
+    expect(output.scriptContent).toContain("OpenClaw macOS app proof requires Xcode 26.x");
     expect(output.scriptContent).toContain(`\n${script}`);
   });
 


### PR DESCRIPTION
## Summary
- require usable `xcodebuild` from Xcode 26.x in the AWS macOS Swift/package proof preflight
- keep the existing Swift 6.2+ gate, but stop treating CommandLineTools Swift as enough for OpenClaw macOS app proof
- add wrapper test assertions for raw Swift, package-script, and script-stdin injection paths

## Repro
- AWS M4 macOS preflight run `run_9449944c66e6` reported Swift 6.2.4, then failed when `xcodebuild -version` hit CommandLineTools: `tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance`.

## Verification
- `git diff --check`
- `node --check scripts/crabbox-wrapper.mjs`
- Targeted Testbox: `tbx_01kvvh9nm1b4sw0h6bh072dfdc`, label `openclaw-crabbox-wrapper-targeted-return-code-20260624`, passed `test/scripts/crabbox-wrapper.test.ts` (186 tests)
- Rebased changed gate: `tbx_01kvvhhmwsv60t3yzxacqdvxqr`, label `openclaw-check-changed-xcode-guard-rebased-20260624`, passed
- Rebased autoreview: clean, no accepted/actionable findings

## Proof gap
- Live AWS re-proof after the patch could not start because the exact M4 dedicated host flipped back to `InsufficientCapacityOnHost` (`run_3506e9c0c79e`). The unit coverage proves the wrapper now injects the Xcode guard, and the failed M4 preflight above is the observed runner state this guard is meant to catch earlier.
