### PR TITLE
fix(chunk): keep emoji whole when length-splitting a long line in chunkByNewline

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -513,6 +513,22 @@ describe("chunkByNewline", () => {
   it.each(["", "   \n\n   "] as const)("returns empty array for input %j", (text) => {
     expect(chunkByNewline(text, 100)).toStrictEqual([]);
   });
+
+  it("does not split surrogate pairs when length-splitting a long line", () => {
+    // A single line of 8 emoji (16 UTF-16 units) with an odd maxLineLength that
+    // would otherwise land mid-surrogate-pair at index 3.
+    const text = "😀".repeat(8);
+    const chunks = chunkByNewline(text, 3);
+
+    expect(chunks.join("")).toBe(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    // No chunk ends on a lone high surrogate.
+    expect(chunks.every((chunk) => !/[\uD800-\uDBFF]$/u.test(chunk))).toBe(true);
+    // No chunk starts on a lone low surrogate.
+    expect(chunks.every((chunk) => !/^[\uDC00-\uDFFF]/u.test(chunk))).toBe(true);
+    // First chunk carries a single whole emoji rather than 😀 + lone surrogate.
+    expect(chunks[0]).toBe("😀");
+  });
 });
 
 describe("chunkTextWithMode", () => {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -164,9 +164,10 @@ export function chunkByNewline(
     }
 
     const firstLimit = Math.max(1, maxLineLength - prefix.length);
-    const first = lineValue.slice(0, firstLimit);
+    const safeLimit = avoidTrailingHighSurrogateBreak(lineValue, 0, firstLimit);
+    const first = lineValue.slice(0, safeLimit);
     chunks.push(prefix + first);
-    const remaining = lineValue.slice(firstLimit);
+    const remaining = lineValue.slice(safeLimit);
     if (remaining) {
       chunks.push(...chunkText(remaining, maxLineLength));
     }


### PR DESCRIPTION
## What Problem This Solves

`chunkByNewline` in `src/auto-reply/chunk.ts` length-splits a long line with a
raw `lineValue.slice(0, firstLimit)`. When `firstLimit` lands on an odd UTF-16
offset, the slice cuts **through** a surrogate pair: the first chunk ends on a
lone high surrogate and the next chunk begins with the orphaned low surrogate.
The astral character (emoji, CJK extension, etc.) is split across the boundary
and renders as a broken / replacement glyph.

Every other length-splitter in this file (`chunkText`, `chunkMarkdownText`)
already guards this boundary with `avoidTrailingHighSurrogateBreak`. This path
was the lone exception, even though the helper is already imported at the top of
the file.

**Repro:** a single 8-emoji line (16 UTF-16 units), `maxLineLength = 3`:

```js
chunkByNewline("😀😀😀😀😀😀😀😀", 3)
```

- **Before (wrong):** first chunk = `lineValue.slice(0, 3)` = `"😀\uD83D"` — one
  full 😀 followed by a **lone high surrogate**; the next chunk starts with the
  orphaned low surrogate `\uDE00`, so the second 😀 is split and renders broken.
- **After (fixed):** the boundary is pulled back to a code-point boundary, so the
  first chunk is a single whole `"😀"` and the rest is carried into the next
  chunk — no lone surrogate is ever emitted.

## Fix

Apply `avoidTrailingHighSurrogateBreak(lineValue, 0, firstLimit)` before slicing,
mirroring the guard already used by `chunkText` / `chunkMarkdownText`. Only the
rare mid-surrogate boundary changes; every other input is byte-identical (verified
below). A regression test is added to `chunk.test.ts`.

## Evidence

Standalone node red-green proof using the real `avoidTrailingHighSurrogateBreak`
extracted verbatim from `src/shared/text-chunking.ts`, plus a disk-content check
asserting the fix is actually written to source:

```
PASS: fix present in worktree source on disk
PASS: repro = 16 UTF-16 units
PASS: expectedOutput: first chunk = single whole 😀
PASS: first chunk does NOT end on lone high surrogate
PASS: remaining does NOT start on lone low surrogate
PASS: lossless: first + remaining == input
PASS: UNAFFECTED ascii: matches naive slice(0,20)
PASS: UNAFFECTED even boundary (limit 4): two whole emoji

ALL CHECKS PASSED
```

The buggy raw slice produces `"😀\uD83D"` (lone high surrogate) for the repro;
the fixed slice produces a single whole `"😀"`. Plain ASCII and even-offset
boundaries are byte-identical before and after, confirming the change is scoped to
the mid-surrogate case only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
