### PR TITLE
fix(telegram): pad inline code spans whose content edges are backticks

### DIFF
--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -226,7 +226,12 @@ function longestBacktickRun(text: string): number {
 
 function markdownInlineCodeDelimiters(content: string): [string, string] {
   const delimiter = "`".repeat(longestBacktickRun(content) + 1);
-  if (content.startsWith(" ") || content.endsWith(" ")) {
+  if (
+    content.startsWith(" ") ||
+    content.endsWith(" ") ||
+    content.startsWith("`") ||
+    content.endsWith("`")
+  ) {
     return [`${delimiter} `, ` ${delimiter}`];
   }
   return [delimiter, delimiter];

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -931,6 +931,23 @@ describe("renderTelegramTextEntities", () => {
     );
   });
 
+  it("pads inline code whose content ends with a backtick so the span parses", () => {
+    const text = "x`";
+    const entities = [{ type: "code", offset: 0, length: 2 }];
+
+    // Per CommonMark, content that ends with a backtick needs single-space
+    // padding inside the fence, otherwise the trailing backtick fuses with the
+    // closing delimiter and the span is rendered as literal text.
+    expect(renderTelegramTextEntities(text, entities)).toBe("`` x` ``");
+  });
+
+  it("pads inline code whose content starts with a backtick so the span parses", () => {
+    const text = "`x";
+    const entities = [{ type: "code", offset: 0, length: 2 }];
+
+    expect(renderTelegramTextEntities(text, entities)).toBe("`` `x ``");
+  });
+
   it("renders pre entities with language fences", () => {
     const text = "const value = 1;";
     const entities = [{ type: "pre", offset: 0, length: text.length, language: "ts" }];


### PR DESCRIPTION
## What Problem This Solves

`renderTelegramTextEntities` converts inbound Telegram message entities into
markdown. For an inline-code (`code`) entity, `markdownInlineCodeDelimiters`
picks a backtick fence one longer than the longest backtick run in the content
and only adds CommonMark space-padding when the content **starts or ends with a
space**.

But CommonMark also requires space-padding when the content **starts or ends
with a backtick** — otherwise the edge backtick fuses with the delimiter run and
the span has no valid closer, so a parser renders the whole thing as **literal
text** instead of inline code.

Repro — an inbound message text `x` + backtick (the two characters `x` and
`` ` ``) with a single entity `{ type: "code", offset: 0, length: 2 }`:

| | Input content | Rendered (before) | Parses as code span? |
|---|---|---|---|
| trailing backtick | `` x` `` | `` ``x``` `` | No — trailing run of 3 backticks, opener is 2; renders as literal `` ``x``` `` |
| leading backtick | `` `x `` | `` ```x`` `` | No — symmetric failure |

For `` x` ``: `longestBacktickRun = 1` so `delimiter = "``"`; the content does
not start/end with a **space**, so no padding is added, giving
`` "``" + "x`" + "``" `` = `` ``x``` ``. A CommonMark parser opens with the
leading run of 2 backticks then looks for a closing run of exactly 2, but the
trailing run is length 3 — no valid closer — so the span never forms.

**After the fix** the content is space-padded, e.g. `` x` `` →
`` `` x` `` `` (open `` "`` " ``, close `` " ``" ``), which round-trips back to
the literal content `` x` ``. Normal inputs (`code`, leading-space content,
interior backticks) are unaffected.

The fix extends the existing padding condition in
`markdownInlineCodeDelimiters` (`extensions/telegram/src/bot/body-helpers.ts`)
to also trigger on a leading/trailing backtick, reusing the already-correct
space-padded branch:

```ts
if (
  content.startsWith(" ") ||
  content.endsWith(" ") ||
  content.startsWith("`") ||
  content.endsWith("`")
) {
  return [`${delimiter} `, ` ${delimiter}`];
}
```

A red/green unit test is added in
`extensions/telegram/src/bot/helpers.test.ts` covering both the
leading- and trailing-backtick cases via the exported
`renderTelegramTextEntities`.

## Evidence

Standalone Node proof replicating the fixed function plus a minimal CommonMark
code-span parser (asserts the old output fails to parse, the new output
round-trips, and unaffected inputs are unchanged):

```
PASS trailing-backtick rendered === expected (got "`` x` ``")
PASS trailing-backtick round-trips to original content (got "x`")
PASS OLD trailing-backtick === buggy output (got "``x```")
PASS OLD trailing-backtick fails to parse as code span (got null)
PASS leading-backtick rendered === expected (got "`` `x ``")
PASS leading-backtick round-trips to original content (got "`x")
PASS OLD leading-backtick === buggy output (got "```x``")
PASS OLD leading-backtick fails to parse
PASS normal 'code' unchanged (new="`code`", old="`code`")
PASS normal 'code' round-trips
PASS leading-space behavior unchanged (new="`  x `", old="`  x `")
PASS interior-backtick unchanged (new="``a`b``", old="``a`b``")
PASS interior-backtick round-trips

ALL CHECKS PASSED
```

The "OLD" rows are the red proof (current `main` behavior); the "PASS … round-trips"
rows are the green proof after the fix.

