### PR TITLE
fix(feishu): truncate streaming-card summary on a code-point boundary

### DIFF
--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -341,6 +341,72 @@ describe("FeishuStreamingSession", () => {
     });
   });
 
+  it("drops a surrogate pair whole when truncating the closeout summary", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(4_200);
+    // 46 'a' + 😀 (U+1F600, UTF-16 indices 46-47) + 20 'b' = 68-char string.
+    // truncateSummary's default max is 50, so it slices at max-3 = 47, which
+    // lands between the high and low surrogate halves of the emoji.
+    const finalText = `${"a".repeat(46)}\u{1F600}${"b".repeat(20)}`;
+    const settingsBodies: string[] = [];
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockImplementation(
+      async ({ url, init }: { url: string; init?: { body?: string } }) => {
+        if (url.includes("/auth/")) {
+          return {
+            response: {
+              ok: true,
+              json: async () => ({
+                code: 0,
+                msg: "ok",
+                tenant_access_token: "token",
+                expire: 7200,
+              }),
+            },
+            release,
+          };
+        }
+        if (url.includes("/settings")) {
+          settingsBodies.push(init?.body ?? "");
+        }
+        return {
+          response: { ok: true, status: 200, json: async () => ({ code: 0, msg: "ok" }) },
+          release,
+        };
+      },
+    );
+
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_summary_surrogate",
+      appSecret: "secret",
+    });
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_surrogate",
+        messageId: "om_surrogate",
+        sequence: 1,
+        currentText: "",
+        sentText: "",
+        hasNote: false,
+      },
+      lastUpdateTime: 3_000,
+    });
+
+    await session.close(finalText);
+
+    expect(settingsBodies).toHaveLength(1);
+    const settingsPayload = JSON.parse(settingsBodies[0] ?? "{}") as { settings?: string };
+    const settings = JSON.parse(settingsPayload.settings ?? "{}") as {
+      config?: { summary?: { content?: string } };
+    };
+    const summary = settings.config?.summary?.content ?? "";
+    // The half-emoji must be dropped whole: 46 a's + "...", and the summary
+    // must NOT end with a lone high surrogate (which Feishu renders as �).
+    expect(summary).toBe(`${"a".repeat(46)}...`);
+    expect(summary).not.toContain("\uD83D");
+    expect(summary.charCodeAt(summary.length - 4)).not.toBe(0xd83d);
+  });
+
   it("logs a final replacement failure when CardKit returns non-OK", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(4_500);

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -9,6 +9,7 @@ import {
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { getFeishuUserAgent } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
@@ -138,7 +139,10 @@ function truncateSummary(text: string, max = 50): string {
     return "";
   }
   const clean = text.replace(/\n/g, " ").trim();
-  return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
+  // Slice on a code-point boundary so a surrogate pair (emoji / astral char)
+  // straddling the limit is dropped whole, instead of leaving a lone surrogate
+  // half that Feishu renders as the replacement char.
+  return clean.length <= max ? clean : sliceUtf16Safe(clean, 0, max - 3) + "...";
 }
 
 function hasNaturalStreamingBoundary(text: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

`truncateSummary` in `extensions/feishu/src/streaming-card.ts` builds the
closeout summary that is embedded in the Card Kit `settings` PATCH (`config.summary.content`).
It truncated with raw UTF-16 indexing:

```ts
return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
```

When an emoji or other astral-plane character (a UTF-16 surrogate pair)
straddles the `max - 3` cut point, `slice` keeps the high surrogate and
drops the low surrogate, leaving a **lone surrogate half** in the summary.
Feishu renders that dangling half as the replacement character `�`.

**Before / after (repro):** input is `"a".repeat(46) + "😀" + "b".repeat(20)`
(a 68-char string with 😀 / U+1F600 at UTF-16 indices 46–47), default `max = 50`,
so the slice happens at `max - 3 = 47` — right between the two halves of the emoji.

- Before: `"aaaa…(46 a's)…" + "\uD83D" + "..."` — the summary ends with a lone
  high surrogate `\uD83D` before `...`, which serializes invalid and renders as `�`.
- After: `"a".repeat(46) + "..."` — the half-emoji is dropped whole.

The fix swaps the raw slice for the repo's surrogate-safe helper,
`sliceUtf16Safe(clean, 0, max - 3)` (from `openclaw/plugin-sdk/text-utility-runtime`),
which snaps the boundary off a surrogate pair so the straddling code point is
dropped whole. This mirrors the existing pattern in
`extensions/slack/src/truncate.ts`. ASCII / non-straddling inputs are unchanged.

## Evidence

Node red-green proof replicating the exact `sliceUtf16Safe` helper plus the
OLD (buggy) and NEW (fixed) `truncateSummary` logic:

```
repro.length = 68
OLD output endsWith lone high surrogate \uD83D: true
OLD output JSON: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\ud83d..."
NEW output JSON: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
PASS: OLD leaves a dangling high surrogate (bug present)
PASS: OLD does NOT equal expected (bug present)
PASS: NEW equals expected (half-emoji dropped whole)
PASS: NEW contains NO lone high surrogate
PASS: NEW is valid (no replacement char on encode roundtrip)
PASS: normal short unchanged
PASS: normal long ASCII unchanged vs old
PASS: normal long ASCII is 47 chars + ...
PASS: empty unchanged
PASS: non-straddling emoji preserved

ALL ASSERTIONS PASSED
```

- **RED:** the old `slice(0, 47)` output is `"…\uD83D..."` — a dangling high
  surrogate (`charCodeAt(len-4) === 0xD83D`), and is not equal to the expected
  surrogate-clean summary.
- **GREEN:** the fixed output equals `"a".repeat(46) + "..."`, contains no lone
  surrogate, and survives a UTF-8 encode roundtrip without a `�`.
- **No behavior change** for unaffected inputs: short strings, long ASCII
  (still `47 chars + "..."`), empty strings, and non-straddling emoji are all
  byte-identical to the previous behavior.

A unit test was added in `extensions/feishu/src/streaming-card.test.ts`
(`"drops a surrogate pair whole when truncating the closeout summary"`) that
drives `session.close(finalText)`, captures the `/settings` PATCH body, and
asserts `config.summary.content` is `"a".repeat(46) + "..."` with no `\uD83D`.
It fails on the old code and passes after the fix.
