### PR TITLE
refactor: route voice call agent runs through session target

### DIFF
--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -21,6 +21,12 @@ type EmbeddedAgentArgs = {
   provider?: string;
   model?: string;
   sessionKey?: string;
+  sessionTarget?: {
+    agentId?: string;
+    sessionId?: string;
+    sessionKey?: string;
+    storePath?: string;
+  };
   sandboxSessionKey?: string;
   agentDir?: string;
   agentId?: string;
@@ -313,7 +319,6 @@ describe("generateVoiceResponse", () => {
       resolveAgentWorkspaceDir,
       resolveAgentIdentity,
       resolveStorePath,
-      resolveSessionFilePath,
       sessionStore,
     } = createAgentRuntime([{ text: '{"spoken":"Default agent."}' }]);
     const coreConfig = {} as CoreConfig;
@@ -336,19 +341,18 @@ describe("generateVoiceResponse", () => {
     if (!defaultSessionEntry) {
       throw new Error("Expected default voice session entry");
     }
-    expect(resolveSessionFilePath).toHaveBeenCalledWith(
-      defaultSessionEntry.sessionId,
-      defaultSessionEntry,
-      {
-        agentId: "main",
-      },
-    );
     const args = requireEmbeddedAgentArgs(runEmbeddedAgent);
     expect(args.agentDir).toBe("/tmp/openclaw/agents/main");
     expect(args.agentId).toBe("main");
+    expect(args.sessionTarget).toStrictEqual({
+      agentId: "main",
+      sessionId: defaultSessionEntry.sessionId,
+      sessionKey: "voice:15550001111",
+      storePath: "/tmp/openclaw/main/sessions.json",
+    });
     expect(args.sandboxSessionKey).toBe("agent:main:voice:15550001111");
     expect(args.workspaceDir).toBe("/tmp/openclaw/workspace/main");
-    expect(args.sessionFile).toBe("/tmp/openclaw/main/sessions/session.jsonl");
+    expect(args.sessionFile).toBeUndefined();
   });
 
   it("uses the configured voice response agent workspace", async () => {
@@ -359,7 +363,6 @@ describe("generateVoiceResponse", () => {
       resolveAgentWorkspaceDir,
       resolveAgentIdentity,
       resolveStorePath,
-      resolveSessionFilePath,
       sessionStore,
     } = createAgentRuntime([{ text: '{"spoken":"Voice agent."}' }]);
     const coreConfig = {} as CoreConfig;
@@ -386,19 +389,18 @@ describe("generateVoiceResponse", () => {
     if (!voiceSessionEntry) {
       throw new Error("Expected routed voice session entry");
     }
-    expect(resolveSessionFilePath).toHaveBeenCalledWith(
-      voiceSessionEntry.sessionId,
-      voiceSessionEntry,
-      {
-        agentId: "voice",
-      },
-    );
     const args = requireEmbeddedAgentArgs(runEmbeddedAgent);
     expect(args.agentDir).toBe("/tmp/openclaw/agents/voice");
     expect(args.agentId).toBe("voice");
+    expect(args.sessionTarget).toStrictEqual({
+      agentId: "voice",
+      sessionId: voiceSessionEntry.sessionId,
+      sessionKey: "voice:15550001111",
+      storePath: "/tmp/openclaw/voice/sessions.json",
+    });
     expect(args.sandboxSessionKey).toBe("agent:voice:voice:15550001111");
     expect(args.workspaceDir).toBe("/tmp/openclaw/workspace/voice");
-    expect(args.sessionFile).toBe("/tmp/openclaw/voice/sessions/session.jsonl");
+    expect(args.sessionFile).toBeUndefined();
   });
 
   it("passes the routed voice agent explicit tool allowlist to the embedded run", async () => {

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -291,10 +291,6 @@ export async function generateVoiceResponse(
   }
   const sessionId = sessionEntry.sessionId;
 
-  const sessionFile = agentRuntime.session.resolveSessionFilePath(sessionId, sessionEntry, {
-    agentId,
-  });
-
   // Resolve thinking level
   const thinkLevel = agentRuntime.resolveThinkingDefault({ cfg, provider, model });
 
@@ -324,10 +320,15 @@ export async function generateVoiceResponse(
     const result = await agentRuntime.runEmbeddedAgent({
       sessionId,
       sessionKey: resolvedSessionKey,
+      sessionTarget: {
+        agentId,
+        sessionId,
+        sessionKey: resolvedSessionKey,
+        storePath,
+      },
       sandboxSessionKey: resolveVoiceSandboxSessionKey(agentId, resolvedSessionKey),
       agentId,
       messageProvider: "voice",
-      sessionFile,
       workspaceDir,
       config: cfg,
       prompt: userMessage,

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -61,6 +61,7 @@ const sessionStoreRuntimeFileBackedCompatNames = new Set([
   "saveSessionStore",
   "updateSessionStore",
 ]);
+const embeddedAgentSessionFileRuntimeNames = new Set(["resolveSessionFilePath"]);
 
 export const allowedSessionStoreRuntimeFileBackedCompatExports = new Set([
   "loadSessionStore",
@@ -141,6 +142,11 @@ export const migratedBundledPluginSessionAccessorFiles = new Set([
   "extensions/telegram/src/bot.ts",
   "extensions/telegram/src/bot-message-dispatch.ts",
   "extensions/telegram/src/bot-native-commands.ts",
+  "extensions/voice-call/src/response-generator.ts",
+]);
+
+export const migratedEmbeddedAgentSessionTargetFiles = new Set([
+  "extensions/voice-call/src/response-generator.ts",
 ]);
 
 export const migratedSessionAccessorWriteFiles = new Set([
@@ -248,6 +254,13 @@ function propertyAccessName(expression) {
   }
   if (ts.isElementAccessExpression(unwrapped) && ts.isStringLiteral(unwrapped.argumentExpression)) {
     return unwrapped.argumentExpression.text;
+  }
+  return null;
+}
+
+function propertyNameText(name) {
+  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name) || ts.isNumericLiteral(name)) {
+    return name.text;
   }
   return null;
 }
@@ -414,6 +427,51 @@ export function findSessionAccessorBoundaryViolations(content, fileName = "sourc
   return findNamedSessionStoreViolations(content, fileName, legacyNames, legacyKind);
 }
 
+export function findEmbeddedAgentSessionTargetViolations(content, fileName = "source.ts") {
+  const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
+  const violations = findNamedBoundaryViolations(
+    content,
+    fileName,
+    embeddedAgentSessionFileRuntimeNames,
+    "legacy embedded-agent session file resolver",
+  );
+
+  const recordDeprecatedSessionFile = (name) => {
+    violations.push({
+      line: toLine(sourceFile, name),
+      reason:
+        'passes deprecated embedded-agent runtime identity field "sessionFile"; use sessionTarget',
+    });
+  };
+
+  const visitRunOptions = (options) => {
+    for (const property of options.properties) {
+      if (ts.isPropertyAssignment(property) && propertyNameText(property.name) === "sessionFile") {
+        recordDeprecatedSessionFile(property.name);
+      } else if (
+        ts.isShorthandPropertyAssignment(property) &&
+        property.name.text === "sessionFile"
+      ) {
+        recordDeprecatedSessionFile(property.name);
+      }
+    }
+  };
+
+  const visit = (node) => {
+    if (ts.isCallExpression(node) && propertyAccessName(node.expression) === "runEmbeddedAgent") {
+      const options = unwrapExpression(node.arguments[0]);
+      if (options && ts.isObjectLiteralExpression(options)) {
+        visitRunOptions(options);
+      }
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return violations;
+}
+
 export function findSessionAccessorWriteBoundaryViolations(content, fileName = "source.ts") {
   return findNamedSessionStoreViolations(content, fileName, legacyWriterNames, "writer");
 }
@@ -565,6 +623,7 @@ export async function main() {
     "extensions/discord/src/monitor",
     "extensions/memory-core/src",
     "extensions/telegram/src",
+    "extensions/voice-call/src",
     "src/acp",
     "src/agents",
     "src/auto-reply",
@@ -656,6 +715,15 @@ export async function main() {
       ),
     findViolations: findMemoryHostSessionCorpusBoundaryViolations,
   });
+  const embeddedAgentSessionTargetViolations = await collectFileViolations({
+    repoRoot,
+    sourceRoots: resolveSourceRoots(repoRoot, ["extensions/voice-call/src"]),
+    skipFile: (filePath) =>
+      !migratedEmbeddedAgentSessionTargetFiles.has(
+        normalizeRelativePath(path.relative(repoRoot, filePath)),
+      ),
+    findViolations: findEmbeddedAgentSessionTargetViolations,
+  });
   const sessionStoreRuntimePath = path.join(repoRoot, "src/plugin-sdk/session-store-runtime.ts");
   const sessionStoreRuntimeCompatViolations =
     findSessionStoreRuntimeFileBackedCompatExportViolations(
@@ -672,6 +740,7 @@ export async function main() {
     ...manualCompactTrimViolations,
     ...lifecycleCleanupViolations,
     ...memoryHostSessionCorpusViolations,
+    ...embeddedAgentSessionTargetViolations,
     ...sessionStoreRuntimeCompatViolations,
   ];
 

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -3,6 +3,7 @@ import {
   allowedSessionStoreRuntimeFileBackedCompatExports,
   collectSessionStoreRuntimeFileBackedCompatExports,
   findGatewaySessionCreateLifecycleViolations,
+  findEmbeddedAgentSessionTargetViolations,
   findMemoryHostSessionCorpusBoundaryViolations,
   findSessionAccessorBoundaryViolations,
   findSessionCompactManualTrimBoundaryViolations,
@@ -11,6 +12,7 @@ import {
   findSessionStoreRuntimeFileBackedCompatExportViolations,
   findTranscriptWriterBoundaryViolations,
   migratedBundledPluginSessionAccessorFiles,
+  migratedEmbeddedAgentSessionTargetFiles,
   migratedMemoryHostSessionCorpusFiles,
   migratedSessionLifecycleCleanupFiles,
   migratedSessionCompactManualTrimFiles,
@@ -95,7 +97,14 @@ describe("session accessor boundary guard", () => {
         "extensions/telegram/src/bot.ts",
         "extensions/telegram/src/bot-message-dispatch.ts",
         "extensions/telegram/src/bot-native-commands.ts",
+        "extensions/voice-call/src/response-generator.ts",
       ]),
+    );
+  });
+
+  it("ratchets only files migrated to embedded-agent session targets", () => {
+    expect(migratedEmbeddedAgentSessionTargetFiles).toEqual(
+      new Set(["extensions/voice-call/src/response-generator.ts"]),
     );
   });
 
@@ -516,6 +525,50 @@ describe("session accessor boundary guard", () => {
       findSessionAccessorBoundaryViolations(`
         // loadSessionStore and readSessionEntries used to be called here.
         const description = "loadSessionStore";
+      `),
+    ).toEqual([]);
+  });
+
+  it("flags embedded-agent calls that pass deprecated sessionFile identity", () => {
+    expect(
+      findEmbeddedAgentSessionTargetViolations(`
+        const sessionFile = agentRuntime.session.resolveSessionFilePath(sessionId, entry);
+        agentRuntime.runEmbeddedAgent({
+          sessionId,
+          sessionKey,
+          sessionFile,
+        });
+        runEmbeddedAgent({
+          sessionId,
+          sessionFile: transcriptPath,
+        });
+      `),
+    ).toEqual([
+      {
+        line: 2,
+        reason: 'references legacy embedded-agent session file resolver "resolveSessionFilePath"',
+      },
+      {
+        line: 6,
+        reason:
+          'passes deprecated embedded-agent runtime identity field "sessionFile"; use sessionTarget',
+      },
+      {
+        line: 10,
+        reason:
+          'passes deprecated embedded-agent runtime identity field "sessionFile"; use sessionTarget',
+      },
+    ]);
+  });
+
+  it("allows embedded-agent calls that pass sessionTarget identity", () => {
+    expect(
+      findEmbeddedAgentSessionTargetViolations(`
+        agentRuntime.runEmbeddedAgent({
+          sessionId,
+          sessionKey,
+          sessionTarget: { agentId, sessionId, sessionKey, storePath },
+        });
       `),
     ).toEqual([]);
   });


### PR DESCRIPTION
## What Problem This Solves

Voice Call still routed classic auto-response agent runs through the legacy `sessionFile` runtime identity path. That kept one bundled plugin on the file-backed session seam after the embedded-agent runtime already supports storage-neutral session targets.

## Why This Change Was Made

Path 3 is migrating runtime callers away from session transcript/file paths and toward accessor/session identity seams. Voice Call already had enough local session identity to pass `agentId`, `sessionId`, `sessionKey`, and `storePath` directly, so preserving the `sessionFile` compatibility path was no longer needed for this caller.

## User Impact

Voice Call response behavior is intended to stay the same. The change only alters the internal identity passed to embedded OpenClaw agent runs: responses still use the same voice session key, agent, model, workspace, timeout, lane, and tool allowlist, but no longer resolve or pass a transcript file path.

## Evidence

- `node scripts/run-vitest.mjs extensions/voice-call/src/response-generator.test.ts`
  - Passed: 10 tests.
- `node scripts/run-vitest.mjs test/scripts/check-session-accessor-boundary.test.ts`
  - Passed: 31 tests.
- `node scripts/check-session-accessor-boundary.mjs`
  - Passed.
- `pnpm exec oxfmt --check --threads=1 extensions/voice-call/src/response-generator.ts extensions/voice-call/src/response-generator.test.ts scripts/check-session-accessor-boundary.mjs test/scripts/check-session-accessor-boundary.test.ts`
  - Passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/voice-call/src/response-generator.ts extensions/voice-call/src/response-generator.test.ts`
  - Passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/check-session-accessor-boundary.mjs test/scripts/check-session-accessor-boundary.test.ts`
  - Passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`
  - Clean: no accepted/actionable findings.
- Live local OpenClaw checkout proof from `/Users/phaedrus/Projects/clawdbot` at `e797e86dbe88ad91a3b6102ba312bbd85d16b10f`:
  - `node --import tsx /tmp/path3-voice-sessiontarget-proof.mjs`
  - Passed: `generateVoiceResponse` returned `"Proof passed."`, called `runEmbeddedAgent` once, passed `sessionTarget`, did not pass `sessionFile`, and did not call `resolveSessionFilePath`.

Live proof note: this is direct runtime seam proof, not full phone/media ingress proof. The phone ingress path that reaches this classic response generator requires a streaming transcript callback; the mock Voice Call gateway methods prove plugin loading/call management but do not invoke `handleInboundResponse`.
