### PR TITLE
fix(openai): preserve cron thinking for GPT-5 nano

### DIFF
--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -42,4 +42,23 @@ describe("OpenAI provider policy artifact", () => {
     expect(lunaLevels).toContain("xhigh");
     expect(lunaLevels).toContain("max");
   });
+
+  it("preserves GPT-5 nano thinking when catalog reasoning metadata is stale", () => {
+    const profile = resolveThinkingProfile({
+      provider: "openai",
+      modelId: "openai/gpt-5-nano",
+    });
+
+    expect(profile?.levels.map((level) => level.id)).toContain("minimal");
+    expect(profile?.preserveWhenCatalogReasoningFalse).toBe(true);
+  });
+
+  it("keeps catalog reasoning=false authoritative for OpenAI chat-latest rows", () => {
+    const profile = resolveThinkingProfile({
+      provider: "openai",
+      modelId: "gpt-5.3-chat-latest",
+    });
+
+    expect(profile?.preserveWhenCatalogReasoningFalse).toBeUndefined();
+  });
 });

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -24,8 +24,13 @@ const OPENAI_UNIFIED_XHIGH_MODEL_IDS = [
   "gpt-5.4-nano",
 ] as const;
 
+const OPENAI_STALE_CATALOG_REASONING_MODEL_RE =
+  /^gpt-5(?:\.\d+)?(?:$|-(?:mini|nano|pro|codex(?:-|$).*|\d{4}-\d{2}-\d{2}$))/u;
+const OPENAI_STALE_CATALOG_O_SERIES_MODEL_RE = /^o(?:1|3|4)(?:-|$)/u;
+
 function normalizeModelId(value: string): string {
-  return value.trim().toLowerCase();
+  const normalized = value.trim().toLowerCase();
+  return normalized.startsWith("openai/") ? normalized.slice("openai/".length) : normalized;
 }
 
 function matchesExactOrPrefix(id: string, values: readonly string[]): boolean {
@@ -34,6 +39,14 @@ function matchesExactOrPrefix(id: string, values: readonly string[]): boolean {
     const normalizedValue = normalizeModelId(value);
     return normalizedId === normalizedValue || normalizedId.startsWith(normalizedValue);
   });
+}
+
+function isOpenAIReasoningModelKnownDespiteStaleCatalog(modelId: string): boolean {
+  const normalizedId = normalizeModelId(modelId);
+  return (
+    OPENAI_STALE_CATALOG_REASONING_MODEL_RE.test(normalizedId) ||
+    OPENAI_STALE_CATALOG_O_SERIES_MODEL_RE.test(normalizedId)
+  );
 }
 
 function buildOpenAIThinkingProfile(params: {
@@ -49,6 +62,9 @@ function buildOpenAIThinkingProfile(params: {
         : []),
       ...(supportsMax ? [{ id: "max" as const }] : []),
     ],
+    ...(isOpenAIReasoningModelKnownDespiteStaleCatalog(params.modelId)
+      ? { preserveWhenCatalogReasoningFalse: true }
+      : {}),
   };
 }
 

--- a/src/cron/isolated-agent.model-overrides.test.ts
+++ b/src/cron/isolated-agent.model-overrides.test.ts
@@ -21,6 +21,18 @@ import {
 } from "./isolated-agent.turn-test-helpers.js";
 import * as isolatedAgentRunRuntime from "./isolated-agent/run.runtime.js";
 
+function isKnownOpenAIReasoningModel(modelId: string): boolean {
+  const normalized = modelId
+    .trim()
+    .toLowerCase()
+    .replace(/^openai\//u, "");
+  return (
+    /^gpt-5(?:\.\d+)?(?:$|-(?:mini|nano|pro|codex(?:-|$).*|\d{4}-\d{2}-\d{2}$))/u.test(
+      normalized,
+    ) || /^o(?:1|3|4)(?:-|$)/u.test(normalized)
+  );
+}
+
 function installThinkingTestProviders() {
   const registry = createTestRegistry();
   registry.providers = ["anthropic", "google", "openai", "openrouter"].map(
@@ -31,18 +43,23 @@ function installThinkingTestProviders() {
         id: providerId,
         label: providerId,
         auth: [],
-        resolveThinkingProfile: ({ modelId }) =>
-          providerId === "google" && modelId === "gemini-3-flash-preview"
-            ? {
-                levels: (["off", "minimal", "low", "medium", "adaptive", "high"] as const).map(
-                  (id) => ({ id }),
-                ),
-                preserveWhenCatalogReasoningFalse: true,
-              }
-            : {
-                levels: BASE_THINKING_LEVELS.map((id) => ({ id })),
-                defaultLevel: "off",
-              },
+        resolveThinkingProfile: ({ modelId }) => {
+          if (providerId === "google" && modelId === "gemini-3-flash-preview") {
+            return {
+              levels: (["off", "minimal", "low", "medium", "adaptive", "high"] as const).map(
+                (id) => ({ id }),
+              ),
+              preserveWhenCatalogReasoningFalse: true,
+            };
+          }
+          return {
+            levels: BASE_THINKING_LEVELS.map((id) => ({ id })),
+            defaultLevel: "off",
+            ...(providerId === "openai" && isKnownOpenAIReasoningModel(modelId)
+              ? { preserveWhenCatalogReasoningFalse: true }
+              : {}),
+          };
+        },
       },
     }),
   );
@@ -261,6 +278,45 @@ describe("runCronIsolatedAgentTurn model overrides", () => {
       const calls = vi.mocked(runEmbeddedAgent).mock.calls;
       const callArgs = calls[calls.length - 1]?.[0];
       expect(callArgs?.thinkLevel).toBe("low");
+    });
+  });
+
+  it("keeps explicit OpenAI GPT-5 nano cron thinking when catalog reasoning metadata is stale", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(loadModelCatalog).mockResolvedValue([
+        {
+          id: "gpt-5-nano",
+          name: "GPT-5 nano",
+          provider: "openai",
+          reasoning: false,
+        },
+      ]);
+
+      await runCronTurn(home, {
+        cfgOverrides: {
+          agents: {
+            defaults: {
+              model: "openai/gpt-5-nano",
+              workspace: path.join(home, "openclaw"),
+              thinkingDefault: "off",
+            },
+          },
+          ...OPENAI_PI_RUNTIME_CONFIG,
+        },
+        jobPayload: {
+          kind: "agentTurn",
+          message: DEFAULT_MESSAGE,
+          model: "openai/gpt-5-nano",
+          thinking: "minimal",
+        },
+        mockTexts: ["done"],
+      });
+
+      const calls = vi.mocked(runEmbeddedAgent).mock.calls;
+      const callArgs = calls[calls.length - 1]?.[0];
+      expect(callArgs?.provider).toBe("openai");
+      expect(callArgs?.model).toBe("gpt-5-nano");
+      expect(callArgs?.thinkLevel).toBe("minimal");
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Refs #63918 and addresses the remaining stale-catalog variant for the same cron/OpenAI thinking failure mode.

Cron `agentTurn` payloads can request `thinking: minimal` for OpenAI `gpt-5-nano`, but stale catalog rows that mark the model as `reasoning: false` can still cause the cron thinking validation path to treat the level as unsupported and downgrade it to `off`/`none`. That produces the same OpenAI 400 shape for scheduled runs that explicitly requested minimal reasoning.

## Why This Change Was Made

OpenAI's provider policy already owns the thinking profile for GPT-5-family reasoning models. This change marks known OpenAI GPT-5 and o-series reasoning models as provider-authoritative when catalog reasoning metadata is stale, while leaving non-reasoning chat rows such as `gpt-5.3-chat-latest` governed by `reasoning: false`.

## Maintainer Scope Note

The original #63918 reporter later said the first observed repro was resolved after upgrading to v2026.4.9. This PR should therefore be reviewed as a fix for the remaining stale-catalog compatibility variant, not as proof that current main still has the exact original minimal-to-none request-shaping bug. If maintainers want #63918 closed only by the original reporter's path, this PR can land as a hardening fix without auto-closing the issue.

## User Impact

Scheduled OpenAI `agentTurn` jobs keep their explicit `payload.thinking` level for `gpt-5-nano` instead of silently downgrading to a disabled reasoning value that the provider rejects when stale catalog metadata says `reasoning: false`.

## Real Behavior Proof

Exact head: `e27513297a0ba60270f8170a73fc283c0e72b57d`.

The after-fix cron/provider path is covered by the isolated cron runtime harness at the exact PR head. The proof seeds the model catalog with a stale OpenAI row for `gpt-5-nano` where `reasoning: false`, then runs an `agentTurn` cron payload that explicitly requests `model: "openai/gpt-5-nano"` and `thinking: "minimal"`.

Observed after-fix harness result:

```text
seed catalog row: { provider: "openai", id: "gpt-5-nano", reasoning: false }
seed cron payload: { kind: "agentTurn", model: "openai/gpt-5-nano", thinking: "minimal" }
observed embedded-agent call: provider == "openai"
observed embedded-agent call: model == "gpt-5-nano"
observed embedded-agent call: thinkLevel == "minimal"
```

Provider-boundary guardrail proof:

```text
resolveThinkingProfile({ provider: "openai", modelId: "openai/gpt-5-nano" })
  -> levels include "minimal"
  -> preserveWhenCatalogReasoningFalse == true

resolveThinkingProfile({ provider: "openai", modelId: "gpt-5.3-chat-latest" })
  -> preserveWhenCatalogReasoningFalse == undefined
```

GitHub exact-head proof/check evidence:

- `Real behavior proof` passed on this PR head: https://github.com/openclaw/openclaw/actions/runs/28122380585/job/83277365306
- Full CI passed on this PR head: https://github.com/openclaw/openclaw/actions/runs/28121786214
- The relevant exact-head CI checks include `check-test-types`, `check-prod-types`, `check-lint`, `check-guards`, `checks-node-compact-*`, `QA Smoke CI`, and `ci-timings-summary`, all passing.

Live OpenAI API proof was not run in this local environment because `OPENAI_API_KEY` is not available. The included proof exercises the scheduled `agentTurn` validation and embedded-agent request-shaping boundary without sending a network request.

## Evidence

- Rebased onto current `origin/main` (`0c7bac34ae`) and resolved the `extensions/openai/provider-policy-api.test.ts` conflict by keeping both the new GPT-5.6 max coverage and this PR's GPT-5 nano stale-catalog coverage.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-provider-openai.config.ts extensions/openai/provider-policy-api.test.ts` — passed (1 file, 4 tests).
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/isolated-agent.model-overrides.test.ts` — passed (1 file, 10 tests).
- `git diff --check` — passed.
- Diff secret scan for private keys/GitHub tokens/AWS keys/generic secret assignments — no findings.

- `node scripts/run-vitest.mjs run extensions/openai/provider-policy-api.test.ts src/cron/isolated-agent.model-overrides.test.ts src/agents/openai-reasoning-effort.test.ts`
- `& .\node_modules\.bin\oxfmt.cmd --check --threads=1 extensions\openai\thinking-policy.ts extensions\openai\provider-policy-api.test.ts src\cron\isolated-agent.model-overrides.test.ts`
- `git diff --check`

Focused regression coverage includes:

- stale `reasoning:false` catalog metadata no longer strips explicit `thinking:minimal` for `openai/gpt-5-nano` cron `agentTurn` jobs;
- the embedded-agent call receives `thinkLevel: "minimal"` after cron validation;
- OpenAI GPT-5 nano provider policy opts into preserving provider thinking metadata over stale catalog rows;
- OpenAI chat-latest rows keep catalog `reasoning:false` authoritative.