### PR TITLE
fix(msteams): escape markup in mention display names

### DIFF
--- a/extensions/msteams/src/jsdom.d.ts
+++ b/extensions/msteams/src/jsdom.d.ts
@@ -1,0 +1,9 @@
+// Minimal type shim for jsdom used in structural mention-markup tests.
+// jsdom ships without bundled type declarations; this covers only the
+// JSDOM constructor and window.document surface needed by mentions.test.ts.
+declare module "jsdom" {
+  export class JSDOM {
+    constructor(html: string);
+    readonly window: Window & typeof globalThis;
+  }
+}

--- a/extensions/msteams/src/mentions.test.ts
+++ b/extensions/msteams/src/mentions.test.ts
@@ -1,6 +1,22 @@
 // Msteams tests cover mentions plugin behavior.
+import { createServer, request, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { JSDOM } from "jsdom";
 import { describe, expect, it } from "vitest";
 import { parseMentions } from "./mentions.js";
+import { buildActivity, sendMSTeamsMessages } from "./messenger.js";
+
+// Parse the Teams mention markup in activity.text using an independent DOM parser
+// (jsdom) so the structural assertion does not depend on the same code under test.
+function parseAtStructure(html: string) {
+  const doc = new JSDOM(`<body>${html}</body>`).window.document;
+  return {
+    atCount: doc.querySelectorAll("at").length,
+    nestedAt: doc.querySelectorAll("at at").length,
+    hasInjectedChild: (doc.querySelector("at")?.children?.length ?? 0) > 0,
+    textContent: doc.querySelector("at")?.textContent ?? null,
+  };
+}
 
 function requireFirstEntity(result: ReturnType<typeof parseMentions>) {
   const entity = result.entities[0];
@@ -89,6 +105,35 @@ describe("parseMentions", () => {
     });
   });
 
+  it("escapes markup characters in mention tags and keeps entity text aligned", () => {
+    const result = parseMentions("Hi @[Tom & <b>Jerry</b>](28:abc-123)");
+    const expectedMention = "<at>Tom &amp; &lt;b&gt;Jerry&lt;/b&gt;</at>";
+
+    expect(result.text).toBe(`Hi ${expectedMention}`);
+    const entity = requireOnlyEntity(result);
+    expect(entity).toEqual({
+      type: "mention",
+      text: expectedMention,
+      mentioned: {
+        id: "28:abc-123",
+        name: "Tom & <b>Jerry</b>",
+      },
+    });
+
+    const start = result.text.indexOf("<at>");
+    const end = result.text.indexOf("</at>", start) + "</at>".length;
+    expect(result.text.slice(start, end)).toBe(entity.text);
+  });
+
+  it("escapes closing at tags inside mention names", () => {
+    const result = parseMentions("Hi @[A</at><at>B](28:abc)");
+    const expectedMention = "<at>A&lt;/at&gt;&lt;at&gt;B</at>";
+
+    expect(result.text).toBe(`Hi ${expectedMention}`);
+    expect(requireOnlyEntity(result).text).toBe(expectedMention);
+    expect(result.text).not.toContain("A</at><at>B");
+  });
+
   it("handles Japanese characters in mention at start of message", () => {
     const input = "@[タナカ タロウ](a1b2c3d4-e5f6-7890-abcd-ef1234567890) スキル化完了しました！";
     const result = parseMentions(input);
@@ -156,5 +201,201 @@ describe("parseMentions", () => {
     expect(result.entities).toHaveLength(0);
     // Original text preserved
     expect(result.text).toBe("See @[docs](https://example.com) for details");
+  });
+});
+
+describe("buildActivity mention markup — jsdom structural oracle", () => {
+  // Drive the full buildActivity → parseMentions call chain and verify
+  // the resulting activity.text with an independent DOM parser (jsdom).
+  // This proves that Teams' XML mention parser would see exactly one <at>
+  // element with the correct textContent and no injected child nodes.
+
+  it("produces exactly one well-formed <at> for a name with angle brackets and ampersand", async () => {
+    const activity = await buildActivity({ text: "@[Alice <Admin> & Bob](28:abc-00001)" }, {});
+    const s = parseAtStructure(activity.text as string);
+
+    expect(s.atCount).toBe(1);
+    expect(s.nestedAt).toBe(0);
+    expect(s.hasInjectedChild).toBe(false);
+    expect(s.textContent).toBe("Alice <Admin> & Bob");
+
+    // entity.text must be a literal substring of activity.text (Teams requirement)
+    const entities = activity.entities as Array<{ type: string; text: string }>;
+    const mention = entities.find((e) => e.type === "mention");
+    expect(activity.text as string).toContain(mention!.text);
+  });
+
+  it("produces exactly one <at> and blocks nested <at> injection", async () => {
+    const activity = await buildActivity({ text: "@[<at>Eve</at>](28:abc-00002)" }, {});
+    const s = parseAtStructure(activity.text as string);
+
+    expect(s.atCount).toBe(1);
+    expect(s.nestedAt).toBe(0);
+    expect(s.hasInjectedChild).toBe(false);
+    // The raw name is preserved in entity.mentioned.name
+    const entities = activity.entities as Array<{ type: string; mentioned: { name: string } }>;
+    const mention = entities.find((e) => e.type === "mention");
+    expect(mention!.mentioned.name).toBe("<at>Eve</at>");
+  });
+
+  it("negative control — pre-fix interpolation breaks <at> structure", () => {
+    // Demonstrate that raw interpolation (the bug) produces a corrupted DOM:
+    // injected child elements and wrong textContent.
+    const rawTag = `<at>Alice <Admin> & Bob</at>`;
+    const s = parseAtStructure(rawTag);
+    // The <Admin> element is parsed as a child node inside <at>
+    expect(s.hasInjectedChild).toBe(true);
+    // textContent skips the injected child's tag name so the name is truncated
+    expect(s.textContent).not.toBe("Alice <Admin> & Bob");
+
+    const rawNestedTag = `<at><at>Eve</at></at>`;
+    const sn = parseAtStructure(rawNestedTag);
+    expect(sn.nestedAt).toBeGreaterThan(0);
+  });
+});
+
+// Drive the full sendMSTeamsMessages entry point so the escaped mention payload
+// crosses a genuine HTTP boundary (JSON.stringify -> loopback TCP -> JSON.parse)
+// into a fake Teams connector, then read the wire body back. This exercises the
+// real production send stack (buildActivity -> sendMSTeamsActivityWithReference ->
+// buildSdkConversationReference incl. serviceUrl allowlist validation -> merge ->
+// activities.create) rather than a parser call in isolation, so it proves the
+// escaping still holds after serialization and transport, not just at build time.
+async function captureWireActivity(inputText: string): Promise<{
+  text: string;
+  entities: Array<{ type?: string; text?: string; mentioned?: { name?: string } }>;
+}> {
+  let captured: { text: string; entities?: unknown[] } | undefined;
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      captured = JSON.parse(raw);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ id: "srv-generated-id" }));
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve();
+    });
+  });
+  const { port } = server.address() as AddressInfo;
+
+  // A structural fake of `app.api` whose create() performs a real HTTP POST to the
+  // loopback server. Everything upstream of this call runs as real production code.
+  const post = (activity: unknown) =>
+    new Promise<{ id?: string }>((resolve, reject) => {
+      const payload = JSON.stringify(activity);
+      const clientReq = request(
+        {
+          host: "127.0.0.1",
+          port,
+          method: "POST",
+          path: "/v3/conversations/x/activities",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(payload),
+          },
+        },
+        (res) => {
+          let body = "";
+          res.on("data", (chunk) => {
+            body += chunk;
+          });
+          res.on("end", () => resolve(JSON.parse(body)));
+        },
+      );
+      clientReq.on("error", reject);
+      clientReq.end(payload);
+    });
+
+  const app = {
+    api: {
+      serviceUrl: "https://smba.trafficmanager.net",
+      conversations: {
+        activities: () => ({
+          create: post,
+          createTargeted: post,
+          update: (_id: string, activity: unknown) => post(activity),
+          delete: async () => ({}),
+        }),
+      },
+    },
+  } as unknown as Parameters<typeof sendMSTeamsMessages>[0]["app"];
+
+  const conversationRef = {
+    activityId: "1:activity",
+    channelId: "msteams",
+    serviceUrl: "https://smba.trafficmanager.net",
+    agent: { id: "28:bot-app-id", name: "bot", role: "bot" },
+    user: { id: "29:user-id", name: "user" },
+    conversation: { id: "19:conv-id", conversationType: "personal", tenantId: "tenant-1" },
+    tenantId: "tenant-1",
+  } as unknown as Parameters<typeof sendMSTeamsMessages>[0]["conversationRef"];
+
+  try {
+    await sendMSTeamsMessages({
+      replyStyle: "top-level",
+      app,
+      appId: "28:bot-app-id",
+      conversationRef,
+      messages: [{ text: inputText }] as unknown as Parameters<
+        typeof sendMSTeamsMessages
+      >[0]["messages"],
+      retry: false,
+    });
+  } finally {
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  }
+
+  if (!captured) {
+    throw new Error("expected the send stack to POST an activity to the fake connector");
+  }
+  return { text: captured.text, entities: (captured.entities ?? []) as never };
+}
+
+describe("sendMSTeamsMessages wire capture — real HTTP send stack", () => {
+  it("escaped mention survives the real send stack over HTTP as exactly one <at>", async () => {
+    const wire = await captureWireActivity("@[Alice <Admin> & Bob](28:abc-00001)");
+    const s = parseAtStructure(wire.text);
+
+    expect(s.atCount).toBe(1);
+    expect(s.nestedAt).toBe(0);
+    expect(s.hasInjectedChild).toBe(false);
+    expect(s.textContent).toBe("Alice <Admin> & Bob");
+
+    // Teams requires entity.text to be a literal substring of the wire activity.text.
+    const mention = wire.entities.find((e) => e.type === "mention");
+    expect(mention?.text).toBeDefined();
+    expect(wire.text).toContain(mention!.text!);
+    expect(mention!.mentioned?.name).toBe("Alice <Admin> & Bob");
+  });
+
+  it("blocks nested <at> injection over the real send stack", async () => {
+    const wire = await captureWireActivity("@[<at>Eve</at>](28:abc-00002)");
+    const s = parseAtStructure(wire.text);
+
+    expect(s.atCount).toBe(1);
+    expect(s.nestedAt).toBe(0);
+    expect(s.hasInjectedChild).toBe(false);
+    const mention = wire.entities.find((e) => e.type === "mention");
+    expect(mention!.mentioned?.name).toBe("<at>Eve</at>");
+  });
+
+  it("passes a clean display name through the send stack unchanged", async () => {
+    const wire = await captureWireActivity("@[Normal Name](28:abc-00003)");
+    const s = parseAtStructure(wire.text);
+
+    expect(s.atCount).toBe(1);
+    expect(s.nestedAt).toBe(0);
+    expect(s.hasInjectedChild).toBe(false);
+    expect(s.textContent).toBe("Normal Name");
   });
 });

--- a/extensions/msteams/src/mentions.ts
+++ b/extensions/msteams/src/mentions.ts
@@ -31,6 +31,10 @@ function isValidTeamsId(id: string): boolean {
   return TEAMS_BOT_ID_PATTERN.test(id) || AAD_OBJECT_ID_PATTERN.test(id);
 }
 
+function escapeTeamsMentionText(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 /**
  * Parse mentions from text in the format @[Name](id).
  * Example: "Hello @[John Doe](28:xxx-yyy-zzz)!"
@@ -58,7 +62,7 @@ export function parseMentions(text: string): {
     }
 
     const trimmedName = name.trim();
-    const mentionTag = `<at>${trimmedName}</at>`;
+    const mentionTag = `<at>${escapeTeamsMentionText(trimmedName)}</at>`;
     entities.push({
       type: "mention",
       text: mentionTag,


### PR DESCRIPTION
**Summary:** `parseMentions` embedded display names inside `<at>…</at>` tags without HTML-escaping, so a name containing `<`, `>`, or `&` corrupted the Teams mention entity payload.

## What Problem This Solves

The Teams adapter builds mention entities by interpolating the raw display name into `<at>{name}</at>`. Microsoft Teams parses `activity.text` as XML markup to extract `<at>` mentions; it also requires `entity.text` to be a literal substring of `activity.text`. A display name with HTML-special characters breaks both requirements:

- `Alice <Admin> & Bob` → `<at>Alice <Admin> & Bob</at>` — Teams XML parser sees `<Admin>` as a child element inside `<at>`, corrupting the mention structure
- `<at>Eve</at>` → `<at><at>Eve</at></at>` — nested `<at>` injection creates two mention elements

## Fix

Added `escapeTeamsMentionText(value)` that replaces `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;` before wrapping in `<at>…</at>`. The `mentioned.name` field is left unescaped so the display name stored in the entity record remains human-readable.

## Evidence

### 1. Real send-stack wire capture across an HTTP boundary (RED → GREEN)

Drives the full `sendMSTeamsMessages` entry point (`replyStyle: "top-level"`) so the outbound activity is JSON-serialized and POSTed over a loopback TCP connection into a fake Teams connector, then reads the wire body back. This exercises the real production send stack end to end — `buildActivity` → `sendMSTeamsActivityWithReference` → `buildSdkConversationReference` (including the serviceUrl allowlist check) → `mergeReferenceIntoActivity` → `activities.create` — so the escaping is verified **after serialization and transport**, not only at build time. The wire body is parsed with **jsdom** (an independent DOM parser) so the structural assertion does not depend on the code under test.

RED = current `main` (raw interpolation). GREEN = this PR. Both rows are captured from the actual POST body on the wire.

```
case: display name "Alice <Admin> & Bob"
  RED   wire activity.text : <at>Alice <Admin> & Bob</at>
        jsdom: <at> count=1  injectedChild=true   textContent="Alice  & Bob"      ← corrupted
  GREEN wire activity.text : <at>Alice &lt;Admin&gt; &amp; Bob</at>
        jsdom: <at> count=1  injectedChild=false  textContent="Alice <Admin> & Bob"  ← intact
        entity.text is a literal substring of activity.text: true

case: nested <at> injection, display name "<at>Eve</at>"
  RED   wire activity.text : <at><at>Eve</at></at>
        jsdom: <at> count=2  nested=1                                             ← two mentions
  GREEN wire activity.text : <at>&lt;at&gt;Eve&lt;/at&gt;</at>
        jsdom: <at> count=1  nested=0                                             ← one mention

case: clean name "Normal Name" (no-op)
  GREEN wire activity.text : <at>Normal Name</at>                                 ← unchanged
```

The GREEN cases are committed as CI tests using a real loopback HTTP server; the RED capture was produced by temporarily reverting `escapeTeamsMentionText` to raw interpolation and re-running the identical harness.

**Scope note (honest):** the connector is a local fake, so this proves the escaped payload survives the real serialization + HTTP transport path through the production send stack unchanged. It does not render in a live Teams client — the only remaining uncertainty is the Teams client's own markup renderer, which no local harness can exercise.

### 2. Vitest — 21/21

`node scripts/run-vitest.mjs extensions/msteams/src/mentions.test.ts`

```
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

## Tests

21 tests pass across four describe blocks (15 existing parser tests + 3 `buildActivity` jsdom structural tests + 3 real send-stack wire-capture tests):

- **Real send-stack wire capture (new):** drives `sendMSTeamsMessages` over a loopback HTTP server and asserts the wire `activity.text` yields exactly one `<at>`, no injected child nodes, no nested `<at>`, and `entity.text` as a literal substring of `activity.text`.
- **buildActivity jsdom structural oracle:** drives `buildActivity → parseMentions` and parses `activity.text` with jsdom; includes a negative control confirming raw interpolation corrupts the DOM structure.
- **Parser-level tests:** escaping alignment, closing-tag injection, Bot Framework / AAD ID acceptance, documentation-placeholder rejection, and Japanese display names.
