### PR TITLE
fix(imessage): only strip standalone role-turn markers, not prose ending in a role word

### DIFF
--- a/extensions/imessage/src/monitor/sanitize-outbound.test.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.test.ts
@@ -49,6 +49,15 @@ describe("sanitizeOutboundText", () => {
     expect(result).not.toMatch(/^assistant:$/m);
   });
 
+  it("preserves prose lines that merely end with 'user:'/'system:'", () => {
+    expect(sanitizeOutboundText("Please send this reply to the user:")).toBe(
+      "Please send this reply to the user:",
+    );
+    expect(sanitizeOutboundText("Here is a note for the system:")).toBe(
+      "Here is a note for the system:",
+    );
+  });
+
   it("collapses excessive blank lines after stripping", () => {
     const text = "Hello\n\n\n\n\nWorld";
     expect(sanitizeOutboundText(text)).toBe("Hello\n\nWorld");

--- a/extensions/imessage/src/monitor/sanitize-outbound.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.ts
@@ -7,7 +7,9 @@ import { stripAssistantInternalScaffolding } from "openclaw/plugin-sdk/text-chun
  */
 const INTERNAL_SEPARATOR_RE = /(?:#\+){2,}#?/g;
 const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*\w+/gi;
-const ROLE_TURN_MARKER_RE = /\b(?:user|system|assistant)\s*:\s*$/gm;
+// Only a standalone role marker on its own line (a leaked turn boundary) — not
+// any line that merely ends with the word "user/system/assistant:" in prose.
+const ROLE_TURN_MARKER_RE = /^[ \t]*(?:user|system|assistant)\s*:\s*$/gm;
 
 /**
  * Strip all assistant-internal scaffolding from outbound text before delivery.


### PR DESCRIPTION
## What Problem This Solves

`sanitizeOutboundText` (`extensions/imessage/src/monitor/sanitize-outbound.ts`) strips leaked assistant turn-boundary markers (a standalone `assistant:` / `user:` / `system:` on its own line). But `ROLE_TURN_MARKER_RE` only anchored the **end** of the line:

```ts
const ROLE_TURN_MARKER_RE = /\b(?:user|system|assistant)\s*:\s*$/gm;
```

So any ordinary outbound line that merely *ends* with one of those words + a colon was truncated before delivery to iMessage:

```
"Please send this reply to the user:"  ->  "Please send this reply to the"   ❌
"Here is a note for the system:"       ->  "Here is a note for the"          ❌
```

`sanitizeOutboundText` is on the live iMessage delivery path (`channel.ts:339` `sanitizeText`, `monitor/deliver.ts`), so this silently drops words from real replies.

## Fix

Anchor the marker to the **whole line** so only a standalone leaked marker is stripped, never a word inside prose:

```ts
const ROLE_TURN_MARKER_RE = /^[ \t]*(?:user|system|assistant)\s*:\s*$/gm;
```

The intended behavior (stripping a standalone `assistant:` / `user:` line) is unchanged.

## Evidence

Added a regression test; verified by running the regex pipeline:

```
"Please send this reply to the user:"   before "Please send this reply to the"  ->  after (unchanged) ✅
"Here is a note for the system:"        before "Here is a note for the"         ->  after (unchanged) ✅
"Hello\nassistant:\nuser:"  (standalone) before "Hello"  ->  after "Hello"       (still stripped ✅, existing test)
"First line\nForward to the user:\nmore" before "...Forward to the \n..."        ->  after (unchanged) ✅
```

Standalone-marker stripping is preserved (existing test stays green); only prose lines that happen to end with the marker word are now left intact.
