### PR TITLE
fix: enforce tool call payload byte limits

### DIFF
--- a/packages/tool-call-repair/src/grammar.ts
+++ b/packages/tool-call-repair/src/grammar.ts
@@ -51,6 +51,35 @@ export function consumeLineBreak(text: string, start: number): number | null {
   return null;
 }
 
+function utf8ByteLengthAt(text: string, index: number): { bytes: number; width: number } {
+  const codePoint = text.codePointAt(index);
+  if (codePoint === undefined) {
+    return { bytes: 0, width: 1 };
+  }
+  if (codePoint <= 0x7f) {
+    return { bytes: 1, width: 1 };
+  }
+  if (codePoint <= 0x7ff) {
+    return { bytes: 2, width: 1 };
+  }
+  if (codePoint <= 0xffff) {
+    return { bytes: 3, width: 1 };
+  }
+  return { bytes: 4, width: 2 };
+}
+
+export function utf8ByteLength(text: string, start = 0, end = text.length): number {
+  let bytes = 0;
+  for (let index = start; index < end; index += 1) {
+    const measured = utf8ByteLengthAt(text, index);
+    bytes += measured.bytes;
+    if (measured.width > 1) {
+      index += measured.width - 1;
+    }
+  }
+  return bytes;
+}
+
 /** Finds the exclusive end offset of a balanced JSON object starting at `start`. */
 export function findJsonObjectEnd(
   text: string,
@@ -60,9 +89,14 @@ export function findJsonObjectEnd(
   let depth = 0;
   let inString = false;
   let escaped = false;
+  let payloadBytes = 0;
   for (let index = start; index < text.length; index += 1) {
-    if (maxPayloadBytes !== undefined && index + 1 - start > maxPayloadBytes) {
-      return null;
+    const measured = utf8ByteLengthAt(text, index);
+    if (maxPayloadBytes !== undefined) {
+      payloadBytes += measured.bytes;
+      if (payloadBytes > maxPayloadBytes) {
+        return null;
+      }
     }
     const char = text[index];
     if (inString) {
@@ -73,6 +107,13 @@ export function findJsonObjectEnd(
       } else if (char === '"') {
         inString = false;
       }
+      if (measured.width > 1) {
+        index += measured.width - 1;
+      }
+      continue;
+    }
+    if (measured.width > 1) {
+      index += measured.width - 1;
       continue;
     }
     if (char === '"') {

--- a/packages/tool-call-repair/src/payload.test.ts
+++ b/packages/tool-call-repair/src/payload.test.ts
@@ -1,0 +1,42 @@
+// Tool Call Repair tests cover payload parsing behavior.
+import { describe, expect, it } from "vitest";
+import { parseStandalonePlainTextToolCallBlocks } from "./payload.js";
+
+describe("parseStandalonePlainTextToolCallBlocks", () => {
+  const multiByteValue = "\u4f60\ud83d\ude42";
+
+  it("enforces JSON maxPayloadBytes as UTF-8 bytes", () => {
+    const payload = JSON.stringify({ text: multiByteValue });
+    expect(Buffer.byteLength(payload, "utf8")).toBeGreaterThan(payload.length);
+
+    expect(
+      parseStandalonePlainTextToolCallBlocks(`[search]\n${payload}[/search]`, {
+        maxPayloadBytes: payload.length,
+      }),
+    ).toBeNull();
+
+    expect(
+      parseStandalonePlainTextToolCallBlocks(`[search]\n${payload}[/search]`, {
+        maxPayloadBytes: Buffer.byteLength(payload, "utf8"),
+      })?.[0]?.arguments,
+    ).toEqual({ text: multiByteValue });
+  });
+
+  it("enforces XML-ish maxPayloadBytes as UTF-8 bytes", () => {
+    const parameter = `<parameter=query>${multiByteValue}</parameter>`;
+    const text = `<function=search>${parameter}</function>`;
+    expect(Buffer.byteLength(parameter, "utf8")).toBeGreaterThan(parameter.length);
+
+    expect(
+      parseStandalonePlainTextToolCallBlocks(text, {
+        maxPayloadBytes: parameter.length,
+      }),
+    ).toBeNull();
+
+    expect(
+      parseStandalonePlainTextToolCallBlocks(text, {
+        maxPayloadBytes: Buffer.byteLength(parameter, "utf8"),
+      })?.[0]?.arguments,
+    ).toEqual({ query: multiByteValue });
+  });
+});

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -9,6 +9,7 @@ import {
   isPlainTextToolNameChar,
   skipHorizontalWhitespace,
   skipWhitespace,
+  utf8ByteLength,
 } from "./grammar.js";
 
 /** Parsed standalone plain-text tool call block with source offsets for repair. */
@@ -252,7 +253,7 @@ function consumeXmlishParameterBlock(
   if (!bounds) {
     return null;
   }
-  if (bounds.end - bounds.start > maxPayloadBytes) {
+  if (utf8ByteLength(text, bounds.start, bounds.end) > maxPayloadBytes) {
     return null;
   }
   return {
@@ -344,7 +345,7 @@ function parseXmlishPlainTextToolCallBlockAt(
     if (!parameter) {
       break;
     }
-    if (parameter.end - opening.end > maxPayloadBytes) {
+    if (utf8ByteLength(text, opening.end, parameter.end) > maxPayloadBytes) {
       return null;
     }
     args[parameter.name] = parameter.value;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plain-text tool-call repair treated `maxPayloadBytes` as UTF-16 string length instead of UTF-8 bytes. Multi-byte JSON or XML-ish payloads could therefore exceed the configured byte cap while still being parsed.

AI-assisted: yes. I reviewed the touched parser paths and ran the focused validation below.

## Why This Change Was Made

The parser now measures payload limits in UTF-8 bytes for balanced JSON payloads and XML-ish parameter blocks. The tests cover multi-byte BMP and surrogate-pair characters so the cap matches the option name and boundary intent.

## User Impact

Provider and model-output repair paths enforce their configured payload cap consistently for non-ASCII tool-call content, reducing oversized repaired payload risk without changing accepted ASCII payloads.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts packages/tool-call-repair/src/payload.test.ts`
- `node_modules\.bin\oxfmt.cmd --check packages/tool-call-repair/src/grammar.ts packages/tool-call-repair/src/payload.ts packages/tool-call-repair/src/payload.test.ts`
- `git diff --check`
## Follow-up Evidence After Review

The review asked for real behavior proof that non-ASCII payloads are measured against UTF-8 bytes rather than JavaScript string length. I ran the parser directly on both supported plaintext syntaxes from this branch.

Live parser output:

```text
{"syntax":"json-bracket","maxPayloadBytes":14,"charLength":14,"byteLength":18,"parsedArguments":null}
{"syntax":"json-bracket","maxPayloadBytes":18,"charLength":14,"byteLength":18,"parsedArguments":{"text":"???"}}
{"syntax":"xmlish","maxPayloadBytes":32,"charLength":32,"byteLength":36,"parsedArguments":null}
{"syntax":"xmlish","maxPayloadBytes":36,"charLength":32,"byteLength":36,"parsedArguments":{"query":"???"}}
```

This shows the old character-count-sized caps reject the payloads, while caps equal to `Buffer.byteLength(..., "utf8")` accept and parse them correctly.

Focused validation:

```text
RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw

Test Files  1 passed (1)
     Tests  2 passed (2)
  Start at  20:32:54
  Duration  906ms (transform 580ms, setup 471ms, import 22ms, tests 126ms, environment 0ms)
```

```text
Checking formatting...

All matched files use the correct format.
Finished in 1156ms on 3 files using 32 threads.
```

`git diff --check` produced no output.