### PR TITLE
fix(media): harden content-disposition filenames

### DIFF
--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -559,6 +559,62 @@ describe("readRemoteMediaBuffer", () => {
     await expectBoundedErrorBodyCase(testCase.fetchImpl);
   });
 
+  it.each([
+    {
+      name: "preserves quoted filenames containing semicolons",
+      contentDisposition: 'attachment; filename="quarter; summary.txt"',
+      expectedFileName: "quarter; summary.txt",
+    },
+    {
+      name: "strips path segments from quoted filenames",
+      contentDisposition: 'attachment; filename="C:\\\\temp\\\\quarter; summary.txt"',
+      expectedFileName: "quarter; summary.txt",
+    },
+    {
+      name: "prefers decoded filename-star over filename",
+      contentDisposition: "attachment; filename=fallback.txt; filename*=UTF-8''report%20Q2.pdf",
+      expectedFileName: "report Q2.pdf",
+    },
+  ] as const)("$name", async ({ contentDisposition, expectedFileName }) => {
+    const media = await readRemoteMediaBuffer(
+      createReadRemoteMediaBufferParams({
+        url: "https://example.com/download",
+        fetchImpl: vi.fn(
+          async () =>
+            new Response("hello", {
+              status: 200,
+              headers: {
+                "content-disposition": contentDisposition,
+                "content-type": "text/plain",
+              },
+            }),
+        ),
+      }),
+    );
+
+    expect(media.fileName).toBe(expectedFileName);
+  });
+
+  it("falls back to the URL filename when content-disposition resolves to a dot segment", async () => {
+    const media = await readRemoteMediaBuffer(
+      createReadRemoteMediaBufferParams({
+        url: "https://example.com/download",
+        fetchImpl: vi.fn(
+          async () =>
+            new Response("%PDF-1.4", {
+              status: 200,
+              headers: {
+                "content-disposition": 'attachment; filename=".."',
+                "content-type": "application/pdf",
+              },
+            }),
+        ),
+      }),
+    );
+
+    expect(media.fileName).toBe("download.pdf");
+  });
+
   it("uses trusted explicit-proxy mode when the caller opts in for proxy-side DNS", async () => {
     const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
     const lookupFn = makeLookupFn();

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -120,27 +120,100 @@ type GuardedMediaResponse = {
   sourceUrl: string;
 };
 
-function stripQuotes(value: string): string {
-  return value.replace(/^["']|["']$/g, "");
+function splitContentDispositionParts(header: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let inQuote = false;
+  let escaped = false;
+  for (let i = 0; i < header.length; i += 1) {
+    const char = header[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && inQuote) {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inQuote = !inQuote;
+      continue;
+    }
+    if (char === ";" && !inQuote) {
+      parts.push(header.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(header.slice(start));
+  return parts;
+}
+
+function unquoteContentDispositionValue(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length < 2 || trimmed[0] !== '"' || trimmed[trimmed.length - 1] !== '"') {
+    return trimmed;
+  }
+  let output = "";
+  for (let i = 1; i < trimmed.length - 1; i += 1) {
+    const char = trimmed[i];
+    if (char === "\\" && i + 1 < trimmed.length - 1) {
+      const next = trimmed[i + 1];
+      if (next === '"' || next === "\\") {
+        i += 1;
+        output += next;
+        continue;
+      }
+    }
+    output += char;
+  }
+  return output;
+}
+
+function basenameFromDispositionFilename(fileName: string): string | undefined {
+  const base = basenameFromAnyPath(fileName);
+  if (!base || base === "." || base === "..") {
+    return undefined;
+  }
+  return base;
+}
+
+function decodeRfc5987Filename(value: string): string {
+  const cleaned = unquoteContentDispositionValue(value);
+  const match = /^([^']*)'[^']*'(.*)$/.exec(cleaned);
+  const encoded = match?.[2] ?? cleaned;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
 }
 
 function parseContentDispositionFileName(header?: string | null): string | undefined {
   if (!header) {
     return undefined;
   }
-  const starMatch = /filename\*\s*=\s*([^;]+)/i.exec(header);
-  if (starMatch?.[1]) {
-    const cleaned = stripQuotes(starMatch[1].trim());
-    const encoded = cleaned.split("''").slice(1).join("''") || cleaned;
-    try {
-      return basenameFromAnyPath(decodeURIComponent(encoded));
-    } catch {
-      return basenameFromAnyPath(encoded);
+
+  const params = new Map<string, string>();
+  for (const part of splitContentDispositionParts(header).slice(1)) {
+    const separator = part.indexOf("=");
+    if (separator === -1) {
+      continue;
+    }
+    const name = part.slice(0, separator).trim().toLowerCase();
+    const value = part.slice(separator + 1);
+    if (name && !params.has(name)) {
+      params.set(name, value);
     }
   }
-  const match = /filename\s*=\s*([^;]+)/i.exec(header);
-  if (match?.[1]) {
-    return basenameFromAnyPath(stripQuotes(match[1].trim()));
+
+  const encodedFileName = params.get("filename*");
+  if (encodedFileName) {
+    return basenameFromDispositionFilename(decodeRfc5987Filename(encodedFileName));
+  }
+
+  const fileName = params.get("filename");
+  if (fileName) {
+    return basenameFromDispositionFilename(unquoteContentDispositionValue(fileName));
   }
   return undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

Remote media downloads can receive `Content-Disposition` filenames from upstream services. The old parser split filename parameters at every semicolon, including semicolons inside quoted filenames, so a valid header like `attachment; filename="quarter; summary.txt"` produced a truncated filename before assistant-media/document download handling saw it. This PR preserves those filenames, keeps RFC 5987 `filename*` precedence/decoding, strips path segments, and falls back to the URL-derived filename when a disposition filename resolves to `.` or `..`.

Validation evidence:

- `PATH=/opt/homebrew/bin:$PATH node scripts/run-vitest.mjs run --config test/vitest/vitest.media.config.ts src/media/fetch.test.ts` passed with 43 tests.
- `PATH=/opt/homebrew/bin:$PATH pnpm check` passed, including preflight guards, typecheck, lint, and policy guards.

## Summary

- Problem: remote media filenames from `Content-Disposition` were parsed with a regex that stopped at semicolons, even inside quoted filenames.
- Why it matters: assistant-media/document downloads can receive mangled filenames before the UI or downstream save path sees them.
- What changed: replaced the fragile regex with quoted-string-aware disposition parameter parsing, decoded `filename*`, stripped path segments, and ignored dot-segment filenames so URL fallback can produce a sane name.
- What did NOT change (scope boundary): no control UI route/header behavior from #96551, no media download networking changes, no Linear linkage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related #96551
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `parseContentDispositionFileName` used `filename\s*=\s*([^;]+)` style matching, which treats every semicolon as a parameter separator even when it is inside a quoted filename.
- Missing detection / guardrail: no `readRemoteMediaBuffer` tests covered quoted semicolons, Windows-style path segments combined with quoted-string parsing, `filename*` precedence, or dot-segment fallback.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #96551 improves assistant document media downloads at the control UI layer; this is a separate media fetch reliability follow-up.
- Why this regressed now: Unknown; likely an old parser limitation exposed by the assistant-media download path.
- If unknown, what was ruled out: this PR does not change the control UI download route or response header logic from #96551.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/media/fetch.test.ts`
- Scenario the test should lock in: quoted filenames with semicolons, Windows path stripping, `filename*` precedence/decoding, and fallback when a disposition filename resolves to `..`.
- Why this is the smallest reliable guardrail: the bug is isolated to remote media response filename parsing before higher-level media/UI code receives the filename.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Downloaded remote media filenames are preserved more accurately when servers return quoted `Content-Disposition` filenames with semicolons or RFC 5987 `filename*` values.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node via Homebrew, pnpm 11.2.2 after upstream refresh
- Model/provider: N/A
- Integration/channel (if any): remote media / assistant-media filename handling
- Relevant config (redacted): N/A

### Steps

1. Fetch remote media whose response includes `Content-Disposition: attachment; filename="quarter; summary.txt"`.
2. Observe `readRemoteMediaBuffer` result metadata.

### Expected

- `fileName` is `quarter; summary.txt`.

### Actual

- Before this change, the regex truncated at the quoted semicolon.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `PATH=/opt/homebrew/bin:$PATH node scripts/run-vitest.mjs run --config test/vitest/vitest.media.config.ts src/media/fetch.test.ts`
  - `PATH=/opt/homebrew/bin:$PATH pnpm check`
- Edge cases checked: quoted semicolons, Windows path segments under quoted-string parsing, decoded `filename*`, dot-segment fallback.
- What you did **not** verify: full browser control UI download flow; #96551 owns that surface.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
