### PR TITLE
fix: Ollama Cloud tool calls fail on second turn

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -115,6 +115,26 @@ describe("buildOllamaChatRequest", () => {
     });
     expect(request.model).toBe("library/qwen3:32b");
   });
+
+  it("keeps native Ollama replay tool arguments as objects", () => {
+    const messages = convertToOllamaMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "gateway",
+            arguments: '{"action":"config.get","path":"gateway.port"}',
+          },
+        ],
+      },
+    ]);
+
+    expect(messages[0]?.tool_calls?.[0]?.function.arguments).toEqual({
+      action: "config.get",
+      path: "gateway.port",
+    });
+  });
 });
 
 describe("createConfiguredOllamaCompatStreamWrapper", () => {
@@ -154,6 +174,67 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
     const payload = requireRecord(patchedPayload, "patched payload");
     expect(payload.thinking).toEqual({ type: "enabled" });
     expect(payload.options).toEqual({ num_ctx: 65536 });
+  });
+
+  it("preserves OpenAI-compatible replay tool arguments as strings", async () => {
+    let patchedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      options?.onPayload?.({
+        messages: [
+          {
+            role: "assistant",
+            function_call: {
+              name: "legacy_gateway",
+              arguments: '{"action":"config.get"}',
+            },
+            tool_calls: [
+              {
+                id: "call_gateway",
+                type: "function",
+                function: {
+                  name: "gateway",
+                  arguments: '{"action":"config.get","path":"gateway.port"}',
+                },
+              },
+            ],
+          },
+        ],
+      });
+      return (async function* () {})();
+    });
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "glm-5.2:cloud",
+      contextWindow: 262144,
+    };
+
+    const wrapped = createConfiguredOllamaCompatStreamWrapper({
+      provider: "ollama",
+      modelId: "glm-5.2:cloud",
+      model,
+      streamFn: baseStreamFn,
+    } as never);
+
+    await wrapped?.(
+      model as never,
+      { messages: [] } as never,
+      {
+        onPayload: (payload: unknown) => {
+          patchedPayload = payload as Record<string, unknown>;
+        },
+      } as never,
+    );
+
+    const payload = requireRecord(patchedPayload, "patched payload");
+    const messages = payload.messages as Array<Record<string, unknown>>;
+    const assistantMessage = requireRecord(messages[0], "assistant message");
+    const functionCall = requireRecord(assistantMessage.function_call, "function call");
+    const toolCalls = assistantMessage.tool_calls as Array<Record<string, unknown>>;
+    const toolCallFunction = requireRecord(toolCalls[0]?.function, "tool call function");
+    expect(functionCall.arguments).toBe('{"action":"config.get"}');
+    expect(toolCallFunction.arguments).toBe('{"action":"config.get","path":"gateway.port"}');
+    expect(payload.options).toEqual({ num_ctx: 262144 });
   });
 
   it("falls back to contextWindow when configured num_ctx is invalid", async () => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -247,7 +247,6 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         payloadRecord.options = {};
       }
       (payloadRecord.options as Record<string, unknown>).num_ctx = numCtx;
-      normalizeOllamaCompatMessageToolArgs(payloadRecord);
     });
 }
 
@@ -734,46 +733,6 @@ function ensureArgsObject(value: unknown): Record<string, unknown> {
 
 function normalizeOllamaToolCallArguments(value: unknown): Record<string, unknown> {
   return ensureArgsObject(value);
-}
-
-function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unknown>): void {
-  const messages = payloadRecord.messages;
-  if (!Array.isArray(messages)) {
-    return;
-  }
-
-  for (const message of messages) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
-      continue;
-    }
-    const messageRecord = message as Record<string, unknown>;
-
-    const functionCall = messageRecord.function_call;
-    if (functionCall && typeof functionCall === "object" && !Array.isArray(functionCall)) {
-      const functionCallRecord = functionCall as Record<string, unknown>;
-      if (Object.hasOwn(functionCallRecord, "arguments")) {
-        functionCallRecord.arguments = ensureArgsObject(functionCallRecord.arguments);
-      }
-    }
-
-    const toolCalls = messageRecord.tool_calls;
-    if (!Array.isArray(toolCalls)) {
-      continue;
-    }
-    for (const toolCall of toolCalls) {
-      if (!toolCall || typeof toolCall !== "object" || Array.isArray(toolCall)) {
-        continue;
-      }
-      const functionSpec = (toolCall as Record<string, unknown>).function;
-      if (!functionSpec || typeof functionSpec !== "object" || Array.isArray(functionSpec)) {
-        continue;
-      }
-      const functionRecord = functionSpec as Record<string, unknown>;
-      if (Object.hasOwn(functionRecord, "arguments")) {
-        functionRecord.arguments = ensureArgsObject(functionRecord.arguments);
-      }
-    }
-  }
 }
 
 function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
Closes #96441

## What Problem This Solves

Fixes an issue where users running Ollama Cloud models through the OpenAI-compatible Chat Completions route would hit a 400 error on the second agent turn after a tool call. The failing replay sent previous `tool_calls.function.arguments` as a JSON object even though the OpenAI-compatible request contract expects JSON strings.

## Why This Change Was Made

The Ollama native `/api/chat` route still needs object arguments, but the OpenAI-compatible `/v1/chat/completions` route must preserve string arguments already produced by the shared OpenAI Chat Completions converter. This change removes the extra compat payload mutation that was converting replayed function arguments back into objects while keeping native Ollama argument normalization covered.

## User Impact

Ollama Cloud users can continue multi-turn tool-calling conversations instead of failing immediately when OpenClaw replays the previous assistant tool call. Native Ollama users keep the existing object-argument behavior for `/api/chat`.

## Evidence

Dependency contract checked:
- `node_modules/openai/resources/chat/completions/completions.d.ts` defines both legacy `function_call.arguments` and `ChatCompletionMessageFunctionToolCall.Function.arguments` as `string` JSON.

Captured after-fix request proof:
- Real environment tested: current source checkout, actual `streamOpenAICompletions` OpenAI SDK HTTP path, Ollama compat wrapper, local OpenAI-compatible `/v1/chat/completions` endpoint capturing the wire request body.
- Exact scenario: second-turn conversation history with a previous assistant `toolCall`, matching the reporter's failing replay shape.
- Observed request path: `/v1/chat/completions`.
- Observed `tool_calls[0].function.arguments` type: `string`.
- Observed `tool_calls[0].function.arguments` value: `{"action":"config.get","path":"gateway.port"}`.
- Observed `options.num_ctx`: `262144`, proving the Ollama compat wrapper still patched the same request.
- Native sibling check in the same proof: `convertToOllamaMessages` still returns object arguments for native Ollama replay: `{ "action": "config.get", "path": "gateway.port" }`.

Captured proof output:

```json
{
  "capturedRequests": 1,
  "requestUrl": "/v1/chat/completions",
  "compatToolArgumentsType": "string",
  "compatToolArgumentsValue": "{\"action\":\"config.get\",\"path\":\"gateway.port\"}",
  "compatOptionsNumCtx": 262144,
  "nativeToolArgumentsType": "object",
  "nativeToolArgumentsValue": {
    "action": "config.get",
    "path": "gateway.port"
  }
}
```

Commands run:
- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts`
- `node scripts/run-vitest.mjs extensions/ollama/index.test.ts`
- `node scripts/run-vitest.mjs extensions/ollama/src/stream.test.ts extensions/ollama/src/stream-runtime.test.ts`
- `pnpm exec oxfmt --write --threads=1 extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`
- `pnpm exec oxlint --config .oxlintrc.json --quiet extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`
- `pnpm exec tsx -` with a stdin harness that starts a local OpenAI-compatible endpoint, calls `streamOpenAICompletions` through `createConfiguredOllamaCompatStreamWrapper`, captures the HTTP request body, and checks the native conversion sibling.
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt 'Review the narrow fix for issue #96441: Ollama OpenAI-compatible Chat Completions payloads must preserve tool call function.arguments as JSON strings, while native Ollama /api/chat replay keeps object arguments. Focus on changed files only and dependency contract fit.'`

Autoreview result:
- `autoreview clean: no accepted/actionable findings reported`

Not tested:
- Live Ollama Cloud credentialed request; the after-fix proof above captures the real OpenAI SDK HTTP request body against a local OpenAI-compatible endpoint without needing live credentials.
