### PR TITLE
fix(slack): truncate on code-point boundaries to avoid splitting surrogate pairs

### DIFF
--- a/extensions/slack/src/truncate.test.ts
+++ b/extensions/slack/src/truncate.test.ts
@@ -1,0 +1,27 @@
+// Slack tests cover truncate plugin behavior.
+import { describe, expect, it } from "vitest";
+import { truncateSlackText } from "./truncate.js";
+
+describe("truncateSlackText", () => {
+  it("drops a surrogate-pair emoji whole when it straddles the limit", () => {
+    // "abc😀def": 😀 (U+1F600) sits at the cut point. Slicing by UTF-16 code unit
+    // would keep only its high surrogate — a lone \uD83D — before the ellipsis,
+    // which serializes to an invalid character in the Slack payload.
+    const out = truncateSlackText("abc😀def", 5);
+    expect(out).toBe("abc…");
+    // No dangling high surrogate (a high surrogate not followed by a low one).
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(out)).toBe(false);
+  });
+
+  it("truncates plain BMP text unchanged", () => {
+    expect(truncateSlackText("hello world", 5)).toBe("hell…");
+  });
+
+  it("keeps an emoji that fits before the cut", () => {
+    expect(truncateSlackText("😀abcdef", 5)).toBe("😀ab…");
+  });
+
+  it("returns the trimmed input unchanged when it fits", () => {
+    expect(truncateSlackText("ab😀cd", 10)).toBe("ab😀cd");
+  });
+});

--- a/extensions/slack/src/truncate.ts
+++ b/extensions/slack/src/truncate.ts
@@ -1,11 +1,16 @@
 // Slack plugin module implements truncate behavior.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
 export function truncateSlackText(value: string, max: number): string {
   const trimmed = value.trim();
   if (trimmed.length <= max) {
     return trimmed;
   }
+  // Slice on a code-point boundary so a surrogate pair (emoji / astral char)
+  // straddling the limit is dropped whole, instead of leaving a lone surrogate
+  // half that serializes to an invalid `\uD83D` in the Slack payload.
   if (max <= 1) {
-    return trimmed.slice(0, max);
+    return sliceUtf16Safe(trimmed, 0, max);
   }
-  return `${trimmed.slice(0, max - 1)}…`;
+  return `${sliceUtf16Safe(trimmed, 0, max - 1)}…`;
 }


### PR DESCRIPTION
## What Problem This Solves

`truncateSlackText` (`extensions/slack/src/truncate.ts`) slices by UTF-16 **code unit**:

```ts
return `${trimmed.slice(0, max - 1)}…`;
```

When an emoji or other astral character (a surrogate pair) straddles the limit, `slice` keeps only its **leading high surrogate**, emitting a lone, invalid `\uD83D` right before the ellipsis:

```
truncateSlackText("abc😀def", 5)
  before: "abc\uD83D…"   ❌ lone high surrogate (renders as �, can be mangled/rejected by strict JSON consumers)
  after : "abc…"         ✅ the un-fitting emoji is dropped whole
```

This text is sent in **live Slack payloads** — `chat.postMessage` text (`send.ts`) and Block Kit section text, button labels, option labels, and header titles (`blocks-render.ts`), which truncate at limits as small as `SLACK_PLAIN_TEXT_MAX = 75`. Any user/agent text ending with an emoji near a limit produces a broken half-character.

## Fix

Use the repo's canonical surrogate-safe slice, `sliceUtf16Safe` (defined in `src/utils.ts`, already re-exported from `openclaw/plugin-sdk/text-utility-runtime` — the module Slack code already imports from). It drops a straddling pair whole. `truncateSlackText` was the lone straggler still slicing raw; this aligns it with the rest of the codebase (`truncateUtf16Safe`, discord `clampToCodePointBoundary`, `src/shared/text-chunking.ts`, etc.).

**Behavior is byte-identical for all-BMP input** — `sliceUtf16Safe(s, 0, n) === s.slice(0, n)` whenever no pair straddles the edge.

## Evidence

Added `extensions/slack/src/truncate.test.ts` (the function is exported; no test existed). Verified by running the exact `sliceUtf16Safe` + `truncateSlackText` logic:

```
truncateSlackText("abc😀def", 5)   before "abc\uD83D…" (LONE surrogate)  ->  after "abc…"        ✅
truncateSlackText("hello world",5) before "hell…"                        ->  after "hell…"       (unchanged)
truncateSlackText("😀abcdef", 5)   before "😀ab…"                        ->  after "😀ab…"        (unchanged)
truncateSlackText("ab😀cd", 10)    before "ab😀cd"                       ->  after "ab😀cd"       (unchanged)
```

All-BMP and emoji-that-fits cases are unchanged; only the straddling-pair case changes, and the fixed output contains no lone surrogate.
