### PR TITLE
fix(googlechat): truncate approval card text on UTF-16 boundary

### DIFF
--- a/extensions/googlechat/src/approval-handler.runtime.test.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.test.ts
@@ -110,6 +110,45 @@ function createDeferred<T>(): {
   return { promise, reject, resolve };
 }
 
+type CardPayloadWithTextWidgets = {
+  cardsV2: Array<{
+    card: {
+      sections?: Array<{
+        header?: string;
+        widgets?: Array<{ textParagraph?: { text: string } }>;
+      }>;
+    };
+  }>;
+};
+
+function getTextParagraphText(payload: unknown, header: string): string {
+  const text = (payload as CardPayloadWithTextWidgets).cardsV2[0]?.card.sections?.find(
+    (section) => section.header === header,
+  )?.widgets?.[0]?.textParagraph?.text;
+  if (typeof text !== "string") {
+    throw new Error(`Expected ${header} text paragraph`);
+  }
+  return text;
+}
+
+function isUtf16WellFormed(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const nextCodeUnit = index + 1 < value.length ? value.charCodeAt(index + 1) : -1;
+      if (nextCodeUnit < 0xdc00 || nextCodeUnit > 0xdfff) {
+        return false;
+      }
+      index += 1;
+      continue;
+    }
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
 describe("googleChatApprovalNativeRuntime", () => {
   async function preparePendingDelivery(view = createPendingView()) {
     const nowMs = Date.now();
@@ -148,6 +187,31 @@ describe("googleChatApprovalNativeRuntime", () => {
     }
     return { pendingPayload, plannedTarget, prepared, request, view };
   }
+
+  it("keeps truncated pending command card text UTF-16 well formed", async () => {
+    const view = createPendingView();
+    view.commandText = `${"a".repeat(1796)}😀${"b".repeat(100)}`;
+
+    const { pendingPayload } = await preparePendingDelivery(view);
+    const commandText = getTextParagraphText(pendingPayload, "Command");
+
+    expect(commandText.length).toBeLessThanOrEqual(1800);
+    expect(commandText.endsWith("...")).toBe(true);
+    expect(isUtf16WellFormed(commandText)).toBe(true);
+    expect(JSON.stringify(pendingPayload.cardsV2)).not.toContain("\\ud83d");
+  });
+
+  it("preserves a complete astral character when it fits before the truncation suffix", async () => {
+    const view = createPendingView();
+    view.commandText = `${"a".repeat(1795)}😀${"b".repeat(100)}`;
+
+    const { pendingPayload } = await preparePendingDelivery(view);
+    const commandText = getTextParagraphText(pendingPayload, "Command");
+
+    expect(commandText).toBe(`${"a".repeat(1795)}😀...`);
+    expect(commandText.length).toBe(1800);
+    expect(isUtf16WellFormed(commandText)).toBe(true);
+  });
 
   it("sends pending cards and updates the delivered message without buttons", async () => {
     sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/msg-1" });

--- a/extensions/googlechat/src/approval-handler.runtime.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.ts
@@ -9,6 +9,7 @@ import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approva
 import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveGoogleChatAccount, type ResolvedGoogleChatAccount } from "./accounts.js";
 import { sendGoogleChatMessage, updateGoogleChatMessage } from "./api.js";
 import {
@@ -87,7 +88,7 @@ function escapeGoogleChatText(text: string): string {
 }
 
 function truncateText(text: string, maxChars = MAX_TEXT_PARAGRAPH_CHARS): string {
-  return text.length <= maxChars ? text : `${text.slice(0, maxChars - 3)}...`;
+  return text.length <= maxChars ? text : `${truncateUtf16Safe(text, maxChars - 3)}...`;
 }
 
 function buildMetadataText(metadata: readonly { label: string; value: string }[]): string {


### PR DESCRIPTION
**Summary:** Google Chat approval-card text was truncated with a raw UTF-16 slice, so an emoji near the limit became a lone surrogate in the `cardsV2` API payload. This uses `truncateUtf16Safe` to truncate on a code-point boundary.

## What Problem This Solves

Google Chat approval cards truncated long text by UTF-16 code unit length. When the truncation boundary landed inside an astral character, such as a command containing `1796` `a` characters followed by `😀`, the old raw `.slice()` behavior kept only the high surrogate (`0xd83d`) before appending `...`.

That produced ill-formed UTF-16 in the Google Chat card text. The terminal proof below reproduces the old boundary with raw `.slice()` and shows `encodeURIComponent` rejecting the result with `URIError: URI malformed`.

## Fix

`extensions/googlechat/src/approval-handler.runtime.ts` now routes Google Chat approval text truncation through the shared `truncateUtf16Safe` helper before appending the suffix.

The helper clamps and floors the requested length, slices through the shared UTF-16-safe path, and adjusts slice edges away from dangling high/low surrogate halves. Google Chat still escapes plain command/card text after truncation, so the final card text remains both HTML-escaped and UTF-16 well formed.

## Evidence

The demo imports the real Google Chat approval runtime from `extensions/googlechat/src/approval-handler.runtime.ts` and calls `googleChatApprovalNativeRuntime.presentation.buildPendingPayload` with an emoji/surrogate-boundary command. The `BEFORE` section uses the old raw `.slice()` shape for comparison; the `AFTER` section reads the actual fixed Google Chat card text.

Command:

```bash
node --import tsx demo.mts
```

Output:

```text
input.length 1898
emoji boundary codePointAt(1796) 0x1f600
BEFORE raw slice length 1800
BEFORE codePointAt(1796) 0xd83d
BEFORE lone-surrogate-hex 0xd83d
BEFORE lone-surrogate true
BEFORE encodeURIComponent URIError: URI malformed
AFTER source googleChatApprovalNativeRuntime.presentation.buildPendingPayload
AFTER fixed card text length 1799
AFTER tail "aaaaa..."
AFTER codePointAt(1796) 0x2e
AFTER lone-surrogate-hex none
AFTER lone-surrogate false
AFTER encodeURIComponent aaaaaaaaa...
```

The fixed runtime output has `lone-surrogate false`, no dangling surrogate hex value, and survives URI encoding, so the Google Chat approval card text is well formed at the emoji truncation boundary.

## Tests

Vitest regression coverage in `extensions/googlechat/src/approval-handler.runtime.test.ts` covers the red/green behavior for Google Chat approval card truncation:

- `keeps truncated pending command card text UTF-16 well formed` covers the exact boundary where raw truncation would leave `\ud83d`.
- `preserves a complete astral character when it fits before the truncation suffix` covers the adjacent case where the complete emoji should be retained before `...`.