### PR TITLE
fix(config): name openai-chatgpt-responses for the removed openai-codex-responses api id

### DIFF
--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -148,6 +148,49 @@ describe("config validation allowed-values metadata", () => {
   });
 });
 
+describe("config validation legacy openai-codex api", () => {
+  it("names openai-chatgpt-responses for the removed openai-codex-responses api id", () => {
+    const result = validateConfigObjectRaw({
+      models: {
+        providers: {
+          "openai-codex": {
+            api: "openai-codex-responses",
+            models: [{ id: "gpt-5.5", api: "openai-codex-responses" }],
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const providerIssue = requireIssue(result.issues, "models.providers.openai-codex.api");
+      expect(providerIssue.message).toContain('"openai-codex-responses" is a removed api id');
+      expect(providerIssue.message).toContain('use "openai-chatgpt-responses"');
+      const modelIssue = requireIssue(result.issues, "models.providers.openai-codex.models.0.api");
+      expect(modelIssue.message).toContain('use "openai-chatgpt-responses"');
+    }
+  });
+
+  it("keeps the generic enum message for other invalid api ids", () => {
+    const result = validateConfigObjectRaw({
+      models: {
+        providers: {
+          "openai-codex": {
+            api: "openai-codex",
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = requireIssue(result.issues, "models.providers.openai-codex.api");
+      expect(issue.message).toContain("expected one of");
+      expect(issue.message).not.toContain("removed api id");
+    }
+  });
+});
+
 describe("config validation numeric bound hints", () => {
   it("appends maximum for inclusive too_big numeric bound", () => {
     const issue = mapFirstIssue(

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -207,7 +207,16 @@ export const SecretsConfigSchema = z
   .strict()
   .optional();
 
-const ModelApiSchema = z.enum(MODEL_APIS);
+const LEGACY_OPENAI_CODEX_RESPONSES_API = "openai-codex-responses";
+const OPENAI_CHATGPT_RESPONSES_API =
+  "openai-chatgpt-responses" satisfies (typeof MODEL_APIS)[number];
+
+const ModelApiSchema = z.enum(MODEL_APIS, {
+  error: (issue) =>
+    issue.input === LEGACY_OPENAI_CODEX_RESPONSES_API
+      ? `"${LEGACY_OPENAI_CODEX_RESPONSES_API}" is a removed api id; use "${OPENAI_CHATGPT_RESPONSES_API}"`
+      : undefined,
+});
 
 const ModelCompatSchema = z
   .object({


### PR DESCRIPTION
## What Problem This Solves

Upgrading a `2026.5.28` config to the June `6.x` train surfaces the removed
`openai-codex-responses` api id as a config validation failure. The validator
printed only a generic enum rejection plus a blanket `openclaw doctor --fix`
hint, and nothing named the supported replacement.

For Codex/ChatGPT OAuth deployments this is operator-hostile: `doctor --fix` also
unifies the `openai-codex` provider into `openai`, so an operator could not tell
the safe one-field api migration apart from the broad provider rewrite they are
trying to avoid. This is request 3 of issue #96197.

Root cause, `src/config/zod-schema.core.ts:210`: the provider/model `api` field
was a plain enum, so the removed id produced only the default rejection.

```ts
// before
const ModelApiSchema = z.enum(MODEL_APIS);
```

The schema already knows `openai-codex-responses` was replaced by
`openai-chatgpt-responses` (the same legacy-to-canonical mapping that
`openclaw doctor --fix` applies in
`src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts`), but it
surfaced none of that.

## Why This Change Was Made

```ts
// after
const LEGACY_OPENAI_CODEX_RESPONSES_API = "openai-codex-responses";
const OPENAI_CHATGPT_RESPONSES_API =
  "openai-chatgpt-responses" satisfies (typeof MODEL_APIS)[number];

const ModelApiSchema = z.enum(MODEL_APIS, {
  error: (issue) =>
    issue.input === LEGACY_OPENAI_CODEX_RESPONSES_API
      ? `"${LEGACY_OPENAI_CODEX_RESPONSES_API}" is a removed api id; use "${OPENAI_CHATGPT_RESPONSES_API}"`
      : undefined,
});
```

The schema owns the api domain, so fixing it here improves every surface that
renders a validation issue at once: `openclaw config validate`, gateway startup
validation, and the snapshot path in `src/cli/config-cli.ts`. A CLI-only hint
would have covered just one surface. `ModelApiSchema` also feeds both the
provider-level `api` (`zod-schema.core.ts:370`) and per-model `api`
(`zod-schema.core.ts:501`) fields, which are exactly the paths the report shows
failing.

No runtime compatibility shim or alias is added. The legacy id stays rejected
(fail closed) and `doctor --fix` remains the canonical migration owner; only the
rejection diagnostic changes. The `satisfies` guard keeps the named replacement a
real member of `MODEL_APIS`. Every other invalid value keeps the generic enum
message.

## User Impact

Operators upgrading a Codex/ChatGPT OAuth config now get told the exact
supported replacement inline, instead of a generic "Invalid option" list that
left them guessing between the narrow api fix and the broad `doctor --fix`
provider rewrite.

## Evidence

Drove the real `openclaw config validate` command action (`runConfigValidate`)
against a real on-disk `openclaw.json` whose `models.providers.openai-codex.api`
and each model `api` equal `openai-codex-responses`, on pristine main
`da15cf48` versus the patched tree with identical input. Real schema validation
and real issue formatting ran; nothing was stubbed.

```
# BEFORE (pristine main da15cf48)
  × models.providers.openai-codex.api: Invalid option: expected one of "openai-completions"|"openai-responses"|"openai-chatgpt-responses"|"anthropic-messages"|"google-generative-ai"|"google-vertex"|"github-copilot"|"bedrock-converse-stream"|"ollama"|"azure-openai-responses"
  × models.providers.openai-codex.models.0.api: Invalid option: expected one of "openai-completions"|"openai-responses"|"openai-chatgpt-responses"|...
  × models.providers.openai-codex.models.1.api: Invalid option: expected one of "openai-completions"|"openai-responses"|"openai-chatgpt-responses"|...

Run `openclaw doctor --fix` to repair, or fix the keys above manually.

# AFTER (this patch, identical input)
  × models.providers.openai-codex.api: "openai-codex-responses" is a removed api id; use "openai-chatgpt-responses" (allowed: "openai-completions", "openai-responses", "openai-chatgpt-responses", "anthropic-messages", "google-generative-ai", "google-vertex", "github-copilot", "bedrock-converse-stream", "ollama", "azure-openai-responses")
  × models.providers.openai-codex.models.0.api: "openai-codex-responses" is a removed api id; use "openai-chatgpt-responses" (allowed: ...)
  × models.providers.openai-codex.models.1.api: "openai-codex-responses" is a removed api id; use "openai-chatgpt-responses" (allowed: ...)

Run `openclaw doctor --fix` to repair, or fix the keys above manually.
```

A different invalid api id (for example `openai-codex`) keeps the generic enum
message, so only the known-legacy id is special-cased.

Checks: `node scripts/run-vitest.mjs src/config/validation.allowed-values.test.ts`
passes 14 cases including the two added; the new case fails on pristine main and
passes with the patch. `node scripts/run-tsgo.mjs` core and core-test lanes,
`oxlint`, and `oxfmt --check` on the two changed files are clean. Type-aware
oxlint and full build were not run; this host OOM-thrashes on them.

The separately reported per-agent SQLite auth-store lookup failure in #96197 is a
different code path and is out of scope here.
