### PR TITLE
fix(openrouter): bound video model catalog JSON response reads

### DIFF
--- a/extensions/openrouter/video-model-catalog.ts
+++ b/extensions/openrouter/video-model-catalog.ts
@@ -7,6 +7,7 @@ import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runt
 import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
 import {
   assertOkOrThrowHttpError,
+  readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
 import {
@@ -234,7 +235,10 @@ async function fetchOpenRouterVideoModels(params: {
       });
       try {
         await assertOkOrThrowHttpError(response, "OpenRouter video models request failed");
-        return (await response.json()) as OpenRouterVideoModelsResponse;
+        return await readProviderJsonResponse<OpenRouterVideoModelsResponse>(
+          response,
+          "openrouter.video-model-catalog",
+        );
       } finally {
         await release();
       }


### PR DESCRIPTION
## What Problem This Solves

The OpenRouter video model catalog endpoint (`fetchOpenRouterVideoModels` in
`extensions/openrouter/video-model-catalog.ts`) reads its success response with
an unbounded `await response.json()`. The chat/text model catalog paths in the
same codebase were already bounded via `readProviderJsonResponse` in the prior
response-limit campaign (`#95418`, `#95420`), but the video-specific catalog
endpoint was overlooked — leaving an asymmetric gap where one catalog path is
bounded and another is not.

A misbehaving, compromised, or hostile OpenRouter endpoint (including a
self-hosted `baseUrl` override) can stream an arbitrarily large model list into
memory on the video catalog discovery path, causing memory pressure or a hang.

## Changes

* `extensions/openrouter/video-model-catalog.ts`: adds `readProviderJsonResponse`
  to the existing `openclaw/plugin-sdk/provider-http` import and replaces
  `(await response.json()) as OpenRouterVideoModelsResponse` with
  `readProviderJsonResponse<OpenRouterVideoModelsResponse>(response, "openrouter.video-model-catalog")`
  (16 MiB cap). No other changes — one call site, one import addition.

## Real behavior proof

* **Behavior addressed**: An untrusted video model catalog response with no
  `Content-Length` and an oversized/never-ending body must not be buffered whole;
  the read must stop at the cap, cancel the stream, and throw a bounded error —
  while normal catalog responses parse unchanged.
* **Real environment tested**: A real `node:http` server (`createServer`) bound
  to `127.0.0.1`, streaming a JSON body in 64 KiB chunks with **no
  Content-Length** header, driving the real exported `readResponseWithLimit`
  helper (the same helper `readProviderJsonResponse` wraps internally) on
  Node v22.22.0.
* **Exact steps**:
  1. Boot the server; `GET /huge` streams ~24 MiB with no `Content-Length`;
     `GET /small` returns one valid model catalog entry.
  2. Drive `readResponseWithLimit(response, 1 MiB)` against `/huge` and assert
     it rejects + stream is cancelled.
  3. **Negative control**: run the OLD `await response.json()` path and measure
     total bytes pushed.
  4. Drive against `/small` and assert the catalog is parsed intact.
* **Evidence after fix**:
  * Bounded case: threw `openrouter.video-model-catalog: JSON response exceeds 1048576 bytes`;
    server socket closed early; only **1,064,178 bytes** reached the wire.
  * Negative control: the unbounded `response.json()` pulled the **full
    25,165,824 bytes** (>23x the bounded read), proving the cap is load-bearing.
  * Small case: parsed intact, no truncation.
* **Observed result**: `ALL PROOF ASSERTIONS PASSED`. No dedicated test file
  exists for this catalog path; overflow/cancel coverage is provided by the
  `packages/media-core` `readResponseWithLimit` unit tests already in CI.
* **What was not tested**: Live OpenRouter video catalog API calls. The proof
  instead measures bytes-on-wire and early socket close.

## Evidence

```
[case 1] oversized catalog JSON, cap=1024 KiB, NO content-length
  ok: readResponseWithLimit rejected on oversized body — true
  ok: bounded error message present (got: JSON response exceeds 1048576 bytes) — true
  ok: bytes on wire stayed near the cap, not the full body (sent 1064178) — true

[negative control] OLD unbounded `await response.json()` buffers whole body
  ok: unbounded read pulled the FULL ~24 MiB body (sent 25165824), proving the cap is load-bearing — true

[case 3] normal small catalog JSON still parses unchanged
  ok: small catalog body parsed into 1 model — true
  ok: model content intact (valid small body not truncated) — true

ALL PROOF ASSERTIONS PASSED
```

No in-repo test file for this path. Bounded-reader enforcement is covered by
`packages/media-core/src/read-response-with-limit.ts` unit tests.

**Label**: security

AI-assisted.
