### PR TITLE
fix(agent-tools): resolve workspace tool fs root lazily (#96429)

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -1002,6 +1002,14 @@ async function statHostFile(absolutePath: string) {
   }
 }
 
+// Defers and memoizes the fs-safe workspace root so it resolves on first use
+// rather than at tool construction. An eager resolve floats an unhandled
+// FsSafeError when the workspace dir is missing and no operation is ever run.
+function createLazyWorkspaceRoot(root: string): () => ReturnType<typeof fsRoot> {
+  let rootPromise: ReturnType<typeof fsRoot> | undefined;
+  return () => (rootPromise ??= fsRoot(root));
+}
+
 async function writeWorkspaceFile(
   root: string,
   rootPromise: ReturnType<typeof fsRoot>,
@@ -1030,8 +1038,10 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
     } as const;
   }
 
-  // When workspaceOnly is true, enforce workspace boundary
-  const rootPromise = fsRoot(root);
+  // Resolve the workspace root lazily: constructing the tool (e.g. for doctor
+  // schema inspection) must not float an FsSafeError when the workspace dir is
+  // missing. The root is only needed once an fs operation actually runs.
+  const resolveRoot = createLazyWorkspaceRoot(root);
   return {
     mkdir: async (dir: string) => {
       const relative = toRelativeWorkspacePath(root, dir, { allowRoot: true });
@@ -1040,10 +1050,10 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
       await fs.mkdir(resolved, { recursive: true });
     },
     writeFile: (absolutePath: string, content: string) =>
-      writeWorkspaceFile(root, rootPromise, absolutePath, content),
+      writeWorkspaceFile(root, resolveRoot(), absolutePath, content),
     readFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
-      return (await (await rootPromise).read(relative)).buffer;
+      return (await (await resolveRoot()).read(relative)).buffer;
     },
     statFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
@@ -1068,16 +1078,18 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
     } as const;
   }
 
-  // When workspaceOnly is true, enforce workspace boundary
-  const rootPromise = fsRoot(root);
+  // Resolve the workspace root lazily: constructing the tool (e.g. for doctor
+  // schema inspection) must not float an FsSafeError when the workspace dir is
+  // missing. The root is only needed once an fs operation actually runs.
+  const resolveRoot = createLazyWorkspaceRoot(root);
   return {
     readFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
-      const safeRead = await (await rootPromise).read(relative);
+      const safeRead = await (await resolveRoot()).read(relative);
       return safeRead.buffer;
     },
     writeFile: (absolutePath: string, content: string) =>
-      writeWorkspaceFile(root, rootPromise, absolutePath, content),
+      writeWorkspaceFile(root, resolveRoot(), absolutePath, content),
     access: async (absolutePath: string) => {
       let relative: string;
       try {
@@ -1091,7 +1103,7 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
         return;
       }
       try {
-        const opened = await (await rootPromise).open(relative);
+        const opened = await (await resolveRoot()).open(relative);
         await opened.handle.close().catch(() => {});
       } catch (error) {
         if (error instanceof FsSafeError && error.code === "not-found") {

--- a/src/agents/agent-tools.read.workspace-root-lazy.test.ts
+++ b/src/agents/agent-tools.read.workspace-root-lazy.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression for #96429: building workspace-only file tools must not eagerly
+ * resolve the fs-safe workspace root. An eager resolve floated an unhandled
+ * `FsSafeError: root dir not found` (crashing `openclaw doctor --lint` /
+ * `--non-interactive`) when the workspace dir was missing and doctor only
+ * inspected the tool schema without ever invoking an fs operation.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createHostWorkspaceEditTool, createHostWorkspaceWriteTool } from "./agent-tools.read.js";
+
+describe("workspace-only tools resolve their root lazily", () => {
+  const rejections: unknown[] = [];
+  const onRejection = (reason: unknown) => {
+    rejections.push(reason);
+  };
+
+  beforeEach(() => {
+    rejections.length = 0;
+    process.on("unhandledRejection", onRejection);
+  });
+
+  afterEach(() => {
+    process.off("unhandledRejection", onRejection);
+  });
+
+  function missingWorkspaceDir(): string {
+    return path.join(os.tmpdir(), `oc-missing-workspace-${process.pid}-${Math.random()}`);
+  }
+
+  it("does not float an unhandled rejection when the workspace dir is missing", async () => {
+    const root = missingWorkspaceDir();
+
+    // Mirror doctor schema inspection: construct the tools but never run an
+    // operation. With eager resolution this floated FsSafeErrors per tool.
+    createHostWorkspaceWriteTool(root, { workspaceOnly: true });
+    createHostWorkspaceEditTool(root, { workspaceOnly: true });
+
+    // Give any floated promise a chance to reject before asserting.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(rejections).toEqual([]);
+  });
+
+  it("resolves the root on first use so writes still create the workspace", async () => {
+    const root = missingWorkspaceDir();
+    const writeTool = createHostWorkspaceWriteTool(root, { workspaceOnly: true });
+
+    try {
+      await writeTool.execute("tc-write", { path: "notes.txt", content: "hello" });
+
+      const written = await fs.readFile(path.join(root, "notes.txt"), "utf-8");
+      expect(written).toBe("hello");
+      expect(rejections).toEqual([]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --lint` and `openclaw doctor --non-interactive` crash with:

```
[openclaw] Unhandled promise rejection: FsSafeError: root dir not found
    at resolveRootContext (.../dist/secure-temp-dir-*.js)
    at async root (.../dist/secure-temp-dir-*.js)
```

`doctor --post-upgrade` and other commands are unaffected. Reported in #96429.

Root cause: the doctor `runtime-tool-schemas` check builds the agent coding tools (`createOpenClawCodingTools`) purely to inspect their input schemas. For the workspace-scoped write/edit tools, `createHostWriteOperations` / `createHostEditOperations` eagerly called `fsRoot(workspaceDir)` at tool-construction time:

```ts
const rootPromise = fsRoot(root); // rejects immediately if root is missing
```

When the agent workspace dir does not exist on disk and no filesystem operation is ever invoked (schema inspection only reads `tool.parameters`), that rejected promise is never awaited, so it surfaces as a global unhandled rejection and exits the process. The surrounding `try/catch` only catches synchronous throws, so the async rejection escapes it.

## Why This Change Was Made

The workspace root only needs to be resolved when an fs operation actually runs, not when the tool is constructed. Resolving it lazily removes the floating rejection and is also strictly more correct: the write tool runs `mkdir` before `writeFile`, so a lazy root lets a first write create a not-yet-existing workspace (the eager version rejected before `mkdir` could run).

## User Impact

- `openclaw doctor --lint` and `openclaw doctor --non-interactive` run to completion again instead of crashing when the agent workspace dir is absent.
- No behavior change for existing workspaces; path-boundary enforcement, `mkdir`, and `stat` paths are untouched.

## What Changed

- Added `createLazyWorkspaceRoot(root)`: a memoized resolver that calls `fsRoot(root)` on first use and caches the promise.
- `createHostWriteOperations` and `createHostEditOperations` (workspace-only branches) now resolve the root via this lazy resolver instead of eagerly at construction.
- Added a regression test covering both the no-floated-rejection guarantee and correct resolution on first operation use.

## Evidence

Reproduced the exact failure with a throwaway test before the fix — constructing the two workspace tools against a missing dir (no operation invoked) floated two `FsSafeError: root dir not found` unhandled rejections:

```
+ [
+   FsSafeError { "message": "root dir not found", "code": "not-found", ... },
+   FsSafeError { "message": "root dir not found", "code": "not-found", ... },
+ ]
```

After the fix, the new regression test passes (no floated rejection; first write still creates the workspace and succeeds):

```
$ node scripts/run-vitest.mjs src/agents/agent-tools.read.workspace-root-lazy.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Existing related suites stay green:

```
$ node scripts/run-vitest.mjs \
    src/agents/agent-tools.read.host-edit-access.test.ts \
    src/agents/agent-tools.read.workspace-root-guard.test.ts \
    src/agents/agent-tools.workspace-only-false.test.ts \
    src/agents/agent-tools.read.host-tilde-expansion.test.ts
 Test Files  4 passed (4)
      Tests  38 passed (38)
```

AI-assisted.
