### PR TITLE
fix(speech): bound TTS/STT voice-list and transcription JSON responses

### DIFF
--- a/extensions/azure-speech/tts.ts
+++ b/extensions/azure-speech/tts.ts
@@ -2,7 +2,10 @@
  * Azure Speech REST helpers. They normalize endpoints, build SSML, list voices,
  * and synthesize speech with response-size and SSRF guards.
  */
-import { assertOkOrThrowProviderError } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowProviderError,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { SpeechVoiceOption } from "openclaw/plugin-sdk/speech-core";
 import { trimToUndefined } from "openclaw/plugin-sdk/speech-core";
@@ -160,7 +163,10 @@ export async function listAzureSpeechVoices(params: {
 
   try {
     await assertOkOrThrowProviderError(response, "Azure Speech voices API error");
-    const voices = (await response.json()) as AzureSpeechVoiceEntry[];
+    const voices = await readProviderJsonResponse<AzureSpeechVoiceEntry[]>(
+      response,
+      "azure-speech.voices",
+    );
     return Array.isArray(voices)
       ? voices
           .filter((voice) => !isDeprecatedVoice(voice))

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -1,7 +1,10 @@
 // Elevenlabs provider module implements model/runtime integration.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictFiniteNumber, parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
-import { assertOkOrThrowProviderError } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowProviderError,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type {
   SpeechDirectiveTokenParseContext,
@@ -367,14 +370,14 @@ async function listElevenLabsVoices(params: {
   });
   try {
     await assertOkOrThrowProviderError(response, "ElevenLabs voices API error");
-    const json = (await response.json()) as {
+    const json = await readProviderJsonResponse<{
       voices?: Array<{
         voice_id?: string;
         name?: string;
         category?: string;
         description?: string;
       }>;
-    };
+    }>(response, "elevenlabs.voices");
     return Array.isArray(json.voices)
       ? json.voices
           .map((voice) => ({

--- a/extensions/microsoft/speech-provider.ts
+++ b/extensions/microsoft/speech-provider.ts
@@ -7,7 +7,10 @@ import {
   generateSecMsGecToken,
 } from "node-edge-tts/dist/drm.js";
 import { isVoiceCompatibleAudio } from "openclaw/plugin-sdk/media-runtime";
-import { assertOkOrThrowProviderError } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowProviderError,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import {
   captureHttpExchange,
   isDebugProxyGlobalFetchPatchInstalled,
@@ -166,7 +169,10 @@ export async function listMicrosoftVoices(): Promise<SpeechVoiceOption[]> {
       });
     }
     await assertOkOrThrowProviderError(response, "Microsoft voices API error");
-    const voices = (await response.json()) as MicrosoftVoiceListEntry[];
+    const voices = await readProviderJsonResponse<MicrosoftVoiceListEntry[]>(
+      response,
+      "microsoft.speech-voices",
+    );
     return Array.isArray(voices)
       ? voices
           .map((voice) => ({

--- a/extensions/minimax/tts.ts
+++ b/extensions/minimax/tts.ts
@@ -1,6 +1,9 @@
 // Minimax plugin module implements tts behavior.
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
-import { assertOkOrThrowProviderError } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowProviderError,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
@@ -105,10 +108,10 @@ export async function minimaxTTS(params: {
     try {
       await assertOkOrThrowProviderError(response, "MiniMax TTS API error");
 
-      const body = (await response.json()) as {
+      const body = await readProviderJsonResponse<{
         data?: { audio?: string };
         base_resp?: { status_code?: number; status_msg?: string };
-      };
+      }>(response, "minimax.tts");
 
       // Check base_resp for envelope errors (HTTP 200 with non-zero status_code).
       // Other MiniMax providers (image, video, music, web-search) already check this.
@@ -119,9 +122,7 @@ export async function minimaxTTS(params: {
         body.base_resp.status_code !== 0
       ) {
         const msg = body.base_resp.status_msg ?? "unknown error";
-        throw new Error(
-          `MiniMax TTS API error (${body.base_resp.status_code}): ${msg}`,
-        );
+        throw new Error(`MiniMax TTS API error (${body.base_resp.status_code}): ${msg}`);
       }
 
       const hexAudio = body?.data?.audio;

--- a/extensions/openrouter/media-understanding-provider.test.ts
+++ b/extensions/openrouter/media-understanding-provider.test.ts
@@ -24,6 +24,8 @@ const { assertOkOrThrowHttpErrorMock, postJsonRequestMock, resolveProviderHttpRe
 vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
   postJsonRequest: postJsonRequestMock,
+  // Pass-through: bounded-reader enforcement is tested via bounded-reader unit tests.
+  readProviderJsonResponse: async (response: { json(): Promise<unknown> }) => response.json(),
   requireTranscriptionText: (value: string | undefined, message: string) => {
     const text = value?.trim();
     if (!text) {

--- a/extensions/openrouter/media-understanding-provider.ts
+++ b/extensions/openrouter/media-understanding-provider.ts
@@ -10,6 +10,7 @@ import {
 import {
   assertOkOrThrowHttpError,
   postJsonRequest,
+  readProviderJsonResponse,
   requireTranscriptionText,
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
@@ -148,7 +149,10 @@ export async function transcribeOpenRouterAudio(
 
   try {
     await assertOkOrThrowHttpError(response, "OpenRouter audio transcription failed");
-    const payload = (await response.json()) as OpenRouterSttResponse;
+    const payload = await readProviderJsonResponse<OpenRouterSttResponse>(
+      response,
+      "openrouter.stt",
+    );
     return {
       text: requireTranscriptionText(
         payload.text,

--- a/extensions/xai/stt.ts
+++ b/extensions/xai/stt.ts
@@ -8,8 +8,9 @@ import {
   assertOkOrThrowHttpError,
   buildAudioTranscriptionFormData,
   postTranscriptionRequest,
-  resolveProviderHttpRequestConfig,
+  readProviderJsonResponse,
   requireTranscriptionText,
+  resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { XAI_BASE_URL } from "./model-definitions.js";
@@ -68,7 +69,7 @@ export async function transcribeXaiAudio(
 
   try {
     await assertOkOrThrowHttpError(response, "xAI audio transcription failed");
-    const payload = (await response.json()) as XaiSttResponse;
+    const payload = await readProviderJsonResponse<XaiSttResponse>(response, "xai.stt");
     return {
       text: requireTranscriptionText(payload.text, "xAI transcription response missing text"),
       ...(model ? { model } : {}),


### PR DESCRIPTION
## What Problem This Solves

Six TTS/STT providers parse their success responses — voice-list catalog calls
and audio transcription results — with an unbounded `await response.json()`.
`response.json()` reads the **entire** body into memory before parsing, with no
byte ceiling and regardless of (or in the absence of) a `Content-Length` header.
These providers are external, untrusted sources: a misbehaving, compromised, or
hostile endpoint (including a self-hosted `baseUrl` override) can stream an
arbitrarily large or never-ending JSON body and force the gateway/plugin to
buffer it all, causing memory pressure or a hang on the TTS/STT code path.

The affected call sites are:
- `extensions/azure-speech/tts.ts` — Azure Speech voice-list catalog
- `extensions/microsoft/speech-provider.ts` — Microsoft Azure speech voice-list catalog
- `extensions/elevenlabs/speech-provider.ts` — ElevenLabs voice-list catalog
- `extensions/minimax/tts.ts` — MiniMax TTS synthesis response
- `extensions/xai/stt.ts` — xAI audio transcription result
- `extensions/openrouter/media-understanding-provider.ts` — OpenRouter STT transcription result

This change closes all six unbounded surfaces, making this the TTS/STT companion
to the `#95103` / `#95108` / `#95218` response-limit campaign.

## Changes

* Each of the six TTS/STT providers now reads its success JSON body through the
  shared bounded reader `readProviderJsonResponse` (from
  `openclaw/plugin-sdk/provider-http`), which enforces a **16 MiB cap** and
  calls the shared `readResponseWithLimit` helper internally.
* On overflow the helper cancels the underlying stream and throws a bounded
  error (`<label>: JSON response exceeds <N> bytes`); existing
  malformed-JSON and HTTP error paths are preserved for backward compatibility.
* No new abstraction — reuses the existing `media-core` bounded reader already
  used across the codebase.
* `extensions/openrouter/media-understanding-provider.test.ts`, which declares
  a closed `vi.mock("openclaw/plugin-sdk/provider-http")` factory, receives a
  pass-through mock for `readProviderJsonResponse` so existing transcription
  fixture tests remain valid; `extensions/xai/stt.test.ts` uses
  `importOriginal` spread and requires no change.

## Real behavior proof

* **Behavior addressed**: An untrusted TTS/STT JSON success response with no
  `Content-Length` and an oversized/never-ending body must not be buffered
  whole; the read must stop at the cap, cancel the stream, and throw a bounded
  error — while valid small responses still parse unchanged.
* **Real environment tested**: A real `node:http` server (`createServer`) bound
  to `127.0.0.1`, streaming a JSON body in 64 KiB chunks with **no**
  **Content-Length** header, driving the **real exported**
  `readResponseWithLimit` helper (the same helper `readProviderJsonResponse`
  wraps internally) on Node v22.22.0.
* **Exact steps**:
  1. Boot the server; `GET /huge` streams an unbounded JSON object (~24 MiB) with
     no `Content-Length`; `GET /small` returns one valid response.
  2. Drive `readResponseWithLimit(response, 1 MiB, { onOverflow: ... })` against
     `/huge` and assert it rejects + the server socket is closed early.
  3. **Negative control**: run the OLD path `await response.json()` against the
     same `/huge` body and measure how many bytes the server pushed.
  4. Drive `readResponseWithLimit(response, 1 MiB)` against `/small` and assert
     the result is parsed intact.
* **Evidence after fix**:
  * Bounded case: threw `JSON response exceeds 1048576 bytes`; server socket
    closed early (stream cancelled); only **1,064,178 bytes** reached the
    wire — near the 1 MiB cap, not the 24 MiB body.
  * Negative control: the unbounded `response.json()` read pulled the **full**
    **25,165,824 bytes** (>23x the bounded read), proving the cap is
    load-bearing.
  * Small case: parsed into the expected result intact, no truncation.
* **Observed result**: `ALL PROOF ASSERTIONS PASSED`. Plus the in-repo Vitest
  suite for the two providers with closed mocks passes — **2/2 files,
  12/12 tests** — including existing transcription fixture tests. `oxlint` is
  clean on changed files.
* **What was not tested**: Live TTS/STT endpoints were not hit (no keys / would
  not reproduce a hostile oversized body). The 64-bit memory-exhaustion end
  state was not driven to OOM — the proof instead measures bytes-on-wire and
  early socket close, which is the load-bearing signal.

## Evidence

```
[case 1] oversized TTS/STT JSON, cap=1024 KiB, NO content-length
  ok: readResponseWithLimit rejected on oversized body — true
  ok: bounded error message present (got: JSON response exceeds 1048576 bytes) — true
  ok: bytes on wire stayed near the cap, not the full body (sent 1064178) — true

[negative control] OLD unbounded `await response.json()` buffers whole body
  ok: unbounded read pulled the FULL ~24 MiB body (sent 25165824), proving the cap is load-bearing — true

[case 3] normal small JSON still parses unchanged
  ok: small body parsed into result — true
  ok: result content intact (valid small body not truncated) — true

ALL PROOF ASSERTIONS PASSED
```

```
 Test Files  2 passed (2)
      Tests  12 passed (12)
   Start at  00:23:51
   Duration  1.00s
```

**Label**: security

AI-assisted.
