### PR TITLE
fix(github-copilot): bound model discovery and embeddings JSON response

### DIFF
--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -75,13 +75,16 @@ function mockDiscoveryResponse(spec: {
   json?: unknown;
   text?: string;
 }) {
+  const status = spec.status ?? (spec.ok ? 200 : 500);
+  const response =
+    spec.json !== undefined
+      ? new Response(JSON.stringify(spec.json), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        })
+      : new Response(spec.text ?? "", { status });
   fetchWithSsrFGuardMock.mockImplementationOnce(async () => ({
-    response: {
-      ok: spec.ok,
-      status: spec.status ?? (spec.ok ? 200 : 500),
-      json: async () => spec.json,
-      text: async () => spec.text ?? "",
-    },
+    response,
     release: vi.fn(async () => {}),
   }));
 }
@@ -228,20 +231,16 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
 
   it("wraps invalid discovery JSON as a setup error", async () => {
     fetchWithSsrFGuardMock.mockImplementationOnce(async () => ({
-      response: {
-        ok: true,
+      response: new Response("not-valid-json{{{", {
         status: 200,
-        json: async () => {
-          throw new SyntaxError("bad json");
-        },
-        text: async () => "",
-      },
+        headers: { "Content-Type": "application/json" },
+      }),
       release: vi.fn(async () => {}),
     }));
 
     await expect(
       githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
-    ).rejects.toThrow("GitHub Copilot model discovery returned invalid JSON");
+    ).rejects.toThrow("github-copilot.model-discovery: malformed JSON response");
   });
 
   it("bounds model discovery error bodies", async () => {
@@ -360,7 +359,7 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
     ).toBe(true);
     expect(
       shouldContinueAutoSelection(
-        new Error("GitHub Copilot model discovery returned invalid JSON"),
+        new Error("github-copilot.model-discovery: malformed JSON response"),
       ),
     ).toBe(true);
     expect(shouldContinueAutoSelection(new Error("Network timeout"))).toBe(false);

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -32,6 +32,7 @@ const COPILOT_HEADERS_STATIC: Record<string, string> = {
   ...buildCopilotIdeHeaders(),
 };
 const COPILOT_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const COPILOT_EMBEDDINGS_RESPONSE_MAX_BYTES = 64 * 1024 * 1024;
 
 function buildSsrfPolicy(baseUrl: string): SsrFPolicy | undefined {
   try {
@@ -245,7 +246,9 @@ async function createGitHubCopilotEmbeddingProvider(
           throw new Error(`GitHub Copilot embeddings HTTP ${response.status}: ${detail}`);
         }
 
-        const payload = await readProviderJsonResponse(response, "github-copilot.embeddings");
+        const payload = await readProviderJsonResponse(response, "github-copilot.embeddings", {
+          maxBytes: COPILOT_EMBEDDINGS_RESPONSE_MAX_BYTES,
+        });
         return parseGitHubCopilotEmbeddingPayload(payload, input.length);
       },
     });

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -7,7 +7,10 @@ import {
   type MemoryEmbeddingProviderAdapter,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { buildCopilotIdeHeaders } from "openclaw/plugin-sdk/provider-auth";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveFirstGithubToken } from "./auth.js";
@@ -70,6 +73,7 @@ function isCopilotSetupError(err: unknown): boolean {
     err.message.includes("Copilot token response") ||
     err.message.includes("No embedding models available") ||
     err.message.includes("GitHub Copilot model discovery") ||
+    err.message.includes("github-copilot.model-discovery") ||
     err.message.includes("GitHub Copilot embedding model") ||
     err.message.includes("Unexpected response from GitHub Copilot token endpoint")
   );
@@ -100,12 +104,7 @@ async function discoverEmbeddingModels(params: {
       const detail = await readResponseTextLimited(response, COPILOT_ERROR_BODY_LIMIT_BYTES);
       throw new Error(`GitHub Copilot model discovery HTTP ${response.status}: ${detail}`);
     }
-    let payload: unknown;
-    try {
-      payload = await response.json();
-    } catch {
-      throw new Error("GitHub Copilot model discovery returned invalid JSON");
-    }
+    const payload = await readProviderJsonResponse(response, "github-copilot.model-discovery");
     const allModels = Array.isArray((payload as { data?: unknown })?.data)
       ? ((payload as { data: CopilotModelEntry[] }).data ?? [])
       : [];
@@ -246,12 +245,7 @@ async function createGitHubCopilotEmbeddingProvider(
           throw new Error(`GitHub Copilot embeddings HTTP ${response.status}: ${detail}`);
         }
 
-        let payload: unknown;
-        try {
-          payload = await response.json();
-        } catch {
-          throw new Error("GitHub Copilot embeddings returned invalid JSON");
-        }
+        const payload = await readProviderJsonResponse(response, "github-copilot.embeddings");
         return parseGitHubCopilotEmbeddingPayload(payload, input.length);
       },
     });


### PR DESCRIPTION
## What Problem This Solves

The GitHub Copilot embeddings plugin already bounds its **error** response
bodies via `readResponseTextLimited` (8 KiB cap), but the **success** JSON reads
for both model discovery and the embeddings call used an unbounded
`await response.json()`. This asymmetry means a misbehaving or hostile Copilot
API endpoint can stream an arbitrarily large success body into memory before
parsing, causing memory pressure on the model discovery and embeddings hot path —
while the same file already demonstrates awareness that response bodies need to
be capped.

The error body is bounded on both paths; this PR closes the symmetric gap on
the success-JSON side, matching the pattern already applied to other provider
paths in the `#95103` / `#95108` / `#95218` response-limit campaign.

## Changes

* `discoverEmbeddingModels`: replaces the `try { payload = await response.json() } catch`
  block with `readProviderJsonResponse(response, "github-copilot.model-discovery")`
  (16 MiB cap) from `openclaw/plugin-sdk/provider-http`.
* `embed` (embeddings call): replaces the identical pattern with
  `readProviderJsonResponse(response, "github-copilot.embeddings")`.
* `isCopilotSetupError`: adds the `"github-copilot.model-discovery"` label prefix
  so auto-selection still falls through on malformed discovery responses with the
  new error format.
* `embeddings.test.ts`:
  * Updates `mockDiscoveryResponse` to return real `Response` objects (required by
    the streaming bounded reader; plain `{ json: async () => ... }` objects lack
    `.body`).
  * Updates the malformed-JSON fixture to use a non-JSON body string instead of
    a throwing `.json()` stub.
  * Updates the `shouldContinueAutoSelection` assertion to match the new error
    message prefix `"github-copilot.model-discovery: malformed JSON response"`.

## Real behavior proof

* **Behavior addressed**: An untrusted Copilot API success response with no
  `Content-Length` and an oversized/never-ending body must not be buffered whole;
  the read must stop at the cap, cancel the stream, and throw a bounded error —
  while valid small responses still parse unchanged.
* **Real environment tested**: A real `node:http` server (`createServer`) bound
  to `127.0.0.1`, streaming a JSON body in 64 KiB chunks with **no
  Content-Length** header, driving the real exported `readResponseWithLimit`
  helper (the same helper `readProviderJsonResponse` wraps internally) on
  Node v22.22.0.
* **Exact steps**:
  1. Boot the server; `GET /huge` streams an unbounded JSON object (~24 MiB) with
     no `Content-Length`; `GET /small` returns one valid response.
  2. Drive `readResponseWithLimit(response, 1 MiB)` against `/huge` and assert
     it rejects + the server socket is closed early.
  3. **Negative control**: run the OLD path `await response.json()` against the
     same `/huge` body and measure how many bytes the server pushed.
  4. Drive `readResponseWithLimit(response, 1 MiB)` against `/small` and assert
     the result is parsed intact.
* **Evidence after fix**:
  * Bounded case: threw `JSON response exceeds 1048576 bytes`; server socket
    closed early (stream cancelled); only **1,064,178 bytes** reached the
    wire — near the 1 MiB cap, not the 24 MiB body.
  * Negative control: the unbounded `response.json()` pulled the **full
    25,165,824 bytes** (>23x the bounded read), proving the cap is load-bearing.
  * Small case: parsed intact, no truncation.
* **Observed result**: `ALL PROOF ASSERTIONS PASSED`. Plus the in-repo Vitest
  suite passes **1/1 file, 12/12 tests** — including the existing bounds-error
  body tests and the updated malformed-JSON fixture. `oxlint` is clean on
  changed files.
* **What was not tested**: Live Copilot API calls with an oversized response.
  The proof instead measures bytes-on-wire and early socket close, which is
  the load-bearing signal.

## Evidence

```
[case 1] oversized JSON, cap=1024 KiB, NO content-length
  ok: readResponseWithLimit rejected on oversized body — true
  ok: bounded error message present (got: JSON response exceeds 1048576 bytes) — true
  ok: bytes on wire stayed near the cap, not the full body (sent 1064178) — true

[negative control] OLD unbounded `await response.json()` buffers whole body
  ok: unbounded read pulled the FULL ~24 MiB body (sent 25165824), proving the cap is load-bearing — true

[case 3] normal small JSON still parses unchanged
  ok: small body parsed into result — true
  ok: result content intact (valid small body not truncated) — true

ALL PROOF ASSERTIONS PASSED
```

```
 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  00:37:43
   Duration  4.01s
```

**Label**: security

AI-assisted.
