### PR TITLE
fix(telegram): clip progress text on code-point boundaries to avoid lone surrogates

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -69,6 +69,7 @@ import {
   resolveDefaultModelForAgent,
 } from "./bot-message-dispatch.agent.runtime.js";
 import { deduplicateBlockSentMedia } from "./bot-message-dispatch.media-dedup.js";
+import { clipTelegramProgressText } from "./truncate.js";
 import {
   generateTopicLabel,
   getAgentScopedMediaLocalRoots,
@@ -364,22 +365,14 @@ async function mirrorTelegramAssistantReplyToTranscript(params: {
   }
 }
 
-const MAX_PROGRESS_MARKDOWN_TEXT_CHARS = 300;
 const TELEGRAM_GENERAL_TOPIC_ID = 1;
-
-function clipProgressMarkdownText(text: string): string {
-  if (text.length <= MAX_PROGRESS_MARKDOWN_TEXT_CHARS) {
-    return text;
-  }
-  return `${text.slice(0, MAX_PROGRESS_MARKDOWN_TEXT_CHARS - 1).trimEnd()}…`;
-}
 
 function sanitizeProgressMarkdownText(text: string): string {
   return text.replaceAll("`", "'");
 }
 
 function formatProgressAsMarkdownCode(text: string): string {
-  const clipped = clipProgressMarkdownText(text);
+  const clipped = clipTelegramProgressText(text);
   return `\`${sanitizeProgressMarkdownText(clipped)}\``;
 }
 
@@ -399,7 +392,7 @@ function escapeTelegramProgressHtml(text: string): string {
 }
 
 function renderTelegramProgressStringLine(text: string): string {
-  const clipped = clipProgressMarkdownText(text.trim());
+  const clipped = clipTelegramProgressText(text.trim());
   const italic = clipped.match(/^_(.*)_$/u);
   if (italic) {
     return `<i>${escapeTelegramProgressHtml(italic[1] ?? "")}</i>`;
@@ -418,7 +411,7 @@ function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): s
   const parts = [`<b>${escapeTelegramProgressHtml(label)}</b>`];
   const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
   if (detail) {
-    parts.push(`<code>${escapeTelegramProgressHtml(clipProgressMarkdownText(detail))}</code>`);
+    parts.push(`<code>${escapeTelegramProgressHtml(clipTelegramProgressText(detail))}</code>`);
   } else {
     const text = line.text.trim();
     if (text && text !== label) {

--- a/extensions/telegram/src/truncate.test.ts
+++ b/extensions/telegram/src/truncate.test.ts
@@ -1,0 +1,48 @@
+// Telegram tests cover progress text clipping behavior.
+import { describe, expect, it } from "vitest";
+import { clipTelegramProgressText, TELEGRAM_PROGRESS_MAX_CHARS } from "./truncate.js";
+
+describe("clipTelegramProgressText", () => {
+  it("drops a surrogate-pair emoji whole when it straddles the limit", () => {
+    // 😀 is U+1F600, encoded as two UTF-16 code units (high \uD83D + low \uDE00).
+    // Placing the emoji at positions [MAX-2, MAX-1] (0-indexed) puts its high
+    // surrogate right on the .slice(0, MAX-1) cut edge. A raw .slice keeps only
+    // \uD83D — an unpaired high surrogate — which is invalid in a Telegram payload.
+    const base = "a".repeat(TELEGRAM_PROGRESS_MAX_CHARS - 2); // 298 'a's
+    const out = clipTelegramProgressText(`${base}😀tail`);
+    expect(out).toBe(`${base}…`);
+    // No dangling high surrogate (high not followed by a low surrogate).
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(out)).toBe(false);
+  });
+
+  it("keeps an emoji that fits entirely before the cut", () => {
+    // 296 'a's + '😀' (2 units) + 'xyz' (3 units) = 301 total > 300.
+    // The emoji sits at [296, 297] — entirely before the cut at 299 — so it stays.
+    const base = "a".repeat(TELEGRAM_PROGRESS_MAX_CHARS - 4); // 296 'a's
+    const out = clipTelegramProgressText(`${base}😀xyz`);
+    expect(out).toBe(`${base}😀x…`);
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(out)).toBe(false);
+  });
+
+  it("returns text unchanged when it is within the limit", () => {
+    const short = "hello 😀 world";
+    expect(clipTelegramProgressText(short)).toBe(short);
+  });
+
+  it("trims trailing whitespace before the ellipsis", () => {
+    // The sliced portion may end in spaces when trailing spaces straddle the cut.
+    const text = `${"a".repeat(TELEGRAM_PROGRESS_MAX_CHARS - 2)}  rest`;
+    const out = clipTelegramProgressText(text);
+    expect(out).not.toContain("  …");
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("handles plain ASCII that fills exactly to the limit", () => {
+    const exact = "x".repeat(TELEGRAM_PROGRESS_MAX_CHARS);
+    expect(clipTelegramProgressText(exact)).toBe(exact);
+    const oneOver = `${"x".repeat(TELEGRAM_PROGRESS_MAX_CHARS)}y`;
+    const out = clipTelegramProgressText(oneOver);
+    expect(out.length).toBeLessThanOrEqual(TELEGRAM_PROGRESS_MAX_CHARS);
+    expect(out.endsWith("…")).toBe(true);
+  });
+});

--- a/extensions/telegram/src/truncate.ts
+++ b/extensions/telegram/src/truncate.ts
@@ -1,0 +1,20 @@
+// Telegram tests cover progress text clipping behavior.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
+export const TELEGRAM_PROGRESS_MAX_CHARS = 300;
+
+/**
+ * Clips Telegram progress text to at most {@link TELEGRAM_PROGRESS_MAX_CHARS} UTF-16 code units,
+ * slicing on a code-point boundary so a surrogate pair straddling the limit is
+ * dropped whole rather than leaving a lone high surrogate in the payload.
+ */
+export function clipTelegramProgressText(text: string): string {
+  if (text.length <= TELEGRAM_PROGRESS_MAX_CHARS) {
+    return text;
+  }
+  // Slice on a code-point boundary so an emoji (or any astral character) that
+  // straddles the limit is dropped whole instead of leaving a lone \uD83D-style
+  // high surrogate before the ellipsis, which serializes to an invalid character
+  // in the Telegram Bot API payload.
+  return `${sliceUtf16Safe(text, 0, TELEGRAM_PROGRESS_MAX_CHARS - 1).trimEnd()}…`;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a Telegram progress update containing an emoji (or any astral Unicode character) that straddles the 300-code-unit progress-text limit would cause the bot to emit an invalid character in the Telegram Bot API payload.

`clipProgressMarkdownText` clipped with `text.slice(0, 299)`. JavaScript `.slice` operates on UTF-16 code units, so a surrogate pair exactly at that boundary is split in two — the high surrogate `\uD83D` is kept but the matching low surrogate is cut off. A lone high surrogate is not valid UTF-8/UTF-16 and Telegram's API rejects messages containing one.

This affects every progress line rendered via `formatProgressAsMarkdownCode`, `renderTelegramProgressStringLine`, and the detail field of `renderTelegramProgressLine`.

## Why This Change Was Made

This is the same class of bug fixed in the Slack plugin by #96382. That PR introduced `sliceUtf16Safe` in `openclaw/plugin-sdk/text-utility-runtime`, which steps back one code unit when the cut falls on a high surrogate, ensuring the pair is dropped whole rather than split.

The Telegram progress clipper was not updated alongside the Slack fix.

## User Impact

Users whose Telegram bots display progress text (e.g. tool-call output, reasoning steps) could see rejected Bot API calls or garbled `?` characters when an emoji appears near the 300-char cutoff.

## Evidence

**Node.js reproduction of the broken behavior (before fix):**

```
const base = 'a'.repeat(298);            // 298 'a's
const input = base + '😀tail';           // total: 302 code units
const broken = input.slice(0, 299);      // → base + '\uD83D' (lone high surrogate)
/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(broken + '…')
// → true  ← invalid character in Telegram payload
```

**With `sliceUtf16Safe`:**
```
sliceUtf16Safe(input, 0, 299)            // steps back at position 298 (high surrogate)
// → base  (emoji dropped whole)
// → base + '…'  — valid, no lone surrogate
```

Five vitest cases in `extensions/telegram/src/truncate.test.ts` cover: the straddle (lone-surrogate) case, an emoji that fits entirely before the cut, an unchanged short string, trailing-whitespace trimming, and plain ASCII at the exact limit.

CI is the authoritative test runner; the test logic was verified with Node.js manually.
