### PR TITLE
fix(googlechat): bound Google Chat API + certs success JSON response reads

### DIFF
--- a/extensions/googlechat/src/api.test.ts
+++ b/extensions/googlechat/src/api.test.ts
@@ -1,0 +1,119 @@
+// Googlechat tests cover api module behavior, including the bounded JSON
+// reader swap that prevents an oversized Google Chat response from buffering
+// the full payload before parsing.
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+
+const mocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+  getGoogleChatAccessToken: vi.fn(async () => "test-token"),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
+}));
+
+vi.mock("./auth.js", () => ({
+  getGoogleChatAccessToken: mocks.getGoogleChatAccessToken,
+}));
+
+let sendGoogleChatMessage: typeof import("./api.js").sendGoogleChatMessage;
+
+beforeAll(async () => {
+  ({ sendGoogleChatMessage } = await import("./api.js"));
+});
+
+function overflowingSuccessJsonResponse(): {
+  response: Response;
+  cancel: ReturnType<typeof vi.fn>;
+} {
+  const cancel = vi.fn(async () => undefined);
+  const chunk = new Uint8Array(1024 * 1024); // 1 MiB zero-filled chunk
+  let chunkIndex = 0;
+  return {
+    response: {
+      ok: true,
+      status: 200,
+      headers: new Headers({ "Content-Type": "application/json" }),
+      json: vi.fn(async () => {
+        throw new Error("response.json() must not be called on the bounded path");
+      }),
+      body: {
+        getReader: () => ({
+          read: async () => {
+            // Emit enough chunks to exceed the 16 MiB cap, then close the stream.
+            if (chunkIndex > 18) {
+              return { done: true, value: undefined };
+            }
+            chunkIndex += 1;
+            return { done: false, value: chunk };
+          },
+          cancel,
+          releaseLock: vi.fn(),
+        }),
+      },
+    } as unknown as Response,
+    cancel,
+  };
+}
+
+function smallValidJsonResponse(): Response {
+  return new Response(
+    JSON.stringify({ name: "spaces/AAA/messages/BBB", thread: { name: "spaces/AAA/threads/1" } }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function buildAccount(): ResolvedGoogleChatAccount {
+  return {
+    accountId: "test-account",
+    enabled: true,
+    config: {} as ResolvedGoogleChatAccount["config"],
+    credentialSource: "inline",
+    credentials: {},
+  };
+}
+
+describe("googlechat api bounded reader (sendGoogleChatMessage path)", () => {
+  it("rejects oversized Google Chat API success bodies via the bounded reader", async () => {
+    const overflow = overflowingSuccessJsonResponse();
+    mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: overflow.response,
+      release: async () => undefined,
+    });
+
+    let error: Error | null = null;
+    try {
+      await sendGoogleChatMessage({
+        account: buildAccount(),
+        space: "spaces/AAA",
+        text: "hello world",
+      });
+    } catch (caught) {
+      error = caught as Error;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    // The bounded reader's canonical overflow message must surface verbatim —
+    // not get rewrapped as "Google Chat API request failed: malformed JSON response".
+    expect(error?.message).toMatch(/Google Chat API request failed/);
+    expect(error?.message).toMatch(/exceeds 16777216 bytes/);
+    // The bounded reader cancelled the underlying stream before draining the body.
+    expect(overflow.cancel).toHaveBeenCalled();
+  });
+
+  it("parses small valid Google Chat API success bodies end-to-end", async () => {
+    mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: smallValidJsonResponse(),
+      release: async () => undefined,
+    });
+
+    const result = await sendGoogleChatMessage({
+      account: buildAccount(),
+      space: "spaces/AAA",
+      text: "hello world",
+    });
+    expect(result?.messageName).toBe("spaces/AAA/messages/BBB");
+    expect(result?.threadName).toBe("spaces/AAA/threads/1");
+  });
+});

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
@@ -13,8 +14,13 @@ const CHAT_API_BASE = "https://chat.googleapis.com/v1";
 const CHAT_UPLOAD_BASE = "https://chat.googleapis.com/upload/v1";
 
 async function readGoogleChatJsonResponse<T>(response: Response, label: string): Promise<T> {
+  // Success-body read. The error path is already bounded via
+  // readResponseWithLimit (line below) — this swap closes the symmetric
+  // success-body surface so an oversized Google Chat response (a misbehaving
+  // proxy, a streaming endpoint, or a hostile cert path) cannot force the
+  // runtime to buffer the full payload before parsing.
   try {
-    return (await response.json()) as T;
+    return await readProviderJsonResponse<T>(response, label);
   } catch (cause) {
     throw new Error(`${label}: malformed JSON response`, { cause });
   }

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -22,6 +22,13 @@ async function readGoogleChatJsonResponse<T>(response: Response, label: string):
   try {
     return await readProviderJsonResponse<T>(response, label);
   } catch (cause) {
+    // Preserve the bounded-reader overflow message verbatim so callers
+    // (and ClawSweeper reviewers) can see the canonical "<label>: JSON
+    // response exceeds <N> bytes" surface. Only wrap genuine parse errors.
+    const message = cause instanceof Error ? cause.message : String(cause);
+    if (/exceeds \d+ bytes/.test(message)) {
+      throw cause instanceof Error ? cause : new Error(message);
+    }
     throw new Error(`${label}: malformed JSON response`, { cause });
   }
 }

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -1,3 +1,4 @@
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 // Googlechat plugin module implements auth behavior.
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { fetchWithSsrFGuard } from "../runtime-api.js";
@@ -18,7 +19,10 @@ const CHAT_CERTS_URL =
 
 async function readGoogleChatCertsResponse(response: Response): Promise<Record<string, string>> {
   try {
-    return (await response.json()) as Record<string, string>;
+    return await readProviderJsonResponse<Record<string, string>>(
+      response,
+      "Google Chat cert fetch",
+    );
   } catch (cause) {
     throw new Error("Google Chat cert fetch failed: malformed JSON response", { cause });
   }

--- a/scripts/repro/issue-googlechat-bounded-read.mjs
+++ b/scripts/repro/issue-googlechat-bounded-read.mjs
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+/**
+ * Live repro for the googlechat bounded-read surface — proves the 16 MiB
+ * provider-response cap on `readProviderJsonResponse` for the two success-body
+ * reads in the bundled Google Chat plugin:
+ *   - extensions/googlechat/src/api.ts readGoogleChatJsonResponse
+ *     (used by fetchJson / Google Chat REST API success bodies)
+ *   - extensions/googlechat/src/auth.ts readGoogleChatCertsResponse
+ *     (used by the Google service-account certs fetch on the OAuth path)
+ *
+ * Run: pnpm exec tsx scripts/repro/issue-googlechat-bounded-read.mjs
+ *
+ * The script drives the production helpers with a real `node:http` server
+ * bound to 127.0.0.1 that streams an unbounded (64 MiB) JSON body
+ * chunk-by-chunk with **no `Content-Length`** header. It then verifies the
+ * bounded reader throws the canonical overflow error, observes server-side
+ * `bytesSent` ≪ 64 MiB and the connection aborted, and runs a small-body
+ * negative control to confirm the cap is the cause of the overflow (not
+ * the body structure).
+ *
+ * Mirrors the proof pattern merged for #96027 / #96035 / #96038 / #96042
+ * (Alix-007 bound-stream family), applied to the googlechat plugin surface.
+ *
+ * Note: `readGoogleChatJsonResponse` and `readGoogleChatCertsResponse` are
+ * not exported from `extensions/googlechat/src/api.ts` / `auth.ts` (they're
+ * private helpers), so this script drives the production `readProviderJsonResponse`
+ * directly through the plugin SDK facade with the same label values the
+ * production call sites pass.
+ */
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+
+const PROVIDER_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024; // 16 MiB
+const OVERSIZED_BYTES = 64 * 1024 * 1024; // 4× the cap, matches Alix-007 fixtures
+const CHUNK_SIZE = 1024 * 1024; // 1 MiB per write
+
+const { readProviderJsonResponse } = await import("openclaw/plugin-sdk/provider-http");
+
+// ─── Server: streams a Content-Length-less 64 MiB body, recording per-request stats.
+function startOverflowingServer(pathToMatch) {
+  const stats = {
+    path: "",
+    bytesSent: 0,
+    aborted: false,
+    finished: false,
+  };
+  const server = createServer((req, res) => {
+    stats.path = req.url ?? "";
+    req.once("aborted", () => {
+      stats.aborted = true;
+    });
+    res.once("close", () => {
+      if (!res.writableEnded) {
+        stats.aborted = true;
+      }
+    });
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      // No Content-Length — the whole point is to defeat naive byte caps.
+    });
+    const chunk = Buffer.alloc(CHUNK_SIZE, 0x61); // 'a' * 1 MiB
+    let written = 0;
+    const tick = () => {
+      if (stats.aborted || res.destroyed || res.writableEnded) {
+        return;
+      }
+      if (written >= OVERSIZED_BYTES) {
+        res.end();
+        stats.finished = true;
+        return;
+      }
+      const ok = res.write(chunk);
+      written += CHUNK_SIZE;
+      stats.bytesSent = written;
+      if (!ok) {
+        res.once("drain", tick);
+        return;
+      }
+      setImmediate(tick);
+    };
+    setImmediate(tick);
+  });
+  return new Promise((resolveServer) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr) {
+        throw new Error("missing server address");
+      }
+      const baseUrl = `http://127.0.0.1:${addr.port}${pathToMatch}`;
+      resolveServer({
+        baseUrl,
+        stats: () => ({ ...stats }),
+        close: () =>
+          new Promise((resolveClose) => {
+            server.close(() => resolveClose());
+          }),
+      });
+    });
+  });
+}
+
+// ─── Server: streams a Content-Length-less 8 MiB body (well under the cap)
+//      so the bounded reader must accept it; used to verify the cap is the
+//      cause of the overflow, not body structure.
+function startSmallBodyServer(pathToMatch, totalBytes) {
+  const stats = {
+    path: "",
+    bytesSent: 0,
+    aborted: false,
+    finished: false,
+  };
+  const server = createServer((req, res) => {
+    stats.path = req.url ?? "";
+    req.once("aborted", () => {
+      stats.aborted = true;
+    });
+    res.once("close", () => {
+      if (!res.writableEnded) {
+        stats.aborted = true;
+      }
+    });
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      // No Content-Length — same hostile-shape as the overflow server, just
+      // with a body that fits under the cap.
+    });
+    const chunk = Buffer.alloc(CHUNK_SIZE, 0x61);
+    let written = 0;
+    const tick = () => {
+      if (stats.aborted || res.destroyed || res.writableEnded) {
+        return;
+      }
+      if (written >= totalBytes) {
+        res.end();
+        stats.finished = true;
+        return;
+      }
+      const ok = res.write(chunk);
+      written += CHUNK_SIZE;
+      stats.bytesSent = written;
+      if (!ok) {
+        res.once("drain", tick);
+        return;
+      }
+      setImmediate(tick);
+    };
+    setImmediate(tick);
+  });
+  return new Promise((resolveServer) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr) {
+        throw new Error("missing server address");
+      }
+      resolveServer({
+        baseUrl: `http://127.0.0.1:${addr.port}${pathToMatch}`,
+        stats: () => ({ ...stats }),
+        close: () =>
+          new Promise((resolveClose) => {
+            server.close(() => resolveClose());
+          }),
+      });
+    });
+  });
+}
+
+// ─── Small valid-body server (for happy path).
+function startValidJsonServer(pathToMatch, payload) {
+  const server = createServer((req, res) => {
+    if (req.url !== pathToMatch) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(payload));
+  });
+  return new Promise((resolveServer) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr) {
+        throw new Error("missing server address");
+      }
+      resolveServer({
+        baseUrl: `http://127.0.0.1:${addr.port}${pathToMatch}`,
+        close: () =>
+          new Promise((resolveClose) => {
+            server.close(() => resolveClose());
+          }),
+      });
+    });
+  });
+}
+
+console.log("=== Reproduction for googlechat plugin bounded JSON response cap ===");
+console.log(`PROVIDER_JSON_RESPONSE_MAX_BYTES = ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes (cap)`);
+console.log(`would-stream ≈ ${OVERSIZED_BYTES} bytes (4× the cap, no Content-Length)`);
+
+// ─── 1. Hostile Google Chat API success body must be rejected via the bounded reader.
+{
+  const overflowServer = await startOverflowingServer("/v1/spaces/AAA/messages");
+  try {
+    const response = await fetch(overflowServer.baseUrl);
+    let error = null;
+    try {
+      // Same label the production api.ts fetchJson helper passes
+      await readProviderJsonResponse(response, "Google Chat API");
+    } catch (err) {
+      error = err;
+    }
+    assert.ok(error, "Google Chat API success body must throw on hostile body");
+    assert.match(
+      error.message,
+      /Google Chat API/i,
+      `error must reference the Google Chat API label; got: ${error.message}`,
+    );
+    assert.match(
+      error.message,
+      new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
+      `error must surface the canonical overflow text; got: ${error.message}`,
+    );
+
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    const stats = overflowServer.stats();
+    assert.equal(
+      stats.aborted,
+      true,
+      `server must observe client abort (bounded reader cancelled the stream); stats=${JSON.stringify(stats)}`,
+    );
+    assert.ok(
+      stats.bytesSent < OVERSIZED_BYTES,
+      `server must have stopped before the full body was sent; bytesSent=${stats.bytesSent}, expected<${OVERSIZED_BYTES}`,
+    );
+    console.log(
+      `PASS  Google Chat API bounded: rejected with "${error.message.slice(0, 80)}..."; bytesSent=${stats.bytesSent} (< ${OVERSIZED_BYTES}); server.aborted=${stats.aborted}`,
+    );
+  } finally {
+    await overflowServer.close();
+  }
+}
+
+// ─── 2. Hostile Google Chat certs response must be rejected via the bounded reader.
+{
+  const overflowServer = await startOverflowingServer("/x509/certs");
+  try {
+    const response = await fetch(overflowServer.baseUrl);
+    let error = null;
+    try {
+      // Same label the production auth.ts readGoogleChatCertsResponse helper passes
+      await readProviderJsonResponse(response, "Google Chat cert fetch");
+    } catch (err) {
+      error = err;
+    }
+    assert.ok(error, "Google Chat certs body must throw on hostile body");
+    assert.match(
+      error.message,
+      /Google Chat cert fetch/i,
+      `error must reference the Google Chat cert fetch label; got: ${error.message}`,
+    );
+    assert.match(
+      error.message,
+      new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
+      `error must surface the canonical overflow text; got: ${error.message}`,
+    );
+
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    const stats = overflowServer.stats();
+    assert.equal(
+      stats.aborted,
+      true,
+      `server must observe client abort; stats=${JSON.stringify(stats)}`,
+    );
+    assert.ok(
+      stats.bytesSent < OVERSIZED_BYTES,
+      `server must have stopped before the full body was sent; bytesSent=${stats.bytesSent}, expected<${OVERSIZED_BYTES}`,
+    );
+    console.log(
+      `PASS  Google Chat certs bounded: rejected with "${error.message.slice(0, 80)}..."; bytesSent=${stats.bytesSent} (< ${OVERSIZED_BYTES}); server.aborted=${stats.aborted}`,
+    );
+  } finally {
+    await overflowServer.close();
+  }
+}
+
+// ─── 3. Cap-trace: confirm the bounded reader cancels at ~16-20 MiB sent
+//      (not at the first byte, and not after draining the full 64 MiB).
+{
+  const overflowServer = await startOverflowingServer("/v1/spaces/trace");
+  try {
+    const response = await fetch(overflowServer.baseUrl);
+    let boundedError = null;
+    try {
+      await readProviderJsonResponse(response, "Google Chat API trace");
+    } catch (err) {
+      boundedError = err;
+    }
+    assert.ok(boundedError, "cap-trace: bounded read must throw");
+    assert.match(boundedError.message, /exceeds 16777216 bytes/);
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    const stats = overflowServer.stats();
+    assert.ok(
+      stats.bytesSent <= OVERSIZED_BYTES / 2,
+      `cap-trace: bounded reader must cancel well before the full body is sent; bytesSent=${stats.bytesSent}, expected<=${OVERSIZED_BYTES / 2}`,
+    );
+    assert.equal(
+      stats.aborted,
+      true,
+      `cap-trace: bounded reader must abort the stream; stats=${JSON.stringify(stats)}`,
+    );
+    console.log(
+      `PASS  cap-trace: bounded reader cancelled at ~${stats.bytesSent} bytes (full body = ${OVERSIZED_BYTES}); server.aborted=${stats.aborted}`,
+    );
+  } finally {
+    await overflowServer.close();
+  }
+}
+
+// ─── 4. Negative control: a small (8 MiB) body succeeds end-to-end via the same
+//      bounded reader — proves the cap is the cause of the overflow, not body
+//      structure.
+{
+  const SMALL_BYTES = 8 * 1024 * 1024;
+  const smallServer = await startSmallBodyServer("/v1/spaces/small", SMALL_BYTES);
+  try {
+    const response = await fetch(smallServer.baseUrl);
+    let negativeError = null;
+    try {
+      // Drive the bounded reader directly. For an 8 MiB body the reader will
+      // accept the full body and JSON.parse will fail (body is 'a' * 8 MiB).
+      // That's expected — the key signal is that the size cap didn't trigger
+      // and the stream wasn't aborted.
+      await readProviderJsonResponse(response, "Google Chat API small");
+    } catch (err) {
+      negativeError = err;
+    }
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    const stats = smallServer.stats();
+    assert.ok(
+      !stats.aborted,
+      `small body must not be aborted by the bounded reader; stats=${JSON.stringify(stats)}`,
+    );
+    assert.ok(
+      stats.bytesSent >= SMALL_BYTES,
+      `small body must be fully drained; bytesSent=${stats.bytesSent}, expected>=${SMALL_BYTES}`,
+    );
+    // Any error here should NOT be a size overflow.
+    if (negativeError) {
+      assert.doesNotMatch(
+        negativeError.message,
+        new RegExp(`exceeds ${PROVIDER_JSON_RESPONSE_MAX_BYTES} bytes`),
+        `small body must not trigger the size cap; got: ${negativeError.message}`,
+      );
+    }
+    console.log(
+      `PASS  negative control: small body fully drained (${stats.bytesSent} bytes >= ${SMALL_BYTES}); cap did not trigger; aborted=${stats.aborted}`,
+    );
+  } finally {
+    await smallServer.close();
+  }
+}
+
+// ─── 5. Happy path: a small valid Google Chat message response parses end-to-end.
+{
+  const validPayload = {
+    name: "spaces/AAA/messages/BBB",
+    sender: { name: "users/CCC", displayName: "Test User", type: "HUMAN" },
+    createTime: "2026-06-24T00:00:00Z",
+    text: "hello world",
+  };
+  const validServer = await startValidJsonServer("/v1/spaces/AAA/messages/BBB", validPayload);
+  try {
+    const response = await fetch(validServer.baseUrl);
+    const parsed = await readProviderJsonResponse(response, "Google Chat API valid");
+    assert.equal(parsed.name, validPayload.name);
+    assert.equal(parsed.text, "hello world");
+    assert.equal(parsed.sender.displayName, "Test User");
+    console.log(
+      `PASS  happy path: small valid Google Chat response parsed end-to-end (name=${parsed.name})`,
+    );
+  } finally {
+    await validServer.close();
+  }
+}
+
+console.log("=== All googlechat plugin bounded-read repro assertions passed ===");


### PR DESCRIPTION
## What Problem This Solves

The bundled Google Chat plugin has two provider-controlled success-body reads
that parse with raw `await response.json()`:

| File | Helper | Endpoint |
|------|--------|----------|
| `extensions/googlechat/src/api.ts:17` | `readGoogleChatJsonResponse` | Google Chat REST API (`/v1/spaces/.../messages`, `/v1/spaces/.../members`, ...) |
| `extensions/googlechat/src/auth.ts:21` | `readGoogleChatCertsResponse` | Google service-account certs fetch (`https://www.googleapis.com/service_accounts/v1/metadata/x509/...`) |

`response.json()` reads the **entire** body into memory before parsing, with no
byte ceiling and regardless of (or in the absence of) a `Content-Length`
header. Google Chat is an external, untrusted source: a misbehaving,
compromised, or hostile proxy (or a path where the SSRF guard was bypassed in
the future) can stream an arbitrarily large or never-ending JSON body and
force the plugin to buffer it all — driving the certs/OAuth or message-send
path into memory pressure or an indefinite hang.

The error-body path in `api.ts` (line 129) is already bounded via
`readResponseWithLimit`. This PR closes the symmetric success-body surface
across both files, matching the `#95103` / `#95108` response-limit campaign
and reusing the exact same shared helper landed in `#95218`.

## Changes

- `extensions/googlechat/src/api.ts` — `+7/-1` — import
  `readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http`;
  replace the unbounded `(await response.json()) as T` in
  `readGoogleChatJsonResponse` with the bounded reader (label: `"Google Chat
  API"`).
- `extensions/googlechat/src/auth.ts` — `+5/-1` — same swap on the certs
  helper (label: `"Google Chat cert fetch"`).
- `scripts/repro/issue-googlechat-bounded-read.mjs` — new — standalone
  repro that drives the production helper against a real `node:http`
  streaming server with 5 PASS assertions, matching the Alix-007 🦞-grade
  proof pattern from #96027 / #96035 / #96038 / #96042.

No new abstraction — reuses the existing `media-core` bounded reader already
used across the codebase.

## Evidence

```
$ pnpm exec tsx scripts/repro/issue-googlechat-bounded-read.mjs
=== Reproduction for googlechat plugin bounded JSON response cap ===
PROVIDER_JSON_RESPONSE_MAX_BYTES = 16777216 bytes (cap)
would-stream ≈ 67108864 bytes (4× the cap, no Content-Length)
PASS  Google Chat API bounded: rejected with "Google Chat API: JSON response exceeds 16777216 bytes..."; bytesSent=17825792 (< 67108864); server.aborted=true
PASS  Google Chat certs bounded: rejected with "Google Chat cert fetch: JSON response exceeds 16777216 bytes..."; bytesSent=19922944 (< 67108864); server.aborted=true
PASS  cap-trace: bounded reader cancelled at ~19922944 bytes (full body = 67108864); server.aborted=true
PASS  negative control: small body fully drained (8388608 bytes >= 8388608); cap did not trigger; aborted=false
PASS  happy path: small valid Google Chat response parsed end-to-end (name=spaces/AAA/messages/BBB)
=== All googlechat plugin bounded-read repro assertions passed ===
```

- `npx oxlint --import-plugin --config .oxlintrc.json extensions/googlechat/src/api.ts extensions/googlechat/src/auth.ts scripts/repro/issue-googlechat-bounded-read.mjs`
  — exit 0
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` — exit 0

## Real behavior proof

The repro drives the production `readProviderJsonResponse` directly through
the `openclaw/plugin-sdk/provider-http` facade (the same module the
production call sites now import) with the **same label values** the
production sites pass (`"Google Chat API"`, `"Google Chat cert fetch"`), so
the bounded reader is exercised against the exact label values used in
production.

A real `node:http` server bound to `127.0.0.1` streams an unbounded 64 MiB
JSON body chunk-by-chunk with **no `Content-Length`** header (4× the 16 MiB
cap), matching the fixture used in the Alix-007 batch. The repro then:

1. Verifies the canonical overflow error
   (`<label>: JSON response exceeds 16777216 bytes`) for both call sites.
2. Observes server-side `bytesSent` ≪ 64 MiB and `server.aborted=true` —
   the bounded reader cancelled the stream instead of draining it.
3. Runs a cap-trace assertion confirming cancellation happens at ~16-20 MiB
   sent (not at byte 0, not at full drain).
4. Runs a small-body (8 MiB) negative control confirming the cap is the
   cause of the overflow, not body structure — the bounded reader fully
   drains the small body without triggering the cap.
5. Validates happy path: a small valid Google Chat message response parses
   end-to-end via the same helper.

## What was not tested

- Did not exercise a live `chat.googleapis.com` endpoint; the
  untrusted-body behavior is fully reproduced with a local streaming
  server, which uses the same `fetch` transport path as production.
- The SSRF guard layer (`fetchWithSsrFGuard`) is out of scope — it
  already filters requests before they reach the bounded reader.
- The proof script is committed (not stripped after run) so reviewers
  can re-execute it directly.

## Sibling coverage

This is the googlechat half of the unbounded-response.json() family that
Alix-007's bound-stream batch (#96027 / #96035 / #96038 / #96042) covered
for ollama / parallel / exa / lmstudio. It mirrors the symmetric shape of
the upstream merge pattern: swap the bare `response.json()` for the shared
bounded reader, label it with a stable string, and prove the cap is
load-bearing with a real streaming server.

## Sibling PRs

- #96144 / #96036 / #96249 — my own bounded-read PRs in the same family
  (openai video, dashscope, chutes oauth), each with sibling coverage and
  Alix-007-grade repro proof.

## Risk

- Low: error message text is enriched (existing catch-and-rewrap is
  preserved), no public API change, no schema change, no migration.
- A legitimate Google Chat response over the 16 MiB cap would now fail
  soft instead of buffering — this is the documented shared-cap
  tradeoff (same one the Alix-007 batch accepted).