### PR TITLE
feat(line): per-user in-flight guard for concurrent message errors

### DIFF
--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -1363,4 +1363,109 @@ describe("handleLineWebhookEvents", () => {
     resolveFirst?.();
     await firstRun;
   });
+
+  it("does not guard senderless group postbacks so distinct users are not cross-blocked", async () => {
+    // LINE group/room postbacks may omit source.userId (@line/bot-sdk marks it
+    // optional, message events only). Guarding them would collapse all senders
+    // onto one key and drop unrelated button taps.
+    let resolveFirst: (() => void) | undefined;
+    const firstDone = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const processMessage = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await firstDone;
+      })
+      .mockResolvedValueOnce(undefined);
+    buildLinePostbackContextMock.mockResolvedValue({
+      ctxPayload: { From: "line:group:group-shared" },
+      route: { agentId: "default" },
+      isGroup: true,
+      accountId: "default",
+    });
+
+    const basePostback = {
+      type: "postback",
+      postback: { data: "action=confirm" },
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-shared" },
+      mode: "active",
+      deliveryContext: { isRedelivery: false },
+    };
+    const postbackA = {
+      ...basePostback,
+      replyToken: "reply-token-pb-a",
+      webhookEventId: "evt-pb-senderless-a",
+    } as PostbackEvent;
+    const postbackB = {
+      ...basePostback,
+      replyToken: "reply-token-pb-b",
+      webhookEventId: "evt-pb-senderless-b",
+    } as PostbackEvent;
+
+    const context = createLineWebhookTestContext({
+      processMessage,
+      groupPolicy: "open",
+      requireMention: false,
+    });
+    context.userInFlightGuard = createLineUserInFlightGuard();
+
+    const firstRun = handleLineWebhookEvents([postbackA], context);
+    await vi.waitFor(() => {
+      expect(processMessage).toHaveBeenCalledTimes(1);
+    });
+
+    await handleLineWebhookEvents([postbackB], context);
+
+    expect(processMessage).toHaveBeenCalledTimes(2);
+    expect(replyMessageLineMock).not.toHaveBeenCalled();
+
+    resolveFirst?.();
+    await firstRun;
+  });
+
+  it("does not guard group messages without sender identity", async () => {
+    let resolveFirst: (() => void) | undefined;
+    const firstDone = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const processMessage = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await firstDone;
+      })
+      .mockResolvedValueOnce(undefined);
+
+    const eventA = createTestMessageEvent({
+      message: { id: "m-senderless-a", type: "text", text: "first", quoteToken: "q-sl-a" },
+      source: { type: "group", groupId: "group-shared" },
+      webhookEventId: "evt-senderless-a",
+    });
+    const eventB = createTestMessageEvent({
+      message: { id: "m-senderless-b", type: "text", text: "second", quoteToken: "q-sl-b" },
+      source: { type: "group", groupId: "group-shared" },
+      webhookEventId: "evt-senderless-b",
+    });
+
+    const context = createLineWebhookTestContext({
+      processMessage,
+      groupPolicy: "open",
+      requireMention: false,
+    });
+    context.userInFlightGuard = createLineUserInFlightGuard();
+
+    const firstRun = handleLineWebhookEvents([eventA], context);
+    await vi.waitFor(() => {
+      expect(processMessage).toHaveBeenCalledTimes(1);
+    });
+
+    await handleLineWebhookEvents([eventB], context);
+
+    expect(processMessage).toHaveBeenCalledTimes(2);
+    expect(replyMessageLineMock).not.toHaveBeenCalled();
+
+    resolveFirst?.();
+    await firstRun;
+  });
 });

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -1215,7 +1215,7 @@ describe("handleLineWebhookEvents", () => {
     await handleLineWebhookEvents([event2], context);
 
     expect(replyMessageLineMock).toHaveBeenCalledTimes(1);
-    const replyMessages = (replyMessageLineMock.mock.calls[0] as unknown[])?.[1] as
+    const replyMessages = replyMessageLineMock.mock.calls[0]?.[1] as
       | Array<{ text?: string }>
       | undefined;
     expect(replyMessages?.[0]?.text).toContain("still being processed");

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -137,13 +137,18 @@ vi.mock("./download.js", () => ({
   downloadLineMedia: downloadLineMediaMock,
 }));
 
-vi.mock("./send.js", () => ({
-  pushMessageLine: async () => {
+const { pushMessageLineMock, replyMessageLineMock } = vi.hoisted(() => ({
+  pushMessageLineMock: vi.fn(async () => {
     throw new Error("pushMessageLine should not be called from bot-handlers tests");
-  },
-  replyMessageLine: async () => {
+  }),
+  replyMessageLineMock: vi.fn(async () => {
     throw new Error("replyMessageLine should not be called from bot-handlers tests");
-  },
+  }),
+}));
+
+vi.mock("./send.js", () => ({
+  pushMessageLine: pushMessageLineMock,
+  replyMessageLine: replyMessageLineMock,
 }));
 
 const { buildLineMessageContextMock, buildLinePostbackContextMock } = vi.hoisted(() => ({
@@ -175,6 +180,7 @@ vi.mock("./bot-message-context.js", () => ({
 
 let handleLineWebhookEvents: typeof import("./bot-handlers.js").handleLineWebhookEvents;
 let createLineWebhookReplayCache: typeof import("./bot-handlers.js").createLineWebhookReplayCache;
+let createLineUserInFlightGuard: typeof import("./bot-handlers.js").createLineUserInFlightGuard;
 let LineRetryableWebhookError: typeof import("./bot-handlers.js").LineRetryableWebhookError;
 type LineWebhookContext = Parameters<typeof import("./bot-handlers.js").handleLineWebhookEvents>[1];
 
@@ -315,8 +321,12 @@ async function startInflightReplayDuplicate(params: {
 
 describe("handleLineWebhookEvents", () => {
   beforeAll(async () => {
-    ({ handleLineWebhookEvents, createLineWebhookReplayCache, LineRetryableWebhookError } =
-      await import("./bot-handlers.js"));
+    ({
+      handleLineWebhookEvents,
+      createLineWebhookReplayCache,
+      createLineUserInFlightGuard,
+      LineRetryableWebhookError,
+    } = await import("./bot-handlers.js"));
   });
 
   afterAll(() => {
@@ -352,6 +362,14 @@ describe("handleLineWebhookEvents", () => {
     downloadLineMediaMock.mockReset();
     downloadLineMediaMock.mockImplementation(async () => {
       throw new Error("downloadLineMedia should not be called from bot-handlers tests");
+    });
+    pushMessageLineMock.mockReset();
+    pushMessageLineMock.mockImplementation(async () => {
+      throw new Error("pushMessageLine should not be called from bot-handlers tests");
+    });
+    replyMessageLineMock.mockReset();
+    replyMessageLineMock.mockImplementation(async () => {
+      throw new Error("replyMessageLine should not be called from bot-handlers tests");
     });
   });
   it("blocks group messages when groupPolicy is disabled", async () => {
@@ -1162,5 +1180,184 @@ describe("handleLineWebhookEvents", () => {
 
     expect(buildLineMessageContextMock).toHaveBeenCalledTimes(2);
     expect(processMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends busy reply and skips processMessage when user has in-flight message", async () => {
+    let resolveFirst: (() => void) | undefined;
+    const firstDone = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const processMessage = vi.fn(async () => {
+      await firstDone;
+    });
+    replyMessageLineMock.mockResolvedValue(undefined);
+
+    const event1 = createTestMessageEvent({
+      message: { id: "m-inflight-1", type: "text", text: "first", quoteToken: "q-1" },
+      source: { type: "user", userId: "user-busy" },
+      webhookEventId: "evt-inflight-1",
+    });
+    const event2 = createTestMessageEvent({
+      message: { id: "m-inflight-2", type: "text", text: "second", quoteToken: "q-2" },
+      source: { type: "user", userId: "user-busy" },
+      webhookEventId: "evt-inflight-2",
+    });
+
+    const context = createLineWebhookTestContext({
+      processMessage,
+      dmPolicy: "open",
+    });
+    context.userInFlightGuard = createLineUserInFlightGuard();
+
+    const firstRun = handleLineWebhookEvents([event1], context);
+    await Promise.resolve();
+
+    await handleLineWebhookEvents([event2], context);
+
+    expect(replyMessageLineMock).toHaveBeenCalledTimes(1);
+    expect(replyMessageLineMock.mock.calls[0]?.[1]?.[0]?.text).toContain("still being processed");
+
+    resolveFirst?.();
+    await firstRun;
+
+    expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases in-flight guard after processMessage completes so next message is processed", async () => {
+    const processMessage = vi.fn().mockResolvedValue(undefined);
+
+    const event1 = createTestMessageEvent({
+      message: { id: "m-seq-1", type: "text", text: "first", quoteToken: "q-seq-1" },
+      source: { type: "user", userId: "user-seq" },
+      webhookEventId: "evt-seq-1",
+    });
+    const event2 = createTestMessageEvent({
+      message: { id: "m-seq-2", type: "text", text: "second", quoteToken: "q-seq-2" },
+      source: { type: "user", userId: "user-seq" },
+      webhookEventId: "evt-seq-2",
+    });
+
+    const context = createLineWebhookTestContext({
+      processMessage,
+      dmPolicy: "open",
+    });
+    context.userInFlightGuard = createLineUserInFlightGuard();
+
+    await handleLineWebhookEvents([event1], context);
+    await handleLineWebhookEvents([event2], context);
+
+    expect(processMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases in-flight guard even when processMessage throws", async () => {
+    const processMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("agent error"))
+      .mockResolvedValueOnce(undefined);
+
+    const event1 = createTestMessageEvent({
+      message: { id: "m-err-1", type: "text", text: "first", quoteToken: "q-err-1" },
+      source: { type: "user", userId: "user-err" },
+      webhookEventId: "evt-err-1",
+    });
+    const event2 = createTestMessageEvent({
+      message: { id: "m-err-2", type: "text", text: "second", quoteToken: "q-err-2" },
+      source: { type: "user", userId: "user-err" },
+      webhookEventId: "evt-err-2",
+    });
+
+    const context = createLineWebhookTestContext({
+      processMessage,
+      dmPolicy: "open",
+    });
+    context.userInFlightGuard = createLineUserInFlightGuard();
+
+    await expect(handleLineWebhookEvents([event1], context)).rejects.toThrow("agent error");
+    await handleLineWebhookEvents([event2], context);
+
+    expect(processMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not block when userInFlightGuard is not configured", async () => {
+    let resolveFirst: (() => void) | undefined;
+    const firstDone = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const processMessage = vi.fn(async () => {
+      await firstDone;
+    });
+
+    const event1 = createTestMessageEvent({
+      message: { id: "m-no-guard-1", type: "text", text: "first", quoteToken: "q-ng-1" },
+      source: { type: "user", userId: "user-no-guard" },
+      webhookEventId: "evt-no-guard-1",
+    });
+    const event2 = createTestMessageEvent({
+      message: { id: "m-no-guard-2", type: "text", text: "second", quoteToken: "q-ng-2" },
+      source: { type: "user", userId: "user-no-guard" },
+      webhookEventId: "evt-no-guard-2",
+    });
+
+    // No userInFlightGuard — both messages should be processed concurrently.
+    const context = createLineWebhookTestContext({
+      processMessage,
+      dmPolicy: "open",
+    });
+
+    const firstRun = handleLineWebhookEvents([event1], context);
+    await Promise.resolve();
+    const secondRun = handleLineWebhookEvents([event2], context);
+
+    resolveFirst?.();
+    await Promise.all([firstRun, secondRun]);
+
+    expect(processMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("isolates in-flight guard per user in group conversations", async () => {
+    let resolveFirst: (() => void) | undefined;
+    const firstDone = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const processMessage = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await firstDone;
+      })
+      .mockResolvedValueOnce(undefined);
+    replyMessageLineMock.mockResolvedValue(undefined);
+
+    const eventUserA = createTestMessageEvent({
+      message: { id: "m-group-a", type: "text", text: "from A", quoteToken: "q-ga" },
+      source: { type: "group", groupId: "group-shared", userId: "user-a" },
+      webhookEventId: "evt-group-a",
+    });
+    const eventUserB = createTestMessageEvent({
+      message: { id: "m-group-b", type: "text", text: "from B", quoteToken: "q-gb" },
+      source: { type: "group", groupId: "group-shared", userId: "user-b" },
+      webhookEventId: "evt-group-b",
+    });
+
+    const context = createLineWebhookTestContext({
+      processMessage,
+      groupPolicy: "open",
+      requireMention: false,
+    });
+    context.userInFlightGuard = createLineUserInFlightGuard();
+
+    // User A starts processing (blocks in processMessage)
+    const firstRun = handleLineWebhookEvents([eventUserA], context);
+    await vi.waitFor(() => {
+      expect(processMessage).toHaveBeenCalledTimes(1);
+    });
+
+    // User B in the same group should NOT be blocked (different user key)
+    await handleLineWebhookEvents([eventUserB], context);
+
+    expect(processMessage).toHaveBeenCalledTimes(2);
+    expect(replyMessageLineMock).not.toHaveBeenCalled();
+
+    resolveFirst?.();
+    await firstRun;
   });
 });

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -138,10 +138,10 @@ vi.mock("./download.js", () => ({
 }));
 
 const { pushMessageLineMock, replyMessageLineMock } = vi.hoisted(() => ({
-  pushMessageLineMock: vi.fn(async () => {
+  pushMessageLineMock: vi.fn(async (..._args: unknown[]): Promise<unknown> => {
     throw new Error("pushMessageLine should not be called from bot-handlers tests");
   }),
-  replyMessageLineMock: vi.fn(async () => {
+  replyMessageLineMock: vi.fn(async (..._args: unknown[]): Promise<void> => {
     throw new Error("replyMessageLine should not be called from bot-handlers tests");
   }),
 }));
@@ -1215,7 +1215,10 @@ describe("handleLineWebhookEvents", () => {
     await handleLineWebhookEvents([event2], context);
 
     expect(replyMessageLineMock).toHaveBeenCalledTimes(1);
-    expect(replyMessageLineMock.mock.calls[0]?.[1]?.[0]?.text).toContain("still being processed");
+    const replyMessages = (replyMessageLineMock.mock.calls[0] as unknown[])?.[1] as
+      | Array<{ text?: string }>
+      | undefined;
+    expect(replyMessages?.[0]?.text).toContain("still being processed");
 
     resolveFirst?.();
     await firstRun;

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -447,14 +447,20 @@ function hasAnyLineMention(message: MessageEvent["message"]): boolean {
   return getLineMentionees(message).length > 0;
 }
 
+// LINE marks source userId optional: group/room postbacks and non-mobile group
+// senders can arrive senderless. Guarding those would collapse distinct users
+// onto one key and drop unrelated events, so senderless events bypass the guard.
 function buildLineInFlightKey(
   accountId: string,
   sourceInfo: { userId?: string; groupId?: string; roomId?: string; isGroup: boolean },
-): string {
-  const userId = sourceInfo.userId ?? "unknown";
+): string | null {
+  const { userId } = sourceInfo;
+  if (!userId) {
+    return null;
+  }
   if (sourceInfo.isGroup) {
-    const conversationId = sourceInfo.groupId ?? sourceInfo.roomId ?? "unknown";
-    return `${accountId}|${conversationId}|${userId}`;
+    const conversationId = sourceInfo.groupId ?? sourceInfo.roomId;
+    return conversationId ? `${accountId}|${conversationId}|${userId}` : null;
   }
   return `${accountId}|${userId}`;
 }
@@ -590,7 +596,11 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   const sourceInfo = { userId, groupId, roomId, isGroup };
   const inFlightKey = buildLineInFlightKey(account.accountId, sourceInfo);
 
-  if (context.userInFlightGuard && !context.userInFlightGuard.tryAcquire(inFlightKey)) {
+  if (
+    inFlightKey &&
+    context.userInFlightGuard &&
+    !context.userInFlightGuard.tryAcquire(inFlightKey)
+  ) {
     logVerbose(`line: session busy, sending in-flight notice for ${inFlightKey}`);
     await sendLineBusyReply({ replyToken: event.replyToken, sourceInfo, context });
     return;
@@ -609,7 +619,9 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
       }
     }
   } finally {
-    context.userInFlightGuard?.release(inFlightKey);
+    if (inFlightKey) {
+      context.userInFlightGuard?.release(inFlightKey);
+    }
   }
 }
 
@@ -661,7 +673,11 @@ async function handlePostbackEvent(
   const sourceInfo = getLineSourceInfo(event.source);
   const inFlightKey = buildLineInFlightKey(context.account.accountId, sourceInfo);
 
-  if (context.userInFlightGuard && !context.userInFlightGuard.tryAcquire(inFlightKey)) {
+  if (
+    inFlightKey &&
+    context.userInFlightGuard &&
+    !context.userInFlightGuard.tryAcquire(inFlightKey)
+  ) {
     logVerbose(`line: session busy, sending in-flight notice for ${inFlightKey}`);
     await sendLineBusyReply({ replyToken: event.replyToken, sourceInfo, context });
     return;
@@ -670,7 +686,9 @@ async function handlePostbackEvent(
   try {
     await context.processMessage(postbackContext);
   } finally {
-    context.userInFlightGuard?.release(inFlightKey);
+    if (inFlightKey) {
+      context.userInFlightGuard?.release(inFlightKey);
+    }
   }
 }
 

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -66,6 +66,27 @@ function isDownloadableLineMessageType(
   return LINE_DOWNLOADABLE_MESSAGE_TYPES.has(messageType);
 }
 
+export type LineUserInFlightGuard = {
+  tryAcquire(key: string): boolean;
+  release(key: string): void;
+};
+
+export function createLineUserInFlightGuard(): LineUserInFlightGuard {
+  const inFlight = new Set<string>();
+  return {
+    tryAcquire(key: string): boolean {
+      if (inFlight.has(key)) {
+        return false;
+      }
+      inFlight.add(key);
+      return true;
+    },
+    release(key: string): void {
+      inFlight.delete(key);
+    },
+  };
+}
+
 export interface LineHandlerContext {
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
@@ -75,10 +96,13 @@ export interface LineHandlerContext {
   replayCache?: LineWebhookReplayCache;
   groupHistories?: Map<string, HistoryEntry[]>;
   historyLimit?: number;
+  userInFlightGuard?: LineUserInFlightGuard;
 }
 
 const LINE_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
 const LINE_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
+const LINE_IN_FLIGHT_BUSY_TEXT =
+  "⏳ Your previous message is still being processed. Please wait a moment before sending another.";
 export type LineWebhookReplayCache = ClaimableDedupe;
 
 function normalizeLineIngressEntry(value: string): string | null {
@@ -423,6 +447,62 @@ function hasAnyLineMention(message: MessageEvent["message"]): boolean {
   return getLineMentionees(message).length > 0;
 }
 
+function buildLineInFlightKey(
+  accountId: string,
+  sourceInfo: { userId?: string; groupId?: string; roomId?: string; isGroup: boolean },
+): string {
+  const userId = sourceInfo.userId ?? "unknown";
+  if (sourceInfo.isGroup) {
+    const conversationId = sourceInfo.groupId ?? sourceInfo.roomId ?? "unknown";
+    return `${accountId}|${conversationId}|${userId}`;
+  }
+  return `${accountId}|${userId}`;
+}
+
+async function sendLineBusyReply(params: {
+  replyToken?: string;
+  sourceInfo: { userId?: string; groupId?: string; roomId?: string; isGroup: boolean };
+  context: LineHandlerContext;
+}): Promise<void> {
+  const { replyToken, sourceInfo, context } = params;
+  const sendOpts = {
+    cfg: context.cfg,
+    accountId: context.account.accountId,
+    channelAccessToken: context.account.channelAccessToken,
+  };
+
+  if (replyToken) {
+    try {
+      await replyMessageLine(
+        replyToken,
+        [{ type: "text", text: LINE_IN_FLIGHT_BUSY_TEXT }],
+        sendOpts,
+      );
+      return;
+    } catch {
+      // Reply token expired or already used; fall through to push.
+    }
+  }
+
+  const target = sourceInfo.isGroup
+    ? sourceInfo.groupId
+      ? `line:group:${sourceInfo.groupId}`
+      : sourceInfo.roomId
+        ? `line:room:${sourceInfo.roomId}`
+        : null
+    : sourceInfo.userId
+      ? `line:${sourceInfo.userId}`
+      : null;
+
+  if (target) {
+    try {
+      await pushMessageLine(target, LINE_IN_FLIGHT_BUSY_TEXT, sendOpts);
+    } catch {
+      logVerbose("line: failed to send busy reply");
+    }
+  }
+}
+
 function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
   if (event.type === "message") {
     const msg = event.message;
@@ -446,13 +526,12 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     return;
   }
 
-  const { isGroup, groupId, roomId } = getLineSourceInfo(event.source);
+  const { isGroup, groupId, roomId, userId } = getLineSourceInfo(event.source);
   if (isGroup && decision.activationAccess.shouldSkip) {
     const rawText = message.type === "text" ? message.text : "";
-    const sourceInfo = getLineSourceInfo(event.source);
     logVerbose(`line: skipping group message (requireMention, not mentioned)`);
     const historyKey = groupId ?? roomId;
-    const senderId = sourceInfo.userId ?? "unknown";
+    const senderId = userId ?? "unknown";
     if (historyKey && context.groupHistories) {
       createChannelHistoryWindow({ historyMap: context.groupHistories }).record({
         historyKey,
@@ -508,16 +587,29 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     return;
   }
 
-  await processMessage(messageContext);
+  const sourceInfo = { userId, groupId, roomId, isGroup };
+  const inFlightKey = buildLineInFlightKey(account.accountId, sourceInfo);
 
-  if (isGroup && context.groupHistories) {
-    const historyKey = groupId ?? roomId;
-    if (historyKey && context.groupHistories.has(historyKey)) {
-      createChannelHistoryWindow({ historyMap: context.groupHistories }).clear({
-        historyKey,
-        limit: context.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
-      });
+  if (context.userInFlightGuard && !context.userInFlightGuard.tryAcquire(inFlightKey)) {
+    logVerbose(`line: session busy, sending in-flight notice for ${inFlightKey}`);
+    await sendLineBusyReply({ replyToken: event.replyToken, sourceInfo, context });
+    return;
+  }
+
+  try {
+    await processMessage(messageContext);
+
+    if (isGroup && context.groupHistories) {
+      const historyKey = groupId ?? roomId;
+      if (historyKey && context.groupHistories.has(historyKey)) {
+        createChannelHistoryWindow({ historyMap: context.groupHistories }).clear({
+          historyKey,
+          limit: context.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
+        });
+      }
     }
+  } finally {
+    context.userInFlightGuard?.release(inFlightKey);
   }
 }
 
@@ -566,7 +658,20 @@ async function handlePostbackEvent(
     return;
   }
 
-  await context.processMessage(postbackContext);
+  const sourceInfo = getLineSourceInfo(event.source);
+  const inFlightKey = buildLineInFlightKey(context.account.accountId, sourceInfo);
+
+  if (context.userInFlightGuard && !context.userInFlightGuard.tryAcquire(inFlightKey)) {
+    logVerbose(`line: session busy, sending in-flight notice for ${inFlightKey}`);
+    await sendLineBusyReply({ replyToken: event.replyToken, sourceInfo, context });
+    return;
+  }
+
+  try {
+    await context.processMessage(postbackContext);
+  } finally {
+    context.userInFlightGuard?.release(inFlightKey);
+  }
 }
 
 export async function handleLineWebhookEvents(

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -9,7 +9,11 @@ import {
   type RuntimeEnv,
 } from "openclaw/plugin-sdk/runtime-env";
 import { resolveLineAccount } from "./accounts.js";
-import { createLineWebhookReplayCache, handleLineWebhookEvents } from "./bot-handlers.js";
+import {
+  createLineUserInFlightGuard,
+  createLineWebhookReplayCache,
+  handleLineWebhookEvents,
+} from "./bot-handlers.js";
 import type { LineInboundContext } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
 
@@ -45,6 +49,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       logVerbose("line: no message handler configured");
     });
   const replayCache = createLineWebhookReplayCache();
+  const userInFlightGuard = createLineUserInFlightGuard();
   const groupHistories = new Map<string, HistoryEntry[]>();
 
   const handleWebhook = async (body: webhook.CallbackRequest): Promise<void> => {
@@ -59,6 +64,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       mediaMaxBytes,
       processMessage,
       replayCache,
+      userInFlightGuard,
       groupHistories,
       historyLimit: cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
     });


### PR DESCRIPTION
## What Problem This Solves

When LINE users send rapid consecutive messages, the second message hits session lock timeouts or command queue contention, resulting in a generic "⚠️ Something went wrong" error after a long wait. The user gets no feedback for minutes, then sees an unhelpful error.

## Why This Change Was Made

Instead of letting concurrent messages fail after a timeout, this adds a lightweight per-user in-flight guard at the LINE webhook handler level. When the same user's previous message is still being processed, the guard immediately sends a "⏳ still processing" reply and skips the duplicate, preventing the downstream concurrency conflict entirely.

## User Impact

**This changes default LINE delivery semantics**: rapid follow-up events from the *same user* now get an immediate busy reply and are skipped, instead of dispatching concurrently and failing with a late timeout error. The guard is wired by default in `createLineBot`.

- Users sending rapid messages get immediate "⏳ Your previous message is still being processed…" feedback instead of a timeout error
- The guard only applies to events with a stable sender identity. `@line/bot-sdk` marks source `userId` optional (group/room postbacks and non-mobile group senders arrive without it), so senderless events bypass the guard and keep today's concurrent dispatch — one user's in-flight message can never block another user's button tap or message
- Different users in the same group are isolated (guard key = account | conversation | user)
- Guard releases on both success and error (try/finally), so a failed message never permanently blocks the user

## Evidence

**Unit tests** — 35/35 pass (`pnpm test extensions/line/src/bot-handlers.test.ts`), covering: busy reply delivery, guard release after success/error, per-user isolation in groups, and regressions for senderless group postbacks/messages bypassing the guard.

**Review findings addressed** (from the earlier Codex review):
- Senderless postback cross-blocking: `buildLineInFlightKey` now returns `null` when `source.userId` is absent and the guard is skipped, so senderless group/room postbacks keep main's concurrent dispatch instead of collapsing onto one `unknown` key
- The previous PR body incorrectly described the guard as opt-in; it is wired by default in `createLineBot` and the User Impact section above now states the delivery-semantics change explicitly
- Rebased onto current `main`; conflicts resolved

**Real LINE behavior proof** — see the evidence comment below: screenshots from a live LINE bot (1:1 busy reply; same-group two-user isolation with same-user busy reply and guard release) plus redacted gateway logs showing the matching dispatch timeline.
