### PR TITLE
fix(approval): forward turnSourceTo on followup for external channel plugins (fixes #96103)

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -16,8 +16,8 @@ vi.mock("../infra/outbound/message.js", () => ({
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { writeSessionStoreForTest } from "../config/sessions/test-helpers.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
+import { writeSessionStoreForTest } from "../config/sessions/test-helpers.js";
 import { sendMessage } from "../infra/outbound/message.js";
 import {
   buildExecApprovalFollowupPrompt,
@@ -500,6 +500,28 @@ describe("exec approval followup", () => {
       sessionKey: "agent:main:telegram:-100123",
       deliver: false,
       channel: "telegram",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("carries turnSourceTo for external channel plugins when deliverable route is unavailable", async () => {
+    // Regression: #96103 — external channel plugin approval followup falls back to webchat
+    await sendExecApprovalFollowup({
+      approvalId: "req-external-96103",
+      sessionKey: "agent:main:lansenger:user:U123",
+      turnSourceChannel: "lansenger",
+      turnSourceTo: "user:U123",
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "thread-abc",
+      resultText: "Exec completed: echo ok",
+    });
+
+    expectGatewayAgentFollowup({
+      sessionKey: "agent:main:lansenger:user:U123",
+      channel: "lansenger",
+      to: "user:U123",
+      accountId: "default",
+      threadId: "thread-abc",
     });
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -261,9 +261,12 @@ function buildAgentFollowupArgs(params: {
   idempotencyKey?: string;
 }) {
   const { deliveryTarget, sessionOnlyOriginChannel } = params;
-  // When the followup run has no deliverable route and no gateway-internal channel,
-  // preserve the raw turnSourceChannel so the spawned agent inherits messageProvider.
+  // When the followup run has no deliverable route, preserve the raw
+  // turnSourceChannel so the spawned agent inherits messageProvider.
   // Without this, tools.elevated.allowFrom.<provider> checks fail with provider=null.
+  // Also forward turnSourceTo / accountId / threadId so external channel plugins
+  // (which are not in isDeliverableMessageChannel) still get a routing target
+  // on the followup agent run instead of falling back to webchat (#96103).
   const fallbackChannel = sessionOnlyOriginChannel ?? params.turnSourceChannel;
   return {
     sessionKey: params.sessionKey,
@@ -271,21 +274,9 @@ function buildAgentFollowupArgs(params: {
     deliver: deliveryTarget.deliver,
     ...(deliveryTarget.deliver ? { bestEffortDeliver: true as const } : {}),
     channel: deliveryTarget.deliver ? deliveryTarget.channel : fallbackChannel,
-    to: deliveryTarget.deliver
-      ? deliveryTarget.to
-      : sessionOnlyOriginChannel
-        ? params.turnSourceTo
-        : undefined,
-    accountId: deliveryTarget.deliver
-      ? deliveryTarget.accountId
-      : sessionOnlyOriginChannel
-        ? params.turnSourceAccountId
-        : undefined,
-    threadId: deliveryTarget.deliver
-      ? deliveryTarget.threadId
-      : sessionOnlyOriginChannel
-        ? params.turnSourceThreadId
-        : undefined,
+    to: deliveryTarget.deliver ? deliveryTarget.to : params.turnSourceTo,
+    accountId: deliveryTarget.deliver ? deliveryTarget.accountId : params.turnSourceAccountId,
+    threadId: deliveryTarget.deliver ? deliveryTarget.threadId : params.turnSourceThreadId,
     idempotencyKey:
       params.idempotencyKey ??
       buildExecApprovalFollowupIdempotencyKey({


### PR DESCRIPTION
## Real behavior proof

- **Behavior addressed:** When an exec approval is resolved in an external channel plugin session, the followup agent run receives `turnSourceTo: undefined` because `buildAgentFollowupArgs` gated the routing target behind `sessionOnlyOriginChannel`, which is only set for gateway-internal channels. This caused the agent's post-approval reply to be delivered to webchat instead of the originating external channel.
- **Environment tested:** macOS 26.4.1, Node 22.19, OpenClaw main @ d4c15184
- **Steps run after the patch:** Ran the exec approval followup test suite including a new test case for external channel plugins with `turnSourceTo`, `turnSourceAccountId`, and `turnSourceThreadId` set.
- **Evidence after fix:**
  ```
  $ node scripts/run-vitest.mjs run src/agents/bash-tools.exec-approval-followup.test.ts
   ✓  agents  src/agents/bash-tools.exec-approval-followup.test.ts (27 tests) 63ms
   Test Files  1 passed (1)
        Tests  27 passed (27)
  ```
- **Observed result after fix:** All 27 tests pass, including the new test verifying that `turnSourceTo`, `turnSourceAccountId`, and `turnSourceThreadId` are forwarded to the gateway agent call for external channel plugins. The `node -e` source verification confirms the old `sessionOnlyOriginChannel` ternary gate is removed and the new unconditional forwarding pattern is in place.
- **What was not tested:** Live round-trip with an actual external channel plugin (Lansenger). The fix is validated via unit tests that mock `callGatewayTool` and verify the routing arguments.
