### PR TITLE
fix(minimax): bound JSON response reads to prevent OOM

### DIFF
--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -7,7 +7,10 @@ import {
   resolvePositiveTimerTimeoutMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -121,7 +124,10 @@ async function requestOAuthCode(params: {
       throw new Error(`MiniMax OAuth authorization failed: ${text || response.statusText}`);
     }
 
-    const payload = (await response.json()) as MiniMaxOAuthAuthorization & { error?: string };
+    const payload = (await readProviderJsonResponse(
+      response,
+      "minimax.oauth-code",
+    )) as MiniMaxOAuthAuthorization & { error?: string };
     if (!payload.user_code || !payload.verification_uri) {
       throw new Error(
         payload.error ??


### PR DESCRIPTION
Related: #95218, #96495, #96889

## What Problem This Solves

Fixes an issue where the MiniMax OAuth device-code authorization path uses
unbounded `response.json()` to parse the upstream authorization success body.
A misbehaving, compromised, or self-hosted MiniMax OAuth endpoint can stream
an arbitrarily large JSON response, causing the gateway process to buffer it
all into memory — leading to memory pressure or OOM on the OAuth setup path.

This is the **last remaining unbounded `response.json()` call site** in the
MiniMax bundled plugin. The shared bounded JSON reader (#95218) already covers
the main provider pipeline, image generation (#96495), and video generation
(#96889). The OAuth authorization success path was missed in those rounds and
is closed here.

## Why This Change Was Made

Replace `response.json()` with `readProviderJsonResponse(response,
"minimax.oauth-code")` — the same shared helper already used across the
codebase. This enforces a **16 MiB default cap** and, on overflow, cancels the
underlying stream and throws a bounded error (`minimax.oauth-code: JSON
response exceeds 16777216 bytes`). Malformed-JSON error messages are preserved
for backward compatibility.

No new abstraction — reuses the existing `media-core`/`plugin-sdk` bounded
reader. Video-generation provider is intentionally left unchanged here and
covered by #96889.

## User Impact

No user-visible impact for normal operation. Operators who point MiniMax OAuth
at a self-hosted or proxied endpoint are now protected against oversized
authorization responses instead of silently buffering them unbounded.

## Evidence

### Real HTTP proof: bounded reader cancels oversized stream

A real `node:http` server streams an oversized JSON body with **no
Content-Length** header. The bounded reader rejects at the cap, cancels the
stream early, and the negative control confirms the old `response.json()` path
buffers the full body.

```
node --import tsx test/_proof_minimax_bound.mts

PASS  oversized body: throws bounded cap error
PASS  stream cancelled at cap: bytesSent=1048576
PASS  happy path: small JSON parsed correctly
PASS  negative control: unbounded read buffers PAST cap

[proof] 4 PASS, 0 FAIL
```

### Unit tests

The in-repo Vitest suite for the MiniMax OAuth module passes in full (12/12),
covering error paths, malformed JSON, and the existing OAuth flow unchanged.

```
pnpm exec vitest run extensions/minimax/oauth.test.ts
 Tests  12 passed (12)
```

### CI

All required checks pass (80+ jobs green): lint, type-check, build, tests,
security guard, dependency guard, OpenGrep, CodeQL, QA smoke.

**Label**: security

AI-assisted.