### PR TITLE
fix(codex): return Computer Use approval content

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -14,7 +14,11 @@ does not vendor the desktop app, execute desktop actions itself, or bypass
 Codex permissions. The bundled `codex` plugin only prepares Codex app-server:
 it enables Codex plugin support, finds or installs the configured Codex
 Computer Use plugin, checks that the `computer-use` MCP server is available, and
-then lets Codex own the native MCP tool calls during Codex-mode turns.
+then lets Codex own the native MCP tool calls during Codex-mode turns. When
+Codex asks OpenClaw to bridge a Computer Use approval form with no fields,
+OpenClaw returns an explicit `{ "approve": true }` confirmation rather than a
+contentless accept, so the downstream MCP helper receives a machine-readable
+approval result.
 
 Use this page when OpenClaw is already using the native Codex harness. For the
 runtime setup itself, see [Codex harness](/plugins/codex-harness).

--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -16,9 +16,9 @@ it enables Codex plugin support, finds or installs the configured Codex
 Computer Use plugin, checks that the `computer-use` MCP server is available, and
 then lets Codex own the native MCP tool calls during Codex-mode turns. When
 Codex asks OpenClaw to bridge a Computer Use approval form with no fields,
-OpenClaw returns an explicit `{ "approve": true }` confirmation rather than a
-contentless accept, so the downstream MCP helper receives a machine-readable
-approval result.
+OpenClaw returns an explicit `{ "approve": true }` confirmation for that
+Computer Use approval instead of changing every empty-schema MCP approval shape.
+Codex still owns the later native `tools/call` execution path.
 
 Use this page when OpenClaw is already using the native Codex harness. For the
 runtime setup itself, see [Codex harness](/plugins/codex-harness).

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -298,7 +298,7 @@ describe("Codex app-server elicitation bridge", () => {
 
     expect(result).toEqual({
       action: "accept",
-      content: null,
+      content: { approve: true },
       _meta: null,
     });
     const approvalRequestCall = gatewayToolCall();
@@ -329,13 +329,32 @@ describe("Codex app-server elicitation bridge", () => {
 
     expect(result).toEqual({
       action: "accept",
-      content: null,
+      content: { approve: true },
       _meta: null,
     });
     expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
       "plugin.approval.request",
       "plugin.approval.waitDecision",
     ]);
+  });
+
+  it("does not return a contentless accept for empty Computer Use schemas", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-computer-use-empty", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-computer-use-empty", decision: "allow-once" });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildComputerUseApprovalElicitation({
+        requestedSchema: { type: "object", properties: {} },
+      }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
+      computerUseMcpServerName: "computer-use",
+    });
+
+    expect(result).toEqual({ action: "accept", content: { approve: true }, _meta: null });
   });
 
   it("maps Computer Use allow-always decisions onto persistent metadata", async () => {
@@ -357,7 +376,7 @@ describe("Codex app-server elicitation bridge", () => {
 
     expect(result).toEqual({
       action: "accept",
-      content: null,
+      content: { approve: true },
       _meta: {
         persist: "always",
       },
@@ -397,7 +416,7 @@ describe("Codex app-server elicitation bridge", () => {
 
     expect(result).toEqual({
       action: "accept",
-      content: null,
+      content: { approve: true },
       _meta: null,
     });
     const approvalRequest = gatewayToolArg(0, 2) as { description: string };
@@ -465,7 +484,7 @@ describe("Codex app-server elicitation bridge", () => {
 
     expect(result).toEqual({
       action: "accept",
-      content: null,
+      content: { approve: true },
       _meta: null,
     });
   });
@@ -506,7 +525,7 @@ describe("Codex app-server elicitation bridge", () => {
 
     expect(result).toEqual({
       action: "accept",
-      content: null,
+      content: { approve: true },
       _meta: null,
     });
     const approvalRequest = gatewayToolArg(0, 2) as {

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -357,6 +357,35 @@ describe("Codex app-server elicitation bridge", () => {
     expect(result).toEqual({ action: "accept", content: { approve: true }, _meta: null });
   });
 
+  it("returns a fresh Computer Use empty-schema content object for each accept", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-computer-use-empty-1", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-computer-use-empty-1", decision: "allow-once" })
+      .mockResolvedValueOnce({ id: "plugin:approval-computer-use-empty-2", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-computer-use-empty-2", decision: "allow-once" });
+
+    const requestParams = buildComputerUseApprovalElicitation({
+      requestedSchema: { type: "object", properties: {} },
+    });
+    const runParams = {
+      requestParams,
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
+      computerUseMcpServerName: "computer-use",
+    };
+
+    const first = await handleCodexAppServerElicitationRequest(runParams);
+    expect(first).toEqual({ action: "accept", content: { approve: true }, _meta: null });
+    (first as { content: Record<string, unknown> }).content.approve = false;
+    (first as { content: Record<string, unknown> }).content.extra = true;
+
+    const second = await handleCodexAppServerElicitationRequest(runParams);
+
+    expect(second).toEqual({ action: "accept", content: { approve: true }, _meta: null });
+  });
+
   it("maps Computer Use allow-always decisions onto persistent metadata", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-computer-use-always", status: "accepted" })

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -338,7 +338,7 @@ describe("Codex app-server elicitation bridge", () => {
     ]);
   });
 
-  it("does not return a contentless accept for empty Computer Use schemas", async () => {
+  it("returns explicit approval content for empty Computer Use schemas", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-computer-use-empty", status: "accepted" })
       .mockResolvedValueOnce({ id: "plugin:approval-computer-use-empty", decision: "allow-once" });

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -284,7 +284,7 @@ describe("Codex app-server elicitation bridge", () => {
     ]);
   });
 
-  it("accepts current Codex MCP approval elicitations with an empty form schema", async () => {
+  it("preserves contentless accepts for non-Computer Use empty-form approvals", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-current", status: "accepted" })
       .mockResolvedValueOnce({ id: "plugin:approval-current", decision: "allow-once" });
@@ -298,7 +298,7 @@ describe("Codex app-server elicitation bridge", () => {
 
     expect(result).toEqual({
       action: "accept",
-      content: { approve: true },
+      content: null,
       _meta: null,
     });
     const approvalRequestCall = gatewayToolCall();

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -31,6 +31,7 @@ type BridgeableApprovalElicitation = {
   meta: JsonObject;
   persistHintsMode?: "legacy" | "explicit";
   allowedDecisions?: ExecApprovalDecision[];
+  emptySchemaAcceptContent?: JsonObject;
 };
 
 type PluginElicitationResolution =
@@ -486,6 +487,7 @@ function readComputerUseApprovalElicitation(
     }),
     requestedSchema,
     meta,
+    emptySchemaAcceptContent: EMPTY_SCHEMA_APPROVAL_CONTENT,
   };
 }
 
@@ -681,7 +683,7 @@ async function requestPluginApprovalOutcome(params: {
 function buildElicitationResponse(
   approvalPrompt: Pick<
     BridgeableApprovalElicitation,
-    "requestedSchema" | "meta" | "persistHintsMode"
+    "requestedSchema" | "meta" | "persistHintsMode" | "emptySchemaAcceptContent"
   >,
   outcome: AppServerApprovalOutcome,
 ): JsonValue {
@@ -698,7 +700,7 @@ function buildElicitationResponse(
     if (hasNoSchemaProperties(requestedSchema)) {
       return {
         action: "accept",
-        content: EMPTY_SCHEMA_APPROVAL_CONTENT,
+        content: approvalPrompt.emptySchemaAcceptContent ?? null,
         _meta: buildAcceptedMeta(meta, outcome, approvalPrompt.persistHintsMode ?? "legacy"),
       };
     }

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -50,7 +50,7 @@ const MCP_TOOL_APPROVAL_CONNECTOR_SOURCE = "connector";
 const CODEX_APPS_SERVER_NAME = "codex_apps";
 const COMPUTER_USE_APPROVAL_TITLE = "Computer Use approval";
 const EMPTY_OBJECT_SCHEMA: JsonObject = { type: "object", properties: {} };
-const EMPTY_SCHEMA_APPROVAL_CONTENT: JsonObject = { approve: true };
+const COMPUTER_USE_EMPTY_SCHEMA_ACCEPT_CONTENT: JsonObject = { approve: true };
 const PLUGIN_APP_ID_META_KEYS = ["app_id", "appId", "codex_app_id", "codexAppId"];
 const PLUGIN_CONNECTOR_ID_META_KEYS = ["connector_id", "connectorId"];
 const PLUGIN_NAME_META_KEYS = ["plugin_name", "pluginName", "codex_plugin_name", "codexPluginName"];
@@ -487,7 +487,7 @@ function readComputerUseApprovalElicitation(
     }),
     requestedSchema,
     meta,
-    emptySchemaAcceptContent: EMPTY_SCHEMA_APPROVAL_CONTENT,
+    emptySchemaAcceptContent: COMPUTER_USE_EMPTY_SCHEMA_ACCEPT_CONTENT,
   };
 }
 
@@ -680,6 +680,13 @@ async function requestPluginApprovalOutcome(params: {
   }
 }
 
+function cloneEmptySchemaAcceptContent(content: JsonObject | undefined): JsonObject | null {
+  if (!content) {
+    return null;
+  }
+  return { ...content };
+}
+
 function buildElicitationResponse(
   approvalPrompt: Pick<
     BridgeableApprovalElicitation,
@@ -700,7 +707,7 @@ function buildElicitationResponse(
     if (hasNoSchemaProperties(requestedSchema)) {
       return {
         action: "accept",
-        content: approvalPrompt.emptySchemaAcceptContent ?? null,
+        content: cloneEmptySchemaAcceptContent(approvalPrompt.emptySchemaAcceptContent),
         _meta: buildAcceptedMeta(meta, outcome, approvalPrompt.persistHintsMode ?? "legacy"),
       };
     }

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -49,6 +49,7 @@ const MCP_TOOL_APPROVAL_CONNECTOR_SOURCE = "connector";
 const CODEX_APPS_SERVER_NAME = "codex_apps";
 const COMPUTER_USE_APPROVAL_TITLE = "Computer Use approval";
 const EMPTY_OBJECT_SCHEMA: JsonObject = { type: "object", properties: {} };
+const EMPTY_SCHEMA_APPROVAL_CONTENT: JsonObject = { approve: true };
 const PLUGIN_APP_ID_META_KEYS = ["app_id", "appId", "codex_app_id", "codexAppId"];
 const PLUGIN_CONNECTOR_ID_META_KEYS = ["connector_id", "connectorId"];
 const PLUGIN_NAME_META_KEYS = ["plugin_name", "pluginName", "codex_plugin_name", "codexPluginName"];
@@ -697,7 +698,7 @@ function buildElicitationResponse(
     if (hasNoSchemaProperties(requestedSchema)) {
       return {
         action: "accept",
-        content: null,
+        content: EMPTY_SCHEMA_APPROVAL_CONTENT,
         _meta: buildAcceptedMeta(meta, outcome, approvalPrompt.persistHintsMode ?? "legacy"),
       };
     }


### PR DESCRIPTION
## What Problem This Solves

This PR isolates the Computer Use approval-payload behavior from the native `computer-use.get_app_state` timeout fix.

During Codex Computer Use setup, OpenClaw bridges configured Computer Use approval elicitations that have an empty form schema. The existing generic empty-schema accept response sends `content: null`. For configured Computer Use approvals, this PR returns an explicit confirmation payload instead:

```json
{ "action": "accept", "content": { "approve": true }, "_meta": null }
```

The change is scoped to configured Computer Use empty-form approvals only. It does not claim to fix the later native `tools/call` timeout from #96452; that timeout path is covered by the canonical native completion PR #96818.

## Review Context Addressed

Latest ClawSweeper review asked not to keep this as a mixed branch:

- Native completion timeout fix: superseded by #96818.
- Approval-payload change: keep separate, prove/document the Computer Use-specific compatibility decision, and avoid presenting it as the generic MCP empty-form contract.

This update follows that direction:

- Removed the duplicated native completion/watchdog change from this PR branch.
- Kept only the Computer Use-specific approval-payload bridge change, tests, and docs.
- Removed the `Fixes #96452` claim and made #96818 the canonical timeout fix.
- Restored a PR-body section named `What Problem This Solves` so the repository proof-policy check can evaluate the authored problem/evidence context.

## Implementation

- Adds optional `emptySchemaAcceptContent` bridge metadata.
- Sets that metadata only for configured Computer Use approval elicitations.
- Returns a cloned `{ "approve": true }` content object for accepted configured Computer Use empty-form approvals.
- Preserves existing `content: null` accepts for non-Computer Use empty-schema Codex MCP approval elicitations.
- Preserves deny/cancel behavior unchanged.
- Preserves fail-closed handling for unmappable non-empty schemas.

## Validation

Current head after scope split: `971efef3d308fc7979520bd0399e3701bf47a661`.

Local pre-check only:

```bash
git diff --check origin/main...HEAD
```

Result: passed before push.

Repository checks will refresh on the new head after the force-push that removed the duplicated native completion patch.

Exact-head focused Computer Use approval proof: https://github.com/snowzlmbot/openclaw/actions/runs/28222850991

Existing focused regression coverage in this branch verifies:

- Configured Computer Use empty-form approvals return `{ "approve": true }`.
- Non-Computer Use empty-form approvals remain contentless.
- Each accepted Computer Use empty-schema response receives a fresh content object.
- The docs state that Codex still owns the later native `tools/call` execution path.

## Evidence Source Map

- Code scope: `extensions/codex/src/app-server/elicitation-bridge.ts`
- Tests: `extensions/codex/src/app-server/elicitation-bridge.test.ts`
- Docs: `docs/plugins/codex-computer-use.md`
- Current-head local pre-check only: `git diff --check origin/main...HEAD` passed.
- Native timeout canonical PR: #96818 carries the native completion/watchdog timeout fix and proof path.

## Maintainer Compatibility Decision Requested

This PR intentionally keeps non-Computer Use empty-schema approvals contentless and changes only configured Computer Use empty-form approvals to `{ "approve": true }`.

The Codex protocol accepts nullable structured content, so this PR treats `{ "approve": true }` as a Computer Use bridge compatibility decision rather than a generic MCP empty-form requirement. Maintainer confirmation is requested for that protocol-facing compatibility boundary.

## Risk

- Compatibility: the approval response payload changes from `null` to `{ "approve": true }` only for configured Computer Use empty-form approvals. Regression coverage preserves the old shape for other empty-schema approvals.
- Protocol boundary: this PR does not claim `{ "approve": true }` is a generic MCP empty-form requirement; it is a Computer Use-specific bridged approval payload.
- Availability: this scoped branch no longer changes native completion idle timeout behavior. The timeout fix is left to #96818.
- Security / permissions: this does not broaden Computer Use permissions, bypass OpenClaw approval, or bypass Codex/platform permission checks.

## Rollback

Revert this PR to restore contentless accepts for configured Computer Use empty-form approval responses. No data migration or irreversible state change is involved.

## Docs Updated

- `docs/plugins/codex-computer-use.md` documents the Computer Use-specific approval response boundary and clarifies that Codex still owns later native tool execution.

## Related

- Related issue: #96452
- Canonical native timeout fix: #96818
- Review discussion with prior live timeout evidence: https://github.com/openclaw/openclaw/pull/96479#issuecomment-4793142338


