### PR TITLE
fix: avoid shortening home path substrings

### DIFF
--- a/packages/terminal-core/src/display-string.test.ts
+++ b/packages/terminal-core/src/display-string.test.ts
@@ -23,5 +23,8 @@ describe("displayString", () => {
       `path=${path.join("$OPENCLAW_HOME", "project")}`,
     );
     expect(displayString(`${home}ice${path.sep}project`)).toBe(`${home}ice${path.sep}project`);
+    expect(displayString(`${home}+logs`)).toBe(`${home}+logs`);
+    expect(displayString(`${home}@logs`)).toBe(`${home}@logs`);
+    expect(displayString(`${home}:logs`)).toBe(`${home}:logs`);
   });
 });

--- a/packages/terminal-core/src/display-string.test.ts
+++ b/packages/terminal-core/src/display-string.test.ts
@@ -1,0 +1,27 @@
+// Terminal Core tests cover display string path shortening.
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { displayString } from "./display-string.js";
+
+describe("displayString", () => {
+  const originalOpenClawHome = process.env.OPENCLAW_HOME;
+
+  afterEach(() => {
+    if (originalOpenClawHome === undefined) {
+      delete process.env.OPENCLAW_HOME;
+    } else {
+      process.env.OPENCLAW_HOME = originalOpenClawHome;
+    }
+  });
+
+  it("shortens the effective home path only at path boundaries", () => {
+    const home = path.resolve("tmp", "openclaw-home", "al");
+    process.env.OPENCLAW_HOME = home;
+
+    expect(displayString(path.join(home, "project"))).toBe(path.join("$OPENCLAW_HOME", "project"));
+    expect(displayString(`path=${path.join(home, "project")}`)).toBe(
+      `path=${path.join("$OPENCLAW_HOME", "project")}`,
+    );
+    expect(displayString(`${home}ice${path.sep}project`)).toBe(`${home}ice${path.sep}project`);
+  });
+});

--- a/packages/terminal-core/src/display-string.ts
+++ b/packages/terminal-core/src/display-string.ts
@@ -73,11 +73,48 @@ function resolveHomeDisplayPrefix(): { home: string; prefix: string } | undefine
   return explicitHome ? { home, prefix: "$OPENCLAW_HOME" } : { home, prefix: "~" };
 }
 
+function isPathSegmentChar(char: string | undefined): boolean {
+  return Boolean(char && /[\p{L}\p{M}\p{N}._~$-]/u.test(char));
+}
+
+function hasPathBoundaryBefore(input: string, index: number): boolean {
+  return index === 0 || !isPathSegmentChar(input[index - 1]);
+}
+
+function hasPathBoundaryAfter(input: string, index: number): boolean {
+  return index >= input.length || !isPathSegmentChar(input[index]);
+}
+
+function replaceHomePath(input: string, home: string, prefix: string): string {
+  let result = "";
+  let cursor = 0;
+
+  while (cursor < input.length) {
+    const index = input.indexOf(home, cursor);
+    if (index === -1) {
+      result += input.slice(cursor);
+      break;
+    }
+
+    const end = index + home.length;
+    if (hasPathBoundaryBefore(input, index) && hasPathBoundaryAfter(input, end)) {
+      result += input.slice(cursor, index) + prefix;
+      cursor = end;
+      continue;
+    }
+
+    result += input.slice(cursor, end);
+    cursor = end;
+  }
+
+  return result;
+}
+
 /** Replace the effective home path with "~" or "$OPENCLAW_HOME" for terminal display. */
 export function displayString(input: string): string {
   if (!input) {
     return input;
   }
   const display = resolveHomeDisplayPrefix();
-  return display ? input.split(display.home).join(display.prefix) : input;
+  return display ? replaceHomePath(input, display.home, display.prefix) : input;
 }

--- a/packages/terminal-core/src/display-string.ts
+++ b/packages/terminal-core/src/display-string.ts
@@ -81,8 +81,12 @@ function hasPathBoundaryBefore(input: string, index: number): boolean {
   return index === 0 || !isPathSegmentChar(input[index - 1]);
 }
 
+function isPathSeparator(char: string | undefined): boolean {
+  return char === "/" || char === "\\";
+}
+
 function hasPathBoundaryAfter(input: string, index: number): boolean {
-  return index >= input.length || !isPathSegmentChar(input[index]);
+  return index >= input.length || isPathSeparator(input[index]);
 }
 
 function replaceHomePath(input: string, home: string, prefix: string): string {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where terminal table and status output could shorten paths that merely shared the same leading characters as the effective home directory. For example, when the effective home ended in `al`, a sibling path ending in `alice` could be displayed with the home marker even though it was outside the configured home.

AI-assisted: yes. I reviewed the touched code and ran the focused validation below.

## Why This Change Was Made

Home path display replacement now checks path-token boundaries before replacing the effective home with `~` or `$OPENCLAW_HOME`. This keeps the existing shortening behavior for real home-contained paths while leaving sibling path names intact.

## User Impact

Users and operators get copyable terminal output that no longer rewrites unrelated sibling paths into misleading home-relative paths.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts packages/terminal-core/src/display-string.test.ts packages/terminal-core/src/table.test.ts`
- `node_modules\.bin\oxfmt.cmd --check packages/terminal-core/src/display-string.ts packages/terminal-core/src/display-string.test.ts`
- `git diff --check`
## Follow-up Evidence After Review

The review correctly asked for concrete terminal behavior proof and tighter sibling-path coverage. I updated the after-boundary check so a home match is shortened only when it is followed by a path separator or the end of the string. This preserves embedded output such as `path=<home>\project` while leaving sibling names like `<home>+logs`, `<home>@logs`, and `<home>:logs` untouched.

Live proof from this branch:

```text
C:\Users\lin20\Documents\New project 3\openclaw\tmp\openclaw-home\al\project => $OPENCLAW_HOME\project
path=C:\Users\lin20\Documents\New project 3\openclaw\tmp\openclaw-home\al\project => path=$OPENCLAW_HOME\project
C:\Users\lin20\Documents\New project 3\openclaw\tmp\openclaw-home\al+logs => C:\Users\lin20\Documents\New project 3\openclaw\tmp\openclaw-home\al+logs
C:\Users\lin20\Documents\New project 3\openclaw\tmp\openclaw-home\al@logs => C:\Users\lin20\Documents\New project 3\openclaw\tmp\openclaw-home\al@logs
C:\Users\lin20\Documents\New project 3\openclaw\tmp\openclaw-home\al:logs => C:\Users\lin20\Documents\New project 3\openclaw\tmp\openclaw-home\al:logs
```

Focused validation after the follow-up patch:

```text
RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw

Test Files  1 passed (1)
     Tests  1 passed (1)
  Start at  20:31:19
  Duration  577ms (transform 409ms, setup 307ms, import 8ms, tests 84ms, environment 0ms)
```

```text
Checking formatting...

All matched files use the correct format.
Finished in 1220ms on 2 files using 32 threads.
```

`git diff --check` produced no output.