### PR TITLE
fix: retry stalled direct chats after session reset

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -3765,6 +3765,7 @@ describe("runAgentTurnWithFallback", () => {
       flush: vi.fn(async () => {}),
       stop: vi.fn(),
       hasBuffered: vi.fn(() => true),
+      hasPendingDelivery: vi.fn(() => false),
       didStream: vi.fn(() => false),
       isAborted: vi.fn(() => false),
       hasSentPayload: vi.fn(() => false),

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -852,6 +852,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => ["file:///tmp/voice.ogg"],
     };
 
@@ -891,6 +892,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => ["file:///tmp/outbound/voice.ogg"],
     };
 
@@ -914,6 +916,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
     // The pipeline streamed some partial content, but the final text payload was
@@ -942,6 +945,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
     // The final text-only payload matches what the pipeline already sent,
@@ -967,6 +971,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
 
@@ -990,6 +995,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
     const presentation = {
@@ -1020,6 +1026,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
 
@@ -1046,6 +1053,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => ["/tmp/generated.png"],
     };
 
@@ -1094,6 +1102,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2953,7 +2953,8 @@ describe("runReplyAgent transient HTTP retry", () => {
     setAgentRunnerSessionResetTestDeps({
       generateSecureUuid: () => "reset-session",
       persistSessionResetLifecycle: async (params) => {
-        await saveSessionStore(params.storePath, { [params.sessionKey]: params.nextEntry });
+        saveSessionStore(params.storePath, { [params.sessionKey]: params.nextEntry });
+        return { replayedMessages: 0 };
       },
     });
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2953,7 +2953,7 @@ describe("runReplyAgent transient HTTP retry", () => {
     setAgentRunnerSessionResetTestDeps({
       generateSecureUuid: () => "reset-session",
       persistSessionResetLifecycle: async (params) => {
-        saveSessionStore(params.storePath, { [params.sessionKey]: params.nextEntry });
+        await saveSessionStore(params.storePath, { [params.sessionKey]: params.nextEntry });
         return { replayedMessages: 0 };
       },
     });
@@ -3065,7 +3065,7 @@ describe("runReplyAgent transient HTTP retry", () => {
     expect(runtimeErrorMock).toHaveBeenCalledWith(
       "Stalled direct session aborted without visible output. Resetting hot session main stalled-session -> reset-session and retrying once.",
     );
-    const persisted = await loadSessionStore(storePath);
+    const persisted = loadSessionStore(storePath);
     expect(persisted[sessionKey]?.sessionId).toBe("reset-session");
   });
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -208,6 +208,7 @@ vi.mock("./private-message-tool-final.js", async (importOriginal) => {
   return { ...actual, warnPrivateMessageToolFinal: warnPrivateFinalSpy };
 });
 
+import { setAgentRunnerSessionResetTestDeps } from "./agent-runner-session-reset.js";
 import { runReplyAgent } from "./agent-runner.js";
 
 type RunWithModelFallbackParams = {
@@ -255,6 +256,7 @@ function firstMockCallArg(mock: MockCallSource, label: string): unknown {
 
 beforeEach(() => {
   vi.useRealTimers();
+  setAgentRunnerSessionResetTestDeps();
   registerCliBackendsForTest();
   clearRuntimeConfigSnapshot();
   resetDiagnosticEventsForTest();
@@ -292,6 +294,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setAgentRunnerSessionResetTestDeps();
   cliBackendsTesting.resetDepsForTest();
   clearRuntimeConfigSnapshot();
   resetDiagnosticEventsForTest();
@@ -2932,6 +2935,253 @@ describe("runReplyAgent response usage footer", () => {
 });
 
 describe("runReplyAgent transient HTTP retry", () => {
+  it("resets and retries once after a stalled compacted direct session aborts without output", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stalled-direct-reset-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "stalled-session",
+      updatedAt: Date.now(),
+      sessionFile: path.join(tmp, "stalled-session.jsonl"),
+      systemSent: true,
+      chatType: "direct",
+      compactionCount: 2,
+      totalTokens: 1_000,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await saveSessionStore(storePath, sessionStore);
+    setAgentRunnerSessionResetTestDeps({
+      generateSecureUuid: () => "reset-session",
+      persistSessionResetLifecycle: async (params) => {
+        await saveSessionStore(params.storePath, { [params.sessionKey]: params.nextEntry });
+      },
+    });
+
+    runEmbeddedAgentMock
+      .mockResolvedValueOnce({
+        payloads: [{ text: "LLM request failed.", isError: true }],
+        meta: {
+          aborted: true,
+          livenessState: "blocked",
+          durationMs: 383_000,
+          agentMeta: {
+            sessionId: "stalled-session",
+            provider: "codex-lb",
+            model: "gpt-5.5",
+          },
+        },
+      })
+      .mockImplementationOnce(async () => {
+        expect(replyRunRegistry.resolveSessionId(sessionKey)).toBe("reset-session");
+        return {
+          payloads: [{ text: "Recovered response" }],
+          meta: {
+            agentMeta: {
+              sessionId: "reset-session",
+              provider: "codex-lb",
+              model: "gpt-5.5",
+            },
+          },
+        };
+      });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "chat:1",
+      AccountId: "primary",
+      MessageSid: "msg",
+      ChatType: "direct",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        sessionId: "stalled-session",
+        sessionKey,
+        messageProvider: "telegram",
+        sessionFile: sessionEntry.sessionFile,
+        workspaceDir: "/tmp",
+        config: createCliBackendTestConfig(),
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    const payload = Array.isArray(result)
+      ? result.find((entry) => entry?.text === "Recovered response")
+      : result;
+    expectRecordFields(payload, { text: "Recovered response" }, "reply result");
+    expect(followupRun.run.sessionId).toBe("reset-session");
+    expect(sessionStore[sessionKey]?.sessionId).toBe("reset-session");
+    expect(sessionStore[sessionKey]?.systemSent).toBe(false);
+    expect(sessionStore[sessionKey]?.totalTokens).toBeUndefined();
+    expect(refreshQueuedFollowupSessionMock).toHaveBeenCalledWith({
+      key: sessionKey,
+      previousSessionId: "stalled-session",
+      nextSessionId: "reset-session",
+      nextSessionFile: sessionStore[sessionKey]?.sessionFile,
+    });
+    expect(runtimeErrorMock).toHaveBeenCalledWith(
+      "Stalled direct session aborted without visible output. Resetting hot session main stalled-session -> reset-session and retrying once.",
+    );
+    const persisted = await loadSessionStore(storePath);
+    expect(persisted[sessionKey]?.sessionId).toBe("reset-session");
+  });
+
+  it("does not reset when a stalled direct session has buffered block output", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stalled-direct-buffered-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "stalled-session",
+      updatedAt: Date.now(),
+      sessionFile: path.join(tmp, "stalled-session.jsonl"),
+      systemSent: true,
+      chatType: "direct",
+      compactionCount: 2,
+      totalTokens: 1_000,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await saveSessionStore(storePath, sessionStore);
+
+    const onBlockReply = vi.fn();
+    runEmbeddedAgentMock.mockImplementationOnce(async (params) => {
+      const block = params.onBlockReply as ((payload: { text?: string }) => void) | undefined;
+      block?.({ text: "Buffered answer" });
+      return {
+        payloads: [{ text: "LLM request failed.", isError: true }],
+        meta: {
+          aborted: true,
+          livenessState: "blocked",
+          agentMeta: {
+            sessionId: "stalled-session",
+            provider: "codex-lb",
+            model: "gpt-5.5",
+          },
+        },
+      };
+    });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "chat:1",
+      AccountId: "primary",
+      MessageSid: "msg",
+      ChatType: "direct",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        sessionId: "stalled-session",
+        sessionKey,
+        messageProvider: "telegram",
+        sessionFile: sessionEntry.sessionFile,
+        workspaceDir: "/tmp",
+        config: createCliBackendTestConfig(),
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      opts: { onBlockReply },
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: true,
+      blockReplyChunking: {
+        minChars: 100,
+        maxChars: 200,
+        breakPreference: "paragraph",
+      },
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Buffered answer" }),
+      expect.any(Object),
+    );
+    expect(followupRun.run.sessionId).toBe("stalled-session");
+    expect(sessionStore[sessionKey]?.sessionId).toBe("stalled-session");
+    expect(refreshQueuedFollowupSessionMock).not.toHaveBeenCalled();
+    expect(runtimeErrorMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("Stalled direct session aborted without visible output"),
+    );
+  });
+
   it("retries once after transient 521 HTML failure and then succeeds", async () => {
     vi.useFakeTimers();
     runEmbeddedAgentMock

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -3069,7 +3069,7 @@ describe("runReplyAgent transient HTTP retry", () => {
     expect(persisted[sessionKey]?.sessionId).toBe("reset-session");
   });
 
-  it("does not reset when a stalled direct session has buffered block output", async () => {
+  it("does not reset when a stalled direct session has pending block delivery", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stalled-direct-buffered-"));
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
@@ -3085,10 +3085,17 @@ describe("runReplyAgent transient HTTP retry", () => {
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await saveSessionStore(storePath, sessionStore);
 
-    const onBlockReply = vi.fn();
+    let resolveBlockDelivery: (() => void) | undefined;
+    const blockDelivery = new Promise<void>((resolve) => {
+      resolveBlockDelivery = resolve;
+    });
+    const onBlockReply = vi.fn(() => blockDelivery);
     runEmbeddedAgentMock.mockImplementationOnce(async (params) => {
-      const block = params.onBlockReply as ((payload: { text?: string }) => void) | undefined;
-      block?.({ text: "Buffered answer" });
+      const block = params.onBlockReply as
+        | ((payload: { text?: string; mediaUrls?: string[] }) => void)
+        | undefined;
+      block?.({ text: "Visible answer", mediaUrls: ["file://visible.png"] });
+      setImmediate(() => resolveBlockDelivery?.());
       return {
         payloads: [{ text: "LLM request failed.", isError: true }],
         meta: {
@@ -3172,7 +3179,7 @@ describe("runReplyAgent transient HTTP retry", () => {
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     expect(onBlockReply).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Buffered answer" }),
+      expect.objectContaining({ text: expect.stringContaining("Visible answer") }),
       expect.any(Object),
     );
     expect(followupRun.run.sessionId).toBe("stalled-session");

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -68,6 +68,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildKnownAgentRunFailureReplyPayload,
+  type AgentRunLoopResult,
   runAgentTurnWithFallback,
 } from "./agent-runner-execution.js";
 import {
@@ -261,7 +262,11 @@ function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
 }
 
 function hasSuccessfulSideEffectDelivery(params: {
-  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
+  blockReplyPipeline: {
+    hasBuffered: () => boolean;
+    didStream: () => boolean;
+    isAborted: () => boolean;
+  } | null;
   directlySentBlockKeys?: Set<string>;
   messagingToolSentTexts?: string[];
   messagingToolSentMediaUrls?: string[];
@@ -279,19 +284,114 @@ function hasSuccessfulSideEffectDelivery(params: {
 }
 
 function hasSuccessfulSourceReplyDelivery(params: {
-  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
+  blockReplyPipeline: {
+    hasBuffered: () => boolean;
+    didStream: () => boolean;
+    isAborted: () => boolean;
+  } | null;
   directlySentBlockKeys?: Set<string>;
   messagingToolSentTexts?: string[];
   messagingToolSentMediaUrls?: string[];
   messagingToolSentTargets?: unknown[];
 }): boolean {
   return (
+    (params.blockReplyPipeline?.hasBuffered() && !params.blockReplyPipeline.isAborted()) ||
     (params.blockReplyPipeline?.didStream() && !params.blockReplyPipeline.isAborted()) ||
     (params.directlySentBlockKeys?.size ?? 0) > 0 ||
     hasNonEmptyStringArray(params.messagingToolSentTexts) ||
     hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
     hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets)
   );
+}
+
+type SuccessfulAgentRunOutcome = Extract<AgentRunLoopResult, { kind: "success" }>;
+
+function hasCompactionHistory(entry: SessionEntry | undefined): boolean {
+  return (
+    (typeof entry?.compactionCount === "number" && entry.compactionCount > 0) ||
+    (Array.isArray(entry?.compactionCheckpoints) && entry.compactionCheckpoints.length > 0)
+  );
+}
+
+function isDirectChatSession(params: {
+  sessionKey?: string;
+  sessionEntry?: SessionEntry;
+  sessionCtx: TemplateContext;
+}): boolean {
+  return (
+    params.sessionEntry?.chatType === "direct" ||
+    params.sessionCtx.ChatType === "direct" ||
+    params.sessionKey?.includes(":direct:") === true
+  );
+}
+
+function hasNonErrorVisibleReplyPayload(payloads: ReplyPayload[] | undefined): boolean {
+  return (payloads ?? []).some((payload) => {
+    if (payload.isError === true || payload.isReasoning === true) {
+      return false;
+    }
+    return (
+      (typeof payload.text === "string" && payload.text.trim().length > 0) ||
+      (typeof payload.mediaUrl === "string" && payload.mediaUrl.trim().length > 0) ||
+      (Array.isArray(payload.mediaUrls) &&
+        payload.mediaUrls.some((url) => url.trim().length > 0)) ||
+      payload.presentation !== undefined ||
+      payload.interactive !== undefined
+    );
+  });
+}
+
+function shouldAutoResetRetryStalledDirectSession(params: {
+  isHeartbeat: boolean;
+  sessionKey?: string;
+  storePath?: string;
+  activeSessionStore?: Record<string, SessionEntry>;
+  activeSessionEntry?: SessionEntry;
+  sessionCtx: TemplateContext;
+  runOutcome: SuccessfulAgentRunOutcome;
+  blockReplyPipeline: {
+    hasBuffered: () => boolean;
+    didStream: () => boolean;
+    isAborted: () => boolean;
+  } | null;
+  pendingToolTasks: Set<Promise<void>>;
+}): boolean {
+  const runResult = params.runOutcome.runResult;
+  if (
+    params.isHeartbeat ||
+    !params.sessionKey ||
+    !params.storePath ||
+    !params.activeSessionStore ||
+    !isDirectChatSession({
+      sessionKey: params.sessionKey,
+      sessionEntry: params.activeSessionEntry,
+      sessionCtx: params.sessionCtx,
+    }) ||
+    !hasCompactionHistory(params.activeSessionEntry)
+  ) {
+    return false;
+  }
+  if (
+    runResult.meta?.aborted !== true ||
+    runResult.meta?.error !== undefined ||
+    runResult.meta?.livenessState !== "blocked" ||
+    params.runOutcome.fallbackExhausted === true ||
+    params.runOutcome.fallbackAttempts.length > 0 ||
+    params.pendingToolTasks.size > 0 ||
+    hasNonErrorVisibleReplyPayload(runResult.payloads)
+  ) {
+    return false;
+  }
+  return !hasSuccessfulSideEffectDelivery({
+    blockReplyPipeline: params.blockReplyPipeline,
+    directlySentBlockKeys: params.runOutcome.directlySentBlockKeys,
+    messagingToolSentTexts: runResult.messagingToolSentTexts,
+    messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
+    messagingToolSentTargets: runResult.messagingToolSentTargets,
+    didSendViaMessagingTool: runResult.didSendViaMessagingTool,
+    successfulCronAdds: runResult.successfulCronAdds,
+    didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
+  });
 }
 
 function resolveConfiguredFallbackModel(params: {
@@ -1720,7 +1820,7 @@ export async function runReplyAgent(params: {
     replyOperation.setPhase("running");
     const runStartedAt = Date.now();
     await persistRestartRecoveryDeliveryContext();
-    const runOutcome = await traceAgentPhase("reply.run_agent_turn", () =>
+    const runAgentTurn = () =>
       runAgentTurnWithFallback({
         commandBody,
         transcriptCommandBody,
@@ -1749,14 +1849,92 @@ export async function runReplyAgent(params: {
         toolProgressDetail,
         replyMediaContext,
         isRestartRecoveryArmed,
-      }),
-    );
+      });
+    let runOutcome = await traceAgentPhase("reply.run_agent_turn", runAgentTurn);
 
     if (runOutcome.kind === "final") {
       if (!replyOperation.result) {
         replyOperation.fail("run_failed", new Error("reply operation exited with final payload"));
       }
       return returnWithQueuedFollowupDrain(runOutcome.payload);
+    }
+
+    if (
+      shouldAutoResetRetryStalledDirectSession({
+        isHeartbeat,
+        sessionKey,
+        storePath,
+        activeSessionStore,
+        activeSessionEntry,
+        sessionCtx,
+        runOutcome,
+        blockReplyPipeline,
+        pendingToolTasks,
+      })
+    ) {
+      const previousSessionId = followupRun.run.sessionId;
+      const retryLifecycleRunId = runOutcome.runId;
+      const compactionCount = activeSessionEntry?.compactionCount;
+      emitAgentEvent({
+        runId: retryLifecycleRunId,
+        sessionKey,
+        sessionId: previousSessionId,
+        stream: "lifecycle",
+        data: {
+          phase: "auto_session_reset_retry",
+          outcome: "attempting",
+          reason: "stalled_direct_session_abort",
+          compactionCount,
+        },
+      });
+      const didReset = await resetSession({
+        failureLabel: "stalled direct session abort",
+        buildLogMessage: (nextSessionId) =>
+          `Stalled direct session aborted without visible output. Resetting hot session ${sessionKey} ${previousSessionId} -> ${nextSessionId} and retrying once.`,
+      });
+      if (didReset) {
+        replyOperation.updateSessionId(followupRun.run.sessionId);
+        runOutcome = await traceAgentPhase(
+          "reply.run_agent_turn_after_session_reset",
+          runAgentTurn,
+        );
+        emitAgentEvent({
+          runId: runOutcome.kind === "success" ? runOutcome.runId : retryLifecycleRunId,
+          sessionKey,
+          sessionId: followupRun.run.sessionId,
+          stream: "lifecycle",
+          data: {
+            phase: "auto_session_reset_retry",
+            outcome: "completed",
+            reason: "stalled_direct_session_abort",
+            previousSessionId,
+            sessionId: followupRun.run.sessionId,
+            compactionCount,
+          },
+        });
+        if (runOutcome.kind === "final") {
+          if (!replyOperation.result) {
+            replyOperation.fail(
+              "run_failed",
+              new Error("reply operation exited with final payload"),
+            );
+          }
+          return returnWithQueuedFollowupDrain(runOutcome.payload);
+        }
+      } else {
+        emitAgentEvent({
+          runId: retryLifecycleRunId,
+          sessionKey,
+          sessionId: previousSessionId,
+          stream: "lifecycle",
+          data: {
+            phase: "auto_session_reset_retry",
+            outcome: "skipped",
+            reason: "reset_unavailable",
+            compactionCount,
+          },
+        });
+      }
     }
 
     const {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -264,6 +264,7 @@ function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
 function hasSuccessfulSideEffectDelivery(params: {
   blockReplyPipeline: {
     hasBuffered: () => boolean;
+    hasPendingDelivery: () => boolean;
     didStream: () => boolean;
     isAborted: () => boolean;
   } | null;
@@ -351,6 +352,7 @@ function shouldAutoResetRetryStalledDirectSession(params: {
   runOutcome: SuccessfulAgentRunOutcome;
   blockReplyPipeline: {
     hasBuffered: () => boolean;
+    hasPendingDelivery: () => boolean;
     didStream: () => boolean;
     isAborted: () => boolean;
   } | null;
@@ -1857,6 +1859,10 @@ export async function runReplyAgent(params: {
         replyOperation.fail("run_failed", new Error("reply operation exited with final payload"));
       }
       return returnWithQueuedFollowupDrain(runOutcome.payload);
+    }
+
+    if (blockReplyPipeline?.hasPendingDelivery() === true && !blockReplyPipeline.isAborted()) {
+      await blockReplyPipeline.flush({ force: true });
     }
 
     if (

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -16,6 +16,7 @@ export type BlockReplyPipeline = {
   flush: (options?: { force?: boolean }) => Promise<void>;
   stop: () => void;
   hasBuffered: () => boolean;
+  hasPendingDelivery: () => boolean;
   didStream: () => boolean;
   isAborted: () => boolean;
   hasSentPayload: (payload: ReplyPayload) => boolean;
@@ -323,6 +324,7 @@ export function createBlockReplyPipeline(params: {
     flush,
     stop,
     hasBuffered: () => coalescer?.hasBuffered() || bufferedPayloads.length > 0,
+    hasPendingDelivery: () => pendingKeys.size > 0,
     didStream: () => didStream,
     isAborted: () => aborted,
     hasSentExactPayload: (payload) => sentContentKeys.has(createBlockReplyContentKey(payload)),


### PR DESCRIPTION
Fixes #90516

## What Problem This Solves

Fixes an issue where users in direct chat could receive a generic `LLM request failed.` response when a compacted hot session became wedged and the active model call was diagnostically aborted without producing visible output.

## Why This Change Was Made

When a compacted direct-session run aborts with no visible payloads, no provider fallback, no pending tool work, and no committed source/stream/tool side effects, the reply runner now rotates the hot session with the existing reply-run session reset path and retries the original turn once. The retry updates the active reply operation's session id before re-entering the runner so stop, steering, and recovery controls target the fresh session. Buffered block-stream output is treated as already-visible work, so the runner does not replay a turn that has output waiting to flush.

Codex contract checked: `../codex/sdk/typescript/src/thread.ts`, `../codex/sdk/typescript/src/events.ts`, `../codex/sdk/typescript/tests/abort.test.ts`, `../codex/codex-rs/mcp-server/src/codex_tool_runner.rs`, and `../codex/codex-rs/mcp-server/src/message_processor.rs`. Those paths confirm abort/error completion is surfaced through the Codex turn/tool-call stream; this PR keeps the repair in OpenClaw's reply/session layer.

## User Impact

Direct chat users get the same message retried on a fresh hot session instead of having to manually run `sessions.reset` and resend after the wedged-session abort pattern. Existing sessions with visible output, buffered stream output, tool side effects, fallback attempts, heartbeat turns, non-direct chats, or non-compacted sessions are not auto-replayed.

## Evidence

Behavior addressed: compacted direct chat run aborts without visible output and previously surfaced `LLM request failed.` instead of resetting and retrying once.

Real environment tested: local OpenClaw source worktree on Node/pnpm with mocked embedded-runner behavior for the exact reply-runner session-state edge.

Exact steps or command run after this patch:
- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-session-reset.test.ts`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `pnpm exec oxlint --threads=1 src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Evidence after fix: regression test covers reset + one retry, active reply operation rebinding to the fresh session, persisted session rotation, queue refresh, and a buffered block-stream non-reset case.

Observed result after fix: focused Vitest passed with 50/50 tests in `agent-runner.misc.runreplyagent.test.ts`; `agent-runner-session-reset.test.ts` passed 2/2; final autoreview reported `autoreview clean: no accepted/actionable findings reported`.

What was not tested: live Telegram delivery and a live Codex provider hang were not exercised; the proof uses the existing mocked embedded runner to deterministically model the stalled-abort state from #90516 without requiring a real wedged provider session.

