### PR TITLE
fix(msteams): truncate reflection prompt on a UTF-16 boundary

### DIFF
--- a/extensions/msteams/src/feedback-reflection-prompt.ts
+++ b/extensions/msteams/src/feedback-reflection-prompt.ts
@@ -1,5 +1,6 @@
 // Msteams plugin module implements feedback reflection prompt behavior.
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 /** Max chars of the thumbed-down response to include in the reflection prompt. */
 const MAX_RESPONSE_CHARS = 500;
@@ -19,7 +20,7 @@ export function buildReflectionPrompt(params: {
   if (params.thumbedDownResponse) {
     const truncated =
       params.thumbedDownResponse.length > MAX_RESPONSE_CHARS
-        ? `${params.thumbedDownResponse.slice(0, MAX_RESPONSE_CHARS)}...`
+        ? `${truncateUtf16Safe(params.thumbedDownResponse, MAX_RESPONSE_CHARS)}...`
         : params.thumbedDownResponse;
     parts.push(`\nYour response was:\n> ${truncated}`);
   }

--- a/extensions/msteams/src/feedback-reflection.test.ts
+++ b/extensions/msteams/src/feedback-reflection.test.ts
@@ -19,6 +19,11 @@ import { msteamsRuntimeStub } from "./test-support/runtime.js";
 
 const previousStateDir = process.env.OPENCLAW_STATE_DIR;
 
+// Matches an unpaired UTF-16 surrogate (lone high or lone low), without relying
+// on the ES2024 String.prototype.isWellFormed() runtime API.
+const UNPAIRED_SURROGATE_RE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
 describe("buildFeedbackEvent", () => {
   it("builds a well-formed custom event", () => {
     const event = buildFeedbackEvent({
@@ -71,6 +76,26 @@ describe("buildReflectionPrompt", () => {
 
     expect(prompt).toContain("...");
     expect(prompt.length).toBeLessThan(longResponse.length + 500);
+  });
+
+  it("does not split UTF-16 surrogate pairs when truncating a thumbed-down response", () => {
+    const thumbedDownResponse = `${"a".repeat(499)}🦞${"b".repeat(20)}`;
+
+    const prompt = buildReflectionPrompt({ thumbedDownResponse });
+
+    expect(prompt).not.toMatch(UNPAIRED_SURROGATE_RE);
+    expect(prompt).toContain(`${"a".repeat(499)}...`);
+    expect(prompt).not.toContain("\ud83e");
+    expect(prompt).not.toContain("\udd9e");
+  });
+
+  it("keeps a boundary emoji when it fully fits before the truncation cap", () => {
+    const thumbedDownResponse = `${"a".repeat(498)}🦞${"b".repeat(20)}`;
+
+    const prompt = buildReflectionPrompt({ thumbedDownResponse });
+
+    expect(prompt).not.toMatch(UNPAIRED_SURROGATE_RE);
+    expect(prompt).toContain(`${"a".repeat(498)}🦞...`);
   });
 
   it("includes user comment when provided", () => {


### PR DESCRIPTION
**Summary:** The Teams feedback reflection prompt was truncated with a raw UTF-16 slice, so an emoji at the boundary became a lone surrogate fed into the LLM prompt. This uses `truncateUtf16Safe` to truncate on a code-point boundary.

## What Problem This Solves

The Microsoft Teams feedback reflection prompt truncated the thumbed-down response with raw UTF-16 slicing. When the response crossed the 500-code-unit cap at an emoji or other surrogate-pair boundary, the prompt could include a lone surrogate.

Trigger input used for proof:

- `"a".repeat(499) + "🦞" + "b".repeat(20)`
- Old truncation with `.slice(0, 500)` keeps only the high surrogate `d83e`, then appends `...`
- That malformed string can fail downstream UTF-8/URI encoding and can produce replacement-character behavior in logs or transport text

## Fix

`extensions/msteams/src/feedback-reflection-prompt.ts` now reuses the shared `truncateUtf16Safe` helper from `openclaw/plugin-sdk/text-utility-runtime` when capping the thumbed-down response before appending the reflection prompt ellipsis.

That keeps the existing 500-character range check and prompt escaping behavior, but avoids cutting a UTF-16 surrogate pair in half. If the boundary emoji does not fully fit, the helper trims before the pair and the prompt remains well-formed.

## Evidence

Command, run from a temporary worktree on `fix/msteams-reflection-truncate-surrogate`:

```bash
node --import tsx demo.mts
```

The demo imports the real fixed function:

```ts
import { buildReflectionPrompt } from "./extensions/msteams/src/feedback-reflection-prompt.ts";
```

Terminal output:

```text
input.length = 521
emoji code point = 0x1f99e
BEFORE raw slice tail = "aaaa\ud83e..."
BEFORE raw slice tail code units = 0061 0061 0061 0061 d83e 002e 002e 002e
BEFORE lone-surrogate = true
BEFORE encodeURIComponent = URIError
AFTER prompt excerpt tail = "aaaaa..."
AFTER prompt excerpt tail code units = 0061 0061 0061 0061 0061 002e 002e 002e
AFTER lone-surrogate = false
AFTER contains boundary emoji = false
```

The fixed `buildReflectionPrompt` output is well-formed for this surrogate-boundary emoji input: the lone-surrogate regex reports `false`, and the boundary emoji is dropped rather than split.

## Tests

Focused Vitest coverage exercises the prompt builder regression cases:

- `does not split UTF-16 surrogate pairs when truncating a thumbed-down response`
- `keeps a boundary emoji when it fully fits before the truncation cap`

Validation command:

```bash
node scripts/run-vitest.mjs extensions/msteams/src/feedback-reflection.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests       20 passed (20)
[test] passed 1 Vitest shard in 78.96s
```