### PR TITLE
fix(context-engine): avoid quarantining read-only discovery factories

### DIFF
--- a/src/commands/doctor/shared/context-engine-host-compat.test.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.test.ts
@@ -1,7 +1,12 @@
 // Context engine host compatibility tests cover doctor warnings for host/context mismatches.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { registerContextEngine } from "../../../context-engine/registry.js";
+import {
+  getContextEngineFactory,
+  getContextEngineRegistration,
+  registerContextEngine,
+  registerContextEngineForOwner,
+} from "../../../context-engine/registry.js";
 import type { ContextEngine, ContextEngineHostCapability } from "../../../context-engine/types.js";
 import {
   collectConfiguredContextEngineAgentRunHosts,
@@ -60,6 +65,23 @@ function configWithEngine(engineId: string, cfg: OpenClawConfig = {}): OpenClawC
 }
 
 describe("doctor context-engine host compatibility", () => {
+  it("distinguishes read-only discovery registrations from runtime entries", () => {
+    const id = uniqueEngineId();
+    const factory = () => {
+      throw new Error("discovery-only");
+    };
+    const result = registerContextEngineForOwner(id, factory, `doctor-test-owner-${id}`, {
+      lifecycle: "readOnlyDiscovery",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(getContextEngineRegistration(id)).toMatchObject({
+      factory,
+      lifecycle: "readOnlyDiscovery",
+    });
+    expect(getContextEngineFactory(id)).toBeUndefined();
+  });
+
   it("collects native Codex and OpenClaw as compatible agent-run hosts", () => {
     const hosts = collectConfiguredContextEngineAgentRunHosts({
       cfg: {

--- a/src/commands/doctor/shared/context-engine-host-compat.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.ts
@@ -16,7 +16,10 @@ import {
   type ContextEngineHostSupport,
 } from "../../../context-engine/host-compat.js";
 import { ensureContextEnginesInitialized } from "../../../context-engine/init.js";
-import { getContextEngineFactory, resolveContextEngine } from "../../../context-engine/registry.js";
+import {
+  getContextEngineRegistration,
+  resolveContextEngine,
+} from "../../../context-engine/registry.js";
 import type { ContextEngineInfo } from "../../../context-engine/types.js";
 import { ensurePluginRegistryLoaded } from "../../../plugins/runtime/runtime-registry-loader.js";
 import { defaultSlotIdForKey } from "../../../plugins/slots.js";
@@ -254,7 +257,7 @@ async function resolveSelectedContextEngineInfo(params: {
   }
 
   ensureContextEnginesInitialized();
-  if (!getContextEngineFactory(engineId)) {
+  if (getContextEngineRegistration(engineId)?.lifecycle !== "runtime") {
     try {
       ensurePluginRegistryLoaded({
         scope: "all",
@@ -263,7 +266,7 @@ async function resolveSelectedContextEngineInfo(params: {
         onlyPluginIds: [engineId],
       });
     } catch (error) {
-      if (!getContextEngineFactory(engineId)) {
+      if (getContextEngineRegistration(engineId)?.lifecycle !== "runtime") {
         const message = error instanceof Error ? error.message : String(error);
         return {
           warnings: [
@@ -272,7 +275,7 @@ async function resolveSelectedContextEngineInfo(params: {
         };
       }
     }
-    if (!getContextEngineFactory(engineId)) {
+    if (getContextEngineRegistration(engineId)?.lifecycle !== "runtime") {
       return {
         warnings: [
           `- plugins.slots.contextEngine: could not inspect context engine "${engineId}" host requirements because it is not registered.`,

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -1084,6 +1084,88 @@ describe("Factory context passing", () => {
   });
 });
 
+describe("Read-only plugin discovery registrations", () => {
+  beforeEach(() => {
+    registerLegacyContextEngine();
+    clearContextEngineRuntimeQuarantine();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not construct or quarantine read-only discovery context-engine factories", async () => {
+    const engineId = uniqueEngineId("lossless-readonly");
+    const owner = "plugin:lossless-claw";
+    let readOnlyFactoryCalls = 0;
+    let runtimeFactoryCalls = 0;
+
+    registerContextEngineForOwner(
+      engineId,
+      () => {
+        readOnlyFactoryCalls += 1;
+        throw new Error("Engine initialization is disabled during read-only plugin registration");
+      },
+      owner,
+      { allowSameOwnerRefresh: true, lifecycle: "readOnlyDiscovery" },
+    );
+
+    const discoveryFallback = await resolveContextEngine(configWithSlot(engineId));
+
+    expect(discoveryFallback.info.id).toBe("legacy");
+    expect(readOnlyFactoryCalls).toBe(0);
+    expect(listContextEngineQuarantines().some((entry) => entry.engineId === engineId)).toBe(false);
+    expect(console.warn).toHaveBeenCalledWith(
+      `[context-engine] Context engine "${engineId}" owner=${owner} is registered for read-only discovery only; falling back to default engine "legacy" without quarantine until runtime activation registers it.`,
+    );
+
+    registerContextEngineForOwner(
+      engineId,
+      () => {
+        runtimeFactoryCalls += 1;
+        return {
+          info: { id: "lossless-claw", name: "Lossless Claw" },
+          async ingest() {
+            return { ingested: true };
+          },
+          async assemble({ messages }: { messages: AgentMessage[] }) {
+            return { messages, estimatedTokens: 0 };
+          },
+          async compact() {
+            return { ok: true, compacted: false };
+          },
+        } satisfies ContextEngine;
+      },
+      owner,
+      { allowSameOwnerRefresh: true, lifecycle: "runtime" },
+    );
+
+    const runtimeEngine = await resolveContextEngine(configWithSlot(engineId));
+
+    expect(runtimeEngine.info.id).toBe("lossless-claw");
+    expect(readOnlyFactoryCalls).toBe(0);
+    expect(runtimeFactoryCalls).toBe(1);
+    expect(listContextEngineQuarantines().some((entry) => entry.engineId === engineId)).toBe(false);
+
+    registerContextEngineForOwner(
+      engineId,
+      () => {
+        readOnlyFactoryCalls += 1;
+        throw new Error("read-only discovery should not replace runtime registration");
+      },
+      owner,
+      { allowSameOwnerRefresh: true, lifecycle: "readOnlyDiscovery" },
+    );
+
+    const stillRuntimeEngine = await resolveContextEngine(configWithSlot(engineId));
+
+    expect(stillRuntimeEngine.info.id).toBe("lossless-claw");
+    expect(readOnlyFactoryCalls).toBe(0);
+    expect(runtimeFactoryCalls).toBe(2);
+  });
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // 4. Invalid engine fallback
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -44,9 +44,11 @@ export type ContextEngineFactory = (
   ctx: ContextEngineFactoryContext,
 ) => ContextEngine | Promise<ContextEngine>;
 export type ContextEngineRegistrationResult = { ok: true } | { ok: false; existingOwner: string };
+export type ContextEngineRegistrationLifecycle = "runtime" | "readOnlyDiscovery";
 
 type RegisterContextEngineForOwnerOptions = {
   allowSameOwnerRefresh?: boolean;
+  lifecycle?: ContextEngineRegistrationLifecycle;
 };
 
 const LEGACY_SESSION_KEY_COMPAT = Symbol.for("openclaw.contextEngine.sessionKeyCompat");
@@ -394,6 +396,7 @@ type ContextEngineRegistryState = {
     {
       factory: ContextEngineFactory;
       owner: string;
+      lifecycle: ContextEngineRegistrationLifecycle;
     }
   >;
   quarantinedEngines: Map<string, ContextEngineRuntimeQuarantine>;
@@ -512,6 +515,7 @@ export function registerContextEngineForOwner(
   opts?: RegisterContextEngineForOwnerOptions,
 ): ContextEngineRegistrationResult {
   const normalizedOwner = requireContextEngineOwner(owner);
+  const lifecycle = opts?.lifecycle ?? "runtime";
   const registry = getContextEngineRegistryState().engines;
   const existing = registry.get(id);
   if (
@@ -524,11 +528,18 @@ export function registerContextEngineForOwner(
   if (existing && existing.owner !== normalizedOwner) {
     return { ok: false, existingOwner: existing.owner };
   }
+  if (existing?.lifecycle === "runtime" && lifecycle === "readOnlyDiscovery") {
+    // Read-only discovery may re-run after live activation. It can collect metadata, but it must
+    // not replace the runtime-safe factory with a closure that captured a read-only plugin mode.
+    return { ok: true };
+  }
   if (existing && opts?.allowSameOwnerRefresh !== true) {
     return { ok: false, existingOwner: existing.owner };
   }
-  registry.set(id, { factory, owner: normalizedOwner });
-  clearContextEngineRuntimeQuarantine(id);
+  registry.set(id, { factory, owner: normalizedOwner, lifecycle });
+  if (lifecycle === "runtime") {
+    clearContextEngineRuntimeQuarantine(id);
+  }
   return { ok: true };
 }
 
@@ -942,6 +953,13 @@ export async function resolveContextEngine(
       error: "not registered",
       defaultEngineId,
     });
+    return resolveDefaultContextEngine(defaultEngineId, factoryCtx);
+  }
+
+  if (!isDefaultEngine && entry.lifecycle === "readOnlyDiscovery") {
+    console.warn(
+      `[context-engine] Context engine "${engineId}" owner=${entry.owner} is registered for read-only discovery only; falling back to default engine "${defaultEngineId}" without quarantine until runtime activation registers it.`,
+    );
     return resolveDefaultContextEngine(defaultEngineId, factoryCtx);
   }
 

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -45,6 +45,11 @@ export type ContextEngineFactory = (
 ) => ContextEngine | Promise<ContextEngine>;
 export type ContextEngineRegistrationResult = { ok: true } | { ok: false; existingOwner: string };
 export type ContextEngineRegistrationLifecycle = "runtime" | "readOnlyDiscovery";
+export type ContextEngineRegistration = {
+  factory: ContextEngineFactory;
+  owner: string;
+  lifecycle: ContextEngineRegistrationLifecycle;
+};
 
 type RegisterContextEngineForOwnerOptions = {
   allowSameOwnerRefresh?: boolean;
@@ -391,14 +396,7 @@ export type ContextEngineRuntimeQuarantine = {
 };
 
 type ContextEngineRegistryState = {
-  engines: Map<
-    string,
-    {
-      factory: ContextEngineFactory;
-      owner: string;
-      lifecycle: ContextEngineRegistrationLifecycle;
-    }
-  >;
+  engines: Map<string, ContextEngineRegistration>;
   quarantinedEngines: Map<string, ContextEngineRuntimeQuarantine>;
 };
 
@@ -561,7 +559,13 @@ export function registerContextEngine(
  * Return the factory for a registered engine, or undefined.
  */
 export function getContextEngineFactory(id: string): ContextEngineFactory | undefined {
-  return getContextEngineRegistryState().engines.get(id)?.factory;
+  const registration = getContextEngineRegistration(id);
+  return registration?.lifecycle === "runtime" ? registration.factory : undefined;
+}
+
+/** Returns registration metadata so callers can distinguish discovery snapshots from runtime entries. */
+export function getContextEngineRegistration(id: string): ContextEngineRegistration | undefined {
+  return getContextEngineRegistryState().engines.get(id);
 }
 
 /**

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2885,6 +2885,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   `plugin:${record.id}`,
                   {
                     allowSameOwnerRefresh: true,
+                    lifecycle: registrationMode === "full" ? "runtime" : "readOnlyDiscovery",
                   },
                 );
                 if (!result.ok) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #96335.

OpenClaw can load plugin context-engine registrations while doing read-only plugin discovery. Some plugins, including lossless-claw 0.13.1, intentionally capture that read-only lifecycle in the registered factory and reject stateful engine initialization from that phase. Current main stores that discovery factory like a runtime factory, then `resolveContextEngine()` invokes it, quarantines the selected plugin engine, and falls back to `legacy` for the process.

This PR keeps read-only discovery useful for metadata collection, but prevents discovery-only context-engine factories from being constructed or quarantined as runtime failures.

## Summary

- Adds a context-engine registration lifecycle marker:
  - `runtime`
  - `readOnlyDiscovery`
- Marks plugin API `registerContextEngine()` calls as `runtime` only during full plugin activation.
- Marks discovery/tool-discovery plugin registrations as `readOnlyDiscovery`.
- Prevents read-only discovery registrations from replacing an already-active runtime registration from the same plugin owner.
- Makes `resolveContextEngine()` fall back to the default engine without quarantine when the selected engine is only registered from read-only discovery.
- Keeps runtime factory failures quarantined exactly as before.
- Keeps runtime plugin activation able to replace a prior read-only discovery registration and activate the configured engine.

## Scope Boundary

This intentionally does **not** change the `lightContext` cron contract from #96334. That issue is currently labeled by ClawSweeper as `clawsweeper:no-new-fix-pr`, `clawsweeper:needs-maintainer-review`, and `clawsweeper:needs-product-decision`, so this PR avoids changing that separate product behavior.

## Regression Coverage

Added focused coverage for the lossless-claw-style lifecycle sequence:

1. A plugin-owned context engine is registered from read-only discovery with a factory that throws the reported error: `Engine initialization is disabled during read-only plugin registration`.
2. `resolveContextEngine()` does not invoke that factory.
3. The selected engine is not quarantined.
4. Runtime/full activation replaces the discovery registration and resolves the plugin engine.
5. A later read-only discovery pass does not overwrite the runtime-safe factory.

## Evidence

Local lightweight preflight:

- `node scripts/run-vitest.mjs src/context-engine/context-engine.test.ts` — passed, 46 tests.
- `corepack pnpm format src/context-engine/registry.ts src/context-engine/context-engine.test.ts src/plugins/registry.ts` — applied formatting to changed files.
- `corepack pnpm format:check src/context-engine/registry.ts src/context-engine/context-engine.test.ts src/plugins/registry.ts` — passed.
- `git diff --check` — passed.

Live / reproducibility notes:

- GitHub Actions for this PR ran on the exact submitted head `0d7cf30c32d2cde431738ba3f46e3ae9640d8902`.
- Official Real behavior proof gate passed: <https://github.com/openclaw/openclaw/actions/runs/28089066083/job/83162223916>.
- Configured plugin context-engine proof passed on the exact PR head: <https://github.com/snowzlmbot/openclaw/actions/runs/28093889925>.
  - Artifact: `context-engine-readonly-registration-proof-0d7cf30c32d2cde431738ba3f46e3ae9640d8902`.
  - The proof dynamically creates a real OpenClaw plugin with `kind: ["context-engine"]`, a real `openclaw.plugin.json`, and a runtime file loaded through `loadOpenClawPlugins()`.
  - It configures `plugins.slots.contextEngine = "proof-context-engine"`, then runs a read-only discovery load followed by a full runtime load.
  - Discovery result: `resolvedEngineId=legacy`, `warningCount=1`, `errorCount=0`, and the warning explicitly says the engine is registered for read-only discovery only and falls back without quarantine.
  - Runtime result: `resolvedEngineId=proof-context-engine`; plugin status is `loaded`; `contextEngineIds` contains `proof-context-engine`.
  - Assertions passed: exact head recorded, discovery fallback without quarantine, read-only factory not invoked/quarantined, runtime activation resolves the configured plugin engine, and the runtime registry records the context-engine registration.
- The regression test uses the real OpenClaw context-engine registry/resolve path and reproduces the exact reported read-only initialization error string.
- The public npm registry does not expose `lossless-claw@0.13.1` as `lossless-claw`, so the test cannot install that package directly from npm. The configured-plugin proof reproduces the observed lifecycle failure through OpenClaw's public plugin-owned context-engine registration path.
- A local filtered `src/plugins/loader.test.ts -t "context engine"` run was stopped after it produced no timely output, to avoid turning local preflight into a broad/heavy test run. Broader verification is delegated to GitHub Actions.

## Risk

Low-to-moderate. The change is intentionally narrow around context-engine factory lifecycle handling. The main behavior change is that discovery-only registrations no longer poison runtime resolution through quarantine. If a configured engine never reaches full activation, resolution still falls back to `legacy`, but now it does so without incorrectly quarantining the plugin for the process.

