### PR TITLE
test(deps): align dependency guard action pin

### DIFF
--- a/test/scripts/dependency-guard-workflow.test.ts
+++ b/test/scripts/dependency-guard-workflow.test.ts
@@ -120,7 +120,7 @@ describe("dependency guard workflow", () => {
     const finalSteps = finalJob?.steps ?? [];
     expect(detectSteps[1].env?.OPENCLAW_DEPENDENCY_GUARD_MODE).toBe("detect");
     expect(autoscrubSteps[1].uses).toBe(
-      "actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3",
+      "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
     );
     expect(autoscrubSteps[1].with).toMatchObject({
       "app-id": "2729701",
@@ -130,7 +130,7 @@ describe("dependency guard workflow", () => {
     });
     expect(autoscrubSteps[1]["continue-on-error"]).toBe(true);
     expect(autoscrubSteps[2].uses).toBe(
-      "actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3",
+      "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
     );
     expect(autoscrubSteps[2].with).toMatchObject({
       "app-id": "2971289",


### PR DESCRIPTION
## Summary

- Updates the dependency guard workflow test expectations to match the `actions/create-github-app-token` SHA already introduced by Dependabot in #96341.
- Keeps the workflow behaviour unchanged; this is the test-side repair for the pinned action update.

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs test/scripts/dependency-guard-workflow.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts --reporter=verbose` (the dependency guard test passed in the broader tooling run; the run later failed on unrelated untracked local files under `node_modules 2/` being discovered by `test/scripts/test-projects.test.ts`)
- `.agents/skills/autoreview/scripts/autoreview --mode local --codex-bin /Applications/Codex.app/Contents/Resources/codex`

## Real behavior proof

Behavior addressed: #96341 was failing the dependency guard workflow test because the workflow now pins `actions/create-github-app-token` at `bcd2ba49218906704ab6c1aa796996da409d3eb1`, while the test still expected the previous SHA.

Real environment tested: Local OpenClaw checkout on `dependabot/github_actions/actions-996f9bea48`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs test/scripts/dependency-guard-workflow.test.ts`.

Evidence after fix: The focused dependency guard workflow test passed all 11 tests, and the same test also passed when included in the broader tooling run.

Observed result after fix: The stale expected action pin no longer fails the guard test.

What was not tested: Upstream CI was not rerun directly from `openclaw/openclaw` because the authenticated GitHub account has read-only permission on the upstream repository.
