### PR TITLE
fix(twitch): chunk on code-point boundaries to keep emoji whole

### DIFF
--- a/extensions/twitch/src/utils/markdown.test.ts
+++ b/extensions/twitch/src/utils/markdown.test.ts
@@ -1,0 +1,67 @@
+// Twitch tests cover markdown stripping and chunk boundary safety.
+import { describe, expect, it } from "vitest";
+import { chunkTextForTwitch, stripMarkdownForTwitch } from "./markdown.js";
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+}
+
+/** True when any chunk starts or ends with a dangling (unpaired) surrogate half. */
+function hasDanglingSurrogate(chunks: string[]): boolean {
+  return chunks.some((chunk) => {
+    if (chunk.length === 0) {
+      return false;
+    }
+    const first = chunk.charCodeAt(0);
+    const last = chunk.charCodeAt(chunk.length - 1);
+    return isLowSurrogate(first) || isHighSurrogate(last);
+  });
+}
+
+describe("stripMarkdownForTwitch", () => {
+  it("strips basic formatting and collapses newlines to spaces", () => {
+    expect(stripMarkdownForTwitch("**bold** and _italic_\nsecond line")).toBe(
+      "bold and italic second line",
+    );
+  });
+});
+
+describe("chunkTextForTwitch", () => {
+  it("returns a single chunk when text fits within the limit", () => {
+    expect(chunkTextForTwitch("hello world", 500)).toEqual(["hello world"]);
+  });
+
+  it("splits on word boundaries when spaces are available", () => {
+    const chunks = chunkTextForTwitch("alpha beta gamma", 7);
+    expect(chunks).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("reassembles back to the original code points after a hard split", () => {
+    // No spaces, so the chunker is forced into the hard-split branch.
+    const input = `x${"\u{1F389}".repeat(300)}`; // one ASCII char + 300 emoji
+    const chunks = chunkTextForTwitch(input, 500);
+    expect(chunks.join("")).toBe(input);
+  });
+
+  it("never splits a surrogate pair across two chunks on a hard split", () => {
+    // 601 UTF-16 units, no spaces: the naive slice(0, 500) lands in the middle
+    // of an emoji surrogate pair, producing dangling halves. The fix must keep
+    // every emoji whole inside a single chunk.
+    const input = `x${"\u{1F389}".repeat(300)}`;
+    const chunks = chunkTextForTwitch(input, 500);
+    expect(hasDanglingSurrogate(chunks)).toBe(false);
+    // First chunk backs off one unit to keep the pair intact (index 499, odd).
+    expect(chunks[0].length).toBe(499);
+  });
+
+  it("keeps a minimal emoji case whole across chunks", () => {
+    const input = `a${"\u{1F600}".repeat(4)}`; // "a😀😀😀😀", limit 2
+    const chunks = chunkTextForTwitch(input, 2);
+    expect(hasDanglingSurrogate(chunks)).toBe(false);
+    expect(chunks.join("")).toBe(input);
+  });
+});

--- a/extensions/twitch/src/utils/markdown.ts
+++ b/extensions/twitch/src/utils/markdown.ts
@@ -5,6 +5,8 @@
  * Based on OpenClaw's markdownToText in src/agents/tools/web-fetch-utils.ts.
  */
 
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
 /**
  * Strip markdown formatting from text for Twitch compatibility.
  *
@@ -80,9 +82,14 @@ export function chunkTextForTwitch(text: string, limit: number): string[] {
     const lastSpaceIndex = window.lastIndexOf(" ");
 
     if (lastSpaceIndex === -1) {
-      // No space found, hard split at limit
-      chunks.push(window);
-      remaining = remaining.slice(limit);
+      // No space found, hard split at limit. Use a surrogate-safe slice so we
+      // never cut a surrogate pair (e.g. an emoji) in half across two chunks.
+      // Fall back to a raw slice when the limit is too small to hold a single
+      // surrogate pair, so the loop always makes progress.
+      const safe = sliceUtf16Safe(remaining, 0, limit);
+      const chunk = safe.length > 0 ? safe : remaining.slice(0, limit);
+      chunks.push(chunk);
+      remaining = remaining.slice(chunk.length);
     } else {
       // Split at the last space
       chunks.push(window.slice(0, lastSpaceIndex));


### PR DESCRIPTION
## What Problem This Solves

`chunkTextForTwitch` (in `extensions/twitch/src/utils/markdown.ts`) splits a
message into Twitch-sized chunks. When a chunk has no space before the limit, it
takes the **hard-split** branch and cut the text at the raw UTF-16 index `limit`:

```ts
chunks.push(window);            // window = remaining.slice(0, limit)
remaining = remaining.slice(limit);
```

`String.prototype.slice` operates on UTF-16 code units, not Unicode code points.
When index `limit` lands **inside a surrogate pair** (any emoji or other astral
character that isn't separated by spaces), the pair is severed:

- the first chunk ends with a lone **high** surrogate (`0xD83C`), rendered as the
  replacement char `�`, and
- the next chunk begins with the orphaned **low** surrogate (`0xDF89`).

The emoji is split in half across two separate Twitch messages and shows as
mojibake on both sides.

### Before / After (repro)

Input: `"x" + "🎉".repeat(300)` — one ASCII char followed by 300 `🎉` emoji
(601 UTF-16 units, no spaces), `limit = 500`.

| | First chunk length | Surrogate halves? | Reassembles to input? |
|---|---|---|---|
| Before | 500 (ends mid-pair, last unit is lone high surrogate `�`) | yes — dangling halves on both chunks | no — `�` corruption |
| After | 499 (backs off one unit, pair kept whole) | none | yes — exact round-trip |

### Fix

In the `lastSpaceIndex === -1` hard-split branch, use the SDK's
`sliceUtf16Safe` (already used for the same class of bug elsewhere in OpenClaw)
so the cut never lands in the middle of a surrogate pair, and advance
`remaining` by the **actual pushed length** so no code unit is dropped or
duplicated. A raw-slice fallback keeps the loop terminating when `limit` is too
small to hold a single pair. Word-boundary splits and ASCII-only inputs are
unchanged.

## Evidence

Standalone red-green node proof replicating both the buggy and fixed
hard-split logic (the fixed branch mirrors `src/utils.ts` `sliceUtf16Safe`):

```
[RED] buggy chunk[0].length = 500, chunkCount = 2
PASS: RED buggy produces a dangling surrogate half
PASS: RED buggy first chunk ends mid-pair at length 500
PASS: RED buggy first chunk last unit is a lone HIGH surrogate (�)
[GREEN] fixed chunk[0].length = 499, chunkCount = 2
PASS: GREEN fixed has NO dangling surrogate halves
PASS: GREEN fixed first chunk backs off to length 499 (pair kept whole)
PASS: GREEN fixed reassembles to the exact original input
PASS: GREEN fixed: every chunk is a valid round-trip via Array.from (no �)
PASS: GREEN mini case has no dangling surrogate
PASS: GREEN mini case reassembles
PASS: UNCHANGED word-boundary split identical between buggy and fixed
PASS: UNCHANGED ascii-only hard split identical between buggy and fixed
PASS: UNCHANGED single chunk under limit

ALL ASSERTIONS PASSED
```

A vitest unit test is added in `extensions/twitch/src/utils/markdown.test.ts`:
it asserts no chunk starts/ends with a dangling surrogate, that chunks
reassemble to the original input, and that word-boundary / single-chunk
behavior is preserved — including the hand-traced minimal case
`chunkTextForTwitch("a😀😀😀😀", 2)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
