### PR TITLE
docs(config-agents): correct built-in alias table for opus and gpt

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -509,9 +509,9 @@ Time format in system prompt. Default: `auto` (OS preference).
 
 | Alias               | Model                           |
 | ------------------- | ------------------------------- |
-| `opus`              | `anthropic/claude-opus-4-6`     |
+| `opus`              | `anthropic/claude-opus-4-8`     |
 | `sonnet`            | `anthropic/claude-sonnet-4-6`   |
-| `gpt`               | `openai/gpt-5.5`                |
+| `gpt`               | `openai/gpt-5.4`                |
 | `gpt-mini`          | `openai/gpt-5.4-mini`           |
 | `gpt-nano`          | `openai/gpt-5.4-nano`           |
 | `gemini`            | `google/gemini-3.1-pro-preview` |


### PR DESCRIPTION
## What Problem This Solves

The "Built-in alias shorthands" table in `docs/gateway/config-agents.md` lists two model ids that no longer match the actual built-in defaults in `src/config/defaults.ts` (`DEFAULT_MODEL_ALIASES`):

| Alias | Doc table (before) | `src/config/defaults.ts` (actual) |
| --- | --- | --- |
| `opus` | `anthropic/claude-opus-4-6` | `anthropic/claude-opus-4-8` |
| `gpt` | `openai/gpt-5.5` | `openai/gpt-5.4` |

The page is also internally inconsistent: its runtime-policy example already uses `anthropic/claude-opus-4-8` while the alias table still says `claude-opus-4-6`. The `docs/help/faq-models` alias table already matches `defaults.ts`; only this page is stale.

## Why This Change Was Made

So the documented built-in aliases match the shipped runtime mapping and the other docs page, and the page stops contradicting itself.

## User Impact

Readers relying on the alias table get the correct model a built-in alias resolves to (`opus` -> Opus 4.8, `gpt` -> GPT 5.4). Docs-only; no runtime/behavior change.

## Evidence

- Source of truth: `src/config/defaults.ts` -> `DEFAULT_MODEL_ALIASES` (`opus: "anthropic/claude-opus-4-8"`, `gpt: "openai/gpt-5.4"`).
- Cross-check: `docs/help/faq-models` alias table already lists the same corrected values.
- Self-contradiction on the edited page: the runtime-policy example uses `anthropic/claude-opus-4-8`.
- Diff is 2 lines, alias table only; table alignment preserved.
