### PR TITLE
fix(media-understanding): align video base64 byte limits

### DIFF
--- a/packages/media-understanding-common/src/video.test.ts
+++ b/packages/media-understanding-common/src/video.test.ts
@@ -1,0 +1,28 @@
+// Media Understanding Common tests cover video payload sizing behavior.
+import { describe, expect, it } from "vitest";
+import { DEFAULT_VIDEO_MAX_BASE64_BYTES } from "./defaults.js";
+import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
+
+describe("estimateBase64Size", () => {
+  it("rounds byte counts to base64 quanta", () => {
+    expect(estimateBase64Size(1)).toBe(4);
+    expect(estimateBase64Size(2)).toBe(4);
+    expect(estimateBase64Size(3)).toBe(4);
+    expect(estimateBase64Size(4)).toBe(8);
+  });
+});
+
+describe("resolveVideoMaxBase64Bytes", () => {
+  it("allows raw byte limits that expand to valid base64 boundaries", () => {
+    expect(resolveVideoMaxBase64Bytes(1)).toBe(4);
+    expect(resolveVideoMaxBase64Bytes(2)).toBe(4);
+    expect(resolveVideoMaxBase64Bytes(3)).toBe(4);
+    expect(resolveVideoMaxBase64Bytes(4)).toBe(8);
+  });
+
+  it("keeps the shared maximum base64 payload cap", () => {
+    expect(resolveVideoMaxBase64Bytes(DEFAULT_VIDEO_MAX_BASE64_BYTES)).toBe(
+      DEFAULT_VIDEO_MAX_BASE64_BYTES,
+    );
+  });
+});

--- a/packages/media-understanding-common/src/video.ts
+++ b/packages/media-understanding-common/src/video.ts
@@ -10,6 +10,6 @@ export function estimateBase64Size(bytes: number): number {
 
 /** Resolve video base64 byte limit from raw byte limit and global cap. */
 export function resolveVideoMaxBase64Bytes(maxBytes: number): number {
-  const expanded = Math.floor(maxBytes * (4 / 3));
+  const expanded = estimateBase64Size(maxBytes);
   return Math.min(expanded, DEFAULT_VIDEO_MAX_BASE64_BYTES);
 }


### PR DESCRIPTION
## What Problem This Solves
Video media-understanding limits were converted from raw bytes to base64 using floor-based arithmetic. For byte limits that are not divisible by three, that underestimates the encoded size and can reject payloads that should fit the configured raw-byte cap.

## Why This Change Was Made
Use the existing quantum-rounded `estimateBase64Size` helper so the limit calculation matches the actual base64 sizing contract. Add boundary coverage for 1, 2, 3, and 4 byte limits plus the global cap.

## User Impact
Video inputs at non-3-byte boundaries are accepted or rejected consistently with the configured raw-byte limit. No config, provider, or network behavior changes.

## Evidence
- Focused test: `packages/media-understanding-common/src/video.test.ts` (3/3 passed).
- Boundary probe: `resolveVideoMaxBase64Bytes(1, 2, 3, 4)` => `4, 4, 4, 8`.
- `git diff --check` passed.
- Autoreview: clean, overall 0.93.
- This is a fresh narrow branch carrying the original author commit via `git cherry-pick -x` after the earlier #96433 branch became broad and was closed as unmergeable.
