### PR TITLE
fix(line): preserve URL action data in confirm directives past the scheme colon

### DIFF
--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -153,6 +153,34 @@ describe("parseLineDirectives", () => {
           },
           expectedText: undefined,
         },
+        {
+          name: "url action data preserved past the scheme colon",
+          text: "[[confirm: Open this? | Open:https://example.com/path?q=1 | Cancel]]",
+          expectedTemplate: {
+            type: "confirm",
+            text: "Open this?",
+            confirmLabel: "Open",
+            confirmData: "https://example.com/path?q=1",
+            cancelLabel: "Cancel",
+            cancelData: "cancel",
+            altText: "Open this?",
+          },
+          expectedText: undefined,
+        },
+        {
+          name: "bare url action data keeps its original case",
+          text: "[[confirm: Open? | https://Example.com/Path?Q=1 | Cancel]]",
+          expectedTemplate: {
+            type: "confirm",
+            text: "Open?",
+            confirmLabel: "https://Example.com/Path?Q=1",
+            confirmData: "https://Example.com/Path?Q=1",
+            cancelLabel: "Cancel",
+            cancelData: "cancel",
+            altText: "Open?",
+          },
+          expectedText: undefined,
+        },
       ] as const;
 
       for (const testCase of cases) {

--- a/extensions/line/src/reply-payload-transform.ts
+++ b/extensions/line/src/reply-payload-transform.ts
@@ -85,12 +85,22 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
     const parts = confirmMatch[1].split("|").map((s) => s.trim());
     if (parts.length >= 3) {
       const [question, yesPart, noPart] = parts;
-      const [yesLabel, yesData] = yesPart.includes(":")
-        ? yesPart.split(":").map((s) => s.trim())
-        : [yesPart, normalizeLowercaseStringOrEmpty(yesPart)];
-      const [noLabel, noData] = noPart.includes(":")
-        ? noPart.split(":").map((s) => s.trim())
-        : [noPart, normalizeLowercaseStringOrEmpty(noPart)];
+      // A confirm segment is `label:data`, but the data may itself be a URL ("Open:https://x?q=1").
+      // Split on the FIRST colon only, and treat a bare URL (or a segment with no colon) as having
+      // no separator. Plain split(":") truncated URL data at the scheme colon (data became "https").
+      const splitLabelData = (part: string): [string, string] => {
+        const lower = normalizeLowercaseStringOrEmpty(part);
+        const isUrl = lower.startsWith("http://") || lower.startsWith("https://");
+        const colonIndex = part.indexOf(":");
+        if (colonIndex === -1 || isUrl) {
+          // A bare URL is its own data and must NOT be lowercased (paths/queries are case-sensitive);
+          // a non-URL no-separator segment keeps the existing lowercased-postback behavior.
+          return [part, isUrl ? part : normalizeLowercaseStringOrEmpty(part)];
+        }
+        return [part.slice(0, colonIndex).trim(), part.slice(colonIndex + 1).trim()];
+      };
+      const [yesLabel, yesData] = splitLabelData(yesPart);
+      const [noLabel, noData] = splitLabelData(noPart);
 
       lineData.templateMessage = {
         type: "confirm",


### PR DESCRIPTION
## Summary

The `[[confirm: ...]]` directive parser in `extensions/line/src/reply-payload-transform.ts` split each `label:data` action segment with `yesPart.split(":")`. When the data is a URL (e.g. `Open:https://example.com/path?q=1`), `split(":")` breaks on the scheme colon too, so the destructured `[label, data]` kept only `["Open", "https"]` — `confirmData`/`cancelData` was truncated to `"https"`, dropping the real URL. The sibling `[[buttons: ...]]` parser already splits URL-aware (first colon + `http(s)://` guard); confirm did not.

### Changes
- `reply-payload-transform.ts` — parse confirm `label:data` with a first-colon split that treats a bare URL (or no-colon segment) as having no separator, preserving the full URL data. Default yes/no and `label:data` (e.g. `OK:action=confirm`) behavior is unchanged.
- `reply-payload-transform.test.ts` — added a confirm case with URL action data.

## Real behavior proof

Behavior addressed: a confirm directive whose action data is a URL had that URL truncated at `https`. After the fix the full URL is preserved.

Real environment tested: Node 22.22.1, macOS, no network/model. Vitest exercises the real exported `parseLineDirectives`. BEFORE is `origin/main`'s file (swapped via `git show`).

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs extensions/line/src/reply-payload-transform.test.ts
```

Evidence after fix:
```
input: "[[confirm: Open this? | Open:https://example.com/path?q=1 | Cancel]]"
BEFORE: confirmLabel="Open"  confirmData="https"                          (URL truncated)
AFTER:  confirmLabel="Open"  confirmData="https://example.com/path?q=1"   (URL preserved)
existing: "OK:action=confirm" -> "action=confirm", "Yes" -> "yes"          (unchanged)
```

Observed result after fix: confirm URL data survives; the existing label:data and default yes/no cases are unchanged. The new test fails on `origin/main` and passes after.

What was not tested: a live LINE template send (the test drives the real `parseLineDirectives`). The full existing suite stays green.

## Additional checks
- `node scripts/run-vitest.mjs extensions/line/src/reply-payload-transform.test.ts` passes; fail-before verified by swapping in `origin/main`'s file. Extension `oxlint` clean.
