### PR TITLE
fix(qqbot): truncate reminder job name on a code-point boundary

### DIFF
--- a/extensions/qqbot/src/engine/tools/remind-logic.test.ts
+++ b/extensions/qqbot/src/engine/tools/remind-logic.test.ts
@@ -97,11 +97,45 @@ describe("engine/tools/remind-logic", () => {
       expect(generateJobName("drink water")).toBe("Reminder: drink water");
     });
 
-    it("truncates long content", () => {
-      const long = "a very long reminder content that exceeds twenty characters";
-      const name = generateJobName(long);
-      expect(name.length).toBeLessThan(40);
-      expect(name).toContain("…");
+    it("truncates long content to a 20 UTF-16-unit budget with an ellipsis", () => {
+      expect(generateJobName("a very long reminder content")).toBe(
+        "Reminder: a very long reminder…",
+      );
+    });
+
+    it("keeps an exactly-fitting all-emoji content unchanged", () => {
+      // 10 emoji = 20 UTF-16 units, exactly at the budget, so no truncation.
+      expect(generateJobName("😀".repeat(10))).toBe(`Reminder: ${"😀".repeat(10)}`);
+    });
+
+    it("does not split surrogate pairs when truncating", () => {
+      const hasLoneSurrogate = (value: string): boolean => {
+        for (let index = 0; index < value.length; index++) {
+          const code = value.charCodeAt(index);
+          if (code >= 0xd800 && code <= 0xdbff) {
+            const next = value.charCodeAt(index + 1);
+            if (!(next >= 0xdc00 && next <= 0xdfff)) {
+              return true;
+            }
+            index++;
+          } else if (code >= 0xdc00 && code <= 0xdfff) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+      // 11 emoji = 22 UTF-16 units > 20; the 11th emoji straddles the cap and is
+      // dropped whole rather than split into a lone surrogate.
+      const allEmoji = generateJobName("😀".repeat(11));
+      expect(allEmoji).toBe(`Reminder: ${"😀".repeat(10)}…`);
+      expect(hasLoneSurrogate(allEmoji)).toBe(false);
+
+      // 19 ASCII + emoji: the emoji's high surrogate would land at unit 20, so the
+      // whole pair is dropped to stay within the 20-unit budget.
+      const name = generateJobName(`${"x".repeat(19)}😀tail`);
+      expect(name).toBe(`Reminder: ${"x".repeat(19)}…`);
+      expect(hasLoneSurrogate(name)).toBe(false);
     });
   });
 

--- a/extensions/qqbot/src/engine/tools/remind-logic.ts
+++ b/extensions/qqbot/src/engine/tools/remind-logic.ts
@@ -1,5 +1,6 @@
 // Qqbot plugin module implements remind logic behavior.
 import { resolveExpiresAtMsFromDurationMs } from "openclaw/plugin-sdk/number-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 /**
  * QQBot reminder tool core logic.
@@ -171,7 +172,7 @@ export function isCronExpression(timeStr: string): boolean {
  */
 export function generateJobName(content: string): string {
   const trimmed = content.trim();
-  const short = trimmed.length > 20 ? `${trimmed.slice(0, 20)}…` : trimmed;
+  const short = trimmed.length > 20 ? `${truncateUtf16Safe(trimmed, 20)}…` : trimmed;
   return `Reminder: ${short}`;
 }
 


### PR DESCRIPTION
**Summary:** The QQBot reminder job name was sliced to 20 UTF-16 units, tearing an emoji at the boundary into a lone surrogate. This truncates on a code-point boundary so multi-unit characters stay intact.

## What Problem This Solves

QQBot reminder job names were truncated with a raw UTF-16 `.slice()` budget. Inputs that place an emoji or other astral character on the truncation boundary can leave a lone surrogate in the generated job name.

Trigger example:

```text
xxxxxxxxxxxxxxxxxxx😀tail
```

The first 20 UTF-16 units contain 19 ASCII characters plus only the emoji high surrogate, producing a malformed string such as:

```text
Reminder: xxxxxxxxxxxxxxxxxxx\ud83d…
```

## Fix

`extensions/qqbot/src/engine/tools/remind-logic.ts` now builds reminder job names with the shared `truncateUtf16Safe` helper instead of raw `.slice()` truncation.

That keeps the existing 20 UTF-16-unit job-name budget and ellipsis behavior, while relying on the shared helper's range validation to avoid cutting between surrogate pairs. The generated job name remains escaped/serializable as a well-formed JavaScript string even when the input contains emoji at the boundary.

## Evidence

Command run from a temporary worktree checked out at `fix/qqbot-jobname-surrogate`:

```bash
node --import tsx demo.mts
```

The demo imports the real `generateJobName` function from `extensions/qqbot/src/engine/tools/remind-logic.ts`, reproduces the old raw `.slice(0, 20)` behavior, then calls the fixed function.

```text
INPUT
content="xxxxxxxxxxxxxxxxxxx😀tail"
utf16_length=25

BEFORE old raw slice(0, 20)
output="Reminder: xxxxxxxxxxxxxxxxxxx\ud83d…"
boundary_char_code=0xd83d
boundary_code_point=0xd83d
lone_surrogate=true
string_from_boundary=�

AFTER generateJobName from remind-logic.ts
output="Reminder: xxxxxxxxxxxxxxxxxxx…"
lone_surrogate=false
utf16_length=30
```

The old path leaves a lone high surrogate (`0xd83d`). The fixed `generateJobName` output is well-formed and the lone-surrogate check returns `false`.

## Tests

Vitest coverage was added for `generateJobName` in `extensions/qqbot/src/engine/tools/remind-logic.test.ts`.

The tests cover:

- short reminder content remaining unchanged;
- long ASCII content preserving the existing 20 UTF-16-unit truncation plus ellipsis behavior;
- exactly-fitting emoji content staying unchanged;
- emoji/surrogate-boundary truncation dropping the whole split pair and producing no lone surrogate.