### PR TITLE
feat: propagate trusted-proxy authenticated user identity into agent inbound context

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -526,6 +526,9 @@ export function buildInboundMetaSystemPrompt(
     provider: normalizePromptMetadataString(ctx.Provider),
     surface: normalizePromptMetadataString(ctx.Surface),
     chat_type: chatType ?? (isDirect ? "direct" : undefined),
+    ...(normalizePromptMetadataString(ctx.AuthUser)
+      ? { user: normalizePromptMetadataString(ctx.AuthUser) }
+      : {}),
     response_format:
       options?.includeFormattingHints === false ? undefined : resolveInboundFormattingHints(ctx),
   };

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -288,6 +288,8 @@ export type MsgContext = {
   AcpDispatchTailAfterReset?: boolean;
   /** Gateway client scopes when the message originates from the gateway. */
   GatewayClientScopes?: string[];
+  /** Authenticated user identity from trusted-proxy header. */
+  AuthUser?: string;
   /** Gateway device id allowed to review approvals initiated by this turn. */
   ApprovalReviewerDeviceId?: string;
   /** Thread identifier (Telegram topic id or Matrix thread event id). */

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -42,6 +42,8 @@ type SharedSecretGatewayAuth = Pick<ResolvedGatewayAuth, "mode">;
 export type AuthorizedGatewayHttpRequest = {
   authMethod?: GatewayAuthResult["method"];
   trustDeclaredOperatorScopes: boolean;
+  /** Authenticated user identity (e.g. email from trusted-proxy header). */
+  user?: string;
 };
 
 export type GatewayHttpRequestAuthCheckResult =
@@ -138,6 +140,7 @@ export async function checkGatewayHttpRequestAuth(params: {
       // must opt in explicitly if they want to treat that shared-secret path as a
       // full trusted-operator surface.
       trustDeclaredOperatorScopes: !usesSharedSecretGatewayMethod(authResult.method),
+      ...(authResult.user ? { user: authResult.user } : {}),
     },
   };
 }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1871,6 +1871,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           connect: connectParams,
           connId,
           isDeviceTokenAuth: authMethod === "device-token",
+          ...(authResult?.user ? { authUser: authResult.user } : {}),
           usesSharedGatewayAuth: sessionUsesSharedGatewayAuth,
           sharedGatewaySessionGeneration: sessionSharedGatewaySessionGeneration,
           presenceKey,

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -15,6 +15,8 @@ export type GatewayWsClient = PluginNodeCapabilityClient & {
   sharedGatewaySessionGeneration?: string;
   presenceKey?: string;
   clientIp?: string;
+  /** Authenticated user identity from trusted-proxy header. */
+  authUser?: string;
   internal?: {
     approvalRuntime?: boolean;
   };


### PR DESCRIPTION
## Problem

When `gateway.auth.mode` is set to `trusted-proxy`, the gateway correctly authenticates users via the configured `userHeader` (e.g. `X-Pomerium-Claim-Email`). However, the authenticated user identity is **dropped** after authentication and never propagated to the agent session's inbound context metadata.

This means the agent cannot see **who it is speaking to** — the `inbound_meta.v2` payload contains `channel`, `provider`, `surface`, and `chat_type`, but no `user` field.

## Solution

Surface the authenticated user identity through the full chain:

1. **`http-auth-utils.ts`** — Add `user?: string` to `AuthorizedGatewayHttpRequest` type; propagate `authResult.user` into `requestAuth`
2. **`ws-types.ts`** — Add `authUser?: string` to `GatewayWsClient` type
3. **`message-handler.ts`** — Store `authResult.user` as `authUser` on the `nextClient` object during WS handshake
4. **`chat.ts`** — Copy `client.authUser` into `ctx.AuthUser` when building the inbound context for chat messages
5. **`templating.ts`** — Add `AuthUser?: string` to `MsgContext` type
6. **`inbound-meta.ts`** — Add `user` field to the `inbound_meta.v2` JSON payload when `ctx.AuthUser` is set

## Result

The `inbound_meta.v2` payload will now include a `user` field when the session is authenticated via trusted-proxy:

```json
{
  "schema": "openclaw.inbound_meta.v2",
  "channel": "webchat",
  "provider": "webchat",
  "surface": "webchat",
  "chat_type": "direct",
  "user": "ppxscal@gmail.com",
  "response_format": { ... }
}
```

This is **backward compatible** — when `authResult.user` is not set (token/password auth, device auth), no `user` field is added and behavior is unchanged.