### PR TITLE
fix(agents): fallback on embedded upstream errors

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1653,12 +1653,13 @@ function isJsonApiInternalServerError(raw: string): boolean {
   return API_ERROR_TRANSIENT_SIGNALS_RE.test(raw);
 }
 
+const STRUCTURED_SERVER_ERROR_RE = /"(?:type|code)"\s*:\s*"(?:server|upstream)_error"/i;
+
 function isStructuredServerErrorMessage(raw: string): boolean {
   if (!raw) {
     return false;
   }
-  const value = normalizeLowercaseStringOrEmpty(raw);
-  return value.includes('"type":"server_error"') || value.includes('"code":"server_error"');
+  return STRUCTURED_SERVER_ERROR_RE.test(raw);
 }
 
 export function parseImageDimensionError(raw: string): {

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -177,6 +177,19 @@ describe("server error status classification", () => {
   it("does not classify prefixed plain internal server error status prose", () => {
     expect(isServerErrorMessage("Proxy notice: Status: Internal Server Error")).toBe(false);
   });
+
+  it("classifies structured upstream_error payloads as server errors", () => {
+    const raw = JSON.stringify({
+      error: {
+        message: "Upstream request failed",
+        type: "upstream_error",
+        param: "",
+        code: null,
+      },
+    });
+
+    expect(classifyFailoverReason(raw)).toBe("server_error");
+  });
 });
 
 describe("generic assistant error text classification (#93931)", () => {

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -282,7 +282,41 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     expect(result).toBeNull();
   });
 
-  it("does not retry non-business transport error payloads", () => {
+  it("classifies upstream_error provider payloads as fallback-worthy", () => {
+    const errorText = JSON.stringify({
+      error: {
+        message: "Upstream request failed",
+        type: "upstream_error",
+        param: "",
+        code: null,
+      },
+    });
+
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "custom",
+      model: "llama-3.1",
+      result: {
+        payloads: [
+          {
+            isError: true,
+            text: errorText,
+          },
+        ],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message: `custom/llama-3.1 ended with a provider error: ${errorText}`,
+      reason: "server_error",
+      code: "embedded_error_payload",
+      rawError: errorText,
+    });
+  });
+
+  it("classifies transient transport error payloads as fallback-worthy", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "custom",
       model: "llama-3.1",
@@ -299,7 +333,12 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
       },
     });
 
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      message: "custom/llama-3.1 ended with a provider error: HTTP 500: internal server error",
+      reason: "timeout",
+      code: "embedded_error_payload",
+      rawError: "HTTP 500: internal server error",
+    });
   });
 
   it("keeps tool-authored incomplete summaries fallback-eligible", () => {

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -146,11 +146,14 @@ function classifyHarnessResult(params: {
   }
 }
 
-/** Maps provider error payloads to fallback-safe business reasons. */
-function classifyBusinessDenialErrorPayloadReason(
+/** Maps provider error payloads to reasons safe for another model attempt. */
+function classifyFallbackSafeProviderErrorPayloadReason(
   errorText: string,
   provider: string,
-): Extract<FailoverReason, "auth" | "auth_permanent" | "billing" | "rate_limit"> | null {
+): Extract<
+  FailoverReason,
+  "auth" | "auth_permanent" | "billing" | "overloaded" | "rate_limit" | "server_error" | "timeout"
+> | null {
   if (!errorText.trim()) {
     return null;
   }
@@ -159,7 +162,10 @@ function classifyBusinessDenialErrorPayloadReason(
     case "auth":
     case "auth_permanent":
     case "billing":
+    case "overloaded":
     case "rate_limit":
+    case "server_error":
+    case "timeout":
       return failoverReason;
     default:
       return null;
@@ -252,7 +258,7 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     .filter((payload) => payload?.isError === true)
     .map((payload) => (typeof payload.text === "string" ? payload.text : ""))
     .join("\n");
-  const failoverReason = classifyBusinessDenialErrorPayloadReason(errorText, params.provider);
+  const failoverReason = classifyFallbackSafeProviderErrorPayloadReason(errorText, params.provider);
   if (failoverReason) {
     return {
       message: `${params.provider}/${params.model} ended with a provider error: ${errorText}`,


### PR DESCRIPTION
Closes #95519

## What Problem This Solves

Embedded agent runs could end immediately on provider-side transient failures even when `agents.defaults.model.fallbacks` was configured. In particular, structured provider payloads such as `{"type":"upstream_error","message":"Upstream request failed"}` were surfaced as `LLM request failed` instead of advancing to the next configured fallback model.

## Why This Change Was Made

The embedded result fallback classifier already delegates provider payload text to the shared failover matcher, but it only accepted auth, billing, and rate-limit reasons. This patch lets the embedded path also treat shared transient provider reasons (`overloaded`, `server_error`, and `timeout`) as fallback-safe, while preserving the existing guards for visible output, hook blocks, replay-invalid state, committed delivery evidence, and unclassified application errors.

The shared matcher also now recognizes structured `server_error` / `upstream_error` JSON fields even when the JSON has spaces around `:` rather than the exact compact string.

## User Impact

Users with configured model fallbacks should now get the next fallback candidate for transient upstream provider failures instead of a failed turn after the primary provider returns an upstream error.

## Evidence

**Behavior addressed:** Embedded provider error payloads with `upstream_error`, HTTP 500 server errors, or existing shared transient failover classifications now produce `embedded_error_payload` fallback classifications so `runWithModelFallback` can advance to the next configured candidate.

**Real environment tested:** Local OpenClaw checkout on macOS, Node 24.16.0, using the repo vitest wrapper in this Codex worktree.

**Exact steps run after the patch:**

```bash
PATH=/Users/harjothk/.nvm/versions/node/v24.16.0/bin:$PATH node scripts/run-vitest.mjs src/agents/embedded-agent-runner/result-fallback-classifier.test.ts src/agents/embedded-agent-helpers/failover-matches.test.ts
PATH=/Users/harjothk/.nvm/versions/node/v24.16.0/bin:$PATH node scripts/run-vitest.mjs src/agents/outcome-fallback-runtime-contract.test.ts src/agents/model-fallback.test.ts
PATH=/Users/harjothk/.nvm/versions/node/v24.16.0/bin:$PATH node_modules/.bin/oxfmt --check src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-helpers/failover-matches.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
PATH=/Users/harjothk/.nvm/versions/node/v24.16.0/bin:$PATH node scripts/run-oxlint.mjs src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-helpers/failover-matches.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
git diff --check
PATH=/Users/harjothk/.nvm/versions/node/v24.16.0/bin:/Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH /Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt "Review scope: fix openclaw/openclaw#95519. This branch should only make embedded-agent provider error payloads with shared transient failover classifications (upstream_error/server_error/timeout/overloaded) trigger configured model fallback, while preserving guards for visible output, hook blocks, replay/side-effect safety, and unclassified application errors."
```

**Evidence after fix:**

- `result-fallback-classifier.test.ts` + `failover-matches.test.ts`: 49 tests passed.
- `outcome-fallback-runtime-contract.test.ts` + `model-fallback.test.ts`: 92 tests passed.
- `oxfmt --check`: all matched files use the correct format.
- `run-oxlint.mjs`: passed for the touched files.
- `git diff --check`: passed.
- `autoreview`: clean, no accepted/actionable findings reported.

**Observed result:** Structured `upstream_error` payloads classify as `server_error`, embedded provider payloads classify as `embedded_error_payload`, and existing fallback-loop tests continue to pass.

**What was not tested:** Live gateway/provider run against an actual failing upstream service. The issue is covered with source-level classifier proof and fallback-loop unit coverage.

AI-assisted: yes. This PR was implemented with Codex assistance; I reviewed the code paths, focused tests, and autoreview result before opening it.
