### PR TITLE
fix: scope native hook relay processes

### DIFF
--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -27,6 +27,7 @@ import {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
   resetGlobalHookRunner();
   setActivePluginRegistry(createEmptyPluginRegistry());
@@ -3229,5 +3230,27 @@ describe("native hook relay command builder", () => {
     ).toBe(
       "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop --timeout 5000",
     );
+  });
+
+  it("wraps relay commands in a user systemd scope when a runtime is available", async () => {
+    const binDir = await fs.mkdtemp(path.join(tmpdir(), "openclaw-systemd-run-"));
+    const systemdRunPath = path.join(binDir, "systemd-run");
+    writeFileSync(systemdRunPath, "", { mode: 0o755 });
+    vi.stubEnv("XDG_RUNTIME_DIR", "/run/user/1000");
+    vi.stubEnv("OPENCLAW_SYSTEMD_RUN_PATH", systemdRunPath);
+
+    expect(
+      buildNativeHookRelayCommand({
+        provider: "codex",
+        relayId: "relay-1",
+        generation: "generation-1",
+        event: "permission_request",
+        executable: "openclaw",
+      }),
+    ).toBe(
+      `${systemdRunPath} --user --scope --quiet -p CPUQuota=25% -p MemoryMax=512M -p TasksMax=32 -- openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request --timeout 5000`,
+    );
+
+    rmSync(binDir, { force: true, recursive: true });
   });
 });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -61,6 +61,10 @@ const NATIVE_HOOK_RELAY_EVENTS = [
 ] as const;
 
 const NATIVE_HOOK_RELAY_PROVIDERS = ["codex"] as const;
+const NATIVE_HOOK_RELAY_SYSTEMD_RUN_CANDIDATE_PATHS = [
+  "/usr/bin/systemd-run",
+  "/bin/systemd-run",
+] as const;
 
 export type NativeHookRelayEvent = (typeof NATIVE_HOOK_RELAY_EVENTS)[number];
 export type NativeHookRelayProvider = (typeof NATIVE_HOOK_RELAY_PROVIDERS)[number];
@@ -545,6 +549,22 @@ function resolveNativeHookRelayCommandTimeoutMs(
   return Math.min(configured, override);
 }
 
+function resolveNativeHookRelaySystemdRunPath(): string | undefined {
+  if (process.platform !== "linux") {
+    return undefined;
+  }
+  if (!process.env.XDG_RUNTIME_DIR?.trim()) {
+    return undefined;
+  }
+  const configuredPath = process.env.OPENCLAW_SYSTEMD_RUN_PATH?.trim();
+  if (configuredPath) {
+    return existsSync(configuredPath) ? configuredPath : undefined;
+  }
+  return NATIVE_HOOK_RELAY_SYSTEMD_RUN_CANDIDATE_PATHS.find((candidatePath) =>
+    existsSync(candidatePath),
+  );
+}
+
 export function buildNativeHookRelayCommand(params: {
   provider: NativeHookRelayProvider;
   relayId: string;
@@ -563,7 +583,7 @@ export function buildNativeHookRelayCommand(params: {
       ? ["openclaw"]
       : [params.nodeExecutable ?? process.execPath, executable];
   const nicePrefix = resolveNativeHookRelayNicePrefix(params.nice);
-  return shellQuoteArgs([
+  const relayCommand = [
     ...nicePrefix,
     ...argv,
     "hooks",
@@ -580,6 +600,24 @@ export function buildNativeHookRelayCommand(params: {
       : []),
     "--timeout",
     String(timeoutMs),
+  ];
+  const systemdRunPath = resolveNativeHookRelaySystemdRunPath();
+  if (!systemdRunPath) {
+    return shellQuoteArgs(relayCommand);
+  }
+  return shellQuoteArgs([
+    systemdRunPath,
+    "--user",
+    "--scope",
+    "--quiet",
+    "-p",
+    "CPUQuota=25%",
+    "-p",
+    "MemoryMax=512M",
+    "-p",
+    "TasksMax=32",
+    "--",
+    ...relayCommand,
   ]);
 }
 


### PR DESCRIPTION
## Summary
- wrap native hook relay commands in a constrained `systemd-run --user --scope` when a Linux user runtime is available
- fall back to the existing relay command shape when `systemd-run` or `XDG_RUNTIME_DIR` is unavailable
- add a unit test covering the scoped command form

## Why
A hotfix investigation on a live OpenClaw deployment found that `openclaw hooks relay` child processes can contend directly with the main gateway process when hook workloads spike. This change adds a minimal isolation layer for relay subprocesses without changing non-Linux or non-systemd behavior.

## Validation
- `pnpm vitest run src/agents/harness/native-hook-relay.test.ts` could not be completed in this environment because `pnpm` started bootstrapping `pnpm@11.2.2` instead of running the workspace test directly.
- Verified the source diff is limited to `src/agents/harness/native-hook-relay.ts` and its unit test.
