### PR TITLE
fix(cron): persist session-id targets in destination session

### DIFF
--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
@@ -260,9 +260,10 @@ describe("tool_result_persist hook", () => {
   it("keeps sensitive parent keys when custom value patterns match the key probe", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-redact-config-"));
     tempDirs.push(tempDir);
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", path.join(tempDir, "openclaw.json"));
+    const configPath = path.join(tempDir, "openclaw.json");
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
     fs.writeFileSync(
-      process.env.OPENCLAW_CONFIG_PATH,
+      configPath,
       JSON.stringify({ logging: { redactPatterns: ["/[a-z0-9]{30,}/g"] } }),
       "utf-8",
     );

--- a/src/cron/session-target.test.ts
+++ b/src/cron/session-target.test.ts
@@ -4,6 +4,7 @@ import {
   resolveCronCurrentSessionTarget,
   resolveCronDeliverySessionKey,
   resolveCronNotificationSessionKey,
+  resolveCronSessionTargetReferenceKey,
   resolveCronSessionTargetSessionKey,
 } from "./session-target.js";
 
@@ -27,6 +28,32 @@ describe("cron session target helpers", () => {
     expect(() => resolveCronSessionTargetSessionKey("session:bad\0id")).toThrow(
       "invalid cron sessionTarget session id",
     );
+  });
+
+  it("resolves persistent session targets from stored session ids", () => {
+    expect(
+      resolveCronSessionTargetReferenceKey({
+        reference: "destination-session-id",
+        entries: [
+          [
+            "agent:main:discord:channel:ops",
+            { sessionId: "destination-session-id", updatedAt: 10 },
+          ],
+        ],
+      }),
+    ).toBe("agent:main:discord:channel:ops");
+  });
+
+  it("preserves explicit session keys before probing session ids", () => {
+    expect(
+      resolveCronSessionTargetReferenceKey({
+        reference: "agent:main:daily-report",
+        entries: [
+          ["agent:main:daily-report", { sessionId: "other-session-id", updatedAt: 10 }],
+          ["agent:main:other", { sessionId: "agent:main:daily-report", updatedAt: 20 }],
+        ],
+      }),
+    ).toBe("agent:main:daily-report");
   });
 
   it("resolves current targets to the creator session key", () => {

--- a/src/cron/session-target.ts
+++ b/src/cron/session-target.ts
@@ -1,4 +1,10 @@
 /** Resolves and validates session-target keys used by cron jobs and delivery. */
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { loadSessionStore } from "../config/sessions/store-load.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSessionIdMatchSelection } from "../sessions/session-id-resolution.js";
+
 const INVALID_CRON_SESSION_TARGET_ID_ERROR = "invalid cron sessionTarget session id";
 
 /** Returns whether an error came from cron session target id validation. */
@@ -28,6 +34,50 @@ export function resolveCronSessionTargetSessionKey(
   return assertSafeCronSessionTargetId(sessionTarget.slice(8));
 }
 
+/** Resolves a `session:` suffix against known persisted session ids when possible. */
+export function resolveCronSessionTargetReferenceKey(params: {
+  reference: string;
+  entries: Array<[string, SessionEntry]>;
+}): string {
+  const reference = assertSafeCronSessionTargetId(params.reference);
+  const exactKeyMatch = params.entries.find(([sessionKey]) => sessionKey === reference);
+  if (exactKeyMatch) {
+    return exactKeyMatch[0];
+  }
+
+  const sessionIdMatches = params.entries.filter(([, entry]) => entry.sessionId === reference);
+  const selection = resolveSessionIdMatchSelection(sessionIdMatches, reference);
+  if (selection.kind === "selected") {
+    return selection.sessionKey;
+  }
+  if (selection.kind === "ambiguous") {
+    throw new Error(
+      `ambiguous cron sessionTarget session id "${reference}" matches multiple sessions: ${selection.sessionKeys.join(", ")}`,
+    );
+  }
+  return reference;
+}
+
+/** Resolves `session:<key-or-sessionId>` to the persisted session key used at runtime. */
+export function resolveCronSessionTargetSessionKeyFromStore(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  sessionTarget?: string | null;
+}): string | undefined {
+  const reference = resolveCronSessionTargetSessionKey(params.sessionTarget);
+  if (!reference) {
+    return undefined;
+  }
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: params.agentId,
+  });
+  const store = loadSessionStore(storePath);
+  return resolveCronSessionTargetReferenceKey({
+    reference,
+    entries: Object.entries(store),
+  });
+}
+
 /** Resolves `current` at creation time so scheduled jobs do not depend on future active UI state. */
 export function resolveCronCurrentSessionTarget(params: {
   sessionTarget?: string | null;
@@ -51,6 +101,28 @@ export function resolveCronDeliverySessionKey(job: {
   }
   return typeof job.sessionKey === "string" && job.sessionKey.trim()
     ? job.sessionKey.trim()
+    : undefined;
+}
+
+/** Chooses the delivery session key after resolving stored session-id references. */
+export function resolveCronDeliverySessionKeyFromStore(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  job: {
+    sessionTarget?: string | null;
+    sessionKey?: string | null;
+  };
+}): string | undefined {
+  const sessionTargetKey = resolveCronSessionTargetSessionKeyFromStore({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionTarget: params.job.sessionTarget,
+  });
+  if (sessionTargetKey) {
+    return sessionTargetKey;
+  }
+  return typeof params.job.sessionKey === "string" && params.job.sessionKey.trim()
+    ? params.job.sessionKey.trim()
     : undefined;
 }
 

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -1,10 +1,14 @@
 // Cron notification tests protect completion-delivery warning behavior,
 // including URL redaction for invalid webhook destinations.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { CronJob } from "../cron/types.js";
 
 const mocks = vi.hoisted(() => ({
+  sendCronAnnouncePayloadStrict: vi.fn(),
   sendFailureNotificationAnnounce: vi.fn(),
 }));
 
@@ -12,15 +16,75 @@ vi.mock("../cron/delivery.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../cron/delivery.js")>();
   return {
     ...actual,
+    sendCronAnnouncePayloadStrict: mocks.sendCronAnnouncePayloadStrict,
     sendFailureNotificationAnnounce: mocks.sendFailureNotificationAnnounce,
   };
 });
 
-import { dispatchGatewayCronFinishedNotifications } from "./server-cron-notifications.js";
+import {
+  dispatchGatewayCronFinishedNotifications,
+  sendGatewayCronFailureAlert,
+} from "./server-cron-notifications.js";
+
+function createSessionStoreWithDestinationSessionId(): { dir: string; storePath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-cron-notify-session-id-"));
+  const storePath = path.join(dir, "sessions.json");
+  fs.writeFileSync(
+    storePath,
+    JSON.stringify({
+      "agent:main:discord:channel:ops": {
+        sessionId: "destination-session-id",
+        updatedAt: 1,
+      },
+    }),
+  );
+  return { dir, storePath };
+}
 
 describe("dispatchGatewayCronFinishedNotifications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("resolves session-id targets before sending immediate failure alerts", async () => {
+    const { dir, storePath } = createSessionStoreWithDestinationSessionId();
+    try {
+      const logger = {
+        warn: vi.fn(),
+      };
+      const job = {
+        id: "cron-failure-alert-session-id",
+        name: "failure alert session id",
+        enabled: true,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "session:destination-session-id",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hello" },
+        state: {},
+      } satisfies CronJob;
+
+      await sendGatewayCronFailureAlert({
+        deps: {} as CliDeps,
+        logger,
+        resolveCronAgent: () => ({ agentId: "main", cfg: { session: { store: storePath } } }),
+        job,
+        text: "boom",
+        channel: "discord",
+        to: "channel:ops",
+      });
+
+      expect(mocks.sendCronAnnouncePayloadStrict).toHaveBeenCalledTimes(1);
+      expect(mocks.sendCronAnnouncePayloadStrict.mock.calls[0]?.[0].target).toEqual({
+        channel: "discord",
+        to: "channel:ops",
+        accountId: undefined,
+        sessionKey: "agent:main:discord:channel:ops",
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("redacts invalid completion webhook targets in warnings", () => {
@@ -114,5 +178,109 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       sessionKey: "agent:main:telegram:group:-1001234567890:thread:42",
       inheritSessionThread: false,
     });
+  });
+
+  it("resolves session-id targets before sending configured failure destinations", () => {
+    const { dir, storePath } = createSessionStoreWithDestinationSessionId();
+    try {
+      const logger = {
+        warn: vi.fn(),
+      };
+      const job = {
+        id: "cron-failure-dest-session-id",
+        name: "failure dest session id",
+        enabled: true,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "session:destination-session-id",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hello" },
+        delivery: {
+          mode: "announce",
+          channel: "discord",
+          to: "channel:ops",
+          failureDestination: {
+            mode: "announce",
+            channel: "discord",
+            to: "channel:ops-failures",
+          },
+        },
+        state: {},
+      } satisfies CronJob;
+
+      dispatchGatewayCronFinishedNotifications({
+        evt: {
+          jobId: job.id,
+          action: "finished",
+          status: "error",
+          error: "boom",
+        },
+        job,
+        deps: {} as CliDeps,
+        logger,
+        resolveCronAgent: () => ({ agentId: "main", cfg: { session: { store: storePath } } }),
+      });
+
+      expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledTimes(1);
+      expect(mocks.sendFailureNotificationAnnounce.mock.calls[0]?.[4]).toEqual({
+        channel: "discord",
+        to: "channel:ops-failures",
+        accountId: undefined,
+        sessionKey: "agent:main:discord:channel:ops",
+        inheritSessionThread: false,
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves session-id targets before sending primary failure notifications", () => {
+    const { dir, storePath } = createSessionStoreWithDestinationSessionId();
+    try {
+      const logger = {
+        warn: vi.fn(),
+      };
+      const job = {
+        id: "cron-primary-failure-session-id",
+        name: "primary failure session id",
+        enabled: true,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "session:destination-session-id",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hello" },
+        delivery: {
+          mode: "announce",
+          channel: "discord",
+          to: "channel:ops",
+        },
+        state: {},
+      } satisfies CronJob;
+
+      dispatchGatewayCronFinishedNotifications({
+        evt: {
+          jobId: job.id,
+          action: "finished",
+          status: "error",
+          error: "boom",
+        },
+        job,
+        deps: {} as CliDeps,
+        logger,
+        resolveCronAgent: () => ({ agentId: "main", cfg: { session: { store: storePath } } }),
+      });
+
+      expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledTimes(1);
+      expect(mocks.sendFailureNotificationAnnounce.mock.calls[0]?.[4]).toEqual({
+        channel: "discord",
+        to: "channel:ops",
+        accountId: undefined,
+        sessionKey: "agent:main:discord:channel:ops",
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -14,7 +14,7 @@ import {
   sendFailureNotificationAnnounce,
 } from "../cron/delivery.js";
 import type { CronEvent } from "../cron/service.js";
-import { resolveCronDeliverySessionKey } from "../cron/session-target.js";
+import { resolveCronDeliverySessionKeyFromStore } from "../cron/session-target.js";
 import type { CronJob, CronMessageChannel } from "../cron/types.js";
 import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -238,7 +238,11 @@ export async function sendGatewayCronFailureAlert(params: {
       channel: params.channel,
       to: params.to,
       accountId: params.accountId,
-      sessionKey: resolveCronDeliverySessionKey(params.job),
+      sessionKey: resolveCronDeliverySessionKeyFromStore({
+        cfg: runtimeConfig,
+        agentId,
+        job: params.job,
+      }),
     },
     message: params.text,
     abortSignal: abortController.signal,
@@ -337,7 +341,6 @@ function dispatchCronFailureDestinationNotifications(params: {
   }
 
   const failureDest = resolveFailureDestination(params.job, params.globalFailureDestination);
-  const deliverySessionKey = resolveCronDeliverySessionKey(params.job);
   const failurePayload = buildCronFailureWebhookPayload({ evt: params.evt, job: params.job });
 
   if (failureDest) {
@@ -371,6 +374,11 @@ function dispatchCronFailureDestinationNotifications(params: {
 
     if (failureDest.mode === "announce") {
       const { agentId, cfg: runtimeConfig } = params.resolveCronAgent(params.job.agentId);
+      const deliverySessionKey = resolveCronDeliverySessionKeyFromStore({
+        cfg: runtimeConfig,
+        agentId,
+        job: params.job,
+      });
       void sendFailureNotificationAnnounce(
         params.deps,
         runtimeConfig,
@@ -397,6 +405,11 @@ function dispatchCronFailureDestinationNotifications(params: {
   }
 
   const { agentId, cfg: runtimeConfig } = params.resolveCronAgent(params.job.agentId);
+  const deliverySessionKey = resolveCronDeliverySessionKeyFromStore({
+    cfg: runtimeConfig,
+    agentId,
+    job: params.job,
+  });
   void sendFailureNotificationAnnounce(
     params.deps,
     runtimeConfig,

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -1,5 +1,6 @@
 // Gateway cron tests cover isolated agent turns, heartbeat wakeups, completion
 // delivery, lifecycle cleanup, hook emission, and SSRF-guarded webhooks.
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -1250,6 +1251,61 @@ describe("buildGatewayCronService", () => {
         sessionTarget: `session:${sessionKey}`,
         wakeMode: "next-heartbeat",
         payload: { kind: "agentTurn", message: "hello" },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      const options = expectIsolatedRunFields({ sessionKey });
+      expect(requireRecord(options.job, "isolated job").id).toBe(job.id);
+      expectCleanupForSessionKeys([sessionKey]);
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("resolves custom session targets by persisted sessionId before isolated cron runs", async () => {
+    const tmpDir = path.join(os.tmpdir(), `server-cron-session-id-target-${Date.now()}`);
+    const sessionStore = path.join(tmpDir, "sessions.json");
+    const sessionKey = "agent:main:discord:channel:ops";
+    fs.mkdirSync(path.dirname(sessionStore), { recursive: true });
+    fs.writeFileSync(
+      sessionStore,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "destination-session-id",
+          updatedAt: Date.now(),
+        },
+      }),
+    );
+    const cfg = {
+      session: {
+        mainKey: "main",
+        store: sessionStore,
+      },
+      cron: {
+        store: path.join(tmpDir, "cron.json"),
+      },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "session-id-target",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "session:destination-session-id",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hello" },
+        delivery: {
+          mode: "announce",
+          channel: "discord",
+          to: "channel:ops",
+        },
       });
 
       await state.cron.run(job.id, "force");

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -23,8 +23,8 @@ import { appendCronRunLog, resolveCronRunLogPruneOptions } from "../cron/run-log
 import type { CronServiceContract } from "../cron/service-contract.js";
 import { CronService } from "../cron/service.js";
 import {
-  resolveCronDeliverySessionKey,
-  resolveCronSessionTargetSessionKey,
+  resolveCronDeliverySessionKeyFromStore,
+  resolveCronSessionTargetSessionKeyFromStore,
 } from "../cron/session-target.js";
 import { resolveCronJobsStorePath } from "../cron/store.js";
 import type { CronJob } from "../cron/types.js";
@@ -392,7 +392,12 @@ export function buildGatewayCronService(params: {
       onLaneWait,
     }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
-      const sessionKey = resolveCronSessionTargetSessionKey(job.sessionTarget) ?? `cron:${job.id}`;
+      const sessionKey =
+        resolveCronSessionTargetSessionKeyFromStore({
+          cfg: runtimeConfig,
+          agentId,
+          sessionTarget: job.sessionTarget,
+        }) ?? `cron:${job.id}`;
       try {
         return await runCronIsolatedAgentTurn({
           cfg: runtimeConfig,
@@ -474,7 +479,11 @@ export function buildGatewayCronService(params: {
             channel: plan.channel,
             to: plan.to,
             accountId: plan.accountId,
-            sessionKey: resolveCronDeliverySessionKey(job),
+            sessionKey: resolveCronDeliverySessionKeyFromStore({
+              cfg: runtimeConfig,
+              agentId,
+              job,
+            }),
           },
           message,
           abortSignal: abortSignal ?? new AbortController().signal,


### PR DESCRIPTION
## What Problem This Solves

Fixes #74743. `openclaw cron add --session "session:<sessionId>" --channel discord --to channel:<id>` could deliver the cron response to Discord while persisting the run under a synthetic session key derived from the session id. The destination channel session then had no transcript record of the message the bot just sent.

## Why This Change Was Made

Cron `session:` targets can now resolve the suffix as either an explicit session key or a persisted `sessionId`. Exact session keys still win first, and only unmatched suffixes are resolved through the current agent session store. Gateway cron execution now passes the resolved session key into isolated-agent runs, and command announce delivery uses the same resolved key.

The follow-up commit also keeps `OPENCLAW_CONFIG_PATH` in a local `configPath` variable in an existing agent test so the repository `check-test-types` lane is not blocked by `string | undefined` from `process.env`.

## User Impact

A cron job targeted at `session:<sessionId>` now appends delivered cron output to the intended destination session history, so the channel agent can remember and refer to what it just sent. Existing `session:<full-session-key>` cron jobs keep their previous behavior.

## Evidence

- `node scripts/run-vitest.mjs run src/cron/session-target.test.ts src/gateway/server-cron.test.ts`
- `node scripts/run-vitest.mjs run src/gateway/server-cron-notifications.test.ts src/cron/delivery.failure-notify.test.ts src/cron/delivery-preview.test.ts`
- `node scripts/run-vitest.mjs run src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts` passed after the follow-up commit.
- `pnpm tsgo:core:test` passed after the follow-up commit.
- `& .\node_modules\.bin\oxfmt.cmd --check --threads=1 src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts` passed after the follow-up commit.
- `& .\node_modules\.bin\oxfmt.cmd --check --threads=1 src/cron/session-target.ts src/cron/session-target.test.ts src/gateway/server-cron.ts src/gateway/server-cron.test.ts`
- `git diff --check` passed after the follow-up commit.