### PR TITLE
fix(telegram): prevent RICH_MESSAGE_EMAIL_INVALID by stripping mailto links and adding rich-message fallback

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -318,12 +318,28 @@ describe("markdownToTelegramHtml", () => {
       '<a href="tg://user?id=123">user</a>',
     );
     expect(markdownToTelegramRichHtml("[support](mailto:user@example.com)")).toBe(
-      '<a href="mailto:user@example.com">support</a>',
+      // mailto: links are dropped because Telegram sendRichMessage validates
+      // email entities from <a href="mailto:..."> and rejects the whole message
+      // with RICH_MESSAGE_EMAIL_INVALID when the address is malformed.
+      // The label text is preserved as plain text instead.
+      "support",
     );
     expect(markdownToTelegramRichHtml("[call](tel:+123456789)")).toBe(
       '<a href="tel:+123456789">call</a>',
     );
     expect(markdownToTelegramRichHtml("[back](#top)")).toBe('<a href="#top">back</a>');
+  });
+
+  it("does not linkify auto-detected emails in rich HTML to prevent RICH_MESSAGE_EMAIL_INVALID", () => {
+    // Auto-detected emails should remain as plain text because Telegram's
+    // sendRichMessage validates email entities from <a href="mailto:...">
+    // and rejects the whole message with RICH_MESSAGE_EMAIL_INVALID when
+    // the address is malformed.
+    expect(markdownToTelegramRichHtml("Contact: user@example.com for help")).toBe(
+      "Contact: user@example.com for help",
+    );
+    // Explicit mailto: links also drop the <a> wrapper; label text is preserved.
+    expect(markdownToTelegramRichHtml("[email](mailto:admin@company.org)")).toBe("email");
   });
 
   it("preserves Markdown heading levels in rich HTML", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -33,7 +33,11 @@ function escapeHtmlAttr(text: string): string {
 }
 
 function isTelegramRichLinkHref(href: string): boolean {
-  return /^(?:https?:\/\/|tg:\/\/|mailto:|tel:|#)/i.test(href);
+  // Exclude mailto: — Telegram sendRichMessage validates email entities from
+  // <a href="mailto:..."> tags and rejects the entire message with
+  // RICH_MESSAGE_EMAIL_INVALID when the address is malformed. Dropping the
+  // <a> wrapper keeps the visible email text without risking message delivery.
+  return /^(?:https?:\/\/|tg:\/\/|tel:|#)/i.test(href);
 }
 
 /**

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1104,6 +1104,41 @@ describe("sendMessageTelegram", () => {
     expect(richHtml).toContain('<a href="https://example.com/docs">docs</a>');
   });
 
+  it("falls back to plain text when sendRichMessage rejects with RICH_MESSAGE_EMAIL_INVALID", async () => {
+    botApi.sendMessage.mockResolvedValue({ message_id: 70, chat: { id: "123" } });
+    botRawApi.sendRichMessage.mockRejectedValueOnce(
+      new Error("400: Bad Request: RICH_MESSAGE_EMAIL_INVALID"),
+    );
+
+    await sendMessageTelegram("123", "Status with user@example.com", {
+      cfg: { channels: { telegram: { richMessages: true } } },
+      token: "tok",
+    });
+
+    // Rich attempt should have been made
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    // Fallback to plain text sendMessage
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(1);
+    const plainCall = botApi.sendMessage.mock.calls[0];
+    expect(plainCall?.[0]).toBe("123");
+    expect(plainCall?.[1]).toContain("user@example.com");
+  });
+
+  it("falls back to plain text when sendRichMessage rejects with RICH_MESSAGE_URL_INVALID", async () => {
+    botApi.sendMessage.mockResolvedValue({ message_id: 71, chat: { id: "123" } });
+    botRawApi.sendRichMessage.mockRejectedValueOnce(
+      new Error("400: Bad Request: RICH_MESSAGE_URL_INVALID"),
+    );
+
+    await sendMessageTelegram("123", "See [docs](/local/path)", {
+      cfg: { channels: { telegram: { richMessages: true } } },
+      token: "tok",
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("renders complex markdown into HTML text", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 46, chat: { id: "123" } });
     const markdown = [

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -275,6 +275,11 @@ function logTelegramOutboundSendOk(params: TelegramOutboundSuccessLogParams): vo
 }
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
+const RICH_MESSAGE_INVALID_RE = /RICH_MESSAGE_\w+_INVALID/i;
+
+function isTelegramRichMessageInvalidError(err: unknown): boolean {
+  return RICH_MESSAGE_INVALID_RE.test(formatErrorMessage(err));
+}
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
 const MESSAGE_HAS_NO_TEXT_RE = /400:\s*Bad Request:\s*there is no text in the message to edit/i;
@@ -841,10 +846,28 @@ export async function sendMessageTelegram(
     }));
   };
 
-  const sendChunkedText = async (rawText: string, context: string) =>
-    useRichMessages
-      ? await sendTelegramRichTextChunks(buildRichTextPlan(rawText), context)
-      : await sendTelegramTextChunks(buildChunkedTextPlan(rawText, context), context);
+  const sendChunkedText = async (rawText: string, context: string) => {
+    if (!useRichMessages) {
+      return await sendTelegramTextChunks(buildChunkedTextPlan(rawText, context), context);
+    }
+    try {
+      return await sendTelegramRichTextChunks(buildRichTextPlan(rawText), context);
+    } catch (err: unknown) {
+      // Rich-message entity validation errors (e.g. RICH_MESSAGE_EMAIL_INVALID,
+      // RICH_MESSAGE_URL_INVALID) reject the entire message. Fall back to plain
+      // text delivery so the user still gets the content instead of a silent drop.
+      if (!isTelegramRichMessageInvalidError(err)) {
+        throw err;
+      }
+      sendLogger.warn(
+        `telegram ${context} rich-message send failed with entity validation error, retrying as plain text: ${formatErrorMessage(err)}`,
+      );
+      return await sendTelegramTextChunks(
+        buildChunkedTextPlan(rawText, `${context}-rich-invalid`),
+        context,
+      );
+    }
+  };
 
   const buildRichTextPlan = (rawText: string): TelegramRichTextChunk[] => {
     const textLimit = Math.min(


### PR DESCRIPTION
## What Problem This Solves

Telegram `/status` slash-command replies fail to deliver when `richMessages=true` is configured. The Gateway executes the slash command, but Telegram's `sendRichMessage` API rejects the payload with `RICH_MESSAGE_EMAIL_INVALID`, leaving the user with no response.

Closes #96363

## Changes

- `extensions/telegram/src/format.ts`: remove `mailto:` from `isTelegramRichLinkHref` so auto-detected or explicit email links render as plain visible text instead of `<a href="mailto:...">` anchors that trigger Telegram rich-message email-entity validation failures.
- `extensions/telegram/src/send.ts`: add `isTelegramRichMessageInvalidError` and catch `RICH_MESSAGE_*_INVALID` errors in `sendChunkedText`, falling back to plain-text `sendMessage` delivery instead of silently dropping the outbound message.
- `extensions/telegram/src/format.test.ts`: update `mailto:` expectations; add regression coverage for auto-detected emails staying plain text in rich HTML.
- `extensions/telegram/src/send.test.ts`: add regression tests that `RICH_MESSAGE_EMAIL_INVALID` and `RICH_MESSAGE_URL_INVALID` trigger plain-text fallback.

## Real behavior proof

- **Behavior addressed**: Telegram rich-message delivery rejects OAuth/status text containing email-like auth profile labels when `richMessages=true`; after the fix, rich HTML no longer emits `mailto:` anchors and oversized/invalid rich payloads fall back to plain text on the outbound send path.
- **Real environment tested**: live Telegram Bot API 10+ against bot `@LocalViewShen_bot`, DM chat id `7985450746`, plus local formatter verification and unit tests on branch `fix/telegram-rich-message-email-invalid`.
- **Exact steps**: (1) send a provider-prefixed `mailto:` rich HTML payload that reproduces `RICH_MESSAGE_EMAIL_INVALID`; (2) generate `/status`-shaped text through patched `markdownToTelegramRichHtml` and send via `sendRichMessage`; (3) send OAuth-shaped status text (`openai:user@example.com`) through the patched formatter and live API; (4) run formatter spot checks and `format.test.ts` / `send.test.ts`.
- **Evidence after fix**: (1) broken provider-prefixed `mailto:` payload returns `400 Bad Request: RICH_MESSAGE_EMAIL_INVALID`; (2) patched formatter output `🔑 oauth (default (user@example.com))` has `Has mailto: false` and live `sendRichMessage` returns `ok: true` (`message_id: 135`); (3) OAuth-shaped label sends successfully (`message_id: 137`); probe messages deleted after verification; (4) unit tests pass (195 total).
- **Observed result**: invalid provider-prefixed `mailto:` rich HTML still fails at the API as expected; fixed rich HTML delivers successfully with email text visible and no `mailto:` anchor; HTTPS links remain clickable.
- **What was not tested**: Mantis Telegram Desktop screen recording; end-to-end `/status` through a running gateway with real auth-profile labels; shared reply-delivery fallback in `bot/delivery.send.ts` (Layer 1 prevention already affects shared rich HTML; Layer 2 fallback currently covers `sendMessageTelegram` only).

## Evidence

**Live Telegram Bot API (repro helper):**

```bash
export TELEGRAM_BOT_TOKEN="<redacted>"
export TELEGRAM_CHAT_ID="7985450746"
export TELEGRAM_PROXY="socks5h://127.0.0.1:7898"   # only if api.telegram.org is not directly reachable
./scripts/local-telegram-rich-proof.sh
```

**Baseline (broken rich HTML — reproduces failure):**

```bash
curl -sS --proxy "${TELEGRAM_PROXY:-}" \
  "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendRichMessage" \
  -H "Content-Type: application/json" \
  -d '{"chat_id":"7985450746","rich_message":{"html":"<a href=\"mailto:openai:user@example.com\">openai:user@example.com</a>"}}'
```

Observed:

```json
{
  "ok": false,
  "error_code": 400,
  "description": "Bad Request: RICH_MESSAGE_EMAIL_INVALID"
}
```

**After fix (patched formatter + live send):**

```bash
FIXED_HTML="$(node --import tsx --no-warnings -e "
import { markdownToTelegramRichHtml } from './extensions/telegram/src/format.ts';
process.stdout.write(markdownToTelegramRichHtml('🔑 oauth (default (user@example.com))'));
")"

curl -sS --proxy "${TELEGRAM_PROXY:-}" \
  "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendRichMessage" \
  -H "Content-Type: application/json" \
  -d "{\"chat_id\":\"7985450746\",\"rich_message\":{\"html\":\"${FIXED_HTML}\"}}"
```

Observed:

```
Generated HTML: 🔑 oauth (default (user@example.com))
Has mailto: false
API: ok=true, message_id=135, chat_id=7985450746
deleteMessage: ok=true
```

**OAuth-shaped status label:**

```
Input:  🔑 openai:user@example.com (user@example.com)
HTML:   🔑 openai:user@example.com (user@example.com)
Live sendRichMessage: ok=true, message_id=137 (probe deleted)
```

**Formatter spot checks:**

```
Test 1: 🔑 oauth (default (user@example.com)) → no mailto ✓
Test 2: [support](mailto:help@company.com) → plain "support" ✓
Test 3: [docs](https://example.com/docs) → HTTPS <a> preserved ✓
Test 4: /status snippet with email + HTTPS link → mailto absent ✓
```

**Unit tests:**

```bash
pnpm test extensions/telegram/src/format.test.ts extensions/telegram/src/send.test.ts
```

```
✓ extensions/telegram/src/format.test.ts — 59 passed
✓ extensions/telegram/src/send.test.ts — 136 passed
Total — 195 passed
```
