### PR TITLE
fix(agents): skip binding-flush probe for warm-stdin claude-cli backends (fixes #96564) (AI-assisted)

### DIFF
--- a/src/agents/cli-runner.binding-flush.test.ts
+++ b/src/agents/cli-runner.binding-flush.test.ts
@@ -106,4 +106,28 @@ describe("isCliBindingFlushed", () => {
     expect(await isCliBindingFlushed("sid-x", undefined)).toBe(true);
     expect(probe).not.toHaveBeenCalled();
   });
+
+  it("returns true without probing for warm-stdin backends", async () => {
+    const probe = vi.fn(async () => false);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(
+      await isCliBindingFlushed("sid-warm", "claude-cli", workspaceDir, {
+        warmStdin: true,
+      }),
+    ).toBe(true);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("still probes when warmStdin is false", async () => {
+    const probe = vi.fn(async () => true);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(
+      await isCliBindingFlushed("sid-probe", "claude-cli", workspaceDir, {
+        warmStdin: false,
+      }),
+    ).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -128,12 +128,19 @@ export async function isCliBindingFlushed(
   sessionId: string | undefined,
   provider: string | undefined,
   workspaceDir?: string,
+  options?: { warmStdin?: boolean },
 ): Promise<boolean> {
   if (!provider || !isClaudeCliProvider(provider)) {
     return true;
   }
   if (!sessionId) {
     return false;
+  }
+  // Warm-stdin backends (liveSession: "claude-stdio") run as persistent stdio
+  // children and never write native transcript files. Probing would always miss
+  // and the miss wipes the session binding, destroying conversation continuity.
+  if (options?.warmStdin) {
+    return true;
   }
   for (const delayMs of [0, 50, 150]) {
     if (delayMs > 0) {
@@ -1056,6 +1063,7 @@ export async function runPreparedCliAgent(
           effectiveCliSessionId,
           params.provider,
           context.cwd ?? context.workspaceDir,
+          { warmStdin: context.preparedBackend.backend.liveSession === "claude-stdio" },
         );
         await runCliAgentEndHook(params, {
           event: {


### PR DESCRIPTION
## What Problem This Solves

The `claude-cli` backend running in headless warm-stdin mode (`liveSession: "claude-stdio"`) loses all conversation continuity after the first turn. Every subsequent message is treated as a cold start with no history.

Root cause: the post-turn transcript-flush probe (`isCliBindingFlushed`) checks for a native `~/.claude/projects/<slug>/<sessionId>.jsonl` transcript file that warm-stdin backends **never write**. The probe always misses, and the miss emits `clearCliSessionBinding: true`, which wipes the session binding. With no binding, the next turn has nothing to `--resume` and the reseed safety net is also disarmed.

## Why This Change Was Made

`isCliBindingFlushed` now accepts an optional `warmStdin` flag. When set (via `liveSession === "claude-stdio"` on the backend config), the probe is skipped entirely and the function returns `true` — the binding is preserved because warm-stdin backends maintain conversation state through their persistent stdio child process, not through native transcript files.

The fix is a single guard clause in `isCliBindingFlushed` plus one call-site change in `runPreparedCliAgent`.

## User Impact

Users running agents on the `claude-cli` backend in warm-stdin mode (the default for Anthropic Max subscriptions) will now have proper multi-turn conversation continuity. Previously, every turn after the first was a cold start.

## Evidence

- **Behavior addressed:** claude-cli warm-stdin backend session binding wiped every turn
- **Environment tested:** OpenClaw 2026.5.28, Node 22.22.3, macOS
- **Steps run after the patch:** Verified `isCliBindingFlushed` returns `true` for warm-stdin backends and `false` for cold backends; ran binding-flush, reliability, and session-store verification suites
- **Evidence after fix:**
```
$ npx tsx --input-type=module -e "
import { isCliBindingFlushed, setCliRunnerTestDeps, restoreCliRunnerTestDeps } from './src/agents/cli-runner.ts';
setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: async () => false, delay: async () => {} });
const cold = await isCliBindingFlushed('test-sid', 'claude-cli', '/tmp/workspace');
console.log('Without warmStdin:', cold);
const warm = await isCliBindingFlushed('test-sid', 'claude-cli', '/tmp/workspace', { warmStdin: true });
console.log('With warmStdin=true:', warm);
restoreCliRunnerTestDeps();
"
Without warmStdin: false
With warmStdin=true: true
```
- **Observed result after fix:** With `warmStdin: true`, the probe is skipped and the function returns `true` (binding preserved). Without it, the probe runs and returns `false` (binding wiped) — matching the pre-fix behavior for cold backends.
- **What was not tested:** End-to-end multi-turn conversation with a live claude-cli backend requires Claude Max subscription authentication; the fix is verified at the function level and through the binding-flush verification suite.

## Real behavior proof

- **Behavior addressed:** claude-cli warm-stdin backend session binding wiped every turn
- **Environment tested:** OpenClaw 2026.5.28, Node 22.22.3, macOS
- **Steps run after the patch:** Called `isCliBindingFlushed` directly with `warmStdin: true` and `warmStdin: false`; ran binding-flush verification suite (9/9 pass), reliability suite (61/61 pass), session-store suite (45/45 pass)
- **Evidence after fix:**
```
$ npx tsx --input-type=module -e "
import { isCliBindingFlushed, setCliRunnerTestDeps, restoreCliRunnerTestDeps } from './src/agents/cli-runner.ts';
setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: async () => false, delay: async () => {} });
const cold = await isCliBindingFlushed('test-sid', 'claude-cli', '/tmp/workspace');
console.log('Without warmStdin:', cold);
const warm = await isCliBindingFlushed('test-sid', 'claude-cli', '/tmp/workspace', { warmStdin: true });
console.log('With warmStdin=true:', warm);
restoreCliRunnerTestDeps();
"
Without warmStdin: false
With warmStdin=true: true
```
- **Observed result after fix:** The `warmStdin` guard prevents the destructive probe from running for `claude-stdio` backends, preserving the session binding across turns.
- **What was not tested:** End-to-end multi-turn conversation with a live claude-cli backend requires Claude Max subscription authentication; the fix is verified at the function level and through the binding-flush verification suite.

- [x] AI-assisted (Hermes Agent)
