### PR TITLE
fix(matrix): truncate thread starter body on code-point boundaries

### DIFF
--- a/extensions/matrix/src/matrix/monitor/thread-context.test.ts
+++ b/extensions/matrix/src/matrix/monitor/thread-context.test.ts
@@ -132,4 +132,24 @@ describe("matrix thread context", () => {
       "[Poll]\nLunch?\n\n1. Pizza\n2. Sushi",
     );
   });
+
+  it("truncates a long thread starter body on a code-point boundary without splitting a surrogate pair", () => {
+    // Body is 496 'a's, then 😀 (U+1F600, two UTF-16 units at indices 496-497),
+    // then 'bcd'. A raw slice(0, 497) would cut the emoji in half, leaving a lone
+    // high surrogate before the ellipsis. The truncation must drop the half emoji.
+    const body = `${"a".repeat(496)}😀bcd`;
+    const summary = summarizeMatrixThreadStarterEvent({
+      event_id: "$root",
+      sender: "@alice:example.org",
+      type: "m.room.message",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body,
+      },
+    } as MatrixRawEvent);
+    expect(summary).toBe(`${"a".repeat(496)}...`);
+    // No orphaned surrogate should survive the truncation.
+    expect(summary && /[\uD800-\uDFFF]/.test(summary)).toBe(false);
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/thread-context.ts
+++ b/extensions/matrix/src/matrix/monitor/thread-context.ts
@@ -1,4 +1,5 @@
 // Matrix plugin module implements thread context behavior.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixClient } from "../sdk.js";
 import { summarizeMatrixMessageContextEvent, trimMatrixMaybeString } from "./context-summary.js";
 import type { MatrixRawEvent } from "./types.js";
@@ -17,7 +18,7 @@ function truncateThreadStarterBody(value: string): string {
   if (value.length <= MAX_THREAD_STARTER_BODY_LENGTH) {
     return value;
   }
-  return `${value.slice(0, MAX_THREAD_STARTER_BODY_LENGTH - 3)}...`;
+  return `${sliceUtf16Safe(value, 0, MAX_THREAD_STARTER_BODY_LENGTH - 3)}...`;
 }
 
 export function summarizeMatrixThreadStarterEvent(event: MatrixRawEvent): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

`truncateThreadStarterBody` in `extensions/matrix/src/matrix/monitor/thread-context.ts` (reached via the exported `summarizeMatrixThreadStarterEvent`) trims an over-length Matrix thread-root body with a raw UTF-16 slice:

```ts
return `${value.slice(0, MAX_THREAD_STARTER_BODY_LENGTH - 3)}...`;
```

`String.prototype.slice` operates on UTF-16 code units, so when the 500-char boundary lands in the middle of an astral character (emoji, many CJK extensions, etc.), the surrogate pair is cut in half. The result is a lone, unpaired high surrogate immediately before the ellipsis, which renders as a broken/replacement glyph (`U+FFFD`).

**Repro** — a thread-root `m.room.message` whose `content.body` is 496 `a` characters, then `😀` (U+1F600 — a surrogate pair at UTF-16 indices 496–497), then `bcd` (total length 501):

```js
summarizeMatrixThreadStarterEvent({
  type: "m.room.message",
  content: { msgtype: "m.text", body: "a".repeat(496) + "😀" + "bcd" },
})
```

- **Before (wrong):** `slice(0, 497)` cuts the emoji in half, leaving a lone high surrogate: `"a".repeat(496) + "\uD83D" + "..."` — a broken glyph followed by the ellipsis.
- **After (fixed):** truncation stops on a code-point boundary, dropping the half emoji entirely: `"a".repeat(496) + "..."` — 496 `a`s then the ellipsis, no orphaned surrogate.

The fix swaps the raw slice for the existing SDK helper `sliceUtf16Safe` (from `openclaw/plugin-sdk/text-utility-runtime`), which already backs the surrogate-safe truncation used by the Discord, Slack, Telegram, and other adapters. Behavior is unchanged for short bodies and for long bodies whose cut point is not inside a surrogate pair.

## Evidence

A standalone Node script replicates the old (buggy) and new (fixed) `truncateThreadStarterBody` logic and asserts the red→green transition plus that unaffected inputs are unchanged:

```
PASS repro input length is 501
PASS RED: old code leaves a lone (orphaned) high surrogate
PASS RED: old code emits half-emoji + ellipsis
PASS GREEN: fixed code drops the half emoji entirely
PASS GREEN: fixed code has NO orphaned surrogate
PASS short body unchanged (old)
PASS short body unchanged (fixed)
PASS long ASCII truncation identical old vs fixed
PASS long ASCII fixed output is 497 x + ellipsis
PASS emoji before cut survives intact
PASS emoji-before-cut output has no lone surrogate

ALL CHECKS PASSED
```

- **RED** confirms the pre-fix code emits `"a".repeat(496) + "\uD83D" + "..."` (a lone high surrogate).
- **GREEN** confirms the fixed code emits `"a".repeat(496) + "..."` with no orphaned surrogate.
- Unaffected inputs (short body, long ASCII body, an emoji that sits safely before the cut) are byte-for-byte unchanged.

A matching unit test was added to `extensions/matrix/src/matrix/monitor/thread-context.test.ts` that calls the exported `summarizeMatrixThreadStarterEvent` directly with the repro body and asserts the surrogate-safe output (`"a".repeat(496) + "..."` with no surrogate code unit surviving).
