### PR TITLE
fix(fal): bound JSON response reads to prevent OOM

### DIFF
--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -92,6 +92,7 @@ const KREA_CREATIVITY_LEVELS = ["raw", "low", "medium", "high"] as const;
 
 const FAL_IMAGE_MALFORMED_RESPONSE = "fal image generation response malformed";
 const DEFAULT_GENERATED_IMAGE_MAX_BYTES = 6 * 1024 * 1024;
+const FAL_IMAGE_JSON_RESPONSE_MAX_BYTES = 1 * 1024 * 1024;
 
 type FalImageSize = string | { width: number; height: number };
 type FalImageModelSchema = {
@@ -645,7 +646,13 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
       try {
         await assertOkOrThrowHttpError(response, "fal image generation failed");
 
-        const payload = parseFalImageGenerationResponse(await response.json());
+        const buffer = await readResponseWithLimit(response, FAL_IMAGE_JSON_RESPONSE_MAX_BYTES, {
+          onOverflow: ({ maxBytes }) =>
+            new Error(`fal image JSON response exceeds ${maxBytes} bytes`),
+        });
+        const payload = parseFalImageGenerationResponse(
+          JSON.parse(buffer.toString("utf8")) as unknown,
+        );
         const images: GeneratedImageAsset[] = [];
         let imageIndex = 0;
         for (const entry of payload.images) {

--- a/extensions/fal/music-generation-provider.test.ts
+++ b/extensions/fal/music-generation-provider.test.ts
@@ -3,6 +3,16 @@ import { expectExplicitMusicGenerationCapabilities } from "openclaw/plugin-sdk/p
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildFalMusicGenerationProvider } from "./music-generation-provider.js";
 
+function makeJsonResponse(value: unknown) {
+  const body = JSON.stringify(value);
+  const buf = Buffer.from(body, "utf8");
+  return {
+    json: async () => value,
+    body: null,
+    arrayBuffer: async () => buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
+  };
+}
+
 const {
   assertOkOrThrowHttpErrorMock,
   postJsonRequestMock,
@@ -73,15 +83,13 @@ describe("fal music generation provider", () => {
 
   it("submits MiniMax music through fal and downloads the generated track", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          audio: {
-            url: "https://v3b.fal.media/files/b/kangaroo/out.mp3",
-            content_type: "audio/mpeg",
-            file_name: "out.mp3",
-          },
-        }),
-      },
+      response: makeJsonResponse({
+        audio: {
+          url: "https://v3b.fal.media/files/b/kangaroo/out.mp3",
+          content_type: "audio/mpeg",
+          file_name: "out.mp3",
+        },
+      }),
       release: vi.fn(async () => {}),
     });
     const fetchMock = vi.fn(
@@ -126,14 +134,12 @@ describe("fal music generation provider", () => {
 
   it("rejects generated music downloads that exceed the configured media cap", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          audio: {
-            url: "https://v3b.fal.media/files/b/out.mp3",
-            content_type: "audio/mpeg",
-          },
-        }),
-      },
+      response: makeJsonResponse({
+        audio: {
+          url: "https://v3b.fal.media/files/b/out.mp3",
+          content_type: "audio/mpeg",
+        },
+      }),
       release: vi.fn(async () => {}),
     });
     vi.stubGlobal(
@@ -168,13 +174,11 @@ describe("fal music generation provider", () => {
 
   it("maps ACE-Step duration and instrumental controls", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          audio: { url: "https://example.com/out.wav", content_type: "audio/wav" },
-          seed: 42,
-          tags: "lofi, chill",
-        }),
-      },
+      response: makeJsonResponse({
+        audio: { url: "https://example.com/out.wav", content_type: "audio/wav" },
+        seed: 42,
+        tags: "lofi, chill",
+      }),
       release: vi.fn(async () => {}),
     });
     vi.stubGlobal(
@@ -206,11 +210,9 @@ describe("fal music generation provider", () => {
 
   it("maps Stable Audio duration controls", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          audio: "https://example.com/stable.wav",
-        }),
-      },
+      response: makeJsonResponse({
+        audio: "https://example.com/stable.wav",
+      }),
       release: vi.fn(async () => {}),
     });
     vi.stubGlobal(

--- a/extensions/fal/music-generation-provider.ts
+++ b/extensions/fal/music-generation-provider.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/music-generation";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { assertOkOrThrowHttpError, postJsonRequest } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveFalHttpRequestConfig } from "./http-config.js";
 
@@ -15,6 +16,7 @@ const FAL_ACE_STEP_MODEL = "fal-ai/ace-step/prompt-to-audio";
 const FAL_STABLE_AUDIO_MODEL = "fal-ai/stable-audio-25/text-to-audio";
 const DEFAULT_TIMEOUT_MS = 180_000;
 const DEFAULT_GENERATED_MUSIC_MAX_BYTES = 16 * 1024 * 1024;
+const FAL_MUSIC_JSON_RESPONSE_MAX_BYTES = 1 * 1024 * 1024;
 
 const FAL_MUSIC_MODELS = [
   DEFAULT_FAL_MUSIC_MODEL,
@@ -161,7 +163,11 @@ export function buildFalMusicGenerationProvider(): MusicGenerationProvider {
 
       try {
         await assertOkOrThrowHttpError(response, "fal music generation failed");
-        const payload = await response.json();
+        const buffer = await readResponseWithLimit(response, FAL_MUSIC_JSON_RESPONSE_MAX_BYTES, {
+          onOverflow: ({ maxBytes }) =>
+            new Error(`fal music JSON response exceeds ${maxBytes} bytes`),
+        });
+        const payload = JSON.parse(buffer.toString("utf8")) as unknown;
         const [candidate] = extractGeneratedMusicFileCandidates(payload);
         if (!candidate) {
           throw new Error("fal music generation response missing audio output");

--- a/extensions/fal/video-generation-provider.test.ts
+++ b/extensions/fal/video-generation-provider.test.ts
@@ -36,9 +36,14 @@ describe("fal video generation provider", () => {
   }
 
   function releasedJson(value: unknown) {
+    const body = JSON.stringify(value);
+    const buffer = Buffer.from(body, "utf8");
     return {
       response: {
         json: async () => value,
+        body: null,
+        arrayBuffer: async () =>
+          buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
       },
       release: vi.fn(async () => {}),
     };
@@ -255,9 +260,8 @@ describe("fal video generation provider", () => {
     mockFalProviderRuntime();
     fetchGuardMock.mockResolvedValueOnce({
       response: {
-        json: async () => {
-          throw new SyntaxError("Unexpected token < in JSON");
-        },
+        body: null,
+        arrayBuffer: async () => Buffer.from("not json", "utf8").buffer,
       },
       release: vi.fn(async () => {}),
     });

--- a/extensions/fal/video-generation-provider.ts
+++ b/extensions/fal/video-generation-provider.ts
@@ -488,7 +488,7 @@ async function fetchFalJson(params: {
       return JSON.parse(buffer.toString("utf8")) as unknown;
     } catch (err) {
       if (err instanceof SyntaxError) {
-        throw new Error(FAL_VIDEO_MALFORMED_RESPONSE);
+        throw new Error(FAL_VIDEO_MALFORMED_RESPONSE, { cause: err });
       }
       throw err;
     }

--- a/extensions/fal/video-generation-provider.ts
+++ b/extensions/fal/video-generation-provider.ts
@@ -61,6 +61,7 @@ const DEFAULT_OPERATION_TIMEOUT_MS = 1_200_000;
 const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 const POLL_INTERVAL_MS = 5_000;
 const FAL_VIDEO_MALFORMED_RESPONSE = "fal video generation response malformed";
+const FAL_JSON_RESPONSE_MAX_BYTES = 1 * 1024 * 1024;
 const FAL_VIDEO_PENDING_STATUSES = new Set([
   "IN_QUEUE",
   "IN_PROGRESS",
@@ -480,9 +481,16 @@ async function fetchFalJson(params: {
   try {
     await assertOkOrThrowHttpError(response, params.errorContext);
     try {
-      return await response.json();
-    } catch {
-      throw new Error(FAL_VIDEO_MALFORMED_RESPONSE);
+      const buffer = await readResponseWithLimit(response, FAL_JSON_RESPONSE_MAX_BYTES, {
+        onOverflow: ({ maxBytes }) =>
+          new Error(`fal video JSON response exceeds ${maxBytes} bytes`),
+      });
+      return JSON.parse(buffer.toString("utf8")) as unknown;
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        throw new Error(FAL_VIDEO_MALFORMED_RESPONSE);
+      }
+      throw err;
     }
   } finally {
     await release();


### PR DESCRIPTION
## What Problem This Solves

Replace unbounded `await response.json()` with `readResponseWithLimit` (1 MiB cap)
in fal video/music/image generation providers — the symmetric counterpart to the
bound-stream work already merged for OpenRouter (#95420, #95418), Google (#95417),
provider-http (#95218), and other modules.

A malicious or faulty fal API endpoint returning an oversized JSON response body
would previously buffer the entire body in memory before parsing.
`readResponseWithLimit` cancels the stream once the cap is reached, preventing
unbounded buffering.  These modules already use `readResponseWithLimit` for
video/image **downloads**, but the JSON API response paths were still unbounded.

## Evidence

- **Tests**: Vitest 49/49 passed (3 test files, ~64s).
  `video-generation-provider.test.ts` (18 tests),
  `music-generation-provider.test.ts` (6 tests),
  `image-generation-provider.test.ts` (25 tests)
- **Static checks**: `oxlint` exits 0 on changed files; `git diff --check` clean;
  `oxfmt` produces no delta
- **Negative control**: reverting any of the 3 JSON reads back to
  `await response.json()` would allow an oversized streamed 200-OK body to
  buffer without bound
- **Prior art**: follows the same bounded-read + `JSON.parse` pattern established
  by #95420, #95417, #95418, #95218 — 1 MiB cap is safe for fal metadata payloads

## Summary

Bound 3 unbounded JSON response reads in fal video/music/image generation
providers with 1 MiB cap.

## Changes

- **`extensions/fal/video-generation-provider.ts`** — bound `fetchFalJson` (central
  JSON fetcher covering queue submit, status polling, and result retrieval)
- **`extensions/fal/music-generation-provider.ts`** — bound `generateMusic` JSON
  response read
- **`extensions/fal/image-generation-provider.ts`** — bound `generateImage` JSON
  response read
- **`extensions/fal/video-generation-provider.test.ts`** — updated `releasedJson`
  helper and non-JSON mock to include `arrayBuffer()` for `readResponseWithLimit`
- **`extensions/fal/music-generation-provider.test.ts`** — added `makeJsonResponse`
  helper providing `arrayBuffer()` on mock Response objects