### PR TITLE
fix(slack): stop logging inbound message previews

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -31,7 +31,20 @@ import {
 } from "./prepare.test-helpers.js";
 import { clearSlackSubteamMentionCacheForTest } from "./subteam-mentions.js";
 
-const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
+const { enqueueSystemEventMock, logVerboseMock, shouldLogVerboseMock } = vi.hoisted(() => ({
+  enqueueSystemEventMock: vi.fn(),
+  logVerboseMock: vi.fn(),
+  shouldLogVerboseMock: vi.fn(() => false),
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    logVerbose: (...args: unknown[]) => logVerboseMock(...args),
+    shouldLogVerbose: () => shouldLogVerboseMock(),
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/system-event-runtime")>();
@@ -54,6 +67,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
     clearSlackAllowFromCacheForTest();
     clearSlackSubteamMentionCacheForTest();
     enqueueSystemEventMock.mockClear();
+    logVerboseMock.mockClear();
+    shouldLogVerboseMock.mockReset();
+    shouldLogVerboseMock.mockReturnValue(false);
   });
 
   afterAll(() => {
@@ -169,6 +185,28 @@ describe("slack prepareSlackMessage inbound contract", () => {
       contextKey: "slack:message:D123:1.000",
     });
     expect(prepared.ctxPayload.BodyForAgent).toContain(body);
+  });
+
+  it("logs inbound metadata without logging message content", async () => {
+    const body = "confidential acquisition target: northstar; do not include this text in logs";
+    shouldLogVerboseMock.mockReturnValue(true);
+
+    const prepared = await prepareWithDefaultCtx(createSlackMessage({ text: body }));
+
+    assertPrepared(prepared);
+    const inboundLog = logVerboseMock.mock.calls
+      .map(([entry]) => entry)
+      .find((entry) => typeof entry === "string" && entry.startsWith("slack inbound:"));
+    const verboseOutput = logVerboseMock.mock.calls
+      .flat()
+      .filter((entry): entry is string => typeof entry === "string")
+      .join("\n");
+    expect(inboundLog).toBe(
+      `slack inbound: account=${prepared.route.accountId} agent=${prepared.route.agentId} channel=D123 message_ts=1.000 thread_ts=none from=slack:U1 chat=direct chars=${body.length}`,
+    );
+    expect(verboseOutput).not.toContain(body);
+    expect(verboseOutput).not.toContain("confidential acquisition target");
+    expect(verboseOutput).not.toContain("preview=");
   });
 
   it("prepares wildcard open-policy account DMs", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1387,7 +1387,9 @@ export async function prepareSlackMessage(params: {
   }
 
   if (shouldLogVerbose()) {
-    logVerbose(`slack inbound: channel=${message.channel} from=${slackFrom} preview="${preview}"`);
+    logVerbose(
+      `slack inbound: account=${route.accountId} agent=${route.agentId} channel=${message.channel} message_ts=${message.ts ?? "unknown"} thread_ts=${effectiveMessageThreadId ?? "none"} from=${slackFrom} chat=${chatType} chars=${rawBody.length}`,
+    );
   }
 
   const updateLastRouteSessionKey = resolveInboundLastRouteSessionKey({ route, sessionKey });


### PR DESCRIPTION
## What Problem This Solves

Slack verbose ingress logging currently includes the first 160 characters of every prepared inbound message. That can copy direct-message text, channel text, or resolved attachment text into production logs even when operators only need routing and correlation data.

## Why This Change Was Made

- Remove raw Slack message previews from the verbose inbound log.
- Retain useful non-content metadata: account, agent, channel, message/thread IDs, sender route, chat type, and character count.
- Add regression coverage that enables verbose logging and verifies confidential message content is absent from every captured verbose entry.

## User Impact

Operators keep the metadata needed to correlate Slack ingress with routing and sessions, while inbound message text is no longer duplicated into verbose logs. Message preparation and delivery behavior are unchanged.

## Evidence

- Exact rebased head: `47d039f9a0fe9b1e9800872b09f74f2efb80857e`.
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare.test.ts` — 1 file, 92 tests passed.
- Blacksmith Testbox through Crabbox `tbx_01kwq136yxfgxrhfmyt925swen` — changed extension production/test typechecks, focused lint, database-first and media guards, and import-cycle checks passed. Actions: https://github.com/openclaw/openclaw/actions/runs/28713269172
- File-scoped Oxfmt check passes.
- `git diff --check` passes.
- Repository autoreview reports no accepted/actionable findings (`patch is correct`, confidence 0.98).
- A read-only Slack logging audit found no other raw inbound-content log sink in the Slack extension.
- Live Slack canary on exact head `47d039f9a0fe9b1e9800872b09f74f2efb80857e` passed through the native Slack driver in 4259ms. With debug file logging enabled, the run emitted two metadata-only `slack inbound:` entries and zero occurrences of the live input phrase, generated marker prefix, or `preview=`. The local artifact contains workspace metadata and is intentionally not published.
