### PR TITLE
fix(acp-core): keep fallback error redaction

### DIFF
--- a/packages/acp-core/src/error-format.test.ts
+++ b/packages/acp-core/src/error-format.test.ts
@@ -1,6 +1,10 @@
 // Error-format helper tests cover the non-Error cause stringifier contract.
 import { describe, expect, it } from "vitest";
-import { stringifyNonErrorCause } from "./error-format.js";
+import {
+  configureAcpErrorRedactor,
+  redactSensitiveText,
+  stringifyNonErrorCause,
+} from "./error-format.js";
 
 describe("stringifyNonErrorCause", () => {
   it("returns a string for values JSON.stringify serializes to undefined", () => {
@@ -15,5 +19,18 @@ describe("stringifyNonErrorCause", () => {
     expect(stringifyNonErrorCause("hi")).toBe("hi");
     expect(stringifyNonErrorCause(42)).toBe("42");
     expect(stringifyNonErrorCause(null)).toBe("null");
+  });
+});
+
+describe("redactSensitiveText", () => {
+  it("applies fallback secret redaction after a configured redactor", () => {
+    configureAcpErrorRedactor((value) => value.replace("prefix", "host-redacted"));
+    try {
+      expect(redactSensitiveText("prefix ghp_123456789012345678901234")).toBe(
+        "host-redacted [REDACTED]",
+      );
+    } finally {
+      configureAcpErrorRedactor(undefined);
+    }
   });
 });

--- a/packages/acp-core/src/error-format.ts
+++ b/packages/acp-core/src/error-format.ts
@@ -42,10 +42,7 @@ export function configureAcpErrorRedactor(redactor: ((value: string) => string) 
 
 /** Redacts common provider, GitHub, HTTP, payment, bot, and private-key secrets from error text. */
 export function redactSensitiveText(value: string): string {
-  if (configuredRedactor) {
-    return configuredRedactor(value);
-  }
-  let redacted = value;
+  let redacted = configuredRedactor ? configuredRedactor(value) : value;
   for (const pattern of SECRET_PATTERNS) {
     redacted = redacted.replace(pattern, (match, ...args: string[]) => {
       if (match.includes("PRIVATE KEY-----")) {


### PR DESCRIPTION
## What Problem This Solves

`configureAcpErrorRedactor` is documented as installing a host redactor used before ACP's fallback secret-pattern redaction. The implementation returned the host-redacted string immediately, so any secret the host redactor missed skipped the built-in fallback patterns entirely.

That could leak provider tokens, GitHub tokens, HTTP auth values, or other built-in secret patterns in ACP error text when a host redactor was configured but incomplete.

## Why This Change Was Made

Host redaction should be additive, not a replacement for ACP's built-in safety net. This patch applies the configured redactor first and then continues through the existing fallback `SECRET_PATTERNS` loop.

## User Impact

ACP error text keeps host-specific redaction behavior while still redacting built-in token patterns the host redactor does not cover.

## Evidence

Live behavior proof from this branch:

```text
host-redacted [REDACTED]
```

That output comes from a configured redactor that only replaces `prefix`, followed by ACP fallback redaction of `ghp_123456789012345678901234`.

Focused validation:

```text
RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw

Test Files  1 passed (1)
     Tests  3 passed (3)
  Start at  20:50:39
  Duration  1.04s (transform 718ms, setup 547ms, import 13ms, tests 153ms, environment 1ms)
```

```text
Checking formatting...

All matched files use the correct format.
Finished in 1226ms on 2 files using 32 threads.
```

`git diff --check` produced no output.

AI-assisted: OpenAI Codex helped inspect the ACP error redaction contract and add focused regression coverage.