### PR TITLE
fix(ui): roll formatTokens over to "M" instead of rendering "1000k"

### DIFF
--- a/ui/src/ui/format.test.ts
+++ b/ui/src/ui/format.test.ts
@@ -6,6 +6,7 @@ import {
   formatMs,
   formatRelativeTimestamp,
   formatTimeMs,
+  formatTokens,
   formatUnknownText,
   parseSessionKeyParts,
   setUiTimeFormatPreference,
@@ -215,5 +216,17 @@ describe("parseSessionKeyParts", () => {
     expect(parseSessionKeyParts("agent:main")).toBeNull();
     expect(parseSessionKeyParts("agent:main:")).toBeNull();
     expect(parseSessionKeyParts("agent:main:telegram")).toBeNull();
+  });
+});
+
+describe("formatTokens", () => {
+  it("rolls a value that rounds up to 1000k over into the M branch", () => {
+    expect(formatTokens(999_500)).toBe("1.0M");
+    expect(formatTokens(999_999)).toBe("1.0M");
+    expect(formatTokens(999_499)).toBe("999k");
+    expect(formatTokens(1_000_000)).toBe("1.0M");
+    expect(formatTokens(12_345)).toBe("12k");
+    expect(formatTokens(5_500)).toBe("5.5k");
+    expect(formatTokens(null)).toBe("0");
   });
 });

--- a/ui/src/ui/format.ts
+++ b/ui/src/ui/format.ts
@@ -162,7 +162,14 @@ export function formatTokens(tokens: number | null | undefined, fallback = "0"):
   }
   if (tokens < 1_000_000) {
     const k = tokens / 1000;
-    return k < 10 ? `${k.toFixed(1)}k` : `${Math.round(k)}k`;
+    if (k < 10) {
+      return `${k.toFixed(1)}k`;
+    }
+    const rounded = Math.round(k);
+    // 999_500..999_999 rounds to 1000k; roll it over to the M branch instead of emitting "1000k".
+    if (rounded < 1000) {
+      return `${rounded}k`;
+    }
   }
   const m = tokens / 1_000_000;
   return m < 10 ? `${m.toFixed(1)}M` : `${Math.round(m)}M`;


### PR DESCRIPTION
## Summary

`formatTokens` (`ui/src/ui/format.ts`) selects the kilo branch on the raw value (`tokens < 1_000_000`), then renders `Math.round(tokens / 1000)`. For `999_500..999_999` that rounds to `1000`, so the label is the nonsensical **`"1000k"`** instead of rolling over to the `M` branch. The sibling `formatCompactTokenCount` (`ui/src/ui/chat/token-format.ts`) already handles this boundary and carries a regression test; `formatTokens` is the divergent twin and had no coverage.

It's reachable from the Overview "Total Tokens" card (`overview-cards.ts`) and the Usage tab (`usage.ts`), where aggregate token totals routinely land in that band.

### Changes
- `format.ts` — after computing the rounded kilo value, fall through to the `M` branch when it reaches `1000`.
- `format.test.ts` — boundary cases (import + `formatTokens` coverage, which was previously untested).

## Real behavior proof

Behavior addressed: token totals of 999,500–999,999 rendered as `"1000k"`. After the fix they roll over to the `M` branch; all other outputs are unchanged.

Real environment tested: Node 22.22.1, macOS, no network/model. Vitest exercises the real exported `formatTokens`. BEFORE is `origin/main`'s `format.ts` (swapped via `git show`).

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs ui/src/ui/format.test.ts
```

Evidence after fix:
```
formatTokens(999_500)   BEFORE: "1000k"   AFTER: "1.0M"
formatTokens(999_999)   BEFORE: "1000k"   AFTER: "1.0M"
formatTokens(999_499)   BOTH: "999k"      (no rollover, unchanged)
formatTokens(1_000_000) BOTH: "1.0M"      (unchanged)
formatTokens(12_345)    BOTH: "12k"       (unchanged)
```

Observed result after fix: the `1000k` band rolls over to `1.0M`; sub-rollover kilo values and existing M outputs are byte-identical. The new test fails on `origin/main` and passes after.

What was not tested: live dashboard render (the test drives the real exported `formatTokens` the cards call). I left the existing `1.0M` format as-is (minimal fix; did not trim the cosmetic trailing `.0`).

## Additional checks
- `node scripts/run-vitest.mjs ui/src/ui/format.test.ts` passes; fail-before verified by swapping in `origin/main`'s file. `oxlint --tsconfig` clean.
