### PR TITLE
fix(cron): reject invalid no-output timeout

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -658,6 +658,29 @@ describe("cron cli", () => {
     },
   );
 
+  it.each(["abc", "0"])(
+    "rejects invalid cron add --no-output-timeout-seconds value %j",
+    async (noOutputTimeoutSeconds) => {
+      await expectCronCommandExit([
+        "cron",
+        "add",
+        "--name",
+        "Invalid no-output timeout",
+        "--every",
+        "10m",
+        "--command",
+        "echo ok",
+        "--no-output-timeout-seconds",
+        noOutputTimeoutSeconds,
+      ]);
+
+      expectRuntimeErrorContaining(
+        "Invalid --no-output-timeout-seconds (must be a positive integer).",
+      );
+      expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.add")).toBe(false);
+    },
+  );
+
   it("rejects cron add with both message and command payloads", async () => {
     await expectCronCommandExit([
       "cron",

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -658,26 +658,26 @@ describe("cron cli", () => {
     },
   );
 
-  it.each(["abc", "0"])(
-    "rejects invalid cron add --no-output-timeout-seconds value %j",
-    async (noOutputTimeoutSeconds) => {
-      await expectCronCommandExit([
-        "cron",
-        "add",
-        "--name",
-        "Invalid no-output timeout",
-        "--every",
-        "10m",
-        "--command",
-        "echo ok",
-        "--no-output-timeout-seconds",
-        noOutputTimeoutSeconds,
-      ]);
+  describe.each(["--no-output-timeout-seconds", "--output-max-bytes"])(
+    "cron add %s validation",
+    (flag) => {
+      it.each(["", "0", "-1", "1.5", "1000ms"])("rejects invalid value %j", async (value) => {
+        await expectCronCommandExit([
+          "cron",
+          "add",
+          "--name",
+          "Invalid command limit",
+          "--every",
+          "10m",
+          "--command",
+          "echo ok",
+          flag,
+          value,
+        ]);
 
-      expectRuntimeErrorContaining(
-        "Invalid --no-output-timeout-seconds (must be a positive integer).",
-      );
-      expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.add")).toBe(false);
+        expectRuntimeErrorContaining(`Invalid ${flag} (must be a positive integer).`);
+        expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.add")).toBe(false);
+      });
     },
   );
 

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -10,10 +10,7 @@ import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
-import {
-  parsePositiveIntOrUndefined,
-  parseStrictPositiveIntOrUndefined,
-} from "../program/helpers.js";
+import { parseStrictPositiveIntOrUndefined } from "../program/helpers.js";
 import { resolveCronCreateScheduleFromArgs } from "./schedule-options.js";
 import {
   getCronChannelOptions,
@@ -243,7 +240,10 @@ export function registerCronAddCommand(cron: Command) {
                     "Invalid --no-output-timeout-seconds (must be a positive integer).",
                   );
                 }
-                const outputMaxBytes = parsePositiveIntOrUndefined(opts.outputMaxBytes);
+                const outputMaxBytes = parseStrictPositiveIntOrUndefined(opts.outputMaxBytes);
+                if (opts.outputMaxBytes !== undefined && outputMaxBytes === undefined) {
+                  throw new Error("Invalid --output-max-bytes (must be a positive integer).");
+                }
                 return {
                   kind: "command" as const,
                   argv: commandArgv ?? ["sh", "-lc", commandShell ?? ""],

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -234,7 +234,15 @@ export function registerCronAddCommand(cron: Command) {
                     ? opts.outputTimeoutSeconds
                     : undefined);
                 const noOutputTimeoutSeconds =
-                  parsePositiveIntOrUndefined(rawNoOutputTimeoutSeconds);
+                  parseStrictPositiveIntOrUndefined(rawNoOutputTimeoutSeconds);
+                if (
+                  rawNoOutputTimeoutSeconds !== undefined &&
+                  noOutputTimeoutSeconds === undefined
+                ) {
+                  throw new Error(
+                    "Invalid --no-output-timeout-seconds (must be a positive integer).",
+                  );
+                }
                 const outputMaxBytes = parsePositiveIntOrUndefined(opts.outputMaxBytes);
                 return {
                   kind: "command" as const,


### PR DESCRIPTION
## What Problem This Solves

`cron add` accepted invalid command `--no-output-timeout-seconds` values such as `abc` or `0` and silently omitted the timeout from the created job.

## Why This Change Was Made

The command payload parser now matches `cron edit`: if a no-output timeout option is explicitly provided but cannot be parsed as a positive integer, the CLI rejects the command before calling `cron.add`.

## User Impact

Users get an immediate validation error instead of creating a cron job that does not include the requested no-output timeout.

## Evidence

- RED: `pnpm test src/cli/cron-cli.test.ts` failed before the fix because the new invalid `--no-output-timeout-seconds` cases resolved instead of rejecting.
- GREEN: `pnpm test src/cli/cron-cli.test.ts` passed after the fix: `98 passed`.
- Lint: `npx oxlint --deny=warn --ignore-path=.oxlintignore src/cli/cron-cli.test.ts src/cli/cron-cli/register.cron-add.ts` passed.
- Whitespace: `git diff --check -- src/cli/cron-cli.test.ts src/cli/cron-cli/register.cron-add.ts` passed.
- CLI proof:

```console
$ pnpm openclaw cron add --name "Invalid no-output timeout" --every 10m --command "echo ok" --no-output-timeout-seconds abc --no-deliver
Error: Invalid --no-output-timeout-seconds (must be a positive integer).
```