### PR TITLE
fix(mattermost): truncate draft preview on code-point boundaries, not raw UTF-16

### DIFF
--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -205,6 +205,31 @@ describe("createMattermostDraftStream", () => {
     expect(stream.postId()).toBeUndefined();
   });
 
+  it("truncates on a code-point boundary so a straddling emoji is dropped whole", async () => {
+    const { client, calls } = createMockClient();
+    // maxChars=12 => cut point is maxChars-3=9. The emoji 😀 occupies UTF-16
+    // indices 8-9, so a raw slice(0,9) would keep the lone high surrogate at
+    // index 8 and drop its low surrogate at index 9, leaking a dangling half.
+    const stream = createMattermostDraftStream({
+      client,
+      channelId: "channel-1",
+      throttleMs: 0,
+      maxChars: 12,
+    });
+
+    const input = `${"a".repeat(8)}\u{1F600}${"b".repeat(5)}`;
+    stream.update(input);
+    await stream.flush();
+
+    expect(calls).toHaveLength(1);
+    const message = parseRequestJson(calls[0]?.init).message;
+    expect(typeof message).toBe("string");
+    const sent = message as string;
+    // The straddling emoji must be dropped whole, leaving no dangling surrogate half.
+    expect(/[\uD800-\uDFFF]/u.test(sent)).toBe(false);
+    expect(sent).toBe("aaaaaaaa...");
+  });
+
   it("does not resend after an update failure followed by stop", async () => {
     const warn = vi.fn();
     const calls: RequestRecord[] = [];

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -1,5 +1,6 @@
 // Mattermost plugin module implements draft stream behavior.
 import { createFinalizableDraftLifecycle } from "openclaw/plugin-sdk/channel-outbound";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   createMattermostPost,
   deleteMattermostPost,
@@ -29,7 +30,7 @@ function normalizeMattermostDraftText(text: string, maxChars: number): string {
   if (trimmed.length <= maxChars) {
     return trimmed;
   }
-  return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+  return `${sliceUtf16Safe(trimmed, 0, Math.max(0, maxChars - 3)).trimEnd()}...`;
 }
 
 export function createMattermostDraftStream(params: {


### PR DESCRIPTION
## What Problem This Solves

`normalizeMattermostDraftText` in `extensions/mattermost/src/mattermost/draft-stream.ts` truncates the streaming draft-preview post with a raw UTF-16 slice:

```ts
return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
```

When an emoji (or any astral code point) straddles the cut point, `String.prototype.slice` cuts between the two UTF-16 code units of a surrogate pair. The slice keeps the high surrogate but drops its low surrogate, and `trimEnd()` does not strip a lone surrogate — so the Mattermost post message carries a dangling surrogate half, which Mattermost renders as the replacement character `�`.

This fires both via an explicit small `maxChars` (passed through `createMattermostDraftStream({ maxChars })`) and at the default `MATTERMOST_STREAM_MAX_CHARS = 4000` cut point (`4000 - 3 = 3997`) whenever a long streamed reply happens to land an emoji on the boundary.

**Repro / before vs. after**

Input: `normalizeMattermostDraftText("a".repeat(8) + "\u{1F600}" + "b".repeat(5), 12)`
The emoji 😀 occupies UTF-16 indices 8–9; the cut point is `maxChars - 3 = 9`, splitting the pair.

- Before: `"aaaaaaaa\ud83d..."` — a lone high surrogate `\uD83D` leaks into the post, rendered as `�`.
- After: `"aaaaaaaa..."` — the straddling emoji is dropped whole on a code-point boundary.

**Fix**

Route the slice through `sliceUtf16Safe` (imported from `openclaw/plugin-sdk/text-utility-runtime`), which snaps the end index off a surrogate boundary. This matches the surrogate-safe truncation already used by the Slack adapter (`extensions/slack/src/truncate.ts`). The change is behavior-preserving for all-BMP text and for inputs at or under the limit — only the straddling-emoji case changes.

## Evidence

Node red-green proof replicating the repo's exact `sliceUtf16Safe` plus the buggy and fixed `normalize` logic (`/tmp/verify-mattermost-draft-surrogate.mjs`):

```
== RED: current (buggy) behavior ==
  before = "aaaaaaaa\ud83d..."
PASS: buggy output contains a lone surrogate half (bug reproduced)
PASS: buggy output equals 'aaaaaaaa\ud83d...'
== GREEN: fixed behavior ==
  after  = "aaaaaaaa..."
PASS: fixed output has NO lone surrogate half
PASS: fixed output == expected 'aaaaaaaa...' (emoji dropped whole)
PASS: fixed: default 4000 cut point drops straddling emoji, no lone surrogate
PASS: fixed: default cut yields 3997 'a' + '...'
PASS: unaffected: short ASCII unchanged & identical to buggy
PASS: unaffected: exactly-at-limit unchanged
PASS: unaffected: long all-BMP truncation identical to buggy
PASS: unaffected: whitespace-only -> ''
PASS: unaffected: leading emoji well before cut is preserved whole

ALL CHECKS PASSED
```

The buggy branch reproduces the dangling surrogate (`aaaaaaaa\ud83d...`); the fixed branch produces the expected `aaaaaaaa...`. Every unaffected case — short ASCII, exactly-at-limit, long all-BMP truncation, whitespace-only, and a non-straddling leading emoji — is byte-identical to the previous behavior.

A unit test covering the straddling-emoji case is added to `extensions/mattermost/src/mattermost/draft-stream.test.ts`, driving the public `createMattermostDraftStream` API with `maxChars: 12` and asserting the posted message contains no surrogate-range code unit and equals `"aaaaaaaa..."`.
