### PR TITLE
fix(media): forward scanned PDF page images in chat turns

### DIFF
--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -59,4 +59,65 @@ describe("resolveCurrentTurnImages", () => {
       });
     });
   });
+
+  it("merges current-turn extracted images with existing inline images", async () => {
+    const existingImage = {
+      type: "image" as const,
+      data: Buffer.from("existing-image").toString("base64"),
+      mimeType: "image/jpeg",
+    };
+    const extractedPdfPage = {
+      type: "image" as const,
+      data: Buffer.from("pdf-page").toString("base64"),
+      mimeType: "image/png",
+    };
+
+    const result = await resolveCurrentTurnImages({
+      ctx: {
+        Body: "<media:document>",
+        CurrentTurnImages: [extractedPdfPage],
+        CurrentTurnImageOrder: ["inline"],
+      } satisfies MsgContext,
+      cfg: {} as OpenClawConfig,
+      images: [existingImage],
+      imageOrder: ["inline"],
+    });
+
+    expect(result).toStrictEqual({
+      images: [existingImage, extractedPdfPage],
+      imageOrder: ["inline", "inline"],
+    });
+  });
+
+  it("does not merge extracted images twice across the prepare and run passes", async () => {
+    const extractedPdfPage = {
+      type: "image" as const,
+      data: Buffer.from("pdf-page").toString("base64"),
+      mimeType: "image/png",
+    };
+    const ctx = {
+      Body: "<media:document>",
+      CurrentTurnImages: [extractedPdfPage],
+      CurrentTurnImageOrder: ["inline"],
+    } satisfies MsgContext;
+
+    const prepared = await resolveCurrentTurnImages({
+      ctx,
+      cfg: {} as OpenClawConfig,
+    });
+    const runPass = await resolveCurrentTurnImages({
+      ctx,
+      cfg: {} as OpenClawConfig,
+      images: prepared.images,
+      imageOrder: prepared.imageOrder,
+    });
+
+    expect(prepared).toStrictEqual({
+      images: [extractedPdfPage],
+      imageOrder: ["inline"],
+    });
+    expect(runPass).toStrictEqual(prepared);
+    expect(ctx.CurrentTurnImages).toBeUndefined();
+    expect(ctx.CurrentTurnImageOrder).toBeUndefined();
+  });
 });

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -88,6 +88,44 @@ function createUndescribedImageContext(
   };
 }
 
+function mergeImagePayloads(params: {
+  baseImages?: ImageContent[];
+  baseImageOrder?: PromptImageOrderEntry[];
+  nextImages?: ImageContent[];
+  nextImageOrder?: PromptImageOrderEntry[];
+}): {
+  images?: ImageContent[];
+  imageOrder?: PromptImageOrderEntry[];
+} {
+  const nextImages = params.nextImages ?? [];
+  if (nextImages.length === 0) {
+    return { images: params.baseImages, imageOrder: params.baseImageOrder };
+  }
+  const images = [...(params.baseImages ?? []), ...nextImages];
+  const nextOrder =
+    params.nextImageOrder && params.nextImageOrder.length === nextImages.length
+      ? params.nextImageOrder
+      : nextImages.map(() => "inline" as const);
+  return {
+    images,
+    imageOrder: [...(params.baseImageOrder ?? []), ...nextOrder],
+  };
+}
+
+export function takeCurrentTurnImages(ctx: MsgContext): {
+  images?: ImageContent[];
+  imageOrder?: PromptImageOrderEntry[];
+} {
+  const images = ctx.CurrentTurnImages;
+  const imageOrder = ctx.CurrentTurnImageOrder;
+  if (images && images.length > 0) {
+    delete ctx.CurrentTurnImages;
+    delete ctx.CurrentTurnImageOrder;
+    return { images, imageOrder };
+  }
+  return {};
+}
+
 /** Resolves current-turn image attachments that were not already described by media understanding. */
 export async function resolveCurrentTurnImages(params: {
   ctx: MsgContext;
@@ -98,30 +136,37 @@ export async function resolveCurrentTurnImages(params: {
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
 }> {
+  const extractedImages = takeCurrentTurnImages(params.ctx);
+  let resolved = mergeImagePayloads({
+    baseImages: params.images,
+    baseImageOrder: params.imageOrder,
+    nextImages: extractedImages.images,
+    nextImageOrder: extractedImages.imageOrder,
+  });
   if (Array.isArray(params.images) && params.images.length > 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
+    return resolved;
   }
 
   const currentImageAttachments = collectCurrentImageAttachments(params.ctx);
   if (currentImageAttachments.length === 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
+    return resolved;
   }
   const describedImageIndexes = collectDescribedImageAttachmentIndexes(params.ctx);
   const undescribedImageAttachments = currentImageAttachments.filter(
     (attachment) => !describedImageIndexes.has(attachment.index),
   );
   if (undescribedImageAttachments.length === 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
+    return resolved;
   }
 
   try {
     // Only send undescribed current images natively; described images already exist as text context.
-    const resolved = await resolveAgentTurnAttachments({
+    const attachmentResult = await resolveAgentTurnAttachments({
       ctx: createUndescribedImageContext(params.ctx, undescribedImageAttachments),
       cfg: params.cfg,
       includeRecentHistoryImages: false,
     });
-    const images = resolved.attachments.map(
+    const images = attachmentResult.attachments.map(
       (attachment): ImageContent => ({
         type: "image",
         data: attachment.data,
@@ -132,15 +177,22 @@ export async function resolveCurrentTurnImages(params: {
       logVerbose(
         `agent-runner: native OpenClaw media resolution produced ${images.length}/${undescribedImageAttachments.length} current image attachment(s); falling back to prompt image refs`,
       );
-      return { images: params.images, imageOrder: params.imageOrder };
+      return resolved;
     }
-    return images.length > 0
-      ? { images, imageOrder: images.map(() => "inline" as const) }
-      : { images: params.images, imageOrder: params.imageOrder };
+    if (images.length === 0) {
+      return resolved;
+    }
+    resolved = mergeImagePayloads({
+      baseImages: resolved.images,
+      baseImageOrder: resolved.imageOrder,
+      nextImages: images,
+      nextImageOrder: images.map(() => "inline" as const),
+    });
+    return resolved;
   } catch (error) {
     logVerbose(
       `agent-runner: media attachment image resolution failed, proceeding without native images: ${formatErrorMessage(error)}`,
     );
-    return { images: params.images, imageOrder: params.imageOrder };
+    return resolved;
   }
 }

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -1192,6 +1192,38 @@ describe("tryDispatchAcpReply", () => {
     ]);
   });
 
+  it("forwards PDF page images extracted during media understanding into ACP runtime turns", async () => {
+    setReadyAcpResolution();
+    const extractedPdfPage = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: Buffer.from("pdf-page").toString("base64"),
+    };
+    mediaUnderstandingMocks.applyMediaUnderstanding.mockImplementationOnce(async (params) => {
+      const ctx = (
+        params as { ctx: { CurrentTurnImages?: unknown; CurrentTurnImageOrder?: unknown } }
+      ).ctx;
+      ctx.CurrentTurnImages = [extractedPdfPage];
+      ctx.CurrentTurnImageOrder = ["inline"];
+    });
+
+    await runDispatch({
+      bodyForAgent: '<file name="scan.pdf">[PDF content rendered to images]</file>',
+      ctxOverrides: {
+        MediaPath: "/tmp/scan.pdf",
+        MediaType: "application/pdf",
+      },
+    });
+
+    expect(mediaUnderstandingMocks.applyMediaUnderstanding).toHaveBeenCalledOnce();
+    expect(runTurnCall().attachments).toEqual([
+      {
+        mediaType: "image/png",
+        data: extractedPdfPage.data,
+      },
+    ]);
+  });
+
   it("preserves chat.send inline image attachments over recent history images", async () => {
     setReadyAcpResolution();
     const image = {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -37,6 +37,7 @@ import {
   resolveInlineAgentImageAttachments,
 } from "./agent-turn-attachments.js";
 import { resolveFirstContextText } from "./context-text.js";
+import { takeCurrentTurnImages } from "./current-turn-images.js";
 import {
   createAcpDispatchDeliveryCoordinator,
   type AcpDispatchDeliveryCoordinator,
@@ -563,22 +564,26 @@ export async function tryDispatchAcpReply(params: {
       cfg: params.cfg,
     });
     const mediaAttachments = resolvedTurnAttachments.attachments;
-    const inlineAttachments = resolveInlineAgentImageAttachments(params.images);
+    const inputInlineAttachments = resolveInlineAgentImageAttachments(params.images);
+    const extractedInlineAttachments = resolveInlineAgentImageAttachments(
+      takeCurrentTurnImages(params.ctx).images,
+    );
+    const inlineAttachments = [...inputInlineAttachments, ...extractedInlineAttachments];
     const mediaAttachmentsAreOnlyRecentHistory =
       mediaAttachments.length > 0 &&
       mediaAttachments.length === resolvedTurnAttachments.recentHistoryImages.length;
-    const attachments =
+    const shouldUseMediaAttachments =
       mediaAttachments.length > 0 &&
-      !(mediaAttachmentsAreOnlyRecentHistory && inlineAttachments.length > 0)
-        ? mediaAttachments
-        : inlineAttachments;
-    const turnPromptText =
-      attachments === mediaAttachments
-        ? appendRecentHistoryImageContext({
-            promptText,
-            images: resolvedTurnAttachments.recentHistoryImages,
-          })
-        : promptText;
+      !(mediaAttachmentsAreOnlyRecentHistory && inlineAttachments.length > 0);
+    const attachments = shouldUseMediaAttachments
+      ? [...mediaAttachments, ...extractedInlineAttachments]
+      : inlineAttachments;
+    const turnPromptText = shouldUseMediaAttachments
+      ? appendRecentHistoryImageContext({
+          promptText,
+          images: resolvedTurnAttachments.recentHistoryImages,
+        })
+      : promptText;
     if (!turnPromptText && attachments.length === 0) {
       const counts = params.dispatcher.getQueuedCounts();
       delivery.applyRoutedCounts(counts);

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -1,9 +1,11 @@
 /** Shared inbound message context types used by prompt templating and reply dispatch. */
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
+import type { ImageContent } from "../llm/types.js";
 import type {
   MediaUnderstandingDecision,
   MediaUnderstandingOutput,
 } from "../media-understanding/types.js";
+import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type { PluginHookChannelContext } from "../plugins/hook-channel-context.types.js";
 import type { InputProvenance } from "../sessions/input-provenance.js";
 import type { CommandTurnContext } from "./command-turn-context.js";
@@ -219,6 +221,9 @@ export type MsgContext = {
   Transcript?: string;
   MediaUnderstanding?: MediaUnderstandingOutput[];
   MediaUnderstandingDecisions?: MediaUnderstandingDecision[];
+  /** Inline images derived during current-turn preprocessing, such as PDF page renders. */
+  CurrentTurnImages?: ImageContent[];
+  CurrentTurnImageOrder?: PromptImageOrderEntry[];
   LinkUnderstanding?: string[];
   Prompt?: string;
   MaxChars?: number;

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -31,6 +31,7 @@ const readRemoteMediaBufferMock = vi.hoisted(() => vi.fn());
 const runFfmpegMock = vi.hoisted(() => vi.fn());
 const convertHeicToJpegMock = vi.hoisted(() => vi.fn());
 const runExecMock = vi.hoisted(() => vi.fn());
+const extractDocumentContentMock = vi.hoisted(() => vi.fn());
 
 let applyMediaUnderstanding: typeof import("./apply.js").applyMediaUnderstanding;
 let clearMediaUnderstandingBinaryCacheForTests: typeof import("./runner.js").clearMediaUnderstandingBinaryCacheForTests;
@@ -39,6 +40,7 @@ const mockedReadRemoteMediaBuffer = readRemoteMediaBufferMock;
 const mockedRunFfmpeg = runFfmpegMock;
 const mockedConvertHeicToJpeg = convertHeicToJpegMock;
 const mockedRunExec = runExecMock;
+const mockedExtractDocumentContent = extractDocumentContentMock;
 
 const TEMP_MEDIA_PREFIX = "openclaw-media-";
 let suiteTempMediaRootDir = "";
@@ -298,6 +300,9 @@ describe("applyMediaUnderstanding", () => {
       runFfmpeg: runFfmpegMock,
       convertHeicToJpeg: convertHeicToJpegMock,
     }));
+    vi.doMock("../media/document-extractors.runtime.js", () => ({
+      extractDocumentContent: extractDocumentContentMock,
+    }));
     vi.doMock("../process/exec.js", () => ({
       runExec: runExecMock,
     }));
@@ -352,6 +357,8 @@ describe("applyMediaUnderstanding", () => {
     mockedConvertHeicToJpeg.mockReset();
     mockedConvertHeicToJpeg.mockResolvedValue(Buffer.from("jpeg-normalized"));
     mockedRunExec.mockReset();
+    mockedExtractDocumentContent.mockReset();
+    mockedExtractDocumentContent.mockResolvedValue({ text: "", images: [] });
     mockedReadRemoteMediaBuffer.mockResolvedValue({
       buffer: createSafeAudioFixtureBuffer(2048),
       contentType: "audio/ogg",
@@ -1740,6 +1747,37 @@ describe("applyMediaUnderstanding", () => {
     });
 
     expectFileNotApplied({ ctx, result, body: "<media:file>" });
+  });
+
+  it("carries rendered PDF page images into current-turn image payloads", async () => {
+    const extractedImage = {
+      type: "image" as const,
+      data: Buffer.from("scanned-page").toString("base64"),
+      mimeType: "image/png",
+    };
+    mockedExtractDocumentContent.mockResolvedValueOnce({
+      text: "",
+      images: [extractedImage],
+    });
+    const pseudoPdf = Buffer.from("%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n", "utf8");
+    const filePath = await createTempMediaFile({
+      fileName: "receipt-scan.pdf",
+      content: pseudoPdf,
+    });
+
+    const { ctx, result } = await applyWithDisabledMedia({
+      body: "<media:document>",
+      mediaPath: filePath,
+      mediaType: "application/pdf",
+    });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain("[PDF content rendered to images]");
+    expect(ctx.Body).not.toContain("images not forwarded");
+    expect(ctx.CurrentTurnImages).toEqual([extractedImage]);
+    expect(ctx.CurrentTurnImageOrder).toEqual(["inline"]);
+    expect(ctx.BodyForAgent).toBe(ctx.Body);
+    expect(ctx.BodyForCommands).toBe(ctx.Body);
   });
 
   it("respects configured allowedMimes for text-like attachments", async () => {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -5,19 +5,20 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
-import type { MsgContext } from "../auto-reply/templating.js";
-import type { OpenClawConfig } from "../config/types.js";
-import { logVerbose, shouldLogVerbose } from "../globals.js";
-import { renderFileContextBlock } from "../media/file-context.js";
-import { extractFileContentFromSource, normalizeMimeType } from "../media/input-files.js";
-import { wrapExternalContent } from "../security/external-content.js";
 import type { ActiveMediaModel } from "../../packages/media-understanding-common/src/active-model.js";
 import {
   extractMediaUserText,
   formatAudioTranscripts,
   formatMediaUnderstandingBody,
 } from "../../packages/media-understanding-common/src/format.js";
+import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { logVerbose, shouldLogVerbose } from "../globals.js";
+import type { ImageContent } from "../llm/types.js";
+import { renderFileContextBlock } from "../media/file-context.js";
+import { extractFileContentFromSource, normalizeMimeType } from "../media/input-files.js";
+import { wrapExternalContent } from "../security/external-content.js";
 import { resolveAttachmentKind } from "./attachments.js";
 import { runWithConcurrency } from "./concurrency.js";
 import { DEFAULT_ECHO_TRANSCRIPT_FORMAT, sendTranscriptEcho } from "./echo-transcript.js";
@@ -47,6 +48,11 @@ type ApplyMediaUnderstandingResult = {
   appliedAudio: boolean;
   appliedVideo: boolean;
   appliedFile: boolean;
+};
+
+type FileExtractionBlocksResult = {
+  blocks: string[];
+  images: ImageContent[];
 };
 
 const CAPABILITY_ORDER: MediaUnderstandingCapability[] = ["image", "audio", "video"];
@@ -109,6 +115,17 @@ function appendFileBlocks(body: string | undefined, blocks: string[]): string {
     return suffix;
   }
   return `${base}\n\n${suffix}`.trim();
+}
+
+function appendCurrentTurnImages(ctx: MsgContext, images: ImageContent[]): void {
+  if (images.length === 0) {
+    return;
+  }
+  ctx.CurrentTurnImages = [...(ctx.CurrentTurnImages ?? []), ...images];
+  ctx.CurrentTurnImageOrder = [
+    ...(ctx.CurrentTurnImageOrder ?? []),
+    ...images.map(() => "inline" as const),
+  ];
 }
 
 function wrapUntrustedAttachmentContent(content: string): string {
@@ -383,12 +400,13 @@ async function extractFileBlocks(params: {
   cfg: OpenClawConfig;
   limits: FileExtractionLimits;
   skipAttachmentIndexes?: Set<number>;
-}): Promise<string[]> {
+}): Promise<FileExtractionBlocksResult> {
   const { attachments, cache, cfg, limits, skipAttachmentIndexes } = params;
   if (!attachments || attachments.length === 0) {
-    return [];
+    return { blocks: [], images: [] };
   }
   const blocks: string[] = [];
+  const images: ImageContent[] = [];
   for (const attachment of attachments) {
     if (!attachment) {
       continue;
@@ -493,11 +511,15 @@ async function extractFileBlocks(params: {
       }
       continue;
     }
+    const extractedImages = extracted?.images ?? [];
+    if (extractedImages.length > 0) {
+      images.push(...extractedImages);
+    }
     const text = extracted?.text?.trim() ?? "";
     let blockText = text ? wrapUntrustedAttachmentContent(text) : "";
     if (!blockText) {
-      if (extracted?.images && extracted.images.length > 0) {
-        blockText = "[PDF content rendered to images; images not forwarded to model]";
+      if (extractedImages.length > 0) {
+        blockText = "[PDF content rendered to images]";
       } else {
         blockText = "[No extractable text]";
       }
@@ -511,7 +533,7 @@ async function extractFileBlocks(params: {
       }),
     );
   }
-  return blocks;
+  return { blocks, images };
 }
 
 export async function applyMediaUnderstanding(params: {
@@ -670,20 +692,21 @@ export async function applyMediaUnderstanding(params: {
         )
         .map((output) => output.attachmentIndex),
     );
-    const fileBlocks = await extractFileBlocks({
+    const fileExtraction = await extractFileBlocks({
       attachments,
       cache,
       cfg,
       limits: resolveFileExtractionLimits(cfg),
       skipAttachmentIndexes: audioAttachmentIndexes.size > 0 ? audioAttachmentIndexes : undefined,
     });
-    if (fileBlocks.length > 0) {
-      ctx.Body = appendFileBlocks(ctx.Body, fileBlocks);
+    if (fileExtraction.blocks.length > 0) {
+      ctx.Body = appendFileBlocks(ctx.Body, fileExtraction.blocks);
     }
-    if (outputs.length > 0 || fileBlocks.length > 0) {
+    appendCurrentTurnImages(ctx, fileExtraction.images);
+    if (outputs.length > 0 || fileExtraction.blocks.length > 0) {
       finalizeInboundContext(ctx, {
         forceBodyForAgent: true,
-        forceBodyForCommands: outputs.length > 0 || fileBlocks.length > 0,
+        forceBodyForCommands: outputs.length > 0 || fileExtraction.blocks.length > 0,
       });
     }
 
@@ -693,7 +716,7 @@ export async function applyMediaUnderstanding(params: {
       appliedImage: outputs.some((output) => output.kind === "image.description"),
       appliedAudio: outputs.some((output) => output.kind === "audio.transcription"),
       appliedVideo: outputs.some((output) => output.kind === "video.description"),
-      appliedFile: fileBlocks.length > 0,
+      appliedFile: fileExtraction.blocks.length > 0,
     };
   } finally {
     await cache.cleanup();


### PR DESCRIPTION
Closes #96541

## What Problem This Solves

Fixes an issue where users sending scanned or image-only PDFs over chat channels would have extracted PDF page images dropped before the model saw them.

## Why This Change Was Made

The chat media-understanding path now carries PDF-rendered page images as transient current-turn inline images while preserving the file context block. The normal agent-runner path consumes those images once to avoid duplicate prepare/run merges, and ACP dispatch forwards the same extracted images into ACP runTurn attachments.

OpenResponses behavior is unchanged.

## User Impact

Scanned receipts, contracts, and image-only PDFs sent through chat channels can now reach vision-capable models as image inputs instead of only a placeholder.

## Evidence

AI-assisted: yes. I used Codex to implement and review this change and understand the resulting diff.

Behavior addressed: scanned / image-only PDF page images extracted on chat channel path are forwarded to the model instead of dropped.

Real environment tested: local source checkout at commit 2cd82bdbc0 on branch oss/96541-scanned-pdf-images-chat, using the real media-understanding, current-turn image hydration, ACP dispatch, agent-runner, and OpenResponses test paths with mocked document extraction where the external PDF-render boundary is intentionally isolated.

Exact steps or command run after this patch:

- `node scripts/run-vitest.mjs src/media-understanding/apply.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/current-turn-images.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-acp.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts`
- `node scripts/run-vitest.mjs src/gateway/openresponses-http.server.file-only.test.ts`
- `git diff --check`
- `/Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 .agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review fix for #96541 after addressing duplicate image merge and ACP dispatch gaps: scanned/image-only PDF extraction on chat path carries extracted PDF page images into inline image payloads for normal agent runner and ACP dispatch, consumes transient extracted images, and preserves existing OpenResponses behavior."`

Evidence after fix:

- `apply.test.ts` now verifies an image-only PDF extraction result populates `CurrentTurnImages` and no longer emits the old "images not forwarded" placeholder.
- `current-turn-images.test.ts` verifies extracted PDF page images merge into inline image payloads and are not merged twice across prepare/run passes.
- `dispatch-acp.test.ts` verifies ACP dispatch passes extracted PDF page images as runTurn attachments.

Observed result after fix: all commands above passed; autoreview clean: no accepted/actionable findings reported.

What was not tested: I did not run a live Telegram, Slack, Discord, or WhatsApp send with a real scanned PDF; the local proof exercises the shared chat media-understanding, normal agent-runner, ACP dispatch, and sibling OpenResponses source paths.
