### PR TITLE
fix(fallback): treat upstream_error as fallbackable

### DIFF
--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -1096,6 +1096,32 @@ describe("classifyAssistantFailoverReason", () => {
       }),
     ).toBe("model_not_found");
   });
+
+  it("treats structured upstream_error assistant payloads as fallbackable timeouts", () => {
+    expect(
+      classifyAssistantFailoverReason({
+        role: "assistant",
+        api: "openai-completions",
+        provider: "openai-compatible",
+        model: "primary-model",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "error",
+        errorMessage: "Upstream request failed",
+        errorType: "upstream_error",
+        errorBody:
+          '{"error":{"message":"Upstream request failed","type":"upstream_error","param":"","code":null}}',
+        content: [],
+        timestamp: 0,
+      }),
+    ).toBe("timeout");
+  });
 });
 
 describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => {

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -917,6 +917,19 @@ function classifyFailoverReasonFromCode(raw: string | undefined): FailoverReason
   }
 }
 
+function classifyFailoverReasonFromErrorType(raw: string | undefined): FailoverReason | null {
+  const normalized = raw?.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  switch (normalized) {
+    case "upstream_error":
+      return "timeout";
+    default:
+      return null;
+  }
+}
+
 function isProvider(provider: string | undefined, match: string): boolean {
   const normalized = normalizeOptionalLowercaseString(provider);
   return Boolean(normalized && normalized.includes(match));
@@ -1180,6 +1193,7 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
     ? toReasonClassification(providerPluginReason)
     : mergeMessageAndDetailClassification(messageClassification, detailClassification);
   const codeReason = classifyFailoverReasonFromCode(signal.code);
+  const errorTypeReason = classifyFailoverReasonFromErrorType(signal.errorType);
   if (codeReason === "auth_permanent") {
     return toReasonClassification(codeReason);
   }
@@ -1193,6 +1207,9 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
   );
   if (statusClassification) {
     return statusClassification;
+  }
+  if (errorTypeReason) {
+    return toReasonClassification(errorTypeReason);
   }
   if (codeReason) {
     return toReasonClassification(codeReason);

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -308,6 +308,49 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("falls back for structured upstream_error assistant failures after rotation is exhausted", () => {
+    const assistantError = {
+      role: "assistant" as const,
+      api: "openai-completions" as const,
+      provider: "openai-compatible",
+      model: "primary-model",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "error" as const,
+      errorMessage: "Upstream request failed",
+      errorType: "upstream_error",
+      content: [],
+      timestamp: 0,
+    };
+    const failoverReason = classifyAssistantFailoverReason(assistantError);
+
+    expect(failoverReason).toBe("timeout");
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: failoverReason !== null,
+        failoverReason,
+        timedOut: false,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "timeout",
+    });
+  });
+
   it("does not fallback assistant tool-execution timeouts even after profile rotation exhausted (#52147)", () => {
     expect(
       resolveRunFailoverDecision({


### PR DESCRIPTION
## Summary
- classify structured assistant errorType=upstream_error as a fallbackable timeout
- cover the assistant failover classifier and fallback policy with regression tests
- preserve existing behavior for other error types

## Testing
- pnpm vitest run src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts src/agents/embedded-agent-runner/run/failover-policy.test.ts

Closes #95519