### PR TITLE
fix(qa): issue unique mock tool call ids

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -1014,6 +1014,27 @@ describe("qa mock openai server", () => {
     expect(firstPayload.output?.[0]?.call_id).not.toBe(secondPayload.output?.[0]?.call_id);
   });
 
+  it("uses unique ids for repeated identical tool calls", async () => {
+    const server = await startMockServer();
+    const body = {
+      stream: false,
+      model: "gpt-5.5",
+      input: [makeUserInput("Read QA_KICKOFF_TASK.md, then answer with exactly QA-READ-OK.")],
+    };
+
+    const first = await expectResponsesJson<{ output?: Array<{ call_id?: string }> }>(server, body);
+    const second = await expectResponsesJson<{ output?: Array<{ call_id?: string }> }>(
+      server,
+      body,
+    );
+
+    const firstCallId = first.output?.[0]?.call_id;
+    const secondCallId = second.output?.[0]?.call_id;
+    expect(firstCallId).toMatch(/^call_mock_read_/);
+    expect(secondCallId).toMatch(/^call_mock_read_/);
+    expect(firstCallId).not.toBe(secondCallId);
+  });
+
   it("continues repo-contract followthrough when a retry user item follows tool output", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -10,6 +10,8 @@ import { writeJson } from "../shared/http-json.js";
 
 type ResponsesInputItem = Record<string, unknown>;
 
+let mockFunctionCallSequence = 0;
+
 type StreamEvent =
   | { type: "response.output_item.added"; item: Record<string, unknown> }
   | {
@@ -773,8 +775,10 @@ function buildMockFunctionCall(name: string, args: Record<string, unknown>) {
     .update(serialized)
     .digest("hex")
     .slice(0, 10);
-  const callId = `call_mock_${name}_${callSuffix}`;
-  const itemId = `fc_mock_${name}_${callSuffix}`;
+  const sequence = ++mockFunctionCallSequence;
+  const uniqueSuffix = `${callSuffix}_${sequence}`;
+  const callId = `call_mock_${name}_${uniqueSuffix}`;
+  const itemId = `fc_mock_${name}_${uniqueSuffix}`;
   const item = {
     type: "function_call",
     id: itemId,
@@ -786,7 +790,7 @@ function buildMockFunctionCall(name: string, args: Record<string, unknown>) {
     callId,
     item,
     itemId,
-    responseId: `resp_mock_${name}_${callSuffix}`,
+    responseId: `resp_mock_${name}_${uniqueSuffix}`,
     serialized,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

The QA runtime parity soak can report a tool error when a scenario legitimately repeats the same tool call. The QA mock provider reused the same `call_id`, function item id, and response id for identical tool name/argument pairs, which violates the provider tool-call identity contract.

## Why This Change Was Made

Keep the existing argument hash for readable, repeatable diagnostics, then append a process-local monotonic sequence to every emitted mock function call. This preserves the useful prefix while guaranteeing distinct identities across repeated turns. The regression test sends the same request twice and asserts distinct call ids.

## User Impact

No production runtime behavior changes. Release QA parity and soak runs no longer produce false tool-error failures from duplicate mock tool-call ids.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.test.ts --run`
- 106 tests passed
- autoreview: clean, no accepted/actionable findings
- Fixes the repeated-call identity failure observed in `runtime-long-context-cache-stability`
