### PR TITLE
fix(opencode-go): treat stream block boundaries as liveness

### DIFF
--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -182,6 +182,82 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     await consumer;
   });
 
+  it("keeps a live stream open when block boundaries arrive between deltas", async () => {
+    const { stream: baseStream, controller } = createFakeBaseStream();
+    let abortCalled = false;
+
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) {
+        options.signal.addEventListener("abort", () => {
+          abortCalled = true;
+        });
+      }
+      return baseStream;
+    });
+
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+      provider: "opencode-go",
+      idleTimeoutMs: 5_000,
+    });
+
+    const downstream = await Promise.resolve(
+      wrapper({ provider: "opencode-go", id: "glm-4.6" } as any, {} as any, {} as any),
+    );
+    expect(downstream).toBeDefined();
+    if (!downstream) {
+      return;
+    }
+
+    const received: AnyEvent[] = [];
+    const consumer = (async () => {
+      for await (const event of downstream) {
+        received.push(event);
+      }
+    })();
+
+    const partial = {
+      role: "assistant",
+      content: [{ type: "toolCall", partialJson: "{", arguments: {}, name: "gateway" }],
+      stopReason: undefined,
+    };
+    controller.emit({ type: "start", partial } as any);
+    controller.emit({ type: "toolcall_delta", contentIndex: 0, delta: "{", partial } as any);
+    await vi.advanceTimersByTimeAsync(0);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    controller.emit({
+      type: "toolcall_end",
+      contentIndex: 0,
+      toolCall: { type: "toolCall", id: "call-1", name: "gateway", arguments: {} },
+      partial,
+    } as any);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    controller.emit({ type: "toolcall_start", contentIndex: 1, partial } as any);
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(abortCalled).toBe(false);
+
+    controller.emit({
+      type: "done",
+      reason: "stop",
+      message: {
+        ...partial,
+        content: [{ type: "text", text: "final answer" }],
+        stopReason: "stop",
+      },
+    } as any);
+    controller.end();
+    await consumer;
+
+    expect(received.some((event) => event.type === "done")).toBe(true);
+    expect(
+      received.some(
+        (event) => event.type === "error" && (event as any).error?.stopReason === "error",
+      ),
+    ).toBe(false);
+  });
+
   it("uses a longer first-event timeout than the inter-event idle timeout", async () => {
     const { stream: baseStream } = createFakeBaseStream();
     let abortCalled = false;

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -51,11 +51,20 @@ function resolveTimeoutMs(model: unknown, fallbackMs: number): number {
   return validTimeoutMs((model as { requestTimeoutMs?: unknown })?.requestTimeoutMs) ?? fallbackMs;
 }
 
-function isProviderProgressEvent(event: AssistantMessageEvent): boolean {
+function isProviderDeltaEvent(event: AssistantMessageEvent): boolean {
   return (
     event.type === "text_delta" ||
     event.type === "thinking_delta" ||
     event.type === "toolcall_delta"
+  );
+}
+
+function isProviderBoundaryLivenessEvent(event: AssistantMessageEvent): boolean {
+  return (
+    event.type === "text_end" ||
+    event.type === "thinking_end" ||
+    event.type === "toolcall_start" ||
+    event.type === "toolcall_end"
   );
 }
 
@@ -200,8 +209,8 @@ function synthesizeMinimalAssistantMessage(
  *
  * Behavior:
  * - Provider-scoped: only applies when `model.provider === options.provider`.
- * - Idle-based: the timer covers stream creation, first event delivery, and
- *   every gap after provider progress begins; if no event arrives within
+ * - Idle-based: the timer covers stream creation, first provider delta, and
+ *   every gap after provider progress begins; if no live event arrives within
  *   `idleTimeoutMs`, the wrapper calls `controller.abort()` on the AbortSignal
  *   injected into the underlying call (so the OpenAI SDK request is genuinely
  *   interrupted, not just the iterator) and pushes a terminal `error` event
@@ -210,7 +219,8 @@ function synthesizeMinimalAssistantMessage(
  *   wrapper forwards the event, clears all timers, and ends the stream.
  *
  * The wrapper never shortens the natural end of a normal completion, because
- * provider progress refreshes the idle timer and a terminal event cancels it entirely.
+ * provider deltas and later block boundaries refresh the idle timer and a terminal event cancels
+ * it entirely.
  */
 export function createOpencodeGoStalledStreamWrapper(
   underlying: ProviderStreamFn,
@@ -246,6 +256,7 @@ export function createOpencodeGoStalledStreamWrapper(
     let idleTimer: ReturnType<typeof setTimeout> | undefined;
     let lastSeenPartial: AssistantMessage | undefined;
     let settled = false;
+    let sawProviderDelta = false;
     let baseIterator: AsyncIterator<AssistantMessageEvent> | undefined;
 
     const clearIdleTimer = () => {
@@ -353,7 +364,10 @@ export function createOpencodeGoStalledStreamWrapper(
           }
           trackPartial(event);
           output.push(event);
-          if (isProviderProgressEvent(event)) {
+          if (isProviderDeltaEvent(event)) {
+            sawProviderDelta = true;
+            armIdleTimer();
+          } else if (sawProviderDelta && isProviderBoundaryLivenessEvent(event)) {
             armIdleTimer();
           }
         }


### PR DESCRIPTION
## What Problem This Solves

The opencode-go stalled-stream watchdog only treated provider delta events as stream liveness. Live streams that emitted block-boundary events, such as tool call end/start transitions, could sit between token deltas long enough for the idle timer to abort the underlying request and replace the eventual completed answer with an error.

## Why This Change Was Made

This keeps the stricter first-delta behavior intact, so synthetic start or block-start events before provider output do not shorten the first-event window. Once a real provider delta has arrived, later provider-owned block boundaries now refresh the idle timer because they prove the SSE stream is still advancing.

## User Impact

Users of opencode-go models should no longer lose completed answers when a provider pauses token deltas while closing one block and opening another. Truly stalled streams are still aborted after the configured idle timeout.

## Evidence

- `node scripts/run-vitest.mjs run extensions/opencode-go/stream-termination.test.ts`
- `& .\node_modules\.bin\oxfmt.cmd --check --threads=1 extensions/opencode-go/stream-termination.ts extensions/opencode-go/stream-termination.test.ts`
- `git diff --check`
Live opencode-go wrapper stream proof from this branch:

```text
$ <script invokes extensions/opencode-go/stream-termination.ts#createOpencodeGoStalledStreamWrapper with real timers and opencode-go stream events>
{
  "source": "extensions/opencode-go/stream-termination.ts#createOpencodeGoStalledStreamWrapper",
  "results": [
    {
      "scenario": "post-delta boundary events keep stream live",
      "idleTimeoutMs": 100,
      "elapsedAfterDeltaMs": 210,
      "boundaryEvents": [
        "toolcall_end",
        "toolcall_start"
      ],
      "abortCalled": false,
      "terminalEvent": "done",
      "errorEvents": 0
    },
    {
      "scenario": "true post-delta stall still aborts",
      "idleTimeoutMs": 100,
      "quietAfterDeltaMs": 160,
      "abortCalled": true,
      "terminalEvent": "error",
      "errorMessage": "opencode-go stream timed out after provider-owned SSE boundary stalled"
    }
  ]
}
```

This exercises the actual opencode-go stalled-stream wrapper. The first stream stays live across post-delta `toolcall_end` and `toolcall_start` boundaries for longer than one idle window and completes with `done`. The second stream has no boundary or delta after its first delta, so the wrapper still aborts and emits the provider-owned stalled-stream error.

Fixes #96518