### PR TITLE
fix(cron): preserve action-required command output

### DIFF
--- a/src/cron/command-output-summary.test.ts
+++ b/src/cron/command-output-summary.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCronCommandSummary,
+  cronCommandSummaryNeedsExternalRedaction,
+  redactCronCommandSummaryForExternalDelivery,
+} from "./command-output-summary.js";
+
+describe("cron command output summaries", () => {
+  it("prepends preserved action lines that were truncated out of the captured tail", () => {
+    const summary = buildCronCommandSummary({
+      stdout: "tail only",
+      stderr: "",
+      preservedStdoutLines: ["Visit https://example.com/device and enter code ABCD-EFGH"],
+    });
+
+    expect(summary).toBe(
+      "action-required output preserved:\nVisit https://example.com/device and enter code ABCD-EFGH\n\ntail only",
+    );
+  });
+
+  it("redacts action-required URLs and codes before external cron delivery", () => {
+    const summary =
+      "action-required output preserved:\nVisit https://example.com/device or www.example.com/device and enter code ABCD-EFGH\n\ncompleted";
+
+    expect(cronCommandSummaryNeedsExternalRedaction(summary)).toBe(true);
+    expect(redactCronCommandSummaryForExternalDelivery(summary)).toBe(
+      "action-required output preserved:\nVisit [redacted-url] or [redacted-url] and enter code [redacted-code]\n\ncompleted",
+    );
+  });
+
+  it("redacts numeric and unseparated codes on action-required lines", () => {
+    const summary =
+      "action-required output preserved:\nEnter code 123456\nCopy this code ABCDEF12\n\nBuild 123456 is complete";
+
+    expect(redactCronCommandSummaryForExternalDelivery(summary)).toBe(
+      "action-required output preserved:\nEnter code [redacted-code]\nCopy this code [redacted-code]\n\nBuild 123456 is complete",
+    );
+  });
+
+  it("masks token assignments on action-required lines before external delivery", () => {
+    const summary =
+      "action-required output preserved:\nLog in with token=opaque-secret-value\n\nLog in with token=opaque-secret-value";
+
+    const redacted = redactCronCommandSummaryForExternalDelivery(summary);
+
+    expect(redacted).not.toContain("opaque-secret-value");
+    expect(redacted).toContain("token=***");
+  });
+});

--- a/src/cron/command-output-summary.ts
+++ b/src/cron/command-output-summary.ts
@@ -1,0 +1,113 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { redactToolPayloadText } from "../logging/redact.js";
+
+const MAX_PRESERVED_ACTION_LINES = 12;
+const ACTION_LINE_PATTERNS = [
+  /\b(device|user|verification|authorization|auth|login)\s+code\b/i,
+  /\benter\s+(?:the\s+)?(?:code|verification code|device code)\b/i,
+  /\bcopy\s+(?:this\s+)?code\b/i,
+  /\bvisit\s+(?:https?:\/\/|www\.)/i,
+  /\bopen\s+(?:https?:\/\/|www\.)/i,
+  /\bbrowser\s+(?:to|at)\s+(?:https?:\/\/|www\.)/i,
+  /\blog(?:\s|-)?in\s+(?:at|to|with)\b/i,
+  /\bauth(?:enticate|orize)\s+(?:at|with|using)\b/i,
+  /\bhttps?:\/\/[^\s]+\/(?:device|activate|login|oauth|authorize|auth)\b/i,
+];
+const URL_PATTERN = /\b(?:https?:\/\/|www\.)\S+/gi;
+const CODE_PATTERN = /\b[A-Z0-9]{4}(?:[- ][A-Z0-9]{3,8}){1,4}\b/g;
+const UNSEPARATED_CODE_PATTERN = /\b[A-Z0-9]{6,12}\b/g;
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b((?:access|refresh)[_-]?token|api[_-]?key|token|password|secret)\s*([:=])\s*([^\s;&]+)/gi;
+
+export function isCronCommandActionCriticalLine(line: string): boolean {
+  const normalized = normalizeOptionalString(line);
+  return Boolean(normalized && ACTION_LINE_PATTERNS.some((pattern) => pattern.test(normalized)));
+}
+
+function normalizeLines(lines: string[] | undefined): string[] {
+  const result: string[] = [];
+  for (const line of lines ?? []) {
+    const normalized = normalizeOptionalString(line);
+    if (normalized && !result.includes(normalized)) {
+      result.push(normalized);
+    }
+    if (result.length >= MAX_PRESERVED_ACTION_LINES) {
+      break;
+    }
+  }
+  return result;
+}
+
+function trimOutput(value: string): string | undefined {
+  return normalizeOptionalString(value);
+}
+
+function combineOutput(params: { stdout?: string; stderr?: string }): string | undefined {
+  const stdout = trimOutput(params.stdout ?? "");
+  const stderr = trimOutput(params.stderr ?? "");
+  if (stdout && stderr) {
+    return `stdout:\n${stdout}\n\nstderr:\n${stderr}`;
+  }
+  return stdout ?? stderr;
+}
+
+function containsLine(haystack: string | undefined, needle: string): boolean {
+  if (!haystack) {
+    return false;
+  }
+  return haystack.split(/\r?\n/).some((line) => line.trim() === needle.trim());
+}
+
+export function buildCronCommandSummary(params: {
+  stdout: string;
+  stderr: string;
+  preservedStdoutLines?: string[];
+  preservedStderrLines?: string[];
+}): string | undefined {
+  const tail = combineOutput({ stdout: params.stdout, stderr: params.stderr });
+  const preserved = [
+    ...normalizeLines(params.preservedStdoutLines),
+    ...normalizeLines(params.preservedStderrLines),
+  ].filter((line) => !containsLine(tail, line));
+  if (preserved.length === 0) {
+    return tail;
+  }
+  const actionBlock = `action-required output preserved:\n${preserved.join("\n")}`;
+  return tail ? `${actionBlock}\n\n${tail}` : actionBlock;
+}
+
+export function cronCommandSummaryNeedsExternalRedaction(summary: string | undefined): boolean {
+  if (!summary) {
+    return false;
+  }
+  return summary
+    .split(/\r?\n/)
+    .some(
+      (line) =>
+        line.startsWith("action-required output preserved:") ||
+        isCronCommandActionCriticalLine(line),
+    );
+}
+
+export function redactCronCommandSummaryForExternalDelivery(
+  summary: string | undefined,
+): string | undefined {
+  if (!summary || !cronCommandSummaryNeedsExternalRedaction(summary)) {
+    return summary;
+  }
+  return summary
+    .split(/(\r?\n)/)
+    .map((part) => {
+      if (/^\r?\n$/.test(part) || !isCronCommandActionCriticalLine(part)) {
+        return part;
+      }
+      return redactToolPayloadText(part)
+        .replace(SECRET_ASSIGNMENT_PATTERN, (_match, key: string, separator: string) => {
+          return `${key}${separator}***`;
+        })
+        .replace(URL_PATTERN, "[redacted-url]")
+        .replace(CODE_PATTERN, "[redacted-code]")
+        .replace(UNSEPARATED_CODE_PATTERN, "[redacted-code]");
+    })
+    .join("");
+}

--- a/src/cron/command-runner.test.ts
+++ b/src/cron/command-runner.test.ts
@@ -75,6 +75,31 @@ describe("runCronCommandJob", () => {
     });
   });
 
+  it("preserves early action-required command output when the captured tail is truncated", async () => {
+    const result = await runCronCommandJob({
+      job: makeCommandJob({
+        kind: "command",
+        argv: [
+          process.execPath,
+          "-e",
+          [
+            "process.stdout.write('Visit https://example.com/device and enter code ABCD-EFGH\\n')",
+            "process.stdout.write('x'.repeat(200))",
+          ].join(";"),
+        ],
+        timeoutSeconds: 5,
+        outputMaxBytes: 24,
+      }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toBe(
+      `action-required output preserved:\nVisit https://example.com/device and enter code ABCD-EFGH\n\n${"x".repeat(24)}`,
+    );
+    expect(result.diagnostics?.summary).toBe(result.summary);
+    expect(result.diagnostics?.entries[0]).toMatchObject({ truncated: true });
+  });
+
   it("marks command timeouts as cron errors", async () => {
     const result = await runCronCommandJob({
       job: makeCommandJob({

--- a/src/cron/command-runner.ts
+++ b/src/cron/command-runner.ts
@@ -1,6 +1,9 @@
 import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runCommandWithTimeout } from "../process/exec.js";
+import {
+  buildCronCommandSummary,
+  isCronCommandActionCriticalLine,
+} from "./command-output-summary.js";
 import type { CronRunDiagnostics, CronRunOutcome, CronRunStatus, CronJob } from "./types.js";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 10 * 60_000;
@@ -18,19 +21,6 @@ function secondsToMs(value: number | undefined): number | undefined {
 
 function formatCommand(argv: string[]): string {
   return argv.map((arg) => JSON.stringify(arg)).join(" ");
-}
-
-function trimOutput(value: string): string | undefined {
-  return normalizeOptionalString(value);
-}
-
-function buildCommandSummary(params: { stdout: string; stderr: string }): string | undefined {
-  const stdout = trimOutput(params.stdout);
-  const stderr = trimOutput(params.stderr);
-  if (stdout && stderr) {
-    return `stdout:\n${stdout}\n\nstderr:\n${stderr}`;
-  }
-  return stdout ?? stderr;
 }
 
 function commandErrorMessage(params: {
@@ -115,6 +105,7 @@ export async function runCronCommandJob(params: {
       ...(payload.env ? { env: payload.env } : {}),
       ...(noOutputTimeoutMs !== undefined ? { noOutputTimeoutMs } : {}),
       ...(payload.outputMaxBytes !== undefined ? { maxOutputBytes: payload.outputMaxBytes } : {}),
+      preserveOutputLine: isCronCommandActionCriticalLine,
       ...(params.abortSignal ? { signal: params.abortSignal } : {}),
       killProcessTree: true,
     });
@@ -125,7 +116,12 @@ export async function runCronCommandJob(params: {
       result.termination !== "no-output-timeout" &&
       result.termination !== "signal";
     const status: CronRunStatus = ok ? "ok" : "error";
-    const summary = buildCommandSummary({ stdout: result.stdout, stderr: result.stderr });
+    const summary = buildCronCommandSummary({
+      stdout: result.stdout,
+      stderr: result.stderr,
+      preservedStdoutLines: result.preservedStdoutLines,
+      preservedStderrLines: result.preservedStderrLines,
+    });
     const error = ok
       ? undefined
       : commandErrorMessage({

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -123,6 +123,8 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
 
   it("redacts command action-required summaries before webhook completion delivery", async () => {
     const logger = { warn: vi.fn() };
+    const sensitiveSummary =
+      "action-required output preserved:\nVisit www.example.com/device and enter code 123456\nLog in with token=opaque-secret-value";
     const job = {
       id: "cron-command-webhook-redact",
       name: "command webhook redact",
@@ -137,7 +139,20 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
         mode: "webhook",
         to: "https://example.invalid/cron",
       },
-      state: {},
+      state: {
+        lastDiagnosticSummary: sensitiveSummary,
+        lastDiagnostics: {
+          summary: sensitiveSummary,
+          entries: [
+            {
+              ts: 1,
+              source: "exec",
+              severity: "warn",
+              message: sensitiveSummary,
+            },
+          ],
+        },
+      },
     } satisfies CronJob;
 
     dispatchGatewayCronFinishedNotifications({
@@ -145,11 +160,9 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
         jobId: job.id,
         action: "finished",
         status: "ok",
-        summary:
-          "action-required output preserved:\nVisit www.example.com/device and enter code 123456\nLog in with token=opaque-secret-value",
+        summary: sensitiveSummary,
         diagnostics: {
-          summary:
-            "action-required output preserved:\nVisit www.example.com/device and enter code 123456\nLog in with token=opaque-secret-value",
+          summary: sensitiveSummary,
           entries: [
             {
               ts: 1,
@@ -160,6 +173,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
             },
           ],
         },
+        job,
       },
       job,
       deps: {} as CliDeps,
@@ -185,6 +199,8 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     expect(body.diagnostics.entries[0].message).not.toContain("www.example.com/device");
     expect(body.diagnostics.entries[0].message).not.toContain("123456");
     expect(body.diagnostics.entries[0].message).not.toContain("opaque-secret-value");
+    expect(body.job.state).not.toHaveProperty("lastDiagnosticSummary");
+    expect(body.job.state).not.toHaveProperty("lastDiagnostics");
   });
 
   it("omits failed command summaries and diagnostics from completion webhook delivery", async () => {

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -5,7 +5,12 @@ import type { CliDeps } from "../cli/deps.types.js";
 import type { CronJob } from "../cron/types.js";
 
 const mocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(async () => ({ release: vi.fn() })),
   sendFailureNotificationAnnounce: vi.fn(),
+}));
+
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
 }));
 
 vi.mock("../cron/delivery.js", async (importOriginal) => {
@@ -114,5 +119,154 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       sessionKey: "agent:main:telegram:group:-1001234567890:thread:42",
       inheritSessionThread: false,
     });
+  });
+
+  it("redacts command action-required summaries before webhook completion delivery", async () => {
+    const logger = { warn: vi.fn() };
+    const job = {
+      id: "cron-command-webhook-redact",
+      name: "command webhook redact",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "command", argv: ["echo", "ok"] },
+      delivery: {
+        mode: "webhook",
+        to: "https://example.invalid/cron",
+      },
+      state: {},
+    } satisfies CronJob;
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: {
+        jobId: job.id,
+        action: "finished",
+        status: "ok",
+        summary:
+          "action-required output preserved:\nVisit www.example.com/device and enter code 123456\nLog in with token=opaque-secret-value",
+        diagnostics: {
+          summary:
+            "action-required output preserved:\nVisit www.example.com/device and enter code 123456\nLog in with token=opaque-secret-value",
+          entries: [
+            {
+              ts: 1,
+              source: "exec",
+              severity: "warn",
+              message:
+                "argv: node -e Visit www.example.com/device and enter code 123456; Log in with token=opaque-secret-value",
+            },
+          ],
+        },
+      },
+      job,
+      deps: {} as CliDeps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    await vi.waitFor(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
+    const [request] = mocks.fetchWithSsrFGuard.mock.calls[0] as unknown as [
+      { init?: { body?: string } },
+    ];
+    const body = JSON.parse(String(request.init?.body));
+    expect(body.summary).toContain("[redacted-url]");
+    expect(body.summary).toContain("[redacted-code]");
+    expect(body.summary).toContain("token=***");
+    expect(body.summary).not.toContain("www.example.com/device");
+    expect(body.summary).not.toContain("123456");
+    expect(body.summary).not.toContain("opaque-secret-value");
+    expect(body.diagnostics.summary).toBe(body.summary);
+    expect(body.diagnostics.entries[0].message).toContain("[redacted-url]");
+    expect(body.diagnostics.entries[0].message).toContain("[redacted-code]");
+    expect(body.diagnostics.entries[0].message).toContain("token=***");
+    expect(body.diagnostics.entries[0].message).not.toContain("www.example.com/device");
+    expect(body.diagnostics.entries[0].message).not.toContain("123456");
+    expect(body.diagnostics.entries[0].message).not.toContain("opaque-secret-value");
+  });
+
+  it("omits failed command summaries and diagnostics from completion webhook delivery", async () => {
+    const logger = { warn: vi.fn() };
+    const sensitiveSummary =
+      "action-required output preserved:\nVisit www.example.com/device and enter code 123456\nLog in with token=opaque-secret-value";
+    const job = {
+      id: "cron-command-webhook-failed-redact",
+      name: "command webhook failed redact",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "command", argv: ["node", "-e", "process.exit(7)"] },
+      delivery: {
+        mode: "announce",
+        completionDestination: {
+          mode: "webhook",
+          to: "https://example.invalid/cron",
+        },
+      },
+      state: {
+        lastDiagnosticSummary: sensitiveSummary,
+        lastDiagnostics: {
+          summary: sensitiveSummary,
+          entries: [
+            {
+              ts: 1,
+              source: "exec",
+              severity: "error",
+              message: sensitiveSummary,
+            },
+          ],
+        },
+      },
+    } satisfies CronJob;
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: {
+        jobId: job.id,
+        action: "finished",
+        status: "error",
+        error: "command exited with code 7",
+        summary: sensitiveSummary,
+        diagnostics: {
+          summary: sensitiveSummary,
+          entries: [
+            {
+              ts: 1,
+              source: "exec",
+              severity: "error",
+              message: sensitiveSummary,
+            },
+          ],
+        },
+        job,
+      },
+      job,
+      deps: {} as CliDeps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    await vi.waitFor(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
+    const [request] = mocks.fetchWithSsrFGuard.mock.calls[0] as unknown as [
+      { init?: { body?: string } },
+    ];
+    const body = JSON.parse(String(request.init?.body));
+    expect(body).toMatchObject({
+      action: "finished",
+      jobId: job.id,
+      status: "error",
+      error: "command exited with code 7",
+    });
+    expect(body).not.toHaveProperty("summary");
+    expect(body).not.toHaveProperty("diagnostics");
+    expect(body.job.state).not.toHaveProperty("lastDiagnosticSummary");
+    expect(body.job.state).not.toHaveProperty("lastDiagnostics");
+    expect(JSON.stringify(body)).not.toContain("www.example.com/device");
+    expect(JSON.stringify(body)).not.toContain("123456");
+    expect(JSON.stringify(body)).not.toContain("opaque-secret-value");
   });
 });

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -23,6 +23,19 @@ vi.mock("../cron/delivery.js", async (importOriginal) => {
 
 import { dispatchGatewayCronFinishedNotifications } from "./server-cron-notifications.js";
 
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object") {
+    throw new Error(`expected ${label}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function webhookRequestBody() {
+  const request = requireRecord(mocks.fetchWithSsrFGuard.mock.calls[0]?.[0], "webhook request");
+  const init = requireRecord(request.init, "webhook request init");
+  return JSON.parse(String(init.body));
+}
+
 describe("dispatchGatewayCronFinishedNotifications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -182,10 +195,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     });
 
     await vi.waitFor(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
-    const [request] = mocks.fetchWithSsrFGuard.mock.calls[0] as unknown as [
-      { init?: { body?: string } },
-    ];
-    const body = JSON.parse(String(request.init?.body));
+    const body = webhookRequestBody();
     expect(body.summary).toContain("[redacted-url]");
     expect(body.summary).toContain("[redacted-code]");
     expect(body.summary).toContain("token=***");
@@ -267,10 +277,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     });
 
     await vi.waitFor(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
-    const [request] = mocks.fetchWithSsrFGuard.mock.calls[0] as unknown as [
-      { init?: { body?: string } },
-    ];
-    const body = JSON.parse(String(request.init?.body));
+    const body = webhookRequestBody();
     expect(body).toMatchObject({
       action: "finished",
       jobId: job.id,

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -65,10 +65,16 @@ function redactCommandCronEventForExternalDelivery(evt: CronEvent, job?: CronJob
   const diagnosticsEntriesChanged = diagnosticsEntries?.some(
     (entry, index) => entry.message !== evt.diagnostics?.entries[index]?.message,
   );
+  const embeddedJobState = evt.job?.state;
+  const stripEmbeddedJobDiagnostics = Boolean(
+    embeddedJobState &&
+    ("lastDiagnostics" in embeddedJobState || "lastDiagnosticSummary" in embeddedJobState),
+  );
   if (
     summary === evt.summary &&
     diagnosticsSummary === evt.diagnostics?.summary &&
-    !diagnosticsEntriesChanged
+    !diagnosticsEntriesChanged &&
+    !stripEmbeddedJobDiagnostics
   ) {
     return evt;
   }
@@ -88,6 +94,15 @@ function redactCommandCronEventForExternalDelivery(evt: CronEvent, job?: CronJob
     if (diagnosticsEntries) {
       redacted.diagnostics.entries = diagnosticsEntries;
     }
+  }
+  if (stripEmbeddedJobDiagnostics && evt.job) {
+    const state = { ...evt.job.state };
+    delete state.lastDiagnostics;
+    delete state.lastDiagnosticSummary;
+    redacted.job = {
+      ...evt.job,
+      state,
+    };
   }
   return redacted;
 }

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -7,6 +7,7 @@ import {
 import type { CliDeps } from "../cli/deps.types.js";
 import type { CronFailureDestinationConfig } from "../config/types.cron.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { redactCronCommandSummaryForExternalDelivery } from "../cron/command-output-summary.js";
 import {
   resolveCronDeliveryPlan,
   resolveFailureDestination,
@@ -49,6 +50,46 @@ function redactWebhookUrl(url: string): string {
 function redactOptionalWebhookUrl(url: unknown): string | undefined {
   const normalized = normalizeOptionalString(url);
   return normalized ? redactWebhookUrl(normalized) : undefined;
+}
+
+function redactCommandCronEventForExternalDelivery(evt: CronEvent, job?: CronJob): CronEvent {
+  if (job?.payload.kind !== "command") {
+    return evt;
+  }
+  const summary = redactCronCommandSummaryForExternalDelivery(evt.summary);
+  const diagnosticsSummary = redactCronCommandSummaryForExternalDelivery(evt.diagnostics?.summary);
+  const diagnosticsEntries = evt.diagnostics?.entries.map((entry) => ({
+    ...entry,
+    message: redactCronCommandSummaryForExternalDelivery(entry.message) ?? entry.message,
+  }));
+  const diagnosticsEntriesChanged = diagnosticsEntries?.some(
+    (entry, index) => entry.message !== evt.diagnostics?.entries[index]?.message,
+  );
+  if (
+    summary === evt.summary &&
+    diagnosticsSummary === evt.diagnostics?.summary &&
+    !diagnosticsEntriesChanged
+  ) {
+    return evt;
+  }
+  const redacted: CronEvent = { ...evt };
+  if (summary !== undefined) {
+    redacted.summary = summary;
+  } else {
+    delete redacted.summary;
+  }
+  if (evt.diagnostics) {
+    redacted.diagnostics = { ...evt.diagnostics };
+    if (diagnosticsSummary !== undefined) {
+      redacted.diagnostics.summary = diagnosticsSummary;
+    } else {
+      delete redacted.diagnostics.summary;
+    }
+    if (diagnosticsEntries) {
+      redacted.diagnostics.entries = diagnosticsEntries;
+    }
+  }
+  return redacted;
 }
 
 /** Resolves direct webhook delivery and completion-destination webhooks. */
@@ -256,6 +297,7 @@ export function dispatchGatewayCronFinishedNotifications(params: {
   globalFailureDestination?: CronFailureDestinationConfig;
 }): void {
   const webhookToken = normalizeOptionalString(params.webhookToken);
+  const redactedWebhookEvent = redactCommandCronEventForExternalDelivery(params.evt, params.job);
   const webhookTargets = resolveCronWebhookTargets({
     delivery:
       params.job?.delivery && typeof params.job.delivery.mode === "string"
@@ -295,7 +337,7 @@ export function dispatchGatewayCronFinishedNotifications(params: {
 
   if (params.evt.summary) {
     for (const webhookTarget of webhookTargets) {
-      const payload = buildCronFinishedWebhookPayload(params.evt);
+      const payload = buildCronFinishedWebhookPayload(redactedWebhookEvent);
       // Completion notification fanout is best-effort; the cron service has
       // already recorded the run result and must not wait on slow webhooks.
       void (async () => {

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -18,6 +18,7 @@ const {
   runHeartbeatOnceMock,
   loadConfigMock,
   fetchWithSsrFGuardMock,
+  sendCronAnnouncePayloadStrictMock,
   runCronIsolatedAgentTurnMock,
   cleanupBrowserSessionsForLifecycleEndMock,
   getGlobalHookRunnerMock,
@@ -34,6 +35,7 @@ const {
   >(async () => ({ status: "ran", durationMs: 1 })),
   loadConfigMock: vi.fn(),
   fetchWithSsrFGuardMock: vi.fn(),
+  sendCronAnnouncePayloadStrictMock: vi.fn(async () => {}),
   runCronIsolatedAgentTurnMock: vi.fn<RunCronIsolatedAgentTurnMock>(async () => ({
     status: "ok",
     summary: "ok",
@@ -155,6 +157,14 @@ vi.mock("../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
+vi.mock("../cron/delivery.js", async () => {
+  const actual = await vi.importActual<typeof import("../cron/delivery.js")>("../cron/delivery.js");
+  return {
+    ...actual,
+    sendCronAnnouncePayloadStrict: sendCronAnnouncePayloadStrictMock,
+  };
+});
+
 vi.mock("../cron/isolated-agent.js", () => ({
   runCronIsolatedAgentTurn: runCronIsolatedAgentTurnMock,
 }));
@@ -272,6 +282,7 @@ describe("buildGatewayCronService", () => {
     runHeartbeatOnceMock.mockClear();
     loadConfigMock.mockClear();
     fetchWithSsrFGuardMock.mockClear();
+    sendCronAnnouncePayloadStrictMock.mockClear();
     runCronIsolatedAgentTurnMock.mockClear();
     cleanupBrowserSessionsForLifecycleEndMock.mockClear();
     runCronChangedMock.mockClear();
@@ -574,6 +585,140 @@ describe("buildGatewayCronService", () => {
 
       expect(state.cron.getJob(job.id)?.state.lastRunStatus).toBe("ok");
       expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("redacts command summary before cron_changed hook delivery", async () => {
+    const cfg = createCronConfig("server-cron-command-hook-redaction");
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "hook-redacted-command",
+        enabled: true,
+        deleteAfterRun: false,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          argv: [
+            process.execPath,
+            "-e",
+            "process.stdout.write('Visit www.example.com/device and enter code 123456; Log in with token=opaque-secret-value\\n')",
+          ],
+        },
+      });
+
+      runCronChangedMock.mockClear();
+      await state.cron.run(job.id, "force");
+
+      const hookEvents = runCronChangedMock.mock.calls as unknown as Array<
+        [{ action?: string; summary?: string }]
+      >;
+      const event = hookEvents.find(([hookEvent]) => hookEvent.action === "finished")?.[0];
+      expect(event).toBeDefined();
+      const summary = event?.summary ?? "";
+      expect(summary).toContain("[redacted-url]");
+      expect(summary).toContain("[redacted-code]");
+      expect(summary).toContain("token=***");
+      expect(summary).not.toContain("www.example.com/device");
+      expect(summary).not.toContain("123456");
+      expect(summary).not.toContain("opaque-secret-value");
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("redacts command summary secrets before announce delivery", async () => {
+    const cfg = createCronConfig("server-cron-command-announce-redaction");
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "announce-redacted-command",
+        enabled: true,
+        deleteAfterRun: false,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          argv: [
+            process.execPath,
+            "-e",
+            "process.stdout.write('Log in with token=opaque-secret-value\\n')",
+          ],
+        },
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "123",
+        },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      const announceCalls = sendCronAnnouncePayloadStrictMock.mock.calls as unknown as Array<
+        [{ message?: string }]
+      >;
+      const message = announceCalls[0]?.[0]?.message ?? "";
+      expect(message).toContain("token=***");
+      expect(message).not.toContain("opaque-secret-value");
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("leaves non-command cron_changed summaries unchanged", async () => {
+    const cfg = createCronConfig("server-cron-non-command-summary");
+    loadConfigMock.mockReturnValue(cfg);
+    const summary = "Visit https://example.com/report and enter code ABCD-EFGH";
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({ status: "ok", summary });
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "non-command-summary",
+        enabled: true,
+        deleteAfterRun: false,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "report" },
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "123",
+        },
+      });
+
+      runCronChangedMock.mockClear();
+      await state.cron.run(job.id, "force");
+
+      expect(sendCronAnnouncePayloadStrictMock).not.toHaveBeenCalled();
+
+      const hookEvents = runCronChangedMock.mock.calls as unknown as Array<
+        [{ action?: string; summary?: string }]
+      >;
+      const event = hookEvents.find(([hookEvent]) => hookEvent.action === "finished")?.[0];
+      expect(event?.summary).toBe(summary);
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -620,12 +620,10 @@ describe("buildGatewayCronService", () => {
       runCronChangedMock.mockClear();
       await state.cron.run(job.id, "force");
 
-      const hookEvents = runCronChangedMock.mock.calls as unknown as Array<
-        [{ action?: string; summary?: string }]
-      >;
-      const event = hookEvents.find(([hookEvent]) => hookEvent.action === "finished")?.[0];
-      expect(event).toBeDefined();
-      const summary = event?.summary ?? "";
+      const event = runCronChangedMock.mock.calls
+        .map((call) => requireRecord(call[0], "cron_changed event"))
+        .find((hookEvent) => hookEvent.action === "finished");
+      const summary = String(event?.summary ?? "");
       expect(summary).toContain("[redacted-url]");
       expect(summary).toContain("[redacted-code]");
       expect(summary).toContain("token=***");
@@ -671,10 +669,11 @@ describe("buildGatewayCronService", () => {
 
       await state.cron.run(job.id, "force");
 
-      const announceCalls = sendCronAnnouncePayloadStrictMock.mock.calls as unknown as Array<
-        [{ message?: string }]
-      >;
-      const message = announceCalls[0]?.[0]?.message ?? "";
+      const announcePayload = requireRecord(
+        callArg(sendCronAnnouncePayloadStrictMock, 0, 0, "cron announce payload"),
+        "cron announce payload",
+      );
+      const message = String(announcePayload.message ?? "");
       expect(message).toContain("token=***");
       expect(message).not.toContain("opaque-secret-value");
     } finally {
@@ -714,10 +713,9 @@ describe("buildGatewayCronService", () => {
 
       expect(sendCronAnnouncePayloadStrictMock).not.toHaveBeenCalled();
 
-      const hookEvents = runCronChangedMock.mock.calls as unknown as Array<
-        [{ action?: string; summary?: string }]
-      >;
-      const event = hookEvents.find(([hookEvent]) => hookEvent.action === "finished")?.[0];
+      const event = runCronChangedMock.mock.calls
+        .map((call) => requireRecord(call[0], "cron_changed event"))
+        .find((hookEvent) => hookEvent.action === "finished");
       expect(event?.summary).toBe(summary);
     } finally {
       state.cron.stop();

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -15,6 +15,7 @@ import {
 import { resolveStorePath } from "../config/sessions/paths.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { redactCronCommandSummaryForExternalDelivery } from "../cron/command-output-summary.js";
 import { runCronCommandJob } from "../cron/command-runner.js";
 import { resolveCronStoredDeliveryContext } from "../cron/delivery-context.js";
 import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/delivery.js";
@@ -124,6 +125,10 @@ function toPluginCronJob(job: CronJob): PluginHookGatewayCronJob {
     createdAtMs: job.createdAtMs,
     updatedAtMs: job.updatedAtMs,
   };
+}
+
+function isCommandCronJob(job: CronJob | null | undefined): boolean {
+  return job?.payload?.kind === "command";
 }
 
 /** Build the cron service state used by Gateway startup and lazy cron loading. */
@@ -453,7 +458,9 @@ export function buildGatewayCronService(params: {
           delivery: deliveryTrace,
         };
       }
-      const message = result.summary;
+      const message = isCommandCronJob(job)
+        ? redactCronCommandSummaryForExternalDelivery(result.summary)
+        : result.summary;
       if (typeof message !== "string") {
         return {
           ...result,
@@ -582,6 +589,10 @@ export function buildGatewayCronService(params: {
       // when the job is known.
       const jobSnapshot = evt.job ?? cron.getJob(evt.jobId);
       const pluginJob = jobSnapshot ? toPluginCronJob(jobSnapshot) : undefined;
+      const hookSummary =
+        isCommandCronJob(jobSnapshot) && typeof evt.summary === "string"
+          ? redactCronCommandSummaryForExternalDelivery(evt.summary)
+          : evt.summary;
       const hookEvt: PluginHookCronChangedEvent = {
         action: evt.action,
         jobId: evt.jobId,
@@ -594,7 +605,6 @@ export function buildGatewayCronService(params: {
           "durationMs",
           "status",
           "error",
-          "summary",
           "delivered",
           "deliveryStatus",
           "deliveryError",
@@ -605,6 +615,7 @@ export function buildGatewayCronService(params: {
           "model",
           "provider",
         ]),
+        ...(hookSummary !== undefined ? { summary: hookSummary } : {}),
       };
       runCronChangedHook(hookEvt);
       if (evt.action === "finished") {

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -34,8 +34,13 @@ async function loadExecModules(options?: { mockSpawn?: boolean; mockExecFile?: b
     vi.doUnmock("node:child_process");
   }
   ({ attachChildProcessBridge } = await import("./child-process-bridge.js"));
-  ({ resolveCommandEnv, resolveProcessExitCode, runCommandWithTimeout, runExec, shouldSpawnWithShell } =
-    await import("./exec.js"));
+  ({
+    resolveCommandEnv,
+    resolveProcessExitCode,
+    runCommandWithTimeout,
+    runExec,
+    shouldSpawnWithShell,
+  } = await import("./exec.js"));
 }
 
 describe("runCommandWithTimeout", () => {
@@ -340,6 +345,47 @@ describe("runCommandWithTimeout", () => {
       expect(result.code).toBe(0);
     },
   );
+
+  it("preserves matching output lines even when the tail capture truncates them", async () => {
+    await loadExecModules();
+    const result = await runCommandWithTimeout(
+      [
+        process.execPath,
+        "-e",
+        [
+          "process.stdout.write('Visit https://example.com/device and enter code ABCD-EFGH\\n')",
+          "process.stdout.write('x'.repeat(200))",
+        ].join(";"),
+      ],
+      {
+        timeoutMs: 3_000,
+        maxOutputBytes: 24,
+        preserveOutputLine: (line) => line.includes("enter code"),
+      },
+    );
+
+    expect(result.stdout).toBe("x".repeat(24));
+    expect(result.stdoutTruncatedBytes).toBeGreaterThan(0);
+    expect(result.preservedStdoutLines).toEqual([
+      "Visit https://example.com/device and enter code ABCD-EFGH",
+    ]);
+  });
+
+  it("bounds preserved matching output for long lines without newlines", async () => {
+    await loadExecModules();
+    const result = await runCommandWithTimeout(
+      [process.execPath, "-e", "process.stdout.write('x'.repeat(10_000))"],
+      {
+        timeoutMs: 3_000,
+        maxOutputBytes: 24,
+        preserveOutputLine: () => true,
+      },
+    );
+
+    expect(result.stdout).toBe("x".repeat(24));
+    expect(result.stdoutTruncatedBytes).toBeGreaterThan(0);
+    expect(result.preservedStdoutLines).toEqual(["x".repeat(24)]);
+  });
 });
 
 describe("attachChildProcessBridge", () => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -3,17 +3,18 @@ import { execFile, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { StringDecoder } from "node:string_decoder";
 import { promisify } from "node:util";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { danger, shouldLogVerbose } from "../globals.js";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
-import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import {
   decodeWindowsOutputBuffer,
   resolveWindowsConsoleEncoding,
 } from "../infra/windows-encoding.js";
 import { getWindowsSystem32ExePath } from "../infra/windows-install-roots.js";
 import { logDebug, logError } from "../logger.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { killProcessTree as terminateProcessTree } from "./kill-tree.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
 import {
@@ -213,6 +214,8 @@ export type SpawnResult = {
   stderr: string;
   stdoutTruncatedBytes?: number;
   stderrTruncatedBytes?: number;
+  preservedStdoutLines?: string[];
+  preservedStderrLines?: string[];
   code: number | null;
   signal: NodeJS.Signals | null;
   killed: boolean;
@@ -230,6 +233,8 @@ export type CommandOptions = {
   noOutputTimeoutMs?: number;
   signal?: AbortSignal;
   maxOutputBytes?: number;
+  maxPreservedOutputLines?: number;
+  preserveOutputLine?: (line: string, stream: "stdout" | "stderr") => boolean;
   killProcessTree?: boolean;
 };
 
@@ -238,11 +243,15 @@ const WINDOWS_CLOSE_STATE_POLL_MS = 10;
 const COMMAND_PROCESS_TREE_KILL_GRACE_MS = 300;
 const TIMEOUT_EXIT_CODE = 124;
 const DEFAULT_COMMAND_OUTPUT_MAX_BYTES = 16 * 1024 * 1024;
+const MAX_PRESERVED_PENDING_LINE_BYTES = 8 * 1024;
 
 type CapturedOutputBuffers = {
   chunks: Buffer[];
   bytes: number;
   truncatedBytes: number;
+  preservedLines: string[];
+  decoder: StringDecoder;
+  pendingLine: string;
 };
 
 function normalizeMaxOutputBytes(value: number | undefined): number {
@@ -279,6 +288,70 @@ function appendCapturedOutput(
       capture.bytes -= overflow;
       capture.truncatedBytes += overflow;
     }
+  }
+}
+
+function trimPreservedPendingLine(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value) <= maxBytes) {
+    return value;
+  }
+  const buffer = Buffer.from(value);
+  return buffer.subarray(buffer.byteLength - maxBytes).toString();
+}
+
+function appendPreservedOutputLines(params: {
+  capture: CapturedOutputBuffers;
+  chunk: Buffer | string;
+  stream: "stdout" | "stderr";
+  preserveOutputLine?: CommandOptions["preserveOutputLine"];
+  maxPreservedOutputLines: number;
+  maxPendingLineBytes: number;
+}): void {
+  if (!params.preserveOutputLine || params.maxPreservedOutputLines <= 0) {
+    return;
+  }
+  const text = Buffer.isBuffer(params.chunk)
+    ? params.capture.decoder.write(params.chunk)
+    : params.chunk;
+  if (!text) {
+    return;
+  }
+  const lines = (params.capture.pendingLine + text).split(/\r?\n/);
+  params.capture.pendingLine = trimPreservedPendingLine(
+    lines.pop() ?? "",
+    params.maxPendingLineBytes,
+  );
+  for (const line of lines) {
+    if (
+      params.capture.preservedLines.length < params.maxPreservedOutputLines &&
+      params.preserveOutputLine(line, params.stream)
+    ) {
+      params.capture.preservedLines.push(line);
+    }
+  }
+}
+
+function flushPreservedOutputLine(params: {
+  capture: CapturedOutputBuffers;
+  stream: "stdout" | "stderr";
+  preserveOutputLine?: CommandOptions["preserveOutputLine"];
+  maxPreservedOutputLines: number;
+  maxPendingLineBytes: number;
+}): void {
+  if (!params.preserveOutputLine || params.maxPreservedOutputLines <= 0) {
+    return;
+  }
+  const trailing = trimPreservedPendingLine(
+    params.capture.pendingLine + params.capture.decoder.end(),
+    params.maxPendingLineBytes,
+  );
+  params.capture.pendingLine = "";
+  if (
+    trailing &&
+    params.capture.preservedLines.length < params.maxPreservedOutputLines &&
+    params.preserveOutputLine(trailing, params.stream)
+  ) {
+    params.capture.preservedLines.push(trailing);
   }
 }
 export function resolveProcessExitCode(params: {
@@ -382,9 +455,25 @@ export async function runCommandWithTimeout(
   });
   // Spawn with inherited stdin (TTY) so interactive tools stay usable when needed.
   return await new Promise((resolve, reject) => {
-    const stdoutCapture: CapturedOutputBuffers = { chunks: [], bytes: 0, truncatedBytes: 0 };
-    const stderrCapture: CapturedOutputBuffers = { chunks: [], bytes: 0, truncatedBytes: 0 };
+    const stdoutCapture: CapturedOutputBuffers = {
+      chunks: [],
+      bytes: 0,
+      truncatedBytes: 0,
+      preservedLines: [],
+      decoder: new StringDecoder("utf8"),
+      pendingLine: "",
+    };
+    const stderrCapture: CapturedOutputBuffers = {
+      chunks: [],
+      bytes: 0,
+      truncatedBytes: 0,
+      preservedLines: [],
+      decoder: new StringDecoder("utf8"),
+      pendingLine: "",
+    };
     const maxOutputBytes = normalizeMaxOutputBytes(options.maxOutputBytes);
+    const maxPreservedPendingLineBytes = Math.min(maxOutputBytes, MAX_PRESERVED_PENDING_LINE_BYTES);
+    const maxPreservedOutputLines = Math.max(0, Math.floor(options.maxPreservedOutputLines ?? 16));
     const windowsEncoding = resolveWindowsConsoleEncoding();
     let settled = false;
     let timedOut = false;
@@ -527,10 +616,26 @@ export async function runCommandWithTimeout(
     }
 
     child.stdout?.on("data", (d) => {
+      appendPreservedOutputLines({
+        capture: stdoutCapture,
+        chunk: d,
+        stream: "stdout",
+        preserveOutputLine: options.preserveOutputLine,
+        maxPreservedOutputLines,
+        maxPendingLineBytes: maxPreservedPendingLineBytes,
+      });
       appendCapturedOutput(stdoutCapture, d, maxOutputBytes);
       armNoOutputTimer();
     });
     child.stderr?.on("data", (d) => {
+      appendPreservedOutputLines({
+        capture: stderrCapture,
+        chunk: d,
+        stream: "stderr",
+        preserveOutputLine: options.preserveOutputLine,
+        maxPreservedOutputLines,
+        maxPendingLineBytes: maxPreservedPendingLineBytes,
+      });
       appendCapturedOutput(stderrCapture, d, maxOutputBytes);
       armNoOutputTimer();
     });
@@ -596,6 +701,20 @@ export async function runCommandWithTimeout(
             ? TIMEOUT_EXIT_CODE
             : resolvedCode
           : resolvedCode;
+      flushPreservedOutputLine({
+        capture: stdoutCapture,
+        stream: "stdout",
+        preserveOutputLine: options.preserveOutputLine,
+        maxPreservedOutputLines,
+        maxPendingLineBytes: maxPreservedPendingLineBytes,
+      });
+      flushPreservedOutputLine({
+        capture: stderrCapture,
+        stream: "stderr",
+        preserveOutputLine: options.preserveOutputLine,
+        maxPreservedOutputLines,
+        maxPendingLineBytes: maxPreservedPendingLineBytes,
+      });
       resolve({
         pid: child.pid ?? undefined,
         stdout: decodeWindowsOutputBuffer({
@@ -608,6 +727,10 @@ export async function runCommandWithTimeout(
         }),
         stdoutTruncatedBytes: stdoutCapture.truncatedBytes || undefined,
         stderrTruncatedBytes: stderrCapture.truncatedBytes || undefined,
+        preservedStdoutLines:
+          stdoutCapture.preservedLines.length > 0 ? stdoutCapture.preservedLines : undefined,
+        preservedStderrLines:
+          stderrCapture.preservedLines.length > 0 ? stderrCapture.preservedLines : undefined,
         code: normalizedCode,
         signal: resolvedSignal,
         killed: child.killed,


### PR DESCRIPTION
## What Problem This Solves

Fixes #96346.

Cron command jobs currently keep only the tail of captured stdout/stderr when `outputMaxBytes` is exceeded. That is usually fine for failures, but it breaks command flows where the actionable line appears near the start and the command later emits noisy output. Device-login and setup commands commonly print a URL/code first, then verbose logs; the cron run summary, run log, announce delivery, and completion webhook can then lose the only line the operator needs.

## Summary

- Adds an opt-in output preservation hook to `runCommandWithTimeout()` without changing default exec capture behavior.
- Uses that hook only for cron command jobs to preserve action-required lines such as device/login/auth code instructions even when the tail capture truncates them.
- Builds cron command summaries with an `action-required output preserved:` block before the bounded stdout/stderr tail.
- Keeps run logs and diagnostics useful for operator recovery.
- Redacts preserved action-required URLs/codes before command summaries are sent through cron announce, successful completion webhook, or `cron_changed` hook delivery.
- Preserves the current failed completion webhook security boundary: failed webhook payloads omit `summary`, `diagnostics`, `job.state.lastDiagnosticSummary`, and `job.state.lastDiagnostics`.
- Keeps the fix cron-scoped: ordinary exec/tool calls still use the existing tail-bound capture behavior unless they explicitly opt into preserved lines.

## Maintainer Decision Boundary

This branch is proposed as the canonical fix for #96346.

- Behavior change is scoped to cron command jobs.
- Operator-facing cron run history and diagnostics retain unredacted preserved action-required lines for recovery.
- External delivery projections redact command action-required output for announce, successful completion webhook payloads, completion webhook diagnostics entries, and `cron_changed` hook summaries.
- Successful command completion webhook payloads also strip persisted command diagnostic state from embedded job snapshots.
- Failed completion webhook payloads continue to omit summaries and diagnostics entirely, including persisted diagnostic state on embedded job snapshots.
- Non-command cron summaries remain unchanged.
- The exec helper API change is additive and opt-in; existing callers retain the previous tail-only capture behavior.
- After this PR lands, sibling preservation candidates for #96346 can be closed or superseded in favor of this canonical branch.

## Security / Delivery Boundary

The preserved action lines are intended for operator-facing cron history and diagnostics. They may include setup URLs or auth/device codes, so this PR does not blindly broadcast the unredacted text through cron delivery:

- cron run summary / diagnostics keep the actionable line for operator recovery
- cron announce delivery uses a redacted command summary
- successful cron completion webhook payloads use a redacted command summary, diagnostics summary, and diagnostics entries, and omit persisted command diagnostic state from embedded job snapshots
- failed cron completion webhook payloads omit `summary` and `diagnostics`, and also omit persisted diagnostic state from embedded job snapshots
- `cron_changed` hook events use a redacted command summary for command jobs
- non-command cron jobs are unchanged

## Evidence

Current head: `024cb8d120c197ffee5a663a552abbd9ca0b44c8`

Latest focused validation:

- Local pre-check only: `node scripts/run-vitest.mjs src/gateway/server-cron-notifications.test.ts` — passed
- Local pre-check only: `git diff --check` — passed
- GitHub Actions exact-head cron proof: <https://github.com/snowzlmbot/openclaw/actions/runs/28211403445> — passed
  - Artifact: `cron-action-critical-summary-proof-024cb8d120c197ffee5a663a552abbd9ca0b44c8`
  - Focused regression log: 7 test files / 91 tests passed across gateway, cron, and process shards
- Repository PR proof gate: <https://github.com/openclaw/openclaw/actions/runs/28191420047> — passed for head `024cb8d120c197ffee5a663a552abbd9ca0b44c8`

Earlier focused validation after rebasing on `upstream/main` at head `4b142a7f262ad5eef78714e8a2c96f1afaadd4c6`:

- `pnpm docs:list` — passed
- `git diff --check` — passed
- `node scripts/run-vitest.mjs src/gateway/server-cron-notifications.test.ts src/cron/command-output-summary.test.ts` — passed
  - `src/gateway/server-cron-notifications.test.ts`: 8 tests passed across gateway shards
  - `src/cron/command-output-summary.test.ts`: 4 tests passed

Regression coverage added or retained:

- `src/process/exec.test.ts` verifies preserved lines survive tail truncation and long no-newline output remains bounded.
- `src/cron/command-runner.test.ts` verifies an early `Visit ... enter code ...` line appears in cron command summary even when `outputMaxBytes` keeps only the final tail.
- `src/cron/command-output-summary.test.ts` verifies summary prepending plus external redaction for URLs, separated codes, numeric codes, unseparated codes, and token/password/secret assignments, including webhook diagnostics entries.
- `src/gateway/server-cron-notifications.test.ts` verifies successful command completion webhooks redact URL/code/token material from `summary`, `diagnostics.summary`, and `diagnostics.entries[].message`.
- `src/gateway/server-cron-notifications.test.ts` verifies successful command completion webhooks strip embedded `job.state.lastDiagnostics` and `job.state.lastDiagnosticSummary` before external delivery.
- `src/gateway/server-cron-notifications.test.ts` verifies failed command completion webhooks omit preserved action lines, diagnostics entries, raw codes, token assignments, and persisted job diagnostic state.
- `src/gateway/server-cron.test.ts` verifies `cron_changed` plugin hook events receive a delivery-safe redacted command summary for command jobs and keep non-command summaries unchanged.

## Real Behavior Proof

Current exact-head cron behavior proof: <https://github.com/snowzlmbot/openclaw/actions/runs/28211403445>

Head: `024cb8d120c197ffee5a663a552abbd9ca0b44c8`

Artifact: `cron-action-critical-summary-proof-024cb8d120c197ffee5a663a552abbd9ca0b44c8`

This proof checks out the exact PR head, runs an actual cron command job with an early device-login style line, numeric verification code, and token assignment plus noisy tail output, then verifies both operator summary preservation and external-delivery redaction for the preserved URL/code/token material. It also runs the focused gateway/cron/process regression set on the exact head.

Proof summary:

```text
targetSha=024cb8d120c197ffee5a663a552abbd9ca0b44c8
status=ok
summaryContainsActionLine=true
redactedContainsRawUrl=false
redactedContainsRawCode=false
redactedContainsRawToken=false
PASS: exact PR head SHA is recorded
PASS: cron command exits successfully
PASS: summary preserves early action-required output
PASS: summary keeps bounded captured tail
PASS: diagnostics mark truncated output
PASS: external delivery summary redacts URL
PASS: external delivery summary redacts code
PASS: external delivery summary omits raw URL
PASS: external delivery summary omits raw code
PASS: external delivery summary masks token assignment
PASS: external delivery summary omits raw token value
```

Focused regression proof log:

```text
src/gateway/server-cron.test.ts — 54 tests passed across gateway shards
src/gateway/server-cron-notifications.test.ts — 8 tests passed across gateway shards
src/cron/command-runner.test.ts — 8 tests passed
src/cron/command-output-summary.test.ts — 4 tests passed
src/process/exec.test.ts — 17 tests passed
```

The repository PR proof gate also passed for the same head: <https://github.com/openclaw/openclaw/actions/runs/28191420047>

## Risk

Low-to-moderate. The exec API grows an optional preservation hook, but default behavior is unchanged. The behavior change is scoped to cron command jobs, and both captured output plus preserved partial-line scanning remain bounded. External-delivery redaction is command-job gated and covers URL, separated-code, numeric-code, unseparated-code, and token/password/secret assignment shapes, so non-command cron summaries remain unchanged. Failed completion webhook payloads keep the stricter current-main omission behavior for summaries and diagnostics.

