### PR TITLE
fix(plugins): stop ClawHub version install from inheriting latest compatibility

### DIFF
--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -847,6 +847,58 @@ describe("installPluginFromClawHub", () => {
     expectSuccessfulClawHubInstall(result);
   });
 
+  it("recovers version-specific compatibility from version endpoint when artifact metadata is sparse", async () => {
+    parseClawHubPluginSpecMock.mockReturnValueOnce({ name: "demo", version: "2026.6.8" });
+    resolveLatestVersionFromPackageMock.mockReturnValue("2026.6.10");
+    fetchClawHubPackageDetailMock.mockResolvedValueOnce({
+      package: {
+        name: "demo",
+        displayName: "Demo",
+        family: "code-plugin",
+        channel: "official",
+        isOfficial: true,
+        createdAt: 0,
+        updatedAt: 0,
+        latestVersion: "2026.6.10",
+        compatibility: {
+          pluginApiRange: ">=2026.6.10",
+          minGatewayVersion: "2026.6.10",
+        },
+      },
+    });
+    resolveCompatibilityHostVersionMock.mockReturnValue("2026.6.5");
+    // Artifact endpoint returns sparse metadata (no compatibility).
+    fetchClawHubPackageArtifactMock.mockResolvedValueOnce({
+      version: {
+        version: "2026.6.8",
+        createdAt: 0,
+        changelog: "",
+        sha256hash: "a9eac48c6129bc44b6f93c9a9f48f6c700d191b7279a1e1915f28df6f59bb1af",
+      },
+    });
+    // Version endpoint has the real version-specific compatibility.
+    fetchClawHubPackageVersionMock.mockResolvedValueOnce({
+      version: {
+        version: "2026.6.8",
+        createdAt: 0,
+        changelog: "",
+        sha256hash: "a9eac48c6129bc44b6f93c9a9f48f6c700d191b7279a1e1915f28df6f59bb1af",
+        compatibility: {
+          pluginApiRange: ">=2026.6.8",
+          minGatewayVersion: "2026.6.8",
+        },
+      },
+    });
+
+    const result = await installPluginFromClawHub({
+      spec: "clawhub:demo@2026.6.8",
+      baseUrl: "https://clawhub.ai",
+    });
+
+    const failure = expectInstallFailure(result);
+    expect(failure.error).toContain("2026.6.8");
+  });
+
   it("enforces package-level compatibility for unpinned latest install when version response omits compatibility", async () => {
     resolveLatestVersionFromPackageMock.mockReturnValue("2026.6.10");
     fetchClawHubPackageDetailMock.mockResolvedValueOnce({

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -810,8 +810,9 @@ describe("installPluginFromClawHub", () => {
     expect(success.clawhub?.clawpackSize).toBeUndefined();
   });
 
-  it("does not inherit package-level compatibility when version-specific compatibility is absent", async () => {
+  it("does not inherit package-level compatibility when version-specific compatibility is absent for pinned older version", async () => {
     parseClawHubPluginSpecMock.mockReturnValueOnce({ name: "demo", version: "2026.6.8" });
+    resolveLatestVersionFromPackageMock.mockReturnValue("2026.6.10");
     fetchClawHubPackageDetailMock.mockResolvedValueOnce({
       package: {
         name: "demo",
@@ -821,6 +822,7 @@ describe("installPluginFromClawHub", () => {
         isOfficial: true,
         createdAt: 0,
         updatedAt: 0,
+        latestVersion: "2026.6.10",
         compatibility: {
           pluginApiRange: ">=2026.6.10",
           minGatewayVersion: "2026.6.10",
@@ -843,6 +845,43 @@ describe("installPluginFromClawHub", () => {
     });
 
     expectSuccessfulClawHubInstall(result);
+  });
+
+  it("enforces package-level compatibility for unpinned latest install when version response omits compatibility", async () => {
+    resolveLatestVersionFromPackageMock.mockReturnValue("2026.6.10");
+    fetchClawHubPackageDetailMock.mockResolvedValueOnce({
+      package: {
+        name: "demo",
+        displayName: "Demo",
+        family: "code-plugin",
+        channel: "official",
+        isOfficial: true,
+        createdAt: 0,
+        updatedAt: 0,
+        latestVersion: "2026.6.10",
+        compatibility: {
+          pluginApiRange: ">=2026.6.10",
+          minGatewayVersion: "2026.6.10",
+        },
+      },
+    });
+    resolveCompatibilityHostVersionMock.mockReturnValue("2026.6.8");
+    fetchClawHubPackageVersionMock.mockResolvedValueOnce({
+      version: {
+        version: "2026.6.10",
+        createdAt: 0,
+        changelog: "",
+        sha256hash: "a9eac48c6129bc44b6f93c9a9f48f6c700d191b7279a1e1915f28df6f59bb1af",
+      },
+    });
+
+    const result = await installPluginFromClawHub({
+      spec: "clawhub:demo",
+      baseUrl: "https://clawhub.ai",
+    });
+
+    const failure = expectInstallFailure(result);
+    expect(failure.error).toContain("2026.6.10");
   });
 
   it("installs when ClawHub advertises a wildcard plugin API range", async () => {

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -810,6 +810,41 @@ describe("installPluginFromClawHub", () => {
     expect(success.clawhub?.clawpackSize).toBeUndefined();
   });
 
+  it("does not inherit package-level compatibility when version-specific compatibility is absent", async () => {
+    parseClawHubPluginSpecMock.mockReturnValueOnce({ name: "demo", version: "2026.6.8" });
+    fetchClawHubPackageDetailMock.mockResolvedValueOnce({
+      package: {
+        name: "demo",
+        displayName: "Demo",
+        family: "code-plugin",
+        channel: "official",
+        isOfficial: true,
+        createdAt: 0,
+        updatedAt: 0,
+        compatibility: {
+          pluginApiRange: ">=2026.6.10",
+          minGatewayVersion: "2026.6.10",
+        },
+      },
+    });
+    resolveCompatibilityHostVersionMock.mockReturnValue("2026.6.8");
+    fetchClawHubPackageVersionMock.mockResolvedValueOnce({
+      version: {
+        version: "2026.6.8",
+        createdAt: 0,
+        changelog: "",
+        sha256hash: "a9eac48c6129bc44b6f93c9a9f48f6c700d191b7279a1e1915f28df6f59bb1af",
+      },
+    });
+
+    const result = await installPluginFromClawHub({
+      spec: "clawhub:demo@2026.6.8",
+      baseUrl: "https://clawhub.ai",
+    });
+
+    expectSuccessfulClawHubInstall(result);
+  });
+
   it("installs when ClawHub advertises a wildcard plugin API range", async () => {
     fetchClawHubPackageVersionMock.mockResolvedValueOnce({
       version: {

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -899,6 +899,47 @@ describe("installPluginFromClawHub", () => {
     expect(failure.error).toContain("2026.6.8");
   });
 
+  it("fails closed when version endpoint is unavailable for sparse artifact metadata on pinned version", async () => {
+    parseClawHubPluginSpecMock.mockReturnValueOnce({ name: "demo", version: "2026.6.8" });
+    resolveLatestVersionFromPackageMock.mockReturnValue("2026.6.10");
+    fetchClawHubPackageDetailMock.mockResolvedValueOnce({
+      package: {
+        name: "demo",
+        displayName: "Demo",
+        family: "code-plugin",
+        channel: "official",
+        isOfficial: true,
+        createdAt: 0,
+        updatedAt: 0,
+        latestVersion: "2026.6.10",
+        compatibility: {
+          pluginApiRange: ">=2026.6.10",
+          minGatewayVersion: "2026.6.10",
+        },
+      },
+    });
+    resolveCompatibilityHostVersionMock.mockReturnValue("2026.6.8");
+    // Artifact endpoint returns sparse metadata (no compatibility).
+    fetchClawHubPackageArtifactMock.mockResolvedValueOnce({
+      version: {
+        version: "2026.6.8",
+        createdAt: 0,
+        changelog: "",
+        sha256hash: "a9eac48c6129bc44b6f93c9a9f48f6c700d191b7279a1e1915f28df6f59bb1af",
+      },
+    });
+    // Version endpoint fails.
+    fetchClawHubPackageVersionMock.mockRejectedValueOnce(new Error("500 Internal Server Error"));
+
+    const result = await installPluginFromClawHub({
+      spec: "clawhub:demo@2026.6.8",
+      baseUrl: "https://clawhub.ai",
+    });
+
+    const failure = expectInstallFailure(result);
+    expect(failure.ok).toBe(false);
+  });
+
   it("enforces package-level compatibility for unpinned latest install when version response omits compatibility", async () => {
     resolveLatestVersionFromPackageMock.mockReturnValue("2026.6.10");
     fetchClawHubPackageDetailMock.mockResolvedValueOnce({

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -883,11 +883,32 @@ async function resolveCompatiblePackageVersion(params: {
   // compatibility requirements.
   const packageCompatibilityFallback =
     resolvedVersion === latestVersion ? (params.detail.package?.compatibility ?? null) : null;
+  // When the artifact endpoint returns sparse metadata (no compatibility) for a
+  // pinned older version, fetch the version endpoint which may have the real
+  // version-specific compatibility data.
+  let versionEndpointCompatibility: ClawHubPackageCompatibility | null = null;
+  if (!artifactVersion.compatibility && resolvedVersion !== latestVersion) {
+    try {
+      const selectedVersion = await fetchClawHubPackageVersion({
+        name: params.detail.package?.name ?? "",
+        version: resolvedVersion,
+        baseUrl: params.baseUrl,
+        token: params.token,
+        timeoutMs: params.timeoutMs,
+      });
+      versionEndpointCompatibility = selectedVersion.version?.compatibility ?? null;
+    } catch {
+      // Version endpoint unavailable; proceed without version-specific compatibility.
+    }
+  }
   if (params.detail.package?.family === "skill") {
     return {
       ok: true,
       version: resolvedVersion,
-      compatibility: artifactVersion.compatibility ?? packageCompatibilityFallback,
+      compatibility:
+        artifactVersion.compatibility ??
+        versionEndpointCompatibility ??
+        packageCompatibilityFallback,
       verification: null,
       clawpack:
         artifactVersion.clawpack ?? resolveTopLevelNpmPackArtifact(artifactResponse.artifact),
@@ -935,7 +956,10 @@ async function resolveCompatiblePackageVersion(params: {
     return {
       ok: true,
       version: resolvedVersion,
-      compatibility: versionDetail.version?.compatibility ?? packageCompatibilityFallback,
+      compatibility:
+        versionDetail.version?.compatibility ??
+        versionEndpointCompatibility ??
+        packageCompatibilityFallback,
       verification: null,
       clawpack,
     };
@@ -946,7 +970,10 @@ async function resolveCompatiblePackageVersion(params: {
   return {
     ok: true,
     version: resolvedVersion,
-    compatibility: versionDetail.version?.compatibility ?? packageCompatibilityFallback,
+    compatibility:
+      versionDetail.version?.compatibility ??
+      versionEndpointCompatibility ??
+      packageCompatibilityFallback,
     verification: verificationState.verification ?? topLevelLegacyVerification,
     clawpack,
   };

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -877,11 +877,17 @@ async function resolveCompatiblePackageVersion(params: {
   }
   const artifactVersion = readArtifactResolverVersion(artifactResponse, requestedVersion);
   const resolvedVersion = normalizeOptionalString(artifactVersion.version) ?? requestedVersion;
+  const latestVersion = resolveLatestVersionFromPackage(params.detail);
+  // Only fall back to package-level compatibility when the resolved version is the
+  // package latest. Older pinned versions should not inherit the latest version's
+  // compatibility requirements.
+  const packageCompatibilityFallback =
+    resolvedVersion === latestVersion ? (params.detail.package?.compatibility ?? null) : null;
   if (params.detail.package?.family === "skill") {
     return {
       ok: true,
       version: resolvedVersion,
-      compatibility: artifactVersion.compatibility ?? null,
+      compatibility: artifactVersion.compatibility ?? packageCompatibilityFallback,
       verification: null,
       clawpack:
         artifactVersion.clawpack ?? resolveTopLevelNpmPackArtifact(artifactResponse.artifact),
@@ -929,7 +935,7 @@ async function resolveCompatiblePackageVersion(params: {
     return {
       ok: true,
       version: resolvedVersion,
-      compatibility: versionDetail.version?.compatibility ?? null,
+      compatibility: versionDetail.version?.compatibility ?? packageCompatibilityFallback,
       verification: null,
       clawpack,
     };
@@ -940,7 +946,7 @@ async function resolveCompatiblePackageVersion(params: {
   return {
     ok: true,
     version: resolvedVersion,
-    compatibility: versionDetail.version?.compatibility ?? null,
+    compatibility: versionDetail.version?.compatibility ?? packageCompatibilityFallback,
     verification: verificationState.verification ?? topLevelLegacyVerification,
     clawpack,
   };

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -897,8 +897,12 @@ async function resolveCompatiblePackageVersion(params: {
         timeoutMs: params.timeoutMs,
       });
       versionEndpointCompatibility = selectedVersion.version?.compatibility ?? null;
-    } catch {
-      // Version endpoint unavailable; proceed without version-specific compatibility.
+    } catch (error) {
+      return mapClawHubRequestError(error, {
+        stage: "version",
+        name: params.detail.package?.name ?? "unknown",
+        version: resolvedVersion,
+      });
     }
   }
   if (params.detail.package?.family === "skill") {

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -881,7 +881,7 @@ async function resolveCompatiblePackageVersion(params: {
     return {
       ok: true,
       version: resolvedVersion,
-      compatibility: artifactVersion.compatibility ?? params.detail.package?.compatibility ?? null,
+      compatibility: artifactVersion.compatibility ?? null,
       verification: null,
       clawpack:
         artifactVersion.clawpack ?? resolveTopLevelNpmPackArtifact(artifactResponse.artifact),
@@ -929,8 +929,7 @@ async function resolveCompatiblePackageVersion(params: {
     return {
       ok: true,
       version: resolvedVersion,
-      compatibility:
-        versionDetail.version?.compatibility ?? params.detail.package?.compatibility ?? null,
+      compatibility: versionDetail.version?.compatibility ?? null,
       verification: null,
       clawpack,
     };
@@ -941,8 +940,7 @@ async function resolveCompatiblePackageVersion(params: {
   return {
     ok: true,
     version: resolvedVersion,
-    compatibility:
-      versionDetail.version?.compatibility ?? params.detail.package?.compatibility ?? null,
+    compatibility: versionDetail.version?.compatibility ?? null,
     verification: verificationState.verification ?? topLevelLegacyVerification,
     clawpack,
   };


### PR DESCRIPTION
## What Problem This Solves

When installing a specific older version of a ClawHub plugin (e.g., `openclaw plugins install clawhub:@openclaw/anthropic-vertex-provider@2026.6.8`), the install fails with an error saying the latest OpenClaw version (e.g., `>= 2026.6.10`) is required, even though the older plugin version should be compatible with an older OpenClaw host.

## Context

This bug was discovered while operating OpenClaw on OpenShift with the Anthropic Vertex provider plugin. Our operator pins a default OpenClaw gateway version (e.g., `2026.6.8`) for stability, but the Vertex plugin on ClawHub requires the latest runtime version. When attempting to pin the plugin to a matching older version:

```
$ openclaw plugins install clawhub:@openclaw/anthropic-vertex-provider@2026.6.8
Resolving clawhub:@openclaw/anthropic-vertex-provider…
Plugin "@openclaw/anthropic-vertex-provider" requires plugin API >=2026.6.9, but this OpenClaw runtime exposes 2026.6.8.
```

Even though version `2026.6.8` of the plugin exists on ClawHub, installing it incorrectly enforces the latest version's compatibility requirement (`>=2026.6.9`). This forces operators to either bump to latest on every plugin release or switch the install source from ClawHub to npm as a workaround (`openclaw plugins install npm:@openclaw/anthropic-vertex-provider@2026.6.8`), which does not exhibit the same bug.

## Why This Change Was Made

In `resolveCompatiblePackageVersion()` (`src/plugins/clawhub.ts`), when resolving compatibility for a requested version, the code fell back to package-level compatibility metadata when the version-specific artifact response lacked it:

```ts
compatibility: artifactVersion.compatibility ?? params.detail.package?.compatibility ?? null
```

The package-level `compatibility` field (from `fetchClawHubPackageDetail`) reflects the **latest** published version's requirements. So when an older version's artifact response omits its own `compatibility` data, the fallback incorrectly applies the latest version's `minGatewayVersion` constraint, blocking installation on older (but perfectly valid) OpenClaw hosts.

The root cause is that the ClawHub artifact endpoint (`/api/v1/packages/{name}/versions/{version}/artifact`) can return sparse metadata without compatibility, while the version endpoint (`/api/v1/packages/{name}/versions/{version}`) has the real version-specific compatibility data.

### Fix

The fix addresses this in three layers:

1. **Recover version-specific compatibility from the version endpoint**: When the artifact endpoint returns sparse metadata (no compatibility) for a pinned older version, the code now fetches the version endpoint to get the real version-specific compatibility data.

2. **Narrow the package-level fallback to latest only**: Package-level compatibility is only used as a fallback when the resolved version matches the package latest, preventing older pinned versions from inheriting the latest version's constraints.

3. **Fail closed on recovery errors**: If the version endpoint is unavailable (transient 500, network failure, etc.), the install fails with an error instead of proceeding without compatibility checks.

4. **Fallback chain**: `artifact compatibility` -> `version endpoint compatibility` -> `package-level compatibility (latest only)`.

## User Impact

Users can now install older versions of ClawHub plugins without being forced to upgrade to the latest OpenClaw release. Compatibility enforcement is preserved using the correct version-specific requirements from the version endpoint, rather than the latest version's requirements.

## Evidence

- All 58 tests pass (54 existing + 4 new regression tests)
- `"does not inherit package-level compatibility when version-specific compatibility is absent for pinned older version"`: Pinned version `2026.6.8` with no version-specific compatibility installs successfully instead of failing with latest version's requirements. Reverting the fix causes this test to fail.
- `"recovers version-specific compatibility from version endpoint when artifact metadata is sparse"`: Pinned version `2026.6.8` where artifact has no compatibility but version endpoint has `>=2026.6.8`; host at `2026.6.5` is correctly rejected using the version-specific requirement.
- `"fails closed when version endpoint is unavailable for sparse artifact metadata on pinned version"`: When the version endpoint fails, the install returns an error instead of proceeding without compatibility checks.
- `"enforces package-level compatibility for unpinned latest install when version response omits compatibility"`: Unpinned/latest installs still enforce the package-level compatibility guard.

## Real Behavior Proof

**Before fix:**
```
$ openclaw plugins install clawhub:@openclaw/anthropic-vertex-provider@2026.6.8
Resolving clawhub:@openclaw/anthropic-vertex-provider…
Plugin "@openclaw/anthropic-vertex-provider" requires plugin API >=2026.6.10, but this OpenClaw runtime exposes 2026.6.8.
```

**After fix (built from this branch and tested locally):**
```
$ openclaw plugins install clawhub:@openclaw/anthropic-vertex-provider@2026.6.8
Resolving clawhub:@openclaw/anthropic-vertex-provider@2026.6.8…
ClawHub code-plugin @openclaw/anthropic-vertex-provider@2026.6.8 channel=official verification=source-linked
Compatibility: pluginApi=>=2026.6.8 minGateway=>=2026.5.12-beta.1
Downloading plugin @openclaw/anthropic-vertex-provider@2026.6.8 from ClawHub…
Extracting openclaw-anthropic-vertex-provider-2026.6.8.tgz…
Plugin manifest id "anthropic-vertex" differs from npm package name "@openclaw/anthropic-vertex-provider"; using manifest id as the config key.
Installing to ~/.openclaw/extensions/anthropic-vertex…
Installing plugin dependencies…
Linked peerDependency "openclaw" -> /home/user/openclaw
Installed plugin: anthropic-vertex
Restart the gateway to load plugins.
```

The version-specific compatibility (`pluginApi=>=2026.6.8`, `minGateway=>=2026.5.12-beta.1`) is now correctly recovered from the version endpoint instead of inheriting the latest version's `>=2026.6.10` requirement.