### PR TITLE
fix(agents): drop stale internal orphan prompts

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -16,6 +16,7 @@ import type {
   PluginHookBeforePromptBuildResult,
 } from "../../../plugins/types.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
+import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../../sessions/input-provenance.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
 import { resolveProcessToolScopeKey } from "../../agent-tools.js";
 import { listActiveProcessSessionReferences } from "../../bash-process-references.js";
@@ -484,6 +485,19 @@ function promptAlreadyIncludesQueuedUserMessage(prompt: string, orphanText: stri
   );
 }
 
+function shouldDropStaleInternalOrphanedUserPrompt(params: {
+  prompt: string;
+  leafMessage: { provenance?: unknown };
+}): boolean {
+  if (!params.prompt.trim()) {
+    return false;
+  }
+  // Internal completion/announcement handoffs are session state, not queued
+  // direct user text. With a fresh prompt present, prepending them can steer
+  // the run away from the latest user instruction.
+  return shouldPreserveUserFacingSessionStateForInputProvenance(params.leafMessage.provenance);
+}
+
 /**
  * Merges a trailing user message that was queued in transcript history but not
  * present in the active prompt. The leaf is removed whether merged or already
@@ -492,13 +506,21 @@ function promptAlreadyIncludesQueuedUserMessage(prompt: string, orphanText: stri
 export function mergeOrphanedTrailingUserPrompt(params: {
   prompt: string;
   trigger: EmbeddedRunAttemptParams["trigger"];
-  leafMessage: { content?: unknown };
+  leafMessage: { content?: unknown; provenance?: unknown };
 }): { prompt: string; merged: boolean; removeLeaf: boolean } {
   const orphanText = extractUserMessagePromptText(params.leafMessage.content);
   if (!orphanText) {
     return { prompt: params.prompt, merged: false, removeLeaf: true };
   }
   if (promptAlreadyIncludesQueuedUserMessage(params.prompt, orphanText)) {
+    return { prompt: params.prompt, merged: false, removeLeaf: true };
+  }
+  if (
+    shouldDropStaleInternalOrphanedUserPrompt({
+      prompt: params.prompt,
+      leafMessage: params.leafMessage,
+    })
+  ) {
     return { prompt: params.prompt, merged: false, removeLeaf: true };
   }
 

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -342,6 +342,15 @@ describe("shouldWarnOnOrphanedUserRepair", () => {
   });
 });
 
+const internalSessionStateSourceTools = [
+  "agent_harness_task",
+  "image_generate",
+  "music_generate",
+  "subagent_announce",
+  "subagent_interrupted_resume",
+  "video_generate",
+] as const;
+
 describe("mergeOrphanedTrailingUserPrompt", () => {
   it("merges an orphaned user leaf into the next user-triggered prompt when missing", () => {
     expect(
@@ -361,22 +370,25 @@ describe("mergeOrphanedTrailingUserPrompt", () => {
     });
   });
 
-  it("drops stale internal inter-session leaves instead of shadowing a fresh prompt", () => {
-    expect(
-      mergeOrphanedTrailingUserPrompt({
+  it.each(internalSessionStateSourceTools)(
+    "drops stale internal inter-session %s leaves instead of shadowing a fresh prompt",
+    (sourceTool) => {
+      expect(
+        mergeOrphanedTrailingUserPrompt({
+          prompt: "newest inbound message",
+          trigger: "user",
+          leafMessage: {
+            content: [{ type: "text", text: `NO_REPLY stale ${sourceTool} completion` }],
+            provenance: { kind: "inter_session", sourceTool },
+          } as never,
+        }),
+      ).toEqual({
+        merged: false,
+        removeLeaf: true,
         prompt: "newest inbound message",
-        trigger: "user",
-        leafMessage: {
-          content: [{ type: "text", text: "NO_REPLY stale subagent completion" }],
-          provenance: { kind: "inter_session", sourceTool: "subagent_announce" },
-        } as never,
-      }),
-    ).toEqual({
-      merged: false,
-      removeLeaf: true,
-      prompt: "newest inbound message",
-    });
-  });
+      });
+    },
+  );
 
   it("keeps user-directed inter-session leaves in the repaired prompt", () => {
     expect(

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -361,6 +361,42 @@ describe("mergeOrphanedTrailingUserPrompt", () => {
     });
   });
 
+  it("drops stale internal inter-session leaves instead of shadowing a fresh prompt", () => {
+    expect(
+      mergeOrphanedTrailingUserPrompt({
+        prompt: "newest inbound message",
+        trigger: "user",
+        leafMessage: {
+          content: [{ type: "text", text: "NO_REPLY stale subagent completion" }],
+          provenance: { kind: "inter_session", sourceTool: "subagent_announce" },
+        } as never,
+      }),
+    ).toEqual({
+      merged: false,
+      removeLeaf: true,
+      prompt: "newest inbound message",
+    });
+  });
+
+  it("keeps user-directed inter-session leaves in the repaired prompt", () => {
+    expect(
+      mergeOrphanedTrailingUserPrompt({
+        prompt: "newest inbound message",
+        trigger: "user",
+        leafMessage: {
+          content: "forwarded user request",
+          provenance: { kind: "inter_session", sourceTool: "sessions_send" },
+        } as never,
+      }),
+    ).toEqual({
+      merged: true,
+      removeLeaf: true,
+      prompt:
+        "[Queued user message that arrived while the previous turn was still active]\n" +
+        "forwarded user request\n\nnewest inbound message",
+    });
+  });
+
   it("does not duplicate orphaned user text already present in the next prompt", () => {
     expect(
       mergeOrphanedTrailingUserPrompt({

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4105,7 +4105,7 @@ export async function runEmbeddedAttempt(
               orphanPromptMerge.removeLeaf
                 ? orphanPromptMerge.merged
                   ? "Merged and removed"
-                  : "Removed already-queued"
+                  : "Removed"
                 : "Preserved"
             } orphaned user message` +
             (orphanPromptMerge.removeLeaf

--- a/src/agents/embedded-agent-runner/run/message-merge-strategy.ts
+++ b/src/agents/embedded-agent-runner/run/message-merge-strategy.ts
@@ -8,7 +8,7 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 type OrphanedTrailingUserPromptMergeParams = {
   prompt: string;
   trigger: EmbeddedRunAttemptParams["trigger"];
-  leafMessage: { content?: unknown };
+  leafMessage: { content?: unknown; provenance?: unknown };
 };
 
 /** Result of merging or dropping a trailing user leaf before provider submission. */

--- a/src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts
+++ b/src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts
@@ -23,6 +23,15 @@ afterEach(() => {
   restoreStrategy = undefined;
 });
 
+const internalSessionStateSourceTools = [
+  "agent_harness_task",
+  "image_generate",
+  "music_generate",
+  "subagent_announce",
+  "subagent_interrupted_resume",
+  "video_generate",
+] as const;
+
 describe("embedded agent transcript repair runtime contract", () => {
   it("merges text orphan leaves into the next prompt with the queued marker", () => {
     const result = mergeOrphanedTrailingUserPrompt({
@@ -38,22 +47,25 @@ describe("embedded agent transcript repair runtime contract", () => {
     });
   });
 
-  it("removes internal completion leaves instead of prepending them to a fresh prompt", () => {
-    const result = mergeOrphanedTrailingUserPrompt({
-      prompt: "newest inbound message",
-      trigger: "user",
-      leafMessage: {
-        content: [{ type: "text", text: "NO_REPLY stale subagent completion" }],
-        provenance: { kind: "inter_session", sourceTool: "subagent_announce" },
-      },
-    });
+  it.each(internalSessionStateSourceTools)(
+    "removes internal %s leaves instead of prepending them to a fresh prompt",
+    (sourceTool) => {
+      const result = mergeOrphanedTrailingUserPrompt({
+        prompt: "newest inbound message",
+        trigger: "user",
+        leafMessage: {
+          content: [{ type: "text", text: `NO_REPLY stale ${sourceTool} completion` }],
+          provenance: { kind: "inter_session", sourceTool },
+        },
+      });
 
-    expect(result).toEqual({
-      merged: false,
-      removeLeaf: true,
-      prompt: "newest inbound message",
-    });
-  });
+      expect(result).toEqual({
+        merged: false,
+        removeLeaf: true,
+        prompt: "newest inbound message",
+      });
+    },
+  );
 
   it("preserves user-directed inter-session leaves in the repaired prompt", () => {
     const result = mergeOrphanedTrailingUserPrompt({

--- a/src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts
+++ b/src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts
@@ -38,6 +38,42 @@ describe("embedded agent transcript repair runtime contract", () => {
     });
   });
 
+  it("removes internal completion leaves instead of prepending them to a fresh prompt", () => {
+    const result = mergeOrphanedTrailingUserPrompt({
+      prompt: "newest inbound message",
+      trigger: "user",
+      leafMessage: {
+        role: "user",
+        content: [{ type: "text", text: "NO_REPLY stale subagent completion" }],
+        provenance: { kind: "inter_session", sourceTool: "subagent_announce" },
+      },
+    });
+
+    expect(result).toEqual({
+      merged: false,
+      removeLeaf: true,
+      prompt: "newest inbound message",
+    });
+  });
+
+  it("preserves user-directed inter-session leaves in the repaired prompt", () => {
+    const result = mergeOrphanedTrailingUserPrompt({
+      prompt: "newest inbound message",
+      trigger: "user",
+      leafMessage: {
+        role: "user",
+        content: "forwarded user request",
+        provenance: { kind: "inter_session", sourceTool: "sessions_send" },
+      },
+    });
+
+    expect(result).toEqual({
+      merged: true,
+      removeLeaf: true,
+      prompt: `${QUEUED_USER_MESSAGE_MARKER}\nforwarded user request\n\nnewest inbound message`,
+    });
+  });
+
   it("does not duplicate an orphan leaf that is already present in the next prompt", () => {
     const result = mergeOrphanedTrailingUserPrompt({
       prompt: "summary\nolder active-turn message\nnewest inbound message",

--- a/src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts
+++ b/src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts
@@ -43,7 +43,6 @@ describe("embedded agent transcript repair runtime contract", () => {
       prompt: "newest inbound message",
       trigger: "user",
       leafMessage: {
-        role: "user",
         content: [{ type: "text", text: "NO_REPLY stale subagent completion" }],
         provenance: { kind: "inter_session", sourceTool: "subagent_announce" },
       },
@@ -61,7 +60,6 @@ describe("embedded agent transcript repair runtime contract", () => {
       prompt: "newest inbound message",
       trigger: "user",
       leafMessage: {
-        role: "user",
         content: "forwarded user request",
         provenance: { kind: "inter_session", sourceTool: "sessions_send" },
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes #76888.

When transcript repair found a trailing orphaned user message from an internal inter-session event, it could prepend that stale content to the next fresh user prompt. For events like subagent announcements or completion markers, that meant the model could answer stale internal text instead of the user's current message.

## Why This Change Was Made

The repair path already needed to preserve user-directed queued messages, including `sessions_send` inter-session input. The bug was that internal session-state events used the same orphaned-user leaf shape, so the merge step treated them as user content.

This change classifies provenance before merging:

- user-facing queued/inter-session input is still merged into the repaired prompt;
- internal session-state-preserving inter-session leaves are removed when a fresh prompt is present;
- empty orphan leaves continue to be removed without changing prompt text.

## User Impact

Users should no longer get a response to stale internal transcript content after a queued/orphaned user-message repair. Legitimate queued user messages remain preserved, so no user-authored follow-up is lost.

## Evidence

Local validation on the PR branch:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.test.ts src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts` passed, 126 tests.
- `node scripts/run-vitest.mjs src/sessions/input-provenance.test.ts` passed, 19 tests.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/message-merge-strategy.test.ts` passed, 2 tests.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.test.ts src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts src/agents/embedded-agent-runner/run/message-merge-strategy.test.ts src/sessions/input-provenance.test.ts` passed, 147 tests.
- `pnpm tsgo:core:test` passed.
- `pnpm check:test-types` passed.
- `node_modules\.bin\oxfmt.cmd --check --threads=1 src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts src/agents/embedded-agent-runner/run/attempt.test.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/message-merge-strategy.ts src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts` passed.
- `node_modules\.bin\oxfmt.cmd --check --threads=1 src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts` passed after the test type follow-up.
- `git diff --check` passed.

CI on PR head `e684ac2cb8b0bac7189459a75daf5b0ef0487dfc` is green, including `check-test-types`, `check-prod-types`, `check-lint`, `check-guards`, `build-artifacts`, `QA Smoke CI`, and `Real behavior proof`.

Regression proof:

Before the production fix, the new stale-internal-leaf tests failed because the repaired prompt included `NO_REPLY stale subagent completion` before the fresh inbound message. After the fix, those tests pass while the user-directed `sessions_send` case is still preserved.

Maintainer validation requested:

I do not have access to a live OpenClaw session setup that can reproduce #76888 end to end. To complete the remaining proof gate, please validate in a real embedded-agent session that:

- a trailing orphaned user leaf with `provenance.kind=inter_session` and `sourceTool=subagent_announce` is removed and does not prepend stale `NO_REPLY`/completion text before the fresh prompt;
- a trailing orphaned user leaf with `sourceTool=sessions_send` is still preserved in the repaired prompt.

Duplicate check:

Before opening this PR I rechecked open PRs/issues for `#76888`, stale inter-session/orphan prompt wording, and the touched merge helpers. The prior direct attempts (#78094 and #90759) were closed unmerged, and I did not find an active PR covering this exact root cause.
