### PR TITLE
fix(terminal-core): tighten docs link URL detection

### DIFF
--- a/packages/terminal-core/src/links.test.ts
+++ b/packages/terminal-core/src/links.test.ts
@@ -13,6 +13,16 @@ describe("formatDocsLink", () => {
     expect(out).toBe("https://example.com/page");
   });
 
+  it("preserves uppercase absolute HTTPS urls", () => {
+    const out = formatDocsLink("HTTPS://example.com/page", "page");
+    expect(out).toBe("HTTPS://example.com/page");
+  });
+
+  it("does not treat http-prefixed relative paths as absolute urls", () => {
+    const out = formatDocsLink("http-status", "HTTP status");
+    expect(out).toBe("https://docs.openclaw.ai/http-status");
+  });
+
   it("treats whitespace-only path like an empty path and falls back to docs root", () => {
     const out = formatDocsLink("   ", "root");
     expect(out).toBe("https://docs.openclaw.ai");

--- a/packages/terminal-core/src/links.ts
+++ b/packages/terminal-core/src/links.ts
@@ -5,6 +5,8 @@ function resolveDocsRoot(): string {
   return "https://docs.openclaw.ai";
 }
 
+const ABSOLUTE_HTTP_URL_RE = /^https?:\/\//i;
+
 export function formatDocsLink(
   path: string | undefined | null,
   label?: string,
@@ -17,7 +19,7 @@ export function formatDocsLink(
   // here unguarded. The typed contract says docsPath is required, but a
   // handful of channel plugins and catalog rows leave it unset at runtime.
   const url = trimmed
-    ? trimmed.startsWith("http")
+    ? ABSOLUTE_HTTP_URL_RE.test(trimmed)
       ? trimmed
       : `${docsRoot}${trimmed.startsWith("/") ? trimmed : `/${trimmed}`}`
     : docsRoot;


### PR DESCRIPTION
## What Problem This Solves

`formatDocsLink()` used `trimmed.startsWith("http")` to decide whether a docs path was already an absolute URL. That creates two bad edge cases:

- relative docs paths such as `http-status` are treated as complete URLs and are not rooted at `https://docs.openclaw.ai`
- uppercase absolute URLs such as `HTTPS://example.com/page` are treated as relative docs paths

## Why This Change Was Made

The helper now uses a case-insensitive `https?://` check. That keeps actual HTTP(S) URLs untouched while routing merely http-prefixed relative docs paths through the docs root.

The regression tests cover both affected directions.

## User Impact

Terminal docs links generated from relative paths that start with `http` point to the OpenClaw docs site correctly, and already-absolute HTTP(S) URLs remain stable regardless of scheme casing.

## Evidence

Direct behavior probe:

```text
$ node --import tsx -e "import('./packages/terminal-core/src/links.ts').then(({ formatDocsLink }) => console.log(JSON.stringify(['http-status', 'HTTPS://example.com/page', 'https://example.com/page'].map((path) => ({ path, out: formatDocsLink(path, 'label') })))))"
[{"path":"http-status","out":"https://docs.openclaw.ai/http-status"},{"path":"HTTPS://example.com/page","out":"HTTPS://example.com/page"},{"path":"https://example.com/page","out":"https://example.com/page"}]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run packages/terminal-core/src/links.test.ts

 RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  21:18:52
   Duration  316ms (transform 32ms, setup 0ms, import 52ms, tests 4ms, environment 0ms)

[test] starting test/vitest/vitest.unit-fast.config.ts
[test] passed 1 Vitest shard in 6.88s
```

Formatting:

```text
$ node_modules\.bin\oxfmt.cmd --check packages/terminal-core/src/links.ts packages/terminal-core/src/links.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 1342ms on 2 files using 32 threads.
```

Whitespace:

```text
$ git diff --check
```

## AI-assisted

Prepared with Codex. I reviewed the change, understand the touched code path, and kept the PR focused on the bug described above.
