### PR TITLE
fix(tools-manager): require clean exit in commandExists

### DIFF
--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -155,3 +155,30 @@ describe("ensureTool", () => {
     );
   });
 });
+
+describe("getToolPath exit-status handling", () => {
+  it("treats a binary that spawns but exits non-zero as missing", async () => {
+    const { getToolPath } = await import("./tools-manager.js");
+    // execve succeeded (no result.error) but the child exited non-zero — the
+    // signature of an installed-but-broken binary (GLIBC / shared-lib mismatch).
+    // Must not be reported as available, or ensureTool skips its download path.
+    spawnSyncMock.mockReturnValue({
+      error: undefined,
+      status: 1,
+      stderr: Buffer.alloc(0),
+      stdout: Buffer.alloc(0),
+    });
+    expect(getToolPath("fd")).toBeNull();
+  });
+
+  it("reports a binary present when it spawns and exits 0", async () => {
+    const { getToolPath } = await import("./tools-manager.js");
+    spawnSyncMock.mockReturnValue({
+      error: undefined,
+      status: 0,
+      stderr: Buffer.alloc(0),
+      stdout: Buffer.alloc(0),
+    });
+    expect(getToolPath("fd")).toBe("fd");
+  });
+});

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -101,9 +101,12 @@ const TOOLS: Record<string, ToolConfig> = {
 // Check if a command exists in PATH by trying to run it
 function commandExists(cmd: string): boolean {
   try {
-    const result = spawnSync(cmd, ["--version"], { stdio: "pipe" });
-    // Check for ENOENT error (command not found)
-    return result.error === undefined || result.error === null;
+    const result = spawnSync(cmd, ["--version"], { stdio: "pipe", timeout: 5_000 });
+    // Require a clean exit, not just a successful spawn. An installed-but-broken
+    // binary (e.g. GLIBC mismatch after a system upgrade, missing shared lib)
+    // spawns fine but exits non-zero; without the status check it would be
+    // misreported as available and block ensureTool's auto-install fallback.
+    return !result.error && result.status === 0;
   } catch {
     return false;
   }


### PR DESCRIPTION
## What Problem This Solves

`commandExists` in `src/agents/utils/tools-manager.ts` only inspected `spawnSync`'s `result.error`, so a binary that **spawns successfully but exits non-zero** (e.g. a `fd`/`rg` broken by a GLIBC or shared-library mismatch after a system upgrade) was misreported as available. `getToolPath` then returned the broken command name and `ensureTool` never reached its auto-install fallback, leaving the agent without a working tool and no self-heal.

## Why This Change Was Made

The sibling `runExtractionCommand` in the same file already requires `!result.error && result.status === 0`; `commandExists` was missing the status half. Node's `spawnSync` only sets `result.error` when a process **cannot be spawned** (ENOENT/EACCES) — a child that starts then crashes leaves `result.error === undefined` with a non-zero `result.status`, which the old check treated as success. This is a real production state (distro upgrade / GLIBC bump), not hypothetical malformed input.

## User Impact

Users whose system `fd`/`rg` is installed but broken now fall through to OpenClaw's automatic download + install path instead of getting stuck on a broken binary. Healthy and absent binaries are unchanged (control case verified).

## Real behavior proof

- **Behavior addressed:** `commandExists` reported a binary that spawns but exits non-zero as present, so `getToolPath` returned the broken command name and `ensureTool` skipped its auto-install fallback.
- **Real environment tested:** Linux x86_64, Node 22, commit `377d560eff` on branch `fix/tools-manager-command-exit-status`.
- **Exact steps or command run after this patch:** `node --import tsx /tmp/verify-command-exists.mjs` (isolates TOOLS_DIR, puts a broken `fd` shebang `exit 1` on PATH, then calls the real exported `getToolPath`.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```text
  Terminal capture of node runtime verification (live stdout):
    scenario: PATH contains a BROKEN 'fd' (spawns, exits non-zero)

    spawnSync(broken fd) => result.error=undefined, result.status=1
    OLD logic (error only):            true   <-- BUG: misreports broken binary as present
    NEW logic (!error && status===0):  false

    getToolPath("fd")  => null   PASS (null = not misreported)
    getToolPath("rg")  => "rg"   PASS (healthy binary still found)

  Verdict: PASS - broken binary falls through, healthy binary still found
  ```

- **Observed result after fix:** A broken `fd` is no longer reported as present (`getToolPath` returns `null`), so `ensureTool` proceeds to download; a healthy `rg` is still detected.
- **What was not tested:** Real GLIBC-mismatched binaries across multiple distros; Windows (motivating scenario is Unix, regression test is Unix-only).

## Tests and validation

```text
$ pnpm test src/agents/utils/tools-manager.test.ts
Test Files  1 passed (1)
Tests       5 passed (5)

$ pnpm tsgo:core:test
EXIT=0 (type check passed)
```

Added two regression cases to `tools-manager.test.ts` (via the exported `getToolPath`, using the file's existing `spawnSync` mock): a spawned-but-non-zero binary must be treated as missing, and a spawned-and-exit-0 binary must still be found.

## Risk checklist

- User-visible behavior: Yes - broken system fd/rg binaries now fall through to auto-install; healthy and absent binaries unchanged.
- Config/env/migration behavior: No - no config or env surface touched.
- Security/auth/secrets/network/tool execution: No - the patch only changes a local binary-availability check; no credential, network, or new command-execution path.
- Plugins/providers/channels/SDK: No - `commandExists` stays module-local; no public/plugin SDK API change.
- Highest-risk area: a 5s spawn timeout is added; strictly safer (a hung PATH entry can no longer block startup) and no caller depends on unbounded blocking.
- Mitigation: control case verifies healthy binaries still detected; type signature unchanged and `tsgo:core:test` green.

Closes: N/A (no existing issue)
