### PR TITLE
fix(memory-core): route dreaming corpus through session metadata

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1987,6 +1987,78 @@ describe("memory-core dreaming phases", () => {
     expect(newOccurrences).toBe(1);
   });
 
+  it("skips reset/deleted archive artifacts without active transcripts during session ingestion", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const archivePath = path.join(
+      sessionsDir,
+      "archived-only.jsonl.deleted.2026-04-06T01-00-00.000Z",
+    );
+    await fs.writeFile(
+      archivePath,
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:01:00.000Z",
+            content: [{ type: "text", text: "Archived session should not be dreamed." }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const mtime = new Date("2026-04-06T01:05:00.000Z");
+    await fs.utimes(archivePath, mtime, mtime);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await withDreamingTestClock(async () => {
+        await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    await expectPathMissing(
+      path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-05.txt"),
+    );
+
+    const sessionIngestion = await testing.readSessionIngestionState(workspaceDir);
+    expect(Object.keys(sessionIngestion.files)).toHaveLength(0);
+  });
+
   it("buckets session snippets by per-message day rather than file mtime", async () => {
     const workspaceDir = await createDreamingWorkspace();
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -848,7 +848,12 @@ async function collectSessionIngestionBatches(params: {
   for (const agentId of agentIds) {
     for (const entry of await listSessionTranscriptCorpusEntriesForAgent(agentId)) {
       const absolutePath = entry.sessionFile;
-      if (isCheckpointSessionTranscriptPath(absolutePath)) {
+      if (
+        // Dreaming learns only from the live corpus. Retained reset/delete
+        // archives stay in the shared corpus for QMD and memory_search.
+        entry.artifactKind === "archive-artifact" ||
+        isCheckpointSessionTranscriptPath(absolutePath)
+      ) {
         continue;
       }
       sessionFiles.push({

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -158,6 +158,91 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
     });
   });
 
+  it("classifies active entries through cron parentage chains", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    const cronPath = path.join(sessionsDir, "cron-run.jsonl");
+    const spawnedChildPath = path.join(sessionsDir, "spawned-child.jsonl");
+    const keyedChildPath = path.join(sessionsDir, "keyed-child.jsonl");
+    const orphanChildPath = path.join(sessionsDir, "orphan-child.jsonl");
+    const normalPath = path.join(sessionsDir, "normal-child.jsonl");
+    for (const filePath of [
+      cronPath,
+      spawnedChildPath,
+      keyedChildPath,
+      orphanChildPath,
+      normalPath,
+    ]) {
+      fsSync.writeFileSync(filePath, "");
+    }
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:cron:job-1:run:run-1": {
+          sessionFile: "cron-run.jsonl",
+          sessionId: "cron-run",
+        },
+        "agent:main:subagent:spawned-child": {
+          sessionFile: "spawned-child.jsonl",
+          sessionId: "spawned-child",
+          spawnedBy: "agent:main:cron:job-1:run:run-1",
+        },
+        "agent:main:subagent:keyed-child": {
+          parentSessionKey: "agent:main:subagent:spawned-child",
+          sessionFile: "keyed-child.jsonl",
+          sessionId: "keyed-child",
+        },
+        "agent:main:subagent:orphan-child": {
+          sessionFile: "orphan-child.jsonl",
+          sessionId: "orphan-child",
+          spawnedBy: "agent:main:cron:job-1:run:missing",
+        },
+        "agent:main:subagent:normal-child": {
+          sessionFile: "normal-child.jsonl",
+          sessionId: "normal-child",
+          spawnedBy: "agent:main:chat:manual",
+        },
+      }),
+    );
+
+    const classification = loadSessionTranscriptClassificationForAgent("main");
+
+    expect(classification.cronRunTranscriptPaths).toEqual(
+      new Set(
+        [cronPath, spawnedChildPath, keyedChildPath, orphanChildPath].map((filePath) =>
+          path.resolve(filePath),
+        ),
+      ),
+    );
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          generatedByCronRun: true,
+          sessionFile: spawnedChildPath,
+          sessionKey: "agent:main:subagent:spawned-child",
+        }),
+        expect.objectContaining({
+          generatedByCronRun: true,
+          sessionFile: keyedChildPath,
+          sessionKey: "agent:main:subagent:keyed-child",
+        }),
+        expect.objectContaining({
+          generatedByCronRun: true,
+          sessionFile: orphanChildPath,
+          sessionKey: "agent:main:subagent:orphan-child",
+        }),
+        expect.objectContaining({
+          sessionFile: normalPath,
+          sessionKey: "agent:main:subagent:normal-child",
+        }),
+      ]),
+    );
+    const entries = await listSessionTranscriptCorpusEntriesForAgent("main");
+    expect(entries.find((entry) => entry.sessionFile === normalPath)?.generatedByCronRun).toBe(
+      undefined,
+    );
+  });
+
   it("keeps archive classification when the active transcript is missing", async () => {
     const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
     fsSync.mkdirSync(sessionsDir, { recursive: true });

--- a/packages/memory-host-sdk/src/host/session-transcript-corpus.ts
+++ b/packages/memory-host-sdk/src/host/session-transcript-corpus.ts
@@ -58,10 +58,6 @@ function isDreamingNarrativeSessionKeyLike(value: unknown): boolean {
   return typeof value === "string" && isDreamingNarrativeSessionStoreKey(value);
 }
 
-function hasCronRunSessionKey(value: unknown): boolean {
-  return typeof value === "string" && isCronRunSessionKey(value);
-}
-
 function normalizeComparablePath(pathname: string): string {
   const resolved = path.resolve(pathname);
   return process.platform === "win32" ? resolved.toLowerCase() : resolved;
@@ -163,6 +159,7 @@ function resolveSessionStoreTranscriptCorpusPath(
 function classifySessionEntry(
   sessionKey: string,
   entry: SessionEntry,
+  cronGeneratedSessionKeys: ReadonlySet<string>,
 ): {
   generatedByDreamingNarrative: boolean;
   generatedByCronRun: boolean;
@@ -171,8 +168,67 @@ function classifySessionEntry(
     generatedByDreamingNarrative:
       isDreamingNarrativeSessionStoreKey(sessionKey) ||
       isDreamingNarrativeSessionKeyLike(entry.spawnedBy),
-    generatedByCronRun: isCronRunSessionKey(sessionKey) || hasCronRunSessionKey(entry.spawnedBy),
+    generatedByCronRun: cronGeneratedSessionKeys.has(sessionKey),
   };
+}
+
+function readParentSessionKeys(entry: SessionEntry | undefined): string[] {
+  const keys = new Set<string>();
+  for (const value of [entry?.parentSessionKey, entry?.spawnedBy]) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) {
+      keys.add(trimmed);
+    }
+  }
+  return [...keys];
+}
+
+function collectCronGeneratedSessionKeys(
+  summaries: readonly SessionEntrySummary[],
+): ReadonlySet<string> {
+  // Build the cron-generated closure once so active entries and archive
+  // artifacts share the same lineage classification.
+  const entriesByKey = new Map(summaries.map((summary) => [summary.sessionKey, summary.entry]));
+  const cronGeneratedKeys = new Set<string>();
+  const cache = new Map<string, boolean>();
+  const resolving = new Set<string>();
+
+  const isCronGenerated = (sessionKey: string, entry: SessionEntry | undefined): boolean => {
+    if (isCronRunSessionKey(sessionKey)) {
+      cache.set(sessionKey, true);
+      cronGeneratedKeys.add(sessionKey);
+      return true;
+    }
+    const cached = cache.get(sessionKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+    if (resolving.has(sessionKey)) {
+      return false;
+    }
+
+    resolving.add(sessionKey);
+    const generated = readParentSessionKeys(entry).some(
+      (parentKey) =>
+        // Parent rows can be pruned before child rows; a cron-shaped parent key
+        // still carries cron lineage without requiring a store entry.
+        isCronRunSessionKey(parentKey) || isCronGenerated(parentKey, entriesByKey.get(parentKey)),
+    );
+    resolving.delete(sessionKey);
+    cache.set(sessionKey, generated);
+    if (generated) {
+      cronGeneratedKeys.add(sessionKey);
+    }
+    return generated;
+  };
+
+  for (const summary of summaries) {
+    isCronGenerated(summary.sessionKey, summary.entry);
+  }
+  return cronGeneratedKeys;
 }
 
 function isRegularSessionTranscriptFile(absPath: string): boolean {
@@ -187,6 +243,7 @@ function toSessionStoreCorpusEntry(
   agentId: string,
   sessionsDir: string,
   summary: SessionEntrySummary,
+  cronGeneratedSessionKeys: ReadonlySet<string>,
 ): SessionTranscriptCorpusEntry | null {
   const sessionFile = resolveSessionStoreTranscriptCorpusPath(agentId, sessionsDir, summary.entry);
   if (!sessionFile || !isUsageCountedSessionTranscriptFileName(path.basename(sessionFile))) {
@@ -200,7 +257,11 @@ function toSessionStoreCorpusEntry(
     return null;
   }
   const sessionKey = summary.sessionKey.trim();
-  const classification = classifySessionEntry(summary.sessionKey, summary.entry);
+  const classification = classifySessionEntry(
+    summary.sessionKey,
+    summary.entry,
+    cronGeneratedSessionKeys,
+  );
   return {
     agentId,
     artifactKind: "active-session",
@@ -299,11 +360,13 @@ export function listSessionTranscriptCorpusEntriesForAgentSync(
   const activeEntryOwnersByPath = new Map<string, string>();
   const artifactDirsByPath = new Map<string, string>();
   rememberArtifactDir(artifactDirsByPath, sessionsDir);
-  for (const summary of listSessionEntries({
+  const sessionEntries = listSessionEntries({
     agentId: normalizedAgentId,
     hydrateSkillPromptRefs: false,
     storePath,
-  })) {
+  });
+  const cronGeneratedSessionKeys = collectCronGeneratedSessionKeys(sessionEntries);
+  for (const summary of sessionEntries) {
     const sessionKey = isSharedFixedStore
       ? summary.sessionKey
       : canonicalizeMainSessionAlias({
@@ -316,7 +379,12 @@ export function listSessionTranscriptCorpusEntriesForAgentSync(
       sessionKey,
       ...(isSharedFixedStore ? {} : { fallbackAgentId: normalizedAgentId }),
     });
-    const entry = toSessionStoreCorpusEntry(ownerAgentId, sessionsDir, summary);
+    const entry = toSessionStoreCorpusEntry(
+      ownerAgentId,
+      sessionsDir,
+      summary,
+      cronGeneratedSessionKeys,
+    );
     if (!entry) {
       continue;
     }

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -128,6 +128,7 @@ export const migratedBundledPluginSessionAccessorFiles = new Set([
   "extensions/discord/src/monitor/native-command-model-picker-apply.ts",
   "extensions/discord/src/monitor/thread-session-close.ts",
   "extensions/feishu/src/reasoning-preview.ts",
+  "extensions/memory-core/src/dreaming-phases.ts",
   "extensions/memory-core/src/dreaming-narrative.ts",
   "extensions/mattermost/src/mattermost/model-picker.ts",
   "extensions/telegram/src/bot-handlers.runtime.ts",

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -82,6 +82,7 @@ describe("session accessor boundary guard", () => {
         "extensions/discord/src/monitor/native-command-model-picker-apply.ts",
         "extensions/discord/src/monitor/thread-session-close.ts",
         "extensions/feishu/src/reasoning-preview.ts",
+        "extensions/memory-core/src/dreaming-phases.ts",
         "extensions/memory-core/src/dreaming-narrative.ts",
         "extensions/mattermost/src/mattermost/model-picker.ts",
         "extensions/telegram/src/bot-handlers.runtime.ts",


### PR DESCRIPTION
## What Problem This Solves

This PR closes the remaining Path 3 3.1b memory-host session corpus follow-up for the Dreaming corpus defects reported in #90313. It keeps retained reset/delete archive artifacts available to the shared memory-host transcript corpus for QMD and `memory_search`, while preventing Dreaming from re-ingesting those archives, and it classifies cron-descended child transcripts through existing session metadata.

## Why This Change Was Made

#93187 found the right bug class, but it pulled the fix through legacy helper surfaces and SDK export churn. This maintainer-owned slice keeps the owner boundary on the existing session transcript corpus seam in `packages/memory-host-sdk`, avoids a new SDK API or SQLite contract, and adds the ratchet coverage needed for the Path 3 tracker.

## User Impact

Dreaming session-corpus files stop filling with reset/delete archive duplicates and cron-spawned child transcript noise. Shared corpus consumers still see archive artifacts where they are expected, so historical transcript search behavior is preserved.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plugin-sdk-surface-report.test.ts packages/memory-host-sdk/src/host/session-files.test.ts extensions/memory-core/src/dreaming-phases.test.ts test/scripts/check-session-accessor-boundary.test.ts` - passed on rebased head `cc7fac26ee9` (72 unit/script tests + 48 memory-core extension tests).
- `node scripts/check-session-accessor-boundary.mjs` - passed.
- `node scripts/plugin-sdk-surface-report.mjs --check` - passed.
- `pnpm exec oxfmt --check --threads=1 ...` - passed for all changed files.
- `node scripts/run-oxlint.mjs ...` - passed for all changed files.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json ...` - passed.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json ...` - passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.packages.json ...` - passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json ...` - passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json ...` - passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main ...` - clean, no accepted/actionable findings; overall patch correct (0.84).
- CI attribution: old head `3d88a034986` failed `checks-node-compact-small-whole-2` in `test/scripts/plugin-sdk-surface-report.test.ts` with `expected +0 to be 1` at line 103. That check was unrelated to this PR's touched files and was fixed upstream by `d01c2906015 test(sdk): assert surface budget growth guard` and `5eec2158ea0 fix(sdk): restore post-build surface budgets`; this branch was rebased to inherit those fixes and pushed as `cc7fac26ee9`. GitHub CI is now green on `cc7fac26ee9` with merge state `CLEAN` (69 successful checks, 29 skipped, CodeQL neutral, no pending or failing checks).

## Real behavior proof

Behavior addressed: Dreaming learns only from live non-cron session transcripts while the shared memory-host session corpus still exposes retained reset/delete archive artifacts for QMD and `memory_search`.

Real environment tested: Local live OpenClaw gateway from `/Users/phaedrus/Projects/clawdbot`, temporarily loaded with pre-rebase proof SHA `7e3590a3f897a536e98905774ad948e49bfddbdd`, OpenClaw `2026.6.10 (7e3590a)`, then restored to the original detached checkout `352c4a40d838d7deb0bfdf38fa33665aef00be72`. Rebased PR head is `cc7fac26ee980af61c53cb2501c2e4a301ad18be`; focused post-rebase tests/checks above passed after the conflict-free code rebase.

Exact steps or command run after this patch:

```bash
cd /Users/phaedrus/Projects/clawdbot
git status -sb
git rev-parse HEAD
pnpm openclaw gateway status --deep
pnpm openclaw gateway call health --json --timeout 10000
curl -fsS http://127.0.0.1:18789/readyz
curl -fsS http://127.0.0.1:18789/healthz
git fetch /Users/phaedrus/.codex/worktrees/405b/clawdbot josh/path3-memory-host-session-corpus:refs/heads/josh/path3-memory-host-session-corpus-live-proof
git switch josh/path3-memory-host-session-corpus-live-proof
pnpm build
pnpm openclaw gateway restart
pnpm openclaw --version
pnpm openclaw gateway status --deep
pnpm openclaw gateway call health --json --timeout 10000
curl -fsS http://127.0.0.1:18789/readyz
curl -fsS http://127.0.0.1:18789/healthz
pnpm exec tsx /tmp/path3-memory-host-session-corpus-live-proof.ts
wc -l /tmp/openclaw-path3-memory-host-corpus-live-proof/workspace/memory/.dreams/session-corpus/2026-04-05.txt
grep -E "Live primary session insight|Normal child should be dreamed|Archived session should not be dreamed|Cron parent should not be dreamed|Cron child should not be dreamed|Cron grandchild should not be dreamed|Orphan cron child should not be dreamed" /tmp/openclaw-path3-memory-host-corpus-live-proof/workspace/memory/.dreams/session-corpus/2026-04-05.txt
find /tmp/openclaw-path3-memory-host-corpus-live-proof/state -maxdepth 4 -type f | sort
rm -rf /tmp/openclaw-path3-memory-host-corpus-live-proof /tmp/path3-memory-host-session-corpus-live-proof.ts
git switch --detach 352c4a40d838d7deb0bfdf38fa33665aef00be72
pnpm build
pnpm openclaw gateway restart
pnpm openclaw --version
pnpm openclaw gateway status --deep
pnpm openclaw gateway call health --json --timeout 10000
curl -fsS http://127.0.0.1:18789/readyz
curl -fsS http://127.0.0.1:18789/healthz
```

Evidence after fix: The isolated live-proof script seeded temp `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` with active, archive-only, cron parent, cron child, cron grandchild, orphan cron child, and normal child transcripts. It reported `verdict: "PASS"`, `corpusEntryCount: 7`, `archiveArtifactVisibleToCorpus: true`, cron-classified paths `cron-parent.jsonl`, `cron-child.jsonl`, `cron-grandchild.jsonl`, and `orphan-child.jsonl`, and a persisted Dreaming corpus file with 28 lines. The grep proof showed only `Live primary session insight` and `Normal child should be dreamed` lines in `memory/.dreams/session-corpus/2026-04-05.txt`; archive and cron phrases were absent. Persisted temp state included `state/state/openclaw.sqlite`, proving the Dreaming plugin-state seam wrote through SQLite. Cleanup removed both the temp proof root and temp proof script. The restored live gateway later reported `OpenClaw 2026.6.10 (352c4a4)`, `ok: true`, `memoryCoreLoaded: true`, `eventLoopDegraded: false`, `/readyz` ready, and `/healthz` live.

Observed result after fix: Shared corpus enumeration still includes retained archive artifacts, but Dreaming skips archive artifacts before parsing and marks cron-lineage transcripts as seen without appending their content to the Dreaming session-corpus. Live/normal session content is appended as expected.

What was not tested: The future SQLite transcript flip, doctor import/migration behavior, new SDK APIs, and defense-in-depth prompt-stem filtering were not tested because they are out of scope for this 3.1b seam slice. The real live proof was run before the rebase from `7e3590a3f897a536e98905774ad948e49bfddbdd` to `cc7fac26ee980af61c53cb2501c2e4a301ad18be`; the rebased head received the focused test/guard/type/autoreview proof listed above.

## Related

- Fixes #90313.
- Supersedes the #90313 fix shape in #93187 with a narrower Path 3 seam-owned implementation.
- Updates #88838 as the active 3.1b memory-host session corpus follow-up.
