### PR TITLE
fix(ollama): Ollama Cloud tool calls fail after first turn

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -191,6 +191,72 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
     expect(payload.options).toEqual({ num_ctx: 131072 });
   });
 
+  it("keeps OpenAI-compatible replay tool-call arguments string encoded", async () => {
+    let patchedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      options?.onPayload?.({
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_gateway",
+                type: "function",
+                function: {
+                  name: "gateway",
+                  arguments: '{"action":"config.get","path":"gateway.port"}',
+                },
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            function_call: {
+              name: "legacy_gateway",
+              arguments: '{"action":"config.get","path":"gateway.host"}',
+            },
+          },
+        ],
+      });
+      return (async function* () {})();
+    });
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "glm-5.2:cloud",
+      contextWindow: 131072,
+      params: { num_ctx: 32768 },
+    };
+
+    const wrapped = createConfiguredOllamaCompatStreamWrapper({
+      provider: "ollama",
+      modelId: "glm-5.2:cloud",
+      model,
+      streamFn: baseStreamFn,
+    } as never);
+
+    await wrapped?.(
+      model as never,
+      { messages: [] } as never,
+      {
+        onPayload: (payload: unknown) => {
+          patchedPayload = payload as Record<string, unknown>;
+        },
+      } as never,
+    );
+
+    const payload = requireRecord(patchedPayload, "patched payload");
+    expect(payload.options).toEqual({ num_ctx: 32768 });
+    const messages = payload.messages as Array<Record<string, unknown>>;
+    const toolCalls = messages[0].tool_calls as Array<{
+      function: { arguments: unknown };
+    }>;
+    const legacyFunctionCall = messages[1].function_call as { arguments: unknown };
+
+    expect(toolCalls[0].function.arguments).toBe('{"action":"config.get","path":"gateway.port"}');
+    expect(legacyFunctionCall.arguments).toBe('{"action":"config.get","path":"gateway.host"}');
+  });
+
   it("forwards think=false on native Ollama chat requests when thinking is off", async () => {
     await withMockNdjsonFetch(
       [

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -257,6 +257,113 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
     expect(legacyFunctionCall.arguments).toBe('{"action":"config.get","path":"gateway.host"}');
   });
 
+  it("replays the same tool call as object args natively but string args for OpenAI-compat", async () => {
+    // #96441 invariant: identical replayed tool calls must diverge by API. Native
+    // /api/chat expects object arguments; OpenAI-compatible Chat Completions requires
+    // JSON-string arguments. This guards against re-unifying the two normalization paths.
+    const stringArgs = '{"action":"config.get","path":"gateway.port"}';
+
+    const nativeMessages = convertToOllamaMessages([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_gateway", name: "gateway", arguments: stringArgs }],
+      },
+    ]);
+    expect(nativeMessages[0].tool_calls).toEqual([
+      {
+        id: "call_gateway",
+        function: { name: "gateway", arguments: { action: "config.get", path: "gateway.port" } },
+      },
+    ]);
+
+    let patchedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      options?.onPayload?.({
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_gateway",
+                type: "function",
+                function: { name: "gateway", arguments: stringArgs },
+              },
+            ],
+          },
+        ],
+      });
+      return (async function* () {})();
+    });
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "glm-5.2:cloud",
+      contextWindow: 131072,
+      params: { num_ctx: 32768 },
+    };
+
+    const wrapped = createConfiguredOllamaCompatStreamWrapper({
+      provider: "ollama",
+      modelId: "glm-5.2:cloud",
+      model,
+      streamFn: baseStreamFn,
+    } as never);
+
+    await wrapped?.(
+      model as never,
+      { messages: [] } as never,
+      {
+        onPayload: (payload: unknown) => {
+          patchedPayload = payload as Record<string, unknown>;
+        },
+      } as never,
+    );
+
+    const payload = requireRecord(patchedPayload, "patched payload");
+    const compatToolCalls = (payload.messages as Array<Record<string, unknown>>)[0]
+      .tool_calls as Array<{
+      function: { arguments: unknown };
+    }>;
+    expect(compatToolCalls[0].function.arguments).toBe(stringArgs);
+  });
+
+  it("injects num_ctx without clobbering existing OpenAI-compat options", async () => {
+    let patchedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      options?.onPayload?.({ options: { temperature: 0.5 } });
+      return (async function* () {})();
+    });
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "glm-5.2:cloud",
+      contextWindow: 131072,
+      params: { num_ctx: 32768 },
+    };
+
+    const wrapped = createConfiguredOllamaCompatStreamWrapper({
+      provider: "ollama",
+      modelId: "glm-5.2:cloud",
+      model,
+      streamFn: baseStreamFn,
+    } as never);
+
+    await wrapped?.(
+      model as never,
+      { messages: [] } as never,
+      {
+        onPayload: (payload: unknown) => {
+          patchedPayload = payload as Record<string, unknown>;
+        },
+      } as never,
+    );
+
+    const payload = requireRecord(patchedPayload, "patched payload");
+    const options = requireRecord(payload.options, "patched options");
+    expect(options.temperature).toBe(0.5);
+    expect(options.num_ctx).toBe(32768);
+  });
+
   it("forwards think=false on native Ollama chat requests when thinking is off", async () => {
     await withMockNdjsonFetch(
       [

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -247,7 +247,6 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         payloadRecord.options = {};
       }
       (payloadRecord.options as Record<string, unknown>).num_ctx = numCtx;
-      normalizeOllamaCompatMessageToolArgs(payloadRecord);
     });
 }
 
@@ -734,46 +733,6 @@ function ensureArgsObject(value: unknown): Record<string, unknown> {
 
 function normalizeOllamaToolCallArguments(value: unknown): Record<string, unknown> {
   return ensureArgsObject(value);
-}
-
-function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unknown>): void {
-  const messages = payloadRecord.messages;
-  if (!Array.isArray(messages)) {
-    return;
-  }
-
-  for (const message of messages) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
-      continue;
-    }
-    const messageRecord = message as Record<string, unknown>;
-
-    const functionCall = messageRecord.function_call;
-    if (functionCall && typeof functionCall === "object" && !Array.isArray(functionCall)) {
-      const functionCallRecord = functionCall as Record<string, unknown>;
-      if (Object.hasOwn(functionCallRecord, "arguments")) {
-        functionCallRecord.arguments = ensureArgsObject(functionCallRecord.arguments);
-      }
-    }
-
-    const toolCalls = messageRecord.tool_calls;
-    if (!Array.isArray(toolCalls)) {
-      continue;
-    }
-    for (const toolCall of toolCalls) {
-      if (!toolCall || typeof toolCall !== "object" || Array.isArray(toolCall)) {
-        continue;
-      }
-      const functionSpec = (toolCall as Record<string, unknown>).function;
-      if (!functionSpec || typeof functionSpec !== "object" || Array.isArray(functionSpec)) {
-        continue;
-      }
-      const functionRecord = functionSpec as Record<string, unknown>;
-      if (Object.hasOwn(functionRecord, "arguments")) {
-        functionRecord.arguments = ensureArgsObject(functionRecord.arguments);
-      }
-    }
-  }
 }
 
 function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
Closes #96441

## What Problem This Solves

Fixes an issue where users running Ollama Cloud models with tools would complete the first tool call but fail on the next turn when OpenClaw replayed the prior assistant tool call back through the OpenAI-compatible Chat Completions path.

The failure showed up as Ollama rejecting the request with `400 json: cannot unmarshal object into Go struct field .messages.tool_calls.function.arguments of type string`.

## Why This Change Was Made

OpenAI-compatible Chat Completions payloads require assistant tool-call and legacy function-call `arguments` to remain JSON strings. The Ollama OpenAI-compatible `num_ctx` wrapper now only injects `options.num_ctx` and no longer applies the native Ollama `/api/chat` object-argument normalization to replayed Chat Completions messages.

Native Ollama response/request argument parsing remains separate and still handles object arguments for the native API path.

## User Impact

Ollama Cloud users can continue multi-turn tool-calling conversations after the first tool call instead of hitting a provider schema error on replay. Native Ollama `/api/chat` behavior is unchanged.

## Evidence

Duplicate/competing PR check:
- Exact live PR search for `96441` across all states returned no PRs before branching.
- Root-cause search found the older merged PR #52253 and closed PR #49179, but no active competing PR for this issue.

Real behavior proof:
- Behavior addressed: Ollama OpenAI-compatible second-turn tool-call replay payload shape.
- Real environment tested: local OpenClaw provider payload wrapper path in the current source checkout; the regression test captures the outgoing payload after `createConfiguredOllamaCompatStreamWrapper` applies its patches.
- Exact steps: added a regression that sends assistant `tool_calls[*].function.arguments` and legacy `function_call.arguments` as JSON strings through the Ollama OpenAI-compatible wrapper.
- Evidence after fix: the captured patched payload keeps both argument fields as JSON strings while still injecting `options.num_ctx`.
- Observed result: focused Ollama tests pass and cover the replay payload contract plus adjacent native/Ollama stream behavior.
- What was not tested: no live Ollama Cloud credentialed request was run from this environment.

Validation commands:
- `node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts` — 1 file, 101 tests passed.
- `node scripts/run-vitest.mjs extensions/ollama/src/stream.test.ts extensions/ollama/src/stream-runtime.test.ts` — 2 files, 116 tests passed.
- `node scripts/run-vitest.mjs extensions/ollama/index.test.ts extensions/ollama/src/stream.test.ts extensions/ollama/src/stream-runtime.test.ts` — 3 files, 173 tests passed.
- Branch autoreview with parallel focused tests: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs extensions/ollama/index.test.ts extensions/ollama/src/stream.test.ts extensions/ollama/src/stream-runtime.test.ts"` — clean, no accepted/actionable findings; tests exited 0.

AI assistance disclosure:
- This PR was implemented with AI assistance in a local Codex session. I reviewed the issue, duplicate PR state, current source behavior, dependency contract (`openai` Chat Completions types), tests, and autoreview output before opening.
