### PR TITLE
fix(acp-core): never return undefined from stringifyNonErrorCause

### DIFF
--- a/packages/acp-core/src/error-format.test.ts
+++ b/packages/acp-core/src/error-format.test.ts
@@ -1,0 +1,19 @@
+// Error-format helper tests cover the non-Error cause stringifier contract.
+import { describe, expect, it } from "vitest";
+import { stringifyNonErrorCause } from "./error-format.js";
+
+describe("stringifyNonErrorCause", () => {
+  it("returns a string for values JSON.stringify serializes to undefined", () => {
+    // JSON.stringify(fn|symbol|undefined) is undefined; the `string`-typed helper must not leak it.
+    expect(stringifyNonErrorCause(() => {})).toBe("[object Function]");
+    expect(stringifyNonErrorCause(Symbol("x"))).toBe("[object Symbol]");
+    expect(stringifyNonErrorCause(undefined)).toBe("[object Undefined]");
+  });
+
+  it("stringifies ordinary scalar and object causes", () => {
+    expect(stringifyNonErrorCause({ a: 1 })).toBe('{"a":1}');
+    expect(stringifyNonErrorCause("hi")).toBe("hi");
+    expect(stringifyNonErrorCause(42)).toBe("42");
+    expect(stringifyNonErrorCause(null)).toBe("null");
+  });
+});

--- a/packages/acp-core/src/error-format.ts
+++ b/packages/acp-core/src/error-format.ts
@@ -75,7 +75,9 @@ export function stringifyNonErrorCause(value: unknown): string {
     return String(value);
   }
   try {
-    return JSON.stringify(value);
+    // JSON.stringify returns undefined (not a string) for functions/symbols/undefined; fall back to
+    // a tag string so this `string`-typed helper never leaks undefined (matches src/infra/errors.ts).
+    return JSON.stringify(value) ?? Object.prototype.toString.call(value);
   } catch {
     return Object.prototype.toString.call(value);
   }


### PR DESCRIPTION
## Summary

`stringifyNonErrorCause` (`packages/acp-core/src/error-format.ts`) is declared to return `string`, but its `try` body returned `JSON.stringify(value)` directly. `JSON.stringify` returns **`undefined`** (not a string) for functions, symbols, and `undefined`, so the helper leaked `undefined` to callers that format nested ACP runtime failure causes and rely on a string (concatenation, `.length`, etc.).

The sibling helper at `src/infra/errors.ts` already guards this exact case with `?? Object.prototype.toString.call(value)`; this aligns acp-core with it.

### Changes
- `error-format.ts` — `return JSON.stringify(value) ?? Object.prototype.toString.call(value);`.
- `error-format.test.ts` — new colocated test that a function/symbol/undefined cause yields a string, and ordinary causes are unchanged.

## Real behavior proof

Behavior addressed: a non-Error cause that `JSON.stringify` cannot serialize (function/symbol/undefined) made `stringifyNonErrorCause` return `undefined` despite its `string` type. After the fix it returns a tag string; ordinary causes are unchanged.

Real environment tested: Node 22.22.1, macOS, no network/model. Vitest exercises the real exported `stringifyNonErrorCause` with constructed inputs. BEFORE is `origin/main`'s `error-format.ts` (swapped in via `git show`).

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs packages/acp-core/src/error-format.test.ts
```

Evidence after fix:
```
stringifyNonErrorCause(() => {})      BEFORE: undefined   AFTER: "[object Function]"
stringifyNonErrorCause(Symbol("x"))   BEFORE: undefined   AFTER: "[object Symbol]"
stringifyNonErrorCause(undefined)     BEFORE: undefined   AFTER: "[object Undefined]"
stringifyNonErrorCause({ a: 1 })      BOTH: '{"a":1}'     (unchanged)
```

Observed result after fix: the three unserializable causes now return a string instead of `undefined`; object/string/number/null causes are byte-identical. The new test fails on `origin/main` and passes after.

What was not tested: end-to-end ACP runtime failure formatting (the test drives the real exported helper that those paths call). No other behavior is touched.

## Additional checks
- `node scripts/run-vitest.mjs packages/acp-core/src/error-format.test.ts` passes; fail-before verified by swapping in `origin/main`'s file. `oxlint --tsconfig` clean.
