### PR TITLE
fix(sessions): keep sibling dirs that share the home prefix unshortened in tool path display

### DIFF
--- a/src/agents/sessions/tools/render-utils.test.ts
+++ b/src/agents/sessions/tools/render-utils.test.ts
@@ -1,5 +1,6 @@
+import * as os from "node:os";
 import { describe, expect, it } from "vitest";
-import { appendSessionToolTruncationWarning } from "./render-utils.js";
+import { appendSessionToolTruncationWarning, shortenPath } from "./render-utils.js";
 
 const theme = {
   fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
@@ -20,5 +21,31 @@ describe("appendSessionToolTruncationWarning", () => {
     ).toBe(
       "output\n<warning>[Truncated: 5 matches limit, 1.0KB limit, some lines truncated]</warning>",
     );
+  });
+});
+
+describe("shortenPath", () => {
+  const home = os.homedir();
+
+  it("shortens paths inside the home directory", () => {
+    expect(shortenPath(`${home}/projects/app.ts`)).toBe("~/projects/app.ts");
+  });
+
+  it("collapses the home directory itself", () => {
+    expect(shortenPath(home)).toBe("~");
+  });
+
+  it("leaves a sibling directory that merely shares the prefix untouched", () => {
+    // `${home}extra` starts with `home` as a substring but is not under it,
+    // so it must not be rewritten to `~extra`.
+    expect(shortenPath(`${home}extra/app.ts`)).toBe(`${home}extra/app.ts`);
+  });
+
+  it("leaves unrelated paths untouched", () => {
+    expect(shortenPath("/var/log/syslog")).toBe("/var/log/syslog");
+  });
+
+  it("returns an empty string for non-string input", () => {
+    expect(shortenPath(undefined)).toBe("");
   });
 });

--- a/src/agents/sessions/tools/render-utils.ts
+++ b/src/agents/sessions/tools/render-utils.ts
@@ -18,7 +18,10 @@ export function shortenPath(path: unknown): string {
     return "";
   }
   const home = os.homedir();
-  if (path.startsWith(home)) {
+  if (path === home) {
+    return "~";
+  }
+  if (path.startsWith(`${home}/`) || path.startsWith(`${home}\\`)) {
     return `~${path.slice(home.length)}`;
   }
   return path;


### PR DESCRIPTION
## What Problem This Solves

The `read` (and other session tool) output in the TUI shortens home paths for display via `shortenPath`. It decided a path was "under home" with a bare `path.startsWith(home)`, with no check for a path separator after the home directory. So a sibling directory that merely shares the home string as a prefix gets mangled:

- home = `/home/me`, the tool shows `/home/metrics/out.log` as `~trics/out.log`
- home = `C:\Users\He`, the tool shows `C:\Users\Helen\notes.md` as `~len\notes.md`

The displayed path is wrong and no longer copy-pasteable, which is the opposite of what the shortening is supposed to do.

## Why This Change Was Made

`src/utils.ts` already gets this right in `shortenHomePath`: it special-cases `input === home` and otherwise only rewrites when the home segment is followed by a separator (`${home}/` or `${home}\\`). The TUI helper just predated that and never picked up the boundary check. This change brings `shortenPath` in line with the existing helper:

- return `~` when the path is exactly the home directory
- only rewrite when home is followed by `/` or `\` (so real subpaths still shorten, siblings don't)

This is the same class of bug as #88449 (which fixes `shortenHomeInString` and the terminal-core display helper). That PR doesn't touch `src/agents/sessions/tools/render-utils.ts`, so this is a complementary fix for the one remaining helper with the naive prefix match.

## User Impact

Session tool output displays sibling-of-home paths verbatim instead of corrupting them. Real subpaths under home keep shortening to `~/...` exactly as before, and the home directory itself now collapses to `~`.

## Evidence

Before/after behavior, captured by running the actual `shortenPath` exported from `src/agents/sessions/tools/render-utils.ts` in this PR's checkout (HEAD `77137f14b`) against the same helper on `main`. I bundled each real module with esbuild and called the exported function directly. `shortenPath` only depends on `node:os`, so the unrelated TUI imports in that file are not in its call path; the `os.homedir()` value is redacted to `/home/alice` through the environment:

```
os.homedir() [redacted] = /home/alice

input                           main (current)        this PR
------------------------------- --------------------- ----------------------------
/home/alice                     ~                     ~
/home/alice/project/app.ts      ~/project/app.ts      ~/project/app.ts
/home/alice-backup/app.ts       ~-backup/app.ts       /home/alice-backup/app.ts   <-- FIXED
/home/alicia/notes.md           /home/alicia/notes.md /home/alicia/notes.md
/home/alice2/tmp/x.log          ~2/tmp/x.log          /home/alice2/tmp/x.log   <-- FIXED
/etc/hosts                      /etc/hosts            /etc/hosts
```

`main` mangles the two sibling paths that only share the home string as a prefix (`~-backup/app.ts` and `~2/tmp/x.log`). This PR leaves them intact while still shortening a real subpath and collapsing the home directory itself to `~`.

The PR also adds a `shortenPath` block to `render-utils.test.ts` covering the same cases: a real subpath shortens, the home dir collapses to `~`, a sibling sharing the prefix is left untouched, an unrelated path is untouched, and non-string input returns `""`. I couldn't run the full vitest suite end to end on my Windows machine, since a clean install pulls several heavyweight native packages (including `@rolldown/binding-win32-x64-msvc`) that don't fetch reliably here, so that test runs in CI rather than locally.

## Note for maintainers

This PR was prepared with AI assistance (Claude Code). I verified the bug, the fix, and the tests myself before opening it.
