### PR TITLE
fix(cron): preserve action-critical command output

### DIFF
--- a/src/cron/action-critical-output.ts
+++ b/src/cron/action-critical-output.ts
@@ -1,0 +1,22 @@
+const DEVICE_AUTH_URL_RE =
+  /\bhttps?:\/\/[^\s<>"']*(?:login\.microsoft\.com\/device|microsoft\.com\/devicelogin|aka\.ms\/devicelogin|\/oauth2?\/device|\/device(?:code|login)?\b|device[-_]?code|device[-_]?login)[^\s<>"']*/iu;
+const LOCAL_CALLBACK_URL_RE =
+  /\bhttps?:\/\/(?:localhost|127(?:\.\d{1,3}){3}|\[::1\])(?::\d{2,5})?(?:\/[^\s<>"']*)?\b/iu;
+const SETUP_CODE_LINE_RE =
+  /\b(?:user|device|verification|setup|one[-_\s]?time)?[-_\s]?(?:code|token)\b.*\b[A-Z0-9]{4,12}(?:-[A-Z0-9]{2,12}){0,4}\b/iu;
+const NEXT_ACTION_INSTRUCTION_RE =
+  /\b(?:enter|use|copy|paste|open|visit)\b.{0,120}\b(?:code|token|url|link|browser|callback|device|verification|setup)\b/iu;
+
+/** Matches short command-output lines users need in order to complete setup/auth flows. */
+export function isActionCriticalOutputLine(line: string): boolean {
+  const text = line.trim();
+  if (!text) {
+    return false;
+  }
+  return (
+    DEVICE_AUTH_URL_RE.test(text) ||
+    LOCAL_CALLBACK_URL_RE.test(text) ||
+    SETUP_CODE_LINE_RE.test(text) ||
+    NEXT_ACTION_INSTRUCTION_RE.test(text)
+  );
+}

--- a/src/cron/command-runner.test.ts
+++ b/src/cron/command-runner.test.ts
@@ -56,6 +56,40 @@ describe("runCronCommandJob", () => {
     expect(result.summary).toBe("NO_REPLY");
   });
 
+  it("preserves action-critical setup lines when command stdout is truncated", async () => {
+    const result = await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [
+          process.execPath,
+          "-e",
+          [
+            "process.stdout.write('To sign in, use a web browser to open https://login.microsoft.com/device and enter the code FAKE-CODE-270 to authenticate.\\n')",
+            "for (let i = 0; i < 40; i += 1) process.stdout.write(`CRON-FILLER-270-line-${i}\\n`)",
+            "process.stdout.write('DONE')",
+          ].join(";"),
+        ],
+        timeoutSeconds: 5,
+        outputMaxBytes: 80,
+      }),
+      nowMs: () => 789,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toContain("https://login.microsoft.com/device");
+    expect(result.summary).toContain("FAKE-CODE-270");
+    expect(result.summary).toContain("[openclaw: stdout tail]");
+    expect(result.summary).toMatch(
+      /\[openclaw: stdout omitted \d+ earlier bytes; Recovery: openclaw cron runs --id "command-job"\]/u,
+    );
+    expect(result.diagnostics?.entries[0]).toMatchObject({
+      ts: 789,
+      source: "exec",
+      severity: "info",
+      truncated: true,
+    });
+  });
+
   it("marks non-zero exit codes as cron errors and keeps stderr as summary", async () => {
     const result = await runCronCommandJob({
       job: makeCommandJob({

--- a/src/cron/command-runner.ts
+++ b/src/cron/command-runner.ts
@@ -1,6 +1,7 @@
 import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runCommandWithTimeout } from "../process/exec.js";
+import { isActionCriticalOutputLine } from "./action-critical-output.js";
 import type { CronRunDiagnostics, CronRunOutcome, CronRunStatus, CronJob } from "./types.js";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 10 * 60_000;
@@ -24,9 +25,83 @@ function trimOutput(value: string): string | undefined {
   return normalizeOptionalString(value);
 }
 
-function buildCommandSummary(params: { stdout: string; stderr: string }): string | undefined {
-  const stdout = trimOutput(params.stdout);
-  const stderr = trimOutput(params.stderr);
+function formatRecoveryHint(jobId: string): string {
+  return `Recovery: openclaw cron runs --id ${JSON.stringify(jobId)}`;
+}
+
+function uniquePreservedLines(params: { output?: string; lines?: string[] }): string[] {
+  const output = params.output ?? "";
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  for (const line of params.lines ?? []) {
+    const normalized = line.trimEnd();
+    if (!normalized || seen.has(normalized) || output.includes(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    lines.push(normalized);
+  }
+  return lines;
+}
+
+function formatCommandStreamOutput(params: {
+  stream: "stdout" | "stderr";
+  output: string;
+  preservedLines?: string[];
+  truncatedBytes?: number;
+  jobId: string;
+}): string | undefined {
+  const output = trimOutput(params.output);
+  const preservedLines = params.truncatedBytes
+    ? uniquePreservedLines({ output, lines: params.preservedLines })
+    : [];
+  if (!output && preservedLines.length === 0) {
+    return undefined;
+  }
+  if (!params.truncatedBytes) {
+    return output;
+  }
+
+  const sections: string[] = [];
+  if (preservedLines.length > 0) {
+    sections.push(`[openclaw: preserved earlier ${params.stream} lines omitted by output cap]`);
+    sections.push(...preservedLines);
+    if (output) {
+      sections.push(`[openclaw: ${params.stream} tail]`);
+    }
+  }
+  if (output) {
+    sections.push(output);
+  }
+  sections.push(
+    `[openclaw: ${params.stream} omitted ${params.truncatedBytes} earlier bytes; ${formatRecoveryHint(params.jobId)}]`,
+  );
+  return sections.join("\n");
+}
+
+function buildCommandSummary(params: {
+  jobId: string;
+  stdout: string;
+  stderr: string;
+  stdoutPreservedLines?: string[];
+  stderrPreservedLines?: string[];
+  stdoutTruncatedBytes?: number;
+  stderrTruncatedBytes?: number;
+}): string | undefined {
+  const stdout = formatCommandStreamOutput({
+    stream: "stdout",
+    output: params.stdout,
+    preservedLines: params.stdoutPreservedLines,
+    truncatedBytes: params.stdoutTruncatedBytes,
+    jobId: params.jobId,
+  });
+  const stderr = formatCommandStreamOutput({
+    stream: "stderr",
+    output: params.stderr,
+    preservedLines: params.stderrPreservedLines,
+    truncatedBytes: params.stderrTruncatedBytes,
+    jobId: params.jobId,
+  });
   if (stdout && stderr) {
     return `stdout:\n${stdout}\n\nstderr:\n${stderr}`;
   }
@@ -115,6 +190,7 @@ export async function runCronCommandJob(params: {
       ...(payload.env ? { env: payload.env } : {}),
       ...(noOutputTimeoutMs !== undefined ? { noOutputTimeoutMs } : {}),
       ...(payload.outputMaxBytes !== undefined ? { maxOutputBytes: payload.outputMaxBytes } : {}),
+      preserveOutputLine: ({ line }) => isActionCriticalOutputLine(line),
       ...(params.abortSignal ? { signal: params.abortSignal } : {}),
       killProcessTree: true,
     });
@@ -125,7 +201,15 @@ export async function runCronCommandJob(params: {
       result.termination !== "no-output-timeout" &&
       result.termination !== "signal";
     const status: CronRunStatus = ok ? "ok" : "error";
-    const summary = buildCommandSummary({ stdout: result.stdout, stderr: result.stderr });
+    const summary = buildCommandSummary({
+      jobId: params.job.id,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      stdoutPreservedLines: result.stdoutPreservedLines,
+      stderrPreservedLines: result.stderrPreservedLines,
+      stdoutTruncatedBytes: result.stdoutTruncatedBytes,
+      stderrTruncatedBytes: result.stderrTruncatedBytes,
+    });
     const error = ok
       ? undefined
       : commandErrorMessage({

--- a/src/process/exec.no-output-timer.test.ts
+++ b/src/process/exec.no-output-timer.test.ts
@@ -121,6 +121,29 @@ describe("runCommandWithTimeout no-output timer", () => {
     expect(result.termination).toBe("exit");
   });
 
+  it("preserves selected early lines without changing bounded tail output", async () => {
+    vi.useFakeTimers();
+    const fake = createFakeSpawnedChild();
+    spawnMock.mockReturnValue(fake.child);
+
+    const runPromise = runCommandWithTimeout(["node", "-e", "ignored"], {
+      timeoutMs: 1_000,
+      maxOutputBytes: 5,
+      preserveOutputLine: ({ line }) => line.includes("code"),
+    });
+
+    fake.stdout.emit("data", Buffer.from("enter code ABCD\n"));
+    fake.stdout.emit("data", Buffer.from("abcdef"));
+    fake.stdout.emit("data", Buffer.from("gh"));
+
+    emitProcessExit(fake, { code: 0 });
+    const result = await runPromise;
+
+    expect(result.stdout).toBe("defgh");
+    expect(result.stdoutPreservedLines).toEqual(["enter code ABCD"]);
+    expect(result.stdoutTruncatedBytes).toBe(19);
+  });
+
   it("marks no-output timeout when the spawned child goes silent", async () => {
     vi.useFakeTimers();
     const fake = createFakeSpawnedChild();

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -7,13 +7,13 @@ import { promisify } from "node:util";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { danger, shouldLogVerbose } from "../globals.js";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
-import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import {
   decodeWindowsOutputBuffer,
   resolveWindowsConsoleEncoding,
 } from "../infra/windows-encoding.js";
 import { getWindowsSystem32ExePath } from "../infra/windows-install-roots.js";
 import { logDebug, logError } from "../logger.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { killProcessTree as terminateProcessTree } from "./kill-tree.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
 import {
@@ -211,6 +211,8 @@ export type SpawnResult = {
   pid?: number;
   stdout: string;
   stderr: string;
+  stdoutPreservedLines?: string[];
+  stderrPreservedLines?: string[];
   stdoutTruncatedBytes?: number;
   stderrTruncatedBytes?: number;
   code: number | null;
@@ -230,6 +232,8 @@ export type CommandOptions = {
   noOutputTimeoutMs?: number;
   signal?: AbortSignal;
   maxOutputBytes?: number;
+  preservedOutputMaxBytes?: number;
+  preserveOutputLine?: (params: { line: string; stream: "stdout" | "stderr" }) => boolean;
   killProcessTree?: boolean;
 };
 
@@ -238,11 +242,15 @@ const WINDOWS_CLOSE_STATE_POLL_MS = 10;
 const COMMAND_PROCESS_TREE_KILL_GRACE_MS = 300;
 const TIMEOUT_EXIT_CODE = 124;
 const DEFAULT_COMMAND_OUTPUT_MAX_BYTES = 16 * 1024 * 1024;
+const DEFAULT_PRESERVED_OUTPUT_MAX_BYTES = 4 * 1024;
 
 type CapturedOutputBuffers = {
   chunks: Buffer[];
   bytes: number;
   truncatedBytes: number;
+  pendingLine: string;
+  preservedBytes: number;
+  preservedLines: string[];
 };
 
 function normalizeMaxOutputBytes(value: number | undefined): number {
@@ -252,12 +260,81 @@ function normalizeMaxOutputBytes(value: number | undefined): number {
   return Math.max(1, Math.floor(value));
 }
 
+function normalizePreservedOutputMaxBytes(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_PRESERVED_OUTPUT_MAX_BYTES;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function appendPreservedOutputLine(
+  capture: CapturedOutputBuffers,
+  line: string,
+  maxPreservedBytes: number,
+): void {
+  const normalized = line.trimEnd();
+  if (!normalized || capture.preservedLines.includes(normalized)) {
+    return;
+  }
+  const bytes = Buffer.byteLength(`${normalized}\n`);
+  if (bytes > maxPreservedBytes || capture.preservedBytes + bytes > maxPreservedBytes) {
+    return;
+  }
+  capture.preservedLines.push(normalized);
+  capture.preservedBytes += bytes;
+}
+
+function scanPreservedOutputLines(params: {
+  capture: CapturedOutputBuffers;
+  text: string;
+  stream: "stdout" | "stderr";
+  maxPreservedBytes: number;
+  preserveOutputLine?: (lineParams: { line: string; stream: "stdout" | "stderr" }) => boolean;
+}): void {
+  if (!params.preserveOutputLine) {
+    return;
+  }
+  params.capture.pendingLine += params.text;
+  const lines = params.capture.pendingLine.split(/\r\n|\r|\n/u);
+  params.capture.pendingLine = lines.pop() ?? "";
+  for (const line of lines) {
+    if (params.preserveOutputLine({ line, stream: params.stream })) {
+      appendPreservedOutputLine(params.capture, line, params.maxPreservedBytes);
+    }
+  }
+}
+
+function flushPreservedOutputLine(params: {
+  capture: CapturedOutputBuffers;
+  stream: "stdout" | "stderr";
+  maxPreservedBytes: number;
+  preserveOutputLine?: (lineParams: { line: string; stream: "stdout" | "stderr" }) => boolean;
+}): void {
+  const line = params.capture.pendingLine;
+  params.capture.pendingLine = "";
+  if (line && params.preserveOutputLine?.({ line, stream: params.stream })) {
+    appendPreservedOutputLine(params.capture, line, params.maxPreservedBytes);
+  }
+}
+
 function appendCapturedOutput(
   capture: CapturedOutputBuffers,
   chunk: Buffer | string,
   maxBytes: number,
+  preserve?: {
+    stream: "stdout" | "stderr";
+    maxPreservedBytes: number;
+    preserveOutputLine?: (params: { line: string; stream: "stdout" | "stderr" }) => boolean;
+  },
 ): void {
   const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+  scanPreservedOutputLines({
+    capture,
+    text: buffer.toString("utf8"),
+    stream: preserve?.stream ?? "stdout",
+    maxPreservedBytes: preserve?.maxPreservedBytes ?? DEFAULT_PRESERVED_OUTPUT_MAX_BYTES,
+    preserveOutputLine: preserve?.preserveOutputLine,
+  });
   if (buffer.byteLength >= maxBytes) {
     capture.chunks = [Buffer.from(buffer.subarray(buffer.byteLength - maxBytes))];
     capture.truncatedBytes += capture.bytes + buffer.byteLength - maxBytes;
@@ -382,9 +459,20 @@ export async function runCommandWithTimeout(
   });
   // Spawn with inherited stdin (TTY) so interactive tools stay usable when needed.
   return await new Promise((resolve, reject) => {
-    const stdoutCapture: CapturedOutputBuffers = { chunks: [], bytes: 0, truncatedBytes: 0 };
-    const stderrCapture: CapturedOutputBuffers = { chunks: [], bytes: 0, truncatedBytes: 0 };
+    const createCapture = (): CapturedOutputBuffers => ({
+      chunks: [],
+      bytes: 0,
+      truncatedBytes: 0,
+      pendingLine: "",
+      preservedBytes: 0,
+      preservedLines: [],
+    });
+    const stdoutCapture = createCapture();
+    const stderrCapture = createCapture();
     const maxOutputBytes = normalizeMaxOutputBytes(options.maxOutputBytes);
+    const maxPreservedOutputBytes = normalizePreservedOutputMaxBytes(
+      options.preservedOutputMaxBytes,
+    );
     const windowsEncoding = resolveWindowsConsoleEncoding();
     let settled = false;
     let timedOut = false;
@@ -527,11 +615,19 @@ export async function runCommandWithTimeout(
     }
 
     child.stdout?.on("data", (d) => {
-      appendCapturedOutput(stdoutCapture, d, maxOutputBytes);
+      appendCapturedOutput(stdoutCapture, d, maxOutputBytes, {
+        stream: "stdout",
+        maxPreservedBytes: maxPreservedOutputBytes,
+        preserveOutputLine: options.preserveOutputLine,
+      });
       armNoOutputTimer();
     });
     child.stderr?.on("data", (d) => {
-      appendCapturedOutput(stderrCapture, d, maxOutputBytes);
+      appendCapturedOutput(stderrCapture, d, maxOutputBytes, {
+        stream: "stderr",
+        maxPreservedBytes: maxPreservedOutputBytes,
+        preserveOutputLine: options.preserveOutputLine,
+      });
       armNoOutputTimer();
     });
     child.on("error", (err) => {
@@ -596,6 +692,18 @@ export async function runCommandWithTimeout(
             ? TIMEOUT_EXIT_CODE
             : resolvedCode
           : resolvedCode;
+      flushPreservedOutputLine({
+        capture: stdoutCapture,
+        stream: "stdout",
+        maxPreservedBytes: maxPreservedOutputBytes,
+        preserveOutputLine: options.preserveOutputLine,
+      });
+      flushPreservedOutputLine({
+        capture: stderrCapture,
+        stream: "stderr",
+        maxPreservedBytes: maxPreservedOutputBytes,
+        preserveOutputLine: options.preserveOutputLine,
+      });
       resolve({
         pid: child.pid ?? undefined,
         stdout: decodeWindowsOutputBuffer({
@@ -606,6 +714,12 @@ export async function runCommandWithTimeout(
           buffer: Buffer.concat(stderrCapture.chunks, stderrCapture.bytes),
           windowsEncoding,
         }),
+        stdoutPreservedLines: stdoutCapture.preservedLines.length
+          ? stdoutCapture.preservedLines
+          : undefined,
+        stderrPreservedLines: stderrCapture.preservedLines.length
+          ? stderrCapture.preservedLines
+          : undefined,
         stdoutTruncatedBytes: stdoutCapture.truncatedBytes || undefined,
         stderrTruncatedBytes: stderrCapture.truncatedBytes || undefined,
         code: normalizedCode,


### PR DESCRIPTION
Closes #96346

Draft safety note: this should stay draft until #95809, or an equivalent cron announce/webhook redaction change, lands. This PR preserves action-critical command output in the stored/interactive summary; current main still sends command summaries to non-interactive delivery paths.

## What Problem This Solves

Fixes an issue where users waiting on cron command results could lose one-time setup or authentication instructions when `outputMaxBytes` tail truncation drops early stdout/stderr lines.

That made device-code flows unactionable: the result could keep filler output while omitting the short code or next-action line needed to complete auth.

## Why This Change Was Made

The command runner now uses a small action-critical output classifier for device-login URLs, local callback URLs, setup codes, and explicit next-action instructions. `runCommandWithTimeout` keeps its existing bounded tail behavior by default, but accepts an explicit bounded `preserveOutputLine` hook so cron command summaries can include matched earlier lines, the tail, and a run-history recovery hint.

This does not duplicate the non-interactive redaction work in #95809. The PR is intentionally draft until that boundary is covered.

## User Impact

Users who run a cron command and wait for the result can still see short auth/setup lines even when later output is large enough to trigger truncation. Output capture remains bounded for ordinary command output.

## Evidence

- Duplicate checks before implementation and again before opening this PR searched open and closed PRs for `#96346`, the final title, `src/cron/action-critical-output.ts`, `src/process/exec.ts preserveOutputLine`, `src/cron/command-runner.ts`, `login.microsoft.com/device`, and the recovery wording. No overlapping PR was found; #95809 remains adjacent redaction-only work.
- `node scripts/run-vitest.mjs src/cron/command-runner.test.ts src/process/exec.no-output-timer.test.ts`
- `node scripts/run-vitest.mjs src/process/exec.test.ts src/cron/run-diagnostics.test.ts src/gateway/server-cron.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 src/cron/action-critical-output.ts src/process/exec.ts src/cron/command-runner.ts src/process/exec.no-output-timer.test.ts src/cron/command-runner.test.ts`
- `git diff --check`

Known proof gap: no live cron service restart/run was performed in this local environment. The regression coverage uses synthetic device-code output and validates the affected command runner/process capture boundaries.
