### PR TITLE
fix(ui): roll usage-metrics formatTokens over to "M" at the 999,950 boundary

### DIFF
--- a/ui/src/ui/views/usage-metrics.test.ts
+++ b/ui/src/ui/views/usage-metrics.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import {
   buildPeakErrorHours,
   buildUsageMosaicStats,
+  formatTokens,
   getHourAndWeekdayForUtcQuarterBucket,
   sessionTouchesSelectedHours,
 } from "./usage-metrics.ts";
@@ -409,5 +410,30 @@ describe("usage mosaic token buckets", () => {
     } as unknown as UsageSessionEntry;
 
     expect(sessionTouchesSelectedHours(session, [11], "utc")).toBe(true);
+  });
+});
+
+describe("formatTokens", () => {
+  it("formats values below 1,000 verbatim", () => {
+    expect(formatTokens(0)).toBe("0");
+    expect(formatTokens(999)).toBe("999");
+  });
+
+  it("formats thousands with one decimal and a K suffix", () => {
+    expect(formatTokens(1_000)).toBe("1.0K");
+    expect(formatTokens(12_500)).toBe("12.5K");
+    expect(formatTokens(999_949)).toBe("999.9K");
+  });
+
+  it("rolls 999,950-999,999 over to the M branch instead of '1000.0K'", () => {
+    // These values round up to "1000.0" at one-decimal thousands precision.
+    // Without the rollover guard they render the nonsensical "1000.0K".
+    expect(formatTokens(999_950)).toBe("1.0M");
+    expect(formatTokens(999_999)).toBe("1.0M");
+  });
+
+  it("formats millions with one decimal and an M suffix", () => {
+    expect(formatTokens(1_000_000)).toBe("1.0M");
+    expect(formatTokens(2_500_000)).toBe("2.5M");
   });
 });

--- a/ui/src/ui/views/usage-metrics.ts
+++ b/ui/src/ui/views/usage-metrics.ts
@@ -20,7 +20,16 @@ function formatTokens(n: number): string {
     return `${(n / 1_000_000).toFixed(1)}M`;
   }
   if (n >= 1_000) {
-    return `${(n / 1_000).toFixed(1)}K`;
+    // Values from 999,950-999,999 round to "1000.0" at one-decimal
+    // thousands precision, which would display the nonsensical "1000.0K"
+    // instead of rolling over to the M branch above. Re-check the
+    // rounded result before formatting. Mirrors the guard in
+    // formatCompactTokenCount (../chat/token-format.ts).
+    const thousands = (n / 1_000).toFixed(1);
+    if (Number(thousands) >= 1_000) {
+      return `${(n / 1_000_000).toFixed(1)}M`;
+    }
+    return `${thousands}K`;
   }
   return String(n);
 }


### PR DESCRIPTION
## What Problem This Solves

The module-local `formatTokens` helper in `ui/src/ui/views/usage-metrics.ts`
formats a token count into a compact label (`12.5K`, `2.5M`, ...). It picks a
branch by magnitude and then rounds with `toFixed(1)`:

```ts
if (n >= 1_000) {
  return `${(n / 1_000).toFixed(1)}K`;
}
```

For inputs in **999,950–999,999**, `(n / 1_000).toFixed(1)` rounds *up* to
`"1000.0"`, so the function emits the nonsensical label **`"1000.0K"`** instead
of rolling over to the millions branch.

**Before / after repro:**

| input | before (wrong) | after (fixed) |
|------:|:--------------:|:-------------:|
| `formatTokens(999_950)` | `"1000.0K"` | `"1.0M"` |
| `formatTokens(999_999)` | `"1000.0K"` | `"1.0M"` |
| `formatTokens(999_949)` | `"999.9K"`  | `"999.9K"` (unchanged) |
| `formatTokens(2_500_000)` | `"2.5M"`  | `"2.5M"` (unchanged) |

This is the same boundary bug the sibling helper `formatCompactTokenCount`
(`ui/src/ui/chat/token-format.ts`) already documents and guards against:

> Values from 999,950-999,999 round to "1000.0" at one-decimal thousands
> precision, which would display the nonsensical "1000k" instead of rolling
> over to the M branch above.

The fix mirrors that existing guard: after computing the rounded thousands
value, re-check it and fall through to the millions branch when it reaches
`1000`. The change is minimal and behavior-preserving for every other input.

## Evidence

A standalone Node script (no project deps) compares the original `origin/main`
logic against the patched logic. It proves the boundary is broken before the
fix (red) and correct after (green), and that all unaffected inputs are
byte-for-byte identical between old and new.

```
--- RED: confirm old logic is buggy on the boundary ---
PASS  OLD formatTokens(999950) is the buggy value: got "1000.0K", want "1000.0K"
PASS  OLD formatTokens(999999) is the buggy value: got "1000.0K", want "1000.0K"

--- GREEN: fixed logic rolls over to M ---
PASS  NEW formatTokens(999950): got "1.0M", want "1.0M"
PASS  NEW formatTokens(999999): got "1.0M", want "1.0M"

--- Unaffected inputs unchanged by the fix ---
PASS  NEW matches OLD for 0: got "0", want "0"
PASS  NEW matches OLD for 999: got "999", want "999"
PASS  NEW matches OLD for 1000: got "1.0K", want "1.0K"
PASS  NEW matches OLD for 12500: got "12.5K", want "12.5K"
PASS  NEW matches OLD for 999949: got "999.9K", want "999.9K"
PASS  NEW matches OLD for 1000000: got "1.0M", want "1.0M"
PASS  NEW matches OLD for 2500000: got "2.5M", want "2.5M"
PASS  NEW formatTokens(0): got "0", want "0"
PASS  NEW formatTokens(999): got "999", want "999"
PASS  NEW formatTokens(12500): got "12.5K", want "12.5K"
PASS  NEW formatTokens(999949): got "999.9K", want "999.9K"
PASS  NEW formatTokens(2500000): got "2.5M", want "2.5M"

ALL CHECKS PASSED
```

A matching unit test is added to `ui/src/ui/views/usage-metrics.test.ts`
(`describe("formatTokens", ...)`), importing the already-exported `formatTokens`
and asserting the `999_950 → "1.0M"` rollover plus the unaffected cases. It fails
on `main` and passes with this change.

> Note: this is a distinct bug from PR #96298, which fixes a *different*
> `formatTokens` in `ui/src/ui/format.ts` (different signature and rounding).
> This PR touches only `ui/src/ui/views/usage-metrics.ts`, which no open PR
> modifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

