### PR TITLE
test(agents): add unit tests for exec output rendering helpers

### DIFF
--- a/src/agents/bash-tools.exec-output.test.ts
+++ b/src/agents/bash-tools.exec-output.test.ts
@@ -1,0 +1,59 @@
+// Tests for exec output rendering helpers.
+import { describe, expect, it } from "vitest";
+import { renderExecOutputText, renderExecUpdateText } from "./bash-tools.exec-output.js";
+
+describe("renderExecOutputText", () => {
+  it("returns placeholder for undefined input", () => {
+    expect(renderExecOutputText(undefined)).toBe("(no output)");
+  });
+
+  it("returns placeholder for empty string", () => {
+    expect(renderExecOutputText("")).toBe("(no output)");
+  });
+
+  it("returns value for non-empty string", () => {
+    expect(renderExecOutputText("hello")).toBe("hello");
+  });
+
+  it("returns value for whitespace-only string", () => {
+    expect(renderExecOutputText("  ")).toBe("  ");
+  });
+
+  it("preserves newlines in output", () => {
+    expect(renderExecOutputText("line1\nline2")).toBe("line1\nline2");
+  });
+});
+
+describe("renderExecUpdateText", () => {
+  it("returns placeholder when no tailText and no warnings", () => {
+    expect(renderExecUpdateText({ warnings: [] })).toBe("(no output)");
+  });
+
+  it("returns tailText when no warnings", () => {
+    expect(renderExecUpdateText({ tailText: "hello", warnings: [] })).toBe("hello");
+  });
+
+  it("returns warnings when no tailText", () => {
+    expect(renderExecUpdateText({ warnings: ["warning1"] })).toBe("warning1\n\n(no output)");
+  });
+
+  it("returns warnings followed by tailText", () => {
+    expect(renderExecUpdateText({ tailText: "hello", warnings: ["warning1"] })).toBe(
+      "warning1\n\nhello",
+    );
+  });
+
+  it("joins multiple warnings with newlines", () => {
+    expect(renderExecUpdateText({ tailText: "hello", warnings: ["warning1", "warning2"] })).toBe(
+      "warning1\nwarning2\n\nhello",
+    );
+  });
+
+  it("handles empty warnings array with tailText", () => {
+    expect(renderExecUpdateText({ tailText: "hello", warnings: [] })).toBe("hello");
+  });
+
+  it("handles undefined tailText with warnings", () => {
+    expect(renderExecUpdateText({ warnings: ["warning1"] })).toBe("warning1\n\n(no output)");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `bash-tools.exec-output.ts` module provides rendering helpers for exec output and status updates. However, this module lacked unit tests to verify the rendering logic, which could lead to regressions when the function is modified.

## Why This Change Was Made

Add unit tests for `renderExecOutputText` and `renderExecUpdateText` functions to verify output rendering behavior including placeholder handling and warning text placement. This improves test coverage and prevents regressions.

Focused tests cover placeholder for empty/undefined output, preserving newlines, warning text placement, multiple warnings handling, empty warnings array with tailText, and undefined tailText with warnings.

## User Impact

Exec output rendering now has comprehensive test coverage, reducing the risk of regressions when the function is modified.

## Evidence

Reproducibility: yes. Source inspection of current main shows the `bash-tools.exec-output.ts` module exists and provides rendering helpers for exec output, but lacks unit tests.

Direct behavior probe:

```text
$ node --import tsx -e "import('./src/agents/bash-tools.exec-output.js').then(({ renderExecOutputText, renderExecUpdateText }) => console.log(JSON.stringify([{ desc: 'Placeholder for undefined', input: undefined, result: renderExecOutputText(undefined) }, { desc: 'Placeholder for empty', input: '', result: renderExecOutputText('') }, { desc: 'Preserving newlines', input: 'line1\nline2', result: renderExecOutputText('line1\nline2') }, { desc: 'Warning text placement', params: { tailText: 'hello', warnings: ['warning1'] }, result: renderExecUpdateText({ tailText: 'hello', warnings: ['warning1'] }) }, { desc: 'Multiple warnings', params: { tailText: 'hello', warnings: ['warning1', 'warning2'] }, result: renderExecUpdateText({ tailText: 'hello', warnings: ['warning1', 'warning2'] }) }], null, 2)))"
[
  {
    "desc": "Placeholder for undefined",
    "result": "(no output)"
  },
  {
    "desc": "Placeholder for empty",
    "input": "",
    "result": "(no output)"
  },
  {
    "desc": "Preserving newlines",
    "input": "line1\nline2",
    "result": "line1\nline2"
  },
  {
    "desc": "Warning text placement",
    "params": {
      "tailText": "hello",
      "warnings": [
        "warning1"
      ]
    },
    "result": "warning1\n\nhello"
  },
  {
    "desc": "Multiple warnings",
    "params": {
      "tailText": "hello",
      "warnings": [
        "warning1",
        "warning2"
      ]
    },
    "result": "warning1\nwarning2\n\nhello"
  }
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/agents/bash-tools.exec-output.test.ts

 RUN  v4.1.8 /home/0668001110/ZTEProject/openclaw-worktrees/pr-94335

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  14:48:45
   Duration  304ms (transform 18ms, setup 0ms, import 39ms, tests 12ms)

[test] passed 1 Vitest shard in 10.51s
```

Formatting:

```text
$ npx oxfmt --check src/agents/bash-tools.exec-output.ts src/agents/bash-tools.exec-output.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 73ms on 2 files using 8 threads.
```

Whitespace:

```text
$ git diff --check
```

## AI-assisted

Prepared with Codex. I reviewed the change, understand the touched code path, and kept the PR focused on the bug described above.
