### PR TITLE
docs: make workflow tracking GitHub-native

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 Optional linked context:
 Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
 below this comment.
+External tracker links are optional extra context, not required closure fields.
 
 Required PR title:
 type: user-facing description

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Skills own workflows; root owns hard policy and routing.
 
 - Repo: `https://github.com/openclaw/openclaw`
 - Replies: repo-root refs only: `extensions/telegram/src/index.ts:80`. No absolute paths, no `~/`.
+- Work tracking: use GitHub issues/PRs by default. External trackers such as Linear are optional only when already linked or explicitly requested.
 - Docs/user-visible work: `pnpm docs:list`, then read relevant docs only.
 - Existing-solutions preflight: before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a lightweight check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this to a brief preflight gate, not a broad research assignment.
 - Fix/triage answers need source, tests, current/shipped behavior, and dependency contract proof.


### PR DESCRIPTION
## What Problem This Solves

Repository workflow guidance did not explicitly state that OpenClaw repo work should use GitHub-native tracking by default, which left room for private external trackers such as Linear to be treated as required context.

## Why This Change Was Made

This adds a root policy line that GitHub issues/PRs are the default tracking surface and clarifies the PR template comment so external tracker links are optional extra context, not required closure fields.

## User Impact

Contributors and agents can prepare OpenClaw PRs without private Linear access. Existing external tracker links can still be included when already available or explicitly requested.

## Evidence

Local verification:

```text
git diff HEAD^..HEAD --check
git grep -n -E 'Linear issue|Linear ticket|Linear is the default|linear-required|Create a Linear|Link Linear|linear_issue|AI-XXX|US-YYY' HEAD -- AGENTS.md .github .agents skills scripts docs
```

Results: whitespace check passed, and the targeted search returned no active mandatory Linear-tracking hits.

Branch hygiene: rebased onto current `upstream/main`; final diff is one commit touching only `AGENTS.md` and `.github/pull_request_template.md`.
