### PR TITLE
fix(slack): stop a stray "<" from swallowing and escaping a valid angle token

### DIFF
--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -93,4 +93,12 @@ describe("normalizeSlackOutboundText", () => {
   it("normalizes markdown for outbound send/update paths", () => {
     expect(normalizeSlackOutboundText(" **bold** ")).toBe("*bold*");
   });
+
+  it("escapes a stray '<' without destroying a following valid Slack token", () => {
+    // The stray "<" must not let the angle-token match span across it and escape the real mention/link.
+    expect(normalizeSlackOutboundText("if x < 10 ping <@U123>")).toBe("if x &lt; 10 ping <@U123>");
+    expect(normalizeSlackOutboundText("5 < 10 so see <https://docs.example.com|the docs>")).toBe(
+      "5 &lt; 10 so see <https://docs.example.com|the docs>",
+    );
+  });
 });

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -13,7 +13,10 @@ function escapeSlackMrkdwnSegment(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
+// Exclude "<" from the token body so a stray "<" in ordinary text (e.g. "x < 10 ping <@U1>") cannot
+// make the match span across it and swallow a following valid Slack token, which would then be
+// escaped and destroyed. Slack angle tokens never contain a nested "<".
+const SLACK_ANGLE_TOKEN_RE = /<[^<>\n]+>/g;
 
 function isAllowedSlackAngleToken(token: string): boolean {
   if (!token.startsWith("<") || !token.endsWith(">")) {


### PR DESCRIPTION
## Summary

`SLACK_ANGLE_TOKEN_RE` (`extensions/slack/src/format.ts:16`) was `/<[^>\n]+>/g`, which matches greedily from the **first** `<` to the first `>`. When ordinary text contains a stray `<` before a legitimate Slack angle token — a mention `<@U1>`, channel `<#C1>`, special `<!here>`, or link `<https://…|label>` — the regex swallows the whole span (e.g. `< b and <@U1>`) as **one** candidate token. `isAllowedSlackAngleToken()` then returns false (the span's inner doesn't start with `@`/`#`/`!`/`mailto:`/`http(s):`/…), so `escapeSlackMrkdwnSegment` escapes the entire span — turning the embedded valid token into `&lt;@U1&gt;`. **The mention/link is destroyed in the sent message.**

This is very common: `if x < 10 ping <@U123>` or `5 < 10 so see <https://docs|the docs>`.

### Changes
- `format.ts` — exclude `<` from the token body (`/<[^<>\n]+>/g`) so a token can't span across an earlier stray `<`. Slack angle tokens never contain a nested `<`, so only the buggy greedy span changes.
- `format.test.ts` — added stray-`<`-before-mention and stray-`<`-before-link cases.

## Real behavior proof

Behavior addressed: a stray `<` before a real Slack mention/link caused the whole span (including the valid token) to be escaped, destroying the mention/link. After the fix the stray `<` is escaped alone and the token is preserved.

Real environment tested: Node 22.22.1, macOS, no network/model. Vitest exercises the real exported `normalizeSlackOutboundText`. BEFORE is `origin/main`'s `format.ts` (swapped via `git show`).

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs extensions/slack/src/format.test.ts
```

Evidence after fix:
```
normalizeSlackOutboundText("if x < 10 ping <@U123>")
  BEFORE: "if x &lt; 10 ping &lt;@U123&gt;"   (mention destroyed — Slack shows literal text, no ping)
  AFTER:  "if x &lt; 10 ping <@U123>"          (mention preserved)
normalizeSlackOutboundText("5 < 10 so see <https://docs.example.com|the docs>")
  BEFORE: "5 &lt; 10 so see &lt;https://docs.example.com|the docs&gt;"   (link destroyed)
  AFTER:  "5 &lt; 10 so see <https://docs.example.com|the docs>"          (link preserved)
```

Observed result after fix: stray `<` is escaped on its own while the valid token survives; the new test fails on `origin/main` and passes after. All 8 existing `format.test.ts` cases stay green.

What was not tested: a live Slack send (the test drives the real `normalizeSlackOutboundText`, which the send/reply/dispatch paths call). 

## Additional checks
- `node scripts/run-vitest.mjs extensions/slack/src/format.test.ts` passes; fail-before verified by swapping in `origin/main`'s file. Extension `oxlint` clean. Diff: 1 prod regex char + comment, +2 test assertions.
