### PR TITLE
fix(line): truncate template title/altText on grapheme boundaries, not raw UTF-16

### DIFF
--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -44,6 +44,16 @@ describe("createButtonTemplate", () => {
     expect((template.template as { title: string }).title.length).toBe(40);
   });
 
+  it("drops a surrogate-pair emoji from the title instead of splitting it", () => {
+    // 39 chars + an emoji land the truncation boundary inside the surrogate pair;
+    // a raw code-unit slice would keep only the lone high surrogate.
+    const template = createButtonTemplate(`${"x".repeat(39)}😀`, "Text", [messageAction("OK")]);
+    const title = (template.template as { title: string }).title;
+
+    expect(title).toBe("x".repeat(39));
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(title)).toBe(false);
+  });
+
   it("truncates text to 60 chars when no thumbnail is provided", () => {
     const longText = "x".repeat(100);
     const template = createButtonTemplate("Title", longText, [messageAction("OK")]);

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -65,6 +65,10 @@ function truncateTemplateText(text: string, limit: number): string {
   return result;
 }
 
+function truncateOptionalTemplateText(value: string | undefined, limit: number): string | undefined {
+  return value === undefined ? undefined : truncateTemplateText(value, limit);
+}
+
 function formatProductCarouselText(description: string, price?: string): string {
   if (!price) {
     return description;
@@ -86,13 +90,13 @@ export function createConfirmTemplate(
 ): TemplateMessage {
   const template: ConfirmTemplate = {
     type: "confirm",
-    text: text.slice(0, 240), // LINE limit
+    text: truncateTemplateText(text, 240), // LINE limit
     actions: [confirmAction, cancelAction],
   };
 
   return {
     type: "template",
-    altText: altText?.slice(0, 400) ?? text.slice(0, 400),
+    altText: truncateOptionalTemplateText(altText, 400) ?? truncateTemplateText(text, 400),
     template,
   };
 }
@@ -120,7 +124,7 @@ export function createButtonTemplate(
   });
   const template: ButtonsTemplate = {
     type: "buttons",
-    title: title.slice(0, 40), // LINE limit
+    title: truncateTemplateText(title, 40), // LINE limit
     text: truncateTemplateText(text, textLimit),
     actions: actions.slice(0, 4), // LINE limit: max 4 actions
     thumbnailImageUrl: options?.thumbnailImageUrl,
@@ -132,7 +136,9 @@ export function createButtonTemplate(
 
   return {
     type: "template",
-    altText: options?.altText?.slice(0, 400) ?? `${title}: ${text}`.slice(0, 400),
+    altText:
+      truncateOptionalTemplateText(options?.altText, 400) ??
+      truncateTemplateText(`${title}: ${text}`, 400),
     template,
   };
 }
@@ -157,7 +163,7 @@ export function createTemplateCarousel(
 
   return {
     type: "template",
-    altText: options?.altText?.slice(0, 400) ?? "View carousel",
+    altText: truncateOptionalTemplateText(options?.altText, 400) ?? "View carousel",
     template,
   };
 }
@@ -179,7 +185,7 @@ export function createCarouselColumn(params: {
   // the buttons template already applies above.
   const textLimit = resolveTemplateTextLimit({ ...params, textOnlyLimit: 120 });
   return {
-    title: params.title?.slice(0, 40),
+    title: truncateOptionalTemplateText(params.title, 40),
     text: truncateTemplateText(params.text, textLimit),
     actions: params.actions.slice(0, 3), // LINE limit: max 3 actions per column
     thumbnailImageUrl: params.thumbnailImageUrl,
@@ -202,7 +208,7 @@ export function createImageCarousel(
 
   return {
     type: "template",
-    altText: altText?.slice(0, 400) ?? "View images",
+    altText: truncateOptionalTemplateText(altText, 400) ?? "View images",
     template,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

`createConfirmTemplate` / `createButtonTemplate` / `createTemplateCarousel` / `createCarouselColumn` / `createImageCarousel` (`extensions/line/src/template-messages.ts`) truncate the `title` and `altText` fields with a raw UTF-16 slice:

```ts
title: title.slice(0, 40),                 // LINE limit
altText: altText?.slice(0, 400) ?? ...,
```

When an emoji / astral char straddles the limit (e.g. a 40-char button title ending in an emoji), `.slice` keeps only the leading high surrogate, producing a lone `\uD83D` that LINE renders as `�` or rejects:

```
createButtonTemplate("x"×39 + "😀", ...).template.title
  before: "x"×39 + "\uD83D"   ❌ lone high surrogate (length 40)
  after : "x"×39              ✅ emoji dropped whole (length 39)
```

These builders are exported and feed live LINE outbound payloads (`buildTemplateMessageFromPayload` → `deliverLineAutoReply`). The `text` body already uses the grapheme-safe `truncateTemplateText`; only `title`/`altText` (and the confirm-template `text`) were still slicing raw.

## Fix

Route every `title`/`altText`/confirm-`text` truncation through the file's existing grapheme-safe `truncateTemplateText` (plus a small `truncateOptionalTemplateText` wrapper for the optional fields). No new import; this just makes the whole file consistent with how the `text` body is already handled. `truncateTemplateText(s, n)` is byte-identical to `s.slice(0, n)` for all-BMP input, so existing behavior is preserved.

## Evidence

Added a regression test on `createButtonTemplate`; verified the grapheme-safe truncation:

```
title "x"×39 + "😀"  limit 40  : before slice -> 40 chars, lone surrogate=true ; after -> "x"×39, lone=false ✅
title "My Title"     limit 40  : unchanged ✅
text  "a"×239 + "😀" limit 240 : after -> "a"×239, lone=false ✅
"hello world"        limit 5   : after "hello" == slice(0,5) ✅ (ASCII unchanged)
```

The existing `truncates title to 40 characters` test (all-ASCII) stays green; only the straddling-emoji case changes, and no fixed output contains a lone surrogate. (The array `.slice(0, N)` calls that cap action/column counts are unrelated and untouched.)
