### PR TITLE
fix: preserve flattened tool call arguments

### DIFF
--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -1101,6 +1101,62 @@ describe("Tool Search", () => {
     expect(secondExecuteInput.input).toEqual({ value: "structured" });
     expect(secondExecuteInput.signal).toBe(abortController.signal);
     expect(secondExecuteInput.onUpdate).toBe(onUpdate);
+
+    await runtimeCallTool.execute("call-lifecycle-input-alias", {
+      id: "fake_lifecycle",
+      input: { value: "input-alias" },
+    });
+
+    const inputAliasExecuteInput = mockCall(executeTool, 2)[0] as { input?: unknown };
+    expect(inputAliasExecuteInput.input).toEqual({ value: "input-alias" });
+
+    await runtimeCallTool.execute("call-lifecycle-flattened", {
+      id: "fake_lifecycle",
+      command: "ls -la /tmp/openclaw",
+      timeout_ms: "5000",
+    });
+
+    const thirdExecuteInput = mockCall(executeTool, 3)[0] as { input?: unknown };
+    expect(thirdExecuteInput.input).toEqual({
+      command: "ls -la /tmp/openclaw",
+      timeout_ms: "5000",
+    });
+
+    await runtimeCallTool.execute("call-lifecycle-flattened-target-id", {
+      toolId: "fake_lifecycle",
+      id: "job-1",
+      action: "get",
+    });
+
+    const fourthExecuteInput = mockCall(executeTool, 4)[0] as { input?: unknown };
+    expect(fourthExecuteInput.input).toEqual({ id: "job-1", action: "get" });
+
+    await runtimeCallTool.execute("call-lifecycle-flattened-target-name", {
+      id: "fake_lifecycle",
+      name: "demo-project",
+      action: "create",
+    });
+
+    const fifthExecuteInput = mockCall(executeTool, 5)[0] as { input?: unknown };
+    expect(fifthExecuteInput.input).toEqual({ name: "demo-project", action: "create" });
+
+    await runtimeCallTool.execute("call-lifecycle-flattened-target-input", {
+      id: "fake_lifecycle",
+      input: "search text",
+      mode: "exact",
+    });
+
+    const sixthExecuteInput = mockCall(executeTool, 6)[0] as { input?: unknown };
+    expect(sixthExecuteInput.input).toEqual({ input: "search text", mode: "exact" });
+
+    await runtimeCallTool.execute("call-lifecycle-flattened-target-input-object", {
+      id: "fake_lifecycle",
+      input: { text: "search text" },
+      mode: "object",
+    });
+
+    const seventhExecuteInput = mockCall(executeTool, 7)[0] as { input?: unknown };
+    expect(seventhExecuteInput.input).toEqual({ input: { text: "search text" }, mode: "object" });
   });
 
   it("projects target tool calls after their Tool Search wrapper result", () => {

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -1679,10 +1679,32 @@ function readSearchArgs(args: unknown, config: ToolSearchConfig): { query: strin
 
 function readCallArgs(args: unknown): { id: string; input: unknown } {
   const params = asToolParamsRecord(args);
-  const id = readId(params);
+  const wrapperKey =
+    typeof params.toolId === "string" && params.toolId.trim()
+      ? "toolId"
+      : typeof params.id === "string" && params.id.trim()
+        ? "id"
+        : "name";
+  const id = readId({ ...params, id: params[wrapperKey] });
+  if (isRecord(params.args)) {
+    return {
+      id,
+      input: params.args,
+    };
+  }
+  const flattenedInputKeys = Object.keys(params).filter(
+    (key) => key !== wrapperKey && key !== "input" && params[key] !== undefined,
+  );
+  if (isRecord(params.input) && flattenedInputKeys.length === 0) {
+    return {
+      id,
+      input: params.input,
+    };
+  }
+  const input = Object.fromEntries(Object.entries(params).filter(([key]) => key !== wrapperKey));
   return {
     id,
-    input: params.args ?? params.input ?? {},
+    input,
   };
 }
 
@@ -2309,12 +2331,22 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
       name: TOOL_CALL_RAW_TOOL_NAME,
       label: "Tool Call",
       description: "Call a selected Tool Search catalog entry through OpenClaw.",
-      parameters: Type.Object({
-        id: Type.String({ description: "Tool search result id or tool name." }),
-        args: Type.Optional(
-          Type.Record(Type.String(), Type.Unknown(), { description: "Tool input." }),
-        ),
-      }),
+      parameters: Type.Object(
+        {
+          id: Type.String({ description: "Tool search result id or tool name." }),
+          toolId: Type.Optional(
+            Type.String({ description: "Tool search result id when target input also needs id." }),
+          ),
+          args: Type.Optional(
+            Type.Record(Type.String(), Type.Unknown(), { description: "Tool input." }),
+          ),
+        },
+        {
+          additionalProperties: Type.Unknown({
+            description: "Flattened target-tool input forwarded when args is omitted.",
+          }),
+        },
+      ),
       execute: async (
         _toolCallId: string,
         args: unknown,


### PR DESCRIPTION
﻿## What Problem This Solves

Fixes #96115.

Local-model compact `tool_call` payloads can omit the canonical `args` wrapper and send target-tool arguments as flattened top-level fields. Before this change, `readCallArgs` only accepted `args` or the legacy `input` wrapper, so compact flattened calls such as `{ id: "run_command", command: "..." }` dropped `command` before dispatch.

## Why This Change Was Made

This keeps `args` as the canonical shape while preserving useful compact-model fallbacks:

- Prefer the wrapper id from `toolId`, `id`, or `name`.
- Preserve canonical `args` when present.
- Preserve the legacy `{ id, input: { ... } }` alias only when `input` is the only payload field.
- Otherwise forward flattened top-level fields after removing the wrapper key.
- Add `toolId` as the explicit escape hatch when the target tool also needs its own `id` field.

This avoids dropping legitimate target-tool arguments while keeping ambiguous `input`-only object payloads on the existing legacy path.

## User Impact

Local-model tool calls are more tolerant of compact JSON emitted by smaller/lean models. Calls that flatten target arguments should now reach the target tool instead of becoming empty argument objects.

## Evidence

AI-assisted: yes, implemented with Codex. I understand the code change: `tool_call` still prefers canonical `args`, keeps the old unambiguous `input` alias, and forwards flattened target arguments with `toolId` available for target `id` collisions.

Testing degree: focused regression tested.

Commands run:

```text
node scripts/run-vitest.mjs src/agents/tool-search.test.ts
# 48 tests passed

git diff --check origin/main...HEAD
# passed

F:\Program\Python\Python313\python.exe .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD
# autoreview clean: no accepted/actionable findings reported
```

Known proof gap: I did not run a live local-model/vLLM reproduction in this environment. The focused test exercises the `createToolSearchTools` `tool_call` dispatch path for canonical, legacy, and flattened payload shapes.
