### PR TITLE
fix(openshell): make sandbox e2e reliable on current gateway

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -609,7 +609,6 @@ jobs:
             requires_repo_e2e: true
             requires_live_suites: false
     env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENCLAW_E2E_WORKERS: "1"
       OPENCLAW_VITEST_MAX_WORKERS: "1"
     steps:
@@ -643,8 +642,73 @@ jobs:
           set -euo pipefail
           case "${{ matrix.suite_id }}" in
             openshell-e2e)
+              echo "OPENCLAW_E2E_OPENSHELL_CONFIG_HOME=$HOME/.config" >> "$GITHUB_ENV"
               ;;
           esac
+
+      - name: Install OpenShell CLI
+        if: |
+          (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id) &&
+          matrix.suite_id == 'openshell-e2e'
+        shell: bash
+        run: |
+          set -euo pipefail
+          export OPENSHELL_VERSION=v0.0.68
+          curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/d64542f69d06694cbd203b64929d286dd0533bbb/install.sh | sh
+          openshell --version
+
+      - name: Bootstrap OpenShell gateway
+        if: |
+          (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id) &&
+          matrix.suite_id == 'openshell-e2e'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mtls_dir="$HOME/.config/openshell/gateways/openshell/mtls"
+          gateway_tls_dir="$RUNNER_TEMP/openshell-gateway-certs"
+          fallback_pid=""
+          if ! openshell --gateway openshell sandbox list >/dev/null 2>&1; then
+            rm -rf "$gateway_tls_dir"
+            openshell-gateway generate-certs \
+              --output-dir "$gateway_tls_dir" \
+              --server-san 127.0.0.1 \
+              --server-san localhost \
+              --server-san host.openshell.internal
+            rm -rf "$mtls_dir"
+            mkdir -p "$mtls_dir"
+            cp "$gateway_tls_dir/ca.crt" "$mtls_dir/ca.crt"
+            cp "$gateway_tls_dir/client/tls.crt" "$mtls_dir/tls.crt"
+            cp "$gateway_tls_dir/client/tls.key" "$mtls_dir/tls.key"
+            openshell gateway remove openshell >/dev/null 2>&1 || true
+            OPENSHELL_LOCAL_TLS_DIR="$gateway_tls_dir" nohup openshell-gateway \
+              --bind-address 0.0.0.0 \
+              --port 17670 \
+              --drivers docker \
+              --tls-cert "$gateway_tls_dir/server/tls.crt" \
+              --tls-key "$gateway_tls_dir/server/tls.key" \
+              --tls-client-ca "$mtls_dir/ca.crt" \
+              >"$RUNNER_TEMP/openshell-gateway.log" 2>&1 &
+            fallback_pid=$!
+            echo "OPENCLAW_OPENSHELL_FALLBACK_PID=$fallback_pid" >> "$GITHUB_ENV"
+            for _ in $(seq 1 30); do
+              if openshell gateway add --local --name openshell https://127.0.0.1:17670; then
+                break
+              fi
+              sleep 1
+            done
+            openshell gateway select openshell
+            for _ in $(seq 1 60); do
+              if openshell --gateway openshell sandbox list >/dev/null 2>&1; then
+                break
+              fi
+              sleep 1
+            done
+          fi
+          if [[ -z "$fallback_pid" ]]; then
+            echo "OPENCLAW_OPENSHELL_FALLBACK_PID=" >> "$GITHUB_ENV"
+          fi
+          openshell --gateway openshell sandbox list >/dev/null
+          openshell gateway list
 
       - name: Validate suite credentials
         if: inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id
@@ -664,6 +728,15 @@ jobs:
           ) &&
           (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id)
         run: ${{ matrix.command }}
+
+      - name: Stop fallback OpenShell gateway
+        if: always() && matrix.suite_id == 'openshell-e2e'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${OPENCLAW_OPENSHELL_FALLBACK_PID:-}" ]]; then
+            kill "$OPENCLAW_OPENSHELL_FALLBACK_PID" 2>/dev/null || true
+          fi
 
   validate_docker_e2e:
     needs: [validate_selected_ref, prepare_docker_e2e_image, plan_release_workflow_matrices]

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -740,17 +740,20 @@ Native dependency policy:
 - Command: `pnpm test:e2e:openshell`
 - File: `extensions/openshell/src/backend.e2e.test.ts`
 - Scope:
-  - Starts an isolated OpenShell gateway on the host via Docker
+  - Reuses an active local OpenShell gateway
   - Creates a sandbox from a temporary local Dockerfile
   - Exercises OpenClaw's OpenShell backend over real `sandbox ssh-config` + SSH exec
   - Verifies remote-canonical filesystem behavior through the sandbox fs bridge
 - Expectations:
   - Opt-in only; not part of the default `pnpm test:e2e` run
   - Requires a local `openshell` CLI plus a working Docker daemon
-  - Uses isolated `HOME` / `XDG_CONFIG_HOME`, then destroys the test gateway and sandbox
+  - Requires an active local OpenShell gateway and its config source
+  - Uses isolated `HOME` / `XDG_CONFIG_HOME`, then destroys the test sandbox
 - Useful overrides:
   - `OPENCLAW_E2E_OPENSHELL=1` to enable the test when running the broader e2e suite manually
   - `OPENCLAW_E2E_OPENSHELL_COMMAND=/path/to/openshell` to point at a non-default CLI binary or wrapper script
+  - `OPENCLAW_E2E_OPENSHELL_CONFIG_HOME=/path/to/config` to expose the registered gateway config to the isolated test
+  - `OPENCLAW_E2E_OPENSHELL_HOST_IP=172.18.0.1` to override the Docker gateway IP used by the host policy fixture
 
 ### Live (real providers + real models)
 

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -18,21 +18,24 @@ const OPENCLAW_OPENSHELL_E2E = process.env.OPENCLAW_E2E_OPENSHELL === "1";
 const OPENCLAW_OPENSHELL_E2E_TIMEOUT_MS = 12 * 60_000;
 const OPENCLAW_OPENSHELL_COMMAND =
   process.env.OPENCLAW_E2E_OPENSHELL_COMMAND?.trim() || "openshell";
+const OPENCLAW_OPENSHELL_CONFIG_HOME =
+  process.env.OPENCLAW_E2E_OPENSHELL_CONFIG_HOME?.trim() || null;
+const OPENCLAW_OPENSHELL_HOST_IP = process.env.OPENCLAW_E2E_OPENSHELL_HOST_IP?.trim() || null;
+const ANSI_ESCAPE_RE = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-?]*[ -/]*[@-~]`, "gu");
 
 const CUSTOM_IMAGE_DOCKERFILE = `FROM python:3.13-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \\
-    coreutils \\
-    curl \\
-    findutils \\
-    iproute2 \\
+    coreutils curl findutils iproute2 nftables \\
   && rm -rf /var/lib/apt/lists/*
 
-RUN groupadd -g 1000 sandbox && \\
-    useradd -m -u 1000 -g sandbox sandbox
+RUN groupadd -g 1000660000 sandbox && \\
+    useradd -m -u 1000660000 -g sandbox sandbox && \\
+    install -d -o sandbox -g sandbox /sandbox
 
 RUN echo "openclaw-openshell-e2e" > /opt/openshell-e2e-marker.txt
 
+USER sandbox
 WORKDIR /sandbox
 CMD ["sleep", "infinity"]
 `;
@@ -125,17 +128,55 @@ async function commandAvailable(command: string): Promise<boolean> {
   }
 }
 
-async function openshellGatewayAvailable(command: string): Promise<boolean> {
+async function activeOpenShellGateway(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | null> {
   try {
     const result = await runCommand({
       command,
-      args: ["gateway", "start", "--help"],
+      args: ["gateway", "list"],
+      env,
       allowFailure: true,
       timeoutMs: 20_000,
     });
-    return result.code === 0 && `${result.stdout}\n${result.stderr}`.includes("--name");
+    if (result.code !== 0) {
+      return null;
+    }
+    const output = `${result.stdout}\n${result.stderr}`.replace(ANSI_ESCAPE_RE, "");
+    for (const line of output.split(/\r?\n/u)) {
+      const match = line.match(/\*\s+(\S+)/u);
+      if (match) {
+        const info = await runCommand({
+          command,
+          args: ["gateway", "info", "--gateway", match[1]],
+          env,
+          allowFailure: true,
+          timeoutMs: 20_000,
+        });
+        const endpoint = `${info.stdout}\n${info.stderr}`
+          .replace(ANSI_ESCAPE_RE, "")
+          .match(/Gateway endpoint:\s+(\S+)/u)?.[1];
+        if (
+          info.code === 0 &&
+          endpoint &&
+          /^(?:https?:\/\/)?(?:127\.0\.0\.1|localhost)(?::\d+)?(?:\/|$)/u.test(endpoint)
+        ) {
+          const status = await runCommand({
+            command,
+            args: ["--gateway", match[1], "sandbox", "list"],
+            env,
+            allowFailure: true,
+            timeoutMs: 20_000,
+          });
+          return status.code === 0 ? match[1] : null;
+        }
+        return null;
+      }
+    }
+    return null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -151,6 +192,41 @@ async function dockerReady(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function resolveOpenShellHostIp(): Promise<string> {
+  if (OPENCLAW_OPENSHELL_HOST_IP) {
+    return OPENCLAW_OPENSHELL_HOST_IP;
+  }
+  const networks = await runCommand({
+    command: "docker",
+    args: ["network", "ls", "--format", "{{.Name}}"],
+    timeoutMs: 20_000,
+  });
+  for (const network of networks.stdout.split(/\r?\n/u).map((value) => value.trim())) {
+    if (!network.startsWith("openshell")) {
+      continue;
+    }
+    const gateway = await runCommand({
+      command: "docker",
+      args: [
+        "network",
+        "inspect",
+        network,
+        "--format",
+        "{{range .IPAM.Config}}{{.Gateway}}{{end}}",
+      ],
+      allowFailure: true,
+      timeoutMs: 20_000,
+    });
+    const hostIp = gateway.stdout.trim();
+    if (gateway.code === 0 && hostIp) {
+      return hostIp;
+    }
+  }
+  throw new Error(
+    "OpenShell E2E could not resolve the OpenShell Docker network gateway; set OPENCLAW_E2E_OPENSHELL_HOST_IP",
+  );
 }
 
 async function allocatePort(): Promise<number> {
@@ -285,14 +361,21 @@ HTTPServer(("0.0.0.0", 8000), Handler).serve_forever()
   throw new Error("docker-backed host policy server did not become ready");
 }
 
-function buildOpenShellPolicyYaml(params: { port: number; binaryPath: string }): string {
+function buildOpenShellPolicyYaml(params: {
+  port: number;
+  binaryPath: string;
+  hostIp: string;
+}): string {
   const networkPolicies = `  host_echo:
     name: host-echo
     endpoints:
       - host: host.openshell.internal
         port: ${params.port}
+        protocol: rest
+        enforcement: enforce
+        access: full
         allowed_ips:
-          - "0.0.0.0/0"
+          - "${params.hostIp}/32"
     binaries:
       - path: ${params.binaryPath}`;
   return `version: 1
@@ -351,13 +434,24 @@ describe("openshell sandbox backend e2e", () => {
     { timeout: OPENCLAW_OPENSHELL_E2E_TIMEOUT_MS },
     async () => {
       if (!(await dockerReady())) {
-        return;
+        throw new Error("OpenShell E2E requires a working Docker daemon");
       }
       if (!(await commandAvailable(OPENCLAW_OPENSHELL_COMMAND))) {
-        return;
+        throw new Error(`OpenShell CLI is unavailable: ${OPENCLAW_OPENSHELL_COMMAND}`);
       }
-      if (!(await openshellGatewayAvailable(OPENCLAW_OPENSHELL_COMMAND))) {
-        return;
+      if (!OPENCLAW_OPENSHELL_CONFIG_HOME) {
+        throw new Error(
+          "OpenShell E2E requires OPENCLAW_E2E_OPENSHELL_CONFIG_HOME because tests isolate HOME and XDG_CONFIG_HOME",
+        );
+      }
+      const openshellConfigHome = OPENCLAW_OPENSHELL_CONFIG_HOME;
+      const hostIp = await resolveOpenShellHostIp();
+      const gatewayName = await activeOpenShellGateway(OPENCLAW_OPENSHELL_COMMAND, {
+        ...process.env,
+        XDG_CONFIG_HOME: openshellConfigHome,
+      });
+      if (!gatewayName) {
+        throw new Error("OpenShell E2E requires an active local registered gateway");
       }
 
       const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-openshell-e2e-"));
@@ -371,10 +465,8 @@ describe("openshell sandbox backend e2e", () => {
       const denyPolicyPath = path.join(rootDir, "deny-policy.yaml");
       const allowPolicyPath = path.join(rootDir, "allow-policy.yaml");
       const scopeSuffix = `${process.pid}-${Date.now()}`;
-      const gatewayName = `openclaw-e2e-${scopeSuffix}`;
       const scopeKey = `session:openshell-e2e-deny:${scopeSuffix}`;
       const allowSandboxName = `openclaw-policy-allow-${scopeSuffix}`;
-      const gatewayPort = await allocatePort();
       let hostPolicyServer: HostPolicyServer | null | undefined;
       const sandboxCfg = {
         mode: "all" as const,
@@ -425,6 +517,16 @@ describe("openshell sandbox backend e2e", () => {
         }
         await fs.mkdir(workspaceDir, { recursive: true });
         await fs.mkdir(dockerfileDir, { recursive: true });
+        const isolatedConfigHome = env.XDG_CONFIG_HOME;
+        if (!isolatedConfigHome) {
+          throw new Error("OpenShell E2E could not create an isolated XDG config home");
+        }
+        await fs.mkdir(isolatedConfigHome, { recursive: true });
+        await fs.cp(
+          path.join(openshellConfigHome, "openshell"),
+          path.join(isolatedConfigHome, "openshell"),
+          { recursive: true },
+        );
         await fs.writeFile(path.join(workspaceDir, "seed.txt"), "seed-from-local\n", "utf8");
         await fs.writeFile(dockerfilePath, CUSTOM_IMAGE_DOCKERFILE, "utf8");
         await fs.writeFile(
@@ -432,6 +534,7 @@ describe("openshell sandbox backend e2e", () => {
           buildOpenShellPolicyYaml({
             port: hostPolicyServer.port,
             binaryPath: "/usr/bin/false",
+            hostIp,
           }),
           "utf8",
         );
@@ -439,25 +542,11 @@ describe("openshell sandbox backend e2e", () => {
           allowPolicyPath,
           buildOpenShellPolicyYaml({
             port: hostPolicyServer.port,
-            binaryPath: "/**",
+            binaryPath: "/usr/bin/curl",
+            hostIp,
           }),
           "utf8",
         );
-
-        await runCommand({
-          command: OPENCLAW_OPENSHELL_COMMAND,
-          args: [
-            "gateway",
-            "start",
-            "--name",
-            gatewayName,
-            "--port",
-            String(gatewayPort),
-            "--recreate",
-          ],
-          env,
-          timeoutMs: 8 * 60_000,
-        });
 
         const execResult = await runBackendExec({
           backend,
@@ -567,13 +656,6 @@ describe("openshell sandbox backend e2e", () => {
           env,
           allowFailure: true,
           timeoutMs: 2 * 60_000,
-        });
-        await runCommand({
-          command: OPENCLAW_OPENSHELL_COMMAND,
-          args: ["gateway", "destroy", "--name", gatewayName],
-          env,
-          allowFailure: true,
-          timeoutMs: 3 * 60_000,
         });
         await hostPolicyServer?.close().catch(() => {});
         await fs.rm(rootDir, { recursive: true, force: true });

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -738,9 +738,11 @@ class OpenShellSandboxBackendImpl {
       async ({ dir: tmpDir }) => {
         // Stage a symlink-free snapshot so upload never dereferences host paths
         // outside the mirrored workspace tree.
+        const remoteRootName = path.posix.basename(remotePath);
+        const stagedRoot = path.join(tmpDir, remoteRootName);
         await stageDirectoryContents({
           sourceDir: localPath,
-          targetDir: tmpDir,
+          targetDir: stagedRoot,
         });
         const result = await runOpenShellCli({
           context: this.params.execContext,
@@ -749,8 +751,8 @@ class OpenShellSandboxBackendImpl {
             "upload",
             "--no-git-ignore",
             this.params.execContext.sandboxName,
-            tmpDir,
-            remotePath,
+            stagedRoot,
+            path.posix.dirname(remotePath),
           ],
           cwd: this.params.createParams.workspaceDir,
         });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenShell-backed sandboxes could upload a directory under a generated staging name, and the OpenShell E2E lane could not reliably run against the current CLI and gateway setup.

## Why This Change Was Made

The backend now stages directory uploads under the requested remote basename so OpenShell's basename-preserving upload behavior lands files at the canonical workspace path. The E2E fixture and CI lane now match OpenShell 0.0.68, isolate CLI configuration, resolve the Docker gateway address for host-policy checks, and bootstrap a local gateway only when the runner does not already have one.

## User Impact

OpenShell sandbox creation and workspace uploads use the expected remote paths. The dedicated E2E lane is repeatable on clean CI runners without requiring a preconfigured gateway or leaking the live provider secret into the setup steps.

## Evidence

- Testbox-through-Crabbox `tbx_01kvw2b5hfn801b9agq09f1784`:
  - `OPENCLAW_E2E_OPENSHELL_CONFIG_HOME=/home/runner/.config corepack pnpm test:e2e:openshell` passed against a real local OpenShell gateway after installing pinned `v0.0.68`.
  - `corepack pnpm check:changed` passed all selected lanes, including extension typecheck/lint, script lint, guards, and import-cycle checks.
- Autoreview: clean, no accepted/actionable findings.
- Focused Docker kitchen-sink RPC and browser CDP snapshot lanes were already green on the same validation track.
