### PR TITLE
fix(control-ui): harden protected route variants

### DIFF
--- a/src/gateway/control-ui-routing.test.ts
+++ b/src/gateway/control-ui-routing.test.ts
@@ -32,8 +32,20 @@ describe("classifyControlUiRequest", () => {
         expected: { kind: "not-control-ui" as const },
       },
       {
+        name: "keeps encoded health probes outside the SPA catch-all",
+        pathname: "/health%252f",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
         name: "keeps plugin routes outside the SPA catch-all",
         pathname: "/plugins/webhook",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps encoded plugin routes outside the SPA catch-all",
+        pathname: "/plugins%2fdiffs/view/abc",
         method: "GET",
         expected: { kind: "not-control-ui" as const },
       },
@@ -42,6 +54,24 @@ describe("classifyControlUiRequest", () => {
         pathname: "/api/sessions",
         method: "GET",
         expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps repeatedly encoded API routes outside the SPA catch-all",
+        pathname: "/api%252fsessions",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "fails closed for malformed encoded API routes",
+        pathname: "/api%zz",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "serves encoded lookalike routes after canonicalization",
+        pathname: "/api%61",
+        method: "GET",
+        expected: { kind: "serve" as const },
       },
       {
         name: "returns not-found for legacy ui routes",

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -1,5 +1,6 @@
 // Control UI route classifier for base-path and root-mounted SPA serving.
 import { isReadHttpMethod } from "./control-ui-http-utils.js";
+import { canonicalizePathForSecurity } from "./security-path.js";
 
 type ControlUiRequestClassification =
   | { kind: "not-control-ui" }
@@ -8,6 +9,41 @@ type ControlUiRequestClassification =
   | { kind: "serve" };
 
 const ROOT_MOUNTED_GATEWAY_PROBE_PATHS = new Set(["/health", "/healthz", "/ready", "/readyz"]);
+const ROOT_MOUNTED_GATEWAY_ROUTE_PREFIXES = ["/api", "/plugins"] as const;
+
+function matchesCanonicalExactPath(pathname: string, paths: ReadonlySet<string>): boolean {
+  const canonical = canonicalizePathForSecurity(pathname);
+  if (canonical.candidates.some((candidate) => paths.has(candidate))) {
+    return true;
+  }
+  if (!canonical.malformedEncoding && !canonical.decodePassLimitReached) {
+    return false;
+  }
+  return Array.from(paths).some(
+    (path) =>
+      canonical.rawNormalizedPath === path || canonical.rawNormalizedPath.startsWith(`${path}%`),
+  );
+}
+
+function matchesCanonicalPrefixPath(pathname: string, prefixes: readonly string[]): boolean {
+  const canonical = canonicalizePathForSecurity(pathname);
+  if (
+    canonical.candidates.some((candidate) =>
+      prefixes.some((prefix) => candidate === prefix || candidate.startsWith(`${prefix}/`)),
+    )
+  ) {
+    return true;
+  }
+  if (!canonical.malformedEncoding && !canonical.decodePassLimitReached) {
+    return false;
+  }
+  return prefixes.some(
+    (prefix) =>
+      canonical.rawNormalizedPath === prefix ||
+      canonical.rawNormalizedPath.startsWith(`${prefix}/`) ||
+      canonical.rawNormalizedPath.startsWith(`${prefix}%`),
+  );
+}
 
 /** Classify an HTTP request as Control UI serving, redirect, 404, or non-Control-UI. */
 export function classifyControlUiRequest(params: {
@@ -23,15 +59,12 @@ export function classifyControlUiRequest(params: {
     }
     // Keep core probe routes outside the root-mounted SPA catch-all so the
     // gateway probe handler can answer them even when the Control UI owns `/`.
-    if (ROOT_MOUNTED_GATEWAY_PROBE_PATHS.has(pathname)) {
+    if (matchesCanonicalExactPath(pathname, ROOT_MOUNTED_GATEWAY_PROBE_PATHS)) {
       return { kind: "not-control-ui" };
     }
     // Keep plugin-owned HTTP routes outside the root-mounted Control UI SPA
     // fallback so untrusted plugins cannot claim arbitrary UI paths.
-    if (pathname === "/plugins" || pathname.startsWith("/plugins/")) {
-      return { kind: "not-control-ui" };
-    }
-    if (pathname === "/api" || pathname.startsWith("/api/")) {
+    if (matchesCanonicalPrefixPath(pathname, ROOT_MOUNTED_GATEWAY_ROUTE_PREFIXES)) {
       return { kind: "not-control-ui" };
     }
     if (!isReadHttpMethod(method)) {


### PR DESCRIPTION
## Summary

- keep encoded root-mounted `/api` and `/plugins` route variants out of the Control UI SPA fallback
- keep encoded probe-route variants routed to gateway probe handling
- add regression coverage for encoded slash, repeated encoding, malformed encoding, and encoded lookalike paths

## What Problem This Solves

When the Control UI is mounted at `/`, protected gateway paths are excluded from the SPA fallback with plain pathname checks. Encoded variants such as `/api%2fsessions` or `/plugins%2fdiffs/view/abc` can miss those checks and be classified as Control UI routes instead of passing through to the API or plugin route handlers. This hardens the classifier by reusing the gateway path canonicalization logic for root-mounted protected routes while preserving non-protected encoded lookalike SPA routes.

## Scope Notes

- Does not touch assistant-media Content-Disposition handling from #96551.
- Does not touch `src/media/fetch` filename parsing from #96555.
- No Linear issue is referenced for this targeted improvement thread.

## Evidence

- `PATH=/opt/homebrew/bin:$PATH node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/control-ui-routing.test.ts`
  - 3 files passed
  - 63 tests passed
- `PATH=/opt/homebrew/bin:$PATH pnpm exec oxfmt --write src/gateway/control-ui-routing.ts src/gateway/control-ui-routing.test.ts`
- `PATH=/opt/homebrew/bin:$PATH pnpm exec oxlint --type-aware src/gateway/control-ui-routing.ts src/gateway/control-ui-routing.test.ts`
- `PATH=/opt/homebrew/bin:$PATH pnpm check`
- `git diff --check`

## Test Plan

- [x] `PATH=/opt/homebrew/bin:$PATH node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/control-ui-routing.test.ts`
- [x] `PATH=/opt/homebrew/bin:$PATH pnpm exec oxfmt --write src/gateway/control-ui-routing.ts src/gateway/control-ui-routing.test.ts`
- [x] `PATH=/opt/homebrew/bin:$PATH pnpm exec oxlint --type-aware src/gateway/control-ui-routing.ts src/gateway/control-ui-routing.test.ts`
- [x] `PATH=/opt/homebrew/bin:$PATH pnpm check`
- [x] `git diff --check`
