### PR TITLE
fix(synology-chat): truncate sanitized input on a UTF-16 boundary

### DIFF
--- a/extensions/synology-chat/src/core.test.ts
+++ b/extensions/synology-chat/src/core.test.ts
@@ -433,6 +433,31 @@ describe("synology-chat security helpers", () => {
     expect(result).toContain("[truncated]");
   });
 
+  it("truncates long inputs without splitting a surrogate pair", () => {
+    const loneSurrogatePattern =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
+    const input = "a".repeat(3999) + "\u{1F600}" + "b".repeat(2000);
+
+    const result = sanitizeInput(input);
+
+    expect(result).toContain("[truncated]");
+    expect(result).not.toMatch(loneSurrogatePattern);
+    expect(result).toBe(`${"a".repeat(3999)}... [truncated]`);
+  });
+
+  it("keeps complete supplementary-plane characters that fit before truncation", () => {
+    const loneSurrogatePattern =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
+    const emoji = "\u{1F600}";
+    const input = "a".repeat(3998) + emoji + "b".repeat(2000);
+
+    const result = sanitizeInput(input);
+
+    expect(result).toContain("[truncated]");
+    expect(result.startsWith(`${"a".repeat(3998)}${emoji}`)).toBe(true);
+    expect(result).not.toMatch(loneSurrogatePattern);
+  });
+
   it("rate limits per user and caps tracked state", () => {
     const limiter = new RateLimiter(3, 60);
     expect(limiter.check("user1")).toBe(true);

--- a/extensions/synology-chat/src/security.ts
+++ b/extensions/synology-chat/src/security.ts
@@ -5,6 +5,7 @@
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   createFixedWindowRateLimiter,
   type FixedWindowRateLimiter,
@@ -64,7 +65,7 @@ export function sanitizeInput(text: string): string {
 
   const maxLength = 4000;
   if (sanitized.length > maxLength) {
-    sanitized = sanitized.slice(0, maxLength) + "... [truncated]";
+    sanitized = truncateUtf16Safe(sanitized, maxLength) + "... [truncated]";
   }
 
   return sanitized;

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -6,6 +6,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import * as querystring from "node:querystring";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   beginWebhookRequestPipelineOrReject,
   createWebhookInFlightLimiter,
@@ -503,7 +504,7 @@ async function parseAndAuthorizeSynologyWebhook(params: {
     respondNoContent(params.res);
     return { ok: false };
   }
-  const preview = cleanText.length > 100 ? `${cleanText.slice(0, 100)}...` : cleanText;
+  const preview = cleanText.length > 100 ? `${truncateUtf16Safe(cleanText, 100)}...` : cleanText;
   return {
     ok: true,
     message: {
@@ -574,7 +575,7 @@ async function processAuthorizedSynologyWebhook(params: {
       deliveryUserId,
       params.account.allowInsecureSsl,
     );
-    const replyPreview = reply.length > 100 ? `${reply.slice(0, 100)}...` : reply;
+    const replyPreview = reply.length > 100 ? `${truncateUtf16Safe(reply, 100)}...` : reply;
     params.log?.info?.(
       `Reply sent to ${params.message.payload.username} (${deliveryUserId}): ${replyPreview}`,
     );


### PR DESCRIPTION
**Summary:** Synology Chat's `sanitizeInput` (and its log previews) truncated with a raw UTF-16 slice, leaving a lone surrogate when the 4000-char cut fell inside an emoji. This uses `truncateUtf16Safe` so truncation stops on a code-point boundary.

## What Problem This Solves

Synology Chat input sanitization truncated long text with raw UTF-16 `.slice()` calls. When the 4,000-code-unit boundary landed between the high and low surrogate of a supplementary-plane character, such as an emoji, the sanitized message could contain a lone surrogate.

Repro shape:

- input: `"a".repeat(3999) + "😀" + "b".repeat(2000)`
- old truncation: `input.slice(0, 4000) + "... [truncated]"`
- result: the output keeps only `0xd83d`, the high surrogate half of `😀`

That produces malformed text at the exact message boundary ClawSweeper flagged.

## Fix

The Synology Chat truncation paths now reuse the shared `truncateUtf16Safe` helper instead of raw `.slice()` for bounded text output.

This updates:

- `extensions/synology-chat/src/security.ts` so `sanitizeInput()` preserves the existing filtering behavior while truncating on a valid UTF-16 boundary.
- `extensions/synology-chat/src/webhook-handler.ts` so inbound and reply log previews use the same UTF-16-safe truncation behavior.

The shared helper clamps the requested range and backs off when the cut would split a surrogate pair, so complete supplementary-plane characters are kept when they fit and removed cleanly when they straddle the boundary.

## Evidence

Command run from an isolated proof worktree checked out at `fix/synology-chat-truncate-surrogate`:

```bash
node --import tsx demo.mts
```

Demo imports the real fixed function:

```ts
import { sanitizeInput } from "./extensions/synology-chat/src/security.ts";
```

Terminal output:

```text
input length: 6001
emoji code point: 0x1f600
BEFORE raw slice length: 4015
BEFORE boundary codePointAt(3999): 0xd83d
BEFORE output tail: "aaaaaaaa\ud83d... [truncated]"
BEFORE lone-surrogate: true
AFTER sanitizeInput length: 4014
AFTER boundary codePointAt(3998): 0x61
AFTER boundary codePointAt(3999): 0x2e
AFTER output tail: "aaaaaaaaa... [truncated]"
AFTER lone-surrogate: false
```

The old raw-slice behavior leaves the lone high surrogate `0xd83d`; the fixed `sanitizeInput()` output is well-formed and the lone-surrogate check is `false`.

## Tests

Vitest coverage in `extensions/synology-chat/src/core.test.ts` adds red/green cases for the repaired boundary:

- `sanitizeInput()` no longer splits a surrogate pair when truncation lands inside an emoji.
- `sanitizeInput()` still keeps a complete supplementary-plane character when the full pair fits before the truncation boundary.