### PR TITLE
fix: route WhatsApp group activation through session accessor

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/group-activation.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-activation.ts
@@ -1,10 +1,14 @@
 // Whatsapp plugin module implements group activation behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/routing";
-import { updateSessionStore } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  getSessionEntry,
+  patchSessionEntry,
+  resolveStorePath,
+  type SessionEntry,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveWhatsAppLegacyGroupSessionKey } from "../../group-session-key.js";
 import { resolveWhatsAppInboundPolicy } from "../../inbound-policy.js";
-import { loadSessionStore, resolveStorePath } from "../config.runtime.js";
 import { normalizeGroupActivation } from "./group-activation.runtime.js";
 
 function hasNamedWhatsAppAccounts(cfg: OpenClawConfig) {
@@ -28,6 +32,7 @@ function isActivationOnlyEntry(
   );
 }
 
+/** Resolves group activation for a WhatsApp conversation and backfills scoped session metadata. */
 export async function resolveGroupActivationFor(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
@@ -38,13 +43,15 @@ export async function resolveGroupActivationFor(params: {
   const storePath = resolveStorePath(params.cfg.session?.store, {
     agentId: params.agentId,
   });
-  const store = loadSessionStore(storePath);
+  const sessionScope = { storePath, agentId: params.agentId };
   const legacySessionKey = resolveWhatsAppLegacyGroupSessionKey({
     sessionKey: params.sessionKey,
     accountId: params.accountId,
   });
-  const legacyEntry = legacySessionKey ? store[legacySessionKey] : undefined;
-  const scopedEntry = store[params.sessionKey];
+  const legacyEntry = legacySessionKey
+    ? getSessionEntry({ ...sessionScope, sessionKey: legacySessionKey })
+    : undefined;
+  const scopedEntry = getSessionEntry({ ...sessionScope, sessionKey: params.sessionKey });
   const normalizedAccountId = normalizeAccountId(params.accountId);
   const ignoreScopedActivation =
     normalizedAccountId === DEFAULT_ACCOUNT_ID &&
@@ -54,15 +61,22 @@ export async function resolveGroupActivationFor(params: {
     (ignoreScopedActivation ? undefined : scopedEntry?.groupActivation) ??
     legacyEntry?.groupActivation;
   if (activation !== undefined && scopedEntry?.groupActivation === undefined) {
-    await updateSessionStore(storePath, (nextStore) => {
-      const nextScopedEntry = nextStore[params.sessionKey];
-      if (nextScopedEntry?.groupActivation !== undefined) {
-        return;
-      }
-      nextStore[params.sessionKey] = {
-        ...nextScopedEntry,
-        groupActivation: activation,
-      };
+    // Activation-only backfills must not synthesize session ids or activity.
+    // replaceEntry preserves existing scoped metadata while keeping fallback writes sparse.
+    await patchSessionEntry({
+      ...sessionScope,
+      sessionKey: params.sessionKey,
+      fallbackEntry: {} as SessionEntry,
+      replaceEntry: true,
+      update: (entry) => {
+        if (entry.groupActivation !== undefined) {
+          return null;
+        }
+        return {
+          ...entry,
+          groupActivation: activation,
+        };
+      },
     });
   }
   const requireMention = resolveWhatsAppInboundPolicy({

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -143,6 +143,7 @@ export const migratedBundledPluginSessionAccessorFiles = new Set([
   "extensions/telegram/src/bot-message-dispatch.ts",
   "extensions/telegram/src/bot-native-commands.ts",
   "extensions/voice-call/src/response-generator.ts",
+  "extensions/whatsapp/src/auto-reply/monitor/group-activation.ts",
 ]);
 
 export const migratedEmbeddedAgentSessionTargetFiles = new Set([

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -98,6 +98,7 @@ describe("session accessor boundary guard", () => {
         "extensions/telegram/src/bot-message-dispatch.ts",
         "extensions/telegram/src/bot-native-commands.ts",
         "extensions/voice-call/src/response-generator.ts",
+        "extensions/whatsapp/src/auto-reply/monitor/group-activation.ts",
       ]),
     );
   });


### PR DESCRIPTION
## What Problem This Solves

WhatsApp group activation still used the legacy whole-session-store helpers to read and backfill group activation metadata. That kept this Path 3.1b slice tied to file-store mutation instead of the session accessor boundary tracked by #88838.

## Why This Change Was Made

The SQLite migration needs WhatsApp group activation writes to go through per-entry accessor operations so the future backend can preserve transaction boundaries. This change keeps the existing legacy/scoped resolution behavior while removing direct `loadSessionStore` / `updateSessionStore` usage from the migrated runtime path.

## User Impact

Users should see no behavior change. Named-account WhatsApp groups still inherit legacy activation settings, sparse activation-only backfills stay sparse, existing scoped session metadata is preserved, and default-account handling in multi-account configs remains mention-required when appropriate.

## Evidence

Rebased head: `1d94cf49aa16c750129019c32ed8c0dbf72af9a2` on current `upstream/main` after the latest Path 3 sibling ratchet changes landed. GitHub reports `mergeStateStatus=CLEAN`; CI completed with 61 successful checks, 25 skipped checks, CodeQL neutral, and no failures.

- `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/monitor/group-activation.test.ts` passed 4 tests on `1d94cf49aa1`.
- `node scripts/run-vitest.mjs test/scripts/check-session-accessor-boundary.test.ts` passed 31 tests on `1d94cf49aa1`.
- `node scripts/check-session-accessor-boundary.mjs` passed on `1d94cf49aa1`.
- `node_modules/.bin/oxfmt --check --threads=1 extensions/whatsapp/src/auto-reply/monitor/group-activation.ts scripts/check-session-accessor-boundary.mjs test/scripts/check-session-accessor-boundary.test.ts` passed on `1d94cf49aa1`.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` passed on `1d94cf49aa1`.
- `autoreview --mode branch --base upstream/main` reported no accepted/actionable findings on `1d94cf49aa1`.
- `pnpm build` passed in the live local checkout at pre-rebase proof head `aa6aedd08669`.
- `pnpm openclaw gateway restart`, `pnpm openclaw --version`, `pnpm openclaw gateway status`, `/healthz`, and `/readyz` passed in the live local checkout at pre-rebase proof head `aa6aedd08669`.

## Real behavior proof

Behavior addressed: WhatsApp group activation reads legacy/scoped metadata and backfills the scoped group key through the session accessor path without whole-store mutation.

Real environment tested: local live Gateway/runtime proof on Josh's machine, rebuilt from pre-rebase proof head `aa6aedd08669` (`OpenClaw 2026.6.10 (aa6aedd)`) with Gateway restarted and healthy on port 18789. Later rebases only reconciled the ratchet list with merged Path 3 sibling work; they did not require another live proof run.

Exact steps or command run after this patch:

```bash
pnpm build
pnpm openclaw gateway restart
pnpm openclaw --version
pnpm openclaw gateway status
curl -fsS http://127.0.0.1:18789/healthz
curl -fsS http://127.0.0.1:18789/readyz
pnpm openclaw gateway call node.list --params '{}'
# Then ran a temporary node --import tsx runtime probe against a mktemp session store.
```

Evidence after fix: Gateway reported `OpenClaw 2026.6.10 (aa6aedd)`, connectivity `ok`, `/healthz` returned `{"ok":true,"status":"live"}`, and `/readyz` returned `{"ready":true,"failing":[]...}`. The runtime probe returned:

```json
{
  "sha": "aa6aedd08669",
  "proof": "whatsapp group activation accessor downgraded runtime proof",
  "externalTransport": false,
  "sparseBackfill": {
    "activation": "always",
    "scopedGroupActivation": "always",
    "scopedSessionId": null,
    "scopedUpdatedAt": null
  },
  "defaultAccountInMultiAccountConfig": {
    "activation": "mention"
  },
  "existingScopedEntry": {
    "activation": "always",
    "scopedGroupActivation": "always",
    "scopedSessionId": "scoped-session",
    "scopedUpdatedAt": 12345
  }
}
```

Observed result after fix: legacy named-account activation resolves to `always`, scoped activation is backfilled, sparse activation-only writes do not synthesize `sessionId` or `updatedAt`, existing scoped metadata is preserved, and the default account remains `mention` in the multi-account activation-only case.

What was not tested: external WhatsApp transport, Baileys authentication, real group receipt, and the future SQLite backend flip. This machine has no configured external WhatsApp/Baileys group transport; the downgraded proof scope was approved by Josh/coordinator.

## Restore note

After the live proof, the local live checkout was restored to the original pre-proof SHA `f8b29f82e2a`, rebuilt, restarted, and checked healthy. Git could not reattach the original branch name because another worktree currently owns it, so the live checkout was restored to that exact SHA in detached mode.

