### PR TITLE
fix(google-meet): fall back to manual OAuth paste when callback port is occupied

### DIFF
--- a/extensions/google-meet/src/oauth.test.ts
+++ b/extensions/google-meet/src/oauth.test.ts
@@ -1,10 +1,38 @@
 // Google Meet tests cover oauth plugin behavior.
+import { createServer, type Server } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildGoogleMeetAuthUrl,
   refreshGoogleMeetAccessToken,
   resolveGoogleMeetAccessToken,
+  waitForGoogleMeetAuthCode,
 } from "./oauth.js";
+
+async function occupyPort(port: number): Promise<Server | null> {
+  const server = createServer();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(port, "localhost", () => {
+        resolve();
+      });
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("EADDRINUSE")) {
+      return null;
+    }
+    throw error;
+  }
+  return server;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+}
 
 describe("Google Meet OAuth", () => {
   afterEach(() => {
@@ -160,5 +188,43 @@ describe("Google Meet OAuth", () => {
     });
 
     expect(tokens.expiresAt).toBe(Date.now());
+  });
+
+  it("falls back to manual paste when the local callback port is occupied", async () => {
+    const blocker = await occupyPort(8085);
+    try {
+      const state = "state-token";
+      const lines: string[] = [];
+      const code = await waitForGoogleMeetAuthCode({
+        state,
+        manual: false,
+        timeoutMs: 60_000,
+        authUrl: "https://accounts.google.com/o/oauth2/v2/auth?x=1",
+        promptInput: async () =>
+          `http://localhost:8085/oauth2callback?code=auth-code-123&state=${state}`,
+        writeLine: (message) => lines.push(message),
+      });
+      expect(code).toBe("auth-code-123");
+      expect(lines.some((line) => line.includes("Switching to manual mode"))).toBe(true);
+    } finally {
+      if (blocker) {
+        await closeServer(blocker);
+      }
+    }
+  });
+
+  it("propagates non-listener callback failures without manual fallback", async () => {
+    const promptInput = vi.fn(async () => "unused");
+    await expect(
+      waitForGoogleMeetAuthCode({
+        state: "state-token",
+        manual: false,
+        timeoutMs: 1,
+        authUrl: "https://accounts.google.com/o/oauth2/v2/auth?x=1",
+        promptInput,
+        writeLine: () => {},
+      }),
+    ).rejects.toThrow(/timeout/i);
+    expect(promptInput).not.toHaveBeenCalled();
   });
 });

--- a/extensions/google-meet/src/oauth.ts
+++ b/extensions/google-meet/src/oauth.ts
@@ -213,6 +213,35 @@ export function createGoogleMeetOAuthState(): string {
   return generateOAuthState();
 }
 
+function isLocalCallbackListenerError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return (
+    error.message.includes("EADDRINUSE") ||
+    error.message.includes("port") ||
+    error.message.includes("listen")
+  );
+}
+
+async function readManualGoogleMeetAuthCode(params: {
+  state: string;
+  promptInput: (message: string) => Promise<string>;
+}): Promise<string> {
+  const input = await params.promptInput("Paste the full redirect URL here: ");
+  const parsed = parseOAuthCallbackInput(input, {
+    missingState: "Missing 'state' parameter. Paste the full redirect URL.",
+    invalidInput: "Paste the full redirect URL, not just the code.",
+  });
+  if ("error" in parsed) {
+    throw new Error(parsed.error);
+  }
+  if (parsed.state !== params.state) {
+    throw new Error("OAuth state mismatch - please try again");
+  }
+  return parsed.code;
+}
+
 export async function waitForGoogleMeetAuthCode(params: {
   state: string;
   manual: boolean;
@@ -223,26 +252,29 @@ export async function waitForGoogleMeetAuthCode(params: {
 }): Promise<string> {
   params.writeLine(`Open this URL in your browser:\n\n${params.authUrl}\n`);
   if (params.manual) {
-    const input = await params.promptInput("Paste the full redirect URL here: ");
-    const parsed = parseOAuthCallbackInput(input, {
-      missingState: "Missing 'state' parameter. Paste the full redirect URL.",
-      invalidInput: "Paste the full redirect URL, not just the code.",
+    return await readManualGoogleMeetAuthCode({
+      state: params.state,
+      promptInput: params.promptInput,
     });
-    if ("error" in parsed) {
-      throw new Error(parsed.error);
-    }
-    if (parsed.state !== params.state) {
-      throw new Error("OAuth state mismatch - please try again");
-    }
-    return parsed.code;
   }
-  const callback = await waitForLocalOAuthCallback({
-    expectedState: params.state,
-    timeoutMs: params.timeoutMs,
-    port: 8085,
-    callbackPath: "/oauth2callback",
-    redirectUri: GOOGLE_MEET_REDIRECT_URI,
-    successTitle: "Google Meet OAuth complete",
-  });
-  return callback.code;
+  try {
+    const callback = await waitForLocalOAuthCallback({
+      expectedState: params.state,
+      timeoutMs: params.timeoutMs,
+      port: 8085,
+      callbackPath: "/oauth2callback",
+      redirectUri: GOOGLE_MEET_REDIRECT_URI,
+      successTitle: "Google Meet OAuth complete",
+    });
+    return callback.code;
+  } catch (error) {
+    if (!isLocalCallbackListenerError(error)) {
+      throw error;
+    }
+    params.writeLine("Local callback server failed. Switching to manual mode...");
+    return await readManualGoogleMeetAuthCode({
+      state: params.state,
+      promptInput: params.promptInput,
+    });
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes the second half of #54299. The Google Meet OAuth login (`openclaw meet auth login`) binds a temporary callback listener on a fixed `localhost:8085`. When that port is already taken by another local service, the listener throws `EADDRINUSE` and the error propagates straight out of `waitForGoogleMeetAuthCode`, aborting the whole login. The user cannot complete OAuth at all until they free the port.

The sibling Gemini CLI OAuth path already handles this exact case: it catches listener/port errors and switches to the manual copy/paste flow so login still succeeds. Google Meet was the one-sided gap.

## Why This Change Was Made

`extensions/google-meet/src/oauth.ts` had no recovery around the local listener:

```ts
const callback = await waitForLocalOAuthCallback({
  expectedState: params.state,
  timeoutMs: params.timeoutMs,
  port: 8085,
  callbackPath: "/oauth2callback",
  redirectUri: GOOGLE_MEET_REDIRECT_URI,
  successTitle: "Google Meet OAuth complete",
});
return callback.code;
```

`waitForLocalOAuthCallback` rejects through its `server.once("error", ...)` handler when `server.listen(8085)` fails, so an occupied port becomes a hard login failure.

The fix mirrors the Gemini path in `extensions/google/oauth.ts` (`err.message.includes("EADDRINUSE") || "port" || "listen"`). On a listener/port error it now writes a notice and falls back to the manual paste handler, which is the same code already used for the explicit `--manual` flag:

```ts
try {
  const callback = await waitForLocalOAuthCallback({ ... });
  return callback.code;
} catch (error) {
  if (!isLocalCallbackListenerError(error)) {
    throw error;
  }
  params.writeLine("Local callback server failed. Switching to manual mode...");
  return await readManualGoogleMeetAuthCode({
    state: params.state,
    promptInput: params.promptInput,
  });
}
```

The pre-existing manual-paste branch was extracted into `readManualGoogleMeetAuthCode` so the explicit `--manual` path and the automatic fallback share one implementation.

This change deliberately does not touch the conditional `client_secret` handling raised in the first half of #54299. That is the Gemini public-client PKCE contract and a maintainer product decision (ClawSweeper labeled it `needs-product-decision` / `needs-security-review`), not a defect to silently flip here.

## Why This Is The Right Boundary

The fix lives in the Google Meet plugin that owns this OAuth flow, reuses the existing manual handler rather than adding a second paste implementation, and does not change the registered redirect URI or port (changing those would require coordinated provider registration and docs, a separate product decision). It only matches the Gemini sibling's already-shipped recovery behavior. Non-listener failures (timeout, state mismatch, OAuth error) still propagate unchanged, so a genuine auth failure is never masked as a manual prompt.

## User Impact

`openclaw meet auth login` now completes via the manual copy/paste flow when port 8085 is occupied, instead of aborting with `EADDRINUSE`. No new config or env var; behavior with a free port is unchanged.

## Verification
- `node scripts/run-vitest.mjs extensions/google-meet/src/oauth.test.ts` passes (8 tests). The new test fails on pristine `origin/main` with `listen EADDRINUSE: address already in use` and passes with the patch.
- `oxlint` and `oxfmt --check` clean on both changed files.
- `tsgo -p extensions/google-meet/tsconfig.json` clean; extension test-types lane shows only unrelated pre-existing errors in `acpx` and `qa-lab`, none in `google-meet`.

## Evidence

Drove the real exported `waitForGoogleMeetAuthCode` against a genuinely occupied port 8085 on pristine `main` and on the patched tree. Before the fix the login aborts with `EADDRINUSE`; after it falls back to manual paste and returns the auth code. Details below.

### Real behavior proof
Behavior addressed: `openclaw meet auth login` aborts with EADDRINUSE when localhost:8085 is occupied, instead of falling back to manual paste like the Gemini path.
Real environment tested: drove the real exported `waitForGoogleMeetAuthCode` from `extensions/google-meet/src/oauth.ts` via tsx on pristine main 3217165be770 and on the patched tree, with a real `node:http` server actually bound to port 8085 to occupy it; the real `waitForLocalOAuthCallback` listener and the real manual-paste parser stayed real, nothing was stubbed.
Exact steps or command run after this patch: bind a real http server on localhost:8085, then call `waitForGoogleMeetAuthCode({ manual: false, state, authUrl, promptInput, writeLine })` where `promptInput` returns the redirect URL `http://localhost:8085/oauth2callback?code=auth-code-123&state=state-token`.
Evidence after fix:
```
# BEFORE (pristine main 3217165be770)
port 8085 is occupied by another local service
[meet login] Open this URL in your browser:

https://accounts.google.com/o/oauth2/v2/auth?x=1

RESULT: login failed with listen EADDRINUSE: address already in use ::1:8085

# AFTER (this patch, identical inputs)
port 8085 is occupied by another local service
[meet login] Open this URL in your browser:

https://accounts.google.com/o/oauth2/v2/auth?x=1

[meet login] Local callback server failed. Switching to manual mode...
RESULT: login succeeded, auth code = auth-code-123
```
Observed result after fix: with port 8085 occupied, the login now switches to manual paste and returns the authorization code, where before it aborted with an EADDRINUSE listener error.
What was not tested: no live Google OAuth token exchange against Google's servers; the callback-listener failure and manual fallback are driven against a real local listener, and the provider HTTP exchange is out of scope for this change. Full build not run.
