### PR TITLE
test(qa): log effective QA channel driver

### DIFF
--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -167,6 +167,32 @@ describe("qa suite", () => {
     expect(qaSuiteProgressTesting.sanitizeQaSuiteProgressValue("\u0000\u0001")).toBe("<empty>");
   });
 
+  it("includes effective channel driver in run start progress logs", () => {
+    expect(
+      qaSuiteProgressTesting.formatQaSuiteRunStartProgress({
+        selectedScenarioCount: 80,
+        concurrency: 8,
+        transportId: "qa-channel",
+      }),
+    ).toBe("run start: scenarios=80 concurrency=8 transport=qa-channel");
+
+    expect(
+      qaSuiteProgressTesting.formatQaSuiteRunStartProgress({
+        selectedScenarioCount: 80,
+        concurrency: 1,
+        transportId: "qa-channel",
+        channelDriverSelection: {
+          capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+          channel: "telegram",
+          channelDriver: "crabline",
+          smokeArtifactPath: "crabline-fake-provider-smoke.json",
+        },
+      }),
+    ).toBe(
+      "run start: scenarios=80 concurrency=1 transport=qa-channel channelDriver=crabline channel=telegram",
+    );
+  });
+
   it("records gateway RSS peak and trace samples", () => {
     expect(
       qaSuiteProgressTesting.buildQaSuiteRuntimeMetrics({

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -200,6 +200,29 @@ function writeQaSuiteProgress(enabled: boolean, message: string) {
   process.stderr.write(`[qa-suite] ${message}\n`);
 }
 
+function formatQaSuiteRunStartProgress(params: {
+  selectedScenarioCount: number;
+  concurrency: number;
+  transportId: QaTransportId;
+  channelDriver?: QaScorecardChannelDriver | null;
+  channelDriverSelection?: OpenClawCrablineChannelDriverSelection | null;
+}) {
+  const channelDriver = params.channelDriver ?? params.channelDriverSelection?.channelDriver;
+  const channel = params.channelDriverSelection?.channel;
+  const parts = [
+    `run start: scenarios=${params.selectedScenarioCount}`,
+    `concurrency=${params.concurrency}`,
+    `transport=${sanitizeQaSuiteProgressValue(params.transportId)}`,
+  ];
+  if (channelDriver) {
+    parts.push(`channelDriver=${sanitizeQaSuiteProgressValue(channelDriver)}`);
+  }
+  if (channel) {
+    parts.push(`channel=${sanitizeQaSuiteProgressValue(channel)}`);
+  }
+  return parts.join(" ");
+}
+
 async function waitForQaLabReady(baseUrl: string, timeoutMs = 10_000) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
@@ -1185,7 +1208,13 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
   const gatewayHeapCheckpointsEnabled = shouldCaptureGatewayHeapCheckpoints();
   writeQaSuiteProgress(
     progressEnabled,
-    `run start: scenarios=${selectedScenarios.length} concurrency=${concurrency} transport=${transportId}`,
+    formatQaSuiteRunStartProgress({
+      selectedScenarioCount: selectedScenarios.length,
+      concurrency,
+      transportId,
+      channelDriver: params?.channelDriver,
+      channelDriverSelection: params?.channelDriverSelection,
+    }),
   );
   const useIsolatedScenarioWorkers = shouldRunQaSuiteWithIsolatedScenarioWorkers({
     scenarios: selectedScenarios,
@@ -1767,6 +1796,7 @@ export const qaSuiteProgressTesting = {
   buildQaGatewayHeapCheckpointRuntimeEnvPatch,
   buildQaIsolatedScenarioWorkerParams,
   buildQaSuiteRuntimeMetrics,
+  formatQaSuiteRunStartProgress,
   buildQaRuntimeEnvPatch,
   mergeQaRuntimeEnvPatches,
   parseQaSuiteBooleanEnv,


### PR DESCRIPTION
## What Problem This Solves

QA suite progress logs can say `transport=qa-channel` even when a profile is running through the Crabline channel driver. That makes CI output look like the run fell back to QA channel even though the summary artifact already records `run.channelDriver=crabline`.

## Why This Change Was Made

The run-start progress line now includes the effective channel driver and selected channel when present, while keeping the existing transport field for older log scans. This is observability-only; it does not change suite planning, transport selection, or QA execution behavior.

## User Impact

Maintainers reading CI logs can distinguish the QA harness transport from the actual Crabline channel driver without opening artifacts first.

## Evidence

- `git diff --check`
- `pnpm exec oxfmt --check extensions/qa-lab/src/suite.ts extensions/qa-lab/src/suite.test.ts`
- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "git diff --check && pnpm exec oxfmt --check extensions/qa-lab/src/suite.ts extensions/qa-lab/src/suite.test.ts && node scripts/run-vitest.mjs extensions/qa-lab/src/suite.test.ts"` clean; no accepted/actionable findings.
