### PR TITLE
fix(slack): truncate approval mrkdwn on a UTF-16 boundary

### DIFF
--- a/extensions/slack/src/approval-handler.runtime.test.ts
+++ b/extensions/slack/src/approval-handler.runtime.test.ts
@@ -33,9 +33,188 @@ function readChatUpdatePayload(
   return payload as ChatUpdatePayload;
 }
 
+const UNPAIRED_SURROGATE_RE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+function readMrkdwnTexts(blocks: unknown): string[] {
+  if (!Array.isArray(blocks)) {
+    return [];
+  }
+
+  const texts: string[] = [];
+  for (const block of blocks) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+
+    const text = (block as { text?: unknown }).text;
+    if (
+      text &&
+      typeof text === "object" &&
+      (text as { type?: unknown }).type === "mrkdwn" &&
+      typeof (text as { text?: unknown }).text === "string"
+    ) {
+      texts.push((text as { text: string }).text);
+    }
+
+    const elements = (block as { elements?: unknown }).elements;
+    if (!Array.isArray(elements)) {
+      continue;
+    }
+    for (const element of elements) {
+      if (
+        element &&
+        typeof element === "object" &&
+        (element as { type?: unknown }).type === "mrkdwn" &&
+        typeof (element as { text?: unknown }).text === "string"
+      ) {
+        texts.push((element as { text: string }).text);
+      }
+    }
+  }
+
+  return texts;
+}
+
+function findApprovalMrkdwn(payload: SlackPayload, prefix: string): string {
+  const text = readMrkdwnTexts(payload.blocks).find((entry) => entry.startsWith(prefix));
+  if (!text) {
+    throw new Error(`Expected Slack mrkdwn block starting with ${prefix}`);
+  }
+  return text;
+}
+
 describe("slackApprovalNativeRuntime", () => {
   it("subscribes to plugin approval events", () => {
     expect(slackApprovalNativeRuntime.eventKinds).toEqual(["exec", "plugin"]);
+  });
+
+  it("does not leave dangling surrogates when truncating exec approval command mrkdwn", async () => {
+    const commandText = `${"a".repeat(2598)}😀tail`;
+    const payload = (await slackApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        app: {} as never,
+        config: {} as never,
+      },
+      request: {
+        id: "req-surrogate",
+        request: {
+          command: commandText,
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "exec",
+      nowMs: 0,
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-surrogate",
+        commandText,
+        metadata: [],
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            command: "/approve req-surrogate allow-once",
+            style: "success",
+          },
+        ],
+      } as never,
+    })) as SlackPayload;
+
+    const commandMrkdwn = findApprovalMrkdwn(payload, "*Command*");
+    expect(commandMrkdwn).toMatch(/…\n```$/);
+    expect(UNPAIRED_SURROGATE_RE.test(commandMrkdwn)).toBe(false);
+  });
+
+  it("does not leave dangling surrogates when truncating plugin approval request mrkdwn", async () => {
+    const title = `${"a".repeat(2598)}😀tail`;
+    const payload = (await slackApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        app: {} as never,
+        config: {} as never,
+      },
+      request: {
+        id: "plugin:req-surrogate",
+        request: {
+          title,
+          description: "Needs approval.",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "plugin",
+      nowMs: 0,
+      view: {
+        approvalKind: "plugin",
+        phase: "pending",
+        approvalId: "plugin:req-surrogate",
+        title,
+        description: "Needs approval.",
+        severity: "warning",
+        pluginId: "test-plugin",
+        toolName: "test-tool",
+        metadata: [],
+        actions: [
+          {
+            decision: "deny",
+            label: "Deny",
+            command: "/approve plugin:req-surrogate deny",
+            style: "danger",
+          },
+        ],
+        expiresAtMs: 60_000,
+      } as never,
+    })) as SlackPayload;
+
+    const requestMrkdwn = findApprovalMrkdwn(payload, "*Request*");
+    expect(requestMrkdwn).toMatch(/…$/);
+    expect(UNPAIRED_SURROGATE_RE.test(requestMrkdwn)).toBe(false);
+  });
+
+  it("still truncates plain BMP approval mrkdwn at the Slack approval preview limit", async () => {
+    const commandText = "b".repeat(2700);
+    const payload = (await slackApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        app: {} as never,
+        config: {} as never,
+      },
+      request: {
+        id: "req-bmp",
+        request: {
+          command: commandText,
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "exec",
+      nowMs: 0,
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-bmp",
+        commandText,
+        metadata: [],
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            command: "/approve req-bmp allow-once",
+            style: "success",
+          },
+        ],
+      } as never,
+    })) as SlackPayload;
+
+    const commandMrkdwn = findApprovalMrkdwn(payload, "*Command*");
+    expect(commandMrkdwn).toMatch(/…\n```$/);
+    expect(commandMrkdwn).toContain(`${"b".repeat(2599)}…`);
+    expect(UNPAIRED_SURROGATE_RE.test(commandMrkdwn)).toBe(false);
   });
 
   it("renders only the allowed pending actions", async () => {

--- a/extensions/slack/src/approval-handler.runtime.ts
+++ b/extensions/slack/src/approval-handler.runtime.ts
@@ -19,6 +19,7 @@ import { buildApprovalPresentationFromActionDescriptors } from "openclaw/plugin-
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logError } from "openclaw/plugin-sdk/logging-core";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   isSlackAnyNativeApprovalClientEnabled,
   resolveSlackApprovalKind,
@@ -73,7 +74,14 @@ function resolveHandlerContext(params: ChannelApprovalCapabilityHandlerContext):
 }
 
 function truncateSlackMrkdwn(text: string, maxChars: number): string {
-  return text.length <= maxChars ? text : `${text.slice(0, maxChars - 1)}…`;
+  const limit = Math.max(0, Math.floor(maxChars));
+  if (text.length <= limit) {
+    return text;
+  }
+  if (limit <= 1) {
+    return truncateUtf16Safe(text, limit);
+  }
+  return `${truncateUtf16Safe(text, limit - 1)}…`;
 }
 
 function buildSlackCodeBlock(text: string): string {


### PR DESCRIPTION
**Summary:** Slack's `truncateSlackMrkdwn` sliced approval mrkdwn on raw UTF-16, leaving a lone surrogate when an emoji sat at the limit. This uses `truncateUtf16Safe` to truncate on a code-point boundary (and clamps the limit to a non-negative integer).

## What Problem This Solves

Slack approval mrkdwn truncation could split an astral Unicode character at a UTF-16 surrogate boundary.

A command or plugin approval title shaped like:

```text
"a".repeat(2598) + "😀" + "tail"
```

puts the emoji across the Slack approval preview truncation boundary. The old raw `.slice()` behavior could keep only the emoji high surrogate before the ellipsis, producing malformed text such as a lone `\uD83D` in the Slack payload.

## Fix

`extensions/slack/src/approval-handler.runtime.ts` now truncates Slack approval mrkdwn with the shared UTF-16-safe `truncateUtf16Safe` helper before appending the ellipsis.

This keeps Slack approval preview text inside the existing Slack Block Kit limits while avoiding split surrogate pairs. The approval path still preserves the existing mrkdwn formatting, code-fence escaping, range checks, and Slack text-object truncation behavior.

Related Slack text truncation also uses the shared UTF-16-safe helper path so fallback Slack text does not emit malformed surrogate halves.

## Evidence

Command:

```bash
node --import tsx demo.mts
```

Terminal output:

```text
BEFORE raw slice()
input length=2604
slice length=2600
tail codeUnits=0061 0061 d83d 2026
tail codePoints=U+61 U+61 U+d83d U+2026
lone-surrogate=true
encodeURIComponent=URIError
AFTER slackApprovalNativeRuntime.presentation.buildPendingPayload()
mrkdwn length=2617
tail text="aaaaaaaaaaa…\n```"
tail codeUnits=0061 0061 0061 2026 000a 0060 0060 0060
tail codePoints=U+61 U+61 U+61 U+2026 U+a U+60 U+60 U+60
lone-surrogate=false
ends-with-ellipsis-fence=true
```

The demo imports the real Slack approval runtime and calls `slackApprovalNativeRuntime.presentation.buildPendingPayload()`, which exercises the fixed approval mrkdwn truncation path in `extensions/slack/src/approval-handler.runtime.ts`. The old raw `.slice()` reproduction leaves a lone surrogate and throws `URIError` under URI encoding; the fixed runtime output is well-formed and `lone-surrogate=false`.

## Tests

Vitest regression coverage covers both affected Slack approval surfaces:

- `extensions/slack/src/approval-handler.runtime.test.ts` verifies exec approval command mrkdwn and plugin approval request mrkdwn do not leave dangling surrogates when the emoji straddles the truncation boundary.
- `extensions/slack/src/approval-handler.runtime.test.ts` also keeps plain BMP approval mrkdwn truncation behavior pinned at the Slack preview limit.
- `extensions/slack/src/truncate.test.ts` verifies Slack text truncation drops a straddling surrogate-pair emoji whole, preserves an emoji that fits before the cut, and keeps unchanged text unchanged when it fits.
```