### PR TITLE
fix(ollama): stop forcing tool_calls.arguments back to an object on the openai-completions path

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -1,4 +1,6 @@
 // Ollama tests cover stream plugin behavior.
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { Context, Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
@@ -9,7 +11,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
-import { buildAssistantMessage, createOllamaStreamFn } from "./stream.js";
+import { buildAssistantMessage, createOllamaStreamFn, wrapOllamaCompatNumCtx } from "./stream.js";
 
 function makeOllamaResponse(params: {
   content?: string;
@@ -494,5 +496,78 @@ describe("createOllamaStreamFn thinking events", () => {
       reason: "aborted",
       error: { stopReason: "aborted" },
     });
+  });
+});
+
+describe("wrapOllamaCompatNumCtx", () => {
+  it("injects num_ctx without touching already-stringified tool_calls.function.arguments", () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn: StreamFn = (model, context, options) => {
+      const payload: Record<string, unknown> = {
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "search", arguments: '{"query":"weather"}' },
+              },
+            ],
+          },
+        ],
+      };
+      options?.onPayload?.(payload, model);
+      capturedPayload = payload;
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = wrapOllamaCompatNumCtx(baseStreamFn, 4096);
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "ollama",
+        id: "glm-5.2:cloud",
+      } as Model<"openai-completions">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect((capturedPayload?.options as Record<string, unknown> | undefined)?.num_ctx).toBe(4096);
+    const messages = capturedPayload?.messages as Array<Record<string, unknown>>;
+    const toolCalls = messages[0]?.tool_calls as Array<{ function: { arguments: unknown } }>;
+    expect(toolCalls[0]?.function.arguments).toBe('{"query":"weather"}');
+  });
+
+  it("leaves legacy function_call arguments untouched as a string", () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn: StreamFn = (model, context, options) => {
+      const payload: Record<string, unknown> = {
+        messages: [
+          {
+            role: "assistant",
+            function_call: { name: "search", arguments: '{"query":"weather"}' },
+          },
+        ],
+      };
+      options?.onPayload?.(payload, model);
+      capturedPayload = payload;
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = wrapOllamaCompatNumCtx(baseStreamFn, 4096);
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "ollama",
+        id: "glm-5.2:cloud",
+      } as Model<"openai-completions">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    const messages = capturedPayload?.messages as Array<Record<string, unknown>>;
+    const functionCall = messages[0]?.function_call as { arguments: unknown };
+    expect(functionCall.arguments).toBe('{"query":"weather"}');
   });
 });

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -247,7 +247,6 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         payloadRecord.options = {};
       }
       (payloadRecord.options as Record<string, unknown>).num_ctx = numCtx;
-      normalizeOllamaCompatMessageToolArgs(payloadRecord);
     });
 }
 
@@ -734,46 +733,6 @@ function ensureArgsObject(value: unknown): Record<string, unknown> {
 
 function normalizeOllamaToolCallArguments(value: unknown): Record<string, unknown> {
   return ensureArgsObject(value);
-}
-
-function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unknown>): void {
-  const messages = payloadRecord.messages;
-  if (!Array.isArray(messages)) {
-    return;
-  }
-
-  for (const message of messages) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
-      continue;
-    }
-    const messageRecord = message as Record<string, unknown>;
-
-    const functionCall = messageRecord.function_call;
-    if (functionCall && typeof functionCall === "object" && !Array.isArray(functionCall)) {
-      const functionCallRecord = functionCall as Record<string, unknown>;
-      if (Object.hasOwn(functionCallRecord, "arguments")) {
-        functionCallRecord.arguments = ensureArgsObject(functionCallRecord.arguments);
-      }
-    }
-
-    const toolCalls = messageRecord.tool_calls;
-    if (!Array.isArray(toolCalls)) {
-      continue;
-    }
-    for (const toolCall of toolCalls) {
-      if (!toolCall || typeof toolCall !== "object" || Array.isArray(toolCall)) {
-        continue;
-      }
-      const functionSpec = (toolCall as Record<string, unknown>).function;
-      if (!functionSpec || typeof functionSpec !== "object" || Array.isArray(functionSpec)) {
-        continue;
-      }
-      const functionRecord = functionSpec as Record<string, unknown>;
-      if (Object.hasOwn(functionRecord, "arguments")) {
-        functionRecord.arguments = ensureArgsObject(functionRecord.arguments);
-      }
-    }
-  }
 }
 
 function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
Fixes #96441

## What Problem This Solves

Ollama Cloud models (e.g. `ollama/glm-5.2:cloud`) fail every second agent turn after a tool call: OpenClaw sends `tool_calls.function.arguments` as a JSON object instead of a JSON string when replaying conversation history through the OpenAI-compatible endpoint, and Ollama's Go server rejects it with `400 json: cannot unmarshal object into Go struct field .messages.tool_calls.function.arguments of type string`. This is a regression — the first turn works, the tool executes, then the agent is stuck.

## Why This Change Was Made

`src/llm/providers/openai-completions.ts` already correctly `JSON.stringify`s `tool_calls.function.arguments` when building the outgoing request (this is the OpenAI Chat Completions wire format, which Ollama's Go server enforces strictly on `:cloud` models routed through `model.api === "openai-completions"`).

`extensions/ollama/src/stream.ts`'s `wrapOllamaCompatNumCtx` ran a payload patch (`normalizeOllamaCompatMessageToolArgs`) right before send that re-coerced those already-correct JSON strings back into objects, undoing the stringify. Tracing this back to its origin: it was added in the same commit (`87abcfd6a6`, fixing #52253) that correctly added `ensureArgsObject()` for the *native* Ollama `/api/chat` path (`extractToolCalls`/`convertToOllamaMessages`), where Ollama's native API does want an object. The same object-coercion was mistakenly also wired into the unrelated `openai-completions` payload-patch path, breaking the opposite contract there.

Fix: remove `normalizeOllamaCompatMessageToolArgs` (and its only call site) from `wrapOllamaCompatNumCtx`. The native-path fix for #52253 (`ensureArgsObject` inside `extractToolCalls`) is untouched.

## User Impact

Restores multi-turn tool use for Ollama Cloud (and any other provider routed through `model.api === "openai-completions"` with `shouldInjectOllamaCompatNumCtx` enabled). No change for native Ollama (`model.api === "ollama"`) users.

## Evidence

Behavior addressed: `wrapOllamaCompatNumCtx`'s payload patch mutated already-stringified `tool_calls.function.arguments` (and legacy `function_call.arguments`) back into an object on the openai-completions path, before the request left the process.

Real environment tested: macOS arm64 (M4), Darwin 25.5.0, Node v25.9.0, branch `fix/ollama-cloud-tool-call-arguments-string`, commit `0564c6d637`.

Exact steps or command run after this patch:
```
node scripts/run-vitest.mjs extensions/ollama/src/stream.test.ts
node scripts/run-oxlint.mjs extensions/ollama/src/stream.ts extensions/ollama/src/stream.test.ts
pnpm tsgo:extensions
pnpm tsgo:extensions:test
```

Evidence after fix:
```
stream.test.ts: 17 passed (17)
oxlint: exit 0, no findings
tsgo:extensions: exit 0
tsgo:extensions:test: exit 0
```

Observed result after fix: added two regression tests for `wrapOllamaCompatNumCtx` (tool_calls and legacy function_call) asserting `arguments` stays a JSON string after the patch runs. Confirmed both new tests fail against the pre-fix code (`{ query: 'weather' }` received instead of `'{"query":"weather"}'`) and pass after the fix, isolating exactly the regression described in #96441.

What was not tested: did not run against a live Ollama Cloud account (no credentials in this environment) — this is a payload-construction unit fix verified by reproducing the exact wire-shape assertion the Go server's `400` implies, not a live round-trip.
