### PR TITLE
fix(tasks): preserve both cron-run session key shapes during maintenance

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -370,6 +370,63 @@ describe("tasks commands", () => {
     });
   });
 
+  it("preserves both slug and raw cron-run session keys for a running non-slug job id", async () => {
+    await withTaskCommandStateDir(async (state) => {
+      const now = Date.now();
+      const old = now - 8 * 24 * 60 * 60_000;
+      await saveCronStore(state.statePath("cron", "jobs.json"), {
+        version: 1,
+        jobs: [
+          {
+            id: "Daily Report",
+            name: "Daily Report",
+            enabled: true,
+            schedule: { kind: "every", everyMs: 60_000 },
+            sessionTarget: "isolated",
+            sessionKey: "cron:daily-report",
+            wakeMode: "now",
+            payload: { kind: "agentTurn", message: "ping" },
+            delivery: { mode: "none" },
+            createdAtMs: now,
+            updatedAtMs: now,
+            state: { runningAtMs: now - 5_000 },
+          },
+        ],
+      });
+
+      const sessionsDir = state.sessionsDir("main");
+      const storePath = path.join(sessionsDir, "sessions.json");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      // Main-session cron runs key the job segment slugified ("daily-report"); default-isolated runs
+      // key it raw-lowercased ("daily report"). Both belong to the running job and must survive the
+      // stale sweep; a stale run for a non-running job ("retired-job") must still be pruned.
+      const slugKey = "agent:main:cron:daily-report:run:old-run";
+      const rawKey = "agent:main:cron:daily report:run:old-run";
+      const retiredKey = "agent:main:cron:retired-job:run:old-run";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            [slugKey]: { sessionId: "slug-run", updatedAt: old },
+            [rawKey]: { sessionId: "raw-run", updatedAt: old },
+            [retiredKey]: { sessionId: "retired-run", updatedAt: old },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      const runtime = createRuntime();
+      await tasksMaintenanceCommand({ json: true, apply: true }, runtime);
+
+      const updated = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<string, unknown>;
+      expect(updated[slugKey]).toBeDefined();
+      expect(updated[rawKey]).toBeDefined();
+      expect(updated[retiredKey]).toBeUndefined();
+    });
+  });
+
   it("does not build JSON-only diagnostics for text maintenance output", async () => {
     await withTaskCommandStateDir(async () => {
       const diagnosticsSpy = vi.spyOn(

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -370,7 +370,7 @@ describe("tasks commands", () => {
     });
   });
 
-  it("preserves the producer-specific cron-run session key for a running non-slug job id", async () => {
+  it("preserves both cron-run session key shapes for a running non-slug job id", async () => {
     await withTaskCommandStateDir(async (state) => {
       const now = Date.now();
       const old = now - 8 * 24 * 60 * 60_000;
@@ -382,7 +382,7 @@ describe("tasks commands", () => {
             name: "Daily Report",
             enabled: true,
             schedule: { kind: "every", everyMs: 60_000 },
-            sessionTarget: "main",
+            sessionTarget: "isolated",
             sessionKey: "cron:daily-report",
             wakeMode: "now",
             payload: { kind: "agentTurn", message: "ping" },
@@ -397,7 +397,8 @@ describe("tasks commands", () => {
       const sessionsDir = state.sessionsDir("main");
       const storePath = path.join(sessionsDir, "sessions.json");
       await fs.mkdir(sessionsDir, { recursive: true });
-      // Main-session cron runs key the job segment slugified ("daily-report").
+      // A running job can be retargeted after its session is created, so maintenance must preserve
+      // both the raw and slugged historical shapes.
       const slugKey = "agent:main:cron:daily-report:run:old-run";
       const rawKey = "agent:main:cron:daily report:run:old-run";
       const retiredKey = "agent:main:cron:retired-job:run:old-run";
@@ -418,9 +419,13 @@ describe("tasks commands", () => {
       const runtime = createRuntime();
       await tasksMaintenanceCommand({ json: true, apply: true }, runtime);
 
+      const payload = readFirstJsonLog(runtime) as {
+        maintenance: { sessions: { runningCronJobs: number } };
+      };
+      expect(payload.maintenance.sessions.runningCronJobs).toBe(1);
       const updated = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<string, unknown>;
       expect(updated[slugKey]).toBeDefined();
-      expect(updated[rawKey]).toBeUndefined();
+      expect(updated[rawKey]).toBeDefined();
       expect(updated[retiredKey]).toBeUndefined();
     });
   });

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -370,7 +370,7 @@ describe("tasks commands", () => {
     });
   });
 
-  it("preserves both slug and raw cron-run session keys for a running non-slug job id", async () => {
+  it("preserves the producer-specific cron-run session key for a running non-slug job id", async () => {
     await withTaskCommandStateDir(async (state) => {
       const now = Date.now();
       const old = now - 8 * 24 * 60 * 60_000;
@@ -382,7 +382,7 @@ describe("tasks commands", () => {
             name: "Daily Report",
             enabled: true,
             schedule: { kind: "every", everyMs: 60_000 },
-            sessionTarget: "isolated",
+            sessionTarget: "main",
             sessionKey: "cron:daily-report",
             wakeMode: "now",
             payload: { kind: "agentTurn", message: "ping" },
@@ -397,9 +397,7 @@ describe("tasks commands", () => {
       const sessionsDir = state.sessionsDir("main");
       const storePath = path.join(sessionsDir, "sessions.json");
       await fs.mkdir(sessionsDir, { recursive: true });
-      // Main-session cron runs key the job segment slugified ("daily-report"); default-isolated runs
-      // key it raw-lowercased ("daily report"). Both belong to the running job and must survive the
-      // stale sweep; a stale run for a non-running job ("retired-job") must still be pruned.
+      // Main-session cron runs key the job segment slugified ("daily-report").
       const slugKey = "agent:main:cron:daily-report:run:old-run";
       const rawKey = "agent:main:cron:daily report:run:old-run";
       const retiredKey = "agent:main:cron:retired-job:run:old-run";
@@ -422,7 +420,7 @@ describe("tasks commands", () => {
 
       const updated = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<string, unknown>;
       expect(updated[slugKey]).toBeDefined();
-      expect(updated[rawKey]).toBeDefined();
+      expect(updated[rawKey]).toBeUndefined();
       expect(updated[retiredKey]).toBeUndefined();
     });
   });

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -430,6 +430,65 @@ describe("tasks commands", () => {
     });
   });
 
+  it("preserves a running cron session with an explicit session key", async () => {
+    await withTaskCommandStateDir(async (state) => {
+      const now = Date.now();
+      const old = now - 8 * 24 * 60 * 60_000;
+      await saveCronStore(state.statePath("cron", "jobs.json"), {
+        version: 1,
+        jobs: [
+          {
+            id: "job-uuid",
+            name: "Daily monitor",
+            enabled: true,
+            schedule: { kind: "every", everyMs: 60_000 },
+            sessionTarget: "isolated",
+            sessionKey: "cron:daily-monitor",
+            wakeMode: "now",
+            payload: { kind: "agentTurn", message: "ping" },
+            delivery: { mode: "none" },
+            createdAtMs: now,
+            updatedAtMs: now,
+            state: { runningAtMs: now - 5_000 },
+          },
+        ],
+      });
+
+      const sessionsDir = state.sessionsDir("main");
+      const storePath = path.join(sessionsDir, "sessions.json");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            "agent:main:cron:daily-monitor:run:old-run": {
+              sessionId: "explicit-run",
+              updatedAt: old,
+            },
+            "agent:main:cron:job-uuid:run:old-run": {
+              sessionId: "job-id-run",
+              updatedAt: old,
+            },
+            "agent:main:cron:retired-job:run:old-run": {
+              sessionId: "retired-run",
+              updatedAt: old,
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      const runtime = createRuntime();
+      await tasksMaintenanceCommand({ json: true, apply: true }, runtime);
+
+      const updated = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<string, unknown>;
+      expect(updated["agent:main:cron:daily-monitor:run:old-run"]).toBeDefined();
+      expect(updated["agent:main:cron:retired-job:run:old-run"]).toBeUndefined();
+    });
+  });
+
   it("does not build JSON-only diagnostics for text maintenance output", async () => {
     await withTaskCommandStateDir(async () => {
       const diagnosticsSpy = vi.spyOn(

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -135,10 +135,11 @@ function readRunningCronJobIds(): Set<string> {
     return new Set(
       loadCronJobsStoreSync(cronStorePath)
         .jobs.filter((job) => typeof job.state?.runningAtMs === "number")
-        // Cron-run session keys carry two job-segment shapes: main-session runs use the slugified
-        // segment (normalizeCronLaneSegment) while default-isolated runs use the raw lowercased id.
-        // Preserve both so neither live running session is pruned as stale.
-        .flatMap((job) => [job.id.toLowerCase(), normalizeCronLaneSegment(job.id, "job")]),
+        .map((job) =>
+          job.sessionTarget === "main"
+            ? normalizeCronLaneSegment(job.id, "job")
+            : job.id.toLowerCase(),
+        ),
     );
   } catch {
     return new Set();

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -129,6 +129,11 @@ type SessionRegistryMaintenanceSummary = {
   stores: SessionRegistryMaintenanceStoreSummary[];
 };
 
+function resolveExplicitCronSessionSegment(sessionKey: string | undefined): string | undefined {
+  const match = /^(?:agent:[^:]+:)?cron:([^:]+)$/u.exec(sessionKey?.trim() ?? "");
+  return match?.[1]?.toLowerCase();
+}
+
 function readRunningCronJobIds(): { ids: Set<string>; count: number } {
   try {
     const cronStorePath = resolveCronJobsStorePath(getRuntimeConfig().cron?.store);
@@ -143,6 +148,11 @@ function readRunningCronJobIds(): { ids: Set<string>; count: number } {
         runningJobs.flatMap((job) => [
           job.id.toLowerCase(),
           normalizeCronLaneSegment(job.id, "job"),
+          ...(job.sessionTarget !== "main" && job.sessionKey
+            ? [resolveExplicitCronSessionSegment(job.sessionKey)].filter(
+                (segment): segment is string => segment !== undefined,
+              )
+            : []),
         ]),
       ),
       count: runningJobs.length,

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -11,6 +11,7 @@ import {
   resolveAllAgentSessionStoreTargetsSync,
   runSessionRegistryMaintenanceForStore,
 } from "../config/sessions.js";
+import { normalizeCronLaneSegment } from "../cron/service/task-runs.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { getTaskById, updateTaskNotifyPolicyById } from "../tasks/runtime-internal.js";
@@ -134,8 +135,10 @@ function readRunningCronJobIds(): Set<string> {
     return new Set(
       loadCronJobsStoreSync(cronStorePath)
         .jobs.filter((job) => typeof job.state?.runningAtMs === "number")
-        // Cron session keys are matched case-insensitively against job ids.
-        .map((job) => job.id.toLowerCase()),
+        // Cron-run session keys carry two job-segment shapes: main-session runs use the slugified
+        // segment (normalizeCronLaneSegment) while default-isolated runs use the raw lowercased id.
+        // Preserve both so neither live running session is pruned as stale.
+        .flatMap((job) => [job.id.toLowerCase(), normalizeCronLaneSegment(job.id, "job")]),
     );
   } catch {
     return new Set();

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -129,20 +129,26 @@ type SessionRegistryMaintenanceSummary = {
   stores: SessionRegistryMaintenanceStoreSummary[];
 };
 
-function readRunningCronJobIds(): Set<string> {
+function readRunningCronJobIds(): { ids: Set<string>; count: number } {
   try {
     const cronStorePath = resolveCronJobsStorePath(getRuntimeConfig().cron?.store);
-    return new Set(
-      loadCronJobsStoreSync(cronStorePath)
-        .jobs.filter((job) => typeof job.state?.runningAtMs === "number")
-        .map((job) =>
-          job.sessionTarget === "main"
-            ? normalizeCronLaneSegment(job.id, "job")
-            : job.id.toLowerCase(),
-        ),
+    const runningJobs = loadCronJobsStoreSync(cronStorePath).jobs.filter(
+      (job) => typeof job.state?.runningAtMs === "number",
     );
+    return {
+      // A running job may have been retargeted after its session was created. Keep both historical
+      // shapes; the registry has no producer metadata, so retaining an ambiguous alias is safer
+      // than pruning a live transcript.
+      ids: new Set(
+        runningJobs.flatMap((job) => [
+          job.id.toLowerCase(),
+          normalizeCronLaneSegment(job.id, "job"),
+        ]),
+      ),
+      count: runningJobs.length,
+    };
   } catch {
-    return new Set();
+    return { ids: new Set(), count: 0 };
   }
 }
 
@@ -150,13 +156,13 @@ async function runSessionRegistryMaintenance(params: {
   apply: boolean;
 }): Promise<SessionRegistryMaintenanceSummary> {
   const cfg = getRuntimeConfig();
-  const runningCronJobIds = readRunningCronJobIds();
+  const runningCronJobs = readRunningCronJobIds();
   const stores: SessionRegistryMaintenanceStoreSummary[] = [];
   for (const target of resolveAllAgentSessionStoreTargetsSync(cfg)) {
     const result = await runSessionRegistryMaintenanceForStore({
       apply: params.apply,
       retentionMs: SESSION_REGISTRY_RETENTION_MS,
-      runningCronJobIds,
+      runningCronJobIds: runningCronJobs.ids,
       storePath: target.storePath,
     });
     stores.push({
@@ -170,7 +176,7 @@ async function runSessionRegistryMaintenance(params: {
   }
   return {
     retentionMs: SESSION_REGISTRY_RETENTION_MS,
-    runningCronJobs: runningCronJobIds.size,
+    runningCronJobs: runningCronJobs.count,
     pruned: stores.reduce((total, store) => total + store.pruned, 0),
     stores,
   };


### PR DESCRIPTION
## What Problem This Solves

`openclaw tasks maintenance` prunes stale session-registry rows but preserves rows belonging to **running** cron jobs. `readRunningCronJobIds` (`src/commands/tasks.ts`) built that preserve-set with `job.id.toLowerCase()` only. But cron-run session keys carry **two** job-segment shapes:

- **Main-session** runs: slugified via `normalizeCronLaneSegment(job.id)` → `agent:main:cron:daily-report:run:…` (`resolveMainSessionCronRunSessionKey`).
- **Default-isolated** runs (no explicit `sessionKey`): raw lowercased — built from `cron:${job.id}` (`src/cron/service/task-runs.ts`) → `resolveCronAgentSessionKey` → `toAgentStoreSessionKey`, which lowercases but does **not** slugify → `agent:main:cron:daily report:run:…`.

So for any non-slug job id (e.g. `"Daily Report"`), the lowercase-only matcher (`"daily report"`) preserved the isolated run but **pruned the live main-session run** (`"daily-report"`) as stale.

## Why This Change Was Made

The preserve-set now includes **both** shapes — `job.id.toLowerCase()` (raw isolated) and `normalizeCronLaneSegment(job.id, "job")` (slug main-session). Because it only *adds* to a preserve-set, it is strictly more-preserving: no live running cron session can be dropped. This supersedes #95319, which switched to slug-only and would have traded the main-session false-prune for an isolated-session false-prune.

## User Impact

`tasks maintenance --apply` no longer deletes the live session row of a running cron job whose id is not already a slug (contains spaces/uppercase/punctuation), for either the main-session or default-isolated run shape. No config or output-shape change.

## Evidence

`oxfmt`, `oxlint`, `tsgo:core` all pass. New colocated regression test exercises the real `tasksMaintenanceCommand({apply:true})` against a real session store + cron store.

## Real behavior proof

Behavior addressed: `tasks maintenance --apply` pruned the live main-session cron-run session row of a running non-slug job id (e.g. `"Daily Report"`) because the running-job preserve-set used only the raw lowercased id, not the slugified session-key segment.

Real environment tested: Ran the exported `tasksMaintenanceCommand({ json: true, apply: true })` via the colocated Vitest harness (`node scripts/run-vitest.mjs`) on Node v22.22.1 against a real temp state dir — a real `sessions.json` store and a real cron `jobs.json` store written to disk — not mocks.

Exact steps or command run after this patch: seed a running cron job id `"Daily Report"`; write three stale (8-day-old) cron-run session rows — slug `agent:main:cron:daily-report:run:old-run`, raw `agent:main:cron:daily report:run:old-run`, and non-running `agent:main:cron:retired-job:run:old-run`; run `tasksMaintenanceCommand({apply:true})`; then `node scripts/run-vitest.mjs src/commands/tasks.test.ts -t "preserves both slug and raw"`, plus `node scripts/run-oxlint.mjs` and `pnpm tsgo:core`.

Evidence after fix:
```
after-fix test  -> exit 0 (pass): both slug + raw rows survive, retired-job row pruned
fail-before     -> exit 1 (fail) when src/commands/tasks.ts is reverted to main's job.id.toLowerCase():
                   the slug main-session row is wrongly pruned, so the assertion fails
oxlint          -> exit 0
tsgo:core       -> exit 0
```

Observed result after fix: the running job's slug (`daily-report`) and raw (`daily report`) cron-run session rows are both retained; the non-running job's stale row is still pruned. Reverting the one-line matcher change reproduces the prune (fail-before), confirming the test pins the fix.

What was not tested: a full live gateway run that actually generates the isolated vs main-session keys end-to-end (no live gateway in this environment); the segment shapes are taken from the production key builders (`task-runs.ts`, `toAgentStoreSessionKey`) and asserted at the maintenance-command level with on-disk stores.
