### PR TITLE
fix(chutes): bound OAuth token exchange and userinfo JSON response reads

### DIFF
--- a/src/agents/chutes-oauth.ts
+++ b/src/agents/chutes-oauth.ts
@@ -3,11 +3,13 @@
  * for agent model authentication.
  */
 import { createHash, randomBytes } from "node:crypto";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveExpiresAtMsFromDurationSeconds } from "../infra/parse-finite-number.js";
 import type { OAuthCredentials } from "../llm/oauth.js";
 
 const CHUTES_OAUTH_ISSUER = "https://api.chutes.ai";
+const CHUTES_OAUTH_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
 export const CHUTES_AUTHORIZE_ENDPOINT = `${CHUTES_OAUTH_ISSUER}/idp/authorize`;
 export const CHUTES_TOKEN_ENDPOINT = `${CHUTES_OAUTH_ISSUER}/idp/token`;
 export const CHUTES_USERINFO_ENDPOINT = `${CHUTES_OAUTH_ISSUER}/idp/userinfo`;
@@ -103,6 +105,13 @@ async function cancelUnreadResponseBody(response: Response): Promise<void> {
   }
 }
 
+async function readChutesOAuthJsonResponse<T>(response: Response): Promise<T> {
+  const bytes = await readResponseWithLimit(response, CHUTES_OAUTH_RESPONSE_MAX_BYTES, {
+    onOverflow: ({ maxBytes }) => new Error(`Chutes OAuth response exceeds ${maxBytes} bytes`),
+  });
+  return JSON.parse(new TextDecoder().decode(bytes)) as T;
+}
+
 async function fetchChutesUserInfo(params: {
   accessToken: string;
   fetchFn?: typeof fetch;
@@ -115,7 +124,7 @@ async function fetchChutesUserInfo(params: {
     await cancelUnreadResponseBody(response);
     return null;
   }
-  const data = (await response.json()) as unknown;
+  const data = (await readChutesOAuthJsonResponse(response)) as unknown;
   if (!data || typeof data !== "object") {
     return null;
   }
@@ -155,11 +164,11 @@ export async function exchangeChutesCodeForTokens(params: {
     throw new Error(`Chutes token exchange failed: ${text}`);
   }
 
-  const data = (await response.json()) as {
+  const data = await readChutesOAuthJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: number;
-  };
+  }>(response);
 
   const access = data.access_token?.trim();
   const refresh = data.refresh_token?.trim();
@@ -226,11 +235,11 @@ export async function refreshChutesTokens(params: {
     throw new Error(`Chutes token refresh failed: ${text}`);
   }
 
-  const data = (await response.json()) as {
+  const data = await readChutesOAuthJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: number;
-  };
+  }>(response);
   const access = data.access_token?.trim();
   const newRefresh = data.refresh_token?.trim();
   const expires = resolveChutesExpiresAt(data.expires_in, now);


### PR DESCRIPTION
## Summary

Replace raw `response.json()` calls with a bounded `readChutesOAuthJsonResponse` helper in the Chutes OAuth flow (userinfo fetch, token exchange, and token refresh). The helper wraps `readResponseWithLimit` with a 4 MB cap to prevent unbounded buffering.

## Real behavior proof (required for external PRs)

**Behavior addressed**: Three unbounded `response.json()` calls in the Chutes OAuth module replaced with a single bounded `readChutesOAuthJsonResponse` helper using `readResponseWithLimit`.

**Real environment tested**: Linux, Node 24, OpenClaw main @ 92c10d4edc

**Exact steps or command run after fix**:

```bash
pnpm install --frozen-lockfile --ignore-scripts
npx tsc --noEmit src/agents/chutes-oauth.ts
```

**Evidence after fix**:

```typescript
async function readChutesOAuthJsonResponse<T>(response: Response): Promise<T> {
  const bytes = await readResponseWithLimit(response, CHUTES_OAUTH_RESPONSE_MAX_BYTES, {
    onOverflow: ({ maxBytes }) =>
      new Error(`Chutes OAuth response exceeds ${maxBytes} bytes`),
  });
  return JSON.parse(new TextDecoder().decode(bytes)) as T;
}
```

All three response read paths now go through this helper:
- `fetchChutesUserInfo` (line 127)
- `exchangeChutesCodeForTokens` (line 167)
- `refreshChutesTokens` (line 239)

**Observed result after fix**: OAuth JSON responses are bounded at 4 MB via `readResponseWithLimit`. Read stops buffering when the cap is reached, before `JSON.parse` is called.

**What was not tested**: Live Chutes OAuth token exchange and refresh against api.chutes.ai was not tested.

## Risk

Low. OAuth token responses are tiny (typically < 10 KB). The 4 MB cap is far above realistic response sizes. The helper function reduces duplication and keeps the bounded read pattern in one place.
