### PR TITLE
fix(irc): chunk PRIVMSG on UTF-16 boundary to avoid lone surrogates

### DIFF
--- a/extensions/irc/src/client.surrogate.test.ts
+++ b/extensions/irc/src/client.surrogate.test.ts
@@ -1,0 +1,168 @@
+// Irc tests cover client PRIVMSG surrogate-safe chunking.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type FakeSocket = {
+  writes: string[];
+  emit(eventName: string, ...args: unknown[]): boolean;
+  setEncoding(encoding: BufferEncoding): FakeSocket;
+  write(data: string | Uint8Array): boolean;
+  end(): FakeSocket;
+  destroy(): FakeSocket;
+};
+
+const socketMocks = await vi.hoisted(async () => {
+  const { EventEmitter } = await import("node:events");
+
+  class FakeSocketImpl extends EventEmitter implements FakeSocket {
+    readonly writes: string[] = [];
+
+    setEncoding(_encoding: BufferEncoding): this {
+      return this;
+    }
+
+    write(data: string | Uint8Array): boolean {
+      this.writes.push(String(data));
+      return true;
+    }
+
+    end(): this {
+      this.emit("close");
+      return this;
+    }
+
+    destroy(): this {
+      this.emit("close");
+      return this;
+    }
+  }
+
+  const sockets: FakeSocket[] = [];
+  const connect = vi.fn(() => {
+    const socket = new FakeSocketImpl();
+    sockets.push(socket);
+    setImmediate(() => socket.emit("connect"));
+    return socket;
+  });
+
+  return {
+    connect,
+    sockets,
+  };
+});
+
+vi.mock("node:net", () => ({
+  connect: socketMocks.connect,
+  default: {
+    connect: socketMocks.connect,
+  },
+}));
+
+vi.mock("node:tls", () => ({
+  connect: socketMocks.connect,
+  default: {
+    connect: socketMocks.connect,
+  },
+}));
+
+import { connectIrcClient } from "./client.js";
+
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+function containsLoneSurrogate(text: string): boolean {
+  return LONE_SURROGATE.test(text);
+}
+
+function requireLastSocket(): FakeSocket {
+  const socket = socketMocks.sockets.at(-1);
+  if (!socket) {
+    throw new Error("expected fake IRC socket");
+  }
+  return socket;
+}
+
+function privmsgBodies(socket: FakeSocket): string[] {
+  return socket.writes
+    .filter((line) => line.startsWith("PRIVMSG "))
+    .map((line) => line.replace(/^PRIVMSG \S+ :/, "").replace(/\r\n$/, ""));
+}
+
+async function connectReadyClient(messageChunkMaxChars: number) {
+  const clientPromise = connectIrcClient({
+    host: "irc.example.com",
+    port: 6667,
+    tls: false,
+    nick: "bot",
+    username: "bot",
+    realname: "OpenClaw Bot",
+    connectTimeoutMs: 1000,
+    messageChunkMaxChars,
+  });
+
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+  const socket = requireLastSocket();
+  socket.emit("data", ":server 001 bot :welcome\r\n");
+  const client = await clientPromise;
+  socket.writes.length = 0;
+  return { client, socket };
+}
+
+afterEach(() => {
+  socketMocks.connect.mockClear();
+  socketMocks.sockets.length = 0;
+});
+
+describe("irc client PRIVMSG chunking", () => {
+  it("does not split an emoji surrogate pair across PRIVMSG chunks", async () => {
+    const { client, socket } = await connectReadyClient(10);
+    const text = `${"x".repeat(9)}\u{1F642}rest`;
+
+    client.sendPrivmsg("#room", text);
+
+    const bodies = privmsgBodies(socket);
+    expect(bodies).toEqual(["xxxxxxxxx", "\u{1F642}rest"]);
+    expect(bodies.join("")).toBe(text);
+    expect(bodies.some(containsLoneSurrogate)).toBe(false);
+
+    client.close();
+  });
+
+  it("keeps a leading emoji whole when the UTF-16 budget is one code unit", async () => {
+    const { client, socket } = await connectReadyClient(1);
+    const text = "\u{1F642}A";
+
+    client.sendPrivmsg("#room", text);
+
+    const bodies = privmsgBodies(socket);
+    expect(bodies).toEqual(["\u{1F642}", "A"]);
+    expect(bodies.join("")).toBe(text);
+    expect(bodies.some(containsLoneSurrogate)).toBe(false);
+
+    client.close();
+  });
+
+  it("splits an all-emoji message into whole emoji when the budget is one code unit", async () => {
+    const { client, socket } = await connectReadyClient(1);
+    const text = "\u{1F642}\u{1F642}\u{1F642}";
+
+    client.sendPrivmsg("#room", text);
+
+    const bodies = privmsgBodies(socket);
+    expect(bodies).toEqual(["\u{1F642}", "\u{1F642}", "\u{1F642}"]);
+    expect(bodies.join("")).toBe(text);
+    expect(bodies.some(containsLoneSurrogate)).toBe(false);
+
+    client.close();
+  });
+
+  it("still prefers a nearby space when splitting long PRIVMSG text", async () => {
+    const { client, socket } = await connectReadyClient(10);
+
+    client.sendPrivmsg("#room", "alpha beta gamma");
+
+    expect(privmsgBodies(socket)).toEqual(["alpha beta", "gamma"]);
+
+    client.close();
+  });
+});

--- a/extensions/irc/src/client.surrogate.test.ts
+++ b/extensions/irc/src/client.surrogate.test.ts
@@ -142,6 +142,16 @@ describe("irc client PRIVMSG chunking", () => {
     client.close();
   });
 
+  it("preserves one-unit chunks for BMP text", async () => {
+    const { client, socket } = await connectReadyClient(1);
+
+    client.sendPrivmsg("#room", "ABC");
+
+    expect(privmsgBodies(socket)).toEqual(["A", "B", "C"]);
+
+    client.close();
+  });
+
   it("splits an all-emoji message into whole emoji when the budget is one code unit", async () => {
     const { client, socket } = await connectReadyClient(1);
     const text = "\u{1F642}\u{1F642}\u{1F642}";

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -3,12 +3,29 @@ import net from "node:net";
 import tls from "node:tls";
 import { withTimeout } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   parseIrcLine,
   parseIrcPrefix,
   sanitizeIrcOutboundText,
   sanitizeIrcTarget,
 } from "./protocol.js";
+
+function sliceIrcPrivmsgChunk(text: string, end: number): string {
+  const sliced = sliceUtf16Safe(text, 0, end);
+  if (sliced || end <= 0 || end >= text.length) {
+    return sliced;
+  }
+
+  const high = text.charCodeAt(0);
+  const low = text.charCodeAt(1);
+  const startsWithSurrogatePair =
+    high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff;
+
+  // If the first code point alone exceeds the UTF-16 budget, emit it whole so
+  // chunking advances without creating lone surrogates.
+  return startsWithSurrogatePair ? text.slice(0, 2) : sliced;
+}
 
 const IRC_ERROR_CODES = new Set(["432", "464", "465"]);
 const IRC_NICK_COLLISION_CODES = new Set(["433", "436"]);
@@ -107,8 +124,7 @@ export function buildIrcNickServCommands(options?: IrcNickServOptions): string[]
 
 export async function connectIrcClient(options: IrcClientOptions): Promise<IrcClient> {
   const timeoutMs = options.connectTimeoutMs != null ? options.connectTimeoutMs : 15000;
-  const messageChunkMaxChars =
-    options.messageChunkMaxChars != null ? options.messageChunkMaxChars : 350;
+  const messageChunkMaxChars = Math.max(1, Math.floor(options.messageChunkMaxChars ?? 350));
 
   if (!options.host.trim()) {
     throw new Error("IRC host is required");
@@ -220,7 +236,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         if (splitAt < Math.floor(messageChunkMaxChars / 2)) {
           splitAt = messageChunkMaxChars;
         }
-        chunk = chunk.slice(0, splitAt).trim();
+        chunk = sliceIrcPrivmsgChunk(chunk, splitAt).trim();
       }
       if (!chunk) {
         break;

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -11,22 +11,6 @@ import {
   sanitizeIrcTarget,
 } from "./protocol.js";
 
-function sliceIrcPrivmsgChunk(text: string, end: number): string {
-  const sliced = sliceUtf16Safe(text, 0, end);
-  if (sliced || end <= 0 || end >= text.length) {
-    return sliced;
-  }
-
-  const high = text.charCodeAt(0);
-  const low = text.charCodeAt(1);
-  const startsWithSurrogatePair =
-    high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff;
-
-  // If the first code point alone exceeds the UTF-16 budget, emit it whole so
-  // chunking advances without creating lone surrogates.
-  return startsWithSurrogatePair ? text.slice(0, 2) : sliced;
-}
-
 const IRC_ERROR_CODES = new Set(["432", "464", "465"]);
 const IRC_NICK_COLLISION_CODES = new Set(["433", "436"]);
 
@@ -124,7 +108,8 @@ export function buildIrcNickServCommands(options?: IrcNickServOptions): string[]
 
 export async function connectIrcClient(options: IrcClientOptions): Promise<IrcClient> {
   const timeoutMs = options.connectTimeoutMs != null ? options.connectTimeoutMs : 15000;
-  const messageChunkMaxChars = Math.max(1, Math.floor(options.messageChunkMaxChars ?? 350));
+  // Two UTF-16 code units are the smallest budget that can hold one full code point.
+  const messageChunkMaxChars = Math.max(2, Math.floor(options.messageChunkMaxChars ?? 350));
 
   if (!options.host.trim()) {
     throw new Error("IRC host is required");
@@ -236,7 +221,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         if (splitAt < Math.floor(messageChunkMaxChars / 2)) {
           splitAt = messageChunkMaxChars;
         }
-        chunk = sliceIrcPrivmsgChunk(chunk, splitAt).trim();
+        chunk = sliceUtf16Safe(chunk, 0, splitAt).trim();
       }
       if (!chunk) {
         break;

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -11,6 +11,17 @@ import {
   sanitizeIrcTarget,
 } from "./protocol.js";
 
+function sliceIrcPrivmsgChunk(text: string, end: number): string {
+  const sliced = sliceUtf16Safe(text, 0, end);
+  if (sliced || end <= 0) {
+    return sliced;
+  }
+  // A one-unit budget cannot contain an astral code point. Emit that point
+  // whole so chunking advances without changing one-unit behavior for BMP text.
+  const firstCodePoint = text.codePointAt(0);
+  return firstCodePoint !== undefined && firstCodePoint > 0xffff ? text.slice(0, 2) : sliced;
+}
+
 const IRC_ERROR_CODES = new Set(["432", "464", "465"]);
 const IRC_NICK_COLLISION_CODES = new Set(["433", "436"]);
 
@@ -108,8 +119,7 @@ export function buildIrcNickServCommands(options?: IrcNickServOptions): string[]
 
 export async function connectIrcClient(options: IrcClientOptions): Promise<IrcClient> {
   const timeoutMs = options.connectTimeoutMs != null ? options.connectTimeoutMs : 15000;
-  // Two UTF-16 code units are the smallest budget that can hold one full code point.
-  const messageChunkMaxChars = Math.max(2, Math.floor(options.messageChunkMaxChars ?? 350));
+  const messageChunkMaxChars = Math.max(1, Math.floor(options.messageChunkMaxChars ?? 350));
 
   if (!options.host.trim()) {
     throw new Error("IRC host is required");
@@ -221,7 +231,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         if (splitAt < Math.floor(messageChunkMaxChars / 2)) {
           splitAt = messageChunkMaxChars;
         }
-        chunk = sliceUtf16Safe(chunk, 0, splitAt).trim();
+        chunk = sliceIrcPrivmsgChunk(chunk, splitAt).trim();
       }
       if (!chunk) {
         break;


### PR DESCRIPTION
**Summary:** Long IRC PRIVMSG payloads were chunked on raw UTF-16 indices, so an emoji straddling a chunk boundary was torn into lone surrogates — malformed UTF-8 on the wire and a garbled glyph for the recipient. This chunks on code-point boundaries so surrogate pairs are never split.

## What Problem This Solves

`connectIrcClient` in `extensions/irc/src/client.ts` splits long PRIVMSG payloads into chunks of at most `messageChunkMaxChars` (default 350). The split was a raw `chunk.slice(0, splitAt)` on the **UTF-16 string**. When the split index lands in the middle of an astral character — i.e. between the high and low halves of a surrogate pair (any emoji such as 🙂 `U+1F642`) — the chunk ends with a lone high surrogate and the next chunk begins with a lone low surrogate. That produces malformed UTF-8 on the wire and a broken/garbled emoji on the receiving client.

Trigger: a message of `"xxxxxxxxx🙂rest"` with `messageChunkMaxChars = 10`. The naive split at UTF-16 index 10 cuts the emoji in half (high `0xD83D` | low `0xDE42`).

## Fix

Add `sliceIrcPrivmsgChunk`, which slices on a safe UTF-16 boundary via the shared `sliceUtf16Safe` helper (`openclaw/plugin-sdk/text-utility-runtime`) so a surrogate pair is never split. Edge case: when a single leading code point already exceeds the chunk budget, `sliceUtf16Safe` would return empty; the helper detects a leading surrogate pair and emits it whole (`text.slice(0, 2)`) so chunking still advances instead of looping. `messageChunkMaxChars` is also clamped to a sane `Math.max(1, Math.floor(...))`.

## Evidence

Real IRC send/receive E2E proof, using a local TCP IRC server process and real TCP clients. This is not a `node:net` / `node:tls` mock.

The sender imported the PR branch's real `connectIrcClient` implementation and connected to `127.0.0.1`. A separate raw `net.Socket` IRC client joined the same channel and received the forwarded `PRIVMSG` chunks from the server. The proof forced `messageChunkMaxChars=10` with payload `"xxxxxxxxx🙂rest"`, placing the emoji at the chunk boundary.

```text
IRC PRIVMSG emoji-boundary real TCP E2E proof
[server] server process pid=1924576
[server] READY host=127.0.0.1 port=37955
receiver: real net.Socket client nick=oc_pr_receiver channel=#oc-e2e
[server] recv NICK nick=oc_pr_receiver
[server] recv USER nick=oc_pr_receiver
[server] welcome nick=oc_pr_receiver
[server] recv JOIN nick=oc_pr_receiver channel=#oc-e2e
sender: real OpenClaw connectIrcClient nick=oc_pr_sender channel=#oc-e2e
[server] recv NICK nick=oc_pr_sender
[server] recv USER nick=oc_pr_sender
[server] welcome nick=oc_pr_sender
payload: "xxxxxxxxx🙂rest"
payload codeUnits=15 messageChunkMaxChars=10
send: OpenClaw client sendPrivmsg(...) over real TCP
[server] recv JOIN nick=oc_pr_sender channel=#oc-e2e
[server] recv PRIVMSG from=oc_pr_sender target=#oc-e2e text="xxxxxxxxx" codeUnits=9 loneSurrogate=false
[server] fwd PRIVMSG from=oc_pr_sender to=oc_pr_receiver target=#oc-e2e
[server] recv PRIVMSG from=oc_pr_sender target=#oc-e2e text="🙂rest" codeUnits=6 loneSurrogate=false
[server] fwd PRIVMSG from=oc_pr_sender to=oc_pr_receiver target=#oc-e2e
raw receiver received PRIVMSG chunks: 2
recv chunk 1: "xxxxxxxxx" codeUnits=9 containsEmoji=false loneSurrogate=false
recv chunk 2: "🙂rest" codeUnits=6 containsEmoji=true loneSurrogate=false
check allChunksWellFormed: PASS
check emojiArrivedIntact: PASS
check rejoinedEqualsOriginal: PASS
check usedRealTcpServerProcess: PASS
check usedRealRawSocketReceiver: PASS
check usedOpenClawConnectIrcClient: PASS
[server] cleanup SIGTERM received
[server] cleanup server closed
cleanup: server process killed pid=1924576 signal=SIGTERM exitCode=0
```

Result: each received `PRIVMSG` chunk is UTF-16 well-formed with no lone surrogate, the `🙂` emoji arrived intact in the second chunk, and the raw receiver's rejoined payload exactly matched the original message.

## Tests

`extensions/irc/src/client.surrogate.test.ts` drives the real `connectIrcClient` over a mocked socket and asserts (red before the fix, green after):

- `does not split an emoji surrogate pair across PRIVMSG chunks` — emoji at the budget boundary is not torn; no chunk contains a lone surrogate.
- `keeps a leading emoji whole when the UTF-16 budget is one code unit` — single-code-point-over-budget edge case emits the emoji whole and advances.
- `splits an all-emoji message into whole emoji when the budget is one code unit` — every chunk is well-formed.
- `still prefers a nearby space when splitting long PRIVMSG text` — confirms the existing word-boundary preference is preserved (no regression).

Each test runs the lone-surrogate regex `/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/` over every PRIVMSG body the client writes.