### PR TITLE
fix(discord): keep default account online when adding named accounts

### DIFF
--- a/extensions/discord/src/secret-config-contract.ts
+++ b/extensions/discord/src/secret-config-contract.ts
@@ -2,10 +2,13 @@
 import {
   collectNestedChannelFieldAssignments,
   collectSimpleChannelFieldAssignments,
-  getChannelSurface,
+  getChannelRecord,
+  hasConfiguredSecretInputValue,
   isBaseFieldActiveForChannelSurface,
   isEnabledFlag,
   isRecord,
+  resolveChannelAccountSurface,
+  type ChannelAccountSurface,
   type ResolverContext,
   type SecretDefaults,
   type SecretTargetRegistryEntry,
@@ -83,16 +86,47 @@ export const secretTargetRegistryEntries: SecretTargetRegistryEntry[] = [
   },
 ];
 
+function withImplicitDefaultDiscordAccount(params: {
+  discord: Record<string, unknown>;
+  surface: ChannelAccountSurface;
+  defaults?: SecretDefaults;
+}): ChannelAccountSurface {
+  if (
+    !params.surface.hasExplicitAccounts ||
+    !hasConfiguredSecretInputValue(params.discord.token, params.defaults) ||
+    params.surface.accounts.some((entry) => entry.accountId.toLowerCase() === "default")
+  ) {
+    return params.surface;
+  }
+  // Discord account listing keeps a top-level token as an implicit default account.
+  // Match that runtime contract so named accounts do not orphan the default SecretRef.
+  return {
+    ...params.surface,
+    accounts: [
+      ...params.surface.accounts,
+      {
+        accountId: "default",
+        account: {},
+        enabled: params.surface.channelEnabled,
+      },
+    ],
+  };
+}
+
 export function collectRuntimeConfigAssignments(params: {
   config: { channels?: Record<string, unknown> };
   defaults?: SecretDefaults;
   context: ResolverContext;
 }): void {
-  const resolved = getChannelSurface(params.config, "discord");
-  if (!resolved) {
+  const discord = getChannelRecord(params.config, "discord");
+  if (!discord) {
     return;
   }
-  const { channel: discord, surface } = resolved;
+  const surface = withImplicitDefaultDiscordAccount({
+    discord,
+    surface: resolveChannelAccountSurface(discord),
+    defaults: params.defaults,
+  });
   collectSimpleChannelFieldAssignments({
     channelKey: "discord",
     field: "token",

--- a/extensions/discord/src/secret-config-contract.ts
+++ b/extensions/discord/src/secret-config-contract.ts
@@ -2,13 +2,11 @@
 import {
   collectNestedChannelFieldAssignments,
   collectSimpleChannelFieldAssignments,
-  getChannelRecord,
+  getChannelSurface,
   hasConfiguredSecretInputValue,
   isBaseFieldActiveForChannelSurface,
   isEnabledFlag,
   isRecord,
-  resolveChannelAccountSurface,
-  type ChannelAccountSurface,
   type ResolverContext,
   type SecretDefaults,
   type SecretTargetRegistryEntry,
@@ -86,47 +84,31 @@ export const secretTargetRegistryEntries: SecretTargetRegistryEntry[] = [
   },
 ];
 
-function withImplicitDefaultDiscordAccount(params: {
-  discord: Record<string, unknown>;
-  surface: ChannelAccountSurface;
-  defaults?: SecretDefaults;
-}): ChannelAccountSurface {
-  if (
-    !params.surface.hasExplicitAccounts ||
-    !hasConfiguredSecretInputValue(params.discord.token, params.defaults) ||
-    params.surface.accounts.some((entry) => entry.accountId.toLowerCase() === "default")
-  ) {
-    return params.surface;
-  }
-  // Discord account listing keeps a top-level token as an implicit default account.
-  // Match that runtime contract so named accounts do not orphan the default SecretRef.
-  return {
-    ...params.surface,
-    accounts: [
-      ...params.surface.accounts,
-      {
-        accountId: "default",
-        account: {},
-        enabled: params.surface.channelEnabled,
-      },
-    ],
-  };
-}
-
 export function collectRuntimeConfigAssignments(params: {
   config: { channels?: Record<string, unknown> };
   defaults?: SecretDefaults;
   context: ResolverContext;
 }): void {
-  const discord = getChannelRecord(params.config, "discord");
-  if (!discord) {
+  const resolved = getChannelSurface(params.config, "discord");
+  if (!resolved) {
     return;
   }
-  const surface = withImplicitDefaultDiscordAccount({
-    discord,
-    surface: resolveChannelAccountSurface(discord),
-    defaults: params.defaults,
-  });
+  const { channel: discord, surface } = resolved;
+  const hasImplicitDefault =
+    surface.hasExplicitAccounts &&
+    !surface.accounts.some(({ accountId }) => accountId === "default") &&
+    [discord.token, params.context.env.DISCORD_BOT_TOKEN].some((value) =>
+      hasConfiguredSecretInputValue(value, params.defaults),
+    );
+  if (hasImplicitDefault) {
+    // Account discovery treats either token source as an implicit default. Keep it in
+    // secret collection so named accounts cannot orphan the default's inherited refs.
+    surface.accounts.push({
+      accountId: "default",
+      account: {},
+      enabled: surface.channelEnabled,
+    });
+  }
   collectSimpleChannelFieldAssignments({
     channelKey: "discord",
     field: "token",

--- a/src/secrets/runtime-discord-surface.test.ts
+++ b/src/secrets/runtime-discord-surface.test.ts
@@ -1,4 +1,7 @@
 /** Tests Discord secret surfaces in runtime preparation. */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import "./runtime-discord.test-support.ts";
 import {
@@ -69,6 +72,69 @@ describe("secrets runtime snapshot discord surface", () => {
     expect(accountSnapshot.config.channels?.discord?.accounts?.default?.token).toBe(
       "default-account-token",
     );
+  });
+
+  it("resolves the implicit default token when named Discord accounts are added", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-secrets-"));
+    try {
+      const secretsPath = path.join(root, "secrets.json");
+      await fs.writeFile(
+        secretsPath,
+        JSON.stringify({
+          discord: {
+            defaultToken: "default-account-token",
+            secondToken: "second-account-token",
+          },
+        }),
+        "utf8",
+      );
+      await fs.chmod(secretsPath, 0o600);
+
+      const snapshot = await prepareSecretsRuntimeSnapshot({
+        config: asConfig({
+          secrets: {
+            providers: {
+              discord_file: {
+                source: "file",
+                path: secretsPath,
+                mode: "json",
+              },
+            },
+          },
+          channels: {
+            discord: {
+              token: {
+                source: "file",
+                provider: "discord_file",
+                id: "/discord/defaultToken",
+              },
+              accounts: {
+                second: {
+                  enabled: true,
+                  token: {
+                    source: "file",
+                    provider: "discord_file",
+                    id: "/discord/secondToken",
+                  },
+                },
+              },
+            },
+          },
+        }),
+        agentDirs: ["/tmp/openclaw-agent-main"],
+        loadAuthStore: () => loadAuthStoreWithProfiles({}),
+      });
+
+      expect(snapshot.config.channels?.discord?.token).toBe("default-account-token");
+      expect(snapshot.config.channels?.discord?.accounts?.second?.token).toBe(
+        "second-account-token",
+      );
+      expect(snapshot.warnings.map((warning) => warning.path)).not.toContain(
+        "channels.discord.token",
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("fails when non-default Discord account inherits an unresolved top-level token ref", async () => {

--- a/src/secrets/runtime-discord-surface.test.ts
+++ b/src/secrets/runtime-discord-surface.test.ts
@@ -1,8 +1,8 @@
 /** Tests Discord secret surfaces in runtime preparation. */
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { withTempDir } from "../test-helpers/temp-dir.js";
 import "./runtime-discord.test-support.ts";
 import {
   asConfig,
@@ -74,67 +74,101 @@ describe("secrets runtime snapshot discord surface", () => {
     );
   });
 
-  it("resolves the implicit default token when named Discord accounts are added", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-secrets-"));
-    try {
-      const secretsPath = path.join(root, "secrets.json");
-      await fs.writeFile(
-        secretsPath,
-        JSON.stringify({
-          discord: {
-            defaultToken: "default-account-token",
-            secondToken: "second-account-token",
-          },
-        }),
-        "utf8",
-      );
-      await fs.chmod(secretsPath, 0o600);
+  it.skipIf(process.platform === "win32")(
+    "resolves the implicit default token when named Discord accounts are added",
+    async () => {
+      await withTempDir({ prefix: "openclaw-discord-secrets-" }, async (root) => {
+        const secretsPath = path.join(root, "secrets.json");
+        await fs.writeFile(
+          secretsPath,
+          JSON.stringify({
+            discord: {
+              defaultToken: "default-account-token",
+              secondToken: "second-account-token",
+            },
+          }),
+          "utf8",
+        );
+        await fs.chmod(secretsPath, 0o600);
 
-      const snapshot = await prepareSecretsRuntimeSnapshot({
-        config: asConfig({
-          secrets: {
-            providers: {
-              discord_file: {
-                source: "file",
-                path: secretsPath,
-                mode: "json",
+        const snapshot = await prepareSecretsRuntimeSnapshot({
+          config: asConfig({
+            secrets: {
+              providers: {
+                discord_file: {
+                  source: "file",
+                  path: secretsPath,
+                  mode: "json",
+                },
               },
             },
-          },
-          channels: {
-            discord: {
-              token: {
-                source: "file",
-                provider: "discord_file",
-                id: "/discord/defaultToken",
-              },
-              accounts: {
-                second: {
-                  enabled: true,
-                  token: {
-                    source: "file",
-                    provider: "discord_file",
-                    id: "/discord/secondToken",
+            channels: {
+              discord: {
+                token: {
+                  source: "file",
+                  provider: "discord_file",
+                  id: "/discord/defaultToken",
+                },
+                accounts: {
+                  second: {
+                    enabled: true,
+                    token: {
+                      source: "file",
+                      provider: "discord_file",
+                      id: "/discord/secondToken",
+                    },
                   },
                 },
               },
             },
-          },
-        }),
-        agentDirs: ["/tmp/openclaw-agent-main"],
-        loadAuthStore: () => loadAuthStoreWithProfiles({}),
-      });
+          }),
+          agentDirs: ["/tmp/openclaw-agent-main"],
+          loadAuthStore: () => loadAuthStoreWithProfiles({}),
+        });
 
-      expect(snapshot.config.channels?.discord?.token).toBe("default-account-token");
-      expect(snapshot.config.channels?.discord?.accounts?.second?.token).toBe(
-        "second-account-token",
-      );
-      expect(snapshot.warnings.map((warning) => warning.path)).not.toContain(
-        "channels.discord.token",
-      );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+        expect(snapshot.config.channels?.discord?.token).toBe("default-account-token");
+        expect(snapshot.config.channels?.discord?.accounts?.second?.token).toBe(
+          "second-account-token",
+        );
+        expect(snapshot.warnings.map((warning) => warning.path)).not.toContain(
+          "channels.discord.token",
+        );
+      });
+    },
+  );
+
+  it("keeps inherited refs active for an env-backed implicit default", async () => {
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          discord: {
+            pluralkit: {
+              token: { source: "env", provider: "default", id: "DISCORD_DEFAULT_PK_TOKEN" },
+            },
+            accounts: {
+              second: {
+                pluralkit: {
+                  token: { source: "env", provider: "default", id: "DISCORD_SECOND_PK_TOKEN" },
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: {
+        DISCORD_BOT_TOKEN: "env-default-token",
+        DISCORD_DEFAULT_PK_TOKEN: "default-pk-token",
+        DISCORD_SECOND_PK_TOKEN: "second-pk-token",
+      },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => loadAuthStoreWithProfiles({}),
+    });
+
+    expect(snapshot.config.channels?.discord?.pluralkit?.token).toBe("default-pk-token");
+    expect(snapshot.config.channels?.discord?.accounts?.second?.pluralkit?.token).toBe(
+      "second-pk-token",
+    );
+    expect(snapshot.warnings).toStrictEqual([]);
   });
 
   it("fails when non-default Discord account inherits an unresolved top-level token ref", async () => {


### PR DESCRIPTION
Closes #92985

## What Problem This Solves

Fixes an issue where users with a working default Discord account could take that account offline when adding a second named Discord account backed by SecretRefs. The default account's top-level token could remain unresolved in the active runtime snapshot, causing Discord startup to treat it as configured but unavailable and enter the restart loop reported in #92985.

## Why This Change Was Made

Discord already treats a configured top-level token as an implicit `default` account even when named accounts exist. This change keeps that implicit-default handling inside the Discord secret contract so Discord SecretRef collection matches Discord account listing/runtime behavior without changing the public shared channel-secret helper signature. Sibling channel behavior remains unchanged.

## User Impact

Adding a named Discord account no longer prevents the existing default account's file-backed SecretRef token from being materialized. Multi-account Discord gateways can keep the default account available while bringing up the additional account.

## Evidence

- `pnpm install --frozen-lockfile`
- `pnpm exec oxfmt --check --threads=1 extensions/discord/src/secret-config-contract.ts src/secrets/channel-secret-basic-runtime.ts src/secrets/runtime-discord-surface.test.ts`
- `node scripts/run-oxlint.mjs extensions/discord/src/secret-config-contract.ts src/secrets/channel-secret-basic-runtime.ts src/secrets/runtime-discord-surface.test.ts`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-92985-private OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/secrets/runtime-discord-surface.test.ts src/secrets/runtime-telegram-token-inheritance.test.ts src/secrets/runtime-channel-inactive-variants.test.ts`
  - 3 files passed, 22 tests passed
- File-backed runtime proof with `node --import tsx`: prepared and activated a runtime snapshot with `channels.discord.token` and `channels.discord.accounts.second.token` both sourced from a JSON file SecretRef, then resolved Discord runtime accounts without printing token values.
  - `snapshotWarnings: []`
  - `materializedConfig.topLevelTokenPresent: true`
  - `materializedConfig.secondTokenPresent: true`
  - `accounts.default.tokenStatus: available`, `tokenSource: config`, `tokenPresent: true`
  - `accounts.second.tokenStatus: available`, `tokenSource: config`, `tokenPresent: true`
  - `enabledAccounts: default, second`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the updated narrow fix for issue #92985 after moving implicit-default SecretRef handling behind the Discord-owned secret contract instead of changing the public shared helper signature. Focus on owner boundary, file-backed SecretRef proof shape, sibling channel behavior, and whether this remains minimal."`
  - clean: no accepted/actionable findings
