### PR TITLE
fix(whatsapp): convert GFM bold-italic without leaving literal asterisks

### DIFF
--- a/extensions/whatsapp/src/targets-runtime.ts
+++ b/extensions/whatsapp/src/targets-runtime.ts
@@ -288,6 +288,15 @@ export function markdownToWhatsApp(text: string): string {
     return `${WHATSAPP_INLINE_CODE_PLACEHOLDER}${inlineCodes.length - 1}${WHATSAPP_PLACEHOLDER_TERMINATOR}`;
   });
 
+  // Convert combined GFM strong+emphasis before plain strong so the plain
+  // rules cannot leave literal `**` around the inner emphasis.
+  result = result.replace(/\*\*\*(.+?)\*\*\*/g, "*_$1_*");
+  result = result.replace(/___(.+?)___/g, "*_$1_*");
+  result = result.replace(/\*\*_(.+?)_\*\*/g, "*_$1_*");
+  result = result.replace(/__\*(.+?)\*__/g, "*_$1_*");
+  result = result.replace(/_\*\*(.+?)\*\*_/g, "*_$1_*");
+  result = result.replace(/\*__(.+?)__\*/g, "*_$1_*");
+
   result = result.replace(/\*\*(.+?)\*\*/g, "*$1*");
   result = result.replace(/__(.+?)__/g, "*$1*");
   result = result.replace(/~~(.+?)~~/g, "~$1~");

--- a/extensions/whatsapp/src/text-runtime.test.ts
+++ b/extensions/whatsapp/src/text-runtime.test.ts
@@ -42,6 +42,17 @@ describe("markdownToWhatsApp", () => {
     ["returns empty string for empty input", "", ""],
     ["returns plain text unchanged", "no formatting here", "no formatting here"],
     ["handles bold inside a sentence", "This is **very** important", "This is *very* important"],
+    ["converts GFM ***bold italic*** to WhatsApp bold+italic", "***bi***", "*_bi_*"],
+    ["converts GFM __*bold italic*__ to WhatsApp bold+italic", "__*y*__", "*_y_*"],
+    ["converts GFM **_bold italic_** to WhatsApp bold+italic", "**_x_**", "*_x_*"],
+    ["converts GFM ___bold italic___ to WhatsApp bold+italic", "___z___", "*_z_*"],
+    ["converts GFM *__bold italic__* to WhatsApp bold+italic", "*__q__*", "*_q_*"],
+    ["converts GFM _**bold italic**_ to WhatsApp bold+italic", "_**r**_", "*_r_*"],
+    [
+      "preserves inline code containing bold-italic markers",
+      "Use `***not bold italic***` here",
+      "Use `***not bold italic***` here",
+    ],
     // Regression: a digit immediately after an inline-code span must not be
     // absorbed into the placeholder index (which previously dropped both).
     ["preserves inline code immediately followed by a digit", "`a`5", "`a`5"],


### PR DESCRIPTION
**Summary:** `markdownToWhatsApp` only stripped one layer of `*`, so GFM combined bold-italic (`***text***`, `__*x*__`) left a literal `**` that WhatsApp renders as plain text. This handles the combined strong+emphasis form first so no stray `**` leaks through.

## What Problem This Solves

`markdownToWhatsApp` in `extensions/whatsapp/src/targets-runtime.ts` converted plain Markdown bold before handling combined GFM bold+italic forms.

That left visible Markdown markers for inputs such as:

```text
***launch 🚀 now***
```

Legacy behavior converted that to:

```text
**launch 🚀 now**
```

so WhatsApp users could see residual `**` instead of a proper bold+italic presentation. The regression is easiest to see with emoji-bearing text because it also verifies the formatter keeps emoji and surrogate-pair content intact and well-formed.

## Fix

This updates `markdownToWhatsApp` so combined GFM strong+emphasis patterns are normalized before the plain strong rules run.

The formatter now converts GFM bold+italic spellings such as `***text***`, `**_text_**`, `__*text*__`, `_**text**_`, and related variants into WhatsApp's `*_text_*` form before applying the ordinary bold conversion.

The code path keeps the existing placeholder protection for fenced and inline code spans, uses escaped placeholder delimiters through `escapeRegExp`, and restores code spans after formatting so code content is not interpreted as WhatsApp markdown.

## Evidence

I ran an equivalent terminal proof in a temporary worktree on this PR branch and imported the real runtime function from `extensions/whatsapp/src/targets-runtime.ts`.

Command:

```bash
node --import tsx demo.mts
```

Output:

```text
INPUT "🚀 ***launch 🚀 now*** 🚀"
BEFORE raw .slice(0, 1) "\ud83d" codePointAt= 0xd83d lone-surrogate= true
BEFORE legacy markdown output "🚀 **launch 🚀 now** 🚀"
BEFORE residual-double-star= true
AFTER real markdownToWhatsApp output "🚀 *_launch 🚀 now_* 🚀"
AFTER residual-double-star= false
AFTER lone-surrogate= false
```

The terminal run demonstrates the old conversion left residual `**`, while the real fixed `markdownToWhatsApp` output is WhatsApp bold+italic markup and remains well-formed UTF-16 with `lone-surrogate=false`.

## Tests

Vitest coverage was added for the red/green markdown conversion cases in `extensions/whatsapp/src/text-runtime.test.ts`.

The tests cover GFM bold+italic inputs including `***bi***`, `**_x_**`, `__*y*__`, `___z___`, `*__q__*`, and `_**r**_`, and they also verify inline code containing bold+italic markers is preserved instead of formatted.