### PR TITLE
fix(line): preserve uploaded file names for media detection

### DIFF
--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -125,6 +125,7 @@ const { readAllowFromStoreMock, upsertPairingRequestMock } = vi.hoisted(() => ({
   readAllowFromStoreMock: vi.fn(async () => [] as string[]),
   upsertPairingRequestMock: vi.fn(async (_args: unknown) => ({ code: "CODE", created: true })),
 }));
+const downloadLineMediaMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
   resolvePairingIdLabel: () => "lineUserId",
@@ -133,9 +134,7 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
 }));
 
 vi.mock("./download.js", () => ({
-  downloadLineMedia: async () => {
-    throw new Error("downloadLineMedia should not be called from bot-handlers tests");
-  },
+  downloadLineMedia: downloadLineMediaMock,
 }));
 
 vi.mock("./send.js", () => ({
@@ -350,6 +349,12 @@ describe("handleLineWebhookEvents", () => {
     readAllowFromStoreMock.mockImplementation(async () => [] as string[]);
     upsertPairingRequestMock.mockReset();
     upsertPairingRequestMock.mockImplementation(async () => ({ code: "CODE", created: true }));
+    downloadLineMediaMock.mockReset();
+    downloadLineMediaMock.mockResolvedValue({
+      path: "/tmp/line-media/voice-note.m4a",
+      contentType: "audio/x-m4a",
+      size: 1234,
+    });
   });
   it("blocks group messages when groupPolicy is disabled", async () => {
     const processMessage = vi.fn();
@@ -1003,6 +1008,43 @@ describe("handleLineWebhookEvents", () => {
     );
 
     expect(buildLineMessageContextMock).toHaveBeenCalledTimes(1);
+    expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards LINE file names to media downloads", async () => {
+    const processMessage = vi.fn();
+    const event = createTestMessageEvent({
+      message: {
+        id: "file-audio-1",
+        type: "file",
+        fileName: "voice-note.m4a",
+        fileSize: 4096,
+      } as MessageEvent["message"],
+      source: { type: "user", userId: "user-file-audio" },
+      webhookEventId: "evt-file-audio",
+    });
+
+    await handleLineWebhookEvents(
+      [event],
+      createLineWebhookTestContext({
+        processMessage,
+        dmPolicy: "open",
+      }),
+    );
+
+    expect(downloadLineMediaMock).toHaveBeenCalledWith("file-audio-1", "token", 1, {
+      originalFilename: "voice-note.m4a",
+    });
+    expect(buildLineMessageContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allMedia: [
+          {
+            path: "/tmp/line-media/voice-note.m4a",
+            contentType: "audio/x-m4a",
+          },
+        ],
+      }),
+    );
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -350,10 +350,8 @@ describe("handleLineWebhookEvents", () => {
     upsertPairingRequestMock.mockReset();
     upsertPairingRequestMock.mockImplementation(async () => ({ code: "CODE", created: true }));
     downloadLineMediaMock.mockReset();
-    downloadLineMediaMock.mockResolvedValue({
-      path: "/tmp/line-media/voice-note.m4a",
-      contentType: "audio/x-m4a",
-      size: 1234,
+    downloadLineMediaMock.mockImplementation(async () => {
+      throw new Error("downloadLineMedia should not be called from bot-handlers tests");
     });
   });
   it("blocks group messages when groupPolicy is disabled", async () => {
@@ -1013,6 +1011,11 @@ describe("handleLineWebhookEvents", () => {
 
   it("forwards LINE file names to media downloads", async () => {
     const processMessage = vi.fn();
+    downloadLineMediaMock.mockResolvedValueOnce({
+      path: "/tmp/line-media/voice-note.m4a",
+      contentType: "audio/x-m4a",
+      size: 1234,
+    });
     const event = createTestMessageEvent({
       message: {
         id: "file-audio-1",

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -24,7 +24,10 @@ import {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/runtime-group-policy";
-import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeOptionalString,
+  normalizeStringEntries,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { firstDefined, normalizeLineAllowEntry } from "./bot-access.js";
 import {
   buildLineMessageContext,
@@ -467,7 +470,11 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
 
   if (isDownloadableLineMessageType(message.type)) {
     try {
-      const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
+      const originalFilename =
+        message.type === "file" ? normalizeOptionalString(message.fileName) : undefined;
+      const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes, {
+        originalFilename,
+      });
       allMedia.push({
         path: media.path,
         contentType: media.contentType,

--- a/extensions/line/src/download.test.ts
+++ b/extensions/line/src/download.test.ts
@@ -144,6 +144,18 @@ describe("downloadLineMedia", () => {
     expect(saveMediaStreamCall()[2]).toBe("inbound");
   });
 
+  it("passes original filenames to the media store for extension fallback", async () => {
+    getMessageContentMock.mockResolvedValueOnce(chunks([Buffer.from("unknown-audio-bytes")]));
+
+    await downloadLineMedia("mid-file-audio", "token", 10 * 1024 * 1024, {
+      originalFilename: "voice-note.m4a",
+    });
+
+    const call = saveMediaStreamCall();
+    expect(call[3]).toBe(10 * 1024 * 1024);
+    expect(call[4]).toBe("voice-note.m4a");
+  });
+
   it("uses media store content type for MP4 video", async () => {
     const mp4 = Buffer.from([
       0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,

--- a/extensions/line/src/download.ts
+++ b/extensions/line/src/download.ts
@@ -13,6 +13,7 @@ export async function downloadLineMedia(
   messageId: string,
   channelAccessToken: string,
   maxBytes = 10 * 1024 * 1024,
+  options?: { originalFilename?: string },
 ): Promise<DownloadResult> {
   const client = new messagingApi.MessagingApiBlobClient({
     channelAccessToken,
@@ -24,6 +25,7 @@ export async function downloadLineMedia(
     undefined,
     "inbound",
     maxBytes,
+    options?.originalFilename,
   );
   logVerbose(`line: persisted media ${messageId} to ${saved.path} (${saved.size} bytes)`);
 


### PR DESCRIPTION
Related: #96163

## What Problem This Solves

Fixes an issue where LINE users who upload an audio file as a file message can lose the original filename before OpenClaw stores the attachment, leaving the media path without the `.m4a`/audio extension hint needed by downstream audio detection when MIME sniffing is inconclusive.

## Why This Change Was Made

LINE `FileMessageContent` already carries `fileName`, and OpenClaw's media store already accepts `originalFilename` for MIME/extension fallback and safe saved-media IDs. This change keeps the fix inside the LINE plugin boundary: file messages normalize and pass the LINE filename into `downloadLineMedia`, and the download wrapper forwards it to `saveMediaStream`.

This intentionally does not claim to fix the separate reported 0-byte LINE content stream behavior from #96163; that still needs live LINE/API evidence before changing download endpoints or stream handling.

## User Impact

LINE audio files uploaded through the file picker can now retain names like `voice-note.m4a` through media storage, allowing the existing media-understanding path to classify them as audio instead of falling back to an unknown extensionless attachment when bytes alone do not identify the format.

Duplicate/work check: I found no open PR for #96163, `downloadLineMedia originalFilename`, `FileMessage fileName saveMediaStream`, or LINE file-upload audio metadata. Nearby open PRs checked: #86873 changes LINE download idle timeouts, not filename propagation; #71517 changes Feishu/shared filename decoding, not LINE `FileMessage.fileName` handoff.

## Evidence

- `node scripts/run-vitest.mjs extensions/line/src/download.test.ts extensions/line/src/bot-handlers.test.ts extensions/line/src/bot-message-context.test.ts src/media-understanding/attachments.guards.test.ts src/media-understanding/apply.test.ts`
- `node scripts/run-vitest.mjs extensions/line/src/bot-handlers.test.ts`
- `pnpm exec oxfmt --check extensions/line/src/download.ts extensions/line/src/bot-handlers.ts extensions/line/src/download.test.ts extensions/line/src/bot-handlers.test.ts`
- `pnpm exec oxfmt --check extensions/line/src/bot-handlers.test.ts && git diff --check`
- `git diff --check`
- `$autoreview` final pass: clean, no accepted/actionable findings

Dependency/source proof checked: local `@line/bot-sdk` `FileMessageContent` type includes `fileName` and `fileSize`; `saveMediaStream` already accepts `originalFilename` and uses it for MIME detection/path extension fallback with sanitization.

## Real behavior proof

Behavior addressed: LINE file-style audio filename preservation through OpenClaw media storage/classification, using the real `saveMediaStream` and `resolveAttachmentKind` runtime path.

Real environment tested: local OpenClaw checkout with Node 26.3.1 and an isolated `OPENCLAW_HOME=$(mktemp -d)`.

Exact steps or command run after this patch: `OPENCLAW_HOME=$(mktemp -d) node --import tsx --input-type=module -` from the repo root, with an inline probe importing `src/media/store.ts` and `src/media-understanding/attachments.normalize.ts`, then streaming unknown bytes through `saveMediaStream` first without an original filename and then with `voice-note.m4a`.

Evidence after fix:

```text
proof: actual saveMediaStream + resolveAttachmentKind runtime path
withoutFilename.originalFilename: <none>
withoutFilename.savedBasename: <uuid>
withoutFilename.savedExtension: <none>
withoutFilename.detectedContentType: <none>
withoutFilename.attachmentKind: unknown
withFilename.originalFilename: voice-note.m4a
withFilename.savedBasename: voice-note---<uuid>.m4a
withFilename.savedExtension: .m4a
withFilename.detectedContentType: audio/x-m4a
withFilename.attachmentKind: audio
```

Observed result after fix: without the filename hint, the saved attachment is extensionless and classifies as `unknown`; with `voice-note.m4a`, the saved basename preserves the sanitized audio extension and the actual attachment classifier returns `audio`.

What was not tested: no live LINE credential/API upload was run, and this does not validate or fix the separate 0-byte LINE content stream behavior from #96163.
