### PR TITLE
fix(config): fail closed when config is unreadable before a full-file write

### DIFF
--- a/src/config/io.eacces.test.ts
+++ b/src/config/io.eacces.test.ts
@@ -2,8 +2,9 @@
 import fsNode from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { createConfigIO } from "./io.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { createConfigIO, resetConfigRuntimeState, writeConfigFile } from "./io.js";
 import type { ConfigWriteOptions } from "./io.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
@@ -147,6 +148,51 @@ describe("config write guard after unreadable config", () => {
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining(["unreadable-config-before-write"]),
       });
+      expect(fsNode.readFileSync(configPath, "utf-8")).toBe(liveBytes);
+      const rejectedArtifacts = fsNode
+        .readdirSync(stateDir)
+        .filter((name) => name.startsWith("openclaw.json.rejected."));
+      expect(rejectedArtifacts).toHaveLength(1);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects exported writes before re-reading an unreadable base snapshot",
+    async () => {
+      const home = fsNode.mkdtempSync(path.join(os.tmpdir(), "openclaw-unreadable-"));
+      tempRoots.push(home);
+      const stateDir = path.join(home, ".openclaw");
+      fsNode.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+      const configPath = path.join(stateDir, "openclaw.json");
+      const liveConfig = {
+        gateway: { mode: "local", port: 18789, auth: { mode: "token" } },
+        meta: { lastTouchedVersion: "2026.5.3-1" },
+      } satisfies OpenClawConfig;
+      const liveBytes = `${JSON.stringify(liveConfig, null, 2)}\n`;
+      fsNode.writeFileSync(configPath, liveBytes, { mode: 0o600 });
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        fsNode.chmodSync(configPath, 0o000);
+        await withEnvAsync(
+          { OPENCLAW_CONFIG_PATH: configPath, OPENCLAW_TEST_FAST: "1" },
+          async () => {
+            await expect(
+              writeConfigFile({ channels: { telegram: { enabled: true } } }),
+            ).rejects.toMatchObject({
+              code: "CONFIG_WRITE_REJECTED",
+              reasons: expect.arrayContaining(["unreadable-config-before-write"]),
+            });
+          },
+        );
+      } finally {
+        resetConfigRuntimeState();
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+        fsNode.chmodSync(configPath, 0o600);
+      }
+
       expect(fsNode.readFileSync(configPath, "utf-8")).toBe(liveBytes);
       const rejectedArtifacts = fsNode
         .readdirSync(stateDir)

--- a/src/config/io.eacces.test.ts
+++ b/src/config/io.eacces.test.ts
@@ -1,6 +1,10 @@
 // Covers config IO permission-denied errors and recovery messaging.
-import { describe, expect, it } from "vitest";
+import fsNode from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { createConfigIO } from "./io.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
 
 function makeEaccesFs(configPath: string) {
   const eaccesErr = Object.assign(new Error(`EACCES: permission denied, open '${configPath}'`), {
@@ -57,5 +61,131 @@ describe("config io EACCES handling", () => {
     const snapshot = await io.readConfigFileSnapshot();
     expect(snapshot.issues[0].message).toContain(configPath);
     expect(snapshot.issues[0].message).toContain("container");
+  });
+
+  it("marks the snapshot with the underlying read error code", async () => {
+    const configPath = "/data/.openclaw/openclaw.json";
+    const io = createConfigIO({
+      configPath,
+      fs: makeEaccesFs(configPath),
+      logger: { error: () => {}, warn: () => {} },
+    });
+
+    const snapshot = await io.readConfigFileSnapshot();
+    expect(snapshot.readError).toEqual({ code: "EACCES" });
+  });
+});
+
+function makeUnreadableConfigFs(configPath: string): typeof fsNode {
+  const eacces = Object.assign(new Error(`EACCES: permission denied, open '${configPath}'`), {
+    code: "EACCES",
+  });
+  const readFileSync = ((target: fsNode.PathOrFileDescriptor, options?: unknown) => {
+    if (target === configPath) {
+      throw eacces;
+    }
+    return fsNode.readFileSync(target, options as never);
+  }) as typeof fsNode.readFileSync;
+  const readFile = ((target: unknown, options?: unknown) => {
+    if (target === configPath) {
+      return Promise.reject(eacces);
+    }
+    return fsNode.promises.readFile(target as never, options as never);
+  }) as typeof fsNode.promises.readFile;
+  return {
+    ...fsNode,
+    readFileSync,
+    promises: { ...fsNode.promises, readFile },
+  } as typeof fsNode;
+}
+
+describe("config write guard after unreadable config", () => {
+  const tempRoots: string[] = [];
+  afterEach(() => {
+    while (tempRoots.length > 0) {
+      const root = tempRoots.pop();
+      if (root) {
+        fsNode.rmSync(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("refuses to overwrite a present-but-unreadable config and preserves the live file", async () => {
+    const home = fsNode.mkdtempSync(path.join(os.tmpdir(), "openclaw-unreadable-"));
+    tempRoots.push(home);
+    const stateDir = path.join(home, ".openclaw");
+    fsNode.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    const configPath = path.join(stateDir, "openclaw.json");
+    const liveConfig = {
+      gateway: { mode: "local", port: 18789, auth: { mode: "token" } },
+      channels: { telegram: { enabled: true } },
+      agents: { list: [{ id: "main" }] },
+      meta: { lastTouchedVersion: "2026.5.3-1" },
+    };
+    const liveBytes = `${JSON.stringify(liveConfig, null, 2)}\n`;
+    fsNode.writeFileSync(configPath, liveBytes, { mode: 0o600 });
+
+    const io = createConfigIO({
+      configPath,
+      fs: makeUnreadableConfigFs(configPath),
+      homedir: () => home,
+      env: {},
+      observe: false,
+      logger: { error: () => {}, warn: () => {} },
+    });
+
+    const snapshot = await io.readConfigFileSnapshot();
+    expect(snapshot.readError).toEqual({ code: "EACCES" });
+
+    const skeletal = { channels: { telegram: { enabled: true } } } as OpenClawConfig;
+    let rejected: { code?: string; reasons?: string[] } | null = null;
+    try {
+      await io.writeConfigFile(skeletal);
+    } catch (err) {
+      rejected = err as { code?: string; reasons?: string[] };
+    }
+
+    expect(rejected?.code).toBe("CONFIG_WRITE_REJECTED");
+    expect(rejected?.reasons).toContain("unreadable-config-before-write");
+    expect(fsNode.readFileSync(configPath, "utf-8")).toBe(liveBytes);
+    const rejectedArtifacts = fsNode
+      .readdirSync(stateDir)
+      .filter((name) => name.startsWith("openclaw.json.rejected."));
+    expect(rejectedArtifacts).toHaveLength(1);
+  });
+
+  it("rejects even when the update doctor pass allows a size drop", async () => {
+    const home = fsNode.mkdtempSync(path.join(os.tmpdir(), "openclaw-unreadable-"));
+    tempRoots.push(home);
+    const stateDir = path.join(home, ".openclaw");
+    fsNode.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    const configPath = path.join(stateDir, "openclaw.json");
+    const liveBytes = `${JSON.stringify(
+      { gateway: { mode: "local", port: 18789 }, meta: { lastTouchedVersion: "2026.5.3-1" } },
+      null,
+      2,
+    )}\n`;
+    fsNode.writeFileSync(configPath, liveBytes, { mode: 0o600 });
+
+    const io = createConfigIO({
+      configPath,
+      fs: makeUnreadableConfigFs(configPath),
+      homedir: () => home,
+      env: {},
+      observe: false,
+      logger: { error: () => {}, warn: () => {} },
+    });
+
+    const skeletal = { channels: { telegram: { enabled: true } } } as OpenClawConfig;
+    let rejected: { code?: string; reasons?: string[] } | null = null;
+    try {
+      await io.writeConfigFile(skeletal, { allowConfigSizeDrop: true });
+    } catch (err) {
+      rejected = err as { code?: string; reasons?: string[] };
+    }
+
+    expect(rejected?.code).toBe("CONFIG_WRITE_REJECTED");
+    expect(rejected?.reasons).toContain("unreadable-config-before-write");
+    expect(fsNode.readFileSync(configPath, "utf-8")).toBe(liveBytes);
   });
 });

--- a/src/config/io.eacces.test.ts
+++ b/src/config/io.eacces.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createConfigIO } from "./io.js";
+import type { ConfigWriteOptions } from "./io.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
 function makeEaccesFs(configPath: string) {
@@ -46,7 +47,6 @@ describe("config io EACCES handling", () => {
     expect(snapshot.issues[0].message).toContain("EACCES");
     expect(snapshot.issues[0].message).toContain("chown");
     expect(snapshot.issues[0].message).toContain(configPath);
-    // Should also emit to the logger
     expect(errors.join("\n")).toContain("chown");
   });
 
@@ -110,82 +110,48 @@ describe("config write guard after unreadable config", () => {
     }
   });
 
-  it("refuses to overwrite a present-but-unreadable config and preserves the live file", async () => {
-    const home = fsNode.mkdtempSync(path.join(os.tmpdir(), "openclaw-unreadable-"));
-    tempRoots.push(home);
-    const stateDir = path.join(home, ".openclaw");
-    fsNode.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-    const configPath = path.join(stateDir, "openclaw.json");
-    const liveConfig = {
-      gateway: { mode: "local", port: 18789, auth: { mode: "token" } },
-      channels: { telegram: { enabled: true } },
-      agents: { list: [{ id: "main" }] },
-      meta: { lastTouchedVersion: "2026.5.3-1" },
-    };
-    const liveBytes = `${JSON.stringify(liveConfig, null, 2)}\n`;
-    fsNode.writeFileSync(configPath, liveBytes, { mode: 0o600 });
+  it.each([
+    { label: "default write" },
+    { label: "update doctor size-drop write", writeOptions: { allowConfigSizeDrop: true } },
+  ] satisfies Array<{ label: string; writeOptions?: ConfigWriteOptions }>)(
+    "refuses to overwrite a present-but-unreadable config during $label",
+    async ({ writeOptions }) => {
+      const home = fsNode.mkdtempSync(path.join(os.tmpdir(), "openclaw-unreadable-"));
+      tempRoots.push(home);
+      const stateDir = path.join(home, ".openclaw");
+      fsNode.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+      const configPath = path.join(stateDir, "openclaw.json");
+      const liveConfig = {
+        gateway: { mode: "local", port: 18789, auth: { mode: "token" } },
+        channels: { telegram: { enabled: true } },
+        agents: { list: [{ id: "main" }] },
+        meta: { lastTouchedVersion: "2026.5.3-1" },
+      };
+      const liveBytes = `${JSON.stringify(liveConfig, null, 2)}\n`;
+      fsNode.writeFileSync(configPath, liveBytes, { mode: 0o600 });
 
-    const io = createConfigIO({
-      configPath,
-      fs: makeUnreadableConfigFs(configPath),
-      homedir: () => home,
-      env: {},
-      observe: false,
-      logger: { error: () => {}, warn: () => {} },
-    });
+      const io = createConfigIO({
+        configPath,
+        fs: makeUnreadableConfigFs(configPath),
+        homedir: () => home,
+        env: {},
+        observe: false,
+        logger: { error: () => {}, warn: () => {} },
+      });
 
-    const snapshot = await io.readConfigFileSnapshot();
-    expect(snapshot.readError).toEqual({ code: "EACCES" });
+      const snapshot = await io.readConfigFileSnapshot();
+      expect(snapshot.readError).toEqual({ code: "EACCES" });
 
-    const skeletal = { channels: { telegram: { enabled: true } } } as OpenClawConfig;
-    let rejected: { code?: string; reasons?: string[] } | null = null;
-    try {
-      await io.writeConfigFile(skeletal);
-    } catch (err) {
-      rejected = err as { code?: string; reasons?: string[] };
-    }
-
-    expect(rejected?.code).toBe("CONFIG_WRITE_REJECTED");
-    expect(rejected?.reasons).toContain("unreadable-config-before-write");
-    expect(fsNode.readFileSync(configPath, "utf-8")).toBe(liveBytes);
-    const rejectedArtifacts = fsNode
-      .readdirSync(stateDir)
-      .filter((name) => name.startsWith("openclaw.json.rejected."));
-    expect(rejectedArtifacts).toHaveLength(1);
-  });
-
-  it("rejects even when the update doctor pass allows a size drop", async () => {
-    const home = fsNode.mkdtempSync(path.join(os.tmpdir(), "openclaw-unreadable-"));
-    tempRoots.push(home);
-    const stateDir = path.join(home, ".openclaw");
-    fsNode.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-    const configPath = path.join(stateDir, "openclaw.json");
-    const liveBytes = `${JSON.stringify(
-      { gateway: { mode: "local", port: 18789 }, meta: { lastTouchedVersion: "2026.5.3-1" } },
-      null,
-      2,
-    )}\n`;
-    fsNode.writeFileSync(configPath, liveBytes, { mode: 0o600 });
-
-    const io = createConfigIO({
-      configPath,
-      fs: makeUnreadableConfigFs(configPath),
-      homedir: () => home,
-      env: {},
-      observe: false,
-      logger: { error: () => {}, warn: () => {} },
-    });
-
-    const skeletal = { channels: { telegram: { enabled: true } } } as OpenClawConfig;
-    let rejected: { code?: string; reasons?: string[] } | null = null;
-    try {
-      await io.writeConfigFile(skeletal, { allowConfigSizeDrop: true });
-    } catch (err) {
-      rejected = err as { code?: string; reasons?: string[] };
-    }
-
-    expect(rejected?.code).toBe("CONFIG_WRITE_REJECTED");
-    expect(rejected?.reasons).toContain("unreadable-config-before-write");
-    expect(fsNode.readFileSync(configPath, "utf-8")).toBe(liveBytes);
-  });
+      const skeletal: OpenClawConfig = { channels: { telegram: { enabled: true } } };
+      await expect(io.writeConfigFile(skeletal, writeOptions)).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining(["unreadable-config-before-write"]),
+      });
+      expect(fsNode.readFileSync(configPath, "utf-8")).toBe(liveBytes);
+      const rejectedArtifacts = fsNode
+        .readdirSync(stateDir)
+        .filter((name) => name.startsWith("openclaw.json.rejected."));
+      expect(rejectedArtifacts).toHaveLength(1);
+    },
+  );
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -503,6 +503,7 @@ function resolveConfigStatMetadata(
 
 function resolveConfigWriteSuspiciousReasons(params: {
   existsBefore: boolean;
+  unreadableBefore: boolean;
   previousBytes: number | null;
   nextBytes: number | null;
   hasMetaBefore: boolean;
@@ -512,6 +513,9 @@ function resolveConfigWriteSuspiciousReasons(params: {
   const reasons: string[] = [];
   if (!params.existsBefore) {
     return reasons;
+  }
+  if (params.unreadableBefore) {
+    reasons.push("unreadable-config-before-write");
   }
   if (
     typeof params.previousBytes === "number" &&
@@ -536,6 +540,7 @@ function resolveConfigWriteBlockingReasons(
 ): string[] {
   return suspicious.filter(
     (reason) =>
+      reason === "unreadable-config-before-write" ||
       (reason.startsWith("size-drop:") && options.allowConfigSizeDrop !== true) ||
       reason === "gateway-mode-removed",
   );
@@ -1329,6 +1334,7 @@ function createConfigFileSnapshot(params: {
   valid: boolean;
   runtimeConfig: OpenClawConfig;
   hash?: string;
+  readError?: { code: string | null };
   issues: ConfigFileSnapshot["issues"];
   warnings: ConfigFileSnapshot["warnings"];
   legacyIssues: LegacyConfigIssue[];
@@ -1346,6 +1352,7 @@ function createConfigFileSnapshot(params: {
     runtimeConfig,
     config: runtimeConfig,
     hash: params.hash,
+    ...(params.readError ? { readError: params.readError } : {}),
     issues: params.issues,
     warnings: params.warnings,
     legacyIssues: params.legacyIssues,
@@ -2121,6 +2128,7 @@ export function createConfigIO(
           valid: false,
           runtimeConfig: fallbackSourceConfig,
           hash: fallbackHash,
+          readError: { code: nodeErr?.code ?? null },
           issues: [{ path: "", message }],
           warnings: [],
           legacyIssues: [],
@@ -2456,6 +2464,7 @@ export function createConfigIO(
     const gatewayModeAfter = resolveGatewayMode(stampedOutputConfig);
     const suspiciousReasons = resolveConfigWriteSuspiciousReasons({
       existsBefore: snapshot.exists,
+      unreadableBefore: snapshot.readError != null,
       previousBytes,
       nextBytes,
       hasMetaBefore,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -309,6 +309,11 @@ function assertBaseSnapshotStillCurrent(
       retryable: false,
     });
   }
+  // Unreadable snapshots cannot be re-read for freshness; the write guard rejects
+  // them before commit unless the caller explicitly requests a destructive write.
+  if (snapshot.readError) {
+    return;
+  }
   const expectedHash = resolveConfigSnapshotHash(snapshot);
   let currentRaw: string | null = null;
   let currentExists = true;
@@ -2128,7 +2133,7 @@ export function createConfigIO(
           valid: false,
           runtimeConfig: fallbackSourceConfig,
           hash: fallbackHash,
-          readError: { code: nodeErr?.code ?? null },
+          ...(fallbackRaw === null ? { readError: { code: nodeErr?.code ?? null } } : {}),
           issues: [{ path: "", message }],
           warnings: [],
           legacyIssues: [],

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -301,6 +301,7 @@ export type ConfigFileSnapshot = {
   /** @deprecated Prefer runtimeConfig. */
   config: RuntimeConfig;
   hash?: string;
+  readError?: { code: string | null };
   issues: ConfigValidationIssue[];
   warnings: ConfigValidationIssue[];
   legacyIssues: LegacyConfigIssue[];


### PR DESCRIPTION
## What Problem This Solves

When the existing `openclaw.json` is present but cannot be read (for example `EACCES` after a `sudo` command leaves it root-owned), the config loader returns an empty best-effort fallback snapshot. A later full-file write (notably `openclaw doctor`, including the update doctor pass) then serializes a skeletal config over the still-rich file on disk, dropping `gateway.mode` and most user state. The gateway afterwards refuses to start because `gateway.mode` is missing.

This makes the write fail closed: when the base config could not be read, a full-file overwrite is rejected and the live config is preserved.

Refs #78493 (the config-clobber half).

## Why This Change Was Made

On an unreadable existing config, the read path returns a `valid:false` fallback snapshot with no raw bytes, and nothing records that the read itself failed:

```ts
// src/config/io.ts - EACCES/read-failure catch (before)
snapshot: createConfigFileSnapshot({
  path: configPath,
  exists: true,
  raw: fallbackRaw,        // null - the file could not be read
  valid: false,
  ...
}),
```

The write guard only blocks `size-drop:` (relative to the in-memory base) and `gateway-mode-removed`:

```ts
// src/config/io.ts - resolveConfigWriteBlockingReasons (before)
return suspicious.filter(
  (reason) =>
    (reason.startsWith("size-drop:") && options.allowConfigSizeDrop !== true) ||
    reason === "gateway-mode-removed",
);
```

Because the fallback base has `raw: null` (so `previousBytes` is null, no size-drop) and an empty resolved config (so `gatewayModeBefore` is null, no gateway-mode-removed), neither guard fires, and the doctor/update path additionally passes `allowConfigSizeDrop: true`. The skeletal config is written over the real one.

The fix records the read failure on the snapshot, then treats an unreadable base as a hard write blocker:

```ts
// src/config/io.ts - EACCES/read-failure catch (after)
readError: { code: nodeErr?.code ?? null },
```

```ts
// src/config/io.ts - resolveConfigWriteBlockingReasons (after)
return suspicious.filter(
  (reason) =>
    reason === "unreadable-config-before-write" ||
    (reason.startsWith("size-drop:") && options.allowConfigSizeDrop !== true) ||
    reason === "gateway-mode-removed",
);
```

`unreadable-config-before-write` is added whenever the write base carries a `readError`. It is filtered as always-blocking, so `allowConfigSizeDrop` (set by the update doctor pass) does not bypass it.

The config IO writer already owns the suspicious/blocking-reason gate and the rejected-artifact path, so this adds one structured signal (`readError`) and one blocking reason at that same owner boundary rather than guarding each caller. The existing `allowDestructiveWrite` escape hatch still bypasses it for explicit recovery, and the rejected payload is still saved to `openclaw.json.rejected.<timestamp>`. Last-known-good recovery writes raw bytes directly via `fs.promises.writeFile` (not through `writeConfigFile`), so restoring a good config is unaffected, and readable configs never set `readError`, so normal writes are unchanged.

## User Impact

A `sudo`-induced `EACCES` on `openclaw.json` no longer leads to the rich config being overwritten by a 173-byte skeleton that drops `gateway.mode` and bricks gateway startup. The write is rejected, the live config is preserved on disk, and the blocked payload is kept as a `.rejected.<timestamp>` artifact for inspection. This is what the reporters asked for on 2026-06-21 and 2026-06-24.

The separate sudo/wrong-UID ownership policy (refuse, re-exec as the target user, or repair ownership) is a maintainer product decision and is intentionally out of scope here; this guard kills the data-loss class regardless of how the ownership got mixed.

## Evidence

Drove the real `createConfigIO(...).writeConfigFile()` runtime on pristine `origin/main` (fa2379dbc8) and on the patched tree with identical inputs, against a real on-disk `~/.openclaw/openclaw.json` in a temp home. The only simulated element is the filesystem read seam returning a genuine Node `EACCES` errno error; the on-disk config bytes, the write guard, the rejected-artifact path, and the atomic write path all stayed real. Two write paths were exercised: the default write and the exact update-doctor path that passes `allowConfigSizeDrop=true`. Steps: write a 383-byte config with `gateway.mode=local`, make reads of that path raise `EACCES`, then call the real `writeConfigFile` with a skeletal config and read the file back from disk.

```
# BEFORE (pristine origin/main fa2379dbc8)
[default] write-outcome: WROTE (no guard) reasons=<none>
[default] config-after: 173 bytes gateway.mode=<missing> live-preserved=false
[update-doctor allowConfigSizeDrop=true] write-outcome: WROTE (no guard) reasons=<none>
[update-doctor allowConfigSizeDrop=true] config-after: 173 bytes gateway.mode=<missing> live-preserved=false
# AFTER (this patch, identical inputs)
[default] write-outcome: CONFIG_WRITE_REJECTED reasons=unreadable-config-before-write
[default] config-after: 383 bytes gateway.mode=local live-preserved=true
[update-doctor allowConfigSizeDrop=true] write-outcome: CONFIG_WRITE_REJECTED reasons=unreadable-config-before-write
[update-doctor allowConfigSizeDrop=true] config-after: 383 bytes gateway.mode=local live-preserved=true
```

On both the default write and the update-doctor `allowConfigSizeDrop=true` write, the unreadable base is rejected as `unreadable-config-before-write`, the on-disk config stays 383 bytes with `gateway.mode=local` intact (versus 173 bytes with `gateway.mode` dropped before), and the blocked payload is saved as a rejected artifact. The `allowConfigSizeDrop=true` line is the exact path the update doctor takes, which is why the clobber reached users before this change.

Automated checks:

- `node scripts/run-vitest.mjs src/config/io.eacces.test.ts src/config/io.write-config.test.ts src/config/io.best-effort.test.ts src/config/io.clobber-snapshot.test.ts src/config/io.audit.test.ts` - 113 passed (5 files), including the full write-config suite (no regression).
- The three new cases in `src/config/io.eacces.test.ts` (read marks `readError`, default write rejected and live file preserved, and the update-doctor `allowConfigSizeDrop=true` write still rejected) fail on pristine `origin/main` and pass with this patch.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` clean on the changed files; `run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` both exit 0.

Not covered: no live macOS sudo/LaunchAgent or Linux systemd reproduction; the sudo/wrong-UID ownership-policy half of #78493; full build not run.
