### PR TITLE
Treat HTTP 530 as transient failover timeout

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.test.ts
+++ b/src/agents/embedded-agent-helpers/errors.test.ts
@@ -4,7 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assistant-error-format.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
-import { formatAssistantErrorText, isLikelyContextOverflowError } from "./errors.js";
+import {
+  classifyFailoverSignal,
+  classifyProviderRuntimeFailureKind,
+  formatAssistantErrorText,
+  isLikelyContextOverflowError,
+} from "./errors.js";
 
 const { toolPolicyAuditInfo } = vi.hoisted(() => ({
   toolPolicyAuditInfo: vi.fn(),
@@ -105,5 +110,23 @@ describe("isLikelyContextOverflowError", () => {
         "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
       ),
     ).toBe(true);
+  });
+});
+
+describe("HTTP 530 failover classification", () => {
+  it("classifies structured HTTP 530 responses as timeout for model fallback", () => {
+    expect(classifyFailoverSignal({ status: 530 })).toEqual({
+      kind: "reason",
+      reason: "timeout",
+    });
+  });
+
+  it("classifies HTTP 530 provider runtime failures as timeout", () => {
+    expect(
+      classifyProviderRuntimeFailureKind({
+        status: 530,
+        message: "The AI service is temporarily unavailable (HTTP 530). Please try again in a moment.",
+      }),
+    ).toBe("timeout");
   });
 });

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -270,7 +270,19 @@ export function extractObservedOverflowTokenCount(errorMessage?: string): number
   return undefined;
 }
 
-const TRANSIENT_HTTP_ERROR_CODES = new Set([499, 500, 502, 503, 504, 521, 522, 523, 524, 529]);
+const TRANSIENT_HTTP_ERROR_CODES = new Set([
+  499,
+  500,
+  502,
+  503,
+  504,
+  521,
+  522,
+  523,
+  524,
+  529,
+  530,
+]);
 
 type PaymentRequiredFailoverReason = Extract<FailoverReason, "billing" | "rate_limit">;
 
@@ -599,7 +611,7 @@ function isTimeoutTransportErrorMessage(raw: string, status?: number): boolean {
   }
   if (
     typeof status === "number" &&
-    [408, 499, 500, 502, 503, 504, 521, 522, 523, 524, 529].includes(status)
+    [408, 499, 500, 502, 503, 504, 521, 522, 523, 524, 529, 530].includes(status)
   ) {
     return true;
   }
@@ -861,7 +873,7 @@ function classifyFailoverClassificationFromHttpStatus(
     }
     return toReasonClassification("timeout");
   }
-  if (status === 500 || status === 502 || status === 504) {
+  if (status === 500 || status === 502 || status === 504 || status === 530) {
     if (messageReason === "server_error") {
       return messageClassification;
     }


### PR DESCRIPTION
Problem

OpenClaw can surface HTTP 530 from the provider/CDN path as a terminal error instead of a fallback-triggering transient timeout. That blocks model failover in the same class of temporary upstream outages that already fall back for 499/500/502/503/504/521/522/523/524/529.

Evidence

- The failover classifier in `src/agents/embedded-agent-helpers/errors.ts` included 529 but not 530 in the transient HTTP status set and timeout branch.
- I reproduced the user-facing failure locally: a session ended with `The AI service is temporarily unavailable (HTTP 530). Please try again in a moment.` before failover later kicked in.
- The model-failover docs describe fallback for transient provider failures; 530 is the missing edge in that path.

Fix

- Treat 530 as transient/timeout in the failover classifier.
- Add regression coverage for structured `status: 530` and provider-runtime classification.