### PR TITLE
fix(telegram): restore bordered attribute on rich HTML tables

### DIFF
--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -984,7 +984,7 @@ function renderTelegramRichHtmlTable(table: MarkdownTableMeta): string {
     )
     .join("");
   const body = bodyRows ? `<tbody>${bodyRows}</tbody>` : "";
-  return `<table>${head}${body}</table>\n\n`;
+  return `<table bordered>${head}${body}</table>\n\n`;
 }
 
 function renderTelegramRichHtmlDocument(


### PR DESCRIPTION
## Summary

Bot API 10.1 `<table>` blocks render without visible borders when the `bordered` attribute is omitted. Tables were rendering correctly in 2026.6.8 but lost their grid lines in a subsequent version.

## Change

In `renderTelegramRichHtmlTable` (`extensions/telegram/src/format.ts`), add the `bordered` attribute to the generated `<table>` tag:

```diff
- return `<table>${head}${body}</table>\n\n`;
+ return `<table bordered>${head}${body}</table>\n\n`;
```

The `bordered` attribute is already listed in the Telegram rich HTML allowlist validator (`["table", /^(?:\s+(?:bordered|striped))*\s*$/]`), so this is a supported Bot API 10.1 attribute.

## Reproduction

1. Set `channels.telegram.richMessages: true`
2. Send a markdown table from an agent
3. **Before fix**: table renders with no visible grid lines
4. **After fix**: table renders with bordered grid lines

## Related

Regression affecting users on 2026.6.10 who rely on `richMessages` for table formatting.
