### PR TITLE
fix: detect Cloudflare Sandbox containers

### DIFF
--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -265,6 +265,39 @@ describe("gateway bonjour advertiser", () => {
     await expect(started.stop()).resolves.toBeUndefined();
   });
 
+  it("auto-disables Bonjour in Cloudflare Cloudchamber containers", async () => {
+    enableAdvertiserUnitMode();
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci\n",
+    );
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    expect(createService).not.toHaveBeenCalled();
+    await expect(started.stop()).resolves.toBeUndefined();
+  });
+
+  it("does not treat cloudchamber.service as a container marker", async () => {
+    enableAdvertiserUnitMode();
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    vi.spyOn(fs, "readFileSync").mockReturnValue("0::/system.slice/cloudchamber.service\n");
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    expect(createService).toHaveBeenCalledTimes(1);
+    await started.stop();
+  });
+
   it("honors explicit Bonjour opt-in inside detected containers", async () => {
     enableAdvertiserUnitMode();
     vi.stubEnv("OPENCLAW_DISABLE_BONJOUR", "0");

--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -265,12 +265,15 @@ describe("gateway bonjour advertiser", () => {
     await expect(started.stop()).resolves.toBeUndefined();
   });
 
-  it("auto-disables Bonjour in Cloudflare Cloudchamber containers", async () => {
+  it.each([
+    "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci",
+    "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci\n1:name=/",
+    "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci\r\n1:name=/",
+    "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci/openclaw\n",
+  ])("auto-disables Bonjour for a Cloudflare Cloudchamber marker: %s", async (cgroup) => {
     enableAdvertiserUnitMode();
     vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    vi.spyOn(fs, "readFileSync").mockReturnValue(
-      "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci\n",
-    );
+    vi.spyOn(fs, "readFileSync").mockReturnValue(cgroup);
 
     const started = await startAdvertiser({
       gatewayPort: 18789,
@@ -280,6 +283,30 @@ describe("gateway bonjour advertiser", () => {
     expect(createService).not.toHaveBeenCalled();
     await expect(started.stop()).resolves.toBeUndefined();
   });
+
+  it.each([
+    "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci.service\n",
+    "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci-extra\n",
+    "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci\tjunk\n",
+  ])(
+    "does not treat a non-terminal Cloudchamber _oci marker as a container: %s",
+    async (cgroup) => {
+      enableAdvertiserUnitMode();
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      vi.spyOn(fs, "readFileSync").mockReturnValue(cgroup);
+      const destroy = vi.fn().mockResolvedValue(undefined);
+      const advertise = vi.fn().mockResolvedValue(undefined);
+      mockCiaoService({ advertise, destroy });
+
+      const started = await startAdvertiser({
+        gatewayPort: 18789,
+        sshPort: 2222,
+      });
+
+      expect(createService).toHaveBeenCalledTimes(1);
+      await started.stop();
+    },
+  );
 
   it("does not treat cloudchamber.service as a container marker", async () => {
     enableAdvertiserUnitMode();

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -83,7 +83,7 @@ function isContainerEnvironment() {
 
   try {
     const cgroup = fs.readFileSync("/proc/1/cgroup", "utf8");
-    return /\/docker\/|cri-containerd-[0-9a-f]|containerd\/[0-9a-f]{64}|\/kubepods[/.]|\blxc\b/u.test(
+    return /\/docker\/|cri-containerd-[0-9a-f]|containerd\/[0-9a-f]{64}|\/cloudchamber(?:_[A-Za-z0-9]+)?\/[^/\s]+_oci\b|\/kubepods[/.]|\blxc\b/u.test(
       cgroup,
     );
   } catch {

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -83,7 +83,7 @@ function isContainerEnvironment() {
 
   try {
     const cgroup = fs.readFileSync("/proc/1/cgroup", "utf8");
-    return /\/docker\/|cri-containerd-[0-9a-f]|containerd\/[0-9a-f]{64}|\/cloudchamber(?:_[A-Za-z0-9]+)?\/[^/\s]+_oci\b|\/kubepods[/.]|\blxc\b/u.test(
+    return /\/docker\/|cri-containerd-[0-9a-f]|containerd\/[0-9a-f]{64}|\/cloudchamber(?:_[A-Za-z0-9]+)?\/[^/\s]+_oci(?=\/|\r?\n|$)|\/kubepods[/.]|\blxc\b/u.test(
       cgroup,
     );
   } catch {

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -637,6 +637,26 @@ describe("isContainerEnvironment", () => {
     expect(isContainerEnvironment()).toBe(true);
   });
 
+  it("returns true when /proc/1/cgroup contains Cloudflare Cloudchamber container marker", () => {
+    const fs = require("node:fs");
+    vi.spyOn(fs, "accessSync").mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci\n",
+    );
+    expect(isContainerEnvironment()).toBe(true);
+  });
+
+  it("returns false when /proc/1/cgroup contains cloudchamber.service (host machine)", () => {
+    const fs = require("node:fs");
+    vi.spyOn(fs, "accessSync").mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    vi.spyOn(fs, "readFileSync").mockReturnValue("0::/system.slice/cloudchamber.service\n");
+    expect(isContainerEnvironment()).toBe(false);
+  });
+
   it("returns false when /proc/1/cgroup contains containerd.service (host machine)", () => {
     const fs = require("node:fs");
     vi.spyOn(fs, "accessSync").mockImplementation(() => {

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -637,15 +637,43 @@ describe("isContainerEnvironment", () => {
     expect(isContainerEnvironment()).toBe(true);
   });
 
-  it("returns true when /proc/1/cgroup contains Cloudflare Cloudchamber container marker", () => {
+  it.each([
+    {
+      name: "at EOF",
+      cgroup: "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci",
+    },
+    {
+      name: "before LF",
+      cgroup: "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci\n1:name=/",
+    },
+    {
+      name: "before CRLF",
+      cgroup: "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci\r\n1:name=/",
+    },
+    {
+      name: "before a descendant path",
+      cgroup: "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci/openclaw\n",
+    },
+  ])("returns true for a Cloudflare Cloudchamber marker $name", ({ cgroup }) => {
     const fs = require("node:fs");
     vi.spyOn(fs, "accessSync").mockImplementation(() => {
       throw new Error("ENOENT");
     });
-    vi.spyOn(fs, "readFileSync").mockReturnValue(
-      "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci\n",
-    );
+    vi.spyOn(fs, "readFileSync").mockReturnValue(cgroup);
     expect(isContainerEnvironment()).toBe(true);
+  });
+
+  it.each([
+    "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci.service\n",
+    "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci-extra\n",
+    "0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci\tjunk\n",
+  ])("returns false for a non-terminal Cloudchamber _oci marker: %s", (cgroup) => {
+    const fs = require("node:fs");
+    vi.spyOn(fs, "accessSync").mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    vi.spyOn(fs, "readFileSync").mockReturnValue(cgroup);
+    expect(isContainerEnvironment()).toBe(false);
   });
 
   it("returns false when /proc/1/cgroup contains cloudchamber.service (host machine)", () => {

--- a/src/infra/container-environment.ts
+++ b/src/infra/container-environment.ts
@@ -39,7 +39,7 @@ function detectContainerEnvironment(): boolean {
   try {
     const cgroup = fs.readFileSync("/proc/1/cgroup", "utf8");
     if (
-      /\/docker\/|cri-containerd-[0-9a-f]|containerd\/[0-9a-f]{64}|\/kubepods[/.]|\blxc\b/.test(
+      /\/docker\/|cri-containerd-[0-9a-f]|containerd\/[0-9a-f]{64}|\/cloudchamber(?:_[A-Za-z0-9]+)?\/[^/\s]+_oci\b|\/kubepods[/.]|\blxc\b/.test(
         cgroup,
       )
     ) {

--- a/src/infra/container-environment.ts
+++ b/src/infra/container-environment.ts
@@ -39,7 +39,7 @@ function detectContainerEnvironment(): boolean {
   try {
     const cgroup = fs.readFileSync("/proc/1/cgroup", "utf8");
     if (
-      /\/docker\/|cri-containerd-[0-9a-f]|containerd\/[0-9a-f]{64}|\/cloudchamber(?:_[A-Za-z0-9]+)?\/[^/\s]+_oci\b|\/kubepods[/.]|\blxc\b/.test(
+      /\/docker\/|cri-containerd-[0-9a-f]|containerd\/[0-9a-f]{64}|\/cloudchamber(?:_[A-Za-z0-9]+)?\/[^/\s]+_oci(?=\/|\r?\n|$)|\/kubepods[/.]|\blxc\b/.test(
         cgroup,
       )
     ) {


### PR DESCRIPTION
Closes #96484

AI-assisted: yes. I understand the change and validated it with the focused repo commands below.

## What Problem This Solves

Fixes an issue where users running OpenClaw inside Cloudflare Sandbox / Cloudchamber containers would have the runtime treated as a non-container host when the usual Docker/container sentinel files are absent.

The observed Cloudflare cgroup shape is:

```text
0::/cloudchamber_v2/00000000-0000-0000-0000-000000000000_oci
```

## Why This Change Was Made

The container detector now recognizes a narrow Cloudchamber cgroup path segment with an `_oci` runtime suffix, matching the reported Cloudflare Sandbox shape without broadly matching host service names. The Bonjour plugin's sibling detector uses the same signal so container auto-disable behavior stays aligned with the shared detector.

This intentionally does not change restart policy, bind defaults, config, or any non-Cloudchamber container signals.

## User Impact

OpenClaw deployments inside Cloudflare Sandbox / Cloudchamber containers can now use the existing container-aware behavior instead of relying on unmanaged-host fallback behavior or local wrapper-specific mitigations.

Host machines with unrelated `cloudchamber.service` cgroup entries are not classified as containers by this change.

## Evidence

Latest refresh after rebasing onto current `main`:

```text
Head SHA: fcceeb040173488d81cbdf6ea314e758b1d6fac1
Base SHA: 5f63f744eadf214c40edc7326f105985af25bbf3

$ node scripts/run-vitest.mjs src/gateway/net.test.ts
128 passed, 1 failed (baseline-only)

$ node scripts/run-vitest.mjs extensions/bonjour/src/advertiser.test.ts
24 passed

$ node scripts/run-vitest.mjs src/infra/process-respawn.test.ts
30 passed

The single gateway failure ("returns 127.0.0.1 for auto mode on non-container host")
reproduces unchanged on current origin/main: 126 passed, 1 failed.

$ node_modules/.bin/oxfmt --check --threads=1 src/infra/container-environment.ts src/gateway/net.test.ts extensions/bonjour/src/advertiser.ts extensions/bonjour/src/advertiser.test.ts
All matched files use the correct format.

$ git diff --check origin/main...HEAD
PASS

$ scripts/run-opengrep.sh --changed --sarif --error
Ran 111 rules on 4 files: 0 findings.
```

Original Magno / Ubuntu 22 Node environment proof:

```text
$ node --version
v22.22.3

$ corepack pnpm install --frozen-lockfile
Done in 34.4s using pnpm v11.2.2

$ node scripts/run-vitest.mjs src/gateway/net.test.ts extensions/bonjour/src/advertiser.test.ts src/infra/process-respawn.test.ts
[test] passed 3 Vitest shards in 19.69s
gateway net: 504 passed
infra process-respawn: 25 passed
bonjour advertiser: 31 passed

$ corepack pnpm exec oxfmt --check --threads=1 src/infra/container-environment.ts src/gateway/net.test.ts extensions/bonjour/src/advertiser.ts extensions/bonjour/src/advertiser.test.ts
All matched files use the correct format.

$ git diff --check
PASS

$ scripts/run-opengrep.sh --changed --sarif --error
Ran 111 rules on 4 files: 0 findings.
```

Remaining proof gap from ClawSweeper: I still need redacted live Cloudflare Sandbox / Cloudchamber output showing `/proc/1/cgroup` and the patched detector returning `container=true`, or maintainer acceptance of the linked reporter sample plus focused tests.

Additional contributor check attempted:

```text
$ codex review --base origin/main
BLOCKED: local Codex CLI auth returned 401 Unauthorized before review could run.
```