### PR TITLE
fix(extensions/google): switch cli-backend to use agy and stdin transport

### DIFF
--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -87,30 +87,17 @@ export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
       );
     },
     config: {
-      command: "gemini",
+      command: "agy",
       args: [
-        "--skip-trust",
-        "--approval-mode",
-        "auto_edit",
-        "--output-format",
-        "stream-json",
-        "--prompt",
-        "{prompt}",
+        "--dangerously-skip-permissions"
       ],
       resumeArgs: [
-        "--skip-trust",
-        "--approval-mode",
-        "auto_edit",
-        "--resume",
-        "{sessionId}",
-        "--output-format",
-        "stream-json",
-        "--prompt",
-        "{prompt}",
+        "--dangerously-skip-permissions",
+        "--conversation",
+        "{sessionId}"
       ],
-      output: "jsonl",
-      input: "arg",
-      jsonlDialect: "gemini-stream-json",
+      output: "text",
+      input: "stdin",
       imageArg: "@",
       imagePathScope: "workspace",
       modelArg: "--model",


### PR DESCRIPTION
This switches the transport for the Google cli-backend from args to stdin to avoid ARG_MAX issues on long contexts, and explicitly invokes agy instead of gemini.