### PR TITLE
fix(clawhub): honor OpenClaw release channels in gateway-minimum checks

### DIFF
--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -197,6 +197,16 @@ describe("clawhub helpers", () => {
     expect(satisfiesGatewayMinimum("unknown", "2026.3.0")).toBe(false);
   });
 
+  it("honors OpenClaw release channels in min gateway checks", () => {
+    // A prerelease gateway must not satisfy a stable (or newer prerelease) floor.
+    expect(satisfiesGatewayMinimum("2026.5.3-beta.1", "2026.5.3")).toBe(false);
+    expect(satisfiesGatewayMinimum("2026.5.3-beta.1", "2026.5.3-beta.3")).toBe(false);
+    expect(satisfiesGatewayMinimum("2026.5.3-beta.3", "2026.5.3-beta.1")).toBe(true);
+    // A stable correction release ships after its base and must satisfy the base floor.
+    expect(satisfiesGatewayMinimum("2026.5.3-1", "2026.5.3")).toBe(true);
+    expect(satisfiesGatewayMinimum("2026.5.3", "2026.5.3-1")).toBe(false);
+  });
+
   it("normalizes raw ClawHub SHA-256 hashes into integrity strings", () => {
     const hex = "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81";
     const integrity = "sha256-A5BYxvLAy0ksUzsKTRTvd8wPeKvMztUofYShogEc+4E=";

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -14,9 +14,9 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { parseStrictPositiveInteger } from "./parse-finite-number.js";
-import { isAtLeast, parseSemver } from "./runtime-guard.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
 import { createTempDownloadTarget } from "./temp-download.js";
+import { compareSemverStrings } from "./update-check.js";
 export { parseClawHubPluginSpec } from "./clawhub-spec.js";
 
 const DEFAULT_CLAWHUB_URL = "https://clawhub.ai";
@@ -1442,6 +1442,12 @@ export function satisfiesPluginApiRange(
   return satisfiesSemverRange(pluginApiVersion, pluginApiRange);
 }
 
+// Pulls a semver token out of a possibly-prefixed version string (e.g. "OpenClaw 2026.3.22"),
+// keeping any -channel/-correction suffix so the comparison stays release-channel aware.
+function extractVersionToken(value: string): string | null {
+  return value.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/)?.[0] ?? null;
+}
+
 /** Checks whether the current gateway version satisfies a package minimum gateway version. */
 export function satisfiesGatewayMinimum(
   currentVersion: string,
@@ -1450,10 +1456,14 @@ export function satisfiesGatewayMinimum(
   if (!minGatewayVersion) {
     return true;
   }
-  const current = parseSemver(currentVersion);
-  const minimum = parseSemver(minGatewayVersion);
+  const current = extractVersionToken(currentVersion);
+  const minimum = extractVersionToken(minGatewayVersion);
   if (!current || !minimum) {
     return false;
   }
-  return isAtLeast(current, minimum);
+  // Use the OpenClaw release-channel-aware comparator: a prerelease gateway (e.g. 2026.5.3-beta.1)
+  // must NOT satisfy a stable floor, while a stable correction release (2026.5.3-1) must. The old
+  // parseSemver/isAtLeast dropped the suffix, so betas wrongly passed stable minimums.
+  const comparison = compareSemverStrings(current, minimum);
+  return comparison !== null && comparison >= 0;
 }


### PR DESCRIPTION
## What Problem This Solves

`satisfiesGatewayMinimum` (`src/infra/clawhub.ts`) gates ClawHub plugin installs by comparing the current gateway version against a package's `minGatewayVersion`. It used `parseSemver`/`isAtLeast`, which compare only `major.minor.patch` and **drop the prerelease**. So a prerelease gateway like `2026.5.3-beta.1` reported as satisfying a stable floor `>=2026.5.3` (and an older beta wrongly satisfied a newer beta floor) — the install gate accepted plugins the host did not actually meet.

## Why This Change Was Made

OpenClaw ships real release channels: `-alpha.N`/`-beta.N` prereleases and numeric **stable correction** releases (`2026.5.3-1`, confirmed in shipped tags). The channel-aware `compareSemverStrings` (already used across the update paths in `src/infra/update-check.ts`) ranks `alpha < beta < stable` and treats correction releases as stable. Reusing it makes the gateway-minimum gate consistent with the rest of the version handling. This mirrors the same fix applied to plugin `minHostVersion` checks in #96299. A small `extractVersionToken` preserves the prior tolerance for embedded labels like `"OpenClaw 2026.3.22"` while keeping the channel suffix.

## User Impact

A beta/alpha gateway will now correctly be told a plugin requires a newer/stable gateway instead of installing a plugin it does not satisfy. Stable and stable-correction hosts are unaffected (a correction release still satisfies its base floor). No config or API surface changes.

## Evidence

`tsgo:core`, `oxlint`, `oxfmt`, and `check:import-cycles` (0 cycles — the new `clawhub → update-check` edge is cycle-free) all pass. Behavior verified by calling the exported `satisfiesGatewayMinimum` directly (below) and by the added regression tests in `src/infra/clawhub.test.ts`.

## Real behavior proof

Behavior addressed: `satisfiesGatewayMinimum` ignored the OpenClaw release channel, so a prerelease gateway (`2026.5.3-beta.1`) wrongly satisfied a stable plugin floor (`>=2026.5.3`), letting the ClawHub install gate accept incompatible plugins.

Real environment tested: Imported and invoked the real exported `src/infra/clawhub.ts` `satisfiesGatewayMinimum` via `tsx` on Node v22.22.1 (no mocks), before and after the patch.

Exact steps or command run after this patch: `npx tsx` calling `satisfiesGatewayMinimum(current, min)` across channel/correction/loose-label cases; plus `node scripts/run-oxlint.mjs`, `pnpm tsgo:core`, `pnpm check:import-cycles`.

Evidence after fix:
```
satisfiesGatewayMinimum("2026.5.3-beta.1", "2026.5.3")        -> false   (before: true)
satisfiesGatewayMinimum("2026.5.3-beta.1", "2026.5.3-beta.3") -> false   (before: true)
satisfiesGatewayMinimum("2026.5.3-beta.3", "2026.5.3-beta.1") -> true
satisfiesGatewayMinimum("2026.5.3-1", "2026.5.3")             -> true    (stable correction satisfies base)
satisfiesGatewayMinimum("2026.5.3", "2026.5.3-1")            -> false
satisfiesGatewayMinimum("2026.3.22", "2026.3.0")             -> true
satisfiesGatewayMinimum("OpenClaw 2026.3.22", "2026.3.0")    -> true    (embedded-label tolerance preserved)
satisfiesGatewayMinimum("2026.2.9", "2026.3.0")             -> false
satisfiesGatewayMinimum("unknown", "2026.3.0")              -> false
```

Observed result after fix: All 9 cases match expectations; the two prerelease cases that previously returned `true` now correctly return `false`, while stable, correction, and loose-label behavior is unchanged. `tsgo:core` exit 0, `oxlint` exit 0, import cycles 0.

What was not tested: An end-to-end ClawHub install against a live registry with a real packaged prerelease gateway (no live ClawHub host / packaged prerelease build in this environment); the change is a pure version-comparison function proven at the function and unit-test level.
