### PR TITLE
fix(codex): keep CLI session preview text on code-point boundaries

### DIFF
--- a/extensions/codex/src/node-cli-sessions.test.ts
+++ b/extensions/codex/src/node-cli-sessions.test.ts
@@ -207,4 +207,65 @@ describe("codex cli node sessions", () => {
       }),
     ).rejects.toThrow("Codex CLI node command returned malformed payloadJSON.");
   });
+
+  it("keeps Codex history session previews on UTF-16 code point boundaries", async () => {
+    const sessionId = "019e2007-1f7e-7eb1-a42b-8c01f4b9b5ce";
+    const text = `${"a".repeat(136)}🤖tail`;
+    await fs.writeFile(
+      path.join(tempDir, "history.jsonl"),
+      JSON.stringify({ session_id: sessionId, ts: 1778678322, text }),
+    );
+
+    const command = createCodexCliSessionNodeHostCommands().find(
+      (entry) => entry.command === CODEX_CLI_SESSIONS_LIST_COMMAND,
+    );
+    const raw = await command?.handle(JSON.stringify({ filter: "", limit: 5 }));
+    const parsed = JSON.parse(raw ?? "{}") as {
+      sessions?: Array<{ lastMessage?: string }>;
+    };
+
+    expect(parsed.sessions?.[0]?.lastMessage).toBe(`${"a".repeat(136)}...`);
+    expect(parsed.sessions?.[0]?.lastMessage).not.toContain("\ud83e");
+    expect(parsed.sessions?.[0]?.lastMessage).not.toContain("\udd16");
+  });
+
+  it("keeps Codex session-file previews on UTF-16 code point boundaries", async () => {
+    const sessionId = "019e23d1-f33d-78e3-959e-0f56f30a5248";
+    const sessionDir = path.join(tempDir, "sessions", "2026", "05", "14");
+    const sessionFile = path.join(sessionDir, `rollout-2026-05-14T00-10-22-${sessionId}.jsonl`);
+    const text = `${"b".repeat(136)}🤖tail`;
+
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          timestamp: "2026-05-14T00:10:23.618Z",
+          type: "session_meta",
+          payload: { id: sessionId, cwd: "/tmp/codex-work" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-05-14T00:10:23.619Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text }],
+          },
+        }),
+      ].join("\n"),
+    );
+
+    const command = createCodexCliSessionNodeHostCommands().find(
+      (entry) => entry.command === CODEX_CLI_SESSIONS_LIST_COMMAND,
+    );
+    const raw = await command?.handle(JSON.stringify({ filter: "", limit: 5 }));
+    const parsed = JSON.parse(raw ?? "{}") as {
+      sessions?: Array<{ lastMessage?: string }>;
+    };
+
+    expect(parsed.sessions?.[0]?.lastMessage).toBe(`${"b".repeat(136)}...`);
+    expect(parsed.sessions?.[0]?.lastMessage).not.toContain("\ud83e");
+    expect(parsed.sessions?.[0]?.lastMessage).not.toContain("\udd16");
+  });
 });

--- a/extensions/codex/src/node-cli-sessions.ts
+++ b/extensions/codex/src/node-cli-sessions.ts
@@ -12,6 +12,7 @@ import type {
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
@@ -691,7 +692,10 @@ function normalizeTimeoutMs(value: unknown): number {
 }
 
 function truncateText(value: string, max: number): string {
-  return value.length > max ? `${value.slice(0, max - 3)}...` : value;
+  if (value.length <= max) {
+    return value;
+  }
+  return `${truncateUtf16Safe(value, Math.max(0, max - 3))}...`;
 }
 
 function compareOptionalStringsDesc(a?: string, b?: string): number {


### PR DESCRIPTION
**Summary:** The Codex CLI session preview (`lastMessage`) was truncated with `value.slice(0, max-3)` on raw UTF-16, tearing an emoji into a lone surrogate in the session-list JSON. This uses `truncateUtf16Safe` to truncate on a code-point boundary.

## What Problem This Solves

Codex CLI session previews in `extensions/codex/src/node-cli-sessions.ts` truncated text with raw UTF-16 `.slice()`. When the preview limit landed between the high and low surrogate of an emoji, the displayed `lastMessage` could contain a lone surrogate.

Trigger input used for proof:

- `136` ASCII characters
- followed by `🤖` (`U+1F916`, two UTF-16 code units)
- followed by trailing text

The old `slice(0, 137) + "..."` behavior kept only the high surrogate (`0xd83e`) before the ellipsis.

## Fix

`truncateText` now reuses the shared `truncateUtf16Safe` helper from `openclaw/plugin-sdk/text-utility-runtime` instead of slicing raw UTF-16 code units.

The fix keeps the existing preview width and ellipsis behavior, clamps the safe truncation budget with `Math.max(0, max - 3)`, and preserves the existing escaping/formatting path by only changing the preview truncation boundary.

## Evidence

Command run from an isolated proof worktree on `fix/codex-session-preview-surrogate`:

```sh
node --import tsx demo.mts
```

The demo imports the real `createCodexCliSessionNodeHostCommands()` entry point from `./extensions/codex/src/node-cli-sessions.ts`, writes a temporary Codex `history.jsonl`, invokes the real `codex.cli.sessions.list` handler, and compares old raw `.slice()` behavior with the fixed handler output.

```text
input.length(code units)= 142
input boundary codePoints= 0x61 0x61 0x1f916 0x74 0x61 0x69
BEFORE old slice preview tail= "aaaaaaaa\ud83e..."
BEFORE old slice tail codeUnits= 0x0061 0x0061 0x0061 0x0061 0xd83e 0x002e 0x002e 0x002e
BEFORE lone-surrogate= true last code unit before ellipsis= 0xd83e
AFTER handler preview tail= "aaaaaaaaa..."
AFTER handler preview length= 139
AFTER handler tail codeUnits= 0x0061 0x0061 0x0061 0x0061 0x0061 0x002e 0x002e 0x002e
AFTER lone-surrogate= false
AFTER preview= "aaaaaaaaaaaaaaaaaaaa…[136 ×'a' elided]..."
```

The old path produces a lone high surrogate at the truncation boundary. The fixed real handler output is well-formed UTF-16 and the lone-surrogate check is `false`.

## Tests

Targeted Vitest coverage was added for both Codex preview sources:

- history-backed session previews keep UTF-16 code point boundaries
- session-file-backed previews keep UTF-16 code point boundaries

Validation run:

```text
node scripts/run-vitest.mjs extensions/codex/src/node-cli-sessions.test.ts

Test Files  1 passed (1)
Tests       7 passed (7)
```