### PR TITLE
fix(duckduckgo): guard out-of-range numeric HTML entities

### DIFF
--- a/extensions/duckduckgo/src/ddg-client.ts
+++ b/extensions/duckduckgo/src/ddg-client.ts
@@ -35,6 +35,10 @@ type DuckDuckGoResult = {
   snippet: string;
 };
 
+function isDecodableCodePoint(cp: number): boolean {
+  return Number.isInteger(cp) && cp >= 0 && cp <= 0x10ffff && (cp < 0xd800 || cp > 0xdfff);
+}
+
 function decodeHtmlEntities(text: string): string {
   return text.replace(
     /&(?:lt|gt|quot|apos|#39|#x27|#x2F|nbsp|ndash|mdash|hellip|amp|#\d+|#x[0-9a-f]+);/gi,
@@ -71,10 +75,12 @@ function decodeHtmlEntities(text: string): string {
         return "&";
       }
       if (normalized.startsWith("&#x")) {
-        return String.fromCodePoint(Number.parseInt(normalized.slice(3, -1), 16));
+        const codePoint = Number.parseInt(normalized.slice(3, -1), 16);
+        return isDecodableCodePoint(codePoint) ? String.fromCodePoint(codePoint) : entity;
       }
       if (normalized.startsWith("&#")) {
-        return String.fromCodePoint(Number.parseInt(normalized.slice(2, -1), 10));
+        const codePoint = Number.parseInt(normalized.slice(2, -1), 10);
+        return isDecodableCodePoint(codePoint) ? String.fromCodePoint(codePoint) : entity;
       }
       return entity;
     },

--- a/extensions/duckduckgo/src/ddg-search-provider.test.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.test.ts
@@ -186,6 +186,20 @@ describe("duckduckgo web search provider", () => {
     );
   });
 
+  it("leaves out-of-range numeric html entities intact instead of throwing", () => {
+    expect(() => ddgClientTesting.decodeHtmlEntities("Result &#99999999; end")).not.toThrow();
+    expect(ddgClientTesting.decodeHtmlEntities("Result &#99999999; end")).toBe(
+      "Result &#99999999; end",
+    );
+    expect(ddgClientTesting.decodeHtmlEntities("Hex &#x110000; tail")).toBe("Hex &#x110000; tail");
+    // Surrogate-range entities would decode to lone UTF-16 surrogates; keep them intact.
+    expect(ddgClientTesting.decodeHtmlEntities("Bad &#55296; end")).toBe("Bad &#55296; end");
+    expect(ddgClientTesting.decodeHtmlEntities("Bad &#xD800; end")).toBe("Bad &#xD800; end");
+    expect(ddgClientTesting.decodeHtmlEntities("Bad &#xDFFF; end")).toBe("Bad &#xDFFF; end");
+    // A valid supplementary-plane entity still decodes.
+    expect(ddgClientTesting.decodeHtmlEntities("Smile &#128512;")).toBe("Smile 😀");
+  });
+
   it("does not double-decode escaped entities (decodes &amp; last)", () => {
     // A result whose text literally shows "&lt;" arrives double-encoded as
     // "&amp;lt;". Decoding &amp; first would re-decode it into "<", corrupting


### PR DESCRIPTION
**Summary:** DuckDuckGo's HTML entity decoder ran `String.fromCodePoint` on parsed numeric entities without validation, so out-of-range values threw `RangeError` (breaking the whole results-page parse) and surrogate-range values produced lone surrogates. This validates the code point (in range, non-surrogate) and otherwise keeps the original entity text.

## What Problem This Solves

DuckDuckGo HTML result parsing decoded numeric HTML entities with `String.fromCodePoint(...)` without validating the parsed code point first.

That meant hostile or malformed result text could break real parsing behavior:

- `&#99999999;` is outside Unicode range and throws `RangeError`.
- `&#55296;` / `&#xD800;` is in the UTF-16 surrogate range and decodes into a lone surrogate (`\uD800`), producing ill-formed output.
- Valid supplementary entities such as `&#128512;` should still decode to the complete emoji surrogate pair.

## Fix

The DuckDuckGo entity decoder now validates numeric entity code points before decoding:

- decimal and hex numeric entities are parsed into a code point first
- only integer code points in `0..0x10ffff` are decoded
- surrogate-range code points `0xd800..0xdfff` are not decoded
- invalid numeric entities are preserved as escaped entity text instead of throwing or producing lone UTF-16 surrogate units

This is a range-validation fix in `extensions/duckduckgo/src/ddg-client.ts`. It does not use a truncation helper because this path is not slicing or truncating text; it is decoding HTML entities. The important invariant is the same UTF-16 safety rule: never emit a lone surrogate into parsed search-result text.

## Evidence

Command run from an isolated worktree checked out at `fix/duckduckgo-entity-range`:

```bash
node --import tsx demo.mts
```

Terminal output:

```text
CASE surrogate decimal entity
INPUT Bad &#55296; end
BEFORE output="Bad \ud800 end"
BEFORE codeUnits=0042 0061 0064 0020 d800 0020 0065 006e 0064
BEFORE lone-surrogate=true
AFTER output="Bad &#55296; end"
AFTER codeUnits=0042 0061 0064 0020 0026 0023 0035 0035 0032 0039 0036 003b 0020 0065 006e 0064
AFTER lone-surrogate=false

CASE surrogate hex entity
INPUT Bad &#xD800; end
BEFORE output="Bad \ud800 end"
BEFORE codeUnits=0042 0061 0064 0020 d800 0020 0065 006e 0064
BEFORE lone-surrogate=true
AFTER output="Bad &#xD800; end"
AFTER codeUnits=0042 0061 0064 0020 0026 0023 0078 0044 0038 0030 0030 003b 0020 0065 006e 0064
AFTER lone-surrogate=false

CASE out-of-range entity
INPUT Bad &#99999999; end
BEFORE error=RangeError
AFTER output="Bad &#99999999; end"
AFTER codeUnits=0042 0061 0064 0020 0026 0023 0039 0039 0039 0039 0039 0039 0039 0039 003b 0020 0065 006e 0064
AFTER lone-surrogate=false

CASE valid supplementary emoji entity
INPUT Smile &#128512; end
BEFORE output="Smile 😀 end"
BEFORE codeUnits=0053 006d 0069 006c 0065 0020 d83d de00 0020 0065 006e 0064
BEFORE lone-surrogate=false
AFTER output="Smile 😀 end"
AFTER codeUnits=0053 006d 0069 006c 0065 0020 d83d de00 0020 0065 006e 0064
AFTER lone-surrogate=false
```

The demo calls the real fixed `testing.decodeHtmlEntities` entry from `extensions/duckduckgo/src/ddg-client.ts`. After the fix, surrogate-range and out-of-range entities stay escaped, valid emoji entities still decode, and every AFTER case reports `lone-surrogate=false`.

## Tests

Focused regression coverage is in `extensions/duckduckgo/src/ddg-search-provider.test.ts`:

- invalid decimal numeric entity stays intact instead of throwing
- invalid hex numeric entity stays intact
- surrogate-range decimal and hex entities stay intact
- valid supplementary-plane emoji entity still decodes

Validation run:

```bash
node scripts/run-vitest.mjs extensions/duckduckgo/src/ddg-search-provider.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests  10 passed (10)
```