### PR TITLE
fix(feishu): process topic sessions in parallel

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -639,14 +639,14 @@ conversion fails, OpenClaw falls back to a file attachment and logs the reason.
 - ✅ Thread replies
 - ✅ Media replies stay thread-aware when replying to a thread message
 
-Native Feishu/Lark topic groups use the event `thread_id` (`omt_*`) as the
-canonical topic session key by default, so different topics run in separate
-sessions while each topic stays serial. Set `groupSessionScope: "group"` or
-`topicSessionMode: "disabled"` to keep a topic group chat-scoped. If a native
-topic starter event omits `thread_id`, OpenClaw hydrates it from Feishu before
-routing the turn. Normal group replies that OpenClaw turns into threads keep
-using the reply root message ID (`om_*`) so the first turn and follow-up turn
-stay in the same session.
+Native Feishu/Lark topic groups stay chat-scoped by default. Set
+`groupSessionScope: "group_topic"` or legacy `topicSessionMode: "enabled"` to
+use the event `thread_id` (`omt_*`) as the canonical topic session key, so
+different topics run in separate sessions while each topic stays serial. If a
+native topic starter event omits `thread_id`, OpenClaw hydrates it from Feishu
+before routing the turn. Normal group replies that OpenClaw turns into threads
+keep using the reply root message ID (`om_*`) so the first turn and follow-up
+turn stay in the same session.
 
 ---
 

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -639,12 +639,14 @@ conversion fails, OpenClaw falls back to a file attachment and logs the reason.
 - ✅ Thread replies
 - ✅ Media replies stay thread-aware when replying to a thread message
 
-For `groupSessionScope: "group_topic"` and `"group_topic_sender"`, native
-Feishu/Lark topic groups use the event `thread_id` (`omt_*`) as the canonical
-topic session key. If a native topic starter event omits `thread_id`, OpenClaw
-hydrates it from Feishu before routing the turn. Normal group replies that
-OpenClaw turns into threads keep using the reply root message ID (`om_*`) so the
-first turn and follow-up turn stay in the same session.
+Native Feishu/Lark topic groups use the event `thread_id` (`omt_*`) as the
+canonical topic session key by default, so different topics run in separate
+sessions while each topic stays serial. Set `groupSessionScope: "group"` or
+`topicSessionMode: "disabled"` to keep a topic group chat-scoped. If a native
+topic starter event omits `thread_id`, OpenClaw hydrates it from Feishu before
+routing the turn. Normal group replies that OpenClaw turns into threads keep
+using the reply root message ID (`om_*`) so the first turn and follow-up turn
+stay in the same session.
 
 ---
 

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -78,11 +78,7 @@ export function resolveConfiguredFeishuGroupSessionScope(params: {
   return (
     params.groupConfig?.groupSessionScope ??
     params.feishuCfg?.groupSessionScope ??
-    (legacyTopicSessionMode === "enabled" ||
-    ((params.chatType === "topic_group" || params.hasThread === true) &&
-      legacyTopicSessionMode !== "disabled")
-      ? "group_topic"
-      : "group")
+    (legacyTopicSessionMode === "enabled" ? "group_topic" : "group")
   );
 }
 

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -39,17 +39,46 @@ type FeishuMessageLike = {
   };
 };
 
-type GroupSessionScope = "group" | "group_sender" | "group_topic" | "group_topic_sender";
+export type FeishuGroupSessionScope =
+  | "group"
+  | "group_sender"
+  | "group_topic"
+  | "group_topic_sender";
 
 type FeishuLogger = (...args: unknown[]) => void;
 
 type ResolvedFeishuGroupSession = {
   peerId: string;
   parentPeer: { kind: "group"; id: string } | null;
-  groupSessionScope: GroupSessionScope;
+  groupSessionScope: FeishuGroupSessionScope;
   replyInThread: boolean;
   threadReply: boolean;
 };
+
+export function resolveConfiguredFeishuGroupSessionScope(params: {
+  groupConfig?: {
+    groupSessionScope?: FeishuGroupSessionScope;
+    topicSessionMode?: "enabled" | "disabled";
+  };
+  feishuCfg?: {
+    groupSessionScope?: FeishuGroupSessionScope;
+    topicSessionMode?: "enabled" | "disabled";
+  };
+  chatType?: FeishuChatType;
+  hasThread?: boolean;
+}): FeishuGroupSessionScope {
+  const legacyTopicSessionMode =
+    params.groupConfig?.topicSessionMode ?? params.feishuCfg?.topicSessionMode;
+  return (
+    params.groupConfig?.groupSessionScope ??
+    params.feishuCfg?.groupSessionScope ??
+    (legacyTopicSessionMode === "enabled" ||
+    ((params.chatType === "topic_group" || params.hasThread === true) &&
+      legacyTopicSessionMode !== "disabled")
+      ? "group_topic"
+      : "group")
+  );
+}
 
 export function resolveFeishuGroupSession(params: {
   chatId: string;
@@ -59,12 +88,12 @@ export function resolveFeishuGroupSession(params: {
   threadId?: string;
   chatType?: FeishuChatType;
   groupConfig?: {
-    groupSessionScope?: GroupSessionScope;
+    groupSessionScope?: FeishuGroupSessionScope;
     topicSessionMode?: "enabled" | "disabled";
     replyInThread?: "enabled" | "disabled";
   };
   feishuCfg?: {
-    groupSessionScope?: GroupSessionScope;
+    groupSessionScope?: FeishuGroupSessionScope;
     topicSessionMode?: "enabled" | "disabled";
     replyInThread?: "enabled" | "disabled";
   };
@@ -77,21 +106,19 @@ export function resolveFeishuGroupSession(params: {
   const replyInThread =
     (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled" ||
     threadReply;
-  const legacyTopicSessionMode =
-    groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";
-  const groupSessionScope: GroupSessionScope =
-    groupConfig?.groupSessionScope ??
-    feishuCfg?.groupSessionScope ??
-    (legacyTopicSessionMode === "enabled" ? "group_topic" : "group");
-  const normalizedTopicGroupThreadId =
-    chatType === "topic_group" ? (normalizedThreadId ?? normalizedRootId) : undefined;
-  const topicScope =
-    groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender"
-      ? (normalizedTopicGroupThreadId ??
-        normalizedRootId ??
-        normalizedThreadId ??
-        (replyInThread ? messageId : null))
-      : null;
+  const groupSessionScope = resolveConfiguredFeishuGroupSessionScope({
+    groupConfig,
+    feishuCfg,
+    chatType,
+    hasThread: chatType === "topic_group" || Boolean(normalizedThreadId && !normalizedRootId),
+  });
+  const isTopicScope =
+    groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender";
+  const nativeTopicId =
+    chatType === "topic_group"
+      ? (normalizedThreadId ?? normalizedRootId)
+      : (normalizedRootId ?? (isTopicScope ? normalizedThreadId : undefined));
+  const topicScope = isTopicScope ? (nativeTopicId ?? (replyInThread ? messageId : null)) : null;
 
   let peerId;
   switch (groupSessionScope) {
@@ -120,11 +147,7 @@ export function resolveFeishuGroupSession(params: {
 
   return {
     peerId,
-    parentPeer:
-      topicScope &&
-      (groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender")
-        ? { kind: "group", id: chatId }
-        : null,
+    parentPeer: topicScope && isTopicScope ? { kind: "group", id: chatId } : null,
     groupSessionScope,
     replyInThread,
     threadReply,

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -45,6 +45,12 @@ export type FeishuGroupSessionScope =
   | "group_topic"
   | "group_topic_sender";
 
+export function isFeishuTopicSessionScope(
+  scope: string,
+): scope is "group_topic" | "group_topic_sender" {
+  return scope === "group_topic" || scope === "group_topic_sender";
+}
+
 type FeishuLogger = (...args: unknown[]) => void;
 
 type ResolvedFeishuGroupSession = {
@@ -112,8 +118,7 @@ export function resolveFeishuGroupSession(params: {
     chatType,
     hasThread: chatType === "topic_group" || Boolean(normalizedThreadId && !normalizedRootId),
   });
-  const isTopicScope =
-    groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender";
+  const isTopicScope = isFeishuTopicSessionScope(groupSessionScope);
   const nativeTopicId =
     chatType === "topic_group"
       ? (normalizedThreadId ?? normalizedRootId)

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -3214,7 +3214,7 @@ describe("handleFeishuMessage command authorization", () => {
     expect(replyRouteRequest.parentPeer).toEqual({ kind: "group", id: "oc-group" });
   });
 
-  it("routes native topic groups as topic sessions by default", async () => {
+  it("keeps native topic groups chat-scoped by default", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -3244,11 +3244,7 @@ describe("handleFeishuMessage command authorization", () => {
 
     await dispatchMessage({ cfg, event });
 
-    expectResolvedRouteCall(
-      0,
-      { kind: "group", id: "oc-group:topic:omt_default_topic" },
-      { kind: "group", id: "oc-group" },
-    );
+    expectResolvedRouteCall(0, { kind: "group", id: "oc-group" }, null);
   });
 
   it("keeps native topic groups chat-scoped when groupSessionScope=group", async () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -3214,6 +3214,77 @@ describe("handleFeishuMessage command authorization", () => {
     expect(replyRouteRequest.parentPeer).toEqual({ kind: "group", id: "oc-group" });
   });
 
+  it("routes native topic groups as topic sessions by default", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_default_topic_message",
+        chat_id: "oc-group",
+        chat_type: "topic_group",
+        root_id: "om_default_topic_root",
+        thread_id: "omt_default_topic",
+        message_type: "text",
+        content: JSON.stringify({ text: "default topic scope" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expectResolvedRouteCall(
+      0,
+      { kind: "group", id: "oc-group:topic:omt_default_topic" },
+      { kind: "group", id: "oc-group" },
+    );
+  });
+
+  it("keeps native topic groups chat-scoped when groupSessionScope=group", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_chat_scoped_topic_message",
+        chat_id: "oc-group",
+        chat_type: "topic_group",
+        root_id: "om_chat_scoped_topic_root",
+        thread_id: "omt_chat_scoped_topic",
+        message_type: "text",
+        content: JSON.stringify({ text: "chat-scoped topic" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expectResolvedRouteCall(0, { kind: "group", id: "oc-group" }, null);
+  });
+
   it("uses thread_id as topic key when root_id is missing", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -35,8 +35,10 @@ import {
   normalizeMentions,
   parseMergeForwardContent,
   parseMessageContent,
+  resolveConfiguredFeishuGroupSessionScope,
   resolveFeishuGroupSession,
   resolveFeishuMediaList,
+  type FeishuGroupSessionScope,
 } from "./bot-content.js";
 import {
   evaluateSupplementalContextVisibility,
@@ -85,8 +87,6 @@ const groupNameCache = new Map<string, { name: string; expiresAt: number }>();
 const GROUP_NAME_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const GROUP_NAME_CACHE_MAX_SIZE = 500; // hard cap
 
-type FeishuGroupSessionScope = "group" | "group_sender" | "group_topic" | "group_topic_sender";
-
 function shouldSendNoVisibleReplyFallback(dispatchResult: {
   counts: { final?: number };
   failedCounts?: { final?: number };
@@ -106,25 +106,6 @@ function shouldSendNoVisibleReplyFallback(dispatchResult: {
     dispatchResult.sendPolicyDenied !== true &&
     dispatchResult.sourceReplyDeliveryMode !== "message_tool_only" &&
     (emptyEligibleDispatch || queuedFinalFailed)
-  );
-}
-
-function resolveConfiguredFeishuGroupSessionScope(params: {
-  groupConfig?: {
-    groupSessionScope?: FeishuGroupSessionScope;
-    topicSessionMode?: "enabled" | "disabled";
-  };
-  feishuCfg?: {
-    groupSessionScope?: FeishuGroupSessionScope;
-    topicSessionMode?: "enabled" | "disabled";
-  };
-}): FeishuGroupSessionScope {
-  const legacyTopicSessionMode =
-    params.groupConfig?.topicSessionMode ?? params.feishuCfg?.topicSessionMode ?? "disabled";
-  return (
-    params.groupConfig?.groupSessionScope ??
-    params.feishuCfg?.groupSessionScope ??
-    (legacyTopicSessionMode === "enabled" ? "group_topic" : "group")
   );
 }
 
@@ -583,7 +564,7 @@ export async function handleFeishuMessage(params: {
     ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId })
     : undefined;
   const groupSessionScope = isGroup
-    ? resolveConfiguredFeishuGroupSessionScope({ groupConfig, feishuCfg })
+    ? resolveConfiguredFeishuGroupSessionScope({ groupConfig, feishuCfg, chatType: ctx.chatType })
     : null;
   let effectiveThreadId = ctx.threadId;
   if (

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -35,10 +35,10 @@ import {
   normalizeMentions,
   parseMergeForwardContent,
   parseMessageContent,
+  isFeishuTopicSessionScope,
   resolveConfiguredFeishuGroupSessionScope,
   resolveFeishuGroupSession,
   resolveFeishuMediaList,
-  type FeishuGroupSessionScope,
 } from "./bot-content.js";
 import {
   evaluateSupplementalContextVisibility,
@@ -107,10 +107,6 @@ function shouldSendNoVisibleReplyFallback(dispatchResult: {
     dispatchResult.sourceReplyDeliveryMode !== "message_tool_only" &&
     (emptyEligibleDispatch || queuedFinalFailed)
   );
-}
-
-function isFeishuTopicSessionScope(scope: FeishuGroupSessionScope): boolean {
-  return scope === "group_topic" || scope === "group_topic_sender";
 }
 
 function evictGroupNameCache(): void {

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -132,8 +132,8 @@ const FeishuToolsConfigSchema = z
  * - "group_topic_sender": one session per (group + topic thread + sender),
  *   falls back to (group + sender) if no topic
  *
- * Native topic groups default to "group_topic" when this option is unset.
- * Other group chats default to "group".
+ * Defaults to "group" when unset. Use "group_topic" to isolate native topic
+ * group threads into separate sessions.
  */
 const GroupSessionScopeSchema = z
   .enum(["group", "group_sender", "group_topic", "group_topic_sender"])
@@ -146,8 +146,8 @@ const GroupSessionScopeSchema = z
  * - "disabled": All messages in a group share one session
  * - "enabled": Messages in different topics get separate sessions
  *
- * Leave unset to use the current default: native topic groups are topic-scoped,
- * while normal groups are chat-scoped unless groupSessionScope says otherwise.
+ * Leave unset to use the current default: group chats, including native topic
+ * groups, are chat-scoped unless groupSessionScope says otherwise.
  *
  * Topic routing uses Feishu topic-group `thread_id` when the event identifies a
  * native topic group, and keeps `root_id` precedence for normal groups so

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -126,11 +126,14 @@ const FeishuToolsConfigSchema = z
 
 /**
  * Group session scope for routing Feishu group messages.
- * - "group" (default): one session per group chat
+ * - "group": one session per group chat
  * - "group_sender": one session per (group + sender)
  * - "group_topic": one session per group topic thread (falls back to group if no topic)
  * - "group_topic_sender": one session per (group + topic thread + sender),
  *   falls back to (group + sender) if no topic
+ *
+ * Native topic groups default to "group_topic" when this option is unset.
+ * Other group chats default to "group".
  */
 const GroupSessionScopeSchema = z
   .enum(["group", "group_sender", "group_topic", "group_topic_sender"])
@@ -140,8 +143,11 @@ const GroupSessionScopeSchema = z
  * @deprecated Use groupSessionScope instead.
  *
  * Topic session isolation mode for group chats.
- * - "disabled" (default): All messages in a group share one session
+ * - "disabled": All messages in a group share one session
  * - "enabled": Messages in different topics get separate sessions
+ *
+ * Leave unset to use the current default: native topic groups are topic-scoped,
+ * while normal groups are chat-scoped unless groupSessionScope says otherwise.
  *
  * Topic routing uses Feishu topic-group `thread_id` when the event identifies a
  * native topic group, and keeps `root_id` precedence for normal groups so

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -303,6 +303,7 @@ function registerEventHandlers(
       recordProcessedMessage: recordProcessedFeishuMessage,
       getBotOpenId: (id) => botOpenIds.get(id),
       getBotName: (id) => botNames.get(id),
+      fetchMessage: getMessageFeishu,
       resolveSequentialKey: getFeishuSequentialKey,
     }),
     "im.message.message_read_v1": async () => {

--- a/extensions/feishu/src/monitor.message-handler.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.test.ts
@@ -204,7 +204,9 @@ describe("createFeishuMessageReceiveHandler topic queueing", () => {
       }),
     );
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     expect(order).toEqual(["omt_thread_1:start", "omt_thread_2:start"]);
 
     releaseSecond.resolve();
@@ -286,7 +288,9 @@ describe("createFeishuMessageReceiveHandler topic queueing", () => {
       }),
     );
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     expect(order).toEqual(["omt_topic_1:start", "omt_topic_2:start"]);
 
     releaseSecond.resolve();
@@ -367,7 +371,9 @@ describe("createFeishuMessageReceiveHandler topic queueing", () => {
       }),
     );
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     expect(order).toEqual(["om_topic_1_first"]);
 
     releaseFirst.resolve();
@@ -423,7 +429,7 @@ describe("createFeishuMessageReceiveHandler topic queueing", () => {
         return {
           messageId: "om_topic_starter",
           chatId: "oc_topic_group",
-          chatType: "topic_group",
+          chatType: "topic_group" as const,
           content: "starter",
           contentType: "text",
           threadId: "omt_topic_1",
@@ -453,11 +459,15 @@ describe("createFeishuMessageReceiveHandler topic queueing", () => {
       }),
     );
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     expect(order).toEqual([]);
 
     releaseFetch.resolve();
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     expect(order).toEqual(["om_topic_starter:start:omt_topic_1"]);
 
     releaseFirst.resolve();

--- a/extensions/feishu/src/monitor.message-handler.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.test.ts
@@ -171,7 +171,17 @@ describe("createFeishuMessageReceiveHandler topic queueing", () => {
       },
     } as unknown as PluginRuntime["channel"];
     const handler = createFeishuMessageReceiveHandler({
-      cfg: {} as ClawdbotConfig,
+      cfg: {
+        channels: {
+          feishu: {
+            groups: {
+              oc_topic_group: {
+                groupSessionScope: "group_topic",
+              },
+            },
+          },
+        },
+      } as ClawdbotConfig,
       channelRuntime,
       accountId: "default",
       chatHistories: new Map(),
@@ -253,7 +263,17 @@ describe("createFeishuMessageReceiveHandler topic queueing", () => {
       },
     } as unknown as PluginRuntime["channel"];
     const handler = createFeishuMessageReceiveHandler({
-      cfg: {} as ClawdbotConfig,
+      cfg: {
+        channels: {
+          feishu: {
+            groups: {
+              oc_topic_group: {
+                groupSessionScope: "group_topic",
+              },
+            },
+          },
+        },
+      } as ClawdbotConfig,
       channelRuntime,
       accountId: "default",
       chatHistories: new Map(),
@@ -336,7 +356,17 @@ describe("createFeishuMessageReceiveHandler topic queueing", () => {
       },
     } as unknown as PluginRuntime["channel"];
     const handler = createFeishuMessageReceiveHandler({
-      cfg: {} as ClawdbotConfig,
+      cfg: {
+        channels: {
+          feishu: {
+            groups: {
+              oc_topic_group: {
+                groupSessionScope: "group_topic",
+              },
+            },
+          },
+        },
+      } as ClawdbotConfig,
       channelRuntime,
       accountId: "default",
       chatHistories: new Map(),
@@ -415,7 +445,17 @@ describe("createFeishuMessageReceiveHandler topic queueing", () => {
       },
     } as unknown as PluginRuntime["channel"];
     const handler = createFeishuMessageReceiveHandler({
-      cfg: {} as ClawdbotConfig,
+      cfg: {
+        channels: {
+          feishu: {
+            groups: {
+              oc_topic_group: {
+                groupSessionScope: "group_topic",
+              },
+            },
+          },
+        },
+      } as ClawdbotConfig,
       channelRuntime,
       accountId: "default",
       chatHistories: new Map(),

--- a/extensions/feishu/src/monitor.message-handler.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.test.ts
@@ -1,16 +1,35 @@
 // Feishu tests cover monitor.message handler plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
+import { resolveFeishuMessageDedupeKey } from "./dedupe-key.js";
 import type { FeishuMessageEvent } from "./event-types.js";
 import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
+import { releaseFeishuMessageProcessing } from "./processing-claims.js";
+import { getFeishuSequentialKey } from "./sequential-key.js";
 
 type MessageReceiveHandlerContext = Parameters<typeof createFeishuMessageReceiveHandler>[0];
 type HandleMessageParams = Parameters<MessageReceiveHandlerContext["handleMessage"]>[0];
+
+function createDeferred() {
+  let resolve: (() => void) | undefined;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  if (!resolve) {
+    throw new Error("Expected deferred resolver to be initialized");
+  }
+  return { promise, resolve };
+}
 
 function createTextEvent(params: {
   messageId: string;
   senderOpenId: string;
   senderType: "bot" | "user";
+  text?: string;
+  chatId?: string;
+  chatType?: FeishuMessageEvent["message"]["chat_type"];
+  rootId?: string;
+  threadId?: string;
 }): FeishuMessageEvent {
   return {
     sender: {
@@ -19,10 +38,12 @@ function createTextEvent(params: {
     },
     message: {
       message_id: params.messageId,
-      chat_id: "oc_chat_1",
-      chat_type: "p2p",
+      chat_id: params.chatId ?? "oc_chat_1",
+      chat_type: params.chatType ?? "p2p",
+      ...(params.rootId ? { root_id: params.rootId } : {}),
+      ...(params.threadId ? { thread_id: params.threadId } : {}),
       message_type: "text",
-      content: JSON.stringify({ text: "hello" }),
+      content: JSON.stringify({ text: params.text ?? "hello" }),
     },
   };
 }
@@ -44,7 +65,12 @@ function createHandler() {
       }),
     },
   } as unknown as PluginRuntime["channel"];
-  const handleMessage = vi.fn(async (_params: HandleMessageParams) => {});
+  const handleMessage = vi.fn(async (params: HandleMessageParams) => {
+    releaseFeishuMessageProcessing(
+      params.messageDedupeKey ?? resolveFeishuMessageDedupeKey(params.event),
+      params.accountId,
+    );
+  });
 
   const handler = createFeishuMessageReceiveHandler({
     cfg: {} as ClawdbotConfig,
@@ -108,5 +134,339 @@ describe("createFeishuMessageReceiveHandler self-message filtering", () => {
     expect(
       handleMessage.mock.calls.map(([params]) => params.event.sender.sender_id.open_id),
     ).toEqual(["ou_other_bot", "ou_user"]);
+  });
+});
+
+describe("createFeishuMessageReceiveHandler topic queueing", () => {
+  it("runs different Feishu thread ids concurrently even when websocket labels the chat as group", async () => {
+    const releaseFirst = createDeferred();
+    const releaseSecond = createDeferred();
+    const order: string[] = [];
+    const handleMessage = vi.fn(async (params: HandleMessageParams) => {
+      const threadId = params.event.message.thread_id;
+      order.push(`${threadId}:start`);
+      try {
+        await (threadId === "omt_thread_1" ? releaseFirst.promise : releaseSecond.promise);
+      } finally {
+        order.push(`${threadId}:end`);
+        releaseFeishuMessageProcessing(
+          params.messageDedupeKey ?? resolveFeishuMessageDedupeKey(params.event),
+          params.accountId,
+        );
+      }
+    });
+    const channelRuntime = {
+      commands: {
+        isControlCommandMessage: () => false,
+      },
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: (params: {
+          onFlush: (entries: FeishuMessageEvent[]) => Promise<void>;
+        }) => ({
+          enqueue: async (event: FeishuMessageEvent) => {
+            await params.onFlush([event]);
+          },
+        }),
+      },
+    } as unknown as PluginRuntime["channel"];
+    const handler = createFeishuMessageReceiveHandler({
+      cfg: {} as ClawdbotConfig,
+      channelRuntime,
+      accountId: "default",
+      chatHistories: new Map(),
+      handleMessage,
+      resolveDebounceText: ({ event }) =>
+        (JSON.parse(event.message.content) as { text: string }).text,
+      hasProcessedMessage: vi.fn(async () => false),
+      recordProcessedMessage: vi.fn(async () => true),
+      resolveSequentialKey: getFeishuSequentialKey,
+    });
+
+    const first = handler(
+      createTextEvent({
+        messageId: "om_thread_1_message",
+        senderOpenId: "ou_user",
+        senderType: "user",
+        chatId: "oc_topic_group",
+        chatType: "group",
+        threadId: "omt_thread_1",
+      }),
+    );
+    const second = handler(
+      createTextEvent({
+        messageId: "om_thread_2_message",
+        senderOpenId: "ou_user",
+        senderType: "user",
+        chatId: "oc_topic_group",
+        chatType: "group",
+        threadId: "omt_thread_2",
+      }),
+    );
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(order).toEqual(["omt_thread_1:start", "omt_thread_2:start"]);
+
+    releaseSecond.resolve();
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual([
+      "omt_thread_1:start",
+      "omt_thread_2:start",
+      "omt_thread_2:end",
+      "omt_thread_1:end",
+    ]);
+  });
+
+  it("runs different Feishu topic-group topics concurrently", async () => {
+    const releaseFirst = createDeferred();
+    const releaseSecond = createDeferred();
+    const order: string[] = [];
+    const handleMessage = vi.fn(async (params: HandleMessageParams) => {
+      const threadId = params.event.message.thread_id;
+      order.push(`${threadId}:start`);
+      try {
+        await (threadId === "omt_topic_1" ? releaseFirst.promise : releaseSecond.promise);
+      } finally {
+        order.push(`${threadId}:end`);
+        releaseFeishuMessageProcessing(
+          params.messageDedupeKey ?? resolveFeishuMessageDedupeKey(params.event),
+          params.accountId,
+        );
+      }
+    });
+    const channelRuntime = {
+      commands: {
+        isControlCommandMessage: () => false,
+      },
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: (params: {
+          onFlush: (entries: FeishuMessageEvent[]) => Promise<void>;
+        }) => ({
+          enqueue: async (event: FeishuMessageEvent) => {
+            await params.onFlush([event]);
+          },
+        }),
+      },
+    } as unknown as PluginRuntime["channel"];
+    const handler = createFeishuMessageReceiveHandler({
+      cfg: {} as ClawdbotConfig,
+      channelRuntime,
+      accountId: "default",
+      chatHistories: new Map(),
+      handleMessage,
+      resolveDebounceText: ({ event }) =>
+        (JSON.parse(event.message.content) as { text: string }).text,
+      hasProcessedMessage: vi.fn(async () => false),
+      recordProcessedMessage: vi.fn(async () => true),
+      resolveSequentialKey: getFeishuSequentialKey,
+    });
+
+    const first = handler(
+      createTextEvent({
+        messageId: "om_topic_1_message",
+        senderOpenId: "ou_user",
+        senderType: "user",
+        chatId: "oc_topic_group",
+        chatType: "topic_group",
+        rootId: "om_topic_1_root",
+        threadId: "omt_topic_1",
+      }),
+    );
+    const second = handler(
+      createTextEvent({
+        messageId: "om_topic_2_message",
+        senderOpenId: "ou_user",
+        senderType: "user",
+        chatId: "oc_topic_group",
+        chatType: "topic_group",
+        rootId: "om_topic_2_root",
+        threadId: "omt_topic_2",
+      }),
+    );
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(order).toEqual(["omt_topic_1:start", "omt_topic_2:start"]);
+
+    releaseSecond.resolve();
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual([
+      "omt_topic_1:start",
+      "omt_topic_2:start",
+      "omt_topic_2:end",
+      "omt_topic_1:end",
+    ]);
+  });
+
+  it("serializes messages from the same Feishu topic-group topic", async () => {
+    const releaseFirst = createDeferred();
+    const order: string[] = [];
+    const handleMessage = vi.fn(async (params: HandleMessageParams) => {
+      order.push(params.event.message.message_id);
+      try {
+        if (params.event.message.message_id === "om_topic_1_first") {
+          await releaseFirst.promise;
+        }
+      } finally {
+        releaseFeishuMessageProcessing(
+          params.messageDedupeKey ?? resolveFeishuMessageDedupeKey(params.event),
+          params.accountId,
+        );
+      }
+    });
+    const channelRuntime = {
+      commands: {
+        isControlCommandMessage: () => false,
+      },
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: (params: {
+          onFlush: (entries: FeishuMessageEvent[]) => Promise<void>;
+        }) => ({
+          enqueue: async (event: FeishuMessageEvent) => {
+            await params.onFlush([event]);
+          },
+        }),
+      },
+    } as unknown as PluginRuntime["channel"];
+    const handler = createFeishuMessageReceiveHandler({
+      cfg: {} as ClawdbotConfig,
+      channelRuntime,
+      accountId: "default",
+      chatHistories: new Map(),
+      handleMessage,
+      resolveDebounceText: ({ event }) =>
+        (JSON.parse(event.message.content) as { text: string }).text,
+      hasProcessedMessage: vi.fn(async () => false),
+      recordProcessedMessage: vi.fn(async () => true),
+      resolveSequentialKey: getFeishuSequentialKey,
+    });
+
+    const first = handler(
+      createTextEvent({
+        messageId: "om_topic_1_first",
+        senderOpenId: "ou_user",
+        senderType: "user",
+        chatId: "oc_topic_group",
+        chatType: "topic_group",
+        rootId: "om_topic_1_root",
+        threadId: "omt_topic_1",
+      }),
+    );
+    const second = handler(
+      createTextEvent({
+        messageId: "om_topic_1_second",
+        senderOpenId: "ou_user",
+        senderType: "user",
+        chatId: "oc_topic_group",
+        chatType: "topic_group",
+        rootId: "om_topic_1_root",
+        threadId: "omt_topic_1",
+      }),
+    );
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(order).toEqual(["om_topic_1_first"]);
+
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["om_topic_1_first", "om_topic_1_second"]);
+  });
+
+  it("serializes a topic starter that needs thread_id hydration with later same-topic replies", async () => {
+    const releaseFetch = createDeferred();
+    const releaseFirst = createDeferred();
+    const order: string[] = [];
+    const handleMessage = vi.fn(async (params: HandleMessageParams) => {
+      order.push(`${params.event.message.message_id}:start:${params.event.message.thread_id}`);
+      try {
+        if (params.event.message.message_id === "om_topic_starter") {
+          await releaseFirst.promise;
+        }
+      } finally {
+        order.push(`${params.event.message.message_id}:end`);
+        releaseFeishuMessageProcessing(
+          params.messageDedupeKey ?? resolveFeishuMessageDedupeKey(params.event),
+          params.accountId,
+        );
+      }
+    });
+    const channelRuntime = {
+      commands: {
+        isControlCommandMessage: () => false,
+      },
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: (params: {
+          onFlush: (entries: FeishuMessageEvent[]) => Promise<void>;
+        }) => ({
+          enqueue: async (event: FeishuMessageEvent) => {
+            await params.onFlush([event]);
+          },
+        }),
+      },
+    } as unknown as PluginRuntime["channel"];
+    const handler = createFeishuMessageReceiveHandler({
+      cfg: {} as ClawdbotConfig,
+      channelRuntime,
+      accountId: "default",
+      chatHistories: new Map(),
+      handleMessage,
+      resolveDebounceText: ({ event }) =>
+        (JSON.parse(event.message.content) as { text: string }).text,
+      hasProcessedMessage: vi.fn(async () => false),
+      recordProcessedMessage: vi.fn(async () => true),
+      fetchMessage: vi.fn(async () => {
+        await releaseFetch.promise;
+        return {
+          messageId: "om_topic_starter",
+          chatId: "oc_topic_group",
+          chatType: "topic_group",
+          content: "starter",
+          contentType: "text",
+          threadId: "omt_topic_1",
+        };
+      }),
+      resolveSequentialKey: getFeishuSequentialKey,
+    });
+
+    const first = handler(
+      createTextEvent({
+        messageId: "om_topic_starter",
+        senderOpenId: "ou_user",
+        senderType: "user",
+        chatId: "oc_topic_group",
+        chatType: "topic_group",
+      }),
+    );
+    const second = handler(
+      createTextEvent({
+        messageId: "om_topic_reply",
+        senderOpenId: "ou_user",
+        senderType: "user",
+        chatId: "oc_topic_group",
+        chatType: "topic_group",
+        rootId: "om_topic_starter",
+        threadId: "omt_topic_1",
+      }),
+    );
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(order).toEqual([]);
+
+    releaseFetch.resolve();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(order).toEqual(["om_topic_starter:start:omt_topic_1"]);
+
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual([
+      "om_topic_starter:start:omt_topic_1",
+      "om_topic_starter:end",
+      "om_topic_reply:start:omt_topic_1",
+      "om_topic_reply:end",
+    ]);
   });
 });

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -1,15 +1,24 @@
 // Feishu plugin module implements monitor.message handler behavior.
 import { isRecord, readStringValue as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ClawdbotConfig, HistoryEntry, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
+import { resolveFeishuAccount } from "./accounts.js";
+import { resolveConfiguredFeishuGroupSessionScope } from "./bot-content.js";
 import { resolveFeishuMessageDedupeKey } from "./dedupe-key.js";
 import type { FeishuMessageEvent } from "./event-types.js";
 import { isMentionForwardRequest } from "./mention.js";
+import { resolveFeishuGroupConfig } from "./policy.js";
 import {
   releaseFeishuMessageProcessing,
   tryBeginFeishuMessageProcessing,
 } from "./processing-claims.js";
 import { createSequentialQueue } from "./sequential-queue.js";
-import type { FeishuChatType } from "./types.js";
+import type { FeishuChatType, FeishuMessageInfo } from "./types.js";
+
+type FeishuMessageFetcher = (params: {
+  cfg: ClawdbotConfig;
+  messageId: string;
+  accountId?: string;
+}) => Promise<FeishuMessageInfo | null>;
 
 type FeishuMessageReceiveHandlerContext = {
   cfg: ClawdbotConfig;
@@ -47,7 +56,9 @@ type FeishuMessageReceiveHandlerContext = {
   ) => Promise<boolean>;
   getBotOpenId?: (accountId: string) => string | undefined;
   getBotName?: (accountId: string) => string | undefined;
+  fetchMessage?: FeishuMessageFetcher;
   resolveSequentialKey?: (params: {
+    cfg: ClawdbotConfig;
     accountId: string;
     event: FeishuMessageEvent;
     botOpenId?: string;
@@ -59,6 +70,91 @@ function normalizeFeishuChatType(value: unknown): FeishuChatType | undefined {
   return value === "group" || value === "topic_group" || value === "private" || value === "p2p"
     ? value
     : undefined;
+}
+
+function resolveFeishuProcessingClaimKey(params: {
+  event: FeishuMessageEvent;
+  messageDedupeKey?: string;
+}): string | undefined {
+  const messageId = params.event.message.message_id?.trim();
+  return params.messageDedupeKey && params.messageDedupeKey !== messageId
+    ? params.messageDedupeKey
+    : messageId;
+}
+
+function isFeishuTopicSessionScope(scope: string): boolean {
+  return scope === "group_topic" || scope === "group_topic_sender";
+}
+
+function shouldHydrateFeishuTopicThreadIdForQueue(params: {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  event: FeishuMessageEvent;
+}): boolean {
+  if (params.event.message.chat_type !== "topic_group" || params.event.message.thread_id?.trim()) {
+    return false;
+  }
+  const chatId = params.event.message.chat_id?.trim();
+  if (!chatId) {
+    return false;
+  }
+  const feishuCfg = resolveFeishuAccount({ cfg: params.cfg, accountId: params.accountId }).config;
+  const groupConfig = resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: chatId });
+  return isFeishuTopicSessionScope(
+    resolveConfiguredFeishuGroupSessionScope({
+      groupConfig,
+      feishuCfg,
+      chatType: params.event.message.chat_type,
+    }),
+  );
+}
+
+function buildPendingTopicChatKey(event: FeishuMessageEvent): string | null {
+  if (event.message.chat_type !== "topic_group") {
+    return null;
+  }
+  return event.message.chat_id?.trim() || null;
+}
+
+async function hydrateFeishuTopicThreadIdForQueue(params: {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  event: FeishuMessageEvent;
+  fetchMessage?: FeishuMessageFetcher;
+  log: (...args: unknown[]) => void;
+}): Promise<FeishuMessageEvent> {
+  if (
+    !params.fetchMessage ||
+    !shouldHydrateFeishuTopicThreadIdForQueue({
+      cfg: params.cfg,
+      accountId: params.accountId,
+      event: params.event,
+    })
+  ) {
+    return params.event;
+  }
+  try {
+    const messageInfo = await params.fetchMessage({
+      cfg: params.cfg,
+      accountId: params.accountId,
+      messageId: params.event.message.message_id,
+    });
+    const threadId = messageInfo?.threadId?.trim();
+    if (threadId) {
+      return {
+        ...params.event,
+        message: {
+          ...params.event.message,
+          thread_id: threadId,
+        },
+      };
+    }
+  } catch (err) {
+    params.log(
+      `feishu[${params.accountId}]: failed to hydrate topic thread_id before queueing message=${params.event.message.message_id}: ${String(err)}`,
+    );
+  }
+  return params.event;
 }
 
 function parseFeishuMessageEventPayload(value: unknown): FeishuMessageEvent | null {
@@ -168,6 +264,7 @@ export function createFeishuMessageReceiveHandler({
   recordProcessedMessage,
   getBotOpenId = () => undefined,
   getBotName = () => undefined,
+  fetchMessage,
   resolveSequentialKey = ({ accountId: accountIdLocal, event }) =>
     `feishu:${accountIdLocal}:${event.message.chat_id?.trim() || "unknown"}`,
 }: FeishuMessageReceiveHandlerContext): (data: unknown) => Promise<void> {
@@ -180,22 +277,27 @@ export function createFeishuMessageReceiveHandler({
   const enqueue = createSequentialQueue({
     onTaskTimeout: (key, timeoutMs) => {
       log(
-        `feishu[${accountId}]: per-chat task exceeded ${timeoutMs}ms cap (key=${key}); evicting from queue so later same-key messages can proceed (#70133)`,
+        `feishu[${accountId}]: per-conversation task exceeded ${timeoutMs}ms cap (key=${key}); evicting from queue so later same-key messages can proceed (#70133)`,
       );
     },
   });
+  const pendingTopicQueueingByChat = new Map<string, Promise<void>>();
 
-  const dispatchFeishuMessage = async (event: FeishuMessageEvent, messageDedupeKey?: string) => {
+  const startFeishuMessageQueueTask = (
+    queueEvent: FeishuMessageEvent,
+    messageDedupeKey?: string,
+  ): Promise<void> => {
     const sequentialKey = resolveSequentialKey({
+      cfg,
       accountId,
-      event,
+      event: queueEvent,
       botOpenId: getBotOpenId(accountId),
       botName: getBotName(accountId),
     });
     const task = () =>
       handleMessage({
         cfg,
-        event,
+        event: queueEvent,
         botOpenId: getBotOpenId(accountId),
         botName: getBotName(accountId),
         runtime,
@@ -205,7 +307,72 @@ export function createFeishuMessageReceiveHandler({
         processingClaimHeld: true,
         messageDedupeKey,
       });
-    await enqueue(sequentialKey, task);
+    return enqueue(sequentialKey, task);
+  };
+
+  const hydrateAndStartFeishuMessageQueueTask = async (
+    event: FeishuMessageEvent,
+    messageDedupeKey?: string,
+  ): Promise<void> => {
+    const queueEvent = await hydrateFeishuTopicThreadIdForQueue({
+      cfg,
+      accountId,
+      event,
+      fetchMessage,
+      log,
+    });
+    await startFeishuMessageQueueTask(queueEvent, messageDedupeKey);
+  };
+
+  const waitForPendingTopicQueueing = async (event: FeishuMessageEvent): Promise<void> => {
+    const chatKey = buildPendingTopicChatKey(event);
+    const pendingQueueing = chatKey ? pendingTopicQueueingByChat.get(chatKey) : undefined;
+    if (!pendingQueueing) {
+      return;
+    }
+    await pendingQueueing.catch(() => undefined);
+  };
+
+  const dispatchFeishuMessage = async (event: FeishuMessageEvent, messageDedupeKey?: string) => {
+    const shouldTrackTopicQueueing =
+      event.message.chat_type === "topic_group" && !event.message.thread_id?.trim();
+    if (shouldTrackTopicQueueing) {
+      const chatKey = buildPendingTopicChatKey(event);
+      const previousQueueing =
+        (chatKey ? pendingTopicQueueingByChat.get(chatKey) : undefined) ?? Promise.resolve();
+      let taskPromise: Promise<void> | undefined;
+      const queueingPromise = previousQueueing
+        .catch(() => undefined)
+        .then(async () => {
+          const queueEvent = await hydrateFeishuTopicThreadIdForQueue({
+            cfg,
+            accountId,
+            event,
+            fetchMessage,
+            log,
+          });
+          taskPromise = startFeishuMessageQueueTask(queueEvent, messageDedupeKey);
+        });
+      if (chatKey) {
+        pendingTopicQueueingByChat.set(chatKey, queueingPromise);
+      }
+      try {
+        await queueingPromise;
+      } finally {
+        if (chatKey && pendingTopicQueueingByChat.get(chatKey) === queueingPromise) {
+          pendingTopicQueueingByChat.delete(chatKey);
+        }
+      }
+      try {
+        await taskPromise;
+      } finally {
+        taskPromise = undefined;
+      }
+      return;
+    }
+
+    await waitForPendingTopicQueueing(event);
+    await hydrateAndStartFeishuMessageQueueTask(event, messageDedupeKey);
   };
 
   const resolveSenderDebounceId = (event: FeishuMessageEvent): string | undefined => {
@@ -252,7 +419,8 @@ export function createFeishuMessageReceiveHandler({
         return null;
       }
       const rootId = event.message.root_id?.trim();
-      const threadKey = rootId ? `thread:${rootId}` : "chat";
+      const threadId = event.message.thread_id?.trim();
+      const threadKey = threadId || rootId ? `thread:${threadId ?? rootId}` : "chat";
       return `feishu:${accountId}:${chatId}:${threadKey}:${senderId}`;
     },
     shouldDebounce: (event) => {
@@ -317,11 +485,11 @@ export function createFeishuMessageReceiveHandler({
     },
   });
 
-  return async (data) => {
+  return (data) => {
     const event = parseFeishuMessageEventPayload(data);
     if (!event) {
       error(`feishu[${accountId}]: ignoring malformed message event payload`);
-      return;
+      return Promise.resolve();
     }
     const messageId = event.message?.message_id?.trim();
     const botOpenId = getBotOpenId(accountId)?.trim();
@@ -330,28 +498,35 @@ export function createFeishuMessageReceiveHandler({
       // Feishu bot receive events identify their sender by open_id. Drop this
       // account's bot before it can consume a claim or debounce slot.
       log(`feishu[${accountId}]: dropping self-authored message ${messageId ?? "unknown"}`);
-      return;
+      return Promise.resolve();
     }
     const messageDedupeKey = resolveFeishuMessageDedupeKey(event);
-    if (!tryBeginFeishuMessageProcessing(messageDedupeKey, accountId)) {
+    const processingClaimKey = resolveFeishuProcessingClaimKey({ event, messageDedupeKey });
+    if (!tryBeginFeishuMessageProcessing(processingClaimKey, accountId)) {
       log(`feishu[${accountId}]: dropping duplicate event for message ${messageId}`);
-      return;
+      return Promise.resolve();
     }
+    log(
+      `feishu[${accountId}]: queued receive event message=${messageId ?? "unknown"} ` +
+        `chat_type=${event.message.chat_type} ` +
+        `thread=${event.message.thread_id?.trim() || "none"} ` +
+        `root=${event.message.root_id?.trim() || "none"}`,
+    );
     const processMessage = async () => {
       await inboundDebouncer.enqueue(event);
     };
     if (fireAndForget) {
-      void processMessage().catch((err: unknown) => {
-        releaseFeishuMessageProcessing(messageDedupeKey, accountId);
-        error(`feishu[${accountId}]: error handling message: ${String(err)}`);
+      setImmediate(() => {
+        void processMessage().catch((err: unknown) => {
+          releaseFeishuMessageProcessing(processingClaimKey, accountId);
+          error(`feishu[${accountId}]: error handling message: ${String(err)}`);
+        });
       });
-      return;
+      return Promise.resolve();
     }
-    try {
-      await processMessage();
-    } catch (err) {
-      releaseFeishuMessageProcessing(messageDedupeKey, accountId);
+    return processMessage().catch((err: unknown) => {
+      releaseFeishuMessageProcessing(processingClaimKey, accountId);
       error(`feishu[${accountId}]: error handling message: ${String(err)}`);
-    }
+    });
   };
 }

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -362,11 +362,7 @@ export function createFeishuMessageReceiveHandler({
           pendingTopicQueueingByChat.delete(chatKey);
         }
       }
-      try {
-        await taskPromise;
-      } finally {
-        taskPromise = undefined;
-      }
+      await taskPromise;
       return;
     }
 

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -2,7 +2,10 @@
 import { isRecord, readStringValue as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ClawdbotConfig, HistoryEntry, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
-import { resolveConfiguredFeishuGroupSessionScope } from "./bot-content.js";
+import {
+  isFeishuTopicSessionScope,
+  resolveConfiguredFeishuGroupSessionScope,
+} from "./bot-content.js";
 import { resolveFeishuMessageDedupeKey } from "./dedupe-key.js";
 import type { FeishuMessageEvent } from "./event-types.js";
 import { isMentionForwardRequest } from "./mention.js";
@@ -80,10 +83,6 @@ function resolveFeishuProcessingClaimKey(params: {
   return params.messageDedupeKey && params.messageDedupeKey !== messageId
     ? params.messageDedupeKey
     : messageId;
-}
-
-function isFeishuTopicSessionScope(scope: string): boolean {
-  return scope === "group_topic" || scope === "group_topic_sender";
 }
 
 function shouldHydrateFeishuTopicThreadIdForQueue(params: {

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -210,6 +210,28 @@ function waitForFeishuWsCycleEnd(params: {
   });
 }
 
+function createFeishuWebSocketEventDispatcher(params: {
+  accountId: string;
+  eventDispatcher: Lark.EventDispatcher;
+  error: (message: string) => void;
+}): Lark.EventDispatcher {
+  const { accountId, eventDispatcher, error } = params;
+  const asyncDispatcher = Object.create(eventDispatcher) as Lark.EventDispatcher & {
+    invoke: (data: unknown, invokeParams?: { needCheck?: boolean }) => Promise<unknown>;
+  };
+  asyncDispatcher.invoke = (data, invokeParams): Promise<unknown> => {
+    // The Feishu SDK awaits invoke before acking/reading the next websocket event.
+    // Hand off immediately so independent topic sessions can run in parallel.
+    setImmediate(() => {
+      void eventDispatcher.invoke(data, invokeParams).catch((err: unknown) => {
+        error(`feishu[${accountId}]: error handling websocket event: ${String(err)}`);
+      });
+    });
+    return Promise.resolve(undefined);
+  };
+  return asyncDispatcher;
+}
+
 export async function monitorWebSocket({
   account,
   accountId,
@@ -251,7 +273,13 @@ export async function monitorWebSocket({
         break;
       }
       wsClients.set(accountId, wsClient);
-      await wsClient.start({ eventDispatcher });
+      await wsClient.start({
+        eventDispatcher: createFeishuWebSocketEventDispatcher({
+          accountId,
+          eventDispatcher,
+          error,
+        }),
+      });
       attempt = 0;
       log(`feishu[${accountId}]: WebSocket client started`);
       const cycleEnd = await waitForFeishuWsCycleEnd({ abortSignal, terminalError });

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -76,7 +76,7 @@ describe("getFeishuSequentialKey", () => {
     ).toBe("feishu:default:oc_dm_chat:btw");
   });
 
-  it("uses native topic ids as the default lane for Feishu topic groups", () => {
+  it("keeps Feishu topic groups on the chat lane by default", () => {
     expect(
       getFeishuSequentialKey({
         accountId: "default",
@@ -88,10 +88,24 @@ describe("getFeishuSequentialKey", () => {
           threadId: "omt_topic_1",
         }),
       }),
-    ).toBe("feishu:default:oc_topic_group:topic:omt_topic_1");
+    ).toBe("feishu:default:oc_topic_group");
+  });
+
+  it("uses native topic ids when Feishu topic groups opt into topic sessions", () => {
     expect(
       getFeishuSequentialKey({
         accountId: "default",
+        cfg: {
+          channels: {
+            feishu: {
+              groups: {
+                oc_topic_group: {
+                  groupSessionScope: "group_topic",
+                },
+              },
+            },
+          },
+        },
         event: createTextEvent({
           text: "topic two",
           chatId: "oc_topic_group",

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -7,6 +7,9 @@ function createTextEvent(params: {
   text: string;
   messageId?: string;
   chatId?: string;
+  chatType?: FeishuMessageEvent["message"]["chat_type"];
+  rootId?: string;
+  threadId?: string;
 }): FeishuMessageEvent {
   return {
     sender: {
@@ -19,7 +22,9 @@ function createTextEvent(params: {
     message: {
       message_id: params.messageId ?? "om_message_1",
       chat_id: params.chatId ?? "oc_dm_chat",
-      chat_type: "p2p",
+      chat_type: params.chatType ?? "p2p",
+      ...(params.rootId ? { root_id: params.rootId } : {}),
+      ...(params.threadId ? { thread_id: params.threadId } : {}),
       message_type: "text",
       content: JSON.stringify({ text: params.text }),
     },
@@ -69,5 +74,57 @@ describe("getFeishuSequentialKey", () => {
         event,
       }),
     ).toBe("feishu:default:oc_dm_chat:btw");
+  });
+
+  it("uses native topic ids as the default lane for Feishu topic groups", () => {
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: createTextEvent({
+          text: "topic one",
+          chatId: "oc_topic_group",
+          chatType: "topic_group",
+          rootId: "om_topic_starter",
+          threadId: "omt_topic_1",
+        }),
+      }),
+    ).toBe("feishu:default:oc_topic_group:topic:omt_topic_1");
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: createTextEvent({
+          text: "topic two",
+          chatId: "oc_topic_group",
+          chatType: "topic_group",
+          rootId: "om_other_topic_starter",
+          threadId: "omt_topic_2",
+        }),
+      }),
+    ).toBe("feishu:default:oc_topic_group:topic:omt_topic_2");
+  });
+
+  it("honors explicit chat-scoped topic group configuration for queue keys", () => {
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        cfg: {
+          channels: {
+            feishu: {
+              groups: {
+                oc_topic_group: {
+                  groupSessionScope: "group",
+                },
+              },
+            },
+          },
+        },
+        event: createTextEvent({
+          text: "topic one",
+          chatId: "oc_topic_group",
+          chatType: "topic_group",
+          threadId: "omt_topic_1",
+        }),
+      }),
+    ).toBe("feishu:default:oc_topic_group");
   });
 });

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -3,18 +3,40 @@ import {
   isAbortRequestText,
   isBtwRequestText,
 } from "openclaw/plugin-sdk/command-primitives-runtime";
+import type { ClawdbotConfig } from "../runtime-api.js";
+import { resolveFeishuAccount } from "./accounts.js";
+import { resolveFeishuGroupSession } from "./bot-content.js";
 import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
+import { resolveFeishuGroupConfig } from "./policy.js";
+import { isFeishuGroupChatType } from "./types.js";
 
 export function getFeishuSequentialKey(params: {
   accountId: string;
   event: FeishuMessageEvent;
+  cfg?: ClawdbotConfig;
   botOpenId?: string;
   botName?: string;
 }): string {
-  const { accountId, event, botOpenId, botName } = params;
+  const { accountId, event, cfg, botOpenId, botName } = params;
   const chatId = event.message.chat_id?.trim() || "unknown";
-  const baseKey = `feishu:${accountId}:${chatId}`;
   const parsed = parseFeishuMessageEvent(event, botOpenId, botName);
+  const feishuCfg = cfg ? resolveFeishuAccount({ cfg, accountId }).config : undefined;
+  const groupConfig = isFeishuGroupChatType(parsed.chatType)
+    ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: chatId })
+    : undefined;
+  const groupSession = isFeishuGroupChatType(parsed.chatType)
+    ? resolveFeishuGroupSession({
+        chatId,
+        senderOpenId: parsed.senderOpenId,
+        messageId: parsed.messageId,
+        rootId: parsed.rootId,
+        threadId: parsed.threadId,
+        chatType: parsed.chatType,
+        groupConfig,
+        feishuCfg,
+      })
+    : null;
+  const baseKey = `feishu:${accountId}:${groupSession?.peerId ?? chatId}`;
   const text = parsed.content.trim();
 
   if (isAbortRequestText(text)) {


### PR DESCRIPTION
## What Problem This Solves

Feishu topic group messages were effectively serialized at the WebSocket event boundary. A long-running OpenClaw turn in one topic blocked delivery and processing for messages in other topics in the same Feishu topic group.

## Why This Change Was Made

This changes the Feishu monitor path so accepted WebSocket events are handed off asynchronously instead of awaiting the full agent turn before acknowledging the SDK callback. It also aligns Feishu topic session and queue keys around the native topic thread id, so messages inside one topic stay serialized while different topics use distinct sessions and queues.

## User Impact

Users can mention OpenClaw in different Feishu topics in the same topic group and get parallel processing across topics. Replies remain scoped to the originating Feishu thread.

## Evidence

- Live Feishu proof in `oc_52005deff2c7d4d4ce67a7871dbe5142`:
  - Slow topic A: `om_x100b6c9218b3dca8b274b250f4ffc70`, thread `omt_195fedaec30f9c8b`, asked OpenClaw to run `sleep 90`, replied `LIVE3_A_DONE_20260623_185155` at 2026-06-23 18:54.
  - Fast topic B: `om_x100b6c92149e7ca4b12baba2c8ceab1`, thread `omt_195fed6c190f5cbe`, replied `LIVE3_B_DONE_20260623_185155` at 2026-06-23 18:53 while A was still running.
- `git diff --check origin/main..HEAD`
- Earlier focused local run on the same patch: `node scripts/run-vitest.mjs extensions/feishu/src/monitor.message-handler.test.ts extensions/feishu/src/sequential-key.test.ts extensions/feishu/src/bot.test.ts` passed 103 tests.

Known local proof gaps:

- A rerun of the same focused Vitest command on this checkout produced no test output for over five minutes and was stopped.
- `pnpm exec oxfmt --check ...` was stopped after `pnpm exec` started downloading optional platform packages and repeatedly hit registry download retries. Prior oxfmt on the same file set passed before PR creation.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` was stopped after 30 minutes of healthy heartbeat without a final review result.
