### PR TITLE
fix(signal): route username targets as usernames, not phone numbers

### DIFF
--- a/extensions/signal/src/normalize.test.ts
+++ b/extensions/signal/src/normalize.test.ts
@@ -3,6 +3,11 @@ import { describe, expect, it } from "vitest";
 import { looksLikeSignalTargetId, normalizeSignalMessagingTarget } from "./normalize.js";
 
 describe("normalizeSignalMessagingTarget", () => {
+  it("canonicalizes username target prefixes", () => {
+    expect(normalizeSignalMessagingTarget("username:Alice.42")).toBe("username:alice.42");
+    expect(normalizeSignalMessagingTarget("signal:u:Alice.42")).toBe("username:alice.42");
+  });
+
   it("normalizes uuid targets by stripping uuid:", () => {
     expect(normalizeSignalMessagingTarget("uuid:123E4567-E89B-12D3-A456-426614174000")).toBe(
       "123e4567-e89b-12d3-a456-426614174000",

--- a/extensions/signal/src/outbound-session.test.ts
+++ b/extensions/signal/src/outbound-session.test.ts
@@ -4,8 +4,6 @@ import { resolveSignalOutboundTarget } from "./outbound-session.js";
 
 describe("resolveSignalOutboundTarget", () => {
   it("keeps username targets intact instead of resolving them as phone numbers", () => {
-    // Before the fix the username flowed through the phone resolver, so normalizeE164 digit-stripped
-    // "alice.42" into "+42" and corrupted both the delivery target and the session key.
     const expected = {
       peer: { kind: "direct", id: "username:alice.42" },
       chatType: "direct",
@@ -15,6 +13,7 @@ describe("resolveSignalOutboundTarget", () => {
     expect(resolveSignalOutboundTarget("username:alice.42")).toEqual(expected);
     expect(resolveSignalOutboundTarget("u:alice.42")).toEqual(expected);
     expect(resolveSignalOutboundTarget("signal:username:alice.42")).toEqual(expected);
+    expect(resolveSignalOutboundTarget("signal:u:ALICE.42")).toEqual(expected);
   });
 
   it("still resolves group and phone targets", () => {

--- a/extensions/signal/src/outbound-session.test.ts
+++ b/extensions/signal/src/outbound-session.test.ts
@@ -1,0 +1,31 @@
+// Signal outbound session route tests cover target-grammar dispatch.
+import { describe, expect, it } from "vitest";
+import { resolveSignalOutboundTarget } from "./outbound-session.js";
+
+describe("resolveSignalOutboundTarget", () => {
+  it("keeps username targets intact instead of resolving them as phone numbers", () => {
+    // Before the fix the username flowed through the phone resolver, so normalizeE164 digit-stripped
+    // "alice.42" into "+42" and corrupted both the delivery target and the session key.
+    const expected = {
+      peer: { kind: "direct", id: "username:alice.42" },
+      chatType: "direct",
+      from: "signal:username:alice.42",
+      to: "signal:username:alice.42",
+    };
+    expect(resolveSignalOutboundTarget("username:alice.42")).toEqual(expected);
+    expect(resolveSignalOutboundTarget("u:alice.42")).toEqual(expected);
+    expect(resolveSignalOutboundTarget("signal:username:alice.42")).toEqual(expected);
+  });
+
+  it("still resolves group and phone targets", () => {
+    expect(resolveSignalOutboundTarget("group:abc==")).toMatchObject({
+      peer: { kind: "group", id: "abc==" },
+      chatType: "group",
+      to: "group:abc==",
+    });
+    expect(resolveSignalOutboundTarget("+15551234567")).toMatchObject({
+      chatType: "direct",
+      to: "signal:+15551234567",
+    });
+  });
+});

--- a/extensions/signal/src/outbound-session.ts
+++ b/extensions/signal/src/outbound-session.ts
@@ -2,6 +2,7 @@
 import type { RoutePeer } from "openclaw/plugin-sdk/routing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveSignalPeerId, resolveSignalRecipient, resolveSignalSender } from "./identity.js";
+import { normalizeSignalMessagingTarget } from "./normalize.js";
 import { looksLikeUuid } from "./uuid.js";
 
 export type ResolvedSignalOutboundTarget = {
@@ -12,13 +13,13 @@ export type ResolvedSignalOutboundTarget = {
 };
 
 export function resolveSignalOutboundTarget(target: string): ResolvedSignalOutboundTarget | null {
-  const stripped = target.replace(/^signal:/i, "").trim();
-  const lowered = normalizeLowercaseStringOrEmpty(stripped);
+  const normalized = normalizeSignalMessagingTarget(target);
+  if (!normalized) {
+    return null;
+  }
+  const lowered = normalizeLowercaseStringOrEmpty(normalized);
   if (lowered.startsWith("group:")) {
-    const groupId = stripped.slice("group:".length).trim();
-    if (!groupId) {
-      return null;
-    }
+    const groupId = normalized.slice("group:".length);
     return {
       peer: { kind: "group", id: groupId },
       chatType: "group",
@@ -27,27 +28,18 @@ export function resolveSignalOutboundTarget(target: string): ResolvedSignalOutbo
     };
   }
 
-  if (lowered.startsWith("username:") || lowered.startsWith("u:")) {
-    const name = stripped.slice(stripped.indexOf(":") + 1).trim();
-    if (!name) {
-      return null;
-    }
-    // A Signal username is NOT a phone number; routing it through the phone/uuid resolver would
-    // E.164-digit-strip "alice.42" into "+42" and corrupt both the delivery target and the session
-    // key. Keep the username grammar intact, mirroring send.ts parseTarget.
-    const id = `username:${name}`;
+  if (lowered.startsWith("username:")) {
+    // Keep delivery and session identity on the canonical username target. Phone normalization
+    // would digit-strip the username and could collide with a real phone session.
     return {
-      peer: { kind: "direct", id },
+      peer: { kind: "direct", id: normalized },
       chatType: "direct",
-      from: `signal:${id}`,
-      to: `signal:${id}`,
+      from: `signal:${normalized}`,
+      to: `signal:${normalized}`,
     };
   }
 
-  const recipient = stripped.trim();
-  if (!recipient) {
-    return null;
-  }
+  const recipient = normalized;
 
   const uuidCandidate = normalizeLowercaseStringOrEmpty(recipient).startsWith("uuid:")
     ? recipient.slice("uuid:".length)

--- a/extensions/signal/src/outbound-session.ts
+++ b/extensions/signal/src/outbound-session.ts
@@ -27,12 +27,24 @@ export function resolveSignalOutboundTarget(target: string): ResolvedSignalOutbo
     };
   }
 
-  let recipient = stripped.trim();
-  if (lowered.startsWith("username:")) {
-    recipient = stripped.slice("username:".length).trim();
-  } else if (lowered.startsWith("u:")) {
-    recipient = stripped.slice("u:".length).trim();
+  if (lowered.startsWith("username:") || lowered.startsWith("u:")) {
+    const name = stripped.slice(stripped.indexOf(":") + 1).trim();
+    if (!name) {
+      return null;
+    }
+    // A Signal username is NOT a phone number; routing it through the phone/uuid resolver would
+    // E.164-digit-strip "alice.42" into "+42" and corrupt both the delivery target and the session
+    // key. Keep the username grammar intact, mirroring send.ts parseTarget.
+    const id = `username:${name}`;
+    return {
+      peer: { kind: "direct", id },
+      chatType: "direct",
+      from: `signal:${id}`,
+      to: `signal:${id}`,
+    };
   }
+
+  const recipient = stripped.trim();
   if (!recipient) {
     return null;
   }

--- a/extensions/signal/src/send.test.ts
+++ b/extensions/signal/src/send.test.ts
@@ -79,6 +79,21 @@ describe("sendMessageSignal receipts", () => {
     expect(result.receipt.sentAt).toBeGreaterThan(0);
   });
 
+  it.each(["username:alice.42", "u:alice.42", "signal:u:ALICE.42"])(
+    "sends %s through the canonical username parameter",
+    async (target) => {
+      signalRpcRequestMock.mockResolvedValueOnce({ timestamp: 1234567890 });
+
+      await sendMessageSignal(target, "hello", { cfg: SIGNAL_TEST_CFG });
+
+      expect(signalRpcRequestMock).toHaveBeenCalledWith(
+        "send",
+        expect.objectContaining({ username: ["alice.42"] }),
+        expect.any(Object),
+      );
+    },
+  );
+
   it("attaches a media receipt for attachment sends", async () => {
     signalRpcRequestMock.mockResolvedValueOnce({ timestamp: 1234567891 });
 

--- a/extensions/signal/src/send.ts
+++ b/extensions/signal/src/send.ts
@@ -14,6 +14,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { resolveSignalAccount } from "./accounts.js";
 import { signalRpcRequest } from "./client-adapter.js";
 import { markdownToSignalText, type SignalTextStyleRange } from "./format.js";
+import { normalizeSignalMessagingTarget } from "./normalize.js";
 import { resolveSignalRpcContext } from "./rpc-context.js";
 
 export type SignalSendOpts = {
@@ -69,13 +70,9 @@ async function resolveSignalRpcAccountInfo(opts: SignalRpcOpts) {
 }
 
 function parseTarget(raw: string): SignalTarget {
-  let value = raw.trim();
+  const value = normalizeSignalMessagingTarget(raw);
   if (!value) {
     throw new Error("Signal recipient is required");
-  }
-  const lower = normalizeLowercaseStringOrEmpty(value);
-  if (lower.startsWith("signal:")) {
-    value = value.slice("signal:".length).trim();
   }
   const normalized = normalizeLowercaseStringOrEmpty(value);
   if (normalized.startsWith("group:")) {
@@ -86,9 +83,6 @@ function parseTarget(raw: string): SignalTarget {
       type: "username",
       username: value.slice("username:".length).trim(),
     };
-  }
-  if (normalized.startsWith("u:")) {
-    return { type: "username", username: value.trim() };
   }
   return { type: "recipient", recipient: value };
 }


### PR DESCRIPTION
## Summary

`resolveSignalOutboundTarget` (`extensions/signal/src/outbound-session.ts`) handled the documented `username:`/`u:` Signal send grammar by stripping the prefix to the bare name — and then fell through to the phone/uuid resolver. `resolveSignalSender` treats any non-empty `sourceNumber` as a phone and runs it through `normalizeE164`, which strips all non-digits. So:

- `username:alice.42` → phone `+42`
- `username:kevin` → `+` (empty)
- `signal:username:bob.99` → `+99`

Both the returned `to`/`from` **and** the `RoutePeer` id (the session key) are corrupted, so an agent replying/sending to a Signal username delivers to a wrong/empty phone number (or fails) and is keyed to the wrong session. Group and phone/uuid targets resolve correctly; only the username grammar was mis-dispatched.

Usernames are a first-class, documented send target (`docs/channels/signal.md`), and the sibling `send.ts parseTarget` maps `username:`/`u:` to a distinct username send — `resolveSignalOutboundTarget` was the one target-grammar surface that didn't honor it.

### Changes
- `outbound-session.ts` — add a dedicated username branch (after the `group:` branch) that returns `{ peer: { kind: "direct", id: "username:<name>" }, chatType: "direct", to/from: "signal:username:<name>" }`, and remove the prefix-stripping that fell through into the phone resolver.
- `outbound-session.test.ts` — new colocated test (username + group + phone).

## Real behavior proof

Behavior addressed: a Signal `username:`/`u:` target was digit-stripped into a bogus phone number, corrupting delivery and the session key. After the fix the username grammar is preserved.

Real environment tested: Node 22.22.1, macOS, no network/model. Vitest exercises the real exported `resolveSignalOutboundTarget`. BEFORE is `origin/main`'s file (swapped via `git show`).

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs extensions/signal/src/outbound-session.test.ts
```

Evidence after fix:
```
resolveSignalOutboundTarget("username:alice.42").to
  BEFORE: "signal:+42"                      AFTER: "signal:username:alice.42"
resolveSignalOutboundTarget("u:alice.42").to / .peer.id
  BEFORE: "signal:+42" / "+42"              AFTER: "signal:username:alice.42" / "username:alice.42"
resolveSignalOutboundTarget("group:abc==")  BOTH: group target, unchanged
resolveSignalOutboundTarget("+15551234567") BOTH: "signal:+15551234567", unchanged
```

Observed result after fix: username targets keep their grammar (correct delivery target + session key); group/phone/uuid paths are unchanged. The new test fails on `origin/main` and passes after.

What was not tested: a live Signal send (the test drives the real `resolveSignalOutboundTarget`, which the outbound route + agent-delivery paths consume to set the delivery target).

## Additional checks
- `node scripts/run-vitest.mjs extensions/signal/src/outbound-session.test.ts` passes; fail-before verified by swapping in `origin/main`'s file. Extension `oxlint` clean.
