### PR TITLE
fix(telegram): topic replies stall after session conflicts

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -418,7 +418,7 @@ type TestTelegramUpdate = {
   update_id: number;
   message: {
     text: string;
-    chat: { id: number; type: "supergroup" };
+    chat: { id: number; type: "private" | "supergroup" };
     message_thread_id?: number;
     is_topic_message?: boolean;
   };
@@ -432,6 +432,16 @@ function topicUpdate(updateId: number, threadId: number, text: string): TestTele
       message_thread_id: threadId,
       is_topic_message: true,
       chat: { id: -100, type: "supergroup" },
+    },
+  };
+}
+
+function directUpdate(updateId: number, chatId: number, text: string): TestTelegramUpdate {
+  return {
+    update_id: updateId,
+    message: {
+      text,
+      chat: { id: chatId, type: "private" },
     },
   };
 }
@@ -1794,6 +1804,93 @@ describe("TelegramPollingSession", () => {
       await runPromise;
     });
   });
+
+  for (const scenario of [
+    {
+      name: "topic",
+      conflict: topicUpdate(42, 10, "retryable session init conflict"),
+      blocked: topicUpdate(43, 10, "same topic must wait behind retry backoff"),
+      other: topicUpdate(44, 11, "other topic can continue"),
+      conflictEvent: "topic10:conflict",
+      blockedEvent: "topic10:overtook",
+      otherEvent: "topic11",
+      error: "reply session initialization conflicted for agent:main:telegram:group:-100:topic:10",
+    },
+    {
+      name: "direct message",
+      conflict: directUpdate(42, 100, "retryable session init conflict"),
+      blocked: directUpdate(43, 100, "same DM must wait behind retry backoff"),
+      other: directUpdate(44, 101, "other DM can continue"),
+      conflictEvent: "dm100:conflict",
+      blockedEvent: "dm100:overtook",
+      otherEvent: "dm101",
+      error: "reply session initialization conflicted for agent:main:telegram:direct:100",
+    },
+  ]) {
+    it(`backs off retryable reply session init conflicts for ${scenario.name} lanes`, async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        await withTempSpool(async (tempDir) => {
+          const abort = new AbortController();
+          const log = vi.fn();
+          let attempts = 0;
+          const events: string[] = [];
+          await writeSpooledTestUpdates(tempDir, [
+            scenario.conflict,
+            scenario.blocked,
+            scenario.other,
+          ]);
+
+          const { runPromise, stopWorker } = startIsolatedIngressSession({
+            abort,
+            spoolDir: tempDir,
+            log,
+            drainIntervalMs: 100,
+            handleUpdate: async (update) => {
+              if (update.update_id === scenario.conflict.update_id) {
+                attempts += 1;
+                events.push(`${scenario.conflictEvent}:${attempts}`);
+                throw new Error(scenario.error);
+              }
+              if (update.update_id === scenario.blocked.update_id) {
+                events.push(scenario.blockedEvent);
+                return;
+              }
+              if (update.update_id === scenario.other.update_id) {
+                events.push(scenario.otherEvent);
+              }
+            },
+          });
+
+          await vi.waitFor(() => expect(attempts).toBe(1));
+          await vi.advanceTimersByTimeAsync(1_000);
+          expect(attempts).toBe(1);
+          await vi.waitFor(() =>
+            expect(events).toEqual([`${scenario.conflictEvent}:1`, scenario.otherEvent]),
+          );
+          expect(await pendingUpdateIds(tempDir, "all")).toEqual([
+            scenario.conflict.update_id,
+            scenario.blocked.update_id,
+          ]);
+          expect(await failedUpdateIds(tempDir)).toEqual([]);
+
+          await vi.advanceTimersByTimeAsync(4_500);
+          await vi.waitFor(() => expect(attempts).toBe(2));
+          expect(events).not.toContain(scenario.blockedEvent);
+          expectLogIncludes(
+            log,
+            `spooled update ${scenario.conflict.update_id} failed; keeping for retry`,
+          );
+
+          abort.abort();
+          stopWorker();
+          await runPromise;
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  }
 
   it("dead-letters wrapped missing harness failures", async () => {
     await withTempSpool(async (tempDir) => {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -131,11 +131,14 @@ const TELEGRAM_SPOOLED_HANDLER_ABORT_GRACE_MS = 5_000;
 const TELEGRAM_SPOOLED_HANDLER_TIMEOUT_ENV = "OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS";
 const TELEGRAM_SPOOLED_DRAIN_START_LIMIT = 100;
 const TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT = TELEGRAM_SPOOLED_DRAIN_START_LIMIT * 10;
+const TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_BASE_MS = 5_000;
+const TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_MAX_MS = 60_000;
 const TELEGRAM_POLLING_CLIENT_TIMEOUT_FLOOR_SECONDS = Math.ceil(
   TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS / 1000,
 );
 const MISSING_AGENT_HARNESS_ERROR_NAME = "MissingAgentHarnessError";
 const MISSING_AGENT_HARNESS_MESSAGE_RE = /Requested agent harness "[^"]+" is not registered\./u;
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /reply session initialization conflicted for \S+/u;
 
 function normalizeTelegramAccountId(accountId?: string | null): string {
   return accountId?.trim() || "default";
@@ -167,6 +170,24 @@ function resolveNonRetryableSpooledUpdateFailure(
     }
   }
   return null;
+}
+
+function resolveSpooledUpdateRetryDelayMs(update: TelegramSpooledUpdate, now = Date.now()): number {
+  const attempts = update.attempts ?? 0;
+  if (
+    !update.lastError ||
+    !REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(update.lastError) ||
+    update.lastAttemptAt === undefined ||
+    attempts <= 0
+  ) {
+    return 0;
+  }
+  const exponent = Math.min(attempts - 1, 8);
+  const delayMs = Math.min(
+    TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_MAX_MS,
+    TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_BASE_MS * 2 ** exponent,
+  );
+  return Math.max(0, update.lastAttemptAt + delayMs - now);
 }
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
@@ -777,7 +798,9 @@ export class TelegramPollingSession {
       }
     }
     try {
-      await releaseTelegramSpooledUpdateClaim(params.update);
+      await releaseTelegramSpooledUpdateClaim(params.update, {
+        lastError: formatErrorMessage(params.err),
+      });
     } catch (releaseErr) {
       this.opts.log(
         `[telegram][diag] spooled update ${params.update.updateId} failed and could not be requeued: ${formatErrorMessage(releaseErr)}`,
@@ -864,6 +887,10 @@ export class TelegramPollingSession {
       const laneKey = this.#spooledUpdateLaneKey(update);
       if (this.opts.abortSignal?.aborted) {
         break;
+      }
+      if (resolveSpooledUpdateRetryDelayMs(update) > 0) {
+        claimedLaneKeys.add(laneKey);
+        continue;
       }
       const handlerKey = buildSpooledUpdateHandlerKey({ spoolDir: params.spoolDir, laneKey });
       if (activeSpooledUpdateHandlersByLane.has(handlerKey)) {
@@ -1533,6 +1560,7 @@ export const testing = {
   createTelegramRestartBackoffState,
   resetTelegramRestartBackoffState,
   resolveTelegramRestartDelayMs,
+  resolveSpooledUpdateRetryDelayMs,
   resolveSpooledUpdateHandlerAbortGraceMs: (valueMs: unknown): number =>
     resolvePositiveTimerTimeoutMs(valueMs, TELEGRAM_SPOOLED_HANDLER_ABORT_GRACE_MS),
 };

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -38,6 +38,9 @@ export type TelegramSpooledUpdate = {
   path: string;
   update: unknown;
   receivedAt: number;
+  attempts?: number;
+  lastAttemptAt?: number;
+  lastError?: string;
   claim?: TelegramSpooledUpdateClaimOwner;
 };
 
@@ -166,6 +169,9 @@ function parseQueueRecord(
     path: pendingPath(spoolDir, payload.updateId),
     update: payload.update,
     receivedAt: payload.receivedAt,
+    attempts: record.attempts,
+    ...(record.lastAttemptAt === undefined ? {} : { lastAttemptAt: record.lastAttemptAt }),
+    ...(record.lastError === undefined ? {} : { lastError: record.lastError }),
   };
 }
 
@@ -267,9 +273,11 @@ export async function claimTelegramSpooledUpdate(
 
 export async function releaseTelegramSpooledUpdateClaim(
   update: ClaimedTelegramSpooledUpdate,
+  options?: { lastError?: string; releasedAt?: number },
 ): Promise<void> {
   await createTelegramIngressQueue(path.dirname(update.pendingPath)).release(
     queueMutationTarget(update),
+    options,
   );
 }
 


### PR DESCRIPTION
## Summary

Back off retryable Telegram spool replays that fail with `reply session initialization conflicted...` so one pending update cannot hot-loop the lane.

This PR is now narrowed to the Telegram follow-up only. The reply-session writer-lane/root fix landed separately in #96847, so the overlapping session-store changes and extra stale-snapshot retry layer were removed from this branch.

## What Problem This Solves

If a Telegram spooled update still hits a retryable reply-session initialization conflict, current `main` immediately releases it back to pending. The drain loop can reclaim the same update every tick, repeatedly fail before an agent turn starts, and keep later same-DM/topic updates stuck behind the hot-looping row.

## Why This Change Was Made

Telegram now persists the retry error metadata already supported by the shared ingress queue. When the pending update's last error is a reply-session initialization conflict, the drain loop waits with capped exponential backoff before retrying that update again.

The same lane is reserved during the backoff window, so later messages in the same DM/topic do not overtake the conflicted update. Other lanes can still drain.

## Upgrade And Data Compatibility

No new persisted fields or migrations. The change uses existing `attempts`, `lastAttemptAt`, and `lastError` ingress-queue fields.

## User Impact

Telegram DMs and forum topics should stop hammering the gateway if a retryable session-init conflict remains after #96847. Same-lane ordering is preserved, and unrelated lanes can continue.

## Review Updates

Addressed ClawSweeper feedback:

- rebased/narrowed the branch after #96847 landed;
- removed the now-redundant reply-session/store-writer changes;
- added direct-message coverage alongside topic coverage;
- kept the fix scoped to Telegram retry pacing.

## Evidence

```text
node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts -t "backs off retryable reply session init conflicts"

Test Files  1 passed (1)
Tests       2 passed | 62 skipped (64)
```

```text
pnpm exec oxfmt --check --threads=1 extensions/telegram/src/polling-session.ts extensions/telegram/src/polling-session.test.ts extensions/telegram/src/telegram-ingress-spool.ts

All matched files use the correct format.
```

```text
git diff --check origin/main...HEAD

(no output)
```

```text
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.79)
```

## What Was Not Tested

No full suite. No new live Telegram/Mantis proof was collected in this pass; the new regression covers both topic and direct-message lane behavior without private identifiers.
