### PR TITLE
fix(telegram): fallback from invalid rich email entities

### DIFF
--- a/extensions/telegram/src/send.rich-message-fallback.test.ts
+++ b/extensions/telegram/src/send.rich-message-fallback.test.ts
@@ -1,0 +1,63 @@
+// Telegram send tests cover rich-message fallback behavior.
+import { describe, expect, it } from "vitest";
+import {
+  getTelegramSendTestMocks,
+  importTelegramSendModule,
+  installTelegramSendTestHooks,
+} from "./send.test-harness.js";
+
+installTelegramSendTestHooks();
+
+const { botApi, botRawApi } = getTelegramSendTestMocks();
+const { sendMessageTelegram } = await importTelegramSendModule();
+
+describe("sendMessageTelegram rich-message fallback", () => {
+  it("falls back to plain text when Telegram rejects rich-message email entities", async () => {
+    const richError = Object.assign(new Error("Bad Request: RICH_MESSAGE_EMAIL_INVALID"), {
+      error_code: 400,
+    });
+    botRawApi.sendRichMessage.mockRejectedValueOnce(richError);
+    botApi.sendMessage.mockResolvedValue({ message_id: 52, chat: { id: "123" } });
+    const statusText =
+      "OpenAI auth profile: openai:keshavbotagent@gmail.com (keshavbotagent@gmail.com)";
+
+    await sendMessageTelegram("123", statusText, {
+      cfg: {
+        channels: {
+          telegram: {
+            richMessages: true,
+          },
+        },
+      },
+      token: "tok",
+      verbose: true,
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(1);
+    expect(botApi.sendMessage).toHaveBeenCalledWith("123", statusText);
+  });
+
+  it("does not hide unrelated rich-message send failures", async () => {
+    const richError = Object.assign(new Error("Bad Request: chat not found"), {
+      error_code: 400,
+    });
+    botRawApi.sendRichMessage.mockRejectedValueOnce(richError);
+
+    await expect(
+      sendMessageTelegram("123", "plain status text", {
+        cfg: {
+          channels: {
+            telegram: {
+              richMessages: true,
+            },
+          },
+        },
+        token: "tok",
+      }),
+    ).rejects.toThrow("chat not found");
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -483,6 +483,11 @@ function isTelegramHtmlParseError(err: unknown): boolean {
   return PARSE_ERR_RE.test(formatErrorMessage(err));
 }
 
+function isTelegramRichMessageEntityError(err: unknown): boolean {
+  const message = formatErrorMessage(err);
+  return /RICH_MESSAGE_[A-Z_]+_INVALID/i.test(message) || /rich_message.*invalid/i.test(message);
+}
+
 async function withTelegramHtmlParseFallback<T>(params: {
   label: string;
   verbose?: boolean;
@@ -498,6 +503,29 @@ async function withTelegramHtmlParseFallback<T>(params: {
     if (params.verbose) {
       sendLogger.warn(
         `telegram ${params.label} failed with HTML parse error, retrying as plain text: ${formatErrorMessage(
+          err,
+        )}`,
+      );
+    }
+    return await params.requestPlain(`${params.label}-plain`);
+  }
+}
+
+async function withTelegramRichMessageFallback<T>(params: {
+  label: string;
+  verbose?: boolean;
+  requestRich: (label: string) => Promise<T>;
+  requestPlain: (label: string) => Promise<T>;
+}): Promise<T> {
+  try {
+    return await params.requestRich(params.label);
+  } catch (err) {
+    if (!isTelegramRichMessageEntityError(err)) {
+      throw err;
+    }
+    if (params.verbose) {
+      sendLogger.warn(
+        `telegram ${params.label} failed with rich-message entity error, retrying as plain text: ${formatErrorMessage(
           err,
         )}`,
       );
@@ -878,19 +906,31 @@ export async function sendMessageTelegram(
         continue;
       }
       const acceptedParams = buildRichTextParams(index === chunks.length - 1);
-      const result = await requestWithChatNotFound(
-        () =>
-          richRawApi.sendRichMessage({
-            chat_id: chatId,
-            rich_message: buildTelegramRichMessage(chunk.text, chunk.textMode, {
-              skipEntityDetection: account.config.linkPreview === false,
-              tableMode,
-            }),
-            ...acceptedParams,
-            ...(opts.silent === true ? { disable_notification: true } : {}),
-          }),
-        "richMessage",
-      );
+      const result = await withTelegramRichMessageFallback({
+        label: "richMessage",
+        verbose: opts.verbose,
+        requestRich: (label) =>
+          requestWithChatNotFound(
+            () =>
+              richRawApi.sendRichMessage({
+                chat_id: chatId,
+                rich_message: buildTelegramRichMessage(chunk.text, chunk.textMode, {
+                  skipEntityDetection: account.config.linkPreview === false,
+                  tableMode,
+                }),
+                ...acceptedParams,
+                ...(opts.silent === true ? { disable_notification: true } : {}),
+              }),
+            label,
+          ),
+        requestPlain: async () => {
+          const { result: plainResult } = await sendTelegramTextChunk(
+            { plainText: chunk.plainText },
+            acceptedParams,
+          );
+          return plainResult;
+        },
+      });
       const messageId = resolveTelegramMessageIdOrThrow(result, context);
       recordSentMessage(chatId, messageId, cfg);
       await recordOutboundMessageForPromptContext({


### PR DESCRIPTION
What Problem This Solves

Telegram rich-message delivery can reject `/status` replies that contain account/profile email-looking text with `RICH_MESSAGE_EMAIL_INVALID`. When `richMessages=true`, that rich-send failure drops the final status reply instead of showing the user the plain text status.

Why This Change Was Made

The rich-message path is now allowed to fail soft only for Telegram rich entity validation errors. When Telegram rejects the rich payload as an invalid rich-message entity, OpenClaw retries the same text chunk through the plain `sendMessage` path so the status reply still reaches the chat. Other rich-message failures continue to surface instead of being hidden.

User Impact

Telegram users with rich messages enabled should still receive `/status` output even when the status text includes provider/auth profile email values that Telegram's rich entity detector rejects. Normal rich-message tables/details still use `sendRichMessage` when accepted.

Evidence

- `node scripts/run-vitest.mjs run extensions/telegram/src/send.rich-message-fallback.test.ts`
- `& .\node_modules\.bin\oxfmt.cmd --check --threads=1 extensions/telegram/src/send.ts extensions/telegram/src/send.rich-message-fallback.test.ts extensions/telegram/src/send.test.ts`
- `git diff --check`

Fixes #96363