### PR TITLE
fix(cli): reject finite-but-unsafe byte sizes

### DIFF
--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -159,6 +159,13 @@ describe("parseByteSize", () => {
   it.each(["", "nope", "-5kb"] as const)("rejects invalid value %j", (input) => {
     expect(() => parseByteSize(input)).toThrow(/Invalid byte size/);
   });
+
+  it.each(["9007199254740993", "9000000tb"] as const)(
+    "rejects finite-but-unsafe values that would round to a different number: %j",
+    (input) => {
+      expect(() => parseByteSize(input)).toThrow(/Invalid byte size/);
+    },
+  );
 });
 
 describe("parseDurationMs", () => {

--- a/src/cli/parse-bytes.ts
+++ b/src/cli/parse-bytes.ts
@@ -28,6 +28,16 @@ function invalidByteSize(raw: string, reason?: string): Error {
   return new Error(`${prefix} Use values like 512kb, 10mb, 1gb, or 500.`);
 }
 
+// Reject finite-but-unsafe results (above Number.MAX_SAFE_INTEGER), which round to a different
+// number than the user typed; mirrors roundSafeDurationMs in parse-duration.ts.
+function roundSafeByteSize(raw: string, value: number): number {
+  const bytes = Math.round(value);
+  if (!Number.isSafeInteger(bytes)) {
+    throw invalidByteSize(raw);
+  }
+  return bytes;
+}
+
 /** Parse a non-negative byte size with optional binary units like kb, mb, gb, or tb. */
 export function parseByteSize(raw: string, opts?: BytesParseOptions): number {
   const trimmed = normalizeLowercaseStringOrEmpty(normalizeOptionalString(raw) ?? "");
@@ -51,9 +61,5 @@ export function parseByteSize(raw: string, opts?: BytesParseOptions): number {
     throw invalidByteSize(raw, `unknown unit "${unit}"`);
   }
 
-  const bytes = Math.round(value * multiplier);
-  if (!Number.isFinite(bytes)) {
-    throw invalidByteSize(raw);
-  }
-  return bytes;
+  return roundSafeByteSize(raw, value * multiplier);
 }

--- a/src/config/byte-size.test.ts
+++ b/src/config/byte-size.test.ts
@@ -1,0 +1,34 @@
+// Verifies byte-size config parsing keeps numeric and string forms in parity.
+import { describe, expect, it } from "vitest";
+import { isValidNonNegativeByteSizeString, parseNonNegativeByteSize } from "./byte-size.js";
+
+describe("parseNonNegativeByteSize", () => {
+  it("parses non-negative numbers and unit strings", () => {
+    expect(parseNonNegativeByteSize(0)).toBe(0);
+    expect(parseNonNegativeByteSize(1024)).toBe(1024);
+    expect(parseNonNegativeByteSize("2mb")).toBe(2 * 1024 * 1024);
+    expect(parseNonNegativeByteSize("500")).toBe(500);
+  });
+
+  it("rejects negatives and non-byte values", () => {
+    expect(parseNonNegativeByteSize(-1)).toBeNull();
+    expect(parseNonNegativeByteSize("-5kb")).toBeNull();
+    expect(parseNonNegativeByteSize("nope")).toBeNull();
+    expect(parseNonNegativeByteSize(undefined)).toBeNull();
+  });
+
+  it("rejects finite-but-unsafe sizes from both numeric and string config forms", () => {
+    // Above Number.MAX_SAFE_INTEGER the value cannot round-trip, so neither form should accept it;
+    // the numeric path previously returned a precision-corrupted number while the string path threw.
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+    expect(parseNonNegativeByteSize(unsafe)).toBeNull();
+    expect(parseNonNegativeByteSize(String(unsafe))).toBeNull();
+    expect(parseNonNegativeByteSize(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("reports validity for byte-size strings", () => {
+    expect(isValidNonNegativeByteSizeString("2mb")).toBe(true);
+    expect(isValidNonNegativeByteSizeString("nope")).toBe(false);
+    expect(isValidNonNegativeByteSizeString(String(Number.MAX_SAFE_INTEGER + 1))).toBe(false);
+  });
+});

--- a/src/config/byte-size.ts
+++ b/src/config/byte-size.ts
@@ -8,7 +8,9 @@ import { parseByteSize } from "../cli/parse-bytes.js";
 export function parseNonNegativeByteSize(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     const int = Math.floor(value);
-    return int >= 0 ? int : null;
+    // Match the string path (parseByteSize): an unsafe-integer byte size silently loses precision,
+    // so reject it instead of returning a corrupted value. Keeps numeric and string config parity.
+    return Number.isSafeInteger(int) && int >= 0 ? int : null;
   }
   if (typeof value === "string") {
     const trimmed = value.trim();

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -316,6 +316,20 @@ describe("agent defaults schema", () => {
     expect(result.compaction?.maxActiveTranscriptBytes).toBe("20mb");
   });
 
+  it("rejects unsafe numeric byte sizes in compaction defaults", () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+    expect(
+      AgentDefaultsSchema.safeParse({
+        compaction: { maxActiveTranscriptBytes: unsafe },
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentDefaultsSchema.safeParse({
+        compaction: { memoryFlush: { forceFlushTranscriptBytes: unsafe } },
+      }).success,
+    ).toBe(false);
+  });
+
   it("accepts compaction.midTurnPrecheck.enabled", () => {
     const result = AgentDefaultsSchema.parse({
       compaction: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -22,7 +22,7 @@ import {
 const SilentReplyPolicySchema = z.union([z.literal("allow"), z.literal("disallow")]);
 
 const NonNegativeByteSizeSchema = z.union([
-  z.number().int().nonnegative(),
+  z.number().int().nonnegative().refine(Number.isSafeInteger, "Expected a safe integer byte size"),
   z.string().refine(isValidNonNegativeByteSizeString, "Expected byte size string like 2mb"),
 ]);
 


### PR DESCRIPTION
## What Problem This Solves

`parseByteSize` rounded byte values and only rejected non-finite results. Inputs above `Number.MAX_SAFE_INTEGER` are finite but precision-corrupted, so values such as `9007199254740993` could be accepted as a different byte count. Numeric config paths had the same unsafe-integer gap.

## Why This Change Was Made

This mirrors the existing safe-duration behavior: byte-size parsing now rejects rounded results that are not safe integers. Config byte-size parsing and agent defaults schema validation use the same safe-integer contract so string and numeric config forms stay in parity.

## User Impact

Valid byte sizes are unchanged. Unsafe byte-size values that JavaScript cannot represent exactly now fail validation instead of silently rounding to a different number.

## Evidence

- `node scripts/run-vitest.mjs src/cli/cli-utils.test.ts src/config/byte-size.test.ts src/config/zod-schema.agent-defaults.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs src/cli/cli-utils.test.ts src/config/byte-size.test.ts src/config/zod-schema.agent-defaults.test.ts"`
