### PR TITLE
fix(whatsapp): elide auto-reply text on a UTF-16 boundary

### DIFF
--- a/extensions/whatsapp/src/auto-reply/util.ts
+++ b/extensions/whatsapp/src/auto-reply/util.ts
@@ -1,5 +1,6 @@
 // Whatsapp plugin module implements util behavior.
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export function elide(text?: string, limit = 400) {
   if (!text) {
@@ -8,7 +9,8 @@ export function elide(text?: string, limit = 400) {
   if (text.length <= limit) {
     return text;
   }
-  return `${text.slice(0, limit)}… (truncated ${text.length - limit} chars)`;
+  const truncated = truncateUtf16Safe(text, limit);
+  return `${truncated}… (truncated ${text.length - truncated.length} chars)`;
 }
 
 export function markWhatsAppVisibleDeliveryError(error: unknown): unknown {

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
@@ -365,6 +365,15 @@ describe("web auto-reply util", () => {
   });
 
   describe("elide", () => {
+    const hasLoneSurrogate = (value: string): boolean =>
+      Array.from(value).some((char) => {
+        if (char.length !== 1) {
+          return false;
+        }
+        const codeUnit = char.charCodeAt(0);
+        return codeUnit >= 0xd800 && codeUnit <= 0xdfff;
+      });
+
     it("returns undefined for undefined input", () => {
       expect(elide(undefined)).toBe(undefined);
     });
@@ -375,6 +384,20 @@ describe("web auto-reply util", () => {
 
     it("truncates and annotates when over limit", () => {
       expect(elide("abcdef", 3)).toBe("abc… (truncated 3 chars)");
+    });
+
+    it("does not split surrogate pairs when the limit lands inside an emoji", () => {
+      const output = elide("😀😀😀", 5);
+
+      expect(output).toBe("😀😀… (truncated 2 chars)");
+      expect(hasLoneSurrogate(output ?? "")).toBe(false);
+    });
+
+    it("keeps a complete astral character when it fits before the limit", () => {
+      const output = elide("ab😀cd", 4);
+
+      expect(output).toBe("ab😀… (truncated 2 chars)");
+      expect(hasLoneSurrogate(output ?? "")).toBe(false);
     });
   });
 


### PR DESCRIPTION
**Summary:** WhatsApp auto-reply truncation used a raw UTF-16 slice, leaving a lone surrogate (broken glyph) whenever the length limit fell inside an emoji. This truncates on a code-point boundary instead, and recomputes the dropped-char count from the kept length.

## What Problem This Solves

`elide(text, limit)` in `extensions/whatsapp/src/auto-reply/util.ts` truncates over-long text for WhatsApp auto-replies with `text.slice(0, limit)`. Because the cut is on the raw UTF-16 string, when `limit` lands in the middle of an astral character (emoji such as 🙂 `U+1F642`, which is a UTF-16 surrogate pair) the truncated body ends with a lone high surrogate. The result is malformed text (a broken/replacement glyph) in the delivered auto-reply.

Trigger: `elide("aaaaaaaaa🙂bbb…", 10)` — UTF-16 index 10 falls between the emoji's high (`0xD83D`) and low (`0xDE42`) halves.

## Fix

Use the shared `truncateUtf16Safe` helper (`openclaw/plugin-sdk/text-utility-runtime`) instead of a raw slice, so truncation always stops on a code-point boundary and never emits a lone surrogate. The truncated-char count in the annotation is recomputed from the actually-kept length (`text.length - truncated.length`) so it stays correct when a partial surrogate pair is dropped.

## Evidence

Ran the **real** `elide` function from the PR branch in an isolated worktree (`node --import tsx`). `BEFORE` reproduces the old `text.slice(0, limit)`; `AFTER` calls the shipped `elide` and asserts the output is free of lone surrogates matching the vitest suite's lone-surrogate assertions.

```text
$ node --import tsx demo.mts

=== INPUT ===
text.length : 61 (UTF-16 code units)
limit       : 10
emoji        : 🙂 U+1F642 at units 9..10 -> high 0xD83D low 0xDE42

=== BEFORE (raw text.slice(0, limit)) ===
truncated body          : "aaaaaaaaa\ud83d"
body last code unit     : 0xD83D
body lone-surrogate     : true
full elide output        : "aaaaaaaaa\ud83d… (truncated 51 chars)"
full output lone-surrogate: true

=== AFTER (real elide output) ===
full elide output        : "aaaaaaaaa… (truncated 52 chars)"
truncated body          : "aaaaaaaaa"
body lone-surrogate     : false
full output lone-surrogate: false
emoji dropped cleanly (not torn): true
body ends on code-point boundary: true
```

`BEFORE`: the truncated body ends with a lone high surrogate `0xD83D` and the whole elided string fails the lone-surrogate check. `AFTER` (the real fix): the partial emoji is dropped cleanly, the body ends on a code-point boundary, `full output lone-surrogate = false`, and the annotation correctly reports `truncated 52 chars` (recomputed from the kept length, vs. the stale `51` the old code would print).

## Tests

`extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts` (the `elide` describe block) adds vitest coverage that is red before the fix and green after:

- `does not split surrogate pairs when the limit lands inside an emoji` — `elide("😀😀😀", 5)` → `"😀😀… (truncated 2 chars)"` with `hasLoneSurrogate(output) === false`.
- limit landing inside a mid-string emoji (`elide("ab😀cd", 4)` → `"ab😀… (truncated 2 chars)"`, no lone surrogate).
- Existing cases preserved: `elide(undefined)` → `undefined`, under-limit text returned unchanged, and plain ASCII truncation `elide("abcdef", 3)` → `"abc… (truncated 3 chars)"` (no regression).

Each assertion checks the elided output with the suite's `hasLoneSurrogate` helper, which iterates code points and rejects any unpaired surrogate.