### PR TITLE
fix(tui): chunk long tokens on code-point boundaries to avoid splitting surrogate pairs

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -376,6 +376,26 @@ describe("sanitizeRenderableText", () => {
     expectTokenWidthUnderLimit(input);
   });
 
+  it("chunks long emoji runs on code-point boundaries without splitting surrogate pairs", () => {
+    // A single non-whitespace run of 33 UTF-16 units: "a" + 16x U+1F600.
+    // The naive UTF-16 slice cut the 16th emoji in half, leaving a lone high
+    // surrogate at the end of chunk 0 and a lone low surrogate as chunk 1.
+    const input = `a${"\u{1F600}".repeat(16)}`;
+    const sanitized = sanitizeRenderableText(input);
+
+    // No lone surrogate halves survive once whole-emoji pairs are removed.
+    const withoutPairs = sanitized.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "");
+    expect(withoutPairs).not.toMatch(/[\uD800-\uDFFF]/);
+
+    // Every emoji code point is preserved (none turned into a replacement char).
+    expect(Array.from(sanitized).filter((cp) => cp === "\u{1F600}")).toHaveLength(16);
+    expect(sanitized).not.toContain("�");
+
+    // Still wrapped: the long run is broken into space-separated chunks.
+    const longestSegment = Math.max(...sanitized.split(/\s+/).map((segment) => segment.length));
+    expect(longestSegment).toBeLessThanOrEqual(32);
+  });
+
   it("preserves long CJK prose without inserting display spaces", () => {
     const input =
       "特蕾莎修女是一个极端投入极有宗教信念愿意亲身服务底层苦难者的人但她不是现代公共卫生意义上的慈善改革者";

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -61,9 +61,24 @@ function chunkToken(token: string, maxChars: number): string[] {
   if (token.length <= maxChars) {
     return [token];
   }
+  // Advance by whole code points so a chunk boundary never lands inside a
+  // surrogate pair (e.g. an emoji). A naive `token.slice(i, i + maxChars)` over
+  // UTF-16 units can cut a pair in half, leaving lone surrogates that render as
+  // replacement glyphs. Behavior is unchanged for pure-ASCII/BMP tokens.
   const chunks: string[] = [];
-  for (let i = 0; i < token.length; i += maxChars) {
-    chunks.push(token.slice(i, i + maxChars));
+  let current = "";
+  let currentLen = 0;
+  for (const codePoint of token) {
+    if (currentLen + codePoint.length > maxChars && current !== "") {
+      chunks.push(current);
+      current = "";
+      currentLen = 0;
+    }
+    current += codePoint;
+    currentLen += codePoint.length;
+  }
+  if (current !== "") {
+    chunks.push(current);
   }
   return chunks;
 }


### PR DESCRIPTION
## What Problem This Solves

`sanitizeRenderableText` breaks up very long unbroken tokens (33+ chars) so they
wrap on narrow terminals. The wrapping is done by `chunkToken`, which sliced the
token by raw **UTF-16 unit** offsets:

```ts
for (let i = 0; i < token.length; i += maxChars) {
  chunks.push(token.slice(i, i + maxChars)); // can cut a surrogate pair in half
}
```

Astral characters (emoji, many CJK ideographs, math symbols) are encoded as a
**surrogate pair** of two UTF-16 units. When a chunk boundary lands between the
two halves, one chunk ends with a lone high surrogate and the next begins with a
lone low surrogate — and a space is inserted between them. The astral character
is destroyed.

**Before / after repro** — a single non-whitespace run of 33 UTF-16 units,
`"a" + "\u{1F600}".repeat(16)` (an `a` followed by 16 grinning-face emoji):

| | Output (escaped) | Rendered in terminal |
|---|---|---|
| **Before (bug)** | `"a😀…😀\uD83D \uDE00"` | `a😀…😀 ` then `� �` — the 16th emoji is two replacement glyphs split by a space |
| **After (fix)** | `"a😀…😀 😀"` | `a😀…😀 😀` — all 16 emoji intact, wrap falls on a code-point boundary |

The fix advances `chunkToken` by **whole code points** (`for (const cp of token)`)
so a chunk boundary can never fall inside a surrogate pair. Pure-ASCII / BMP
tokens are chunked exactly as before (verified below), so the common case is
unchanged. The repo already ships `sliceUtf16Safe`/`truncateUtf16Safe` in
`plugin-sdk/text-utility-runtime` for the same class of bug; this keeps the
helper self-contained while applying the same code-point-boundary guarantee.

## Evidence

A standalone Node script replicates the buggy and fixed `chunkToken` (plus the
`normalizeLongTokenForDisplay` gating that the repro token hits) and asserts the
red → green transition, plus that ASCII/BMP chunking is byte-identical to the
pre-fix behavior.

```
RED  ok: buggy output = "a😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀\ud83d \ude00"
GREEN ok: fixed output = "a😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀 😀"
UNCHANGED ok: ASCII/BMP chunking identical to pre-fix behavior

ALL ASSERTIONS PASSED
```

- **RED**: the pre-fix code emits `\uD83D \uDE00` (lone high surrogate, space,
  lone low surrogate); decoding the output yields a replacement char `�`.
- **GREEN**: the fixed code yields `"a" + 15 emoji + " " + 1 emoji`; all 16 emoji
  survive, no replacement char, and the longest space-separated segment stays
  within the 32-unit width limit.
- **UNCHANGED**: for several pure-ASCII tokens (`"x".repeat(70)`,
  `"y".repeat(33)`, mixed alnum/punct runs), the fixed chunking is `deepEqual` to
  the pre-fix chunking.

A matching regression test is added to `src/tui/tui-formatters.test.ts`
(`sanitizeRenderableText` → "chunks long emoji runs on code-point boundaries
without splitting surrogate pairs"): it asserts no lone surrogate survives, all
16 emoji are preserved, the output contains no `�`, and the run is still wrapped
under the width limit. This test fails on the pre-fix code and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
