### PR TITLE
fix(media-generation): preserve trimmed default model flag

### DIFF
--- a/packages/media-generation-core/src/catalog.test.ts
+++ b/packages/media-generation-core/src/catalog.test.ts
@@ -55,4 +55,27 @@ describe("media-generation catalog", () => {
       }),
     ).toEqual(["video-default", "video-pro"]);
   });
+
+  it("marks a trimmed default model as the catalog default", () => {
+    expect(
+      synthesizeMediaGenerationCatalogEntries({
+        kind: "video_generation",
+        provider: {
+          id: "example",
+          defaultModel: " video-default ",
+          models: ["video-default"],
+          capabilities: {},
+        },
+      }),
+    ).toEqual([
+      {
+        kind: "video_generation",
+        provider: "example",
+        model: "video-default",
+        source: "static",
+        default: true,
+        capabilities: {},
+      },
+    ]);
+  });
 });

--- a/packages/media-generation-core/src/catalog.ts
+++ b/packages/media-generation-core/src/catalog.ts
@@ -51,6 +51,7 @@ export function synthesizeMediaGenerationCatalogEntries<TCapabilities>(params: {
   provider: MediaGenerationCatalogProvider<TCapabilities>;
   modes?: readonly string[];
 }): Array<MediaGenerationCatalogEntry<TCapabilities>> {
+  const defaultModel = uniqueTrimmedStrings([params.provider.defaultModel])[0];
   return uniqueModels(params.provider).map((model) => {
     const entry: MediaGenerationCatalogEntry<TCapabilities> = {
       kind: params.kind,
@@ -62,7 +63,7 @@ export function synthesizeMediaGenerationCatalogEntries<TCapabilities>(params: {
     if (params.provider.label) {
       entry.label = params.provider.label;
     }
-    if (model === params.provider.defaultModel) {
+    if (model === defaultModel) {
       entry.default = true;
     }
     if (params.modes) {


### PR DESCRIPTION
## What Problem This Solves

Static media-generation catalog synthesis trims and de-duplicates provider model ids before emitting rows. However, the `default` flag compared each trimmed row against the raw `provider.defaultModel` string.

If provider metadata supplied a default model with harmless surrounding whitespace, the synthesized row used the trimmed model id but lost `default: true`.

## Why This Change Was Made

The default comparison should use the same normalized model value as the generated rows. This patch normalizes `defaultModel` through the same unique/trim helper before marking catalog entries.

## User Impact

Media generation provider catalogs keep the intended default model marker even when provider metadata includes surrounding whitespace on `defaultModel`.

## Evidence

Live behavior proof from this branch:

```text
{"kind":"video_generation","provider":"example","model":"video-default","source":"static","capabilities":{},"default":true}
```

Focused validation:

```text
RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw

Test Files  1 passed (1)
     Tests  3 passed (3)
  Start at  20:53:45
  Duration  940ms (transform 647ms, setup 499ms, import 14ms, tests 130ms, environment 0ms)
```

```text
Checking formatting...

All matched files use the correct format.
Finished in 1367ms on 2 files using 32 threads.
```

`git diff --check` produced no output.

AI-assisted: OpenAI Codex helped inspect media-generation catalog normalization and add focused regression coverage.