### PR TITLE
fix(control-ui): download assistant document media

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -63,6 +63,15 @@ describe("handleControlUiHttpRequest", () => {
     return end.mock.calls[0]?.length ?? -1;
   }
 
+  function responseHeader(
+    setHeader: ReturnType<typeof makeMockHttpResponse>["setHeader"],
+    name: string,
+  ): unknown {
+    return setHeader.mock.calls.find(
+      ([headerName]) => String(headerName).toLowerCase() === name.toLowerCase(),
+    )?.[1];
+  }
+
   function expectNotFoundResponse(params: {
     handled: boolean;
     res: ReturnType<typeof makeMockHttpResponse>["res"];
@@ -157,7 +166,7 @@ describe("handleControlUiHttpRequest", () => {
     trustedProxies?: string[];
     remoteAddress?: string;
   }) {
-    const { res, end } = makeMockHttpResponse();
+    const { res, setHeader, end } = makeMockHttpResponse();
     const handled = await handleControlUiAssistantMediaRequest(
       {
         url: params.url,
@@ -172,7 +181,7 @@ describe("handleControlUiHttpRequest", () => {
         ...(params.trustedProxies ? { trustedProxies: params.trustedProxies } : {}),
       },
     );
-    return { res, end, handled };
+    return { res, setHeader, end, handled };
   }
 
   function createTrustedProxyAuth(): ResolvedGatewayAuth {
@@ -375,6 +384,46 @@ describe("handleControlUiHttpRequest", () => {
         });
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
+      },
+    });
+  });
+
+  it("serves assistant image media inline with the original filename", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-inline-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "photo.png");
+        await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
+        const { res, setHeader, handled } = await runAssistantMediaRequest({
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+          method: "GET",
+          auth: { mode: "token", token: "test-token", allowTailscale: false },
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(responseHeader(setHeader, "Content-Disposition")).toBe(
+          'inline; filename="photo.png"',
+        );
+      },
+    });
+  });
+
+  it("serves assistant document media as an attachment with the original filename", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-attachment-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "report.docx");
+        await fs.writeFile(filePath, Buffer.from("not-a-real-docx"));
+        const { res, setHeader, handled } = await runAssistantMediaRequest({
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+          method: "GET",
+          auth: { mode: "token", token: "test-token", allowTailscale: false },
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(responseHeader(setHeader, "Content-Disposition")).toBe(
+          'attachment; filename="report.docx"',
+        );
       },
     });
   });

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -3,7 +3,7 @@
 import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import type { IncomingMessage } from "node:http";
+import { validateHeaderValue, type IncomingMessage } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -424,6 +424,29 @@ describe("handleControlUiHttpRequest", () => {
         expect(responseHeader(setHeader, "Content-Disposition")).toBe(
           'attachment; filename="report.docx"',
         );
+      },
+    });
+  });
+
+  it("serves unicode assistant document filenames with an ASCII fallback", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-unicode-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "報告.pdf");
+        await fs.writeFile(filePath, Buffer.from("not-a-real-pdf"));
+        const { res, setHeader, handled } = await runAssistantMediaRequest({
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+          method: "GET",
+          auth: { mode: "token", token: "test-token", allowTailscale: false },
+        });
+        const disposition = responseHeader(setHeader, "Content-Disposition");
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(disposition).toBe(
+          "attachment; filename=\"__.pdf\"; filename*=UTF-8''%E5%A0%B1%E5%91%8A.pdf",
+        );
+        expect(() => validateHeaderValue("Content-Disposition", String(disposition))).not.toThrow();
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -264,6 +264,16 @@ function resolveAssistantMediaRoutePath(basePath?: string): string {
   return `${normalizedBasePath}${CONTROL_UI_ASSISTANT_MEDIA_PREFIX}`;
 }
 
+function escapeContentDispositionFilename(filename: string): string {
+  return filename.replace(/[\r\n]/g, "_").replace(/["\\]/g, "\\$&");
+}
+
+function buildAssistantMediaContentDisposition(filePath: string, mime: string): string {
+  const disposition = mime.startsWith("image/") ? "inline" : "attachment";
+  const filename = path.basename(filePath) || "assistant-media";
+  return `${disposition}; filename="${escapeContentDispositionFilename(filename)}"`;
+}
+
 function resolveAssistantMediaAuthToken(req: IncomingMessage): string | undefined {
   const bearer = getBearerToken(req);
   if (bearer) {
@@ -628,11 +638,12 @@ export async function handleControlUiAssistantMediaRequest(
       buffer: sniffBuffer?.subarray(0, bytesRead),
       filePath: localPath,
     });
-    if (mime) {
-      res.setHeader("Content-Type", mime);
-    } else {
-      res.setHeader("Content-Type", "application/octet-stream");
-    }
+    const contentType = mime ?? "application/octet-stream";
+    res.setHeader("Content-Type", contentType);
+    res.setHeader(
+      "Content-Disposition",
+      buildAssistantMediaContentDisposition(localPath, contentType),
+    );
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Content-Length", String(opened.stat.size));
     const stream = opened.handle.createReadStream({ start: 0, autoClose: false });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -268,10 +268,26 @@ function escapeContentDispositionFilename(filename: string): string {
   return filename.replace(/[\r\n]/g, "_").replace(/["\\]/g, "\\$&");
 }
 
+function toAsciiContentDispositionFilename(filename: string): string {
+  const ascii = filename.replace(/[^\x20-\x7e]/g, "_");
+  return ascii.trim() ? ascii : "assistant-media";
+}
+
+function encodeContentDispositionFilenameStar(filename: string): string {
+  return encodeURIComponent(filename).replace(
+    /[!'()*]/g,
+    (value) => `%${value.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
 function buildAssistantMediaContentDisposition(filePath: string, mime: string): string {
   const disposition = mime.startsWith("image/") ? "inline" : "attachment";
-  const filename = path.basename(filePath) || "assistant-media";
-  return `${disposition}; filename="${escapeContentDispositionFilename(filename)}"`;
+  const filename = (path.basename(filePath) || "assistant-media").replace(/[\r\n]/g, "_");
+  const fallbackFilename = toAsciiContentDispositionFilename(filename);
+  const base = `${disposition}; filename="${escapeContentDispositionFilename(fallbackFilename)}"`;
+  return fallbackFilename === filename
+    ? base
+    : `${base}; filename*=UTF-8''${encodeContentDispositionFilenameStar(filename)}`;
 }
 
 function resolveAssistantMediaAuthToken(req: IncomingMessage): string | undefined {


### PR DESCRIPTION
## Summary

- set `Content-Disposition` on Control UI assistant media responses
- keep image media inline with the original filename
- serve non-image assistant media as attachments with the original filename
- encode non-ASCII download filenames with an ASCII fallback plus `filename*`

Fixes #96545.

## What Problem This Solves

Assistant media downloads from the Control UI used the same inline response shape for every file type. That is fine for image previews, but document-like assistant media should prompt download behavior and preserve the original filename. The initial fix also passed raw Unicode through `filename="..."`, which can make Node reject the header with `ERR_INVALID_CHAR` for non-ASCII filenames.

## Why This Change Was Made

The gateway now builds one `Content-Disposition` value for assistant media:

- image MIME types stay `inline`
- non-image MIME types use `attachment`
- ASCII filenames stay in `filename="..."`
- Unicode filenames use an ASCII fallback in `filename="..."` plus RFC 5987 `filename*=UTF-8''...`

## User Impact

Operators can preview image assistant media inline and download document-like assistant media with stable filenames. Non-ASCII filenames no longer break header serialization.

## Evidence

- `/opt/homebrew/bin/pnpm exec oxfmt --check src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts`
- `/opt/homebrew/bin/pnpm exec oxlint --type-aware src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs src/gateway/control-ui.http.test.ts`
  - 4 files passed
  - 240 tests passed
- `node --import tsx ../assistant-media-proof.ts`
  - `photo.png: status=200 content-disposition=inline; filename="photo.png"`
  - `report.pdf: status=200 content-disposition=attachment; filename="report.pdf"`
  - `報告.pdf: status=200 content-disposition=attachment; filename="__.pdf"; filename*=UTF-8''%E5%A0%B1%E5%91%8A.pdf`
