### PR TITLE
fix(heartbeat): detect HEARTBEAT_OK through reasoning/thinking blocks

### DIFF
--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -124,6 +124,38 @@ describe("isHeartbeatOkResponse", () => {
     expect(isHeartbeatOkResponse(toolCallOnlyMessage)).toBe(false);
   });
 
+  it("ignores silent reasoning/thinking blocks when checking for heartbeat acknowledgements", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "I should confirm the heartbeat." },
+          { type: "text", text: "HEARTBEAT_OK" },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "opaque" },
+          { type: "text", text: "HEARTBEAT_OK" },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "thinking" },
+          { type: "tool_use", id: "tool-1", name: "search", input: {} },
+        ],
+      }),
+    ).toBe(false);
+  });
+
   it("respects ackMaxChars overrides", () => {
     expect(
       isHeartbeatOkResponse(

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -14,6 +14,7 @@ import { MESSAGE_TOOL_DELIVERY_HINTS } from "./reply/delivery-hints.js";
 const HEARTBEAT_TASK_PROMPT_PREFIX =
   "Run the following periodic tasks (only those due based on their intervals):";
 const HEARTBEAT_TASK_PROMPT_ACK = "After completing all due tasks, reply HEARTBEAT_OK.";
+const REASONING_BLOCK_TYPES = new Set(["thinking", "redacted_thinking"]);
 const TOOL_CALL_BLOCK_TYPES = new Set([
   "toolCall",
   "functionCall",
@@ -254,7 +255,10 @@ function matchesHeartbeatPromptText(text: string, prompt: string | undefined): b
   return Boolean(normalized) && (text === normalized || text.startsWith(`${normalized}\n`));
 }
 
-function resolveMessageText(content: unknown): { text: string; hasNonTextContent: boolean } {
+function resolveMessageText(
+  content: unknown,
+  ignoredNonTextTypes?: ReadonlySet<string>,
+): { text: string; hasNonTextContent: boolean } {
   if (typeof content === "string") {
     return { text: content, hasNonTextContent: false };
   }
@@ -268,16 +272,21 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
       hasNonTextContent = true;
       continue;
     }
-    if (block.type !== "text" && block.type !== "input_text" && block.type !== "output_text") {
-      hasNonTextContent = true;
+    const type = readString(block.type);
+    if (type === "text" || type === "input_text" || type === "output_text") {
+      const blockText = (block as { text?: unknown }).text;
+      if (typeof blockText !== "string") {
+        hasNonTextContent = true;
+        continue;
+      }
+      text += blockText;
+    } else if (ignoredNonTextTypes?.has(type ?? "")) {
+      // Silent internal content (e.g. reasoning/thinking blocks) does not prevent
+      // a message from being treated as a plain heartbeat acknowledgement.
       continue;
-    }
-    const blockText = (block as { text?: unknown }).text;
-    if (typeof blockText !== "string") {
+    } else {
       hasNonTextContent = true;
-      continue;
     }
-    text += blockText;
   }
   return { text, hasNonTextContent };
 }
@@ -336,7 +345,7 @@ export function isHeartbeatOkResponse(
   if (hasAssistantToolCall(message)) {
     return false;
   }
-  const { text, hasNonTextContent } = resolveMessageText(message.content);
+  const { text, hasNonTextContent } = resolveMessageText(message.content, REASONING_BLOCK_TYPES);
   if (hasNonTextContent) {
     return false;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes #95796. When the assistant's heartbeat acknowledgement contains silent reasoning/thinking content blocks alongside `HEARTBEAT_OK`, `isHeartbeatOkResponse` rejected the whole message as non-text and the heartbeat span was not stripped from the transcript. This inflated context and could confuse the model on the next turn.

## Why This Change Was Made

`resolveMessageText` flagged any block other than `text`/`input_text`/`output_text` as non-text. Reasoning/thinking blocks are internal model output, not meaningful user-visible content, so they should not prevent a plain `HEARTBEAT_OK` ack from being recognized.

## User Impact

Heartbeat prompts/acks are now correctly pruned when the model emits reasoning/thinking blocks, keeping the transcript clean and reducing context noise.

## Evidence

- Added unit tests in `src/auto-reply/heartbeat-filter.test.ts` covering `thinking`, `redacted_thinking`, and mixed tool-use cases.
- `pnpm exec vitest run src/auto-reply/heartbeat-filter.test.ts` passes (35/35).
- `pnpm exec oxfmt --check src/auto-reply/heartbeat-filter.ts src/auto-reply/heartbeat-filter.test.ts` passes.
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/heartbeat-filter.ts src/auto-reply/heartbeat-filter.test.ts` passes.

🤖 This PR includes code generated by an AI assistant.