### PR TITLE
fix(openrouter): bound video catalog JSON reads

### DIFF
--- a/extensions/openrouter/video-generation-provider.test.ts
+++ b/extensions/openrouter/video-generation-provider.test.ts
@@ -54,10 +54,31 @@ vi.mock("openclaw/plugin-sdk/provider-http", async () => {
 
 function releasedJson(value: unknown) {
   return {
-    response: {
-      json: async () => value,
-    },
+    response: new Response(JSON.stringify(value), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
     release: vi.fn(async () => {}),
+  };
+}
+
+function releasedOversizedJsonStream() {
+  let canceled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array(16 * 1024 * 1024 + 1));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    release: vi.fn(async () => {}),
+    wasCanceled: () => canceled,
   };
 }
 
@@ -290,6 +311,40 @@ describe("openrouter video generation provider", () => {
       enabled: true,
       maxInputImages: 2,
     });
+  });
+
+  it("cancels oversized OpenRouter video catalog success bodies", async () => {
+    const oversized = releasedOversizedJsonStream();
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(oversized);
+
+    await expect(
+      listOpenRouterVideoModelCatalog({
+        config: {
+          models: {
+            providers: {
+              openrouter: {
+                baseUrl: "https://custom.openrouter.test/openrouter/api/v1",
+              },
+            },
+          },
+        } as never,
+        env: {},
+        resolveProviderApiKey: () => ({
+          apiKey: "OPENROUTER_API_KEY",
+          discoveryApiKey: "resolved-openrouter-key",
+        }),
+        resolveProviderAuth: () => ({
+          apiKey: "OPENROUTER_API_KEY",
+          discoveryApiKey: "resolved-openrouter-key",
+          mode: "api_key",
+          source: "env",
+        }),
+      }),
+    ).rejects.toThrow(
+      "OpenRouter video models request failed: JSON response exceeds 16777216 bytes",
+    );
+    expect(oversized.wasCanceled()).toBe(true);
+    expect(oversized.release).toHaveBeenCalledOnce();
   });
 
   it("skips live OpenRouter video catalog discovery without an API key", async () => {

--- a/extensions/openrouter/video-model-catalog.ts
+++ b/extensions/openrouter/video-model-catalog.ts
@@ -7,6 +7,7 @@ import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runt
 import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
 import {
   assertOkOrThrowHttpError,
+  readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
 import {
@@ -234,7 +235,10 @@ async function fetchOpenRouterVideoModels(params: {
       });
       try {
         await assertOkOrThrowHttpError(response, "OpenRouter video models request failed");
-        return (await response.json()) as OpenRouterVideoModelsResponse;
+        return await readProviderJsonResponse<OpenRouterVideoModelsResponse>(
+          response,
+          "OpenRouter video models request failed",
+        );
       } finally {
         await release();
       }


### PR DESCRIPTION
## Summary

- Bound OpenRouter video model catalog success JSON reads through the shared provider JSON reader.
- Add coverage that exercises the catalog path with real `Response` bodies, including an oversized stream that must be canceled.

## What Problem This Solves

`extensions/openrouter/video-model-catalog.ts` fetched `/videos/models` and parsed successful responses with `response.json()`. That bypassed the provider response byte cap, so a provider endpoint or user-configured OpenRouter-compatible `baseUrl` could stream an oversized JSON success body and make the runtime buffer it before parsing.

## User Impact

- **Why it matters / User impact:** Users who enable OpenRouter video model discovery keep the same catalog behavior for normal responses. Oversized or runaway catalog success bodies now fail with a bounded provider error instead of being read without a byte limit.
- **What did NOT change:** The patch only changes the OpenRouter video model catalog success-body parser. It does not change auth headers, provider routing, catalog caching, model projection, API key resolution, or other OpenRouter media response paths.
- **Architecture / source-of-truth check:** The canonical source-of-truth contract for provider JSON body limits is `readProviderJsonResponse`, which wraps `readResponseWithLimit` with the shared 16 MiB cap and overflow cancellation. This extension now uses that SDK contract instead of a one-off parser.

## Origin / follow-up

Follow-up to #95420. That PR bounded a sibling OpenRouter catalog response path; this patch applies the same shared provider JSON reader to the OpenRouter video model catalog path.

## Competition / linked PR analysis

Related open PR scan: checked for an open PR covering an OpenRouter video model catalog bounded response reader and did not find one. This patch is intentionally limited to `extensions/openrouter/video-model-catalog.ts` and its existing provider test so it does not overlap with open bounded-reader work in other extensions.

## Real behavior proof

- **Behavior or issue addressed:** The OpenRouter video model catalog success path now reads JSON through `readProviderJsonResponse`, which enforces the shared 16 MiB cap and cancels the stream on overflow.
- **Real environment tested:** Local OpenClaw worktree on Node v22.22.0 / pnpm v11.2.2, using real Web `Response` and `ReadableStream` bodies. No OpenRouter credential was used; the proof targets the response-body boundary after the HTTP result is returned.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/openrouter/video-generation-provider.test.ts
pnpm exec tsx <evidence-only bounded-reader proof script>
```

- **Evidence after fix:**

```json
{
  "proof": "openrouter-video-catalog-bounded-json-reader",
  "boundary": "real Response and ReadableStream body without Content-Length",
  "reader": "src/agents/provider-http-errors.ts readProviderJsonResponse",
  "caller": "extensions/openrouter/video-model-catalog.ts OpenRouter video model catalog success path",
  "normalPathModel": "openrouter/video-ok",
  "overflowMessage": "OpenRouter video models request failed: JSON response exceeds 16777216 bytes",
  "expectedMessage": "OpenRouter video models request failed: JSON response exceeds 16777216 bytes",
  "streamCanceled": true
}
```

```text
Test Files  1 passed (1)
Tests  17 passed (17)
[test] passed 1 Vitest shard
```

- **Observed result after fix:** Normal catalog JSON still parses, while a no-Content-Length `ReadableStream` that exceeds 16 MiB throws `OpenRouter video models request failed: JSON response exceeds 16777216 bytes`; the stream cancellation hook ran, and the guarded fetch release callback was called.
- **What was not tested:** A live OpenRouter `/videos/models` request was not run because the current environment does not provide an OpenRouter API key. Other OpenRouter response paths, including audio transcription, were not changed in this patch.
- **Fix classification:** Root cause fix

## Review findings addressed

No maintainer review findings are attached to this follow-up yet. The patch addresses the bounded-reader gap found while comparing the already-merged OpenRouter catalog fix with remaining OpenRouter video catalog response reads.

## Regression Test Plan

- **Target test file:** `extensions/openrouter/video-generation-provider.test.ts`
- **Scenario locked in:** The catalog path receives a successful OpenRouter video model response backed by a real Web `Response`; normal JSON still maps into catalog entries, and an oversized no-Content-Length stream fails at the shared 16 MiB cap.
- **Why this is the smallest reliable guardrail:** The test calls the exported `listOpenRouterVideoModelCatalog` path rather than only testing the helper, and asserts the overflow stream is canceled and the guarded fetch release callback runs. This directly guards the changed parser call site without adding a broader provider fixture.

```bash
node scripts/run-vitest.mjs extensions/openrouter/video-generation-provider.test.ts
pnpm exec tsx <evidence-only bounded-reader proof script>
```

## Merge risk

- **Risk labels considered:** no broad merge-risk labels apply; this is a two-file provider-boundary patch with one production import/call-site change and one focused provider test update.
- **Risk explanation:** The only behavior change is for successful OpenRouter video model catalog bodies that exceed the shared provider JSON cap or contain malformed JSON. Valid responses under the cap still parse and project through the same catalog code.
- **Why acceptable:** The new behavior matches the existing provider JSON reader contract used by sibling provider paths and prevents an unbounded external response body from being buffered.

## Risk / Compatibility

Low risk. Valid JSON responses under the shared provider cap follow the same parsing and catalog projection path as before. Responses over the cap now fail earlier with the same provider-reader error shape used by other provider JSON responses.

## What was not changed

- OpenRouter authentication and headers were not changed.
- Catalog caching and model projection were not changed.
- Other OpenRouter media or transcription response readers were not changed.
- The shared 16 MiB provider JSON cap was not changed.

## Maintainer-ready confidence

- **Maintainer-ready confidence:** High. The diff is small, follows an existing shared helper contract, and has fresh runtime proof plus the targeted provider test.
- **Patch quality notes:** The patch does not add a new abstraction or provider-specific limit; it reuses `readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http`, keeping extension code on the existing SDK boundary.

## Root Cause

- **Root cause:** The root cause was that the OpenRouter video model catalog success path used the platform `response.json()` parser directly at the external response boundary, bypassing the shared provider JSON reader contract that is responsible for bounded response parsing.
- **Why this is root-cause fix:** This fixes the source parser invariant because the unbounded read happened at the exact success-body parse site after `assertOkOrThrowHttpError`. Replacing that call with `readProviderJsonResponse` moves the byte cap and cancellation behavior before JSON parsing can buffer an oversized body, while leaving endpoint selection, auth, caching, and catalog projection unchanged.
