### PR TITLE
fix(mattermost): route the group: target prefix to channels

### DIFF
--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -455,6 +455,21 @@ describe("parseMattermostTarget", () => {
     expect(target).toEqual({ kind: "channel-name", name: "abc123" });
   });
 
+  it("parses the group: prefix as a channel (group conversations are id-addressed channels)", () => {
+    expect(parseMattermostTarget("group:dthcxgoxhifn3pwh65cut3ud3w")).toEqual({
+      kind: "channel",
+      id: "dthcxgoxhifn3pwh65cut3ud3w",
+    });
+    expect(parseMattermostTarget("Group:dthcxgoxhifn3pwh65cut3ud3w")).toEqual({
+      kind: "channel",
+      id: "dthcxgoxhifn3pwh65cut3ud3w",
+    });
+    expect(parseMattermostTarget("group:off-topic")).toEqual({
+      kind: "channel-name",
+      name: "off-topic",
+    });
+  });
+
   it("parses user: prefix as user id", () => {
     const target = parseMattermostTarget("user:usr456");
     expect(target).toEqual({ kind: "user", id: "usr456" });

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -140,8 +140,11 @@ export function parseMattermostTarget(raw: string): MattermostTarget {
     throw new Error("Recipient is required for Mattermost sends");
   }
   const lower = normalizeLowercaseStringOrEmpty(trimmed);
-  if (lower.startsWith("channel:")) {
-    const id = trimmed.slice("channel:".length).trim();
+  if (lower.startsWith("channel:") || lower.startsWith("group:")) {
+    // Mattermost group conversations (P/G) are still channels addressed by id, so the documented
+    // group: prefix resolves exactly like channel: (matching normalizeMattermostMessagingTarget).
+    // Without this, group:<id> fell through to channel-name lookup and the send failed.
+    const id = trimmed.slice(trimmed.indexOf(":") + 1).trim();
     if (!id) {
       throw new Error("Channel id is required for Mattermost sends");
     }


### PR DESCRIPTION
## Summary

`parseMattermostTarget` (`extensions/mattermost/src/mattermost/send.ts`) — the sole target parser for `sendMessageMattermost` — handles `channel:`, `user:`, `mattermost:`, `@`, and `#` prefixes, but has **no branch for the generic `group:` prefix**. An input like `group:dthcxgoxhifn3pwh65cut3ud3w` (a valid 26-char Mattermost channel id) falls through to the final `channel-name` fallback, so it's treated as a channel literally **named** `group:dthc…`. `resolveChannelIdByName` then searches every team, finds nothing, and throws `Mattermost channel "#group:dthc…" not found in any team` — the send fails entirely.

Group conversations (P/G) are still channels addressed by id, so `group:` should resolve exactly like `channel:`. The same plugin's siblings already agree: `normalizeMattermostMessagingTarget` maps `group:<id>` → `channel:<id>`, and `looksLikeMattermostTargetId` recognizes `group:` via `/^(user|channel|group|mattermost):/i`. Only the send-path parser omitted it.

The core builds generic `group:<id>` targets for group conversations (`sessions-send-helpers.ts`, `subagent-announce-delivery.ts`), and the agent message action passes the raw caller-supplied target straight to `sendMessageMattermost` without normalizing — so any caller/agent sending to a `group:<channelId>` hit the failure.

### Changes
- `send.ts` — extend the `channel:` branch to also match `group:` (both strip the prefix and resolve as a channel id / channel-name). No behavior change for `channel:` (the `indexOf(":")+1` slice equals `"channel:".length` for `channel:` inputs).
- `send.test.ts` — `group:` id, case-insensitive `Group:`, and non-id `group:` cases.

## Real behavior proof

Behavior addressed: a `group:<channelId>` send threw "channel not found in any team" because `group:` was treated as a channel name. After the fix it resolves to the channel id.

Real environment tested: Node 22.22.1, macOS, no network/model. Vitest exercises the real exported `parseMattermostTarget`. BEFORE is `origin/main`'s file (swapped via `git show`).

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/send.test.ts
```

Evidence after fix:
```
parseMattermostTarget("group:dthcxgoxhifn3pwh65cut3ud3w")
  BEFORE: { kind: "channel-name", name: "group:dthcxgoxhifn3pwh65cut3ud3w" }  (-> send throws "not found")
  AFTER:  { kind: "channel", id: "dthcxgoxhifn3pwh65cut3ud3w" }
parseMattermostTarget("group:off-topic")  AFTER: { kind: "channel-name", name: "off-topic" }
parseMattermostTarget("channel:...")       BOTH: unchanged
```

Observed result after fix: `group:` resolves like `channel:`; the new test fails on `origin/main` and passes after, and the existing channel:/user:/mattermost:/@/# cases stay green.

What was not tested: a live Mattermost group send (the test drives the real `parseMattermostTarget`, which `sendMessageMattermost` calls to resolve the target).

## Additional checks
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/send.test.ts` passes; fail-before verified by swapping in `origin/main`'s file. Extension `oxlint` clean.
