### PR TITLE
fix(whatsapp): deliver interactive button/list/template selections to the agent

### DIFF
--- a/extensions/whatsapp/src/inbound/extract.test.ts
+++ b/extensions/whatsapp/src/inbound/extract.test.ts
@@ -1,7 +1,7 @@
 // Whatsapp tests cover extract plugin behavior.
 import type { proto } from "baileys";
 import { describe, expect, it } from "vitest";
-import { extractMentionedJids, hasInboundUserContent } from "./extract.js";
+import { extractMentionedJids, extractText, hasInboundUserContent } from "./extract.js";
 
 describe("extractMentionedJids", () => {
   const botJid = "5511999999999@s.whatsapp.net";
@@ -279,5 +279,40 @@ describe("hasInboundUserContent", () => {
     expect(hasInboundUserContent({ extendedTextMessage: { text: "  " } } as proto.IMessage)).toBe(
       false,
     );
+  });
+});
+
+describe("extractText", () => {
+  it("extracts the user-visible selection text from interactive replies", () => {
+    expect(
+      extractText({
+        buttonsResponseMessage: { selectedButtonId: "yes", selectedDisplayText: "Yes" },
+      } as proto.IMessage),
+    ).toBe("Yes");
+    expect(
+      extractText({ buttonsResponseMessage: { selectedButtonId: "yes" } } as proto.IMessage),
+    ).toBe("yes");
+    expect(
+      extractText({
+        listResponseMessage: { title: "Option A", singleSelectReply: { selectedRowId: "a" } },
+      } as proto.IMessage),
+    ).toBe("Option A");
+    expect(
+      extractText({
+        templateButtonReplyMessage: { selectedDisplayText: "Click" },
+      } as proto.IMessage),
+    ).toBe("Click");
+    // A template reply can carry only selectedId (no display text); fall back to it so the tap
+    // still extracts a body instead of being dropped as empty.
+    expect(
+      extractText({
+        templateButtonReplyMessage: { selectedId: "tmpl_confirm" },
+      } as proto.IMessage),
+    ).toBe("tmpl_confirm");
+    expect(
+      extractText({
+        interactiveResponseMessage: { body: { text: "Flow done" } },
+      } as proto.IMessage),
+    ).toBe("Flow done");
   });
 });

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -231,6 +231,28 @@ export function extractMentionedJids(rawMessage: proto.IMessage | undefined): st
   return uniqueStrings(flattened);
 }
 
+// Interactive replies (button/list/template/flow taps) carry the user's selection in their own
+// fields, not conversation/caption. hasInboundUserContent already treats these as inbound content so
+// they pass the access gate; extractText must surface the selection text too, otherwise the tap
+// enriches to an empty body and is dropped before reaching the agent.
+function extractInteractiveSelectionText(message: proto.IMessage): string | undefined {
+  const candidates = [
+    message.buttonsResponseMessage?.selectedDisplayText ??
+      message.buttonsResponseMessage?.selectedButtonId,
+    message.listResponseMessage?.title ??
+      message.listResponseMessage?.singleSelectReply?.selectedRowId,
+    message.templateButtonReplyMessage?.selectedDisplayText ??
+      message.templateButtonReplyMessage?.selectedId,
+    message.interactiveResponseMessage?.body?.text,
+  ];
+  for (const candidate of candidates) {
+    if (candidate?.trim()) {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
 export function extractText(rawMessage: proto.IMessage | undefined): string | undefined {
   const message = unwrapMessage(rawMessage);
   if (!message) {
@@ -255,6 +277,10 @@ export function extractText(rawMessage: proto.IMessage | undefined): string | un
       candidate.documentMessage?.caption;
     if (caption?.trim()) {
       return caption.trim();
+    }
+    const interactive = extractInteractiveSelectionText(candidate);
+    if (interactive) {
+      return interactive;
     }
   }
   const contactPlaceholder =


### PR DESCRIPTION
## Summary

`extractText()` (`extensions/whatsapp/src/inbound/extract.ts`) extracts inbound text from `conversation`, `extendedTextMessage`, and image/video/document captions — but **not** from interactive replies (`buttonsResponseMessage`, `listResponseMessage`, `templateButtonReplyMessage`, `interactiveResponseMessage`). Yet the sibling `hasInboundUserContent()` in the same module deliberately reports those four interactive keys as inbound user content (so button taps pass the pairing access-control gate).

The result: in `monitor.ts`, the access gate (`hasInboundUserContent`) lets a button/list selection through, but then `enrichInboundMessage` → `extractText` finds no body, no location, no media placeholder, and returns `null` — so the message is treated as **undeliverable and dropped**, and the user's tap never reaches the agent.

### Changes
- `extract.ts` — add `extractInteractiveSelectionText(message)` returning the first non-empty of the user-visible selection texts (button `selectedDisplayText`/`selectedButtonId`, list `title`/`selectedRowId`, template `selectedDisplayText`, interactive `body.text`), called inside `extractText`'s candidate loop after the caption check. Mirrors `hasInboundUserContent`'s key enumeration.
- `extract.test.ts` — interactive-reply cases.

## Real behavior proof

Behavior addressed: a WhatsApp button/list/template tap passed the access gate but `extractText` returned `undefined`, so the tap was dropped before reaching the agent. After the fix the selection text is extracted.

Real environment tested: Node 22.22.1, macOS, no network/model. Vitest exercises the real exported `extractText`. BEFORE is `origin/main`'s `extract.ts` (swapped via `git show`).

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs extensions/whatsapp/src/inbound/extract.test.ts
```

Evidence after fix:
```
extractText({ buttonsResponseMessage: { selectedButtonId: "yes", selectedDisplayText: "Yes" } })   BEFORE: undefined  AFTER: "Yes"
extractText({ buttonsResponseMessage: { selectedButtonId: "yes" } })                                 BEFORE: undefined  AFTER: "yes"
extractText({ listResponseMessage: { title: "Option A", singleSelectReply: { selectedRowId: "a" } }})BEFORE: undefined  AFTER: "Option A"
extractText({ templateButtonReplyMessage: { selectedDisplayText: "Click" } })                        BEFORE: undefined  AFTER: "Click"
extractText({ interactiveResponseMessage: { body: { text: "Flow done" } } })                         BEFORE: undefined  AFTER: "Flow done"
```

Observed result after fix: interactive selections now yield their text instead of `undefined`; the new test fails on `origin/main` and passes after. `tsgo:extensions` confirms the baileys proto field accesses typecheck.

What was not tested: a live WhatsApp interactive round-trip (the test drives the real `extractText`, exactly what `enrichInboundMessage` calls). Conversation/caption extraction is unchanged.

## Additional checks
- `node scripts/run-vitest.mjs extensions/whatsapp/src/inbound/extract.test.ts` passes; fail-before verified by swapping in `origin/main`'s file. Extension `oxlint` and `tsgo:extensions` clean.
