### PR TITLE
fix(webchat): preserve session context on first send after page load (#96331)

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -6448,3 +6448,271 @@ describe("initSessionState internal channel routing preservation", () => {
     expect(result.sessionEntry.deliveryContext?.accountId).toBe("work");
   });
 });
+
+describe("initSessionState caller-verified session", () => {
+  it("reuses a stale-by-daily-reset session when CallerSessionId matches the store entry", async () => {
+    const root = await makeCaseDir("openclaw-caller-verified-daily-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:webchat:daily-reuse";
+    const existingSessionId = "caller-verified-session";
+
+    // Stale under the default daily reset (atHour 4): started 48h ago
+    const staleStartedAt = Date.now() - 48 * 60 * 60 * 1000;
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        lastInteractionAt: staleStartedAt,
+        systemSent: true,
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello again",
+        SessionKey: sessionKey,
+        CallerSessionId: existingSessionId,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // The session must be reused — not rolled over to a new sessionId.
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe(existingSessionId);
+  });
+
+  it("reuses a stale-by-idle session when CallerSessionId matches", async () => {
+    const root = await makeCaseDir("openclaw-caller-verified-idle-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:webchat:idle-reuse";
+    const existingSessionId = "caller-verified-idle-session";
+
+    // Stale under 5-minute idle timeout
+    const staleUpdatedAt = Date.now() - 10 * 60 * 1000;
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: staleUpdatedAt,
+        sessionStartedAt: staleUpdatedAt,
+        lastInteractionAt: staleUpdatedAt,
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, reset: { mode: "idle", idleMinutes: 5 } },
+    } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello again",
+        SessionKey: sessionKey,
+        CallerSessionId: existingSessionId,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // The session must be reused — not rolled over.
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe(existingSessionId);
+  });
+
+  it("does NOT prevent /new from creating a new session even with CallerSessionId", async () => {
+    const root = await makeCaseDir("openclaw-caller-verified-new-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:webchat:new-reset";
+    const existingSessionId = "caller-verified-new-session";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+        sessionStartedAt: Date.now(),
+        lastInteractionAt: Date.now(),
+        systemSent: true,
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "/new",
+        Body: "/new",
+        SessionKey: sessionKey,
+        CallerSessionId: existingSessionId,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // /new must still create a new session regardless of CallerSessionId.
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+  });
+
+  it("falls through to normal freshness evaluation when CallerSessionId does not match", async () => {
+    const root = await makeCaseDir("openclaw-caller-verified-mismatch-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:webchat:mismatch";
+    const realSessionId = "real-session";
+
+    // Stale session
+    const staleStartedAt = Date.now() - 48 * 60 * 60 * 1000;
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: realSessionId,
+        updatedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        lastInteractionAt: staleStartedAt,
+        systemSent: true,
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello",
+        SessionKey: sessionKey,
+        // Claim a sessionId that does NOT match the store entry
+        CallerSessionId: "wrong-session-id",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Mismatch → fall through to normal freshness → stale → new session.
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe(realSessionId);
+  });
+
+  it("creates a new session when CallerSessionId is set but no entry exists", async () => {
+    const root = await makeCaseDir("openclaw-caller-verified-no-entry-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:webchat:no-entry";
+
+    // Empty store — no entry for the session key
+    await writeSessionStoreFast(storePath, {});
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello",
+        SessionKey: sessionKey,
+        CallerSessionId: "some-session-id",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // No entry → canReuseExistingEntry is false → new session.
+    expect(result.isNewSession).toBe(true);
+  });
+
+  it("does not activate for an empty CallerSessionId string", async () => {
+    const root = await makeCaseDir("openclaw-caller-verified-empty-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:webchat:empty";
+    const existingSessionId = "empty-caller-session";
+
+    const staleStartedAt = Date.now() - 48 * 60 * 60 * 1000;
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        lastInteractionAt: staleStartedAt,
+        systemSent: true,
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello",
+        SessionKey: sessionKey,
+        CallerSessionId: "",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Empty string → length > 0 guard blocks activation → stale → new session.
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+  });
+
+  it("does not affect heartbeat system events (CallerSessionId not set)", async () => {
+    const root = await makeCaseDir("openclaw-caller-verified-heartbeat-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:webchat:heartbeat";
+    const existingSessionId = "heartbeat-caller-session";
+
+    // Stale under daily reset
+    const staleStartedAt = Date.now() - 48 * 60 * 60 * 1000;
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        lastInteractionAt: staleStartedAt,
+        systemSent: true,
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "heartbeat check",
+        SessionKey: sessionKey,
+        Provider: "heartbeat",
+        // Heartbeat does NOT set CallerSessionId
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Heartbeat uses isSystemEvent guard — it reuses the session independently.
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe(existingSessionId);
+  });
+
+  it("does NOT bypass freshness for a fresh session with matching CallerSessionId (one-shot proof)", async () => {
+    const root = await makeCaseDir("openclaw-caller-verified-fresh-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:webchat:fresh-no-bypass";
+    const existingSessionId = "fresh-caller-session";
+
+    // Fresh session — updated just now, well within all reset windows
+    const now = Date.now();
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: now,
+        sessionStartedAt: now,
+        lastInteractionAt: now,
+        systemSent: true,
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello again",
+        SessionKey: sessionKey,
+        CallerSessionId: existingSessionId,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Fresh session is reused via normal freshness — not via the caller bypass.
+    // The callerVerifiedSession guard must NOT activate when entryFreshness?.fresh
+    // is true, keeping the path one-shot (only activates for stale sessions).
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe(existingSessionId);
+  });
+});

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -687,7 +687,23 @@ async function initSessionStateAttemptLocked(
     !resetTriggered &&
     (entryFreshness?.fresh ?? false) &&
     isRecoverableTerminalSessionStatus(entry?.status);
+  // Caller-verified session: when a caller (e.g. chat.send) has already loaded
+  // the session entry and passes its sessionId via ctx.CallerSessionId, trust
+  // that verification and skip freshness evaluation. This is naturally one-shot
+  // because it only activates when the entry is stale (entryFreshness?.fresh
+  // === false); after the first successful send updates the session timestamp,
+  // subsequent sends go through normal freshness.
+  // The sessionId MUST match the store entry to prevent spoofing.
+  // Explicit /new and /reset (isNewSession) always take precedence.
+  const callerVerifiedSession =
+    !isNewSession &&
+    typeof ctx.CallerSessionId === "string" &&
+    ctx.CallerSessionId.length > 0 &&
+    canReuseExistingEntry &&
+    entry?.sessionId === ctx.CallerSessionId &&
+    entryFreshness?.fresh === false;
   const freshEntry =
+    callerVerifiedSession ||
     (lockedModelSelection && canReuseExistingEntry) ||
     (isSystemEvent && canReuseExistingEntry) ||
     (((reconnectResumeRequested && canReuseExistingEntry) ||

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -353,6 +353,16 @@ export type MsgContext = {
    * Used for hook confirmation messages like "Session context saved to memory".
    */
   HookMessages?: string[];
+  /**
+   * Caller-verified session id. When set by a caller that has already validated
+   * the session entry (e.g. chat.send via its own loadSessionEntry call),
+   * initSessionState will honor this and skip freshness evaluation when the id
+   * matches the current store entry AND the entry is stale. This is naturally
+   * one-shot: after the first successful send updates the session timestamp,
+   * subsequent sends go through normal freshness evaluation. Does NOT apply to
+   * explicit /new or /reset commands.
+   */
+  CallerSessionId?: string;
 };
 
 export type FinalizedMsgContext = Omit<MsgContext, "CommandAuthorized"> & {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -4685,6 +4685,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         InputProvenance: systemInputProvenance,
         SessionKey: sessionKey,
         AgentId: agentId,
+        CallerSessionId: backingSessionId,
         Provider: INTERNAL_MESSAGE_CHANNEL,
         Surface: INTERNAL_MESSAGE_CHANNEL,
         OriginatingChannel: originatingChannel,


### PR DESCRIPTION
## Summary

WebChat `chat.send` now preserves session context on the first send after page load by passing the WebChat-backed `backingSessionId` as `CallerSessionId` through `MsgContext`, allowing `initSessionState` to trust the caller-verified session and skip freshness evaluation when the ID matches the store entry AND the entry is stale. This closes the gap where `chat.history` displayed full history but `chat.send` lost model-visible context after gateway restart.

- **Problem**: `chat.history` reads the transcript directly from disk and displays full history, but `chat.send` independently evaluates session freshness via `initSessionState` and mints a new session when the existing one is stale (daily reset / idle expiry). After gateway restart or crossing the 4 AM daily reset boundary, the model responds without prior context even though history is visible.
- **Solution**: The gateway `chat.send` handler already has `backingSessionId` from the WebChat client. Pass it as `CallerSessionId` in the `MsgContext`. In `initSessionState`, add a `callerVerifiedSession` guard — when the caller has already validated the session entry, the IDs match, AND the entry is stale (`entryFreshness?.fresh === false`), skip freshness evaluation and reuse the existing session. The `entryFreshness?.fresh === false` check makes this naturally one-shot: after the first successful send updates the session timestamp, subsequent sends go through normal freshness evaluation. `/new` and `/reset` always take precedence via the `!isNewSession` guard. Mismatched IDs fall through to normal freshness evaluation.
- **What changed**: `src/gateway/server-methods/chat.ts` (+1: pass `CallerSessionId: backingSessionId`), `src/auto-reply/templating.ts` (+10: add `CallerSessionId` field to `MsgContext` type), `src/auto-reply/reply/session.ts` (+16: add `callerVerifiedSession` guard to `freshEntry` computation, placed before `lockedModelSelection` to preserve existing guard priority), `src/auto-reply/reply/session.test.ts` (+268: 8 regression tests covering all guard paths including one-shot proof)
- **What did NOT change**: Backend session init (`session.ts` existing freshness logic), gateway dispatch (`chat.ts` except one line), `MsgContext` type except the new optional field, plugin SDK exports, config, migration paths, `/new` and `/reset` behavior, heartbeat/system events, `reconnectResumeRequested` path, `lockedModelSelection` guard (preserved as-is in the `freshEntry` chain)

## Change Type & Scope

### Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

### Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue

- Closes #96331
- [x] This PR fixes a bug or regression

## Motivation

Web UI users returning to a chat session after gateway restart (most commonly noticed the next morning after the 4 AM daily reset boundary) would see their full chat history displayed correctly via `chat.history`, but the model would respond as if it had no prior context. The root cause was that `chat.history` reads the transcript directly from disk without freshness evaluation, while `chat.send` independently evaluates freshness via `initSessionState` and mints a new session when stale — the two paths disagreed on whether the session was valid.

The fix is gateway-side, not UI-side: the `chat.send` handler already has `backingSessionId` from the WebChat client. By passing it through `MsgContext` as a caller-verified signal, `initSessionState` can trust the caller's session validation when the IDs match, without changing any freshness policy.

## Review Contract

```text
Ref: #96331 / PR #96391
Surface: Gateway / session init / chat.send dispatch / MsgContext type

Bug: chat.history shows session history but chat.send loses it after gateway restart
Cause: chat.history reads transcript directly from disk (no freshness check) while
  chat.send independently evaluates freshness via initSessionState and mints a new
  sessionId when stale. The two paths disagreed on session validity.
  (src/auto-reply/reply/session.ts:689-712, src/gateway/server-methods/chat.ts:4686)
  Confidence: confirmed by code analysis + reproducible scenario

Provenance:
  introduced by: PR #89017 (added reconnectResumeRequested infrastructure but only
    for WebSocket reconnect, not fresh page load)
  made visible by: gateway restart + daily reset boundary crossing
  Confidence: clear

Best fix: Yes. The gateway chat.send handler already has backingSessionId from the
  WebChat client. Adding one field to MsgContext and one guard to freshEntry is the
  minimal correct fix. The callerVerifiedSession guard sits before lockedModelSelection
  in the freshEntry OR chain, preserving all existing guards (isSystemEvent,
  reconnectResumeRequested, recoverTerminalVisibleEntry, softResetAllowed)
  without modifying any of them. The entryFreshness?.fresh === false check makes
  the bypass naturally one-shot — it only activates for truly stale sessions.

Refactor: No — existing backend infrastructure is unchanged and sufficient.

Proof: 149 session tests + 2 gateway chat tests pass (8 new), see test output below.

Risk: Low. The guard requires FIVE conditions: !isNewSession, non-empty
  CallerSessionId string, canReuseExistingEntry, entry?.sessionId ===
  ctx.CallerSessionId, AND entryFreshness?.fresh === false. All five must pass.
  The freshness check makes this naturally one-shot. Mismatch falls through to
  normal evaluation. /new and /reset always win. Heartbeat uses isSystemEvent
  (separate guard). The CallerSessionId field is optional on MsgContext —
  no existing callers are affected.
```

## Real Behavior Proof

**Behavior addressed**: Web UI `chat.history` displays full history but `chat.send` reaches model without context after gateway restart. After fix: `chat.send` carries `CallerSessionId`, `initSessionState` skips freshness evaluation when IDs match AND session is stale, model receives full context.

**Real environment tested**: Linux 4.19.112-2.el8.x86_64, Node 22.19+, branch `fix/webchat-session-context-restart-96331`, rebased on upstream/main (`dfa580e9895`)

**Exact steps or command run after this patch**:

```bash
# Session tests — full regression suite
pnpm test src/auto-reply/reply/session.test.ts --run
```

```
 Test Files  1 passed (1)
      Tests  149 passed (149)
```

```bash
# Gateway chat.send tests
pnpm test src/gateway/server-methods/chat.send-deleted-agent.test.ts --run
```

```
 Test Files  2 passed (2)
      Tests  2 passed (2)
```

**Evidence after fix**:

Total: 151 tests passed across 3 test files, 0 regressions.

New test coverage matrix (8 new tests):

```
Test scenario                                                    => Expected
CallerSessionId matches daily-stale entry                       => isNewSession=false, session reused
CallerSessionId matches idle-stale entry                        => isNewSession=false, session reused
CallerSessionId with /new command                               => isNewSession=true, reset triggered
CallerSessionId mismatches store entry                          => isNewSession=true, falls through
CallerSessionId set but no store entry exists                   => isNewSession=true
CallerSessionId is empty string                                 => isNewSession=true, guard blocked
Heartbeat without CallerSessionId (isSystemEvent guard)         => isNewSession=false, independent path
CallerSessionId matches fresh session (one-shot proof)          => isNewSession=false, normal freshness
```

**Observed result after fix**:

- `CallerSessionId: backingSessionId` is passed in every `chat.send` MsgContext
- `callerVerifiedSession` guard activates when: `!isNewSession` AND non-empty `CallerSessionId` string AND `canReuseExistingEntry` AND `entry.sessionId === ctx.CallerSessionId` AND `entryFreshness?.fresh === false`
- All five conditions must pass — no single condition can bypass freshness
- The `entryFreshness?.fresh === false` check makes the bypass naturally one-shot: after the first successful send updates the session timestamp, subsequent sends go through normal freshness evaluation
- `callerVerifiedSession` sits before `lockedModelSelection` in the `freshEntry` OR chain to preserve existing guard priority
- `/new` and `/reset` always win via the `!isNewSession` guard
- Heartbeat system events continue through independent `isSystemEvent` guard
- `reconnectResumeRequested` path is unchanged
- `recoverTerminalVisibleEntry` path is unchanged
- `lockedModelSelection` guard is unchanged
- All 149 existing session tests pass — zero regressions

**What was not tested**:

- Multi-tab Web UI scenarios with different sessions
- Rapid page reload + send race conditions

### Environment

- OS: Linux 4.19.112-2.el8.x86_64
- Runtime: Node 22.19+
- Branch: `fix/webchat-session-context-restart-96331`

## Conflicts Resolved

Rebased onto `origin/main` (`dfa580e9895`). Resolved merge conflict in `src/auto-reply/reply/session.ts`: the `freshEntry` computation had gained a new `(lockedModelSelection && canReuseExistingEntry) ||` guard upstream. The `callerVerifiedSession` guard was placed before `lockedModelSelection` in the OR chain so it takes priority when the caller has already verified the session. All existing guards are preserved without modification. Also picked up `b575b5ee9b1` which fixes a `gateway-protocol` type import in `server-chat.ts` that was failing CI builds.

## Risks and Mitigations

- **Highest risk area**: The `callerVerifiedSession` guard skips freshness evaluation when `CallerSessionId` matches AND the entry is stale. If the WebChat client passes a stale/incorrect `backingSessionId`, the guard could match a truly-expired session. Mitigation: the session ID MUST match exactly (`entry.sessionId === ctx.CallerSessionId`), the entry MUST be stale (`entryFreshness?.fresh === false`), and `canReuseExistingEntry` must be true (entry exists, not force-new). The freshness check makes the bypass one-shot — it cannot permanently suppress configured reset policy.
- **Compatibility impact**: None. `CallerSessionId` is an optional field on `MsgContext`. Existing callers (bots, cron, integrations) never set it, so they follow the same freshness path as before.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes — optional field on MsgContext, all existing callers unaffected
- [x] Config/env changes? No
- [x] Migration needed? No

## Human Verification

- **Verified scenarios**: 

### Step 1: Open Web UI

Open **http://127.0.0.1:18788/** in your browser 

### Step 2: Build a conversation with context

1. Start a new chat in the Web UI
2. Send several meaningful messages

<img width="1849" height="860" alt="image" src="https://github.com/user-attachments/assets/484d9045-2a23-4101-a985-f06e4ddd01ec" />

3. Confirm the model correctly responds and references prior context across 3-4 turns

### Step 3: Restart the gateway (trigger the bug)

```bash
# Kill the current gateway
kill $(pgrep -f "run-node.mjs.*gateway")
```

<img width="1256" height="760" alt="image" src="https://github.com/user-attachments/assets/df76f369-6001-4806-8c87-1e86583e513a" />

```bash
# Wait 2 seconds then restart
sleep 2
OPENCLAW_SKIP_CHANNELS=1 nohup node scripts/run-node.mjs gateway > /tmp/openclaw-gateway.log 2>&1 &
```
<img width="990" height="122" alt="image" src="https://github.com/user-attachments/assets/85cf331b-a739-4688-a53a-e69b02f0e08b" />

### Step 4: Verify the fix

1. Reopen/refresh the Web UI and navigate back to the **same** chat session
2. **Verify chat.history first**: the UI should display the full conversation history from before restart (all prior messages visible on the page)
3. **Verify chat.send**: send a new message referencing the prior conversation
4. Observe the model's response

<img width="1880" height="972" alt="image" src="https://github.com/user-attachments/assets/f375f7b6-4577-45db-93a9-ae6dfc88f761" />

- **Edge cases checked**: Empty `currentSessionId` (no-op), mismatched session IDs (backend fallthrough), heartbeat events (independent isSystemEvent guard)
- **What you did NOT verify**: Multi-tab scenarios, rapid reload + send races

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Issue #96331 analysis → identified gap between chat.history and chat.send session resolution → designed CallerSessionId propagation fix reusing existing MsgContext infrastructure and initSessionState guard pattern → squashed 3 commits into 1, rebased onto latest main, resolved `lockedModelSelection` conflict, picked up `b575b5ee9b1` type import fix

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Closes #96331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
