### PR TITLE
feat(copilot): add BYOK provider parity

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f7247b5bbfe3f96bffffd25a8be2f89b37999e36731f34a159ae21ded1cedd05  plugin-sdk-api-baseline.json
-ce88a53dadc194ceccc63f50146aee03a1a425f551117da826a21519d5bf80db  plugin-sdk-api-baseline.jsonl
+267b152897f63cb73d1df4357887c1943fdb04ec5a26f780a3632e7661ab251d  plugin-sdk-api-baseline.json
+6be9b74fdee8d8928fdb667515b2859c6db6aa7c13c524d7c86587a95477aa1c  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/copilot.md
+++ b/docs/plugins/copilot.md
@@ -103,8 +103,65 @@ The harness advertises support for the canonical `github-copilot` provider
 
 - `github-copilot`
 
-Anything outside that set falls through `selection.ts`'s `auto_pi` branch back
-to PI.
+It also supports custom `models.providers` entries when the selected model has
+a non-empty `baseUrl` and one of these API shapes:
+
+- `openai-responses`
+- `openai-completions`
+- `ollama` (OpenAI-compatible completions)
+- `azure-openai-responses`
+- `anthropic-messages`
+
+Native provider ids such as `openai`, `anthropic`, `google`, and `ollama` remain
+owned by their native runtimes. Use a distinct custom provider id when routing
+an endpoint through Copilot BYOK.
+
+Copilot BYOK endpoints must be public-network HTTPS URLs. The harness gives the
+Copilot SDK a per-attempt loopback proxy URL, then forwards provider traffic
+through OpenClaw's guarded fetch path so DNS pinning and SSRF policy stay
+owned by OpenClaw. Use the native OpenClaw runtime for local Ollama, LM Studio,
+or LAN model servers.
+
+## BYOK
+
+Copilot BYOK uses the SDK's session-level custom provider contract. OpenClaw
+passes the resolved model endpoint, API key, bearer-token mode, headers, model
+id, and context/output limits without moving provider transport logic into
+core.
+
+For example:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: "custom-proxy/llama-3.1-8b",
+      models: {
+        "custom-proxy/llama-3.1-8b": {
+          agentRuntime: { id: "copilot" },
+        },
+      },
+    },
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      "custom-proxy": {
+        baseUrl: "https://api.example.com/v1",
+        apiKey: "${CUSTOM_PROXY_API_KEY}",
+        api: "openai-responses",
+        authHeader: true,
+        models: [{ id: "llama-3.1-8b", name: "Llama 3.1 8B" }],
+      },
+    },
+  },
+}
+```
+
+BYOK sessions are separately keyed from subscription sessions and from other
+endpoints or credential fingerprints. Rotating the key, headers, model, or
+endpoint creates a fresh Copilot SDK session instead of resuming incompatible
+state.
 
 ## Auth
 
@@ -151,10 +208,11 @@ Override with `copilotHome: <path>` on the attempt input when you need a
 custom location (for example, a shared mount for migration).
 
 Live harness tests use `OPENCLAW_COPILOT_AGENT_LIVE_TOKEN` when a direct token
-is needed. The shared live-test setup intentionally scrubs `COPILOT_GITHUB_TOKEN`,
-`GH_TOKEN`, and `GITHUB_TOKEN` after staging real auth profiles into the isolated
-test home, so passing a `gh auth token` value through the dedicated live-test
-variable avoids false skips without exposing the token to unrelated suites.
+is needed. The shared live-test setup intentionally scrubs
+`COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN` after staging real auth
+profiles into the isolated test home, so passing a `gh auth token` value
+through the dedicated live-test variable avoids false skips without exposing
+the token to unrelated suites.
 
 ## Configuration surface
 
@@ -163,9 +221,9 @@ The harness reads its config from per-attempt input
 `extensions/copilot/src/`:
 
 - `copilotHome` — per-agent CLI state directory (defaults documented above).
-- `model` — string or `{ provider, id, api? }`. When omitted, OpenClaw uses
-  the agent's normal model selection and the harness verifies the resolved
-  provider is in the supported set.
+- `model` — string or `{ provider, id, api?, baseUrl?, headers?, authHeader? }`.
+  When omitted, OpenClaw uses the agent's normal model selection and the
+  harness verifies the resolved provider is supported.
 - `reasoningEffort` — `"low" | "medium" | "high" | "xhigh"`. Maps from
   OpenClaw's `ThinkLevel` / `ReasoningLevel` resolution in
   `auto-reply/thinking.ts`.
@@ -252,9 +310,9 @@ under `describe("runSideQuestion")`.
 
 ## Limitations
 
-- The harness only claims the canonical `github-copilot` provider at MVP.
-  Additional providers (BYOK or otherwise) should land in follow-up PRs that
-  ship the adapter alongside the wire-up.
+- The harness claims `github-copilot` plus unowned custom BYOK provider ids.
+  Manifest-owned native provider ids stay on their owning runtime even when
+  `agentRuntime.id` is forced to `copilot`.
 - The harness does not deliver TUI; PI's TUI is unaffected and remains the
   fallback for whatever runtimes do not have a peer surface.
 - PI session state is not migrated when an agent switches to `copilot`.

--- a/extensions/copilot/README.md
+++ b/extensions/copilot/README.md
@@ -10,10 +10,11 @@ openclaw plugins install @openclaw/copilot
 
 Restart the Gateway after installing or updating the plugin.
 
-The harness claims the canonical subscription `github-copilot` provider and
-is opt-in only — selection requires explicit `agentRuntime.id: "copilot"`
-on a model or provider entry; `auto` never picks it. PI remains the default
-embedded runtime.
+The harness claims the canonical subscription `github-copilot` provider plus
+custom BYOK provider entries that the Copilot SDK can represent. Manifest-owned
+native provider ids stay with their owning runtimes. The harness is opt-in only:
+selection requires explicit `agentRuntime.id: "copilot"` on a model or provider
+entry; `auto` never picks it. PI remains the default embedded runtime.
 
 See [GitHub Copilot agent runtime](../../docs/plugins/copilot.md) for
 configuration, the doctor contract, transcript mirroring, compaction, side

--- a/extensions/copilot/harness.test.ts
+++ b/extensions/copilot/harness.test.ts
@@ -1,4 +1,5 @@
 // Copilot tests cover harness plugin behavior.
+import { attachModelProviderRequestTransport } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
@@ -7,11 +8,12 @@ import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtim
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CopilotClientPool } from "./harness.js";
 import { createCopilotAgentHarness, type CopilotSessionBinding } from "./harness.js";
+import { COPILOT_BYOK_PROVIDER_ERROR } from "./src/provider-bridge.js";
 
 const mocks = vi.hoisted(() => ({
   runCopilotAttempt: vi.fn(),
   resolvePoolAcquire: vi.fn(
-    () =>
+    (_params: any) =>
       ({
         auth: {
           agentId: "test",
@@ -22,12 +24,17 @@ const mocks = vi.hoisted(() => ({
         options: { copilotHome: "/tmp/copilot", useLoggedInUser: true },
       }) as any,
   ),
+  createCopilotByokProxy: vi.fn(),
   createCopilotClientPool: vi.fn(),
 }));
 
 vi.mock("./src/attempt.js", () => ({
   resolvePoolAcquire: mocks.resolvePoolAcquire,
   runCopilotAttempt: mocks.runCopilotAttempt,
+}));
+
+vi.mock("./src/byok-proxy.js", () => ({
+  createCopilotByokProxy: mocks.createCopilotByokProxy,
 }));
 
 vi.mock("./src/runtime.js", () => ({
@@ -86,6 +93,7 @@ describe("createCopilotAgentHarness", () => {
   beforeEach(() => {
     mocks.runCopilotAttempt.mockReset();
     mocks.resolvePoolAcquire.mockClear();
+    mocks.createCopilotByokProxy.mockReset();
     mocks.createCopilotClientPool.mockReset();
     mocks.runCopilotAttempt.mockResolvedValue(ATTEMPT_RESULT);
     mocks.resolvePoolAcquire.mockReturnValue({
@@ -98,6 +106,7 @@ describe("createCopilotAgentHarness", () => {
       options: { copilotHome: "/tmp/copilot", useLoggedInUser: true },
     });
     mocks.createCopilotClientPool.mockImplementation(() => makePoolMock());
+    mocks.createCopilotByokProxy.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -180,32 +189,108 @@ describe("createCopilotAgentHarness", () => {
     ).toEqual({ supported: true, priority: 100 });
   });
 
-  it("supports rejects providers outside the whitelist", () => {
+  it("supports custom provider ids for BYOK model entries", () => {
     const harness = createCopilotAgentHarness();
 
     expect(
       harness.supports({
-        provider: "anthropic",
-        modelId: "claude-sonnet-4.5",
+        provider: "custom-proxy",
+        modelId: "llama-3.1-8b",
+        modelProvider: {
+          api: "openai-responses",
+          baseUrl: "https://proxy.example/v1",
+        },
+        providerOwnerStatus: "unowned",
+        providerOwnerPluginIds: [],
+        requestedRuntime: "copilot",
+      }),
+    ).toEqual({ supported: true, priority: 100 });
+  });
+
+  it("supports rejects custom provider ids without a supported BYOK model shape", () => {
+    const harness = createCopilotAgentHarness();
+
+    expect(
+      harness.supports({
+        provider: "custom-proxy",
+        modelId: "llama-3.1-8b",
+        providerOwnerStatus: "unowned",
+        providerOwnerPluginIds: [],
         requestedRuntime: "copilot",
       }),
     ).toEqual({
       supported: false,
-      reason: "provider is not one of: github-copilot",
+      reason:
+        "provider is not a supported Copilot BYOK model (requires supported api, baseUrl, and no request transport policy overrides)",
     });
-    // Legacy aspirational ids should not be claimed by the harness.
-    for (const legacyId of ["github", "openclaw", "copilot"]) {
+    expect(
+      harness.supports({
+        provider: "custom-proxy",
+        modelId: "llama-3.1-8b",
+        modelProvider: {
+          api: "openai-responses",
+          baseUrl: "https://proxy.example/v1",
+          request: { proxy: { mode: "env-proxy" } },
+        },
+        providerOwnerStatus: "unowned",
+        providerOwnerPluginIds: [],
+        requestedRuntime: "copilot",
+      }),
+    ).toEqual({
+      supported: false,
+      reason:
+        "provider is not a supported Copilot BYOK model (requires supported api, baseUrl, and no request transport policy overrides)",
+    });
+  });
+
+  it("supports rejects manifest-owned providers outside the whitelist", () => {
+    const harness = createCopilotAgentHarness();
+
+    for (const [provider, ownerPluginIds] of [
+      ["anthropic", ["anthropic"]],
+      ["azure-openai-responses", ["openai"]],
+      ["deepinfra", ["deepinfra"]],
+      ["fireworks", ["fireworks"]],
+      ["github", ["github"]],
+      ["openclaw", ["openclaw"]],
+      ["sglang", ["sglang"]],
+      ["together", ["together"]],
+      ["vllm", ["vllm"]],
+    ] as const) {
       expect(
         harness.supports({
-          provider: legacyId,
+          provider,
           modelId: "gpt-4.1",
           requestedRuntime: "copilot",
+          providerOwnerStatus: "owned",
+          providerOwnerPluginIds: ownerPluginIds,
         }),
       ).toEqual({
         supported: false,
         reason: "provider is not one of: github-copilot",
       });
     }
+  });
+
+  it("supports rejects ambiguous custom provider ownership", () => {
+    const harness = createCopilotAgentHarness();
+
+    expect(
+      harness.supports({
+        provider: "custom-proxy",
+        modelId: "proxy-model",
+        modelProvider: {
+          api: "openai-responses",
+          baseUrl: "https://proxy.example/v1",
+        },
+        requestedRuntime: "copilot",
+        providerOwnerStatus: "ambiguous",
+        providerOwnerPluginIds: ["first-owner", "second-owner"],
+      }),
+    ).toEqual({
+      supported: false,
+      reason: "provider is not one of: github-copilot",
+    });
   });
 
   it("runAttempt lazy-imports attempt by waiting until invocation to create a pool", async () => {
@@ -220,6 +305,18 @@ describe("createCopilotAgentHarness", () => {
 
     expect(mocks.createCopilotClientPool).toHaveBeenCalledTimes(1);
     expect(mocks.runCopilotAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps invalid BYOK provider configuration on the structured attempt path", async () => {
+    const pool = makePoolMock();
+    mocks.createCopilotClientPool.mockReturnValue(pool);
+    mocks.resolvePoolAcquire.mockImplementationOnce(() => {
+      throw new Error(COPILOT_BYOK_PROVIDER_ERROR);
+    });
+    const harness = createCopilotAgentHarness();
+
+    await expect(harness.runAttempt(ATTEMPT_PARAMS)).resolves.toBe(ATTEMPT_RESULT);
+    expect(mocks.runCopilotAttempt).toHaveBeenCalledWith(ATTEMPT_PARAMS, { pool });
   });
 
   it("runAttempt creates one pool lazily and reuses it across two attempts on the same harness", async () => {
@@ -1186,6 +1283,88 @@ describe("createCopilotAgentHarness", () => {
       expect(secondCallParams.initialReplayState?.sdkSessionId).toBe("sdk-sess-sqlite");
     });
 
+    it("persists BYOK session compatibility with endpoint fingerprints instead of raw URLs", async () => {
+      const sessionStore = makeSessionStoreMock();
+      mocks.runCopilotAttempt.mockImplementation(async (_params, deps) => {
+        deps.onSessionEstablished?.({
+          sdkSessionId: "sdk-sess-byok",
+          pooledClient: { key: {} as any, client: { deleteSession: vi.fn() } as any },
+          sessionConfig: TEST_SESSION_CONFIG,
+        });
+        return ATTEMPT_RESULT;
+      });
+      const harness = createCopilotAgentHarness({
+        pool: makePoolMock(),
+        sessionStore: sessionStore.store,
+      });
+
+      await harness.runAttempt(
+        makeAttemptParams({
+          provider: "custom-proxy",
+          model: {
+            provider: "custom-proxy",
+            id: "proxy-model",
+            api: "openai-responses",
+            baseUrl: "https://proxy.example/v1?routing=blue",
+          },
+          auth: undefined,
+          authProfileId: "custom-proxy:main",
+          resolvedApiKey: "byok-token",
+        }),
+      );
+
+      const stored = sessionStore.entries.get("oc-sess-reuse");
+      expect(stored?.compatKey).toContain("baseUrlFingerprint=sha256:");
+      expect(stored?.compatKey).not.toContain("proxy.example");
+      expect(stored?.compatKey).not.toContain("routing=blue");
+    });
+
+    it("does not reuse BYOK sessions when attached request auth mode changes", async () => {
+      const pool = makePoolMock();
+      const model = {
+        provider: "custom-proxy",
+        id: "proxy-model",
+        api: "openai-responses",
+        baseUrl: "https://proxy.example/v1",
+      };
+      mocks.runCopilotAttempt.mockImplementation(async (_params, deps) => {
+        deps.onSessionEstablished?.({
+          sdkSessionId: "sdk-sess-byok",
+          pooledClient: { key: {} as any, client: { deleteSession: vi.fn() } as any },
+          sessionConfig: TEST_SESSION_CONFIG,
+        });
+        return ATTEMPT_RESULT;
+      });
+      const harness = createCopilotAgentHarness({ pool });
+
+      await harness.runAttempt(
+        makeAttemptParams({
+          provider: "custom-proxy",
+          model: attachModelProviderRequestTransport(model, { auth: { mode: "provider-default" } }),
+          auth: undefined,
+          authProfileId: "custom-proxy:main",
+          resolvedApiKey: "byok-token",
+        }),
+      );
+      await harness.runAttempt(
+        makeAttemptParams({
+          runId: "t2",
+          provider: "custom-proxy",
+          model: attachModelProviderRequestTransport(model, {
+            auth: { mode: "header", headerName: "x-api-key", value: "byok-token" },
+          }),
+          auth: undefined,
+          authProfileId: "custom-proxy:main",
+          resolvedApiKey: "byok-token",
+        }),
+      );
+
+      const secondCallParams = mocks.runCopilotAttempt.mock.calls[1]?.[0] as {
+        initialReplayState?: { sdkSessionId?: string };
+      };
+      expect(secondCallParams.initialReplayState?.sdkSessionId).toBeUndefined();
+    });
+
     it("resumes shipped schema v1 plugin-state bindings for attempts", async () => {
       const sessionStore = makeSessionStoreMock();
       mocks.runCopilotAttempt.mockImplementation(async (_params, deps) => {
@@ -1884,6 +2063,148 @@ describe("createCopilotAgentHarness", () => {
         }),
       );
       expect(matchingResult?.compacted).toBe(true);
+    });
+
+    it("compacts tracked BYOK sessions from production compact params with a fresh proxy", async () => {
+      const compact = vi.fn(async () => ({
+        success: true,
+        tokensRemoved: 45,
+        messagesRemoved: 2,
+      }));
+      const resumeSession = vi.fn(async () => ({
+        disconnect: vi.fn(async () => undefined),
+        rpc: { history: { compact } },
+      }));
+      const pool = makePoolMock();
+      const acquire = vi.fn(async () => ({
+        key: {} as any,
+        client: { deleteSession: vi.fn(), resumeSession } as any,
+      }));
+      pool.acquire = acquire;
+      pool.release = vi.fn(async () => undefined);
+      const trackedRuntimeModel = {
+        provider: "local-proxy",
+        id: "proxy-model",
+        api: "openai-responses",
+        baseUrl: "https://proxy.example/v1",
+      };
+      mocks.resolvePoolAcquire.mockImplementation((params: any) => {
+        const runtimeModel = params.runtimeModel ?? params.model;
+        if (!runtimeModel?.baseUrl) {
+          throw new Error(COPILOT_BYOK_PROVIDER_ERROR);
+        }
+        return {
+          auth: {
+            agentId: "test",
+            authMode: "byok",
+            authProfileId: "byok:local-proxy",
+            authProfileVersion:
+              runtimeModel.baseUrl === trackedRuntimeModel.baseUrl
+                ? "sha256:provider"
+                : "sha256:rotated",
+            copilotHome: "/copilot-home",
+          },
+          key: { agentId: "test", authMode: "byok", copilotHome: "/copilot-home" },
+          options: { copilotHome: "/copilot-home" },
+        };
+      });
+      const closeByokProxy = vi.fn(async () => undefined);
+      mocks.createCopilotByokProxy.mockImplementation(async (provider: any) => ({
+        close: closeByokProxy,
+        provider: {
+          ...provider,
+          provider: {
+            ...provider.provider,
+            baseUrl: "http://127.0.0.1:49152/proxy/v1",
+          },
+        },
+      }));
+      const trackedProvider = {
+        type: "openai" as const,
+        wireApi: "responses" as const,
+        baseUrl: "https://proxy.example/v1",
+        modelId: "proxy-model",
+        wireModel: "proxy-model",
+      };
+      mocks.runCopilotAttempt.mockImplementation(async (_params, deps) => {
+        deps.onSessionEstablished?.({
+          compactionSessionConfig: {
+            ...TEST_SESSION_CONFIG,
+            provider: trackedProvider,
+          },
+          sdkSessionId: "sdk-sess-byok",
+          pooledClient: {
+            key: {} as any,
+            client: { deleteSession: vi.fn(), resumeSession } as any,
+          },
+          sessionConfig: TEST_SESSION_CONFIG,
+        });
+        return ATTEMPT_RESULT;
+      });
+      const harness = createCopilotAgentHarness({ pool });
+
+      await harness.runAttempt(
+        makeCompactParams({
+          model: trackedRuntimeModel,
+          provider: "local-proxy",
+          authProfileId: "byok:local-proxy",
+          resolvedApiKey: "byok-token",
+          sessionId: "oc-sess-byok",
+        }),
+      );
+      mocks.resolvePoolAcquire.mockClear();
+
+      const rotatedResult = await harness.compact?.(
+        makeCompactParams({
+          model: "proxy-model",
+          runtimeModel: {
+            ...trackedRuntimeModel,
+            baseUrl: "https://rotated.example/v1",
+          },
+          provider: "local-proxy",
+          authProfileId: "byok:local-proxy",
+          sessionId: "oc-sess-byok",
+        }),
+      );
+
+      expect(mocks.resolvePoolAcquire).toHaveBeenCalledTimes(1);
+      expect(resumeSession).not.toHaveBeenCalled();
+      expect(rotatedResult).toEqual({
+        ok: false,
+        compacted: false,
+        reason: "missing_thread_binding",
+        failure: { reason: "missing_thread_binding" },
+      });
+      mocks.resolvePoolAcquire.mockClear();
+
+      const result = await harness.compact?.(
+        makeCompactParams({
+          model: "proxy-model",
+          runtimeModel: trackedRuntimeModel,
+          provider: "local-proxy",
+          authProfileId: "byok:local-proxy",
+          sessionId: "oc-sess-byok",
+        }),
+      );
+
+      expect(mocks.resolvePoolAcquire).toHaveBeenCalledTimes(1);
+      expect(mocks.createCopilotByokProxy).toHaveBeenCalledWith({
+        mode: "byok",
+        provider: trackedProvider,
+      });
+      expect(resumeSession).toHaveBeenCalledWith(
+        "sdk-sess-byok",
+        expect.objectContaining({
+          continuePendingWork: false,
+          model: "gpt-4.1",
+          provider: expect.objectContaining({
+            baseUrl: "http://127.0.0.1:49152/proxy/v1",
+          }),
+          suppressResumeEvent: true,
+        }),
+      );
+      expect(closeByokProxy).toHaveBeenCalledTimes(1);
+      expect(result?.compacted).toBe(true);
     });
 
     it("does not compact a tracked SDK session after model changes", async () => {

--- a/extensions/copilot/harness.ts
+++ b/extensions/copilot/harness.ts
@@ -3,6 +3,7 @@ import type { CopilotClient } from "@github/copilot-sdk";
 import {
   buildAgentHookContextChannelFields,
   compactWithSafetyTimeout,
+  getModelProviderRequestTransport,
   resolveCompactionTimeoutMs,
   runAgentHarnessAfterCompactionHook,
   runAgentHarnessBeforeCompactionHook,
@@ -15,7 +16,13 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { CopilotSessionConfig } from "./src/attempt.js";
-import { resolveCopilotAuth } from "./src/auth-bridge.js";
+import { createCopilotByokAuth, resolveCopilotAuth, tokenFingerprint } from "./src/auth-bridge.js";
+import { createCopilotByokProxy } from "./src/byok-proxy.js";
+import {
+  isCopilotByokUnsupportedProviderError,
+  resolveCopilotProvider,
+  supportsCopilotByokProviderShape,
+} from "./src/provider-bridge.js";
 import type {
   ClientCreateOptions,
   CopilotClientPool,
@@ -52,7 +59,7 @@ interface TrackedSession {
   // replaces this entry via `onSessionEstablished`.
   compatKey: string;
   compactKey: string;
-  authMode: "gitHubToken" | "useLoggedInUser";
+  authMode: "gitHubToken" | "useLoggedInUser" | "byok";
   authProfileId?: string;
   authProfileVersion?: string;
 }
@@ -88,7 +95,7 @@ export type CopilotSessionBinding = {
   sdkSessionId: string;
   compatKey: string;
   compactKey: string;
-  authMode: "gitHubToken" | "useLoggedInUser";
+  authMode: "gitHubToken" | "useLoggedInUser" | "byok";
   authProfileId?: string;
   authProfileVersion?: string;
   updatedAt: number;
@@ -119,9 +126,9 @@ type CopilotSessionAuth = Pick<
 >;
 
 function sessionAuthFields(auth: CopilotSessionAuth): CopilotSessionAuth {
-  return auth.authMode === "gitHubToken"
+  return auth.authMode === "gitHubToken" || auth.authMode === "byok"
     ? {
-        authMode: "gitHubToken",
+        authMode: auth.authMode,
         authProfileId: auth.authProfileId,
         authProfileVersion: auth.authProfileVersion,
       }
@@ -136,7 +143,7 @@ function sessionAuthMatches(stored: CopilotSessionAuth, current: CopilotSessionA
     return true;
   }
   return (
-    current.authMode === "gitHubToken" &&
+    current.authMode === stored.authMode &&
     stored.authProfileId === current.authProfileId &&
     stored.authProfileVersion === current.authProfileVersion
   );
@@ -154,8 +161,10 @@ function normalizeBinding(
     value.compatKey.trim() === "" ||
     typeof value.compactKey !== "string" ||
     value.compactKey.trim() === "" ||
-    (value.authMode !== "gitHubToken" && value.authMode !== "useLoggedInUser") ||
-    (value.authMode === "gitHubToken" &&
+    (value.authMode !== "gitHubToken" &&
+      value.authMode !== "byok" &&
+      value.authMode !== "useLoggedInUser") ||
+    ((value.authMode === "gitHubToken" || value.authMode === "byok") &&
       (typeof value.authProfileId !== "string" ||
         value.authProfileId.trim() === "" ||
         typeof value.authProfileVersion !== "string" ||
@@ -171,7 +180,7 @@ function normalizeBinding(
     compatKey: value.compatKey,
     compactKey: value.compactKey,
     authMode: value.authMode,
-    ...(value.authMode === "gitHubToken"
+    ...(value.authMode === "gitHubToken" || value.authMode === "byok"
       ? {
           authProfileId: value.authProfileId,
           authProfileVersion: value.authProfileVersion,
@@ -346,21 +355,88 @@ function computeSessionKey(
     copilotHome?: string;
     cwd?: string;
     modelId?: string;
-    model?: string | { api?: string; id?: string; provider?: string };
+    model?:
+      | {
+          api?: string;
+          id?: string;
+          provider?: string;
+          baseUrl?: string;
+          azureApiVersion?: string;
+          headers?: Record<string, string | null | undefined>;
+          authHeader?: boolean;
+          params?: Record<string, unknown>;
+          request?: {
+            auth?: { mode?: unknown };
+            proxy?: unknown;
+            tls?: unknown;
+            allowPrivateNetwork?: unknown;
+          };
+          contextTokens?: number;
+          contextWindow?: number;
+          maxTokens?: number;
+        }
+      | string;
+    runtimeModel?: {
+      api?: string;
+      id?: string;
+      provider?: string;
+      baseUrl?: string;
+      azureApiVersion?: string;
+      headers?: Record<string, string | null | undefined>;
+      authHeader?: boolean;
+      params?: Record<string, unknown>;
+      request?: {
+        auth?: { mode?: unknown };
+        proxy?: unknown;
+        tls?: unknown;
+        allowPrivateNetwork?: unknown;
+      };
+      contextTokens?: number;
+      contextWindow?: number;
+      maxTokens?: number;
+    };
     profileVersion?: string;
     resolvedApiKey?: string;
     sessionKey?: string;
     workspaceDir?: string;
   };
-  const modelObj: { api?: string; id?: string; provider?: string } =
+  const modelObj: {
+    api?: string;
+    id?: string;
+    provider?: string;
+    baseUrl?: string;
+    azureApiVersion?: string;
+    headers?: Record<string, string | null | undefined>;
+    authHeader?: boolean;
+    params?: Record<string, unknown>;
+    request?: {
+      auth?: { mode?: unknown };
+      proxy?: unknown;
+      tls?: unknown;
+      allowPrivateNetwork?: unknown;
+    };
+    contextTokens?: number;
+    contextWindow?: number;
+    maxTokens?: number;
+  } =
     p.model && typeof p.model === "object"
       ? p.model
+      : p.runtimeModel && typeof p.runtimeModel === "object"
+        ? p.runtimeModel
       : { id: typeof p.model === "string" ? p.model : undefined };
   const provider = modelObj.provider ?? (typeof p.provider === "string" ? p.provider : "");
   const modelId =
     modelObj.id ??
     (typeof p.modelId === "string" ? p.modelId : undefined) ??
     (typeof p.model === "string" ? p.model : "");
+  const requestTransport =
+    p.model && typeof p.model === "object" ? getModelProviderRequestTransport(p.model) : undefined;
+  const requestAuthMode = readSessionString(
+    requestTransport?.auth?.mode ?? modelObj.request?.auth?.mode,
+  );
+  const azureApiVersion = readSessionString(
+    modelObj.azureApiVersion ?? modelObj.params?.azureApiVersion,
+  );
   // resolveCopilotAuth can throw when an explicit `auth.gitHubToken`
   // is supplied without profileId + profileVersion (the existing
   // pool-key safety invariant). That same error would surface
@@ -373,16 +449,63 @@ function computeSessionKey(
   let resolvedAgentId = "";
   let resolvedCopilotHome = "";
   try {
-    const resolved = resolveCopilotAuth({
-      agentId: typeof p.agentId === "string" ? p.agentId : readAgentIdFromSessionKey(p.sessionKey),
-      agentDir: typeof p.agentDir === "string" ? p.agentDir : undefined,
-      workspaceDir: typeof p.workspaceDir === "string" ? p.workspaceDir : undefined,
-      copilotHome: typeof p.copilotHome === "string" ? p.copilotHome : undefined,
-      auth: p.auth,
-      resolvedApiKey: typeof p.resolvedApiKey === "string" ? p.resolvedApiKey : undefined,
-      authProfileId: typeof p.authProfileId === "string" ? p.authProfileId : undefined,
-      profileVersion: typeof p.profileVersion === "string" ? p.profileVersion : undefined,
-    });
+    const resolved = !options.includeAuth
+      ? resolveCopilotAuth({
+          agentId:
+            typeof p.agentId === "string" ? p.agentId : readAgentIdFromSessionKey(p.sessionKey),
+          agentDir: typeof p.agentDir === "string" ? p.agentDir : undefined,
+          workspaceDir: typeof p.workspaceDir === "string" ? p.workspaceDir : undefined,
+          copilotHome: typeof p.copilotHome === "string" ? p.copilotHome : undefined,
+          auth: { useLoggedInUser: true },
+        })
+      : (() => {
+          const modelProvider = resolveCopilotProvider({
+            model: {
+              api: modelObj.api,
+              id: modelId,
+              provider,
+              baseUrl: modelObj.baseUrl,
+              azureApiVersion,
+              headers: modelObj.headers,
+              authHeader: modelObj.authHeader,
+              requestAuthMode,
+              requestProxy: requestTransport?.proxy ?? modelObj.request?.proxy,
+              requestTls: requestTransport?.tls ?? modelObj.request?.tls,
+              requestAllowPrivateNetwork:
+                requestTransport?.allowPrivateNetwork ?? modelObj.request?.allowPrivateNetwork,
+              contextTokens: modelObj.contextTokens,
+              contextWindow: modelObj.contextWindow,
+              maxTokens: modelObj.maxTokens,
+            },
+            resolvedApiKey: typeof p.resolvedApiKey === "string" ? p.resolvedApiKey : undefined,
+            authProfileId: typeof p.authProfileId === "string" ? p.authProfileId : undefined,
+          });
+          return modelProvider.mode === "byok"
+            ? createCopilotByokAuth({
+                agentId:
+                  typeof p.agentId === "string"
+                    ? p.agentId
+                    : readAgentIdFromSessionKey(p.sessionKey),
+                agentDir: typeof p.agentDir === "string" ? p.agentDir : undefined,
+                workspaceDir: typeof p.workspaceDir === "string" ? p.workspaceDir : undefined,
+                copilotHome: typeof p.copilotHome === "string" ? p.copilotHome : undefined,
+                authProfileId: modelProvider.authProfileId,
+                authProfileVersion: modelProvider.authProfileVersion,
+              })
+            : resolveCopilotAuth({
+                agentId:
+                  typeof p.agentId === "string"
+                    ? p.agentId
+                    : readAgentIdFromSessionKey(p.sessionKey),
+                agentDir: typeof p.agentDir === "string" ? p.agentDir : undefined,
+                workspaceDir: typeof p.workspaceDir === "string" ? p.workspaceDir : undefined,
+                copilotHome: typeof p.copilotHome === "string" ? p.copilotHome : undefined,
+                auth: p.auth,
+                resolvedApiKey: typeof p.resolvedApiKey === "string" ? p.resolvedApiKey : undefined,
+                authProfileId: typeof p.authProfileId === "string" ? p.authProfileId : undefined,
+                profileVersion: typeof p.profileVersion === "string" ? p.profileVersion : undefined,
+              });
+        })();
     resolvedAgentId = resolved.agentId;
     resolvedCopilotHome = resolved.copilotHome;
     authParts = [
@@ -390,6 +513,9 @@ function computeSessionKey(
       `auth.profileId=${resolved.authProfileId ?? ""}`,
       `auth.profileVersion=${resolved.authProfileVersion ?? ""}`,
     ];
+    if (!options.includeAuth) {
+      authParts = [];
+    }
   } catch {
     authParts = ["auth=unresolvable"];
   }
@@ -397,6 +523,9 @@ function computeSessionKey(
     `provider=${provider}`,
     `model=${modelId}`,
     ...(options.includeApi ? [`api=${modelObj.api ?? ""}`] : []),
+    ...(options.includeApi
+      ? [`baseUrlFingerprint=${fingerprintSessionValue(modelObj.baseUrl)}`]
+      : []),
     `cwd=${p.cwd ?? p.workspaceDir ?? ""}`,
     `agentId=${resolvedAgentId}`,
     `agentDir=${p.agentDir ?? ""}`,
@@ -405,6 +534,14 @@ function computeSessionKey(
     ...(options.includeAuth ? authParts : []),
   ];
   return parts.join("|");
+}
+
+function readSessionString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function fingerprintSessionValue(value: unknown): string {
+  return typeof value === "string" && value ? tokenFingerprint(value) : "";
 }
 
 function computeSessionCompatKey(params: CopilotSessionCompatParams): string {
@@ -531,10 +668,36 @@ export function createCopilotAgentHarness(
         return { supported: false, reason: "copilot is opt-in only" };
       }
       const provider = ctx.provider.trim().toLowerCase();
-      if (!COPILOT_PROVIDER_IDS.has(provider)) {
+      if (!provider) {
+        return { supported: false, reason: "provider is required" };
+      }
+      if (COPILOT_PROVIDER_IDS.has(provider)) {
+        return { supported: true, priority: 100 };
+      }
+      const providerOwnerPluginIds = ctx.providerOwnerPluginIds;
+      if (
+        ctx.providerOwnerStatus !== "unowned" ||
+        !providerOwnerPluginIds ||
+        providerOwnerPluginIds.length > 0
+      ) {
         return {
           supported: false,
           reason: `provider is not one of: ${[...COPILOT_PROVIDER_IDS].toSorted().join(", ")}`,
+        };
+      }
+      if (
+        !supportsCopilotByokProviderShape({
+          api: ctx.modelProvider?.api,
+          baseUrl: ctx.modelProvider?.baseUrl,
+          requestProxy: ctx.modelProvider?.request?.proxy,
+          requestTls: ctx.modelProvider?.request?.tls,
+          requestAllowPrivateNetwork: ctx.modelProvider?.request?.allowPrivateNetwork,
+        })
+      ) {
+        return {
+          supported: false,
+          reason:
+            "provider is not a supported Copilot BYOK model (requires supported api, baseUrl, and no request transport policy overrides)",
         };
       }
       return { supported: true, priority: 100 };
@@ -549,10 +712,21 @@ export function createCopilotAgentHarness(
         if (disposed) {
           throw new Error("[copilot] harness was disposed while starting an attempt");
         }
-        const poolAcquire = resolvePoolAcquire(params as never);
         const pool = await getPool();
         if (disposed) {
           throw new Error("[copilot] harness was disposed while starting an attempt");
+        }
+        let poolAcquire: ReturnType<typeof resolvePoolAcquire>;
+        try {
+          poolAcquire = resolvePoolAcquire(params as never);
+        } catch (error) {
+          // Keep invalid forced BYOK model configuration on the normal attempt
+          // result path so callers receive `model_not_supported` instead of an
+          // uncaught harness rejection. Other auth/pool errors remain fatal.
+          if (isCopilotByokUnsupportedProviderError(error)) {
+            return runCopilotAttempt(params, { pool });
+          }
+          throw error;
         }
         const openclawSessionId =
           typeof params.sessionId === "string" ? params.sessionId : undefined;
@@ -611,10 +785,12 @@ export function createCopilotAgentHarness(
           pool,
           onSessionEstablished: openclawSessionId
             ? ({
+                compactionSessionConfig,
                 sdkSessionId,
                 pooledClient,
                 sessionConfig,
               }: {
+                compactionSessionConfig?: CopilotSessionConfig;
                 sdkSessionId: string;
                 pooledClient: PooledClient;
                 sessionConfig: CopilotSessionConfig;
@@ -626,7 +802,7 @@ export function createCopilotAgentHarness(
                   compatKey: currentCompatKey,
                   compactKey: currentCompactKey,
                   poolKey: pooledClient.key,
-                  sessionConfig,
+                  sessionConfig: compactionSessionConfig ?? sessionConfig,
                   ...sessionAuthFields(poolAcquire.auth),
                 });
                 registerStoredBinding(options?.sessionStore, openclawSessionId, {
@@ -768,8 +944,24 @@ export function createCopilotAgentHarness(
       const tracked = trackedSessions.get(openclawSessionId);
       const currentCompactKey = computeSessionCompactKey(params);
       const { resolvePoolAcquire } = await import("./src/attempt.js");
-      const resolvedPoolAcquire = resolvePoolAcquire(params as never);
-      const currentAuth = sessionAuthFields(resolvedPoolAcquire.auth);
+      let resolvedPoolAcquire: ReturnType<typeof resolvePoolAcquire> | undefined;
+      let currentAuth: CopilotSessionAuth | undefined;
+      try {
+        resolvedPoolAcquire = resolvePoolAcquire(params as never);
+      } catch (error) {
+        if (isCopilotByokUnsupportedProviderError(error)) {
+          return {
+            ok: false,
+            compacted: false,
+            reason: "missing_thread_binding",
+            failure: { reason: "missing_thread_binding" },
+          };
+        }
+        throw error;
+      }
+      if (!currentAuth) {
+        currentAuth = sessionAuthFields(resolvedPoolAcquire.auth);
+      }
       const compatibleTracked =
         tracked?.compactKey === currentCompactKey && sessionAuthMatches(tracked, currentAuth)
           ? tracked
@@ -785,19 +977,32 @@ export function createCopilotAgentHarness(
           failure: { reason: "missing_thread_binding" },
         };
       }
-      const poolAcquire = compatibleTracked
-        ? { key: compatibleTracked.poolKey, options: compatibleTracked.clientOptions }
-        : resolvedPoolAcquire;
+      const poolAcquire = {
+        key: compatibleTracked.poolKey,
+        options: compatibleTracked.clientOptions,
+      };
       let compactResult: CopilotHistoryCompactResult;
       let handle: PooledClient | undefined;
       let pool: CopilotClientPool | undefined;
       let activeSdkSession: CopilotHistoryCompactSession | undefined;
+      let cleanupByokProxy: (() => Promise<void>) | undefined;
       const hookContext = buildCopilotCompactionHookContext(params);
       try {
         throwIfAborted(params.abortSignal);
         pool = await getPool();
         handle = await pool.acquire(poolAcquire.key, poolAcquire.options);
         const client = handle.client;
+        const byokProxy =
+          compatibleTracked.authMode === "byok" && compatibleTracked.sessionConfig.provider
+            ? await createCopilotByokProxy({
+                mode: "byok",
+                provider: compatibleTracked.sessionConfig.provider,
+              })
+            : undefined;
+        cleanupByokProxy = byokProxy?.close;
+        const sessionConfig = byokProxy?.provider.provider
+          ? { ...compatibleTracked.sessionConfig, provider: byokProxy.provider.provider }
+          : compatibleTracked.sessionConfig;
         // Manual compaction resumes a distinct SDK session, bypassing the attempt event bridge.
         // Run the portable lifecycle hook here so both compaction paths stay observable.
         await runAgentHarnessBeforeCompactionHook({
@@ -812,13 +1017,13 @@ export function createCopilotAgentHarness(
               customInstructions: params.customInstructions,
               gitHubToken:
                 compatibleTracked?.clientOptions.gitHubToken ??
-                (resolvedPoolAcquire.auth.authMode === "gitHubToken"
+                (resolvedPoolAcquire?.auth.authMode === "gitHubToken"
                   ? resolvedPoolAcquire.auth.gitHubToken
                   : undefined),
               onSession: (session) => {
                 activeSdkSession = session;
               },
-              sessionConfig: compatibleTracked.sessionConfig,
+              sessionConfig,
               sdkSessionId: compatibleTracked.sdkSessionId,
             }),
           resolveCompactionTimeoutMs(
@@ -852,6 +1057,7 @@ export function createCopilotAgentHarness(
           },
         };
       } finally {
+        await cleanupByokProxy?.();
         if (pool && handle) {
           try {
             await pool.release(handle);

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { CopilotClient, Tool as SdkTool } from "@github/copilot-sdk";
 import {
   abortAgentHarnessRun,
+  attachModelProviderRequestTransport,
   queueAgentHarnessMessage,
   type AgentHarnessAttemptParams,
   type AgentHarnessAttemptResult,
@@ -104,11 +105,12 @@ function createDeferred<T>() {
 function flushAsync() {
   // Pump enough microtasks for the attempt to settle past every
   // pre-createSession `await` in attempt.ts (resolvePoolAcquire,
-  // resolveCopilotWorkspaceBootstrapContext, createSession, etc.).
+  // BYOK proxy setup, resolveCopilotWorkspaceBootstrapContext,
+  // createSession, etc.).
   // Each chained `then` is one tick; tests rely on this to observe
   // `sdk.sessions[0]` being populated before they emit deltas.
   const tick = () => Promise.resolve();
-  return tick().then(tick).then(tick);
+  return tick().then(tick).then(tick).then(tick).then(tick);
 }
 
 function waitForEventLoopTurn(): Promise<void> {
@@ -2338,6 +2340,152 @@ describe("runCopilotAttempt", () => {
     expect(options.useLoggedInUser).toBe(false);
   });
 
+  it("pool keying: BYOK does not resolve unrelated GitHub auth", async () => {
+    const sdk = makeFakeSdk();
+    const pool = makeFakePool(sdk);
+
+    await runCopilotAttempt(
+      makeParams({
+        auth: { gitHubToken: "unrelated-token" } as never,
+        model: {
+          api: "openai-responses",
+          baseUrl: "https://api.example.test/v1",
+          id: "gpt-test",
+          provider: "custom-openai",
+        } as never,
+        resolvedApiKey: "byok-token",
+        authProfileId: "custom-openai:main",
+      } as never),
+      { pool },
+    );
+
+    const key = (vi.mocked(pool["acquire"]).mock.calls[0] as unknown[] | undefined)?.[0] as {
+      authMode: string;
+      authProfileId?: string;
+    };
+    const options = (vi.mocked(pool["acquire"]).mock.calls[0] as unknown[] | undefined)?.[1] as {
+      gitHubToken?: string;
+      useLoggedInUser?: boolean;
+    };
+    const cfg = (sdk.createSession.mock.calls[0] as unknown[] | undefined)?.[0] as {
+      provider?: { apiKey?: string; baseUrl?: string };
+    };
+
+    expect(key.authMode).toBe("byok");
+    expect(key.authProfileId).toBe("custom-openai:main");
+    expect(options.gitHubToken).toBeUndefined();
+    expect(options.useLoggedInUser).toBe(false);
+    expect(cfg.provider).toEqual(
+      expect.objectContaining({
+        apiKey: "byok-token",
+        baseUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/[a-f0-9]{24}\/v1$/),
+      }),
+    );
+  });
+
+  it("forwards BYOK provider headers on the model request turn", async () => {
+    const sdk = makeFakeSdk();
+    const pool = makeFakePool(sdk);
+
+    await runCopilotAttempt(
+      makeParams({
+        model: {
+          api: "anthropic-messages",
+          baseUrl: "https://anthropic.example.test",
+          headers: {
+            "X-Tenant": "tenant-a",
+            "X-Trace": "trace-1",
+          },
+          id: "claude-test",
+          provider: "anthropic-proxy",
+        } as never,
+        resolvedApiKey: "byok-token",
+        authProfileId: "anthropic-proxy:main",
+      } as never),
+      { pool },
+    );
+
+    const cfg = (sdk.createSession.mock.calls[0] as unknown[] | undefined)?.[0] as {
+      provider?: { headers?: Record<string, string> };
+    };
+    const sendOptions = sdk.sessions[0]?.sendAndWait.mock.calls[0]?.[0] as {
+      requestHeaders?: Record<string, string>;
+    };
+    expect(cfg.provider?.headers).toEqual({
+      "X-Tenant": "tenant-a",
+      "X-Trace": "trace-1",
+    });
+    expect(sendOptions.requestHeaders).toEqual({
+      "X-Tenant": "tenant-a",
+      "X-Trace": "trace-1",
+    });
+  });
+
+  it("preserves prepared BYOK header-auth without synthesizing SDK apiKey auth", async () => {
+    const sdk = makeFakeSdk();
+    const pool = makeFakePool(sdk);
+    const model = attachModelProviderRequestTransport(
+      {
+        api: "openai-responses",
+        baseUrl: "https://proxy.example.test/v1",
+        headers: { "x-api-key": "header-secret" },
+        id: "gpt-test",
+        provider: "custom-header-proxy",
+      },
+      { auth: { mode: "header", headerName: "x-api-key", value: "header-secret" } },
+    );
+
+    await runCopilotAttempt(
+      makeParams({
+        model: model as never,
+        resolvedApiKey: "header-secret",
+        authProfileId: "custom-header-proxy:main",
+      } as never),
+      { pool },
+    );
+
+    const cfg = (sdk.createSession.mock.calls[0] as unknown[] | undefined)?.[0] as {
+      provider?: { apiKey?: string; headers?: Record<string, string> };
+    };
+    const sendOptions = sdk.sessions[0]?.sendAndWait.mock.calls[0]?.[0] as {
+      requestHeaders?: Record<string, string>;
+    };
+    expect(cfg.provider).toEqual(
+      expect.objectContaining({
+        headers: { "x-api-key": "header-secret" },
+      }),
+    );
+    expect(cfg.provider).not.toHaveProperty("apiKey");
+    expect(sendOptions.requestHeaders).toEqual({ "x-api-key": "header-secret" });
+  });
+
+  it("rejects BYOK providers with request transport policy overrides before creating a SDK session", async () => {
+    const sdk = makeFakeSdk();
+    const pool = makeFakePool(sdk);
+    const model = attachModelProviderRequestTransport(
+      {
+        api: "openai-responses",
+        baseUrl: "https://proxy.example.test/v1",
+        id: "gpt-test",
+        provider: "custom-header-proxy",
+      },
+      { proxy: { mode: "env-proxy" } },
+    );
+
+    const result = await runCopilotAttempt(
+      makeParams({
+        model: model as never,
+        resolvedApiKey: "header-secret",
+        authProfileId: "custom-header-proxy:main",
+      } as never),
+      { pool },
+    );
+
+    expect(getPromptErrorCode(result)).toBe("model_not_supported");
+    expect((result.promptError as Error | undefined)?.message).toContain("request proxy");
+    expect(sdk.createSession).not.toHaveBeenCalled();
+  });
+
   describe("session-level gitHubToken (independent of client-level)", () => {
     // The SDK contract (@github/copilot-sdk/dist/types.d.ts:1168-1178)
     // makes `SessionConfig.gitHubToken` independent of the client-level
@@ -2399,6 +2547,37 @@ describe("runCopilotAttempt", () => {
       expect(sdk.resumeSession).toHaveBeenCalledTimes(1);
       const resumeCfg = sdk.resumeSession.mock.calls[0]?.[1] as { gitHubToken?: string };
       expect(resumeCfg.gitHubToken).toBe("contract-token-resume");
+    });
+
+    it("BYOK provider config is forwarded to resumeSession", async () => {
+      const sdk = makeFakeSdk();
+      const pool = makeFakePool(sdk);
+
+      await runCopilotAttempt(
+        makeParams({
+          auth: { gitHubToken: "unrelated-token" } as never,
+          model: {
+            api: "openai-responses",
+            baseUrl: "https://api.example.test/v1",
+            id: "gpt-test",
+            provider: "custom-openai",
+          } as never,
+          resolvedApiKey: "byok-token",
+          authProfileId: "custom-openai:main",
+          initialReplayState: { sdkSessionId: "resume-target" } as never,
+        } as never),
+        { pool },
+      );
+
+      const resumeCfg = sdk.resumeSession.mock.calls[0]?.[1] as {
+        provider?: { apiKey?: string; baseUrl?: string };
+      };
+      expect(resumeCfg.provider).toEqual(
+        expect.objectContaining({
+          apiKey: "byok-token",
+          baseUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/[a-f0-9]{24}\/v1$/),
+        }),
+      );
     });
 
     it("SessionConfig.gitHubToken is omitted when useLoggedInUser is the resolved mode", async () => {

--- a/extensions/copilot/src/attempt.ts
+++ b/extensions/copilot/src/attempt.ts
@@ -10,6 +10,7 @@ import type {
 import {
   buildAgentHookContextChannelFields,
   detectAndLoadAgentHarnessPromptImages,
+  getModelProviderRequestTransport,
   resolveAgentHarnessBeforePromptBuildResult,
   resolveAttemptFsWorkspaceOnly,
   resolveAttemptSpawnWorkspaceDir,
@@ -27,7 +28,8 @@ import {
   clearActiveEmbeddedRun,
   setActiveEmbeddedRun,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { resolveCopilotAuth } from "./auth-bridge.js";
+import { createCopilotByokAuth, resolveCopilotAuth } from "./auth-bridge.js";
+import { createCopilotByokProxy } from "./byok-proxy.js";
 import {
   createInfiniteSessionConfig,
   type CopilotInfiniteSessionOptions,
@@ -50,6 +52,7 @@ import {
   rejectAllPolicy,
   type CopilotPermissionPolicy,
 } from "./permission-bridge.js";
+import { resolveCopilotProvider, type ResolvedCopilotProvider } from "./provider-bridge.js";
 import {
   classifyResumeFailure,
   computeReplayMetadata,
@@ -79,6 +82,7 @@ export type CopilotSessionConfig = Pick<
   | "model"
   | "onPermissionRequest"
   | "onUserInputRequest"
+  | "provider"
   | "reasoningEffort"
   | "systemMessage"
   | "tools"
@@ -115,7 +119,42 @@ type AttemptParamsLike = AgentHarnessAttemptParams & {
   // internal expansion. Symmetric to `EmbeddedRunAttemptParams.transcriptPrompt`.
   transcriptPrompt?: string;
 };
-type ModelRef = { api?: string; id: string; provider: string };
+type ModelRef = {
+  api?: string;
+  id: string;
+  provider: string;
+  baseUrl?: string;
+  azureApiVersion?: string;
+  headers?: Record<string, string | null | undefined>;
+  authHeader?: boolean;
+  requestAuthMode?: string;
+  requestProxy?: unknown;
+  requestTls?: unknown;
+  requestAllowPrivateNetwork?: unknown;
+  contextTokens?: number;
+  contextWindow?: number;
+  maxTokens?: number;
+};
+
+type ModelRefInputObject = {
+  api?: unknown;
+  id?: unknown;
+  provider?: unknown;
+  baseUrl?: unknown;
+  azureApiVersion?: unknown;
+  params?: { azureApiVersion?: unknown };
+  headers?: ModelRef["headers"];
+  authHeader?: boolean;
+  request?: {
+    auth?: { mode?: unknown };
+    proxy?: unknown;
+    tls?: unknown;
+    allowPrivateNetwork?: unknown;
+  };
+  contextTokens?: number;
+  contextWindow?: number;
+  maxTokens?: number;
+};
 
 export type { AttemptParamsLike as CopilotPoolAcquireInput, ModelRef };
 export { SUPPORTED_PROVIDERS };
@@ -142,6 +181,7 @@ export interface CopilotAttemptDeps {
    * attempt.
    */
   onSessionEstablished?: (info: {
+    compactionSessionConfig?: CopilotSessionConfig;
     sdkSessionId: string;
     pooledClient: PooledClient;
     sessionConfig: CopilotSessionConfig;
@@ -228,6 +268,7 @@ function deferBackgroundCompactionCleanup(params: {
   bridge: ReturnType<typeof attachEventBridge>;
   handle: PooledClient;
   pool: CopilotClientPool;
+  cleanupByokProxy?: () => Promise<void>;
   cleanupToolBridge?: () => void;
   finalizeNativeSubagents?: () => void;
   sdkSessionId?: string;
@@ -260,6 +301,7 @@ function deferBackgroundCompactionCleanup(params: {
         // The attempt has already returned its timeout result.
       }
       params.cleanupToolBridge?.();
+      await params.cleanupByokProxy?.();
       if (outcome !== "completed" && params.sdkSessionId) {
         try {
           await params.handle.client.deleteSession(params.sdkSessionId);
@@ -384,15 +426,18 @@ export async function runCopilotAttempt(
     );
   }
 
-  if (!SUPPORTED_PROVIDERS.has(modelRef.provider)) {
+  try {
+    resolveCopilotProvider({
+      model: modelRef,
+      resolvedApiKey: readString(params.resolvedApiKey),
+      authProfileId: readString(params.authProfileId),
+    });
+  } catch (error) {
     return finishAttempt(
       createResult(input, {
         messagesSnapshot: messages,
         now,
-        promptError: createPromptError(
-          "model_not_supported",
-          `[copilot-attempt] provider ${modelRef.provider} is not supported at MVP (subscription Copilot models only; BYOK arrives via byok-mapping-skeleton)`,
-        ),
+        promptError: createPromptError("model_not_supported", toError(error).message, error),
         sdkSessionId: undefined,
         sessionIdUsed: input.sessionId,
       }),
@@ -549,6 +594,22 @@ export async function runCopilotAttempt(
       })
     : undefined;
   const poolAcquire = resolvePoolAcquire(input);
+  let byokProxy: Awaited<ReturnType<typeof createCopilotByokProxy>>;
+  try {
+    byokProxy = await createCopilotByokProxy(poolAcquire.provider);
+  } catch (error) {
+    return finishAttempt(
+      createResult(input, {
+        messagesSnapshot: messages,
+        now,
+        promptError: createPromptError("model_not_supported", toError(error).message, error),
+        sdkSessionId: undefined,
+        sessionIdUsed: input.sessionId,
+      }),
+    );
+  }
+  const cleanupByokProxy = byokProxy?.close;
+  const sessionProvider = byokProxy?.provider ?? poolAcquire.provider;
 
   // Mutable session holder shared with the tool bridge so onYield
   // (raised inside wrapped-tool execution) can route to the live SDK
@@ -562,6 +623,7 @@ export async function runCopilotAttempt(
     let sdkTools: SdkTool[];
     try {
       const toolBridge = await createToolBridge({
+        allowModelTools: poolAcquire.provider.mode === "byok",
         modelProvider: modelRef.provider,
         modelId: modelRef.id,
         agentId: readString(params.agentId) ?? "copilot",
@@ -692,6 +754,7 @@ export async function runCopilotAttempt(
       modelRef.id,
       sdkTools,
       poolAcquire.auth,
+      sessionProvider,
       promptBuild.developerInstructions || undefined,
       effectiveWorkspaceDir,
       effectiveCwd,
@@ -703,6 +766,25 @@ export async function runCopilotAttempt(
           }
         : undefined,
     );
+    const compactionSessionConfig = byokProxy
+      ? createSessionConfig(
+          attemptInput,
+          modelRef.id,
+          sdkTools,
+          poolAcquire.auth,
+          poolAcquire.provider,
+          promptBuild.developerInstructions || undefined,
+          effectiveWorkspaceDir,
+          effectiveCwd,
+          userInputBridge.onUserInputRequest,
+          hasNativePromptHook
+            ? {
+                onUserPromptSubmitted: ({ additionalContext, prompt }) =>
+                  emitLlmInput(prompt, additionalContext),
+              }
+            : undefined,
+        )
+      : sessionConfig;
     const replayDecision = decideReplayAction({
       sdkSessionId: input.initialReplayState?.sdkSessionId,
       replayInvalid: input.initialReplayState?.replayInvalid,
@@ -749,7 +831,12 @@ export async function runCopilotAttempt(
     sessionIdUsed = sdkSessionId ?? input.sessionId;
     if (sdkSessionId && deps.onSessionEstablished) {
       try {
-        deps.onSessionEstablished({ sdkSessionId, pooledClient: handle, sessionConfig });
+        deps.onSessionEstablished({
+          compactionSessionConfig,
+          sdkSessionId,
+          pooledClient: handle,
+          sessionConfig,
+        });
       } catch {
         // never let session-tracking callbacks break attempts
       }
@@ -809,6 +896,7 @@ export async function runCopilotAttempt(
     const messageOptions = await createMessageOptions(attemptInput, {
       effectiveCwd,
       effectiveWorkspaceDir,
+      provider: poolAcquire.provider,
       sandbox,
       workspaceOnly: effectiveFsWorkspaceOnly,
     });
@@ -890,6 +978,7 @@ export async function runCopilotAttempt(
         awaitSessionIdle: !bridge.hasObservedSessionIdle(),
         bridge,
         cleanupToolBridge,
+        cleanupByokProxy,
         finalizeNativeSubagents: () => nativeSubagentTaskMirror?.finalizeActiveRuns(),
         handle,
         pool: deps.pool,
@@ -922,6 +1011,7 @@ export async function runCopilotAttempt(
       await bridge?.awaitAgentEventChain();
       nativeSubagentTaskMirror?.finalizeActiveRuns();
       cleanupToolBridge?.();
+      await cleanupByokProxy?.();
       bridge?.detach();
       params.abortSignal?.removeEventListener("abort", onAbort);
 
@@ -1191,6 +1281,7 @@ function createSessionConfig(
   sdkModelId: string,
   sdkTools: SdkTool[],
   resolvedAuth: ReturnType<typeof resolveCopilotAuth>,
+  resolvedProvider: ResolvedCopilotProvider,
   systemMessageContent: string | undefined,
   effectiveWorkspaceDir: string | undefined,
   effectiveCwd: string | undefined,
@@ -1225,6 +1316,10 @@ function createSessionConfig(
     // Registers the SDK ask_user bridge. The bridge itself owns pending
     // reply routing so generic mid-run steering still fails closed.
     onUserInputRequest,
+    // The SDK's ResumeSessionConfig declaration omits ProviderConfig, but its
+    // client forwards config.provider on both session.create and session.resume.
+    // Keep one session config so BYOK resume/compaction stays on the same wire.
+    ...(resolvedProvider.provider ? { provider: resolvedProvider.provider } : {}),
     // Preserve the shipped native SDK hook contract. These callbacks expose
     // Copilot-specific events and decisions that generic lifecycle hooks do
     // not model.
@@ -1314,14 +1409,28 @@ async function createMessageOptions(
   context: {
     effectiveCwd: string | undefined;
     effectiveWorkspaceDir: string | undefined;
+    provider: ResolvedCopilotProvider;
     sandbox: SandboxContext | null;
     workspaceOnly: boolean;
   },
 ): Promise<MessageOptions> {
   const attachments = createPromptImageAttachments(await resolvePromptImages(params, context));
-  return attachments.length > 0
-    ? { prompt: params.prompt, attachments }
-    : { prompt: params.prompt };
+  const requestHeaders = resolveProviderRequestHeaders(context.provider);
+  return {
+    prompt: params.prompt,
+    ...(attachments.length > 0 ? { attachments } : {}),
+    // The SDK declares session-level provider headers, but its Anthropic
+    // runtime path consumes per-turn requestHeaders. Mirror them here so BYOK
+    // tenant/proxy headers survive every supported adapter.
+    ...(requestHeaders ? { requestHeaders } : {}),
+  };
+}
+
+function resolveProviderRequestHeaders(
+  provider: ResolvedCopilotProvider,
+): Record<string, string> | undefined {
+  const headers = provider.provider?.headers;
+  return headers && Object.keys(headers).length > 0 ? { ...headers } : undefined;
 }
 
 function createPromptImageAttachments(
@@ -1488,18 +1597,35 @@ function readResolvedAttemptPath(value: unknown): string | undefined {
 }
 
 export function resolveModelRef(params: AttemptParamsLike): ModelRef {
-  const rawModel = params.model;
+  const rawModel = (params as { runtimeModel?: unknown }).runtimeModel ?? params.model;
   if (rawModel && typeof rawModel === "object") {
+    const model = rawModel as ModelRefInputObject;
+    const requestTransport = getModelProviderRequestTransport(rawModel);
+    const rawRequest = model.request;
     return {
-      api: readString(rawModel.api),
+      api: readString(model.api),
       id:
-        readString(rawModel.id) ??
+        readString(model.id) ??
         readString((params as { modelId?: unknown }).modelId) ??
         "unknown-model",
       provider:
-        readString(rawModel.provider) ??
+        readString(model.provider) ??
         readString((params as { provider?: unknown }).provider) ??
         "unknown-provider",
+      baseUrl: readString(model.baseUrl),
+      azureApiVersion: readString(
+        model.azureApiVersion ?? model.params?.azureApiVersion,
+      ),
+      headers: model.headers,
+      authHeader: model.authHeader,
+      requestAuthMode: readString(requestTransport?.auth?.mode ?? rawRequest?.auth?.mode),
+      requestProxy: requestTransport?.proxy ?? rawRequest?.proxy,
+      requestTls: requestTransport?.tls ?? rawRequest?.tls,
+      requestAllowPrivateNetwork:
+        requestTransport?.allowPrivateNetwork ?? rawRequest?.allowPrivateNetwork,
+      contextTokens: model.contextTokens,
+      contextWindow: model.contextWindow,
+      maxTokens: model.maxTokens,
     };
   }
   return {
@@ -1529,40 +1655,59 @@ export function resolvePoolAcquire(params: AttemptParamsLike): {
    * setting both.
    */
   auth: ReturnType<typeof resolveCopilotAuth>;
+  provider: ResolvedCopilotProvider;
 } {
-  const resolved = resolveCopilotAuth({
-    agentId: readString(params.agentId),
-    agentDir: readString(params.agentDir),
-    workspaceDir: readString(params.workspaceDir),
-    copilotHome: readString(params.copilotHome),
-    auth: params.auth,
-    // Contract-resolved auth (EmbeddedRunAttemptParams): the production
-    // main path for agents with a configured `github-copilot` auth
-    // profile. Falling through to env / useLoggedInUser when absent
-    // keeps the direct-CLI / dogfood paths working unchanged.
+  const model = resolveModelRef(params);
+  const provider = resolveCopilotProvider({
+    model,
     resolvedApiKey: readString(params.resolvedApiKey),
     authProfileId: readString(params.authProfileId),
-    profileVersion: readString(params.profileVersion),
   });
-
+  const auth =
+    provider.mode === "byok"
+      ? createCopilotByokAuth({
+          agentId: readString(params.agentId),
+          agentDir: readString(params.agentDir),
+          workspaceDir: readString(params.workspaceDir),
+          copilotHome: readString(params.copilotHome),
+          authProfileId: provider.authProfileId,
+          authProfileVersion: provider.authProfileVersion,
+        })
+      : resolveCopilotAuth({
+          agentId: readString(params.agentId),
+          agentDir: readString(params.agentDir),
+          workspaceDir: readString(params.workspaceDir),
+          copilotHome: readString(params.copilotHome),
+          auth: params.auth,
+          // Contract-resolved auth (EmbeddedRunAttemptParams): the production
+          // main path for agents with a configured `github-copilot` auth
+          // profile. Falling through to env / useLoggedInUser when absent
+          // keeps the direct-CLI / dogfood paths working unchanged.
+          resolvedApiKey: readString(params.resolvedApiKey),
+          authProfileId: readString(params.authProfileId),
+          profileVersion: readString(params.profileVersion),
+        });
   return {
     key: {
-      agentId: resolved.agentId,
-      authMode: resolved.authMode,
-      ...(resolved.authMode === "gitHubToken"
+      agentId: auth.agentId,
+      authMode: auth.authMode,
+      ...(auth.authMode === "gitHubToken" || auth.authMode === "byok"
         ? {
-            authProfileId: resolved.authProfileId,
-            authProfileVersion: resolved.authProfileVersion,
+            authProfileId: auth.authProfileId,
+            authProfileVersion: auth.authProfileVersion,
           }
         : {}),
-      copilotHome: resolved.copilotHome,
+      copilotHome: auth.copilotHome,
     },
     options: {
-      copilotHome: resolved.copilotHome,
-      gitHubToken: resolved.authMode === "gitHubToken" ? resolved.gitHubToken : undefined,
-      useLoggedInUser: resolved.authMode === "useLoggedInUser",
+      copilotHome: auth.copilotHome,
+      ...(auth.authMode === "gitHubToken" && auth.gitHubToken
+        ? { gitHubToken: auth.gitHubToken }
+        : {}),
+      useLoggedInUser: auth.authMode === "useLoggedInUser",
     },
-    auth: resolved,
+    auth,
+    provider,
   };
 }
 

--- a/extensions/copilot/src/auth-bridge.ts
+++ b/extensions/copilot/src/auth-bridge.ts
@@ -54,17 +54,44 @@ export const COPILOT_DEFAULT_AGENT_ID = "copilot";
 
 /** Resolved auth shape that the runtime / pool consumes. */
 export interface ResolvedCopilotAuth {
-  authMode: "useLoggedInUser" | "gitHubToken";
+  authMode: "useLoggedInUser" | "gitHubToken" | "byok";
   /** Present only when authMode is "gitHubToken". */
   gitHubToken?: string;
-  /** Present only when authMode is "gitHubToken". */
+  /** Present for token and BYOK auth modes. */
   authProfileId?: string;
-  /** Present only when authMode is "gitHubToken". */
+  /** Present for token and BYOK auth modes. */
   authProfileVersion?: string;
   /** Absolute, normalized path. */
   copilotHome: string;
   /** Validated agent id used for path defaults and pool keying. */
   agentId: string;
+}
+
+export function createCopilotByokAuth(input: {
+  agentId?: string;
+  agentDir?: string;
+  workspaceDir?: string;
+  copilotHome?: string;
+  authProfileId?: string;
+  authProfileVersion?: string;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: () => string;
+}): ResolvedCopilotAuth {
+  const base = resolveCopilotAuth({
+    agentId: input.agentId,
+    agentDir: input.agentDir,
+    workspaceDir: input.workspaceDir,
+    copilotHome: input.copilotHome,
+    env: input.env,
+    homeDir: input.homeDir,
+    auth: { useLoggedInUser: true },
+  });
+  return {
+    ...base,
+    authMode: "byok",
+    authProfileId: input.authProfileId?.trim() || "byok:resolved",
+    authProfileVersion: input.authProfileVersion?.trim() || "byok:unfingerprinted",
+  };
 }
 
 export interface ResolveCopilotAuthInput {

--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -1,0 +1,167 @@
+// Copilot BYOK proxy tests verify SDK-local transport is guarded outbound fetch.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCopilotByokProxy } from "./byok-proxy.js";
+import { resolveCopilotProvider } from "./provider-bridge.js";
+
+const ssrfRuntimeMock = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: ssrfRuntimeMock.fetchWithSsrFGuard,
+}));
+
+describe("createCopilotByokProxy", () => {
+  afterEach(() => {
+    ssrfRuntimeMock.fetchWithSsrFGuard.mockReset();
+  });
+
+  it("presents a loopback SDK endpoint and forwards through guarded fetch", async () => {
+    const release = vi.fn(async () => undefined);
+    ssrfRuntimeMock.fetchWithSsrFGuard.mockResolvedValue({
+      response: new Response("ok", {
+        status: 201,
+        headers: {
+          "content-encoding": "gzip",
+          "content-length": "999",
+          "x-upstream": "yes",
+        },
+      }),
+      release,
+    });
+    const resolvedProvider = resolveCopilotProvider({
+      model: {
+        provider: "custom-proxy",
+        api: "openai-responses",
+        id: "proxy-model",
+        baseUrl: "https://proxy.example/v1?routing=blue",
+      },
+      resolvedApiKey: "secret-key",
+    });
+
+    const proxy = await createCopilotByokProxy(resolvedProvider);
+    expect(proxy?.provider.provider?.baseUrl).toMatch(
+      /^http:\/\/127\.0\.0\.1:\d+\/[a-f0-9]{24}\/v1$/,
+    );
+
+    try {
+      const response = await fetch(`${proxy?.provider.provider?.baseUrl}/responses?trace=request`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret-key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: "proxy-model" }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.headers.get("content-encoding")).toBeNull();
+      expect(response.headers.get("content-length")).toBeNull();
+      expect(response.headers.get("x-upstream")).toBe("yes");
+      expect(await response.text()).toBe("ok");
+      expect(ssrfRuntimeMock.fetchWithSsrFGuard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          auditContext: "copilot-byok-provider",
+          requireHttps: true,
+          url: "https://proxy.example/v1/responses?routing=blue&trace=request",
+          init: expect.objectContaining({
+            method: "POST",
+            headers: expect.objectContaining({
+              "accept-encoding": "identity",
+              authorization: "Bearer secret-key",
+              "content-type": "application/json",
+            }),
+            signal: expect.any(AbortSignal),
+          }),
+        }),
+      );
+      expect(release).toHaveBeenCalledTimes(1);
+    } finally {
+      await proxy?.close();
+    }
+  });
+
+  it("aborts in-flight upstream fetches when the proxy closes", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    ssrfRuntimeMock.fetchWithSsrFGuard.mockImplementation(async ({ init }: any) => {
+      upstreamSignal = init.signal;
+      await new Promise((_, reject) => {
+        upstreamSignal?.addEventListener("abort", () => reject(new Error("upstream aborted")), {
+          once: true,
+        });
+      });
+      throw new Error("unreachable");
+    });
+    const resolvedProvider = resolveCopilotProvider({
+      model: {
+        provider: "custom-proxy",
+        api: "openai-responses",
+        id: "proxy-model",
+        baseUrl: "https://proxy.example/v1",
+      },
+    });
+    const proxy = await createCopilotByokProxy(resolvedProvider);
+
+    const responsePromise = fetch(`${proxy?.provider.provider?.baseUrl}/responses`, {
+      method: "POST",
+      body: JSON.stringify({ model: "proxy-model" }),
+    }).catch((error: unknown) => error);
+
+    await vi.waitFor(() => {
+      expect(upstreamSignal).toBeDefined();
+    });
+
+    await proxy?.close();
+
+    expect(upstreamSignal?.aborted).toBe(true);
+    await responsePromise;
+  });
+
+  it("accepts Azure SDK paths that are rebuilt from the proxy origin", async () => {
+    ssrfRuntimeMock.fetchWithSsrFGuard.mockResolvedValue({
+      response: new Response("azure-ok", { status: 200 }),
+      release: vi.fn(async () => undefined),
+    });
+    const resolvedProvider = resolveCopilotProvider({
+      model: {
+        provider: "custom-azure",
+        api: "azure-openai-responses",
+        id: "deployment-gpt",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+      },
+      resolvedApiKey: "azure-key",
+    });
+
+    const proxy = await createCopilotByokProxy(resolvedProvider);
+    expect(proxy?.provider.provider?.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+
+    try {
+      const response = await fetch(
+        `${proxy?.provider.provider?.baseUrl}/openai/v1/responses?trace=request`,
+        {
+          method: "POST",
+          headers: { "api-key": "azure-key" },
+          body: JSON.stringify({ model: "deployment-gpt" }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("azure-ok");
+      expect(ssrfRuntimeMock.fetchWithSsrFGuard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requireHttps: true,
+          url: "https://example.openai.azure.com/openai/v1/responses?trace=request",
+          init: expect.objectContaining({
+            headers: expect.objectContaining({
+              "accept-encoding": "identity",
+              "api-key": "azure-key",
+            }),
+          }),
+        }),
+      );
+    } finally {
+      await proxy?.close();
+    }
+  });
+});

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -1,0 +1,269 @@
+// Copilot BYOK transport proxy keeps OpenClaw in charge of outbound network policy.
+import { randomBytes } from "node:crypto";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import type { ResolvedCopilotProvider } from "./provider-bridge.js";
+
+const LOOPBACK_HOST = "127.0.0.1";
+
+export type CopilotByokProxyHandle = {
+  close: () => Promise<void>;
+  provider: ResolvedCopilotProvider;
+};
+
+type HeaderValue = string | number | string[] | undefined;
+
+export async function createCopilotByokProxy(
+  resolvedProvider: ResolvedCopilotProvider,
+): Promise<CopilotByokProxyHandle | undefined> {
+  if (resolvedProvider.mode !== "byok") {
+    return undefined;
+  }
+  const providerConfig = resolvedProvider.provider;
+  if (!providerConfig?.baseUrl) {
+    throw new Error("[copilot-attempt] BYOK requires a provider baseUrl");
+  }
+
+  const targetBaseUrl = new URL(providerConfig.baseUrl);
+  const nonce = randomBytes(12).toString("hex");
+  const targetPathPrefix = trimTrailingSlash(targetBaseUrl.pathname);
+  const proxyPathPrefix = `/${nonce}${targetPathPrefix}`;
+  const acceptsAzureSdkPaths = providerConfig.type === "azure";
+  const activeFetches = new Set<AbortController>();
+  const server = createServer((req, res) => {
+    void handleProxyRequest(req, res, {
+      acceptsAzureSdkPaths,
+      activeFetches,
+      proxyPathPrefix,
+      targetBaseUrl,
+      targetPathPrefix,
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, LOOPBACK_HOST, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("[copilot-attempt] failed to start BYOK network proxy");
+  }
+
+  const proxyBaseUrl = `http://${LOOPBACK_HOST}:${address.port}${proxyPathPrefix}`;
+  const sdkBaseUrl = acceptsAzureSdkPaths
+    ? `http://${LOOPBACK_HOST}:${address.port}`
+    : proxyBaseUrl;
+  return {
+    provider: {
+      ...resolvedProvider,
+      provider: {
+        ...providerConfig,
+        baseUrl: sdkBaseUrl,
+      },
+    },
+    close: async () => {
+      for (const controller of activeFetches) {
+        controller.abort();
+      }
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+async function handleProxyRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  params: {
+    acceptsAzureSdkPaths: boolean;
+    activeFetches: Set<AbortController>;
+    proxyPathPrefix: string;
+    targetBaseUrl: URL;
+    targetPathPrefix: string;
+  },
+): Promise<void> {
+  let guarded: Awaited<ReturnType<typeof fetchWithSsrFGuard>> | undefined;
+  const upstreamAbort = new AbortController();
+  params.activeFetches.add(upstreamAbort);
+  const abortUpstream = () => upstreamAbort.abort();
+  req.on("aborted", abortUpstream);
+  res.on("close", () => {
+    if (!res.writableEnded) {
+      abortUpstream();
+    }
+  });
+  try {
+    const url = resolveTargetUrl(req, params);
+    if (!url) {
+      res.writeHead(404);
+      res.end("Not found");
+      return;
+    }
+    const body = req.method === "GET" || req.method === "HEAD" ? undefined : await readBody(req);
+    guarded = await fetchWithSsrFGuard({
+      url: url.toString(),
+      init: {
+        method: req.method,
+        headers: normalizeProxyRequestHeaders(req.headers),
+        signal: upstreamAbort.signal,
+        ...(body ? { body: toFetchBody(body) } : {}),
+      },
+      auditContext: "copilot-byok-provider",
+      requireHttps: true,
+    });
+    res.writeHead(
+      guarded.response.status,
+      guarded.response.statusText,
+      normalizeProxyResponseHeaders(guarded.response.headers),
+    );
+    if (!guarded.response.body) {
+      res.end();
+      return;
+    }
+    await finished(
+      Readable.fromWeb(
+        guarded.response.body as unknown as NodeReadableStream<Uint8Array>,
+      ).pipe(res),
+    );
+  } catch (error) {
+    if (res.destroyed || res.writableEnded) {
+      return;
+    }
+    if (res.headersSent) {
+      res.destroy(error instanceof Error ? error : undefined);
+      return;
+    }
+    res.writeHead(502);
+    res.end(error instanceof Error ? error.message : "BYOK provider proxy failed");
+  } finally {
+    req.off("aborted", abortUpstream);
+    params.activeFetches.delete(upstreamAbort);
+    await guarded?.release().catch(() => undefined);
+  }
+}
+
+function resolveTargetUrl(
+  req: IncomingMessage,
+  params: {
+    acceptsAzureSdkPaths: boolean;
+    proxyPathPrefix: string;
+    targetBaseUrl: URL;
+    targetPathPrefix: string;
+  },
+): URL | undefined {
+  const incomingUrl = new URL(req.url ?? "/", `http://${LOOPBACK_HOST}`);
+  if (
+    incomingUrl.pathname !== params.proxyPathPrefix &&
+    !incomingUrl.pathname.startsWith(`${params.proxyPathPrefix}/`)
+  ) {
+    return params.acceptsAzureSdkPaths && isAzureSdkProxyPath(incomingUrl.pathname)
+      ? resolveDirectTargetUrl(incomingUrl, params.targetBaseUrl)
+      : undefined;
+  }
+  const suffix = incomingUrl.pathname.slice(params.proxyPathPrefix.length);
+  const targetUrl = new URL(params.targetBaseUrl);
+  targetUrl.pathname = `${params.targetPathPrefix}${suffix}` || "/";
+  for (const [key, value] of incomingUrl.searchParams) {
+    targetUrl.searchParams.append(key, value);
+  }
+  return targetUrl;
+}
+
+function resolveDirectTargetUrl(incomingUrl: URL, targetBaseUrl: URL): URL {
+  const targetUrl = new URL(targetBaseUrl);
+  targetUrl.pathname = incomingUrl.pathname;
+  for (const [key, value] of incomingUrl.searchParams) {
+    targetUrl.searchParams.append(key, value);
+  }
+  return targetUrl;
+}
+
+function isAzureSdkProxyPath(pathname: string): boolean {
+  return pathname === "/openai" || pathname.startsWith("/openai/");
+}
+
+async function readBody(req: IncomingMessage): Promise<Buffer | undefined> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+}
+
+function toFetchBody(body: Buffer): Uint8Array<ArrayBuffer> {
+  const copy = new Uint8Array(body.byteLength);
+  copy.set(body);
+  return copy;
+}
+
+function normalizeProxyRequestHeaders(headers: IncomingMessage["headers"]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (isHopByHopHeader(key) || key.toLowerCase() === "accept-encoding") {
+      continue;
+    }
+    const normalized = normalizeHeaderValue(value);
+    if (normalized !== undefined) {
+      out[key] = normalized;
+    }
+  }
+  out["accept-encoding"] = "identity";
+  return out;
+}
+
+function normalizeProxyResponseHeaders(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    if (!isHopByHopHeader(key) && !isContentEncodingHeader(key)) {
+      out[key] = value;
+    }
+  });
+  return out;
+}
+
+function normalizeHeaderValue(value: HeaderValue): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return Array.isArray(value) ? value.join(", ") : String(value);
+}
+
+function isHopByHopHeader(key: string): boolean {
+  switch (key.toLowerCase()) {
+    case "connection":
+    case "host":
+    case "keep-alive":
+    case "proxy-authenticate":
+    case "proxy-authorization":
+    case "te":
+    case "trailer":
+    case "transfer-encoding":
+    case "upgrade":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isContentEncodingHeader(key: string): boolean {
+  switch (key.toLowerCase()) {
+    case "content-encoding":
+    case "content-length":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function trimTrailingSlash(pathname: string): string {
+  const trimmed = pathname.replace(/\/+$/, "");
+  return trimmed === "" ? "" : trimmed;
+}

--- a/extensions/copilot/src/event-bridge.test.ts
+++ b/extensions/copilot/src/event-bridge.test.ts
@@ -17,6 +17,7 @@ const REGISTERED_EVENT_TYPES = [
   "tool.execution_complete",
   "session.plan_changed",
   "exit_plan_mode.requested",
+  "exit_plan_mode.completed",
   "subagent.started",
   "subagent.completed",
   "subagent.failed",
@@ -147,6 +148,50 @@ describe("attachEventBridge", () => {
     );
 
     expect(bridge.snapshot().assistantTexts).toEqual(["hello"]);
+  });
+
+  it("ignores child assistant and usage events but keeps child tool side effects", async () => {
+    const session = createFakeSession();
+    const onAssistantDelta = vi.fn();
+    const bridge = attachEventBridge(session, {
+      getSdkSessionId: () => "sdk-session-id",
+      isAborted: () => false,
+      onAssistantDelta,
+    });
+
+    session.emit("assistant.message_delta", {
+      ...makeEvent("assistant.message_delta", { deltaContent: "child", messageId: "child-msg" }),
+      agentId: "child-1",
+    } as SessionEvent);
+    session.emit(
+      "assistant.message_delta",
+      makeEvent("assistant.message_delta", { deltaContent: "root", messageId: "root-msg" }),
+    );
+    session.emit("tool.execution_start", {
+      ...makeEvent("tool.execution_start", { toolCallId: "child-call", toolName: "write" }),
+      agentId: "child-1",
+    } as SessionEvent);
+    session.emit("tool.execution_complete", {
+      ...makeEvent("tool.execution_complete", {
+        result: { content: "child write" },
+        success: true,
+        toolCallId: "child-call",
+      }),
+      agentId: "child-1",
+    } as SessionEvent);
+    session.emit("assistant.usage", {
+      ...makeEvent("assistant.usage", { inputTokens: 99, outputTokens: 99 }),
+      agentId: "child-1",
+    } as SessionEvent);
+
+    expect(bridge.snapshot().assistantTexts).toEqual(["root"]);
+    expect(bridge.snapshot().startedCount).toBe(0);
+    expect(bridge.snapshot().toolMetas).toEqual([
+      { toolName: "write" },
+      { meta: "child write", toolName: "write" },
+    ]);
+    await bridge.awaitDeltaChain();
+    expect(onAssistantDelta).toHaveBeenCalledTimes(1);
   });
 
   it("interleaved messageIds produce two ordered assistantTexts entries", () => {
@@ -483,10 +528,18 @@ describe("attachEventBridge", () => {
         summary: "Plan ready",
       }),
     );
+    session.emit(
+      "exit_plan_mode.completed",
+      makeEvent("exit_plan_mode.completed", {
+        approved: true,
+        requestId: "request-1",
+        selectedAction: "approve",
+      }),
+    );
 
     await bridge.awaitAgentEventChain();
 
-    expect(onAgentEvent).toHaveBeenCalledTimes(2);
+    expect(onAgentEvent).toHaveBeenCalledTimes(3);
     expect(onAgentEvent).toHaveBeenNthCalledWith(1, {
       stream: "plan",
       data: {
@@ -507,6 +560,17 @@ describe("attachEventBridge", () => {
         actions: ["approve", "edit"],
         requestId: "request-1",
         recommendedAction: "approve",
+      },
+    });
+    expect(onAgentEvent).toHaveBeenNthCalledWith(3, {
+      stream: "plan",
+      data: {
+        phase: "update",
+        title: "Plan decision",
+        source: "copilot-sdk",
+        requestId: "request-1",
+        approved: true,
+        selectedAction: "approve",
       },
     });
   });

--- a/extensions/copilot/src/event-bridge.ts
+++ b/extensions/copilot/src/event-bridge.ts
@@ -128,6 +128,9 @@ export function attachEventBridge(
   const unsubscribeFns: Array<() => void> = [];
 
   registerListener(session, unsubscribeFns, "assistant.message_delta", (event) => {
+    if (!isRootSessionEvent(event)) {
+      return;
+    }
     const messageId = readString(event.data.messageId) ?? "assistant-message";
     const delta = event.data.deltaContent;
     if (!delta) {
@@ -162,6 +165,9 @@ export function attachEventBridge(
   });
 
   registerListener(session, unsubscribeFns, "assistant.reasoning_delta", (event) => {
+    if (!isRootSessionEvent(event)) {
+      return;
+    }
     const reasoningId = readString(event.data.reasoningId) ?? "assistant-reasoning";
     const delta = event.data.deltaContent;
     if (!delta) {
@@ -175,6 +181,9 @@ export function attachEventBridge(
   });
 
   registerListener(session, unsubscribeFns, "assistant.message", (event) => {
+    if (!isRootSessionEvent(event)) {
+      return;
+    }
     lastAssistantEvent = event;
     const entry = ensureMessageAccumulator(messagesById, messageOrder, event.data.messageId);
     if (typeof event.data.content === "string" && event.data.content.length >= entry.text.length) {
@@ -183,17 +192,24 @@ export function attachEventBridge(
   });
 
   registerListener(session, unsubscribeFns, "assistant.usage", (event) => {
+    if (!isRootSessionEvent(event)) {
+      return;
+    }
     usage = normalizeCopilotUsage(event.data);
   });
 
   registerListener(session, unsubscribeFns, "tool.execution_start", (event) => {
-    startedCount += 1;
+    if (isRootSessionEvent(event)) {
+      startedCount += 1;
+    }
     toolNamesByCallId.set(event.data.toolCallId, event.data.toolName);
     toolMetas.push({ toolName: event.data.toolName });
   });
 
   registerListener(session, unsubscribeFns, "tool.execution_complete", (event) => {
-    completedCount += 1;
+    if (isRootSessionEvent(event)) {
+      completedCount += 1;
+    }
     const toolName = toolNamesByCallId.get(event.data.toolCallId);
     const meta = event.data.success
       ? (event.data.result?.detailedContent ?? event.data.result?.content)
@@ -231,6 +247,25 @@ export function attachEventBridge(
         ...(event.data.recommendedAction
           ? { recommendedAction: event.data.recommendedAction }
           : {}),
+        ...(event.agentId ? { agentId: event.agentId } : {}),
+      },
+    });
+  });
+
+  registerListener(session, unsubscribeFns, "exit_plan_mode.completed", (event) => {
+    enqueueAgentEvent({
+      stream: "plan",
+      data: {
+        phase: "update",
+        title: "Plan decision",
+        source: "copilot-sdk",
+        requestId: event.data.requestId,
+        ...(event.data.approved !== undefined ? { approved: event.data.approved } : {}),
+        ...(event.data.autoApproveEdits !== undefined
+          ? { autoApproveEdits: event.data.autoApproveEdits }
+          : {}),
+        ...(event.data.feedback ? { feedback: event.data.feedback } : {}),
+        ...(event.data.selectedAction ? { selectedAction: event.data.selectedAction } : {}),
         ...(event.agentId ? { agentId: event.agentId } : {}),
       },
     });
@@ -531,10 +566,14 @@ function isAssistantMessageEvent(
   return event?.type === "assistant.message";
 }
 
+function isRootSessionEvent(event: { agentId?: string }): boolean {
+  return event.agentId === undefined;
+}
+
 function isRootCompactionEvent(event: { agentId?: string }): boolean {
   // SDK session events include subagent compaction; only root compaction
   // affects the pooled root session's cleanup and reuse lifecycle.
-  return event.agentId === undefined;
+  return isRootSessionEvent(event);
 }
 
 function joinReasoning(order: string[], reasoningById: Map<string, string>): string {

--- a/extensions/copilot/src/provider-bridge.test.ts
+++ b/extensions/copilot/src/provider-bridge.test.ts
@@ -1,0 +1,376 @@
+// Copilot tests cover BYOK provider mapping behavior.
+import { describe, expect, it } from "vitest";
+import {
+  COPILOT_BYOK_PROVIDER_ERROR,
+  COPILOT_BYOK_ENDPOINT_POLICY_ERROR,
+  COPILOT_BYOK_TRANSPORT_POLICY_ERROR,
+  resolveCopilotProvider,
+  supportsCopilotByokProviderShape,
+} from "./provider-bridge.js";
+
+describe("resolveCopilotProvider", () => {
+  it("keeps the subscription provider on the native Copilot auth path", () => {
+    expect(
+      resolveCopilotProvider({
+        model: {
+          provider: "github-copilot",
+          api: "github-copilot",
+          id: "gpt-5",
+          baseUrl: "https://ignored.example",
+        },
+        resolvedApiKey: "ignored",
+      }),
+    ).toEqual({ mode: "github-copilot" });
+  });
+
+  it("maps OpenAI Responses BYOK with a bearer token and stable limits", () => {
+    const result = resolveCopilotProvider({
+      model: {
+        provider: "local-proxy",
+        api: "openai-responses",
+        id: "proxy-model",
+        baseUrl: "https://proxy.example/v1",
+        authHeader: true,
+        contextTokens: 12_000,
+        maxTokens: 512,
+        headers: { "X-Trace": "test" },
+      },
+      resolvedApiKey: "secret-key",
+      authProfileId: "local-proxy:main",
+    });
+
+    expect(result.mode).toBe("byok");
+    expect(result.authProfileId).toBe("local-proxy:main");
+    expect(result.authProfileVersion).toMatch(/^sha256:/);
+    expect(result.provider).toEqual({
+      type: "openai",
+      wireApi: "responses",
+      baseUrl: "https://proxy.example/v1",
+      modelId: "proxy-model",
+      wireModel: "proxy-model",
+      bearerToken: "secret-key",
+      headers: { "X-Trace": "test" },
+      maxPromptTokens: 12_000,
+      maxOutputTokens: 512,
+    });
+  });
+
+  it("defaults custom BYOK providers without an api to OpenAI Responses", () => {
+    const result = resolveCopilotProvider({
+      model: {
+        provider: "custom-proxy",
+        id: "proxy-model",
+        baseUrl: "https://proxy.example/v1",
+      },
+      resolvedApiKey: "secret-key",
+    });
+
+    expect(result.provider).toMatchObject({
+      type: "openai",
+      wireApi: "responses",
+      baseUrl: "https://proxy.example/v1",
+    });
+    expect(supportsCopilotByokProviderShape({ baseUrl: "https://proxy.example/v1" })).toBe(true);
+  });
+
+  it("changes the BYOK compatibility fingerprint when token limits change", () => {
+    const base = {
+      provider: "custom-proxy",
+      api: "openai-responses",
+      id: "proxy-model",
+      baseUrl: "https://proxy.example/v1",
+    };
+
+    const small = resolveCopilotProvider({
+      model: { ...base, contextTokens: 8_000, maxTokens: 512 },
+      resolvedApiKey: "secret-key",
+    });
+    const large = resolveCopilotProvider({
+      model: { ...base, contextTokens: 16_000, maxTokens: 1024 },
+      resolvedApiKey: "secret-key",
+    });
+
+    expect(small.authProfileVersion).not.toBe(large.authProfileVersion);
+  });
+
+  it("maps Anthropic and Ollama-compatible APIs", () => {
+    expect(
+      resolveCopilotProvider({
+        model: {
+          provider: "anthropic-proxy",
+          api: "anthropic-messages",
+          id: "claude",
+          baseUrl: "https://anthropic.example",
+        },
+      }).provider,
+    ).toMatchObject({ type: "anthropic", baseUrl: "https://anthropic.example" });
+
+    expect(
+      resolveCopilotProvider({
+        model: {
+          provider: "ollama-compatible",
+          api: "ollama",
+          id: "qwen",
+          baseUrl: "https://ollama-compatible.example/v1",
+        },
+      }).provider,
+    ).toMatchObject({ type: "openai", wireApi: "completions" });
+  });
+
+  it("normalizes Azure OpenAI Responses config for the Copilot SDK provider contract", () => {
+    const result = resolveCopilotProvider({
+      model: {
+        provider: "custom-azure",
+        api: "azure-openai-responses",
+        id: "deployment-gpt",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+        azureApiVersion: "2025-01-01-preview",
+      },
+      resolvedApiKey: "azure-key",
+    });
+
+    expect(result.provider).toEqual({
+      type: "azure",
+      wireApi: "responses",
+      baseUrl: "https://example.openai.azure.com",
+      modelId: "deployment-gpt",
+      wireModel: "deployment-gpt",
+      apiKey: "azure-key",
+      azure: { apiVersion: "2025-01-01-preview" },
+    });
+    expect(
+      resolveCopilotProvider({
+        model: {
+          provider: "custom-azure",
+          api: "azure-openai-responses",
+          id: "deployment-gpt",
+          baseUrl: "https://example.cognitiveservices.azure.com/openai/v1",
+        },
+      }).provider,
+    ).toMatchObject({
+      type: "azure",
+      baseUrl: "https://example.cognitiveservices.azure.com",
+    });
+    expect(
+      resolveCopilotProvider({
+        model: {
+          provider: "custom-azure",
+          api: "azure-openai-responses",
+          id: "deployment",
+          baseUrl: "https://example.cognitiveservices.azure.com/openai/v1",
+        },
+      }).provider,
+    ).not.toHaveProperty("azure");
+    expect(
+      resolveCopilotProvider({
+        model: {
+          provider: "custom-azure",
+          api: "azure-openai-responses",
+          id: "deployment-gpt",
+          baseUrl: "https://project.services.ai.azure.com/api/projects/demo/openai/v1",
+        },
+        resolvedApiKey: "azure-key",
+      }).provider,
+    ).toEqual({
+      type: "openai",
+      wireApi: "responses",
+      baseUrl: "https://project.services.ai.azure.com/api/projects/demo/openai/v1",
+      modelId: "deployment-gpt",
+      wireModel: "deployment-gpt",
+      apiKey: "azure-key",
+    });
+  });
+
+  it("does not forward local auth markers or null no-auth headers", () => {
+    const result = resolveCopilotProvider({
+      model: {
+        provider: "local-proxy",
+        api: "openai-completions",
+        id: "local-model",
+        baseUrl: "https://proxy.example/v1",
+        authHeader: true,
+        headers: {
+          Authorization: null,
+          "X-Local": "true",
+        },
+      },
+      resolvedApiKey: "custom-local",
+    });
+
+    expect(result.provider).toEqual({
+      type: "openai",
+      wireApi: "completions",
+      baseUrl: "https://proxy.example/v1",
+      modelId: "local-model",
+      wireModel: "local-model",
+      headers: { "X-Local": "true" },
+    });
+  });
+
+  it("does not synthesize SDK apiKey auth when request auth already prepared headers", () => {
+    const result = resolveCopilotProvider({
+      model: {
+        provider: "custom-header-proxy",
+        api: "openai-responses",
+        id: "proxy-model",
+        baseUrl: "https://proxy.example/v1",
+        headers: { "x-api-key": "header-secret" },
+        requestAuthMode: "header",
+      },
+      resolvedApiKey: "header-secret",
+    });
+
+    expect(result.provider).toEqual({
+      type: "openai",
+      wireApi: "responses",
+      baseUrl: "https://proxy.example/v1",
+      modelId: "proxy-model",
+      wireModel: "proxy-model",
+      headers: { "x-api-key": "header-secret" },
+    });
+  });
+
+  it("rejects request transport policy the SDK provider config cannot enforce", () => {
+    for (const model of [
+      { requestProxy: { mode: "env-proxy" } },
+      { requestTls: { ca: "ca-pem" } },
+      { requestAllowPrivateNetwork: false },
+    ]) {
+      expect(() =>
+        resolveCopilotProvider({
+          model: {
+            provider: "custom-proxy",
+            api: "openai-responses",
+            id: "proxy-model",
+            baseUrl: "https://proxy.example/v1",
+            ...model,
+          },
+        }),
+      ).toThrow(COPILOT_BYOK_TRANSPORT_POLICY_ERROR);
+    }
+  });
+
+  it("rejects BYOK endpoints blocked by OpenClaw SSRF policy", () => {
+    for (const baseUrl of [
+      "file://public.example/v1",
+      "ftp://public.example/v1",
+      "http://proxy.example/v1",
+      "https://user:pass@proxy.example/v1",
+      "https://proxy.example/v1?api_key=secret",
+      "https://proxy.example/v1?x-api-key=secret",
+      "https://proxy.example/v1?x-auth-token=secret",
+      "https://proxy.example/v1?password=secret",
+      "https://proxy.example/v1?client%5Fse%E2%80%8Bcret=secret",
+      "http://169.254.169.254/v1",
+      "http://metadata.google.internal/v1",
+      "http://localhost:11434/v1",
+    ]) {
+      expect(() =>
+        resolveCopilotProvider({
+          model: {
+            provider: "custom-proxy",
+            api: "openai-responses",
+            id: "proxy-model",
+            baseUrl,
+          },
+        }),
+      ).toThrow(COPILOT_BYOK_ENDPOINT_POLICY_ERROR);
+    }
+  });
+
+  it("advertises support only for representable BYOK provider shapes", () => {
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "openai-responses",
+        baseUrl: "https://proxy.example/v1",
+      }),
+    ).toBe(true);
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "azure-openai-responses",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+      }),
+    ).toBe(true);
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "azure-openai-responses",
+        baseUrl: "https://project.services.ai.azure.com/api/projects/demo/openai/v1",
+      }),
+    ).toBe(true);
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "azure-openai-responses",
+        baseUrl: "https://project.services.ai.azure.com/api/projects/demo",
+      }),
+    ).toBe(false);
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "google-generative-ai",
+        baseUrl: "https://google.example",
+      }),
+    ).toBe(false);
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "openai-responses",
+        baseUrl: "file://public.example/v1",
+      }),
+    ).toBe(false);
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "openai-responses",
+        baseUrl: "http://proxy.example/v1",
+      }),
+    ).toBe(false);
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "openai-responses",
+        baseUrl: "https://user:pass@proxy.example/v1",
+      }),
+    ).toBe(false);
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "openai-responses",
+        baseUrl: "https://proxy.example/v1?api_key=secret",
+      }),
+    ).toBe(false);
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "openai-responses",
+        baseUrl: "https://proxy.example/v1?x-api-key=secret",
+      }),
+    ).toBe(false);
+    expect(supportsCopilotByokProviderShape({ api: "openai-responses" })).toBe(false);
+    expect(
+      supportsCopilotByokProviderShape({
+        api: "openai-responses",
+        baseUrl: "https://proxy.example/v1",
+        requestProxy: { mode: "env-proxy" },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects provider APIs the SDK adapter cannot represent", () => {
+    expect(() =>
+      resolveCopilotProvider({
+        model: {
+          provider: "google",
+          api: "google-generative-ai",
+          id: "gemini",
+          baseUrl: "https://google.example",
+        },
+      }),
+    ).toThrow(COPILOT_BYOK_PROVIDER_ERROR);
+  });
+
+  it("requires an endpoint for non-subscription providers", () => {
+    expect(() =>
+      resolveCopilotProvider({
+        model: {
+          provider: "custom",
+          api: "openai-completions",
+          id: "model",
+        },
+      }),
+    ).toThrow(COPILOT_BYOK_PROVIDER_ERROR);
+  });
+});

--- a/extensions/copilot/src/provider-bridge.ts
+++ b/extensions/copilot/src/provider-bridge.ts
@@ -1,0 +1,339 @@
+// Copilot plugin module implements BYOK provider mapping.
+import type { ProviderConfig } from "@github/copilot-sdk";
+import { isNonSecretApiKeyMarker } from "openclaw/plugin-sdk/provider-auth";
+import { isBlockedHostnameOrIp } from "openclaw/plugin-sdk/ssrf-runtime";
+import { tokenFingerprint } from "./auth-bridge.js";
+
+export const COPILOT_BYOK_PROVIDER_ERROR =
+  "[copilot-attempt] BYOK requires an OpenAI-compatible or Anthropic model api and a non-empty baseUrl";
+export const COPILOT_BYOK_TRANSPORT_POLICY_ERROR =
+  "[copilot-attempt] BYOK does not support OpenClaw provider request proxy, TLS, or private-network policy overrides";
+export const COPILOT_BYOK_ENDPOINT_POLICY_ERROR =
+  "[copilot-attempt] BYOK endpoint is blocked by OpenClaw SSRF policy";
+
+const CREDENTIAL_QUERY_PARAM_NAMES = new Set([
+  "accesstoken",
+  "appsecret",
+  "auth",
+  "authtoken",
+  "apikey",
+  "authorization",
+  "clientsecret",
+  "code",
+  "credential",
+  "hooktoken",
+  "idtoken",
+  "jwt",
+  "key",
+  "pass",
+  "passwd",
+  "password",
+  "privatekey",
+  "refreshtoken",
+  "secret",
+  "session",
+  "sig",
+  "signature",
+  "token",
+  "xapikey",
+  "xaccesstoken",
+  "xamzsecuritytoken",
+  "xamzsignature",
+  "xauthtoken",
+]);
+const QUERY_PARAM_NAME_SEPARATOR_RE = /[\p{C}\p{Z}\u115F\u1160\u3164\uFFA0+]/gu;
+
+export type CopilotProviderMode = "github-copilot" | "byok";
+
+export type CopilotModelProviderInput = {
+  api?: string;
+  id: string;
+  provider: string;
+  baseUrl?: string;
+  azureApiVersion?: string;
+  headers?: Record<string, string | null | undefined>;
+  authHeader?: boolean;
+  requestAuthMode?: string;
+  requestProxy?: unknown;
+  requestTls?: unknown;
+  requestAllowPrivateNetwork?: unknown;
+  contextTokens?: number;
+  contextWindow?: number;
+  maxTokens?: number;
+};
+
+export type ResolvedCopilotProvider = {
+  mode: CopilotProviderMode;
+  provider?: ProviderConfig;
+  authProfileId?: string;
+  authProfileVersion?: string;
+};
+
+/**
+ * Maps OpenClaw's prepared model facts into the Copilot SDK's session-level
+ * provider contract. The SDK owns the wire request; OpenClaw only supplies
+ * the already-resolved endpoint, model, headers, and credential.
+ */
+export function resolveCopilotProvider(params: {
+  model: CopilotModelProviderInput;
+  resolvedApiKey?: string;
+  authProfileId?: string;
+}): ResolvedCopilotProvider {
+  if (params.model.provider.trim().toLowerCase() === "github-copilot") {
+    return { mode: "github-copilot" };
+  }
+
+  const baseUrl = readString(params.model.baseUrl);
+  if (!baseUrl) {
+    throw new Error(COPILOT_BYOK_PROVIDER_ERROR);
+  }
+  assertByokEndpointAllowed(baseUrl);
+  if (hasUnsupportedTransportPolicy(params.model)) {
+    throw new Error(COPILOT_BYOK_TRANSPORT_POLICY_ERROR);
+  }
+
+  const api = readString(params.model.api)?.toLowerCase() ?? "openai-responses";
+  const provider = resolveProviderType(api, baseUrl, params.model.azureApiVersion);
+  const resolvedApiKey = resolveProviderCredential(params.resolvedApiKey);
+  const headers = resolveProviderHeaders(params.model.headers);
+  const requestAuthMode = readString(params.model.requestAuthMode)?.toLowerCase();
+  const usePreparedRequestAuth =
+    requestAuthMode !== undefined && requestAuthMode !== "provider-default";
+  const providerConfig: ProviderConfig = {
+    type: provider.type,
+    ...(provider.wireApi ? { wireApi: provider.wireApi } : {}),
+    baseUrl: provider.baseUrl,
+    modelId: params.model.id,
+    wireModel: params.model.id,
+    ...(resolvedApiKey && !usePreparedRequestAuth
+      ? params.model.authHeader
+        ? { bearerToken: resolvedApiKey }
+        : { apiKey: resolvedApiKey }
+      : {}),
+    ...(headers ? { headers } : {}),
+    ...(provider.azure ? { azure: provider.azure } : {}),
+    ...((params.model.contextTokens ?? params.model.contextWindow)
+      ? { maxPromptTokens: params.model.contextTokens ?? params.model.contextWindow }
+      : {}),
+    ...(params.model.maxTokens ? { maxOutputTokens: params.model.maxTokens } : {}),
+  };
+  const authProfileId = params.authProfileId?.trim() || `byok:${params.model.provider}`;
+  const authProfileVersion = tokenFingerprint(
+    stableSerialize({
+      api,
+      baseUrl: provider.baseUrl,
+      azureApiVersion: provider.azure?.apiVersion,
+      headers,
+      authHeader: params.model.authHeader,
+      requestAuthMode: params.model.requestAuthMode,
+      apiKey: resolvedApiKey,
+      modelId: params.model.id,
+      maxPromptTokens: params.model.contextTokens ?? params.model.contextWindow,
+      maxOutputTokens: params.model.maxTokens,
+    }),
+  );
+
+  return {
+    mode: "byok",
+    provider: providerConfig,
+    authProfileId,
+    authProfileVersion,
+  };
+}
+
+export function isCopilotByokUnsupportedProviderError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === COPILOT_BYOK_PROVIDER_ERROR ||
+      error.message === COPILOT_BYOK_TRANSPORT_POLICY_ERROR ||
+      error.message === COPILOT_BYOK_ENDPOINT_POLICY_ERROR)
+  );
+}
+
+export function supportsCopilotByokProviderShape(
+  model: Pick<
+    CopilotModelProviderInput,
+    "api" | "baseUrl" | "requestProxy" | "requestTls" | "requestAllowPrivateNetwork"
+  >,
+): boolean {
+  if (!readString(model.baseUrl) || hasUnsupportedTransportPolicy(model)) {
+    return false;
+  }
+  try {
+    resolveProviderType(
+      readString(model.api)?.toLowerCase() ?? "openai-responses",
+      readString(model.baseUrl)!,
+      undefined,
+    );
+    assertByokEndpointHostAllowed(readString(model.baseUrl)!);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasUnsupportedTransportPolicy(
+  model: Pick<
+    CopilotModelProviderInput,
+    "requestProxy" | "requestTls" | "requestAllowPrivateNetwork"
+  >,
+): boolean {
+  return (
+    model.requestProxy !== undefined ||
+    model.requestTls !== undefined ||
+    model.requestAllowPrivateNetwork !== undefined
+  );
+}
+
+function assertByokEndpointHostAllowed(baseUrl: string): void {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new Error(COPILOT_BYOK_PROVIDER_ERROR);
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(COPILOT_BYOK_ENDPOINT_POLICY_ERROR);
+  }
+  if (url.username || url.password) {
+    throw new Error(COPILOT_BYOK_ENDPOINT_POLICY_ERROR);
+  }
+  for (const key of url.searchParams.keys()) {
+    if (CREDENTIAL_QUERY_PARAM_NAMES.has(normalizeCredentialQueryParamName(key))) {
+      throw new Error(COPILOT_BYOK_ENDPOINT_POLICY_ERROR);
+    }
+  }
+  const hostname = url.hostname.toLowerCase().replace(/\.+$/, "");
+  if (isBlockedHostnameOrIp(hostname)) {
+    throw new Error(COPILOT_BYOK_ENDPOINT_POLICY_ERROR);
+  }
+}
+
+function normalizeCredentialQueryParamName(name: string): string {
+  const stripped = name.replace(QUERY_PARAM_NAME_SEPARATOR_RE, "");
+  try {
+    return decodeURIComponent(stripped)
+      .replace(QUERY_PARAM_NAME_SEPARATOR_RE, "")
+      .toLowerCase()
+      .replace(/[-_]/g, "");
+  } catch {
+    return stripped.toLowerCase().replace(/[-_]/g, "");
+  }
+}
+
+function assertByokEndpointAllowed(baseUrl: string): void {
+  assertByokEndpointHostAllowed(baseUrl);
+}
+
+function resolveProviderType(
+  api: string | undefined,
+  baseUrl: string,
+  azureApiVersion: string | undefined,
+): {
+  type: NonNullable<ProviderConfig["type"]>;
+  wireApi?: NonNullable<ProviderConfig["wireApi"]>;
+  baseUrl: string;
+  azure?: NonNullable<ProviderConfig["azure"]>;
+} {
+  switch (api) {
+    case "anthropic-messages":
+      return { type: "anthropic", baseUrl };
+    case "azure-openai-responses":
+      return resolveAzureProviderType(baseUrl, azureApiVersion);
+    case "openai-responses":
+      return { type: "openai", wireApi: "responses", baseUrl };
+    case "openai-completions":
+    case "ollama":
+      return { type: "openai", wireApi: "completions", baseUrl };
+    default:
+      throw new Error(COPILOT_BYOK_PROVIDER_ERROR);
+  }
+}
+
+function resolveAzureProviderType(
+  baseUrl: string,
+  apiVersion: string | undefined,
+): {
+  type: NonNullable<ProviderConfig["type"]>;
+  wireApi: NonNullable<ProviderConfig["wireApi"]>;
+  baseUrl: string;
+  azure?: NonNullable<ProviderConfig["azure"]>;
+} {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new Error(COPILOT_BYOK_PROVIDER_ERROR);
+  }
+  if (isOpenAICompatibleAzureResponsesBaseUrl(url)) {
+    return { type: "openai", wireApi: "responses", baseUrl };
+  }
+  if (!isTraditionalAzureOpenAIHost(url.hostname)) {
+    throw new Error(COPILOT_BYOK_PROVIDER_ERROR);
+  }
+  url.pathname = "";
+  url.search = "";
+  url.hash = "";
+  const resolvedApiVersion = readString(apiVersion);
+  return {
+    type: "azure",
+    wireApi: "responses",
+    baseUrl: url.toString().replace(/\/+$/, ""),
+    ...(resolvedApiVersion ? { azure: { apiVersion: resolvedApiVersion } } : {}),
+  };
+}
+
+function isTraditionalAzureOpenAIHost(hostname: string): boolean {
+  return (
+    hostname.endsWith(".openai.azure.com") || hostname.endsWith(".cognitiveservices.azure.com")
+  );
+}
+
+function isOpenAICompatibleAzureResponsesBaseUrl(url: URL): boolean {
+  if (isTraditionalAzureOpenAIHost(url.hostname)) {
+    return false;
+  }
+  const hostname = url.hostname.toLowerCase();
+  const isFoundryHost =
+    hostname.endsWith(".services.ai.azure.com") ||
+    hostname.endsWith(".api.cognitive.microsoft.com");
+  if (!isFoundryHost) {
+    return false;
+  }
+  const normalizedPath = url.pathname.replace(/\/+$/, "");
+  return normalizedPath === "/openai/v1" || normalizedPath.endsWith("/openai/v1");
+}
+
+function stableSerialize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableSerialize(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function resolveProviderCredential(value: string | undefined): string | undefined {
+  const credential = readString(value);
+  return credential && !isNonSecretApiKeyMarker(credential) ? credential : undefined;
+}
+
+function resolveProviderHeaders(
+  headers: Record<string, string | null | undefined> | undefined,
+): Record<string, string> | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const resolved = Object.fromEntries(
+    Object.entries(headers).filter(([, value]) => typeof value === "string"),
+  ) as Record<string, string>;
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
+}

--- a/extensions/copilot/src/runtime.ts
+++ b/extensions/copilot/src/runtime.ts
@@ -14,7 +14,7 @@ const POOL_DISPOSED_MESSAGE = "[copilot-pool] pool disposed";
 export interface PoolKey {
   readonly agentId: string;
   readonly copilotHome: string;
-  readonly authMode: "useLoggedInUser" | "gitHubToken";
+  readonly authMode: "useLoggedInUser" | "gitHubToken" | "byok";
   readonly authProfileId?: string;
   readonly authProfileVersion?: string;
 }

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -107,6 +107,29 @@ describe("createCopilotToolBridge", () => {
     expect(createOpenClawCodingTools).toHaveBeenCalledTimes(0);
   });
 
+  it("allows vetted BYOK providers to expose model tools", async () => {
+    const sourceTools = [makeTool()];
+    const createOpenClawCodingTools = vi.fn(async () => sourceTools);
+
+    const result = await createCopilotToolBridge({
+      agentId: "agent-1",
+      allowModelTools: true,
+      createOpenClawCodingTools,
+      modelId: "gpt-test",
+      modelProvider: "custom-openai",
+      sessionId: "session-1",
+    });
+
+    expect(createOpenClawCodingTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: "gpt-test",
+        modelProvider: "custom-openai",
+      }),
+    );
+    expect(result.sourceTools).toEqual(sourceTools);
+    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool-a"]);
+  });
+
   it("forwards supported fields to injected createOpenClawCodingTools", async () => {
     const controller = new AbortController();
     const createOpenClawCodingTools = vi.fn(async () => [makeTool()]);

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -69,6 +69,7 @@ export type CopilotToolCompletion = {
 };
 
 export interface CopilotToolBridgeInput {
+  allowModelTools?: boolean;
   modelProvider: string;
   modelId: string;
   agentId: string;
@@ -151,7 +152,7 @@ export function supportsModelTools(modelProvider: string): boolean {
 export async function createCopilotToolBridge(
   input: CopilotToolBridgeInput,
 ): Promise<CopilotToolBridge> {
-  if (!supportsModelTools(input.modelProvider)) {
+  if (!input.allowModelTools && !supportsModelTools(input.modelProvider)) {
     return { sdkTools: [], sourceTools: [] };
   }
 

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -138,7 +138,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "secret-file-runtime": 1,
   "security-runtime": 7,
   "agent-harness": 7,
-  "agent-harness-runtime": 7,
+  "agent-harness-runtime": 11,
   types: 6,
   "agent-config-primitives": 2,
   "command-auth": 81,
@@ -202,8 +202,8 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10377),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5206),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10381),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5210),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3247,

--- a/src/agents/embedded-agent-runner/compact.types.ts
+++ b/src/agents/embedded-agent-runner/compact.types.ts
@@ -6,6 +6,7 @@ import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
+import type { Model } from "openclaw/plugin-sdk/llm";
 import type { CommandQueueEnqueueFn } from "../../process/command-queue.types.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import type { ExecElevatedDefaults, ExecToolDefaults } from "../bash-tools.exec-types.js";
@@ -57,6 +58,8 @@ export type CompactEmbeddedAgentSessionParams = {
   senderIsOwner?: boolean;
   provider?: string;
   model?: string;
+  /** Caller-resolved model/provider shape used by native harness compactors. */
+  runtimeModel?: Model;
   /** Effective model fallback chain for this session attempt. Undefined uses config defaults. */
   modelFallbacksOverride?: string[];
   /** Optional caller-resolved context engine for harness-owned compaction. */

--- a/src/agents/harness/compaction.ts
+++ b/src/agents/harness/compaction.ts
@@ -5,6 +5,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
+import type { Model } from "openclaw/plugin-sdk/llm";
 import { isDefaultAgentRuntimeId, normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
 import type { CompactEmbeddedAgentSessionParams } from "../embedded-agent-runner/compact.types.js";
@@ -62,19 +63,13 @@ function resolveHarnessCompactIdentity(params: CompactEmbeddedAgentSessionParams
 async function resolveHarnessCompactApiKey(params: {
   agentDir: string;
   compactParams: CompactEmbeddedAgentSessionParams;
-}): Promise<string | undefined> {
+}): Promise<{ apiKey?: string; runtimeModel?: Model }> {
   const { agentDir, compactParams } = params;
   const existing = compactParams.resolvedApiKey?.trim();
-  if (existing) {
-    return existing;
+  if (!compactParams.provider?.trim() || !compactParams.model?.trim()) {
+    return existing ? { apiKey: existing } : {};
   }
-  if (
-    !compactParams.authProfileId?.trim() ||
-    !compactParams.provider?.trim() ||
-    !compactParams.model?.trim()
-  ) {
-    return undefined;
-  }
+  const authProfileId = compactParams.authProfileId?.trim() || undefined;
   const workspaceDir = resolveUserPath(compactParams.workspaceDir);
   const { model } = await resolveModelAsync(
     compactParams.provider,
@@ -82,21 +77,34 @@ async function resolveHarnessCompactApiKey(params: {
     agentDir,
     compactParams.config,
     {
-      authProfileId: compactParams.authProfileId,
+      authProfileId,
       workspaceDir,
     },
   );
   if (!model) {
-    return undefined;
+    return existing ? { apiKey: existing } : {};
   }
-  const apiKeyInfo = await getApiKeyForModel({
-    model,
-    cfg: compactParams.config,
-    profileId: compactParams.authProfileId,
-    agentDir,
-    workspaceDir,
-  });
-  return apiKeyInfo.apiKey?.trim() || undefined;
+  if (existing) {
+    return { apiKey: existing, runtimeModel: model };
+  }
+  try {
+    const apiKeyInfo = await getApiKeyForModel({
+      model,
+      cfg: compactParams.config,
+      profileId: authProfileId,
+      agentDir,
+      workspaceDir,
+    });
+    return {
+      apiKey: apiKeyInfo.apiKey?.trim() || undefined,
+      runtimeModel: model,
+    };
+  } catch (err) {
+    log.debug("agent harness compaction credential lookup failed", {
+      error: formatErrorMessage(err),
+    });
+    return { runtimeModel: model };
+  }
 }
 
 /** Runs harness-provided compaction when the selected runtime supports it. */
@@ -169,20 +177,28 @@ export async function maybeCompactAgentHarnessSession(
     agentDir: compactIdentity.agentDir,
     agentId: compactIdentity.agentId,
   };
-  let resolvedApiKey: string | undefined;
+  let resolvedApiKey = compactParams.resolvedApiKey?.trim() || undefined;
+  let runtimeModel: Model | undefined;
   try {
-    resolvedApiKey = await resolveHarnessCompactApiKey({
+    const resolved = await resolveHarnessCompactApiKey({
       agentDir: compactIdentity.agentDir,
       compactParams,
     });
+    resolvedApiKey = resolved.apiKey;
+    runtimeModel = resolved.runtimeModel;
   } catch (err) {
     log.debug("agent harness compaction credential lookup failed", {
       error: formatErrorMessage(err),
     });
   }
-  const resolvedCompactParams = resolvedApiKey
-    ? { ...compactParams, resolvedApiKey }
-    : compactParams;
+  const resolvedCompactParams =
+    resolvedApiKey || runtimeModel
+      ? {
+          ...compactParams,
+          ...(resolvedApiKey ? { resolvedApiKey } : {}),
+          ...(runtimeModel ? { runtimeModel } : {}),
+        }
+      : compactParams;
   if (shouldCompactAfterContextEngine) {
     return internalHarness.compactAfterContextEngine?.(resolvedCompactParams);
   }

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -31,6 +31,9 @@ const compactAuthMocks = vi.hoisted(() => ({
   getApiKeyForModel: vi.fn(),
   resolveModelAsync: vi.fn(),
 }));
+const providerOwnerMocks = vi.hoisted(() => ({
+  resolveProviderRefOwnership: vi.fn(),
+}));
 
 vi.mock("./builtin-openclaw.js", () => ({
   createOpenClawAgentHarness: (): AgentHarness => ({
@@ -47,6 +50,9 @@ vi.mock("../model-auth.js", () => ({
 vi.mock("../embedded-agent-runner/model.js", () => ({
   resolveModelAsync: compactAuthMocks.resolveModelAsync,
 }));
+vi.mock("../../plugins/providers.js", () => ({
+  resolveProviderRefOwnership: providerOwnerMocks.resolveProviderRefOwnership,
+}));
 
 const originalRuntime = process.env.OPENCLAW_AGENT_RUNTIME;
 
@@ -56,6 +62,8 @@ beforeEach(() => {
     model: { id: "gpt-5.5", provider: "openai" },
   });
   compactAuthMocks.getApiKeyForModel.mockResolvedValue({ apiKey: "test-key" });
+  providerOwnerMocks.resolveProviderRefOwnership.mockReset();
+  providerOwnerMocks.resolveProviderRefOwnership.mockReturnValue({ status: "unowned" });
   cliBackendsTesting.setDepsForTest({
     resolvePluginSetupRegistry: () => ({
       providers: [],
@@ -87,6 +95,7 @@ afterEach(() => {
   agentRunAttempt.mockClear();
   compactAuthMocks.resolveModelAsync.mockReset();
   compactAuthMocks.getApiKeyForModel.mockReset();
+  providerOwnerMocks.resolveProviderRefOwnership.mockReset();
   if (originalRuntime == null) {
     delete process.env.OPENCLAW_AGENT_RUNTIME;
   } else {
@@ -639,6 +648,141 @@ describe("selectAgentHarness", () => {
     expect(supports).toHaveBeenCalledTimes(1);
   });
 
+  it("passes manifest provider owners into plugin support checks", () => {
+    providerOwnerMocks.resolveProviderRefOwnership.mockReturnValue({
+      status: "owned",
+      pluginIds: ["anthropic"],
+    });
+    const supports = vi.fn(() => ({
+      supported: false as const,
+      reason: "provider is owned by a native plugin",
+    }));
+    const config = providerRuntimeConfig("anthropic", "copilot");
+    registerAgentHarness({
+      id: "copilot",
+      label: "Copilot",
+      supports,
+      runAttempt: vi.fn(async () => createAttemptResult("copilot")),
+    });
+
+    expect(() =>
+      selectAgentHarness({
+        provider: "anthropic",
+        modelId: "claude-sonnet-4.6",
+        config,
+        agentHarnessRuntimeOverride: "copilot",
+      }),
+    ).toThrow("provider is owned by a native plugin");
+
+    expect(providerOwnerMocks.resolveProviderRefOwnership).toHaveBeenCalledWith({
+      provider: "anthropic",
+      config,
+    });
+    expect(supports).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        modelId: "claude-sonnet-4.6",
+        requestedRuntime: "copilot",
+        providerOwnerStatus: "owned",
+        providerOwnerPluginIds: ["anthropic"],
+      }),
+    );
+  });
+
+  it("passes ambiguous provider ownership into plugin support checks", () => {
+    providerOwnerMocks.resolveProviderRefOwnership.mockReturnValue({
+      status: "ambiguous",
+      pluginIds: ["first-owner", "second-owner"],
+    });
+    const supports = vi.fn(() => ({
+      supported: false as const,
+      reason: "provider ownership is ambiguous",
+    }));
+    const config = providerRuntimeConfig("custom-proxy", "copilot");
+    registerAgentHarness({
+      id: "copilot",
+      label: "Copilot",
+      supports,
+      runAttempt: vi.fn(async () => createAttemptResult("copilot")),
+    });
+
+    expect(() =>
+      selectAgentHarness({
+        provider: "custom-proxy",
+        modelId: "proxy-model",
+        config,
+        agentHarnessRuntimeOverride: "copilot",
+      }),
+    ).toThrow("provider ownership is ambiguous");
+
+    expect(supports).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "custom-proxy",
+        providerOwnerStatus: "ambiguous",
+        providerOwnerPluginIds: ["first-owner", "second-owner"],
+      }),
+    );
+  });
+
+  it("passes resolved provider model shape into plugin support checks", () => {
+    const supports = vi.fn(() => ({
+      supported: false as const,
+      reason: "unsupported test provider",
+    }));
+    const config = {
+      models: {
+        providers: {
+          "custom-proxy": {
+            api: "openai-completions",
+            baseUrl: "https://provider.example/v1",
+            request: { auth: { mode: "provider-default" as const } },
+            agentRuntime: { id: "copilot" },
+            models: [
+              {
+                id: "gpt-test",
+                name: "GPT Test",
+                api: "openai-responses",
+                baseUrl: "https://model.example/v1",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 8_192,
+                maxTokens: 1_024,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    registerAgentHarness({
+      id: "copilot",
+      label: "Copilot",
+      supports,
+      runAttempt: vi.fn(async () => createAttemptResult("copilot")),
+    });
+
+    expect(() =>
+      selectAgentHarness({
+        provider: "custom-proxy",
+        modelId: "gpt-test",
+        config,
+        agentHarnessRuntimeOverride: "copilot",
+      }),
+    ).toThrow("unsupported test provider");
+
+    expect(supports).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "custom-proxy",
+        modelId: "gpt-test",
+        modelProvider: expect.objectContaining({
+          api: "openai-responses",
+          baseUrl: "https://model.example/v1",
+          request: { auth: { mode: "provider-default" } },
+        }),
+      }),
+    );
+  });
+
   it("honors explicit OpenClaw runtime overrides when selecting a harness", async () => {
     registerSuccessfulCodexHarness();
 
@@ -649,6 +793,7 @@ describe("selectAgentHarness", () => {
     });
 
     expect(harness.id).toBe("openclaw");
+    expect(providerOwnerMocks.resolveProviderRefOwnership).not.toHaveBeenCalled();
 
     const result = await runAgentHarnessAttempt({
       ...createAttemptParams(),
@@ -833,6 +978,7 @@ describe("selectAgentHarness", () => {
         workspaceDir: "/tmp/workspace",
         provider: "openai",
         model: "gpt-5.5",
+        authProfileId: "main-profile",
         agentHarnessId: "codex",
         config: {
           agents: {
@@ -850,6 +996,11 @@ describe("selectAgentHarness", () => {
     expect(compact.mock.calls[0]?.[0]).toMatchObject({
       agentDir: "/tmp/main-agent",
       agentId: "main",
+      resolvedApiKey: "test-key",
+      runtimeModel: {
+        id: "gpt-5.5",
+        provider: "openai",
+      },
     });
   });
 
@@ -987,6 +1138,118 @@ describe("selectAgentHarness", () => {
       expect.objectContaining({
         authProfileId: "deleted-profile",
         workspaceDir: "/tmp/workspace",
+      }),
+    );
+  });
+
+  it("preserves resolved compaction credentials when model lookup fails", async () => {
+    compactAuthMocks.resolveModelAsync.mockRejectedValue(new Error("model lookup unavailable"));
+    const compact = vi.fn<NonNullable<AgentHarness["compact"]>>(async () => ({
+      ok: true,
+      compacted: false,
+    }));
+    registerAgentHarness(
+      {
+        id: "copilot",
+        label: "Copilot",
+        supports: (ctx) =>
+          ctx.provider === "local-proxy"
+            ? { supported: true, priority: 100 }
+            : { supported: false },
+        runAttempt: vi.fn(async () => createAttemptResult("copilot")),
+        compact,
+      },
+      { ownerPluginId: "copilot" },
+    );
+
+    await expect(
+      maybeCompactAgentHarnessSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        provider: "local-proxy",
+        model: "proxy-model",
+        resolvedApiKey: "already-resolved",
+        agentHarnessId: "copilot",
+      }),
+    ).resolves.toEqual({ ok: true, compacted: false });
+
+    expect(compactAuthMocks.getApiKeyForModel).not.toHaveBeenCalled();
+    expect(compact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resolvedApiKey: "already-resolved",
+      }),
+    );
+  });
+
+  it("passes runtime model and default credentials to compaction when auth profile id is absent", async () => {
+    compactAuthMocks.resolveModelAsync.mockResolvedValue({
+      model: {
+        id: "proxy-model",
+        provider: "local-proxy",
+        api: "openai-responses",
+        baseUrl: "https://proxy.example/v1",
+      },
+    });
+    const compact = vi.fn<NonNullable<AgentHarness["compact"]>>(async () => ({
+      ok: true,
+      compacted: false,
+    }));
+    registerAgentHarness(
+      {
+        id: "copilot",
+        label: "Copilot",
+        supports: (ctx) =>
+          ctx.provider === "local-proxy"
+            ? { supported: true, priority: 100 }
+            : { supported: false },
+        runAttempt: vi.fn(async () => createAttemptResult("copilot")),
+        compact,
+      },
+      { ownerPluginId: "copilot" },
+    );
+
+    await expect(
+      maybeCompactAgentHarnessSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        provider: "local-proxy",
+        model: "proxy-model",
+        agentHarnessId: "copilot",
+      }),
+    ).resolves.toEqual({ ok: true, compacted: false });
+
+    expect(compactAuthMocks.resolveModelAsync).toHaveBeenCalledWith(
+      "local-proxy",
+      "proxy-model",
+      expect.any(String),
+      undefined,
+      expect.objectContaining({
+        authProfileId: undefined,
+        workspaceDir: "/tmp/workspace",
+      }),
+    );
+    expect(compactAuthMocks.getApiKeyForModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDir: expect.any(String),
+        model: expect.objectContaining({
+          baseUrl: "https://proxy.example/v1",
+          id: "proxy-model",
+        }),
+        profileId: undefined,
+        workspaceDir: "/tmp/workspace",
+      }),
+    );
+    expect(compact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resolvedApiKey: "test-key",
+        runtimeModel: expect.objectContaining({
+          baseUrl: "https://proxy.example/v1",
+          id: "proxy-model",
+        }),
       }),
     );
   });

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -1,3 +1,4 @@
+import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 /**
  * Selects and invokes native agent harnesses for embedded run attempts.
  */
@@ -11,6 +12,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveProviderRefOwnership } from "../../plugins/providers.js";
 import { isDefaultAgentRuntimeId, normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
 import {
   resolveEffectiveToolPolicy,
@@ -43,7 +45,7 @@ import {
   type AgentHarnessPolicy,
 } from "./policy.js";
 import { getRegisteredAgentHarness, listRegisteredAgentHarnesses } from "./registry.js";
-import type { AgentHarness, AgentHarnessSupport } from "./types.js";
+import type { AgentHarness, AgentHarnessSupport, AgentHarnessSupportContext } from "./types.js";
 
 const log = createSubsystemLogger("agents/harness");
 export { resolveAgentHarnessPolicy } from "./policy.js";
@@ -153,6 +155,56 @@ function compareHarnessSupport(
   return left.harness.id.localeCompare(right.harness.id);
 }
 
+function buildAgentHarnessSupportContext(params: {
+  provider: string;
+  modelId?: string;
+  requestedRuntime: AgentHarnessSupportContext["requestedRuntime"];
+  config?: OpenClawConfig;
+}): AgentHarnessSupportContext {
+  const providerOwnership = resolveProviderRefOwnership({
+    provider: params.provider,
+    config: params.config,
+  });
+  return {
+    provider: params.provider,
+    modelId: params.modelId,
+    modelProvider: buildAgentHarnessSupportModelProvider(params),
+    requestedRuntime: params.requestedRuntime,
+    providerOwnerStatus: providerOwnership.status,
+    providerOwnerPluginIds:
+      providerOwnership.status === "unowned" ? [] : providerOwnership.pluginIds,
+  };
+}
+
+function buildAgentHarnessSupportModelProvider(params: {
+  provider: string;
+  modelId?: string;
+  config?: OpenClawConfig;
+}): AgentHarnessSupportContext["modelProvider"] {
+  const providerConfig = findNormalizedProviderValue(
+    params.config?.models?.providers,
+    params.provider,
+  );
+  if (!providerConfig) {
+    return undefined;
+  }
+  const modelConfig = params.modelId
+    ? providerConfig.models?.find((entry) => entry.id === params.modelId)
+    : undefined;
+  return {
+    api: modelConfig?.api ?? providerConfig.api ?? "openai-responses",
+    baseUrl: modelConfig?.baseUrl ?? providerConfig.baseUrl,
+    azureApiVersion: readStringParam(
+      modelConfig?.params?.azureApiVersion ?? providerConfig.params?.azureApiVersion,
+    ),
+    request: providerConfig.request,
+  };
+}
+
+function readStringParam(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 export function selectAgentHarness(params: {
   provider: string;
   modelId?: string;
@@ -200,11 +252,13 @@ function selectAgentHarnessDecision(params: {
   if (runtime !== "auto") {
     const forced = pluginHarnesses.find((entry) => entry.id === runtime);
     if (forced) {
-      const support = forced.supports({
+      const supportContext = buildAgentHarnessSupportContext({
         provider: params.provider,
         modelId: params.modelId,
         requestedRuntime: runtime,
+        config: params.config,
       });
+      const support = forced.supports(supportContext);
       if (support.supported) {
         return buildSelectionDecision({
           harness: forced,
@@ -261,14 +315,21 @@ function selectAgentHarnessDecision(params: {
     throw new MissingAgentHarnessError(runtime);
   }
 
-  const candidates = pluginHarnesses.map((harness) => ({
-    harness,
-    support: harness.supports({
-      provider: params.provider,
-      modelId: params.modelId,
-      requestedRuntime: runtime,
-    }),
-  }));
+  const candidates =
+    pluginHarnesses.length > 0
+      ? (() => {
+          const supportContext = buildAgentHarnessSupportContext({
+            provider: params.provider,
+            modelId: params.modelId,
+            requestedRuntime: runtime,
+            config: params.config,
+          });
+          return pluginHarnesses.map((harness) => ({
+            harness,
+            support: harness.supports(supportContext),
+          }));
+        })()
+      : [];
   const supported = candidates
     .filter(
       (

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -4,7 +4,20 @@
 export type AgentHarnessSupportContext = {
   provider: string;
   modelId?: string;
+  modelProvider?: {
+    api?: string;
+    baseUrl?: string;
+    azureApiVersion?: string;
+    request?: {
+      auth?: { mode?: unknown };
+      proxy?: unknown;
+      tls?: unknown;
+      allowPrivateNetwork?: unknown;
+    };
+  };
   requestedRuntime: import("../agent-runtime-id.js").EmbeddedAgentRuntime;
+  providerOwnerStatus?: "unowned" | "owned" | "ambiguous";
+  providerOwnerPluginIds?: readonly string[];
 };
 
 export type AgentHarnessSupport =

--- a/src/plugin-sdk/agent-harness-runtime.test.ts
+++ b/src/plugin-sdk/agent-harness-runtime.test.ts
@@ -3,10 +3,12 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  attachModelProviderRequestTransport,
   buildAgentHarnessUserInputAnswers,
   classifyAgentHarnessTerminalOutcome,
   deliverAgentHarnessUserInputPrompt,
   formatAgentHarnessUserInputPrompt,
+  getModelProviderRequestTransport,
   type AgentHarnessTerminalOutcomeClassification,
 } from "./agent-harness-runtime.js";
 
@@ -153,6 +155,17 @@ describe("agent harness runtime SDK facade", () => {
     await import("./agent-harness-runtime.js");
 
     expect(loadResearchAutocapture).not.toHaveBeenCalled();
+  });
+
+  it("exposes attached model request transport metadata helpers", () => {
+    const model = attachModelProviderRequestTransport(
+      { id: "gpt-test", provider: "custom-openai" },
+      { auth: { mode: "header", headerName: "x-api-key", value: "secret" } },
+    );
+
+    expect(getModelProviderRequestTransport(model)).toEqual({
+      auth: { mode: "header", headerName: "x-api-key", value: "secret" },
+    });
   });
 });
 

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -177,6 +177,10 @@ export {
 } from "../agents/embedded-agent-runner/run/attempt-tool-construction-plan.js";
 export { getPluginToolMeta } from "../plugins/tools.js";
 export {
+  attachModelProviderRequestTransport,
+  getModelProviderRequestTransport,
+} from "../agents/provider-request-config.js";
+export {
   abortAndDrainEmbeddedAgentRun as abortAndDrainAgentHarnessRun,
   abortEmbeddedAgentRun as abortAgentHarnessRun,
   clearActiveEmbeddedRun,

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -37,6 +37,7 @@ const applyPluginAutoEnableMock = vi.fn<ApplyPluginAutoEnable>();
 let resolveOwningPluginIdsForProvider: typeof import("./providers.js").resolveOwningPluginIdsForProvider;
 let resolveOwningPluginIdsForProviderRef: typeof import("./providers.js").resolveOwningPluginIdsForProviderRef;
 let resolveOwningPluginIdsForModelRef: typeof import("./providers.js").resolveOwningPluginIdsForModelRef;
+let resolveProviderRefOwnership: typeof import("./providers.js").resolveProviderRefOwnership;
 let resolveActivatableProviderOwnerPluginIds: typeof import("./providers.js").resolveActivatableProviderOwnerPluginIds;
 let resolveEnabledProviderPluginIds: typeof import("./providers.js").resolveEnabledProviderPluginIds;
 let resolveCatalogHookProviderPluginIds: typeof import("./providers.js").resolveCatalogHookProviderPluginIds;
@@ -520,6 +521,7 @@ describe("resolvePluginProviders", () => {
       resolveOwningPluginIdsForProvider,
       resolveOwningPluginIdsForProviderRef,
       resolveOwningPluginIdsForModelRef,
+      resolveProviderRefOwnership,
       resolveEnabledProviderPluginIds,
       resolveCatalogHookProviderPluginIds,
       resolveExternalAuthProfileCompatFallbackPluginIds,
@@ -557,6 +559,32 @@ describe("resolvePluginProviders", () => {
     setOwningProviderManifestPlugins();
 
     expect(resolveOwningPluginIdsForProviderRef({ provider: "claude-cli" })).toEqual(["anthropic"]);
+    expect(resolveProviderRefOwnership({ provider: "claude-cli" })).toEqual({
+      status: "owned",
+      pluginIds: ["anthropic"],
+    });
+  });
+
+  it("marks explicit provider refs with multiple owners as ambiguous", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "first-owner",
+        providerIds: [],
+        cliBackends: ["shared-cli"],
+        origin: "workspace",
+      }),
+      createManifestProviderPlugin({
+        id: "second-owner",
+        providerIds: [],
+        cliBackends: ["shared-cli"],
+        origin: "workspace",
+      }),
+    ]);
+
+    expect(resolveProviderRefOwnership({ provider: "shared-cli" })).toEqual({
+      status: "ambiguous",
+      pluginIds: ["first-owner", "second-owner"],
+    });
   });
 
   it("maps explicit cli-backend model refs to owning plugin ids", () => {

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -37,6 +37,10 @@ type NormalizedPluginsConfig = ReturnType<typeof normalizePluginsConfigWithRegis
 type ProviderRegistryLoadParams = ProviderManifestLoadParams & {
   onlyPluginIds?: readonly string[];
 };
+export type ProviderRefOwnership =
+  | { status: "unowned" }
+  | { status: "owned"; pluginIds: string[] }
+  | { status: "ambiguous"; pluginIds: string[] };
 
 function loadProviderRegistrySnapshot(params: ProviderManifestLoadParams): PluginRegistrySnapshot {
   if (params.registry) {
@@ -518,6 +522,16 @@ function dedupeSortedPluginIds(values: Iterable<string>): string[] {
   return sortUniqueStrings(values);
 }
 
+function classifyProviderRefOwnership(pluginIds: string[] | undefined): ProviderRefOwnership {
+  if (!pluginIds || pluginIds.length === 0) {
+    return { status: "unowned" };
+  }
+  if (pluginIds.length === 1) {
+    return { status: "owned", pluginIds };
+  }
+  return { status: "ambiguous", pluginIds };
+}
+
 function listNormalizedOwnerMapPluginIds(
   owners: ReadonlyMap<string, readonly string[]>,
   normalizedId: string,
@@ -699,6 +713,31 @@ export function resolveOwningPluginIdsForProviderRef(params: {
       manifestRegistry: params.manifestRegistry,
       metadataSnapshot: params.metadataSnapshot,
     })
+  );
+}
+
+export function resolveProviderRefOwnership(params: {
+  provider: string;
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+  manifestRegistry?: PluginManifestRegistry;
+  metadataSnapshot?: Pick<PluginMetadataSnapshot, "owners" | "manifestRegistry" | "byPluginId">;
+}): ProviderRefOwnership {
+  const providerOwnerIds = resolveOwningPluginIdsForProvider(params);
+  const providerOwnership = classifyProviderRefOwnership(providerOwnerIds);
+  if (providerOwnership.status !== "unowned") {
+    return providerOwnership;
+  }
+  return classifyProviderRefOwnership(
+    resolveOwningPluginIdsForCliBackend({
+      backend: params.provider,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      manifestRegistry: params.manifestRegistry,
+      metadataSnapshot: params.metadataSnapshot,
+    }),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Copilot was still behind the Codex harness path for BYOK and runtime-session parity: custom provider routing could not safely use the Copilot SDK session-level provider contract, native compaction did not carry the resolved runtime model/API key consistently, and harness selection could not distinguish unowned custom providers from provider ids owned by another plugin/runtime.

## Why This Change Was Made

- Adds a generic provider-ownership signal for harness selection so plugin harnesses can claim only the custom provider ids they can actually own.
- Adds a plugin-SDK request transport seam and native compaction runtime-model plumbing so BYOK/native paths share the same resolved model/auth contract.
- Adds Copilot BYOK provider mapping and a loopback proxy that keeps SDK-local traffic local while outbound provider traffic stays behind OpenClaw guarded fetch.
- Keeps unsafe transport shapes out of Copilot BYOK: no provider proxy/TLS/private-network overrides, HTTPS-only provider endpoints, no URL userinfo, no credential-bearing query params, SSRF-blocked hosts rejected, and guarded fetch enforces HTTPS across redirects.
- Updates the plugin SDK surface budget for the new public harness runtime helpers.

## User Impact

Copilot can now run explicit `agentRuntime.id: "copilot"` custom BYOK provider entries for supported OpenAI-compatible, Azure OpenAI Responses, Ollama-compatible completions, and Anthropic Messages shapes. Native provider ids such as `openai`, `anthropic`, `google`, and `ollama` remain owned by their native runtimes; Copilot only claims unowned custom provider ids.

Compaction and session reuse are keyed against the actual runtime model, endpoint, headers, credential fingerprint, and token limits, so rotated BYOK configuration gets a fresh Copilot SDK session instead of reusing an incompatible one.

## Evidence

- Live Copilot smoke: `OPENCLAW_LIVE_TEST=1 OPENCLAW_COPILOT_AGENT_LIVE_TEST=1 ... attempt.live.test.ts` passed earlier in this branch with the local GitHub token path.
- Focused Testbox-through-Crabbox proof: `tbx_01kvwhn813hxy2q7b3ef3fkfvq`, GitHub Actions run `28091101470`, passed `node scripts/run-vitest.mjs extensions/copilot/src/provider-bridge.test.ts extensions/copilot/src/byok-proxy.test.ts extensions/copilot/harness.test.ts src/agents/harness/selection.test.ts src/plugins/providers.test.ts src/plugin-sdk/agent-harness-runtime.test.ts test/scripts/plugin-sdk-surface-report.test.ts`.
- Same Testbox run passed `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.
- Structured autoreview on `76595ab5f9` returned clean: no accepted/actionable findings.
- `scripts/pr prepare-run 96345` reached full local `pnpm test`; broad local suite exposed unrelated baseline failures plus the now-fixed plugin SDK surface-budget drift. The focused surface test above validates the PR-owned fix.
