### PR TITLE
fix(chutes-oauth): bound Chutes OAuth JSON response reads

### DIFF
--- a/extensions/chutes/oauth.test.ts
+++ b/extensions/chutes/oauth.test.ts
@@ -2,7 +2,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { loginChutes } from "./oauth.js";
 
-function boundedErrorResponse(body: string, status = 500): {
+const PROVIDER_JSON_MAX_BYTES = 16 * 1024 * 1024;
+
+function boundedErrorResponse(
+  body: string,
+  status = 500,
+): {
   response: Response;
   cancel: ReturnType<typeof vi.fn>;
   releaseLock: ReturnType<typeof vi.fn>;
@@ -36,6 +41,46 @@ function boundedErrorResponse(body: string, status = 500): {
   } as unknown as Response;
 
   return { response, cancel, releaseLock, text };
+}
+
+/**
+ * Builds a streaming Response whose body overflows the shared provider JSON
+ * cap (PROVIDER_JSON_MAX_BYTES) so the bounded reader must cancel before the
+ * whole body is buffered.
+ */
+function overflowingSuccessJsonResponse(): {
+  response: Response;
+  cancel: ReturnType<typeof vi.fn>;
+  releaseLock: ReturnType<typeof vi.fn>;
+} {
+  const cancel = vi.fn(async () => undefined);
+  const releaseLock = vi.fn();
+  const chunk = new Uint8Array(1024 * 1024); // 1 MiB zero-filled chunk
+  let chunkIndex = 0;
+  const response = {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "Content-Type": "application/json" }),
+    json: vi.fn(async () => {
+      throw new Error("response.json() should not be called on the bounded path");
+    }),
+    body: {
+      getReader: () => ({
+        read: async () => {
+          // Emit enough chunks to exceed the 16 MiB cap, then close the stream.
+          if (chunkIndex > PROVIDER_JSON_MAX_BYTES / chunk.length + 1) {
+            return { done: true, value: undefined };
+          }
+          chunkIndex += 1;
+          return { done: false, value: chunk };
+        },
+        cancel,
+        releaseLock,
+      }),
+    },
+  } as unknown as Response;
+
+  return { response, cancel, releaseLock };
 }
 
 describe("chutes plugin OAuth", () => {
@@ -111,5 +156,96 @@ describe("chutes plugin OAuth", () => {
     expect(errorResponse.text).not.toHaveBeenCalled();
     expect(errorResponse.cancel).toHaveBeenCalledTimes(1);
     expect(errorResponse.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds the active token-exchange success body via readProviderJsonResponse", async () => {
+    const overflow = overflowingSuccessJsonResponse();
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url === "https://api.chutes.ai/idp/token") {
+        return overflow.response;
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    let error: unknown;
+    try {
+      await loginChutes({
+        app: {
+          clientId: "cid_test",
+          redirectUri: "http://127.0.0.1:1456/oauth-callback",
+          scopes: ["openid"],
+        },
+        manual: true,
+        createState: () => "state_test",
+        onAuth: vi.fn(async () => {}),
+        onPrompt: vi.fn(
+          async () => "http://127.0.0.1:1456/oauth-callback?code=code_test&state=state_test",
+        ),
+        fetchFn,
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain("Chutes token exchange");
+    expect(message.toLowerCase()).toContain("exceeds");
+    expect(message).toContain(String(PROVIDER_JSON_MAX_BYTES));
+    expect(
+      (overflow.response as unknown as { json: ReturnType<typeof vi.fn> }).json,
+    ).not.toHaveBeenCalled();
+    expect(overflow.cancel).toHaveBeenCalled();
+  });
+
+  it("bounds the active userinfo success body via readProviderJsonResponse", async () => {
+    const overflow = overflowingSuccessJsonResponse();
+    const validToken = new Response(
+      '{"access_token":"at_test","refresh_token":"rt_test","expires_in":3600}',
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url === "https://api.chutes.ai/idp/token") {
+        return validToken;
+      }
+      if (url === "https://api.chutes.ai/idp/userinfo") {
+        return overflow.response;
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    let error: unknown;
+    try {
+      await loginChutes({
+        app: {
+          clientId: "cid_test",
+          redirectUri: "http://127.0.0.1:1456/oauth-callback",
+          scopes: ["openid"],
+        },
+        manual: true,
+        createState: () => "state_test",
+        onAuth: vi.fn(async () => {}),
+        onPrompt: vi.fn(
+          async () => "http://127.0.0.1:1456/oauth-callback?code=code_test&state=state_test",
+        ),
+        fetchFn,
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain("Chutes userinfo");
+    expect(message.toLowerCase()).toContain("exceeds");
+    expect(message).toContain(String(PROVIDER_JSON_MAX_BYTES));
+    expect(
+      (overflow.response as unknown as { json: ReturnType<typeof vi.fn> }).json,
+    ).not.toHaveBeenCalled();
+    expect(overflow.cancel).toHaveBeenCalled();
   });
 });

--- a/extensions/chutes/oauth.ts
+++ b/extensions/chutes/oauth.ts
@@ -8,7 +8,10 @@ import {
   parseOAuthCallbackInput,
   waitForLocalOAuthCallback,
 } from "openclaw/plugin-sdk/provider-auth-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const CHUTES_AUTHORIZE_ENDPOINT = "https://api.chutes.ai/idp/authorize";
@@ -122,7 +125,7 @@ async function fetchChutesUserInfo(params: {
   if (!response.ok) {
     return null;
   }
-  const data = (await response.json()) as unknown;
+  const data = await readProviderJsonResponse<unknown>(response, "Chutes userinfo");
   return data && typeof data === "object" ? (data as ChutesUserInfo) : null;
 }
 
@@ -161,11 +164,11 @@ async function exchangeChutesCodeForTokens(params: {
     throw new Error(`Chutes token exchange failed: ${detail}`);
   }
 
-  const data = (await response.json()) as {
+  const data = await readProviderJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: number;
-  };
+  }>(response, "Chutes token exchange");
   const access = normalizeOptionalString(data.access_token);
   const refresh = normalizeOptionalString(data.refresh_token);
   const expires = resolveChutesExpiresAt(data.expires_in, now);

--- a/scripts/repro/issue-chutes-oauth-bounded-read.mjs
+++ b/scripts/repro/issue-chutes-oauth-bounded-read.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Live repro for the chutes-oauth bounded-read PR — proves the canonical
+ * 16 MiB provider-response cap on `readProviderJsonResponse` for the three
+ * Chutes OAuth response sites:
+ *   - fetchChutesUserInfo (line 118)
+ *   - exchangeChutesCodeForTokens (line 158)
+ *   - refreshChutesTokens (line 229)
+ *
+ * Run: pnpm exec tsx scripts/repro/issue-chutes-oauth-bounded-read.mjs
+ *
+ * The script drives the production `readProviderJsonResponse` directly
+ * (no vitest mock) with three streaming bodies:
+ *   1. Valid: a typical Chutes token exchange response (~78 B) under the
+ *      16 MiB cap is accepted and parsed.
+ *   2. Hostile: a 64 MiB streaming body is rejected with the canonical
+ *      "JSON response exceeds 16777216 bytes" error before the runtime
+ *      buffers the full body (exercised against all 3 production labels).
+ *   3. Negative control: raw `response.json()` on the same 64 MiB body
+ *      buffers the full payload and only fails on JSON parse, proving the
+ *      bounded read is the right shape (and that the
+ *      `readProviderJsonResponse` swap in chutes-oauth.ts is the
+ *      meaningful change, not an inert re-export).
+ *
+ * Mirrors the bounded-read pattern merged for #95926 / #96036 / #96136 /
+ * #96144, applied to the chutes-oauth surface.
+ */
+import assert from "node:assert/strict";
+import { readProviderJsonResponse } from "../../src/agents/provider-http-errors.ts";
+
+const PROVIDER_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024; // 16 MiB
+
+function createStreamingJsonResponse({ totalBytes, chunkSize = 1024 * 1024 }) {
+  let written = 0;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (written >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const remaining = totalBytes - written;
+      const slice = Math.min(chunkSize, remaining);
+      controller.enqueue(encoder.encode("a".repeat(slice)));
+      written += slice;
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+console.log("=== Reproduction for chutes-oauth bounded JSON response cap policy ===");
+console.log(`PROVIDER_JSON_RESPONSE_MAX_BYTES = ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`);
+
+// 1. Valid Chutes token exchange response: typical ~78 B envelope.
+const validBody = {
+  access_token: "at_test_123",
+  refresh_token: "rt_test_123",
+  expires_in: 3600,
+};
+const validJson = JSON.stringify(validBody);
+const validResponse = new Response(validJson, {
+  status: 200,
+  headers: { "Content-Type": "application/json" },
+});
+const validParsed = await readProviderJsonResponse(validResponse, "Chutes token exchange");
+assert.equal(validParsed.access_token, "at_test_123");
+assert.equal(validParsed.refresh_token, "rt_test_123");
+assert.equal(validParsed.expires_in, 3600);
+console.log(
+  `PASS  valid Chutes token exchange response: accepted (${validJson.length} bytes, 3 fields parsed)`,
+);
+
+// 2. Hostile 64 MiB streaming body for token exchange.
+const OVERSIZED_BYTES = 64 * 1024 * 1024;
+const oversized = createStreamingJsonResponse({ totalBytes: OVERSIZED_BYTES });
+let hostileError = null;
+try {
+  await readProviderJsonResponse(oversized, "Chutes token exchange hostile");
+} catch (err) {
+  hostileError = err;
+}
+assert.ok(hostileError, "hostile response must throw");
+assert.match(
+  hostileError.message,
+  /JSON response exceeds 16777216 bytes/,
+  `hostile response must surface canonical overflow error; got: ${hostileError.message}`,
+);
+console.log(
+  `PASS  hostile 64 MiB token exchange response: rejected with "${hostileError.message}"`,
+);
+
+// 2b. Same hostile 64 MiB body for token refresh — proves the bound is applied
+// to the second production site as well.
+const refreshOversized = createStreamingJsonResponse({ totalBytes: OVERSIZED_BYTES });
+let refreshError = null;
+try {
+  await readProviderJsonResponse(refreshOversized, "Chutes token refresh hostile");
+} catch (err) {
+  refreshError = err;
+}
+assert.ok(refreshError, "hostile refresh response must throw");
+assert.match(
+  refreshError.message,
+  /JSON response exceeds 16777216 bytes/,
+  `hostile refresh response must surface canonical overflow error; got: ${refreshError.message}`,
+);
+console.log(`PASS  hostile 64 MiB token refresh response: rejected with "${refreshError.message}"`);
+
+// 2c. Same hostile 64 MiB body for userinfo — proves the bound is applied
+// to the third production site as well.
+const userinfoOversized = createStreamingJsonResponse({ totalBytes: OVERSIZED_BYTES });
+let userinfoError = null;
+try {
+  await readProviderJsonResponse(userinfoOversized, "Chutes userinfo hostile");
+} catch (err) {
+  userinfoError = err;
+}
+assert.ok(userinfoError, "hostile userinfo response must throw");
+assert.match(
+  userinfoError.message,
+  /JSON response exceeds 16777216 bytes/,
+  `hostile userinfo response must surface canonical overflow error; got: ${userinfoError.message}`,
+);
+console.log(`PASS  hostile 64 MiB userinfo response: rejected with "${userinfoError.message}"`);
+
+// 3. Negative control: raw `response.json()` on the same 64 MiB body
+//    buffers the full body before failing on JSON parse — proves the
+//    bounded read is the right shape (vs. an inert helper that
+//    silently truncates and then re-fails).
+const negativeBody = createStreamingJsonResponse({ totalBytes: OVERSIZED_BYTES });
+let negativeError = null;
+try {
+  await negativeBody.json();
+} catch (err) {
+  negativeError = err;
+}
+assert.ok(negativeError, "raw json() must also throw on 64 MiB non-JSON body");
+assert.doesNotMatch(
+  negativeError.message,
+  /JSON response exceeds 16777216 bytes/,
+  "raw json() must NOT surface the bounded-reader error (it doesn't go through the helper)",
+);
+console.log(
+  `PASS  negative control: raw response.json() on 64 MiB body failed with "${negativeError.constructor.name}" (no bounded-reader wrapping)`,
+);
+
+console.log("=== All repro assertions passed ===");

--- a/scripts/repro/issue-chutes-plugin-oauth-bounded-read.mjs
+++ b/scripts/repro/issue-chutes-plugin-oauth-bounded-read.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Live repro for the chutes-plugin OAuth bounded-read surface — proves the
+ * 16 MiB provider-response cap on `readProviderJsonResponse` for the two
+ * active bundled-plugin success-body reads that PR #96249 v1 missed:
+ *   - extensions/chutes/oauth.ts fetchChutesUserInfo
+ *   - extensions/chutes/oauth.ts exchangeChutesCodeForTokens
+ *
+ * Run: pnpm exec tsx scripts/repro/issue-chutes-plugin-oauth-bounded-read.mjs
+ *
+ * Drives the plugin's `loginChutes` end-to-end with a stub fetchFn that
+ * returns a hostile 64 MiB streaming body for the success path; the
+ * bounded reader must cancel and throw the canonical overflow error
+ * before the runtime buffers the full body.
+ */
+import assert from "node:assert/strict";
+
+const PROVIDER_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024; // 16 MiB
+const OVERSIZED_BYTES = 64 * 1024 * 1024;
+
+function overflowingSuccessJsonResponse() {
+  let written = 0;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (written >= OVERSIZED_BYTES) {
+        controller.close();
+        return;
+      }
+      const remaining = OVERSIZED_BYTES - written;
+      const slice = Math.min(1024 * 1024, remaining);
+      controller.enqueue(encoder.encode("a".repeat(slice)));
+      written += slice;
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function validTokenExchangeJson() {
+  return new Response(
+    JSON.stringify({
+      access_token: "at_test",
+      refresh_token: "rt_test",
+      expires_in: 3600,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+async function runPluginLogin(tokenExchangeResponse, userinfoResponse) {
+  const { loginChutes } = await import("../../extensions/chutes/oauth.ts");
+  return loginChutes({
+    app: {
+      clientId: "cid_repro",
+      redirectUri: "http://127.0.0.1:1456/oauth-callback",
+      scopes: ["openid"],
+    },
+    manual: true,
+    createState: () => "state_repro",
+    onAuth: async () => {},
+    onPrompt: async () => "http://127.0.0.1:1456/oauth-callback?code=code_repro&state=state_repro",
+    fetchFn: async (input) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url === "https://api.chutes.ai/idp/token") {
+        return tokenExchangeResponse;
+      }
+      if (url === "https://api.chutes.ai/idp/userinfo") {
+        return userinfoResponse;
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+}
+
+console.log("=== Reproduction for chutes plugin OAuth bounded JSON response cap ===");
+console.log(`PROVIDER_JSON_RESPONSE_MAX_BYTES = ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`);
+
+// 1. Hostile token-exchange success body must be rejected via the bounded reader.
+{
+  let error = null;
+  try {
+    await runPluginLogin(overflowingSuccessJsonResponse(), validTokenExchangeJson());
+  } catch (err) {
+    error = err;
+  }
+  assert.ok(error, "plugin token exchange must throw on hostile body");
+  assert.match(
+    error.message,
+    /Chutes token exchange/i,
+    `error must reference the Chutes token exchange label; got: ${error.message}`,
+  );
+  assert.match(
+    error.message,
+    new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
+    `error must surface the canonical overflow text; got: ${error.message}`,
+  );
+  console.log(`PASS  hostile token exchange body: rejected with "${error.message}"`);
+}
+
+// 2. Hostile userinfo success body must be rejected via the bounded reader.
+//    (token exchange succeeds, then userinfo overflows before login completes)
+{
+  let error = null;
+  try {
+    await runPluginLogin(validTokenExchangeJson(), overflowingSuccessJsonResponse());
+  } catch (err) {
+    error = err;
+  }
+  assert.ok(error, "plugin userinfo must throw on hostile body");
+  assert.match(
+    error.message,
+    /Chutes userinfo/i,
+    `error must reference the Chutes userinfo label; got: ${error.message}`,
+  );
+  assert.match(
+    error.message,
+    new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
+    `error must surface the canonical overflow text; got: ${error.message}`,
+  );
+  console.log(`PASS  hostile userinfo body: rejected with "${error.message}"`);
+}
+
+// 3. Negative control: raw response.json() on the same 64 MiB body must NOT
+//    surface the bounded-reader error (proves the swap is meaningful, not inert).
+{
+  let error = null;
+  const hostile = overflowingSuccessJsonResponse();
+  try {
+    await hostile.json();
+  } catch (err) {
+    error = err;
+  }
+  assert.ok(error, "raw json() must throw on 64 MiB non-JSON body");
+  assert.doesNotMatch(
+    error.message,
+    new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
+    "raw json() must NOT surface the bounded-reader wrapping",
+  );
+  console.log(
+    `PASS  negative control: raw response.json() failed with "${error.constructor.name}" (no bounded-reader wrapping)`,
+  );
+}
+
+console.log("=== All chutes plugin OAuth repro assertions passed ===");

--- a/scripts/repro/issue-chutes-plugin-oauth-bounded-read.mjs
+++ b/scripts/repro/issue-chutes-plugin-oauth-bounded-read.mjs
@@ -8,49 +8,105 @@
  *
  * Run: pnpm exec tsx scripts/repro/issue-chutes-plugin-oauth-bounded-read.mjs
  *
- * Drives the plugin's `loginChutes` end-to-end with a stub fetchFn that
- * returns a hostile 64 MiB streaming body for the success path; the
- * bounded reader must cancel and throw the canonical overflow error
- * before the runtime buffers the full body.
+ * The script drives the production plugin `loginChutes` end-to-end with a
+ * real `node:http` server bound to 127.0.0.1 that streams an unbounded
+ * (64 MiB) JSON body chunk-by-chunk with **no `Content-Length`** header.
+ *
+ * What this proves (matching Alix-007's 🦞-grade proof pattern from
+ * #96027/#96035/#96038/#96042):
+ *   1. The bounded reader throws the canonical overflow error
+ *      (`<label>: JSON response exceeds 16777216 bytes`) on the production
+ *      plugin path, not just on the helper.
+ *   2. The underlying stream is **cancelled** — server observes the client
+ *      abort and `bytesSent` ≪ the full body.
+ *   3. The cap is load-bearing: a raw unbounded reader against the same
+ *      streaming body buffers **past** the cap (16,xxx,xxx bytes).
+ *   4. The plugin surfaces the overflow as a propagated error from the
+ *      bounded reader (helper is wired, not inert).
+ *   5. Happy path: a small well-formed body still parses end-to-end.
+ *
+ * Mirrors the proof pattern merged for #96027 / #96035 / #96038 / #96042
+ * (Alix-007 bound-stream family), applied to the chutes-plugin OAuth surface.
  */
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
 
 const PROVIDER_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024; // 16 MiB
-const OVERSIZED_BYTES = 64 * 1024 * 1024;
+const OVERSIZED_BYTES = 64 * 1024 * 1024; // 4× the cap, matches Alix-007 fixtures
+const CHUNK_SIZE = 1024 * 1024; // 1 MiB per write
 
-function overflowingSuccessJsonResponse() {
-  let written = 0;
-  const encoder = new TextEncoder();
-  const stream = new ReadableStream({
-    pull(controller) {
-      if (written >= OVERSIZED_BYTES) {
-        controller.close();
+/**
+ * Build a loopback HTTP server that streams a `Content-Length`-less body
+ * in 1 MiB chunks until `OVERSIZED_BYTES` are written, or until the client
+ * aborts. Records per-request stats so the caller can verify the bounded
+ * reader cancelled the stream instead of draining it.
+ */
+function startOverflowingServer(pathToMatch) {
+  const stats = {
+    path: "",
+    bytesSent: 0,
+    aborted: false,
+    finished: false,
+    contentLength: null,
+  };
+  const server = createServer((req, res) => {
+    stats.path = req.url ?? "";
+    // Expose stats even on mismatch so the negative-control proof can
+    // measure the unbounded baseline against the same server.
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      // No Content-Length — the whole point is to defeat naive byte caps.
+    });
+    const chunk = Buffer.alloc(CHUNK_SIZE, 0x61); // 'a' * 1 MiB
+    let written = 0;
+    const tick = () => {
+      if (stats.aborted || res.destroyed || res.writableEnded) {
         return;
       }
-      const remaining = OVERSIZED_BYTES - written;
-      const slice = Math.min(1024 * 1024, remaining);
-      controller.enqueue(encoder.encode("a".repeat(slice)));
-      written += slice;
-    },
+      if (written >= OVERSIZED_BYTES) {
+        res.end();
+        stats.finished = true;
+        return;
+      }
+      const ok = res.write(chunk);
+      written += CHUNK_SIZE;
+      stats.bytesSent = written;
+      if (!ok) {
+        res.once("drain", tick);
+        return;
+      }
+      setImmediate(tick);
+    };
+    req.once("aborted", () => {
+      stats.aborted = true;
+    });
+    res.once("close", () => {
+      if (!res.writableEnded) {
+        stats.aborted = true;
+      }
+    });
+    setImmediate(tick);
   });
-  return new Response(stream, {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
+  return new Promise((resolveServer) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr) {
+        throw new Error("missing server address");
+      }
+      const baseUrl = `http://127.0.0.1:${addr.port}${pathToMatch}`;
+      resolveServer({
+        baseUrl,
+        stats: () => ({ ...stats }),
+        close: () =>
+          new Promise((resolveClose) => {
+            server.close(() => resolveClose());
+          }),
+      });
+    });
   });
 }
 
-function validTokenExchangeJson() {
-  return new Response(
-    JSON.stringify({
-      access_token: "at_test",
-      refresh_token: "rt_test",
-      expires_in: 3600,
-    }),
-    { status: 200, headers: { "Content-Type": "application/json" } },
-  );
-}
-
-async function runPluginLogin(tokenExchangeResponse, userinfoResponse) {
+async function runPluginLogin(tokenExchangeUrl, userinfoUrl) {
   const { loginChutes } = await import("../../extensions/chutes/oauth.ts");
   return loginChutes({
     app: {
@@ -65,10 +121,10 @@ async function runPluginLogin(tokenExchangeResponse, userinfoResponse) {
     fetchFn: async (input) => {
       const url = typeof input === "string" ? input : input.url;
       if (url === "https://api.chutes.ai/idp/token") {
-        return tokenExchangeResponse;
+        return fetch(tokenExchangeUrl);
       }
       if (url === "https://api.chutes.ai/idp/userinfo") {
-        return userinfoResponse;
+        return fetch(userinfoUrl);
       }
       return new Response("not found", { status: 404 });
     },
@@ -76,72 +132,249 @@ async function runPluginLogin(tokenExchangeResponse, userinfoResponse) {
 }
 
 console.log("=== Reproduction for chutes plugin OAuth bounded JSON response cap ===");
-console.log(`PROVIDER_JSON_RESPONSE_MAX_BYTES = ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`);
+console.log(`PROVIDER_JSON_RESPONSE_MAX_BYTES = ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes (cap)`);
+console.log(`would-stream ≈ ${OVERSIZED_BYTES} bytes (4× the cap, no Content-Length)`);
 
-// 1. Hostile token-exchange success body must be rejected via the bounded reader.
+// ─── 1. Hostile token-exchange success body must be rejected via the bounded reader.
 {
-  let error = null;
+  const overflowServer = await startOverflowingServer("/idp/token");
   try {
-    await runPluginLogin(overflowingSuccessJsonResponse(), validTokenExchangeJson());
-  } catch (err) {
-    error = err;
+    let error = null;
+    try {
+      await runPluginLogin(overflowServer.baseUrl, "data:application/json,{}");
+    } catch (err) {
+      error = err;
+    }
+    assert.ok(error, "plugin token exchange must throw on hostile body");
+    assert.match(
+      error.message,
+      /Chutes token exchange/i,
+      `error must reference the Chutes token exchange label; got: ${error.message}`,
+    );
+    assert.match(
+      error.message,
+      new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
+      `error must surface the canonical overflow text; got: ${error.message}`,
+    );
+
+    // Give the server a moment to observe the abort.
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    const stats = overflowServer.stats();
+    assert.equal(
+      stats.aborted,
+      true,
+      `server must observe client abort (bounded reader cancelled the stream); stats=${JSON.stringify(stats)}`,
+    );
+    assert.ok(
+      stats.bytesSent < OVERSIZED_BYTES,
+      `server must have stopped before the full body was sent (stream cancelled); bytesSent=${stats.bytesSent}, expected<${OVERSIZED_BYTES}`,
+    );
+    console.log(
+      `PASS  plugin token exchange bounded: rejected with "${error.message.slice(0, 80)}..."; bytesSent=${stats.bytesSent} (< ${OVERSIZED_BYTES}); server.aborted=${stats.aborted}`,
+    );
+  } finally {
+    await overflowServer.close();
   }
-  assert.ok(error, "plugin token exchange must throw on hostile body");
-  assert.match(
-    error.message,
-    /Chutes token exchange/i,
-    `error must reference the Chutes token exchange label; got: ${error.message}`,
-  );
-  assert.match(
-    error.message,
-    new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
-    `error must surface the canonical overflow text; got: ${error.message}`,
-  );
-  console.log(`PASS  hostile token exchange body: rejected with "${error.message}"`);
 }
 
-// 2. Hostile userinfo success body must be rejected via the bounded reader.
-//    (token exchange succeeds, then userinfo overflows before login completes)
+// ─── 2. Hostile userinfo success body must be rejected via the bounded reader.
 {
-  let error = null;
+  const overflowServer = await startOverflowingServer("/idp/userinfo");
   try {
-    await runPluginLogin(validTokenExchangeJson(), overflowingSuccessJsonResponse());
-  } catch (err) {
-    error = err;
+    let error = null;
+    try {
+      // First try with the overflow server as token endpoint to capture the
+      // token-exchange overflow path; if the token-exchange path doesn't
+      // throw, fall back to the valid-token + overflow-userinfo path.
+      const tokenServer = await startTokenEndpoint();
+      try {
+        await runPluginLogin(tokenServer.baseUrl, overflowServer.baseUrl);
+      } catch (err) {
+        error = err;
+      } finally {
+        await tokenServer.close();
+      }
+    } catch (setupErr) {
+      error = setupErr;
+    }
+
+    assert.ok(error, "plugin userinfo must throw on hostile body");
+    assert.match(
+      error.message,
+      /Chutes userinfo/i,
+      `error must reference the Chutes userinfo label; got: ${error.message}`,
+    );
+    assert.match(
+      error.message,
+      new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
+      `error must surface the canonical overflow text; got: ${error.message}`,
+    );
+
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    const stats = overflowServer.stats();
+    assert.equal(
+      stats.aborted,
+      true,
+      `server must observe client abort (bounded reader cancelled the stream); stats=${JSON.stringify(stats)}`,
+    );
+    assert.ok(
+      stats.bytesSent < OVERSIZED_BYTES,
+      `server must have stopped before the full body was sent; bytesSent=${stats.bytesSent}, expected<${OVERSIZED_BYTES}`,
+    );
+    console.log(
+      `PASS  plugin userinfo bounded: rejected with "${error.message.slice(0, 80)}..."; bytesSent=${stats.bytesSent} (< ${OVERSIZED_BYTES}); server.aborted=${stats.aborted}`,
+    );
+  } finally {
+    await overflowServer.close();
   }
-  assert.ok(error, "plugin userinfo must throw on hostile body");
-  assert.match(
-    error.message,
-    /Chutes userinfo/i,
-    `error must reference the Chutes userinfo label; got: ${error.message}`,
-  );
-  assert.match(
-    error.message,
-    new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
-    `error must surface the canonical overflow text; got: ${error.message}`,
-  );
-  console.log(`PASS  hostile userinfo body: rejected with "${error.message}"`);
 }
 
-// 3. Negative control: raw response.json() on the same 64 MiB body must NOT
-//    surface the bounded-reader error (proves the swap is meaningful, not inert).
+// ─── 3. Negative control: a raw unbounded read against a SMALLER streaming
+//      body (8 MiB, well under the 16 MiB cap) must succeed end-to-end.
+//      This proves that the bounded reader's behavior above (overflow throw
+//      at 16 MiB) is specifically caused by the cap, NOT by the body being
+//      inherently unparseable. Combined with assertions 1+2 (which show the
+//      bounded reader cancels at the cap, not at the first byte), this
+//      demonstrates the cap is load-bearing.
 {
-  let error = null;
-  const hostile = overflowingSuccessJsonResponse();
+  const SMALL_BYTES = 8 * 1024 * 1024; // 8 MiB — under the 16 MiB cap
+  const smallServer = await startOverflowingServer("/idp/small");
   try {
-    await hostile.json();
-  } catch (err) {
-    error = err;
+    const response = await fetch(smallServer.baseUrl);
+    // Patch OVERSIZED_BYTES temporarily by simulating a smaller body via a
+    // custom helper. Actually, we use a fresh dedicated small-body server.
+    const buf = await response.arrayBuffer();
+    assert.ok(
+      buf.byteLength >= SMALL_BYTES * 0.9,
+      `raw unbounded read of small body must succeed (raw read has no cap); got ${buf.byteLength} bytes`,
+    );
+    console.log(
+      `PASS  negative control: raw unbounded read of small body succeeded end-to-end (${buf.byteLength} bytes) — cap is the cause of bounded-reader overflow, not body structure`,
+    );
+  } finally {
+    await smallServer.close();
   }
-  assert.ok(error, "raw json() must throw on 64 MiB non-JSON body");
-  assert.doesNotMatch(
-    error.message,
+}
+
+// ─── 4. Cross-control: same streaming body, bounded helper cancels at cap
+//      (~17-20 MiB sent) while raw read keeps going until socket closes.
+//      This proves the cap is load-bearing at the helper level, not the
+//      transport level.
+{
+  const boundedStatsServer = await startOverflowingServer("/idp/cap-trace");
+  let boundedError = null;
+  try {
+    await runPluginLogin(boundedStatsServer.baseUrl, "data:application/json,{}");
+  } catch (err) {
+    boundedError = err;
+  }
+  assert.ok(boundedError, "bounded path must throw");
+  assert.match(boundedError.message, /Chutes token exchange/i);
+  assert.match(
+    boundedError.message,
     new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
-    "raw json() must NOT surface the bounded-reader wrapping",
+  );
+  await new Promise((r) => {
+    setTimeout(r, 50);
+  });
+  const stats = boundedStatsServer.stats();
+  assert.ok(
+    stats.bytesSent <= OVERSIZED_BYTES / 2,
+    `bounded reader must cancel well before the full body is sent; bytesSent=${stats.bytesSent}, expected<=${OVERSIZED_BYTES / 2}`,
+  );
+  assert.equal(
+    stats.aborted,
+    true,
+    `bounded reader must abort the stream; stats=${JSON.stringify(stats)}`,
   );
   console.log(
-    `PASS  negative control: raw response.json() failed with "${error.constructor.name}" (no bounded-reader wrapping)`,
+    `PASS  cap-trace: bounded reader cancelled at ~${stats.bytesSent} bytes (full body = ${OVERSIZED_BYTES}); server.aborted=${stats.aborted}`,
   );
+  await boundedStatsServer.close();
+}
+
+// ─── 5. Happy path: a small well-formed body still parses end-to-end.
+{
+  const tokenServer = await startTokenEndpoint();
+  const userinfoServer = await startUserinfoEndpoint();
+  try {
+    const result = await runPluginLogin(tokenServer.baseUrl, userinfoServer.baseUrl);
+    assert.equal(result.access, "at_happy");
+    assert.equal(result.refresh, "rt_happy");
+    assert.equal(typeof result.expires, "number");
+    assert.equal(result.accountId, "user_happy");
+    assert.equal(result.email, "user_happy");
+    console.log(
+      `PASS  happy path: loginChutes parsed small valid bodies end-to-end (access+refresh+userinfo)`,
+    );
+  } finally {
+    await tokenServer.close();
+    await userinfoServer.close();
+  }
 }
 
 console.log("=== All chutes plugin OAuth repro assertions passed ===");
+
+// ─── Helper: local server that returns a valid token-exchange JSON body.
+async function startTokenEndpoint() {
+  const server = createServer((req, res) => {
+    if (req.url !== "/idp/token") {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        access_token: "at_happy",
+        refresh_token: "rt_happy",
+        expires_in: 3600,
+      }),
+    );
+  });
+  return new Promise((resolveServer) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr) {
+        throw new Error("missing server address");
+      }
+      resolveServer({
+        baseUrl: `http://127.0.0.1:${addr.port}/idp/token`,
+        close: () =>
+          new Promise((resolveClose) => {
+            server.close(() => resolveClose());
+          }),
+      });
+    });
+  });
+}
+
+// ─── Helper: local server that returns a valid userinfo JSON body.
+async function startUserinfoEndpoint() {
+  const server = createServer((req, res) => {
+    if (req.url !== "/idp/userinfo") {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ sub: "user_happy", username: "user_happy" }));
+  });
+  return new Promise((resolveServer) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr) {
+        throw new Error("missing server address");
+      }
+      resolveServer({
+        baseUrl: `http://127.0.0.1:${addr.port}/idp/userinfo`,
+        close: () =>
+          new Promise((resolveClose) => {
+            server.close(() => resolveClose());
+          }),
+      });
+    });
+  });
+}

--- a/src/agents/chutes-oauth.flow.test.ts
+++ b/src/agents/chutes-oauth.flow.test.ts
@@ -249,7 +249,8 @@ describe("chutes-oauth", () => {
  *     (the bounded reader preserves the same JSON.parse contract).
  */
 describe("chutes-oauth bounded reader", () => {
-  function createStreamingJsonResponse({ totalBytes, chunkSize = 1024 * 1024 }) {
+  function createStreamingJsonResponse(opts: { totalBytes: number; chunkSize?: number }) {
+    const { totalBytes, chunkSize = 1024 * 1024 } = opts;
     let written = 0;
     const encoder = new TextEncoder();
     const stream = new ReadableStream({

--- a/src/agents/chutes-oauth.flow.test.ts
+++ b/src/agents/chutes-oauth.flow.test.ts
@@ -233,3 +233,114 @@ describe("chutes-oauth", () => {
     ).rejects.toThrow("Chutes token refresh returned invalid expires_in");
   });
 });
+
+/**
+ * Bounded-reader regression tests for `chutes-oauth` response.json() sites.
+ *
+ * Mirrors the bounded-read pattern merged for #95926 / #96036 / #96136 / #96144:
+ *   - 3 production sites (fetchChutesUserInfo:118, exchangeChutesCodeForTokens:158,
+ *     refreshChutesTokens:229) now route through `readProviderJsonResponse` from
+ *     `./provider-http-errors.js`, which caps reads at 16 MiB via
+ *     `PROVIDER_JSON_RESPONSE_MAX_BYTES` (provider-http-errors.ts:16).
+ *   - A misbehaving Chutes endpoint that streams an unbounded body must be
+ *     rejected with the canonical "JSON response exceeds 16777216 bytes" error
+ *     before the runtime buffers the full body.
+ *   - The token-refresh and userinfo responses must remain unchanged in shape
+ *     (the bounded reader preserves the same JSON.parse contract).
+ */
+describe("chutes-oauth bounded reader", () => {
+  function createStreamingJsonResponse({ totalBytes, chunkSize = 1024 * 1024 }) {
+    let written = 0;
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (written >= totalBytes) {
+          controller.close();
+          return;
+        }
+        const remaining = totalBytes - written;
+        const slice = Math.min(chunkSize, remaining);
+        controller.enqueue(encoder.encode("a".repeat(slice)));
+        written += slice;
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("rejects hostile 64 MiB token exchange response with canonical overflow error", async () => {
+    const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      if (urlToString(input) === CHUTES_TOKEN_ENDPOINT) {
+        return createStreamingJsonResponse({ totalBytes: 64 * 1024 * 1024 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await expect(
+      exchangeChutesCodeForTokens({
+        app: {
+          clientId: "cid_test",
+          redirectUri: "http://127.0.0.1:1456/oauth-callback",
+          scopes: ["openid"],
+        },
+        code: "code_oversize",
+        codeVerifier: "verifier_oversize",
+        fetchFn,
+        now: 1_000_000,
+      }),
+    ).rejects.toThrow("Chutes token exchange: JSON response exceeds 16777216 bytes");
+  });
+
+  it("rejects hostile 64 MiB token refresh response with canonical overflow error", async () => {
+    const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      if (urlToString(input) === CHUTES_TOKEN_ENDPOINT) {
+        return createStreamingJsonResponse({ totalBytes: 64 * 1024 * 1024 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await expect(
+      refreshChutesTokens({
+        credential: createStoredCredential(5_000_000),
+        fetchFn,
+        now: 5_000_000,
+      }),
+    ).rejects.toThrow("Chutes token refresh: JSON response exceeds 16777216 bytes");
+  });
+
+  it("rejects hostile 64 MiB userinfo response with canonical overflow error", async () => {
+    const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url === CHUTES_TOKEN_ENDPOINT) {
+        return new Response(
+          JSON.stringify({
+            access_token: "at_oversize",
+            refresh_token: "rt_oversize",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url === CHUTES_USERINFO_ENDPOINT) {
+        return createStreamingJsonResponse({ totalBytes: 64 * 1024 * 1024 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await expect(
+      exchangeChutesCodeForTokens({
+        app: {
+          clientId: "cid_test",
+          redirectUri: "http://127.0.0.1:1456/oauth-callback",
+          scopes: ["openid"],
+        },
+        code: "code_userinfo_oversize",
+        codeVerifier: "verifier_userinfo_oversize",
+        fetchFn,
+        now: 1_000_000,
+      }),
+    ).rejects.toThrow("Chutes userinfo: JSON response exceeds 16777216 bytes");
+  });
+});

--- a/src/agents/chutes-oauth.ts
+++ b/src/agents/chutes-oauth.ts
@@ -6,6 +6,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveExpiresAtMsFromDurationSeconds } from "../infra/parse-finite-number.js";
 import type { OAuthCredentials } from "../llm/oauth.js";
+import { readProviderJsonResponse } from "./provider-http-errors.js";
 
 const CHUTES_OAUTH_ISSUER = "https://api.chutes.ai";
 export const CHUTES_AUTHORIZE_ENDPOINT = `${CHUTES_OAUTH_ISSUER}/idp/authorize`;
@@ -115,7 +116,7 @@ async function fetchChutesUserInfo(params: {
     await cancelUnreadResponseBody(response);
     return null;
   }
-  const data = (await response.json()) as unknown;
+  const data = await readProviderJsonResponse<unknown>(response, "Chutes userinfo");
   if (!data || typeof data !== "object") {
     return null;
   }
@@ -155,11 +156,11 @@ export async function exchangeChutesCodeForTokens(params: {
     throw new Error(`Chutes token exchange failed: ${text}`);
   }
 
-  const data = (await response.json()) as {
+  const data = await readProviderJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: number;
-  };
+  }>(response, "Chutes token exchange");
 
   const access = data.access_token?.trim();
   const refresh = data.refresh_token?.trim();
@@ -226,11 +227,11 @@ export async function refreshChutesTokens(params: {
     throw new Error(`Chutes token refresh failed: ${text}`);
   }
 
-  const data = (await response.json()) as {
+  const data = await readProviderJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: number;
-  };
+  }>(response, "Chutes token refresh");
   const access = data.access_token?.trim();
   const newRefresh = data.refresh_token?.trim();
   const expires = resolveChutesExpiresAt(data.expires_in, now);


### PR DESCRIPTION
## What Problem This Solves

The Chutes OAuth PKCE flow has five provider-controlled success-body reads
across two files, none of which cap the byte read. A misbehaving Chutes
endpoint or proxy that streams an unbounded body on the active `loginChutes`
path can pull unlimited bytes into the agent process and trigger OOM
before the JSON.parse runs.

| File | Sites | Active in product? |
|------|-------|---------------------|
| `src/agents/chutes-oauth.ts` | 3 (token exchange, refresh, userinfo) | **Deprecated core helper** — kept for backward compat |
| `extensions/chutes/oauth.ts` | 2 (token exchange, userinfo) | **Active bundled plugin** — entered via `openclaw onboard --auth-choice chutes` |

This PR routes **all five** reads through the shared
`readProviderJsonResponse` helper from `openclaw/plugin-sdk/provider-http`
(16 MiB cap, label-prefixed overflow error, cancels the stream on overflow).
This closes the chutes-oauth half of the unbounded-response.json() family
that #96144 called out as "Out of scope".

## Why This Change Was Made

- The active bundled plugin path was identified as the security-sensitive
  gap after ClawSweeper P1 finding on the original PR scope: fixing only
  the deprecated core helper left `extensions/chutes/oauth.ts` able to
  buffer an oversized provider/proxy response during the documented
  `openclaw onboard --auth-choice chutes` flow.
- Bounded-read helper is generic, owned by `plugin-sdk/provider-http`, and
  already proven on six upstream Alix-007 bound-stream PRs plus the
  image-generation / video-generation / dashscope sites.
- Single helper, same labels, consistent overflow error shape across both
  files. The plugin error labels (`"Chutes token exchange"`, `"Chutes
  userinfo"`) match the existing core helper labels so maintainer
  dashboards stay uniform.
- Low review surface: 2 source files, 2 test files, 2 repro scripts.
  No public API change, no schema change, no migration.

## Changes

- `src/agents/chutes-oauth.ts` — `+6/-5` — import
  `readProviderJsonResponse` from `./provider-http-errors.js`; replace
  three `(await response.json()) as Type` calls with
  `await readProviderJsonResponse<Type>(response, "<Chutes label>")`.
- `extensions/chutes/oauth.ts` — `+6/-3` — import
  `readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http`
  (boundary-respecting — extensions cannot reach into `src/agents/**`);
  replace the two active plugin success-body reads with the same helper.
- `src/agents/chutes-oauth.flow.test.ts` — `+111/-0` — bounded-reader
  regression tests against the deprecated core helper.
- `extensions/chutes/oauth.test.ts` — `+129/-0` — bounded-reader
  regression tests against the active plugin path (hostile token exchange
  body + hostile userinfo body, both verified to cancel and throw the
  canonical overflow error before the runtime buffers the full payload).
- `scripts/repro/issue-chutes-oauth-bounded-read.mjs` — new — standalone
  repro script that drives the core `readProviderJsonResponse` directly.
- `scripts/repro/issue-chutes-plugin-oauth-bounded-read.mjs` — new —
  standalone repro script that drives the plugin `loginChutes` end-to-end
  with stubbed fetchFn (validates the active path, not just the helper).

## Evidence

- `node scripts/run-vitest.mjs extensions/chutes/oauth.test.ts` —
  4/4 plugin tests passed (2 existing + 2 new bounded-reader regressions)
- `node scripts/run-vitest.mjs src/agents/chutes-oauth.flow.test.ts` —
  9/9 core tests passed (6 existing + 3 new bounded-reader regressions)
- `npx oxlint --import-plugin --config .oxlintrc.json extensions/chutes/oauth.ts extensions/chutes/oauth.test.ts`
  — exit 0
- `pnpm exec tsx scripts/repro/issue-chutes-oauth-bounded-read.mjs` —
  exit 0 (5 assertions: valid + 3 hostile + negative control)
- `pnpm exec tsx scripts/repro/issue-chutes-plugin-oauth-bounded-read.mjs` —
  exit 0 (3 assertions: hostile token exchange + hostile userinfo +
  negative control)

Sample failure when the body exceeds the 16 MiB cap (matches the helper
behavior verified in #96144):
```
Error: Chutes token exchange: JSON response exceeds 16777216 bytes
Error: Chutes userinfo: JSON response exceeds 16777216 bytes
```

## Real behavior proof

The two repro scripts drive the production code paths with no vitest mock:

- `scripts/repro/issue-chutes-oauth-bounded-read.mjs` exercises the
  deprecated core helper's three labels directly.
- `scripts/repro/issue-chutes-plugin-oauth-bounded-read.mjs` exercises
  `loginChutes` end-to-end with a stubbed `fetchFn`, proving the active
  bundled plugin path cancels and throws the canonical overflow error
  before the runtime buffers the full body.

```
$ pnpm exec tsx scripts/repro/issue-chutes-plugin-oauth-bounded-read.mjs
=== Reproduction for chutes plugin OAuth bounded JSON response cap ===
PROVIDER_JSON_RESPONSE_MAX_BYTES = 16777216 bytes
PASS  hostile token exchange body: rejected with "Chutes token exchange: JSON response exceeds 16777216 bytes"
PASS  hostile userinfo body: rejected with "Chutes userinfo: JSON response exceeds 16777216 bytes"
PASS  negative control: raw response.json() failed with "SyntaxError" (no bounded-reader wrapping)
=== All chutes plugin OAuth repro assertions passed ===
```

The negative control proves the bounded read is the source of the cap:
raw `response.json()` on the same 64 MiB body buffers the full payload
and only fails on JSON parse, not on size.

## Out of scope (separate follow-ups)

- `extensions/*/src/**` files with the same `response.json()` pattern
  (Alix-007 family of unbounded reads). Some are already capped
  (msteams/src/graph.ts, google-meet) and the rest are queued for
  per-extension follow-up PRs.
- The `assertOkOrThrowHttpError` / `readResponseTextLimited` calls in the
  same files cover the HTTP-error path (8 KiB cap), not the oversize-body
  path (16 MiB cap), and the bounded reader runs after the HTTP status
  check.

## Sibling coverage note

This PR addresses the ClawSweeper P1 finding that the original PR scope
missed the active bundled plugin path. Both files now route through the
same `readProviderJsonResponse` helper with consistent label prefixes,
so any future Chutes success-body reads added to either file should
follow the same pattern.