### PR TITLE
fix(canvas): stop self-closing embed from starting a greedy block match

### DIFF
--- a/src/chat/canvas-render.test.ts
+++ b/src/chat/canvas-render.test.ts
@@ -1,0 +1,38 @@
+// Canvas-render tests cover [embed] shortcode extraction and text stripping.
+import { describe, expect, it } from "vitest";
+import { extractCanvasShortcodes } from "./canvas-render.ts";
+
+describe("extractCanvasShortcodes", () => {
+  it("does not let a self-closing embed start a greedy block match", () => {
+    // Regression: the block regex used to greedily swallow the span from a
+    // self-closing "[embed ... /]" open tag up to a later stray "[/embed]",
+    // deleting the visible text in between (" keep me ") from channel delivery.
+    const input = '[embed url="https://a.com" /] keep me [/embed]';
+    const { text, previews } = extractCanvasShortcodes(input);
+
+    expect(previews).toHaveLength(1);
+    expect(previews[0]?.url).toBe("https://a.com");
+    // The visible text between the self-closing embed and the stray close
+    // marker must be preserved, not silently stripped.
+    expect(text).toContain("keep me");
+    expect(text).toBe("keep me [/embed]");
+  });
+
+  it("still extracts a normal block embed and strips only the shortcode span", () => {
+    const input = 'before [embed ref="doc1"] hi [/embed] after';
+    const { text, previews } = extractCanvasShortcodes(input);
+
+    expect(previews).toHaveLength(1);
+    expect(previews[0]?.viewId).toBe("doc1");
+    expect(text).toBe("before  after");
+  });
+
+  it("still extracts a plain self-closing embed and keeps surrounding text", () => {
+    const input = 'see [embed url="https://b.com" /] end';
+    const { text, previews } = extractCanvasShortcodes(input);
+
+    expect(previews).toHaveLength(1);
+    expect(previews[0]?.url).toBe("https://b.com");
+    expect(text).toBe("see  end");
+  });
+});

--- a/src/chat/canvas-render.ts
+++ b/src/chat/canvas-render.ts
@@ -203,7 +203,10 @@ export function extractCanvasShortcodes(text: string | undefined): {
     attrs: Record<string, string>;
     body?: string;
   }> = [];
-  const blockRe = /\[embed\s+([^\]]*?)\]([\s\S]*?)\[\/embed\]/gi;
+  // Exclude a self-closing open tag ("[embed ... /]") from starting a block
+  // match by requiring the attrs group not to end with a slash; otherwise the
+  // block regex greedily swallows visible text up to a later stray [/embed].
+  const blockRe = /\[embed\s+([^\]]*?[^\]/]|)\]([\s\S]*?)\[\/embed\]/gi;
   const selfClosingRe = /\[embed\s+([^\]]*?)\/\]/gi;
   for (const re of [blockRe, selfClosingRe]) {
     let match: RegExpExecArray | null;


### PR DESCRIPTION
## What Problem This Solves

`extractCanvasShortcodes` in `src/chat/canvas-render.ts` extracts `[embed ...]` canvas shortcodes from assistant text and returns the text with the consumed shortcodes stripped for channel delivery.

The block-embed regex used an open-tag attrs group that allowed a trailing slash:

```
const blockRe = /\[embed\s+([^\]]*?)\]([\s\S]*?)\[\/embed\]/gi;
```

Because `[^\]]*?` can end with `/`, a **self-closing** open tag `[embed ... /]` could start a **block** match. The block pattern then greedily ran to the next stray `[/embed]`, swallowing all visible text in between. That text was stripped from the returned string and silently lost from channel delivery.

Repro: `extractCanvasShortcodes('[embed url="https://a.com" /] keep me [/embed]')`

- Before (wrong): `blockRe` matches the entire span as ONE block embed (group1 = `url="https://a.com" /`, group2 = ` keep me `). Returns `text: ""` with one preview — the visible ` keep me ` is deleted.
- After (correct): only the self-closing shortcode `[embed url="https://a.com" /]` is consumed (by `selfClosingRe`); the surrounding visible text is preserved. Returns `text: "keep me [/embed]"` with one preview.

### The fix

Anchor the block open-tag group so the attrs cannot end with a slash, preventing a self-closing open tag from initiating a block match:

```diff
-  const blockRe = /\[embed\s+([^\]]*?)\]([\s\S]*?)\[\/embed\]/gi;
+  const blockRe = /\[embed\s+([^\]]*?[^\]/]|)\]([\s\S]*?)\[\/embed\]/gi;
```

`([^\]]*?[^\]/]|)` requires the last attrs character before `]` to be neither `]` nor `/` (or the group to be empty). A self-closing `[embed ... /]` open tag therefore no longer starts a block match, while every normal block embed (attrs ending in a quote, word char, etc.) is unaffected. This is a minimal, behavior-preserving change — no refactor.

## Evidence

Red-green proof replicating the function's match/strip logic (run with `node`), asserting the repro maps to the expected output and that unaffected inputs are unchanged:

```
=== RED (old regex) demonstrates the bug ===
before.text = ""
before.previews = [{"kind":"canvas","surface":"assistant_message","render":"url","url":"https://a.com"}]
PASS - RED: old regex strips ' keep me ' (text empty)
PASS - RED: old regex emits one preview

=== GREEN (new regex) preserves visible text ===
after.text = "keep me [/embed]"
after.previews = [{"kind":"canvas","surface":"assistant_message","render":"url","url":"https://a.com"}]
PASS - GREEN: exactly one preview (self-closing)
PASS - GREEN: preview url is https://a.com
PASS - GREEN: ' keep me ' is preserved in text
PASS - GREEN: text is 'keep me [/embed]'

=== Regression: normal block embed unchanged ===
block old = {"text":"before  after","previews":[{...,"url":".../doc1/index.html","viewId":"doc1"}]}
block new = {"text":"before  after","previews":[{...,"url":".../doc1/index.html","viewId":"doc1"}]}
PASS - block embed: old === new (unchanged)
PASS - block embed: preview emitted
PASS - block embed: surrounding text kept

=== Regression: plain self-closing embed unchanged ===
selfclose old = {"text":"see  end","previews":[{...,"url":"https://b.com"}]}
selfclose new = {"text":"see  end","previews":[{...,"url":"https://b.com"}]}
PASS - plain self-closing: old === new (unchanged)

RESULT: ALL ASSERTIONS PASSED
```

A colocated Vitest unit test is added at `src/chat/canvas-render.test.ts` (picked up by the unit project's `src/**/*.test.ts` glob). It imports the already-exported `extractCanvasShortcodes` directly and covers:
- the self-closing-vs-greedy regression (fails on the old regex, passes on the new one),
- a normal block embed still extracting and stripping only its span,
- a plain self-closing embed still extracting and keeping surrounding text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
