### PR TITLE
fix(auth): restore OAuth-backed OpenAI batch audio transcription

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -511,6 +511,36 @@ describe("getApiKeyForModel", () => {
     ).rejects.toThrow(/requires an OpenAI API key profile/);
   });
 
+  it("allows an explicit OpenAI OAuth profile for OpenAI audio transcription models", async () => {
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openai:chatgpt": {
+          type: "oauth" as const,
+          provider: "openai",
+          ...oauthFixture,
+        },
+      },
+    };
+
+    const resolved = await getApiKeyForModel({
+      model: {
+        id: "gpt-4o-mini-transcribe",
+        provider: "openai",
+        api: "openai-audio-transcriptions",
+      } as Model,
+      profileId: "openai:chatgpt",
+      lockedProfile: true,
+      store,
+    });
+
+    expect(resolved).toMatchObject({
+      apiKey: oauthFixture.access,
+      mode: "oauth",
+      profileId: "openai:chatgpt",
+    });
+  });
+
   it("uses the config default agent dir when resolving provider profiles", async () => {
     await withOpenClawTestState(
       {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -91,15 +91,18 @@ export type RuntimeProviderAuthLookup = {
 const log = createSubsystemLogger("model-auth");
 const OPENAI_PROVIDER_ID = "openai";
 const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";
+const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";
 
 function directOpenAIPlatformModelRequiresApiKey(params: {
   provider: string;
   modelApi?: string;
 }): boolean {
+  const modelApi = normalizeLowercaseStringOrEmpty(params.modelApi);
   return (
     normalizeProviderId(params.provider) === OPENAI_PROVIDER_ID &&
-    params.modelApi !== undefined &&
-    normalizeLowercaseStringOrEmpty(params.modelApi) !== OPENAI_CODEX_RESPONSES_API
+    modelApi !== "" &&
+    modelApi !== OPENAI_CODEX_RESPONSES_API &&
+    modelApi !== OPENAI_AUDIO_TRANSCRIPTIONS_API
   );
 }
 

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -748,4 +748,78 @@ describe("CORE_HEALTH_CHECKS", () => {
       }),
     );
   });
+
+  it("warns when OpenAI audio transcription is configured without an explicit API key", async () => {
+    const check = getCheck(createCoreHealthChecks(createDeps()), "core/doctor/openai-audio-oauth");
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          audio: {
+            models: [{ provider: "openai", model: "gpt-4o-mini-transcribe" }],
+          },
+        },
+      },
+    };
+
+    const findings = await check.detect({ mode: "lint", runtime, cfg });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      checkId: "core/doctor/openai-audio-oauth",
+      severity: "warning",
+      path: "tools.media.audio.models",
+    });
+  });
+
+  it("does not warn when OpenAI audio transcription has an explicit API key", async () => {
+    const check = getCheck(createCoreHealthChecks(createDeps()), "core/doctor/openai-audio-oauth");
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          audio: {
+            models: [{ provider: "openai", model: "gpt-4o-mini-transcribe" }],
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            apiKey: "sk-test",
+            models: [],
+          },
+        },
+      },
+    };
+
+    const findings = await check.detect({ mode: "lint", runtime, cfg });
+
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does not warn when audio models use a non-OpenAI provider", async () => {
+    const check = getCheck(createCoreHealthChecks(createDeps()), "core/doctor/openai-audio-oauth");
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          audio: {
+            models: [{ provider: "mistral", model: "voxtral-mini-latest" }],
+          },
+        },
+      },
+    };
+
+    const findings = await check.detect({ mode: "lint", runtime, cfg });
+
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does not warn when audio models are not configured", async () => {
+    const check = getCheck(createCoreHealthChecks(createDeps()), "core/doctor/openai-audio-oauth");
+    const cfg: OpenClawConfig = {};
+
+    const findings = await check.detect({ mode: "lint", runtime, cfg });
+
+    expect(findings).toHaveLength(0);
+  });
 });

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -2,6 +2,10 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
+  findNormalizedProviderValue,
+  normalizeProviderId,
+} from "../agents/model-selection-normalize.js";
+import {
   detectLegacyClawdBrowserProfileResidue,
   maybeArchiveLegacyClawdBrowserProfileResidue,
   noteChromeMcpBrowserReadiness,
@@ -895,6 +899,44 @@ const finalConfigValidationCheck: HealthCheck = {
   },
 };
 
+const openaiAudioOAuthCheck: HealthCheck = {
+  id: "core/doctor/openai-audio-oauth",
+  kind: "core",
+  description: "OpenAI batch audio transcription uses an API-key profile for best compatibility.",
+  source: "doctor",
+  async detect(ctx) {
+    const audioModels = ctx.cfg.tools?.media?.audio?.models;
+    if (!Array.isArray(audioModels) || audioModels.length === 0) {
+      return [];
+    }
+    const hasOpenAiAudio = audioModels.some((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return false;
+      }
+      const provider = (entry as { provider?: string }).provider;
+      return typeof provider === "string" && normalizeProviderId(provider) === "openai";
+    });
+    if (!hasOpenAiAudio) {
+      return [];
+    }
+    const openaiProviderConfig = findNormalizedProviderValue(ctx.cfg.models?.providers, "openai");
+    if (openaiProviderConfig && (openaiProviderConfig as { apiKey?: unknown }).apiKey) {
+      return [];
+    }
+    return [
+      {
+        checkId: "core/doctor/openai-audio-oauth",
+        severity: "warning",
+        message:
+          "OpenAI batch audio transcription is configured without an explicit OpenAI Platform API key. OpenAI Platform /v1/audio/transcriptions recommends an API-key profile; OAuth-backed transcription may fail depending on your account type.",
+        path: "tools.media.audio.models",
+        fixHint:
+          "Configure an OpenAI Platform API key for the openai provider, or switch to a different audio transcription provider.",
+      },
+    ];
+  },
+};
+
 const shellCompletionCheck: HealthCheck = {
   id: "core/doctor/shell-completion",
   kind: "core",
@@ -1011,6 +1053,7 @@ export function createCoreHealthChecks(
     commandOwnerCheck,
     createSkillsReadinessCheck(deps),
     browserClawdProfileResidueCheck,
+    openaiAudioOAuthCheck,
     finalConfigValidationCheck,
   ];
 }

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -113,7 +113,7 @@ describe("runCapability auto audio entries", () => {
     const resolveApiKeyForProvider = vi.mocked(modelAuth.resolveApiKeyForProvider);
     hasAvailableAuthForProvider.mockImplementation(async (params) => {
       if (params.provider === "openai") {
-        return params.modelApi === undefined;
+        return false;
       }
       return params.provider === "mistral";
     });


### PR DESCRIPTION
Fixes #96135

## What Problem This Solves

Users with OpenAI/Codex OAuth profiles configured for `tools.media.audio` could no longer perform batch audio transcription after updating to version 2026.6.9. The system threw:
```
Auth profile "[redacted]" uses oauth auth, but openai/openai-audio-transcriptions requires an OpenAI API key profile.
```

This was a regression: the same configuration worked in prior versions.

## Why This Change Was Made

PR #90793 ("Fix OpenAI audio auth to use API keys") explicitly set the `modelApi` for OpenAI batch audio to `openai-audio-transcriptions`. At the same time, commit `d92b3b5cc2` ("refactor: unify OpenAI provider identity") introduced `directOpenAIPlatformModelRequiresApiKey`, which forces `api-key` for every OpenAI API except `openai-chatgpt-responses`. The combination caused OAuth to be rejected for audio transcription.

The fix adds `openai-audio-transcriptions` to the OAuth-allowlist in `directOpenAIPlatformModelRequiresApiKey`, restoring the pre-PR-90793 behavior. It also corrects a boundary condition: `normalizeLowercaseStringOrEmpty(undefined)` returns `""` rather than `undefined`, so the check now compares against `""` instead of `undefined`.

Additionally, a new `core/doctor/openai-audio-oauth` health check is registered so that `openclaw doctor --lint` warns when OpenAI audio is configured without an explicit Platform API key, giving users a heads-up about potential compatibility limits.

No other provider auth rules were changed, no config options were added, and no extension code was modified.

## User Impact

Users who rely on OpenAI/Codex OAuth for batch audio transcription will see the feature work again after this fix. A doctor warning will appear if OpenAI audio is configured without a Platform API key, recommending either adding an API key or switching to a different provider. All other users (those with API keys or non-OpenAI audio providers) are unaffected.

## Evidence

Environment: Ubuntu 22.04, Node v22.23.0, pnpm v11.2.2, OpenClaw 2026.6.9 (cd7e3df1ea), worktree SHA cd7e3df1ea

Before fix (negative control — new regression test fails on old code):

```bash
$ git stash
$ pnpm test src/agents/model-auth.profiles.test.ts
 FAIL  |agents| src/agents/model-auth.profiles.test.ts > getApiKeyForModel > allows an explicit OpenAI OAuth profile for OpenAI audio transcription models
Error: Auth profile "openai:chatgpt" uses oauth auth, but openai/openai-audio-transcriptions requires an OpenAI API key profile.
```

After fix:

```bash
$ pnpm test src/agents/model-auth.profiles.test.ts
 Test Files  1 passed (1)
      Tests  71 passed (71)

$ pnpm test src/media-understanding/runner.auto-audio.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)

$ pnpm test src/flows/doctor-core-checks.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

Lint/format clean:

```bash
$ npx oxfmt --check src/agents/model-auth.ts src/agents/model-auth.profiles.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-core-checks.test.ts src/media-understanding/runner.auto-audio.test.ts
All matched files use the correct format.

$ npx oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/model-auth.ts src/agents/model-auth.profiles.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-core-checks.test.ts src/media-understanding/runner.auto-audio.test.ts
Found 0 warnings and 0 errors.
```

Tests

| File | Tests | Status |
|------|-------|--------|
| `src/agents/model-auth.profiles.test.ts` | 71 (1 new regression) | ✅ All pass |
| `src/media-understanding/runner.auto-audio.test.ts` | 9 | ✅ All pass |
| `src/flows/doctor-core-checks.test.ts` | 19 (4 new) | ✅ All pass |
