### PR TITLE
fix(secrets): strip control characters from secret input

### DIFF
--- a/packages/web-content-core/src/provider-runtime-shared.test.ts
+++ b/packages/web-content-core/src/provider-runtime-shared.test.ts
@@ -30,6 +30,15 @@ describe("readWebProviderEnvValue", () => {
   it("normalizes env credentials before returning them", () => {
     expect(readWebProviderEnvValue(["API_KEY"], { API_KEY: " key\r\nvalue🙂 " })).toBe("keyvalue");
   });
+
+  it("strips embedded controls from env credentials while preserving ordinary spaces", () => {
+    expect(readWebProviderEnvValue(["API_KEY"], { API_KEY: " sk-\u0000ab\tc\u007f\u0085 " })).toBe(
+      "sk-abc",
+    );
+    expect(readWebProviderEnvValue(["API_KEY"], { API_KEY: " Bearer token value " })).toBe(
+      "Bearer token value",
+    );
+  });
 });
 
 describe("hasWebProviderEntryCredential", () => {

--- a/packages/web-content-core/src/provider-runtime-shared.ts
+++ b/packages/web-content-core/src/provider-runtime-shared.ts
@@ -56,7 +56,12 @@ function normalizeSecretInput(value: unknown): string {
   let latin1Only = "";
   for (const char of collapsed) {
     const codePoint = char.codePointAt(0);
-    if (typeof codePoint === "number" && codePoint <= 0xff) {
+    const isControl =
+      typeof codePoint === "number" &&
+      ((codePoint >= 0x00 && codePoint <= 0x1f) ||
+        codePoint === 0x7f ||
+        (codePoint >= 0x80 && codePoint <= 0x9f));
+    if (typeof codePoint === "number" && codePoint <= 0xff && !isControl) {
       latin1Only += char;
     }
   }

--- a/src/utils/normalize-secret-input.test.ts
+++ b/src/utils/normalize-secret-input.test.ts
@@ -14,6 +14,11 @@ describe("normalizeSecretInput", () => {
     expect(normalizeSecretInput("  sk-\r\nabc\n123  ")).toBe("sk-abc123");
   });
 
+  it("strips embedded control characters while preserving ordinary spaces", () => {
+    expect(normalizeSecretInput("  sk-\u0000ab\tc\u007f\u0085  ")).toBe("sk-abc");
+    expect(normalizeSecretInput("  Bearer token value  ")).toBe("Bearer token value");
+  });
+
   it("drops non-Latin1 code points that can break HTTP ByteString headers", () => {
     // U+0417 (Cyrillic З) and U+2502 (box drawing │) are > 255.
     expect(normalizeSecretInput("key-\u0417\u2502-token")).toBe("key--token");

--- a/src/utils/normalize-secret-input.ts
+++ b/src/utils/normalize-secret-input.ts
@@ -25,7 +25,12 @@ export function normalizeSecretInput(value: unknown): string {
   const chars: string[] = [];
   for (const char of collapsed) {
     const codePoint = char.codePointAt(0);
-    if (typeof codePoint === "number" && codePoint <= 0xff) {
+    const isControl =
+      typeof codePoint === "number" &&
+      ((codePoint >= 0x00 && codePoint <= 0x1f) ||
+        codePoint === 0x7f ||
+        (codePoint >= 0x80 && codePoint <= 0x9f));
+    if (typeof codePoint === "number" && codePoint <= 0xff && !isControl) {
       chars.push(char);
     }
   }


### PR DESCRIPTION
## What Problem This Solves

`normalizeSecretInput()` strips line breaks and non-Latin1 characters from copied credentials, but it still preserved other embedded terminal/header control characters such as NUL, TAB, DEL, and C1 controls. Those characters can still make downstream header construction fail or carry invisible garbage in configured secrets.

## Why This Change Was Made

The existing character filter now also drops C0/C1/DEL control characters while continuing to preserve printable Latin-1 and ordinary internal spaces. This keeps the documented `Bearer <token>` style behavior intact.

A focused regression test covers embedded controls and verifies ordinary spaces are still preserved.

## User Impact

Copied API keys and tokens with hidden control characters normalize to usable values instead of failing later in provider request setup. Human-readable values with intentional spaces remain unchanged apart from edge trimming.

## Evidence

Direct behavior probe:

```text
$ node --import tsx -e "import('./src/utils/normalize-secret-input.ts').then(({ normalizeSecretInput }) => console.log(JSON.stringify({ controls: normalizeSecretInput(' sk-\u0000ab\tc\u007f\u0085 '), spaces: normalizeSecretInput(' Bearer token value ') })))"
{"controls":"sk-abc","spaces":"Bearer token value"}
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/utils/normalize-secret-input.test.ts

 RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  21:26:26
   Duration  270ms (transform 27ms, setup 0ms, import 42ms, tests 5ms, environment 0ms)

[test] starting test/vitest/vitest.unit-fast.config.ts
[test] passed 1 Vitest shard in 7.04s
```

Formatting:

```text
$ node_modules\.bin\oxfmt.cmd --check src/utils/normalize-secret-input.ts src/utils/normalize-secret-input.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 1335ms on 2 files using 32 threads.
```

Whitespace:

```text
$ git diff --check
```

## AI-assisted

Prepared with Codex. I reviewed the change, understand the touched code path, and kept the PR focused on the bug described above.
