### PR TITLE
fix(reply): sanitize explicit reply directive ids

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, test } from "vitest";
 import {
   parseInlineDirectives,
+  sanitizeReplyDirectiveId,
   stripInlineDirectiveTagsForDelivery,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
@@ -54,6 +55,15 @@ describe("stripInlineDirectiveTagsForDelivery", () => {
 });
 
 describe("parseInlineDirectives", () => {
+  test("sanitizes explicit reply directive ids", () => {
+    const result = parseInlineDirectives("hello [[reply_to: abc\u0000\r\u0085def ]]");
+
+    expect(result.hasReplyTag).toBe(true);
+    expect(result.replyToExplicitId).toBe("abcdef");
+    expect(result.replyToId).toBe("abcdef");
+    expect(result.text).toBe("hello");
+  });
+
   test("preserves leading spaces after stripping a reply tag", () => {
     const input = "[[reply_to_current]]    keep this indent\n        and this one";
     const result = parseInlineDirectives(input);
@@ -207,6 +217,12 @@ describe("parseInlineDirectives", () => {
     expect(result.text).toBe(
       [`literal ${sentinelLikeText} text`, "```ts", "    const value = 1;", "```"].join("\n"),
     );
+  });
+});
+
+describe("sanitizeReplyDirectiveId", () => {
+  test("strips bracket and control characters from explicit reply ids", () => {
+    expect(sanitizeReplyDirectiveId(" [abc]\u0000\r\u0085def ")).toBe("abcdef");
   });
 });
 

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -98,7 +98,13 @@ function stripUnsafeReplyDirectiveChars(value: string): string {
   const chars: string[] = [];
   for (const ch of value) {
     const code = ch.charCodeAt(0);
-    if ((code >= 0 && code <= 31) || code === 127 || ch === "[" || ch === "]") {
+    if (
+      (code >= 0 && code <= 31) ||
+      code === 127 ||
+      (code >= 0x80 && code <= 0x9f) ||
+      ch === "[" ||
+      ch === "]"
+    ) {
       continue;
     }
     chars.push(ch);
@@ -221,7 +227,7 @@ export function parseInlineDirectives(
     if (idRaw === undefined) {
       sawCurrent = true;
     } else {
-      const id = idRaw.trim();
+      const id = sanitizeReplyDirectiveId(idRaw);
       if (id) {
         lastExplicitId = id;
       }


### PR DESCRIPTION
## What Problem This Solves

Explicit `[[reply_to:...]]` directives were parsed with a raw `trim()`, bypassing the existing reply directive sanitizer. A malformed inline directive could leave C0/C1 control characters in `replyToExplicitId` / `replyToId`, even though the public sanitizer already strips unsafe characters for reply IDs.

## Why This Change Was Made

`parseInlineDirectives()` should produce the same safe reply ID shape as `sanitizeReplyDirectiveId()`. This change routes explicit directive IDs through that sanitizer and extends unsafe-character stripping to C1 controls (`0x80`-`0x9f`) alongside the existing C0, DEL, and bracket filtering.

## User Impact

Reply directive parsing now produces stable, display-safe IDs when pasted/generated directive text contains hidden control characters. Valid IDs continue to work unchanged, while malformed IDs are normalized before they reach reply routing state.

## Evidence

Regression test:

```text
node scripts/run-vitest.mjs run src/utils/directive-tags.test.ts

Test Files  1 passed (1)
Tests  29 passed (29)
```

Formatting and whitespace checks:

```text
node_modules\.bin\oxfmt.cmd --check src/utils/directive-tags.ts src/utils/directive-tags.test.ts
All matched files use the correct format.

git diff --check
(no output)
```

Behavior probe after the fix:

```text
node --import tsx -e "import('./src/utils/directive-tags.ts').then(({ parseInlineDirectives, sanitizeReplyDirectiveId }) => { const result = parseInlineDirectives('hello [[reply_to: abc\u0000\r\u0085def ]]'); console.log(JSON.stringify({ replyToId: result.replyToId, replyToExplicitId: result.replyToExplicitId, sanitized: sanitizeReplyDirectiveId(' [abc]\u0000\r\u0085def '), text: result.text })); })"
{"replyToId":"abcdef","replyToExplicitId":"abcdef","sanitized":"abcdef","text":"hello"}
```

## AI-assisted

Prepared with Codex. I reviewed the change, understand the touched code path, and kept the PR focused on the bug described above.
