### PR TITLE
fix(cli): explain inherited config defaults cannot be unset

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1193,8 +1193,7 @@ describe("config cli", () => {
           issues: [
             {
               path: "update.channel",
-              message:
-                'Invalid input (allowed: "stable", "extended-stable", "beta", "dev")',
+              message: 'Invalid input (allowed: "stable", "extended-stable", "beta", "dev")',
               allowedValues: ["stable", "extended-stable", "beta", "dev"],
               allowedValuesHiddenCount: 0,
             },
@@ -3407,6 +3406,23 @@ describe("config cli", () => {
       expect(mockError.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
         "Run openclaw config get <path>",
       );
+
+      setSnapshot(resolved, runtimeMerged);
+      await expect(
+        runConfigCommand(["config", "unset", aliasPath, "--dry-run", "--json"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(parseLastLogPayload()).toMatchObject({
+        ok: false,
+        errors: [
+          {
+            kind: "missing-path",
+            message: expect.stringContaining(
+              `Config path not found in authored config: ${aliasPath}.`,
+            ),
+          },
+        ],
+      });
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
 

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -3371,6 +3371,45 @@ describe("config cli", () => {
       ]);
     });
 
+    it("explains when unset targets a runtime-only default shown by config get", async () => {
+      const resolved = {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.4": {},
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const runtimeMerged = {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.4": { alias: "gpt" },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const aliasPath = 'agents.defaults.models["openai/gpt-5.4"].alias';
+      setSnapshot(resolved, runtimeMerged);
+
+      await runConfigCommand(["config", "get", aliasPath]);
+
+      expect(mockLog).toHaveBeenCalledWith("gpt");
+      mockLog.mockClear();
+      setSnapshot(resolved, runtimeMerged);
+
+      await expect(runConfigCommand(["config", "unset", aliasPath])).rejects.toThrow("__exit__:1");
+
+      expectErrorIncludes(`Config path not found in authored config: ${aliasPath}.`);
+      expectErrorIncludes("It only exists after runtime defaults are applied");
+      expectErrorIncludes("openclaw config set <path> <value>");
+      expect(mockError.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
+        "Run openclaw config get <path>",
+      );
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
     it("validates existing refs when unset dry-run removes all secret providers", async () => {
       const resolved: OpenClawConfig = {
         gateway: { port: 18789 },

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -521,6 +521,16 @@ function getAtPath(root: unknown, path: PathSegment[]): { found: boolean; value?
   return { found: true, value: current };
 }
 
+function formatConfigUnsetMissingPathMessage(params: {
+  path: string;
+  runtimeOnly: boolean;
+}): string {
+  if (params.runtimeOnly) {
+    return `Config path not found in authored config: ${params.path}. It only exists after runtime defaults are applied, so there is nothing for config unset to remove. Use ${formatCliCommand("openclaw config set <path> <value>")} to override the inherited value.`;
+  }
+  return `Config path not found: ${params.path}. Nothing was changed. Run ${formatCliCommand("openclaw config get <path>")} first if you are unsure of the path.`;
+}
+
 type JsonSchemaRecord = {
   type?: unknown;
   properties?: unknown;
@@ -2486,6 +2496,11 @@ export async function runConfigUnset(opts: {
     );
     const unsetResult = unsetAtPath(next, parsedPath);
     if (!unsetResult.removed) {
+      const runtimeOnly = getAtPath(snapshot.config, parsedPath).found;
+      const missingPathMessage = formatConfigUnsetMissingPathMessage({
+        path: opts.path,
+        runtimeOnly,
+      });
       if (cliOptions.dryRun && cliOptions.json) {
         throw new ConfigSetDryRunValidationError({
           ok: false,
@@ -2502,16 +2517,14 @@ export async function runConfigUnset(opts: {
           errors: [
             {
               kind: "missing-path",
-              message: `Config path not found: ${opts.path}. Nothing was changed.`,
+              message: runtimeOnly
+                ? missingPathMessage
+                : `Config path not found: ${opts.path}. Nothing was changed.`,
             },
           ],
         });
       }
-      runtime.error(
-        danger(
-          `Config path not found: ${opts.path}. Nothing was changed. Run ${formatCliCommand("openclaw config get <path>")} first if you are unsure of the path.`,
-        ),
-      );
+      runtime.error(danger(missingPathMessage));
       runtime.exit(1);
       return;
     }

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -2496,7 +2496,7 @@ export async function runConfigUnset(opts: {
     );
     const unsetResult = unsetAtPath(next, parsedPath);
     if (!unsetResult.removed) {
-      const runtimeOnly = getAtPath(snapshot.config, parsedPath).found;
+      const runtimeOnly = getAtPath(snapshot.runtimeConfig, parsedPath).found;
       const missingPathMessage = formatConfigUnsetMissingPathMessage({
         path: opts.path,
         runtimeOnly,


### PR DESCRIPTION
## What Problem This Solves

Values materialized by runtime defaults are visible through `openclaw config get` but do not exist in the authored config file. `config unset` correctly could not delete them, yet its old missing-path message sent users back to `config get` without explaining how to override the value.

## Why This Change Was Made

The repaired implementation keeps the existing mutation boundary: authored `resolved` config remains the only write target. It consults immutable `runtimeConfig` only to diagnose a runtime-only value and suggest `openclaw config set <path> <value>`.

## User Impact

Users receive actionable guidance for inherited runtime defaults instead of a loop between `config get` and `config unset`. Missing authored paths and dry runs remain non-mutating.

## Evidence

- Blacksmith Testbox `tbx_01kww7nmt4dctps3ngaxgdrw9c`: all 129 config CLI tests passed.
- An isolated real CLI proof confirmed `config get` returns the inherited alias, normal and JSON dry-run unset return the new guidance, and the authored config checksum remains unchanged.
- Same Testbox: `pnpm check:changed` passed.
- Fresh Codex autoreview: no actionable findings.

Credit: @moeghashim authored the original diagnosis and fix.

AI-assisted: yes. Maintainer repair, full owner/caller/sibling review, regression proof, and final validation were performed before landing.
