### PR TITLE
refactor: remove Telegram session deps adapter

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -12,6 +12,9 @@ type AnyMock = ReturnType<typeof vi.fn>;
 type AnyAsyncMock = ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<unknown>>>;
 type GetRuntimeConfigFn =
   typeof import("openclaw/plugin-sdk/runtime-config-snapshot").getRuntimeConfig;
+type GetSessionEntryFn = typeof import("openclaw/plugin-sdk/session-store-runtime").getSessionEntry;
+type ListSessionEntriesFn =
+  typeof import("openclaw/plugin-sdk/session-store-runtime").listSessionEntries;
 type LoadSessionStoreFn =
   typeof import("openclaw/plugin-sdk/session-store-runtime").loadSessionStore;
 type ResolveStorePathFn =
@@ -61,7 +64,9 @@ vi.mock("openclaw/plugin-sdk/web-media", () => ({
 }));
 
 const {
+  getSessionEntryMock,
   getRuntimeConfig,
+  listSessionEntriesMock,
   loadSessionStoreMock,
   readSessionUpdatedAtMock,
   recordInboundSessionMock,
@@ -69,7 +74,9 @@ const {
   sessionStoreEntries,
 } = vi.hoisted(
   (): {
+    getSessionEntryMock: MockFn<GetSessionEntryFn>;
     getRuntimeConfig: MockFn<GetRuntimeConfigFn>;
+    listSessionEntriesMock: MockFn<ListSessionEntriesFn>;
     loadSessionStoreMock: MockFn<LoadSessionStoreFn>;
     readSessionUpdatedAtMock: MockFn<ReadSessionUpdatedAtFn>;
     recordInboundSessionMock: MockFn<NonNullable<TelegramBotDeps["recordInboundSession"]>>;
@@ -77,12 +84,23 @@ const {
     sessionStoreEntries: { value: SessionStore };
   } => ({
     getRuntimeConfig: vi.fn<GetRuntimeConfigFn>(() => ({})),
-    loadSessionStoreMock: vi.fn<LoadSessionStoreFn>(
-      (_storePath, _opts) => sessionStoreEntries.value,
-    ),
     resolveStorePathMock: vi.fn<ResolveStorePathFn>(
       (storePath?: string) => storePath ?? sessionStorePath,
     ),
+    loadSessionStoreMock: vi.fn<LoadSessionStoreFn>(
+      (_storePath, _opts) => sessionStoreEntries.value,
+    ),
+    getSessionEntryMock: vi.fn<GetSessionEntryFn>(({ storePath, sessionKey, agentId }) => {
+      const resolvedStorePath = storePath ?? resolveStorePathMock(undefined, { agentId });
+      return loadSessionStoreMock(resolvedStorePath)[sessionKey];
+    }),
+    listSessionEntriesMock: vi.fn<ListSessionEntriesFn>(({ storePath, agentId } = {}) => {
+      const resolvedStorePath = storePath ?? resolveStorePathMock(undefined, { agentId });
+      return Object.entries(loadSessionStoreMock(resolvedStorePath)).map(([sessionKey, entry]) => ({
+        sessionKey,
+        entry,
+      }));
+    }),
     readSessionUpdatedAtMock: vi.fn<ReadSessionUpdatedAtFn>(() => undefined),
     recordInboundSessionMock: vi.fn(async () => undefined),
     sessionStoreEntries: { value: {} as SessionStore },
@@ -444,6 +462,8 @@ export const telegramBotRuntimeForTest: TelegramBotRuntimeForTest = {
 };
 export const telegramBotDepsForTest: TelegramBotDeps = {
   getRuntimeConfig,
+  getSessionEntry: getSessionEntryMock,
+  listSessionEntries: listSessionEntriesMock,
   loadSessionStore: loadSessionStoreMock as TelegramBotDeps["loadSessionStore"],
   resolveStorePath: resolveStorePathMock,
   readSessionUpdatedAt: readSessionUpdatedAtMock,
@@ -564,6 +584,19 @@ beforeEach(() => {
   loadSessionStoreMock.mockImplementation(() => sessionStoreEntries.value);
   resolveStorePathMock.mockReset();
   resolveStorePathMock.mockImplementation((storePath?: string) => storePath ?? sessionStorePath);
+  getSessionEntryMock.mockReset();
+  getSessionEntryMock.mockImplementation(({ storePath, sessionKey, agentId }) => {
+    const resolvedStorePath = storePath ?? resolveStorePathMock(undefined, { agentId });
+    return loadSessionStoreMock(resolvedStorePath)[sessionKey];
+  });
+  listSessionEntriesMock.mockReset();
+  listSessionEntriesMock.mockImplementation(({ storePath, agentId } = {}) => {
+    const resolvedStorePath = storePath ?? resolveStorePathMock(undefined, { agentId });
+    return Object.entries(loadSessionStoreMock(resolvedStorePath)).map(([sessionKey, entry]) => ({
+      sessionKey,
+      entry,
+    }));
+  });
   readSessionUpdatedAtMock.mockReset();
   readSessionUpdatedAtMock.mockReturnValue(undefined);
   recordInboundSessionMock.mockReset();

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -1,11 +1,10 @@
 // Telegram plugin module implements bot behavior.
-import { getSessionEntry, listSessionEntries } from "openclaw/plugin-sdk/session-store-runtime";
 import {
   createTelegramBotCore,
   getTelegramSequentialKey,
   setTelegramBotRuntimeForTest,
 } from "./bot-core.js";
-import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
+import { defaultTelegramBotDeps } from "./bot-deps.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 
 export type { TelegramBotOptions } from "./bot.types.js";
@@ -17,39 +16,6 @@ export function createTelegramBot(
 ): ReturnType<typeof createTelegramBotCore> {
   return createTelegramBotCore({
     ...opts,
-    telegramDeps: withTelegramSessionAccessorDeps(opts.telegramDeps ?? defaultTelegramBotDeps),
+    telegramDeps: opts.telegramDeps ?? defaultTelegramBotDeps,
   });
-}
-
-function withTelegramSessionAccessorDeps(deps: TelegramBotDeps): TelegramBotDeps {
-  if (!deps.loadSessionStore) {
-    return {
-      ...deps,
-      getSessionEntry: deps.getSessionEntry ?? getSessionEntry,
-      listSessionEntries: deps.listSessionEntries ?? listSessionEntries,
-    };
-  }
-
-  const listInjectedEntries = (
-    scope: Parameters<NonNullable<TelegramBotDeps["listSessionEntries"]>>[0] = {},
-  ) => {
-    const storePath =
-      scope.storePath ?? deps.resolveStorePath(undefined, { agentId: scope.agentId });
-    return Object.entries(deps.loadSessionStore?.(storePath) ?? {}).map(([sessionKey, entry]) => ({
-      sessionKey,
-      entry,
-    }));
-  };
-
-  return {
-    ...deps,
-    // Existing Telegram tests and custom deps inject loadSessionStore; expose
-    // the same data through the accessor seam consumed by migrated handlers.
-    getSessionEntry:
-      deps.getSessionEntry ??
-      ((scope) =>
-        listInjectedEntries(scope).find(({ sessionKey }) => sessionKey === scope.sessionKey)
-          ?.entry),
-    listSessionEntries: deps.listSessionEntries ?? listInjectedEntries,
-  };
 }

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -131,6 +131,7 @@ export const migratedBundledPluginSessionAccessorFiles = new Set([
   "extensions/memory-core/src/dreaming-narrative.ts",
   "extensions/mattermost/src/mattermost/model-picker.ts",
   "extensions/telegram/src/bot-handlers.runtime.ts",
+  "extensions/telegram/src/bot.ts",
 ]);
 
 export const migratedSessionAccessorWriteFiles = new Set([

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -85,6 +85,7 @@ describe("session accessor boundary guard", () => {
         "extensions/memory-core/src/dreaming-narrative.ts",
         "extensions/mattermost/src/mattermost/model-picker.ts",
         "extensions/telegram/src/bot-handlers.runtime.ts",
+        "extensions/telegram/src/bot.ts",
       ]),
     );
   });


### PR DESCRIPTION
## What Problem This Solves

This removes the remaining Telegram-only compatibility adapter that translated injected `loadSessionStore` dependencies into the current session accessor contract. Telegram production code now consumes `getSessionEntry` and `listSessionEntries` directly, matching the Path 3 accessor boundary used by the rest of the bundled plugin migration.

## Why This Change Was Made

The adapter was only supporting the local test harness/custom injected-deps shape. Keeping it in `extensions/telegram/src/bot.ts` left a steady-state runtime fallback for a retired internal dependency shape, so the test harness now supplies the canonical accessors directly and the production file is covered by the session accessor ratchet.

## User Impact

No user-visible Telegram behavior is intended to change. Telegram still starts in polling mode, resolves the same stored Telegram session, sends outbound messages through the gateway, and supports message deletion. External runtime callers are expected to use the current injected dependency contract.

## Evidence

- `node scripts/check-session-accessor-boundary.mjs`
  - Passed after adding `extensions/telegram/src/bot.ts` to the migrated bundled plugin ratchet.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/bot.test.ts extensions/telegram/src/bot.command-menu.test.ts extensions/telegram/src/bot.fetch-abort.test.ts`
  - Passed: 4 files, 210 tests.
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Clean before PR open and clean again after the CI ratchet-test expectation fix.
- CI follow-up after initial push:
  - `checks-node-compact-large-whole-1` failed because `test/scripts/check-session-accessor-boundary.test.ts` still expected the old migrated bundled-plugin file set.
  - Fixed by adding `extensions/telegram/src/bot.ts` to that test expectation.
  - `node scripts/check-session-accessor-boundary.mjs` passed.
  - `node scripts/run-vitest.mjs test/scripts/check-session-accessor-boundary.test.ts` passed: 1 file, 28 tests.
  - Later `checks-node-compact-small-whole-2` failure was unrelated benchmark timing noise in untouched `test/scripts/bench-gateway-restart.test.ts`; failed job rerun passed.
  - Final CI state on `72d3ebf0c1d`: green.
- Local live OpenClaw proof on runtime-equivalent head `6aeefb8938ded8f91543f16b53d00c97ef7867f2`:
  - Final PR head adds only the ratchet test expectation for the already-live-proofed production ratchet change; production/runtime code is unchanged from the live proof.
  - Recorded live checkout before proof: detached `352c4a40d838d7deb0bfdf38fa33665aef00be72`, clean, `OpenClaw 2026.6.10 (352c4a4)`.
  - Loaded PR head into `/Users/phaedrus/Projects/clawdbot`, ran `pnpm build`, restarted the local gateway, and verified `OpenClaw 2026.6.10 (6aeefb8)`.
  - `pnpm openclaw gateway call channels.status --json --timeout 20000` showed `telegram` configured/running with event loop not degraded.
  - `pnpm openclaw gateway call send --json --timeout 30000 --params '{"channel":"telegram","to":"telegram:-1003774691294","sessionKey":"agent:main:main","message":"Path 3 Telegram injected-deps cleanup live proof: gateway send from 6aeefb8.","idempotencyKey":"path3-telegram-injected-deps-6aeefb8-20260624T1058"}'` returned `messageId: "28761"`.
  - `sessions.preview` for `agent:main:main` showed `Path 3 Telegram injected-deps cleanup live proof: gateway send from 6aeefb8.`
  - `message.action` delete for Telegram `messageId: "28761"` returned `{ "ok": true, "deleted": true }`.
  - Restored live checkout to detached `352c4a40d838d7deb0bfdf38fa33665aef00be72`, rebuilt, restarted gateway, and verified `OpenClaw 2026.6.10 (352c4a4)` plus `healthz` live.

Refs openclaw/openclaw#88838
