### PR TITLE
fix(openai): stop double-prefixing SSE bodies mislabeled as JSON

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1193,6 +1193,59 @@ describe("buildGuardedModelFetch", () => {
     expect(items).toEqual([{ ok: true }]);
   });
 
+  it("does not re-prefix SSE bodies mislabeled as JSON by streaming gateways", async () => {
+    const encoder = new TextEncoder();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"id":"a","choices":[{"index":0,"delta":{"content":"Hi","role":"assistant"}}]}\n\n',
+              ),
+            );
+            controller.enqueue(
+              encoder.encode(
+                'data: {"id":"a","choices":[{"index":0,"delta":{"content":" there"}}]}\n\n',
+              ),
+            );
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        // Mislabeled: SSE body served with a JSON content-type.
+        { headers: { "content-type": "application/json; charset=utf-8" } },
+      ),
+      finalUrl: "https://gateway.example/v1/chat/completions",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "MiniMax-M3",
+      provider: "hetu",
+      api: "openai-completions",
+      baseUrl: "https://gateway.example/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://gateway.example/v1/chat/completions",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "MiniMax-M3", stream: true }),
+      },
+    );
+
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    const items = [];
+    for await (const item of Stream.fromSSEResponse(response, new AbortController())) {
+      items.push(item);
+    }
+    expect(items).toEqual([
+      { id: "a", choices: [{ index: 0, delta: { content: "Hi", role: "assistant" } }] },
+      { id: "a", choices: [{ index: 0, delta: { content: " there" } }] },
+    ]);
+  });
+
   it("does not clone Request bodies while checking for streaming JSON fallbacks", async () => {
     const cloneSpy = vi.spyOn(Request.prototype, "clone");
     fetchWithSsrFGuardMock.mockResolvedValue({

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1194,25 +1194,14 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("does not re-prefix SSE bodies mislabeled as JSON by streaming gateways", async () => {
-    const encoder = new TextEncoder();
+    const source = openResponseStreamText(
+      'data: {"id":"a","choices":[{"index":0,"delta":{"content":"Hi","role":"assistant"}}]}\n\n' +
+        'data: {"id":"a","choices":[{"index":0,"delta":{"content":" there"}}]}\n\n' +
+        "data: [DONE]\n\n",
+    );
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(
-        new ReadableStream({
-          start(controller) {
-            controller.enqueue(
-              encoder.encode(
-                'data: {"id":"a","choices":[{"index":0,"delta":{"content":"Hi","role":"assistant"}}]}\n\n',
-              ),
-            );
-            controller.enqueue(
-              encoder.encode(
-                'data: {"id":"a","choices":[{"index":0,"delta":{"content":" there"}}]}\n\n',
-              ),
-            );
-            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-            controller.close();
-          },
-        }),
+        source.stream,
         // Mislabeled: SSE body served with a JSON content-type.
         { headers: { "content-type": "application/json; charset=utf-8" } },
       ),
@@ -1226,7 +1215,7 @@ describe("buildGuardedModelFetch", () => {
       baseUrl: "https://gateway.example/v1",
     } as unknown as Model<"openai-completions">;
 
-    const response = await buildGuardedModelFetch(model)(
+    const responsePromise = buildGuardedModelFetch(model)(
       "https://gateway.example/v1/chat/completions",
       {
         method: "POST",
@@ -1234,7 +1223,17 @@ describe("buildGuardedModelFetch", () => {
         body: JSON.stringify({ model: "MiniMax-M3", stream: true }),
       },
     );
+    const timeout = Symbol("timeout");
+    const result = await Promise.race<Response | typeof timeout>([
+      responsePromise,
+      new Promise<typeof timeout>((resolve) => {
+        setTimeout(() => resolve(timeout), 100);
+      }),
+    ]);
+    source.close();
 
+    expect(result).not.toBe(timeout);
+    const response = result as Response;
     expect(response.headers.get("content-type")).toContain("text/event-stream");
     const items = [];
     for await (const item of Stream.fromSSEResponse(response, new AbortController())) {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -293,10 +293,6 @@ function isJsonContentType(contentType: string): boolean {
   return /\bapplication\/json\b/i.test(contentType) || /\+json\b/i.test(contentType);
 }
 
-function isOpenAISdkStreamContentType(contentType: string): boolean {
-  return /\btext\/event-stream\b/i.test(contentType) || isJsonContentType(contentType);
-}
-
 type OpenAISdkStreamBodyKind = "html" | "json" | "sse" | "unknown";
 
 function classifyOpenAISdkStreamBodyPrefix(text: string): OpenAISdkStreamBodyKind {
@@ -371,7 +367,20 @@ async function normalizeOpenAISdkStreamContentType(params: {
   localServiceLease?: ProviderLocalServiceLease;
 }): Promise<Response> {
   const contentType = params.response.headers.get("content-type") ?? "";
-  if (!params.response.ok || !params.response.body || isOpenAISdkStreamContentType(contentType)) {
+  if (!params.response.ok || !params.response.body) {
+    return params.response;
+  }
+  if (/\btext\/event-stream\b/i.test(contentType)) {
+    return params.response;
+  }
+  if (isJsonContentType(contentType)) {
+    // Some OpenAI-compatible gateways stream real SSE (`data: {...}`) but mislabel
+    // the response as JSON. Without relabeling, the JSON-wrap fallback below would
+    // re-prefix each frame as `data: data: {...}`, breaking JSON.parse in the SDK.
+    const kind = await classifyOpenAISdkStreamBody(params.response).catch(() => "unknown" as const);
+    if (kind === "sse") {
+      return withOpenAISdkStreamContentType(params.response, "text/event-stream; charset=utf-8");
+    }
     return params.response;
   }
   if (!contentType.trim()) {


### PR DESCRIPTION
## What Problem This Solves

Closes #96497.

Agent runs fail before producing any reply when using an OpenAI-compatible
streaming gateway whose response body is standard SSE (`data: {...}`) but whose
`Content-Type` header is `application/json`. OpenClaw re-prefixes each frame, so
the OpenAI SDK's SSE parser receives `data: data: {...}` and throws:

```
Could not parse message into JSON: data: {"id":"..."}
From chunk: ['data: data: {"id":"..."}']
Unexpected token 'd', "data: {"id"... is not valid JSON
```

This is a regression: the same gateway works on 2026.5.4 and earlier, broken on
2026.6.x.

## Why This Change Was Made

The double prefix comes from the streaming JSON-wrap fallback in
`src/agents/provider-transport-fetch.ts` (introduced in `1725eebe62`,
"fix(openai): handle json streaming fallbacks"). That fallback exists for
gateways that ignore `stream: true` and return a single JSON object: it wraps the
body once as `data: <json>\n\n` so the SDK can parse it.

The branch is selected purely from `Content-Type`. When a gateway streams real
SSE but mislabels it as `application/json`, the already-SSE body is wrapped a
second time, yielding `data: data: {...}`. The fix makes the decision
content-aware: JSON-labeled streaming bodies are sniffed (reusing the existing
`classifyOpenAISdkStreamBody` helper), and genuine SSE is relabeled
`text/event-stream` so the existing SSE sanitizer parses it verbatim instead of
re-wrapping it. True JSON bodies still take the wrap path unchanged.

No new config option is added; correctness is restored for both `data: {...}` and
`{...}` shapes automatically.

## User Impact

Self-hosted / custom OpenAI-compatible gateways (vLLM, Ollama proxies, custom
proxies) that stream SSE with a JSON content-type now stream normally again
instead of crashing the run before any reply. No behavior change for native
OpenAI, or for gateways that correctly send `text/event-stream` or that return a
single JSON object.

## Evidence

The regression in `src/agents/provider-transport-fetch.test.ts` drives the real
`openai` SDK SSE parser (`Stream.fromSSEResponse`) against a gateway response
with an SSE body and `Content-Type: application/json`. A maintainer fixup keeps
that source stream open until the guarded fetch returns, proving normalization
does not wait for EOF, then asserts both delta frames parse correctly.

### Maintainer verification

Exact head `1658484a507ba2f87fe3c392b3561b032b532177` was tested in a fresh,
sanitized direct AWS Crabbox with public networking, no Tailscale, no instance
profile, isolated HOME, and the trusted untrusted-PR bootstrap. Run
[`run_e3ecd39b9939`](https://crabbox.openclaw.ai/portal/runs/run_e3ecd39b9939):

```
$ pnpm test src/agents/provider-transport-fetch.test.ts
 Test Files  1 passed (1)
      Tests  80 passed (80)
```

Fresh exact-head Codex autoreview found no accepted or actionable findings.
Exact-head GitHub CI: [run 28810952463](https://github.com/openclaw/openclaw/actions/runs/28810952463).

### Contributor verification

Narrow suite (worktree-safe runner):

```
$ node scripts/run-vitest.mjs src/agents/provider-transport-fetch.test.ts
 Test Files  1 passed (1)
      Tests  74 passed (74)
```

Negative control — reverting only the source fix makes the new test fail with the
exact double-prefix bug, confirming it reproduces the issue:

```
 × does not re-prefix SSE bodies mislabeled as JSON by streaming gateways
 Tests  1 failed | 73 passed (74)
```

### Real behavior proof (live localhost gateway + real `openai` SDK stream)

The fix was also exercised end-to-end over a real socket: a local HTTP gateway
streams genuine SSE frames (`data: {...}`) while mislabeling the response as
`Content-Type: application/json` (the #96497 shape), driven through the
production `buildGuardedModelFetch` wrapper and the real `openai` SDK streaming
consumer (`client.chat.completions.create({ stream: true })`). No mocked fetch —
the real guarded fetch performs the SSRF check and content-type normalization on
a real network round-trip.

Before the fix (source reverted), the real SDK stream parser throws the exact
reported error while consuming the stream:

```
Could not parse message into JSON: data: {"id":"a","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}
From chunk: [ 'data: data: {"id":"a","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}' ]
SyntaxError: Unexpected token 'd', "data: {"id"... is not valid JSON
  ❯ Stream.iterator node_modules/openai/src/core/streaming.ts:62
```

After the fix, the same harness streams the assistant reply normally:

```
[REALPROOF] streamed assistant text = "Hi there"
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Formatting verified with `oxfmt --check` (clean). Broader typecheck/lint/build
left to CI.

AI-assisted.

Fix and original reproduction by @ZengWen-DT; open-stream regression hardening
and final verification by @steipete.

