### PR TITLE
fix(model-param-b): match both adjacent <num>b tokens sharing one delimiter

### DIFF
--- a/src/shared/model-param-b.test.ts
+++ b/src/shared/model-param-b.test.ts
@@ -10,6 +10,12 @@ describe("shared/model-param-b", () => {
     expect(inferParamBFromIdOrName("(70b) + m1.5b + qwen-14b")).toBe(70);
   });
 
+  it("matches both tokens when two are separated by a single delimiter", () => {
+    expect(inferParamBFromIdOrName("8b 70b")).toBe(70);
+    expect(inferParamBFromIdOrName("8b-70b")).toBe(70);
+    expect(inferParamBFromIdOrName("7b-13b")).toBe(13);
+  });
+
   it("ignores malformed, zero, and non-delimited matches", () => {
     expect(inferParamBFromIdOrName("abc70beta 0b x70b2")).toBeNull();
     expect(inferParamBFromIdOrName("model 0b")).toBeNull();

--- a/src/shared/model-param-b.ts
+++ b/src/shared/model-param-b.ts
@@ -4,7 +4,9 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 /** Infers the largest `<number>b` parameter-size token from a model id or display name. */
 export function inferParamBFromIdOrName(text: string): number | null {
   const raw = normalizeLowercaseStringOrEmpty(text);
-  const matches = raw.matchAll(/(?:^|[^a-z0-9])[a-z]?(\d+(?:\.\d+)?)b(?:[^a-z0-9]|$)/g);
+  // Trailing boundary is a lookahead so two adjacent `<num>b` tokens sharing one delimiter (e.g.
+  // "8b 70b" / "8b-70b") both match; a consuming boundary ate the delimiter and skipped the second.
+  const matches = raw.matchAll(/(?:^|[^a-z0-9])[a-z]?(\d+(?:\.\d+)?)b(?=[^a-z0-9]|$)/g);
   let best: number | null = null;
   for (const match of matches) {
     const numRaw = match[1];


### PR DESCRIPTION
## Summary

`inferParamBFromIdOrName` (`src/shared/model-param-b.ts`) finds the largest `<number>b` parameter-size token in a model id/name. Its regex used a **consuming** trailing boundary — `b(?:[^a-z0-9]|$)`. When two `<num>b` tokens are separated by a single delimiter (a space or dash, e.g. `8b 70b`, `8b-70b`), the first match consumes that shared delimiter, so the next match's required leading boundary `(?:^|[^a-z0-9])` has nothing left to match and the second token is silently skipped — the function returns the first (often smaller) size instead of the largest.

### Changes
- `model-param-b.ts` — make the trailing boundary a non-consuming lookahead (`b(?=[^a-z0-9]|$)`) so a shared delimiter remains available as the next token's leading boundary.
- `model-param-b.test.ts` — added single-delimiter multi-token cases.

## Real behavior proof

Behavior addressed: two adjacent `<num>b` tokens sharing one delimiter returned only the first size. After the fix the largest is returned. Tokens separated by multiple non-alphanumerics already worked and are unchanged.

Real environment tested: Node 22.22.1, macOS, no network/model. Vitest exercises the real exported `inferParamBFromIdOrName`. BEFORE is `origin/main`'s file (swapped via `git show`).

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs src/shared/model-param-b.test.ts
```

Evidence after fix:
```
inferParamBFromIdOrName("8b 70b")   BEFORE: 8   AFTER: 70
inferParamBFromIdOrName("8b-70b")   BEFORE: 8   AFTER: 70
inferParamBFromIdOrName("7b-13b")   BEFORE: 7   AFTER: 13
inferParamBFromIdOrName("llama-8b mixtral-22b")  BOTH: 22   (multi-delimiter, unchanged)
```

Observed result after fix: single-delimiter pairs now return the largest size; all existing cases (multi-delimiter, malformed/zero/non-delimited negatives) are unchanged. The new test fails on `origin/main` and passes after.

What was not tested: end-to-end provider model-size inference (the test drives the real exported helper those paths call).

## Additional checks
- `node scripts/run-vitest.mjs src/shared/model-param-b.test.ts` passes; fail-before verified by swapping in `origin/main`'s file. `oxlint --tsconfig` clean. Diff: 1 prod regex char + comment, +3 test cases.
