### PR TITLE
feat(reply): annotate recent history images with thread context

### DIFF
--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -932,6 +932,23 @@ describe("tryDispatchAcpReply", () => {
     expect(text).not.toContain("/tmp/secret.png");
   });
 
+  it("omits invalid recent history image timestamps", () => {
+    const text = appendRecentHistoryImageContext({
+      promptText: "what is this?",
+      images: [
+        {
+          path: "/tmp/secret.png",
+          contentType: "image/png",
+          sender: "@alice",
+          timestampMs: Number.MAX_VALUE,
+        },
+      ],
+    });
+
+    expect(text).toContain("Recent image 1 from @alice, attached as media.");
+    expect(text).not.toContain("sent");
+  });
+
   it("forwards recent history image attachments into agent runtime turns", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dispatch-acp-history-"));
     const imagePath = path.join(tempDir, "recent.png");

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -875,24 +875,36 @@ describe("tryDispatchAcpReply", () => {
         contentType: "image/png",
         sender: "Recent 2",
         messageId: "recent-2",
+        timestampMs: now - 3_000,
+        historyPosition: 6,
+        historyTotal: 9,
       },
       {
         path: "/tmp/recent-3.png",
         contentType: "image/png",
         sender: "Recent 3",
         messageId: "recent-3",
+        timestampMs: now - 2_000,
+        historyPosition: 7,
+        historyTotal: 9,
       },
       {
         path: "/tmp/recent-4.png",
         contentType: "image/png",
         sender: "Recent 4",
         messageId: "recent-4",
+        timestampMs: now - 1_000,
+        historyPosition: 8,
+        historyTotal: 9,
       },
       {
         path: "C:\\Users\\Alice\\Pictures\\recent.png",
         contentType: "image/png",
         sender: "Windows",
         messageId: "windows",
+        timestampMs: now - 500,
+        historyPosition: 9,
+        historyTotal: 9,
       },
     ]);
   });
@@ -906,12 +918,17 @@ describe("tryDispatchAcpReply", () => {
           contentType: "image/png",
           sender: "@alice",
           messageId: "msg-1",
+          timestampMs: 1_700_000_000_000,
+          historyPosition: 2,
+          historyTotal: 4,
         },
       ],
     });
 
     expect(text).toContain("what is this?");
     expect(text).toContain("Recent image 1 from @alice, message msg-1");
+    expect(text).toContain("sent 2023-11-14T22:13:20.000Z");
+    expect(text).toContain("message 2 of 4 in thread");
     expect(text).not.toContain("/tmp/secret.png");
   });
 

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -985,6 +985,9 @@ describe("tryDispatchAcpReply", () => {
           contentType: "image/png",
           sender: "@alice",
           messageId: "msg-1",
+          timestampMs: 1_700_000_000_000,
+          historyPosition: 1,
+          historyTotal: 1,
         },
       ]);
     } finally {
@@ -1229,6 +1232,9 @@ describe("tryDispatchAcpReply", () => {
           contentType: "image/png",
           sender: "@alice",
           messageId: "msg-history",
+          timestampMs: 1_700_000_000_000,
+          historyPosition: 1,
+          historyTotal: 1,
         },
       ]);
     } finally {

--- a/src/auto-reply/reply/history-media.ts
+++ b/src/auto-reply/reply/history-media.ts
@@ -13,6 +13,9 @@ export type RecentInboundHistoryImage = {
   contentType: string;
   sender: string;
   messageId?: string;
+  timestampMs?: number;
+  historyPosition?: number;
+  historyTotal?: number;
 };
 
 function isRemotePath(value: string): boolean {
@@ -100,6 +103,9 @@ export function resolveRecentInboundHistoryImages(params: {
         path: mediaPath,
         contentType,
         sender: entry.sender,
+        timestampMs: timestamp,
+        historyPosition: index + 1,
+        historyTotal: entries.length,
         ...(messageId ? { messageId } : {}),
       });
     }
@@ -116,7 +122,14 @@ export function appendRecentHistoryImageContext(params: {
   }
   const notes = params.images.map((image, index) => {
     const message = image.messageId ? `, message ${image.messageId}` : "";
-    return `[Recent image ${index + 1} from ${image.sender}${message}, attached as media.]`;
+    const sentAt =
+      image.timestampMs === undefined ? "" : `, sent ${new Date(image.timestampMs).toISOString()}`;
+    const position =
+      image.historyPosition === undefined || image.historyTotal === undefined
+        ? ""
+        : `, message ${image.historyPosition} of ${image.historyTotal} in thread`;
+    const context = `${message}${sentAt}${position}`;
+    return `[Recent image ${index + 1} from ${image.sender}${context}, attached as media.]`;
   });
   return [params.promptText, notes.join("\n")]
     .filter((part) => part.trim().length > 0)

--- a/src/auto-reply/reply/history-media.ts
+++ b/src/auto-reply/reply/history-media.ts
@@ -53,6 +53,17 @@ function resolveHistoryEntries(ctx: MsgContext): HistoryEntry[] {
   return Array.isArray(ctx.InboundHistory) ? ctx.InboundHistory : [];
 }
 
+function formatHistoryImageTimestamp(timestampMs: number | undefined): string {
+  if (timestampMs === undefined) {
+    return "";
+  }
+  const date = new Date(timestampMs);
+  if (!Number.isFinite(date.getTime())) {
+    return "";
+  }
+  return `, sent ${date.toISOString()}`;
+}
+
 export function resolveRecentInboundHistoryImages(params: {
   ctx: MsgContext;
   nowMs?: number;
@@ -122,8 +133,7 @@ export function appendRecentHistoryImageContext(params: {
   }
   const notes = params.images.map((image, index) => {
     const message = image.messageId ? `, message ${image.messageId}` : "";
-    const sentAt =
-      image.timestampMs === undefined ? "" : `, sent ${new Date(image.timestampMs).toISOString()}`;
+    const sentAt = formatHistoryImageTimestamp(image.timestampMs);
     const position =
       image.historyPosition === undefined || image.historyTotal === undefined
         ? ""


### PR DESCRIPTION
Restored replacement for #94388 after the fork/head repository was recreated.

## Summary

- Carry timestamp and bounded thread position metadata on recent inbound history images.
- Add those details to the prompt-side recent image note without exposing local file paths.
- Extend and fix existing ACP history-image tests to cover sent-time and message-position annotations.

Fixes #48321.

## Verification

- `node scripts/run-vitest.mjs run src/auto-reply/reply/dispatch-acp.test.ts src/auto-reply/reply/history.test.ts --reporter=verbose`
- `git diff --check origin/main...HEAD`

## Real behavior proof

Behavior addressed: Recent inbound history images passed into an ACP reply turn now include timestamp and bounded thread-position context in the agent-facing prompt note, without exposing local media paths.

Real environment tested: Local full OpenClaw checkout on PR branch `codex/history-image-context-metadata-48321-20260618`, exercising ACP reply dispatch and recent history image selection through the repository auto-reply and unit-fast Vitest harnesses after the patch.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs run src/auto-reply/reply/dispatch-acp.test.ts src/auto-reply/reply/history.test.ts --reporter=verbose
git diff --check origin/main...HEAD
```

Evidence after fix: Terminal capture from the focused history-image run showed the changed ACP prompt/context paths passing:

```text
✓ |unit-fast| src/auto-reply/reply/history.test.ts > history media recording > keeps only bounded local image media
✓ |auto-reply| src/auto-reply/reply/dispatch-acp.test.ts > tryDispatchAcpReply > selects bounded recent local history images
✓ |auto-reply| src/auto-reply/reply/dispatch-acp.test.ts > tryDispatchAcpReply > adds recent history image context without exposing paths
✓ |auto-reply| src/auto-reply/reply/dispatch-acp.test.ts > tryDispatchAcpReply > forwards recent history image attachments into agent runtime turns
✓ |auto-reply| src/auto-reply/reply/dispatch-acp.test.ts > tryDispatchAcpReply > falls back to recent history images when current image attachments are unusable

Test Files  2 passed (2)
Tests  56 passed (56)
[test] passed 2 Vitest shards in 6.33s
```

Observed result after fix: The focused tests verify recent local history images remain bounded, the ACP prompt note includes the new recent-image context without local paths, the attachment path still reaches agent runtime turns, and exact recentHistoryImages assertions pass with the new metadata shape. `git diff --check origin/main...HEAD` produced no output.

What was not tested: A live Slack, Discord, or Telegram thread with real channel credentials was not started in this environment; the focused ACP dispatch/history tests exercise the changed prompt-side metadata projection without external messaging credentials.


## What Problem This Solves
Recent inbound history images passed into ACP reply turns lacked timestamp and bounded thread-position context in the prompt note. The agent could receive images without enough safe context to understand when and where they appeared, while local media paths still needed to remain hidden.

## Evidence
Focused ACP/history tests passed after the change: `node scripts/run-vitest.mjs run src/auto-reply/reply/dispatch-acp.test.ts src/auto-reply/reply/history.test.ts --reporter=verbose`, plus `git diff --check origin/main...HEAD`. The Real behavior proof section includes the passing tests that verify bounded history-image metadata, prompt context without local paths, runtime attachment forwarding, and fallback behavior. No live Slack, Discord, or Telegram thread was started locally.
