### PR TITLE
fix(line): truncate action label/data on code-point boundaries

### DIFF
--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -1,5 +1,6 @@
 // Line plugin module implements actions behavior.
 import type { messagingApi } from "@line/bot-sdk";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export type Action = messagingApi.Action;
 
@@ -9,7 +10,7 @@ export type Action = messagingApi.Action;
 export function messageAction(label: string, text?: string): Action {
   return {
     type: "message",
-    label: label.slice(0, 20),
+    label: truncateUtf16Safe(label, 20),
     text: text ?? label,
   };
 }
@@ -20,7 +21,7 @@ export function messageAction(label: string, text?: string): Action {
 export function uriAction(label: string, uri: string): Action {
   return {
     type: "uri",
-    label: label.slice(0, 20),
+    label: truncateUtf16Safe(label, 20),
     uri,
   };
 }
@@ -31,9 +32,9 @@ export function uriAction(label: string, uri: string): Action {
 export function postbackAction(label: string, data: string, displayText?: string): Action {
   return {
     type: "postback",
-    label: label.slice(0, 20),
-    data: data.slice(0, 300),
-    displayText: displayText?.slice(0, 300),
+    label: truncateUtf16Safe(label, 20),
+    data: truncateUtf16Safe(data, 300),
+    displayText: displayText === undefined ? undefined : truncateUtf16Safe(displayText, 300),
   };
 }
 
@@ -52,8 +53,8 @@ export function datetimePickerAction(
 ): Action {
   return {
     type: "datetimepicker",
-    label: label.slice(0, 20),
-    data: data.slice(0, 300),
+    label: truncateUtf16Safe(label, 20),
+    data: truncateUtf16Safe(data, 300),
     mode,
     initial: options?.initial,
     max: options?.max,

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -1,5 +1,6 @@
 // Line tests cover message cards plugin behavior.
 import { describe, expect, it } from "vitest";
+import { datetimePickerAction, postbackAction, uriAction } from "./actions.js";
 import {
   createActionCard,
   createCarousel,
@@ -270,5 +271,71 @@ describe("flex cards", () => {
     expect(card.size).toBe("mega");
     const body = card.body as { contents: Array<{ type: string }> };
     expect(body.contents).toHaveLength(3);
+  });
+});
+
+describe("action label/data surrogate-safe truncation", () => {
+  const loneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+  // 19 ASCII chars + 😀 (U+1F600, two UTF-16 code units) = 21 code units; a raw
+  // .slice(0, 20) would keep the first 19 chars plus the lone high surrogate.
+  const labelWithEmoji = `${"1234567890123456789"}😀`;
+
+  it("messageAction drops a half emoji instead of leaving a lone surrogate", () => {
+    const action = messageAction(labelWithEmoji);
+
+    expect(action.label).toBe("1234567890123456789");
+    expect(loneHighSurrogate.test(action.label)).toBe(false);
+  });
+
+  it("messageAction leaves a short ASCII label unchanged", () => {
+    const action = messageAction("Yes");
+
+    expect(action.label).toBe("Yes");
+  });
+
+  it("uriAction drops a half emoji instead of leaving a lone surrogate", () => {
+    const action = uriAction(labelWithEmoji, "https://example.com");
+
+    expect(action.label).toBe("1234567890123456789");
+    expect(loneHighSurrogate.test(action.label)).toBe(false);
+  });
+
+  it("postbackAction truncates label and data on surrogate boundaries", () => {
+    // 299 ASCII chars + 😀 = 301 code units; the 300-unit slice cuts the emoji.
+    const data = `${"d".repeat(299)}😀`;
+    const action = postbackAction(labelWithEmoji, data) as {
+      label: string;
+      data: string;
+    };
+
+    expect(action.label).toBe("1234567890123456789");
+    expect(loneHighSurrogate.test(action.label)).toBe(false);
+    expect(action.data).toBe("d".repeat(299));
+    expect(loneHighSurrogate.test(action.data)).toBe(false);
+  });
+
+  it("postbackAction truncates displayText on surrogate boundaries but keeps undefined", () => {
+    const displayText = `${"t".repeat(299)}😀`;
+    const withDisplay = postbackAction("Label", "data", displayText) as {
+      displayText?: string;
+    };
+    const withoutDisplay = postbackAction("Label", "data") as { displayText?: string };
+
+    expect(withDisplay.displayText).toBe("t".repeat(299));
+    expect(loneHighSurrogate.test(withDisplay.displayText ?? "")).toBe(false);
+    expect(withoutDisplay.displayText).toBeUndefined();
+  });
+
+  it("datetimePickerAction truncates label and data on surrogate boundaries", () => {
+    const data = `${"d".repeat(299)}😀`;
+    const action = datetimePickerAction(labelWithEmoji, data, "datetime") as {
+      label: string;
+      data: string;
+    };
+
+    expect(action.label).toBe("1234567890123456789");
+    expect(loneHighSurrogate.test(action.label)).toBe(false);
+    expect(action.data).toBe("d".repeat(299));
+    expect(loneHighSurrogate.test(action.data)).toBe(false);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The LINE action builders in `extensions/line/src/actions.ts` enforce LINE's
field limits by calling `String.prototype.slice` directly:

- `messageAction` / `uriAction` / `postbackAction` / `datetimePickerAction` →
  `label.slice(0, 20)`
- `postbackAction` / `datetimePickerAction` → `data.slice(0, 300)` and
  `displayText?.slice(0, 300)`

A raw UTF-16 slice cuts an emoji in half whenever the limit lands inside a
surrogate pair. The returned `label` then ends in an **unpaired high
surrogate**, which LINE renders as a replacement character (or rejects the
payload).

**Repro:** `messageAction("1234567890123456789😀")` — 19 ASCII chars + 😀
(U+1F600, 2 UTF-16 code units) = 21 code units.

| | `label` returned |
|---|---|
| Before (buggy) | `"1234567890123456789\uD83D"` — trailing lone high surrogate |
| After (fixed) | `"1234567890123456789"` — half-emoji dropped, no lone surrogate |

The fix swaps the raw slices for `truncateUtf16Safe(value, limit)` from
`openclaw/plugin-sdk/text-utility-runtime`, which drops a dangling surrogate
instead of emitting it. This matches how this plugin already truncates LINE
template titles (`truncateTemplateText` in `template-messages.ts`). Normal
inputs (short labels, exactly-at-limit ASCII, fully-fitting emoji) are
unchanged, and `displayText` stays `undefined` when omitted.

## Evidence

Standalone red→green proof (replicates `truncateUtf16Safe` + the old vs. new
action logic):

```
RED  ok: old messageAction label = "1234567890123456789\ud83d" (lone surrogate present)
GREEN ok: messageAction label = "1234567890123456789"
GREEN ok: postbackAction label/data/displayText all surrogate-safe
GREEN ok: postbackAction displayText undefined is preserved
GREEN ok: normal/unaffected inputs unchanged

ALL ASSERTIONS PASSED — fix produces expectedOutput and preserves normal behavior.
```

The script asserts:
- **RED:** the old `label.slice(0, 20)` keeps a lone high surrogate (`\uD83D`).
- **GREEN:** the fixed builders return `"1234567890123456789"` (no lone
  surrogate) for `label`, and surrogate-safe `data` / `displayText`.
- **Preservation:** `"Yes"` → `"Yes"`, 20-char ASCII unchanged, 25-char ASCII
  truncated to 20, fully-fitting `"hi😀"` preserved, and `displayText` stays
  `undefined` when not passed.

New unit tests in `extensions/line/src/message-cards.test.ts` cover
`messageAction`, `uriAction`, `postbackAction` (label, data, displayText), and
`datetimePickerAction`, asserting no `/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/`
lone surrogate survives truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
