### PR TITLE
fix(infra): reject C1 controls in SCP targets

### DIFF
--- a/src/infra/scp-host.test.ts
+++ b/src/infra/scp-host.test.ts
@@ -34,6 +34,7 @@ describe("scp remote host", () => {
     "bot@fe80::1",
     "bot@[fe80::1%en0]",
     "bot name@gateway-host",
+    "bot@host\u0085name",
   ])("rejects unsafe host tokens: %j", (value) => {
     expect(normalizeScpRemoteHost(value)).toBeUndefined();
     expect(isSafeScpRemoteHost(value)).toBe(false);
@@ -68,6 +69,7 @@ describe("scp remote path", () => {
       '/Users/demo/Library/Messages/Attachments/ab/cd/bad"path.jpg',
       "/Users/demo/Library/Messages/Attachments/ab/cd/bad'path.jpg",
       "/Users/demo/Library/Messages/Attachments/ab/cd/bad\\path.jpg",
+      "/Users/demo/Library/Messages/Attachments/ab/cd/bad\u0085path.jpg",
     ].map((entry) =>
       typeof entry === "object" && entry !== null && "value" in entry
         ? entry

--- a/src/infra/scp-host.ts
+++ b/src/infra/scp-host.ts
@@ -8,10 +8,14 @@ const BRACKETED_IPV6 = /^\[[0-9A-Fa-f:.%]+\]$/;
 const WHITESPACE = /\s/;
 const SCP_REMOTE_PATH_UNSAFE_CHARS = new Set(["\\", "'", '"', "`", "$", ";", "|", "&", "<", ">"]);
 
+function isControlCharacter(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return code <= 0x1f || code === 0x7f || (code >= 0x80 && code <= 0x9f);
+}
+
 function hasControlOrWhitespace(value: string): boolean {
   for (const char of value) {
-    const code = char.charCodeAt(0);
-    if (code <= 0x1f || code === 0x7f || WHITESPACE.test(char)) {
+    if (isControlCharacter(char) || WHITESPACE.test(char)) {
       return true;
     }
   }
@@ -74,8 +78,7 @@ export function normalizeScpRemotePath(value: string | null | undefined): string
   }
 
   for (const char of trimmed) {
-    const code = char.charCodeAt(0);
-    if (code <= 0x1f || code === 0x7f || SCP_REMOTE_PATH_UNSAFE_CHARS.has(char)) {
+    if (isControlCharacter(char) || SCP_REMOTE_PATH_UNSAFE_CHARS.has(char)) {
       return undefined;
     }
   }


### PR DESCRIPTION
## What Problem This Solves

`normalizeScpRemotePath()` rejected C0 controls and DEL before building SCP targets, but it still accepted C1 control characters (`0x80`-`0x9f`) in remote paths. That left hidden terminal/control bytes inside the validated `host:path` argument used by sandbox media staging for remote iMessage attachments.

## Why This Change Was Made

The SCP normalizer already treats control bytes as unsafe input before command construction. This change makes that contract cover both C0 and C1 controls through one shared helper, so host and path validation stay aligned instead of carrying separate byte-range checks.

## User Impact

Remote iMessage/SCP media staging now rejects hidden C1 control characters in remote paths instead of passing them through as validated targets. Normal absolute remote paths, including file names with spaces, still pass unchanged.

## Evidence

Duplicate preflight:

```text
repo:openclaw/openclaw is:pr is:open scp remote path control characters -> 0
repo:openclaw/openclaw is:pr is:open normalizeScpRemotePath C1 controls -> 0
repo:openclaw/openclaw is:pr is:open scp-host controls -> 0
```

Current-main behavior probe before the fix:

```text
node --import tsx -e "import('./src/infra/scp-host.ts').then(({ normalizeScpRemotePath, normalizeScpRemoteHost }) => { console.log(JSON.stringify({ pathC1: normalizeScpRemotePath('/tmp/a\u0085b'), pathEsc: normalizeScpRemotePath('/tmp/a\u001bb'), hostC1: normalizeScpRemoteHost('bot@host\u0085x') })); })"
{"pathC1":"/tmp/ab"}
```

Focused regression test:

```text
node scripts/run-vitest.mjs run src/infra/scp-host.test.ts

Test Files  1 passed (1)
Tests  39 passed (39)
```

Formatting and whitespace checks:

```text
node_modules\.bin\oxfmt.cmd --check src/infra/scp-host.ts src/infra/scp-host.test.ts
All matched files use the correct format.

git diff --check
(no output)
```

Behavior probe after the fix:

```text
node --import tsx -e "import('./src/infra/scp-host.ts').then(({ normalizeScpRemotePath, normalizeScpRemoteHost }) => { const pathC1 = normalizeScpRemotePath('/tmp/a\u0085b') ?? null; const hostC1 = normalizeScpRemoteHost('bot@host\u0085x') ?? null; const safePath = normalizeScpRemotePath('/tmp/ok path.jpg') ?? null; console.log(JSON.stringify({ pathC1, hostC1, safePath })); })"
{"pathC1":null,"hostC1":null,"safePath":"/tmp/ok path.jpg"}
```