### PR TITLE
refactor: narrow bundled session runtime barrels

### DIFF
--- a/extensions/feishu/runtime-api.ts
+++ b/extensions/feishu/runtime-api.ts
@@ -43,10 +43,7 @@ export {
   filterSupplementalContextItems,
   resolveChannelContextVisibilityMode,
 } from "openclaw/plugin-sdk/context-visibility-runtime";
-export {
-  loadSessionStore,
-  resolveSessionStoreEntry,
-} from "openclaw/plugin-sdk/session-store-runtime";
+export { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 export { readJsonFileWithFallback } from "openclaw/plugin-sdk/json-store";
 export { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 export { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";

--- a/extensions/feishu/src/bot-runtime-api.ts
+++ b/extensions/feishu/src/bot-runtime-api.ts
@@ -10,4 +10,4 @@ export {
   filterSupplementalContextItems,
   normalizeAgentId,
 } from "../runtime-api.js";
-export { loadSessionStore, resolveSessionStoreEntry } from "../runtime-api.js";
+export { getSessionEntry } from "../runtime-api.js";

--- a/extensions/feishu/src/reasoning-preview.test.ts
+++ b/extensions/feishu/src/reasoning-preview.test.ts
@@ -3,8 +3,8 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "./bot-runtime-api.js";
 import { resolveFeishuReasoningPreviewEnabled } from "./reasoning-preview.js";
 
-const { loadSessionStoreMock } = vi.hoisted(() => ({
-  loadSessionStoreMock: vi.fn(),
+const { getSessionEntryMock } = vi.hoisted(() => ({
+  getSessionEntryMock: vi.fn(),
 }));
 
 vi.mock("./bot-runtime-api.js", async () => {
@@ -12,7 +12,7 @@ vi.mock("./bot-runtime-api.js", async () => {
     await vi.importActual<typeof import("./bot-runtime-api.js")>("./bot-runtime-api.js");
   return {
     ...actual,
-    loadSessionStore: loadSessionStoreMock,
+    getSessionEntry: getSessionEntryMock,
   };
 });
 
@@ -29,9 +29,12 @@ describe("resolveFeishuReasoningPreviewEnabled", () => {
   });
 
   it("enables previews only for stream reasoning sessions", () => {
-    loadSessionStoreMock.mockReturnValue({
-      "agent:main:feishu:dm:ou_sender_1": { reasoningLevel: "stream" },
-      "agent:main:feishu:dm:ou_sender_2": { reasoningLevel: "on" },
+    getSessionEntryMock.mockImplementation(({ sessionKey }) => {
+      const entries = {
+        "agent:main:feishu:dm:ou_sender_1": { reasoningLevel: "stream" },
+        "agent:main:feishu:dm:ou_sender_2": { reasoningLevel: "on" },
+      };
+      return entries[sessionKey as keyof typeof entries];
     });
 
     expect(
@@ -50,10 +53,15 @@ describe("resolveFeishuReasoningPreviewEnabled", () => {
         sessionKey: "agent:main:feishu:dm:ou_sender_2",
       }),
     ).toBe(false);
+    expect(getSessionEntryMock).toHaveBeenCalledWith({
+      storePath: "/tmp/feishu-sessions.json",
+      sessionKey: "agent:main:feishu:dm:ou_sender_1",
+      readConsistency: "latest",
+    });
   });
 
   it("returns false for missing sessions or load failures", () => {
-    loadSessionStoreMock.mockImplementationOnce(() => {
+    getSessionEntryMock.mockImplementationOnce(() => {
       throw new Error("disk unavailable");
     });
 
@@ -75,9 +83,12 @@ describe("resolveFeishuReasoningPreviewEnabled", () => {
   });
 
   it("falls back to configured stream defaults", () => {
-    loadSessionStoreMock.mockReturnValue({
-      "agent:main:feishu:dm:ou_sender_1": {},
-      "agent:main:feishu:dm:ou_sender_2": { reasoningLevel: "off" },
+    getSessionEntryMock.mockImplementation(({ sessionKey }) => {
+      const entries = {
+        "agent:main:feishu:dm:ou_sender_1": {},
+        "agent:main:feishu:dm:ou_sender_2": { reasoningLevel: "off" },
+      };
+      return entries[sessionKey as keyof typeof entries];
     });
 
     const cfg: ClawdbotConfig = {

--- a/extensions/feishu/src/reasoning-preview.ts
+++ b/extensions/feishu/src/reasoning-preview.ts
@@ -1,6 +1,6 @@
 // Feishu plugin module implements reasoning preview behavior.
 import { resolveFeishuConfigReasoningDefault } from "./agent-config.js";
-import { loadSessionStore, resolveSessionStoreEntry } from "./bot-runtime-api.js";
+import { getSessionEntry } from "./bot-runtime-api.js";
 import type { ClawdbotConfig } from "./bot-runtime-api.js";
 
 export function resolveFeishuReasoningPreviewEnabled(params: {
@@ -16,9 +16,11 @@ export function resolveFeishuReasoningPreviewEnabled(params: {
   }
 
   try {
-    const store = loadSessionStore(params.storePath, { skipCache: true });
-    const level = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey }).existing
-      ?.reasoningLevel;
+    const level = getSessionEntry({
+      storePath: params.storePath,
+      sessionKey: params.sessionKey,
+      readConsistency: "latest",
+    })?.reasoningLevel;
     if (level === "on" || level === "stream" || level === "off") {
       return level === "stream";
     }

--- a/extensions/mattermost/runtime-api.ts
+++ b/extensions/mattermost/runtime-api.ts
@@ -46,7 +46,7 @@ export {
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/runtime-group-policy";
 export { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
-export { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+export { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 export { formatInboundFromLabel } from "openclaw/plugin-sdk/channel-inbound";
 export { logInboundDrop } from "openclaw/plugin-sdk/channel-inbound";
 export { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";

--- a/extensions/mattermost/src/mattermost/model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.test.ts
@@ -214,4 +214,66 @@ describe("Mattermost model picker", () => {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
   });
+
+  it("resolves current and parent model overrides from targeted session entries", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "mm-model-picker-"));
+    try {
+      const storePath = path.join(testDir, "{agentId}.json");
+      const supportStorePath = path.join(testDir, "support.json");
+      const parentSessionKey = "agent:support:mattermost:default:channel-1";
+      const childSessionKey = `${parentSessionKey}:thread:root-1`;
+      const directSessionKey = "agent:support:mattermost:default:direct-1";
+      fs.writeFileSync(
+        supportStorePath,
+        JSON.stringify(
+          {
+            [parentSessionKey]: {
+              providerOverride: "anthropic",
+              modelOverride: "claude-sonnet-4-5",
+              sessionId: "parent-session",
+            },
+            [childSessionKey]: {
+              parentSessionKey,
+              sessionId: "child-session",
+            },
+            [directSessionKey]: {
+              providerOverride: "openai",
+              modelOverride: "gpt-5",
+              sessionId: "direct-session",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      const cfg: OpenClawConfig = {
+        session: {
+          store: storePath,
+        },
+      };
+
+      expect(
+        resolveMattermostModelPickerCurrentModel({
+          cfg,
+          route: {
+            agentId: "support",
+            sessionKey: directSessionKey,
+          },
+          data,
+        }),
+      ).toBe("openai/gpt-5");
+      expect(
+        resolveMattermostModelPickerCurrentModel({
+          cfg,
+          route: {
+            agentId: "support",
+            sessionKey: childSessionKey,
+          },
+          data,
+        }),
+      ).toBe("anthropic/claude-sonnet-4-5");
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/extensions/mattermost/src/mattermost/model-picker.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.ts
@@ -7,7 +7,8 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
-import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { parseThreadSessionSuffix } from "openclaw/plugin-sdk/routing";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
@@ -38,6 +39,8 @@ type MattermostModelPickerRenderedView = {
   text: string;
   buttons: MattermostInteractiveButtonInput[][];
 };
+
+type MattermostModelPickerSessionEntry = ReturnType<typeof getSessionEntry>;
 
 function splitModelRef(modelRef?: string | null): { provider: string; model: string } | null {
   const trimmed = normalizeOptionalString(modelRef);
@@ -75,6 +78,24 @@ function normalizePage(value: number | undefined): number {
     return 1;
   }
   return Math.max(1, Math.floor(value as number));
+}
+
+function resolveMattermostModelPickerParentSessionKey(params: {
+  sessionEntry: MattermostModelPickerSessionEntry;
+  sessionKey: string;
+}): string | undefined {
+  // Preserve inherited model overrides without exposing whole-store reads to the UI path.
+  const persistedParent =
+    typeof params.sessionEntry?.parentSessionKey === "string"
+      ? params.sessionEntry.parentSessionKey.trim()
+      : "";
+  if (persistedParent && persistedParent !== params.sessionKey) {
+    return persistedParent;
+  }
+  const parsed = parseThreadSessionSuffix(params.sessionKey);
+  return parsed.threadId && parsed.baseSessionKey && parsed.baseSessionKey !== params.sessionKey
+    ? parsed.baseSessionKey
+    : undefined;
 }
 
 function paginateItems<T>(items: T[], page?: number, pageSize = MODELS_PAGE_SIZE) {
@@ -244,14 +265,31 @@ export function resolveMattermostModelPickerCurrentModel(params: {
     const storePath = resolveStorePath(params.cfg.session?.store, {
       agentId: params.route.agentId,
     });
-    const sessionStore = params.skipCache
-      ? loadSessionStore(storePath, { skipCache: true })
-      : loadSessionStore(storePath);
-    const sessionEntry = sessionStore[params.route.sessionKey];
+    const readOptions = {
+      storePath,
+      ...(params.skipCache ? { readConsistency: "latest" as const } : {}),
+    };
+    const sessionEntry = getSessionEntry({
+      ...readOptions,
+      sessionKey: params.route.sessionKey,
+    });
+    const parentSessionKey = resolveMattermostModelPickerParentSessionKey({
+      sessionEntry,
+      sessionKey: params.route.sessionKey,
+    });
+    const parentEntry = parentSessionKey
+      ? getSessionEntry({
+          ...readOptions,
+          sessionKey: parentSessionKey,
+        })
+      : undefined;
     const override = resolveStoredModelOverride({
       sessionEntry,
-      sessionStore,
+      ...(parentEntry && parentSessionKey
+        ? { sessionStore: { [parentSessionKey]: parentEntry } }
+        : {}),
       sessionKey: params.route.sessionKey,
+      parentSessionKey,
       defaultProvider: params.data.resolvedDefault.provider,
     });
     if (!override?.model) {

--- a/extensions/mattermost/src/runtime-api.ts
+++ b/extensions/mattermost/src/runtime-api.ts
@@ -36,7 +36,6 @@ export {
   isTrustedProxyAddress,
   listSkillCommandsForAgents,
   loadOutboundMediaFromUrl,
-  loadSessionStore,
   logInboundDrop,
   logTypingFailure,
   migrateBaseNameToDefaultAccount,

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -127,7 +127,9 @@ export const migratedSessionAccessorFiles = new Set([
 export const migratedBundledPluginSessionAccessorFiles = new Set([
   "extensions/discord/src/monitor/native-command-model-picker-apply.ts",
   "extensions/discord/src/monitor/thread-session-close.ts",
+  "extensions/feishu/src/reasoning-preview.ts",
   "extensions/memory-core/src/dreaming-narrative.ts",
+  "extensions/mattermost/src/mattermost/model-picker.ts",
   "extensions/telegram/src/bot-handlers.runtime.ts",
 ]);
 

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -1,5 +1,6 @@
 // Narrow session-store helpers for channel hot paths.
 
+import { resolveStorePath as resolveSessionStorePath } from "../config/sessions/paths.js";
 import {
   cleanupSessionLifecycleArtifacts as cleanupAccessorSessionLifecycleArtifacts,
   listSessionEntries as listAccessorSessionEntries,
@@ -10,7 +11,6 @@ import {
   type SessionAccessScope,
   updateSessionEntry,
 } from "../config/sessions/session-accessor.js";
-import { resolveStorePath as resolveSessionStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore as loadSessionStoreImpl } from "../config/sessions/store-load.js";
 import type { ResolvedSessionMaintenanceConfig } from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -19,6 +19,7 @@ type SessionStoreReadParams = {
   agentId?: string;
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
+  readConsistency?: "latest";
   sessionKey: string;
   storePath?: string;
 };
@@ -89,6 +90,7 @@ function toSessionAccessScope(params: SessionStoreReadParams): SessionAccessScop
     ...(params.hydrateSkillPromptRefs !== undefined
       ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
       : {}),
+    ...(params.readConsistency !== undefined ? { readConsistency: params.readConsistency } : {}),
     ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
   };
 }

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -81,7 +81,9 @@ describe("session accessor boundary guard", () => {
       new Set([
         "extensions/discord/src/monitor/native-command-model-picker-apply.ts",
         "extensions/discord/src/monitor/thread-session-close.ts",
+        "extensions/feishu/src/reasoning-preview.ts",
         "extensions/memory-core/src/dreaming-narrative.ts",
+        "extensions/mattermost/src/mattermost/model-picker.ts",
         "extensions/telegram/src/bot-handlers.runtime.ts",
       ]),
     );


### PR DESCRIPTION
## What Problem This Solves

Path 3.1b still had Feishu and Mattermost bundled runtime barrels exporting deprecated session whole-store helpers even though the remaining production callers only need targeted session-entry reads. That kept private bundled runtime/API surfaces wider than the accessor migration needs.

## Why This Change Was Made

The runtime read paths can use the existing session accessor seam directly while preserving current behavior, including latest-read semantics and Mattermost parent model-override inheritance. Feishu doctor/migration code keeps its file-backed compatibility import because doctor cleanup is the correct owner for that legacy whole-store mutation.

## User Impact

No user-visible behavior change is intended. Feishu reasoning previews and Mattermost model-picker summaries continue to read the same session metadata, but the bundled runtime barrels no longer expose deprecated whole-store helpers for those hot paths.

## Evidence

- `node scripts/run-vitest.mjs extensions/feishu/src/reasoning-preview.test.ts extensions/mattermost/src/mattermost/model-picker.test.ts src/plugin-sdk/session-store-runtime.test.ts test/scripts/check-session-accessor-boundary.test.ts` passed 4 Vitest shards.
- `node scripts/check-session-accessor-boundary.mjs` passed.
- `git diff --check` passed.
- `AGENTS_HOME="$HOME/.agents" "$HOME/.agents/skills/autoreview/scripts/autoreview" --mode branch --base upstream/main` reported no accepted/actionable findings.
- Live local OpenClaw proof was judged unnecessary for this slice because it is private API/barrel cleanup plus unit-covered targeted read-path preservation, not a live gateway behavior change.

Refs #88838
