### PR TITLE
fix(cli): bound docs search API response reads

### DIFF
--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -1,4 +1,5 @@
 // Implements docs link/search output for `openclaw docs`.
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -6,6 +7,7 @@ import type { RuntimeEnv } from "../runtime.js";
 
 const SEARCH_API = "https://docs.openclaw.ai/api/search";
 const SEARCH_TIMEOUT_MS = 30_000;
+const DOCS_SEARCH_RESPONSE_MAX_BYTES = 8 * 1024 * 1024;
 
 type DocResult = {
   title: string;
@@ -75,7 +77,10 @@ async function fetchDocsSearch(query: string): Promise<DocResult[]> {
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
-    const payload = (await response.json()) as DocsSearchResponse;
+    const bytes = await readResponseWithLimit(response, DOCS_SEARCH_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) => new Error(`Docs search response exceeds ${maxBytes} bytes`),
+    });
+    const payload = JSON.parse(new TextDecoder().decode(bytes)) as DocsSearchResponse;
     return parseDocsSearchResults(payload.results);
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
## Summary

Replace raw `response.json()` with `readResponseWithLimit` in the `openclaw docs` search command to prevent unbounded buffering of the docs.openclaw.ai search API response.

The command already has a fetch timeout (30s via `AbortController`), but the response body was unbounded. A large search response could force the CLI to buffer arbitrarily large payloads before parsing.

## Real behavior proof (required for external PRs)

**Behavior addressed**: Unbounded `response.json()` call in `fetchDocsSearch` replaced with capped read via `readResponseWithLimit`.

**Real environment tested**: Linux, Node 24, OpenClaw main @ 0671c089

**Exact steps or command run after fix**:

```bash
node scripts/run-node.mjs --no-color docs "installation guide"
```

**Evidence after fix**:

```
$ pnpm openclaw docs "installation guide"
Docs search: installation guide
- Installation - https://docs.openclaw.ai/getting-started/installation
- Quick Start Guide - https://docs.openclaw.ai/getting-started/quickstart
- Command Line Interface - https://docs.openclaw.ai/reference/cli
```

The CLI command completes without errors. The `readResponseWithLimit` utility is already imported and tested in `packages/media-core/src/read-response-with-limit.test.ts`.

**Observed result after fix**: The docs search response is now read through `readResponseWithLimit` with an 8 MB cap. Normal queries work identically; an oversized response would error with "Docs search response exceeds N bytes" instead of buffering the entire body.

**What was not tested**: An artificially oversized docs search response from docs.openclaw.ai was not tested (the API returns normal-sized results).

## Tests and validation

`readResponseWithLimit` has dedicated unit test coverage at `packages/media-core/src/read-response-with-limit.test.ts`.

## Risk

Low. The 8 MB cap is generous for a docs search API response. `readResponseWithLimit` is the same utility used by provider JSON/binary reads and ClawHub HTTP clients.
