### PR TITLE
fix(matrix): dedupe poll answers before applying max_selections

### DIFF
--- a/extensions/matrix/src/matrix/poll-types.test.ts
+++ b/extensions/matrix/src/matrix/poll-types.test.ts
@@ -183,6 +183,48 @@ describe("buildPollResultsSummary", () => {
     expect(summary?.totalVotes).toBe(1);
   });
 
+  it("dedupes duplicate answer ids before applying max_selections", () => {
+    const summary = buildPollResultsSummary({
+      pollEventId: "$p",
+      roomId: "!r",
+      sender: "@host:x",
+      senderName: "H",
+      content: {
+        "m.poll.start": {
+          question: { "m.text": "Q" },
+          kind: "m.poll.disclosed",
+          max_selections: 2,
+          answers: [
+            { id: "a1", "m.text": "A1" },
+            { id: "a2", "m.text": "A2" },
+            { id: "a3", "m.text": "A3" },
+          ],
+        },
+      },
+      relationEvents: [
+        {
+          event_id: "$v1",
+          sender: "@bob:x",
+          type: "m.poll.response",
+          origin_server_ts: 1,
+          content: {
+            "m.poll.response": { answers: ["a1", "a1", "a2"] },
+            "m.relates_to": { rel_type: "m.reference", event_id: "$p" },
+          },
+        },
+      ],
+    });
+
+    // Duplicate "a1" must not consume a selection slot: both distinct
+    // selections (within max_selections=2) should be counted.
+    expect(summary?.entries).toEqual([
+      { id: "a1", text: "A1", votes: 1 },
+      { id: "a2", text: "A2", votes: 1 },
+      { id: "a3", text: "A3", votes: 0 },
+    ]);
+    expect(summary?.totalVotes).toBe(1);
+  });
+
   it("formats disclosed poll results with vote totals", () => {
     const text = formatPollResultsAsText({
       eventId: "$poll",

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -308,10 +308,9 @@ export function buildPollResultsSummary(params: {
       new Set(
         rawAnswers
           .map((answerId) => normalizeOptionalString(answerId) ?? "")
-          .filter((answerId) => answerIds.has(answerId))
-          .slice(0, parsed.maxSelections),
+          .filter((answerId) => answerIds.has(answerId)),
       ),
-    );
+    ).slice(0, parsed.maxSelections);
     latestVoteBySender.set(senderId, {
       ts: eventTs,
       eventId: typeof event.event_id === "string" ? event.event_id : "",


### PR DESCRIPTION
## What Problem This Solves

`buildPollResultsSummary` in `extensions/matrix/src/matrix/poll-types.ts` capped each voter's selections with `.slice(0, parsed.maxSelections)` **before** `new Set(...)` deduplicated the answer ids. When a voter's `m.poll.response` repeated a valid answer id, the duplicate consumed a selection slot, silently dropping a distinct, valid vote.

**Repro:** a multi-select poll (`max_selections: 2`) with answers `a1, a2, a3`, and one voter whose `answers` array is `["a1","a1","a2"]`.

- **Before (wrong):** `["a1","a1","a2"]` -> `.slice(0,2)` -> `["a1","a1"]` -> `Set` -> `["a1"]`. Result entries: `a1=1`, `a2=0`, `a3=0`; `totalVotes=1`. The valid vote for `a2` is dropped.
- **After (fixed):** `["a1","a1","a2"]` -> `Set` -> `["a1","a2"]` -> `.slice(0,2)` -> `["a1","a2"]`. Result entries: `a1=1`, `a2=1`, `a3=0`; `totalVotes=1`. Both distinct selections (within `max_selections=2`) are counted.

The fix is a one-line reordering: move `.slice(0, parsed.maxSelections)` to **after** the `Set` dedup, so duplicate answer ids no longer consume selection slots. The `max_selections` cap is still enforced, now over distinct selections.

```diff
     const normalizedAnswers = Array.from(
       new Set(
         rawAnswers
           .map((answerId) => normalizeOptionalString(answerId) ?? "")
-          .filter((answerId) => answerIds.has(answerId))
-          .slice(0, parsed.maxSelections),
+          .filter((answerId) => answerIds.has(answerId)),
       ),
-    );
+    ).slice(0, parsed.maxSelections);
```

A unit test in `extensions/matrix/src/matrix/poll-types.test.ts` (`dedupes duplicate answer ids before applying max_selections`) fails on the old ordering and passes after the fix.

## Evidence

Node red/green proof replicating both the buggy and fixed normalization orderings:

```
PASS RED buggy drops valid a2 -> ["a1"]
PASS GREEN fixed keeps a1 and a2 -> ["a1","a2"]
PASS normal single select unchanged -> ["a1"]
PASS normal single select (buggy) identical -> ["a1"]
PASS limit still enforced on distinct ids -> ["a1","a2"]
PASS invalid filtered + dedup + slice -> ["a2","a1"]

ALL ASSERTIONS PASSED
```

- **RED** confirms the original `slice`-before-`Set` ordering reproduces the wrong output (`["a1"]`, dropping `a2`).
- **GREEN** confirms the fixed `Set`-before-`slice` ordering yields `["a1","a2"]`.
- The normal single-select case is **unchanged** by the reordering (identical under both orderings).
- The `max_selections` cap is **still enforced** over distinct ids (`["a1","a2","a3"]` with cap 2 -> `["a1","a2"]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
