### PR TITLE
fix(harness): run agent_turn_prepare and drain queued injections on harness prompt builds

### DIFF
--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -4,7 +4,10 @@ import {
   resetGlobalHookRunner,
 } from "../../plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../../plugins/hooks.test-helpers.js";
-import { resolveAgentHarnessBeforePromptBuildResult } from "./prompt-compaction-hook-helpers.js";
+import {
+  forgetHarnessPromptBuildDrainCacheForRun,
+  resolveAgentHarnessBeforePromptBuildResult,
+} from "./prompt-compaction-hook-helpers.js";
 
 afterEach(() => {
   resetGlobalHookRunner();
@@ -146,5 +149,82 @@ describe("resolveAgentHarnessBeforePromptBuildResult", () => {
 
     expect(handler).not.toHaveBeenCalled();
     expect(result.prompt).toBe("hello");
+  });
+
+  it("runs agent_turn_prepare hook and prepends its contribution", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "agent_turn_prepare",
+          handler: () => ({ prependContext: "prepare context" }),
+        },
+      ]),
+    );
+
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "test",
+      developerInstructions: "base",
+      messages: [],
+      ctx: { agentId: "a", sessionKey: "s" },
+    });
+
+    expect(result.prompt).toBe("prepare context\n\ntest");
+  });
+
+  it("runs agent_turn_prepare before heartbeat contributions in hook ordering", async () => {
+    const calls: string[] = [];
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "agent_turn_prepare",
+          handler: () => {
+            calls.push("agent_turn_prepare");
+            return { prependContext: "prepare" };
+          },
+        },
+        {
+          hookName: "heartbeat_prompt_contribution",
+          handler: () => {
+            calls.push("heartbeat");
+            return { prependContext: "heartbeat" };
+          },
+        },
+      ]),
+    );
+
+    await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "test",
+      developerInstructions: "base",
+      messages: [],
+      ctx: { trigger: "heartbeat", agentId: "a", sessionKey: "s" },
+    });
+
+    expect(calls).toEqual(["agent_turn_prepare", "heartbeat"]);
+  });
+
+  it("skips agent_turn_prepare when no hooks are registered", async () => {
+    const handler = vi.fn(() => ({ prependContext: "should not appear" }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_prompt_build", handler }]),
+    );
+
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "test",
+      developerInstructions: "base",
+      messages: [],
+      ctx: { agentId: "a", sessionKey: "s" },
+    });
+
+    expect(result.prompt).toBe("should not appear\n\ntest");
+  });
+});
+
+describe("forgetHarnessPromptBuildDrainCacheForRun", () => {
+  it("is a no-op when runId is undefined", () => {
+    expect(() => forgetHarnessPromptBuildDrainCacheForRun(undefined)).not.toThrow();
+  });
+
+  it("is a no-op when runId is an empty string", () => {
+    expect(() => forgetHarnessPromptBuildDrainCacheForRun("")).not.toThrow();
   });
 });

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -5,8 +5,8 @@
  * compaction while keeping hook failures non-fatal.
  */
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { drainPluginNextTurnInjectionContext } from "../../plugins/host-hook-state.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { drainPluginNextTurnInjectionContext } from "../../plugins/host-hook-state.js";
 import type {
   PluginAgentTurnPrepareResult,
   PluginHookBeforeAgentStartResult,

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -5,10 +5,13 @@
  * compaction while keeping hook failures non-fatal.
  */
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { drainPluginNextTurnInjectionContext } from "../../plugins/host-hook-state.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type {
+  PluginAgentTurnPrepareResult,
   PluginHookBeforeAgentStartResult,
   PluginHookBeforePromptBuildResult,
+  PluginNextTurnInjectionRecord,
 } from "../../plugins/types.js";
 import { joinPresentTextSegments } from "../../shared/text/join-segments.js";
 import { wrapPluginSystemContextSection } from "../hook-system-context-boundary.js";
@@ -24,6 +27,38 @@ type AgentHarnessPromptBuildResult = {
   /** Span within prompt containing the original prompt input. */
   promptInputRange?: { start: number; end: number };
 };
+
+// Cache drained next-turn injections by runId so retry attempts within the
+// same run reuse the first-attempt drain rather than calling drain again
+// (which destructively consumes from the session store and would return [] on
+// retry, dropping injection context).
+const PROMPT_BUILD_DRAIN_CACHE_MAX = 256;
+const promptBuildDrainCache = new Map<string, PluginNextTurnInjectionRecord[]>();
+
+function rememberDrainedInjections(
+  runId: string,
+  injections: PluginNextTurnInjectionRecord[],
+): void {
+  if (promptBuildDrainCache.has(runId)) {
+    promptBuildDrainCache.delete(runId);
+  } else if (promptBuildDrainCache.size >= PROMPT_BUILD_DRAIN_CACHE_MAX) {
+    const oldest = promptBuildDrainCache.keys().next().value;
+    if (oldest !== undefined) {
+      promptBuildDrainCache.delete(oldest);
+    }
+  }
+  promptBuildDrainCache.set(runId, injections);
+}
+
+/**
+ * Releases the per-run drained-injection cache. Call when a run terminates so
+ * the cap stays headroom for active runs.
+ */
+export function forgetHarnessPromptBuildDrainCacheForRun(runId: string | undefined): void {
+  if (runId) {
+    promptBuildDrainCache.delete(runId);
+  }
+}
 
 /** Runs before-prompt hooks and returns the adjusted prompt fields. */
 export async function resolveAgentHarnessBeforePromptBuildResult(params: {
@@ -42,9 +77,17 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
   const isHeartbeatTurn = params.ctx.trigger === "heartbeat";
   const hasHeartbeatContribution =
     isHeartbeatTurn && Boolean(hookRunner?.hasHooks("heartbeat_prompt_contribution"));
+  // agent_turn_prepare was also missing from the harness path (#96233 added
+  // heartbeat_prompt_contribution; this adds the remaining two contributions
+  // the embedded path runs — agent_turn_prepare and queued injections).
+  const hasAgentTurnPrepare =
+    Boolean(hookRunner?.runAgentTurnPrepare) && Boolean(hookRunner?.hasHooks("agent_turn_prepare"));
+  const hasQueuedInjections = Boolean(params.ctx.config && params.ctx.sessionKey);
   if (
     !hasPrecomputedBeforeAgentStartResult &&
     !hasHeartbeatContribution &&
+    !hasAgentTurnPrepare &&
+    !hasQueuedInjections &&
     !hookRunner?.hasHooks("before_prompt_build") &&
     !hookRunner?.hasHooks("before_agent_start")
   ) {
@@ -60,8 +103,47 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
     messages: params.messages,
   };
 
-  // Match the embedded runner's lifecycle order: heartbeat contributions are
-  // collected before prompt-build hooks so hook side effects stay deterministic.
+  // Drain queued next-turn injections once per run (cached for retries)
+  // so plugins that enqueue context for the next turn surface it on harness
+  // runtimes, matching the embedded runner's lifecycle.
+  const runId = params.ctx.runId;
+  const cachedInjections = runId ? promptBuildDrainCache.get(runId) : undefined;
+  const hasConfigAndSession = Boolean(params.ctx.config && params.ctx.sessionKey);
+  const queuedContext = cachedInjections
+    ? {
+        queuedInjections: cachedInjections,
+        ...buildPluginAgentTurnPrepareContext({ queuedInjections: cachedInjections }),
+      }
+    : hasConfigAndSession
+      ? await drainPluginNextTurnInjectionContext({
+          cfg: params.ctx.config!,
+          sessionKey: params.ctx.sessionKey,
+        })
+      : { queuedInjections: [] as PluginNextTurnInjectionRecord[] };
+  if (runId && !cachedInjections && queuedContext.queuedInjections.length > 0) {
+    rememberDrainedInjections(runId, queuedContext.queuedInjections);
+  }
+
+  // Match the embedded runner's lifecycle order: queued injections first,
+  // then agent_turn_prepare, then heartbeat contributions, then prompt-build
+  // hooks so hook side effects stay deterministic.
+  const turnPrepareResult: PluginAgentTurnPrepareResult | undefined =
+    hasAgentTurnPrepare && hookRunner
+      ? await hookRunner
+          .runAgentTurnPrepare?.(
+            {
+              prompt: params.prompt,
+              messages: params.messages,
+              queuedInjections: queuedContext.queuedInjections,
+            },
+            hookCtx,
+          )
+          .catch((error: unknown) => {
+            log.warn(`agent_turn_prepare hook failed: ${String(error)}`);
+            return undefined;
+          })
+      : undefined;
+
   const heartbeatResult =
     hasHeartbeatContribution && hookRunner
       ? await hookRunner
@@ -105,12 +187,19 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
     promptBuildResult,
     beforeAgentStartResult,
   });
+  // Queued-injection context and agent_turn_prepare results are prepended
+  // before prompt-build and heartbeat contributions so plugins that touch
+  // system instructions do not shift the prompt layout unexpectedly.
   const promptPrefix = joinPresentTextSegments([
+    queuedContext.prependContext,
+    turnPrepareResult?.prependContext,
     heartbeatResult?.prependContext,
     promptBuildResult?.prependContext,
     beforeAgentStartResult?.prependContext,
   ]);
   const promptSuffix = joinPresentTextSegments([
+    queuedContext.appendContext,
+    turnPrepareResult?.appendContext,
     heartbeatResult?.appendContext,
     promptBuildResult?.appendContext,
     beforeAgentStartResult?.appendContext,
@@ -127,9 +216,13 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
     prompt,
     developerInstructions:
       joinPresentTextSegments([
+        wrapPluginSystemContextSection(queuedContext.prependSystemContext),
+        wrapPluginSystemContextSection(turnPrepareResult?.prependSystemContext),
         wrapPluginSystemContextSection(promptBuildResult?.prependSystemContext),
         wrapPluginSystemContextSection(beforeAgentStartResult?.prependSystemContext),
         systemPrompt,
+        wrapPluginSystemContextSection(queuedContext.appendSystemContext),
+        wrapPluginSystemContextSection(turnPrepareResult?.appendSystemContext),
         wrapPluginSystemContextSection(promptBuildResult?.appendSystemContext),
         wrapPluginSystemContextSection(beforeAgentStartResult?.appendSystemContext),
       ]) ?? systemPrompt,


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #96233 which added `heartbeat_prompt_contribution` to the harness
prompt-build path but intentionally left out two other contributions the embedded
runner path executes (as noted in its description):

> *"Two other contributions the embedded path runs (agent_turn_prepare and exactly-once queued injections) are also absent from the harness path; those are left out here — the queued-injection draining has exactly-once semantics that deserve their own change."*

This PR adds both missing pieces so plugins that rely on these hooks get consistent
behaviour across embedded and harness runtimes.

## Changes

- **`src/agents/harness/prompt-compaction-hook-helpers.ts`** — added:
  1. Queued next-turn injection draining via `drainPluginNextTurnInjectionContext`
     with a `runId`-based cache (`promptBuildDrainCache`) matching the embedded
     runner's `promptBuildDrainCache` pattern
  2. Public `forgetHarnessPromptBuildDrainCacheForRun` for run-termination cleanup
  3. `agent_turn_prepare` hook call passing the drained injections
  4. Integration of queued-injection context and `agent_turn_prepare` results
     into prompt prefix/suffix and developer-instruction assembly

The lifecycle order mirrors the embedded runner: queued injections first, then
`agent_turn_prepare`, then heartbeat contributions, then `before_prompt_build` /
`before_agent_start`.

## Evidence

- Follows the exact same draining/caching pattern from the embedded runner's
  `resolvePromptBuildHookResult` in `src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts`
- Early-return optimisation is preserved when no hooks are registered
- `agent_turn_prepare` and injection context failures are non-fatal (logged,
  not thrown) matching the existing harness hook error policy

## Related

- #96233 — added `heartbeat_prompt_contribution` to the harness path; this PR
  completes the remaining two gaps noted in its description