### PR TITLE
fix(msteams): keep truncated parent context text well-formed

### DIFF
--- a/extensions/msteams/src/thread-parent-context.test.ts
+++ b/extensions/msteams/src/thread-parent-context.test.ts
@@ -10,6 +10,11 @@ import {
   summarizeParentMessage,
 } from "./thread-parent-context.js";
 
+// Matches an unpaired UTF-16 surrogate (lone high or lone low), without relying
+// on the ES2024 String.prototype.isWellFormed() runtime API.
+const UNPAIRED_SURROGATE_RE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
 describe("summarizeParentMessage", () => {
   it("returns undefined for missing message", () => {
     expect(summarizeParentMessage(undefined)).toBeUndefined();
@@ -80,6 +85,20 @@ describe("summarizeParentMessage", () => {
     const summary = summarizeParentMessage(msg);
     expect(summary?.text.length).toBeLessThanOrEqual(400);
     expect(summary?.text.endsWith("…")).toBe(true);
+  });
+
+  it("keeps truncated parent text well-formed when truncating surrogate pairs", () => {
+    const msg: GraphThreadMessage = {
+      id: "p1",
+      from: { user: { displayName: "Dana" } },
+      body: { content: `${"a".repeat(398)}🦞${"b".repeat(50)}`, contentType: "text" },
+    };
+
+    const summary = summarizeParentMessage(msg);
+
+    expect(summary?.text).not.toMatch(UNPAIRED_SURROGATE_RE);
+    expect(summary?.text).toBe(`${"a".repeat(398)}…`);
+    expect(summary?.text.endsWith("\ud83e…")).toBe(false);
   });
 });
 

--- a/extensions/msteams/src/thread-parent-context.ts
+++ b/extensions/msteams/src/thread-parent-context.ts
@@ -17,6 +17,7 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { fetchChannelMessage, stripHtmlFromTeamsMessage } from "./graph-thread.js";
 import type { GraphThreadMessage } from "./graph-thread.js";
 
@@ -138,7 +139,9 @@ export function summarizeParentMessage(
   return {
     sender,
     text:
-      text.length > PARENT_TEXT_MAX_CHARS ? `${text.slice(0, PARENT_TEXT_MAX_CHARS - 1)}…` : text,
+      text.length > PARENT_TEXT_MAX_CHARS
+        ? `${truncateUtf16Safe(text, PARENT_TEXT_MAX_CHARS - 1)}…`
+        : text,
   };
 }
 


### PR DESCRIPTION
**Summary:** The Teams parent-message summary was truncated with a raw UTF-16 slice, so an emoji at the 400-char boundary became a lone surrogate in the injected `Replying to @sender: …` context event. This uses the shared `truncateUtf16Safe` helper to truncate on a code-point boundary.

## What Problem This Solves

MS Teams thread parent context summarization truncated long parent-message text with raw UTF-16 slicing. When the 400-character parent preview limit landed between the high and low surrogate of an emoji, the generated `Replying to @sender: ...` context could contain a lone surrogate.

Trigger input:

- parent text starts with 398 ASCII characters
- followed by an emoji such as `🦞` (`U+1F99E`, encoded as a UTF-16 surrogate pair)
- followed by additional text
- legacy truncation used `slice(0, 399) + "…"` and kept only the high surrogate before the ellipsis

That leaves malformed text in the injected MS Teams parent-context event and can break consumers that require well-formed strings.

## Fix

`extensions/msteams/src/thread-parent-context.ts` now reuses the shared `truncateUtf16Safe` helper from `openclaw/plugin-sdk/text-utility-runtime` when shortening parent-message text.

The fix keeps the existing 400-character parent-context limit and ellipsis behavior, but the truncation boundary is now validated before the ellipsis is appended. If the limit would split a surrogate pair, the helper backs up to the last complete UTF-16 boundary, so the final escaped/injected parent context remains well-formed.

## Evidence

Command run from an isolated temporary worktree on `fix/msteams-parent-truncate`:

```bash
node --import tsx demo.mts
```

Terminal output:

```text
input.length=450
emoji.codePoint=1f99e
BEFORE legacy slice(0, 399) + ellipsis
before.length=400
before.tailCodeUnits=0061 0061 0061 d83e 2026
before.loneSurrogate=true
before.loneSurrogateCodeUnit=d83e
before.encodeURIComponent=URIError
AFTER summarizeParentMessage (real msteams repair path)
after.text=aaaaaaaaaaaaaaaaaaaa…[398 ×'a' elided]…
after.length=399
after.tailCodeUnits=0061 0061 0061 0061 2026
after.loneSurrogate=false
after.endsWithHighSurrogateEllipsis=false
after.encodeURIComponent=aaaaaaaaa%E2%80%A6
```

This demo calls the real exported `summarizeParentMessage` path from `extensions/msteams/src/thread-parent-context.ts`. The legacy reproduction leaves a lone high surrogate (`d83e`) and throws `URIError` during URI encoding; the fixed path returns well-formed text with `loneSurrogate=false`.

## Tests

`extensions/msteams/src/thread-parent-context.test.ts` adds focused Vitest regression coverage for surrogate-boundary truncation in MS Teams parent-context summaries.

The test constructs the same boundary shape, verifies the summarized text does not match the unpaired-surrogate regex, confirms the emoji is not split before the ellipsis, and preserves the expected compact parent-context output shape.