### PR TITLE
fix(telegram): reject surrogate/out-of-range numeric HTML entities

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -554,6 +554,27 @@ describe("markdownToTelegramHtml", () => {
     ).toBe("Name | Age\nAlice | 30");
   });
 
+  it("does not decode surrogate numeric entities into Telegram HTML fallback text", () => {
+    const cases = [
+      ["hex high surrogate", "x &#xD800; y", "x &#xD800; y"],
+      ["decimal high surrogate", "x &#55296; y", "x &#55296; y"],
+      ["hex low surrogate", "x &#xDFFF; y", "x &#xDFFF; y"],
+    ] as const;
+
+    for (const [name, input, expected] of cases) {
+      const output = telegramHtmlToPlainTextFallback(input);
+      expect(output, name).toBe(expected);
+      expect(containsLoneSurrogate(output), name).toBe(false);
+    }
+  });
+
+  it("continues to decode valid astral numeric entities in Telegram HTML fallback text", () => {
+    const output = telegramHtmlToPlainTextFallback("x &#x1F600; &#128512; y");
+
+    expect(output).toBe("x 😀 😀 y");
+    expect(containsLoneSurrogate(output)).toBe(false);
+  });
+
   it("fails loudly when tag overhead leaves no room for text", () => {
     expect(() => splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10)).toThrow(/tag overhead/i);
   });

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -468,16 +468,25 @@ function escapeUnsupportedTelegramHtml(
   return result;
 }
 
+function isValidTelegramHtmlEntityCodePoint(codePoint: number): boolean {
+  return (
+    Number.isInteger(codePoint) &&
+    codePoint >= 0 &&
+    codePoint <= 0x10ffff &&
+    !(codePoint >= 0xd800 && codePoint <= 0xdfff)
+  );
+}
+
 function decodeTelegramHtmlEntity(entity: string, fallback: string): string {
   if (entity.startsWith("#x") || entity.startsWith("#X")) {
     const codePoint = Number.parseInt(entity.slice(2), 16);
-    return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+    return isValidTelegramHtmlEntityCodePoint(codePoint)
       ? String.fromCodePoint(codePoint)
       : fallback;
   }
   if (entity.startsWith("#")) {
     const codePoint = Number.parseInt(entity.slice(1), 10);
-    return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+    return isValidTelegramHtmlEntityCodePoint(codePoint)
       ? String.fromCodePoint(codePoint)
       : fallback;
   }


### PR DESCRIPTION
**Summary:** Telegram's numeric HTML-entity fallback decoder accepted UTF-16 surrogate-range code points (`0xD800`–`0xDFFF`) and decoded them with `String.fromCodePoint`, emitting a lone surrogate into the delivered fallback text. This rejects surrogate-range entities and keeps their original entity text.

## What Problem This Solves

The Telegram fallback-text entity decoder maps numeric HTML entities (`&#NNN;` / `&#xHH;`) via `String.fromCodePoint`. The existing guard already bounded the value to a valid integer in `0..0x10ffff`, so out-of-range entities were never the problem. The gap is that **surrogate-range code points `0xD800`–`0xDFFF` still passed that guard and decoded into a lone surrogate** — e.g. `&#xD800;` became `\uD800` — producing malformed delivered text.

## Fix

Extract an `isValidTelegramHtmlEntityCodePoint` helper that keeps the existing `0..0x10ffff` integer bound **and additionally rejects the surrogate range** `0xD800`–`0xDFFF`. Surrogate-range entities are now preserved as their original entity text; valid supplementary-plane entities (e.g. `&#x1F600;` → 😀) still decode normally.

## Evidence

OpenClaw's **Mantis** end-to-end system captured native **Telegram Desktop before/after proof** for this fix — run [`28134917996`](https://github.com/openclaw/openclaw/actions/runs/28134917996):

- Baseline `3ab8d6a` (pre-fix): **pass** — reproduces the malformed lone-surrogate delivery on a real Telegram Desktop client;
- Candidate `4dc853e` (this PR): **pass** — the candidate preserves `&#xD800;` literally and decodes `&#x1F600;` as the 😀 emoji;
- Overall: **true**.

Telegram Desktop PNG/GIF/MP4 artifacts are attached to the `openclaw-mantis` comment on this PR. This is a real Telegram client render of the fixed behavior from a real runtime/transport, not a mock or terminal log.

## Tests

A regression in `extensions/telegram/src/format.test.ts` asserts that surrogate-range numeric entities — decimal `&#55296;` and hex `&#xD800;` — are preserved as their original text (no lone surrogate), while a valid astral entity `&#x1F600;` still decodes to 😀. Red before the fix, green after.