### PR TITLE
fix(terminal-core): strip controls from terminal links

### DIFF
--- a/packages/terminal-core/src/links.test.ts
+++ b/packages/terminal-core/src/links.test.ts
@@ -27,4 +27,12 @@ describe("formatDocsLink", () => {
     const out = formatDocsLink(null as unknown as string);
     expect(out).toBe("https://docs.openclaw.ai");
   });
+
+  it("strips terminal controls from non-OSC docs fallback text", () => {
+    const out = formatDocsLink("https://example.com/a\u0007b", "docs\u001b[31m", {
+      force: false,
+    });
+
+    expect(out).toBe("https://example.com/ab");
+  });
 });

--- a/packages/terminal-core/src/terminal-link.test.ts
+++ b/packages/terminal-core/src/terminal-link.test.ts
@@ -1,0 +1,23 @@
+// Terminal Core tests cover terminal hyperlink formatting behavior.
+import { describe, expect, it } from "vitest";
+import { formatTerminalLink } from "./terminal-link.js";
+
+describe("formatTerminalLink", () => {
+  it("strips terminal control characters from OSC labels and urls", () => {
+    const out = formatTerminalLink(
+      "safe\u0007la\u001bbel",
+      "https://example.test/a\u0007oops\u001b[31m",
+      { force: true },
+    );
+
+    expect(out).toBe("\u001b]8;;https://example.test/aoops[31m\u0007safelabel\u001b]8;;\u0007");
+  });
+
+  it("strips terminal control characters from plain fallback text", () => {
+    const out = formatTerminalLink("safe\u0007label", "https://example.test/a\u001b[31m", {
+      force: false,
+    });
+
+    expect(out).toBe("safelabel (https://example.test/a[31m)");
+  });
+});

--- a/packages/terminal-core/src/terminal-link.test.ts
+++ b/packages/terminal-core/src/terminal-link.test.ts
@@ -29,4 +29,13 @@ describe("formatTerminalLink", () => {
 
     expect(out).toBe("fallbacktext[31m");
   });
+
+  it("preserves explicit empty fallback text", () => {
+    const out = formatTerminalLink("label", "https://example.test", {
+      fallback: "",
+      force: false,
+    });
+
+    expect(out).toBe("");
+  });
 });

--- a/packages/terminal-core/src/terminal-link.test.ts
+++ b/packages/terminal-core/src/terminal-link.test.ts
@@ -20,4 +20,13 @@ describe("formatTerminalLink", () => {
 
     expect(out).toBe("safelabel (https://example.test/a[31m)");
   });
+
+  it("strips terminal control characters from explicit fallback text", () => {
+    const out = formatTerminalLink("label", "https://example.test", {
+      fallback: "fallback\u0007text\u001b[31m",
+      force: false,
+    });
+
+    expect(out).toBe("fallbacktext[31m");
+  });
 });

--- a/packages/terminal-core/src/terminal-link.ts
+++ b/packages/terminal-core/src/terminal-link.ts
@@ -22,7 +22,7 @@ export function formatTerminalLink(
   const safeUrl = stripTerminalLinkControls(url);
   const allow = opts?.force === true ? true : opts?.force === false ? false : process.stdout.isTTY;
   if (!allow) {
-    return opts?.fallback ?? `${safeLabel} (${safeUrl})`;
+    return opts?.fallback ? stripTerminalLinkControls(opts.fallback) : `${safeLabel} (${safeUrl})`;
   }
   return `\u001b]8;;${safeUrl}\u0007${safeLabel}\u001b]8;;\u0007`;
 }

--- a/packages/terminal-core/src/terminal-link.ts
+++ b/packages/terminal-core/src/terminal-link.ts
@@ -22,7 +22,9 @@ export function formatTerminalLink(
   const safeUrl = stripTerminalLinkControls(url);
   const allow = opts?.force === true ? true : opts?.force === false ? false : process.stdout.isTTY;
   if (!allow) {
-    return opts?.fallback ? stripTerminalLinkControls(opts.fallback) : `${safeLabel} (${safeUrl})`;
+    return opts?.fallback === undefined
+      ? `${safeLabel} (${safeUrl})`
+      : stripTerminalLinkControls(opts.fallback);
   }
   return `\u001b]8;;${safeUrl}\u0007${safeLabel}\u001b]8;;\u0007`;
 }

--- a/packages/terminal-core/src/terminal-link.ts
+++ b/packages/terminal-core/src/terminal-link.ts
@@ -1,14 +1,25 @@
 // OSC 8 terminal hyperlink formatting with plain-text fallback.
 
+function stripTerminalLinkControls(value: string): string {
+  let out = "";
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    const isControl = (code >= 0x00 && code <= 0x1f) || (code >= 0x7f && code <= 0x9f);
+    if (!isControl) {
+      out += char;
+    }
+  }
+  return out;
+}
+
 /** Format a clickable terminal link when supported, otherwise return a readable fallback. */
 export function formatTerminalLink(
   label: string,
   url: string,
   opts?: { fallback?: string; force?: boolean },
 ): string {
-  const esc = "\u001b";
-  const safeLabel = label.replaceAll(esc, "");
-  const safeUrl = url.replaceAll(esc, "");
+  const safeLabel = stripTerminalLinkControls(label);
+  const safeUrl = stripTerminalLinkControls(url);
   const allow = opts?.force === true ? true : opts?.force === false ? false : process.stdout.isTTY;
   if (!allow) {
     return opts?.fallback ?? `${safeLabel} (${safeUrl})`;


### PR DESCRIPTION
## What Problem This Solves

`formatTerminalLink()` only removed ESC from OSC-8 labels and URLs. Other terminal control characters, especially BEL (`\u0007`), could still be embedded in the user-provided URL or label. In forced OSC output, BEL terminates the OSC sequence, so an input URL could prematurely end the hyperlink URL segment and leak the remaining text into the terminal output structure.

## Why This Change Was Made

The formatter now strips C0/C1 terminal control characters from both label and URL before building either OSC-8 output or plain fallback output. This preserves the existing behavior of dropping ESC while covering the delimiter used by the generated OSC sequence.

A focused test covers both forced OSC output and fallback output.

## User Impact

Terminal links remain readable, but untrusted label/URL text can no longer inject control characters into the OSC-8 hyperlink structure.

## Evidence

Direct behavior probe:

```text
$ node --import tsx -e "import('./packages/terminal-core/src/terminal-link.ts').then(({ formatTerminalLink }) => { const out = formatTerminalLink('safe\u0007label', 'https://example.test/a\u0007oops', { force: true }); console.log(JSON.stringify({ out, containsInjectedDelimiter: out.includes('\u0007oops') })); })"
{"out":"\u001b]8;;https://example.test/aoops\u0007safelabel\u001b]8;;\u0007","containsInjectedDelimiter":false}
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run packages/terminal-core/src/terminal-link.test.ts

 RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  21:20:48
   Duration  324ms (transform 25ms, setup 0ms, import 48ms, tests 4ms, environment 0ms)

[test] starting test/vitest/vitest.unit-fast.config.ts
[test] passed 1 Vitest shard in 6.48s
```

Formatting:

```text
$ node_modules\.bin\oxfmt.cmd --check packages/terminal-core/src/terminal-link.ts packages/terminal-core/src/terminal-link.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 1219ms on 2 files using 32 threads.
```

Whitespace:

```text
$ git diff --check
```

## AI-assisted

Prepared with Codex. I reviewed the change, understand the touched code path, and kept the PR focused on the bug described above.
