### PR TITLE
fix(matrix): truncate reply context on code-point boundaries to avoid splitting surrogate pairs

### DIFF
--- a/extensions/matrix/src/matrix/monitor/reply-context.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reply-context.test.ts
@@ -39,6 +39,30 @@ describe("matrix reply context", () => {
     expect(result.endsWith("...")).toBe(true);
   });
 
+  it("truncates on a code-point boundary without orphaning a surrogate half", () => {
+    // Body is 496 'a' + 😀 (U+1F600, a surrogate pair at UTF-16 indices 496-497)
+    // + "bcd". Raw `.slice(0, 497)` would split the emoji and leave a lone high
+    // surrogate (\uD83D) before the ellipsis. The fix must drop the half emoji.
+    const body = `${"a".repeat(496)}😀bcd`;
+    expect(body.length).toBe(501);
+    const result = summarizeMatrixReplyEvent({
+      event_id: "$original",
+      sender: "@alice:example.org",
+      type: "m.room.message",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body,
+      },
+    } as MatrixRawEvent);
+    if (result === undefined) {
+      throw new Error("expected truncated reply context");
+    }
+    expect(result).toBe(`${"a".repeat(496)}...`);
+    // No dangling high surrogate should survive the truncation.
+    expect(result.includes("\uD83D")).toBe(false);
+  });
+
   it("handles media-only reply events", () => {
     expect(
       summarizeMatrixReplyEvent({

--- a/extensions/matrix/src/matrix/monitor/reply-context.ts
+++ b/extensions/matrix/src/matrix/monitor/reply-context.ts
@@ -1,4 +1,5 @@
 // Matrix plugin module implements reply context behavior.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixClient } from "../sdk.js";
 import { summarizeMatrixMessageContextEvent, trimMatrixMaybeString } from "./context-summary.js";
 import type { MatrixRawEvent } from "./types.js";
@@ -16,7 +17,7 @@ function truncateReplyBody(value: string): string {
   if (value.length <= MAX_REPLY_BODY_LENGTH) {
     return value;
   }
-  return `${value.slice(0, MAX_REPLY_BODY_LENGTH - 3)}...`;
+  return `${sliceUtf16Safe(value, 0, MAX_REPLY_BODY_LENGTH - 3)}...`;
 }
 
 export function summarizeMatrixReplyEvent(event: MatrixRawEvent): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

`truncateReplyBody` in `extensions/matrix/src/matrix/monitor/reply-context.ts` (reached via the exported `summarizeMatrixReplyEvent`) shortens long reply bodies with a raw `value.slice(0, MAX_REPLY_BODY_LENGTH - 3)`. UTF-16 `.slice` cuts at a code-**unit** index, not a code-**point** boundary. When the cut index lands between the two halves of a surrogate pair (any emoji or other astral character), the slice keeps a lone high surrogate, which is appended directly before the `...` ellipsis. The reply context surfaced to the agent then contains a dangling `\uD83D` that renders as a broken replacement glyph.

**Repro:** a plain `m.room.message` whose `content.body` is 496 `a` characters, then the emoji 😀 (`U+1F600`, a surrogate pair at UTF-16 indices 496–497), then `bcd` (total length 501):

```js
summarizeMatrixReplyEvent({
  type: "m.room.message",
  content: { msgtype: "m.text", body: "a".repeat(496) + "😀" + "bcd" },
});
```

- **Before (wrong):** `value.slice(0, 497)` splits the emoji, returning `"a".repeat(496) + "\uD83D" + "..."` — a lone high surrogate (broken glyph) before the ellipsis.
- **After (fixed):** truncation falls back to the previous code-point boundary: `"a".repeat(496) + "..."`. The half emoji is dropped; no orphaned surrogate.

The fix swaps the raw slice for `sliceUtf16Safe` (already exported from `openclaw/plugin-sdk/text-utility-runtime` and used by sibling extensions such as discord and memory-lancedb), which never cuts inside a surrogate pair. Bodies without astral characters are unaffected — a 600-char ASCII body still truncates to `"x".repeat(497) + "..."` exactly as before.

## Evidence

Standalone Node red/green proof. It copies `sliceUtf16Safe` verbatim from `src/utils.ts` and runs both the buggy (`.slice`) and fixed (`sliceUtf16Safe`) versions of `truncateReplyBody` against the repro input plus an unaffected normal body:

```
PASS: repro input length is 501
PASS: emoji high surrogate at index 496
PASS: emoji low surrogate at index 497
PASS: BEFORE leaves a lone high surrogate (the bug)
PASS: BEFORE differs from expected (proves bug)
PASS: BEFORE is 'a'*496 + \uD83D + '...'
PASS: AFTER equals expected (a*496 + ...)
PASS: AFTER has no orphaned high surrogate
PASS: AFTER length <= 500
PASS: AFTER ends with ...
PASS: normal long ASCII body: BEFORE === AFTER (no behavior change)
PASS: normal long ASCII body truncates to x*497 + ...
PASS: short body unchanged BEFORE
PASS: short body unchanged AFTER

ALL CHECKS PASSED — red/green proof confirmed.
```

A regression test is added to `reply-context.test.ts` (`truncates on a code-point boundary without orphaning a surrogate half`) that fails on the raw-slice code and passes with the fix.
