### PR TITLE
fix(context): count fullwidth chars in token estimates

### DIFF
--- a/src/utils/cjk-chars.test.ts
+++ b/src/utils/cjk-chars.test.ts
@@ -46,6 +46,13 @@ describe("estimateStringChars", () => {
     expect(estimateStringChars("안녕하세요")).toBe(20);
   });
 
+  it("handles East Asian fullwidth letters, numbers, and punctuation", () => {
+    expect(estimateStringChars("ＡＢＣ１２３")).toBe(6 * CHARS_PER_TOKEN_ESTIMATE);
+    expect(estimateStringChars("hello，world")).toBe(
+      "helloworld".length + CHARS_PER_TOKEN_ESTIMATE,
+    );
+  });
+
   it("handles CJK punctuation and symbols in the extended range", () => {
     // "⺀" (U+2E80) is in CJK Radicals Supplement range
     expect(estimateStringChars("⺀")).toBe(CHARS_PER_TOKEN_ESTIMATE);

--- a/src/utils/cjk-chars.ts
+++ b/src/utils/cjk-chars.ts
@@ -20,9 +20,10 @@ export const CHARS_PER_TOKEN_ESTIMATE = 4;
 /**
  * Matches CJK Unified Ideographs, CJK Extension A/B, CJK Compatibility
  * Ideographs, Hangul Syllables, Hiragana, Katakana, and other non-Latin
- * scripts that typically use ~1 token per character.
+ * scripts and East Asian fullwidth forms that typically use ~1 token per character.
  */
-const NON_LATIN_RE = /[\u2E80-\u9FFF\uA000-\uA4FF\uAC00-\uD7AF\uF900-\uFAFF\u{20000}-\u{2FA1F}]/gu;
+const NON_LATIN_RE =
+  /[\u2E80-\u9FFF\uA000-\uA4FF\uAC00-\uD7AF\uF900-\uFAFF\uFF01-\uFF60\uFFE0-\uFFE6\u{20000}-\u{2FA1F}]/gu;
 
 /**
  * Return an adjusted character length that accounts for non-Latin (CJK, etc.)


### PR DESCRIPTION
## What Problem This Solves

`estimateStringChars()` inflates CJK/Hangul/Japanese text before downstream token estimates divide by `CHARS_PER_TOKEN_ESTIMATE`, but it did not include East Asian fullwidth forms. Fullwidth text such as `ABC123` was counted like ordinary ASCII, so budget and pruning estimates undercounted that content.

## Why This Change Was Made

The estimator now includes the Unicode fullwidth ranges `U+FF01-U+FF60` and `U+FFE0-U+FFE6` in the same weighted path used for other East Asian scripts. Ordinary ASCII remains unchanged.

Focused tests cover fullwidth letters, numbers, and punctuation.

## User Impact

Context budgeting and token estimate surfaces are less likely to undercount fullwidth CJK-style text, reducing the chance of overlarge prompts slipping past preflight estimates.

## Evidence

Direct behavior probe:

```text
$ node --import tsx -e "import('./src/utils/cjk-chars.ts').then(({ estimateStringChars }) => console.log(JSON.stringify(['ABC123', 'ABC123', 'hello,world'].map((text) => ({ text, chars: text.length, estimated: estimateStringChars(text) })))))"
[{"text":"ABC123","chars":6,"estimated":6},{"text":"ABC123","chars":6,"estimated":24},{"text":"hello,world","chars":11,"estimated":14}]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/utils/cjk-chars.test.ts

 RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw


 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  21:24:39
   Duration  274ms (transform 32ms, setup 0ms, import 54ms, tests 16ms, environment 0ms)

[test] starting test/vitest/vitest.unit-fast.config.ts
[test] passed 1 Vitest shard in 6.14s
```

Formatting:

```text
$ node_modules\.bin\oxfmt.cmd --check src/utils/cjk-chars.ts src/utils/cjk-chars.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 1188ms on 2 files using 32 threads.
```

Whitespace:

```text
$ git diff --check
```

## AI-assisted

Prepared with Codex. I reviewed the change, understand the touched code path, and kept the PR focused on the bug described above.
