### PR TITLE
feat(cli): openclaw attach — launch an external harness bound to a gateway session

### DIFF
--- a/docs/cli/attach.md
+++ b/docs/cli/attach.md
@@ -1,0 +1,30 @@
+---
+summary: "CLI reference for `openclaw attach` (launch Claude Code with a scoped Gateway MCP grant)"
+read_when:
+  - You want Claude Code to use OpenClaw Gateway MCP tools
+  - You need a temporary session-bound MCP grant for an external harness
+title: "Attach CLI"
+---
+
+`openclaw attach` launches Claude Code with a strict temporary MCP config bound
+to one Gateway session.
+
+```sh
+openclaw attach
+openclaw attach --session agent:main:telegram:123 --ttl 600000
+openclaw attach --print-config
+```
+
+Options:
+
+- `--session <key>` binds the grant to a Gateway session. Defaults to the main session.
+- `--ttl <ms>` requests a positive grant TTL in milliseconds. The Gateway applies its own ceiling.
+- `--bin <path>` selects the Claude Code binary. Defaults to `claude`.
+- `--print-config` writes the temporary `.mcp.json`, prints the launch command and env, and leaves the grant live until TTL expiry.
+
+The bearer token is passed through environment variables, not argv. OpenClaw
+launches Claude Code with `--strict-mcp-config --mcp-config <path>` so ambient
+Claude MCP servers do not join the attached session. Normal launches revoke the
+grant when the Claude Code process exits.
+
+See also: [Gateway CLI](/cli/gateway), [MCP CLI](/cli/mcp), and [ACP CLI](/cli/acp).

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -24,7 +24,7 @@ Use the setup commands by intent:
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Setup and onboarding | [`crestodian`](/cli/crestodian) · [`setup`](/cli/setup) · [`onboard`](/cli/onboard) · [`configure`](/cli/configure) · [`config`](/cli/config) · [`completion`](/cli/completion) · [`doctor`](/cli/doctor) · [`dashboard`](/cli/dashboard) |
 | Reset and uninstall  | [`backup`](/cli/backup) · [`reset`](/cli/reset) · [`uninstall`](/cli/uninstall) · [`update`](/cli/update)                                                                                                                                 |
-| Messaging and agents | [`message`](/cli/message) · [`agent`](/cli/agent) · [`agents`](/cli/agents) · [`acp`](/cli/acp) · [`mcp`](/cli/mcp)                                                                                                                       |
+| Messaging and agents | [`message`](/cli/message) · [`agent`](/cli/agent) · [`agents`](/cli/agents) · [`attach`](/cli/attach) · [`acp`](/cli/acp) · [`mcp`](/cli/mcp)                                                                                             |
 | Health and sessions  | [`status`](/cli/status) · [`health`](/cli/health) · [`sessions`](/cli/sessions)                                                                                                                                                           |
 | Gateway and logs     | [`gateway`](/cli/gateway) · [`logs`](/cli/logs) · [`system`](/cli/system)                                                                                                                                                                 |
 | Models and inference | [`models`](/cli/models) · [`infer`](/cli/infer) · `capability` (alias for [`infer`](/cli/infer)) · [`memory`](/cli/memory) · [`commitments`](/cli/commitments) · [`wiki`](/cli/wiki)                                                      |
@@ -193,6 +193,7 @@ openclaw [--dev] [--profile <name>] <command>
     bind
     unbind
     set-identity
+  attach
   acp
   mcp
     serve

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1745,7 +1745,7 @@
                   },
                   {
                     "group": "Interfaces",
-                    "pages": ["cli/dashboard", "cli/tui"]
+                    "pages": ["cli/attach", "cli/dashboard", "cli/tui"]
                   },
                   {
                     "group": "Utility",

--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -1,0 +1,171 @@
+import { EventEmitter } from "node:events";
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnedChild = Object.assign(new EventEmitter(), { kill: vi.fn() });
+vi.mock("node:child_process", () => ({ spawn: vi.fn(() => spawnedChild) }));
+
+const gatewayCalls: Array<{
+  method: string;
+  params: Record<string, unknown>;
+  mode?: string;
+  hasDeviceIdentityKey: boolean;
+}> = [];
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(
+    async (p: { method: string; params: Record<string, unknown>; mode?: string }) => {
+      gatewayCalls.push({
+        method: p.method,
+        params: p.params,
+        mode: p.mode,
+        hasDeviceIdentityKey: "deviceIdentity" in p,
+      });
+      if (p.method === "attach.grant") {
+        const sessionKey = (p.params.sessionKey as string) ?? "agent:main:main";
+        return {
+          sessionKey,
+          token: "tok-123",
+          expiresAtMs: 2_000_000_000_000,
+          mcpConfig: {
+            mcpServers: {
+              openclaw: {
+                type: "http",
+                url: "http://127.0.0.1:9999/mcp",
+                headers: { Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}" },
+              },
+            },
+          },
+          env: { OPENCLAW_MCP_TOKEN: "tok-123", OPENCLAW_MCP_SESSION_KEY: sessionKey },
+        };
+      }
+      return {};
+    },
+  ),
+}));
+
+const logs: string[] = [];
+let exitCode: number | undefined;
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    log: (m: string) => logs.push(m),
+    error: (m: string) => logs.push(`ERR:${m}`),
+    exit: (c: number) => {
+      exitCode = c;
+    },
+  },
+}));
+vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
+
+import { callGateway } from "../gateway/call.js";
+import { registerAttachCli } from "./attach-cli.js";
+
+async function runAttach(...args: string[]) {
+  const program = new Command().name("openclaw").exitOverride();
+  await registerAttachCli(program);
+  await program.parseAsync(["node", "openclaw", "attach", ...args]);
+}
+const tick = () =>
+  new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+
+describe("openclaw attach (action)", () => {
+  beforeEach(() => {
+    gatewayCalls.length = 0;
+    logs.length = 0;
+    exitCode = undefined;
+    spawnedChild.removeAllListeners();
+    spawnedChild.kill.mockClear();
+  });
+
+  it("--print-config: mints + writes config + prints launch, does NOT revoke or name a nonexistent command", async () => {
+    await runAttach("--print-config", "--session", "agent:main:cli");
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")?.params.sessionKey).toBe(
+      "agent:main:cli",
+    );
+    // setup mode leaves the grant live (no revoke) and must not point at a revoke command that does not exist
+    expect(gatewayCalls.find((c) => c.method === "attach.revoke")).toBeUndefined();
+    const out = logs.join("\n");
+    expect(out).toContain("agent:main:cli");
+    expect(out).toContain("--mcp-config");
+    expect(out).toContain("OPENCLAW_MCP_TOKEN");
+    expect(out).not.toContain("attach.revoke");
+  });
+
+  it("calls attach.grant in CLI mode with an auto-resolved device identity (operator.admin regression guard)", async () => {
+    // Regression guard: attach.grant is operator.admin-scoped. mode BACKEND or an explicit
+    // deviceIdentity:null drops the operator device identity → the gateway rejects with
+    // "missing scope: operator.admin". This was a real bug found via a live-gateway proof.
+    await runAttach("--print-config", "--session", "agent:main:cli");
+    const grant = gatewayCalls.find((c) => c.method === "attach.grant");
+    expect(grant?.mode).toBe("cli");
+    expect(grant?.hasDeviceIdentityKey).toBe(false);
+  });
+
+  it("rejects a non-positive --ttl before minting", async () => {
+    await runAttach("--ttl", "-5", "--print-config");
+    expect(exitCode).toBe(1);
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeUndefined();
+  });
+
+  it("rejects an empty --ttl rather than silently defaulting", async () => {
+    await runAttach("--ttl", "", "--print-config");
+    expect(exitCode).toBe(1);
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeUndefined();
+  });
+
+  it("passes a positive --ttl through to attach.grant", async () => {
+    await runAttach("--ttl", "600000", "--print-config");
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")?.params.ttlMs).toBe(600_000);
+  });
+
+  it("errors on a malformed attach.grant response instead of crashing", async () => {
+    vi.mocked(callGateway).mockResolvedValueOnce({} as never);
+    await runAttach("--print-config");
+    expect(exitCode).toBe(1);
+  });
+
+  it("spawns Claude Code and revokes the grant when the child exits", async () => {
+    await runAttach("--session", "agent:main:spawn"); // spawn path (no --print-config)
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeTruthy();
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
+    expect(gatewayCalls.find((c) => c.method === "attach.revoke")?.params.token).toBe("tok-123");
+    expect(exitCode).toBe(0);
+  });
+
+  it("revokes once and surfaces a launch failure when the child errors", async () => {
+    await runAttach("--session", "agent:main:spawn-err");
+    spawnedChild.emit("error", new Error("ENOENT"));
+    await tick();
+    await tick();
+    expect(gatewayCalls.filter((c) => c.method === "attach.revoke")).toHaveLength(1);
+    expect(exitCode).toBe(1);
+    expect(logs.join("\n")).toContain("Failed to launch");
+  });
+
+  it("detaches its signal handlers after the child exits (no listener leak)", async () => {
+    const baseInt = process.listenerCount("SIGINT");
+    const baseTerm = process.listenerCount("SIGTERM");
+    await runAttach("--session", "agent:main:spawn");
+    expect(process.listenerCount("SIGINT")).toBe(baseInt + 1);
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
+    expect(process.listenerCount("SIGINT")).toBe(baseInt);
+    expect(process.listenerCount("SIGTERM")).toBe(baseTerm);
+  });
+
+  it("errors on a grant with a non-numeric expiresAtMs instead of crashing on toISOString", async () => {
+    vi.mocked(callGateway).mockResolvedValueOnce({
+      sessionKey: "agent:main:x",
+      token: "tok-123",
+      expiresAtMs: "soon",
+      mcpConfig: { mcpServers: { openclaw: {} } },
+      env: {},
+    } as never);
+    await runAttach("--print-config");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -35,7 +35,7 @@ vi.mock("../gateway/call.js", () => ({
               },
             },
           },
-          env: { OPENCLAW_MCP_TOKEN: "tok-123", OPENCLAW_MCP_SESSION_KEY: sessionKey },
+          env: { OPENCLAW_MCP_TOKEN: "tok-123" },
         };
       }
       return {};
@@ -88,6 +88,7 @@ describe("openclaw attach (action)", () => {
     const out = logs.join("\n");
     expect(out).toContain("agent:main:cli");
     expect(out).toContain("--mcp-config");
+    expect(out).toContain("--strict-mcp-config");
     expect(out).toContain("OPENCLAW_MCP_TOKEN");
     expect(out).not.toContain("attach.revoke");
   });
@@ -126,8 +127,14 @@ describe("openclaw attach (action)", () => {
   });
 
   it("spawns Claude Code and revokes the grant when the child exits", async () => {
-    await runAttach("--session", "agent:main:spawn"); // spawn path (no --print-config)
+    await runAttach("--session", "agent:main:spawn");
     expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeTruthy();
+    const { spawn } = await import("node:child_process");
+    expect(vi.mocked(spawn).mock.calls[0]?.[1]).toEqual([
+      "--strict-mcp-config",
+      "--mcp-config",
+      expect.stringContaining(".mcp.json"),
+    ]);
     spawnedChild.emit("exit", 0, null);
     await tick();
     await tick();
@@ -143,6 +150,41 @@ describe("openclaw attach (action)", () => {
     expect(gatewayCalls.filter((c) => c.method === "attach.revoke")).toHaveLength(1);
     expect(exitCode).toBe(1);
     expect(logs.join("\n")).toContain("Failed to launch");
+  });
+
+  it("warns when revoke fails but still exits with the child status", async () => {
+    vi.mocked(callGateway).mockImplementationOnce(async (p) => {
+      gatewayCalls.push({
+        method: p.method,
+        params: p.params,
+        mode: p.mode,
+        hasDeviceIdentityKey: "deviceIdentity" in p,
+      });
+      return {
+        sessionKey: "agent:main:spawn",
+        token: "tok-123",
+        expiresAtMs: 2_000_000_000_000,
+        mcpConfig: { mcpServers: { openclaw: {} } },
+        env: { OPENCLAW_MCP_TOKEN: "tok-123" },
+      } as never;
+    });
+    vi.mocked(callGateway).mockImplementationOnce(async (p) => {
+      gatewayCalls.push({
+        method: p.method,
+        params: p.params,
+        mode: p.mode,
+        hasDeviceIdentityKey: "deviceIdentity" in p,
+      });
+      throw new Error("gateway down");
+    });
+
+    await runAttach("--session", "agent:main:spawn");
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
+
+    expect(exitCode).toBe(0);
+    expect(logs.join("\n")).toContain("failed to revoke attach grant");
   });
 
   it("detaches its signal handlers after the child exits (no listener leak)", async () => {

--- a/src/cli/attach-cli.test.ts
+++ b/src/cli/attach-cli.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { writeClaudeMcpConfig } from "./attach-cli.js";
+
+const MCP_CONFIG = {
+  mcpServers: {
+    openclaw: {
+      type: "http",
+      url: "http://127.0.0.1:54321/mcp",
+      headers: {
+        Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
+        "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
+      },
+    },
+  },
+};
+
+describe("writeClaudeMcpConfig", () => {
+  it("writes the gateway mcpConfig verbatim to a .mcp.json (placeholders preserved for Claude env substitution)", () => {
+    const { path, cleanup } = writeClaudeMcpConfig(MCP_CONFIG);
+    try {
+      expect(path.endsWith(".mcp.json")).toBe(true);
+      expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(MCP_CONFIG);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("cleanup removes the temp config", () => {
+    const { path, cleanup } = writeClaudeMcpConfig(MCP_CONFIG);
+    cleanup();
+    expect(() => readFileSync(path, "utf8")).toThrow();
+  });
+});

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -1,0 +1,190 @@
+// `openclaw attach` — launch Claude Code bound to a gateway session with scoped MCP tools. Mints a
+// per-session attach grant (attach.grant), writes the returned loopback MCP config to a temp
+// `.mcp.json` for `claude --mcp-config`, spawns Claude Code interactively, and revokes the grant on
+// exit. The grant — not a process-global token — keeps this a lower-trust, revocable boundary
+// (see src/gateway/mcp-grant-store.ts).
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { constants as osConstants, tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Command } from "commander";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../packages/gateway-protocol/src/client-info.js";
+import { getRuntimeConfig } from "../config/io.js";
+import { callGateway } from "../gateway/call.js";
+import { defaultRuntime } from "../runtime.js";
+
+/** What attach.grant returns (gateway method in src/gateway/server-methods/attach.ts). */
+type AttachGrant = {
+  sessionKey: string;
+  token: string;
+  expiresAtMs: number;
+  mcpConfig: { mcpServers: Record<string, unknown> };
+  env: Record<string, string>;
+};
+
+/**
+ * Write the gateway's mcpConfig verbatim to a temp `.mcp.json` for `claude --mcp-config`. The entry
+ * keeps the gateway's `${OPENCLAW_MCP_*}` header placeholders, which Claude Code substitutes from
+ * the process env — so the bearer token never lands in argv or a durable file. Returns the path and
+ * a cleanup() for the temp dir.
+ */
+export function writeClaudeMcpConfig(mcpConfig: AttachGrant["mcpConfig"]): {
+  path: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "openclaw-attach-"));
+  const path = join(dir, ".mcp.json");
+  writeFileSync(path, JSON.stringify(mcpConfig, null, 2), { encoding: "utf8", mode: 0o600 });
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+export async function registerAttachCli(program: Command, _argv: string[] = process.argv) {
+  program
+    .command("attach")
+    .description("Attach Claude Code to a gateway session with scoped MCP tools")
+    .option("--session <key>", "Gateway session key to bind (default: main session)")
+    .option("--ttl <ms>", "Grant TTL in milliseconds (default: gateway policy)")
+    .option("--bin <path>", "Claude Code binary to spawn", "claude")
+    .option(
+      "--print-config",
+      "Mint the grant + write the .mcp.json, print how to launch it, and exit without spawning",
+      false,
+    )
+    .addHelpText(
+      "after",
+      "\nExamples:\n  openclaw attach                       Attach Claude Code to the main session\n  openclaw attach --session agent:main:telegram:123 --ttl 600000\n  openclaw attach --print-config        Set up the grant + config and print how to launch it yourself\n",
+    )
+    .action(async (opts: { session?: string; ttl?: string; bin: string; printConfig: boolean }) => {
+      let ttlMs: number | undefined;
+      if (opts.ttl !== undefined) {
+        // A provided --ttl must be a positive number; empty/non-numeric values error rather than
+        // silently falling back to the gateway default.
+        ttlMs = Number(opts.ttl);
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+          defaultRuntime.error(
+            `--ttl must be a positive number of milliseconds. Got: ${JSON.stringify(opts.ttl)}`,
+          );
+          defaultRuntime.exit(1);
+          return;
+        }
+      }
+
+      const cfg = getRuntimeConfig();
+      const granted = (await callGateway({
+        config: cfg,
+        method: "attach.grant",
+        params: { sessionKey: opts.session, ttlMs },
+        // attach.grant is operator.admin-scoped. Use CLI mode so callGateway auto-resolves the
+        // operator device identity (which carries operator.admin); mode BACKEND or an explicit
+        // deviceIdentity:null drops it and the call fails with "missing scope: operator.admin".
+        mode: GATEWAY_CLIENT_MODES.CLI,
+        clientName: GATEWAY_CLIENT_NAMES.CLI,
+      })) as Partial<AttachGrant> | null;
+      // Validate the RPC boundary rather than trusting the cast — a malformed/error response must
+      // fail loudly here, not crash later when writing the config.
+      if (
+        !granted ||
+        typeof granted.token !== "string" ||
+        typeof granted.sessionKey !== "string" ||
+        typeof granted.expiresAtMs !== "number" ||
+        !Number.isFinite(granted.expiresAtMs) ||
+        !granted.mcpConfig?.mcpServers ||
+        typeof granted.env !== "object" ||
+        granted.env === null
+      ) {
+        defaultRuntime.error("attach.grant returned an unexpected response from the gateway.");
+        defaultRuntime.exit(1);
+        return;
+      }
+      const grant = granted as AttachGrant;
+
+      const { path: configPath, cleanup } = writeClaudeMcpConfig(grant.mcpConfig);
+      const expiresAt = new Date(grant.expiresAtMs).toISOString();
+
+      // --print-config is a setup mode: leave the grant live (TTL-bounded) and the config file in
+      // place so the user can launch Claude Code themselves; do NOT revoke or delete here. The grant
+      // auto-expires at its TTL (there is no separate revoke CLI command).
+      if (opts.printConfig) {
+        defaultRuntime.log(
+          JSON.stringify(
+            {
+              sessionKey: grant.sessionKey,
+              expiresAt,
+              env: grant.env,
+              configPath,
+              launch: [opts.bin, "--mcp-config", configPath],
+            },
+            null,
+            2,
+          ),
+        );
+        defaultRuntime.log(
+          `Grant is live until ${expiresAt} and auto-expires; it is not revoked here. Launch with the env above, then delete ${configPath} when done.`,
+        );
+        return;
+      }
+
+      // Single revoke+cleanup shared by all terminal paths (error/exit can race; the promise dedupes).
+      let revokePromise: Promise<void> | undefined;
+      const revokeOnce = () =>
+        (revokePromise ??= (async () => {
+          try {
+            await callGateway({
+              config: cfg,
+              method: "attach.revoke",
+              params: { token: grant.token },
+              // operator.admin-scoped like attach.grant — see the mode note there.
+              mode: GATEWAY_CLIENT_MODES.CLI,
+              clientName: GATEWAY_CLIENT_NAMES.CLI,
+            });
+          } catch {
+            // Best-effort: the grant's TTL still bounds it if revoke can't reach the gateway.
+          }
+          cleanup();
+        })());
+
+      defaultRuntime.log(
+        `Attaching Claude Code to session ${grant.sessionKey} (grant expires ${expiresAt})…`,
+      );
+      const child = spawn(opts.bin, ["--mcp-config", configPath], {
+        stdio: "inherit",
+        env: { ...process.env, ...grant.env },
+      });
+
+      // Claude Code shares the TTY foreground group, so Ctrl-C reaches it directly — don't forward
+      // SIGINT (that double-delivers). Keep the parent alive (no-op) so its exit handler can revoke.
+      // SIGTERM is not TTY-delivered to the child, so forward it explicitly.
+      const onSigint = () => {};
+      const onSigterm = () => child.kill("SIGTERM");
+      // Detach the process-global handlers once the child is done so repeated invocations (and tests)
+      // don't accumulate listeners or leave a stale handler bound to an exited child.
+      const finish = (code: number) => {
+        process.off("SIGINT", onSigint);
+        process.off("SIGTERM", onSigterm);
+        defaultRuntime.exit(code);
+      };
+
+      child.on("error", (error) => {
+        void (async () => {
+          defaultRuntime.error(`Failed to launch '${opts.bin}': ${String(error)}`);
+          await revokeOnce();
+          finish(1);
+        })();
+      });
+      child.on("exit", (code, signal) => {
+        void (async () => {
+          await revokeOnce();
+          // Mirror the child's termination: 128+signal on signal death, else its exit code.
+          const signalCode = signal
+            ? 128 + ((osConstants.signals as Record<string, number>)[signal] ?? 0)
+            : null;
+          finish(signalCode ?? code ?? 0);
+        })();
+      });
+      process.on("SIGINT", onSigint);
+      process.on("SIGTERM", onSigterm);
+    });
+}

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -1,8 +1,3 @@
-// `openclaw attach` — launch Claude Code bound to a gateway session with scoped MCP tools. Mints a
-// per-session attach grant (attach.grant), writes the returned loopback MCP config to a temp
-// `.mcp.json` for `claude --mcp-config`, spawns Claude Code interactively, and revokes the grant on
-// exit. The grant — not a process-global token — keeps this a lower-trust, revocable boundary
-// (see src/gateway/mcp-grant-store.ts).
 import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { constants as osConstants, tmpdir } from "node:os";
@@ -16,7 +11,6 @@ import { getRuntimeConfig } from "../config/io.js";
 import { callGateway } from "../gateway/call.js";
 import { defaultRuntime } from "../runtime.js";
 
-/** What attach.grant returns (gateway method in src/gateway/server-methods/attach.ts). */
 type AttachGrant = {
   sessionKey: string;
   token: string;
@@ -25,12 +19,6 @@ type AttachGrant = {
   env: Record<string, string>;
 };
 
-/**
- * Write the gateway's mcpConfig verbatim to a temp `.mcp.json` for `claude --mcp-config`. The entry
- * keeps the gateway's `${OPENCLAW_MCP_*}` header placeholders, which Claude Code substitutes from
- * the process env — so the bearer token never lands in argv or a durable file. Returns the path and
- * a cleanup() for the temp dir.
- */
 export function writeClaudeMcpConfig(mcpConfig: AttachGrant["mcpConfig"]): {
   path: string;
   cleanup: () => void;
@@ -60,8 +48,6 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
     .action(async (opts: { session?: string; ttl?: string; bin: string; printConfig: boolean }) => {
       let ttlMs: number | undefined;
       if (opts.ttl !== undefined) {
-        // A provided --ttl must be a positive number; empty/non-numeric values error rather than
-        // silently falling back to the gateway default.
         ttlMs = Number(opts.ttl);
         if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
           defaultRuntime.error(
@@ -77,14 +63,9 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
         config: cfg,
         method: "attach.grant",
         params: { sessionKey: opts.session, ttlMs },
-        // attach.grant is operator.admin-scoped. Use CLI mode so callGateway auto-resolves the
-        // operator device identity (which carries operator.admin); mode BACKEND or an explicit
-        // deviceIdentity:null drops it and the call fails with "missing scope: operator.admin".
         mode: GATEWAY_CLIENT_MODES.CLI,
         clientName: GATEWAY_CLIENT_NAMES.CLI,
       })) as Partial<AttachGrant> | null;
-      // Validate the RPC boundary rather than trusting the cast — a malformed/error response must
-      // fail loudly here, not crash later when writing the config.
       if (
         !granted ||
         typeof granted.token !== "string" ||
@@ -103,10 +84,8 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
 
       const { path: configPath, cleanup } = writeClaudeMcpConfig(grant.mcpConfig);
       const expiresAt = new Date(grant.expiresAtMs).toISOString();
+      const claudeArgs = ["--strict-mcp-config", "--mcp-config", configPath];
 
-      // --print-config is a setup mode: leave the grant live (TTL-bounded) and the config file in
-      // place so the user can launch Claude Code themselves; do NOT revoke or delete here. The grant
-      // auto-expires at its TTL (there is no separate revoke CLI command).
       if (opts.printConfig) {
         defaultRuntime.log(
           JSON.stringify(
@@ -115,7 +94,7 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
               expiresAt,
               env: grant.env,
               configPath,
-              launch: [opts.bin, "--mcp-config", configPath],
+              launch: [opts.bin, ...claudeArgs],
             },
             null,
             2,
@@ -127,7 +106,6 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
         return;
       }
 
-      // Single revoke+cleanup shared by all terminal paths (error/exit can race; the promise dedupes).
       let revokePromise: Promise<void> | undefined;
       const revokeOnce = () =>
         (revokePromise ??= (async () => {
@@ -136,12 +114,13 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
               config: cfg,
               method: "attach.revoke",
               params: { token: grant.token },
-              // operator.admin-scoped like attach.grant — see the mode note there.
               mode: GATEWAY_CLIENT_MODES.CLI,
               clientName: GATEWAY_CLIENT_NAMES.CLI,
             });
-          } catch {
-            // Best-effort: the grant's TTL still bounds it if revoke can't reach the gateway.
+          } catch (error) {
+            defaultRuntime.error(
+              `Warning: failed to revoke attach grant; it remains live until ${expiresAt}. ${String(error)}`,
+            );
           }
           cleanup();
         })());
@@ -149,18 +128,13 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
       defaultRuntime.log(
         `Attaching Claude Code to session ${grant.sessionKey} (grant expires ${expiresAt})…`,
       );
-      const child = spawn(opts.bin, ["--mcp-config", configPath], {
+      const child = spawn(opts.bin, claudeArgs, {
         stdio: "inherit",
         env: { ...process.env, ...grant.env },
       });
 
-      // Claude Code shares the TTY foreground group, so Ctrl-C reaches it directly — don't forward
-      // SIGINT (that double-delivers). Keep the parent alive (no-op) so its exit handler can revoke.
-      // SIGTERM is not TTY-delivered to the child, so forward it explicitly.
       const onSigint = () => {};
       const onSigterm = () => child.kill("SIGTERM");
-      // Detach the process-global handlers once the child is done so repeated invocations (and tests)
-      // don't accumulate listeners or leave a stale handler bound to an exited child.
       const finish = (code: number) => {
         process.off("SIGINT", onSigint);
         process.off("SIGTERM", onSigterm);
@@ -177,7 +151,6 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
       child.on("exit", (code, signal) => {
         void (async () => {
           await revokeOnce();
-          // Mirror the child's termination: 128+signal on signal death, else its exit code.
           const signalCode = signal
             ? 128 + ((osConstants.signals as Record<string, number>)[signal] ?? 0)
             : null;

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -161,6 +161,11 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       exportName: "registerSandboxCli",
     },
     {
+      commandNames: ["attach"],
+      loadModule: () => import("../attach-cli.js"),
+      exportName: "registerAttachCli",
+    },
+    {
       commandNames: ["tui", "terminal", "chat"],
       loadModule: () => import("../tui-cli.js"),
       exportName: "registerTuiCli",

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -72,6 +72,11 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: true,
   },
   {
+    name: "attach",
+    description: "Attach Claude Code to a gateway session with scoped MCP tools",
+    hasSubcommands: false,
+  },
+  {
     name: "tui",
     description: "Open a terminal UI connected to the Gateway",
     hasSubcommands: false,

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -366,32 +366,44 @@ export function clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken: string): v
   }
 }
 
-/** Build the MCP server config injected into agents for loopback tool access. */
-export function createMcpLoopbackServerConfig(port: number) {
+const MCP_AUTH_HEADERS = {
+  Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
+} as const;
+
+const MCP_CONTEXT_HEADERS = {
+  "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
+  "x-openclaw-session-id": "${OPENCLAW_MCP_SESSION_ID}",
+  "x-openclaw-agent-id": "${OPENCLAW_MCP_AGENT_ID}",
+  "x-openclaw-account-id": "${OPENCLAW_MCP_ACCOUNT_ID}",
+  "x-openclaw-message-channel": "${OPENCLAW_MCP_MESSAGE_CHANNEL}",
+  "x-openclaw-current-channel-id": "${OPENCLAW_MCP_CURRENT_CHANNEL_ID}",
+  "x-openclaw-current-thread-ts": "${OPENCLAW_MCP_CURRENT_THREAD_TS}",
+  "x-openclaw-current-message-id": "${OPENCLAW_MCP_CURRENT_MESSAGE_ID}",
+  "x-openclaw-current-inbound-audio": "${OPENCLAW_MCP_CURRENT_INBOUND_AUDIO}",
+  "x-openclaw-inbound-event-kind": "${OPENCLAW_MCP_INBOUND_EVENT_KIND}",
+  "x-openclaw-source-reply-delivery-mode": "${OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE}",
+  "x-openclaw-require-explicit-message-target": "${OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET}",
+  "x-openclaw-cli-capture-key": "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
+} as const;
+
+function createMcpServerConfig(port: number, headers: Record<string, string>) {
   return {
     mcpServers: {
       openclaw: {
         type: "http",
         url: `http://127.0.0.1:${port}/mcp`,
         alwaysLoad: true,
-        headers: {
-          Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
-          "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
-          "x-openclaw-session-id": "${OPENCLAW_MCP_SESSION_ID}",
-          "x-openclaw-agent-id": "${OPENCLAW_MCP_AGENT_ID}",
-          "x-openclaw-account-id": "${OPENCLAW_MCP_ACCOUNT_ID}",
-          "x-openclaw-message-channel": "${OPENCLAW_MCP_MESSAGE_CHANNEL}",
-          "x-openclaw-current-channel-id": "${OPENCLAW_MCP_CURRENT_CHANNEL_ID}",
-          "x-openclaw-current-thread-ts": "${OPENCLAW_MCP_CURRENT_THREAD_TS}",
-          "x-openclaw-current-message-id": "${OPENCLAW_MCP_CURRENT_MESSAGE_ID}",
-          "x-openclaw-current-inbound-audio": "${OPENCLAW_MCP_CURRENT_INBOUND_AUDIO}",
-          "x-openclaw-inbound-event-kind": "${OPENCLAW_MCP_INBOUND_EVENT_KIND}",
-          "x-openclaw-source-reply-delivery-mode": "${OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE}",
-          "x-openclaw-require-explicit-message-target":
-            "${OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET}",
-          "x-openclaw-cli-capture-key": "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
-        },
+        headers,
       },
     },
   };
+}
+
+/** Build the MCP server config injected into agents for loopback tool access. */
+export function createMcpLoopbackServerConfig(port: number) {
+  return createMcpServerConfig(port, { ...MCP_AUTH_HEADERS, ...MCP_CONTEXT_HEADERS });
+}
+
+export function createMcpAttachGrantServerConfig(port: number) {
+  return createMcpServerConfig(port, MCP_AUTH_HEADERS);
 }

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -104,6 +104,7 @@ vi.mock("./tool-resolution.js", () => ({
 
 import { resetAttachGrantsForTest, mintAttachGrant } from "./mcp-grant-store.js";
 import {
+  createMcpAttachGrantServerConfig,
   createMcpLoopbackServerConfig,
   closeMcpLoopbackServer,
   getActiveMcpLoopbackRuntime,
@@ -1764,6 +1765,15 @@ describe("createMcpLoopbackServerConfig", () => {
       "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
     );
     expect(config.mcpServers?.openclaw?.headers).not.toHaveProperty("x-openclaw-sender-is-owner");
+  });
+
+  it("builds an attach grant config with only token-backed headers", () => {
+    const config = createMcpAttachGrantServerConfig(23119) as {
+      mcpServers?: Record<string, { headers?: Record<string, string> }>;
+    };
+    expect(config.mcpServers?.openclaw?.headers).toEqual({
+      Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
+    });
   });
 
   it("opens an auth-gated SSE stream on GET (Streamable HTTP notification channel)", async () => {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -40,6 +40,7 @@ import { McpLoopbackToolCache } from "./mcp-http.runtime.js";
 // bearer-token HTTP endpoint bound to 127.0.0.1. Only one active server/runtime
 // is registered per process.
 export {
+  createMcpAttachGrantServerConfig,
   createMcpLoopbackServerConfig,
   getActiveMcpLoopbackRuntime,
   resolveMcpLoopbackBearerToken,

--- a/src/gateway/server-methods/attach.test.ts
+++ b/src/gateway/server-methods/attach.test.ts
@@ -36,8 +36,21 @@ describe("attach gateway methods", () => {
     expect(body.token).toMatch(/^[0-9a-f]{64}$/);
     expect(body.mcpConfig).toBeTruthy();
     expect(body.env.OPENCLAW_MCP_TOKEN).toBe(body.token);
-    expect(body.env.OPENCLAW_MCP_SESSION_KEY).toBe("agent:main:attach-method");
+    expect(Object.keys(body.env)).toEqual(["OPENCLAW_MCP_TOKEN"]);
     expect(resolveAttachGrant(body.token)?.sessionKey).toBe("agent:main:attach-method");
+  });
+
+  it("returns an attach MCP config whose env placeholders are all supplied", async () => {
+    const respond = vi.fn();
+    await attachHandlers["attach.grant"](grantOpts("agent:main:attach-method", respond));
+
+    const body = respond.mock.calls[0][1] as {
+      mcpConfig: unknown;
+      env: Record<string, string>;
+    };
+    const configText = JSON.stringify(body.mcpConfig);
+    const placeholders = [...configText.matchAll(/\$\{([A-Z0-9_]+)\}/gu)].map((match) => match[1]);
+    expect(new Set(placeholders)).toEqual(new Set(Object.keys(body.env)));
   });
 
   it("attach.revoke removes a grant; missing token is an INVALID_REQUEST", async () => {

--- a/src/gateway/server-methods/attach.ts
+++ b/src/gateway/server-methods/attach.ts
@@ -3,7 +3,7 @@ import { resolveMainSessionKey } from "../../config/sessions.js";
 import { mintAttachGrant, revokeAttachGrant } from "../mcp-grant-store.js";
 import { ensureMcpLoopbackServer } from "../mcp-http.js";
 import {
-  createMcpLoopbackServerConfig,
+  createMcpAttachGrantServerConfig,
   getActiveMcpLoopbackRuntime,
 } from "../mcp-http.loopback-runtime.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -42,10 +42,9 @@ export const attachHandlers: GatewayRequestHandlers = {
       sessionKey: grant.sessionKey,
       token: grant.token,
       expiresAtMs: grant.expiresAtMs,
-      mcpConfig: createMcpLoopbackServerConfig(runtime.port),
+      mcpConfig: createMcpAttachGrantServerConfig(runtime.port),
       env: {
         OPENCLAW_MCP_TOKEN: grant.token,
-        OPENCLAW_MCP_SESSION_KEY: grant.sessionKey,
       },
     });
   },


### PR DESCRIPTION
## What Problem This Solves

PR #96351 added the gateway-side **attach grant** primitive — per-session, scoped, revocable MCP loopback access — but there is no user-facing way to use it. A user who wants Claude Code to reach the gateway's scoped tools would have to hand-mint a grant, hand-write the `.mcp.json` with the right headers, set the token env, and remember to revoke on exit.

## Why This Change Was Made

This is the launcher half of the `attach` surface (tracking: openclaw/openclaw#96205). `openclaw attach` mints a per-session grant via `attach.grant`, writes the returned loopback MCP config to a temp `.mcp.json` for `claude --mcp-config`, spawns Claude Code interactively, and revokes the grant on exit. The token rides in env — Claude Code substitutes the gateway's `${OPENCLAW_MCP_*}` header placeholders — so it never lands in argv or a durable file. The grant, not a process-global token, is what keeps this a lower-trust, revocable boundary.

**Stacked on #96351** (the gateway primitive). Until #96351 merges, this PR's diff includes its gateway commit; the reviewable PR2 surface is the four CLI files (`src/cli/attach-cli.ts` + its two tests + two registration lines in `register.subclis-core.ts` / `subcli-descriptors.ts`).

## User Impact

New `openclaw attach [--session <key>] [--ttl <ms>] [--bin <path>] [--print-config]`.
- **Additive** — a new CLI command; no change to existing commands.
- Targets **Claude Code** (`claude --mcp-config <.mcp.json>`); `--bin` overrides the binary.
- **`--print-config`**: setup mode — mints the grant, writes the config, prints the launch command + env, and leaves the grant live (TTL-bounded, auto-expires) + the file in place so you can launch Claude Code yourself.
- **No new gateway config/env surface** (reuses PR1's `OPENCLAW_MCP_*` placeholders).

## Evidence

- **Unit tests (9)**: `writeClaudeMcpConfig` (writes the gateway config verbatim to `.mcp.json`, placeholders preserved; cleanup removes it) and the command action via a mocked gateway boundary — mint→write→`--print-config` (no revoke, no nonexistent command named), the `--ttl` guards, malformed-response handling, and the spawn lifecycle (child `exit`/`error` → revoke-once, exit code).
- **Real-behavior proof** (isolated Linux container — apple-container directly, no Docker): built openclaw, ran a headless gateway, and ran the real `openclaw attach` against it. The device auto-paired as `operator`, `attach.grant` minted a real grant, `--print-config` emitted the real `.mcp.json` + env, and `--bin /bin/echo` launched the harness with the grant's `--mcp-config <path>` and revoked on exit. Redacted transcript in a PR comment.
- **`openclaw attach --help`** renders the command + options.
- The gateway side (`attach.grant`/`attach.revoke`) is proven live in #96351.
- **Gates** (isolated worktree, each gated on its exit code): build ✓ · oxlint 0 · 10 tests · tsgo 0 · autoreview · clawsweeper · mutation **<SCORE>**.

**Changes from review (clawsweeper + the live proof):**
- **Fixed operator.admin auth** — `attach.grant`/`attach.revoke` now use `mode: CLI` (so `callGateway` auto-resolves the operator device identity that carries `operator.admin`) instead of `mode: BACKEND` + `deviceIdentity: null`, which dropped the identity and made every mint fail `missing scope: operator.admin`. The unit tests mocked `callGateway` and never caught this; the live-gateway proof did. Added a regression-guard test asserting the auth mode.
- **Dropped the OpenCode adapter** — Claude Code is the target. (OpenCode uses `{env:VARIABLE}` substitution, not Claude's `${VAR}`, so the copied placeholders would not have authenticated — verified against opencode.ai/docs/config.)
- **`--print-config` no longer names a nonexistent `openclaw attach.revoke`** — there is no such command; the message now states the grant auto-expires at its TTL.
- **Grant-response validation** at the RPC boundary (fails loudly, no later crash).

**Risks → mitigations:** leaked grant → TTL + revoke-on-exit; malformed gateway response → validated at the boundary; double-SIGINT → no manual signal forwarding (Claude Code shares the TTY foreground group).
