### PR TITLE
fix(ollama): preserve tool_calls arguments as JSON strings in OpenAI-compatible path

### DIFF
--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -247,7 +247,11 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         payloadRecord.options = {};
       }
       (payloadRecord.options as Record<string, unknown>).num_ctx = numCtx;
-      normalizeOllamaCompatMessageToolArgs(payloadRecord);
+      // FIX #96441: Do not normalize tool call arguments here — the upstream
+      // OpenAI-compatible converter (openai-completions.ts) already serializes
+      // arguments as JSON strings per the OpenAI API spec. Re-normalizing them
+      // back to objects breaks Ollama Cloud's Go server which enforces the spec
+      // strictly. The native Ollama path has its own normalization elsewhere.
     });
 }
 

--- a/extensions/ollama/src/wrap-ollama-compat.test.ts
+++ b/extensions/ollama/src/wrap-ollama-compat.test.ts
@@ -1,0 +1,134 @@
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
+// Tests for wrapOllamaCompatNumCtx — verifies FIX #96441:
+// OpenAI-compatible tool_calls.function.arguments must remain as JSON strings
+// (not be normalized back to objects).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Track every payload patcher that wrapOllamaCompatNumCtx registers.
+const capturedPatchers: Array<(payload: Record<string, unknown>) => void> = [];
+
+vi.mock("openclaw/plugin-sdk/provider-stream-shared", () => ({
+  streamWithPayloadPatch: vi.fn(
+    (
+      _streamFn: unknown,
+      _model: unknown,
+      _context: unknown,
+      _options: unknown,
+      patcher: (payload: Record<string, unknown>) => void,
+    ) => {
+      capturedPatchers.push(patcher);
+      return createAssistantMessageEventStream();
+    },
+  ),
+}));
+
+import { wrapOllamaCompatNumCtx } from "./stream.js";
+
+describe("wrapOllamaCompatNumCtx — FIX #96441", () => {
+  beforeEach(() => {
+    capturedPatchers.length = 0;
+  });
+
+  it("injects num_ctx into payload options", async () => {
+    const wrapped = wrapOllamaCompatNumCtx(undefined, 4096);
+    await wrapped({} as any, { messages: [], systemPrompt: "" } as any);
+
+    expect(capturedPatchers.length).toBe(1);
+    const patcher = capturedPatchers[0];
+
+    const payload: Record<string, unknown> = { options: {}, messages: [] };
+    patcher(payload);
+
+    expect((payload.options as Record<string, unknown>).num_ctx).toBe(4096);
+  });
+
+  it("preserves tool_calls[*].function.arguments as strings (FIX #96441)", async () => {
+    const wrapped = wrapOllamaCompatNumCtx(undefined, 4096);
+    await wrapped({} as any, { messages: [], systemPrompt: "" } as any);
+
+    expect(capturedPatchers.length).toBe(1);
+    const patcher = capturedPatchers[0];
+
+    // Simulate the payload that openai-completions.ts produces:
+    // arguments is a JSON string per the OpenAI API spec.
+    const payload: Record<string, unknown> = {
+      options: {},
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: "config_get",
+                arguments: '{"action":"config.get","path":"gateway.port"}',
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    patcher(payload);
+
+    // Read back the tool_calls and verify arguments stayed as a string.
+    const messages = payload.messages as Array<Record<string, unknown>>;
+    const toolCalls = messages[0].tool_calls as Array<Record<string, unknown>>;
+    const fnSpec = toolCalls[0].function as Record<string, unknown>;
+
+    expect(typeof fnSpec.arguments).toBe("string");
+    expect(fnSpec.arguments).toBe('{"action":"config.get","path":"gateway.port"}');
+  });
+
+  it("preserves function_call.arguments as strings (legacy format)", async () => {
+    const wrapped = wrapOllamaCompatNumCtx(undefined, 4096);
+    await wrapped({} as any, { messages: [], systemPrompt: "" } as any);
+
+    expect(capturedPatchers.length).toBe(1);
+    const patcher = capturedPatchers[0];
+
+    // Some older models use the legacy function_call format.
+    const payload: Record<string, unknown> = {
+      options: {},
+      messages: [
+        {
+          role: "assistant",
+          function_call: {
+            name: "get_weather",
+            arguments: '{"city":"London"}',
+          },
+        },
+      ],
+    };
+
+    patcher(payload);
+
+    const messages = payload.messages as Array<Record<string, unknown>>;
+    const fnCall = messages[0].function_call as Record<string, unknown>;
+
+    expect(typeof fnCall.arguments).toBe("string");
+    expect(fnCall.arguments).toBe('{"city":"London"}');
+  });
+
+  it("handles messages without tool_calls or function_call gracefully", async () => {
+    const wrapped = wrapOllamaCompatNumCtx(undefined, 4096);
+    await wrapped({} as any, { messages: [], systemPrompt: "" } as any);
+
+    expect(capturedPatchers.length).toBe(1);
+    const patcher = capturedPatchers[0];
+
+    // Payload with a plain user message — no tool-related fields.
+    const payload: Record<string, unknown> = {
+      options: {},
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there" },
+      ],
+    };
+
+    // Should not throw or modify anything.
+    expect(() => patcher(payload)).not.toThrow();
+    expect((payload.messages as Array<Record<string, unknown>>)[1].content).toBe("Hi there");
+  });
+});


### PR DESCRIPTION
## Summary

Ollama Cloud models fail on the second agent turn when tool calls are involved. OpenClaw sends `tool_calls.function.arguments` as a JSON **object** instead of a JSON **string**, causing Ollama's Go server to reject the request with `400`.

**Root cause**: The `wrapOllamaCompatNumCtx` function in the Ollama extension (`extensions/ollama/src/stream.ts`) called `normalizeOllamaCompatMessageToolArgs`, which converts tool call arguments from JSON strings back to objects. The upstream OpenAI-compatible converter (`openai-completions.ts`) already correctly serializes arguments as strings per the OpenAI API spec — this normalization was over-applied.

**Fix**: Removed the over-application of `normalizeOllamaCompatMessageToolArgs` from the OpenAI-compatible wrapper while keeping the native Ollama `/api/chat` normalization intact.

Fixes #96441

## Real behavior proof (required for external PRs)

**Behavior addressed**: Ollama Cloud returns 400 `cannot unmarshal object into Go struct field .messages.tool_calls.function.arguments of type string` on second-turn tool call replay.

**Evidence type**: terminal (unit tests + code review)

**Real setup tested**:
- **Runtime**: Node v24.13.1, Linux x86_64
- **Test suite**: 266 tests pass (11 files), including 4 new regression tests

**Exact steps or command run after fix**:

```bash
pnpm test -- --project extension-providers extensions/ollama/src/
```

**After-fix evidence**:

```
Test Files  11 passed (11)
     Tests  266 passed (266)
```

**Observed result after the fix**: All 266 tests pass. New regression tests confirm that `tool_calls[*].function.arguments` remain as JSON strings through `wrapOllamaCompatNumCtx`. The native Ollama path (`normalizeOllamaToolCallArguments`) is unaffected.

**What was not tested**: End-to-end Ollama Cloud credential test (requires a live Ollama Cloud API key). The existing issue report already provides HTTP interceptor evidence showing the wire-format problem, and the code-level fix is directly verifiable from the payload structure.

## Tests and validation

| Test Type | Result | Details |
|-----------|--------|---------|
| New Regression Tests | ✅ 4/4 | `wrap-ollama-compat.test.ts` — verifies arguments stay as strings |
| Stream Tests | ✅ 15/15 | Existing `stream.test.ts` |
| Stream Runtime Tests | ✅ 100/100 | Existing `stream-runtime.test.ts` |
| All Ollama Tests | ✅ 266/266 | 11 test files, 0 failures |

## Risk checklist

Did user-visible behavior change? (`No`)

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- Native Ollama `/api/chat` path: not affected — it uses `normalizeOllamaToolCallArguments` in `buildOllamaChatRequest`, a completely separate code path.
- Other OpenAI-compatible providers: not affected — they don't use Ollama's normalization function.

How is that risk mitigated?
- The change is narrow (remove 1 line), fully unit-tested (4 new tests), and the separate native path is explicitly documented.
- All 266 existing tests pass with 0 regressions.
