### PR TITLE
test(tooling): stabilize lifecycle measure pid fixtures

### DIFF
--- a/test/scripts/plugin-lifecycle-measure.test.ts
+++ b/test/scripts/plugin-lifecycle-measure.test.ts
@@ -330,7 +330,6 @@ describe("plugin lifecycle resource sampler", () => {
           },
         );
 
-        expect(waitForNonEmptyPath(pidFile, 1000)).toBe(true);
         descendantPid = Number.parseInt(readFileSync(pidFile, "utf8"), 10);
         expect(result.status).toBe(124);
         expect(result.stdout).toContain("signal=timeout");

--- a/test/scripts/plugin-lifecycle-measure.test.ts
+++ b/test/scripts/plugin-lifecycle-measure.test.ts
@@ -2,11 +2,11 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import {
   chmodSync,
-  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -53,17 +53,25 @@ function waitForPidExit(pid: number, timeoutMs: number): boolean {
   return !pidExists(pid);
 }
 
-function waitForPath(filePath: string, timeoutMs: number): boolean {
+function nonEmptyPathExists(filePath: string): boolean {
+  try {
+    return statSync(filePath).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+function waitForNonEmptyPath(filePath: string, timeoutMs: number): boolean {
   const waitBuffer = new SharedArrayBuffer(4);
   const waitView = new Int32Array(waitBuffer);
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (existsSync(filePath)) {
+    if (nonEmptyPathExists(filePath)) {
       return true;
     }
     Atomics.wait(waitView, 0, 0, 5);
   }
-  return existsSync(filePath);
+  return nonEmptyPathExists(filePath);
 }
 
 function waitForChildClose(
@@ -314,14 +322,15 @@ describe("plugin lifecycle resource sampler", () => {
             encoding: "utf8",
             env: {
               ...process.env,
-              OPENCLAW_PLUGIN_LIFECYCLE_PHASE_TIMEOUT_MS: "250",
-              OPENCLAW_PLUGIN_LIFECYCLE_TIMEOUT_KILL_GRACE_MS: "50",
+              OPENCLAW_PLUGIN_LIFECYCLE_PHASE_TIMEOUT_MS: "3000",
+              OPENCLAW_PLUGIN_LIFECYCLE_TIMEOUT_KILL_GRACE_MS: "200",
               PID_FILE: pidFile,
             },
-            timeout: 5000,
+            timeout: 7000,
           },
         );
 
+        expect(waitForNonEmptyPath(pidFile, 1000)).toBe(true);
         descendantPid = Number.parseInt(readFileSync(pidFile, "utf8"), 10);
         expect(result.status).toBe(124);
         expect(result.stdout).toContain("signal=timeout");
@@ -369,7 +378,7 @@ describe("plugin lifecycle resource sampler", () => {
           },
         );
 
-        expect(waitForPath(pidFile, 2000)).toBe(true);
+        expect(waitForNonEmptyPath(pidFile, 2000)).toBe(true);
         descendantPid = Number.parseInt(readFileSync(pidFile, "utf8"), 10);
         result.kill("SIGTERM");
         const close = await waitForChildClose(result, 5000);
@@ -418,7 +427,7 @@ describe("plugin lifecycle resource sampler", () => {
         },
       );
 
-      expect(waitForPath(readyFile, 1000)).toBe(true);
+      expect(waitForNonEmptyPath(readyFile, 1000)).toBe(true);
       const started = Date.now();
       result.kill("SIGTERM");
       const close = await waitForChildClose(result, 5000);
@@ -457,7 +466,7 @@ describe("plugin lifecycle resource sampler", () => {
         },
       );
 
-      expect(waitForPath(readyFile, 1000)).toBe(true);
+      expect(waitForNonEmptyPath(readyFile, 1000)).toBe(true);
       const started = Date.now();
       result.kill("SIGTERM");
       const close = await waitForChildClose(result, 5000);


### PR DESCRIPTION
## What Problem This Solves

`checks-node-core-tooling` can fail in the plugin lifecycle measure tests before the code under test is actually exercised. The Linux fixture reads temporary pid/ready files written by nested shell descendants. On a busy runner, the file path can be missing or still empty when the assertion reads it, and the `stubborn-descendant` fixture also used a 1s lifecycle timeout that can expire during nested process startup. The observed failure mode is `ENOENT` while reading `descendant.pid` in `test/scripts/plugin-lifecycle-measure.test.ts`.

This patch makes those fixtures wait for non-empty pid/ready files and gives the stubborn-descendant fixture enough startup budget while still verifying timeout cleanup and process-group termination.

## Summary

- wait for pid/ready fixture files to be non-empty before reading them in plugin lifecycle measure tests
- relax the stubborn-descendant phase timeout so Linux CI startup jitter does not race the fixture before it writes `descendant.pid`

## Evidence

Observed CI failure from a Linux `checks-node-core-tooling` run:

```text
FAIL test/scripts/plugin-lifecycle-measure.test.ts > plugin lifecycle resource sampler > kills stubborn descendants after the timeout grace period
Error: ENOENT: no such file or directory, open '/tmp/openclaw-plugin-lifecycle-measure-.../descendant.pid'

FAIL test/scripts/plugin-lifecycle-measure.test.ts > plugin lifecycle resource sampler > forwards external termination to the measured process group
Error: ENOENT: no such file or directory, open '/tmp/openclaw-plugin-lifecycle-measure-.../descendant.pid'
```

Linux after-fix CI proof on this PR:

- `checks-node-compact-small-whole-2` passed: https://github.com/openclaw/openclaw/actions/runs/28111932652/job/83241443839
- The same Linux job ran `test/vitest/vitest.tooling.config.ts` and logged:

```text
test/scripts/plugin-lifecycle-measure.test.ts (12 tests) 4360ms
  kills stubborn descendants after the timeout grace period 3241ms
Test Files 278 passed | 1 skipped (279)
Tests 4413 passed | 15 skipped (4428)
[test] passed 2 Vitest shards in 296.34s
```

Full PR checks also passed after the body proof update, including `Real behavior proof`, `check-lint`, `check-test-types`, `check-prod-types`, and the Node compact shards.

Local verification on macOS:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/plugin-lifecycle-measure.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests  4 passed | 8 skipped (12)
```

Additional local checks:

```text
./node_modules/.bin/oxfmt --check --threads=1 test/scripts/plugin-lifecycle-measure.test.ts
All matched files use the correct format.

node scripts/run-oxlint.mjs test/scripts/plugin-lifecycle-measure.test.ts
# exit 0

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-all.tsbuildinfo
# exit 0
```

Note: the lifecycle process-group assertions are Linux-only and are skipped on my local macOS host; the linked Linux CI job above covers the affected assertions after the patch.
