### PR TITLE
fix(subagents): truncate display label on code-point boundaries

### DIFF
--- a/src/shared/subagents-format.test.ts
+++ b/src/shared/subagents-format.test.ts
@@ -40,6 +40,24 @@ describe("shared/subagents-format", () => {
     expect(truncateLine("trim me   ", 7)).toBe("trim me...");
   });
 
+  it("never cuts a surrogate pair in half when truncating", () => {
+    // "y" x47 (units 0..46), then 😀 occupying units 47-48, then "tail".
+    // A raw value.slice(0, 48) would keep the lone high surrogate at unit 47,
+    // emitting a broken label that ends with an unpaired surrogate before "...".
+    const value = `${"y".repeat(47)}\u{1F600}tail`;
+    const result = truncateLine(value, 48);
+    expect(result).toBe(`${"y".repeat(47)}...`);
+    // No dangling/lone surrogate code unit anywhere in the displayed label.
+    for (const codeUnit of result) {
+      const code = codeUnit.codePointAt(0) ?? 0;
+      expect(code >= 0xd800 && code <= 0xdfff).toBe(false);
+    }
+    // The emoji fully fits below the limit, so it is preserved intact.
+    expect(truncateLine(`${"y".repeat(46)}\u{1F600}tail`, 48)).toBe(
+      `${"y".repeat(46)}\u{1F600}...`,
+    );
+  });
+
   it("resolves token totals and io breakdowns from valid numeric fields only", () => {
     expect(resolveTotalTokens()).toBeUndefined();
     expect(resolveTotalTokens({ totalTokens: 42 })).toBe(42);

--- a/src/shared/subagents-format.ts
+++ b/src/shared/subagents-format.ts
@@ -1,4 +1,6 @@
 // Subagent formatting helpers expose compact durations and status text.
+import { truncateUtf16Safe } from "../utils.js";
+
 export { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 
 /** Formats token counts using compact k/m suffixes for subagent summaries. */
@@ -29,7 +31,9 @@ export function truncateLine(value: string, maxLength: number) {
   if (value.length <= maxLength) {
     return value;
   }
-  return `${value.slice(0, maxLength).trimEnd()}...`;
+  // Cut on a code-point boundary so an emoji (surrogate pair) straddling the
+  // limit is dropped whole instead of leaving a lone surrogate before the "...".
+  return `${truncateUtf16Safe(value, maxLength).trimEnd()}...`;
 }
 
 type TokenUsageLike = {


### PR DESCRIPTION
## What Problem This Solves

`truncateLine` in `src/shared/subagents-format.ts` truncates a subagent display
label with a raw `value.slice(0, maxLength)`. UTF-16 `.slice` cuts at a code
**unit** boundary, so when an emoji (a surrogate pair) straddles the limit the
slice keeps only the **high** surrogate half. `trimEnd()` is a no-op on a lone
surrogate, and `"..."` is appended after it — producing a label that ends in an
unpaired surrogate, which renders as a broken `�` glyph (or worse, corrupts
downstream encoding).

Repro — `truncateLine("y".repeat(47) + "\u{1F600}" + "tail", 48)`
(47 `y`s, then 😀 occupying UTF-16 units 47-48, then `tail`; string length 53,
max 48):

- Before (wrong): `"yyy…y" + "\uD83D" + "..."` — the slice stops at unit 48,
  keeping the lone high surrogate `\uD83D` (the 😀 cut in half) right before the
  ellipsis.
- After (fixed): `"yyy…y..."` — the cut backs off to the code-point boundary
  before the emoji (unit 47), so the emoji is dropped whole and the label never
  contains a lone surrogate.

The fix reuses the already-shared `truncateUtf16Safe` helper from `src/utils.ts`
(the same helper used by `tasks/task-status.ts`, the embedded-agent tools, etc.).
For any input without a surrogate pair on the boundary, `truncateUtf16Safe`
returns exactly `value.slice(0, maxLength)`, so non-emoji behavior — including
the trailing-whitespace trim and the short-string passthrough — is unchanged.

## Evidence

Node red-green proof. The script replicates the canonical `sliceUtf16Safe` /
`truncateUtf16Safe` helpers and both the buggy and fixed `truncateLine` bodies,
then asserts the repro input maps to the expected output and that unaffected
inputs are byte-for-byte unchanged:

```
reproInput length: 53 (expected 53)
BEFORE codes: 2e,2e,2e
AFTER  : "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy..."
PASS: RED: buggy output contains a lone surrogate
PASS: RED: buggy output != expected
PASS: GREEN: fixed output === expectedOutput got="yyy…yyy..."
PASS: GREEN: fixed output has no lone surrogate
PASS: unchanged: short string passthrough
PASS: unchanged: trailing-whitespace trim case
PASS: unchanged: ascii truncation matches buggy (no surrogates) fixed="abcd..."
PASS: preserved: emoji below limit kept whole got="yyy…yy😀..."

ALL CHECKS PASSED
```

(In the RED case, walking the buggy output's code units finds an unpaired high
surrogate `\uD83D` immediately before the `2e,2e,2e` = `...` tail.)

A matching unit test is added in `src/shared/subagents-format.test.ts`
("never cuts a surrogate pair in half when truncating"): it asserts the repro
maps to `"y".repeat(47) + "..."`, scans the result for any lone surrogate code
unit, and confirms an emoji that fully fits under the limit is preserved intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
