### PR TITLE
fix(doctor): merge colliding model-ref map keys instead of dropping

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2463,6 +2463,40 @@ describe("legacy model compat migrate", () => {
     ]);
   });
 
+  it("merges colliding model ref map keys instead of dropping per-key tuning", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4o": { params: { reasoning_effort: "high" }, streaming: false },
+            "openai/gpt-4": { params: { reasoning_effort: "low" }, alias: "legacy-four" },
+          },
+        },
+      },
+    });
+
+    expect(res.config?.agents?.defaults?.models).toEqual({
+      "openai/gpt-5.5": {
+        params: { reasoning_effort: "high" },
+        streaming: false,
+        alias: "legacy-four",
+      },
+    });
+    const mergeChanges = res.changes.filter((change) =>
+      change.includes("config.agents.defaults.models key"),
+    );
+    expect(
+      mergeChanges.some(
+        (change) =>
+          change.includes("Merged") &&
+          change.includes('"openai/gpt-4"') &&
+          change.includes('"openai/gpt-5.5"') &&
+          change.includes("conflicting fields") &&
+          change.includes("params.reasoning_effort"),
+      ),
+    ).toBe(true);
+  });
+
   it("removes unrecognized model compat thinkingFormat values", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2497,6 +2497,22 @@ describe("legacy model compat migrate", () => {
     ).toBe(true);
   });
 
+  it("does not pollute prototypes when merging colliding model ref map keys", () => {
+    const polluted = JSON.parse(
+      '{"agents":{"defaults":{"models":{"openai/gpt-4o":{"streaming":false},"openai/gpt-4":{"__proto__":{"polluted":true},"alias":"legacy-four"}}}}}',
+    );
+    const res = migrateLegacyConfigForTest(polluted);
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    const merged = res.config?.agents?.defaults?.models?.["openai/gpt-5.5"] as Record<
+      string,
+      unknown
+    >;
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
+    expect(merged.polluted).toBeUndefined();
+    expect(merged).toEqual({ streaming: false, alias: "legacy-four" });
+  });
+
   it("removes unrecognized model compat thinkingFormat values", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2497,6 +2497,46 @@ describe("legacy model compat migrate", () => {
     ).toBe(true);
   });
 
+  it("merges when the canonical key follows the retired key", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4": { alias: "legacy-four" },
+            "openai/gpt-5.5": { streaming: false },
+          },
+        },
+      },
+    });
+
+    expect(res.config?.agents?.defaults?.models).toEqual({
+      "openai/gpt-5.5": {
+        alias: "legacy-four",
+        streaming: false,
+      },
+    });
+  });
+
+  it("keeps canonical values when canonical and retired keys collide", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4": { alias: "legacy-four", streaming: true },
+            "openai/gpt-5.5": { alias: "current-five" },
+          },
+        },
+      },
+    });
+
+    expect(res.config?.agents?.defaults?.models).toEqual({
+      "openai/gpt-5.5": {
+        alias: "current-five",
+        streaming: true,
+      },
+    });
+  });
+
   it("does not pollute prototypes when merging colliding model ref map keys", () => {
     const polluted = JSON.parse(
       '{"agents":{"defaults":{"models":{"openai/gpt-4o":{"streaming":false},"openai/gpt-4":{"__proto__":{"polluted":true},"alias":"legacy-four"}}}}}',

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2463,13 +2463,25 @@ describe("legacy model compat migrate", () => {
     ]);
   });
 
-  it("merges colliding model ref map keys instead of dropping per-key tuning", () => {
+  it("deep-merges colliding retired model refs and reports only unequal fields", () => {
     const res = migrateLegacyConfigForTest({
       agents: {
         defaults: {
           models: {
-            "openai/gpt-4o": { params: { reasoning_effort: "high" }, streaming: false },
-            "openai/gpt-4": { params: { reasoning_effort: "low" }, alias: "legacy-four" },
+            "openai/gpt-4o": {
+              params: {
+                reasoning: { effort: "high", budget: 100 },
+                tags: ["stable"],
+              },
+              streaming: false,
+            },
+            "openai/gpt-4": {
+              params: {
+                reasoning: { effort: "low", summary: "auto" },
+                tags: ["stable"],
+              },
+              alias: "legacy-four",
+            },
           },
         },
       },
@@ -2477,120 +2489,178 @@ describe("legacy model compat migrate", () => {
 
     expect(res.config?.agents?.defaults?.models).toEqual({
       "openai/gpt-5.5": {
-        params: { reasoning_effort: "high" },
+        params: {
+          reasoning: { effort: "high", budget: 100, summary: "auto" },
+          tags: ["stable"],
+        },
         streaming: false,
         alias: "legacy-four",
       },
     });
-    const mergeChanges = res.changes.filter((change) =>
-      change.includes("config.agents.defaults.models key"),
-    );
-    expect(
-      mergeChanges.some(
-        (change) =>
-          change.includes("Merged") &&
-          change.includes('"openai/gpt-4"') &&
-          change.includes('"openai/gpt-5.5"') &&
-          change.includes("conflicting fields") &&
-          change.includes("params.reasoning_effort"),
-      ),
-    ).toBe(true);
+    expect(res.changes.filter((change) => change.includes("Merged"))).toEqual([
+      'Merged config.agents.defaults.models key "openai/gpt-4" into "openai/gpt-5.5"; kept existing values for conflicting fields: params.reasoning.effort.',
+    ]);
   });
 
-  it("merges when the canonical key follows the retired key", () => {
+  it("does not report conflicts between model refs that normalize to the same value", () => {
     const res = migrateLegacyConfigForTest({
       agents: {
         defaults: {
           models: {
-            "openai/gpt-4": { alias: "legacy-four" },
-            "openai/gpt-5.5": { streaming: false },
+            "openai/gpt-5.5": { params: { fallbacks: ["openai/gpt-4"] } },
+            "openai/gpt-4o": { params: { fallbacks: ["openai/gpt-5.5"] } },
           },
         },
       },
     });
 
     expect(res.config?.agents?.defaults?.models).toEqual({
-      "openai/gpt-5.5": {
-        alias: "legacy-four",
-        streaming: false,
-      },
+      "openai/gpt-5.5": { params: { fallbacks: ["openai/gpt-5.5"] } },
     });
+    expect(res.changes.filter((change) => change.includes("Merged"))).toEqual([
+      'Merged config.agents.defaults.models key "openai/gpt-4o" into "openai/gpt-5.5".',
+    ]);
   });
 
-  it("keeps canonical values when canonical and retired keys collide", () => {
+  it.each(["first", "last"] as const)(
+    "keeps canonical values when the canonical key appears %s",
+    (canonicalPosition) => {
+      const canonical = [
+        "openai/gpt-5.5",
+        {
+          alias: "canonical-five",
+          params: { reasoning: { effort: "medium", canonicalOnly: true } },
+          agentRuntime: { id: "codex" },
+        },
+      ] as const;
+      const retired = [
+        [
+          "openai/gpt-4",
+          {
+            alias: "legacy-four",
+            params: { reasoning: { effort: "low", fourOnly: true } },
+          },
+        ],
+        [
+          "openai/gpt-4o",
+          {
+            streaming: false,
+            params: { reasoning: { effort: "high", fourOOnly: true } },
+          },
+        ],
+      ] as const;
+      const entries =
+        canonicalPosition === "first" ? [canonical, ...retired] : [...retired, canonical];
+      const res = migrateLegacyConfigForTest({
+        agents: { defaults: { models: Object.fromEntries(entries) } },
+      });
+
+      expect(res.config?.agents?.defaults?.models).toEqual({
+        "openai/gpt-5.5": {
+          alias: "canonical-five",
+          params: {
+            reasoning: {
+              effort: "medium",
+              canonicalOnly: true,
+              fourOnly: true,
+              fourOOnly: true,
+            },
+          },
+          agentRuntime: { id: "codex" },
+          streaming: false,
+        },
+      });
+      expect(res.changes.filter((change) => change.includes("Merged"))).toEqual([
+        'Merged config.agents.defaults.models key "openai/gpt-4" into "openai/gpt-5.5"; kept existing values for conflicting fields: alias, params.reasoning.effort.',
+        'Merged config.agents.defaults.models key "openai/gpt-4o" into "openai/gpt-5.5"; kept existing values for conflicting fields: params.reasoning.effort.',
+      ]);
+    },
+  );
+
+  it("merges colliding model refs in per-agent model maps", () => {
     const res = migrateLegacyConfigForTest({
       agents: {
-        defaults: {
-          models: {
-            "openai/gpt-4": { alias: "legacy-four", streaming: true },
-            "openai/gpt-5.5": { alias: "current-five" },
+        list: [
+          {
+            id: "research",
+            models: {
+              "openai/gpt-4": { alias: "legacy-four" },
+              "openai/gpt-4o": { streaming: false },
+            },
           },
-        },
+        ],
       },
     });
 
-    expect(res.config?.agents?.defaults?.models).toEqual({
-      "openai/gpt-5.5": {
-        alias: "current-five",
-        streaming: true,
-      },
+    expect(res.config?.agents?.list?.[0]?.models).toEqual({
+      "openai/gpt-5.5": { alias: "legacy-four", streaming: false },
     });
+    expect(res.changes.filter((change) => change.includes("Merged"))).toEqual([
+      'Merged config.agents.list.0.models key "openai/gpt-4o" into "openai/gpt-5.5".',
+    ]);
   });
 
-  it("does not pollute prototypes when merging colliding model ref map keys", () => {
-    const polluted = JSON.parse(
-      '{"agents":{"defaults":{"models":{"openai/gpt-4o":{"streaming":false},"openai/gpt-4":{"__proto__":{"polluted":true},"alias":"legacy-four"}}}}}',
-    );
-    const res = migrateLegacyConfigForTest(polluted);
-
-    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  it.each([
+    {
+      side: "canonical",
+      raw: '{"agents":{"defaults":{"models":{"openai/gpt-5.5":{"__proto__":{"polluted":true},"alias":"canonical-five","params":{"nested":{"__proto__":{"polluted":true},"model":"openai/gpt-4o"}}},"openai/gpt-4":{"streaming":false}}}}}',
+    },
+    {
+      side: "retired",
+      raw: '{"agents":{"defaults":{"models":{"openai/gpt-5.5":{"alias":"canonical-five"},"openai/gpt-4":{"__proto__":{"polluted":true},"streaming":false,"params":{"nested":{"__proto__":{"polluted":true},"model":"openai/gpt-4o"}}}}}}}',
+    },
+  ])("filters blocked keys recursively from the $side collision side", ({ raw }) => {
+    const res = migrateLegacyConfigForTest(JSON.parse(raw));
     const merged = res.config?.agents?.defaults?.models?.["openai/gpt-5.5"] as Record<
       string,
       unknown
     >;
-    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
-    expect(merged.polluted).toBeUndefined();
-    expect(merged).toEqual({ streaming: false, alias: "legacy-four" });
-  });
+    const params = merged.params as Record<string, unknown>;
+    const nested = params.nested as Record<string, unknown>;
 
-  it("does not pollute prototypes when the first colliding entry carries a blocked key", () => {
-    const polluted = JSON.parse(
-      '{"agents":{"defaults":{"models":{"openai/gpt-4o":{"__proto__":{"polluted":true},"fallback":["openai/gpt-4o"],"streaming":false},"openai/gpt-4":{"alias":"legacy-four"}}}}}',
-    );
-    const res = migrateLegacyConfigForTest(polluted);
-
+    for (const record of [merged, params, nested]) {
+      expect(Object.getOwnPropertyNames(record)).not.toContain("__proto__");
+      expect(Object.getPrototypeOf(record)).toBe(Object.prototype);
+      expect(record.polluted).toBeUndefined();
+    }
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
-    const merged = res.config?.agents?.defaults?.models?.["openai/gpt-5.5"] as Record<
-      string,
-      unknown
-    >;
-    expect(Object.getOwnPropertyNames(merged)).not.toContain("__proto__");
-    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
-    expect(merged.polluted).toBeUndefined();
     expect(merged).toEqual({
-      fallback: ["openai/gpt-5.5"],
+      alias: "canonical-five",
+      params: { nested: { model: "openai/gpt-5.5" } },
       streaming: false,
-      alias: "legacy-four",
     });
   });
 
-  it("names the retired source key when the canonical key follows the retired key", () => {
+  it("does not invoke prototype setters when copying the rewritten config root", () => {
+    const raw = JSON.parse(
+      '{"__proto__":{"polluted":true},"agents":{"defaults":{"model":"openai/gpt-4"}}}',
+    ) as Record<string, unknown>;
+    const res = migrateLegacyConfigForTest(raw);
+    const config = res.config as unknown as Record<string, unknown>;
+
+    expect(Object.getPrototypeOf(config)).toBe(Object.prototype);
+    expect(Object.hasOwn(config, "__proto__")).toBe(true);
+    expect(config.polluted).toBeUndefined();
+    expect(res.config?.agents?.defaults?.model).toBe("openai/gpt-5.5");
+  });
+
+  it("reports malformed scalar collisions without claiming equal values conflict", () => {
     const res = migrateLegacyConfigForTest({
       agents: {
         defaults: {
           models: {
-            "openai/gpt-4": { alias: "legacy-four" },
-            "openai/gpt-5.5": { streaming: false },
+            "openai/gpt-5.5": false,
+            "openai/gpt-4": true,
+            "openai/gpt-4o": false,
           },
         },
       },
     });
 
-    const mergeChanges = res.changes.filter(
-      (change) => change.includes("config.agents.defaults.models key") && change.includes("Merged"),
-    );
-    expect(mergeChanges).toEqual([
-      'Merged config.agents.defaults.models key "openai/gpt-4" into "openai/gpt-5.5".',
+    expect(res.config?.agents?.defaults?.models?.["openai/gpt-5.5"]).toBe(false);
+    expect(res.changes.filter((change) => change.includes("Merged"))).toEqual([
+      'Merged config.agents.defaults.models key "openai/gpt-4" into "openai/gpt-5.5"; kept existing values for conflicting fields: value.',
+      'Merged config.agents.defaults.models key "openai/gpt-4o" into "openai/gpt-5.5".',
     ]);
   });
 

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2553,6 +2553,47 @@ describe("legacy model compat migrate", () => {
     expect(merged).toEqual({ streaming: false, alias: "legacy-four" });
   });
 
+  it("does not pollute prototypes when the first colliding entry carries a blocked key", () => {
+    const polluted = JSON.parse(
+      '{"agents":{"defaults":{"models":{"openai/gpt-4o":{"__proto__":{"polluted":true},"fallback":["openai/gpt-4o"],"streaming":false},"openai/gpt-4":{"alias":"legacy-four"}}}}}',
+    );
+    const res = migrateLegacyConfigForTest(polluted);
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    const merged = res.config?.agents?.defaults?.models?.["openai/gpt-5.5"] as Record<
+      string,
+      unknown
+    >;
+    expect(Object.getOwnPropertyNames(merged)).not.toContain("__proto__");
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
+    expect(merged.polluted).toBeUndefined();
+    expect(merged).toEqual({
+      fallback: ["openai/gpt-5.5"],
+      streaming: false,
+      alias: "legacy-four",
+    });
+  });
+
+  it("names the retired source key when the canonical key follows the retired key", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4": { alias: "legacy-four" },
+            "openai/gpt-5.5": { streaming: false },
+          },
+        },
+      },
+    });
+
+    const mergeChanges = res.changes.filter(
+      (change) => change.includes("config.agents.defaults.models key") && change.includes("Merged"),
+    );
+    expect(mergeChanges).toEqual([
+      'Merged config.agents.defaults.models key "openai/gpt-4" into "openai/gpt-5.5".',
+    ]);
+  });
+
   it("removes unrecognized model compat thinkingFormat values", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1,4 +1,5 @@
 // Legacy model runtime config migrations for stale model refs, compat fields, and catalog data.
+import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { splitTrailingAuthProfile } from "../../../agents/model-ref-profile.js";
 import {
@@ -848,51 +849,84 @@ function rewriteModelRefString(value: string, path: string, changes: string[]): 
   return upgraded;
 }
 
-function mergeModelRefMapEntries(
-  existing: unknown,
-  incoming: unknown,
-): { value: unknown; conflicts: string[] } {
-  const existingRecord = getRecord(existing);
-  const incomingRecord = getRecord(incoming);
-  if (!existingRecord || !incomingRecord) {
-    return { value: existing, conflicts: existingRecord || incomingRecord ? ["value"] : [] };
-  }
-  const merged: Record<string, unknown> = {};
-  for (const [field, existingValue] of Object.entries(existingRecord)) {
-    if (isBlockedObjectKey(field)) {
-      continue;
-    }
-    merged[field] = existingValue;
-  }
-  const conflicts: string[] = [];
-  for (const [field, incomingValue] of Object.entries(incomingRecord)) {
-    if (incomingValue === undefined || isBlockedObjectKey(field)) {
-      continue;
-    }
-    if (!hasOwnDefinedProperty(existingRecord, field)) {
-      merged[field] = incomingValue;
-      continue;
-    }
-    const existingField = getRecord(existingRecord[field]);
-    const incomingField = getRecord(incomingValue);
-    if (existingField && incomingField) {
-      const nested = mergeModelRefMapEntries(existingField, incomingField);
-      merged[field] = nested.value;
-      conflicts.push(...nested.conflicts.map((c) => `${field}.${c}`));
-      continue;
-    }
-    conflicts.push(field);
-  }
-  return { value: merged, conflicts };
-}
-
-function setModelRefMapEntry(record: Record<string, unknown>, key: string, value: unknown): void {
+function setRecordEntry(record: Record<string, unknown>, key: string, value: unknown): void {
+  // Config dictionaries can contain hostile keys; define own properties so
+  // rebuilding or copying them never invokes Object.prototype setters.
   Object.defineProperty(record, key, {
     configurable: true,
     enumerable: true,
     value,
     writable: true,
   });
+}
+
+function sanitizeModelRefMapEntry(value: unknown): unknown {
+  // Collisions combine both entries before recursive ref rewriting, so blocked
+  // keys must be removed at every depth on both sides of the merge.
+  if (Array.isArray(value)) {
+    return value.map(sanitizeModelRefMapEntry);
+  }
+  const record = getRecord(value);
+  if (!record) {
+    return value;
+  }
+  const sanitized: Record<string, unknown> = {};
+  for (const [field, child] of Object.entries(record)) {
+    if (!isBlockedObjectKey(field)) {
+      setRecordEntry(sanitized, field, sanitizeModelRefMapEntry(child));
+    }
+  }
+  return sanitized;
+}
+
+function modelRefValuesAreEqual(existing: unknown, incoming: unknown, path: string): boolean {
+  if (isDeepStrictEqual(existing, incoming)) {
+    return true;
+  }
+  const normalizedExisting = rewriteKnownModelRefs(existing, path, []).value;
+  const normalizedIncoming = rewriteKnownModelRefs(incoming, path, []).value;
+  return isDeepStrictEqual(normalizedExisting, normalizedIncoming);
+}
+
+function mergeModelRefMapEntries(
+  existing: unknown,
+  incoming: unknown,
+  path: string,
+): { value: unknown; conflicts: string[] } {
+  const existingRecord = getRecord(existing);
+  const incomingRecord = getRecord(incoming);
+  if (!existingRecord || !incomingRecord) {
+    return {
+      value: sanitizeModelRefMapEntry(existing),
+      conflicts: modelRefValuesAreEqual(existing, incoming, path) ? [] : ["value"],
+    };
+  }
+  const merged = sanitizeModelRefMapEntry(existingRecord) as Record<string, unknown>;
+  const conflicts: string[] = [];
+  for (const [field, incomingValue] of Object.entries(incomingRecord)) {
+    if (incomingValue === undefined || isBlockedObjectKey(field)) {
+      continue;
+    }
+    if (!hasOwnDefinedProperty(existingRecord, field)) {
+      setRecordEntry(merged, field, sanitizeModelRefMapEntry(incomingValue));
+      continue;
+    }
+    const existingValue = existingRecord[field];
+    const fieldPath = `${path}.${field}`;
+    if (modelRefValuesAreEqual(existingValue, incomingValue, fieldPath)) {
+      continue;
+    }
+    const existingField = getRecord(existingValue);
+    const incomingField = getRecord(incomingValue);
+    if (existingField && incomingField) {
+      const nested = mergeModelRefMapEntries(existingField, incomingField, fieldPath);
+      setRecordEntry(merged, field, nested.value);
+      conflicts.push(...nested.conflicts.map((c) => `${field}.${c}`));
+      continue;
+    }
+    conflicts.push(field);
+  }
+  return { value: merged, conflicts };
 }
 
 function rewriteModelRefMapKeys(
@@ -902,46 +936,40 @@ function rewriteModelRefMapKeys(
 ): { value: Record<string, unknown>; changed: boolean } {
   let changed = false;
   const next: Record<string, unknown> = {};
-  const canonicalKeys = new Set<string>();
-  const retiredSourceKeys = new Map<string, string>();
+  const consumedCanonicalKeys = new Set<string>();
   for (const [key, child] of Object.entries(record)) {
     const upgradedKey = upgradeRetiredModelRef(key);
     const nextKey = upgradedKey ?? key;
-    const isCanonicalEntry = !upgradedKey;
+    if (!upgradedKey && consumedCanonicalKeys.has(key)) {
+      continue;
+    }
     if (upgradedKey) {
       changes.push(
         `Upgraded ${path} key from ${JSON.stringify(key)} to ${JSON.stringify(upgradedKey)}.`,
       );
       changed = true;
     }
+    if (upgradedKey && !Object.hasOwn(next, nextKey) && Object.hasOwn(record, nextKey)) {
+      // Seed the canonical entry before its retired aliases so canonical conflict
+      // precedence and per-alias change reporting do not depend on authored key order.
+      setRecordEntry(next, nextKey, record[nextKey]);
+      consumedCanonicalKeys.add(nextKey);
+    }
     if (Object.hasOwn(next, nextKey)) {
       const existing = next[nextKey];
-      const canonicalWins = isCanonicalEntry && !canonicalKeys.has(nextKey);
-      const { value, conflicts } = canonicalWins
-        ? mergeModelRefMapEntries(child, existing)
-        : mergeModelRefMapEntries(existing, child);
-      setModelRefMapEntry(next, nextKey, value);
-      const sourceKey = canonicalWins ? (retiredSourceKeys.get(nextKey) ?? key) : key;
-      if (conflicts.length > 0) {
+      const { value, conflicts } = mergeModelRefMapEntries(existing, child, `${path}.${nextKey}`);
+      setRecordEntry(next, nextKey, value);
+      const sortedConflicts = conflicts.toSorted();
+      if (sortedConflicts.length > 0) {
         changes.push(
-          `Merged ${path} key ${JSON.stringify(sourceKey)} into ${JSON.stringify(nextKey)}; kept existing values for conflicting fields: ${conflicts.join(", ")}.`,
+          `Merged ${path} key ${JSON.stringify(key)} into ${JSON.stringify(nextKey)}; kept existing values for conflicting fields: ${sortedConflicts.join(", ")}.`,
         );
       } else {
-        changes.push(
-          `Merged ${path} key ${JSON.stringify(sourceKey)} into ${JSON.stringify(nextKey)}.`,
-        );
-      }
-      if (isCanonicalEntry) {
-        canonicalKeys.add(nextKey);
+        changes.push(`Merged ${path} key ${JSON.stringify(key)} into ${JSON.stringify(nextKey)}.`);
       }
       continue;
     }
-    setModelRefMapEntry(next, nextKey, child);
-    if (isCanonicalEntry) {
-      canonicalKeys.add(nextKey);
-    } else {
-      retiredSourceKeys.set(nextKey, key);
-    }
+    setRecordEntry(next, nextKey, child);
   }
   return { value: changed ? next : record, changed };
 }
@@ -990,7 +1018,7 @@ function rewriteKnownModelRefs(
   for (const [childKey, child] of Object.entries(working)) {
     const rewritten = rewriteKnownModelRefs(child, `${path}.${childKey}`, changes);
     changed ||= rewritten.changed;
-    next[childKey] = rewritten.value;
+    setRecordEntry(next, childKey, rewritten.value);
   }
   return { value: changed ? next : value, changed };
 }
@@ -1408,13 +1436,16 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS: LegacyConfigMigrationSpec[
     legacyRules: RETIRED_MODEL_REF_RULES,
     apply: (raw, changes) => {
       const rewritten = rewriteKnownModelRefs(raw, "config", changes);
-      if (!rewritten.changed || !getRecord(rewritten.value)) {
+      const rewrittenRecord = getRecord(rewritten.value);
+      if (!rewritten.changed || !rewrittenRecord) {
         return;
       }
       for (const key of Object.keys(raw)) {
         delete raw[key];
       }
-      Object.assign(raw, rewritten.value);
+      for (const [key, value] of Object.entries(rewrittenRecord)) {
+        setRecordEntry(raw, key, value);
+      }
     },
   }),
   defineLegacyConfigMigration({

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -880,6 +880,15 @@ function mergeModelRefMapEntries(
   return { value: merged, conflicts };
 }
 
+function setModelRefMapEntry(record: Record<string, unknown>, key: string, value: unknown): void {
+  Object.defineProperty(record, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
 function rewriteModelRefMapKeys(
   record: Record<string, unknown>,
   path: string,
@@ -887,18 +896,24 @@ function rewriteModelRefMapKeys(
 ): { value: Record<string, unknown>; changed: boolean } {
   let changed = false;
   const next: Record<string, unknown> = {};
+  const canonicalKeys = new Set<string>();
   for (const [key, child] of Object.entries(record)) {
     const upgradedKey = upgradeRetiredModelRef(key);
     const nextKey = upgradedKey ?? key;
+    const isCanonicalEntry = !upgradedKey;
     if (upgradedKey) {
       changes.push(
         `Upgraded ${path} key from ${JSON.stringify(key)} to ${JSON.stringify(upgradedKey)}.`,
       );
       changed = true;
     }
-    if (nextKey in next && upgradedKey) {
-      const { value, conflicts } = mergeModelRefMapEntries(next[nextKey], child);
-      next[nextKey] = value;
+    if (Object.hasOwn(next, nextKey)) {
+      const existing = next[nextKey];
+      const { value, conflicts } =
+        isCanonicalEntry && !canonicalKeys.has(nextKey)
+          ? mergeModelRefMapEntries(child, existing)
+          : mergeModelRefMapEntries(existing, child);
+      setModelRefMapEntry(next, nextKey, value);
       if (conflicts.length > 0) {
         changes.push(
           `Merged ${path} key ${JSON.stringify(key)} into ${JSON.stringify(nextKey)}; kept existing values for conflicting fields: ${conflicts.join(", ")}.`,
@@ -906,9 +921,15 @@ function rewriteModelRefMapKeys(
       } else {
         changes.push(`Merged ${path} key ${JSON.stringify(key)} into ${JSON.stringify(nextKey)}.`);
       }
+      if (isCanonicalEntry) {
+        canonicalKeys.add(nextKey);
+      }
       continue;
     }
-    next[nextKey] = child;
+    setModelRefMapEntry(next, nextKey, child);
+    if (isCanonicalEntry) {
+      canonicalKeys.add(nextKey);
+    }
   }
   return { value: changed ? next : record, changed };
 }

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -9,6 +9,7 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { isModelThinkingFormat, type ModelDefinitionConfig } from "../../../config/types.models.js";
+import { isBlockedObjectKey } from "../../../infra/prototype-keys.js";
 import { isLegacyModelsAddCodexMetadataModel } from "./legacy-models-add-metadata.js";
 
 const STALE_CONTEXT_WINDOW_FIXES: Record<string, { stale: number; correct: number }> = {
@@ -859,7 +860,7 @@ function mergeModelRefMapEntries(
   const merged: Record<string, unknown> = { ...existingRecord };
   const conflicts: string[] = [];
   for (const [field, incomingValue] of Object.entries(incomingRecord)) {
-    if (incomingValue === undefined) {
+    if (incomingValue === undefined || isBlockedObjectKey(field)) {
       continue;
     }
     if (!hasOwnDefinedProperty(existingRecord, field)) {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -847,6 +847,38 @@ function rewriteModelRefString(value: string, path: string, changes: string[]): 
   return upgraded;
 }
 
+function mergeModelRefMapEntries(
+  existing: unknown,
+  incoming: unknown,
+): { value: unknown; conflicts: string[] } {
+  const existingRecord = getRecord(existing);
+  const incomingRecord = getRecord(incoming);
+  if (!existingRecord || !incomingRecord) {
+    return { value: existing, conflicts: existingRecord || incomingRecord ? ["value"] : [] };
+  }
+  const merged: Record<string, unknown> = { ...existingRecord };
+  const conflicts: string[] = [];
+  for (const [field, incomingValue] of Object.entries(incomingRecord)) {
+    if (incomingValue === undefined) {
+      continue;
+    }
+    if (!hasOwnDefinedProperty(existingRecord, field)) {
+      merged[field] = incomingValue;
+      continue;
+    }
+    const existingField = getRecord(existingRecord[field]);
+    const incomingField = getRecord(incomingValue);
+    if (existingField && incomingField) {
+      const nested = mergeModelRefMapEntries(existingField, incomingField);
+      merged[field] = nested.value;
+      conflicts.push(...nested.conflicts.map((c) => `${field}.${c}`));
+      continue;
+    }
+    conflicts.push(field);
+  }
+  return { value: merged, conflicts };
+}
+
 function rewriteModelRefMapKeys(
   record: Record<string, unknown>,
   path: string,
@@ -864,6 +896,15 @@ function rewriteModelRefMapKeys(
       changed = true;
     }
     if (nextKey in next && upgradedKey) {
+      const { value, conflicts } = mergeModelRefMapEntries(next[nextKey], child);
+      next[nextKey] = value;
+      if (conflicts.length > 0) {
+        changes.push(
+          `Merged ${path} key ${JSON.stringify(key)} into ${JSON.stringify(nextKey)}; kept existing values for conflicting fields: ${conflicts.join(", ")}.`,
+        );
+      } else {
+        changes.push(`Merged ${path} key ${JSON.stringify(key)} into ${JSON.stringify(nextKey)}.`);
+      }
       continue;
     }
     next[nextKey] = child;

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -857,7 +857,13 @@ function mergeModelRefMapEntries(
   if (!existingRecord || !incomingRecord) {
     return { value: existing, conflicts: existingRecord || incomingRecord ? ["value"] : [] };
   }
-  const merged: Record<string, unknown> = { ...existingRecord };
+  const merged: Record<string, unknown> = {};
+  for (const [field, existingValue] of Object.entries(existingRecord)) {
+    if (isBlockedObjectKey(field)) {
+      continue;
+    }
+    merged[field] = existingValue;
+  }
   const conflicts: string[] = [];
   for (const [field, incomingValue] of Object.entries(incomingRecord)) {
     if (incomingValue === undefined || isBlockedObjectKey(field)) {
@@ -897,6 +903,7 @@ function rewriteModelRefMapKeys(
   let changed = false;
   const next: Record<string, unknown> = {};
   const canonicalKeys = new Set<string>();
+  const retiredSourceKeys = new Map<string, string>();
   for (const [key, child] of Object.entries(record)) {
     const upgradedKey = upgradeRetiredModelRef(key);
     const nextKey = upgradedKey ?? key;
@@ -909,17 +916,20 @@ function rewriteModelRefMapKeys(
     }
     if (Object.hasOwn(next, nextKey)) {
       const existing = next[nextKey];
-      const { value, conflicts } =
-        isCanonicalEntry && !canonicalKeys.has(nextKey)
-          ? mergeModelRefMapEntries(child, existing)
-          : mergeModelRefMapEntries(existing, child);
+      const canonicalWins = isCanonicalEntry && !canonicalKeys.has(nextKey);
+      const { value, conflicts } = canonicalWins
+        ? mergeModelRefMapEntries(child, existing)
+        : mergeModelRefMapEntries(existing, child);
       setModelRefMapEntry(next, nextKey, value);
+      const sourceKey = canonicalWins ? (retiredSourceKeys.get(nextKey) ?? key) : key;
       if (conflicts.length > 0) {
         changes.push(
-          `Merged ${path} key ${JSON.stringify(key)} into ${JSON.stringify(nextKey)}; kept existing values for conflicting fields: ${conflicts.join(", ")}.`,
+          `Merged ${path} key ${JSON.stringify(sourceKey)} into ${JSON.stringify(nextKey)}; kept existing values for conflicting fields: ${conflicts.join(", ")}.`,
         );
       } else {
-        changes.push(`Merged ${path} key ${JSON.stringify(key)} into ${JSON.stringify(nextKey)}.`);
+        changes.push(
+          `Merged ${path} key ${JSON.stringify(sourceKey)} into ${JSON.stringify(nextKey)}.`,
+        );
       }
       if (isCanonicalEntry) {
         canonicalKeys.add(nextKey);
@@ -929,6 +939,8 @@ function rewriteModelRefMapKeys(
     setModelRefMapEntry(next, nextKey, child);
     if (isCanonicalEntry) {
       canonicalKeys.add(nextKey);
+    } else {
+      retiredSourceKeys.set(nextKey, key);
     }
   }
   return { value: changed ? next : record, changed };


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --fix` upgrades retired model refs in map keys such as `agents.defaults.models` and `agents.list[].models`. When multiple retired keys upgrade to the same canonical ref—or a retired key upgrades onto an already-authored canonical key—the shipped migration logged each upgrade but silently skipped every later collision. Users could therefore lose `params`, `alias`, `streaming`, or `agentRuntime` tuning while doctor reported success.

Both `openai/gpt-4` and `openai/gpt-4o`, for example, currently upgrade to `openai/gpt-5.5`. The skip behavior entered in `b6530beb05da7441f1cbd832d470feb8a06dd4ee` and shipped in stable releases beginning with `v2026.5.26`.

## Why This Change Was Made

The fix stays in the doctor-owned legacy migration boundary. It now:

- gives an authored canonical key precedence regardless of whether it appears before or after retired aliases;
- recursively fills only missing fields from every converging retired alias;
- reports sorted leaf conflict paths only when values remain different after model-ref normalization;
- attributes each merge to the actual retired source key;
- recursively filters blocked prototype keys from both collision inputs; and
- rebuilds records and the final config root with safe own-property definitions so hostile keys cannot invoke prototype setters.

Existing merge helpers were audited but do not match this contract: `mergeMissing` lacks conflict reporting and recursive sanitization, RFC merge-patch treats `null` as deletion, and the include merge concatenates arrays/source-wins. The focused helper here preserves arbitrary tuning values while keeping one canonical migration path.

Issue #90047 is a sibling precedent for collision-safe provider-array migration, not the report for this map-key bug.

## User Impact

After an upgrade, `openclaw doctor --fix` preserves disjoint tuning from every retired alias that converges on a canonical model. Explicit canonical values win deterministically, and the doctor report names only genuine conflicts instead of claiming upgrades for discarded or effectively equal values.

No new config key, runtime fallback, or compatibility surface is added.

## Evidence

Final head: `9c9fe8dd1c`

- `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts` — 124/124 passed.
- Real isolated `openclaw doctor --fix --non-interactive` persisted-config proof — Blacksmith Testbox `tbx_01kwdegncjbcjhv1m0jcetfx66`, [Actions run 28483061881](https://github.com/openclaw/openclaw/actions/runs/28483061881), passed.
- Remote `corepack pnpm check:changed` — Blacksmith Testbox `tbx_01kwdeh9qh34esmmqmrfx09eb1`, [Actions run 28483076398](https://github.com/openclaw/openclaw/actions/runs/28483076398), passed core/coreTests typecheck, lint, import-cycle, and policy gates.
- `oxfmt --check` on both changed files and `git diff --check` — passed.
- Fresh autoreview after all fixes — no accepted/actionable findings, overall confidence 0.97.

Focused coverage includes canonical-first and canonical-last order, multiple aliases converging on one key, nested conflicts, normalized-equality logs, per-agent maps, malformed scalar entries, recursive blocked keys on both sides, and root prototype-setter safety.
