### PR TITLE
docs(docker): document Claude CLI persistence

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -199,6 +199,10 @@ claude auth status --text
 openclaw models auth login --provider anthropic --method cli --set-default
 ```
 
+Docker installs need Claude Code installed and logged in inside the persisted
+container home, not only on the host. See
+[Claude CLI backend in Docker](/install/docker#claude-cli-backend-in-docker).
+
 Use `agents.defaults.cliBackends.claude-cli.command` only when the `claude`
 binary is not already on `PATH`.
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -279,6 +279,100 @@ If you use your own Compose file or `docker run` command, add the same host
 mapping yourself, for example
 `--add-host=host.docker.internal:host-gateway`.
 
+### Claude CLI backend in Docker
+
+The official OpenClaw Docker image does not pre-install Claude Code. Install and
+log in to Claude Code inside the container user that runs OpenClaw, then persist
+that container home so image upgrades do not erase the binary or Claude auth
+state.
+
+For new Docker installs, enable a persistent `/home/node` volume before running
+setup:
+
+```bash
+export OPENCLAW_IMAGE="ghcr.io/openclaw/openclaw:latest"
+export OPENCLAW_HOME_VOLUME="openclaw_home"
+./scripts/docker/setup.sh
+```
+
+For an existing Docker install, stop the stack first and reload the current
+Docker `.env` values before rerunning setup. The setup script does not read
+`.env` on its own; it rewrites `.env` from the current shell and defaults. For
+the generated `.env`, run:
+
+```bash
+set -a
+. ./.env
+set +a
+export OPENCLAW_HOME_VOLUME="${OPENCLAW_HOME_VOLUME:-openclaw_home}"
+./scripts/docker/setup.sh
+```
+
+If your `.env` contains values your shell cannot source, manually re-export the
+existing values you rely on first, such as `OPENCLAW_IMAGE`, ports, bind mode,
+custom paths, `OPENCLAW_EXTRA_MOUNTS`, sandbox, and skip-onboarding settings.
+The generated overlay mounts the home volume for both `openclaw-gateway` and
+`openclaw-cli`.
+
+Run the remaining commands with the generated Compose overlay so both services
+mount the persisted home. If your setup also uses `docker-compose.override.yml`,
+include it before `docker-compose.extra.yml`.
+
+Install Claude Code in that persisted home:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.extra.yml run --rm \
+  --entrypoint sh openclaw-cli -lc \
+  'curl -fsSL https://claude.ai/install.sh | bash'
+```
+
+The native installer writes the `claude` binary under
+`/home/node/.local/bin/claude`. Tell OpenClaw to use that container path:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.extra.yml run --rm \
+  openclaw-cli config set \
+  agents.defaults.cliBackends.claude-cli.command \
+  /home/node/.local/bin/claude
+```
+
+Log in and verify from inside the same persisted container home:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.extra.yml run --rm \
+  --entrypoint /home/node/.local/bin/claude openclaw-cli auth login
+docker compose -f docker-compose.yml -f docker-compose.extra.yml run --rm \
+  --entrypoint /home/node/.local/bin/claude openclaw-cli auth status --text
+docker compose -f docker-compose.yml -f docker-compose.extra.yml run --rm \
+  openclaw-cli models auth login \
+  --provider anthropic --method cli --set-default
+docker compose -f docker-compose.yml -f docker-compose.extra.yml run --rm \
+  openclaw-cli models list --provider anthropic
+```
+
+After that, you can use the bundled `claude-cli` backend:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.extra.yml run --rm \
+  openclaw-cli agent \
+  --agent main \
+  --model claude-cli/claude-sonnet-4-6 \
+  --message "Say hello from Docker Claude CLI"
+```
+
+`OPENCLAW_HOME_VOLUME` persists the native Claude Code install under
+`/home/node/.local/bin` and `/home/node/.local/share/claude`, plus Claude Code
+settings and auth state under `/home/node/.claude` and `/home/node/.claude.json`.
+Persisting only `/home/node/.openclaw` is not enough for Claude CLI reuse. If
+you use `OPENCLAW_EXTRA_MOUNTS` instead of a home volume, mount all of those
+Claude paths into both Docker services.
+
+<Note>
+For shared production automation or predictable Anthropic billing, prefer the
+Anthropic API-key path. Claude CLI reuse follows Claude Code's installed
+version, account login, billing, and update behavior.
+</Note>
+
 ### Bonjour / mDNS
 
 Docker bridge networking usually does not forward Bonjour/mDNS multicast

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -104,9 +104,12 @@ Anthropic's current public docs:
 
     <Warning>
     Claude CLI reuse expects the OpenClaw process to run on the same host as the
-    Claude CLI login. Container installs such as [Podman](/install/podman) do
-    not mount host `~/.claude` into setup or runtime; use an Anthropic API key
-    there, or choose a provider with OpenClaw-managed OAuth such as
+    Claude CLI login. Docker installs can persist a container home and log in to
+    Claude Code there; see
+    [Claude CLI backend in Docker](/install/docker#claude-cli-backend-in-docker).
+    Other container installs such as [Podman](/install/podman) do not mount host
+    `~/.claude` into setup or runtime; use an Anthropic API key there, or choose
+    a provider with OpenClaw-managed OAuth such as
     [OpenAI Codex](/providers/openai).
     </Warning>
 


### PR DESCRIPTION
Closes #66874

## What Problem This Solves

Resolves a problem where Docker users could choose the Claude CLI backend, but the official Docker docs did not explain that Claude Code must be installed and logged in inside the persisted container home. Users who only mounted `/home/node/.openclaw` or reused a host Claude login could lose the `claude` binary/auth state across container replacement and then see the bundled `claude-cli` backend fail.

## Why This Change Was Made

This documents the conservative supported path requested on the issue: use the existing `OPENCLAW_HOME_VOLUME` Docker setup surface, include the generated `docker-compose.extra.yml` overlay for follow-up commands, and point `agents.defaults.cliBackends.claude-cli.command` at the container-side Claude Code binary.

It intentionally does not pre-install Claude Code in the official image or change Dockerfile, release workflow, runtime, auth, config schema, or provider behavior. Those remain separate release-artifact and supply-chain decisions.

## User Impact

Docker users now get a copy-pasteable path to persist `/home/node`, install Claude Code in the container, configure OpenClaw to call `/home/node/.local/bin/claude`, log in from the same persisted home, verify Anthropic CLI auth, and run a `claude-cli` agent turn.

The Anthropic provider and CLI backend docs now point Docker users to the Docker-specific flow instead of implying that a host Claude login is enough inside a container.

## Evidence

Real behavior proof

Behavior addressed: Docker Claude CLI setup now documents the persisted install/auth path using existing Docker and CLI backend contracts.

Real environment tested: Local OpenClaw docs/source checkout on branch `codex/docker-claude-cli-docs`, rebased onto `origin/main` before final validation.

Exact steps or command run after this patch:

```bash
pnpm docs:list
pnpm docs:check-mdx
pnpm docs:check-links
pnpm docs:spellcheck docs/install/docker.md docs/gateway/cli-backends.md docs/providers/anthropic.md
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --prompt 'Review the final docs-only OpenClaw PR commit for issue #66874. Intended behavior: document the conservative Docker Claude CLI path using existing OPENCLAW_HOME_VOLUME persistence and agents.defaults.cliBackends.claude-cli.command override. Scope boundary: no Dockerfile, release workflow, runtime, config schema, or auth behavior changes. Re-check command accuracy, compose overlay usage for the persisted home, existing-install .env/custom Docker override guidance, docs anchors, and misleading compatibility claims.'
```

Evidence after fix:

- `docs:check-mdx` passed across 684 files.
- `docs:check-links` passed with `checked_internal_links=5469` and `broken_links=0`.
- Touched-file spellcheck passed.
- `git diff --check` passed.
- Final autoreview reported: `autoreview clean: no accepted/actionable findings reported` and specifically checked the Compose overlay, persisted `/home/node`, CLI command override, and `.env` guidance.
- Source contract checked: `scripts/docker/setup.sh` writes `docker-compose.extra.yml` for `OPENCLAW_HOME_VOLUME`; `docker-compose.yml` sets `HOME=/home/node` for gateway and CLI services; `extensions/anthropic/cli-backend.ts` defaults the backend command to `claude`; `src/config/types.agent-defaults.ts` supports `agents.defaults.cliBackends` command overrides.
- External contract checked against Anthropic's current Claude Code install docs: https://code.claude.com/docs/en/getting-started

Observed result after fix: The docs now tell users to load existing Docker `.env` overrides before rerunning setup, use `docker-compose.extra.yml` for every follow-up command, install Claude Code in the persisted container home, and configure OpenClaw to call the persisted `/home/node/.local/bin/claude` path.

What was not tested: I did not run a live Docker Claude Code login or paid Anthropic CLI agent turn because it requires an interactive user-owned Claude account/session. This PR is docs-only and does not modify runtime behavior.
