### PR TITLE
fix(msteams): decode &amp; last in stripHtmlFromTeamsMessage to avoid double-decoding

### DIFF
--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -37,6 +37,15 @@ describe("stripHtmlFromTeamsMessage", () => {
     );
   });
 
+  it("does not double-decode escaped entities (decodes &amp; last)", () => {
+    // Graph encodes literally-typed entity text by escaping its '&' to '&amp;'.
+    // Decoding '&amp;' first would re-decode the now-bare '&lt;'/'&gt;' into
+    // angle brackets, corrupting the user's literal text.
+    expect(stripHtmlFromTeamsMessage("The token is &amp;lt;APIKEY&amp;gt;")).toBe(
+      "The token is &lt;APIKEY&gt;",
+    );
+  });
+
   it("normalizes multiple whitespace to single space", () => {
     expect(stripHtmlFromTeamsMessage("hello   world")).toBe("hello world");
   });

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -35,14 +35,16 @@ export function stripHtmlFromTeamsMessage(html: string): string {
   let text = html.replace(/<at[^>]*>(.*?)<\/at>/gi, "@$1");
   // Strip remaining HTML tags.
   text = text.replace(/<[^>]*>/g, " ");
-  // Decode common HTML entities.
+  // Decode common HTML entities. &amp; must be decoded LAST to prevent
+  // double-decoding (e.g. &amp;lt; → &lt; not <), matching decodeHtmlEntities
+  // in inbound.ts.
   text = text
-    .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, " ");
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&");
   // Normalize whitespace.
   return text.replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
## What Problem This Solves

`stripHtmlFromTeamsMessage` (`extensions/msteams/src/graph-thread.ts`) decodes `&amp;` **first** when un-escaping HTML entities. Microsoft Graph returns message bodies as HTML, so literal entity text a user types (e.g. they type `&lt;APIKEY&gt;`) comes back double-encoded as `&amp;lt;APIKEY&amp;gt;`. Decoding `&amp;` first turns the now-bare `&lt;`/`&gt;` into real angle brackets on the subsequent passes, corrupting the user's literal text into markup:

```
Input : "The token is &amp;lt;APIKEY&amp;gt;"
Before: "The token is <APIKEY>"        ❌ (fabricates angle brackets the user never typed)
After : "The token is &lt;APIKEY&gt;"  ✅
```

This stripped text feeds model/thread context (`graph-thread.ts:156`, `thread-parent-context.ts:134`), so the corruption reaches the agent.

## Fix

Decode `&amp;` **last**, mirroring the sibling decoder `decodeHtmlEntities` in the same package (`extensions/msteams/src/inbound.ts`), whose comment already documents the rule: *"must be last to prevent double-decoding (e.g. `&amp;lt;` → `&lt;` not `<`)"*. `graph-thread.ts` simply never matched that ordering. The change is behavior-preserving for all singly-encoded input.

## Evidence

Added a regression test `does not double-decode escaped entities` in `extensions/msteams/src/graph-thread.test.ts`, and verified **red → green** by executing the exact `stripHtmlFromTeamsMessage` entity-decode logic against both the bug case and the existing test:

```
[double-encoded entity — the bug]
  input : "The token is &amp;lt;APIKEY&amp;gt;"
  want  : "The token is &lt;APIKEY&gt;"
  before: "The token is <APIKEY>"          <-- RED  (current code on main — wrong)
  after : "The token is &lt;APIKEY&gt;"    <-- GREEN (this PR)

[existing "decodes common HTML entities" test — must stay green]
  input : "&amp; &lt;b&gt; &quot;x&quot; &#39;y&#39; &nbsp;z"
  before: "& <b> \"x\" 'y' z"   (unchanged)
  after : "& <b> \"x\" 'y' z"   (unchanged)
```

The reorder only affects the buggy double-decode path; every singly-encoded input (everything the existing tests exercise) is byte-for-byte unchanged.
