### PR TITLE
fix(agent-core): preserve empty prompt arguments

### DIFF
--- a/packages/agent-core/src/harness/prompt-template-arguments.test.ts
+++ b/packages/agent-core/src/harness/prompt-template-arguments.test.ts
@@ -1,0 +1,11 @@
+// Agent Core tests cover prompt template argument parsing behavior.
+import { describe, expect, it } from "vitest";
+import { parseCommandArgs, substituteArgs } from "./prompt-template-arguments.js";
+
+describe("prompt template arguments", () => {
+  it("preserves quoted empty arguments so positional placeholders stay aligned", () => {
+    expect(parseCommandArgs('first "" third')).toEqual(["first", "", "third"]);
+    expect(parseCommandArgs("first '' third")).toEqual(["first", "", "third"]);
+    expect(substituteArgs("$1|$2|$3", parseCommandArgs('first "" third'))).toBe("first||third");
+  });
+});

--- a/packages/agent-core/src/harness/prompt-template-arguments.ts
+++ b/packages/agent-core/src/harness/prompt-template-arguments.ts
@@ -5,26 +5,31 @@ export function parseCommandArgs(argsString: string): string[] {
   const args: string[] = [];
   let current = "";
   let inQuote: string | null = null;
+  let hasToken = false;
 
   for (const char of argsString) {
     if (inQuote) {
       if (char === inQuote) {
         inQuote = null;
       } else {
+        hasToken = true;
         current += char;
       }
     } else if (char === '"' || char === "'") {
+      hasToken = true;
       inQuote = char;
     } else if (/\s/.test(char)) {
-      if (current) {
+      if (hasToken) {
         args.push(current);
         current = "";
+        hasToken = false;
       }
     } else {
+      hasToken = true;
       current += char;
     }
   }
-  if (current) {
+  if (hasToken) {
     args.push(current);
   }
   return args;


### PR DESCRIPTION
## What Problem This Solves

Prompt template command arguments silently dropped quoted empty values (`""` / `''`). That shifted positional placeholders after the empty argument, so a template using `$1`, `$2`, `$3` could substitute the third shell token into `$2` instead of preserving the intended blank value.

## Why This Change Was Made

The parser previously used `current` as both the accumulated value and the token-presence flag. Empty quoted strings are valid arguments, but their accumulated value is intentionally empty, so they were indistinguishable from whitespace-only gaps.

This patch tracks whether the parser is currently inside a real token separately from the token text, preserving empty quoted arguments while leaving whitespace collapsing unchanged.

## User Impact

Prompt templates can now intentionally pass blank positional arguments without corrupting later argument positions.

## Evidence

Real behavior proof added in `packages/agent-core/src/harness/prompt-template-arguments.test.ts`:

```ts
expect(parseCommandArgs('first "" third')).toEqual(["first", "", "third"]);
expect(parseCommandArgs("first '' third")).toEqual(["first", "", "third"]);
expect(substituteArgs("$1|$2|$3", parseCommandArgs('first "" third'))).toBe("first||third");
```

Validation run from this branch:

```text
RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw

Test Files  1 passed (1)
     Tests  1 passed (1)
  Start at  20:29:05
  Duration  876ms (transform 591ms, setup 481ms, import 11ms, tests 121ms, environment 0ms)
```

```text
Checking formatting...

All matched files use the correct format.
Finished in 1155ms on 2 files using 32 threads.
```

`git diff --check` produced no output.

AI-assisted: OpenAI Codex helped identify the parser edge case and prepare the focused regression test.
## Follow-up Evidence After Review

The review asked for stronger real behavior proof beyond the regression assertions. I ran the parser/substitution helpers directly from this branch:

```text
{"input":"first \"\" third","args":["first","","third"],"rendered":"first||third"}
{"input":"first '' third","args":["first","","third"],"rendered":"first||third"}
```

This shows both quoted-empty forms preserve the blank second positional argument, so `$3` remains aligned with `third` instead of shifting into `$2`.