### PR TITLE
fix(agents): truncate exec command detail on code-point boundaries

### DIFF
--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -5,6 +5,7 @@
  */
 import { asOptionalObjectRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { redactToolPayloadText } from "../logging/redact.js";
+import { sliceUtf16Safe } from "../utils.js";
 import {
   binaryName,
   firstPositional,
@@ -442,7 +443,7 @@ function compactRawCommand(raw: string, maxLength = 120): string {
     return oneLine;
   }
   const half = Math.floor((maxLength - 1) / 2);
-  return `${oneLine.slice(0, half)}…${oneLine.slice(-(maxLength - 1 - half))}`;
+  return `${sliceUtf16Safe(oneLine, 0, half)}…${sliceUtf16Safe(oneLine, -(maxLength - 1 - half))}`;
 }
 
 export type ToolDetailMode = "explain" | "raw";

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -562,6 +562,28 @@ describe("compactRawCommand middle truncation", () => {
     expect(result).not.toContain("AKIDABCDEFGHIJKLMNOP1234567890");
     expect(result).toContain("AKIDAB…7890");
   });
+
+  it("does not split a surrogate pair when the head boundary lands on an emoji", () => {
+    // The one-line form is 140 UTF-16 units. With the default maxLength=120 the head
+    // slice ends at index 59, but the 😀 emoji (U+1F600, a surrogate pair) occupies
+    // indices 58-59 — so a raw .slice(0, 59) would keep the high surrogate and drop
+    // its low half, leaving a lone surrogate that renders as the replacement char.
+    const emoji = String.fromCodePoint(0x1f600);
+    // Unknown binary so resolveExecDetail returns the compact raw form directly.
+    const longCommand = `/opt/custom/bin/run ${"a".repeat(38)}${emoji}${"b".repeat(80)}`;
+    const result = resolveExecDetail({ command: longCommand });
+
+    expect(result).toBeDefined();
+    // The whole emoji is dropped at the boundary rather than half of it.
+    expect(result).not.toContain(emoji);
+    // No dangling/lone surrogate code units remain in the rendered detail.
+    expect(result).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(result).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+    // Start and end of the command are still preserved around the ellipsis.
+    expect(result).toContain("/opt/custom/bin/run");
+    expect(result).toContain("…");
+    expect(result).toMatch(/b{4}$/);
+  });
 });
 
 describe("coerceDisplayValue middle truncation", () => {


### PR DESCRIPTION
## What Problem This Solves

`compactRawCommand` in `src/agents/tool-display-exec.ts` builds the short, redacted exec-command label shown in tool-call summaries (chat timeline and transcripts). When the one-line command is longer than `maxLength` (default 120), it middle-truncates with raw `String.prototype.slice`:

```ts
const half = Math.floor((maxLength - 1) / 2);
return `${oneLine.slice(0, half)}…${oneLine.slice(-(maxLength - 1 - half))}`;
```

`String.prototype.slice` operates on UTF-16 code units, not code points. When a truncation boundary falls **between the two halves of a surrogate pair** (e.g. an emoji such as 😀 `U+1F600`, encoded as the surrogate pair `D83D DE00`), the head slice keeps the high surrogate `\uD83D` and drops its low half — leaving a **lone surrogate** that renders as the replacement character `�` in the displayed detail. The symmetric tail slice can likewise begin on a lone low surrogate.

### Before / after repro

Input (normalized one-line form is 140 UTF-16 units; the 😀 high surrogate sits at the head boundary index 58):

```
git commit -m aaaaaaaa…aaaa😀bbbb…bbbb   (44× 'a', emoji, 80× 'b')
```

- **Before:** head = `git commit -m aaa…aaa\uD83D` — a dangling high surrogate, shown as `…aaa�…` in the tool-call summary.
- **After:** the whole emoji is dropped at the boundary; head = `git commit -m aaa…aaa` (no trailing lone surrogate), matching the repo's existing UTF-16-safe behavior.

### Fix

Use the existing `sliceUtf16Safe` helper from `src/utils.ts` for both ends. It already nudges either edge off a dangling surrogate half (the same helper backing `truncateUtf16Safe`). The change is **behavior-preserving for all non-surrogate input** (byte-identical output).

```ts
return `${sliceUtf16Safe(oneLine, 0, half)}…${sliceUtf16Safe(oneLine, -(maxLength - 1 - half))}`;
```

A regression test was added to `src/agents/tool-display.test.ts` (alongside the existing `compactRawCommand middle truncation` cases), exercising the public `resolveExecDetail` API with an unknown binary so the compact raw form is returned directly. It asserts the rendered detail contains no lone surrogate and drops the whole emoji.

## Evidence

Standalone node red-green proof replicating the exact `compactRawCommand` logic before and after the fix, plus `sliceUtf16Safe` copied verbatim from `src/utils.ts`:

```
--- RED (buggy, current behavior) ---
ok - buggy output contains a lone surrogate (bug reproduced)
ok - buggy head ends with a lone HIGH surrogate \uD83D

--- GREEN (fixed, expected behavior) ---
ok - fixed output has NO lone surrogate
ok - fixed head is the emoji-dropped prefix (ends in 'aaa', emoji fully removed)
ok - fixed output does not contain the (now-dropped) emoji
ok - ellipsis preserved in the middle
ok - tail of the command preserved

--- BEHAVIOR-PRESERVING on non-surrogate input (must be byte-identical) ---
ok - non-surrogate input unchanged: short (no truncation)
ok - non-surrogate input unchanged: long ASCII truncated
ok - non-surrogate input unchanged: long ASCII path command
ok - non-surrogate input unchanged: whitespace-collapsing

--- tail-side surrogate boundary also safe ---
ok - tail-side fixed output has no lone surrogate

=== verification complete; exitCode: 0 ===
```

The bug reproduces with the buggy slice (lone `\uD83D` at the head boundary) and is gone after switching to `sliceUtf16Safe`, while every non-surrogate input is byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
