### PR TITLE
fix: warn when configured channel plugins cannot load

### DIFF
--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -8,7 +8,8 @@ const pluginRegistryMocks = vi.hoisted(() => ({
   loadPluginManifestRegistryForPluginRegistry: vi.fn(),
 }));
 
-vi.mock("../plugins/plugin-registry-contributions.js", () => ({
+vi.mock("../plugins/plugin-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/plugin-registry.js")>()),
   loadPluginManifestRegistryForPluginRegistry:
     pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry,
 }));
@@ -101,7 +102,34 @@ describe("gateway startup log", () => {
 
     expect(warn.mock.calls).toEqual([
       [
-        "configured channel warning: channels.slack is configured but no channel plugin is loadable (untrusted-plugin). Run `openclaw doctor --fix` or update plugins.allow/plugins.entries before relying on this channel.",
+        'configured channel warning: channels.slack: channel is configured, but external plugin "slack" is installed without explicit trust. Add plugins.entries.slack.enabled=true. Fix plugin enablement before relying on setup guidance for this channel.',
+      ],
+    ]);
+  });
+
+  it("warns when a configured channel has no owning plugin", async () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await logGatewayStartup({
+      cfg: {
+        channels: {
+          "missing-chat": {
+            enabled: true,
+            token: "configured",
+          },
+        },
+      },
+      bindHost: "127.0.0.1",
+      loadedPluginIds: [],
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    expect(warn.mock.calls).toEqual([
+      [
+        "configured channel warning: channels.missing-chat is configured but no channel plugin is installed or loadable (no-channel-owner). Run `openclaw doctor --fix` or install the channel plugin before relying on this channel.",
       ],
     ]);
   });
@@ -138,7 +166,7 @@ describe("gateway startup log", () => {
       isNixMode: false,
     });
 
-    expect(warn.mock.calls[0]?.[0]).toContain("channels.slack is configured");
+    expect(warn.mock.calls[0]?.[0]).toContain("channels.slack: channel is configured");
     expect(warn.mock.calls[0]?.[0]).not.toContain(String.fromCharCode(0x1b));
   });
 

--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -1,10 +1,27 @@
 // Startup log tests cover security warnings, model detail formatting, plugin
 // summaries, bind URLs, ANSI output, and dangerous config reporting.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { formatAgentModelStartupDetails, logGatewayStartup } from "./server-startup-log.js";
 
+const pluginRegistryMocks = vi.hoisted(() => ({
+  loadPluginManifestRegistryForPluginRegistry: vi.fn(),
+}));
+
+vi.mock("../plugins/plugin-registry-contributions.js", () => ({
+  loadPluginManifestRegistryForPluginRegistry:
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry,
+}));
+
 describe("gateway startup log", () => {
+  beforeEach(() => {
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReset();
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -41,6 +58,123 @@ describe("gateway startup log", () => {
 
     await logGatewayStartup({
       cfg: {},
+      bindHost: "127.0.0.1",
+      loadedPluginIds: [],
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when a configured channel plugin is blocked from startup", async () => {
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "slack",
+          origin: "global",
+          channels: ["slack"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    });
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await logGatewayStartup({
+      cfg: {
+        channels: {
+          slack: {
+            enabled: true,
+            botToken: "configured",
+          },
+        },
+      },
+      bindHost: "127.0.0.1",
+      loadedPluginIds: [],
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    expect(warn.mock.calls).toEqual([
+      [
+        "configured channel warning: channels.slack is configured but no channel plugin is loadable (untrusted-plugin). Run `openclaw doctor --fix` or update plugins.allow/plugins.entries before relying on this channel.",
+      ],
+    ]);
+  });
+
+  it("sanitizes configured channel ids in startup warnings", async () => {
+    const unsafeChannelId = `slack${String.fromCharCode(0x1b)}[31m`;
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "slack",
+          origin: "global",
+          channels: [unsafeChannelId],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    });
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await logGatewayStartup({
+      cfg: {
+        channels: {
+          [unsafeChannelId]: {
+            enabled: true,
+            botToken: "configured",
+          },
+        },
+      },
+      bindHost: "127.0.0.1",
+      loadedPluginIds: [],
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    expect(warn.mock.calls[0]?.[0]).toContain("channels.slack is configured");
+    expect(warn.mock.calls[0]?.[0]).not.toContain(String.fromCharCode(0x1b));
+  });
+
+  it("does not warn when startup activation enables the configured channel owner", async () => {
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "openclaw-modern-chat",
+          origin: "global",
+          channels: ["legacy-chat"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    });
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await logGatewayStartup({
+      cfg: {
+        channels: {
+          "legacy-chat": {
+            enabled: true,
+            token: "configured",
+          },
+        },
+      },
+      activationSourceConfig: {
+        plugins: {
+          entries: {
+            "openclaw-modern-chat": {
+              enabled: true,
+            },
+          },
+        },
+      },
       bindHost: "127.0.0.1",
       loadedPluginIds: [],
       port: 18789,

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -15,10 +15,6 @@ import {
 import { resolveThinkingDefault } from "../agents/model-thinking-default.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getResolvedLoggerSettings } from "../logging.js";
-import {
-  resolveConfiguredChannelPresencePolicy,
-  type ConfiguredChannelPresencePolicyEntry,
-} from "../plugins/channel-presence-policy.js";
 import { collectEnabledInsecureOrDangerousFlagsFromCurrentSnapshot } from "../security/dangerous-config-flags-current.js";
 
 type StartupThinkLevel =
@@ -70,7 +66,7 @@ export async function logGatewayStartup(params: {
     params.log.info("gateway: running in Nix mode (config managed externally)");
   }
 
-  for (const warning of collectConfiguredChannelStartupWarnings({
+  for (const warning of await collectConfiguredChannelStartupWarnings({
     cfg: params.cfg,
     activationSourceConfig: params.activationSourceConfig,
   })) {
@@ -178,28 +174,50 @@ export function formatAgentModelStartupDetails(params: {
   return `thinking=${thinking}, fast=${formatFastModeValue(fast.mode)}`;
 }
 
-function collectConfiguredChannelStartupWarnings(params: {
+async function collectConfiguredChannelStartupWarnings(params: {
   cfg: OpenClawConfig;
   activationSourceConfig?: OpenClawConfig;
-}): string[] {
-  return resolveConfiguredChannelPresencePolicy({
+}): Promise<string[]> {
+  const [blockerModule, presencePolicyModule, pluginRegistryModule] = await Promise.all([
+    import("../commands/doctor/shared/channel-plugin-blockers.js"),
+    import("../plugins/channel-presence-policy.js"),
+    import("../plugins/plugin-registry.js"),
+  ]);
+  const manifestRegistry = pluginRegistryModule.loadPluginManifestRegistryForPluginRegistry({
     config: params.cfg,
-    activationSourceConfig: params.activationSourceConfig,
-    includePersistedAuthState: false,
-  })
-    .filter((entry) => !entry.effective && entry.blockedReasons.length > 0)
-    .map(formatConfiguredChannelStartupWarning);
+    env: process.env,
+    includeDisabled: true,
+  });
+  const hits = blockerModule.scanConfiguredChannelPluginBlockers(
+    params.cfg,
+    process.env,
+    params.activationSourceConfig,
+  );
+  const blockerWarnings = blockerModule
+    .collectConfiguredChannelPluginBlockerWarnings(hits)
+    .map((warning) => `configured channel warning: ${warning.replace(/^[-]\s*/u, "")}`);
+  const missingOwnerWarnings = presencePolicyModule
+    .resolveConfiguredChannelPresencePolicy({
+      config: params.cfg,
+      activationSourceConfig: params.activationSourceConfig,
+      includePersistedAuthState: false,
+      manifestRecords: manifestRegistry.plugins,
+    })
+    .filter((entry) => !entry.effective && entry.blockedReasons.includes("no-channel-owner"))
+    .map(formatConfiguredChannelMissingOwnerStartupWarning);
+  return [...blockerWarnings, ...missingOwnerWarnings];
 }
 
-function formatConfiguredChannelStartupWarning(
-  entry: ConfiguredChannelPresencePolicyEntry,
-): string {
+function formatConfiguredChannelMissingOwnerStartupWarning(entry: {
+  channelId: string;
+  blockedReasons: readonly string[];
+}): string {
   const channelId = sanitizeForLog(entry.channelId);
   const reasons = normalizeSortedUniqueStringEntries(entry.blockedReasons).join(", ");
   return (
     `configured channel warning: channels.${channelId} is configured but no channel plugin ` +
-    `is loadable (${reasons}). Run \`openclaw doctor --fix\` or update plugins.allow/plugins.entries ` +
-    "before relying on this channel."
+    `is installed or loadable (${reasons}). Run \`openclaw doctor --fix\` or install the ` +
+    "channel plugin before relying on this channel."
   );
 }
 

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -2,6 +2,7 @@
 // Produces the compact ready banner with resolved model and safety state.
 import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import chalk from "chalk";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveDefaultAgentId, resolveAgentConfig } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { formatFastModeValue, resolveFastModeState } from "../agents/fast-mode.js";
@@ -14,6 +15,10 @@ import {
 import { resolveThinkingDefault } from "../agents/model-thinking-default.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getResolvedLoggerSettings } from "../logging.js";
+import {
+  resolveConfiguredChannelPresencePolicy,
+  type ConfiguredChannelPresencePolicyEntry,
+} from "../plugins/channel-presence-policy.js";
 import { collectEnabledInsecureOrDangerousFlagsFromCurrentSnapshot } from "../security/dangerous-config-flags-current.js";
 
 type StartupThinkLevel =
@@ -29,6 +34,7 @@ type StartupThinkLevel =
 /** Emit startup summary lines after Gateway bind and plugin loading complete. */
 export async function logGatewayStartup(params: {
   cfg: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
   bindHost: string;
   bindHosts?: string[];
   port: number;
@@ -62,6 +68,13 @@ export async function logGatewayStartup(params: {
   params.log.info(`log file: ${getResolvedLoggerSettings().file}`);
   if (params.isNixMode) {
     params.log.info("gateway: running in Nix mode (config managed externally)");
+  }
+
+  for (const warning of collectConfiguredChannelStartupWarnings({
+    cfg: params.cfg,
+    activationSourceConfig: params.activationSourceConfig,
+  })) {
+    params.log.warn(warning);
   }
 
   const enabledDangerousFlags =
@@ -163,6 +176,31 @@ export function formatAgentModelStartupDetails(params: {
   });
 
   return `thinking=${thinking}, fast=${formatFastModeValue(fast.mode)}`;
+}
+
+function collectConfiguredChannelStartupWarnings(params: {
+  cfg: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
+}): string[] {
+  return resolveConfiguredChannelPresencePolicy({
+    config: params.cfg,
+    activationSourceConfig: params.activationSourceConfig,
+    includePersistedAuthState: false,
+  })
+    .filter((entry) => !entry.effective && entry.blockedReasons.length > 0)
+    .map(formatConfiguredChannelStartupWarning);
+}
+
+function formatConfiguredChannelStartupWarning(
+  entry: ConfiguredChannelPresencePolicyEntry,
+): string {
+  const channelId = sanitizeForLog(entry.channelId);
+  const reasons = normalizeSortedUniqueStringEntries(entry.blockedReasons).join(", ");
+  return (
+    `configured channel warning: channels.${channelId} is configured but no channel plugin ` +
+    `is loadable (${reasons}). Run \`openclaw doctor --fix\` or update plugins.allow/plugins.entries ` +
+    "before relying on this channel."
+  );
 }
 
 /** Format plugin count/list and optional startup duration for the ready log line. */

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -388,6 +388,11 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(hoisted.setInternalHooksEnabled).not.toHaveBeenCalled();
     expect(hoisted.logGatewayStartup).toHaveBeenCalledTimes(1);
     expect(firstStartupLog().loadedPluginIds).toEqual(["beta", "alpha"]);
+    expect(hoisted.logGatewayStartup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activationSourceConfig: { hooks: { internal: { enabled: false } } },
+      }),
+    );
     expect(log.info).toHaveBeenCalledWith("gateway ready");
     expect(hoisted.scheduleRestartAbortedMainSessionRecovery).toHaveBeenCalledWith({
       cfg: { hooks: { internal: { enabled: false } } },
@@ -2240,6 +2245,7 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
       error: vi.fn(),
     },
     gatewayPluginConfigAtStart: { hooks: { internal: { enabled: false } } } as never,
+    activationSourceConfig: { hooks: { internal: { enabled: false } } } as never,
     pluginRegistry: {
       plugins: [
         { id: "beta", status: "loaded" },

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1096,6 +1096,7 @@ export async function startGatewayPostAttachRuntime(
       debug?: (msg: string) => void;
     };
     gatewayPluginConfigAtStart: OpenClawConfig;
+    activationSourceConfig: OpenClawConfig;
     pluginRegistry: ReturnType<typeof loadOpenClawPlugins>;
     defaultWorkspaceDir: string;
     deps: CliDeps;
@@ -1176,7 +1177,7 @@ export async function startGatewayPostAttachRuntime(
   const startupLogPromise = measureStartup(params.startupTrace, "post-attach.log", () =>
     runtimeDeps.logGatewayStartup({
       cfg: params.cfgAtStart,
-      activationSourceConfig: params.gatewayPluginConfigAtStart,
+      activationSourceConfig: params.activationSourceConfig,
       bindHost: params.bindHost,
       bindHosts: params.bindHosts,
       port: params.port,

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1176,6 +1176,7 @@ export async function startGatewayPostAttachRuntime(
   const startupLogPromise = measureStartup(params.startupTrace, "post-attach.log", () =>
     runtimeDeps.logGatewayStartup({
       cfg: params.cfgAtStart,
+      activationSourceConfig: params.gatewayPluginConfigAtStart,
       bindHost: params.bindHost,
       bindHosts: params.bindHosts,
       port: params.port,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1640,6 +1640,7 @@ export async function startGatewayServer(
             controlUiBasePath,
             logTailscale,
             gatewayPluginConfigAtStart,
+            activationSourceConfig: startupActivationSourceConfig,
             pluginRegistry,
             defaultWorkspaceDir,
             deps,


### PR DESCRIPTION
Related: #91873

## What Problem This Solves

Addresses the gateway-startup visibility part of #91873: when a configured external channel is present but its channel plugin is not loadable under the current plugin trust/allow policy, the gateway can otherwise print a normal ready banner while the channel is absent from the loaded plugin list.

## Why This Change Was Made

The change keeps the explicit plugin trust boundary intact and makes the failure mode visible during gateway startup. Startup logging now uses the raw activation source config for channel-plugin trust checks, so runtime-only auto-enable state does not hide an unresolved `plugins.allow`/`plugins.entries` problem.

## User Impact

Operators now get a startup warning when a configured channel has no loadable channel plugin. The warning names the configured channel and points to the plugin enablement/trust fix instead of leaving the channel silently absent.

## Evidence

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-91873 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/gateway/server-startup-log.test.ts src/gateway/server-startup-post-attach.test.ts src/gateway/server-import-boundary.test.ts`  
  Result: 6 files passed, 128 tests passed.
- `pnpm exec oxfmt --check src/gateway/server.impl.ts src/gateway/server-startup-log.ts src/gateway/server-startup-log.test.ts src/gateway/server-startup-post-attach.ts src/gateway/server-startup-post-attach.test.ts`  
  Result: all matched files use the correct format.
- `pnpm exec oxlint src/gateway/server.impl.ts src/gateway/server-startup-log.ts src/gateway/server-startup-log.test.ts src/gateway/server-startup-post-attach.ts src/gateway/server-startup-post-attach.test.ts`  
  Result: passed.
- `git diff --check`  
  Result: passed.
- Real gateway startup proof with a temporary installed `proof-chat` channel plugin and two isolated configs: one blocked by `plugins.allow=["browser"]`, one trusted with `plugins.entries.proof-chat.enabled=true`.  
  Result excerpt:
  - blocked: `http server listening (1 plugin: browser; 0.8s)`
  - blocked: `configured channel warning: channels.proof-chat: channel is configured, but plugin "proof-chat" is installed but omitted from plugins.allow. Include "proof-chat" in plugins.allow. Fix plugin enablement before relying on setup guidance for this channel.`
  - trusted: `http server listening (1 plugin: proof-chat; 0.8s)`
  - trusted: no `configured channel warning: channels.proof-chat`
- `.agents/skills/autoreview/scripts/autoreview --mode local`  
  Result: first run found a missing-owner regression; after fixing that fallback, final run was clean with no accepted/actionable findings.

## Real behavior proof

Behavior addressed: Gateway startup now logs a warning when a configured channel has no loadable channel plugin under the startup activation policy, including restrictive `plugins.allow` cases.

Real environment tested: Local source checkout on macOS with the repo CLI, using isolated temporary `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` values.

Exact steps or command run after this patch: Installed a temporary local channel plugin with `pnpm openclaw plugins install <temp proof plugin> --force`; started `pnpm openclaw gateway run --port <temp port> --bind loopback --auth token --token proof-token --force --allow-unconfigured` once with `plugins.allow=["browser"]` and `channels.proof-chat` configured, then once with `plugins.entries.proof-chat.enabled=true`; also ran the focused Vitest, oxfmt, oxlint, `git diff --check`, and autoreview commands listed above.

Evidence after fix: The blocked gateway run reached the ready banner with only `browser` loaded and then emitted the configured-channel warning for `channels.proof-chat`; the trusted gateway run reached the ready banner with `proof-chat` loaded and emitted no configured-channel warning.

Observed result after fix: A configured-but-unloadable channel no longer disappears behind only the normal ready banner; startup emits a warning with the configured channel id and remediation path, while a trusted configured channel does not false-positive.

What was not tested: I did not run a live Slack Socket Mode upgrade or external Slack API connection; this PR proves the gateway startup warning and activation-policy behavior with a real local gateway process and a synthetic channel plugin.
