### PR TITLE
fix(agents): classify upstream_error provider transport failures as fallbackable

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1658,7 +1658,13 @@ function isStructuredServerErrorMessage(raw: string): boolean {
     return false;
   }
   const value = normalizeLowercaseStringOrEmpty(raw);
-  return value.includes('"type":"server_error"') || value.includes('"code":"server_error"');
+  return (
+    value.includes('"type":"server_error"') ||
+    value.includes('"code":"server_error"') ||
+    // Upstream provider transport failures (#95519): `{"error":{"type":"upstream_error", ...}}`
+    // is a transient relay failure, not a primary-provider model error.
+    value.includes('"type":"upstream_error"')
+  );
 }
 
 export function parseImageDimensionError(raw: string): {

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -179,6 +179,25 @@ describe("server error status classification", () => {
   });
 });
 
+describe("upstream_error transport failure classification (#95519)", () => {
+  it("classifies a raw {error:{type:'upstream_error'}} JSON body as a server error (fallbackable)", () => {
+    // Provider-side relay/transport failure shaped like OpenAI's error
+    // envelope — distinct from a model-level error, must engage the
+    // configured fallback chain rather than ending the turn immediately.
+    const raw =
+      '{"error":{"message":"Upstream request failed","type":"upstream_error","param":"","code":null}}';
+    expect(classifyFailoverReason(raw)).toBe("server_error");
+  });
+
+  it("classifies the bare message 'Upstream request failed' as transient", () => {
+    expect(classifyFailoverReason("Upstream request failed")).toBe("timeout");
+  });
+
+  it("matches isServerErrorMessage for the bare upstream_error type string", () => {
+    expect(isServerErrorMessage("upstream_error")).toBe(true);
+  });
+});
+
 describe("generic assistant error text classification (#93931)", () => {
   it("classifies the generic 'LLM request failed.' as a timeout (transient)", () => {
     // The generic error text wraps provider availability failures (model not

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -121,6 +121,10 @@ const ERROR_PATTERNS = {
     "upstream error",
     "upstream connect error",
     "connection reset",
+    // Provider-side relay/transport failure (#95519): distinct from a model
+    // error — the upstream call itself failed before reaching the model.
+    "upstream_error",
+    "upstream request failed",
     // Chinese provider server error messages
     "内部错误",
     "服务器错误",


### PR DESCRIPTION
Fixes #95519

## What Problem This Solves

When the primary provider returns a transport-level `upstream_error` (`{"error":{"message":"Upstream request failed","type":"upstream_error",...}}`), OpenClaw ends the turn immediately with the generic `LLM request failed` error instead of trying any configured fallback models under `agents.defaults.model.fallbacks`. The trajectory shows only the primary provider/model — no `model.fallback_step` events, no fallback attempt — even though this is exactly the class of transient failure the fallback chain exists for.

## Why This Change Was Made

Failover classification in `src/agents/embedded-agent-helpers/errors.ts` / `failover-matches.ts` matches known transient error shapes (`server_error`, `overloaded`, rate limits, timeouts, etc.) against the raw error text/JSON to decide whether to engage the configured fallback chain. Neither the structured JSON shape `"type":"upstream_error"` nor the bare message `Upstream request failed` matched any existing pattern — `"upstream error"` (with a space) and `"upstream connect error"` were already covered, but not the underscored `upstream_error` type or its associated message text, so this exact failure fell through to "unclassified" and ended the turn.

Fix:
- `isStructuredServerErrorMessage` in `errors.ts` now also matches `"type":"upstream_error"` (alongside the existing `"type":"server_error"` / `"code":"server_error"` checks), since it is structurally the same kind of relay/transport failure.
- `ERROR_PATTERNS.serverError` in `failover-matches.ts` now also matches the bare strings `upstream_error` and `upstream request failed`, covering callers that only see the flattened message text rather than the full JSON body.

Both lead to an already-existing, already-fallbackable `FailoverReason` (`server_error` / `timeout`) — no new reason code, no change to non-transient error handling.

## User Impact

Configured fallback models now get a chance to handle a primary-provider `upstream_error` transport failure instead of the turn ending immediately. Non-transient/intentional errors (auth, billing, format) are unaffected — the new checks only add a previously-unmatched transient shape.

## Evidence

Behavior addressed: neither the JSON-shaped `"type":"upstream_error"` provider error nor its plain message `Upstream request failed` were classified as a fallbackable `FailoverReason`, so `agents.defaults.model.fallbacks` was never engaged.

Real environment tested: macOS arm64 (M4), Darwin 25.5.0, Node v25.9.0, branch `fix/fallback-trigger-on-upstream-error`, commit `2cf755c2b7`.

Exact steps or command run after this patch:
```
node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/failover-matches.test.ts src/agents/embedded-agent-helpers/errors.test.ts
node scripts/run-oxlint.mjs src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-helpers/failover-matches.ts src/agents/embedded-agent-helpers/failover-matches.test.ts
pnpm tsgo:core
pnpm tsgo:core:test
```

Evidence after fix:
```
failover-matches.test.ts: 32 passed (32)
errors.test.ts: 5 passed (5)
oxlint: exit 0, no findings
tsgo:core: exit 0
tsgo:core:test: exit 0
```

Observed result after fix: added 3 regression tests reproducing the exact issue shape — the full `{"error":{"type":"upstream_error",...}}` JSON body now classifies as `"server_error"` via `classifyFailoverReason`, the bare message `"Upstream request failed"` classifies as `"timeout"`, and `isServerErrorMessage("upstream_error")` returns `true`. Confirmed all three fail against the pre-fix code (return `null`/`false`) by reverting just the two source files while keeping the tests, then pass after restoring the fix.

What was not tested: did not reproduce against a live provider that actually emits `upstream_error` (no credentials/access to such a provider in this environment) — this is a classifier unit fix verified against the exact error shape quoted in the issue, not a live end-to-end fallback round-trip.
