### PR TITLE
docs(media): clarify legacy MEDIA line formatting

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -9153,6 +9153,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /reference/rich-output-protocol
 - Headings:
   - H2: Media attachments
+  - H2: Legacy MEDIA: lines
   - H2: `[embed ...]`
   - H2: Stored rendering shape
   - H2: Related

--- a/docs/reference/rich-output-protocol.md
+++ b/docs/reference/rich-output-protocol.md
@@ -31,7 +31,34 @@ Do not emit text commands for attachments from tools, plugins, streaming blocks,
 Legacy final-reply text may still be normalized for compatibility, but this is not a general plugin/tool protocol.
 </Warning>
 
-Plain Markdown image syntax (`![alt](url)`) stays text by default. Channels that want Markdown images treated as media replies opt in at their outbound adapter; Telegram does this so `![alt](url)` becomes a media attachment.
+### Legacy `MEDIA:` lines
+
+Legacy final assistant replies can still attach local media with a plain
+standalone `MEDIA:` line. The parser only recognizes lines whose trimmed text
+starts with `MEDIA:` outside Markdown wrappers and code fences.
+
+Valid legacy final reply:
+
+```text
+Here is the generated image.
+
+MEDIA:/workspace/image.png
+```
+
+These remain ordinary text and do not attach media:
+
+```text
+**MEDIA:/workspace/image.png**
+`MEDIA:/workspace/image.png`
+Here is your image: MEDIA:/workspace/image.png
+```
+
+Prefer structured `mediaUrl` / `mediaUrls` fields for tools, plugins, browser
+output, streaming blocks, and message actions.
+
+Plain Markdown image syntax stays text by default. Channels that intentionally
+map Markdown image replies to media attachments opt in at their outbound
+adapter; Telegram does this so `![alt](url)` can still become a media reply.
 
 When block streaming is enabled, media must ride on structured payload fields. If the same media URL appears in a streamed block and again in the final assistant payload, OpenClaw delivers it once and strips the duplicate from the final payload.
 

--- a/docs/reference/rich-output-protocol.md
+++ b/docs/reference/rich-output-protocol.md
@@ -31,7 +31,7 @@ Do not emit text commands for attachments from tools, plugins, streaming blocks,
 Legacy final-reply text may still be normalized for compatibility, but this is not a general plugin/tool protocol.
 </Warning>
 
-### Legacy `MEDIA:` lines
+## Legacy `MEDIA:` lines
 
 Legacy final assistant replies can still attach local media with a plain
 standalone `MEDIA:` line. The parser only recognizes lines whose trimmed text

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -212,6 +212,12 @@ Outbound attachments from the agent use structured media fields on the message t
 
 OpenClaw sends structured media alongside the text. Legacy final assistant replies may still be normalized for compatibility, but tool output, browser output, streaming blocks, and message actions do not parse text as attachment commands.
 
+If you must use a legacy final-reply `MEDIA:` line, keep it as standalone plain
+text. Markdown wrappers, code fences, and inline prose such as
+`**MEDIA:/path.png**`, `` `MEDIA:/path.png` ``, or
+`Here is the image: MEDIA:/path.png` stay text and do not attach media. See
+[Rich output protocol](/reference/rich-output-protocol#legacy-media-lines).
+
 Local-path behavior follows the same file-read trust model as the agent:
 
 - If `tools.fs.workspaceOnly` is `true`, outbound local media paths stay restricted to the OpenClaw temp root, the media cache, agent workspace paths, and sandbox-generated files.


### PR DESCRIPTION
Restored replacement for #94436 after the fork/head repository was recreated.

## Summary
- Document that legacy final-reply `MEDIA:` attachments must be standalone plain-text lines.
- Add valid and invalid examples for Markdown-wrapped or inline `MEDIA:` text.
- Add a short start-page warning with a link to the rich output protocol details.

Fixes #78495.

## Verification

- `node scripts/format-docs.mjs --check`
- `node scripts/check-docs-mdx.mjs docs README.md`
- `node scripts/docs-list.js`
- `git diff --check origin/main...HEAD`

## Real behavior proof

Behavior addressed: Readers of the OpenClaw docs can now see that legacy final-reply `MEDIA:` attachments are only recognized when emitted as standalone plain-text lines, and that Markdown-wrapped or inline `MEDIA:` examples are invalid.

Real environment tested: Local full OpenClaw checkout on PR branch `codex/media-directive-docs-78495-reopen-20260618`, using the repository documentation scripts directly against the docs tree after the patch.

Exact steps or command run after this patch:

```text
node scripts/format-docs.mjs --check
node scripts/check-docs-mdx.mjs docs README.md
node scripts/docs-list.js
git diff --check origin/main...HEAD
```

Evidence after fix: Terminal capture from the local documentation checks showed the patched documentation renders as valid formatted docs and remains in the generated docs listing:

```text
Docs formatting clean (664 files).
Docs MDX check passed (679 files, 1789ms).
Listing all markdown files in docs folder:
...
reference/rich-output-protocol.md - Rich output protocol for structured media, embeds, audio hints, and replies
...
start/openclaw.md - End-to-end guide for running OpenClaw as a personal assistant with safety cautions
...
Reminder: keep docs up to date as behavior changes.
```

Observed result after fix: The docs formatter reported a clean tree, the MDX checker passed across the docs and README set, `docs-list` included the changed docs pages, and `git diff --check origin/main...HEAD` produced no whitespace or conflict-marker output.

What was not tested: A packaged docs-site build was not started in this environment; this PR changes only Markdown documentation and was validated with the repository docs format, MDX, listing, and diff checks.

---
Reopened after active-PR limit cleanup. Supersedes closed PR #94389.


## What Problem This Solves
Readers need to know that legacy final-reply `MEDIA:` attachments are parsed only when emitted as standalone plain-text lines. Without that clarification, examples that wrap `MEDIA:` in Markdown or place it inline can look valid while failing the legacy parser behavior.

## Evidence
The repository documentation checks passed after the docs update: `node scripts/format-docs.mjs --check`, `node scripts/check-docs-mdx.mjs docs README.md`, `node scripts/docs-list.js`, and `git diff --check origin/main...HEAD`. The detailed terminal output is included in the Real behavior proof section above. A packaged docs-site build was not started locally.
