### PR TITLE
fix(nextcloud-talk): ignore signed non-message webhook events

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -182,6 +182,45 @@ describe("createNextcloudTalkWebhookServer replay handling", () => {
 });
 
 describe("createNextcloudTalkWebhookServer payload validation", () => {
+  it("acknowledges signed non-message Create events instead of rejecting them", async () => {
+    const payload = {
+      type: "Create",
+      actor: { type: "Person", id: "alice", name: "Alice" },
+      object: {
+        type: "Document",
+        id: "file-1",
+        name: "report.pdf",
+        content: "",
+        mediaType: "application/pdf",
+      },
+      target: { type: "Collection", id: "room-1", name: "Room 1" },
+    };
+    const body = JSON.stringify(payload);
+    const { random, signature } = generateNextcloudTalkSignature({
+      body,
+      secret: "nextcloud-secret", // pragma: allowlist secret
+    });
+    const onMessage = vi.fn();
+    const harness = await startWebhookServer({
+      path: "/nextcloud-non-message-event",
+      onMessage,
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-nextcloud-talk-random": random,
+        "x-nextcloud-talk-signature": signature,
+        "x-nextcloud-talk-backend": "https://nextcloud.example",
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed webhook payloads after signature verification", async () => {
     const payload = {
       type: "Create",

--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -221,6 +221,38 @@ describe("createNextcloudTalkWebhookServer payload validation", () => {
     expect(onMessage).not.toHaveBeenCalled();
   });
 
+  it("acknowledges signed non-Create Talk events instead of rejecting them", async () => {
+    const payload = {
+      type: "Join",
+      actor: { type: "Application", id: "bots/bot-1", name: "Bot" },
+      object: { type: "Collection", id: "room-1", name: "Room 1" },
+    };
+    const body = JSON.stringify(payload);
+    const { random, signature } = generateNextcloudTalkSignature({
+      body,
+      secret: "nextcloud-secret", // pragma: allowlist secret
+    });
+    const onMessage = vi.fn();
+    const harness = await startWebhookServer({
+      path: "/nextcloud-lifecycle-event",
+      onMessage,
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-nextcloud-talk-random": random,
+        "x-nextcloud-talk-signature": signature,
+        "x-nextcloud-talk-backend": "https://nextcloud.example",
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed webhook payloads after signature verification", async () => {
     const payload = {
       type: "Create",

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -44,7 +44,7 @@ const NextcloudTalkWebhookPayloadSchema: z.ZodType<NextcloudTalkWebhookPayload> 
   }),
 });
 const NextcloudTalkWebhookEnvelopeSchema = z.object({
-  type: z.enum(["Create", "Update", "Delete"]),
+  type: z.string().min(1),
   object: z
     .object({
       type: z.string().min(1).optional(),

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -43,6 +43,15 @@ const NextcloudTalkWebhookPayloadSchema: z.ZodType<NextcloudTalkWebhookPayload> 
     name: z.string(),
   }),
 });
+const NextcloudTalkWebhookEnvelopeSchema = z.object({
+  type: z.enum(["Create", "Update", "Delete"]),
+  object: z
+    .object({
+      type: z.string().min(1).optional(),
+    })
+    .passthrough()
+    .optional(),
+});
 const WEBHOOK_ERRORS = {
   missingSignatureHeaders: "Missing signature headers",
   invalidBackend: "Invalid backend",
@@ -184,13 +193,21 @@ function decodeWebhookCreateMessage(params: {
   | { kind: "message"; message: NextcloudTalkInboundMessage }
   | { kind: "ignore" }
   | { kind: "invalid" } {
+  const envelope = safeParseJsonWithSchema(NextcloudTalkWebhookEnvelopeSchema, params.body);
+  if (!envelope) {
+    writeWebhookError(params.res, 400, WEBHOOK_ERRORS.invalidPayloadFormat);
+    return { kind: "invalid" };
+  }
+  if (envelope.type !== "Create") {
+    return { kind: "ignore" };
+  }
+  if (envelope.object?.type && envelope.object.type !== "Note") {
+    return { kind: "ignore" };
+  }
   const payload = parseWebhookPayload(params.body);
   if (!payload) {
     writeWebhookError(params.res, 400, WEBHOOK_ERRORS.invalidPayloadFormat);
     return { kind: "invalid" };
-  }
-  if (payload.type !== "Create") {
-    return { kind: "ignore" };
   }
   return { kind: "message", message: payloadToInboundMessage(payload) };
 }


### PR DESCRIPTION
## What Problem This Solves

Signed Nextcloud Talk lifecycle, reaction, and file-share webhook events can
reach the bot endpoint even though only `Create` events with a `Note` object
are chat messages. The strict message schema currently turns those valid
non-message events into HTTP 400 responses, which makes Nextcloud count bot
errors and can eventually disable delivery.

## Why This Change Was Made

Parse a small signed Activity Streams envelope before applying the strict
chat-message schema. Acknowledging non-`Create` events and `Create` events
whose object is not a `Note` keeps the message contract strict while treating
events this bot does not handle as successful no-ops.

## User Impact

Nextcloud Talk bots stop returning 400 for valid non-message webhook events.
Supported `Create`/`Note` messages continue through the existing message
handler, and malformed message-shaped payloads still return `Invalid payload
format`.

## Evidence

- `node scripts/run-vitest.mjs extensions/nextcloud-talk/src/monitor.replay.test.ts`
  — 12 tests passed.
- `node scripts/run-vitest.mjs extensions/nextcloud-talk/src`
  — 15 files and 93 tests passed.
- `./node_modules/.bin/oxfmt --check extensions/nextcloud-talk/src/monitor.ts extensions/nextcloud-talk/src/monitor.replay.test.ts`
- `git diff --check`
- Fresh autoreview: clean.
- Regression coverage sends signed `Document` and `Join` events and verifies
  HTTP 200 with no message dispatch, while malformed `Create`/`Note` payloads
  remain HTTP 400.

Fixes #81566
