### PR TITLE
fix: require env resolution for web provider refs

### DIFF
--- a/packages/web-content-core/src/provider-runtime-shared.test.ts
+++ b/packages/web-content-core/src/provider-runtime-shared.test.ts
@@ -80,6 +80,43 @@ describe("hasWebProviderEntryCredential", () => {
     ).toBe(true);
   });
 
+  it("does not treat env secret refs as literal credentials when env resolution misses", () => {
+    expect(
+      hasWebProviderEntryCredential({
+        provider,
+        config: {},
+        toolConfig: undefined,
+        resolveRawValue: () => "${CUSTOM_API_KEY}",
+        resolveEnvValue: () => undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat fallback env secret refs as literal credentials", () => {
+    expect(
+      hasWebProviderEntryCredential({
+        provider,
+        config: {},
+        toolConfig: undefined,
+        resolveRawValue: () => undefined,
+        resolveFallbackRawValue: () => "$CUSTOM_API_KEY",
+        resolveEnvValue: () => undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps non-reference config strings as literal credentials", () => {
+    expect(
+      hasWebProviderEntryCredential({
+        provider,
+        config: {},
+        toolConfig: undefined,
+        resolveRawValue: () => "literal-secret",
+        resolveEnvValue: () => undefined,
+      }),
+    ).toBe(true);
+  });
+
   it("falls back to provider auth before env probing", () => {
     expect(
       hasWebProviderEntryCredential({

--- a/packages/web-content-core/src/provider-runtime-shared.ts
+++ b/packages/web-content-core/src/provider-runtime-shared.ts
@@ -190,7 +190,9 @@ export function hasWebProviderEntryCredential<
   if (configuredRef && configuredRef.source !== "env") {
     return true;
   }
-  const fromConfig = normalizeSecretInput(normalizeSecretInputString(rawValue));
+  const fromConfig = configuredRef
+    ? ""
+    : normalizeSecretInput(normalizeSecretInputString(rawValue));
   if (fromConfig) {
     return true;
   }
@@ -217,7 +219,9 @@ export function hasWebProviderEntryCredential<
   if (fallbackRef && fallbackRef.source !== "env") {
     return true;
   }
-  const fallbackConfig = normalizeSecretInput(normalizeSecretInputString(fallbackRawValue));
+  const fallbackConfig = fallbackRef
+    ? ""
+    : normalizeSecretInput(normalizeSecretInputString(fallbackRawValue));
   if (fallbackConfig) {
     return true;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where web provider credential detection treated env secret references such as `${CUSTOM_API_KEY}` or `$CUSTOM_API_KEY` as literal configured credentials when the referenced environment variable was missing.

AI-assisted: yes. I reviewed the touched credential detection path and ran the focused validation below.

## Why This Change Was Made

Recognized env secret refs now prove credential availability only through the env resolver, while non-env secret refs and normal literal strings keep their existing behavior. The same rule applies to primary and fallback credential sources.

## User Impact

Web search/fetch provider setup no longer reports a provider as credentialed just because a missing env reference string is present in config. Operators get more accurate provider availability and fallback behavior.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts packages/web-content-core/src/provider-runtime-shared.test.ts`
- `node_modules\.bin\oxfmt.cmd --check packages/web-content-core/src/provider-runtime-shared.ts packages/web-content-core/src/provider-runtime-shared.test.ts`
- `git diff --check`
## Follow-up Evidence After Review

The review asked for real provider/config behavior proof and compatibility notes. I ran the shared web provider credential path directly with a configured web search provider using `apiKey: "${CUSTOM_API_KEY}"`.

Live provider/config output from this branch:

```text
{"label":"missing env ref","configuredApiKey":"${CUSTOM_API_KEY}","envHasCustomApiKey":false,"credentialed":false}
{"label":"resolved env ref","configuredApiKey":"${CUSTOM_API_KEY}","envHasCustomApiKey":true,"credentialed":true}
{"label":"literal compatibility","configuredApiKey":"literal-redacted-secret","envHasCustomApiKey":false,"credentialed":true}
```

Compatibility/auth-provider note: non-env SecretRefs (`file` / `exec`) and provider auth entries are still treated as configured credentials. Literal config strings are still accepted as before. This change only prevents env-style refs (`${CUSTOM_API_KEY}`, `$CUSTOM_API_KEY`, and legacy env markers) from being counted as a credential when env resolution actually misses.

Focused validation:

```text
RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw

Test Files  1 passed (1)
     Tests  9 passed (9)
  Start at  20:34:05
  Duration  674ms (transform 472ms, setup 366ms, import 13ms, tests 100ms, environment 0ms)
```

```text
Checking formatting...

All matched files use the correct format.
Finished in 1195ms on 2 files using 32 threads.
```

`git diff --check` produced no output.