### PR TITLE
fix(cron): engage model fallback on embedded result-level failures (reasoning-only / empty / incomplete_turn)

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -297,6 +297,25 @@ export function createCronPromptExecutor(params: {
       }
     | undefined;
 
+  // CLI providers surface their own terminal classification; only the embedded
+  // branch returns fallback-safe result-level failures (reasoning-only,
+  // empty-visible, incomplete_turn) that the model-fallback loop must reclassify
+  // to advance to the configured fallback. Resolve CLI-ness once so the run path
+  // and the classifier agree on which branch produced a candidate result.
+  const resolveCronExecutionProvider = (provider: string, model: string) => {
+    const executionProvider =
+      resolveCliRuntimeExecutionProvider({
+        provider,
+        cfg: params.cfgWithAgentDefaults,
+        agentId: params.agentId,
+        modelId: model,
+      }) ?? provider;
+    return {
+      executionProvider,
+      isCli: isCliProvider(executionProvider, params.cfgWithAgentDefaults),
+    };
+  };
+
   const runPrompt = async (promptText: string) => {
     const userTurnTranscriptRecorder =
       pendingUserTurn?.promptText === promptText
@@ -341,25 +360,28 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      // Returned result-level failures (reasoning-only/empty/incomplete_turn) do
+      // not throw, so without a classifier the loop treats the first candidate as
+      // a success and never engages the configured fallback chain. Scope this to
+      // the embedded branch; the CLI runner owns its own terminal classification.
       classifyResult: ({ provider, model, result }) =>
-        classifyEmbeddedAgentRunResultForModelFallback({ provider, model, result }),
+        resolveCronExecutionProvider(provider, model).isCli
+          ? null
+          : classifyEmbeddedAgentRunResultForModelFallback({ provider, model, result }),
       mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());
         }
-        const executionProvider =
-          resolveCliRuntimeExecutionProvider({
-            provider: providerOverride,
-            cfg: params.cfgWithAgentDefaults,
-            agentId: params.agentId,
-            modelId: modelOverride,
-          }) ?? providerOverride;
+        const { executionProvider, isCli } = resolveCronExecutionProvider(
+          providerOverride,
+          modelOverride,
+        );
         const bootstrapPromptWarningSignature =
           bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
         // CLI providers can resume provider-native sessions; embedded providers
         // use OpenClaw's transcript/session file plus prompt-cache affinity.
-        if (isCliProvider(executionProvider, params.cfgWithAgentDefaults)) {
+        if (isCli) {
           const cliSessionBinding = params.cronSession.isNewSession
             ? undefined
             : await getCliSessionBinding(params.cronSession.sessionEntry, executionProvider);

--- a/src/cron/isolated-agent/run.result-fallback-gap.test.ts
+++ b/src/cron/isolated-agent/run.result-fallback-gap.test.ts
@@ -1,0 +1,162 @@
+// Covers the cron embedded-run path wiring the embedded result classifier and
+// merge helper into runWithModelFallback, so returned result-level failures
+// (reasoning-only / empty-visible / incomplete_turn) engage the configured
+// fallback chain instead of silently dropping the answer.
+import { describe, expect, it } from "vitest";
+import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  isCliProviderMock,
+  loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
+  runEmbeddedAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+/** Fallback-safe result-level failure: reasoning-only / incomplete_turn, no visible reply. */
+function makeReasoningOnlyIncompleteResult() {
+  return {
+    payloads: [{ text: "Agent couldn't generate a response.", isError: true }],
+    meta: {
+      agentMeta: {},
+      agentHarnessResultClassification: "reasoning-only",
+      error: {
+        kind: "incomplete_turn",
+        message: "Agent couldn't generate a response.",
+        fallbackSafe: true,
+        terminalPresentation: false,
+      },
+    },
+  };
+}
+
+function makeHealthyFallbackResult() {
+  return {
+    payloads: [{ text: "Workspace cleaned up: removed 12 stale files." }],
+    meta: {
+      agentMeta: {},
+      finalAssistantVisibleText: "Workspace cleaned up: removed 12 stale files.",
+    },
+  };
+}
+
+/**
+ * Minimal faithful model-fallback loop that drives the real classifier/merge the
+ * cron path passes, advancing candidates exactly when a classification is returned.
+ */
+function installFaithfulFallbackLoop(): void {
+  runWithModelFallbackMock.mockImplementation(
+    async ({ provider, model, run, fallbacksOverride, classifyResult, mergeExhaustedResult }) => {
+      const candidates = [
+        { provider, model },
+        ...((fallbacksOverride ?? []) as string[]).map((ref) => {
+          const slash = ref.indexOf("/");
+          return { provider: ref.slice(0, slash), model: ref.slice(slash + 1) };
+        }),
+      ];
+      let latest = { result: undefined as unknown, provider, model };
+      for (let index = 0; index < candidates.length; index += 1) {
+        const candidate = candidates[index];
+        const result = await run(candidate.provider, candidate.model, {
+          isFinalFallbackAttempt: index === candidates.length - 1,
+        });
+        const classification = await classifyResult?.({
+          result,
+          provider: candidate.provider,
+          model: candidate.model,
+          attempt: index + 1,
+          total: candidates.length,
+        });
+        if (!classification) {
+          return { result, provider: candidate.provider, model: candidate.model, attempts: [] };
+        }
+        latest = { result, provider: candidate.provider, model: candidate.model };
+      }
+      const merged = mergeExhaustedResult
+        ? mergeExhaustedResult({ latestResult: latest.result, preferredResult: latest.result })
+        : latest.result;
+      return { result: merged, provider: latest.provider, model: latest.model, attempts: [] };
+    },
+  );
+}
+
+describe("runCronIsolatedAgentTurn — result-level fallback wiring", () => {
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
+
+  it("engages the configured fallback when the primary returns a reasoning-only / incomplete_turn result", async () => {
+    installFaithfulFallbackLoop();
+    runEmbeddedAgentMock.mockReset();
+    runEmbeddedAgentMock
+      .mockResolvedValueOnce(makeReasoningOnlyIncompleteResult())
+      .mockResolvedValueOnce(makeHealthyFallbackResult());
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          payload: {
+            kind: "agentTurn",
+            message: "test",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        }),
+      }),
+    );
+
+    // Without the classifier wiring the loop would stop on the first reasoning-only
+    // result and record a cron error; the fallback model must be reached instead.
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    expect(runEmbeddedAgentMock.mock.calls[1]?.[0]).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    expect(result.status).toBe("ok");
+  });
+
+  it("passes the embedded classifier and merge helper scoped to the embedded branch", async () => {
+    mockRunCronFallbackPassthrough();
+
+    await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
+
+    const request = runWithModelFallbackMock.mock.calls[0]?.[0] as {
+      classifyResult?: (input: {
+        result: unknown;
+        provider: string;
+        model: string;
+        attempt: number;
+        total: number;
+      }) => unknown | Promise<unknown>;
+      mergeExhaustedResult?: unknown;
+    };
+    expect(typeof request?.classifyResult).toBe("function");
+    expect(request?.mergeExhaustedResult).toBe(
+      mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+    );
+
+    const reasoningOnly = makeReasoningOnlyIncompleteResult();
+    // Embedded provider: the result-level failure is classified so the loop advances.
+    expect(
+      await request.classifyResult?.({
+        result: reasoningOnly,
+        provider: "openai",
+        model: "gpt-5.4",
+        attempt: 1,
+        total: 2,
+      }),
+    ).toBeTruthy();
+
+    // CLI providers own their own terminal classification and must be skipped here.
+    isCliProviderMock.mockImplementation((provider: string) => provider === "claude-cli");
+    expect(
+      await request.classifyResult?.({
+        result: reasoningOnly,
+        provider: "claude-cli",
+        model: "claude-sonnet-4-6",
+        attempt: 1,
+        total: 2,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/cron/isolated-agent/run.result-fallback-gap.test.ts
+++ b/src/cron/isolated-agent/run.result-fallback-gap.test.ts
@@ -3,12 +3,13 @@
 // (reasoning-only / empty-visible / incomplete_turn) engage the configured
 // fallback chain instead of silently dropping the answer.
 import { describe, expect, it } from "vitest";
-import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
+  classifyEmbeddedAgentRunResultForModelFallbackMock,
   isCliProviderMock,
   loadRunCronIsolatedAgentTurn,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock,
   mockRunCronFallbackPassthrough,
   runEmbeddedAgentMock,
   runWithModelFallbackMock,
@@ -88,6 +89,10 @@ describe("runCronIsolatedAgentTurn — result-level fallback wiring", () => {
 
   it("engages the configured fallback when the primary returns a reasoning-only / incomplete_turn result", async () => {
     installFaithfulFallbackLoop();
+    classifyEmbeddedAgentRunResultForModelFallbackMock.mockReturnValue({
+      reason: "format",
+      code: "incomplete_result",
+    });
     runEmbeddedAgentMock.mockReset();
     runEmbeddedAgentMock
       .mockResolvedValueOnce(makeReasoningOnlyIncompleteResult())
@@ -127,15 +132,19 @@ describe("runCronIsolatedAgentTurn — result-level fallback wiring", () => {
         model: string;
         attempt: number;
         total: number;
-      }) => unknown | Promise<unknown>;
+      }) => unknown;
       mergeExhaustedResult?: unknown;
     };
     expect(typeof request?.classifyResult).toBe("function");
     expect(request?.mergeExhaustedResult).toBe(
-      mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+      mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock,
     );
 
     const reasoningOnly = makeReasoningOnlyIncompleteResult();
+    classifyEmbeddedAgentRunResultForModelFallbackMock.mockReturnValue({
+      reason: "format",
+      code: "incomplete_result",
+    });
     // Embedded provider: the result-level failure is classified so the loop advances.
     expect(
       await request.classifyResult?.({


### PR DESCRIPTION
## What Problem This Solves

Isolated cron / scheduled `agentTurn` jobs on embedded (non-CLI) providers with a configured model fallback chain silently drop the answer when the primary model returns a *result-level* terminal failure (reasoning-only, empty-visible, or `incomplete_turn`). The configured fallback model is never called, the run is recorded as `status: "error"`, and the operator receives the generic "Agent couldn't generate a response." payload — even though a healthy fallback model was configured and would have produced the real answer.

This contradicts the documented contract (`docs/automation/cron-jobs.md`) that configured fallback chains still apply when the job primary fails. Thrown `FailoverError`s (auth, rate-limit, overload) already engage the chain via the catch path; only the returned result-level failure class was missed. Because reasoning-only / empty output is a routine outcome for reasoning models and cron fires repeatedly, the failure recurs every run until a human notices.

## Why This Change Was Made

The cron embedded-run path (`src/cron/isolated-agent/run-executor.ts`) called `runWithModelFallback` without a `classifyResult` or `mergeExhaustedResult`. Every other answer-bearing caller passes both (`src/agents/agent-command.ts`, `src/auto-reply/reply/agent-runner-execution.ts`).

`runEmbeddedAgent` does not *throw* for a fallback-safe incomplete turn — it returns a result carrying `meta.error.kind = "incomplete_turn"`, `fallbackSafe: true`, and `meta.agentHarnessResultClassification` (e.g. `"reasoning-only"`). With `classifyResult` undefined, `runWithModelFallback` resolves no classification, returns the first candidate as a success, and never advances to candidate 2+. Cron then turns the returned `meta.error` into a fatal error payload and records `status: "error"`.

This change wires `classifyEmbeddedAgentRunResultForModelFallback` and `mergeEmbeddedAgentRunResultForModelFallbackExhaustion` into the cron call, exactly as the interactive and auto-reply paths do. Classification is scoped to the embedded branch (a shared `resolveCronExecutionProvider` helper reused by the run path and the classifier), so the CLI runner keeps owning its own terminal classification and CLI fallback semantics are unchanged.

## User Impact

Scheduled/cron `agentTurn` jobs on embedded providers with a configured fallback chain (`model.fallbacks` or per-job payload `fallbacks`) now advance to the healthy fallback model when the primary returns a reasoning-only / empty-visible / `incomplete_turn` result, delivering the real answer instead of recurring "Agent couldn't generate a response." errors. CLI-provider cron jobs are unaffected.

## Evidence

### Regression test

New regression test `src/cron/isolated-agent/run.result-fallback-gap.test.ts` drives the real `run-executor` wiring:

- **Engages the fallback**: a faithful minimal fallback loop exercises the real `classifyResult`/`mergeExhaustedResult` the cron path now passes; the primary embedded run returns a reasoning-only `incomplete_turn` result and the fallback returns a healthy answer. The embedded runner is reached twice (second call = the configured fallback model) and the cron status is `ok`.
- **Scoped to embedded**: the captured request's `classifyResult` returns a classification for an embedded reasoning-only result but returns `null` for a CLI provider; `mergeExhaustedResult` is the embedded merge helper.

Both assertions are RED on `main` (`classifyResult` is `undefined`; the loop stops on the first reasoning-only result) and GREEN with this change. Verified locally:

```
node scripts/run-vitest.mjs src/cron/isolated-agent/run.result-fallback-gap.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Adjacent cron suites stay green (`run.payload-fallbacks`, `run.meta-error-status`, `run-fallback-policy`, `run.cron-model-override`, `run.live-session-model-switch`, `run.interim-retry` — 45 tests). Changed files formatted with `oxfmt`.

### Real-behavior proof (loopback real-HTTP transport)

End-to-end run where every layer is real production code — the real `openai-completions` transport, the real `classifyEmbeddedAgentRunResultForModelFallback`, and the real `runWithModelFallback` loop. The only injected piece is a loopback OpenAI-compatible model server, which is the only way to deterministically force the reasoning-only / empty-content primary response (the Qwen3 thinking-mode leak independently reported in production on this thread).

**A — real transport:** empty `content` + populated `reasoning_content` yields empty visible text:

```
[A] real-transport primary: {"text":"","thinking":"Let me think..."} serverHits: ["empty-primary-qwen"]
```

**B — real classifier** flags the empty / reasoning-only result as fallback-eligible:

```
[B] classification: {"message":"Agent couldn't generate a response.","reason":"format","code":"incomplete_result","preserveResultOnExhaustion":true,"preserveResultPriority":0}
```

**C — real `runWithModelFallback` over real HTTP,** without vs with the classifier the cron path now passes:

```
[C-before no classifier]  winnerModel: empty-primary-qwen  visible: (none)  serverHits: ["empty-primary-qwen"]
[C-after  with classifier] winnerModel: healthy-fallback   visible: Workspace cleaned up: removed 12 stale files.  serverHits: ["empty-primary-qwen","healthy-fallback"]
```

`before` (= cron on `main`, called with no `classifyResult`) treats the empty primary as success and never contacts the fallback (`serverHits` has only the primary). `after` (this PR) advances to the configured fallback over real HTTP (`serverHits` includes `healthy-fallback`) and delivers the real answer. The `incomplete_turn` / `fallbackSafe` result shape used in B/C is what the embedded runner already produces for this case and is unchanged by this PR.

AI-assisted.
