### PR TITLE
fix(agents): truncate console text on code-point boundaries

### DIFF
--- a/src/agents/console-sanitize.test.ts
+++ b/src/agents/console-sanitize.test.ts
@@ -1,0 +1,20 @@
+// Console sanitizer tests cover control-char filtering and code-point-safe truncation.
+import { describe, expect, it } from "vitest";
+import { sanitizeForConsole } from "./console-sanitize.js";
+
+const hasLoneSurrogate = (value: string) =>
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(value);
+
+describe("sanitizeForConsole", () => {
+  it("truncates on code-point boundaries without splitting a surrogate pair", () => {
+    const grin = String.fromCodePoint(0x1f600); // 😀 — two UTF-16 code units
+    const out = sanitizeForConsole(grin.repeat(6), 3);
+    expect(out).toBe(`${grin.repeat(3)}…`);
+    expect(out !== undefined && hasLoneSurrogate(out)).toBe(false);
+  });
+
+  it("filters control chars, flattens whitespace, and leaves short strings intact", () => {
+    expect(sanitizeForConsole("  hello\tworld  ")).toBe("hello world");
+    expect(sanitizeForConsole(undefined)).toBeUndefined();
+  });
+});

--- a/src/agents/console-sanitize.ts
+++ b/src/agents/console-sanitize.ts
@@ -22,5 +22,11 @@ export function sanitizeForConsole(text: string | undefined, maxChars = 200): st
     .replace(/[\r\n\t]+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-  return sanitized.length > maxChars ? `${sanitized.slice(0, maxChars)}…` : sanitized;
+  const codePoints = Array.from(sanitized);
+  if (codePoints.length <= maxChars) {
+    return sanitized;
+  }
+  // Cap on code-point boundaries so a maxChars cut never splits a surrogate pair (emoji/astral) and
+  // leaves a lone surrogate before the ellipsis.
+  return `${codePoints.slice(0, maxChars).join("")}…`;
 }


### PR DESCRIPTION
## Summary

`sanitizeForConsole` (`src/agents/console-sanitize.ts`) filters control characters code-point-aware (`Array.from(...).filter(...)`), but then truncates with `sanitized.slice(0, maxChars)`, which operates on **UTF-16 code units**. When the `maxChars` boundary lands between the two code units of an astral character (emoji, many CJK-extension chars), `.slice()` cuts the surrogate pair in half and the output ends in a **lone high surrogate** immediately before the ellipsis — rendering as `�`.

### Changes
- `console-sanitize.ts` — cap on **code points** (reuse `Array.from(sanitized)`), mirroring the code-point truncation already used by the sibling Telegram command-text truncator.
- `console-sanitize.test.ts` — new colocated test asserting no lone surrogate after truncation, plus control-char/whitespace coverage.

## Real behavior proof

Behavior addressed: truncating a string whose cap lands mid-emoji produced a lone surrogate (`�`). After the fix the cut falls on whole characters.

Real environment tested: Node 22.22.1, macOS, no network/model. Vitest exercises the real exported `sanitizeForConsole`. BEFORE is `origin/main`'s file (swapped via `git show`).

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs src/agents/console-sanitize.test.ts
```

Evidence after fix:
```
sanitizeForConsole("😀😀😀😀😀😀", 3)
  BEFORE: "😀\ud83d…"   (lone high surrogate — broken glyph)
  AFTER:  "😀😀😀…"      (whole code points, no lone surrogate)
sanitizeForConsole("  hello\tworld  ")  BOTH: "hello world"  (control/whitespace handling unchanged)
```

Observed result after fix: truncation never emits a lone surrogate; control-char filtering and whitespace flattening are unchanged. The new test fails on `origin/main` and passes after.

What was not tested: end-to-end console logging (the test drives the real exported helper those log/display paths call).

## Additional checks
- `node scripts/run-vitest.mjs src/agents/console-sanitize.test.ts` passes; fail-before verified by swapping in `origin/main`'s file. `oxlint --tsconfig` clean.
