### PR TITLE
fix(daemon): prevent gateway OOM crash loops under sustained load

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -382,6 +382,26 @@ describe("gatherDaemonStatus", () => {
     expect(inspectWindowsGatewayFirewall).not.toHaveBeenCalled();
   });
 
+  it("reports the heap limit from the installed Gateway service", async () => {
+    serviceReadCommand.mockResolvedValueOnce({
+      programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
+      environment: {
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-daemon",
+        OPENCLAW_CONFIG_PATH: "/tmp/openclaw-daemon/openclaw.json",
+        NODE_OPTIONS: "--max-old-space-size=6144",
+      },
+    });
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: false,
+      deep: false,
+    });
+
+    expect(status.service.gatewayHeap).toMatchObject({ appliedMiB: 6144 });
+    expect(status.service.gatewayHeap?.memorySource).toMatch(/^(constrained|physical)$/u);
+  });
+
   it("includes Windows firewall diagnostics during deep LAN gateway status", async () => {
     inspectWindowsGatewayFirewall.mockResolvedValueOnce({
       applies: true,

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -16,6 +16,7 @@ import type {
 } from "../../config/types.js";
 import { resolveSecretInputRef } from "../../config/types.secrets.js";
 import { readLastGatewayErrorLine } from "../../daemon/diagnostics.js";
+import { inspectGatewayHeapLimit, type GatewayHeapLimitReport } from "../../daemon/gateway-heap.js";
 import type { FindExtraGatewayServicesOptions } from "../../daemon/inspect.js";
 import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import type { ServiceConfigAudit } from "../../daemon/service-audit.js";
@@ -295,6 +296,7 @@ export type DaemonStatus = {
     } | null;
     runtime?: GatewayServiceRuntime;
     configAudit?: ServiceConfigAudit;
+    gatewayHeap?: GatewayHeapLimitReport;
     restartHandoff?: GatewayRestartHandoff;
     staleUpdateLaunchdJobs?: StaleOpenClawUpdateLaunchdJob[];
   };
@@ -781,6 +783,9 @@ export async function gatherDaemonStatus(
       command,
       runtime,
       configAudit,
+      ...(command
+        ? { gatewayHeap: inspectGatewayHeapLimit(command.environment?.NODE_OPTIONS) }
+        : {}),
       ...(restartHandoff ? { restartHandoff } : {}),
       ...(staleUpdateLaunchdJobs.length > 0 ? { staleUpdateLaunchdJobs } : {}),
     },

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -99,6 +99,34 @@ describe("printDaemonStatus", () => {
     isWSLEnvMock.mockClear();
   });
 
+  it("prints the applied Gateway heap limit and derivation", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          gatewayHeap: {
+            appliedMiB: 6144,
+            maxOldSpaceSizeMiB: 4096,
+            availableMemoryMiB: 8192,
+            memorySource: "constrained",
+            floorMiB: 2048,
+            capMiB: 8192,
+            headroomCapMiB: 6144,
+          },
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    expectMockLineContains(runtime.log, "Gateway heap: 6144 MiB");
+    expectMockLineContains(runtime.log, "adaptive default 4096 MiB");
+    expectMockLineContains(runtime.log, "8192 MiB constrained memory");
+  });
+
   it("prints stale gateway pid guidance when runtime does not own the listener", () => {
     printDaemonStatus(
       {

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -5,6 +5,7 @@ import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
 } from "../../daemon/constants.js";
+import { formatGatewayHeapLimitReport } from "../../daemon/gateway-heap.js";
 import { renderGatewayServiceCleanupHints } from "../../daemon/inspect.js";
 import {
   resolveGatewayRestartLogPath,
@@ -127,6 +128,11 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
   const daemonEnvLines = safeDaemonEnv(service.command?.environment);
   if (daemonEnvLines.length > 0) {
     defaultRuntime.log(`${label("Service env:")} ${daemonEnvLines.join(" ")}`);
+  }
+  if (service.gatewayHeap) {
+    defaultRuntime.log(
+      `${label("Gateway heap:")} ${infoText(formatGatewayHeapLimitReport(service.gatewayHeap))}`,
+    );
   }
   spacer();
 

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -279,6 +279,26 @@ describe("buildGatewayInstallPlan", () => {
     expect(serviceEnvRequest?.extraPathDirs).toStrictEqual(["/custom"]);
   });
 
+  it("passes only the existing service NODE_OPTIONS to heap resolution", async () => {
+    mockNodeGatewayPlanFixture();
+
+    await buildGatewayInstallPlan({
+      env: {
+        HOME: isolatedHome,
+        NODE_OPTIONS: "--max-old-space-size=16384",
+      },
+      port: 3000,
+      runtime: "node",
+      existingEnvironment: {
+        NODE_OPTIONS: "--max-old-space-size=6144",
+      },
+    });
+
+    expect(
+      firstMockArg(mocks.buildServiceEnvironment, "buildServiceEnvironment").existingNodeOptions,
+    ).toBe("--max-old-space-size=6144");
+  });
+
   it("adds the active openclaw command bin directory to the managed service PATH", async () => {
     mockNodeGatewayPlanFixture();
     const originalArgv = process.argv;

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -775,6 +775,7 @@ export async function buildGatewayInstallPlan(params: {
   const serviceEnvironment = buildServiceEnvironment({
     env: serviceInputEnv,
     port: params.port,
+    existingNodeOptions: params.existingEnvironment?.NODE_OPTIONS,
     launchdLabel:
       platform === "darwin"
         ? resolveGatewayLaunchAgentLabel(serviceInputEnv.OPENCLAW_PROFILE)

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -404,6 +404,19 @@ describe("maybeRepairGatewayServiceConfig", () => {
     }
   });
 
+  it("reports the installed Gateway heap limit and derivation", async () => {
+    const command = createGatewayCommand("/opt/openclaw/dist/index.js");
+    command.environment = { NODE_OPTIONS: "--max-old-space-size=6144" };
+    mocks.readCommand.mockResolvedValue(command);
+    mocks.auditGatewayServiceConfig.mockResolvedValue({ ok: true, issues: [] });
+    mocks.buildGatewayInstallPlan.mockResolvedValue(command);
+
+    await runRepair({ gateway: {} });
+
+    expectNoteContaining("6144 MiB", "Gateway heap");
+    expectNoteContaining("adaptive default", "Gateway heap");
+  });
+
   it("treats gateway.auth.token as source of truth for service token repairs", async () => {
     setupGatewayTokenRepairScenario();
 

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -10,6 +10,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { replaceConfigFile, type OpenClawConfig } from "../config/config.js";
 import { resolveGatewayPort, resolveIsNixMode } from "../config/paths.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { formatGatewayHeapLimitReport, inspectGatewayHeapLimit } from "../daemon/gateway-heap.js";
 import {
   findExtraGatewayServices,
   renderGatewayServiceCleanupHints,
@@ -491,6 +492,10 @@ export async function maybeRepairGatewayServiceConfig(
   if (!command) {
     return cfg;
   }
+  note(
+    formatGatewayHeapLimitReport(inspectGatewayHeapLimit(command.environment?.NODE_OPTIONS)),
+    "Gateway heap",
+  );
   const serviceInstallEnv = buildGatewayServiceRepairEnv(command);
   const serviceWrapperPath = resolveGatewayServiceWrapperPath(command);
   if (serviceWrapperPath) {

--- a/src/daemon/gateway-heap.test.ts
+++ b/src/daemon/gateway-heap.test.ts
@@ -3,8 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   formatGatewayHeapLimitReport,
   inspectGatewayHeapLimit,
-  parseMaxOldSpaceSizeMiB,
-  resolveGatewayHeapLimit,
   resolveGatewayHeapNodeOptions,
 } from "./gateway-heap.js";
 
@@ -13,7 +11,7 @@ const MIB = 1024 * 1024;
 describe("resolveGatewayHeapLimit", () => {
   it("prefers constrained memory", () => {
     expect(
-      resolveGatewayHeapLimit({
+      inspectGatewayHeapLimit(undefined, {
         constrainedMemoryBytes: 12_288 * MIB,
         physicalMemoryBytes: 64_000 * MIB,
       }),
@@ -26,7 +24,7 @@ describe("resolveGatewayHeapLimit", () => {
 
   it("falls back to physical memory when no constraint is reported", () => {
     expect(
-      resolveGatewayHeapLimit({
+      inspectGatewayHeapLimit(undefined, {
         constrainedMemoryBytes: 0,
         physicalMemoryBytes: 8192 * MIB,
       }),
@@ -39,7 +37,7 @@ describe("resolveGatewayHeapLimit", () => {
 
   it("applies the floor when the host has enough headroom", () => {
     expect(
-      resolveGatewayHeapLimit({
+      inspectGatewayHeapLimit(undefined, {
         constrainedMemoryBytes: 3072 * MIB,
         physicalMemoryBytes: 8192 * MIB,
       }).maxOldSpaceSizeMiB,
@@ -48,7 +46,7 @@ describe("resolveGatewayHeapLimit", () => {
 
   it("bounds the floor to leave native headroom on smaller hosts", () => {
     expect(
-      resolveGatewayHeapLimit({
+      inspectGatewayHeapLimit(undefined, {
         constrainedMemoryBytes: 2048 * MIB,
         physicalMemoryBytes: 8192 * MIB,
       }).maxOldSpaceSizeMiB,
@@ -57,7 +55,7 @@ describe("resolveGatewayHeapLimit", () => {
 
   it("caps the default on large hosts", () => {
     expect(
-      resolveGatewayHeapLimit({
+      inspectGatewayHeapLimit(undefined, {
         constrainedMemoryBytes: 64_000 * MIB,
         physicalMemoryBytes: 128_000 * MIB,
       }).maxOldSpaceSizeMiB,
@@ -66,7 +64,7 @@ describe("resolveGatewayHeapLimit", () => {
 
   it("bounds an oversized constraint by physical memory", () => {
     expect(
-      resolveGatewayHeapLimit({
+      inspectGatewayHeapLimit(undefined, {
         constrainedMemoryBytes: 64_000 * MIB,
         physicalMemoryBytes: 8192 * MIB,
       }),
@@ -80,21 +78,21 @@ describe("resolveGatewayHeapLimit", () => {
 
 describe("Gateway service NODE_OPTIONS", () => {
   it("recognizes canonical, underscore, separated, and quoted heap flags", () => {
-    expect(parseMaxOldSpaceSizeMiB("--max-old-space-size=4096")).toBe(4096);
-    expect(parseMaxOldSpaceSizeMiB("--max_old_space_size=5120")).toBe(5120);
-    expect(parseMaxOldSpaceSizeMiB("--max-old-space-size 6144")).toBe(6144);
-    expect(parseMaxOldSpaceSizeMiB('--max-old-space-size="7168"')).toBe(7168);
-    expect(parseMaxOldSpaceSizeMiB('"--max-old-space-size=7680"')).toBe(7680);
+    expect(inspectGatewayHeapLimit("--max-old-space-size=4096").appliedMiB).toBe(4096);
+    expect(inspectGatewayHeapLimit("--max_old_space_size=5120").appliedMiB).toBe(5120);
+    expect(inspectGatewayHeapLimit("--max-old-space-size 6144").appliedMiB).toBe(6144);
+    expect(inspectGatewayHeapLimit('--max-old-space-size="7168"').appliedMiB).toBe(7168);
+    expect(inspectGatewayHeapLimit('"--max-old-space-size=7680"').appliedMiB).toBe(7680);
   });
 
   it("rejects malformed quoted NODE_OPTIONS", () => {
-    expect(parseMaxOldSpaceSizeMiB('--max-old-space-size="6144')).toBeNull();
+    expect(inspectGatewayHeapLimit('--max-old-space-size="6144').appliedMiB).toBeNull();
   });
 
   it("uses the last explicit heap flag", () => {
-    expect(parseMaxOldSpaceSizeMiB("--max-old-space-size=4096 --max_old_space_size=7168")).toBe(
-      7168,
-    );
+    expect(
+      inspectGatewayHeapLimit("--max-old-space-size=4096 --max_old_space_size=7168").appliedMiB,
+    ).toBe(7168);
   });
 
   it("preserves only an explicit service heap limit", () => {

--- a/src/daemon/gateway-heap.test.ts
+++ b/src/daemon/gateway-heap.test.ts
@@ -1,0 +1,118 @@
+// Managed Gateway heap tests cover adaptive sizing and safe service overrides.
+import { describe, expect, it } from "vitest";
+import {
+  formatGatewayHeapLimitReport,
+  inspectGatewayHeapLimit,
+  parseMaxOldSpaceSizeMiB,
+  resolveGatewayHeapLimit,
+  resolveGatewayHeapNodeOptions,
+} from "./gateway-heap.js";
+
+const MIB = 1024 * 1024;
+
+describe("resolveGatewayHeapLimit", () => {
+  it("prefers constrained memory", () => {
+    expect(
+      resolveGatewayHeapLimit({
+        constrainedMemoryBytes: 12_288 * MIB,
+        physicalMemoryBytes: 64_000 * MIB,
+      }),
+    ).toMatchObject({
+      maxOldSpaceSizeMiB: 6144,
+      availableMemoryMiB: 12_288,
+      memorySource: "constrained",
+    });
+  });
+
+  it("falls back to physical memory when no constraint is reported", () => {
+    expect(
+      resolveGatewayHeapLimit({
+        constrainedMemoryBytes: 0,
+        physicalMemoryBytes: 8192 * MIB,
+      }),
+    ).toMatchObject({
+      maxOldSpaceSizeMiB: 4096,
+      availableMemoryMiB: 8192,
+      memorySource: "physical",
+    });
+  });
+
+  it("applies the floor when the host has enough headroom", () => {
+    expect(
+      resolveGatewayHeapLimit({
+        constrainedMemoryBytes: 3072 * MIB,
+        physicalMemoryBytes: 8192 * MIB,
+      }).maxOldSpaceSizeMiB,
+    ).toBe(2048);
+  });
+
+  it("bounds the floor to leave native headroom on smaller hosts", () => {
+    expect(
+      resolveGatewayHeapLimit({
+        constrainedMemoryBytes: 2048 * MIB,
+        physicalMemoryBytes: 8192 * MIB,
+      }).maxOldSpaceSizeMiB,
+    ).toBe(1536);
+  });
+
+  it("caps the default on large hosts", () => {
+    expect(
+      resolveGatewayHeapLimit({
+        constrainedMemoryBytes: 64_000 * MIB,
+        physicalMemoryBytes: 128_000 * MIB,
+      }).maxOldSpaceSizeMiB,
+    ).toBe(8192);
+  });
+
+  it("bounds an oversized constraint by physical memory", () => {
+    expect(
+      resolveGatewayHeapLimit({
+        constrainedMemoryBytes: 64_000 * MIB,
+        physicalMemoryBytes: 8192 * MIB,
+      }),
+    ).toMatchObject({
+      maxOldSpaceSizeMiB: 4096,
+      availableMemoryMiB: 8192,
+      memorySource: "physical",
+    });
+  });
+});
+
+describe("Gateway service NODE_OPTIONS", () => {
+  it("recognizes canonical, underscore, separated, and quoted heap flags", () => {
+    expect(parseMaxOldSpaceSizeMiB("--max-old-space-size=4096")).toBe(4096);
+    expect(parseMaxOldSpaceSizeMiB("--max_old_space_size=5120")).toBe(5120);
+    expect(parseMaxOldSpaceSizeMiB("--max-old-space-size 6144")).toBe(6144);
+    expect(parseMaxOldSpaceSizeMiB('--max-old-space-size="7168"')).toBe(7168);
+    expect(parseMaxOldSpaceSizeMiB('"--max-old-space-size=7680"')).toBe(7680);
+  });
+
+  it("rejects malformed quoted NODE_OPTIONS", () => {
+    expect(parseMaxOldSpaceSizeMiB('--max-old-space-size="6144')).toBeNull();
+  });
+
+  it("uses the last explicit heap flag", () => {
+    expect(parseMaxOldSpaceSizeMiB("--max-old-space-size=4096 --max_old_space_size=7168")).toBe(
+      7168,
+    );
+  });
+
+  it("preserves only an explicit service heap limit", () => {
+    expect(
+      resolveGatewayHeapNodeOptions(
+        "--require /tmp/preload.js --max-old-space-size=6144 --inspect=0.0.0.0:9229",
+        { constrainedMemoryBytes: 32_000 * MIB },
+      ),
+    ).toBe("--max-old-space-size=6144");
+  });
+
+  it("reports the applied limit and adaptive derivation", () => {
+    const report = inspectGatewayHeapLimit("--max-old-space-size=6144", {
+      constrainedMemoryBytes: 8192 * MIB,
+      physicalMemoryBytes: 16_384 * MIB,
+    });
+    expect(formatGatewayHeapLimitReport(report)).toBe(
+      "6144 MiB (service setting; adaptive default 4096 MiB from 50% of 8192 MiB constrained memory, target range 2048-8192 MiB, native headroom cap 6144 MiB)",
+    );
+  });
+});

--- a/src/daemon/gateway-heap.ts
+++ b/src/daemon/gateway-heap.ts
@@ -1,0 +1,160 @@
+/** Adaptive Node heap policy for the managed Gateway service. */
+import os from "node:os";
+
+const MEBIBYTE_BYTES = 1024 * 1024;
+const GATEWAY_HEAP_FLOOR_MIB = 2048;
+const GATEWAY_HEAP_CAP_MIB = 8192;
+
+export type GatewayHeapMemorySource = "constrained" | "physical";
+
+export type GatewayHeapLimit = {
+  maxOldSpaceSizeMiB: number;
+  availableMemoryMiB: number;
+  memorySource: GatewayHeapMemorySource;
+  floorMiB: number;
+  capMiB: number;
+  headroomCapMiB: number;
+};
+
+export type GatewayHeapLimitReport = GatewayHeapLimit & {
+  appliedMiB: number | null;
+};
+
+type GatewayHeapMemoryInputs = {
+  constrainedMemoryBytes?: number;
+  physicalMemoryBytes?: number;
+};
+
+function readAvailableMemory(params: GatewayHeapMemoryInputs): {
+  bytes: number;
+  source: GatewayHeapMemorySource;
+} {
+  const constrainedMemoryBytes = params.constrainedMemoryBytes ?? process.constrainedMemory();
+  const physicalMemoryBytes = params.physicalMemoryBytes ?? os.totalmem();
+  if (
+    Number.isFinite(constrainedMemoryBytes) &&
+    constrainedMemoryBytes > 0 &&
+    constrainedMemoryBytes <= physicalMemoryBytes
+  ) {
+    return { bytes: constrainedMemoryBytes, source: "constrained" };
+  }
+  return {
+    bytes: physicalMemoryBytes,
+    source: "physical",
+  };
+}
+
+export function resolveGatewayHeapLimit(params: GatewayHeapMemoryInputs = {}): GatewayHeapLimit {
+  const memory = readAvailableMemory(params);
+  const availableMemoryMiB = Math.floor(memory.bytes / MEBIBYTE_BYTES);
+  const halfMemoryMiB = Math.floor(availableMemoryMiB / 2);
+  // Old space is only part of Gateway RSS. Bound the nominal floor so smaller
+  // hosts retain room for young-generation, native, and buffer allocations.
+  const headroomCapMiB = Math.floor(availableMemoryMiB * 0.75);
+  return {
+    maxOldSpaceSizeMiB: Math.min(
+      GATEWAY_HEAP_CAP_MIB,
+      Math.max(GATEWAY_HEAP_FLOOR_MIB, halfMemoryMiB),
+      headroomCapMiB,
+    ),
+    availableMemoryMiB,
+    memorySource: memory.source,
+    floorMiB: GATEWAY_HEAP_FLOOR_MIB,
+    capMiB: GATEWAY_HEAP_CAP_MIB,
+    headroomCapMiB,
+  };
+}
+
+function parseNodeOptionsTokens(nodeOptions: string): string[] | null {
+  // Match Node's NODE_OPTIONS splitter: space delimiters, double quotes, and
+  // backslash escapes only inside quotes. Other shell quoting does not apply.
+  const tokens: string[] = [];
+  let token = "";
+  let inQuotes = false;
+  let tokenStarted = false;
+  for (let index = 0; index < nodeOptions.length; index += 1) {
+    let char = nodeOptions[index];
+    if (char === "\\" && inQuotes) {
+      index += 1;
+      if (index >= nodeOptions.length) {
+        return null;
+      }
+      char = nodeOptions[index];
+    } else if (char === " " && !inQuotes) {
+      if (tokenStarted) {
+        tokens.push(token);
+        token = "";
+        tokenStarted = false;
+      }
+      continue;
+    } else if (char === '"') {
+      inQuotes = !inQuotes;
+      tokenStarted = true;
+      continue;
+    }
+    token += char;
+    tokenStarted = true;
+  }
+  if (inQuotes) {
+    return null;
+  }
+  if (tokenStarted) {
+    tokens.push(token);
+  }
+  return tokens;
+}
+
+export function parseMaxOldSpaceSizeMiB(nodeOptions: string | undefined): number | null {
+  if (!nodeOptions) {
+    return null;
+  }
+  const tokens = parseNodeOptionsTokens(nodeOptions);
+  if (!tokens) {
+    return null;
+  }
+  const heapFlag = /^--max[-_]old[-_]space[-_]size$/iu;
+  const heapAssignment = /^--max[-_]old[-_]space[-_]size=(\d+)$/iu;
+  let result: number | null = null;
+  for (let index = 0; index < tokens.length; index += 1) {
+    const assignment = heapAssignment.exec(tokens[index] ?? "");
+    const rawValue =
+      assignment?.[1] ?? (heapFlag.test(tokens[index] ?? "") ? tokens[index + 1] : null);
+    const value = Number(rawValue);
+    if (Number.isSafeInteger(value) && value > 0) {
+      result = value;
+    }
+  }
+  return result;
+}
+
+export function resolveGatewayHeapNodeOptions(
+  existingNodeOptions: string | undefined,
+  memory: GatewayHeapMemoryInputs = {},
+): string {
+  const existingLimit = parseMaxOldSpaceSizeMiB(existingNodeOptions);
+  const limit = existingLimit ?? resolveGatewayHeapLimit(memory).maxOldSpaceSizeMiB;
+  // Keep the durable service value heap-only. Ambient or adjacent startup flags
+  // must not reopen the NODE_OPTIONS preload/debug boundary.
+  return `--max-old-space-size=${limit}`;
+}
+
+export function inspectGatewayHeapLimit(
+  nodeOptions: string | undefined,
+  memory: GatewayHeapMemoryInputs = {},
+): GatewayHeapLimitReport {
+  return {
+    ...resolveGatewayHeapLimit(memory),
+    appliedMiB: parseMaxOldSpaceSizeMiB(nodeOptions),
+  };
+}
+
+export function formatGatewayHeapLimitReport(report: GatewayHeapLimitReport): string {
+  const derivation = `50% of ${report.availableMemoryMiB} MiB ${report.memorySource} memory, target range ${report.floorMiB}-${report.capMiB} MiB, native headroom cap ${report.headroomCapMiB} MiB`;
+  if (report.appliedMiB === null) {
+    return `not set; adaptive default ${report.maxOldSpaceSizeMiB} MiB (${derivation})`;
+  }
+  if (report.appliedMiB === report.maxOldSpaceSizeMiB) {
+    return `${report.appliedMiB} MiB (adaptive default: ${derivation})`;
+  }
+  return `${report.appliedMiB} MiB (service setting; adaptive default ${report.maxOldSpaceSizeMiB} MiB from ${derivation})`;
+}

--- a/src/daemon/gateway-heap.ts
+++ b/src/daemon/gateway-heap.ts
@@ -5,9 +5,9 @@ const MEBIBYTE_BYTES = 1024 * 1024;
 const GATEWAY_HEAP_FLOOR_MIB = 2048;
 const GATEWAY_HEAP_CAP_MIB = 8192;
 
-export type GatewayHeapMemorySource = "constrained" | "physical";
+type GatewayHeapMemorySource = "constrained" | "physical";
 
-export type GatewayHeapLimit = {
+type GatewayHeapLimit = {
   maxOldSpaceSizeMiB: number;
   availableMemoryMiB: number;
   memorySource: GatewayHeapMemorySource;
@@ -44,7 +44,7 @@ function readAvailableMemory(params: GatewayHeapMemoryInputs): {
   };
 }
 
-export function resolveGatewayHeapLimit(params: GatewayHeapMemoryInputs = {}): GatewayHeapLimit {
+function resolveGatewayHeapLimit(params: GatewayHeapMemoryInputs = {}): GatewayHeapLimit {
   const memory = readAvailableMemory(params);
   const availableMemoryMiB = Math.floor(memory.bytes / MEBIBYTE_BYTES);
   const halfMemoryMiB = Math.floor(availableMemoryMiB / 2);
@@ -104,7 +104,7 @@ function parseNodeOptionsTokens(nodeOptions: string): string[] | null {
   return tokens;
 }
 
-export function parseMaxOldSpaceSizeMiB(nodeOptions: string | undefined): number | null {
+function parseMaxOldSpaceSizeMiB(nodeOptions: string | undefined): number | null {
   if (!nodeOptions) {
     return null;
   }

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { resolveAutoNodeExtraCaCerts } from "../bootstrap/node-extra-ca-certs.js";
-import { resolveGatewayHeapLimit } from "./gateway-heap.js";
+import { inspectGatewayHeapLimit } from "./gateway-heap.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import {
   buildNodeServiceEnvironment,
@@ -733,7 +733,7 @@ describe("buildServiceEnvironment NODE_OPTIONS", () => {
       port: 18789,
     });
     expect(env.NODE_OPTIONS).toBe(
-      `--max-old-space-size=${resolveGatewayHeapLimit().maxOldSpaceSizeMiB}`,
+      `--max-old-space-size=${inspectGatewayHeapLimit(undefined).maxOldSpaceSizeMiB}`,
     );
   });
 

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { resolveAutoNodeExtraCaCerts } from "../bootstrap/node-extra-ca-certs.js";
+import { resolveGatewayHeapLimit } from "./gateway-heap.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import {
   buildNodeServiceEnvironment,
@@ -726,69 +727,42 @@ describe("buildServiceEnvironment", () => {
 });
 
 describe("buildServiceEnvironment NODE_OPTIONS", () => {
-  it("sets default --max-old-space-size=8192 when no NODE_OPTIONS is present", () => {
+  it("sets the adaptive default heap flag", () => {
     const env = buildServiceEnvironment({
       env: { HOME: "/home/user" },
       port: 18789,
     });
-    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
+    expect(env.NODE_OPTIONS).toBe(
+      `--max-old-space-size=${resolveGatewayHeapLimit().maxOldSpaceSizeMiB}`,
+    );
   });
 
-  it("drops ambient NODE_OPTIONS and uses default heap flag", () => {
-    // Hostile NODE_OPTIONS (--require, --inspect, etc.) must not leak into
-    // managed services. The service env only gets the OpenClaw-owned heap flag.
+  it("drops ambient NODE_OPTIONS", () => {
     const env = buildServiceEnvironment({
       env: {
         HOME: "/home/user",
-        NODE_OPTIONS: "--max-old-space-size=16384 --no-warnings",
+        NODE_OPTIONS: "--require /tmp/preload.js --max-old-space-size=16384",
       },
       port: 18789,
     });
-    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
-  });
-
-  it("drops ambient NODE_OPTIONS with other flags and sets default heap", () => {
-    const env = buildServiceEnvironment({
-      env: {
-        HOME: "/home/user",
-        NODE_OPTIONS: "--no-warnings --experimental-vm-modules",
-      },
-      port: 18789,
-    });
-    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
-  });
-
-  it("drops hostile --require in ambient NODE_OPTIONS", () => {
-    // A --require preload in the host process must never persist into
-    // managed services — that would re-open a startup preload boundary.
-    const env = buildServiceEnvironment({
-      env: {
-        HOME: "/home/user",
-        NODE_OPTIONS: "--require /tmp/malicious.js --max-old-space-size=4096",
-      },
-      port: 18789,
-    });
-    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
     expect(env.NODE_OPTIONS).not.toContain("--require");
+    expect(env.NODE_OPTIONS).not.toContain("16384");
   });
 
-  it("drops --inspect in ambient NODE_OPTIONS", () => {
+  it("keeps an explicit heap flag from the existing service only", () => {
     const env = buildServiceEnvironment({
-      env: {
-        HOME: "/home/user",
-        NODE_OPTIONS: "--inspect=0.0.0.0:9229 --max-old-space-size=4096",
-      },
+      env: { HOME: "/home/user" },
       port: 18789,
+      existingNodeOptions: "--require /tmp/preload.js --max_old_space_size=6144",
     });
-    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
-    expect(env.NODE_OPTIONS).not.toContain("--inspect");
+    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=6144");
   });
 
-  it("includes NODE_OPTIONS in buildNodeServiceEnvironment", () => {
+  it("does not apply the Gateway heap policy to node services", () => {
     const env = buildNodeServiceEnvironment({
       env: { HOME: "/home/user" },
     });
-    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
+    expect(env.NODE_OPTIONS).toBeUndefined();
   });
 });
 

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -725,6 +725,73 @@ describe("buildServiceEnvironment", () => {
   });
 });
 
+describe("buildServiceEnvironment NODE_OPTIONS", () => {
+  it("sets default --max-old-space-size=8192 when no NODE_OPTIONS is present", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+    });
+    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
+  });
+
+  it("drops ambient NODE_OPTIONS and uses default heap flag", () => {
+    // Hostile NODE_OPTIONS (--require, --inspect, etc.) must not leak into
+    // managed services. The service env only gets the OpenClaw-owned heap flag.
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        NODE_OPTIONS: "--max-old-space-size=16384 --no-warnings",
+      },
+      port: 18789,
+    });
+    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
+  });
+
+  it("drops ambient NODE_OPTIONS with other flags and sets default heap", () => {
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        NODE_OPTIONS: "--no-warnings --experimental-vm-modules",
+      },
+      port: 18789,
+    });
+    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
+  });
+
+  it("drops hostile --require in ambient NODE_OPTIONS", () => {
+    // A --require preload in the host process must never persist into
+    // managed services — that would re-open a startup preload boundary.
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        NODE_OPTIONS: "--require /tmp/malicious.js --max-old-space-size=4096",
+      },
+      port: 18789,
+    });
+    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
+    expect(env.NODE_OPTIONS).not.toContain("--require");
+  });
+
+  it("drops --inspect in ambient NODE_OPTIONS", () => {
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        NODE_OPTIONS: "--inspect=0.0.0.0:9229 --max-old-space-size=4096",
+      },
+      port: 18789,
+    });
+    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
+    expect(env.NODE_OPTIONS).not.toContain("--inspect");
+  });
+
+  it("includes NODE_OPTIONS in buildNodeServiceEnvironment", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user" },
+    });
+    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
+  });
+});
+
 describe("buildNodeServiceEnvironment", () => {
   it("passes through HOME for node services", () => {
     const env = buildNodeServiceEnvironment({

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,4 +1,7 @@
 /** Builds minimal, portable environment blocks for managed daemon services. */
+
+const GATEWAY_DEFAULT_MAX_OLD_SPACE_MB = 8192;
+
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -474,6 +477,16 @@ export function buildNodeServiceEnvironment(params: {
   };
 }
 
+function resolveServiceNodeOptions(): string {
+  // Generate only the OpenClaw-owned heap flag. Ambient NODE_OPTIONS from
+  // the host process (e.g. --require, --inspect, --expose-gc) must never
+  // leak into managed services — that would re-open a startup preload
+  // boundary the current install path already blocks.
+  // 8192 MB is chosen as a safe default that prevents the common OOM crash
+  // loop with the default Node ~4 GB heap under sustained load (#96203).
+  return `--max-old-space-size=${GATEWAY_DEFAULT_MAX_OLD_SPACE_MB}`;
+}
+
 function buildCommonServiceEnvironment(
   env: Record<string, string | undefined>,
   sharedEnv: SharedServiceEnvironmentFields,
@@ -481,6 +494,7 @@ function buildCommonServiceEnvironment(
   const serviceEnv: Record<string, string | undefined> = {
     HOME: env.HOME,
     TMPDIR: sharedEnv.tmpDir,
+    NODE_OPTIONS: resolveServiceNodeOptions(),
     NODE_EXTRA_CA_CERTS: sharedEnv.nodeCaCerts,
     NODE_USE_SYSTEM_CA: sharedEnv.nodeUseSystemCa,
     OPENCLAW_STATE_DIR: sharedEnv.stateDir,

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,7 +1,4 @@
 /** Builds minimal, portable environment blocks for managed daemon services. */
-
-const GATEWAY_DEFAULT_MAX_OLD_SPACE_MB = 8192;
-
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -21,6 +18,7 @@ import {
   resolveNodeSystemdServiceName,
   resolveNodeWindowsTaskName,
 } from "./constants.js";
+import { resolveGatewayHeapNodeOptions } from "./gateway-heap.js";
 import { resolveGatewayStateDir } from "./paths.js";
 
 type MinimalServicePathOptions = {
@@ -410,6 +408,7 @@ function resolveGatewaySystemdUnitEnv(env: Record<string, string | undefined>): 
 export function buildServiceEnvironment(params: {
   env: Record<string, string | undefined>;
   port: number;
+  existingNodeOptions?: string;
   launchdLabel?: string;
   platform?: NodeJS.Platform;
   extraPathDirs?: string[];
@@ -430,6 +429,7 @@ export function buildServiceEnvironment(params: {
   const systemdUnit = resolveGatewaySystemdUnitEnv(env);
   return {
     ...buildCommonServiceEnvironment(env, sharedEnv),
+    NODE_OPTIONS: resolveGatewayHeapNodeOptions(params.existingNodeOptions),
     OPENCLAW_PROFILE: profile,
     OPENCLAW_WRAPPER: wrapperPath,
     OPENCLAW_GATEWAY_PORT: String(port),
@@ -477,16 +477,6 @@ export function buildNodeServiceEnvironment(params: {
   };
 }
 
-function resolveServiceNodeOptions(): string {
-  // Generate only the OpenClaw-owned heap flag. Ambient NODE_OPTIONS from
-  // the host process (e.g. --require, --inspect, --expose-gc) must never
-  // leak into managed services — that would re-open a startup preload
-  // boundary the current install path already blocks.
-  // 8192 MB is chosen as a safe default that prevents the common OOM crash
-  // loop with the default Node ~4 GB heap under sustained load (#96203).
-  return `--max-old-space-size=${GATEWAY_DEFAULT_MAX_OLD_SPACE_MB}`;
-}
-
 function buildCommonServiceEnvironment(
   env: Record<string, string | undefined>,
   sharedEnv: SharedServiceEnvironmentFields,
@@ -494,7 +484,6 @@ function buildCommonServiceEnvironment(
   const serviceEnv: Record<string, string | undefined> = {
     HOME: env.HOME,
     TMPDIR: sharedEnv.tmpDir,
-    NODE_OPTIONS: resolveServiceNodeOptions(),
     NODE_EXTRA_CA_CERTS: sharedEnv.nodeCaCerts,
     NODE_USE_SYSTEM_CA: sharedEnv.nodeUseSystemCa,
     OPENCLAW_STATE_DIR: sharedEnv.stateDir,


### PR DESCRIPTION
Closes #96203

## What Problem This Solves

Fixes an issue where a managed Gateway under sustained multi-agent load could exhaust Node's old-space heap, enter a rapid crash loop, and block agent workflows. The incident in #96203 reproduced this with roughly 30 agents and more than 2,000 restarts in one day; an explicit heap limit stopped the loop.

## Why This Change Was Made

Managed Gateway installs now derive a heap-only `NODE_OPTIONS` value from the smaller of Node's constrained-memory result and physical RAM. The adaptive default targets 50% of available memory, uses a 2048 MiB floor when native headroom allows, keeps 25% headroom on smaller hosts, and caps old space at 8192 MiB.

The policy applies only to the Gateway service because the reported failure and evidence are Gateway-specific. Node services remain unchanged. A heap-size flag already present in the installed service is preserved and normalized, while ambient or adjacent startup flags such as preload and inspector options remain blocked. No config key, CLI flag, or public environment knob is added.

## User Impact

After Gateway service installation or regeneration, operators get a host-appropriate old-space limit instead of relying on Node's generic default. `openclaw gateway status` and `openclaw doctor` show the applied limit and its derivation, including whether the installed service uses a distinct explicit setting.

Release note: Managed Gateway services now use a constrained-memory-aware Node heap limit to prevent sustained-load OOM crash loops.

## Evidence

- Focused regression proof: `node scripts/run-vitest.mjs` across heap math/parser, service environment, install planning, status gather/print, and doctor suites — 254 tests passed.
- Hosted changed gate: formatting, core and core-test typechecks, full core lint, SDK/boundary checks, import cycles, and repository guards passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/29547762003).
- Security boundary: tests prove ambient `NODE_OPTIONS` is ignored, only an installed heap-size flag is retained, quoted Node-compatible values are normalized, and node services receive no Gateway heap default.
- Incident proof and operational workaround: #96203.
- Source-blind local status probe was limited because this host has no installed Gateway service; no host service was installed or modified for validation.
