### PR TITLE
fix(cron): clear agentTurn thinking override by blanking the field

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -169,6 +169,9 @@ If stdout is non-empty, that text is the delivered result. If stdout is empty an
 <ParamField path="--thinking" type="string">
   Thinking level override.
 </ParamField>
+<ParamField path="--clear-thinking" type="boolean">
+  On `cron edit`, removes the per-job thinking override so the job follows normal cron thinking precedence. Cannot be combined with `--thinking`.
+</ParamField>
 <ParamField path="--light-context" type="boolean">
   Skip workspace bootstrap file injection.
 </ParamField>

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -170,7 +170,7 @@ Use `--due` when you want the manual command to run only if the job is currently
 
 ## Models
 
-`cron add|edit --model <ref>` selects an allowed model for the job. `cron add|edit --fallbacks <list>` sets per-job fallback models, for example `--fallbacks openrouter/gpt-4.1-mini,openai/gpt-5`; pass `--fallbacks ""` for a strict run with no fallbacks. `cron edit <job-id> --clear-fallbacks` removes the per-job fallback override. `cron edit <job-id> --clear-model` removes the per-job model override so the job follows normal cron model-selection precedence (a stored cron-session override if present, otherwise the agent/default model); it cannot be combined with `--model`.
+`cron add|edit --model <ref>` selects an allowed model for the job. `cron add|edit --fallbacks <list>` sets per-job fallback models, for example `--fallbacks openrouter/gpt-4.1-mini,openai/gpt-5`; pass `--fallbacks ""` for a strict run with no fallbacks. `cron edit <job-id> --clear-fallbacks` removes the per-job fallback override. `cron edit <job-id> --clear-model` removes the per-job model override so the job follows normal cron model-selection precedence (a stored cron-session override if present, otherwise the agent/default model); it cannot be combined with `--model`. `cron add|edit --thinking <level>` sets a per-job thinking override; `cron edit <job-id> --clear-thinking` removes it so the job follows normal cron thinking precedence, and it cannot be combined with `--thinking`.
 
 <Warning>
 If the model is not allowed or cannot be resolved, cron fails the run with an explicit validation error instead of falling back to the job's agent or default model selection.

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -15,6 +15,7 @@ function cronAgentTurnPayloadSchema(params: {
   model: TSchema;
   fallbacks: TSchema;
   toolsAllow: TSchema;
+  thinking: TSchema;
 }) {
   return Type.Object(
     {
@@ -22,7 +23,7 @@ function cronAgentTurnPayloadSchema(params: {
       message: params.message,
       model: Type.Optional(params.model),
       fallbacks: Type.Optional(params.fallbacks),
-      thinking: Type.Optional(Type.String()),
+      thinking: Type.Optional(params.thinking),
       timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
       lightContext: Type.Optional(Type.Boolean()),
@@ -238,6 +239,7 @@ export const CronPayloadSchema = Type.Union([
     model: Type.String(),
     fallbacks: Type.Array(Type.String()),
     toolsAllow: Type.Array(Type.String()),
+    thinking: Type.String(),
   }),
   cronCommandPayloadSchema({
     argv: Type.Array(NonEmptyString, { minItems: 1 }),
@@ -258,6 +260,7 @@ export const CronPayloadPatchSchema = Type.Union([
     model: Type.Union([Type.String(), Type.Null()]),
     fallbacks: Type.Union([Type.Array(Type.String()), Type.Null()]),
     toolsAllow: Type.Union([Type.Array(Type.String()), Type.Null()]),
+    thinking: Type.Union([Type.String(), Type.Null()]),
   }),
   cronCommandPayloadSchema({
     argv: Type.Optional(Type.Array(NonEmptyString, { minItems: 1 })),

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -222,11 +222,50 @@ describe("cron edit command", () => {
     );
   });
 
+  it("clears the thinking override with --clear-thinking (CLI parity with cron.update thinking:null)", async () => {
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--clear-thinking"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.update",
+      expect.objectContaining({ clearThinking: true }),
+      {
+        id: "job-1",
+        patch: {
+          payload: {
+            kind: "agentTurn",
+            thinking: null,
+          },
+        },
+      },
+    );
+  });
+
+  it("rejects combining --thinking with --clear-thinking", async () => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--thinking", "high", "--clear-thinking"], {
+      from: "user",
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Use --thinking or --clear-thinking, not both"),
+    );
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
   it("documents the --clear-model flag alongside the sibling --clear-tools", () => {
     const editCommand = createCronProgram().commands.find((command) => command.name() === "edit");
     const help = editCommand?.helpInformation() ?? "";
 
     expect(help).toContain("--clear-model");
+    expect(help).toContain("--clear-thinking");
     expect(help).toContain("--clear-tools");
   });
 

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -112,6 +112,11 @@ export function registerCronEditCommand(cron: Command) {
         "--thinking <level>",
         "Thinking level for agent jobs (off|minimal|low|medium|high|xhigh)",
       )
+      .option(
+        "--clear-thinking",
+        "Remove the per-job thinking override (restore normal cron thinking precedence)",
+        false,
+      )
       .option("--model <model>", "Model override for agent jobs")
       .option("--fallbacks <list>", "Fallback model list for agent jobs")
       .option("--clear-fallbacks", "Remove per-job fallback override", false)
@@ -292,6 +297,9 @@ export function registerCronEditCommand(cron: Command) {
             throw new Error("Use --model or --clear-model, not both");
           }
           const thinking = normalizeOptionalString(opts.thinking);
+          if (thinking && opts.clearThinking) {
+            throw new Error("Use --thinking or --clear-thinking, not both");
+          }
           const fallbacks = parseCronFallbacks(opts.fallbacks);
           if (typeof opts.fallbacks === "string" && opts.clearFallbacks) {
             throw new Error("Use --fallbacks or --clear-fallbacks, not both");
@@ -370,6 +378,7 @@ export function registerCronEditCommand(cron: Command) {
             typeof opts.fallbacks !== "string" &&
             !opts.clearFallbacks &&
             !thinking &&
+            !opts.clearThinking &&
             typeof opts.lightContext !== "boolean" &&
             typeof opts.tools !== "string" &&
             !Array.isArray(opts.tools) &&
@@ -385,6 +394,7 @@ export function registerCronEditCommand(cron: Command) {
             typeof opts.fallbacks === "string" ||
             Boolean(opts.clearFallbacks) ||
             Boolean(thinking) ||
+            Boolean(opts.clearThinking) ||
             (hasTimeoutSeconds &&
               !hasCommandSpecificPayloadField &&
               timeoutOnlyPayloadKind !== "command") ||
@@ -418,7 +428,11 @@ export function registerCronEditCommand(cron: Command) {
             }
             assignIf(payload, "fallbacks", fallbacks, typeof opts.fallbacks === "string");
             assignIf(payload, "fallbacks", null, Boolean(opts.clearFallbacks));
-            assignIf(payload, "thinking", thinking, Boolean(thinking));
+            if (opts.clearThinking) {
+              payload.thinking = null;
+            } else {
+              assignIf(payload, "thinking", thinking, Boolean(thinking));
+            }
             assignIf(payload, "timeoutSeconds", timeoutSeconds, hasTimeoutSeconds);
             assignIf(
               payload,

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -154,6 +154,20 @@ describe("normalizeCronJobCreate", () => {
     expect(normalized.payload?.model).toBeNull();
   });
 
+  it("preserves explicit null thinking clear in payload patches", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        thinking: null,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.thinking).toBeNull();
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
+  });
+
   it("coerces ISO schedule.at to normalized ISO (UTC)", () => {
     expectNormalizedAtSchedule({ kind: "at", at: "2026-01-12T18:00:00" });
   });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -194,11 +194,17 @@ function coercePayload(payload: UnknownRecord) {
     }
   }
   if ("thinking" in next) {
-    const thinking = parseOptionalField(TrimmedNonEmptyStringFieldSchema, next.thinking);
-    if (thinking !== undefined) {
-      next.thinking = thinking;
+    // Preserve an explicit null so patches can clear a stored thinking override,
+    // matching the model/fallbacks/toolsAllow clear paths.
+    if (next.thinking === null) {
+      next.thinking = null;
     } else {
-      delete next.thinking;
+      const thinking = parseOptionalField(TrimmedNonEmptyStringFieldSchema, next.thinking);
+      if (thinking !== undefined) {
+        next.thinking = thinking;
+      } else {
+        delete next.thinking;
+      }
     }
   }
   if ("timeoutSeconds" in next) {

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -520,6 +520,75 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("persists agentTurn payload.thinking updates when editing existing jobs", () => {
+    const job = createIsolatedAgentTurnJob("job-thinking", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      thinking: "high",
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        thinking: "low",
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.thinking).toBe("low");
+    }
+  });
+
+  it("clears agentTurn payload.thinking when patch requests null", () => {
+    const job = createIsolatedAgentTurnJob("job-thinking-clear", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      thinking: "high",
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        thinking: null,
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.message).toBe("do it");
+      expect(job.payload.thinking).toBeUndefined();
+    }
+  });
+
+  it("omits null thinking when patch builds a replacement agentTurn payload", () => {
+    const job = createMainSystemEventJob("job-thinking-replace", { mode: "none" });
+
+    applyJobPatch(job, {
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        thinking: null,
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.message).toBe("do it");
+      expect(job.payload.thinking).toBeUndefined();
+    }
+  });
+
   it("applies payload.lightContext when replacing payload kind via patch", () => {
     const job = createIsolatedAgentTurnJob("job-light-context-switch", {
       mode: "announce",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -999,6 +999,8 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   applyAgentTurnToolsAllowPatch(next, patch, existing);
   if (typeof patch.thinking === "string") {
     next.thinking = patch.thinking;
+  } else if (patch.thinking === null) {
+    delete next.thinking;
   }
   if (typeof patch.timeoutSeconds === "number") {
     next.timeoutSeconds = patch.timeoutSeconds;
@@ -1045,7 +1047,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     message: patch.message,
     model: typeof patch.model === "string" ? patch.model : undefined,
     fallbacks: Array.isArray(patch.fallbacks) ? patch.fallbacks : undefined,
-    thinking: patch.thinking,
+    thinking: typeof patch.thinking === "string" ? patch.thinking : undefined,
     timeoutSeconds: patch.timeoutSeconds,
     lightContext: patch.lightContext,
     allowUnsafeExternalContent: patch.allowUnsafeExternalContent,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -258,10 +258,11 @@ type CronAgentTurnPayload = {
 
 type CronAgentTurnPayloadPatch = {
   kind: "agentTurn";
-} & Partial<Omit<CronAgentTurnPayloadFields, "model" | "fallbacks" | "toolsAllow">> & {
+} & Partial<Omit<CronAgentTurnPayloadFields, "model" | "fallbacks" | "toolsAllow" | "thinking">> & {
     model?: string | null;
     fallbacks?: string[] | null;
     toolsAllow?: string[] | null;
+    thinking?: string | null;
   };
 
 type CronCommandPayloadFields = {

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -405,6 +405,108 @@ describe("cron controller", () => {
     });
   });
 
+  it("sends explicit null model/thinking clears when blanking stored overrides on edit", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-clear-overrides" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-clear-overrides" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+
+    const state = createState({
+      client: {
+        request,
+      } as unknown as CronState["client"],
+      cronEditingJobId: "job-clear-overrides",
+      cronJobs: [
+        {
+          id: "job-clear-overrides",
+          payload: {
+            kind: "agentTurn",
+            message: "do work",
+            model: "openai/gpt-5.5",
+            thinking: "high",
+          },
+        } as unknown as CronState["cronJobs"][number],
+      ],
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "clear overrides",
+        scheduleKind: "every",
+        everyAmount: "30",
+        everyUnit: "minutes",
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payloadKind: "agentTurn",
+        payloadText: "do work",
+        payloadModel: "",
+        payloadThinking: "",
+      },
+    });
+
+    await addCronJob(state);
+
+    const updateCall = findRequestCall(request.mock.calls, "cron.update");
+    expectNestedRecordFields(requestPatch(updateCall), "payload", {
+      kind: "agentTurn",
+      message: "do work",
+      model: null,
+      thinking: null,
+    });
+  });
+
+  it("does not send null model/thinking for a new job with blank fields", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.add") {
+        return { id: "job-new-blank" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-new-blank" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+
+    const state = createState({
+      client: {
+        request,
+      } as unknown as CronState["client"],
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "new blank",
+        scheduleKind: "every",
+        everyAmount: "30",
+        everyUnit: "minutes",
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payloadKind: "agentTurn",
+        payloadText: "do work",
+        payloadModel: "",
+        payloadThinking: "",
+      },
+    });
+
+    await addCronJob(state);
+
+    const addCall = findRequestCall(request.mock.calls, "cron.add");
+    // A new job never had a stored override, so a blank field stays omitted
+    // (no explicit null clear) rather than being mistaken for a cleared value.
+    expectNestedRecordFields(requestPayload(addCall), "payload", {
+      kind: "agentTurn",
+      message: "do work",
+      model: undefined,
+      thinking: undefined,
+    });
+  });
+
   it("does not submit stale announce delivery when unsupported", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.add") {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -631,8 +631,8 @@ function buildCronPayload(form: CronFormState) {
   const payload: {
     kind: "agentTurn";
     message: string;
-    model?: string;
-    thinking?: string;
+    model?: string | null;
+    thinking?: string | null;
     timeoutSeconds?: number;
     lightContext?: boolean;
   } = { kind: "agentTurn", message };
@@ -721,14 +721,22 @@ export async function addCronJob(state: CronState): Promise<boolean> {
       state.cronEditingJobId && form.payloadLocked && editingPayload?.kind === "command",
     );
     const payload = preserveLockedPayload ? undefined : buildCronPayload(form);
-    if (payload?.kind === "agentTurn") {
-      const existingLightContext =
-        editingPayload?.kind === "agentTurn" ? editingPayload.lightContext : undefined;
-      if (
-        !form.payloadLightContext &&
-        state.cronEditingJobId &&
-        existingLightContext !== undefined
-      ) {
+    if (
+      payload?.kind === "agentTurn" &&
+      state.cronEditingJobId &&
+      editingPayload?.kind === "agentTurn"
+    ) {
+      // When editing, a blanked field that previously held a stored override must
+      // send an explicit clear; an omitted key means "leave unchanged" on merge.
+      // The form only shows stored overrides (not inherited defaults), so a blank
+      // input with a stored value is an intentional clear.
+      if (!form.payloadModel.trim() && editingPayload.model !== undefined) {
+        payload.model = null;
+      }
+      if (!form.payloadThinking.trim() && editingPayload.thinking !== undefined) {
+        payload.thinking = null;
+      }
+      if (!form.payloadLightContext && editingPayload.lightContext !== undefined) {
         payload.lightContext = false;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Clearing the **Model** and **Thinking/Effort** fields in the Cron Control UI did not remove previously saved `agentTurn` overrides. After blanking a field and saving, reopening the job (or running `openclaw cron get <id>`) showed the old value again.

Two distinct gaps combined to cause this:

1. **Control UI** omitted blank Model/Thinking fields from the `cron.update` patch instead of sending an explicit clear. Because cron updates are partial/merge-based, an omitted nested payload key means "leave unchanged", so a cleared field was indistinguishable from an untouched one.
2. **Backend `thinking` had no clear path at all.** `model`, `fallbacks`, and `toolsAllow` already accept `null` end-to-end (schema → normalizer → merge), but `thinking` did not: the patch schema/normalizer dropped `thinking: null` before validation, and `mergeCronPayload` only handled a string value. So even an API/CLI caller could not clear a stored thinking override.

Fixes #96287.

## Why This Change Was Made

The clear-by-null contract was already established for the sibling fields and is the canonical way cron patches express "remove this override" (see prior #91298 for `model`, #95874 for the CLI `--clear-model`). `thinking` was simply missing from that contract on every layer, and the UI never emitted a clear for any field on edit. This change closes that asymmetry rather than introducing a new mechanism:

- `packages/gateway-protocol/src/schema/cron.ts` — `thinking` in an `agentTurn` **patch** now accepts `string | null` (create stays `string`), mirroring `model`/`fallbacks`/`toolsAllow`.
- `src/cron/types.ts` — `CronAgentTurnPayloadPatch.thinking` is now `string | null`.
- `src/cron/normalize.ts` — preserves an explicit `thinking: null` instead of dropping it (same branch shape as `model`).
- `src/cron/service/jobs.ts` — `mergeCronPayload` deletes `thinking` on `null`; `buildPayloadFromPatch` coalesces `null` → `undefined` when materializing a fresh payload (matching `model`).
- `ui/src/ui/controllers/cron.ts` — when editing a job, a blanked field that previously held a **stored** override now sends an explicit `null` clear (consolidated with the existing `lightContext` edit-clear logic). The form only displays stored overrides, not inherited defaults, so a blank input over a stored value is treated as an intentional clear; new jobs and inherited-default displays still omit the key.
- `src/cli/cron-cli/register.cron-edit.ts` — adds `--clear-thinking` for parity with `--clear-model`/`--clear-fallbacks`/`--clear-tools`.
- `docs/automation/cron-jobs.md`, `docs/cli/cron.md` — document `--clear-thinking` beside the sibling clear flags, including that it cannot be combined with `--thinking`.

## User Impact

- Blanking **Model** or **Thinking/Effort** on an existing cron job in the Control UI now removes the override; the job inherits the default model/thinking on the next run.
- `openclaw cron edit <id> --clear-thinking` removes a stored thinking override from the CLI.
- No migration or config change. Existing behavior for omitted fields ("leave unchanged"), `model` clearing, and new-job creation is unchanged. The create payload schema is untouched, so stored jobs and existing API/CLI snippets keep working.

## Evidence

### Live behavior proof (real Gateway + DeepSeek, CLI roundtrip)

Ran against a real `openclaw gateway run` instance with a live `deepseek/deepseek-v4-pro` agent. Created an `agentTurn` job with a stored `thinking` override, cleared it with the new flag, and re-read the persisted job. `thinking` is removed while the sibling `model` override is preserved, and the mutual-exclusion guard fires (`<job-id>` is the ephemeral UUID):

```text
$ openclaw cron add --every 1h --name clear-thinking-demo --message ping --thinking high --model deepseek/deepseek-v4-pro
  "payload": {
    "kind": "agentTurn",
    "message": "ping",
    "model": "deepseek/deepseek-v4-pro",
    "thinking": "high"
  }

$ openclaw cron get <job-id>          # BEFORE: stored payload has thinking:high + model
  "payload": {
    "kind": "agentTurn",
    "message": "ping",
    "model": "deepseek/deepseek-v4-pro",
    "thinking": "high"
  }

$ openclaw cron edit <job-id> --clear-thinking
  "payload": {
    "kind": "agentTurn",
    "message": "ping",
    "model": "deepseek/deepseek-v4-pro"
  }

$ openclaw cron get <job-id>          # AFTER: thinking removed from the persisted job, model preserved
  "payload": {
    "kind": "agentTurn",
    "message": "ping",
    "model": "deepseek/deepseek-v4-pro"
  }

$ openclaw cron edit <job-id> --thinking low --clear-thinking   # mutual-exclusion guard
Error: Use --thinking or --clear-thinking, not both
```

This exercises the full runtime path: CLI patch (`payload.thinking: null`) → gateway `cron.update` → schema validation → normalize → `mergeCronPayload` delete → SQLite persist → `cron get` read-back.

### Automated proof

`build`/`test`/`typecheck`/`format` all green on the changed surfaces (worktree-scoped runner + tsgo). Highlights:

**Negative control — revert only the production code, keep the new tests → the thinking-clear paths fail (bug reproduced):**

```
× clears agentTurn payload.thinking when patch requests null
× omits null thinking when patch builds a replacement agentTurn payload
× preserves explicit null thinking clear in payload patches
 Test Files  2 failed (2)
      Tests  3 failed | 123 passed (126)
```

**With the fix — all targeted suites pass:**

```
# src/cron/normalize.test.ts + src/cron/service.jobs.test.ts
 Test Files  2 passed (2)
      Tests  126 passed (126)
# src/cli/cron-cli/register.cron-edit.test.ts
 Test Files  1 passed (1)
      Tests  21 passed (21)
# ui/src/ui/controllers/cron.test.ts
 Test Files  1 passed (1)
      Tests  42 passed (42)
```

**Typecheck (tsgo) clean:**

```
# tsgo -p tsconfig.core.json            → exit 0, 0 errors
# tsgo -p test/tsconfig/tsconfig.test.ui.json → exit 0, 0 errors
```

**Format:** `oxfmt --check` clean on all changed files.

New tests added cover: normalizer preserves `thinking: null` (and the patch validates), merge clears `thinking` on `null`, merge updates `thinking` on a string, fresh-build omits `null` thinking, CLI `--clear-thinking` emits `payload.thinking: null`, CLI rejects `--thinking` + `--clear-thinking`, UI sends explicit `model`/`thinking` null clears when blanking stored overrides on edit, and UI does **not** send null for a new job with blank fields.

---

AI-assisted.
