### PR TITLE
fix(dashboard): copy SecretRef gateway token on request

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -13,6 +13,7 @@ Open the Control UI using your current auth.
 ```bash
 openclaw dashboard
 openclaw dashboard --no-open
+openclaw dashboard --copy-token
 ```
 
 Notes:
@@ -24,7 +25,8 @@ Notes:
   `dashboard` logs a safe manual-auth hint naming `OPENCLAW_GATEWAY_TOKEN`,
   `gateway.auth.token`, and fragment key `token` without printing the token
   value.
-- For SecretRef-managed tokens (resolved or unresolved), `dashboard` prints/copies/opens a non-tokenized URL to avoid exposing external secrets in terminal output, clipboard history, or browser-launch arguments.
+- For SecretRef-managed tokens, `dashboard` prints/copies/opens a non-tokenized URL by default to avoid exposing external secrets in terminal output, clipboard history, or browser-launch arguments.
+- Use `openclaw dashboard --copy-token` only when the Control UI prompts for a token and you need an explicit local recovery path. The command copies the resolved gateway token to the clipboard, never prints it, and opens a clean dashboard URL.
 - If `gateway.auth.token` is SecretRef-managed but unresolved in this command path, the command prints a non-tokenized URL and explicit remediation guidance instead of embedding an invalid token placeholder.
 
 ## Related

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -59,6 +59,10 @@ Prefer localhost, Tailscale Serve, or an SSH tunnel.
   prints/copies/opens a non-tokenized URL by design. This avoids exposing
   externally managed tokens in shell logs, clipboard history, or browser-launch
   arguments.
+- If the Control UI prompts for shared-secret auth and you need to recover a
+  resolved local token, run `openclaw dashboard --copy-token`. It copies the
+  gateway token to the clipboard for manual paste, never prints the token, and
+  opens a clean dashboard URL.
 - If `gateway.auth.token` is configured as a SecretRef and is unresolved in your
   current shell, `openclaw dashboard` still prints a non-tokenized URL plus
   actionable auth setup guidance.
@@ -93,8 +97,9 @@ Prefer localhost, Tailscale Serve, or an SSH tunnel.
   - Token: `openclaw config get gateway.auth.token`
   - Password: resolve the configured `gateway.auth.password` or
     `OPENCLAW_GATEWAY_PASSWORD`
-  - SecretRef-managed token: resolve the external secret provider or export
-    `OPENCLAW_GATEWAY_TOKEN` in this shell, then rerun `openclaw dashboard`
+  - SecretRef-managed token: run `openclaw dashboard --copy-token` on the
+    gateway host, or resolve the external secret provider/export
+    `OPENCLAW_GATEWAY_TOKEN` in this shell and rerun `openclaw dashboard`
   - No shared secret configured: `openclaw doctor --generate-gateway-token`
 - In the dashboard settings, paste the token or password into the auth field,
   then connect.

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -172,6 +172,17 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(options.noOpen).toBe(true);
   });
 
+  it("passes copyToken to dashboard command", async () => {
+    dashboardCommand.mockResolvedValue(undefined);
+
+    await runMaintenanceCli(["dashboard", "--copy-token"]);
+
+    expect(dashboardCommand).toHaveBeenCalledTimes(1);
+    const [runtimeArg, options] = commandCall(dashboardCommand);
+    expect(runtimeArg).toBe(runtime);
+    expect(options.copyToken).toBe(true);
+  });
+
   it("passes reset options to reset command", async () => {
     resetCommand.mockResolvedValue(undefined);
 

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -107,12 +107,14 @@ export function registerMaintenanceCommands(program: Command) {
       () =>
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/dashboard", "docs.openclaw.ai/cli/dashboard")}\n`,
     )
+    .option("--copy-token", "Copy the resolved gateway token for manual Control UI auth")
     .option("--no-open", "Print URL but do not launch a browser")
     .option("--yes", "Start/install the gateway without prompting when needed", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { dashboardCommand } = await import("../../commands/dashboard.js");
         await dashboardCommand(defaultRuntime, {
+          copyToken: Boolean(opts.copyToken),
           noOpen: opts.open === false,
           yes: Boolean(opts.yes),
         });

--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -295,6 +295,57 @@ describe("dashboardCommand", () => {
     expectNoLogWith("Token auto-auth unavailable");
   });
 
+  it("copies the resolved gateway token without overwriting it with the dashboard URL", async () => {
+    mockSnapshot({
+      source: "file",
+      provider: "local",
+      id: "/values/openclaw/gateway/auth/token",
+    });
+    resolveSecretRefValuesMock.mockResolvedValue(
+      new Map([["file:local:/values/openclaw/gateway/auth/token", "resolved-token"]]),
+    );
+    copyToClipboardMock.mockResolvedValue(true);
+    detectBrowserOpenSupportMock.mockResolvedValue({ ok: true });
+    openUrlMock.mockResolvedValue(true);
+
+    await dashboardCommand(runtime, { copyToken: true });
+
+    expect(copyToClipboardMock).toHaveBeenCalledTimes(1);
+    expect(copyToClipboardMock).toHaveBeenCalledWith("resolved-token");
+    expect(openUrlMock).toHaveBeenCalledWith("http://127.0.0.1:18789/");
+    expectLogWith("Gateway token copied to clipboard");
+    for (const call of runtime.log.mock.calls) {
+      expect(String(call[0])).not.toContain("resolved-token");
+      expect(String(call[0])).not.toContain("#token=");
+    }
+  });
+
+  it("opens a clean URL when copying a plaintext config token", async () => {
+    mockSnapshot("plain-token");
+    copyToClipboardMock.mockResolvedValue(true);
+    detectBrowserOpenSupportMock.mockResolvedValue({ ok: true });
+    openUrlMock.mockResolvedValue(true);
+
+    await dashboardCommand(runtime, { copyToken: true });
+
+    expect(copyToClipboardMock).toHaveBeenCalledTimes(1);
+    expect(copyToClipboardMock).toHaveBeenCalledWith("plain-token");
+    expect(openUrlMock).toHaveBeenCalledWith("http://127.0.0.1:18789/");
+    expectLogWith("Token auto-auth URL disabled because --copy-token");
+    expectNoLogWith("Token auto-auth included in browser/clipboard URL.");
+  });
+
+  it("does not copy the dashboard URL when --copy-token has no token to copy", async () => {
+    mockSnapshot("");
+    copyToClipboardMock.mockResolvedValue(true);
+
+    await dashboardCommand(runtime, { copyToken: true, noOpen: true });
+
+    expect(copyToClipboardMock).not.toHaveBeenCalled();
+    expectLogWith("Gateway token unavailable");
+    expectLogWith("openclaw dashboard --copy-token");
+  });
+
   it("keeps URL non-tokenized when env-template gateway.auth.token is unresolved", async () => {
     mockSnapshot("${CUSTOM_GATEWAY_TOKEN}");
     copyToClipboardMock.mockResolvedValue(true);

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -13,6 +13,7 @@ import {
 } from "./onboard-helpers.js";
 
 type DashboardOptions = {
+  copyToken?: boolean;
   noOpen?: boolean;
   yes?: boolean;
 };
@@ -79,8 +80,11 @@ export async function dashboardCommand(
   const { port, basePath, links, resolvedToken, token, includeTokenInUrl, dashboardUrl } = target;
 
   runtime.log(`Dashboard URL: ${links.httpUrl}`);
-  if (includeTokenInUrl) {
+  if (includeTokenInUrl && !options.copyToken) {
     runtime.log("Token auto-auth included in browser/clipboard URL.");
+  }
+  if (token && options.copyToken) {
+    runtime.log("Token auto-auth URL disabled because --copy-token copies the token separately.");
   }
   if (resolvedToken.secretRefConfigured && token) {
     runtime.log(
@@ -94,15 +98,32 @@ export async function dashboardCommand(
     );
   }
 
-  const copied = await copyToClipboard(dashboardUrl).catch(() => false);
-  runtime.log(copied ? "Copied to clipboard." : "Copy to clipboard unavailable.");
+  let copied = false;
+  if (options.copyToken) {
+    if (token) {
+      copied = await copyToClipboard(token).catch(() => false);
+      runtime.log(
+        copied
+          ? "Gateway token copied to clipboard. Paste it into the Control UI auth prompt."
+          : "Gateway token copy unavailable. Resolve gateway.auth.token or set OPENCLAW_GATEWAY_TOKEN, then paste it into the Control UI auth prompt.",
+      );
+    } else {
+      runtime.log(
+        "Gateway token unavailable. Resolve gateway.auth.token or set OPENCLAW_GATEWAY_TOKEN, then rerun `openclaw dashboard --copy-token`.",
+      );
+    }
+  } else {
+    copied = await copyToClipboard(dashboardUrl).catch(() => false);
+    runtime.log(copied ? "Copied to clipboard." : "Copy to clipboard unavailable.");
+  }
 
   let opened = false;
   let hint: string | undefined;
+  const browserUrl = options.copyToken ? links.httpUrl : dashboardUrl;
   if (!options.noOpen) {
     const browserSupport = await detectBrowserOpenSupport();
     if (browserSupport.ok) {
-      opened = await openUrl(dashboardUrl);
+      opened = await openUrl(browserUrl);
     }
     if (!opened) {
       hint = formatControlUiSshHint({
@@ -111,10 +132,16 @@ export async function dashboardCommand(
       });
     }
   } else {
-    hint =
-      copied && includeTokenInUrl
-        ? "Browser launch disabled (--no-open). Token-authenticated URL copied to clipboard."
+    if (options.copyToken) {
+      hint = copied
+        ? "Browser launch disabled (--no-open). Gateway token copied to clipboard."
         : "Browser launch disabled (--no-open). Use the URL above.";
+    } else {
+      hint =
+        copied && includeTokenInUrl
+          ? "Browser launch disabled (--no-open). Token-authenticated URL copied to clipboard."
+          : "Browser launch disabled (--no-open). Use the URL above.";
+    }
   }
 
   const fallbackToManualAuth = !copied && !opened && includeTokenInUrl;

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -131,17 +131,15 @@ export async function dashboardCommand(
         basePath,
       });
     }
+  } else if (options.copyToken) {
+    hint = copied
+      ? "Browser launch disabled (--no-open). Gateway token copied to clipboard."
+      : "Browser launch disabled (--no-open). Use the URL above.";
   } else {
-    if (options.copyToken) {
-      hint = copied
-        ? "Browser launch disabled (--no-open). Gateway token copied to clipboard."
+    hint =
+      copied && includeTokenInUrl
+        ? "Browser launch disabled (--no-open). Token-authenticated URL copied to clipboard."
         : "Browser launch disabled (--no-open). Use the URL above.";
-    } else {
-      hint =
-        copied && includeTokenInUrl
-          ? "Browser launch disabled (--no-open). Token-authenticated URL copied to clipboard."
-          : "Browser launch disabled (--no-open). Use the URL above.";
-    }
   }
 
   const fallbackToManualAuth = !copied && !opened && includeTokenInUrl;


### PR DESCRIPTION
Fixes #93043

## Summary

- Adds an explicit `openclaw dashboard --copy-token` recovery path for users whose Control UI session lost the gateway token.
- Keeps the default SecretRef behavior unchanged: normal `openclaw dashboard` still prints/copies/opens a clean non-tokenized URL for SecretRef-managed tokens.
- Makes `--copy-token` copy only the resolved gateway token, open a clean dashboard URL, and never print the token to logs/stdout.
- Updates dashboard CLI/web docs and adds focused regression coverage for CLI option wiring, final clipboard payload, clean browser URLs, and the no-token case.

## Verification

- `pnpm exec oxfmt --check src/commands/dashboard.ts src/commands/dashboard.links.test.ts src/cli/program/register.maintenance.ts src/cli/program/register.maintenance.test.ts docs/cli/dashboard.md docs/web/dashboard.md`
- `git diff --check`
- `node scripts/run-vitest.mjs src/commands/dashboard.test.ts src/commands/dashboard.links.test.ts src/cli/program/register.maintenance.test.ts`
- `pnpm docs:list`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt 'Scope: issue #93043 only...'` -> `autoreview clean: no accepted/actionable findings reported`
- `node dist/entry.js dashboard --help` shows `--copy-token`

`pnpm docs:check-i18n-glossary` currently fails on unrelated pre-existing changed doc labels such as `Raft`, `ClawHub CLI`, `Windows Hub`, and `llama.cpp Provider`; none are introduced by this dashboard diff.

`pnpm build` completed the expensive build phases far enough to produce `dist/.buildstamp`, `dist/.runtime-postbuildstamp`, and a runnable `dist/entry.js`, but the parent command was cut off by the 10 minute tool timeout after the final metadata phase output. I verified the built CLI entry directly with `node dist/entry.js dashboard --help`.

## Real behavior proof

**Behavior addressed:** A user with a SecretRef-managed `gateway.auth.token` can explicitly recover the token for Control UI login without putting the bearer in terminal output, dashboard URLs, or browser-launch arguments.

**Real environment tested:** macOS host, local running OpenClaw Gateway on loopback, built CLI entry from this branch, temporary single-value file SecretRef provider for `gateway.auth.token`. Clipboard was restored after the proof.

**Exact steps or command run after this patch:**

- First copied the live gateway token with `node dist/entry.js dashboard --copy-token --no-open` without printing it.
- Wrote that value to a temporary `mode: "singleValue"` file SecretRef provider and configured `gateway.auth.token` as `{ source: "file", provider: "gateway_file", id: "value" }`.
- Ran `OPENCLAW_CONFIG_PATH=<temp-config> OPENCLAW_STATE_DIR=<temp-state> OPENCLAW_WORKSPACE_DIR=<temp-workspace> node dist/entry.js dashboard --copy-token --no-open`.
- Compared clipboard contents in-process without printing the token.
- Requested `GET /control-ui-config.json` with `Authorization: Bearer <clipboard-token>` and again without auth.
- Searched dashboard logs for the copied token value and redacted all temporary paths/tokens from reported output.

**Evidence after fix:**

```text
file_secretref_clipboard_matches_live_gateway_token=true
file_secretref_log_leaked_token=false
file_secretref_success_log=true
file_secretref_auth_control_ui_config_http=200
file_secretref_noauth_control_ui_config_http=401
initial_live_dashboard_log_leaked_token=false
```

**Observed result after fix:** The file SecretRef-managed gateway token is copied to clipboard, no dashboard log contains the token, the copied token authenticates the protected Control UI config endpoint, and the unauthenticated request is rejected.

**What was not tested:** Full browser paste flow with a visual screenshot/video. The endpoint proof exercises the same gateway bearer needed by Control UI auth without exposing the token in test output.



### Visual browser proof after fix

- Behavior addressed: SecretRef-backed token copied by `openclaw dashboard --copy-token --no-open` can be pasted into the served Control UI from a clean URL.
- Real environment tested: macOS local checkout, isolated temporary Gateway on loopback, Chromium via Playwright, temporary env SecretRef config. The Gateway process used the same token as runtime auth; the dashboard command process did not have `OPENCLAW_GATEWAY_TOKEN` and resolved the token through `gateway.auth.token` SecretRef.
- Exact steps or command run after this patch: temporary Gateway + `node dist/entry.js dashboard --copy-token --no-open`; Playwright opened `http://127.0.0.1:<port>/`, filled the Gateway Token field from clipboard, clicked Connect, and waited for the Control UI ready state.
- Evidence after fix: `isolated_gateway_started=true`, `dashboard_secretref_env_only=true`, `dashboard_exit_code=0`, `dashboard_log_clean_url=true`, `dashboard_log_leaked_token=false`, `os_clipboard_matches_secretref_token=true`, `browser_url_clean=true`, `browser_token_input_visible=true`, `browser_reached_chat_ready_after_paste=true`, `browser_body_leaked_token=false`, `control_ui_config_auth_http=200`, `control_ui_config_noauth_http=401`.
- Observed result after fix: the browser reached the Control UI chat-ready state after pasting the copied token; the terminal output and page body did not contain the token.
- What was not tested: a recorded/screenshot artifact was not attached because the proof avoids persisting token-adjacent browser artifacts.
