### PR TITLE
fix(model-catalog): normalize manifest alias keys

### DIFF
--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -28,6 +28,26 @@ describe("provider model id policy normalization", () => {
     );
   });
 
+  it("matches manifest aliases using normalized alias keys", () => {
+    const policies = collectManifestModelIdNormalizationPolicies([
+      {
+        modelIdNormalization: {
+          providers: {
+            openai: {
+              aliases: {
+                " GPT-5.4 ": "gpt-5.4-chat",
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(normalizeStaticProviderModelIdWithPolicies("openai", "gpt-5.4", policies)).toBe(
+      "gpt-5.4-chat",
+    );
+  });
+
   it("normalizes provider-prefixed Google catalog refs behind gateway prefixes", () => {
     expect(
       normalizeConfiguredProviderCatalogModelId(

--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -48,6 +48,27 @@ describe("provider model id policy normalization", () => {
     );
   });
 
+  it("keeps exact normalized alias keys ahead of normalized fallback matches", () => {
+    const policies = collectManifestModelIdNormalizationPolicies([
+      {
+        modelIdNormalization: {
+          providers: {
+            openai: {
+              aliases: {
+                " GPT-5.4 ": "variant-target",
+                "gpt-5.4": "exact-target",
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(normalizeStaticProviderModelIdWithPolicies("openai", "gpt-5.4", policies)).toBe(
+      "exact-target",
+    );
+  });
+
   it("normalizes provider-prefixed Google catalog refs behind gateway prefixes", () => {
     expect(
       normalizeConfiguredProviderCatalogModelId(

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -73,6 +73,10 @@ function resolvePolicyAlias(
   modelId: string,
 ): string | undefined {
   const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
+  const exactTarget = aliases?.[normalizedModelId];
+  if (exactTarget !== undefined) {
+    return exactTarget;
+  }
   for (const [alias, target] of Object.entries(aliases ?? {})) {
     if (normalizeLowercaseStringOrEmpty(alias) === normalizedModelId) {
       return target;

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -68,6 +68,19 @@ function formatPrefixedModelId(prefix: string, modelId: string): string {
   return `${prefix.replace(/\/+$/u, "")}/${modelId.replace(/^\/+/u, "")}`;
 }
 
+function resolvePolicyAlias(
+  aliases: Record<string, string> | undefined,
+  modelId: string,
+): string | undefined {
+  const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
+  for (const [alias, target] of Object.entries(aliases ?? {})) {
+    if (normalizeLowercaseStringOrEmpty(alias) === normalizedModelId) {
+      return target;
+    }
+  }
+  return undefined;
+}
+
 /** Strip a duplicated self-provider prefix from a model id. */
 export function stripSelfProviderModelPrefix(provider: string, model: string): string {
   const prefix = `${normalizeLowercaseStringOrEmpty(provider)}/`;
@@ -103,7 +116,7 @@ export function normalizeProviderModelIdWithPolicies(params: {
     }
   }
 
-  modelId = policy.aliases?.[normalizeLowercaseStringOrEmpty(modelId)] ?? modelId;
+  modelId = resolvePolicyAlias(policy.aliases, modelId) ?? modelId;
 
   if (!hasProviderPrefix(modelId)) {
     for (const rule of policy.prefixWhenBareAfterAliasStartsWith ?? []) {


### PR DESCRIPTION
## What Problem This Solves

Manifest model-id aliases are intended to normalize configured model names before provider-specific built-in normalization runs. The caller input was already trimmed/lowercased before lookup, but the manifest alias keys themselves were used as raw object keys.

That meant aliases such as `" GPT-5.4 "` or `"GPT-5.4"` would not match `gpt-5.4`, even though the surrounding manifest normalization code already treats prefixes and provider ids with normalized matching.

## Why This Change Was Made

This patch resolves aliases by comparing normalized alias keys to the normalized model id while preserving the alias target string exactly as authored. That keeps real provider model ids case-sensitive where needed, but makes manifest key matching tolerant in the same way as the rest of this policy path.

## User Impact

Plugin/provider manifests can define model aliases without silently missing matches because of harmless casing or whitespace in the alias key.

## Evidence

Live behavior proof from this branch:

```text
{"model":"gpt-5.4","normalized":"gpt-5.4-chat"}
{"model":" GPT-5.4 ","normalized":"gpt-5.4-chat"}
{"model":"GPT-5.4","normalized":"gpt-5.4-chat"}
```

Focused validation:

```text
RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw

Test Files  1 passed (1)
     Tests  10 passed (10)
  Start at  20:44:27
  Duration  1.01s (transform 715ms, setup 543ms, import 30ms, tests 149ms, environment 0ms)
```

```text
Checking formatting...

All matched files use the correct format.
Finished in 1238ms on 2 files using 32 threads.
```

`git diff --check` produced no output.

AI-assisted: OpenAI Codex helped identify the manifest alias lookup edge case and add focused regression coverage.
## Follow-up Evidence After Review

ClawSweeper correctly flagged that the first implementation could change routing precedence when a manifest contained both an exact normalized key and a whitespace/case variant with the same normalized form. I updated `resolvePolicyAlias` to keep the exact normalized-key lookup first, then fall back to normalized variant scanning.

Live proof from the follow-up patch:

```text
{"case":"exact precedence","normalized":"exact-target"}
{"case":"fallback variant","normalized":"variant-target"}
```

Focused validation after the follow-up patch:

```text
RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw

Test Files  1 passed (1)
     Tests  11 passed (11)
  Start at  20:55:55
  Duration  858ms (transform 627ms, setup 449ms, import 21ms, tests 132ms, environment 0ms)
```

```text
Checking formatting...

All matched files use the correct format.
Finished in 1332ms on 2 files using 32 threads.
```

`git diff --check` produced no output.