### PR TITLE
fix(auth): strip controls from masked API keys

### DIFF
--- a/src/utils/mask-api-key.test.ts
+++ b/src/utils/mask-api-key.test.ts
@@ -18,4 +18,10 @@ describe("maskApiKey", () => {
   it("masks long values with first and last 8 chars", () => {
     expect(maskApiKey("1234567890abcdefghijklmnop")).toBe("12345678...ijklmnop"); // pragma: allowlist secret
   });
+
+  it("strips control characters before masking diagnostic output", () => {
+    expect(maskApiKey("abcd\nefghijklmnop")).toBe("ab...op");
+    expect(maskApiKey("abcd\u0000efghijklmnop")).toBe("ab...op");
+    expect(maskApiKey("\u0000\n")).toBe("missing");
+  });
 });

--- a/src/utils/mask-api-key.test.ts
+++ b/src/utils/mask-api-key.test.ts
@@ -22,6 +22,7 @@ describe("maskApiKey", () => {
   it("strips control characters before masking diagnostic output", () => {
     expect(maskApiKey("abcd\nefghijklmnop")).toBe("ab...op");
     expect(maskApiKey("abcd\u0000efghijklmnop")).toBe("ab...op");
+    expect(maskApiKey("abcd\u007f\u0085efghijklmnop")).toBe("ab...op");
     expect(maskApiKey("\u0000\n")).toBe("missing");
   });
 });

--- a/src/utils/mask-api-key.ts
+++ b/src/utils/mask-api-key.ts
@@ -1,6 +1,6 @@
 /** Masks credential-like values for diagnostics while preserving enough prefix/suffix to identify them. */
 export const maskApiKey = (value: string): string => {
-  const trimmed = value.trim();
+  const trimmed = stripControlCharacters(value).trim();
   if (!trimmed) {
     return "missing";
   }
@@ -12,3 +12,15 @@ export const maskApiKey = (value: string): string => {
   }
   return `${trimmed.slice(0, 8)}...${trimmed.slice(-8)}`;
 };
+
+function stripControlCharacters(value: string): string {
+  let out = "";
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    const isControl = (code >= 0x00 && code <= 0x1f) || (code >= 0x7f && code <= 0x9f);
+    if (!isControl) {
+      out += char;
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## What Problem This Solves

`maskApiKey()` trims credential-like values before redacting them, but embedded control characters were preserved in the masked diagnostic output. A copied value containing a newline or NUL could therefore make masked auth/setup text multiline or carry invisible control bytes even though the secret itself was redacted.

## Why This Change Was Made

The masker now strips C0/C1/DEL control characters before applying the existing length-based redaction rules. This keeps the same visible masking format for printable values while making diagnostic output single-line/control-free.

A focused regression test covers newline, NUL, and all-control input.

## User Impact

Onboarding, auth overview, and directive responses that display masked credentials no longer echo hidden control characters from malformed input.

## Evidence

Direct behavior probe:

```text
$ node --import tsx -e "import('./src/utils/mask-api-key.ts').then(({ maskApiKey }) => console.log(JSON.stringify({ newline: maskApiKey('abcd\nefghijklmnop'), nul: maskApiKey('abcd\u0000efghijklmnop'), delC1: maskApiKey('abcd\u007f\u0085efghijklmnop'), emptyControls: maskApiKey('\u0000\n\u0085') })))"
{"newline":"ab...op","nul":"ab...op","delC1":"ab...op","emptyControls":"missing"}
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/utils/mask-api-key.test.ts

 RUN  v4.1.8 C:/Users/lin20/Documents/New project 3/openclaw


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  21:29:22
   Duration  351ms (transform 30ms, setup 0ms, import 54ms, tests 5ms, environment 0ms)

[test] starting test/vitest/vitest.unit-fast.config.ts
[test] passed 1 Vitest shard in 7.09s
```

Formatting:

```text
$ node_modules\.bin\oxfmt.cmd --check src/utils/mask-api-key.ts src/utils/mask-api-key.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 1246ms on 2 files using 32 threads.
```

Whitespace:

```text
$ git diff --check
```

## AI-assisted

Prepared with Codex. I reviewed the change, understand the touched code path, and kept the PR focused on the bug described above.
