### PR TITLE
fix(acp-core): clear stale active run lookups

### DIFF
--- a/packages/acp-core/src/session.test.ts
+++ b/packages/acp-core/src/session.test.ts
@@ -34,6 +34,19 @@ describe("acp session manager", () => {
     expect(store.getSessionByRunId("run-1")).toBeUndefined();
   });
 
+  it("removes stale run lookup entries when rebinding an active run", () => {
+    const session = store.createSession({
+      sessionKey: "acp:rebind",
+      cwd: "/tmp",
+    });
+
+    store.setActiveRun(session.sessionId, "run-old", new AbortController());
+    store.setActiveRun(session.sessionId, "run-new", new AbortController());
+
+    expect(store.getSessionByRunId("run-old")).toBeUndefined();
+    expect(store.getSessionByRunId("run-new")?.sessionId).toBe(session.sessionId);
+  });
+
   it("deletes sessions and aborts active runs on close", () => {
     const session = store.createSession({
       sessionId: "close-me",

--- a/packages/acp-core/src/session.ts
+++ b/packages/acp-core/src/session.ts
@@ -150,6 +150,9 @@ export function createInMemorySessionStore(options: AcpSessionStoreOptions = {})
     if (!session) {
       return;
     }
+    if (session.activeRunId && session.activeRunId !== runId) {
+      runIdToSessionId.delete(session.activeRunId);
+    }
     session.activeRunId = runId;
     session.abortController = abortController;
     runIdToSessionId.set(runId, sessionId);


### PR DESCRIPTION
## What Problem This Solves

The in-memory ACP session store keeps a reverse `runId -> sessionId` map so callers can find the session that owns an active runtime run. When `setActiveRun` rebound the same session to a new run id, it added the new lookup but left the previous run id in the reverse map.

That made stale run ids continue resolving to the session after they were no longer active.

## Why This Change Was Made

`clearActiveRun`, `cancelActiveRun`, and session deletion already remove the current active run id from the reverse lookup. Rebinding now maintains the same invariant: each session has at most one active run lookup, and old run ids stop resolving as soon as the session is rebound.

This PR branch was rebuilt on current `origin/main` so the diff is limited to the ACP session store and its regression test.

## User Impact

ACP run/session lookup no longer returns a session for a stale run id after a session starts a newer active run.

## Evidence

- `node scripts/run-vitest.mjs run packages/acp-core/src/session.test.ts` - 1 file, 10 tests passed.
- `.\node_modules\.bin\oxfmt.cmd --check --threads=1 packages/acp-core/src/session.ts packages/acp-core/src/session.test.ts` - passed.
- `node scripts/run-oxlint.mjs packages/acp-core/src/session.ts packages/acp-core/src/session.test.ts` - passed.
- `pnpm tsgo:core:test` - passed.
- `pnpm tsgo:core` - passed.
- `pnpm tsgo:test` - passed.
- `git diff --check origin/main...HEAD` - passed.

Live ACP session-store behavior proof from this branch:

```text
$ node --import tsx --input-type=module --eval "import { createInMemorySessionStore } from './packages/acp-core/src/session.ts'; const store = createInMemorySessionStore({ now: () => 1700000000000 }); const session = store.createSession({ sessionKey: 'demo-key', cwd: '/tmp/openclaw-acp-proof', sessionId: 'session-proof' }); store.setActiveRun(session.sessionId, 'run-old', new AbortController()); const beforeRebindOld = store.getSessionByRunId('run-old')?.sessionId ?? null; store.setActiveRun(session.sessionId, 'run-new', new AbortController()); const afterRebindOld = store.getSessionByRunId('run-old')?.sessionId ?? null; const afterRebindNew = store.getSessionByRunId('run-new')?.sessionId ?? null; console.log(JSON.stringify({ source: 'packages/acp-core/src/session.ts#createInMemorySessionStore', sessionId: session.sessionId, beforeRebindOld, afterRebindOld, afterRebindNew, activeRunId: store.getSession(session.sessionId)?.activeRunId ?? null }, null, 2));"
{
  "source": "packages/acp-core/src/session.ts#createInMemorySessionStore",
  "sessionId": "session-proof",
  "beforeRebindOld": "session-proof",
  "afterRebindOld": null,
  "afterRebindNew": "session-proof",
  "activeRunId": "run-new"
}
```

This exercises the real ACP in-memory session store implementation. It shows the old run id resolves before rebinding, stops resolving after rebinding, and the new active run id resolves to the same session.

AI-assisted: OpenAI Codex helped inspect the ACP session store invariant and add the focused regression test.