### PR TITLE
refactor: migrate bundled session metadata reads

### DIFF
--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -11,11 +11,7 @@ import type {
   PluginHookInboundClaimEvent,
 } from "openclaw/plugin-sdk/plugin-entry";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
-import {
-  loadSessionStore,
-  resolveSessionStoreEntry,
-  resolveStorePath,
-} from "openclaw/plugin-sdk/session-store-runtime";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveCodexAppServerForModelProvider } from "./app-server/app-server-policy.js";
 import { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-bridge.js";
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
@@ -881,10 +877,11 @@ function readSessionExecOverrides(params: {
     return undefined;
   }
   const storePath = resolveStorePath(params.config.session?.store, { agentId: params.agentId });
-  const entry = resolveSessionStoreEntry({
-    store: loadSessionStore(storePath, { skipCache: true }),
+  const entry = getSessionEntry({
+    storePath,
     sessionKey,
-  }).existing;
+    readConsistency: "latest",
+  });
   if (!entry?.execSecurity && !entry?.execAsk) {
     return undefined;
   }

--- a/extensions/discord/src/monitor/native-command-model-picker-ui.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-ui.ts
@@ -8,7 +8,7 @@ import {
 } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
-import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -202,11 +202,10 @@ export async function resolveDiscordNativeChoiceContext(params: {
     const storePath = resolveStorePath(params.cfg.session?.store, {
       agentId: route.agentId,
     });
-    const sessionStore = loadSessionStore(storePath);
-    const sessionEntry = sessionStore[route.sessionKey];
+    const sessionEntry = getSessionEntry({ storePath, sessionKey: route.sessionKey });
     const override = resolveStoredModelOverride({
       sessionEntry,
-      sessionStore,
+      loadSessionEntry: (sessionKey) => getSessionEntry({ storePath, sessionKey }),
       sessionKey: route.sessionKey,
       defaultProvider: fallback.provider,
     });
@@ -238,11 +237,15 @@ export function resolveDiscordModelPickerCurrentModel(params: {
     const storePath = resolveStorePath(params.cfg.session?.store, {
       agentId: params.route.agentId,
     });
-    const sessionStore = loadSessionStore(storePath, { skipCache: true });
-    const sessionEntry = sessionStore[params.route.sessionKey];
+    const sessionEntry = getSessionEntry({
+      storePath,
+      sessionKey: params.route.sessionKey,
+      readConsistency: "latest",
+    });
     const override = resolveStoredModelOverride({
       sessionEntry,
-      sessionStore,
+      loadSessionEntry: (sessionKey) =>
+        getSessionEntry({ storePath, sessionKey, readConsistency: "latest" }),
       sessionKey: params.route.sessionKey,
       defaultProvider: params.data.resolvedDefault.provider,
     });
@@ -267,9 +270,12 @@ export function resolveDiscordModelPickerCurrentRuntime(params: {
     const storePath = resolveStorePath(params.cfg.session?.store, {
       agentId: params.route.agentId,
     });
-    const sessionStore = loadSessionStore(storePath, { skipCache: true });
     const sessionRuntime = normalizeOptionalString(
-      sessionStore[params.route.sessionKey]?.agentRuntimeOverride,
+      getSessionEntry({
+        storePath,
+        sessionKey: params.route.sessionKey,
+        readConsistency: "latest",
+      })?.agentRuntimeOverride,
     );
     if (sessionRuntime) {
       return sessionRuntime;

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -40,10 +40,7 @@ import {
 import type { GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
-import {
-  loadSessionStore,
-  resolveSessionStoreEntry,
-} from "openclaw/plugin-sdk/session-store-runtime";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
   CoreConfig,
@@ -347,12 +344,11 @@ function resolveMatrixSharedDmContextNotice(params: {
   }
 
   try {
-    const store = loadSessionStore(params.storePath);
     const currentSession = resolveMatrixStoredSessionMeta(
-      resolveSessionStoreEntry({
-        store,
+      getSessionEntry({
+        storePath: params.storePath,
         sessionKey: params.sessionKey,
-      }).existing,
+      }),
     );
     if (!currentSession) {
       return null;

--- a/extensions/matrix/src/session-route.ts
+++ b/extensions/matrix/src/session-route.ts
@@ -6,11 +6,7 @@ import {
   type ChannelOutboundSessionRouteParams,
 } from "openclaw/plugin-sdk/channel-core";
 import { parseThreadSessionSuffix } from "openclaw/plugin-sdk/routing";
-import {
-  loadSessionStore,
-  resolveSessionStoreEntry,
-  resolveStorePath,
-} from "openclaw/plugin-sdk/session-store-runtime";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveMatrixAccountConfig } from "./matrix/account-config.js";
 import { resolveDefaultMatrixAccountId } from "./matrix/accounts.js";
 import { resolveMatrixStoredSessionMeta } from "./matrix/session-store-metadata.js";
@@ -51,11 +47,10 @@ function resolveMatrixCurrentDmRoomId(params: {
     const storePath = resolveStorePath(params.cfg.session?.store, {
       agentId: params.agentId,
     });
-    const store = loadSessionStore(storePath);
-    const existing = resolveSessionStoreEntry({
-      store,
+    const existing = getSessionEntry({
+      storePath,
       sessionKey,
-    }).existing;
+    });
     const currentSession = resolveMatrixStoredSessionMeta(existing);
     if (!currentSession) {
       return undefined;

--- a/extensions/mattermost/src/mattermost/model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.test.ts
@@ -221,7 +221,7 @@ describe("Mattermost model picker", () => {
       const storePath = path.join(testDir, "{agentId}.json");
       const supportStorePath = path.join(testDir, "support.json");
       const parentSessionKey = "agent:support:mattermost:default:channel-1";
-      const childSessionKey = `${parentSessionKey}:thread:root-1`;
+      const childSessionKey = "agent:support:mattermost:default:child-with-explicit-parent";
       const directSessionKey = "agent:support:mattermost:default:direct-1";
       fs.writeFileSync(
         supportStorePath,

--- a/extensions/mattermost/src/mattermost/model-picker.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.ts
@@ -7,7 +7,6 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
-import { parseThreadSessionSuffix } from "openclaw/plugin-sdk/routing";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import {
   normalizeOptionalString,
@@ -39,8 +38,6 @@ type MattermostModelPickerRenderedView = {
   text: string;
   buttons: MattermostInteractiveButtonInput[][];
 };
-
-type MattermostModelPickerSessionEntry = ReturnType<typeof getSessionEntry>;
 
 function splitModelRef(modelRef?: string | null): { provider: string; model: string } | null {
   const trimmed = normalizeOptionalString(modelRef);
@@ -78,24 +75,6 @@ function normalizePage(value: number | undefined): number {
     return 1;
   }
   return Math.max(1, Math.floor(value as number));
-}
-
-function resolveMattermostModelPickerParentSessionKey(params: {
-  sessionEntry: MattermostModelPickerSessionEntry;
-  sessionKey: string;
-}): string | undefined {
-  // Preserve inherited model overrides without exposing whole-store reads to the UI path.
-  const persistedParent =
-    typeof params.sessionEntry?.parentSessionKey === "string"
-      ? params.sessionEntry.parentSessionKey.trim()
-      : "";
-  if (persistedParent && persistedParent !== params.sessionKey) {
-    return persistedParent;
-  }
-  const parsed = parseThreadSessionSuffix(params.sessionKey);
-  return parsed.threadId && parsed.baseSessionKey && parsed.baseSessionKey !== params.sessionKey
-    ? parsed.baseSessionKey
-    : undefined;
 }
 
 function paginateItems<T>(items: T[], page?: number, pageSize = MODELS_PAGE_SIZE) {
@@ -258,38 +237,28 @@ export function resolveMattermostModelPickerCurrentModel(params: {
   cfg: OpenClawConfig;
   route: { agentId: string; sessionKey: string };
   data: ModelsProviderData;
-  skipCache?: boolean;
+  readConsistency?: "latest";
 }): string {
   const fallback = `${params.data.resolvedDefault.provider}/${params.data.resolvedDefault.model}`;
   try {
     const storePath = resolveStorePath(params.cfg.session?.store, {
       agentId: params.route.agentId,
     });
-    const readOptions = {
-      storePath,
-      ...(params.skipCache ? { readConsistency: "latest" as const } : {}),
-    };
     const sessionEntry = getSessionEntry({
-      ...readOptions,
+      storePath,
       sessionKey: params.route.sessionKey,
+      ...(params.readConsistency === "latest" ? { readConsistency: "latest" as const } : {}),
     });
-    const parentSessionKey = resolveMattermostModelPickerParentSessionKey({
-      sessionEntry,
-      sessionKey: params.route.sessionKey,
-    });
-    const parentEntry = parentSessionKey
-      ? getSessionEntry({
-          ...readOptions,
-          sessionKey: parentSessionKey,
-        })
-      : undefined;
     const override = resolveStoredModelOverride({
       sessionEntry,
-      ...(parentEntry && parentSessionKey
-        ? { sessionStore: { [parentSessionKey]: parentEntry } }
-        : {}),
+      loadSessionEntry: (sessionKey) =>
+        getSessionEntry({
+          storePath,
+          sessionKey,
+          ...(params.readConsistency === "latest" ? { readConsistency: "latest" as const } : {}),
+        }),
       sessionKey: params.route.sessionKey,
-      parentSessionKey,
+      parentSessionKey: sessionEntry?.parentSessionKey,
       defaultProvider: params.data.resolvedDefault.provider,
     });
     if (!override?.model) {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1256,7 +1256,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           cfg,
           route: modelSessionRoute,
           data,
-          skipCache: true,
+          readConsistency: "latest",
         });
         const view = renderMattermostModelsPickerView({
           ownerUserId: pickerState.ownerUserId,

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -20,7 +20,7 @@ import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
-import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -112,14 +112,13 @@ function resolveSlackCommandMenuModelContext(params: {
       agentId: params.agentId,
     });
     const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
-    const store = loadSessionStore(storePath);
-    const entry = store[params.sessionKey];
+    const entry = getSessionEntry({ storePath, sessionKey: params.sessionKey });
     if (entry?.modelOverrideSource === "auto" && normalizeOptionalString(entry.modelOverride)) {
       return { provider: defaultModel.provider, model: defaultModel.model };
     }
     const override = resolveStoredModelOverride({
       sessionEntry: entry,
-      sessionStore: store,
+      loadSessionEntry: (sessionKey) => getSessionEntry({ storePath, sessionKey }),
       sessionKey: params.sessionKey,
       defaultProvider: defaultModel.provider,
     });

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -310,12 +310,11 @@ export function createTelegramBotCore(
       `agent:${agentId}:telegram:group:${buildTelegramGroupPeerId(params.chatId, params.messageThreadId)}`;
     const storePath = telegramDeps.resolveStorePath(cfg.session?.store, { agentId });
     try {
-      const loadSessionStore = telegramDeps.loadSessionStore;
-      if (!loadSessionStore) {
+      const getSessionEntry = telegramDeps.getSessionEntry;
+      if (!getSessionEntry) {
         return undefined;
       }
-      const store = loadSessionStore(storePath);
-      const entry = store[sessionKey];
+      const entry = getSessionEntry({ storePath, sessionKey });
       if (entry?.groupActivation === "always") {
         return false;
       }

--- a/extensions/telegram/src/bot-message-dispatch.runtime.ts
+++ b/extensions/telegram/src/bot-message-dispatch.runtime.ts
@@ -1,8 +1,8 @@
 // Telegram plugin module implements bot message dispatch behavior.
 export {
-  loadSessionStore,
-  resolveSessionStoreEntry,
+  getSessionEntry,
   resolveStorePath,
+  type SessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
 export { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 export { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -83,6 +83,7 @@ const appendAssistantMirrorMessageByIdentity = vi.hoisted(() =>
     messageId: "m1",
   })),
 );
+const getSessionEntry = vi.hoisted(() => vi.fn());
 const loadSessionStore = vi.hoisted(() => vi.fn());
 const readLatestAssistantTextByIdentity = vi.hoisted(() =>
   vi.fn<() => Promise<{ text: string; timestamp?: number } | undefined>>(async () => undefined),
@@ -102,11 +103,6 @@ const getAgentScopedMediaLocalRoots = vi.hoisted(() =>
 );
 const resolveChunkMode = vi.hoisted(() => vi.fn(() => undefined));
 const resolveMarkdownTableMode = vi.hoisted(() => vi.fn(() => "preserve"));
-const resolveSessionStoreEntry = vi.hoisted(() =>
-  vi.fn(({ store, sessionKey }: { store: Record<string, unknown>; sessionKey: string }) => ({
-    existing: store[sessionKey],
-  })),
-);
 
 vi.mock("./draft-stream.js", () => ({
   createTelegramDraftStream,
@@ -153,12 +149,11 @@ vi.mock("./send.js", () => ({
 
 vi.mock("./bot-message-dispatch.runtime.js", () => ({
   generateTopicLabel,
+  getSessionEntry,
   getAgentScopedMediaLocalRoots,
-  loadSessionStore,
   resolveAutoTopicLabelConfig: resolveAutoTopicLabelConfigRuntime,
   resolveChunkMode,
   resolveMarkdownTableMode,
-  resolveSessionStoreEntry,
   resolveStorePath,
 }));
 
@@ -203,6 +198,7 @@ function installTelegramStateRuntimeForTest(): void {
 const telegramDepsForTest: TelegramBotDeps = {
   getRuntimeConfig: loadConfig as TelegramBotDeps["getRuntimeConfig"],
   resolveStorePath: resolveStorePath as TelegramBotDeps["resolveStorePath"],
+  getSessionEntry: getSessionEntry as TelegramBotDeps["getSessionEntry"],
   loadSessionStore: loadSessionStore as TelegramBotDeps["loadSessionStore"],
   readChannelAllowFromStore:
     readChannelAllowFromStore as TelegramBotDeps["readChannelAllowFromStore"],
@@ -266,13 +262,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     wasSentByBot.mockReset();
     appendAssistantMirrorMessageByIdentity.mockReset();
     readLatestAssistantTextByIdentity.mockReset();
+    getSessionEntry.mockReset();
     loadSessionStore.mockReset();
     resolveStorePath.mockReset();
     generateTopicLabel.mockReset();
     getAgentScopedMediaLocalRoots.mockClear();
     resolveChunkMode.mockClear();
     resolveMarkdownTableMode.mockClear();
-    resolveSessionStoreEntry.mockClear();
     describeStickerImage.mockReset();
     loadModelCatalog.mockReset();
     findModelInCatalog.mockReset();
@@ -325,6 +321,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
       messageId: "m1",
     });
     loadSessionStore.mockReturnValue({});
+    getSessionEntry.mockImplementation(
+      ({ sessionKey }: { sessionKey: string }) =>
+        (loadSessionStore() as Record<string, unknown>)[sessionKey],
+    );
     generateTopicLabel.mockResolvedValue("Topic label");
     describeStickerImage.mockResolvedValue(null);
     loadModelCatalog.mockResolvedValue({});

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -69,15 +69,14 @@ import {
   resolveDefaultModelForAgent,
 } from "./bot-message-dispatch.agent.runtime.js";
 import { deduplicateBlockSentMedia } from "./bot-message-dispatch.media-dedup.js";
-import { clipTelegramProgressText } from "./truncate.js";
 import {
   generateTopicLabel,
   getAgentScopedMediaLocalRoots,
-  loadSessionStore,
+  getSessionEntry,
   resolveAutoTopicLabelConfig,
   resolveChunkMode,
   resolveMarkdownTableMode,
-  resolveSessionStoreEntry,
+  type SessionEntry,
 } from "./bot-message-dispatch.runtime.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import { deliverReplies, emitInternalMessageSentHook } from "./bot/delivery.js";
@@ -144,6 +143,7 @@ import {
   shouldSupersedeTelegramReplyFence,
   supersedeTelegramReplyFence,
 } from "./telegram-reply-fence.js";
+import { clipTelegramProgressText } from "./truncate.js";
 
 export { resetTelegramReplyFenceForTests };
 
@@ -244,33 +244,37 @@ export type TelegramDispatchResult =
 type TelegramReasoningLevel = "off" | "on" | "stream";
 
 type TelegramTranscriptMirrorPayload = { text?: string; mediaUrls?: string[] };
-type TelegramSessionStore = ReturnType<typeof loadSessionStore>;
 type TelegramScopedTranscriptSession = { sessionId: string; storePath: string };
-type FreshTelegramSessionStoreLoader = ((agentId: string) => {
+type FreshTelegramSessionEntryLoader = ((
+  agentId: string,
+  sessionKey: string,
+) => {
   storePath: string;
-  store: TelegramSessionStore;
+  entry?: SessionEntry;
 }) & {
   clear: () => void;
 };
 
-function createFreshTelegramSessionStoreLoader(params: {
+function createFreshTelegramSessionEntryLoader(params: {
   cfg: OpenClawConfig;
   telegramDeps: TelegramBotDeps;
-}): FreshTelegramSessionStoreLoader {
-  const storesByPath = new Map<string, TelegramSessionStore>();
-  const load = ((agentId: string) => {
+}): FreshTelegramSessionEntryLoader {
+  const entriesByPathAndKey = new Map<string, SessionEntry | undefined>();
+  const load = ((agentId: string, sessionKey: string) => {
     const storePath = params.telegramDeps.resolveStorePath(params.cfg.session?.store, { agentId });
-    const cachedStore = storesByPath.get(storePath);
-    if (cachedStore) {
-      return { storePath, store: cachedStore };
+    const cacheKey = `${storePath}\0${sessionKey}`;
+    if (entriesByPathAndKey.has(cacheKey)) {
+      return { storePath, entry: entriesByPathAndKey.get(cacheKey) };
     }
-    const store = (params.telegramDeps.loadSessionStore ?? loadSessionStore)(storePath, {
-      skipCache: true,
+    const entry = (params.telegramDeps.getSessionEntry ?? getSessionEntry)({
+      storePath,
+      sessionKey,
+      readConsistency: "latest",
     });
-    storesByPath.set(storePath, store);
-    return { storePath, store };
-  }) as FreshTelegramSessionStoreLoader;
-  load.clear = () => storesByPath.clear();
+    entriesByPathAndKey.set(cacheKey, entry);
+    return { storePath, entry };
+  }) as FreshTelegramSessionEntryLoader;
+  load.clear = () => entriesByPathAndKey.clear();
   return load;
 }
 
@@ -278,7 +282,7 @@ function resolveTelegramReasoningLevel(params: {
   cfg: OpenClawConfig;
   sessionKey?: string;
   agentId: string;
-  loadFreshSessionStore: FreshTelegramSessionStoreLoader;
+  loadFreshSessionEntry: FreshTelegramSessionEntryLoader;
 }): TelegramReasoningLevel {
   const { cfg, sessionKey, agentId } = params;
   const configDefault = resolveTelegramConfigReasoningDefault(cfg, agentId);
@@ -286,8 +290,7 @@ function resolveTelegramReasoningLevel(params: {
     return configDefault;
   }
   try {
-    const { store } = params.loadFreshSessionStore(agentId);
-    const entry = resolveSessionStoreEntry({ store, sessionKey }).existing;
+    const { entry } = params.loadFreshSessionEntry(agentId, sessionKey);
     const level = entry?.reasoningLevel;
     if (level === "on" || level === "stream" || level === "off") {
       return level;
@@ -318,11 +321,10 @@ function resolveTelegramMirroredTranscriptText(
 
 function resolveTelegramScopedTranscriptSession(params: {
   agentId: string;
-  loadFreshSessionStore: FreshTelegramSessionStoreLoader;
+  loadFreshSessionEntry: FreshTelegramSessionEntryLoader;
   sessionKey: string;
 }): TelegramScopedTranscriptSession | undefined {
-  const { store, storePath } = params.loadFreshSessionStore(params.agentId);
-  const entry = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey }).existing;
+  const { entry, storePath } = params.loadFreshSessionEntry(params.agentId, params.sessionKey);
   const sessionId = entry?.sessionId?.trim();
   return sessionId ? { sessionId, storePath } : undefined;
 }
@@ -330,7 +332,7 @@ function resolveTelegramScopedTranscriptSession(params: {
 async function mirrorTelegramAssistantReplyToTranscript(params: {
   cfg: OpenClawConfig;
   idempotencyKey: string;
-  loadFreshSessionStore: FreshTelegramSessionStoreLoader;
+  loadFreshSessionEntry: FreshTelegramSessionEntryLoader;
   route: TelegramMessageContext["route"];
   sessionKey: string;
   payload: TelegramTranscriptMirrorPayload;
@@ -341,7 +343,7 @@ async function mirrorTelegramAssistantReplyToTranscript(params: {
   }
   const session = resolveTelegramScopedTranscriptSession({
     agentId: params.route.agentId,
-    loadFreshSessionStore: params.loadFreshSessionStore,
+    loadFreshSessionEntry: params.loadFreshSessionEntry,
     sessionKey: params.sessionKey,
   });
   if (!session) {
@@ -756,7 +758,7 @@ export const dispatchTelegramMessage = async ({
   const dispatchContext = resolveDispatchTelegramContext({ cfg, context });
   const telegramDeps =
     injectedTelegramDeps ?? (await import("./bot-deps.js")).defaultTelegramBotDeps;
-  const loadFreshSessionStore = createFreshTelegramSessionStoreLoader({ cfg, telegramDeps });
+  const loadFreshSessionEntry = createFreshTelegramSessionEntryLoader({ cfg, telegramDeps });
   const {
     ctxPayload,
     msg,
@@ -892,7 +894,7 @@ export const dispatchTelegramMessage = async ({
     cfg,
     sessionKey: ctxPayload.SessionKey,
     agentId: route.agentId,
-    loadFreshSessionStore,
+    loadFreshSessionEntry,
   });
   const forceBlockStreamingForReasoning = resolvedReasoningLevel === "on";
   const streamReasoningDraft = resolvedReasoningLevel === "stream";
@@ -1459,8 +1461,7 @@ export const dispatchTelegramMessage = async ({
       return undefined;
     }
     try {
-      const { store, storePath } = loadFreshSessionStore(route.agentId);
-      const sessionEntry = resolveSessionStoreEntry({ store, sessionKey }).existing;
+      const { entry: sessionEntry, storePath } = loadFreshSessionEntry(route.agentId, sessionKey);
       if (!sessionEntry?.sessionId) {
         return undefined;
       }
@@ -1508,7 +1509,7 @@ export const dispatchTelegramMessage = async ({
           await mirrorTelegramAssistantReplyToTranscript({
             cfg,
             idempotencyKey,
-            loadFreshSessionStore,
+            loadFreshSessionEntry,
             route,
             sessionKey,
             payload,
@@ -1866,10 +1867,9 @@ export const dispatchTelegramMessage = async ({
 
     if (isDmTopic) {
       try {
-        const { store } = loadFreshSessionStore(route.agentId);
         const sessionKeyLocal = ctxPayload.SessionKey;
         if (sessionKeyLocal) {
-          const entry = resolveSessionStoreEntry({ store, sessionKey: sessionKeyLocal }).existing;
+          const { entry } = loadFreshSessionEntry(route.agentId, sessionKeyLocal);
           isFirstTurnInSession = !entry?.systemSent;
         } else {
           logVerbose("auto-topic-label: SessionKey is absent, skipping first-turn detection");
@@ -1878,7 +1878,7 @@ export const dispatchTelegramMessage = async ({
         logVerbose(`auto-topic-label: session store error: ${formatErrorMessage(err)}`);
       }
     }
-    loadFreshSessionStore.clear();
+    loadFreshSessionEntry.clear();
 
     if (statusReactionController && !isRoomEvent) {
       void statusReactionController.setThinking();

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -572,6 +572,10 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     ]);
     sessionMocks.getSessionEntry.mockClear().mockReturnValue(undefined);
     sessionMocks.loadSessionStore.mockClear().mockReturnValue({});
+    sessionMocks.getSessionEntry.mockImplementation(
+      ({ storePath, sessionKey }: { storePath: string; sessionKey: string }) =>
+        sessionMocks.loadSessionStore(storePath)[sessionKey],
+    );
     sessionMocks.recordSessionMetaFromInbound.mockClear().mockResolvedValue(undefined);
     sessionMocks.resolveSessionTranscriptLegacyFileTarget.mockClear().mockResolvedValue({
       agentId: "main",
@@ -651,7 +655,10 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       { provider: "anthropic", model: "claude-opus-4-7" },
       "thinking menu call",
     );
-    expect(sessionMocks.loadSessionStore).toHaveBeenCalledWith("/tmp/openclaw-sessions.json");
+    expect(sessionMocks.getSessionEntry).toHaveBeenCalledWith({
+      storePath: "/tmp/openclaw-sessions.json",
+      sessionKey: "agent:main:main",
+    });
     expectSendMessageCall({
       sendMessage,
       chatId: 100,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -40,8 +40,6 @@ import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
   getSessionEntry,
-  loadSessionStore,
-  resolveSessionStoreEntry,
   resolveStorePath,
   type SessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
@@ -255,8 +253,7 @@ function resolveTelegramCommandMenuModelContext(params: {
       cfg: params.cfg,
       agentId: params.agentId,
     });
-    const store = loadSessionStore(storePath);
-    const entry = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey }).existing;
+    const entry = getSessionEntry({ storePath, sessionKey: params.sessionKey });
     const thinkingLevel = normalizeOptionalString(entry?.thinkingLevel);
     const fastMode = entry?.fastMode;
     if (entry?.modelOverrideSource === "auto" && normalizeOptionalString(entry.modelOverride)) {
@@ -269,7 +266,7 @@ function resolveTelegramCommandMenuModelContext(params: {
     }
     const override = resolveStoredModelOverride({
       sessionEntry: entry,
-      sessionStore: store,
+      loadSessionEntry: (sessionKey) => getSessionEntry({ storePath, sessionKey }),
       sessionKey: params.sessionKey,
       defaultProvider: defaultModel.provider,
     });
@@ -318,14 +315,13 @@ function resolveTelegramFastCommandModelContext(params: {
   }
   try {
     const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
-    const store = loadSessionStore(storePath);
-    const entry = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey }).existing;
+    const entry = getSessionEntry({ storePath, sessionKey: params.sessionKey });
     if (entry?.modelOverrideSource === "auto" && normalizeOptionalString(entry.modelOverride)) {
       return fallback();
     }
     const override = resolveStoredModelOverride({
       sessionEntry: entry,
-      sessionStore: store,
+      loadSessionEntry: (sessionKey) => getSessionEntry({ storePath, sessionKey }),
       sessionKey: params.sessionKey,
       defaultProvider: defaultModel.provider,
     });
@@ -359,8 +355,7 @@ function resolveTelegramFastCommandState(params: {
   }
   try {
     const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
-    const store = loadSessionStore(storePath);
-    const entry = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey }).existing;
+    const entry = getSessionEntry({ storePath, sessionKey: params.sessionKey });
     const modelContext = resolveTelegramFastCommandModelContext(params);
     return resolveFastModeState({
       cfg: params.cfg,

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -125,14 +125,22 @@ export const migratedSessionAccessorFiles = new Set([
 ]);
 
 export const migratedBundledPluginSessionAccessorFiles = new Set([
+  "extensions/codex/src/conversation-binding.ts",
+  "extensions/discord/src/monitor/native-command-model-picker-ui.ts",
   "extensions/discord/src/monitor/native-command-model-picker-apply.ts",
   "extensions/discord/src/monitor/thread-session-close.ts",
   "extensions/feishu/src/reasoning-preview.ts",
   "extensions/memory-core/src/dreaming-phases.ts",
   "extensions/memory-core/src/dreaming-narrative.ts",
   "extensions/mattermost/src/mattermost/model-picker.ts",
+  "extensions/matrix/src/matrix/monitor/handler.ts",
+  "extensions/matrix/src/session-route.ts",
+  "extensions/slack/src/monitor/slash.ts",
+  "extensions/telegram/src/bot-core.ts",
   "extensions/telegram/src/bot-handlers.runtime.ts",
   "extensions/telegram/src/bot.ts",
+  "extensions/telegram/src/bot-message-dispatch.ts",
+  "extensions/telegram/src/bot-native-commands.ts",
 ]);
 
 export const migratedSessionAccessorWriteFiles = new Set([

--- a/src/auto-reply/reply/stored-model-override.test.ts
+++ b/src/auto-reply/reply/stored-model-override.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveStoredModelOverride } from "./stored-model-override.js";
+
+describe("resolveStoredModelOverride", () => {
+  it("loads parent overrides without requiring a whole session store", () => {
+    const loadSessionEntry = vi.fn((sessionKey: string) =>
+      sessionKey === "agent:main:telegram:dm:parent"
+        ? {
+            sessionId: "parent-session",
+            updatedAt: 1782259200000,
+            providerOverride: "anthropic",
+            modelOverride: "claude-sonnet-4-7",
+          }
+        : undefined,
+    );
+
+    expect(
+      resolveStoredModelOverride({
+        defaultProvider: "openai",
+        loadSessionEntry,
+        sessionKey: "agent:main:telegram:dm:parent:thread:child",
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-7",
+      source: "parent",
+    });
+    expect(loadSessionEntry).toHaveBeenCalledWith("agent:main:telegram:dm:parent");
+  });
+});

--- a/src/auto-reply/reply/stored-model-override.ts
+++ b/src/auto-reply/reply/stored-model-override.ts
@@ -34,6 +34,7 @@ function resolveParentSessionKeyCandidate(params: {
 
 /** Resolves the persisted model override visible to the current session. */
 export function resolveStoredModelOverride(params: {
+  loadSessionEntry?: (sessionKey: string) => SessionEntry | undefined;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
@@ -56,10 +57,10 @@ export function resolveStoredModelOverride(params: {
     sessionKey: params.sessionKey,
     parentSessionKey: params.parentSessionKey,
   });
-  if (!parentKey || !params.sessionStore) {
+  if (!parentKey) {
     return null;
   }
-  const parentEntry = params.sessionStore[parentKey];
+  const parentEntry = params.loadSessionEntry?.(parentKey) ?? params.sessionStore?.[parentKey];
   const normalizedParentOverride = normalizeStoredOverrideModel({
     providerOverride: parentEntry?.providerOverride,
     modelOverride: parentEntry?.modelOverride,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -143,6 +143,8 @@ export type LogicalSessionAccessScope = {
   sessionKey: string;
 };
 
+type SessionEntryListScope = Partial<Omit<SessionAccessScope, "sessionKey">>;
+
 export type ResolvedSessionEntryAccessTarget = {
   /** Agent owner inferred from the canonical session key. */
   agentId: string;
@@ -917,9 +919,7 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
 }
 
 /** Lists entries from the resolved store, preserving the persisted key for each row. */
-export function listSessionEntries(
-  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
-): SessionEntrySummary[] {
+export function listSessionEntries(scope: SessionEntryListScope = {}): SessionEntrySummary[] {
   if (scope.clone === false) {
     return Object.entries(
       loadSessionStore(resolveAccessStorePath({ ...scope, sessionKey: "" }), {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -26,7 +26,11 @@ import {
 } from "./disk-budget.js";
 import { extractGeneratedTranscriptSessionId } from "./generated-transcript-session-id.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
-import { resolveExplicitSessionFilePath, resolveSessionFilePath, resolveStorePath } from "./paths.js";
+import {
+  resolveExplicitSessionFilePath,
+  resolveSessionFilePath,
+  resolveStorePath,
+} from "./paths.js";
 import {
   ensureSessionStorePromptBlobsForPersistence,
   isSessionSkillPromptBlobReadable,

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -35,6 +35,7 @@ type RuntimeSessionStoreReadParams = {
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   sessionKey: string;
+  readConsistency?: "latest";
   storePath?: string;
 };
 
@@ -95,6 +96,7 @@ function toSessionAccessScope(params: RuntimeSessionStoreReadParams): SessionAcc
     ...(params.hydrateSkillPromptRefs !== undefined
       ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
       : {}),
+    ...(params.readConsistency !== undefined ? { readConsistency: params.readConsistency } : {}),
     ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
   };
 }

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -65,6 +65,7 @@ type RuntimeSessionStoreReadParams = {
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   sessionKey: string;
+  readConsistency?: "latest";
   storePath?: string;
 };
 type RuntimeSessionStoreListParams = Partial<Omit<RuntimeSessionStoreReadParams, "sessionKey">>;

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -79,14 +79,22 @@ describe("session accessor boundary guard", () => {
   it("ratchets only the bundled plugin files migrated by this slice", () => {
     expect(migratedBundledPluginSessionAccessorFiles).toEqual(
       new Set([
+        "extensions/codex/src/conversation-binding.ts",
+        "extensions/discord/src/monitor/native-command-model-picker-ui.ts",
         "extensions/discord/src/monitor/native-command-model-picker-apply.ts",
         "extensions/discord/src/monitor/thread-session-close.ts",
         "extensions/feishu/src/reasoning-preview.ts",
         "extensions/memory-core/src/dreaming-phases.ts",
         "extensions/memory-core/src/dreaming-narrative.ts",
         "extensions/mattermost/src/mattermost/model-picker.ts",
+        "extensions/matrix/src/matrix/monitor/handler.ts",
+        "extensions/matrix/src/session-route.ts",
+        "extensions/slack/src/monitor/slash.ts",
+        "extensions/telegram/src/bot-core.ts",
         "extensions/telegram/src/bot-handlers.runtime.ts",
         "extensions/telegram/src/bot.ts",
+        "extensions/telegram/src/bot-message-dispatch.ts",
+        "extensions/telegram/src/bot-native-commands.ts",
       ]),
     );
   });


### PR DESCRIPTION
## What Problem This Solves

Bundled plugins still had several read-only session metadata lookups that loaded or resolved whole session stores while Path 3 is moving runtime reads behind the session accessor seam. That kept model-picker, dispatch, routing, and group-activation paths coupled to broader store reads.

## Why This Change Was Made

This finishes the remaining bundled read-only metadata slice after #96507 merged the narrower Feishu/Mattermost/runtime barrel cleanup. The branch was rebuilt on current `main` after #96507, preserving only the unique accessor migrations and avoiding duplicate Feishu/runtime-barrel churn.

## User Impact

No user-facing command behavior should change. Discord, Mattermost, Slack, Matrix, Codex, and Telegram metadata reads now use targeted `getSessionEntry` access, with latest-read support where command UIs need fresh model/runtime overrides. Parent-session model override resolution can now load only the parent entry instead of the whole store.

## Evidence

- Rebuilt branch from `upstream/main` at `4d4769c0d6a55cecb40ac3910527e0eb0a1232f1`, the #96507 merge commit.
- Overlap with #96507 is limited to Mattermost model-picker and shared runtime/ratchet files; Feishu barrel cleanup remains owned by #96507 and is not reintroduced here.
- `node scripts/check-session-accessor-boundary.mjs`
- `node scripts/run-vitest.mjs src/auto-reply/reply/stored-model-override.test.ts test/scripts/check-session-accessor-boundary.test.ts extensions/mattermost/src/mattermost/model-picker.test.ts extensions/discord/src/monitor/native-command.model-picker.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot-native-commands.session-meta.test.ts`
- `git diff --check`
- `pnpm lint:tmp:session-accessor-boundary`
- `pnpm exec oxfmt --check --threads=1 <touched files>`
- `pnpm tsgo:test:src`
- `AGENTS_HOME="$HOME/.agents" "$HOME/.agents/skills/autoreview/scripts/autoreview" --mode local`
- Live proof on `/Users/phaedrus/Projects/clawdbot`: recorded original detached live SHA `352c4a40d838d7deb0bfdf38fa33665aef00be72`, checked out proof SHA `9bc2ea1652d6a25666cd0d80a77bdf7c040c9774`, ran `pnpm build`, `pnpm openclaw gateway restart`, `pnpm openclaw gateway status --deep --require-rpc --json`, `curl -fsS http://127.0.0.1:18789/healthz`, `curl -fsS http://127.0.0.1:18789/readyz`, and `pnpm openclaw gateway call health --json`.
- Live read probe on proof SHA read existing live `agent:main:main` and Telegram group/topic session keys with `readConsistency: "latest"`, resolved Discord and Mattermost current-model helper output as `openai/gpt-5.5-codex`, and confirmed the live store had 54 entries with no parent-session chain to exercise without writing synthetic state.
- Restored live checkout to detached SHA `352c4a40d838d7deb0bfdf38fa33665aef00be72`, rebuilt, restarted the gateway, and confirmed RPC health with Discord and Telegram both connected.

Refs #88838.
