### PR TITLE
fix(agents): bound model catalog JSON response reads for bedrock-mantle and huggingface

### DIFF
--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -1,5 +1,6 @@
 // Huggingface plugin module implements models behavior.
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import {
   fetchWithSsrFGuard,
@@ -165,7 +166,10 @@ export async function discoverHuggingfaceModels(
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);
       }
 
-      const body = (await response.json()) as OpenAIListModelsResponse;
+      const body = await readProviderJsonResponse<OpenAIListModelsResponse>(
+        response,
+        "huggingface.model-discovery",
+      );
       const data = body?.data;
       if (!Array.isArray(data) || data.length === 0) {
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);


### PR DESCRIPTION
## What Problem This Solves

Amazon Bedrock Mantle model discovery (`/v1/models`) and HuggingFace model discovery (`/models`) both parse successful HTTP responses with an unbounded `await response.json()`. On Node, `response.json()` buffers the entire body before parsing, so a provider-controlled endpoint can stream an arbitrarily large or never-ending JSON payload and push the discovery path into memory pressure, hangs, or OOM.

That matters here because both inputs are untrusted:

- Mantle discovery reads from an operator-selected AWS endpoint.
- HuggingFace discovery reads from an external router endpoint.

This PR closes the same response-body gap already fixed for sibling catalog surfaces in `#95418`, `#95420`, and `#96027`, but for the two remaining bundled provider discovery reads still using unbounded success-path JSON parsing on current `main`.

## Changes

- Replace the Mantle success-path read in `discoverMantleModels` with `readProviderJsonResponse(response, "bedrock-mantle.model-discovery")`.
- Replace the HuggingFace success-path read in `discoverHuggingfaceModels` with `readProviderJsonResponse(response, "huggingface.model-discovery")`.
- Reuse the existing shared provider JSON reader instead of introducing a new provider-local helper. That helper already enforces the standard 16 MiB JSON byte cap and wraps malformed JSON with a caller label.
- Preserve the existing fail-soft behavior around the changed call sites: Mantle still falls back to cached models or `[]` on discovery failure, and HuggingFace still falls back to the static bundled catalog on discovery failure.
- Update Mantle discovery tests to return real `Response` objects instead of plain `{ json() {} }` mocks so the changed path uses the same body/stream API shape as production.
- Add `scripts/proof-mantle-catalog-bound.mjs`, an affected-path proof harness that drives the real `discoverMantleModels` entry point against a local streaming server via injected `fetchFn`.

## Real behavior proof

- **Behavior addressed:** a successful catalog response with no `Content-Length` must not be buffered whole if it exceeds the JSON safety cap; the read must stop near the cap, cancel the stream, and fail soft through the existing discovery fallback paths instead of draining the full body.
- **Affected entry point:** `discoverMantleModels` in `extensions/amazon-bedrock-mantle/discovery.ts` — the exact success-path function changed by this PR.
- **Real environment tested:** Node v22, local `node:http` server on `127.0.0.1`, streaming ~24 MiB catalog JSON in 64 KiB chunks with **no** `Content-Length`, injected via the production `fetchFn` parameter.
- **Exact proof shape:**
  1. Call `discoverMantleModels({ fetchFn })` against `/huge` → fail-soft fallback (`[]` when cache cold) plus early stream stop near the 16 MiB cap.
  2. Call against `/small` → normal catalog parses with model id intact.
  3. Warm cache from `/small`, expire refresh window, hit `/huge` → bounded overflow falls back to cached models.
- **Evidence after fix:**
  - Oversized stream: `discoverMantleModels` returned `[]` when cache was cold.
  - Early cancel: server sent **17,104,912 bytes**, near the 16 MiB cap rather than the full ~24 MiB body.
  - Happy path: small catalog parsed into exactly one model with id `anthropic.claude-sonnet-4-6`.
  - Cached fallback: after warm cache + stale refresh, oversized stream returned the cached model instead of hanging or OOM.
- **Suite coverage:** `pnpm test extensions/amazon-bedrock-mantle/discovery.test.ts` passed **29/29** tests, including updated Mantle discovery tests that now use real `Response` objects on the success path.
- **HuggingFace note:** `discoverHuggingfaceModels` has no injectable fetch seam, but uses the same `readProviderJsonResponse` call-site pattern; Mantle affected-path proof exercises the bounded read + fail-soft catch path through the real changed discovery function.
- **What was not tested:** live Mantle or HuggingFace network endpoints; direct `discoverHuggingfaceModels` harness against a local streaming server.

## Evidence

```text
$ node --import tsx scripts/proof-mantle-catalog-bound.mjs

[case 1] discoverMantleModels + oversized /v1/models stream, no Content-Length
  ok: fail-soft fallback returns empty catalog when body exceeds cap — true
  ok: server stopped near 16 MiB cap, not full ~24 MiB (sent 17104912) — true
  ok: server did not stream the entire hostile body (sent 17104912 < 22649242) — true

[case 2] discoverMantleModels + normal small catalog still parses
  ok: small catalog returns one model — true
  ok: model id intact (anthropic.claude-sonnet-4-6) — true

[case 3] discoverMantleModels uses cached models after oversized stream when cache warm
  ok: warm cache populated from small catalog — true
  ok: oversized stream falls back to cached models — true
  ok: cached model id preserved (anthropic.claude-sonnet-4-6) — true
  ok: stale refresh re-fetched before bounded overflow fallback — true

ALL PROOF ASSERTIONS PASSED
```

```text
$ pnpm test extensions/amazon-bedrock-mantle/discovery.test.ts -- --reporter=verbose

Test Files  1 passed (1)
     Tests  29 passed (29)
```

**Label**: security

AI-assisted.
