### PR TITLE
fix(memory): separate active-memory resource release from manager close

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-5959f0da5d8e4b26b5356e23fc57f072e55545fe9e403c96dec27716c575bc00  plugin-sdk-api-baseline.json
-264d30710e79bac502c0f20da2e799b98780df0915727d4dfaa79fd6e59cd7d3  plugin-sdk-api-baseline.jsonl
+0b9f10da844b043d1dfc0117674a6335b811ade639369ddcd155628abad9530c  plugin-sdk-api-baseline.json
+644c34f4d537d5f8816ed3d85b70cb554410c87aa7476bf61ca3d56809783a3d  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-abdff20b710c6b0fecb5af25603d7cfad7ade80600ca374ebe38f69d78933b50  plugin-sdk-api-baseline.json
-630367961e4d14463020f588564c23308159ae2de6e4301418b2b0c471797e70  plugin-sdk-api-baseline.jsonl
+5959f0da5d8e4b26b5356e23fc57f072e55545fe9e403c96dec27716c575bc00  plugin-sdk-api-baseline.json
+264d30710e79bac502c0f20da2e799b98780df0915727d4dfaa79fd6e59cd7d3  plugin-sdk-api-baseline.jsonl

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -3374,6 +3374,7 @@ describe("active-memory plugin", () => {
     expect(hoisted.closeActiveMemorySearchManager).toHaveBeenCalledWith({
       cfg: configFile,
       agentId: "main",
+      scope: "resources",
     });
   });
 

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -959,16 +959,21 @@ function scheduleMemorySearchCleanupAfterTimeout(
 ): void {
   const cfg = resolveActiveMemoryCleanupConfig(api);
   setTimeout(() => {
-    void closeActiveMemorySearchManager({ cfg: cfg ?? api.config, agentId })
+    // Release only the disposable per-agent recall resources a hung recall can
+    // leave open (#84048). Keep the shared QMD manager alive so concurrent and
+    // later chat memory_search calls do not surface "memory search manager is
+    // closed" (#96455); the recall's in-flight query is already cancelled via
+    // the embedded run abort signal.
+    void closeActiveMemorySearchManager({ cfg: cfg ?? api.config, agentId, scope: "resources" })
       .then(() => {
-        api.logger.debug?.(`${logPrefix} released memory search managers after timeout`);
+        api.logger.debug?.(`${logPrefix} released memory recall resources after timeout`);
       })
       .catch((error: unknown) => {
         const message = toSingleLineLogValue(
           error instanceof Error ? error.message : String(error),
         );
         api.logger.warn?.(
-          `${logPrefix} failed to release memory search managers after timeout: ${message}`,
+          `${logPrefix} failed to release memory recall resources after timeout: ${message}`,
         );
       });
   }, 0);

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -13,10 +13,12 @@ import {
 import { buildPromptSection } from "./src/prompt-section.js";
 
 const closeMemorySearchManagerMock = vi.hoisted(() => vi.fn(async () => {}));
+const releaseMemorySearchResourcesForAgentMock = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("./src/runtime-provider.js", () => ({
   memoryRuntime: {
     closeAllMemorySearchManagers: vi.fn(async () => {}),
+    releaseMemorySearchResourcesForAgent: releaseMemorySearchResourcesForAgentMock,
     closeMemorySearchManager: closeMemorySearchManagerMock,
     getMemorySearchManager: vi.fn(async () => null),
   },
@@ -111,6 +113,18 @@ describe("memory-core plugin runtime registration", () => {
     await runtime.closeMemorySearchManager?.({ cfg, agentId: "main" });
 
     expect(closeMemorySearchManagerMock).toHaveBeenCalledWith({ cfg, agentId: "main" });
+  });
+
+  it("wires scoped memory search resource release through the lazy runtime", async () => {
+    const runtime = registerMemoryCoreRuntime();
+    const cfg = {} as OpenClawConfig;
+
+    await runtime.releaseMemorySearchResourcesForAgent?.({ cfg, agentId: "main" });
+
+    expect(releaseMemorySearchResourcesForAgentMock).toHaveBeenCalledWith({
+      cfg,
+      agentId: "main",
+    });
   });
 });
 

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -170,6 +170,10 @@ const memoryRuntime: MemoryPluginRuntime = {
     const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
     await runtime.closeAllMemorySearchManagers?.();
   },
+  async releaseMemorySearchResourcesForAgent(params) {
+    const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
+    await runtime.releaseMemorySearchResourcesForAgent?.(params);
+  },
   async closeMemorySearchManager(params) {
     const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
     await runtime.closeMemorySearchManager?.(params);

--- a/extensions/memory-core/src/memory/index.ts
+++ b/extensions/memory-core/src/memory/index.ts
@@ -9,6 +9,7 @@ export {
   closeAllMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
+  releaseMemorySearchResourcesForAgent,
   type MemorySearchManagerPurpose,
   type MemorySearchManagerResult,
 } from "./search-manager.js";

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -139,6 +139,7 @@ import {
   closeAllMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
+  releaseMemorySearchResourcesForAgent,
 } from "./search-manager.js";
 const createQmdManagerMock = vi.mocked(QmdMemoryManager["create"]);
 
@@ -1052,6 +1053,19 @@ describe("getMemorySearchManager caching", () => {
     });
     expect(nextMain.manager).not.toBe(mainManager);
     expect(nextOther.manager).toBe(otherManager);
+  });
+
+  it("preserves the shared qmd manager when releasing scoped active-memory resources", async () => {
+    const cfg = createQmdCfg("main");
+    const first = await getMemorySearchManager({ cfg, agentId: "main" });
+    const firstManager = requireManager(first);
+
+    await releaseMemorySearchResourcesForAgent({ cfg, agentId: "main" });
+
+    expect(mockPrimary.close).not.toHaveBeenCalled();
+    const second = await getMemorySearchManager({ cfg, agentId: "main" });
+    expect(second.manager).toBe(firstManager);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
   });
 
   it("closes the requested agent builtin index manager on scoped teardown", async () => {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -424,6 +424,20 @@ export async function closeAllMemorySearchManagers(): Promise<void> {
   }
 }
 
+export async function releaseMemorySearchResourcesForAgent(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+}): Promise<void> {
+  if (managerRuntimePromise === null) {
+    return;
+  }
+  const { closeMemoryIndexManagersForAgent } = await loadManagerRuntime();
+  await closeMemoryIndexManagersForAgent({
+    cfg: params.cfg,
+    agentId: normalizeAgentId(params.agentId),
+  });
+}
+
 export async function closeMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -445,8 +459,7 @@ export async function closeMemorySearchManager(params: {
     }
   }
   if (managerRuntimePromise !== null) {
-    const { closeMemoryIndexManagersForAgent } = await loadManagerRuntime();
-    await closeMemoryIndexManagersForAgent({ cfg: params.cfg, agentId: normalizedAgentId });
+    await releaseMemorySearchResourcesForAgent({ cfg: params.cfg, agentId: normalizedAgentId });
   }
 }
 

--- a/extensions/memory-core/src/runtime-provider.ts
+++ b/extensions/memory-core/src/runtime-provider.ts
@@ -5,6 +5,7 @@ import {
   closeAllMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
+  releaseMemorySearchResourcesForAgent,
 } from "./memory/index.js";
 
 export const memoryRuntime: MemoryPluginRuntime = {
@@ -20,6 +21,9 @@ export const memoryRuntime: MemoryPluginRuntime = {
   },
   async closeAllMemorySearchManagers() {
     await closeAllMemorySearchManagers();
+  },
+  async releaseMemorySearchResourcesForAgent(params) {
+    await releaseMemorySearchResourcesForAgent(params);
   },
   async closeMemorySearchManager(params) {
     await closeMemorySearchManager(params);

--- a/src/plugin-sdk/memory-host-search.test.ts
+++ b/src/plugin-sdk/memory-host-search.test.ts
@@ -56,4 +56,16 @@ describe("memory-host-search facade", () => {
 
     expect(closeActiveMemorySearchManagerMock).toHaveBeenCalledWith({ cfg, agentId: "main" });
   });
+
+  it("passes the resources scope through to the lazy runtime module", async () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+
+    await closeActiveMemorySearchManager({ cfg, agentId: "main", scope: "resources" });
+
+    expect(closeActiveMemorySearchManagerMock).toHaveBeenCalledWith({
+      cfg,
+      agentId: "main",
+      scope: "resources",
+    });
+  });
 });

--- a/src/plugin-sdk/memory-host-search.ts
+++ b/src/plugin-sdk/memory-host-search.ts
@@ -34,10 +34,19 @@ export async function closeActiveMemorySearchManagers(cfg?: OpenClawConfig): Pro
   await runtime.closeActiveMemorySearchManagers(cfg);
 }
 
-/** Closes the active memory search manager for one agent. */
+/**
+ * Closes the active memory search manager for one agent.
+ *
+ * `scope` defaults to "manager" (retire the agent's shared manager). Pass
+ * "resources" to release only the disposable per-agent recall resources and keep
+ * the shared manager alive — active-memory recall-timeout cleanup uses this so a
+ * request-scoped timeout does not retire the QMD manager that chat memory_search
+ * shares (#96455).
+ */
 export async function closeActiveMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
+  scope?: "manager" | "resources";
 }): Promise<void> {
   const runtime = await loadMemoryHostSearchRuntime();
   await runtime.closeActiveMemorySearchManager(params);

--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -69,6 +69,7 @@ function createMemoryRuntimeFixture() {
   return {
     getMemorySearchManager: vi.fn(async () => ({ manager: null, error: "no index" })),
     resolveMemoryBackendConfig: vi.fn(() => ({ backend: "builtin" as const })),
+    releaseMemorySearchResourcesForAgent: vi.fn(async () => {}),
     closeMemorySearchManager: vi.fn(async () => {}),
   };
 }
@@ -351,6 +352,22 @@ describe("memory runtime auto-enable loading", () => {
   it("delegates scoped cleanup to the loaded memory runtime without reloading plugins", async () => {
     const runtime = createMemoryRuntimeFixture();
     const cfg = { plugins: {} };
+    getMemoryRuntimeMock.mockReturnValue(runtime);
+
+    await closeActiveMemorySearchManager({ cfg: cfg as never, agentId: "main" });
+
+    expect(runtime.releaseMemorySearchResourcesForAgent).toHaveBeenCalledWith({
+      cfg,
+      agentId: "main",
+    });
+    expect(runtime.closeMemorySearchManager).not.toHaveBeenCalled();
+    expectNoMemoryRuntimeBootstrap();
+  });
+
+  it("falls back to scoped close when the memory runtime has no resource-release hook", async () => {
+    const runtime = createMemoryRuntimeFixture();
+    const cfg = { plugins: {} };
+    delete (runtime as Partial<typeof runtime>).releaseMemorySearchResourcesForAgent;
     getMemoryRuntimeMock.mockReturnValue(runtime);
 
     await closeActiveMemorySearchManager({ cfg: cfg as never, agentId: "main" });

--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -364,6 +364,30 @@ describe("memory runtime auto-enable loading", () => {
     expectNoMemoryRuntimeBootstrap();
   });
 
+  it("preserves the runtime receiver when delegating scoped resource release", async () => {
+    const cfg = { plugins: {} };
+    const runtime = {
+      getMemorySearchManager: vi.fn(async () => ({ manager: null, error: "no index" })),
+      resolveMemoryBackendConfig: vi.fn(() => ({ backend: "builtin" as const })),
+      releasedAgentId: "",
+      async releaseMemorySearchResourcesForAgent(
+        this: { releasedAgentId: string },
+        params: { cfg: never; agentId: string },
+      ) {
+        void params.cfg;
+        this.releasedAgentId = params.agentId;
+      },
+      closeMemorySearchManager: vi.fn(async () => {}),
+    };
+    getMemoryRuntimeMock.mockReturnValue(runtime);
+
+    await closeActiveMemorySearchManager({ cfg: cfg as never, agentId: "main" });
+
+    expect(runtime.releasedAgentId).toBe("main");
+    expect(runtime.closeMemorySearchManager).not.toHaveBeenCalled();
+    expectNoMemoryRuntimeBootstrap();
+  });
+
   it("falls back to scoped close when the memory runtime has no resource-release hook", async () => {
     const runtime = createMemoryRuntimeFixture();
     const cfg = { plugins: {} };

--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -349,12 +349,33 @@ describe("memory runtime auto-enable loading", () => {
     await expectCloseMemoryRuntimeCase({ config, setup });
   });
 
-  it("delegates scoped cleanup to the loaded memory runtime without reloading plugins", async () => {
+  it("retires the shared manager by default so the close facade contract is preserved", async () => {
     const runtime = createMemoryRuntimeFixture();
     const cfg = { plugins: {} };
     getMemoryRuntimeMock.mockReturnValue(runtime);
 
+    // No scope: existing callers keep the full manager-retire behavior even
+    // though memory-core now exposes the narrow resource-release hook (#96455).
     await closeActiveMemorySearchManager({ cfg: cfg as never, agentId: "main" });
+
+    expect(runtime.closeMemorySearchManager).toHaveBeenCalledWith({
+      cfg,
+      agentId: "main",
+    });
+    expect(runtime.releaseMemorySearchResourcesForAgent).not.toHaveBeenCalled();
+    expectNoMemoryRuntimeBootstrap();
+  });
+
+  it("releases only scoped recall resources when the caller opts into scope resources", async () => {
+    const runtime = createMemoryRuntimeFixture();
+    const cfg = { plugins: {} };
+    getMemoryRuntimeMock.mockReturnValue(runtime);
+
+    await closeActiveMemorySearchManager({
+      cfg: cfg as never,
+      agentId: "main",
+      scope: "resources",
+    });
 
     expect(runtime.releaseMemorySearchResourcesForAgent).toHaveBeenCalledWith({
       cfg,
@@ -381,20 +402,30 @@ describe("memory runtime auto-enable loading", () => {
     };
     getMemoryRuntimeMock.mockReturnValue(runtime);
 
-    await closeActiveMemorySearchManager({ cfg: cfg as never, agentId: "main" });
+    await closeActiveMemorySearchManager({
+      cfg: cfg as never,
+      agentId: "main",
+      scope: "resources",
+    });
 
     expect(runtime.releasedAgentId).toBe("main");
     expect(runtime.closeMemorySearchManager).not.toHaveBeenCalled();
     expectNoMemoryRuntimeBootstrap();
   });
 
-  it("falls back to scoped close when the memory runtime has no resource-release hook", async () => {
+  it("falls back to full close for scope resources when the runtime lacks the release hook", async () => {
     const runtime = createMemoryRuntimeFixture();
     const cfg = { plugins: {} };
+    // A legacy/external memory runtime without releaseMemorySearchResourcesForAgent
+    // must keep its prior post-timeout cleanup (#84048) instead of becoming a no-op.
     delete (runtime as Partial<typeof runtime>).releaseMemorySearchResourcesForAgent;
     getMemoryRuntimeMock.mockReturnValue(runtime);
 
-    await closeActiveMemorySearchManager({ cfg: cfg as never, agentId: "main" });
+    await closeActiveMemorySearchManager({
+      cfg: cfg as never,
+      agentId: "main",
+      scope: "resources",
+    });
 
     expect(runtime.closeMemorySearchManager).toHaveBeenCalledWith({
       cfg,

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -86,5 +86,10 @@ export async function closeActiveMemorySearchManager(params: {
   agentId: string;
 }): Promise<void> {
   const runtime = getMemoryRuntime();
+  const releaseResources = runtime?.releaseMemorySearchResourcesForAgent;
+  if (releaseResources) {
+    await releaseResources(params);
+    return;
+  }
   await runtime?.closeMemorySearchManager?.(params);
 }

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -80,15 +80,27 @@ export async function closeActiveMemorySearchManagers(cfg?: OpenClawConfig): Pro
   await runtime?.closeAllMemorySearchManagers?.();
 }
 
-/** Closes the plugin-backed memory search manager for one agent. */
+/**
+ * Closes the plugin-backed memory search manager for one agent.
+ *
+ * `scope` defaults to "manager": retire the agent's shared search manager
+ * (existing behavior). "resources" releases only the disposable per-agent recall
+ * resources and keeps the shared manager alive — active-memory recall-timeout
+ * cleanup opts into this so a request-scoped timeout does not tear down the
+ * long-lived QMD manager used by chat memory_search (#96455). A runtime without
+ * the narrow hook falls through to the full close, so legacy/external runtimes
+ * keep their prior post-timeout cleanup (#84048) instead of becoming a no-op.
+ */
 export async function closeActiveMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
+  scope?: "manager" | "resources";
 }): Promise<void> {
   const runtime = getMemoryRuntime();
-  if (runtime?.releaseMemorySearchResourcesForAgent) {
-    await runtime.releaseMemorySearchResourcesForAgent(params);
+  const target = { cfg: params.cfg, agentId: params.agentId };
+  if (params.scope === "resources" && runtime?.releaseMemorySearchResourcesForAgent) {
+    await runtime.releaseMemorySearchResourcesForAgent(target);
     return;
   }
-  await runtime?.closeMemorySearchManager?.(params);
+  await runtime?.closeMemorySearchManager?.(target);
 }

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -86,9 +86,8 @@ export async function closeActiveMemorySearchManager(params: {
   agentId: string;
 }): Promise<void> {
   const runtime = getMemoryRuntime();
-  const releaseResources = runtime?.releaseMemorySearchResourcesForAgent;
-  if (releaseResources) {
-    await releaseResources(params);
+  if (runtime?.releaseMemorySearchResourcesForAgent) {
+    await runtime.releaseMemorySearchResourcesForAgent(params);
     return;
   }
   await runtime?.closeMemorySearchManager?.(params);

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -108,6 +108,10 @@ export type MemoryPluginRuntime = {
     cfg: OpenClawConfig;
     agentId: string;
   }): MemoryRuntimeBackendConfig;
+  releaseMemorySearchResourcesForAgent?(params: {
+    cfg: OpenClawConfig;
+    agentId: string;
+  }): Promise<void>;
   closeMemorySearchManager?(params: { cfg: OpenClawConfig; agentId: string }): Promise<void>;
   closeAllMemorySearchManagers?(): Promise<void>;
 };


### PR DESCRIPTION
## Summary

This is an alternative implementation for #96455 and related to #96459.

It separates active-memory timeout cleanup from the broader memory-search manager close lifecycle:

- adds `releaseMemorySearchResourcesForAgent` to the memory runtime contract;
- routes `closeActiveMemorySearchManager` through that narrower resource-release hook when available;
- calls the new release hook through the runtime object so method receivers are preserved;
- keeps `closeMemorySearchManager` as the actual scoped manager close operation;
- wires memory-core's lazy runtime provider through the new hook;
- adds focused regressions proving active-memory-scoped resource release preserves the shared QMD manager;
- updates the Plugin SDK API baseline for the intentional runtime-contract addition.

## What Problem This Solves

`active-memory` timeout cleanup currently calls `closeActiveMemorySearchManager`, which delegates to the memory runtime's `closeMemorySearchManager`. For QMD-backed memory this closes the agent-scoped shared QMD full manager. That manager is reused by chat `memory_search` and startup/watch maintenance, so a request-scoped active-memory timeout can cause later chat memory calls to fail with `"memory search manager is closed"` even though the QMD backend is healthy.

The timeout cleanup was intended to release disposable local embedding/index resources left behind by hung recall work, not to tear down the shared QMD manager.

Rather than changing the meaning of `closeMemorySearchManager`, this PR introduces a narrower runtime hook for the active-memory cleanup path. The old close hook keeps its existing semantics for callers that really do want to close an agent-scoped manager, while active-memory timeout cleanup gets a resource-release path that preserves shared QMD managers.

## Evidence

Ran a redacted, local-only QMD proof on a Linux test host with Node v22.23.1, pnpm v11.2.2, and qmd v2.5.3. The proof used a temporary workspace and a synthetic token only; it did not read user memory.

Scenario:

1. Create a temporary workspace with `MEMORY.md` and `memory/note.md` containing `QMD_PROOF_TOKEN_PR96465`.
2. Configure OpenClaw memory with `backend: "qmd"`, `searchMode: "search"`, and the qmd v2.5.3 binary.
3. Open the memory-core QMD manager through `getMemorySearchManager`.
4. Run QMD sync and verify `memory_search` hits before cleanup.
5. Call `releaseMemorySearchResourcesForAgent`, matching the active-memory timeout cleanup path after this PR.
6. Fetch the manager again and run the same search.

Redacted output:

```text
qmd watcher starting for agent "proof-main" paths=2
qmd manager initialized for agent "proof-main" mode=full collections=2 durationMs=917
manager1.backend=qmd
qmd watcher ready for agent "proof-main" paths=2 durationMs=78
qmd sync completed for agent "proof-main" reason=pr-96465-proof durationMs=297
before_release.hit_count=2
before_release.first_path=memory/note.md
release_resources.completed=true
same_manager_after_release=true
manager2.backend=qmd
after_release.hit_count=2
after_release.first_path=memory/note.md
closed_error_after_release=false
```

This proves the active-memory-scoped cleanup path no longer closes the shared QMD manager used by chat `memory_search`.

Focused validation run against the exact PR branch source copied to a Linux test host, Node v22.23.1, pnpm v11.2.2:

```bash
node --no-maglev node_modules/vitest/vitest.mjs run \
  --config test/vitest/vitest.extension-memory.config.ts \
  extensions/memory-core/src/memory/search-manager.test.ts \
  --reporter=verbose --passWithNoTests=false
```

Result: 37 passed.

```bash
node --no-maglev node_modules/vitest/vitest.mjs run \
  --config test/vitest/vitest.extension-memory.config.ts \
  extensions/memory-core/index.test.ts \
  --reporter=verbose --passWithNoTests=false
```

Result: 16 passed.

```bash
node --no-maglev node_modules/vitest/vitest.mjs run \
  --config test/vitest/vitest.plugins.config.ts \
  src/plugins/memory-runtime.test.ts \
  --reporter=verbose --passWithNoTests=false
```

Result: 13 passed. The receiver-preservation regression fails before the final fix with `Cannot set properties of undefined (setting 'releasedAgentId')` and passes after calling the hook through `runtime.releaseMemorySearchResourcesForAgent(...)`.

```bash
pnpm exec oxfmt --check \
  extensions/memory-core/index.ts \
  extensions/memory-core/index.test.ts \
  extensions/memory-core/src/memory/index.ts \
  extensions/memory-core/src/memory/search-manager.ts \
  extensions/memory-core/src/memory/search-manager.test.ts \
  extensions/memory-core/src/runtime-provider.ts \
  src/plugins/memory-runtime.ts \
  src/plugins/memory-runtime.test.ts \
  src/plugins/memory-state.ts
```

Result: passed on 9 files.

```bash
pnpm plugin-sdk:api:check
pnpm tsgo:extensions:test
pnpm tsgo:core:test
```

Result: all passed.

GitHub Actions on `b74bd678199d6082a0470125d2d23459aa4f777e` completed successfully for CI, OpenGrep, CodeQL, CodeQL Critical Quality, and iOS Periphery.

AI-assisted.