### PR TITLE
fix(image-generation): bound OpenAI-compatible image API response reads

### DIFF
--- a/src/image-generation/openai-compatible-image-provider.test.ts
+++ b/src/image-generation/openai-compatible-image-provider.test.ts
@@ -138,8 +138,21 @@ function mockGeneratedResponse() {
       },
     ],
   };
-  postJsonRequestMock.mockResolvedValue({ response: { json: async () => payload }, release });
-  postMultipartRequestMock.mockResolvedValue({ response: { json: async () => payload }, release });
+  const body = JSON.stringify(payload);
+  postJsonRequestMock.mockResolvedValue({
+    response: {
+      json: async () => payload,
+      arrayBuffer: async () => new TextEncoder().encode(body).buffer,
+    },
+    release,
+  });
+  postMultipartRequestMock.mockResolvedValue({
+    response: {
+      json: async () => payload,
+      arrayBuffer: async () => new TextEncoder().encode(body).buffer,
+    },
+    release,
+  });
   return release;
 }
 
@@ -249,8 +262,12 @@ describe("OpenAI-compatible image provider helper", () => {
   });
 
   it("honors default operation timeouts and empty-response errors", async () => {
+    const emptyBody = JSON.stringify({ data: [] });
     postJsonRequestMock.mockResolvedValue({
-      response: { json: async () => ({ data: [] }) },
+      response: {
+        json: async () => JSON.parse(emptyBody),
+        arrayBuffer: async () => new TextEncoder().encode(emptyBody).buffer,
+      },
       release: vi.fn(async () => {}),
     });
     const provider = createProvider({
@@ -281,8 +298,12 @@ describe("OpenAI-compatible image provider helper", () => {
   });
 
   it("wraps malformed successful image responses with provider-owned errors", async () => {
+    const malformedBody = JSON.stringify({ data: { b64_json: "not-an-array" } });
     postJsonRequestMock.mockResolvedValue({
-      response: { json: async () => ({ data: { b64_json: "not-an-array" } }) },
+      response: {
+        json: async () => JSON.parse(malformedBody),
+        arrayBuffer: async () => new TextEncoder().encode(malformedBody).buffer,
+      },
       release: vi.fn(async () => {}),
     });
     const provider = createProvider();

--- a/src/image-generation/openai-compatible-image-provider.ts
+++ b/src/image-generation/openai-compatible-image-provider.ts
@@ -1,4 +1,5 @@
 /** Factory for image providers with OpenAI-compatible generation/edit endpoints. */
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -20,6 +21,8 @@ import type {
   ImageGenerationResult,
   ImageGenerationSourceImage,
 } from "./types.js";
+
+const IMAGE_GENERATION_API_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
 // Factory for providers that expose OpenAI-style /images/generations and
 // /images/edits endpoints while still allowing provider-specific bodies.
@@ -269,13 +272,26 @@ export function createOpenAiCompatibleImageGenerationProvider(
             ? (options.failureLabels?.edit ?? `${options.label} image edit failed`)
             : (options.failureLabels?.generate ?? `${options.label} image generation failed`),
         );
-        const images = parseOpenAiCompatibleImageResponse(await response.json(), {
-          ...options.response,
-          malformedResponseError:
-            mode === "edit"
-              ? `${options.label} image edit response malformed`
-              : `${options.label} image generation response malformed`,
-        });
+        const imageBytes = await readResponseWithLimit(
+          response,
+          IMAGE_GENERATION_API_RESPONSE_MAX_BYTES,
+          {
+            onOverflow: ({ maxBytes }) =>
+              new Error(
+                `${options.label} image ${mode === "edit" ? "edit" : "generation"} response exceeds ${maxBytes} bytes`,
+              ),
+          },
+        );
+        const images = parseOpenAiCompatibleImageResponse(
+          JSON.parse(new TextDecoder().decode(imageBytes)) as unknown,
+          {
+            ...options.response,
+            malformedResponseError:
+              mode === "edit"
+                ? `${options.label} image edit response malformed`
+                : `${options.label} image generation response malformed`,
+          },
+        );
         if (images.length === 0) {
           throw new Error(
             options.emptyResponseError ??

--- a/src/image-generation/openai-compatible-image-provider.ts
+++ b/src/image-generation/openai-compatible-image-provider.ts
@@ -1,5 +1,3 @@
-/** Factory for image providers with OpenAI-compatible generation/edit endpoints. */
-import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -13,6 +11,8 @@ import {
   sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+/** Factory for image providers with OpenAI-compatible generation/edit endpoints. */
+import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import { parseOpenAiCompatibleImageResponse } from "./image-assets.js";
 import type {
   ImageGenerationProvider,
@@ -21,8 +21,6 @@ import type {
   ImageGenerationResult,
   ImageGenerationSourceImage,
 } from "./types.js";
-
-const IMAGE_GENERATION_API_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
 // Factory for providers that expose OpenAI-style /images/generations and
 // /images/edits endpoints while still allowing provider-specific bodies.
@@ -272,26 +270,18 @@ export function createOpenAiCompatibleImageGenerationProvider(
             ? (options.failureLabels?.edit ?? `${options.label} image edit failed`)
             : (options.failureLabels?.generate ?? `${options.label} image generation failed`),
         );
-        const imageBytes = await readResponseWithLimit(
-          response,
-          IMAGE_GENERATION_API_RESPONSE_MAX_BYTES,
-          {
-            onOverflow: ({ maxBytes }) =>
-              new Error(
-                `${options.label} image ${mode === "edit" ? "edit" : "generation"} response exceeds ${maxBytes} bytes`,
-              ),
-          },
-        );
-        const images = parseOpenAiCompatibleImageResponse(
-          JSON.parse(new TextDecoder().decode(imageBytes)) as unknown,
-          {
-            ...options.response,
-            malformedResponseError:
-              mode === "edit"
-                ? `${options.label} image edit response malformed`
-                : `${options.label} image generation response malformed`,
-          },
-        );
+        const label =
+          mode === "edit"
+            ? (options.failureLabels?.edit ?? `${options.label} image edit failed`)
+            : (options.failureLabels?.generate ?? `${options.label} image generation failed`);
+        const payload = await readProviderJsonResponse(response, label);
+        const images = parseOpenAiCompatibleImageResponse(payload, {
+          ...options.response,
+          malformedResponseError:
+            mode === "edit"
+              ? `${options.label} image edit response malformed`
+              : `${options.label} image generation response malformed`,
+        });
         if (images.length === 0) {
           throw new Error(
             options.emptyResponseError ??


### PR DESCRIPTION
## Summary

Replace custom `readResponseWithLimit` + `JSON.parse` with the shared `readProviderJsonResponse` from `provider-http-errors.ts` in the OpenAI-compatible image generation provider. Update test mock response objects with `arrayBuffer` so the bounded read path works in tests.

## Real behavior proof (required for external PRs)

**Behavior addressed**: Custom bounded read replaced with shared `readProviderJsonResponse`. Test mocks updated with `arrayBuffer` support.

**Real environment tested**: Linux, Node 24, OpenClaw main @ 56d95b18f4

**Exact steps or command run after fix**:

```bash
node scripts/run-vitest.mjs run src/image-generation/openai-compatible-image-provider.test.ts
```

**Evidence after fix**:

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

All 5 tests pass including:
- `generates images via JSON request body` — normal JSON path
- `generates images via multipart request body` — multipart path
- `honors default operation timeouts and empty-response errors` — edge case
- `wraps malformed successful image responses with provider-owned errors` — error wrapping preserved

Mock responses now include `arrayBuffer` alongside `json` so `readProviderJsonResponse` can read the body through `readResponseWithLimit`.

**Observed result after fix**: Image API response reads use the shared `readProviderJsonResponse` with the standard 16 MB cap. Error wrapping is preserved through the provider-owned failure label.

**What was not tested**: A live image generation API call against a real endpoint was not tested.

## Tests and validation

- `openai-compatible-image-provider.test.ts`: 5/5 passed ✅

## Risk

Low. Uses shared `readProviderJsonResponse` which is the standard bounded reader for all provider JSON responses. No custom bounded-read implementation remains.
