### PR TITLE
fix(zalouser): bound non-interactive media sends

### DIFF
--- a/extensions/zalouser/src/channel.adapters.ts
+++ b/extensions/zalouser/src/channel.adapters.ts
@@ -44,6 +44,7 @@ import {
 const loadZalouserChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
 
 const ZALOUSER_TEXT_CHUNK_LIMIT = 2000;
+const ZALOUSER_SEND_TIMEOUT_MS = 35_000;
 
 type ZalouserSendTextContext = {
   to: string;
@@ -141,6 +142,7 @@ async function sendZalouserMediaFromContext({
     textMode: "markdown",
     textChunkMode: resolveZalouserOutboundChunkMode(cfg, account.accountId),
     textChunkLimit: resolveZalouserOutboundTextChunkLimit(cfg, account.accountId),
+    sendTimeoutMs: ZALOUSER_SEND_TIMEOUT_MS,
   });
 }
 

--- a/extensions/zalouser/src/types.ts
+++ b/extensions/zalouser/src/types.ts
@@ -67,6 +67,7 @@ export type ZaloSendOptions = {
   isGroup?: boolean;
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
+  sendTimeoutMs?: number;
   textMode?: "markdown" | "plain";
   textChunkMode?: "length" | "newline";
   textChunkLimit?: number;

--- a/extensions/zalouser/src/zalo-js.credentials.test.ts
+++ b/extensions/zalouser/src/zalo-js.credentials.test.ts
@@ -19,7 +19,12 @@ import type { API, Credentials, LoginQRCallbackEvent } from "./zca-client.js";
 import { LoginQRCallbackEventType } from "./zca-constants.js";
 
 const createZaloMock = vi.hoisted(() => vi.fn());
+const loadOutboundMediaFromUrlMock = vi.hoisted(() => vi.fn());
 const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
+
+vi.mock("openclaw/plugin-sdk/outbound-media", () => ({
+  loadOutboundMediaFromUrl: loadOutboundMediaFromUrlMock,
+}));
 
 vi.mock("./zca-client.js", () => ({
   createZalo: createZaloMock,
@@ -31,6 +36,7 @@ import {
   listZaloFriends,
   sendZaloLink,
   sendZaloReaction,
+  sendZaloTextMessage,
   startZaloQrLogin,
   waitForZaloQrLogin,
 } from "./zalo-js.js";
@@ -62,12 +68,27 @@ async function readStoredCredentials(
   ) as StoredCredentialFile;
 }
 
+async function writeStoredCredentials(stateDir: string, profile: string): Promise<void> {
+  await mkdir(path.dirname(credentialPath(stateDir, profile)), { recursive: true });
+  await writeFile(
+    credentialPath(stateDir, profile),
+    JSON.stringify({
+      imei: "stored-imei",
+      cookie: [{ key: "zpsid", value: "stored", domain: "chat.zalo.me" }],
+      userAgent: "stored-user-agent",
+    }),
+  );
+}
+
 function createMockApi(params: {
   imei: string;
   userAgent: string;
   language?: string;
   cookies: unknown[] | (() => unknown[]);
   getAllFriends?: API["getAllFriends"];
+  sendMessage?: API["sendMessage"];
+  sendVoice?: API["sendVoice"];
+  uploadAttachment?: API["uploadAttachment"];
 }): API {
   return {
     getContext: () => ({
@@ -88,6 +109,9 @@ function createMockApi(params: {
       avatar: "",
     }),
     getAllFriends: params.getAllFriends ?? vi.fn(async () => []),
+    sendMessage: params.sendMessage ?? vi.fn(async () => ({})),
+    sendVoice: params.sendVoice ?? vi.fn(async () => ({})),
+    uploadAttachment: params.uploadAttachment ?? vi.fn(async () => []),
     listener: {
       on: vi.fn(),
       off: vi.fn(),
@@ -100,6 +124,7 @@ function createMockApi(params: {
 describe("zalouser credential persistence", () => {
   beforeEach(() => {
     createZaloMock.mockReset();
+    loadOutboundMediaFromUrlMock.mockReset();
   });
 
   it("persists the final API cookie jar after QR login", async () => {
@@ -384,6 +409,220 @@ describe("zalouser credential persistence", () => {
           profile: "missing-session",
         });
         expectMissingSessionResult(result);
+      });
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails boundedly before final send when a zalouser media upload never resolves", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-zalouser-credentials-"));
+    const profile = "hanging-media-upload";
+    await writeStoredCredentials(stateDir, profile);
+
+    loadOutboundMediaFromUrlMock.mockResolvedValueOnce({
+      buffer: Buffer.from("pdf"),
+      contentType: "application/pdf",
+      fileName: "report.pdf",
+      kind: "file",
+    });
+    const uploadAttachment = vi.fn(() => new Promise<never>(() => {}));
+    const sendMessage = vi.fn(async () => ({}));
+    const api = createMockApi({
+      imei: "api-imei",
+      userAgent: "api-user-agent",
+      cookies: [{ key: "zpsid", value: "api", domain: "chat.zalo.me" }],
+      sendMessage,
+      uploadAttachment,
+    });
+    createZaloMock.mockResolvedValueOnce({ login: vi.fn(async () => api) });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const result = await sendZaloTextMessage("thread-1", "report", {
+          profile,
+          mediaUrl: "file:///allowed/report.pdf",
+          sendTimeoutMs: 5,
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain("Timed out uploading zalouser media attachment");
+        expect(result.error).toContain("live gateway listener session");
+        expect(uploadAttachment).toHaveBeenCalledTimes(1);
+        expect(sendMessage).not.toHaveBeenCalled();
+      });
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps zalouser media upload probing opt-in", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-zalouser-credentials-"));
+    const profile = "media-no-timeout";
+    await writeStoredCredentials(stateDir, profile);
+
+    loadOutboundMediaFromUrlMock.mockResolvedValueOnce({
+      buffer: Buffer.from("pdf"),
+      contentType: "application/pdf",
+      fileName: "report.pdf",
+      kind: "file",
+    });
+    const uploadAttachment = vi.fn(async () => []);
+    const sendMessage = vi.fn(async () => ({ attachment: [{ msgId: "att-1" }] }));
+    const api = createMockApi({
+      imei: "api-imei",
+      userAgent: "api-user-agent",
+      cookies: [{ key: "zpsid", value: "api", domain: "chat.zalo.me" }],
+      sendMessage,
+      uploadAttachment,
+    });
+    createZaloMock.mockResolvedValueOnce({ login: vi.fn(async () => api) });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const result = await sendZaloTextMessage("thread-1", "report", {
+          profile,
+          mediaUrl: "file:///allowed/report.pdf",
+        });
+
+        expect(result.ok).toBe(true);
+        expect(uploadAttachment).not.toHaveBeenCalled();
+        expect(sendMessage).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("sends timed zalouser media from the uploaded attachment", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-zalouser-credentials-"));
+    const profile = "media-uploaded-send";
+    await writeStoredCredentials(stateDir, profile);
+
+    loadOutboundMediaFromUrlMock.mockResolvedValueOnce({
+      buffer: Buffer.from("pdf"),
+      contentType: "application/pdf",
+      fileName: "report.pdf",
+      kind: "file",
+    });
+    const uploadAttachment = vi.fn(async () => [
+      {
+        fileType: "others" as const,
+        fileUrl: "https://file.example/report.pdf",
+        fileId: "file-1",
+        fileName: "report.pdf",
+        checksum: "checksum",
+        clientFileId: "client-file-1",
+        totalSize: 3,
+      },
+    ]);
+    const sendMessage = vi.fn(async () => ({}));
+    const makeURL = vi.fn((baseURL: string) => `${baseURL}&nretry=0`);
+    const encodeAES = vi.fn(() => "encrypted-params");
+    const request = vi.fn(async () => ({}) as Response);
+    const resolve = vi.fn(async () => ({ msgId: "uploaded-1" }));
+    const api = createMockApi({
+      imei: "api-imei",
+      userAgent: "api-user-agent",
+      cookies: [{ key: "zpsid", value: "api", domain: "chat.zalo.me" }],
+      sendMessage,
+      uploadAttachment,
+    }) as API & {
+      zpwServiceMap: { file: string[] };
+      custom: (
+        name: "openclawSendUploadedAttachment",
+        callback: (params: {
+          ctx: { imei: string };
+          utils: {
+            makeURL: typeof makeURL;
+            encodeAES: typeof encodeAES;
+            request: typeof request;
+            resolve: typeof resolve;
+          };
+          props: unknown;
+        }) => Promise<unknown>,
+      ) => void;
+      openclawSendUploadedAttachment?: (props: unknown) => Promise<unknown>;
+    };
+    api.zpwServiceMap = { file: ["https://file.zalo.test"] };
+    api.custom = (name, callback) => {
+      Object.defineProperty(api, name, {
+        value: async (props: unknown) =>
+          await callback({
+            ctx: { imei: "api-imei" },
+            utils: { makeURL, encodeAES, request, resolve },
+            props,
+          }),
+      });
+    };
+    createZaloMock.mockResolvedValueOnce({ login: vi.fn(async () => api) });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const result = await sendZaloTextMessage("thread-1", "", {
+          profile,
+          mediaUrl: "file:///allowed/report.pdf",
+          sendTimeoutMs: 5,
+        });
+
+        expect(result).toMatchObject({ ok: true, messageId: "uploaded-1" });
+        expect(uploadAttachment).toHaveBeenCalledTimes(1);
+        expect(sendMessage).not.toHaveBeenCalled();
+        expect(makeURL).toHaveBeenCalledWith("https://file.zalo.test/api/message/asyncfile/msg?", {
+          nretry: "0",
+        });
+        expect(encodeAES).toHaveBeenCalledWith(expect.stringContaining('"fileId":"file-1"'));
+        expect(request).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps timed zalouser GIF media on zca-js sendMessage", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-zalouser-credentials-"));
+    const profile = "media-gif-send";
+    await writeStoredCredentials(stateDir, profile);
+
+    loadOutboundMediaFromUrlMock.mockResolvedValueOnce({
+      buffer: Buffer.from("gif"),
+      contentType: "image/gif",
+      fileName: "animation.gif",
+      kind: "image",
+    });
+    const uploadAttachment = vi.fn(async () => []);
+    const sendMessage = vi.fn(async () => ({ attachment: [{ msgId: "gif-1" }] }));
+    const api = createMockApi({
+      imei: "api-imei",
+      userAgent: "api-user-agent",
+      cookies: [{ key: "zpsid", value: "api", domain: "chat.zalo.me" }],
+      sendMessage,
+      uploadAttachment,
+    });
+    createZaloMock.mockResolvedValueOnce({ login: vi.fn(async () => api) });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const result = await sendZaloTextMessage("thread-1", "animation", {
+          profile,
+          mediaUrl: "file:///allowed/animation.gif",
+          sendTimeoutMs: 5,
+        });
+
+        expect(result).toMatchObject({ ok: true, messageId: "gif-1" });
+        expect(uploadAttachment).not.toHaveBeenCalled();
+        expect(sendMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            msg: "animation",
+            attachments: [
+              expect.objectContaining({
+                filename: "animation.gif",
+              }),
+            ],
+          }),
+          "thread-1",
+          0,
+        );
       });
     } finally {
       await rm(stateDir, { recursive: true, force: true });

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -92,6 +92,38 @@ const activeListeners = new Map<string, ActiveZaloListener>();
 const groupContextCache = new Map<string, { value: ZaloGroupContext; expiresAt: number }>();
 
 type AccountInfoResponse = Awaited<ReturnType<API["fetchAccountInfo"]>>;
+type ZaloUploadedAttachment = Awaited<ReturnType<API["uploadAttachment"]>>[number];
+
+type SendUploadedZaloAttachmentParams = {
+  msg: string;
+  attachment: ZaloUploadedAttachment;
+  threadId: string;
+  type: (typeof ThreadType)[keyof typeof ThreadType];
+};
+
+type OpenClawZaloAttachmentApi = API & {
+  zpwServiceMap?: { file: string[] };
+  custom?: (
+    name: "openclawSendUploadedAttachment",
+    callback: (params: {
+      ctx: {
+        imei: string;
+      };
+      utils: {
+        makeURL(
+          baseURL: string,
+          params?: Record<string, string | number>,
+          apiVersion?: boolean,
+        ): string;
+        encodeAES(data: string): string | null;
+        request(url: string, options?: RequestInit, raw?: boolean): Promise<Response>;
+        resolve(response: Response): Promise<unknown>;
+      };
+      props: SendUploadedZaloAttachmentParams;
+    }) => Promise<unknown>,
+  ) => void;
+  openclawSendUploadedAttachment?: (params: SendUploadedZaloAttachmentParams) => Promise<unknown>;
+};
 
 type ApiTypingCapability = {
   sendTypingEvent: (
@@ -537,6 +569,121 @@ function buildZaloVoicePlaybackUrl(asset: { fileUrl: string; fileName?: string }
   // zca-js uses uploadAttachment(...).fileUrl directly for sendVoice.
   // Appending filename can produce URLs that play only in the local session.
   return asset.fileUrl.trim();
+}
+
+function removeUndefinedZaloParams(params: Record<string, unknown>): Record<string, unknown> {
+  for (const key of Object.keys(params)) {
+    if (params[key] === undefined) {
+      delete params[key];
+    }
+  }
+  return params;
+}
+
+function uploadedAttachmentExtension(attachment: ZaloUploadedAttachment): string {
+  return path.extname(attachment.fileName ?? "").replace(/^\./u, "");
+}
+
+function isZaloGifMedia(params: { fileName: string; contentType?: string }): boolean {
+  return (
+    path.extname(params.fileName).toLowerCase() === ".gif" ||
+    normalizeOptionalLowercaseString(params.contentType)?.split(";", 1)[0] === "image/gif"
+  );
+}
+
+function ensureUploadedAttachmentSender(
+  api: API,
+): (params: SendUploadedZaloAttachmentParams) => Promise<unknown> {
+  const customApi = api as OpenClawZaloAttachmentApi;
+  if (customApi.openclawSendUploadedAttachment) {
+    return customApi.openclawSendUploadedAttachment.bind(customApi);
+  }
+  if (typeof customApi.custom !== "function") {
+    throw new Error("zca-js custom API is unavailable for uploaded zalouser attachments");
+  }
+
+  customApi.custom("openclawSendUploadedAttachment", async ({ utils, props }) => {
+    const isGroupMessage = props.type === ThreadType.Group;
+    const fileServiceUrl = customApi.zpwServiceMap?.file[0];
+    if (!fileServiceUrl) {
+      throw new Error("zca-js file service URL is unavailable");
+    }
+    const attachmentBaseUrl = `${fileServiceUrl}/api/${isGroupMessage ? "group" : "message"}/`;
+    const clientId = Date.now().toString();
+    const attachment = props.attachment;
+    const endpoint = attachment.fileType === "image" ? "photo_original/send?" : "asyncfile/msg?";
+    const params =
+      attachment.fileType === "image"
+        ? removeUndefinedZaloParams({
+            photoId: attachment.photoId,
+            clientId,
+            desc: props.msg,
+            width: attachment.width,
+            height: attachment.height,
+            toid: isGroupMessage ? undefined : props.threadId,
+            grid: isGroupMessage ? props.threadId : undefined,
+            rawUrl: attachment.normalUrl,
+            hdUrl: attachment.hdUrl,
+            thumbUrl: attachment.thumbUrl,
+            oriUrl: isGroupMessage ? attachment.normalUrl : undefined,
+            normalUrl: isGroupMessage ? undefined : attachment.normalUrl,
+            hdSize: String(attachment.totalSize ?? 0),
+            zsource: -1,
+            ttl: 0,
+            jcp: '{"convertible":"jxl"}',
+          })
+        : removeUndefinedZaloParams({
+            fileId: attachment.fileId,
+            checksum: attachment.checksum,
+            checksumSha: "",
+            extention: uploadedAttachmentExtension(attachment),
+            totalSize: attachment.totalSize,
+            fileName: attachment.fileName,
+            clientId: attachment.clientFileId,
+            fType: 1,
+            fileCount: 0,
+            fdata: "{}",
+            toid: isGroupMessage ? undefined : props.threadId,
+            grid: isGroupMessage ? props.threadId : undefined,
+            fileUrl: attachment.fileUrl,
+            zsource: -1,
+            ttl: 0,
+          });
+    const encryptedParams = utils.encodeAES(JSON.stringify(params));
+    if (!encryptedParams) {
+      throw new Error("Failed to encrypt zalouser attachment message");
+    }
+    const response = await utils.request(
+      utils.makeURL(`${attachmentBaseUrl}${endpoint}`, { nretry: "0" }),
+      {
+        method: "POST",
+        body: new URLSearchParams({ params: encryptedParams }),
+      },
+    );
+    return await utils.resolve(response);
+  });
+
+  const registeredSender = (api as OpenClawZaloAttachmentApi).openclawSendUploadedAttachment;
+  if (!registeredSender) {
+    throw new Error("Failed to register uploaded zalouser attachment sender");
+  }
+  return registeredSender.bind(customApi);
+}
+
+async function withZaloSendOperationTimeout<T>(
+  promise: Promise<T>,
+  operation: string,
+  timeoutMs: number | undefined,
+): Promise<T> {
+  if (!timeoutMs) {
+    return await promise;
+  }
+  return await withTimeout(promise, timeoutMs, {
+    message:
+      `Timed out ${operation} after ${timeoutMs}ms. ` +
+      "For zalouser media/file sends, keep the live gateway listener session running " +
+      "and retry from that connected session.",
+  });
 }
 
 function mapFriend(friend: User): ZcaFriend {
@@ -1243,7 +1390,7 @@ export async function sendZaloTextMessage(
 
           if (media.kind === "audio") {
             let textMessageId: string | undefined;
-            if (payloadText) {
+            if (payloadText && !options.sendTimeoutMs) {
               const textResponse = await api.sendMessage(
                 textStyles ? { msg: payloadText, styles: textStyles } : payloadText,
                 trimmedThreadId,
@@ -1251,26 +1398,37 @@ export async function sendZaloTextMessage(
               );
               textMessageId = extractSendMessageId(textResponse);
             }
-
             const attachmentFileName = fileName.includes(".") ? fileName : `${fileName}.bin`;
-            const uploaded = await api.uploadAttachment(
-              [
-                {
-                  data: media.buffer,
-                  filename: attachmentFileName as `${string}.${string}`,
-                  metadata: {
-                    totalSize: media.buffer.length,
+            const uploaded = await withZaloSendOperationTimeout(
+              api.uploadAttachment(
+                [
+                  {
+                    data: media.buffer,
+                    filename: attachmentFileName as `${string}.${string}`,
+                    metadata: {
+                      totalSize: media.buffer.length,
+                    },
                   },
-                },
-              ],
-              trimmedThreadId,
-              type,
+                ],
+                trimmedThreadId,
+                type,
+              ),
+              "uploading zalouser audio attachment",
+              options.sendTimeoutMs,
             );
             const voiceAsset = resolveUploadedVoiceAsset(uploaded);
             if (!voiceAsset) {
               throw new Error("Failed to resolve uploaded audio URL for voice message");
             }
             const voiceUrl = buildZaloVoicePlaybackUrl(voiceAsset);
+            if (payloadText && options.sendTimeoutMs) {
+              const textResponse = await api.sendMessage(
+                textStyles ? { msg: payloadText, styles: textStyles } : payloadText,
+                trimmedThreadId,
+                type,
+              );
+              textMessageId = extractSendMessageId(textResponse);
+            }
             const response = await api.sendVoice({ voiceUrl }, trimmedThreadId, type);
             const voiceMessageId = extractSendMessageId(response);
             return {
@@ -1284,29 +1442,70 @@ export async function sendZaloTextMessage(
             };
           }
 
-          const response = await api.sendMessage(
-            {
-              msg: payloadText,
-              ...(textStyles ? { styles: textStyles } : {}),
-              attachments: [
-                {
-                  data: media.buffer,
-                  filename: fileName.includes(".") ? fileName : `${fileName}.bin`,
-                  metadata: {
-                    totalSize: media.buffer.length,
-                  },
-                },
-              ],
+          const attachment = {
+            data: media.buffer,
+            filename: (fileName.includes(".")
+              ? fileName
+              : `${fileName}.bin`) as `${string}.${string}`,
+            metadata: {
+              totalSize: media.buffer.length,
             },
-            trimmedThreadId,
-            type,
+          };
+          if (
+            !options.sendTimeoutMs ||
+            isZaloGifMedia({ fileName, contentType: media.contentType })
+          ) {
+            // zca-js sends GIFs through a dedicated thumbnail + gif endpoint.
+            // uploadAttachment would downgrade them to generic files.
+            const response = await api.sendMessage(
+              {
+                msg: payloadText,
+                ...(textStyles ? { styles: textStyles } : {}),
+                attachments: [attachment],
+              },
+              trimmedThreadId,
+              type,
+            );
+            const messageId = extractSendMessageId(response);
+            return {
+              ok: true,
+              messageId,
+              receipt: createZalouserSendReceipt({
+                messageId,
+                threadId: trimmedThreadId,
+                kind: "media",
+              }),
+            };
+          }
+          const [uploadedAttachment] = await withZaloSendOperationTimeout(
+            api.uploadAttachment([attachment], trimmedThreadId, type),
+            "uploading zalouser media attachment",
+            options.sendTimeoutMs,
           );
-          const messageId = extractSendMessageId(response);
+          if (!uploadedAttachment) {
+            throw new Error("Failed to resolve uploaded zalouser attachment");
+          }
+          let textMessageId: string | undefined;
+          if (payloadText && uploadedAttachment.fileType !== "image") {
+            const textResponse = await api.sendMessage(
+              textStyles ? { msg: payloadText, styles: textStyles } : payloadText,
+              trimmedThreadId,
+              type,
+            );
+            textMessageId = extractSendMessageId(textResponse);
+          }
+          const attachmentResponse = await ensureUploadedAttachmentSender(api)({
+            msg: uploadedAttachment.fileType === "image" ? payloadText : "",
+            attachment: uploadedAttachment,
+            threadId: trimmedThreadId,
+            type,
+          });
+          const messageId = extractSendMessageId(attachmentResponse);
           return {
             ok: true,
-            messageId,
+            messageId: messageId ?? textMessageId,
             receipt: createZalouserSendReceipt({
-              messageId,
+              messageId: messageId ?? textMessageId,
               threadId: trimmedThreadId,
               kind: "media",
             }),

--- a/extensions/zalouser/src/zca-client.ts
+++ b/extensions/zalouser/src/zca-client.ts
@@ -208,6 +208,15 @@ export type API = {
       msgId?: string | number;
       fileId?: string;
       fileName?: string;
+      checksum?: string;
+      clientFileId?: string | number;
+      totalSize?: number;
+      normalUrl?: string;
+      hdUrl?: string;
+      thumbUrl?: string;
+      photoId?: string;
+      width?: number;
+      height?: number;
     }>
   >;
   sendVoice(


### PR DESCRIPTION
Closes #91524

## What Problem This Solves

Fixes an issue where users sending media or files through the zalouser channel could have non-interactive sends hang indefinitely when the underlying Zalo media upload callback never arrived.

## Why This Change Was Made

zalouser now bounds the zca-js upload-callback wait used by non-interactive outbound media delivery and returns an actionable failure instead of leaving CLI, agent-message, or cron flows stuck on an unsettled promise. Text-only sends, untimed media sends, and GIF media stay on the existing zca-js send paths. The fix does not add a new user config or environment surface.

## Intended Product Outcome

This PR intentionally fixes the reported stuck-run failure as a bounded-failure mitigation for non-interactive zalouser media/file sends. It does not claim to make live non-interactive attachments deliver successfully when the Zalo upload callback path is unavailable; that still requires live-session routing proof and maintainer product judgment.

## User Impact

Automated zalouser media/file sends no longer hang forever in the known callback-loss case. If the live upload callback path is unavailable, users get a bounded error that points them back to a connected gateway listener session instead of an eventual Node top-level-await exit.

## Evidence

- Focused regression: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-91524 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/zalouser/src/zalo-js.credentials.test.ts` -> 13 passed.
- Formatting: `node_modules/.bin/oxfmt --check extensions/zalouser/src/types.ts extensions/zalouser/src/channel.adapters.ts extensions/zalouser/src/zalo-js.ts extensions/zalouser/src/zalo-js.credentials.test.ts extensions/zalouser/src/zca-client.ts` -> passed.
- Whitespace: `git diff --check` -> passed.
- Production typecheck: `node scripts/run-tsgo.mjs -p extensions/zalouser/tsconfig.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/zalouser-91524.tsbuildinfo` -> exit 0.
- Extension test typecheck: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test-91524.tsbuildinfo` -> exit 0.
- Lint: `node scripts/run-oxlint.mjs extensions/zalouser/src/types.ts extensions/zalouser/src/channel.adapters.ts extensions/zalouser/src/zalo-js.ts extensions/zalouser/src/zalo-js.credentials.test.ts extensions/zalouser/src/zca-client.ts` -> exit 0.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --prompt ...` -> clean, no accepted/actionable findings.

Real behavior proof

Behavior addressed: zalouser media/file sends with the non-interactive channel timeout now return a bounded failure while waiting for zca-js upload callbacks, before final media delivery is attempted.

Real environment tested: local OpenClaw source checkout with `zca-js@2.1.2` package source inspected for `uploadAttachment`, `sendMessage`, and `custom` API behavior, plus regression tests simulating unresolved upload callbacks and the uploaded-attachment final send path.

Exact steps or command run after this patch: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-91524 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/zalouser/src/zalo-js.credentials.test.ts`.

Evidence after fix: the regression tests create saved zalouser sessions, mock outbound media loading for PDF/GIF media, simulate an unresolved `api.uploadAttachment`, and verify `sendZaloTextMessage` returns `ok: false` with the timeout message before calling final send. They also verify untimed media stays on zca-js `sendMessage`, GIF media stays on the zca-js GIF-capable path, and timed non-GIF media sends from the already uploaded attachment without re-entering zca-js `sendMessage` with attachments.

Observed result after fix: Vitest reported `Test Files 1 passed` and `Tests 13 passed`; the bounded-hang, no-timeout, uploaded-attachment, and GIF regression tests passed.

What was not tested: live Zalo Personal account delivery was not exercised in this environment, so this PR proves bounded failure for the callback-loss path and preserves tested send-path routing rather than proving successful live platform upload receipt.

