### PR TITLE
fix(session-write-lock): enable reclaim of locks held past holder's own maxHoldMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## 2026.6.10
+
+### Fixes
+
+- **Session write lock:** bound `maxHoldMs` by the acquire `timeoutMs` + grace so a plugin hook that runs a long operation (e.g. active-memory sub-agent) can no longer hold the session write lock for the full default 5 min while other acquirers time out after 60 s, producing `SessionWriteLockTimeoutError` for concurrent sessions.
+
 ## 2026.6.9
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 Docs: https://docs.openclaw.ai
 
-## 2026.6.10
-
-### Fixes
-
-- **Session write lock:** bound `maxHoldMs` by the acquire `timeoutMs` + grace so a plugin hook that runs a long operation (e.g. active-memory sub-agent) can no longer hold the session write lock for the full default 5 min while other acquirers time out after 60 s, producing `SessionWriteLockTimeoutError` for concurrent sessions.
-
 ## 2026.6.9
 
 ### Highlights

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -668,12 +668,12 @@ describe("acquireSessionWriteLock", () => {
     expect(resolveSessionLockMaxHoldFromTimeout({ timeoutMs: 1_000, minMs: 5_000 })).toBe(121_000);
   });
 
-  it("acquireSessionWriteLock bounds maxHoldMs by timeoutMs plus grace", async () => {
-    // When no explicit maxHoldMs is provided, the effective hold limit must be
-    // bounded by timeoutMs + graceMs so a holder cannot starve other acquirers
-    // past their acquire timeout.  Previously the default maxHoldMs (300 s)
-    // was used even when the acquire timeout was only 60 s, causing
-    // SessionWriteLockTimeoutError for concurrent sessions.
+  it("acquireSessionWriteLock bounds maxHoldMs by timeoutMs", async () => {
+    // When no explicit maxHoldMs is provided, the effective hold limit must
+    // equal timeoutMs so a holder cannot block other acquirers past their
+    // acquire timeout.  Previously the default maxHoldMs (300 s) was used
+    // even when the acquire timeout was only 60 s, causing
+    // SessionWriteLockTimeoutError for concurrent operations.
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-hold-"));
     const sessionFile = path.join(root, "session.jsonl");
     await fs.writeFile(sessionFile, "", "utf8");
@@ -683,13 +683,12 @@ describe("acquireSessionWriteLock", () => {
         timeoutMs: 60_000,
       });
       try {
-        // The bound must equal timeoutMs + DEFAULT_TIMEOUT_GRACE_MS (120 s),
-        // NOT the old default maxHoldMs (300 s).
+        // maxHoldMs must equal timeoutMs (60 s), not the old 300 s default.
         const payload = await import("node:fs/promises").then((m) =>
           m.readFile(`${sessionFile}.lock`, "utf8"),
         );
         const parsed = JSON.parse(payload) as { maxHoldMs?: number };
-        expect(parsed.maxHoldMs).toBe(60_000 + 120_000);
+        expect(parsed.maxHoldMs).toBe(60_000);
         expect(parsed.maxHoldMs).toBeLessThan(300_000);
       } finally {
         await lock.release();

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -680,19 +680,17 @@ describe("acquireSessionWriteLock", () => {
     try {
       const lock = await acquireSessionWriteLock({
         sessionFile,
-        timeoutMs: 1_000,
+        timeoutMs: 60_000,
       });
       try {
-        // The lock was acquired with a bounded hold.  If the holder exceeds
-        // timeoutMs + graceMs without releasing, the watchdog is allowed to
-        // force-release it rather than letting it block other acquirers
-        // indefinitely.
+        // The bound must equal timeoutMs + DEFAULT_TIMEOUT_GRACE_MS (120 s),
+        // NOT the old default maxHoldMs (300 s).
         const payload = await import("node:fs/promises").then((m) =>
           m.readFile(`${sessionFile}.lock`, "utf8"),
         );
         const parsed = JSON.parse(payload) as { maxHoldMs?: number };
-        expect(parsed.maxHoldMs).toBeLessThanOrEqual(1_000 + 120_000);
-        expect(parsed.maxHoldMs).toBeGreaterThan(0);
+        expect(parsed.maxHoldMs).toBe(60_000 + 120_000);
+        expect(parsed.maxHoldMs).toBeLessThan(300_000);
       } finally {
         await lock.release();
       }

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -730,7 +730,9 @@ describe("acquireSessionWriteLock", () => {
       const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "openclaw"], {
         stdio: "ignore",
       });
-      if (!owner.pid) throw new Error("missing pid");
+      if (!owner.pid) {
+        throw new Error("missing pid");
+      }
       // Lock is past staleMs (30s > 20s) but within its own maxHoldMs (100000 >> 30s).
       await fs.writeFile(
         lockPath,

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -675,11 +675,10 @@ describe("acquireSessionWriteLock", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-reclaim-"));
     const sessionFile = path.join(root, "session.jsonl");
     const lockPath = `${sessionFile}.lock`;
-    writeFileSync(sessionFile, "", "utf8");
+    await fs.writeFile(sessionFile, "", "utf8");
     try {
       // Spawn a process that holds the lock, then write the lock file with its PID.
       // The process just sleeps — simulating a live OpenClaw process that is alive but wedged.
-      const { spawn } = await import("node:child_process");
       const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "openclaw"], {
         stdio: "ignore",
       });
@@ -688,7 +687,7 @@ describe("acquireSessionWriteLock", () => {
       }
       // Live OpenClaw owner, within staleMs but past its own recorded maxHoldMs: a stuck
       // holder whose in-process watchdog can never fire must still be reclaimable.
-      writeFileSync(
+      await fs.writeFile(
         lockPath,
         JSON.stringify({
           pid: owner.pid,
@@ -706,7 +705,7 @@ describe("acquireSessionWriteLock", () => {
           timeoutMs: 500,
           staleMs: 600_000,
         });
-        const payload = JSON.parse(readFileSync(lockPath, "utf8"));
+        const payload = JSON.parse(await fs.readFile(lockPath, "utf8")) as { createdAt: string };
         // The lock was reclaimed: createdAt is now recent (the old 30s-old value is gone).
         const ageMs = Date.now() - new Date(payload.createdAt).getTime();
         expect(ageMs).toBeLessThan(5_000);
@@ -715,7 +714,7 @@ describe("acquireSessionWriteLock", () => {
         owner.kill("SIGTERM");
       }
     } finally {
-      rmSync(root, { recursive: true, force: true });
+      await fs.rm(root, { recursive: true, force: true });
     }
   });
 
@@ -725,16 +724,15 @@ describe("acquireSessionWriteLock", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-live-"));
     const sessionFile = path.join(root, "session.jsonl");
     const lockPath = `${sessionFile}.lock`;
-    writeFileSync(sessionFile, "", "utf8");
+    await fs.writeFile(sessionFile, "", "utf8");
     try {
       // Spawn a child as the lock owner so isPidAlive + isOpenClawSessionOwnerArgv succeed.
-      const { spawn } = await import("node:child_process");
       const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "openclaw"], {
         stdio: "ignore",
       });
       if (!owner.pid) throw new Error("missing pid");
       // Lock is past staleMs (30s > 20s) but within its own maxHoldMs (100000 >> 30s).
-      writeFileSync(
+      await fs.writeFile(
         lockPath,
         JSON.stringify({
           pid: owner.pid,
@@ -752,7 +750,7 @@ describe("acquireSessionWriteLock", () => {
         owner.kill("SIGTERM");
       }
     } finally {
-      rmSync(root, { recursive: true, force: true });
+      await fs.rm(root, { recursive: true, force: true });
     }
   });
 

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -670,9 +670,9 @@ describe("acquireSessionWriteLock", () => {
 
   it("acquireSessionWriteLock bounds maxHoldMs by timeoutMs", async () => {
     // When no explicit maxHoldMs is provided, the effective hold limit must
-    // equal timeoutMs so a holder cannot block other acquirers past their
-    // acquire timeout.  Previously the default maxHoldMs (300 s) was used
-    // even when the acquire timeout was only 60 s, causing
+    // be bounded by timeoutMs so a holder cannot block other acquirers past
+    // their acquire timeout.  Previously the default maxHoldMs (300 s) was
+    // used even when the acquire timeout was only 60 s, causing
     // SessionWriteLockTimeoutError for concurrent operations.
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-hold-"));
     const sessionFile = path.join(root, "session.jsonl");
@@ -683,12 +683,13 @@ describe("acquireSessionWriteLock", () => {
         timeoutMs: 60_000,
       });
       try {
-        // maxHoldMs must equal timeoutMs (60 s), not the old 300 s default.
+        // maxHoldMs must be bounded by timeoutMs (≈60 s), not the old 300 s
+        // default.
         const payload = await import("node:fs/promises").then((m) =>
           m.readFile(`${sessionFile}.lock`, "utf8"),
         );
         const parsed = JSON.parse(payload) as { maxHoldMs?: number };
-        expect(parsed.maxHoldMs).toBe(60_000);
+        expect(parsed.maxHoldMs).toBeLessThanOrEqual(60_001);
         expect(parsed.maxHoldMs).toBeLessThan(300_000);
       } finally {
         await lock.release();
@@ -716,6 +717,35 @@ describe("acquireSessionWriteLock", () => {
         );
         const parsed = JSON.parse(payload) as { maxHoldMs?: number };
         expect(parsed.maxHoldMs).toBe(5_000);
+      } finally {
+        await lock.release();
+      }
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("acquireSessionWriteLock caps configured maxHoldMs at timeoutMs", async () => {
+    // If the caller sets maxHoldMs above the acquire timeout, the cap lowers
+    // it to approximately timeoutMs so a holder cannot block waiters past
+    // their timeout.  This is intentional: operators should configure
+    // maxHoldMs ≤ timeoutMs.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-hold-high-"));
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(sessionFile, "", "utf8");
+    try {
+      const lock = await acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: 60_000,
+        maxHoldMs: 500_000,
+      });
+      try {
+        const payload = await import("node:fs/promises").then((m) =>
+          m.readFile(`${sessionFile}.lock`, "utf8"),
+        );
+        const parsed = JSON.parse(payload) as { maxHoldMs?: number };
+        expect(parsed.maxHoldMs).toBeLessThanOrEqual(60_001);
+        expect(parsed.maxHoldMs).toBeLessThan(500_000);
       } finally {
         await lock.release();
       }

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -668,89 +668,91 @@ describe("acquireSessionWriteLock", () => {
     expect(resolveSessionLockMaxHoldFromTimeout({ timeoutMs: 1_000, minMs: 5_000 })).toBe(121_000);
   });
 
-  it("acquireSessionWriteLock bounds maxHoldMs by timeoutMs", async () => {
-    // When no explicit maxHoldMs is provided, the effective hold limit must
-    // be bounded by timeoutMs so a holder cannot block other acquirers past
-    // their acquire timeout.  Previously the default maxHoldMs (300 s) was
-    // used even when the acquire timeout was only 60 s, causing
-    // SessionWriteLockTimeoutError for concurrent operations.
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-hold-"));
+  it("reclaims a live OpenClaw-owned lock that exceeded its own maxHoldMs", async () => {
+    // A live holder past its own recorded maxHoldMs is overdue by its own contract and must
+    // be reclaimable by a contender.  This covers the case where a holder's event loop is wedged
+    // (e.g. synchronous CPU loop) so its in-process watchdog cannot fire. (#87483)
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-reclaim-"));
     const sessionFile = path.join(root, "session.jsonl");
-    await fs.writeFile(sessionFile, "", "utf8");
+    const lockPath = `${sessionFile}.lock`;
+    writeFileSync(sessionFile, "", "utf8");
     try {
-      const lock = await acquireSessionWriteLock({
-        sessionFile,
-        timeoutMs: 60_000,
+      // Spawn a process that holds the lock, then write the lock file with its PID.
+      // The process just sleeps — simulating a live OpenClaw process that is alive but wedged.
+      const { spawn } = await import("node:child_process");
+      const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "openclaw"], {
+        stdio: "ignore",
       });
+      if (!owner.pid) {
+        throw new Error("missing lock owner pid");
+      }
+      // Live OpenClaw owner, within staleMs but past its own recorded maxHoldMs: a stuck
+      // holder whose in-process watchdog can never fire must still be reclaimable.
+      writeFileSync(
+        lockPath,
+        JSON.stringify({
+          pid: owner.pid,
+          createdAt: new Date(Date.now() - 30_000).toISOString(),
+          maxHoldMs: 1_000,
+        }),
+        "utf8",
+      );
+
       try {
-        // maxHoldMs must be bounded by timeoutMs (≈60 s), not the old 300 s
-        // default.
-        const payload = await import("node:fs/promises").then((m) =>
-          m.readFile(`${sessionFile}.lock`, "utf8"),
-        );
-        const parsed = JSON.parse(payload) as { maxHoldMs?: number };
-        expect(parsed.maxHoldMs).toBeLessThanOrEqual(60_001);
-        expect(parsed.maxHoldMs).toBeLessThan(300_000);
-      } finally {
+        // Before the fix this throws SessionWriteLockStaleError because
+        // "hold-exceeded" was report-only. After the fix the lock is reclaimed.
+        const lock = await acquireSessionWriteLock({
+          sessionFile,
+          timeoutMs: 500,
+          staleMs: 600_000,
+        });
+        const payload = JSON.parse(readFileSync(lockPath, "utf8"));
+        // The lock was reclaimed: createdAt is now recent (the old 30s-old value is gone).
+        const ageMs = Date.now() - new Date(payload.createdAt).getTime();
+        expect(ageMs).toBeLessThan(5_000);
         await lock.release();
+      } finally {
+        owner.kill("SIGTERM");
       }
     } finally {
-      await fs.rm(root, { recursive: true, force: true });
+      rmSync(root, { recursive: true, force: true });
     }
   });
 
-  it("acquireSessionWriteLock respects explicit maxHoldMs below the timeout-derived bound", async () => {
-    // If the caller explicitly requests a maxHoldMs below the timeout-derived
-    // bound, the lower value must be honored.
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-hold-explicit-"));
+  it("does NOT reclaim a live OpenClaw-owned lock merely past global staleMs but within its own maxHoldMs", async () => {
+    // "too-old" stays report-only: a live holder within its own maxHoldMs must not have its
+    // lock stolen on the global staleMs heuristic alone.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-live-"));
     const sessionFile = path.join(root, "session.jsonl");
-    await fs.writeFile(sessionFile, "", "utf8");
+    const lockPath = `${sessionFile}.lock`;
+    writeFileSync(sessionFile, "", "utf8");
     try {
-      const lock = await acquireSessionWriteLock({
-        sessionFile,
-        timeoutMs: 60_000,
-        maxHoldMs: 5_000,
+      // Spawn a child as the lock owner so isPidAlive + isOpenClawSessionOwnerArgv succeed.
+      const { spawn } = await import("node:child_process");
+      const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "openclaw"], {
+        stdio: "ignore",
       });
-      try {
-        const payload = await import("node:fs/promises").then((m) =>
-          m.readFile(`${sessionFile}.lock`, "utf8"),
-        );
-        const parsed = JSON.parse(payload) as { maxHoldMs?: number };
-        expect(parsed.maxHoldMs).toBe(5_000);
-      } finally {
-        await lock.release();
-      }
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
+      if (!owner.pid) throw new Error("missing pid");
+      // Lock is past staleMs (30s > 20s) but within its own maxHoldMs (100000 >> 30s).
+      writeFileSync(
+        lockPath,
+        JSON.stringify({
+          pid: owner.pid,
+          createdAt: new Date(Date.now() - 30_000).toISOString(),
+          maxHoldMs: 100_000,
+        }),
+        "utf8",
+      );
 
-  it("acquireSessionWriteLock caps configured maxHoldMs at timeoutMs", async () => {
-    // If the caller sets maxHoldMs above the acquire timeout, the cap lowers
-    // it to approximately timeoutMs so a holder cannot block waiters past
-    // their timeout.  This is intentional: operators should configure
-    // maxHoldMs ≤ timeoutMs.
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-hold-high-"));
-    const sessionFile = path.join(root, "session.jsonl");
-    await fs.writeFile(sessionFile, "", "utf8");
-    try {
-      const lock = await acquireSessionWriteLock({
-        sessionFile,
-        timeoutMs: 60_000,
-        maxHoldMs: 500_000,
-      });
       try {
-        const payload = await import("node:fs/promises").then((m) =>
-          m.readFile(`${sessionFile}.lock`, "utf8"),
-        );
-        const parsed = JSON.parse(payload) as { maxHoldMs?: number };
-        expect(parsed.maxHoldMs).toBeLessThanOrEqual(60_001);
-        expect(parsed.maxHoldMs).toBeLessThan(500_000);
+        await expect(
+          acquireSessionWriteLock({ sessionFile, timeoutMs: 500, staleMs: 20_000 }),
+        ).rejects.toThrow(/stale/);
       } finally {
-        await lock.release();
+        owner.kill("SIGTERM");
       }
     } finally {
-      await fs.rm(root, { recursive: true, force: true });
+      rmSync(root, { recursive: true, force: true });
     }
   });
 

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -668,6 +668,65 @@ describe("acquireSessionWriteLock", () => {
     expect(resolveSessionLockMaxHoldFromTimeout({ timeoutMs: 1_000, minMs: 5_000 })).toBe(121_000);
   });
 
+  it("acquireSessionWriteLock bounds maxHoldMs by timeoutMs plus grace", async () => {
+    // When no explicit maxHoldMs is provided, the effective hold limit must be
+    // bounded by timeoutMs + graceMs so a holder cannot starve other acquirers
+    // past their acquire timeout.  Previously the default maxHoldMs (300 s)
+    // was used even when the acquire timeout was only 60 s, causing
+    // SessionWriteLockTimeoutError for concurrent sessions.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-hold-"));
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(sessionFile, "", "utf8");
+    try {
+      const lock = await acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: 1_000,
+      });
+      try {
+        // The lock was acquired with a bounded hold.  If the holder exceeds
+        // timeoutMs + graceMs without releasing, the watchdog is allowed to
+        // force-release it rather than letting it block other acquirers
+        // indefinitely.
+        const payload = await import("node:fs/promises").then((m) =>
+          m.readFile(`${sessionFile}.lock`, "utf8"),
+        );
+        const parsed = JSON.parse(payload) as { maxHoldMs?: number };
+        expect(parsed.maxHoldMs).toBeLessThanOrEqual(1_000 + 120_000);
+        expect(parsed.maxHoldMs).toBeGreaterThan(0);
+      } finally {
+        await lock.release();
+      }
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("acquireSessionWriteLock respects explicit maxHoldMs below the timeout-derived bound", async () => {
+    // If the caller explicitly requests a maxHoldMs below the timeout-derived
+    // bound, the lower value must be honored.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-hold-explicit-"));
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(sessionFile, "", "utf8");
+    try {
+      const lock = await acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: 60_000,
+        maxHoldMs: 5_000,
+      });
+      try {
+        const payload = await import("node:fs/promises").then((m) =>
+          m.readFile(`${sessionFile}.lock`, "utf8"),
+        );
+        const parsed = JSON.parse(payload) as { maxHoldMs?: number };
+        expect(parsed.maxHoldMs).toBe(5_000);
+      } finally {
+        await lock.release();
+      }
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("resolves the session write-lock acquire timeout", () => {
     expect(resolveSessionWriteLockAcquireTimeoutMs()).toBe(60_000);
     expect(

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -902,6 +902,13 @@ export async function acquireSessionWriteLock(params: {
   // maxHoldMs (5 min) even though other acquirers time out after 60 s,
   // producing SessionWriteLockTimeoutError for every other operation that
   // shares the lock (e.g. mirrorCodexAppServerTranscript).
+  //
+  // Compatibility: this cap applies to ALL callers, including operators who
+  // configured a high maxHoldMs via config.session.writeLock.maxHoldMs or
+  // OPENCLAW_SESSION_WRITE_LOCK_MAX_HOLD_MS.  If your workload needs a hold
+  // longer than the acquire timeout, increase the acquire timeout instead —
+  // holding the lock past the acquire timeout causes other writers to fail.
+  //
   // Note: pass minMs=1 and graceMs=1 because resolveSessionLockMaxHoldFromTimeout
   // defaults minMs to DEFAULT_SESSION_WRITE_LOCK_MAX_HOLD_MS (300 s) and
   // resolvePositiveMs rejects values ≤ 0, which would make the cap a no-op for

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -895,18 +895,20 @@ export async function acquireSessionWriteLock(params: {
     allowInfinity: true,
   });
   const staleMs = resolvePositiveMs(params.staleMs, defaultOptions.staleMs);
-  // Bound maxHoldMs by the acquire timeout + grace so a holder cannot block
-  // other acquirers past their timeout.  Without this, a plugin hook that
-  // runs a long operation (e.g. active-memory sub-agent) while holding the
-  // session write lock would hold it for the full default maxHoldMs (5 min)
-  // even though other acquirers time out after 60 s, producing
-  // SessionWriteLockTimeoutError for every other session that shares the lock.
-  // Note: pass minMs=0 because resolveSessionLockMaxHoldFromTimeout defaults
-  // minMs to DEFAULT_SESSION_WRITE_LOCK_MAX_HOLD_MS (300 s), which would make
-  // the cap a no-op for the common case of a 60 s acquire timeout.
+  // Bound maxHoldMs by the acquire timeout so a holder cannot block other
+  // acquirers past their timeout.  Without this, a plugin hook that runs a
+  // long operation (e.g. active-memory sub-agent) while a session lock
+  // controller holds the write lock would hold it for the full default
+  // maxHoldMs (5 min) even though other acquirers time out after 60 s,
+  // producing SessionWriteLockTimeoutError for every other operation that
+  // shares the lock (e.g. mirrorCodexAppServerTranscript).
+  // Note: pass minMs=0 and graceMs=0 because resolveSessionLockMaxHoldFromTimeout
+  // defaults minMs to DEFAULT_SESSION_WRITE_LOCK_MAX_HOLD_MS (300 s), which
+  // would make the cap a no-op for the common case of a 60 s acquire timeout.
   const maxHoldFromTimeout = resolveSessionLockMaxHoldFromTimeout({
     timeoutMs,
     minMs: 0,
+    graceMs: 0,
   });
   const maxHoldMs = Math.min(
     resolvePositiveMs(params.maxHoldMs, defaultOptions.maxHoldMs),

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -51,7 +51,11 @@ const DEFAULT_SESSION_WRITE_LOCK_MAX_HOLD_MS = 5 * 60 * 1000;
 const DEFAULT_SESSION_WRITE_LOCK_ACQUIRE_TIMEOUT_MS = 60_000;
 const DEFAULT_WATCHDOG_INTERVAL_MS = 60_000;
 const DEFAULT_TIMEOUT_GRACE_MS = 2 * 60 * 1000;
-const REPORT_ONLY_STALE_LOCK_REASONS = new Set(["too-old", "hold-exceeded"]);
+// "too-old" (past global staleMs) stays report-only — a live holder may still be within its own
+// maxHoldMs. "hold-exceeded" (past the holder's OWN recorded maxHoldMs) is overdue by contract and
+// reclaimable; acquire's remove-if-unchanged still skips a lock whose file changed (e.g. a release).
+// (#87483)
+const REPORT_ONLY_STALE_LOCK_REASONS = new Set(["too-old"]);
 
 /**
  * Yield control to the event loop so other sessions can make progress
@@ -895,33 +899,7 @@ export async function acquireSessionWriteLock(params: {
     allowInfinity: true,
   });
   const staleMs = resolvePositiveMs(params.staleMs, defaultOptions.staleMs);
-  // Bound maxHoldMs by the acquire timeout so a holder cannot block other
-  // acquirers past their timeout.  Without this, a plugin hook that runs a
-  // long operation (e.g. active-memory sub-agent) while a session lock
-  // controller holds the write lock would hold it for the full default
-  // maxHoldMs (5 min) even though other acquirers time out after 60 s,
-  // producing SessionWriteLockTimeoutError for every other operation that
-  // shares the lock (e.g. mirrorCodexAppServerTranscript).
-  //
-  // Compatibility: this cap applies to ALL callers, including operators who
-  // configured a high maxHoldMs via config.session.writeLock.maxHoldMs or
-  // OPENCLAW_SESSION_WRITE_LOCK_MAX_HOLD_MS.  If your workload needs a hold
-  // longer than the acquire timeout, increase the acquire timeout instead —
-  // holding the lock past the acquire timeout causes other writers to fail.
-  //
-  // Note: pass minMs=1 and graceMs=1 because resolveSessionLockMaxHoldFromTimeout
-  // defaults minMs to DEFAULT_SESSION_WRITE_LOCK_MAX_HOLD_MS (300 s) and
-  // resolvePositiveMs rejects values ≤ 0, which would make the cap a no-op for
-  // the common case of a 60 s acquire timeout.
-  const maxHoldFromTimeout = resolveSessionLockMaxHoldFromTimeout({
-    timeoutMs,
-    minMs: 1,
-    graceMs: 1,
-  });
-  const maxHoldMs = Math.min(
-    resolvePositiveMs(params.maxHoldMs, defaultOptions.maxHoldMs),
-    maxHoldFromTimeout,
-  );
+  const maxHoldMs = resolvePositiveMs(params.maxHoldMs, defaultOptions.maxHoldMs);
   const orphanPayloadGraceMs = resolveOrphanLockPayloadGraceMs(timeoutMs);
   const sessionFile = path.resolve(params.sessionFile);
   const sessionDir = path.dirname(sessionFile);

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -667,6 +667,7 @@ function resolveRemainingAcquireTimeoutMs(
 
 async function shouldRetryStaleAcquireFailure(params: {
   lockPath: string;
+  normalizedSessionFile: string;
   lockMissingAtDiagnostics: boolean;
   inspected: LockInspectionDetails;
   heldByThisProcess: boolean;
@@ -674,7 +675,10 @@ async function shouldRetryStaleAcquireFailure(params: {
   nowMs: number;
   orphanPayloadGraceMs: number;
 }): Promise<boolean> {
-  if (params.lockMissingAtDiagnostics) {
+  if (
+    params.lockMissingAtDiagnostics &&
+    !sessionLockHeldByThisProcess(params.normalizedSessionFile)
+  ) {
     return true;
   }
   return !(await shouldReportContendedLockStale({
@@ -1016,6 +1020,7 @@ export async function acquireSessionWriteLock(params: {
           resolveRemainingAcquireTimeoutMs(timeoutMs, startedAtMs, Date.now()) > 0 &&
           (await shouldRetryStaleAcquireFailure({
             lockPath: errorLockPath,
+            normalizedSessionFile,
             lockMissingAtDiagnostics,
             inspected,
             heldByThisProcess,

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -901,7 +901,13 @@ export async function acquireSessionWriteLock(params: {
   // session write lock would hold it for the full default maxHoldMs (5 min)
   // even though other acquirers time out after 60 s, producing
   // SessionWriteLockTimeoutError for every other session that shares the lock.
-  const maxHoldFromTimeout = resolveSessionLockMaxHoldFromTimeout({ timeoutMs });
+  // Note: pass minMs=0 because resolveSessionLockMaxHoldFromTimeout defaults
+  // minMs to DEFAULT_SESSION_WRITE_LOCK_MAX_HOLD_MS (300 s), which would make
+  // the cap a no-op for the common case of a 60 s acquire timeout.
+  const maxHoldFromTimeout = resolveSessionLockMaxHoldFromTimeout({
+    timeoutMs,
+    minMs: 0,
+  });
   const maxHoldMs = Math.min(
     resolvePositiveMs(params.maxHoldMs, defaultOptions.maxHoldMs),
     maxHoldFromTimeout,

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -902,13 +902,14 @@ export async function acquireSessionWriteLock(params: {
   // maxHoldMs (5 min) even though other acquirers time out after 60 s,
   // producing SessionWriteLockTimeoutError for every other operation that
   // shares the lock (e.g. mirrorCodexAppServerTranscript).
-  // Note: pass minMs=0 and graceMs=0 because resolveSessionLockMaxHoldFromTimeout
-  // defaults minMs to DEFAULT_SESSION_WRITE_LOCK_MAX_HOLD_MS (300 s), which
-  // would make the cap a no-op for the common case of a 60 s acquire timeout.
+  // Note: pass minMs=1 and graceMs=1 because resolveSessionLockMaxHoldFromTimeout
+  // defaults minMs to DEFAULT_SESSION_WRITE_LOCK_MAX_HOLD_MS (300 s) and
+  // resolvePositiveMs rejects values ≤ 0, which would make the cap a no-op for
+  // the common case of a 60 s acquire timeout.
   const maxHoldFromTimeout = resolveSessionLockMaxHoldFromTimeout({
     timeoutMs,
-    minMs: 0,
-    graceMs: 0,
+    minMs: 1,
+    graceMs: 1,
   });
   const maxHoldMs = Math.min(
     resolvePositiveMs(params.maxHoldMs, defaultOptions.maxHoldMs),

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -895,7 +895,17 @@ export async function acquireSessionWriteLock(params: {
     allowInfinity: true,
   });
   const staleMs = resolvePositiveMs(params.staleMs, defaultOptions.staleMs);
-  const maxHoldMs = resolvePositiveMs(params.maxHoldMs, defaultOptions.maxHoldMs);
+  // Bound maxHoldMs by the acquire timeout + grace so a holder cannot block
+  // other acquirers past their timeout.  Without this, a plugin hook that
+  // runs a long operation (e.g. active-memory sub-agent) while holding the
+  // session write lock would hold it for the full default maxHoldMs (5 min)
+  // even though other acquirers time out after 60 s, producing
+  // SessionWriteLockTimeoutError for every other session that shares the lock.
+  const maxHoldFromTimeout = resolveSessionLockMaxHoldFromTimeout({ timeoutMs });
+  const maxHoldMs = Math.min(
+    resolvePositiveMs(params.maxHoldMs, defaultOptions.maxHoldMs),
+    maxHoldFromTimeout,
+  );
   const orphanPayloadGraceMs = resolveOrphanLockPayloadGraceMs(timeoutMs);
   const sessionFile = path.resolve(params.sessionFile);
   const sessionDir = path.dirname(sessionFile);


### PR DESCRIPTION
## What Problem This Solves

The session write lock's reclaim mechanism treated `"hold-exceeded"` (past the holder's own `maxHoldMs`) as report-only, meaning a contending process could never remove a lock that was overdue by the holder's own declared contract. Combined with the fact that the in-process watchdog (`setInterval`) cannot fire when the holder's event loop is wedged, this caused session locks to pin indefinitely — producing `session file locked (timeout 60000ms)` for every concurrent writer until the gateway was restarted.

The fix removes `"hold-exceeded"` from `REPORT_ONLY_STALE_LOCK_REASONS`. A holder past its **own recorded `maxHoldMs`** is overdue by its own contract and is now reclaimable by a contender. The conservative `"too-old"` (global `staleMs`) stays report-only — a live holder merely past the global heuristic but within its own `maxHoldMs` is still respected.

A secondary guard fix: `shouldRetryStaleAcquireFailure` now checks `sessionLockHeldByThisProcess` when the lock file is missing, preventing an infinite retry loop when the lock is actually held by this process.

### Compatibility

- Operators who configured `session.writeLock.maxHoldMs` or `OPENCLAW_SESSION_WRITE_LOCK_MAX_HOLD_MS` will see the value preserved in the lock file. The change only affects what happens when a lock exceeds that value: contenders can now reclaim it.
- The `remove-if-unchanged` recovery still skips a lock whose file changed (e.g. a concurrent release), so only a genuinely stalled holder loses the lock.
- The `cleanStaleLockFiles` doctor sweep does not pass `respectMaxHold` and is unchanged.

## Evidence

Deterministic regression tests in `src/agents/session-write-lock.test.ts`:

```text
reclaims a live OpenClaw-owned lock that exceeded its own maxHoldMs
does NOT reclaim a live OpenClaw-owned lock merely past global staleMs but within its own maxHoldMs
```

Run after the patch:

```text
$ node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts
  ✓  agents  src/agents/session-write-lock.test.ts (55 tests) 386ms
  Test Files  1 passed (1)
  Tests  55 passed (55)
```

The new reclaim case fails on current `main` exactly as the issue describes — `SessionWriteLockStaleError: session file lock stale (hold-exceeded): … alive=true` — and passes after dropping `"hold-exceeded"` from the report-only set, while all existing cases (including the conservative "report live too-old locks without removing them") stay green.

### Observed result (overdue live holder reclaimed; conservative live holder respected)

```text
=== Test 1: Reclaim a live OpenClaw-owned lock past its own maxHoldMs ===
  Lock reclaimed: createdAt is 0ms old (< 5000ms)
  PASS

=== Test 2: Do NOT reclaim a live lock within its own maxHoldMs ===
  Correctly rejected: session file lock stale (too-old): pid=... alive=true ageMs=30001
  PASS
```

### Lock payload before/after

Before:
```json
{"pid": 1302, "createdAt": "…", "maxHoldMs": 300000}
```

After:
```json
{"pid": 1302, "createdAt": "…", "maxHoldMs": 300000}
```

The `maxHoldMs` value itself is unchanged — only the reclaim behavior when that deadline is exceeded changes. A contender that previously saw an unrecoverable stale lock now successfully reclaims and re-acquires.

## Changes

- `src/agents/session-write-lock.ts`:
  - drop `"hold-exceeded"` from `REPORT_ONLY_STALE_LOCK_REASONS` (one element + comment).
  - guard the missing-pid retry with `!sessionLockHeldByThisProcess` to avoid spinning on our own lock.
- `src/agents/session-write-lock.test.ts`:
  - regression test: a live OpenClaw-owned lock past its own `maxHoldMs` (but within `staleMs`) is reclaimed.
  - regression test: a live OpenClaw-owned lock merely past global `staleMs` (within its `maxHoldMs`) is NOT reclaimed.

## Reproduction

Issue #87483: a session write-lock held by a **live** gateway process persisted for 8+ hours past `maxHoldMs`/`staleMs`; the watchdog never reclaimed it, so later requests failed with `session file locked (timeout 60000ms): pid=…`. The reporter's holder process was alive and busy (83% CPU) while holding the lock despite the lock recording `maxHoldMs: 1020000` (17 min).

### Before fix

1. A long-running gateway holds a session write-lock and gets stuck in a synchronous CPU loop (event loop blocked).
2. The holder's in-process watchdog can't fire, so the lock is never self-released past `maxHoldMs`.
3. Another request tries to write the same session; it sees the lock past the holder's `maxHoldMs` but cannot reclaim it because `shouldRemoveContendedLockFile` treats `"hold-exceeded"` as report-only.
4. The contender fails with a stale/`session file locked` error; the lock persists until the gateway restarts or the file is deleted manually.

### After fix

The contender reclaims the lock (the stalled holder's overdue lock is removed-if-unchanged) and proceeds.

## Risk / Mitigation

- **Risk**: reclaiming a live holder's lock could race with a holder still writing the transcript.
  **Mitigation**: no new race is introduced. The target case is a *wedged* holder whose event loop is blocked — it cannot be writing the transcript (transcript writes are async and need the event loop). A holder that is still making progress already releases at `maxHoldMs` by its own in-process watchdog, so `maxHoldMs` was already the hard hold limit before this change; the cross-process reclaim only restores that limit for the wedged case where the watchdog cannot fire. `remove-if-unchanged` additionally skips a lock whose file changed.
- **Risk**: behavior change in session-state concurrency.
  **Mitigation**: the change narrows report-only to the global `staleMs` heuristic; it does not touch thresholds, the watchdog, or the doctor sweep, and the conservative live-`too-old` behavior is preserved (covered by an existing test).
