### PR TITLE
fix(slack): show tool status in assistant threads

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1155,6 +1155,7 @@ Hide raw command/exec text while keeping compact progress lines:
 Slack native progress task cards are opt-in for progress mode. Set `channels.slack.streaming.progress.nativeTaskCards` to `true` with `channels.slack.streaming.mode="progress"` to send a Slack-native plan/task card while work is running, then update the same task card at completion. Without this flag, progress mode keeps the portable draft-preview behavior.
 
 - A reply thread must be available for native text streaming and Slack assistant thread status to appear. Thread selection still follows `replyToMode`.
+- Assistant thread status starts with the normal typing indicator, then changes to short tool-level labels such as `Running command...`, `Searching the web...`, or `Reading files...` while the agent loop works.
 - Channel, group-chat, and top-level DM roots can still use the normal draft preview when native streaming is unavailable or no reply thread exists.
 - Top-level Slack DMs stay off-thread by default, so they do not show Slack's thread-style native stream/status preview; OpenClaw posts and edits a draft preview in the DM instead.
 - Media and non-text payloads fall back to normal delivery.
@@ -1203,7 +1204,7 @@ Legacy keys:
 
 ## Typing reaction fallback
 
-`typingReaction` adds a temporary reaction to the inbound Slack message while OpenClaw is processing a reply, then removes it when the run finishes. This is most useful outside of thread replies, which use a default "is typing..." status indicator.
+`typingReaction` adds a temporary reaction to the inbound Slack message while OpenClaw is processing a reply, then removes it when the run finishes. This is most useful outside of thread replies, which use Slack assistant thread status for typing and tool-level progress labels when a reply thread is available.
 
 Resolution order:
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -94,6 +94,19 @@ let capturedReplyOptions:
         deleted?: string[];
         summary?: string;
       }) => Promise<void> | void;
+      onPlanUpdate?: (payload: {
+        phase?: string;
+        title?: string;
+        explanation?: string;
+        steps?: string[];
+      }) => Promise<void> | void;
+      onApprovalEvent?: (payload: {
+        phase?: string;
+        title?: string;
+        command?: string;
+        reason?: string;
+        message?: string;
+      }) => Promise<void> | void;
       onPartialReply?: (payload: { text: string }) => Promise<void> | void;
     }
   | undefined;
@@ -183,6 +196,21 @@ let mockedReplyOptionEvents: Array<
       name?: string;
       status?: string;
       exitCode?: number | null;
+    }
+  | {
+      kind: "plan";
+      phase?: string;
+      title?: string;
+      explanation?: string;
+      steps?: string[];
+    }
+  | {
+      kind: "approval";
+      phase?: string;
+      title?: string;
+      command?: string;
+      reason?: string;
+      message?: string;
     }
   | { kind: "concurrent_items"; progressTexts: string[] }
   | { kind: "partial"; text: string }
@@ -505,13 +533,39 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
       event?: string;
       itemId?: string;
       toolCallId?: string;
+      phase?: string;
       progressText?: string;
       summary?: string;
       title?: string;
       name?: string;
       status?: string;
       exitCode?: number | null;
+      command?: string;
+      reason?: string;
+      message?: string;
+      explanation?: string;
+      steps?: string[];
+      added?: string[];
+      modified?: string[];
+      deleted?: string[];
     }) => {
+      if (params.event === "plan") {
+        return {
+          kind: "plan",
+          text: params.explanation ?? params.steps?.[0] ?? params.title ?? "planning",
+          label: "Update plan",
+          toolName: "update_plan",
+        };
+      }
+      if (params.event === "approval") {
+        return {
+          kind: "approval",
+          text: params.command ?? params.message ?? params.reason ?? params.title ?? "approval",
+          label: "Approval",
+          status: "requested",
+          toolName: "approval",
+        };
+      }
       if (params.event === "command-output") {
         const status =
           params.exitCode === 0
@@ -529,6 +583,22 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
           toolName: params.name ?? "exec",
         };
       }
+      if (params.event === "patch") {
+        return {
+          kind: "patch",
+          ...((params.itemId ?? params.toolCallId)
+            ? { id: params.itemId ?? params.toolCallId }
+            : {}),
+          text:
+            params.summary ??
+            params.added?.[0] ??
+            params.modified?.[0] ??
+            params.deleted?.[0] ??
+            "patch",
+          label: params.name ?? "apply_patch",
+          toolName: params.name ?? "apply_patch",
+        };
+      }
       const text = params.progressText ?? params.summary ?? params.title ?? params.name;
       return text
         ? {
@@ -538,6 +608,7 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
               : {}),
             text,
             label: params.title ?? params.name ?? "Update",
+            ...(params.name ? { toolName: params.name } : {}),
           }
         : undefined;
     },
@@ -553,12 +624,14 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
         itemId?: string;
         toolCallId?: string;
         itemKind?: string;
+        phase?: string;
         args?: Record<string, unknown>;
         meta?: string;
         progressText?: string;
         summary?: string;
         title?: string;
         name?: string;
+        status?: string;
       },
     ) => {
       if (params.event === "tool") {
@@ -611,6 +684,8 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
             ...(id ? { id } : {}),
             text,
             label: params.title ?? params.name ?? "Update",
+            ...(params.status ? { status: params.status } : {}),
+            ...(params.name ? { toolName: params.name } : {}),
           }
         : undefined;
     },
@@ -988,6 +1063,19 @@ vi.mock("../reply.runtime.js", () => ({
         deleted?: string[];
         summary?: string;
       }) => Promise<void> | void;
+      onPlanUpdate?: (payload: {
+        phase?: string;
+        title?: string;
+        explanation?: string;
+        steps?: string[];
+      }) => Promise<void> | void;
+      onApprovalEvent?: (payload: {
+        phase?: string;
+        title?: string;
+        command?: string;
+        reason?: string;
+        message?: string;
+      }) => Promise<void> | void;
       onAssistantMessageStart?: () => Promise<void> | void;
       onReasoningEnd?: () => Promise<void> | void;
       onReasoningStream?: (payload?: {
@@ -1043,6 +1131,21 @@ vi.mock("../reply.runtime.js", () => ({
             modified: entry.modified,
             deleted: entry.deleted,
             summary: entry.summary,
+          });
+        } else if (entry.kind === "plan") {
+          await params.replyOptions?.onPlanUpdate?.({
+            phase: entry.phase,
+            title: entry.title,
+            explanation: entry.explanation,
+            steps: entry.steps,
+          });
+        } else if (entry.kind === "approval") {
+          await params.replyOptions?.onApprovalEvent?.({
+            phase: entry.phase,
+            title: entry.title,
+            command: entry.command,
+            reason: entry.reason,
+            message: entry.message,
           });
         } else if (entry.kind === "concurrent_items") {
           await Promise.all(
@@ -1136,6 +1239,19 @@ vi.mock("../reply.runtime.js", () => ({
         deleted?: string[];
         summary?: string;
       }) => Promise<void> | void;
+      onPlanUpdate?: (payload: {
+        phase?: string;
+        title?: string;
+        explanation?: string;
+        steps?: string[];
+      }) => Promise<void> | void;
+      onApprovalEvent?: (payload: {
+        phase?: string;
+        title?: string;
+        command?: string;
+        reason?: string;
+        message?: string;
+      }) => Promise<void> | void;
       onPartialReply?: (payload: { text: string }) => Promise<void> | void;
     };
     dispatcher: {
@@ -1177,6 +1293,21 @@ vi.mock("../reply.runtime.js", () => ({
             modified: entry.modified,
             deleted: entry.deleted,
             summary: entry.summary,
+          });
+        } else if (entry.kind === "plan") {
+          await params.replyOptions?.onPlanUpdate?.({
+            phase: entry.phase,
+            title: entry.title,
+            explanation: entry.explanation,
+            steps: entry.steps,
+          });
+        } else if (entry.kind === "approval") {
+          await params.replyOptions?.onApprovalEvent?.({
+            phase: entry.phase,
+            title: entry.title,
+            command: entry.command,
+            reason: entry.reason,
+            message: entry.message,
           });
         } else if (entry.kind === "concurrent_items") {
           await Promise.all(
@@ -1756,6 +1887,37 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(removeReactionCall[2]).toBe("hourglass_flowing_sand");
     expect(requireRecord(removeReactionCall[3], "remove Slack reaction options").token).toBe(
       "xoxb-test",
+    );
+  });
+
+  it("updates Slack assistant thread status from tool progress callbacks", async () => {
+    const setSlackThreadStatus = vi.fn(async () => undefined);
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      { kind: "tool_start", name: "exec", phase: "start" },
+      { kind: "tool_start", name: "web_search", phase: "start" },
+      { kind: "item", name: "Read", phase: "update", progressText: "package.json" },
+      {
+        kind: "command_output",
+        name: "exec",
+        phase: "end",
+        exitCode: 0,
+      },
+      { kind: "approval", phase: "requested", command: "rm -rf build" },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage({ setSlackThreadStatus }));
+    await requireCapturedTyping().stop?.();
+
+    expect(setSlackThreadStatus.mock.calls.map(([payload]) => payload.status)).toEqual([
+      "Running command...",
+      "Searching the web...",
+      "Reading files...",
+      "Waiting for approval...",
+      "",
+    ]);
+    expect(setSlackThreadStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "Exec..." }),
     );
   });
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -126,6 +126,49 @@ const SLACK_REASONING_TAG_RE =
   /<\s*(\/?)\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 const SLACK_REASONING_LABEL_PREFIX_RE = /^\s*(?:>\s*)?Reasoning:\s*/iu;
 const SLACK_THINKING_LABEL_PREFIX_RE = /^\s*(?:>\s*)?Thinking\.{0,3}(?=\s*(?:\n|_))/iu;
+const SLACK_TOOL_STATUS_LABELS: Record<string, string> = {
+  apply_patch: "Applying patch",
+  bash: "Running command",
+  exec: "Running command",
+  message: "Sending message",
+  memory_search: "Checking memory",
+  read: "Reading files",
+  tts: "Converting to speech",
+  update_plan: "Updating plan",
+  web_fetch: "Fetching URL",
+  web_search: "Searching the web",
+};
+
+function normalizeSlackToolStatusName(name: string | undefined): string | undefined {
+  const normalized = normalizeOptionalLowercaseString(name)?.replace(/-/g, "_");
+  return normalized || undefined;
+}
+
+function sentenceCaseSlackStatus(value: string): string {
+  const normalized = value.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return "Working";
+  }
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+function buildSlackToolStatusText(line: ChannelProgressDraftLine | undefined): string | undefined {
+  if (!line) {
+    return undefined;
+  }
+  if (line.kind === "approval") {
+    return "Waiting for approval...";
+  }
+  const status = normalizeOptionalLowercaseString(line.status);
+  if (status === "completed" || status === "failed" || status?.startsWith("exit ")) {
+    return undefined;
+  }
+  const normalizedToolName = normalizeSlackToolStatusName(line.toolName);
+  const label =
+    (normalizedToolName ? SLACK_TOOL_STATUS_LABELS[normalizedToolName] : undefined) ??
+    sentenceCaseSlackStatus(line.label || line.toolName || line.text);
+  return `${label}...`;
+}
 
 function resolveSlackMessageTimestampMs(message: SlackMessageEvent): number | undefined {
   const ts = message.event_ts ?? message.ts;
@@ -670,6 +713,24 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       },
     },
   });
+  const updateSlackThreadStatusFromProgressLine = async (
+    line: ChannelProgressDraftLine | undefined,
+    options?: { phase?: string },
+  ) => {
+    if (!statusThreadTs || options?.phase === "end") {
+      return;
+    }
+    const status = buildSlackToolStatusText(line);
+    if (!status) {
+      return;
+    }
+    didSetStatus = true;
+    await ctx.setSlackThreadStatus({
+      channelId: message.channel,
+      threadTs: statusThreadTs,
+      status,
+    });
+  };
 
   const slackStreaming = resolveSlackStreamingConfig({
     streaming: account.config.streaming,
@@ -1897,103 +1958,102 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           if (statusReactionsEnabled) {
             await statusReactions.setTool(payload.name);
           }
-          await pushPreviewToolProgress(
-            buildChannelProgressDraftLineForEntry(
-              account.config,
-              {
-                event: "tool",
-                itemId: payload.itemId,
-                toolCallId: payload.toolCallId,
-                name: payload.name,
-                phase: payload.phase,
-                args: payload.args,
-              },
-              payload.detailMode ? { detailMode: payload.detailMode } : undefined,
-            ),
-            { toolName: payload.name },
-          );
-        },
-        onItemEvent: async (payload) => {
-          await pushPreviewToolProgress(
-            buildChannelProgressDraftLineForEntry(account.config, {
-              event: "item",
+          const line = buildChannelProgressDraftLineForEntry(
+            account.config,
+            {
+              event: "tool",
               itemId: payload.itemId,
               toolCallId: payload.toolCallId,
-              itemKind: payload.kind,
-              title: payload.title,
               name: payload.name,
               phase: payload.phase,
-              status: payload.status,
-              summary: payload.summary,
-              progressText: payload.progressText,
-              meta: payload.meta,
-            }),
+              args: payload.args,
+            },
+            payload.detailMode ? { detailMode: payload.detailMode } : undefined,
           );
+          await updateSlackThreadStatusFromProgressLine(line, { phase: payload.phase });
+          await pushPreviewToolProgress(line, { toolName: payload.name });
+        },
+        onItemEvent: async (payload) => {
+          const line = buildChannelProgressDraftLineForEntry(account.config, {
+            event: "item",
+            itemId: payload.itemId,
+            toolCallId: payload.toolCallId,
+            itemKind: payload.kind,
+            title: payload.title,
+            name: payload.name,
+            phase: payload.phase,
+            status: payload.status,
+            summary: payload.summary,
+            progressText: payload.progressText,
+            meta: payload.meta,
+          });
+          await updateSlackThreadStatusFromProgressLine(line, { phase: payload.phase });
+          await pushPreviewToolProgress(line);
         },
         onPlanUpdate: async (payload) => {
           if (payload.phase !== "update") {
             return;
           }
-          await pushPreviewToolProgress(
-            buildChannelProgressDraftLine({
-              event: "plan",
-              phase: payload.phase,
-              title: payload.title,
-              explanation: payload.explanation,
-              steps: payload.steps,
-            }),
-          );
+          const line = buildChannelProgressDraftLine({
+            event: "plan",
+            phase: payload.phase,
+            title: payload.title,
+            explanation: payload.explanation,
+            steps: payload.steps,
+          });
+          await updateSlackThreadStatusFromProgressLine(line, { phase: payload.phase });
+          await pushPreviewToolProgress(line);
         },
         onApprovalEvent: async (payload) => {
           if (payload.phase !== "requested") {
             return;
           }
-          await pushPreviewToolProgress(
-            buildChannelProgressDraftLine({
-              event: "approval",
-              phase: payload.phase,
-              title: payload.title,
-              command: payload.command,
-              reason: payload.reason,
-              message: payload.message,
-            }),
-          );
+          const line = buildChannelProgressDraftLine({
+            event: "approval",
+            phase: payload.phase,
+            title: payload.title,
+            command: payload.command,
+            reason: payload.reason,
+            message: payload.message,
+          });
+          await updateSlackThreadStatusFromProgressLine(line, { phase: payload.phase });
+          await pushPreviewToolProgress(line);
         },
         onCommandOutput: async (payload) => {
           if (payload.phase !== "end") {
             return;
           }
-          await pushPreviewToolProgress(
-            buildChannelProgressDraftLine({
-              event: "command-output",
-              itemId: payload.itemId,
-              toolCallId: payload.toolCallId,
-              phase: payload.phase,
-              title: payload.title,
-              name: payload.name,
-              status: payload.status,
-              exitCode: payload.exitCode,
-            }),
-          );
+          const line = buildChannelProgressDraftLine({
+            event: "command-output",
+            itemId: payload.itemId,
+            toolCallId: payload.toolCallId,
+            phase: payload.phase,
+            title: payload.title,
+            name: payload.name,
+            status: payload.status,
+            exitCode: payload.exitCode,
+          });
+          await updateSlackThreadStatusFromProgressLine(line, { phase: payload.phase });
+          await pushPreviewToolProgress(line);
         },
         onPatchSummary: async (payload) => {
           if (payload.phase !== "end") {
             return;
           }
-          await pushPreviewToolProgress(
-            buildChannelProgressDraftLine({
-              event: "patch",
-              itemId: payload.itemId,
-              toolCallId: payload.toolCallId,
-              phase: payload.phase,
-              title: payload.title,
-              name: payload.name,
-              added: payload.added,
-              modified: payload.modified,
-              deleted: payload.deleted,
-              summary: payload.summary,
-            }),
-          );
+          const line = buildChannelProgressDraftLine({
+            event: "patch",
+            itemId: payload.itemId,
+            toolCallId: payload.toolCallId,
+            phase: payload.phase,
+            title: payload.title,
+            name: payload.name,
+            added: payload.added,
+            modified: payload.modified,
+            deleted: payload.deleted,
+            summary: payload.summary,
+          });
+          await updateSlackThreadStatusFromProgressLine(line, { phase: payload.phase });
+          await pushPreviewToolProgress(line);
         },
       },
     });


### PR DESCRIPTION
What Problem This Solves
Fixes #33413. Slack assistant thread status stayed on a generic typing indicator during long agent runs, so users could not tell whether OpenClaw was running a command, searching the web, reading files, or waiting on approval.

Why This Change Was Made
Slack already receives structured tool progress callbacks in the dispatch layer. This change reuses those progress lines to set short assistant thread status labels, maps common tool names to user-readable text, skips terminal end events, and keeps the existing status clear path when the run finishes. It avoids adding a new config surface.

User Impact
Slack assistant threads now show labels such as `Running command...`, `Searching the web...`, `Reading files...`, and `Waiting for approval...` while work is happening. Channels without a reply thread keep the existing behavior, and the status is still cleared at the end of the run.

Evidence
- `node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/slack/src/monitor.tool-result.test.ts`
- `node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`
- `./node_modules/.bin/oxfmt.cmd --check --threads=1 extensions/slack/src/monitor/message-handler/dispatch.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`
- `./node_modules/.bin/oxfmt.cmd --check --threads=1 docs/channels/slack.md`
- `git diff --check`