### PR TITLE
fix(telegram): preserve inline buttons for empty capabilities

### DIFF
--- a/extensions/telegram/src/account-config.ts
+++ b/extensions/telegram/src/account-config.ts
@@ -90,6 +90,10 @@ export function mergeTelegramAccountConfig(
     baseAllowFrom: base.allowFrom,
     accountAllowFrom: account.allowFrom,
   });
+  const capabilities =
+    Array.isArray(account.capabilities) && account.capabilities.length === 0
+      ? base.capabilities
+      : (account.capabilities ?? base.capabilities);
 
-  return { ...base, ...account, allowFrom, groups };
+  return { ...base, ...account, allowFrom, capabilities, groups };
 }

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1703,6 +1703,25 @@ describe("handleTelegramAction", () => {
     expect(sendMessageTelegram).toHaveBeenCalled();
   });
 
+  it("allows inline buttons when legacy capabilities are empty", async () => {
+    await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "@testchannel",
+        content: "Choose",
+        presentation: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Ok", value: "cmd:ok" }] }],
+        },
+      },
+      telegramConfig({ capabilities: [] }),
+    );
+    const call = mockCall(sendMessageTelegram, 0, "empty legacy capabilities");
+    expect(call[0]).toBe("@testchannel");
+    expect(requireRecord(call[2], "empty legacy capabilities options").buttons).toEqual([
+      [{ text: "Ok", callback_data: "cmd:ok" }],
+    ]);
+  });
+
   it("uses interactive button labels as fallback text when message text is omitted", async () => {
     await handleTelegramAction(
       {

--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -58,6 +58,21 @@ describe("telegram actions contract", () => {
     expect(capabilities).toContain("inlineButtons");
   });
 
+  it("does not advertise inline buttons for non-empty legacy Telegram capabilities without inlineButtons", () => {
+    const capabilities = telegramPlugin.agentPrompt?.messageToolCapabilities?.({
+      cfg: {
+        channels: {
+          telegram: {
+            botToken: "123:telegram-test-token",
+            capabilities: ["vision"],
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(capabilities).not.toContain("inlineButtons");
+  });
+
   it("uses the selected Telegram account's rich text setting", () => {
     const capabilities = telegramPlugin.agentPrompt?.messageToolCapabilities?.({
       cfg: {

--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -43,6 +43,21 @@ describe("telegram actions contract", () => {
     expect(capabilities?.includes("richText")).toBe(expected);
   });
 
+  it("advertises inline buttons when legacy Telegram capabilities are empty", () => {
+    const capabilities = telegramPlugin.agentPrompt?.messageToolCapabilities?.({
+      cfg: {
+        channels: {
+          telegram: {
+            botToken: "123:telegram-test-token",
+            capabilities: [],
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(capabilities).toContain("inlineButtons");
+  });
+
   it("uses the selected Telegram account's rich text setting", () => {
     const capabilities = telegramPlugin.agentPrompt?.messageToolCapabilities?.({
       cfg: {

--- a/extensions/telegram/src/inline-buttons.test.ts
+++ b/extensions/telegram/src/inline-buttons.test.ts
@@ -123,6 +123,25 @@ describe("resolveTelegramInlineButtonsScope (#75433 SecretRef tolerance)", () =>
     expect(isTelegramInlineButtonsEnabled({ cfg })).toBe(true);
   });
 
+  it("inherits the channel scope when an account legacy capabilities array is empty", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          capabilities: { inlineButtons: "off" },
+          accounts: {
+            ops: {
+              botToken: "123:telegram-ops-token",
+              capabilities: [],
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(resolveTelegramInlineButtonsScope({ cfg, accountId: "ops" })).toBe("off");
+    expect(isTelegramInlineButtonsEnabled({ cfg, accountId: "ops" })).toBe(false);
+  });
+
   it('preserves configured "off" when botToken is an unresolved SecretRef', () => {
     const cfg = {
       channels: {

--- a/extensions/telegram/src/inline-buttons.test.ts
+++ b/extensions/telegram/src/inline-buttons.test.ts
@@ -109,6 +109,20 @@ describe("resolveTelegramInlineButtonsScope (#75433 SecretRef tolerance)", () =>
     expect(isTelegramInlineButtonsEnabled({ cfg })).toBe(true);
   });
 
+  it("preserves the default inline-buttons scope when legacy capabilities are empty", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: { source: "exec", provider: "default", id: "telegram-token" },
+          capabilities: [],
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(resolveTelegramInlineButtonsScope({ cfg })).toBe("allowlist");
+    expect(isTelegramInlineButtonsEnabled({ cfg })).toBe(true);
+  });
+
   it('preserves configured "off" when botToken is an unresolved SecretRef', () => {
     const cfg = {
       channels: {

--- a/extensions/telegram/src/inline-buttons.ts
+++ b/extensions/telegram/src/inline-buttons.ts
@@ -47,6 +47,9 @@ export function resolveTelegramInlineButtonsScopeFromCapabilities(
     return DEFAULT_INLINE_BUTTONS_SCOPE;
   }
   if (Array.isArray(capabilities)) {
+    if (capabilities.length === 0) {
+      return DEFAULT_INLINE_BUTTONS_SCOPE;
+    }
     const enabled = capabilities.some(
       (entry) => normalizeLowercaseStringOrEmpty(String(entry)) === "inlinebuttons",
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes #96098.

Telegram configs with the legacy array shape `channels.telegram.capabilities: []` were treated as an explicit inline-buttons opt-out. That made the Telegram agent prompt omit `inlineButtons`, so button choices could degrade into plain text even though the documented default scope is `allowlist`.

Note: the `inlineQueries=false` capability probe shown by `openclaw channels capabilities --channel telegram` is Telegram Bot API `supportsInlineQueries`, not OpenClaw's message-tool `inlineButtons` capability. The broken path here is the prompt capability resolver.

## Why This Change Was Made

The fix only changes the empty legacy array case to use the default inline-buttons scope. It intentionally preserves existing semantics for non-empty legacy arrays:

- `capabilities: ["inlineButtons"]` still maps to `all`.
- Non-empty arrays without `inlineButtons` still map to `off`.
- Object config such as `capabilities: { inlineButtons: "off" }` still explicitly disables buttons.

This keeps the fix narrow and preserves explicit opt-out behavior.

## User Impact

Users with existing Telegram config that contains an empty legacy capabilities array get the default `allowlist` inline-button prompt capability again. Explicit Telegram inline-button opt-outs remain respected.

## Evidence

Before fix on main source repro:

```text
resolver=off
messageToolCapabilities=[]
```

After fix source/runtime repro:

```text
resolver=allowlist
messageToolCapabilities=["inlineButtons"]
```

Live Telegram/OpenClaw proof with `channels.telegram.capabilities: []` and a real bot send; private chat identifiers redacted:

```text
agentPrompt.capabilities=["inlineButtons"]
agentPrompt.hasInlineButtons=true
telegram.sent=true
telegram.inlineKeyboardRows=1
telegram.firstButton={"text":"Issue 96098 proof","callback_data":"oc96098"}
```

Local checks after rebasing on `origin/main`:

```text
pnpm test extensions/telegram/src/inline-buttons.test.ts extensions/telegram/src/channel-actions.contract.test.ts
Test Files 2 passed (2)
Tests 27 passed (27)

npx oxlint --deny=warn --ignore-path=.oxlintignore extensions/telegram/src/inline-buttons.ts extensions/telegram/src/inline-buttons.test.ts extensions/telegram/src/channel-actions.contract.test.ts
passed

npx oxfmt --check extensions/telegram/src/inline-buttons.ts extensions/telegram/src/inline-buttons.test.ts extensions/telegram/src/channel-actions.contract.test.ts
All matched files use the correct format.
```

Independent review:

```text
No Critical or Important findings. Minor request to cover non-empty legacy arrays without inlineButtons was addressed with a prompt-capability negative test.
```

Additional local sweep:

```text
pnpm test extensions/telegram
Test Files 1 failed | 123 passed (124)
Tests 1 failed | 2208 passed (2209)
```

The failing test is outside this diff: `extensions/telegram/src/setup-surface.test.ts` expects `Telegram allowFrom (numeric sender id)` but current output is `Telegram allowFrom（数字发送者 ID）`.