### PR TITLE
fix(media): strip internal UUID suffix from outbound media filenames

### DIFF
--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -573,6 +573,16 @@ describe("loadWebMedia", () => {
     expect(result.fileName).toBe("fake.png");
   });
 
+  it("strips internal media-store UUID suffix from outbound fileName", async () => {
+    const stagedName = "narahari_resume---a1b2c3d4-5678-90ab-cdef-1234567890ab.png";
+    const stagedFile = path.join(fixtureRoot, stagedName);
+    await fs.writeFile(stagedFile, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    const result = await loadWebMedia(stagedFile, createLocalWebMediaOptions());
+
+    expect(result.fileName).toBe("narahari_resume.png");
+  });
+
   it("uses only the leaf filename from Windows-style sandbox-validated media paths", async () => {
     const result = await loadWebMedia(String.raw`C:\workspace\captures\tiny.png`, {
       maxBytes: 1024 * 1024,

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -574,13 +574,28 @@ describe("loadWebMedia", () => {
   });
 
   it("strips internal media-store UUID suffix from outbound fileName", async () => {
-    const stagedName = "narahari_resume---a1b2c3d4-5678-90ab-cdef-1234567890ab.png";
-    const stagedFile = path.join(fixtureRoot, stagedName);
+    const stagedName = "report---a1b2c3d4-5678-90ab-cdef-1234567890ab.png";
+    const mediaDir = path.join(stateDir, "media", "outbound");
+    const stagedFile = path.join(mediaDir, stagedName);
+    await fs.mkdir(mediaDir, { recursive: true });
     await fs.writeFile(stagedFile, Buffer.from(TINY_PNG_BASE64, "base64"));
 
-    const result = await loadWebMedia(stagedFile, createLocalWebMediaOptions());
+    const result = await loadWebMedia(stagedFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: [mediaDir],
+    });
 
-    expect(result.fileName).toBe("narahari_resume.png");
+    expect(result.fileName).toBe("report.png");
+  });
+
+  it("preserves non-media-store filenames that match the UUID suffix shape", async () => {
+    const fileName = "report---a1b2c3d4-5678-90ab-cdef-1234567890ab.png";
+    const filePath = path.join(fixtureRoot, fileName);
+    await fs.writeFile(filePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    const result = await loadWebMedia(filePath, createLocalWebMediaOptions());
+
+    expect(result.fileName).toBe(fileName);
   });
 
   it("uses only the leaf filename from Windows-style sandbox-validated media paths", async () => {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -33,6 +33,7 @@ import {
   readImageMetadataFromHeader,
   readImageProbeFromHeader,
 } from "./media-services.js";
+import { extractOriginalFilename } from "./store.js";
 
 export { getDefaultLocalRoots, LocalMediaAccessError };
 export type { LocalMediaAccessErrorCode };
@@ -1075,6 +1076,9 @@ async function loadWebMediaInternal(
     });
   }
   let fileName = basenameFromAnyPath(mediaUrl) || undefined;
+  if (fileName) {
+    fileName = extractOriginalFilename(fileName);
+  }
   if (fileName && !extnameFromAnyPath(fileName) && mime) {
     const ext = extensionForMime(mime);
     if (ext) {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -33,7 +33,7 @@ import {
   readImageMetadataFromHeader,
   readImageProbeFromHeader,
 } from "./media-services.js";
-import { extractOriginalFilename } from "./store.js";
+import { extractOriginalFilename, getMediaDir } from "./store.js";
 
 export { getDefaultLocalRoots, LocalMediaAccessError };
 export type { LocalMediaAccessErrorCode };
@@ -283,6 +283,13 @@ function isPathInsideRoot(filePath: string | undefined, root: string): boolean {
   return (
     relative === "" || (relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative))
   );
+}
+
+function resolveLocalMediaFileName(filePath: string): string | undefined {
+  const fileName = basenameFromAnyPath(filePath) || undefined;
+  return fileName && isPathInsideRoot(filePath, getMediaDir())
+    ? extractOriginalFilename(fileName)
+    : fileName;
 }
 
 function hasHtmlDocumentShape(text: string): boolean {
@@ -1075,10 +1082,7 @@ async function loadWebMediaInternal(
       trustedGeneratedHtmlPath,
     });
   }
-  let fileName = basenameFromAnyPath(mediaUrl) || undefined;
-  if (fileName) {
-    fileName = extractOriginalFilename(fileName);
-  }
+  let fileName = resolveLocalMediaFileName(mediaUrl);
   if (fileName && !extnameFromAnyPath(fileName) && mime) {
     const ext = extensionForMime(mime);
     if (ext) {


### PR DESCRIPTION
Closes #96538

## What Problem This Solves

Fixes an issue where users receiving files from an agent on Telegram (and other chat channels) would see internal cache suffixes in the filename, e.g. `resume---a1b2c3d4-5678-90ab-cdef-1234567890ab.pdf` instead of `resume.pdf`. The internal media-store UUID used for deduplication was leaking into the recipient-visible attachment filename.

## Why This Change Was Made

The shared outbound media loader (`loadWebMediaInternal`) derives the recipient-facing filename from the staged file's basename, which includes an internal `---<uuid>` suffix for cache deduplication. The media store already exposes `extractOriginalFilename` to strip this suffix, but it was not being called on the outbound path. This change applies that existing helper at the shared media boundary so all channels benefit.

## User Impact

Users receiving file attachments from agents on Telegram, Slack, Discord, and other chat channels will now see clean original filenames instead of filenames polluted with internal cache identifiers.

## Evidence

All 74 existing tests pass plus a new regression test that verifies a staged file named with the internal UUID suffix produces a clean outbound filename.

