### PR TITLE
feat(xiaomi): expose MiMo V2.5 on pay-as-you-go and default to mimo-v2.5

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -280,26 +280,26 @@ messages and normalizes `stats.cached` into `cacheRead`; legacy
 
 ### Other bundled provider plugins
 
-| Provider                                | Id                               | Auth env                                             | Example model                                              |
-| --------------------------------------- | -------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------- |
-| BytePlus                                | `byteplus` / `byteplus-plan`     | `BYTEPLUS_API_KEY`                                   | `byteplus-plan/ark-code-latest`                            |
-| Cohere                                  | `cohere`                         | `COHERE_API_KEY`                                     | `cohere/command-a-03-2025`                                 |
-| GitHub Copilot                          | `github-copilot`                 | `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` | -                                                          |
-| Hugging Face Inference                  | `huggingface`                    | `HUGGINGFACE_HUB_TOKEN` or `HF_TOKEN`                | `huggingface/deepseek-ai/DeepSeek-R1`                      |
-| MiniMax                                 | `minimax` / `minimax-portal`     | `MINIMAX_API_KEY` / `MINIMAX_OAUTH_TOKEN`            | `minimax/MiniMax-M3`                                       |
-| Mistral                                 | `mistral`                        | `MISTRAL_API_KEY`                                    | `mistral/mistral-large-latest`                             |
-| Moonshot                                | `moonshot`                       | `MOONSHOT_API_KEY`                                   | `moonshot/kimi-k2.6`                                       |
-| NVIDIA                                  | `nvidia`                         | `NVIDIA_API_KEY`                                     | `nvidia/nvidia/nemotron-3-ultra-550b-a55b`                 |
-| NovitaAI                                | `novita`                         | `NOVITA_API_KEY`                                     | `novita/deepseek/deepseek-v3-0324`                         |
-| [Ollama Cloud](/providers/ollama-cloud) | `ollama-cloud`                   | `OLLAMA_API_KEY`                                     | `ollama-cloud/kimi-k2.6`                                   |
-| OpenRouter                              | `openrouter`                     | OpenRouter OAuth or `OPENROUTER_API_KEY`             | `openrouter/auto`                                          |
-| [Qwen OAuth](/providers/qwen-oauth)     | `qwen-oauth`                     | `QWEN_API_KEY`                                       | `qwen-oauth/qwen3.5-plus`                                  |
-| Together                                | `together`                       | `TOGETHER_API_KEY`                                   | `together/meta-llama/Llama-3.3-70B-Instruct-Turbo`         |
-| Venice                                  | `venice`                         | `VENICE_API_KEY`                                     | -                                                          |
-| Vercel AI Gateway                       | `vercel-ai-gateway`              | `AI_GATEWAY_API_KEY`                                 | `vercel-ai-gateway/anthropic/claude-opus-4.6`              |
-| Volcano Engine (Doubao)                 | `volcengine` / `volcengine-plan` | `VOLCANO_ENGINE_API_KEY`                             | `volcengine-plan/ark-code-latest`                          |
-| xAI                                     | `xai`                            | SuperGrok/X Premium OAuth or `XAI_API_KEY`           | `xai/grok-4.3`                                             |
-| Xiaomi                                  | `xiaomi` / `xiaomi-token-plan`   | `XIAOMI_API_KEY` / `XIAOMI_TOKEN_PLAN_API_KEY`       | `xiaomi/mimo-v2-flash` / `xiaomi-token-plan/mimo-v2.5-pro` |
+| Provider                                | Id                               | Auth env                                             | Example model                                      |
+| --------------------------------------- | -------------------------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| BytePlus                                | `byteplus` / `byteplus-plan`     | `BYTEPLUS_API_KEY`                                   | `byteplus-plan/ark-code-latest`                    |
+| Cohere                                  | `cohere`                         | `COHERE_API_KEY`                                     | `cohere/command-a-03-2025`                         |
+| GitHub Copilot                          | `github-copilot`                 | `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` | -                                                  |
+| Hugging Face Inference                  | `huggingface`                    | `HUGGINGFACE_HUB_TOKEN` or `HF_TOKEN`                | `huggingface/deepseek-ai/DeepSeek-R1`              |
+| MiniMax                                 | `minimax` / `minimax-portal`     | `MINIMAX_API_KEY` / `MINIMAX_OAUTH_TOKEN`            | `minimax/MiniMax-M3`                               |
+| Mistral                                 | `mistral`                        | `MISTRAL_API_KEY`                                    | `mistral/mistral-large-latest`                     |
+| Moonshot                                | `moonshot`                       | `MOONSHOT_API_KEY`                                   | `moonshot/kimi-k2.6`                               |
+| NVIDIA                                  | `nvidia`                         | `NVIDIA_API_KEY`                                     | `nvidia/nvidia/nemotron-3-ultra-550b-a55b`         |
+| NovitaAI                                | `novita`                         | `NOVITA_API_KEY`                                     | `novita/deepseek/deepseek-v3-0324`                 |
+| [Ollama Cloud](/providers/ollama-cloud) | `ollama-cloud`                   | `OLLAMA_API_KEY`                                     | `ollama-cloud/kimi-k2.6`                           |
+| OpenRouter                              | `openrouter`                     | OpenRouter OAuth or `OPENROUTER_API_KEY`             | `openrouter/auto`                                  |
+| [Qwen OAuth](/providers/qwen-oauth)     | `qwen-oauth`                     | `QWEN_API_KEY`                                       | `qwen-oauth/qwen3.5-plus`                          |
+| Together                                | `together`                       | `TOGETHER_API_KEY`                                   | `together/meta-llama/Llama-3.3-70B-Instruct-Turbo` |
+| Venice                                  | `venice`                         | `VENICE_API_KEY`                                     | -                                                  |
+| Vercel AI Gateway                       | `vercel-ai-gateway`              | `AI_GATEWAY_API_KEY`                                 | `vercel-ai-gateway/anthropic/claude-opus-4.6`      |
+| Volcano Engine (Doubao)                 | `volcengine` / `volcengine-plan` | `VOLCANO_ENGINE_API_KEY`                             | `volcengine-plan/ark-code-latest`                  |
+| xAI                                     | `xai`                            | SuperGrok/X Premium OAuth or `XAI_API_KEY`           | `xai/grok-4.3`                                     |
+| Xiaomi                                  | `xiaomi` / `xiaomi-token-plan`   | `XIAOMI_API_KEY` / `XIAOMI_TOKEN_PLAN_API_KEY`       | `xiaomi/mimo-v2.5` / `xiaomi-token-plan/mimo-v2.5` |
 
 #### Quirks worth knowing
 

--- a/docs/providers/xiaomi.md
+++ b/docs/providers/xiaomi.md
@@ -23,7 +23,7 @@ The same plugin also registers the `xiaomi` speech (TTS) provider.
 | Contracts        | chat completions + `speechProviders`                                                                                                               |
 | API              | OpenAI-compatible (`openai-completions`)                                                                                                           |
 | Base URLs        | Pay-as-you-go: `https://api.xiaomimimo.com/v1`; Token Plan presets: `token-plan-{cn,sgp,ams}...`                                                   |
-| Default models   | `xiaomi/mimo-v2-flash`, `xiaomi-token-plan/mimo-v2.5-pro`                                                                                          |
+| Default models   | `xiaomi/mimo-v2.5`, `xiaomi-token-plan/mimo-v2.5`                                                                                                  |
 | TTS default      | `mimo-v2.5-tts`, voice `mimo_default`; voicedesign model `mimo-v2.5-tts-voicedesign`                                                               |
 
 ## Getting started
@@ -64,15 +64,21 @@ The same plugin also registers the `xiaomi` speech (TTS) provider.
 
 ## Pay-as-you-go catalog
 
-| Model ref              | Input       | Context   | Max output | Reasoning | Notes         |
-| ---------------------- | ----------- | --------- | ---------- | --------- | ------------- |
-| `xiaomi/mimo-v2-flash` | text        | 262,144   | 8,192      | No        | Default model |
-| `xiaomi/mimo-v2-pro`   | text        | 1,048,576 | 32,000     | Yes       | Large context |
-| `xiaomi/mimo-v2-omni`  | text, image | 262,144   | 32,000     | Yes       | Multimodal    |
+| Model ref              | Input       | Context   | Max output | Reasoning | Notes                             |
+| ---------------------- | ----------- | --------- | ---------- | --------- | --------------------------------- |
+| `xiaomi/mimo-v2.5-pro` | text        | 1,048,576 | 131,072    | Yes       | Reasoning flagship (text)         |
+| `xiaomi/mimo-v2.5`     | text, image | 1,048,576 | 131,072    | Yes       | Default model, multimodal         |
+| `xiaomi/mimo-v2-flash` | text        | 262,144   | 8,192      | No        | Legacy                            |
+| `xiaomi/mimo-v2-pro`   | text        | 1,048,576 | 32,000     | Yes       | Legacy, large context             |
+| `xiaomi/mimo-v2-omni`  | text, image | 262,144   | 32,000     | Yes       | Legacy, superseded by `mimo-v2.5` |
 
 <Tip>
-The default model ref is `xiaomi/mimo-v2-flash`. The provider is injected automatically when `XIAOMI_API_KEY` is set or an auth profile exists.
+The default model ref is `xiaomi/mimo-v2.5` (Xiaomi's documented replacement for the retired `mimo-v2-flash`). The provider is injected automatically when `XIAOMI_API_KEY` is set or an auth profile exists. The `mimo-v2-*` rows remain selectable for continuity but are superseded by the V2.5 generation.
 </Tip>
+
+<Note>
+`mimo-v2.5` is natively an omni model (text, image, audio, and video). The bundled catalog advertises `text, image` because the plugin manifest `modelCatalog` input set is limited to `text`/`image`/`document`; declare a custom `models` entry in `openclaw.json` if you need to advertise audio/video inputs to routing.
+</Note>
 
 ## Token Plan catalog
 
@@ -82,10 +88,10 @@ Choose the Token Plan auth choice that matches the regional base URL shown in Xi
 - `xiaomi-token-plan-sgp` -> `https://token-plan-sgp.xiaomimimo.com/v1`
 - `xiaomi-token-plan-ams` -> `https://token-plan-ams.xiaomimimo.com/v1`
 
-| Model ref                         | Input       | Context   | Max output | Reasoning | Notes         |
-| --------------------------------- | ----------- | --------- | ---------- | --------- | ------------- |
-| `xiaomi-token-plan/mimo-v2.5-pro` | text        | 1,048,576 | 131,072    | Yes       | Default model |
-| `xiaomi-token-plan/mimo-v2.5`     | text, image | 1,048,576 | 131,072    | Yes       | Multimodal    |
+| Model ref                         | Input       | Context   | Max output | Reasoning | Notes                     |
+| --------------------------------- | ----------- | --------- | ---------- | --------- | ------------------------- |
+| `xiaomi-token-plan/mimo-v2.5-pro` | text        | 1,048,576 | 131,072    | Yes       | Reasoning flagship (text) |
+| `xiaomi-token-plan/mimo-v2.5`     | text, image | 1,048,576 | 131,072    | Yes       | Default model, multimodal |
 
 <Tip>
 Token Plan onboarding validates the key shape and warns when a `tp-...` key is entered into the pay-as-you-go path, or an `sk-...` key is entered into the Token Plan path.
@@ -160,7 +166,7 @@ output to 48kHz Opus with `ffmpeg` before delivery.
 ```json5
 {
   env: { XIAOMI_API_KEY: "your-key" },
-  agents: { defaults: { model: { primary: "xiaomi/mimo-v2-flash" } } },
+  agents: { defaults: { model: { primary: "xiaomi/mimo-v2.5" } } },
   models: {
     mode: "merge",
     providers: {
@@ -169,6 +175,22 @@ output to 48kHz Opus with `ffmpeg` before delivery.
         api: "openai-completions",
         apiKey: "XIAOMI_API_KEY",
         models: [
+          {
+            id: "mimo-v2.5-pro",
+            name: "Xiaomi MiMo V2.5 Pro",
+            reasoning: true,
+            input: ["text"],
+            contextWindow: 1048576,
+            maxTokens: 131072,
+          },
+          {
+            id: "mimo-v2.5",
+            name: "Xiaomi MiMo V2.5",
+            reasoning: true,
+            input: ["text", "image"],
+            contextWindow: 1048576,
+            maxTokens: 131072,
+          },
           {
             id: "mimo-v2-flash",
             name: "Xiaomi MiMo V2 Flash",
@@ -207,7 +229,7 @@ Token Plan:
 ```json5
 {
   env: { XIAOMI_TOKEN_PLAN_API_KEY: "tp-your-key" },
-  agents: { defaults: { model: { primary: "xiaomi-token-plan/mimo-v2.5-pro" } } },
+  agents: { defaults: { model: { primary: "xiaomi-token-plan/mimo-v2.5" } } },
   models: {
     mode: "merge",
     providers: {
@@ -247,11 +269,11 @@ Pricing comes from the bundled manifest (Token Plan models include tiered cache-
   </Accordion>
 
   <Accordion title="Model details">
-    - **mimo-v2-flash** — lightweight and fast, ideal for general-purpose text tasks. No reasoning support.
-    - **mimo-v2-pro** — supports reasoning with a 1M token context window for long-document workloads.
-    - **mimo-v2-omni** — reasoning-enabled multimodal model that accepts both text and image inputs.
-    - **mimo-v2.5-pro** — Token Plan default with Xiaomi's current V2.5 reasoning stack.
-    - **mimo-v2.5** — Token Plan multimodal V2.5 route.
+    - **mimo-v2.5** — default model on both providers and Xiaomi's documented replacement for `mimo-v2-flash`; reasoning-enabled and supersedes `mimo-v2-omni`. Natively omni (text, image, audio, video), but the bundled catalog advertises `text, image` (see the catalog note above).
+    - **mimo-v2.5-pro** — Xiaomi's current V2.5 reasoning flagship (text), available on both the pay-as-you-go and Token Plan providers.
+    - **mimo-v2-flash** — legacy lightweight, fast text model. No reasoning support.
+    - **mimo-v2-pro** — legacy reasoning model with a 1M token context window for long-document workloads.
+    - **mimo-v2-omni** — legacy reasoning multimodal model (text and image only); superseded by `mimo-v2.5`.
 
     <Note>
     Pay-as-you-go models use the `xiaomi/` prefix. Token Plan models use the `xiaomi-token-plan/` prefix.

--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -291,10 +291,25 @@ describe("xiaomi provider plugin", () => {
     expect(catalogProvider.baseUrl).toBe("https://api.xiaomimimo.com/v1");
 
     const modelIds = catalogProvider.models?.map((m) => m.id);
-    expect(modelIds).toContain("mimo-v2-pro");
-    expect(modelIds).toContain("mimo-v2-omni");
-    expect(modelIds).toContain("mimo-v2-flash");
+    // Pay-as-you-go now serves the V2.5 reasoning stack, listed ahead of the legacy V2 rows.
+    expect(modelIds).toEqual([
+      "mimo-v2.5-pro",
+      "mimo-v2.5",
+      "mimo-v2-flash",
+      "mimo-v2-pro",
+      "mimo-v2-omni",
+    ]);
 
+    expect(catalogProvider.models?.find((m) => m.id === "mimo-v2.5-pro")?.reasoning).toBe(true);
+    expect(catalogProvider.models?.find((m) => m.id === "mimo-v2.5")?.reasoning).toBe(true);
+    // The manifest modelCatalog path only supports text/image inputs (MODEL_CATALOG_INPUTS in
+    // @openclaw/model-catalog-core), so mimo-v2.5 advertises text+image here even though the model
+    // is natively omni; audio/video would require extending the catalog input set in core.
+    expect(catalogProvider.models?.find((m) => m.id === "mimo-v2.5")?.input).toEqual([
+      "text",
+      "image",
+    ]);
+    expect(catalogProvider.models?.find((m) => m.id === "mimo-v2.5-pro")?.input).toEqual(["text"]);
     expect(catalogProvider.models?.find((m) => m.id === "mimo-v2-pro")?.reasoning).toBe(true);
     expect(catalogProvider.models?.find((m) => m.id === "mimo-v2-omni")?.reasoning).toBe(true);
     expect(catalogProvider.models?.find((m) => m.id === "mimo-v2-flash")?.reasoning).toBeFalsy();

--- a/extensions/xiaomi/onboard.test.ts
+++ b/extensions/xiaomi/onboard.test.ts
@@ -18,15 +18,19 @@ describe("xiaomi onboard", () => {
     const provider = cfg.models?.providers?.xiaomi;
     expect(provider).toEqual(buildXiaomiProvider());
     expect(provider?.models.map((m) => m.id)).toEqual([
+      "mimo-v2.5-pro",
+      "mimo-v2.5",
       "mimo-v2-flash",
       "mimo-v2-pro",
       "mimo-v2-omni",
     ]);
-    expect(cfg.agents?.defaults?.models?.["xiaomi/mimo-v2-flash"]).toEqual({ alias: "Xiaomi" });
-    expect(cfg.agents?.defaults?.model).toEqual({ primary: "xiaomi/mimo-v2-flash" });
+    expect(cfg.agents?.defaults?.models?.["xiaomi/mimo-v2.5"]).toEqual({
+      alias: "Xiaomi MiMo V2.5",
+    });
+    expect(cfg.agents?.defaults?.model).toEqual({ primary: "xiaomi/mimo-v2.5" });
     expectProviderOnboardPrimaryModel({
       applyConfig: applyXiaomiConfig,
-      modelRef: "xiaomi/mimo-v2-flash",
+      modelRef: "xiaomi/mimo-v2.5",
     });
   });
 
@@ -42,6 +46,8 @@ describe("xiaomi onboard", () => {
     });
     expect(provider?.models.map((m) => m.id)).toEqual([
       "custom-model",
+      "mimo-v2.5-pro",
+      "mimo-v2.5",
       "mimo-v2-flash",
       "mimo-v2-pro",
       "mimo-v2-omni",
@@ -56,13 +62,13 @@ describe("xiaomi onboard", () => {
       baseUrl: "https://token-plan-ams.xiaomimimo.com/v1",
     });
     expect(provider?.models.map((m) => m.id)).toEqual(["mimo-v2.5-pro", "mimo-v2.5"]);
-    expect(cfg.agents?.defaults?.models?.["xiaomi-token-plan/mimo-v2.5-pro"]).toEqual({
-      alias: "Xiaomi MiMo V2.5 Pro",
+    expect(cfg.agents?.defaults?.models?.["xiaomi-token-plan/mimo-v2.5"]).toEqual({
+      alias: "Xiaomi MiMo V2.5",
     });
-    expect(cfg.agents?.defaults?.model).toEqual({ primary: "xiaomi-token-plan/mimo-v2.5-pro" });
+    expect(cfg.agents?.defaults?.model).toEqual({ primary: "xiaomi-token-plan/mimo-v2.5" });
     expectProviderOnboardPrimaryModel({
       applyConfig: (config) => applyXiaomiTokenPlanConfig(config, "ams"),
-      modelRef: "xiaomi-token-plan/mimo-v2.5-pro",
+      modelRef: "xiaomi-token-plan/mimo-v2.5",
     });
   });
 

--- a/extensions/xiaomi/onboard.ts
+++ b/extensions/xiaomi/onboard.ts
@@ -27,7 +27,15 @@ const xiaomiPresetAppliers = createDefaultModelsPresetAppliers({
       baseUrl: defaultProvider.baseUrl,
       defaultModels: defaultProvider.models ?? [],
       defaultModelId: XIAOMI_DEFAULT_MODEL_ID,
-      aliases: [{ modelRef: XIAOMI_DEFAULT_MODEL_REF, alias: "Xiaomi" }],
+      aliases: (() => {
+        const defaultModel = defaultProvider.models?.find((m) => m.id === XIAOMI_DEFAULT_MODEL_ID);
+        return [
+          {
+            modelRef: XIAOMI_DEFAULT_MODEL_REF,
+            alias: defaultModel?.name ?? "MiMo V2.5",
+          },
+        ];
+      })(),
     };
   },
 });
@@ -49,7 +57,7 @@ const xiaomiTokenPlanPresetAppliers = createDefaultModelsPresetAppliers({
         return [
           {
             modelRef: XIAOMI_TOKEN_PLAN_DEFAULT_MODEL_REF,
-            alias: defaultModel?.name ?? "MiMo V2.5 Pro",
+            alias: defaultModel?.name ?? "MiMo V2.5",
           },
         ];
       })(),

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -26,6 +26,34 @@
         "api": "openai-completions",
         "models": [
           {
+            "id": "mimo-v2.5-pro",
+            "name": "Xiaomi MiMo V2.5 Pro",
+            "input": ["text"],
+            "reasoning": true,
+            "contextWindow": 1048576,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0.435,
+              "output": 0.87,
+              "cacheRead": 0.0036,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "mimo-v2.5",
+            "name": "Xiaomi MiMo V2.5",
+            "input": ["text", "image"],
+            "reasoning": true,
+            "contextWindow": 1048576,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0.14,
+              "output": 0.28,
+              "cacheRead": 0.0028,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "mimo-v2-flash",
             "name": "Xiaomi MiMo V2 Flash",
             "input": ["text"],

--- a/extensions/xiaomi/provider-catalog.ts
+++ b/extensions/xiaomi/provider-catalog.ts
@@ -5,8 +5,8 @@ import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 export const XIAOMI_PROVIDER_ID = "xiaomi";
 export const XIAOMI_TOKEN_PLAN_PROVIDER_ID = "xiaomi-token-plan";
-export const XIAOMI_DEFAULT_MODEL_ID = "mimo-v2-flash";
-export const XIAOMI_TOKEN_PLAN_DEFAULT_MODEL_ID = "mimo-v2.5-pro";
+export const XIAOMI_DEFAULT_MODEL_ID = "mimo-v2.5";
+export const XIAOMI_TOKEN_PLAN_DEFAULT_MODEL_ID = "mimo-v2.5";
 
 const XIAOMI_TOKEN_PLAN_BASE_URLS = {
   ams: "https://token-plan-ams.xiaomimimo.com/v1",


### PR DESCRIPTION
Refs #87277

## What Problem This Solves

Pay-as-you-go Xiaomi users could not select Xiaomi's current model generation.
The `xiaomi` provider (pay-as-you-go, `https://api.xiaomimimo.com/v1`) only
listed the legacy MiMo V2 catalog (`mimo-v2-flash`, `mimo-v2-pro`,
`mimo-v2-omni`) and defaulted to `mimo-v2-flash`, even though the same endpoint
already serves the MiMo V2.5 generation. Only `xiaomi-token-plan` listed V2.5.
During onboarding and model selection, pay-as-you-go users were steered to a
retired default and could not pick `mimo-v2.5` / `mimo-v2.5-pro` at all.

## Why This Change Was Made

Adds `mimo-v2.5-pro` and `mimo-v2.5` to the `xiaomi` pay-as-you-go catalog
(ahead of the legacy V2 rows) and changes **both** the pay-as-you-go and Token
Plan defaults to `xiaomi/mimo-v2.5`. Xiaomi's deprecation docs map the retired
`mimo-v2-flash` to `mimo-v2.5` (not the higher-priced `-pro` tier), so the
default follows Xiaomi's documented replacement. The alias derivation in both
onboarding presets is aligned to use the model display name. Legacy `mimo-v2-*`
rows stay selectable for continuity and are marked superseded in docs.

**MiMo V2.5 omni note (scoping):** `mimo-v2.5` is natively an omni model
(text, image, audio, video). The bundled plugin manifest `modelCatalog` input
set is limited to `text` / `image` / `document` by `MODEL_CATALOG_INPUTS` in
`@openclaw/model-catalog-core`
(`packages/model-catalog-core/src/model-catalog-normalize.ts:32`) — `audio` /
`video` declared in a manifest row are dropped during normalization. So this PR
advertises `mimo-v2.5` as `text, image` to match runtime reality and documents
the `openclaw.json` `models` path for audio/video (the user-config path does
accept all four via `zod-schema.core.ts`). Advertising native omni from the
bundled catalog needs a separate core change.

### Issue #87277 checklist status

| Item | Status |
|---|---|
| Add `mimo-v2.5` to built-in Xiaomi catalog | Done (both `xiaomi` and `xiaomi-token-plan`) |
| Add `mimo-v2.5` to onboarding model selection | Done (catalog drives the picker; now the default) |
| Update docs with V2.5 catalog row | Done (`docs/providers/xiaomi.md`) |
| Migration note: V2.5 supersedes V2-Omni | Done (docs note + default → `mimo-v2.5`) |
| `input: ["text","image","audio","video"]` in catalog | Partial — blocked on `MODEL_CATALOG_INPUTS` (see note); advertised as `text, image` |
| `multimodalFallback` config key | Out of scope (core agent-routing feature, not provider metadata) |
| Pre-dispatch input-type inspection + history injection | Out of scope (same core routing feature) |

## User Impact

- Pay-as-you-go onboarding now defaults to `xiaomi/mimo-v2.5` (Xiaomi's
  documented `mimo-v2-flash` replacement) and offers `xiaomi/mimo-v2.5-pro`.
- `openclaw models list --provider xiaomi` lists the V2.5 rows.
- Existing configs pinning a `mimo-v2-*` model keep working; those rows remain
  in the catalog.

## Model parameters

Pricing = Xiaomi's published overseas pay-as-you-go USD/1M tokens
(https://mimo.mi.com/docs/zh-CN/price/pay-as-you-go), cross-checked against
https://mimo.mi.com/models/mimo-v2.5 , https://mimo.mi.com/models/mimo-v2.5-pro
and the live OpenRouter models API (https://openrouter.ai/api/v1/models).

| Model | Input | Context | Max output | Reasoning | input $ | output $ | cacheRead $ |
|---|---|---|---|---|---|---|---|
| `mimo-v2.5` | text, image | 1,048,576 | 131,072 | Yes | 0.14 | 0.28 | 0.0028 |
| `mimo-v2.5-pro` | text | 1,048,576 | 131,072 | Yes | 0.435 | 0.87 | 0.0036 |

Pay-as-you-go has no context-length tiered pricing (unlike Token Plan), so no
`tieredPricing` is set. `mimo-v2.5-pro`'s `0.435/0.87/0.0036` match OpenRouter
exactly.

## Evidence

**After-fix real CLI — `openclaw models list --provider xiaomi`** (static catalog, no key needed):

```
Model                                      Input      Ctx         Local Auth  Tags
xiaomi/mimo-v2-flash                       text       256k        no    no
xiaomi/mimo-v2-omni                        text+image 256k        no    no
xiaomi/mimo-v2-pro                         text       1024k       no    no
xiaomi/mimo-v2.5                           text+image 1024k       no    no
xiaomi/mimo-v2.5-pro                       text       1024k       no    no
```

**After-fix real onboarding/default** — `openclaw onboard --auth-choice xiaomi-api-key --xiaomi-api-key sk-REDACTED --non-interactive --accept-risk` in an isolated `OPENCLAW_HOME`, generated `openclaw.json`:

```
primary: {"primary": "xiaomi/mimo-v2.5"}
aliases: {"xiaomi/mimo-v2.5": {"alias": "Xiaomi MiMo V2.5"}}
```

Token Plan onboarding (`--auth-choice xiaomi-token-plan-sgp`) likewise resolves
the default to `xiaomi-token-plan/mimo-v2.5`.

**Focused tests** — `pnpm test extensions/xiaomi/onboard.test.ts extensions/xiaomi/index.test.ts` → 23 passed. They assert the exact pay-as-you-go catalog order, reasoning flags, `mimo-v2.5` resolving to `["text","image"]` from the manifest, and the new `xiaomi/mimo-v2.5` default + `Xiaomi MiMo V2.5` alias for both providers.
