### PR TITLE
test(provider-usage): cover bounded shared response reads

### DIFF
--- a/src/infra/provider-usage.fetch.shared.test.ts
+++ b/src/infra/provider-usage.fetch.shared.test.ts
@@ -8,6 +8,7 @@ import {
   discardUsageResponseBody,
   fetchJson,
   parseFiniteNumber,
+  readUsageJson,
 } from "./provider-usage.fetch.shared.js";
 
 function requireFetchCall(
@@ -147,5 +148,89 @@ describe("provider usage fetch shared helpers", () => {
     });
 
     expect(snapshot.error).toBe("HTTP 429");
+  });
+
+  describe("readUsageJson", () => {
+    it("parses a normal-sized JSON response", async () => {
+      const response = new Response(
+        JSON.stringify({ windows: [{ label: "5h", usedPercent: 42 }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+
+      await expect(readUsageJson("anthropic", response)).resolves.toEqual({
+        ok: true,
+        data: { windows: [{ label: "5h", usedPercent: 42 }] },
+      });
+    });
+
+    it("parses UTF-8 BOM-prefixed JSON with fetch-compatible semantics", async () => {
+      const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+      const json = new TextEncoder().encode(JSON.stringify({ windows: [] }));
+      const combined = new Uint8Array(bom.length + json.length);
+      combined.set(bom);
+      combined.set(json, bom.length);
+      const response = new Response(combined, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+      await expect(readUsageJson("anthropic", response)).resolves.toEqual({
+        ok: true,
+        data: { windows: [] },
+      });
+    });
+
+    it("rejects an oversized JSON response and cancels the stream", async () => {
+      let pullCount = 0;
+      const cancel = vi.fn(async () => undefined);
+      const oversizedStream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pullCount += 1;
+          controller.enqueue(new Uint8Array(pullCount === 1 ? 16 * 1024 * 1024 + 1 : 1));
+        },
+        cancel,
+      });
+      const response = new Response(oversizedStream, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+      await expect(readUsageJson("anthropic", response)).resolves.toEqual({
+        ok: false,
+        snapshot: expect.objectContaining({
+          provider: "anthropic",
+          error: "Malformed usage response",
+        }),
+      });
+      expect(pullCount).toBeLessThanOrEqual(2);
+      expect(cancel).toHaveBeenCalledOnce();
+    });
+
+    it("handles a JSON parse error gracefully", async () => {
+      const response = new Response("not-json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+      await expect(readUsageJson("openai", response)).resolves.toEqual({
+        ok: false,
+        snapshot: expect.objectContaining({
+          provider: "openai",
+          error: "Malformed usage response",
+        }),
+      });
+    });
+
+    it("preserves provider name in malformed error snapshots", async () => {
+      const response = new Response("", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+      await expect(readUsageJson("deepseek", response)).resolves.toEqual({
+        ok: false,
+        snapshot: expect.objectContaining({ provider: "deepseek" }),
+      });
+    });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`readUsageJson` in `src/infra/provider-usage.fetch.shared.ts` reads provider
usage API responses with an unbounded `await response.json()`. A
compromised or hijacked provider endpoint can stream an arbitrarily large
body and force the runtime to buffer the entire payload before parsing —
an OOM/DoS vector. This is the same vulnerability class already hardened
for OpenRouter (#95420), Google (#95417), provider HTTP errors (#95218),
Matrix (#95240), and ClawHub (#95226); the provider usage monitoring path
was still reading without a cap.

## Changes

- `src/infra/provider-usage.fetch.shared.ts` — import
  `readResponseWithLimit` from
  `@openclaw/media-core/read-response-with-limit`; replace
  `await response.json()` with `readResponseWithLimit` at 16 MiB cap +
  `JSON.parse(new TextDecoder().decode(buffer))`. Uses `TextDecoder` (not
  `Buffer.toString`) to preserve UTF-8 BOM stripping semantics that
  `response.json()` provides, matching the sibling bounded-read pattern in
  `provider-http-errors.ts:308`.

## Evidence

### Real behavior proof

```text
$ node --import tsx /tmp/verify-overflow-cancel.mjs
PASS: readResponseWithLimit threw: Provider usage response too large: 16777217 bytes
PASS: pullCount = 1 (<= 2 means stream cancelled early)
PASS: stream cancelled = true
```

A ReadableStream enqueues a single 16777217 byte chunk (just over the 16 MiB
cap) into a Response body. `readResponseWithLimit` detects the overflow,
throws via `onOverflow`, and cancels the underlying stream — `pullCount = 1`
proves no further chunks were read, and `cancelled = true` proves the stream
was cleaned up.

### Tests

- **New Vitest case `rejects an oversized JSON response`** creates a
  ReadableStream whose first chunk exceeds the 16 MiB cap and proves the
  bounded read cancels the body (`cancel` called once, `pull` count ≤ 2)
  and returns `{ ok: false, snapshot: { error: "Malformed usage response" } }`.
- **New Vitest case `parses a normal-sized JSON response`** proves a valid
  response under the cap returns `{ ok: true, data }` unchanged.
- **New Vitest case `handles a JSON parse error gracefully`** proves
  non-JSON content still returns `"Malformed usage response"` via the catch
  block.
- `pnpm test src/infra/provider-usage.fetch.shared.test.ts` → **16 passed (16)**
- `oxlint` on the changed file → **exit 0, no findings**