### PR TITLE
feat(gateway): add deferred activation control port

### DIFF
--- a/package.json
+++ b/package.json
@@ -1889,6 +1889,7 @@
     "test:fast": "node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts",
     "test:force": "node --import tsx scripts/test-force.ts",
     "test:gateway": "node scripts/run-with-env.mjs OPENCLAW_GATEWAY_PROJECT_SHARDS=1 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts",
+    "test:gateway-deferred-state-io": "bash scripts/e2e/gateway-deferred-activation-state-io.sh",
     "test:gateway:cpu-scenarios": "node scripts/check-gateway-cpu-scenarios.mjs",
     "test:gateway:memory-fd-repro": "node scripts/check-memory-fd-repro.mjs",
     "test:gateway:watch-regression": "node scripts/check-gateway-watch-regression.mjs",

--- a/scripts/e2e/gateway-deferred-activation-state-io.sh
+++ b/scripts/e2e/gateway-deferred-activation-state-io.sh
@@ -72,8 +72,9 @@ cleanup() {
   trap - EXIT
 
   if [[ -n "$GATEWAY_PGID" ]]; then
-    # A parked process group ignores TERM until it is continued, so cleanup always
-    # resumes the traced tree before sending the bounded TERM/KILL shutdown.
+    # Tracees may still be parked while the strace leader keeps draining ptrace
+    # events, so cleanup resumes any stopped members before bounded TERM/KILL.
+    continue_stopped_non_leader_tracees
     kill -CONT -- "-$GATEWAY_PGID" 2>/dev/null || true
     kill -TERM -- "-$GATEWAY_PGID" 2>/dev/null || true
     if ! wait_for_process_group_exit 80 0.05; then
@@ -139,30 +140,144 @@ list_process_group_members() {
   ps -o pid=,pgid=,state= -e | awk -v pgid="$pgid" '$2 == pgid { print $1 " " $3 }'
 }
 
-process_group_has_members() {
-  local pgid=$1
-  local members
-  members="$(list_process_group_members "$pgid")"
-  [[ -n "$members" ]]
+process_state_is_stopped() {
+  case "$1" in
+    T|t) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
-process_group_is_stopped() {
-  local pgid=$1
-  local saw_member=0
+process_state_is_zombie_or_dead() {
+  case "$1" in
+    Z|z|X|x) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+process_state_is_live() {
+  ! process_state_is_zombie_or_dead "$1"
+}
+
+process_group_has_live_members_from_listing() {
+  local members=$1
   local pid state
 
   while read -r pid state; do
     if [[ -z "${pid:-}" ]]; then
       continue
     fi
-    saw_member=1
-    case "$state" in
-      T|t|Z|z|X|x) ;;
-      *) return 1 ;;
-    esac
-  done < <(list_process_group_members "$pgid")
+    if process_state_is_live "$state"; then
+      return 0
+    fi
+  done <<<"$members"
 
-  [[ $saw_member -eq 1 ]]
+  return 1
+}
+
+process_group_has_live_non_leader_members_from_listing() {
+  local leader_pid=$1
+  local members=$2
+  local pid state
+
+  while read -r pid state; do
+    if [[ -z "${pid:-}" || "$pid" == "$leader_pid" ]]; then
+      continue
+    fi
+    if process_state_is_live "$state"; then
+      return 0
+    fi
+  done <<<"$members"
+
+  return 1
+}
+
+list_live_unstopped_non_leader_pids_from_listing() {
+  local leader_pid=$1
+  local members=$2
+  local pid state
+
+  while read -r pid state; do
+    if [[ -z "${pid:-}" || "$pid" == "$leader_pid" ]]; then
+      continue
+    fi
+    if ! process_state_is_live "$state"; then
+      continue
+    fi
+    if process_state_is_stopped "$state"; then
+      continue
+    fi
+    printf '%s\n' "$pid"
+  done <<<"$members"
+}
+
+list_stopped_non_leader_pids_from_listing() {
+  local leader_pid=$1
+  local members=$2
+  local pid state
+
+  while read -r pid state; do
+    if [[ -z "${pid:-}" || "$pid" == "$leader_pid" ]]; then
+      continue
+    fi
+    if ! process_state_is_stopped "$state"; then
+      continue
+    fi
+    printf '%s\n' "$pid"
+  done <<<"$members"
+}
+
+process_group_live_non_leader_members_are_stopped_from_listing() {
+  local leader_pid=$1
+  local members=$2
+  local saw_live_non_leader=0
+  local pid state
+
+  while read -r pid state; do
+    if [[ -z "${pid:-}" || "$pid" == "$leader_pid" ]]; then
+      continue
+    fi
+    if ! process_state_is_live "$state"; then
+      continue
+    fi
+    saw_live_non_leader=1
+    if ! process_state_is_stopped "$state"; then
+      return 1
+    fi
+  done <<<"$members"
+
+  [[ $saw_live_non_leader -eq 1 ]]
+}
+
+process_group_has_live_members() {
+  local pgid=$1
+  local members
+
+  members="$(list_process_group_members "$pgid")"
+  process_group_has_live_members_from_listing "$members"
+}
+
+process_group_has_live_non_leader_members() {
+  local leader_pid=$1
+  local pgid=$2
+  local members
+
+  members="$(list_process_group_members "$pgid")"
+  process_group_has_live_non_leader_members_from_listing "$leader_pid" "$members"
+}
+
+continue_stopped_non_leader_tracees() {
+  local members
+  local -a stopped_pids=()
+
+  if [[ -z "$GATEWAY_PGID" || -z "$GATEWAY_PID" ]]; then
+    return 0
+  fi
+
+  members="$(list_process_group_members "$GATEWAY_PGID")"
+  mapfile -t stopped_pids < <(list_stopped_non_leader_pids_from_listing "$GATEWAY_PID" "$members")
+  if [[ ${#stopped_pids[@]} -gt 0 ]]; then
+    kill -CONT -- "${stopped_pids[@]}" 2>/dev/null || true
+  fi
 }
 
 wait_for_process_group_exit() {
@@ -175,7 +290,7 @@ wait_for_process_group_exit() {
   fi
 
   for ((attempt = 1; attempt <= attempts; attempt += 1)); do
-    if ! process_group_has_members "$GATEWAY_PGID"; then
+    if ! process_group_has_live_members "$GATEWAY_PGID"; then
       return 0
     fi
     sleep "$sleep_s"
@@ -196,7 +311,7 @@ wait_for_http_ok() {
     if curl -fsS --max-time 2 "$url" >"$body_path" 2>/dev/null; then
       return 0
     fi
-    if [[ -n "$GATEWAY_PGID" ]] && ! process_group_has_members "$GATEWAY_PGID"; then
+    if [[ -n "$GATEWAY_PGID" && -n "$GATEWAY_PID" ]] && ! process_group_has_live_non_leader_members "$GATEWAY_PID" "$GATEWAY_PGID"; then
       WAIT_FAILURE_REASON="process-group-exited"
       return 1
     fi
@@ -207,20 +322,84 @@ wait_for_http_ok() {
   return 1
 }
 
-wait_for_process_group_stopped() {
+wait_for_live_non_leader_tracees_stopped() {
   local attempts=$1
   local sleep_s=$2
   local attempt
+  local members
+  local -a live_unstopped_pids=()
 
   WAIT_FAILURE_REASON=""
   for ((attempt = 1; attempt <= attempts; attempt += 1)); do
-    if [[ -n "$GATEWAY_PGID" ]] && process_group_is_stopped "$GATEWAY_PGID"; then
-      return 0
-    fi
-    if [[ -n "$GATEWAY_PGID" ]] && ! process_group_has_members "$GATEWAY_PGID"; then
+    members="$(list_process_group_members "$GATEWAY_PGID")"
+    if ! process_group_has_live_non_leader_members_from_listing "$GATEWAY_PID" "$members"; then
       WAIT_FAILURE_REASON="process-group-exited"
       return 1
     fi
+
+    mapfile -t live_unstopped_pids < <(list_live_unstopped_non_leader_pids_from_listing "$GATEWAY_PID" "$members")
+    if [[ ${#live_unstopped_pids[@]} -gt 0 ]]; then
+      kill -STOP -- "${live_unstopped_pids[@]}" 2>/dev/null || true
+    fi
+
+    members="$(list_process_group_members "$GATEWAY_PGID")"
+    if process_group_live_non_leader_members_are_stopped_from_listing "$GATEWAY_PID" "$members"; then
+      return 0
+    fi
+
+    sleep "$sleep_s"
+  done
+
+  WAIT_FAILURE_REASON="timeout"
+  return 1
+}
+
+combined_trace_output_size_bytes() {
+  shopt -s nullglob
+  local trace_files=("$TRACE_PREFIX"*)
+  local total_bytes=0
+  local trace_file file_bytes
+  shopt -u nullglob
+
+  for trace_file in "${trace_files[@]}"; do
+    file_bytes="$(wc -c <"$trace_file")"
+    file_bytes="${file_bytes//[[:space:]]/}"
+    total_bytes=$((total_bytes + file_bytes))
+  done
+
+  printf '%s\n' "$total_bytes"
+}
+
+wait_for_trace_quiescence() {
+  local attempts=$1
+  local sleep_s=$2
+  local required_stable_polls=$3
+  local attempt
+  local members
+  local current_size
+  local previous_size=""
+  local stable_polls=0
+
+  WAIT_FAILURE_REASON=""
+  for ((attempt = 1; attempt <= attempts; attempt += 1)); do
+    members="$(list_process_group_members "$GATEWAY_PGID")"
+    if ! process_group_has_live_non_leader_members_from_listing "$GATEWAY_PID" "$members"; then
+      WAIT_FAILURE_REASON="process-group-exited"
+      return 1
+    fi
+
+    current_size="$(combined_trace_output_size_bytes)"
+    if [[ "$current_size" == "$previous_size" ]]; then
+      stable_polls=$((stable_polls + 1))
+    else
+      previous_size="$current_size"
+      stable_polls=1
+    fi
+
+    if [[ $stable_polls -ge $required_stable_polls ]]; then
+      return 0
+    fi
+
     sleep "$sleep_s"
   done
 
@@ -253,6 +432,44 @@ assert_no_matches() {
   rm -f "$matches_file"
 }
 
+run_self_tests() {
+  local members
+  local unstopped
+  local stopped
+
+  members=$'100 S\n101 T\n102 t\n103 Z'
+  process_group_has_live_members_from_listing "$members" || fail "self-test: expected live members to ignore zombie rows"
+  process_group_has_live_non_leader_members_from_listing "100" "$members" || fail "self-test: expected live non-leader members to exclude the strace leader"
+  process_group_live_non_leader_members_are_stopped_from_listing "100" "$members" || fail "self-test: expected stopped non-leader members to satisfy the parked-state predicate"
+
+  if process_group_has_live_members_from_listing $'100 Z'; then
+    fail "self-test: zombie-only groups must not count as live"
+  fi
+
+  if process_group_has_live_non_leader_members_from_listing "100" $'100 S\n101 Z'; then
+    fail "self-test: zombie-only non-leader rows must not count as live tracees"
+  fi
+
+  unstopped="$(list_live_unstopped_non_leader_pids_from_listing "100" $'100 S\n101 S\n102 T\n103 Z')"
+  if [[ "$unstopped" != "101" ]]; then
+    fail "self-test: expected only live unstopped non-leader pid 101, got '${unstopped}'"
+  fi
+
+  stopped="$(list_stopped_non_leader_pids_from_listing "100" $'100 S\n101 T\n102 t\n103 Z')"
+  if [[ "$stopped" != $'101\n102' ]]; then
+    fail "self-test: expected stopped non-leader pids 101 and 102, got '${stopped}'"
+  fi
+
+  RESULT="PASS"
+  RESULT_NOTE="self-test-passed"
+  printf 'PASS: shell helper self-tests passed\n'
+  exit 0
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  run_self_tests
+fi
+
 if [[ "$(uname -s)" != "Linux" ]]; then
   skip "gateway deferred state-I/O proof requires Linux strace/curl; run via Crabbox/Testbox"
 fi
@@ -264,6 +481,7 @@ assert_tool node
 assert_tool ps
 assert_tool setsid
 assert_tool strace
+assert_tool wc
 
 if [[ ! -f "$ROOT_DIR/openclaw.mjs" ]]; then
   fail "missing openclaw.mjs launcher at repo root"
@@ -304,22 +522,32 @@ if ! wait_for_http_ok "http://127.0.0.1:${CONTROL_PORT}/healthz" "$HEALTHZ_BODY"
   esac
 fi
 
-# Freeze the dedicated traced process group so the strace files stay quiescent
-# while the pre-activation snapshot and negative-match assertions run.
-if ! kill -STOP -- "-$GATEWAY_PGID" 2>/dev/null; then
-  fail_phase "park-before-snapshot" "failed to stop the dedicated process group"
-fi
-
-if ! wait_for_process_group_stopped 200 0.01; then
+# Park only the live non-leader tracees. The setsid leader is strace and must
+# keep running so it can drain ptrace events before the snapshot/grep checks.
+if ! wait_for_live_non_leader_tracees_stopped 200 0.01; then
   case "$WAIT_FAILURE_REASON" in
     process-group-exited)
-      fail_phase "park-before-snapshot" "process group exited before all traced members reached the stopped state"
+      fail_phase "park-before-snapshot" "process group exited before all live non-leader tracees reached the stopped state"
       ;;
     timeout)
-      fail_phase "park-before-snapshot" "timed out waiting for all traced members to reach the stopped state"
+      fail_phase "park-before-snapshot" "timed out waiting for all live non-leader tracees to reach the stopped state"
       ;;
     *)
       fail_phase "park-before-snapshot" "wait failed (${WAIT_FAILURE_REASON:-unknown})"
+      ;;
+  esac
+fi
+
+if ! wait_for_trace_quiescence 200 0.02 3; then
+  case "$WAIT_FAILURE_REASON" in
+    process-group-exited)
+      fail_phase "quiesce-before-snapshot" "process group exited before the pre-activation trace output became quiescent"
+      ;;
+    timeout)
+      fail_phase "quiesce-before-snapshot" "timed out waiting for the pre-activation trace output to become quiescent"
+      ;;
+    *)
+      fail_phase "quiesce-before-snapshot" "wait failed (${WAIT_FAILURE_REASON:-unknown})"
       ;;
   esac
 fi
@@ -339,7 +567,7 @@ assert_no_matches \
   pre_activation_gateway_port_access \
   grep -R -E -n "bind\\(.*${GATEWAY_PORT}|connect\\(.*${GATEWAY_PORT}" "$PRE_ACTIVATION_TRACE_DIR"
 
-kill -CONT -- "-$GATEWAY_PGID" 2>/dev/null || true
+continue_stopped_non_leader_tracees
 
 if ! curl -fsS --max-time 2 \
   -X POST \

--- a/scripts/e2e/gateway-deferred-activation-state-io.sh
+++ b/scripts/e2e/gateway-deferred-activation-state-io.sh
@@ -20,6 +20,8 @@ READYZ_BODY="$ARTIFACT_DIR/gateway-readyz.json"
 SUMMARY_FILE="$ARTIFACT_DIR/summary.txt"
 CONTROL_PORT="${OPENCLAW_TEST_CONTROL_PORT:-19792}"
 GATEWAY_PORT="${OPENCLAW_TEST_GATEWAY_PORT:-18789}"
+CONTROL_READY_ATTEMPTS="${OPENCLAW_TEST_CONTROL_READY_ATTEMPTS:-200}"
+GATEWAY_READY_ATTEMPTS="${OPENCLAW_TEST_GATEWAY_READY_ATTEMPTS:-2400}"
 ACTIVATION_TOKEN="state-io-test-token"
 GATEWAY_TOKEN="state-io-gateway-auth-token"
 RESULT="UNKNOWN"
@@ -49,12 +51,27 @@ artifact_dir=$ARTIFACT_DIR
 root_dir=$ROOT_DIR
 control_port=$CONTROL_PORT
 gateway_port=$GATEWAY_PORT
+control_ready_attempts=$CONTROL_READY_ATTEMPTS
+gateway_ready_attempts=$GATEWAY_READY_ATTEMPTS
 launcher=node openclaw.mjs gateway run --allow-unconfigured --auth token --port $GATEWAY_PORT
 stdout_log=$STDOUT_LOG
 stderr_log=$STDERR_LOG
 trace_prefix=$TRACE_PREFIX
 pre_activation_trace_dir=$PRE_ACTIVATION_TRACE_DIR
 EOF
+}
+
+require_positive_digits() {
+  local name=$1
+  local value=$2
+
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    fail "${name} must be digits and >0, got '${value}'"
+  fi
+
+  if (( value <= 0 )); then
+    fail "${name} must be digits and >0, got '${value}'"
+  fi
 }
 
 on_signal() {
@@ -460,6 +477,32 @@ run_self_tests() {
     fail "self-test: expected stopped non-leader pids 101 and 102, got '${stopped}'"
   fi
 
+  CONTROL_READY_ATTEMPTS=1
+  GATEWAY_READY_ATTEMPTS=2400
+  require_positive_digits "CONTROL_READY_ATTEMPTS" "$CONTROL_READY_ATTEMPTS"
+  require_positive_digits "GATEWAY_READY_ATTEMPTS" "$GATEWAY_READY_ATTEMPTS"
+
+  if (
+    set +e
+    require_positive_digits "CONTROL_READY_ATTEMPTS" "0"
+  ); then
+    fail "self-test: expected CONTROL_READY_ATTEMPTS=0 to fail validation"
+  fi
+
+  if (
+    set +e
+    require_positive_digits "CONTROL_READY_ATTEMPTS" "-1"
+  ); then
+    fail "self-test: expected CONTROL_READY_ATTEMPTS=-1 to fail validation"
+  fi
+
+  if (
+    set +e
+    require_positive_digits "GATEWAY_READY_ATTEMPTS" "text"
+  ); then
+    fail "self-test: expected GATEWAY_READY_ATTEMPTS=text to fail validation"
+  fi
+
   RESULT="PASS"
   RESULT_NOTE="self-test-passed"
   printf 'PASS: shell helper self-tests passed\n'
@@ -473,6 +516,9 @@ fi
 if [[ "$(uname -s)" != "Linux" ]]; then
   skip "gateway deferred state-I/O proof requires Linux strace/curl; run via Crabbox/Testbox"
 fi
+
+require_positive_digits "CONTROL_READY_ATTEMPTS" "$CONTROL_READY_ATTEMPTS"
+require_positive_digits "GATEWAY_READY_ATTEMPTS" "$GATEWAY_READY_ATTEMPTS"
 
 assert_tool awk
 assert_tool curl
@@ -508,7 +554,7 @@ printf 'Using artifact directory: %s\n' "$ARTIFACT_DIR"
 GATEWAY_PID=$!
 GATEWAY_PGID=$GATEWAY_PID
 
-if ! wait_for_http_ok "http://127.0.0.1:${CONTROL_PORT}/healthz" "$HEALTHZ_BODY" 200 0.05; then
+if ! wait_for_http_ok "http://127.0.0.1:${CONTROL_PORT}/healthz" "$HEALTHZ_BODY" "$CONTROL_READY_ATTEMPTS" 0.05; then
   case "$WAIT_FAILURE_REASON" in
     process-group-exited)
       fail_phase "control-healthz" "process group exited before deferred activation control /healthz became ready"
@@ -578,7 +624,7 @@ if ! curl -fsS --max-time 2 \
   fail_phase "activation" "activation request failed"
 fi
 
-if ! wait_for_http_ok "http://127.0.0.1:${GATEWAY_PORT}/readyz" "$READYZ_BODY" 400 0.05; then
+if ! wait_for_http_ok "http://127.0.0.1:${GATEWAY_PORT}/readyz" "$READYZ_BODY" "$GATEWAY_READY_ATTEMPTS" 0.05; then
   case "$WAIT_FAILURE_REASON" in
     process-group-exited)
       fail_phase "post-activation-readyz" "process group exited before gateway /readyz became ready"

--- a/scripts/e2e/gateway-deferred-activation-state-io.sh
+++ b/scripts/e2e/gateway-deferred-activation-state-io.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUN_ID="$(date -u +%Y-%m-%dT%H-%M-%SZ)-$$"
+ARTIFACT_PARENT="${OPENCLAW_GATEWAY_DEFERRED_STATE_IO_ARTIFACT_ROOT:-${TMPDIR:-/tmp}/openclaw-gateway-deferred-state-io}"
+ARTIFACT_DIR="${OPENCLAW_GATEWAY_DEFERRED_STATE_IO_ARTIFACT_DIR:-$ARTIFACT_PARENT/$RUN_ID}"
+STATE_DIR="$ARTIFACT_DIR/state"
+CONFIG_DIR="$ARTIFACT_DIR/config"
+CONFIG_PATH="$CONFIG_DIR/openclaw.json"
+TRACE_DIR="$ARTIFACT_DIR/strace"
+TRACE_PREFIX="$TRACE_DIR/trace.log"
+PRE_ACTIVATION_TRACE_DIR="$ARTIFACT_DIR/pre-activation-trace"
+STDOUT_LOG="$ARTIFACT_DIR/stdout.log"
+STDERR_LOG="$ARTIFACT_DIR/stderr.log"
+HEALTHZ_BODY="$ARTIFACT_DIR/control-healthz.json"
+ACTIVATE_BODY="$ARTIFACT_DIR/activate.json"
+READYZ_BODY="$ARTIFACT_DIR/gateway-readyz.json"
+SUMMARY_FILE="$ARTIFACT_DIR/summary.txt"
+CONTROL_PORT="${OPENCLAW_TEST_CONTROL_PORT:-19792}"
+GATEWAY_PORT="${OPENCLAW_TEST_GATEWAY_PORT:-18789}"
+ACTIVATION_TOKEN="state-io-test-token"
+GATEWAY_TOKEN="state-io-gateway-auth-token"
+RESULT="UNKNOWN"
+RESULT_NOTE="not-finished"
+GATEWAY_PID=""
+ARTIFACT_DIR_PRINTED=0
+
+mkdir -p "$STATE_DIR" "$CONFIG_DIR" "$TRACE_DIR" "$PRE_ACTIVATION_TRACE_DIR"
+chmod -R a+rwX "$ARTIFACT_DIR" || true
+
+print_artifact_dir() {
+  if [[ "$ARTIFACT_DIR_PRINTED" -eq 1 ]]; then
+    return
+  fi
+  ARTIFACT_DIR_PRINTED=1
+  printf 'Artifact directory: %s\n' "$ARTIFACT_DIR"
+}
+
+write_summary() {
+  cat >"$SUMMARY_FILE" <<EOF
+run_id=$RUN_ID
+result=$RESULT
+note=$RESULT_NOTE
+artifact_dir=$ARTIFACT_DIR
+root_dir=$ROOT_DIR
+control_port=$CONTROL_PORT
+gateway_port=$GATEWAY_PORT
+launcher=node openclaw.mjs gateway run --allow-unconfigured --auth token
+stdout_log=$STDOUT_LOG
+stderr_log=$STDERR_LOG
+trace_prefix=$TRACE_PREFIX
+pre_activation_trace_dir=$PRE_ACTIVATION_TRACE_DIR
+EOF
+}
+
+cleanup() {
+  local exit_code=$?
+  if [[ -n "$GATEWAY_PID" ]] && kill -0 "$GATEWAY_PID" 2>/dev/null; then
+    kill -TERM "$GATEWAY_PID" 2>/dev/null || true
+    wait "$GATEWAY_PID" || true
+  elif [[ -n "$GATEWAY_PID" ]]; then
+    wait "$GATEWAY_PID" || true
+  fi
+  write_summary
+  if [[ "$RESULT" == "UNKNOWN" ]]; then
+    RESULT="FAIL"
+    RESULT_NOTE="unexpected-exit"
+    write_summary
+  fi
+  if [[ $exit_code -ne 0 ]]; then
+    print_artifact_dir >&2
+  fi
+}
+trap cleanup EXIT
+
+skip() {
+  RESULT="SKIP"
+  RESULT_NOTE="$1"
+  write_summary
+  printf 'SKIP: %s\n' "$1" >&2
+  print_artifact_dir >&2
+  exit 2
+}
+
+fail() {
+  RESULT="FAIL"
+  RESULT_NOTE="$1"
+  write_summary
+  printf 'ERROR: %s\n' "$1" >&2
+  print_artifact_dir >&2
+  exit 1
+}
+
+assert_tool() {
+  local tool=$1
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    fail "required tool '$tool' is not installed"
+  fi
+}
+
+wait_for_http_ok() {
+  local url=$1
+  local body_path=$2
+  local attempts=$3
+  local sleep_s=$4
+  local attempt
+  for ((attempt = 1; attempt <= attempts; attempt += 1)); do
+    if curl -fsS --max-time 2 "$url" >"$body_path" 2>/dev/null; then
+      return 0
+    fi
+    if [[ -n "$GATEWAY_PID" ]] && ! kill -0 "$GATEWAY_PID" 2>/dev/null; then
+      return 1
+    fi
+    sleep "$sleep_s"
+  done
+  return 1
+}
+
+snapshot_pre_activation_trace() {
+  shopt -s nullglob
+  local trace_files=("$TRACE_PREFIX"*)
+  shopt -u nullglob
+  if [[ ${#trace_files[@]} -eq 0 ]]; then
+    fail "strace did not produce any trace files before activation"
+  fi
+  cp "${trace_files[@]}" "$PRE_ACTIVATION_TRACE_DIR/"
+}
+
+assert_no_matches() {
+  local match_name=$1
+  shift
+  local matches_file="$ARTIFACT_DIR/${match_name}.matches.txt"
+  if "$@" >"$matches_file" 2>&1; then
+    fail "$match_name matched; see $matches_file"
+  else
+    local status=$?
+    if [[ $status -gt 1 ]]; then
+      fail "$match_name grep failed; see $matches_file"
+    fi
+  fi
+  rm -f "$matches_file"
+}
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  skip "gateway deferred state-I/O proof requires Linux strace/curl; run via Crabbox/Testbox"
+fi
+
+assert_tool strace
+assert_tool curl
+assert_tool node
+
+if [[ ! -f "$ROOT_DIR/openclaw.mjs" ]]; then
+  fail "missing openclaw.mjs launcher at repo root"
+fi
+
+if [[ ! -f "$ROOT_DIR/dist/entry.js" && ! -f "$ROOT_DIR/dist/entry.mjs" ]]; then
+  fail "missing dist/entry.(m)js build output; run pnpm build first"
+fi
+
+printf 'Running gateway deferred zero-state-I/O proof (run_id=%s)\n' "$RUN_ID"
+printf 'Using artifact directory: %s\n' "$ARTIFACT_DIR"
+
+(
+  cd "$ROOT_DIR"
+  OPENCLAW_STATE_DIR="$STATE_DIR" \
+  OPENCLAW_CONFIG_PATH="$CONFIG_PATH" \
+  OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT="$CONTROL_PORT" \
+  OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN="$ACTIVATION_TOKEN" \
+  OPENCLAW_GATEWAY_TOKEN="$GATEWAY_TOKEN" \
+  strace -ff -e trace=file,network -s 0 -o "$TRACE_PREFIX" \
+    node openclaw.mjs gateway run --allow-unconfigured --auth token
+) >"$STDOUT_LOG" 2>"$STDERR_LOG" &
+GATEWAY_PID=$!
+
+if ! wait_for_http_ok "http://127.0.0.1:${CONTROL_PORT}/healthz" "$HEALTHZ_BODY" 200 0.05; then
+  fail "timed out waiting for deferred activation control /healthz"
+fi
+
+snapshot_pre_activation_trace
+
+assert_no_matches \
+  pre_activation_state_dir_access \
+  grep -R -F -n "$STATE_DIR" "$PRE_ACTIVATION_TRACE_DIR"
+assert_no_matches \
+  pre_activation_config_dir_access \
+  grep -R -F -n "$CONFIG_DIR" "$PRE_ACTIVATION_TRACE_DIR"
+assert_no_matches \
+  pre_activation_state_file_access \
+  grep -R -E -n 'openclaw\.sqlite|gateway\.lock' "$PRE_ACTIVATION_TRACE_DIR"
+assert_no_matches \
+  pre_activation_gateway_port_access \
+  grep -R -E -n "bind\\(.*${GATEWAY_PORT}|connect\\(.*${GATEWAY_PORT}" "$PRE_ACTIVATION_TRACE_DIR"
+
+if ! curl -fsS --max-time 2 \
+  -X POST \
+  -H "x-openclaw-activation-token: ${ACTIVATION_TOKEN}" \
+  -H 'content-type: application/json' \
+  --data '{"activationId":"state-io-proof"}' \
+  "http://127.0.0.1:${CONTROL_PORT}/activate" >"$ACTIVATE_BODY"; then
+  fail "activation request failed"
+fi
+
+if ! wait_for_http_ok "http://127.0.0.1:${GATEWAY_PORT}/readyz" "$READYZ_BODY" 400 0.05; then
+  fail "timed out waiting for gateway /readyz after activation"
+fi
+
+RESULT="PASS"
+RESULT_NOTE="no pre-activation state/config/lock or gateway-port access detected in trace snapshot"
+write_summary
+printf 'PASS: %s\n' "$RESULT_NOTE"
+print_artifact_dir

--- a/scripts/e2e/gateway-deferred-activation-state-io.sh
+++ b/scripts/e2e/gateway-deferred-activation-state-io.sh
@@ -25,7 +25,9 @@ GATEWAY_TOKEN="state-io-gateway-auth-token"
 RESULT="UNKNOWN"
 RESULT_NOTE="not-finished"
 GATEWAY_PID=""
+GATEWAY_PGID=""
 ARTIFACT_DIR_PRINTED=0
+WAIT_FAILURE_REASON=""
 
 mkdir -p "$STATE_DIR" "$CONFIG_DIR" "$TRACE_DIR" "$PRE_ACTIVATION_TRACE_DIR"
 chmod -R a+rwX "$ARTIFACT_DIR" || true
@@ -47,7 +49,7 @@ artifact_dir=$ARTIFACT_DIR
 root_dir=$ROOT_DIR
 control_port=$CONTROL_PORT
 gateway_port=$GATEWAY_PORT
-launcher=node openclaw.mjs gateway run --allow-unconfigured --auth token
+launcher=node openclaw.mjs gateway run --allow-unconfigured --auth token --port $GATEWAY_PORT
 stdout_log=$STDOUT_LOG
 stderr_log=$STDERR_LOG
 trace_prefix=$TRACE_PREFIX
@@ -55,25 +57,51 @@ pre_activation_trace_dir=$PRE_ACTIVATION_TRACE_DIR
 EOF
 }
 
+on_signal() {
+  local signal_name=$1
+  local exit_code=$2
+  if [[ "$RESULT" == "UNKNOWN" ]]; then
+    RESULT="FAIL"
+    RESULT_NOTE="interrupted-by-${signal_name}"
+  fi
+  exit "$exit_code"
+}
+
 cleanup() {
   local exit_code=$?
-  if [[ -n "$GATEWAY_PID" ]] && kill -0 "$GATEWAY_PID" 2>/dev/null; then
-    kill -TERM "$GATEWAY_PID" 2>/dev/null || true
-    wait "$GATEWAY_PID" || true
-  elif [[ -n "$GATEWAY_PID" ]]; then
-    wait "$GATEWAY_PID" || true
+  trap - EXIT
+
+  if [[ -n "$GATEWAY_PGID" ]]; then
+    # A parked process group ignores TERM until it is continued, so cleanup always
+    # resumes the traced tree before sending the bounded TERM/KILL shutdown.
+    kill -CONT -- "-$GATEWAY_PGID" 2>/dev/null || true
+    kill -TERM -- "-$GATEWAY_PGID" 2>/dev/null || true
+    if ! wait_for_process_group_exit 80 0.05; then
+      kill -KILL -- "-$GATEWAY_PGID" 2>/dev/null || true
+      wait_for_process_group_exit 40 0.05 || true
+    fi
   fi
-  write_summary
+
+  if [[ -n "$GATEWAY_PID" ]]; then
+    wait "$GATEWAY_PID" 2>/dev/null || true
+  fi
+
   if [[ "$RESULT" == "UNKNOWN" ]]; then
     RESULT="FAIL"
     RESULT_NOTE="unexpected-exit"
-    write_summary
   fi
+  write_summary
+
   if [[ $exit_code -ne 0 ]]; then
     print_artifact_dir >&2
   fi
+
+  exit "$exit_code"
 }
 trap cleanup EXIT
+trap 'on_signal INT 130' INT
+trap 'on_signal TERM 143' TERM
+trap 'on_signal HUP 129' HUP
 
 skip() {
   RESULT="SKIP"
@@ -93,11 +121,67 @@ fail() {
   exit 1
 }
 
+fail_phase() {
+  local phase=$1
+  local detail=$2
+  fail "${phase}: ${detail}; stderr_log=${STDERR_LOG}; artifact_dir=${ARTIFACT_DIR}"
+}
+
 assert_tool() {
   local tool=$1
   if ! command -v "$tool" >/dev/null 2>&1; then
     fail "required tool '$tool' is not installed"
   fi
+}
+
+list_process_group_members() {
+  local pgid=$1
+  ps -o pid=,pgid=,state= -e | awk -v pgid="$pgid" '$2 == pgid { print $1 " " $3 }'
+}
+
+process_group_has_members() {
+  local pgid=$1
+  local members
+  members="$(list_process_group_members "$pgid")"
+  [[ -n "$members" ]]
+}
+
+process_group_is_stopped() {
+  local pgid=$1
+  local saw_member=0
+  local pid state
+
+  while read -r pid state; do
+    if [[ -z "${pid:-}" ]]; then
+      continue
+    fi
+    saw_member=1
+    case "$state" in
+      T|t|Z|z|X|x) ;;
+      *) return 1 ;;
+    esac
+  done < <(list_process_group_members "$pgid")
+
+  [[ $saw_member -eq 1 ]]
+}
+
+wait_for_process_group_exit() {
+  local attempts=$1
+  local sleep_s=$2
+  local attempt
+
+  if [[ -z "$GATEWAY_PGID" ]]; then
+    return 0
+  fi
+
+  for ((attempt = 1; attempt <= attempts; attempt += 1)); do
+    if ! process_group_has_members "$GATEWAY_PGID"; then
+      return 0
+    fi
+    sleep "$sleep_s"
+  done
+
+  return 1
 }
 
 wait_for_http_ok() {
@@ -106,15 +190,41 @@ wait_for_http_ok() {
   local attempts=$3
   local sleep_s=$4
   local attempt
+
+  WAIT_FAILURE_REASON=""
   for ((attempt = 1; attempt <= attempts; attempt += 1)); do
     if curl -fsS --max-time 2 "$url" >"$body_path" 2>/dev/null; then
       return 0
     fi
-    if [[ -n "$GATEWAY_PID" ]] && ! kill -0 "$GATEWAY_PID" 2>/dev/null; then
+    if [[ -n "$GATEWAY_PGID" ]] && ! process_group_has_members "$GATEWAY_PGID"; then
+      WAIT_FAILURE_REASON="process-group-exited"
       return 1
     fi
     sleep "$sleep_s"
   done
+
+  WAIT_FAILURE_REASON="timeout"
+  return 1
+}
+
+wait_for_process_group_stopped() {
+  local attempts=$1
+  local sleep_s=$2
+  local attempt
+
+  WAIT_FAILURE_REASON=""
+  for ((attempt = 1; attempt <= attempts; attempt += 1)); do
+    if [[ -n "$GATEWAY_PGID" ]] && process_group_is_stopped "$GATEWAY_PGID"; then
+      return 0
+    fi
+    if [[ -n "$GATEWAY_PGID" ]] && ! process_group_has_members "$GATEWAY_PGID"; then
+      WAIT_FAILURE_REASON="process-group-exited"
+      return 1
+    fi
+    sleep "$sleep_s"
+  done
+
+  WAIT_FAILURE_REASON="timeout"
   return 1
 }
 
@@ -133,11 +243,11 @@ assert_no_matches() {
   shift
   local matches_file="$ARTIFACT_DIR/${match_name}.matches.txt"
   if "$@" >"$matches_file" 2>&1; then
-    fail "$match_name matched; see $matches_file"
+    fail "${match_name} matched; see ${matches_file}"
   else
     local status=$?
     if [[ $status -gt 1 ]]; then
-      fail "$match_name grep failed; see $matches_file"
+      fail "${match_name} grep failed; see ${matches_file}"
     fi
   fi
   rm -f "$matches_file"
@@ -147,9 +257,13 @@ if [[ "$(uname -s)" != "Linux" ]]; then
   skip "gateway deferred state-I/O proof requires Linux strace/curl; run via Crabbox/Testbox"
 fi
 
-assert_tool strace
+assert_tool awk
 assert_tool curl
+assert_tool grep
 assert_tool node
+assert_tool ps
+assert_tool setsid
+assert_tool strace
 
 if [[ ! -f "$ROOT_DIR/openclaw.mjs" ]]; then
   fail "missing openclaw.mjs launcher at repo root"
@@ -164,18 +278,50 @@ printf 'Using artifact directory: %s\n' "$ARTIFACT_DIR"
 
 (
   cd "$ROOT_DIR"
-  OPENCLAW_STATE_DIR="$STATE_DIR" \
-  OPENCLAW_CONFIG_PATH="$CONFIG_PATH" \
-  OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT="$CONTROL_PORT" \
-  OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN="$ACTIVATION_TOKEN" \
-  OPENCLAW_GATEWAY_TOKEN="$GATEWAY_TOKEN" \
-  strace -ff -e trace=file,network -s 0 -o "$TRACE_PREFIX" \
-    node openclaw.mjs gateway run --allow-unconfigured --auth token
+  exec setsid env \
+    OPENCLAW_STATE_DIR="$STATE_DIR" \
+    OPENCLAW_CONFIG_PATH="$CONFIG_PATH" \
+    OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT="$CONTROL_PORT" \
+    OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN="$ACTIVATION_TOKEN" \
+    OPENCLAW_GATEWAY_TOKEN="$GATEWAY_TOKEN" \
+    strace -ff -e trace=file,network -s 0 -o "$TRACE_PREFIX" \
+      node openclaw.mjs gateway run --allow-unconfigured --auth token --port "$GATEWAY_PORT"
 ) >"$STDOUT_LOG" 2>"$STDERR_LOG" &
 GATEWAY_PID=$!
+GATEWAY_PGID=$GATEWAY_PID
 
 if ! wait_for_http_ok "http://127.0.0.1:${CONTROL_PORT}/healthz" "$HEALTHZ_BODY" 200 0.05; then
-  fail "timed out waiting for deferred activation control /healthz"
+  case "$WAIT_FAILURE_REASON" in
+    process-group-exited)
+      fail_phase "control-healthz" "process group exited before deferred activation control /healthz became ready"
+      ;;
+    timeout)
+      fail_phase "control-healthz" "timed out waiting for deferred activation control /healthz"
+      ;;
+    *)
+      fail_phase "control-healthz" "wait failed (${WAIT_FAILURE_REASON:-unknown})"
+      ;;
+  esac
+fi
+
+# Freeze the dedicated traced process group so the strace files stay quiescent
+# while the pre-activation snapshot and negative-match assertions run.
+if ! kill -STOP -- "-$GATEWAY_PGID" 2>/dev/null; then
+  fail_phase "park-before-snapshot" "failed to stop the dedicated process group"
+fi
+
+if ! wait_for_process_group_stopped 200 0.01; then
+  case "$WAIT_FAILURE_REASON" in
+    process-group-exited)
+      fail_phase "park-before-snapshot" "process group exited before all traced members reached the stopped state"
+      ;;
+    timeout)
+      fail_phase "park-before-snapshot" "timed out waiting for all traced members to reach the stopped state"
+      ;;
+    *)
+      fail_phase "park-before-snapshot" "wait failed (${WAIT_FAILURE_REASON:-unknown})"
+      ;;
+  esac
 fi
 
 snapshot_pre_activation_trace
@@ -193,21 +339,33 @@ assert_no_matches \
   pre_activation_gateway_port_access \
   grep -R -E -n "bind\\(.*${GATEWAY_PORT}|connect\\(.*${GATEWAY_PORT}" "$PRE_ACTIVATION_TRACE_DIR"
 
+kill -CONT -- "-$GATEWAY_PGID" 2>/dev/null || true
+
 if ! curl -fsS --max-time 2 \
   -X POST \
   -H "x-openclaw-activation-token: ${ACTIVATION_TOKEN}" \
   -H 'content-type: application/json' \
   --data '{"activationId":"state-io-proof"}' \
   "http://127.0.0.1:${CONTROL_PORT}/activate" >"$ACTIVATE_BODY"; then
-  fail "activation request failed"
+  fail_phase "activation" "activation request failed"
 fi
 
 if ! wait_for_http_ok "http://127.0.0.1:${GATEWAY_PORT}/readyz" "$READYZ_BODY" 400 0.05; then
-  fail "timed out waiting for gateway /readyz after activation"
+  case "$WAIT_FAILURE_REASON" in
+    process-group-exited)
+      fail_phase "post-activation-readyz" "process group exited before gateway /readyz became ready"
+      ;;
+    timeout)
+      fail_phase "post-activation-readyz" "timed out waiting for gateway /readyz after activation"
+      ;;
+    *)
+      fail_phase "post-activation-readyz" "wait failed (${WAIT_FAILURE_REASON:-unknown})"
+      ;;
+  esac
 fi
 
 RESULT="PASS"
-RESULT_NOTE="no pre-activation state/config/lock or gateway-port access detected in trace snapshot"
+RESULT_NOTE="no pre-activation state/config/lock or gateway-port access detected in quiesced trace snapshot"
 write_summary
 printf 'PASS: %s\n' "$RESULT_NOTE"
 print_artifact_dir

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -233,6 +233,50 @@ async function sendRawHttpRequest(
   };
 }
 
+async function openRawHttpRequest(
+  port: number,
+  request: string,
+): Promise<{
+  destroy: () => void;
+  result: Promise<{
+    closedWithError: boolean;
+    responseText: string;
+  }>;
+}> {
+  const socket = createConnection({ host: "127.0.0.1", port });
+  const responseChunks: Buffer[] = [];
+  socket.on("data", (chunk) => {
+    responseChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  });
+  socket.on("error", () => {});
+  const connected = new Promise<void>((resolve, reject) => {
+    socket.once("connect", () => resolve());
+    socket.once("error", reject);
+  });
+  const closed = new Promise<boolean>((resolve) => {
+    socket.once("close", (hadError) => resolve(hadError));
+  });
+
+  await connected;
+  await new Promise<void>((resolve, reject) => {
+    socket.write(request, (error?: Error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  return {
+    destroy: () => socket.destroy(),
+    result: closed.then((closedWithError) => ({
+      closedWithError,
+      responseText: Buffer.concat(responseChunks).toString("utf8"),
+    })),
+  };
+}
+
 function captureSignalListeners() {
   return Object.fromEntries(
     SIGNALS.map((signal) => [signal, new Set(process.listeners(signal))]),
@@ -397,6 +441,44 @@ describe("waitForDeferredGatewayActivation", () => {
     });
     await expectLoopbackListenerClosed(port);
     await expectFreshProcessEquivalentCanReuseControlPort(port, "restart-after-client-abort");
+  });
+
+  it("delivers the full 202 activation acknowledgement over a raw socket before resolving", async () => {
+    const port = await reserveLoopbackPort();
+    const { waiting } = await waitForParkedGateway(port);
+    const activationId = "activation-raw-socket";
+    const body = JSON.stringify({ activationId });
+    const rawClient = await openRawHttpRequest(
+      port,
+      [
+        "POST /activate HTTP/1.1",
+        "Host: 127.0.0.1",
+        "Connection: keep-alive",
+        "content-type: application/json",
+        `content-length: ${Buffer.byteLength(body)}`,
+        `x-openclaw-activation-token: ${TOKEN}`,
+        "",
+        body,
+      ].join("\r\n"),
+    );
+
+    try {
+      const response = await expectSettlesWithin(rawClient.result, 1_000);
+      expect(response.closedWithError).toBe(false);
+      expect(response.responseText).toContain("HTTP/1.1 202 Accepted");
+      expect(response.responseText).toContain("Connection: close");
+      expect(response.responseText).toContain(
+        `{"status":"accepted","activationId":"${activationId}"}`,
+      );
+      await expect(expectSettlesWithin(waiting, 1_000)).resolves.toEqual({
+        mode: "activated",
+        activationId,
+      });
+      await expectLoopbackListenerClosed(port);
+      await expectFreshProcessEquivalentCanReuseControlPort(port, "restart-after-raw-socket");
+    } finally {
+      rawClient.destroy();
+    }
   });
 
   it.each([

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./deferred-activation.js";
 
 const TOKEN = "activation-secret";
-const SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1"] as const;
+const SIGNALS = ["SIGTERM", "SIGINT"] as const;
 type ParkingSignal = (typeof SIGNALS)[number];
 
 function deferredActivationEnv(port: number) {
@@ -155,6 +155,45 @@ async function openPartialHeaderClient(port: number): Promise<{
   };
 }
 
+async function sendCompleteActivationThenAbort(port: number, activationId: string): Promise<void> {
+  const socket = createConnection({ host: "127.0.0.1", port });
+  socket.on("error", () => {});
+  const connected = new Promise<void>((resolve, reject) => {
+    socket.once("connect", () => resolve());
+    socket.once("error", reject);
+  });
+  const closed = new Promise<void>((resolve) => {
+    socket.once("close", () => resolve());
+  });
+  const body = JSON.stringify({ activationId });
+  const request = [
+    "POST /activate HTTP/1.1",
+    "Host: 127.0.0.1",
+    "content-type: application/json",
+    `content-length: ${Buffer.byteLength(body)}`,
+    `x-openclaw-activation-token: ${TOKEN}`,
+    "",
+    body,
+  ].join("\r\n");
+
+  await connected;
+  await new Promise<void>((resolve, reject) => {
+    socket.write(request, (error?: Error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+  if (typeof socket.resetAndDestroy === "function") {
+    socket.resetAndDestroy();
+  } else {
+    socket.destroy();
+  }
+  await closed;
+}
+
 function captureSignalListeners() {
   return Object.fromEntries(
     SIGNALS.map((signal) => [signal, new Set(process.listeners(signal))]),
@@ -186,6 +225,15 @@ function countAddedSignalListeners(
       ).length,
     ]),
   ) as Record<ParkingSignal, number>;
+}
+
+function countAddedListenersForSignal(
+  signal: NodeJS.Signals,
+  existing: Set<(...args: unknown[]) => void>,
+): number {
+  return (process.listeners(signal) as Array<(...args: unknown[]) => void>).filter(
+    (listener) => !existing.has(listener),
+  ).length;
 }
 
 afterEach(async () => {
@@ -280,6 +328,20 @@ describe("waitForDeferredGatewayActivation", () => {
     }
   });
 
+  it("commits the first valid activation even when the client aborts after sending the full request", async () => {
+    const port = await reserveLoopbackPort();
+    const { waiting } = await waitForParkedGateway(port);
+
+    await sendCompleteActivationThenAbort(port, "activation-client-abort");
+
+    await expect(expectSettlesWithin(waiting, 1_000)).resolves.toEqual({
+      mode: "activated",
+      activationId: "activation-client-abort",
+    });
+    await expectLoopbackListenerClosed(port);
+    await expectFreshProcessEquivalentCanReuseControlPort(port, "restart-after-client-abort");
+  });
+
   it.each([
     ["missing", {}, 400],
     ["non-string", { activationId: 7 }, 400],
@@ -340,6 +402,32 @@ describe("waitForDeferredGatewayActivation", () => {
     });
   });
 
+  it("parks only SIGTERM and SIGINT temporary listeners", async () => {
+    const signalListeners = captureSignalListeners();
+    const sigusr1Listeners = new Set(
+      process.listeners("SIGUSR1") as Array<(...args: unknown[]) => void>,
+    );
+    const port = await reserveLoopbackPort();
+    const { waiting } = await waitForParkedGateway(port);
+
+    try {
+      expect(countAddedSignalListeners(signalListeners)).toEqual({
+        SIGTERM: 1,
+        SIGINT: 1,
+      });
+      expect(countAddedListenersForSignal("SIGUSR1", sigusr1Listeners)).toBe(0);
+      expect((await postActivate(port, TOKEN, { activationId: "cleanup-signals" })).status).toBe(
+        202,
+      );
+      await expect(waiting).resolves.toEqual({
+        mode: "activated",
+        activationId: "cleanup-signals",
+      });
+    } finally {
+      await resetDeferredGatewayActivationForTest();
+    }
+  });
+
   it.each(["SIGTERM", "SIGINT"] as const)(
     "re-signals %s only after cleanup and listener close, even with a slow parked socket",
     async (signal) => {
@@ -351,7 +439,6 @@ describe("waitForDeferredGatewayActivation", () => {
         expect(countAddedSignalListeners(signalListeners)).toEqual({
           SIGTERM: 0,
           SIGINT: 0,
-          SIGUSR1: 0,
         });
         killPortReuse.current = expectPortReusable(port);
         return true;
@@ -364,7 +451,6 @@ describe("waitForDeferredGatewayActivation", () => {
         expect(countAddedSignalListeners(signalListeners)).toEqual({
           SIGTERM: 1,
           SIGINT: 1,
-          SIGUSR1: 1,
         });
 
         const addedSignalListener = findAddedSignalListener(signal, signalListeners[signal]);
@@ -379,7 +465,6 @@ describe("waitForDeferredGatewayActivation", () => {
         expect(countAddedSignalListeners(signalListeners)).toEqual({
           SIGTERM: 0,
           SIGINT: 0,
-          SIGUSR1: 0,
         });
         await expectFreshProcessEquivalentCanReuseControlPort(port, `restart-${signal}`);
       } finally {
@@ -387,37 +472,4 @@ describe("waitForDeferredGatewayActivation", () => {
       }
     },
   );
-
-  it("rejects SIGUSR1 without re-signaling and closes slow parked sockets", async () => {
-    const signalListeners = captureSignalListeners();
-    const killSpy = vi.spyOn(process, "kill");
-    const port = await reserveLoopbackPort();
-    const { waiting } = await waitForParkedGateway(port);
-    const slowClient = await openPartialHeaderClient(port);
-
-    try {
-      expect(countAddedSignalListeners(signalListeners)).toEqual({
-        SIGTERM: 1,
-        SIGINT: 1,
-        SIGUSR1: 1,
-      });
-
-      const addedSignalListener = findAddedSignalListener("SIGUSR1", signalListeners.SIGUSR1);
-      expect(addedSignalListener).not.toBeNull();
-      addedSignalListener?.();
-
-      await expect(waiting).rejects.toThrow("deferred activation interrupted by SIGUSR1");
-      expect(killSpy).not.toHaveBeenCalled();
-      await expect(expectSettlesWithin(slowClient.closed, 1_000)).resolves.toBeUndefined();
-      await expectLoopbackListenerClosed(port);
-      expect(countAddedSignalListeners(signalListeners)).toEqual({
-        SIGTERM: 0,
-        SIGINT: 0,
-        SIGUSR1: 0,
-      });
-      await expectFreshProcessEquivalentCanReuseControlPort(port, "restart-SIGUSR1");
-    } finally {
-      slowClient.destroy();
-    }
-  });
 });

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -306,26 +306,44 @@ describe("waitForDeferredGatewayActivation", () => {
     ).rejects.toThrow("invalid deferred activation control port");
   });
 
-  it.each(["", " \t "])(
-    "rejects %j control token before preload or listener bind",
-    async (controlToken) => {
-      const port = await reserveLoopbackPort();
-      const preload = vi.fn(async () => undefined);
+  it.each([
+    ["empty", ""],
+    ["all-whitespace", " \t "],
+    ["leading space", ` ${TOKEN}`],
+    ["trailing space", `${TOKEN} `],
+    ["carriage return", "activation\rsecret"],
+    ["line feed", "activation\nsecret"],
+    ["NUL", "activation\u0000secret"],
+    ["DEL", "activation\u007fsecret"],
+  ])("rejects %s control token before preload or listener bind", async (_name, controlToken) => {
+    const port = await reserveLoopbackPort();
+    const preload = vi.fn(async () => undefined);
 
-      await expect(
-        waitForDeferredGatewayActivation({
-          env: {
-            OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
-            OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: controlToken,
-          },
-          preload,
-        }),
-      ).rejects.toThrow("deferred activation control token must be non-empty");
+    await expect(
+      waitForDeferredGatewayActivation({
+        env: {
+          OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
+          OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: controlToken,
+        },
+        preload,
+      }),
+    ).rejects.toThrow("invalid deferred activation control token");
 
-      expect(preload).not.toHaveBeenCalled();
-      await expectPortReusable(port);
-    },
-  );
+    expect(preload).not.toHaveBeenCalled();
+    await expectPortReusable(port);
+  });
+
+  it("accepts the existing control token bytes without normalization", async () => {
+    const port = await reserveLoopbackPort();
+    const { waiting } = await waitForParkedGateway(port);
+
+    const accepted = await postActivate(port, TOKEN, { activationId: "exact-token-bytes" });
+    expect(accepted.status).toBe(202);
+    await expect(waiting).resolves.toEqual({
+      mode: "activated",
+      activationId: "exact-token-bytes",
+    });
+  });
 
   it("parks until one authenticated bounded activation", async () => {
     const port = await reserveLoopbackPort();
@@ -552,6 +570,44 @@ describe("waitForDeferredGatewayActivation", () => {
       writeHeadSpy.mockRestore();
     }
   });
+
+  it.each(["SIGTERM", "SIGINT"] as const)(
+    "rejects %s immediately after waitForDeferredGatewayActivation returns, before any listening await",
+    async (signal) => {
+      const signalListeners = captureSignalListeners();
+      const killPortReuse: { current: Promise<void> | null } = { current: null };
+      const port = await reserveLoopbackPort();
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid, resentSignal) => {
+        expect(pid).toBe(process.pid);
+        expect(resentSignal).toBe(signal);
+        expect(countAddedSignalListeners(signalListeners)).toEqual({
+          SIGTERM: 0,
+          SIGINT: 0,
+        });
+        killPortReuse.current = expectPortReusable(port);
+        return true;
+      }) as typeof process.kill);
+
+      const waiting = waitForDeferredGatewayActivation({ env: deferredActivationEnv(port) });
+      expect(countAddedSignalListeners(signalListeners)).toEqual({
+        SIGTERM: 1,
+        SIGINT: 1,
+      });
+
+      const addedSignalListener = findAddedSignalListener(signal, signalListeners[signal]);
+      expect(addedSignalListener).not.toBeNull();
+      addedSignalListener?.();
+
+      await expect(waiting).rejects.toThrow(`deferred activation interrupted by ${signal}`);
+      expect(killSpy).toHaveBeenCalledWith(process.pid, signal);
+      await expect(killPortReuse.current).resolves.toBeUndefined();
+      expect(countAddedSignalListeners(signalListeners)).toEqual({
+        SIGTERM: 0,
+        SIGINT: 0,
+      });
+      await expectFreshProcessEquivalentCanReuseControlPort(port, `restart-immediate-${signal}`);
+    },
+  );
 
   it.each(["SIGTERM", "SIGINT"] as const)(
     "re-signals %s only after cleanup and listener close, even with a slow parked socket",

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -9,6 +9,13 @@ const TOKEN = "activation-secret";
 const SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1"] as const;
 type ParkingSignal = (typeof SIGNALS)[number];
 
+function deferredActivationEnv(port: number) {
+  return {
+    OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
+    OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
+  };
+}
+
 async function reserveLoopbackPort(): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
     const server = createServer();
@@ -46,6 +53,39 @@ async function postActivate(port: number, token: string, body: unknown) {
     },
     body: JSON.stringify(body),
   });
+}
+
+async function waitForParkedGateway(port: number): Promise<{
+  waiting: ReturnType<typeof waitForDeferredGatewayActivation>;
+}> {
+  const waiting = waitForDeferredGatewayActivation({
+    env: deferredActivationEnv(port),
+  });
+  await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+  return { waiting };
+}
+
+async function expectLoopbackListenerClosed(port: number): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      await fetch(`http://127.0.0.1:${port}/healthz`);
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`expected loopback listener on ${port} to close`);
+}
+
+async function expectFreshProcessEquivalentCanReuseControlPort(
+  port: number,
+  activationId: string,
+): Promise<void> {
+  await resetDeferredGatewayActivationForTest();
+  const { waiting } = await waitForParkedGateway(port);
+  expect((await fetch(`http://127.0.0.1:${port}/healthz`)).status).toBe(200);
+  expect((await postActivate(port, TOKEN, { activationId })).status).toBe(202);
+  await expect(waiting).resolves.toEqual({ mode: "activated", activationId });
 }
 
 function captureSignalListeners() {
@@ -113,13 +153,7 @@ describe("waitForDeferredGatewayActivation", () => {
 
   it("parks until one authenticated bounded activation", async () => {
     const port = await reserveLoopbackPort();
-    const waiting = waitForDeferredGatewayActivation({
-      env: {
-        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
-        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
-      },
-    });
-    await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+    const { waiting } = await waitForParkedGateway(port);
 
     expect((await fetch(`http://127.0.0.1:${port}/healthz`)).status).toBe(200);
     expect((await fetch(`http://127.0.0.1:${port}/readyz`)).status).toBe(503);
@@ -140,13 +174,8 @@ describe("waitForDeferredGatewayActivation", () => {
     ["id too large", { activationId: "a".repeat(257) }, 400],
   ])("rejects %s activation ids and remains parked", async (_name, body, status) => {
     const port = await reserveLoopbackPort();
-    const waiting = waitForDeferredGatewayActivation({
-      env: {
-        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
-        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
-      },
-    });
-    await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+    const { waiting } = await waitForParkedGateway(port);
+
     expect((await postActivate(port, TOKEN, body)).status).toBe(status);
     expect((await fetch(`http://127.0.0.1:${port}/healthz`)).status).toBe(200);
     expect((await postActivate(port, TOKEN, { activationId: "cleanup" })).status).toBe(202);
@@ -155,13 +184,8 @@ describe("waitForDeferredGatewayActivation", () => {
 
   it("rejects a body over 16 KiB and remains parked", async () => {
     const port = await reserveLoopbackPort();
-    const waiting = waitForDeferredGatewayActivation({
-      env: {
-        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
-        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
-      },
-    });
-    await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+    const { waiting } = await waitForParkedGateway(port);
+
     const response = await fetch(`http://127.0.0.1:${port}/activate`, {
       method: "POST",
       headers: {
@@ -178,13 +202,7 @@ describe("waitForDeferredGatewayActivation", () => {
 
   it("accepts only one concurrent activation request", async () => {
     const port = await reserveLoopbackPort();
-    const waiting = waitForDeferredGatewayActivation({
-      env: {
-        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
-        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
-      },
-    });
-    await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+    const { waiting } = await waitForParkedGateway(port);
 
     const requests = await Promise.allSettled([
       postActivate(port, TOKEN, { activationId: "activation-1" }),
@@ -209,32 +227,31 @@ describe("waitForDeferredGatewayActivation", () => {
     });
   });
 
-  it("rejects parking on SIGTERM and removes temporary signal handlers", async () => {
-    const signalListeners = captureSignalListeners();
-    const port = await reserveLoopbackPort();
-    const waiting = waitForDeferredGatewayActivation({
-      env: {
-        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
-        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
-      },
-    });
-    await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+  it.each(SIGNALS)(
+    "rejects parking on %s, removes temporary handlers, and allows same-port reuse",
+    async (signal) => {
+      const signalListeners = captureSignalListeners();
+      const port = await reserveLoopbackPort();
+      const { waiting } = await waitForParkedGateway(port);
 
-    expect(countAddedSignalListeners(signalListeners)).toEqual({
-      SIGTERM: 1,
-      SIGINT: 1,
-      SIGUSR1: 1,
-    });
+      expect(countAddedSignalListeners(signalListeners)).toEqual({
+        SIGTERM: 1,
+        SIGINT: 1,
+        SIGUSR1: 1,
+      });
 
-    const sigterm = findAddedSignalListener("SIGTERM", signalListeners.SIGTERM);
-    expect(sigterm).not.toBeNull();
-    sigterm?.();
+      const addedSignalListener = findAddedSignalListener(signal, signalListeners[signal]);
+      expect(addedSignalListener).not.toBeNull();
+      addedSignalListener?.();
 
-    await expect(waiting).rejects.toThrow("deferred activation interrupted by SIGTERM");
-    expect(countAddedSignalListeners(signalListeners)).toEqual({
-      SIGTERM: 0,
-      SIGINT: 0,
-      SIGUSR1: 0,
-    });
-  });
+      await expect(waiting).rejects.toThrow(`deferred activation interrupted by ${signal}`);
+      expect(countAddedSignalListeners(signalListeners)).toEqual({
+        SIGTERM: 0,
+        SIGINT: 0,
+        SIGUSR1: 0,
+      });
+      await expectLoopbackListenerClosed(port);
+      await expectFreshProcessEquivalentCanReuseControlPort(port, `restart-${signal}`);
+    },
+  );
 });

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -1,0 +1,240 @@
+import { createServer } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resetDeferredGatewayActivationForTest,
+  waitForDeferredGatewayActivation,
+} from "./deferred-activation.js";
+
+const TOKEN = "activation-secret";
+const SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1"] as const;
+type ParkingSignal = (typeof SIGNALS)[number];
+
+async function reserveLoopbackPort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("expected TCP address"));
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+}
+
+async function waitForHttp(url: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (response.status < 500) return;
+    } catch {
+      // Listener is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${url}`);
+}
+
+async function postActivate(port: number, token: string, body: unknown) {
+  return await fetch(`http://127.0.0.1:${port}/activate`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-openclaw-activation-token": token,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function captureSignalListeners() {
+  return Object.fromEntries(
+    SIGNALS.map((signal) => [signal, new Set(process.listeners(signal))]),
+  ) as Record<ParkingSignal, Set<(...args: unknown[]) => void>>;
+}
+
+function findAddedSignalListener(
+  signal: ParkingSignal,
+  existing: Set<(...args: unknown[]) => void>,
+): (() => void) | null {
+  const listeners = process.listeners(signal) as Array<(...args: unknown[]) => void>;
+  for (let index = listeners.length - 1; index >= 0; index -= 1) {
+    const listener = listeners[index];
+    if (listener && !existing.has(listener)) {
+      return listener as () => void;
+    }
+  }
+  return null;
+}
+
+function countAddedSignalListeners(
+  existing: Record<ParkingSignal, Set<(...args: unknown[]) => void>>,
+): Record<ParkingSignal, number> {
+  return Object.fromEntries(
+    SIGNALS.map((signal) => [
+      signal,
+      (process.listeners(signal) as Array<(...args: unknown[]) => void>).filter(
+        (listener) => !existing[signal].has(listener),
+      ).length,
+    ]),
+  ) as Record<ParkingSignal, number>;
+}
+
+afterEach(async () => {
+  await resetDeferredGatewayActivationForTest();
+});
+
+describe("waitForDeferredGatewayActivation", () => {
+  it("is disabled only when both control variables are absent", async () => {
+    await expect(waitForDeferredGatewayActivation({ env: {} })).resolves.toEqual({
+      mode: "disabled",
+    });
+  });
+
+  it("rejects a half-configured control surface", async () => {
+    await expect(
+      waitForDeferredGatewayActivation({
+        env: { OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN },
+      }),
+    ).rejects.toThrow("control port and token must be configured together");
+  });
+
+  it.each(["0", "65536", "NaN"])("rejects invalid control port %s", async (port) => {
+    await expect(
+      waitForDeferredGatewayActivation({
+        env: {
+          OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: port,
+          OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
+        },
+      }),
+    ).rejects.toThrow("invalid deferred activation control port");
+  });
+
+  it("parks until one authenticated bounded activation", async () => {
+    const port = await reserveLoopbackPort();
+    const waiting = waitForDeferredGatewayActivation({
+      env: {
+        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
+        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
+      },
+    });
+    await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+
+    expect((await fetch(`http://127.0.0.1:${port}/healthz`)).status).toBe(200);
+    expect((await fetch(`http://127.0.0.1:${port}/readyz`)).status).toBe(503);
+    expect((await postActivate(port, "wrong", { activationId: "a" })).status).toBe(401);
+
+    const accepted = await postActivate(port, TOKEN, { activationId: "activation-1" });
+    expect(accepted.status).toBe(202);
+    await expect(waiting).resolves.toEqual({
+      mode: "activated",
+      activationId: "activation-1",
+    });
+  });
+
+  it.each([
+    ["missing", {}, 400],
+    ["non-string", { activationId: 7 }, 400],
+    ["empty", { activationId: "" }, 400],
+    ["id too large", { activationId: "a".repeat(257) }, 400],
+  ])("rejects %s activation ids and remains parked", async (_name, body, status) => {
+    const port = await reserveLoopbackPort();
+    const waiting = waitForDeferredGatewayActivation({
+      env: {
+        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
+        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
+      },
+    });
+    await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+    expect((await postActivate(port, TOKEN, body)).status).toBe(status);
+    expect((await fetch(`http://127.0.0.1:${port}/healthz`)).status).toBe(200);
+    expect((await postActivate(port, TOKEN, { activationId: "cleanup" })).status).toBe(202);
+    await expect(waiting).resolves.toEqual({ mode: "activated", activationId: "cleanup" });
+  });
+
+  it("rejects a body over 16 KiB and remains parked", async () => {
+    const port = await reserveLoopbackPort();
+    const waiting = waitForDeferredGatewayActivation({
+      env: {
+        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
+        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
+      },
+    });
+    await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+    const response = await fetch(`http://127.0.0.1:${port}/activate`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-openclaw-activation-token": TOKEN,
+      },
+      body: JSON.stringify({ activationId: "a".repeat(17 * 1024) }),
+    });
+    expect(response.status).toBe(413);
+    expect((await fetch(`http://127.0.0.1:${port}/healthz`)).status).toBe(200);
+    expect((await postActivate(port, TOKEN, { activationId: "cleanup" })).status).toBe(202);
+    await expect(waiting).resolves.toEqual({ mode: "activated", activationId: "cleanup" });
+  });
+
+  it("accepts only one concurrent activation request", async () => {
+    const port = await reserveLoopbackPort();
+    const waiting = waitForDeferredGatewayActivation({
+      env: {
+        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
+        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
+      },
+    });
+    await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+
+    const requests = await Promise.allSettled([
+      postActivate(port, TOKEN, { activationId: "activation-1" }),
+      postActivate(port, TOKEN, { activationId: "activation-2" }),
+    ]);
+    const acceptedResponses = requests.filter(
+      (request): request is PromiseFulfilledResult<Response> =>
+        request.status === "fulfilled" && request.value.status === 202,
+    );
+
+    expect(acceptedResponses).toHaveLength(1);
+    expect(
+      requests.filter((request) => request.status === "rejected" || request.value.status !== 202),
+    ).toHaveLength(1);
+
+    const acceptedBody = (await acceptedResponses[0].value.json()) as {
+      activationId: string;
+    };
+    await expect(waiting).resolves.toEqual({
+      mode: "activated",
+      activationId: acceptedBody.activationId,
+    });
+  });
+
+  it("rejects parking on SIGTERM and removes temporary signal handlers", async () => {
+    const signalListeners = captureSignalListeners();
+    const port = await reserveLoopbackPort();
+    const waiting = waitForDeferredGatewayActivation({
+      env: {
+        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
+        OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: TOKEN,
+      },
+    });
+    await waitForHttp(`http://127.0.0.1:${port}/healthz`);
+
+    expect(countAddedSignalListeners(signalListeners)).toEqual({
+      SIGTERM: 1,
+      SIGINT: 1,
+      SIGUSR1: 1,
+    });
+
+    const sigterm = findAddedSignalListener("SIGTERM", signalListeners.SIGTERM);
+    expect(sigterm).not.toBeNull();
+    sigterm?.();
+
+    await expect(waiting).rejects.toThrow("deferred activation interrupted by SIGTERM");
+    expect(countAddedSignalListeners(signalListeners)).toEqual({
+      SIGTERM: 0,
+      SIGINT: 0,
+      SIGUSR1: 0,
+    });
+  });
+});

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -654,6 +654,49 @@ describe("waitForDeferredGatewayActivation", () => {
   });
 
   it.each(["SIGTERM", "SIGINT"] as const)(
+    "does not re-signal %s when a prior listener already received the real signal",
+    async (signal) => {
+      const externalListener = vi.fn();
+      process.on(signal, externalListener);
+      const signalListeners = captureSignalListeners();
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid) => {
+        expect(pid).toBe(process.pid);
+        return true;
+      }) as typeof process.kill);
+      const port = await reserveLoopbackPort();
+      const { waiting } = await waitForParkedGateway(port);
+
+      try {
+        expect(countAddedSignalListeners(signalListeners)).toEqual({
+          SIGTERM: 1,
+          SIGINT: 1,
+        });
+
+        const addedSignalListener = findAddedSignalListener(signal, signalListeners[signal]);
+        expect(addedSignalListener).not.toBeNull();
+
+        externalListener();
+        addedSignalListener?.();
+
+        await expect(waiting).rejects.toThrow(`deferred activation interrupted by ${signal}`);
+        expect(externalListener).toHaveBeenCalledTimes(1);
+        expect(killSpy).not.toHaveBeenCalled();
+        expect(countAddedSignalListeners(signalListeners)).toEqual({
+          SIGTERM: 0,
+          SIGINT: 0,
+        });
+        await expectLoopbackListenerClosed(port);
+        await expectFreshProcessEquivalentCanReuseControlPort(
+          port,
+          `restart-no-resignal-${signal}`,
+        );
+      } finally {
+        process.removeListener(signal, externalListener);
+      }
+    },
+  );
+
+  it.each(["SIGTERM", "SIGINT"] as const)(
     "rejects %s immediately after waitForDeferredGatewayActivation returns, before any listening await",
     async (signal) => {
       const signalListeners = captureSignalListeners();

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -195,6 +195,44 @@ async function sendCompleteActivationThenAbort(port: number, activationId: strin
   await closed;
 }
 
+async function sendRawHttpRequest(
+  port: number,
+  request: string,
+): Promise<{
+  closedWithError: boolean;
+  responseText: string;
+}> {
+  const socket = createConnection({ host: "127.0.0.1", port });
+  const responseChunks: Buffer[] = [];
+  socket.on("data", (chunk) => {
+    responseChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  });
+  socket.on("error", () => {});
+  const connected = new Promise<void>((resolve, reject) => {
+    socket.once("connect", () => resolve());
+    socket.once("error", reject);
+  });
+  const closed = new Promise<boolean>((resolve) => {
+    socket.once("close", (hadError) => resolve(hadError));
+  });
+
+  await connected;
+  await new Promise<void>((resolve, reject) => {
+    socket.end(request, (error?: Error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  return {
+    closedWithError: await closed,
+    responseText: Buffer.concat(responseChunks).toString("utf8"),
+  };
+}
+
 function captureSignalListeners() {
   return Object.fromEntries(
     SIGNALS.map((signal) => [signal, new Set(process.listeners(signal))]),
@@ -374,6 +412,44 @@ describe("waitForDeferredGatewayActivation", () => {
     expect((await fetch(`http://127.0.0.1:${port}/healthz`)).status).toBe(200);
     expect((await postActivate(port, TOKEN, { activationId: "cleanup" })).status).toBe(202);
     await expect(waiting).resolves.toEqual({ mode: "activated", activationId: "cleanup" });
+  });
+
+  it("rejects malformed absolute-form request targets without closing the control listener", async () => {
+    const port = await reserveLoopbackPort();
+    const { waiting } = await waitForParkedGateway(port);
+    const activationBody = JSON.stringify({ activationId: "ignored-malformed-target" });
+
+    const malformedResponse = await sendRawHttpRequest(
+      port,
+      [
+        "POST http://%zz/activate HTTP/1.1",
+        "Host: 127.0.0.1",
+        "content-type: application/json",
+        `content-length: ${Buffer.byteLength(activationBody)}`,
+        `x-openclaw-activation-token: ${TOKEN}`,
+        "Connection: close",
+        "",
+        activationBody,
+      ].join("\r\n"),
+    );
+
+    expect(malformedResponse.closedWithError).toBe(false);
+    expect(malformedResponse.responseText).toContain("HTTP/1.1 400 Bad Request");
+    expect(malformedResponse.responseText).toContain('{"error":"invalid request target"}');
+    expect((await fetch(`http://127.0.0.1:${port}/healthz`)).status).toBe(200);
+
+    const accepted = await postActivate(port, TOKEN, {
+      activationId: "activation-after-malformed-target",
+    });
+    expect(accepted.status).toBe(202);
+    await expect(accepted.json()).resolves.toEqual({
+      status: "accepted",
+      activationId: "activation-after-malformed-target",
+    });
+    await expect(waiting).resolves.toEqual({
+      mode: "activated",
+      activationId: "activation-after-malformed-target",
+    });
   });
 
   it("accepts only one concurrent activation request", async () => {

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -1,3 +1,4 @@
+import { ServerResponse } from "node:http";
 import { createConnection, createServer } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -425,6 +426,54 @@ describe("waitForDeferredGatewayActivation", () => {
       });
     } finally {
       await resetDeferredGatewayActivationForTest();
+    }
+  });
+
+  it("removes temporary SIGTERM/SIGINT listeners synchronously before writing the accepted 202", async () => {
+    const signalListeners = captureSignalListeners();
+    const originalWriteHead = Object.getOwnPropertyDescriptor(
+      ServerResponse.prototype,
+      "writeHead",
+    )?.value;
+    if (originalWriteHead === undefined) {
+      throw new Error("expected ServerResponse.writeHead");
+    }
+    const writeHeadSpy = vi
+      .spyOn(ServerResponse.prototype, "writeHead")
+      .mockImplementation(function (
+        ...args: Parameters<typeof ServerResponse.prototype.writeHead>
+      ) {
+        if (args[0] === 202) {
+          expect(countAddedSignalListeners(signalListeners)).toEqual({
+            SIGTERM: 0,
+            SIGINT: 0,
+          });
+        }
+        return Reflect.apply(originalWriteHead, this, args);
+      });
+    const port = await reserveLoopbackPort();
+    const { waiting } = await waitForParkedGateway(port);
+
+    try {
+      expect(countAddedSignalListeners(signalListeners)).toEqual({
+        SIGTERM: 1,
+        SIGINT: 1,
+      });
+
+      const accepted = await postActivate(port, TOKEN, {
+        activationId: "cleanup-before-accepted-response",
+      });
+      expect(accepted.status).toBe(202);
+      expect(countAddedSignalListeners(signalListeners)).toEqual({
+        SIGTERM: 0,
+        SIGINT: 0,
+      });
+      await expect(waiting).resolves.toEqual({
+        mode: "activated",
+        activationId: "cleanup-before-accepted-response",
+      });
+    } finally {
+      writeHeadSpy.mockRestore();
     }
   });
 

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -1,5 +1,5 @@
-import { createServer } from "node:net";
-import { afterEach, describe, expect, it } from "vitest";
+import { createConnection, createServer } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   resetDeferredGatewayActivationForTest,
   waitForDeferredGatewayActivation,
@@ -100,6 +100,61 @@ async function expectFreshProcessEquivalentCanReuseControlPort(
   await expect(waiting).resolves.toEqual({ mode: "activated", activationId });
 }
 
+async function expectSettlesWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function expectPortReusable(port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+}
+
+async function openPartialHeaderClient(port: number): Promise<{
+  destroy: () => void;
+  closed: Promise<void>;
+}> {
+  const socket = createConnection({ host: "127.0.0.1", port });
+  socket.on("error", () => {});
+  const connected = new Promise<void>((resolve, reject) => {
+    socket.once("connect", () => resolve());
+    socket.once("error", reject);
+  });
+  const closed = new Promise<void>((resolve) => {
+    socket.once("close", () => resolve());
+  });
+  await connected;
+  socket.write("GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\n");
+  return {
+    destroy: () => socket.destroy(),
+    closed,
+  };
+}
+
 function captureSignalListeners() {
   return Object.fromEntries(
     SIGNALS.map((signal) => [signal, new Set(process.listeners(signal))]),
@@ -134,6 +189,7 @@ function countAddedSignalListeners(
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await resetDeferredGatewayActivationForTest();
 });
 
@@ -163,6 +219,27 @@ describe("waitForDeferredGatewayActivation", () => {
     ).rejects.toThrow("invalid deferred activation control port");
   });
 
+  it.each(["", " \t "])(
+    "rejects %j control token before preload or listener bind",
+    async (controlToken) => {
+      const port = await reserveLoopbackPort();
+      const preload = vi.fn(async () => undefined);
+
+      await expect(
+        waitForDeferredGatewayActivation({
+          env: {
+            OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT: String(port),
+            OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN: controlToken,
+          },
+          preload,
+        }),
+      ).rejects.toThrow("deferred activation control token must be non-empty");
+
+      expect(preload).not.toHaveBeenCalled();
+      await expectPortReusable(port);
+    },
+  );
+
   it("parks until one authenticated bounded activation", async () => {
     const port = await reserveLoopbackPort();
     const { waiting } = await waitForParkedGateway(port);
@@ -177,6 +254,30 @@ describe("waitForDeferredGatewayActivation", () => {
       mode: "activated",
       activationId: "activation-1",
     });
+  });
+
+  it("resolves accepted activation promptly even when a slow partial-header socket is parked", async () => {
+    const port = await reserveLoopbackPort();
+    const { waiting } = await waitForParkedGateway(port);
+    const slowClient = await openPartialHeaderClient(port);
+
+    try {
+      const accepted = await postActivate(port, TOKEN, { activationId: "activation-slow-socket" });
+      expect(accepted.status).toBe(202);
+      await expect(accepted.json()).resolves.toEqual({
+        status: "accepted",
+        activationId: "activation-slow-socket",
+      });
+      await expect(expectSettlesWithin(waiting, 1_000)).resolves.toEqual({
+        mode: "activated",
+        activationId: "activation-slow-socket",
+      });
+      await expect(expectSettlesWithin(slowClient.closed, 1_000)).resolves.toBeUndefined();
+      await expectLoopbackListenerClosed(port);
+      await expectFreshProcessEquivalentCanReuseControlPort(port, "restart-after-slow-socket");
+    } finally {
+      slowClient.destroy();
+    }
   });
 
   it.each([
@@ -239,31 +340,84 @@ describe("waitForDeferredGatewayActivation", () => {
     });
   });
 
-  it.each(SIGNALS)(
-    "rejects parking on %s, removes temporary handlers, and allows same-port reuse",
+  it.each(["SIGTERM", "SIGINT"] as const)(
+    "re-signals %s only after cleanup and listener close, even with a slow parked socket",
     async (signal) => {
       const signalListeners = captureSignalListeners();
+      const killPortReuse: { current: Promise<void> | null } = { current: null };
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid, resentSignal) => {
+        expect(pid).toBe(process.pid);
+        expect(resentSignal).toBe(signal);
+        expect(countAddedSignalListeners(signalListeners)).toEqual({
+          SIGTERM: 0,
+          SIGINT: 0,
+          SIGUSR1: 0,
+        });
+        killPortReuse.current = expectPortReusable(port);
+        return true;
+      }) as typeof process.kill);
       const port = await reserveLoopbackPort();
       const { waiting } = await waitForParkedGateway(port);
+      const slowClient = await openPartialHeaderClient(port);
 
+      try {
+        expect(countAddedSignalListeners(signalListeners)).toEqual({
+          SIGTERM: 1,
+          SIGINT: 1,
+          SIGUSR1: 1,
+        });
+
+        const addedSignalListener = findAddedSignalListener(signal, signalListeners[signal]);
+        expect(addedSignalListener).not.toBeNull();
+        addedSignalListener?.();
+
+        await expect(waiting).rejects.toThrow(`deferred activation interrupted by ${signal}`);
+        expect(killSpy).toHaveBeenCalledWith(process.pid, signal);
+        await expect(expectSettlesWithin(slowClient.closed, 1_000)).resolves.toBeUndefined();
+        await expectLoopbackListenerClosed(port);
+        await expect(killPortReuse.current).resolves.toBeUndefined();
+        expect(countAddedSignalListeners(signalListeners)).toEqual({
+          SIGTERM: 0,
+          SIGINT: 0,
+          SIGUSR1: 0,
+        });
+        await expectFreshProcessEquivalentCanReuseControlPort(port, `restart-${signal}`);
+      } finally {
+        slowClient.destroy();
+      }
+    },
+  );
+
+  it("rejects SIGUSR1 without re-signaling and closes slow parked sockets", async () => {
+    const signalListeners = captureSignalListeners();
+    const killSpy = vi.spyOn(process, "kill");
+    const port = await reserveLoopbackPort();
+    const { waiting } = await waitForParkedGateway(port);
+    const slowClient = await openPartialHeaderClient(port);
+
+    try {
       expect(countAddedSignalListeners(signalListeners)).toEqual({
         SIGTERM: 1,
         SIGINT: 1,
         SIGUSR1: 1,
       });
 
-      const addedSignalListener = findAddedSignalListener(signal, signalListeners[signal]);
+      const addedSignalListener = findAddedSignalListener("SIGUSR1", signalListeners.SIGUSR1);
       expect(addedSignalListener).not.toBeNull();
       addedSignalListener?.();
 
-      await expect(waiting).rejects.toThrow(`deferred activation interrupted by ${signal}`);
+      await expect(waiting).rejects.toThrow("deferred activation interrupted by SIGUSR1");
+      expect(killSpy).not.toHaveBeenCalled();
+      await expect(expectSettlesWithin(slowClient.closed, 1_000)).resolves.toBeUndefined();
+      await expectLoopbackListenerClosed(port);
       expect(countAddedSignalListeners(signalListeners)).toEqual({
         SIGTERM: 0,
         SIGINT: 0,
         SIGUSR1: 0,
       });
-      await expectLoopbackListenerClosed(port);
-      await expectFreshProcessEquivalentCanReuseControlPort(port, `restart-${signal}`);
-    },
-  );
+      await expectFreshProcessEquivalentCanReuseControlPort(port, "restart-SIGUSR1");
+    } finally {
+      slowClient.destroy();
+    }
+  });
 });

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -178,13 +178,9 @@ async function sendCompleteActivationThenAbort(port: number, activationId: strin
   ].join("\r\n");
 
   await connected;
-  await new Promise<void>((resolve, reject) => {
-    socket.write(request, (error?: Error) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
-      }
+  await new Promise<void>((resolve) => {
+    socket.write(request, () => {
+      resolve();
     });
   });
   if (typeof socket.resetAndDestroy === "function") {
@@ -217,13 +213,9 @@ async function sendRawHttpRequest(
   });
 
   await connected;
-  await new Promise<void>((resolve, reject) => {
-    socket.end(request, (error?: Error) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
-      }
+  await new Promise<void>((resolve) => {
+    socket.end(request, () => {
+      resolve();
     });
   });
 
@@ -258,13 +250,9 @@ async function openRawHttpRequest(
   });
 
   await connected;
-  await new Promise<void>((resolve, reject) => {
-    socket.write(request, (error?: Error) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
-      }
+  await new Promise<void>((resolve) => {
+    socket.write(request, () => {
+      resolve();
     });
   });
 
@@ -617,6 +605,7 @@ describe("waitForDeferredGatewayActivation", () => {
     const writeHeadSpy = vi
       .spyOn(ServerResponse.prototype, "writeHead")
       .mockImplementation(function (
+        this: ServerResponse,
         ...args: Parameters<typeof ServerResponse.prototype.writeHead>
       ) {
         if (args[0] === 202) {

--- a/src/cli/gateway-cli/deferred-activation.test.ts
+++ b/src/cli/gateway-cli/deferred-activation.test.ts
@@ -26,7 +26,13 @@ async function reserveLoopbackPort(): Promise<number> {
         reject(new Error("expected TCP address"));
         return;
       }
-      server.close((error) => (error ? reject(error) : resolve(address.port)));
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(address.port);
+        }
+      });
     });
   });
 }
@@ -35,11 +41,15 @@ async function waitForHttp(url: string): Promise<void> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     try {
       const response = await fetch(url);
-      if (response.status < 500) return;
+      if (response.status < 500) {
+        return;
+      }
     } catch {
       // Listener is still starting.
     }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
   }
   throw new Error(`timed out waiting for ${url}`);
 }
@@ -72,7 +82,9 @@ async function expectLoopbackListenerClosed(port: number): Promise<void> {
     } catch {
       return;
     }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
   }
   throw new Error(`expected loopback listener on ${port} to close`);
 }

--- a/src/cli/gateway-cli/deferred-activation.ts
+++ b/src/cli/gateway-cli/deferred-activation.ts
@@ -145,6 +145,7 @@ async function waitForDeferredGatewayActivationOnce(
   return await new Promise<DeferredActivationResult>((resolve, reject) => {
     let state: "open" | "closing" | "accepted" | "settled" = "open";
     const signalHandlers = new Map<ShutdownSignal, () => void>();
+    const signalHadPreexistingListeners = new Map<ShutdownSignal, boolean>();
     const trackedSockets = new Set<Socket>();
 
     const settleResolve = (result: DeferredActivationResult) => {
@@ -257,10 +258,15 @@ async function waitForDeferredGatewayActivationOnce(
       if (state !== "open") {
         return;
       }
-      closeServerAndReject(new Error(`deferred activation interrupted by ${signal}`), signal);
+      const hadPreexistingListeners = signalHadPreexistingListeners.get(signal) ?? false;
+      closeServerAndReject(
+        new Error(`deferred activation interrupted by ${signal}`),
+        hadPreexistingListeners ? undefined : signal,
+      );
     };
 
     for (const signal of SIGNALS) {
+      signalHadPreexistingListeners.set(signal, process.listenerCount(signal) > 0);
       const handler = () => handleSignal(signal);
       signalHandlers.set(signal, handler);
       process.on(signal, handler);

--- a/src/cli/gateway-cli/deferred-activation.ts
+++ b/src/cli/gateway-cli/deferred-activation.ts
@@ -318,6 +318,9 @@ async function waitForDeferredGatewayActivationOnce(
         };
 
         state = "accepted";
+        // This accepted-state handoff is synchronous: restore default SIGTERM/SIGINT
+        // semantics before any 202 write/end so bootstrap cannot swallow them.
+        cleanupSignalHandlers();
         // A valid authenticated activation must still commit after the body is read
         // even if the client disappears before it can receive the best-effort 202.
         response.on("finish", commitAcceptedActivation);

--- a/src/cli/gateway-cli/deferred-activation.ts
+++ b/src/cli/gateway-cli/deferred-activation.ts
@@ -1,0 +1,291 @@
+import { timingSafeEqual } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+const CONTROL_PORT_ENV = "OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT";
+const CONTROL_TOKEN_ENV = "OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN";
+const TOKEN_HEADER = "x-openclaw-activation-token";
+const MAX_BODY_BYTES = 16 * 1024;
+const MAX_ACTIVATION_ID_BYTES = 256;
+const CONTROL_HOST = "127.0.0.1";
+const SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1"] as const;
+type ShutdownSignal = (typeof SIGNALS)[number];
+
+type ProcessEnv = Record<string, string | undefined>;
+
+export type DeferredActivationResult =
+  | { mode: "disabled" }
+  | { mode: "activated"; activationId: string };
+
+export type DeferredActivationParams = {
+  env?: ProcessEnv;
+  preload?: () => Promise<void>;
+};
+
+let activeServer: Server | null = null;
+let singleton: Promise<DeferredActivationResult> | null = null;
+
+function tokensEqual(actual: string | undefined, expected: string): boolean {
+  if (actual === undefined) return false;
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
+}
+
+async function readBoundedJson(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += bytes.length;
+    if (size > MAX_BODY_BYTES) throw new Error("activation body too large");
+    chunks.push(bytes);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function parseActivationId(value: unknown): string {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("activation body must be an object");
+  }
+  const activationId = (value as { activationId?: unknown }).activationId;
+  if (typeof activationId !== "string" || activationId.length === 0) {
+    throw new Error("activationId must be a non-empty string");
+  }
+  if (Buffer.byteLength(activationId) > MAX_ACTIVATION_ID_BYTES) {
+    throw new Error("activationId too large");
+  }
+  return activationId;
+}
+
+function parseControlPort(value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error("invalid deferred activation control port");
+  }
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("invalid deferred activation control port");
+  }
+  return port;
+}
+
+function drainRequest(request: IncomingMessage) {
+  request.resume();
+}
+
+function writeJson(
+  response: ServerResponse,
+  statusCode: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): void {
+  response.writeHead(statusCode, {
+    "content-type": "application/json",
+    ...headers,
+  });
+  response.end(JSON.stringify(body));
+}
+
+export function waitForDeferredGatewayActivation(
+  params: DeferredActivationParams = {},
+): Promise<DeferredActivationResult> {
+  singleton ??= waitForDeferredGatewayActivationOnce(params);
+  return singleton;
+}
+
+async function waitForDeferredGatewayActivationOnce(
+  params: DeferredActivationParams = {},
+): Promise<DeferredActivationResult> {
+  const env = params.env ?? process.env;
+  const controlPortValue = env[CONTROL_PORT_ENV];
+  const controlToken = env[CONTROL_TOKEN_ENV];
+
+  if (controlPortValue === undefined && controlToken === undefined) {
+    return { mode: "disabled" };
+  }
+  if (controlPortValue === undefined || controlToken === undefined) {
+    throw new Error("control port and token must be configured together");
+  }
+
+  const controlPort = parseControlPort(controlPortValue);
+  await params.preload?.();
+
+  return await new Promise<DeferredActivationResult>((resolve, reject) => {
+    let state: "open" | "closing" | "accepted" | "settled" = "open";
+    const signalHandlers = new Map<ShutdownSignal, () => void>();
+
+    const settleResolve = (result: DeferredActivationResult) => {
+      if (state === "settled") {
+        return;
+      }
+      state = "settled";
+      resolve(result);
+    };
+
+    const settleReject = (error: unknown) => {
+      if (state === "settled") {
+        return;
+      }
+      state = "settled";
+      reject(error);
+    };
+
+    const cleanupSignalHandlers = () => {
+      for (const [signal, handler] of signalHandlers) {
+        process.removeListener(signal, handler);
+      }
+      signalHandlers.clear();
+    };
+
+    const server = createServer((request, response) => {
+      void handleRequest(request, response).catch((error) => {
+        const reason = error instanceof Error ? error : new Error(String(error));
+        if (!response.headersSent) {
+          writeJson(response, 500, { error: "internal server error" });
+        } else {
+          response.destroy(reason);
+        }
+        closeServerAndReject(reason);
+      });
+    });
+    activeServer = server;
+
+    const closeServerAndReject = (error: Error) => {
+      if (state === "settled") {
+        return;
+      }
+      state = "closing";
+      cleanupSignalHandlers();
+      if (!server.listening) {
+        activeServer = null;
+        settleReject(error);
+        return;
+      }
+      server.close((closeError) => {
+        activeServer = null;
+        settleReject(closeError ?? error);
+      });
+    };
+
+    const handleSignal = (signal: ShutdownSignal) => {
+      if (state !== "open") {
+        return;
+      }
+      closeServerAndReject(new Error(`deferred activation interrupted by ${signal}`));
+    };
+
+    for (const signal of SIGNALS) {
+      const handler = () => handleSignal(signal);
+      signalHandlers.set(signal, handler);
+      process.on(signal, handler);
+    }
+
+    server.once("close", () => {
+      if (activeServer === server) {
+        activeServer = null;
+      }
+      cleanupSignalHandlers();
+    });
+
+    server.once("error", (error) => {
+      if (activeServer === server) {
+        activeServer = null;
+      }
+      cleanupSignalHandlers();
+      settleReject(error);
+    });
+
+    const handleRequest = async (request: IncomingMessage, response: ServerResponse) => {
+      const method = request.method ?? "GET";
+      const pathname = new URL(request.url ?? "/", `http://${CONTROL_HOST}`).pathname;
+
+      if (pathname === "/healthz") {
+        if (method !== "GET") {
+          drainRequest(request);
+          writeJson(response, 405, { error: "method not allowed" }, { allow: "GET" });
+          return;
+        }
+        writeJson(response, 200, { status: "ok" });
+        return;
+      }
+
+      if (pathname === "/readyz") {
+        if (method !== "GET") {
+          drainRequest(request);
+          writeJson(response, 405, { error: "method not allowed" }, { allow: "GET" });
+          return;
+        }
+        writeJson(response, 503, { status: "waiting" });
+        return;
+      }
+
+      if (pathname !== "/activate") {
+        drainRequest(request);
+        writeJson(response, 404, { error: "not found" });
+        return;
+      }
+
+      if (method !== "POST") {
+        drainRequest(request);
+        writeJson(response, 405, { error: "method not allowed" }, { allow: "POST" });
+        return;
+      }
+
+      // Only one validated activation may win before the listener closes.
+      if (state !== "open") {
+        drainRequest(request);
+        writeJson(response, 409, { error: "activation already accepted" });
+        return;
+      }
+
+      const tokenHeader = request.headers[TOKEN_HEADER];
+      const actualToken = typeof tokenHeader === "string" ? tokenHeader : undefined;
+      if (!tokensEqual(actualToken, controlToken)) {
+        drainRequest(request);
+        writeJson(response, 401, { error: "unauthorized" });
+        return;
+      }
+
+      try {
+        const body = await readBoundedJson(request);
+        const activationId = parseActivationId(body);
+
+        if (state !== "open") {
+          writeJson(response, 409, { error: "activation already accepted" });
+          return;
+        }
+
+        state = "accepted";
+        response.writeHead(202, { "content-type": "application/json" });
+        response.end(JSON.stringify({ status: "accepted", activationId }), () => {
+          cleanupSignalHandlers();
+          server.close((error) => {
+            activeServer = null;
+            if (error) {
+              settleReject(error);
+            } else {
+              settleResolve({ mode: "activated", activationId });
+            }
+          });
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "invalid activation request";
+        const statusCode = message === "activation body too large" ? 413 : 400;
+        writeJson(response, statusCode, {
+          error: statusCode === 413 ? "activation body too large" : "invalid activation request",
+        });
+      }
+    };
+
+    server.listen(controlPort, CONTROL_HOST);
+  });
+}
+
+export async function resetDeferredGatewayActivationForTest(): Promise<void> {
+  const server = activeServer;
+  activeServer = null;
+  singleton = null;
+  if (!server || !server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/src/cli/gateway-cli/deferred-activation.ts
+++ b/src/cli/gateway-cli/deferred-activation.ts
@@ -25,7 +25,9 @@ let activeServer: Server | null = null;
 let singleton: Promise<DeferredActivationResult> | null = null;
 
 function tokensEqual(actual: string | undefined, expected: string): boolean {
-  if (actual === undefined) return false;
+  if (actual === undefined) {
+    return false;
+  }
   const actualBytes = Buffer.from(actual);
   const expectedBytes = Buffer.from(expected);
   return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
@@ -37,7 +39,9 @@ async function readBoundedJson(request: IncomingMessage): Promise<unknown> {
   for await (const chunk of request) {
     const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
     size += bytes.length;
-    if (size > MAX_BODY_BYTES) throw new Error("activation body too large");
+    if (size > MAX_BODY_BYTES) {
+      throw new Error("activation body too large");
+    }
     chunks.push(bytes);
   }
   return JSON.parse(Buffer.concat(chunks).toString("utf8"));
@@ -126,7 +130,8 @@ async function waitForDeferredGatewayActivationOnce(
         return;
       }
       state = "settled";
-      reject(error);
+      const reason = error instanceof Error ? error : new Error(String(error));
+      reject(reason);
     };
 
     const cleanupSignalHandlers = () => {
@@ -137,7 +142,7 @@ async function waitForDeferredGatewayActivationOnce(
     };
 
     const server = createServer((request, response) => {
-      void handleRequest(request, response).catch((error) => {
+      void handleRequest(request, response).catch((error: unknown) => {
         const reason = error instanceof Error ? error : new Error(String(error));
         if (!response.headersSent) {
           writeJson(response, 500, { error: "internal server error" });
@@ -284,7 +289,9 @@ export async function resetDeferredGatewayActivationForTest(): Promise<void> {
   const server = activeServer;
   activeServer = null;
   singleton = null;
-  if (!server || !server.listening) return;
+  if (!server || !server.listening) {
+    return;
+  }
   await new Promise<void>((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));
   });

--- a/src/cli/gateway-cli/deferred-activation.ts
+++ b/src/cli/gateway-cli/deferred-activation.ts
@@ -6,6 +6,7 @@ import {
   type ServerResponse,
   validateHeaderValue,
 } from "node:http";
+import type { Socket } from "node:net";
 
 const CONTROL_PORT_ENV = "OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT";
 const CONTROL_TOKEN_ENV = "OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN";
@@ -144,6 +145,7 @@ async function waitForDeferredGatewayActivationOnce(
   return await new Promise<DeferredActivationResult>((resolve, reject) => {
     let state: "open" | "closing" | "accepted" | "settled" = "open";
     const signalHandlers = new Map<ShutdownSignal, () => void>();
+    const trackedSockets = new Set<Socket>();
 
     const settleResolve = (result: DeferredActivationResult) => {
       if (state === "settled") {
@@ -169,6 +171,16 @@ async function waitForDeferredGatewayActivationOnce(
       signalHandlers.clear();
     };
 
+    const destroyTrackedSockets = (preservedSocket?: Socket) => {
+      for (const socket of trackedSockets) {
+        if (socket === preservedSocket) {
+          continue;
+        }
+        trackedSockets.delete(socket);
+        socket.destroy();
+      }
+    };
+
     const server = createServer((request, response) => {
       void handleRequest(request, response).catch((error: unknown) => {
         const reason = error instanceof Error ? error : new Error(String(error));
@@ -180,9 +192,15 @@ async function waitForDeferredGatewayActivationOnce(
         closeServerAndReject(reason);
       });
     });
+    server.on("connection", (socket) => {
+      trackedSockets.add(socket);
+      socket.once("close", () => {
+        trackedSockets.delete(socket);
+      });
+    });
     activeServer = server;
 
-    const closeServer = (onClosed: (error: Error | null) => void) => {
+    const closeServer = (onClosed: (error: Error | null) => void, preservedSocket?: Socket) => {
       // server.listen(...) is already issued before any parked signal/request path can
       // reach this helper, but Node may not flip server.listening yet. Always close so
       // shutdown cancels a pending bind instead of leaving the control port reserved.
@@ -192,10 +210,12 @@ async function waitForDeferredGatewayActivationOnce(
         }
         onClosed(normalizeServerCloseError(closeError ?? null));
       });
-      server.closeAllConnections();
+      // server.close(...) stops new accepts; destroy parked peers immediately,
+      // but let the accepted 202 socket flush and close itself to EOF.
+      destroyTrackedSockets(preservedSocket);
     };
 
-    const closeServerAndResolve = (result: DeferredActivationResult) => {
+    const closeServerAndResolve = (result: DeferredActivationResult, preservedSocket?: Socket) => {
       if (state !== "accepted") {
         return;
       }
@@ -207,7 +227,7 @@ async function waitForDeferredGatewayActivationOnce(
         } else {
           settleResolve(result);
         }
-      });
+      }, preservedSocket);
     };
 
     const closeServerAndReject = (error: Error, resignal?: ShutdownSignal) => {
@@ -257,6 +277,7 @@ async function waitForDeferredGatewayActivationOnce(
       if (activeServer === server) {
         activeServer = null;
       }
+      destroyTrackedSockets();
       cleanupSignalHandlers();
       settleReject(error);
     });
@@ -332,6 +353,7 @@ async function waitForDeferredGatewayActivationOnce(
           return;
         }
 
+        const acceptedSocket = request.socket;
         const acceptedResult: DeferredActivationResult = { mode: "activated", activationId };
         let activationCommitted = false;
         const commitAcceptedActivation = () => {
@@ -341,7 +363,7 @@ async function waitForDeferredGatewayActivationOnce(
           activationCommitted = true;
           response.removeListener("finish", commitAcceptedActivation);
           response.removeListener("close", commitAcceptedActivation);
-          closeServerAndResolve(acceptedResult);
+          closeServerAndResolve(acceptedResult, acceptedSocket);
         };
 
         state = "accepted";
@@ -357,8 +379,7 @@ async function waitForDeferredGatewayActivationOnce(
           return;
         }
 
-        response.writeHead(202, { "content-type": "application/json" });
-        response.end(JSON.stringify({ status: "accepted", activationId }));
+        writeJson(response, 202, { status: "accepted", activationId }, { Connection: "close" });
       } catch (error) {
         const message = error instanceof Error ? error.message : "invalid activation request";
         const statusCode = message === "activation body too large" ? 413 : 400;

--- a/src/cli/gateway-cli/deferred-activation.ts
+++ b/src/cli/gateway-cli/deferred-activation.ts
@@ -9,6 +9,7 @@ const MAX_ACTIVATION_ID_BYTES = 256;
 const CONTROL_HOST = "127.0.0.1";
 const SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1"] as const;
 type ShutdownSignal = (typeof SIGNALS)[number];
+type DefaultExitSignal = "SIGTERM" | "SIGINT";
 
 type ProcessEnv = Record<string, string | undefined>;
 
@@ -61,6 +62,13 @@ function parseActivationId(value: unknown): string {
   return activationId;
 }
 
+function parseControlToken(value: string): string {
+  if (value.trim().length === 0) {
+    throw new Error("deferred activation control token must be non-empty");
+  }
+  return value;
+}
+
 function parseControlPort(value: string): number {
   if (!/^\d+$/.test(value)) {
     throw new Error("invalid deferred activation control port");
@@ -101,15 +109,16 @@ async function waitForDeferredGatewayActivationOnce(
 ): Promise<DeferredActivationResult> {
   const env = params.env ?? process.env;
   const controlPortValue = env[CONTROL_PORT_ENV];
-  const controlToken = env[CONTROL_TOKEN_ENV];
+  const controlTokenValue = env[CONTROL_TOKEN_ENV];
 
-  if (controlPortValue === undefined && controlToken === undefined) {
+  if (controlPortValue === undefined && controlTokenValue === undefined) {
     return { mode: "disabled" };
   }
-  if (controlPortValue === undefined || controlToken === undefined) {
+  if (controlPortValue === undefined || controlTokenValue === undefined) {
     throw new Error("control port and token must be configured together");
   }
 
+  const controlToken = parseControlToken(controlTokenValue);
   const controlPort = parseControlPort(controlPortValue);
   await params.preload?.();
 
@@ -154,20 +163,58 @@ async function waitForDeferredGatewayActivationOnce(
     });
     activeServer = server;
 
-    const closeServerAndReject = (error: Error) => {
+    const closeServer = (onClosed: (error: Error | null) => void) => {
+      if (!server.listening) {
+        if (activeServer === server) {
+          activeServer = null;
+        }
+        onClosed(null);
+        return;
+      }
+      server.close((closeError) => {
+        if (activeServer === server) {
+          activeServer = null;
+        }
+        onClosed(closeError ?? null);
+      });
+      server.closeAllConnections();
+    };
+
+    const closeServerAndResolve = (result: DeferredActivationResult) => {
       if (state === "settled") {
         return;
       }
       state = "closing";
       cleanupSignalHandlers();
-      if (!server.listening) {
-        activeServer = null;
-        settleReject(error);
+      closeServer((closeError) => {
+        if (closeError) {
+          settleReject(closeError);
+        } else {
+          settleResolve(result);
+        }
+      });
+    };
+
+    const closeServerAndReject = (error: Error, resignal?: DefaultExitSignal) => {
+      if (state === "settled") {
         return;
       }
-      server.close((closeError) => {
-        activeServer = null;
-        settleReject(closeError ?? error);
+      state = "closing";
+      cleanupSignalHandlers();
+      closeServer((closeError) => {
+        const finalError = closeError ?? error;
+        if (resignal) {
+          // Re-emit default-exit signals only after the parked listener is closed
+          // so this helper does not turn a normal signal exit into code 1.
+          try {
+            process.kill(process.pid, resignal);
+          } catch (killError) {
+            const reason = killError instanceof Error ? killError : new Error(String(killError));
+            settleReject(reason);
+            return;
+          }
+        }
+        settleReject(finalError);
       });
     };
 
@@ -175,7 +222,10 @@ async function waitForDeferredGatewayActivationOnce(
       if (state !== "open") {
         return;
       }
-      closeServerAndReject(new Error(`deferred activation interrupted by ${signal}`));
+      closeServerAndReject(
+        new Error(`deferred activation interrupted by ${signal}`),
+        signal === "SIGTERM" || signal === "SIGINT" ? signal : undefined,
+      );
     };
 
     for (const signal of SIGNALS) {
@@ -262,15 +312,8 @@ async function waitForDeferredGatewayActivationOnce(
         state = "accepted";
         response.writeHead(202, { "content-type": "application/json" });
         response.end(JSON.stringify({ status: "accepted", activationId }), () => {
-          cleanupSignalHandlers();
-          server.close((error) => {
-            activeServer = null;
-            if (error) {
-              settleReject(error);
-            } else {
-              settleResolve({ mode: "activated", activationId });
-            }
-          });
+          // Let the accepted 202 body flush before forcing all parked sockets closed.
+          closeServerAndResolve({ mode: "activated", activationId });
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : "invalid activation request";
@@ -294,5 +337,6 @@ export async function resetDeferredGatewayActivationForTest(): Promise<void> {
   }
   await new Promise<void>((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));
+    server.closeAllConnections();
   });
 }

--- a/src/cli/gateway-cli/deferred-activation.ts
+++ b/src/cli/gateway-cli/deferred-activation.ts
@@ -247,7 +247,18 @@ async function waitForDeferredGatewayActivationOnce(
 
     const handleRequest = async (request: IncomingMessage, response: ServerResponse) => {
       const method = request.method ?? "GET";
-      const pathname = new URL(request.url ?? "/", `http://${CONTROL_HOST}`).pathname;
+      let pathname: string;
+      try {
+        pathname = new URL(request.url ?? "/", `http://${CONTROL_HOST}`).pathname;
+      } catch {
+        drainRequest(request);
+        if (response.headersSent || response.writableEnded || response.destroyed) {
+          response.destroy();
+        } else {
+          writeJson(response, 400, { error: "invalid request target" });
+        }
+        return;
+      }
 
       if (pathname === "/healthz") {
         if (method !== "GET") {

--- a/src/cli/gateway-cli/deferred-activation.ts
+++ b/src/cli/gateway-cli/deferred-activation.ts
@@ -1,5 +1,11 @@
 import { timingSafeEqual } from "node:crypto";
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+  validateHeaderValue,
+} from "node:http";
 
 const CONTROL_PORT_ENV = "OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT";
 const CONTROL_TOKEN_ENV = "OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN";
@@ -62,8 +68,13 @@ function parseActivationId(value: unknown): string {
 }
 
 function parseControlToken(value: string): string {
-  if (value.trim().length === 0) {
-    throw new Error("deferred activation control token must be non-empty");
+  if (value.length === 0 || value.trim() !== value) {
+    throw new Error("invalid deferred activation control token");
+  }
+  try {
+    validateHeaderValue(TOKEN_HEADER, value);
+  } catch {
+    throw new Error("invalid deferred activation control token");
   }
   return value;
 }
@@ -81,6 +92,13 @@ function parseControlPort(value: string): number {
 
 function drainRequest(request: IncomingMessage) {
   request.resume();
+}
+
+function normalizeServerCloseError(error: Error | null | undefined): Error | null {
+  if (!error) {
+    return null;
+  }
+  return (error as { code?: unknown }).code === "ERR_SERVER_NOT_RUNNING" ? null : error;
 }
 
 function writeJson(
@@ -119,7 +137,9 @@ async function waitForDeferredGatewayActivationOnce(
 
   const controlToken = parseControlToken(controlTokenValue);
   const controlPort = parseControlPort(controlPortValue);
-  await params.preload?.();
+  if (params.preload) {
+    await params.preload();
+  }
 
   return await new Promise<DeferredActivationResult>((resolve, reject) => {
     let state: "open" | "closing" | "accepted" | "settled" = "open";
@@ -163,18 +183,14 @@ async function waitForDeferredGatewayActivationOnce(
     activeServer = server;
 
     const closeServer = (onClosed: (error: Error | null) => void) => {
-      if (!server.listening) {
-        if (activeServer === server) {
-          activeServer = null;
-        }
-        onClosed(null);
-        return;
-      }
+      // server.listen(...) is already issued before any parked signal/request path can
+      // reach this helper, but Node may not flip server.listening yet. Always close so
+      // shutdown cancels a pending bind instead of leaving the control port reserved.
       server.close((closeError) => {
         if (activeServer === server) {
           activeServer = null;
         }
-        onClosed(closeError ?? null);
+        onClosed(normalizeServerCloseError(closeError ?? null));
       });
       server.closeAllConnections();
     };
@@ -360,11 +376,18 @@ export async function resetDeferredGatewayActivationForTest(): Promise<void> {
   const server = activeServer;
   activeServer = null;
   singleton = null;
-  if (!server || !server.listening) {
+  if (!server) {
     return;
   }
   await new Promise<void>((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    server.close((error) => {
+      const normalizedError = normalizeServerCloseError(error ?? null);
+      if (normalizedError) {
+        reject(normalizedError);
+      } else {
+        resolve();
+      }
+    });
     server.closeAllConnections();
   });
 }

--- a/src/cli/gateway-cli/deferred-activation.ts
+++ b/src/cli/gateway-cli/deferred-activation.ts
@@ -7,9 +7,8 @@ const TOKEN_HEADER = "x-openclaw-activation-token";
 const MAX_BODY_BYTES = 16 * 1024;
 const MAX_ACTIVATION_ID_BYTES = 256;
 const CONTROL_HOST = "127.0.0.1";
-const SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1"] as const;
+const SIGNALS = ["SIGTERM", "SIGINT"] as const;
 type ShutdownSignal = (typeof SIGNALS)[number];
-type DefaultExitSignal = "SIGTERM" | "SIGINT";
 
 type ProcessEnv = Record<string, string | undefined>;
 
@@ -181,7 +180,7 @@ async function waitForDeferredGatewayActivationOnce(
     };
 
     const closeServerAndResolve = (result: DeferredActivationResult) => {
-      if (state === "settled") {
+      if (state !== "accepted") {
         return;
       }
       state = "closing";
@@ -195,7 +194,7 @@ async function waitForDeferredGatewayActivationOnce(
       });
     };
 
-    const closeServerAndReject = (error: Error, resignal?: DefaultExitSignal) => {
+    const closeServerAndReject = (error: Error, resignal?: ShutdownSignal) => {
       if (state === "settled") {
         return;
       }
@@ -222,10 +221,7 @@ async function waitForDeferredGatewayActivationOnce(
       if (state !== "open") {
         return;
       }
-      closeServerAndReject(
-        new Error(`deferred activation interrupted by ${signal}`),
-        signal === "SIGTERM" || signal === "SIGINT" ? signal : undefined,
-      );
+      closeServerAndReject(new Error(`deferred activation interrupted by ${signal}`), signal);
     };
 
     for (const signal of SIGNALS) {
@@ -309,12 +305,30 @@ async function waitForDeferredGatewayActivationOnce(
           return;
         }
 
+        const acceptedResult: DeferredActivationResult = { mode: "activated", activationId };
+        let activationCommitted = false;
+        const commitAcceptedActivation = () => {
+          if (activationCommitted) {
+            return;
+          }
+          activationCommitted = true;
+          response.removeListener("finish", commitAcceptedActivation);
+          response.removeListener("close", commitAcceptedActivation);
+          closeServerAndResolve(acceptedResult);
+        };
+
         state = "accepted";
+        // A valid authenticated activation must still commit after the body is read
+        // even if the client disappears before it can receive the best-effort 202.
+        response.on("finish", commitAcceptedActivation);
+        response.on("close", commitAcceptedActivation);
+        if (response.destroyed) {
+          commitAcceptedActivation();
+          return;
+        }
+
         response.writeHead(202, { "content-type": "application/json" });
-        response.end(JSON.stringify({ status: "accepted", activationId }), () => {
-          // Let the accepted 202 body flush before forcing all parked sockets closed.
-          closeServerAndResolve({ mode: "activated", activationId });
-        });
+        response.end(JSON.stringify({ status: "accepted", activationId }));
       } catch (error) {
         const message = error instanceof Error ? error.message : "invalid activation request";
         const statusCode = message === "activation body too large" ? 413 : 400;

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -421,15 +421,8 @@ describe("runGatewayLoop", () => {
       const { runtime } = createRuntimeWithExitSignal();
       const beginBoot = vi.fn();
       const completeBoot = vi.fn();
-      let acquiredLock:
-        | {
-            release: ReturnType<typeof vi.fn>;
-          }
-        | undefined;
-      acquireGatewayLock.mockImplementationOnce(async (_opts?: { port?: number }) => {
-        acquiredLock = { release: vi.fn(async () => {}) };
-        return acquiredLock;
-      });
+      const releaseGatewayLock = vi.fn(async () => {});
+      acquireGatewayLock.mockResolvedValueOnce({ release: releaseGatewayLock });
       const start = vi.fn(async (_params?: { startupStartedAt?: number }) => {
         throw startupFailure;
       });
@@ -455,7 +448,7 @@ describe("runGatewayLoop", () => {
         reason: "b".repeat(500),
       });
       expect(acquireGatewayLock).toHaveBeenCalledTimes(1);
-      expect(acquiredLock?.release).toHaveBeenCalledTimes(1);
+      expect(releaseGatewayLock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -412,6 +412,53 @@ function expectRestartHandoffCall(expected: {
 }
 
 describe("runGatewayLoop", () => {
+  it("completes the initial boot once when startup fails before a server handle exists", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async () => {
+      const failure = "b".repeat(600);
+      const startupFailure = new Error(failure);
+      const { runtime } = createRuntimeWithExitSignal();
+      const beginBoot = vi.fn();
+      const completeBoot = vi.fn();
+      let acquiredLock:
+        | {
+            release: ReturnType<typeof vi.fn>;
+          }
+        | undefined;
+      acquireGatewayLock.mockImplementationOnce(async (_opts?: { port?: number }) => {
+        acquiredLock = { release: vi.fn(async () => {}) };
+        return acquiredLock;
+      });
+      const start = vi.fn(async (_params?: { startupStartedAt?: number }) => {
+        throw startupFailure;
+      });
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      await expect(
+        runGatewayLoop({
+          start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+          runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+          beginBoot,
+          completeBoot,
+        }),
+      ).rejects.toBe(startupFailure);
+
+      expect(beginBoot).toHaveBeenCalledTimes(1);
+      const startedAt = beginBoot.mock.calls[0]?.[0];
+      expect(typeof startedAt).toBe("number");
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(start).toHaveBeenCalledWith({ startupStartedAt: startedAt });
+      expect(completeBoot).toHaveBeenCalledTimes(1);
+      expect(completeBoot).toHaveBeenCalledWith({
+        outcome: "startup_failed",
+        reason: "b".repeat(500),
+      });
+      expect(acquireGatewayLock).toHaveBeenCalledTimes(1);
+      expect(acquiredLock?.release).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("keeps truncated startup failure reasons free of lone surrogates", async () => {
     await withIsolatedSignals(async () => {
       const failure = `${"a".repeat(499)}😀tail`;

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -1375,6 +1375,35 @@ describe("gateway run option collisions", () => {
     expect(options.auth?.token).toBe("tok_run");
   });
 
+  it("records one boot start for one canonical successful iteration", async () => {
+    runGatewayLoop.mockImplementationOnce(
+      async ({
+        beginBoot,
+        start,
+      }: {
+        beginBoot?: (startedAtMs: number) => Promise<void> | void;
+        start: GatewayLoopStart;
+      }) => {
+        await beginBoot?.(1234);
+        await start({ startupStartedAt: 1234 });
+      },
+    );
+
+    await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
+
+    expect(bootLifecycle.inspect).toHaveBeenCalledTimes(1);
+    expect(bootLifecycle.inspect.mock.calls[0]?.[1]).toBe(1234);
+    expect(bootLifecycle.record).toHaveBeenCalledTimes(1);
+    expect(bootLifecycle.record.mock.calls[0]?.[1]).toBe(1234);
+    expect(bootLifecycle.record.mock.calls[0]?.[2]).toBeUndefined();
+    expect(startGatewayServer).toHaveBeenCalledTimes(1);
+    expect(gatewayStartOptions().startupStartedAt).toBe(1234);
+    expect(bootLifecycle.complete).not.toHaveBeenCalled();
+    expect(bootLifecycle.record.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+      startGatewayServer.mock.invocationCallOrder[0] ?? Infinity,
+    );
+  });
+
   it("uses the startup snapshot only for the first in-process gateway start", async () => {
     runGatewayLoop.mockImplementationOnce(async ({ start }: { start: GatewayLoopStart }) => {
       await start({ startupStartedAt: 1000 });

--- a/src/cli/gateway-run-argv.test.ts
+++ b/src/cli/gateway-run-argv.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+type GatewayRunArgvModule = {
+  isGatewayRunInvocationArgv?: (argv: string[]) => boolean;
+};
+
+describe("isGatewayRunInvocationArgv", () => {
+  it("matches the same bare gateway and gateway run shapes used by deferred activation", async () => {
+    const { isGatewayRunInvocationArgv } =
+      (await import("./gateway-run-argv.js")) as GatewayRunArgvModule;
+
+    expect(isGatewayRunInvocationArgv).toBeTypeOf("function");
+
+    expect(isGatewayRunInvocationArgv!(["node", "openclaw", "gateway"])).toBe(true);
+    expect(isGatewayRunInvocationArgv!(["node", "openclaw", "gateway", "run"])).toBe(true);
+    expect(
+      isGatewayRunInvocationArgv!(["node", "openclaw", "--no-color", "gateway", "run", "--force"]),
+    ).toBe(true);
+    expect(isGatewayRunInvocationArgv!(["node", "openclaw", "gateway", "--bind", "loopback"])).toBe(
+      true,
+    );
+    expect(isGatewayRunInvocationArgv!(["node", "openclaw", "gateway", "--help"])).toBe(true);
+    expect(isGatewayRunInvocationArgv!(["node", "openclaw", "gateway", "call", "health"])).toBe(
+      false,
+    );
+    expect(isGatewayRunInvocationArgv!(["node", "openclaw", "gateway", "status"])).toBe(false);
+    expect(isGatewayRunInvocationArgv!(["node", "openclaw", "status"])).toBe(false);
+  });
+});

--- a/src/cli/gateway-run-argv.test.ts
+++ b/src/cli/gateway-run-argv.test.ts
@@ -16,6 +16,17 @@ describe("isGatewayRunInvocationArgv", () => {
     expect(
       isGatewayRunInvocationArgv!(["node", "openclaw", "--no-color", "gateway", "run", "--force"]),
     ).toBe(true);
+    expect(
+      isGatewayRunInvocationArgv!([
+        "node",
+        "openclaw",
+        "--profile",
+        "demo",
+        "gateway",
+        "run",
+        "--force",
+      ]),
+    ).toBe(true);
     expect(isGatewayRunInvocationArgv!(["node", "openclaw", "gateway", "--bind", "loopback"])).toBe(
       true,
     );

--- a/src/cli/gateway-run-argv.ts
+++ b/src/cli/gateway-run-argv.ts
@@ -133,6 +133,15 @@ export function resolveGatewayCatalogCommandPath(argv: string[]): string[] | nul
   return ["gateway"];
 }
 
+/** Returns whether argv targets bare `gateway` or `gateway run`. */
+export function isGatewayRunInvocationArgv(argv: string[]): boolean {
+  const commandPath = resolveGatewayCatalogCommandPath(argv);
+  return (
+    commandPath?.length === 1 ||
+    (commandPath?.length === 2 && commandPath[0] === "gateway" && commandPath[1] === "run")
+  );
+}
+
 /** Resolve destructive gateway-run flags before Commander registration. */
 export function resolveGatewayRunPreBootstrapOptions(
   argv: string[],

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -23,6 +23,9 @@ const routeLogsToStderrMock = vi.fn();
 const prepareGatewayRunBootstrapMock = vi.fn(async () => true);
 const recheckGatewayRunBootstrapMock = vi.fn(async () => true);
 const reloadTrustedGatewayRunEnvironmentMock = vi.fn(async () => true);
+const waitForDeferredGatewayActivationMock = vi.hoisted(() =>
+  vi.fn(async () => ({ mode: "disabled" as const })),
+);
 
 const runtimeMock = {
   log: vi.fn(),
@@ -66,6 +69,10 @@ vi.mock("../gateway-cli/pre-bootstrap.js", () => ({
   reloadTrustedGatewayRunEnvironment: reloadTrustedGatewayRunEnvironmentMock,
 }));
 
+vi.mock("../gateway-cli/deferred-activation.js", () => ({
+  waitForDeferredGatewayActivation: waitForDeferredGatewayActivationMock,
+}));
+
 let registerPreActionHooks: typeof import("./preaction.js").registerPreActionHooks;
 let originalProcessArgv: string[];
 let originalProcessTitle: string;
@@ -81,6 +88,8 @@ beforeAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  waitForDeferredGatewayActivationMock.mockReset();
+  waitForDeferredGatewayActivationMock.mockResolvedValue({ mode: "disabled" });
   originalProcessArgv = [...process.argv];
   originalProcessTitle = process.title;
   originalProcessTitleDescriptor = Object.getOwnPropertyDescriptor(process, "title");
@@ -279,6 +288,41 @@ describe("registerPreActionHooks", () => {
     processTitleSetSpy.mockRestore();
   });
 
+  it.each([
+    ["gateway run", ["gateway", "run"], ["node", "openclaw", "gateway", "run"]],
+    ["bare gateway", ["gateway"], ["node", "openclaw", "gateway"]],
+  ])(
+    "waits for deferred activation before gateway bootstrap for %s",
+    async (_name, parseArgv, processArgv) => {
+      const events: string[] = [];
+      waitForDeferredGatewayActivationMock.mockImplementation(async () => {
+        events.push("activation:start");
+        await Promise.resolve();
+        events.push("activation:end");
+        return { mode: "disabled" };
+      });
+      prepareGatewayRunBootstrapMock.mockImplementation(async () => {
+        events.push("prepare");
+        return true;
+      });
+      ensureConfigReadyMock.mockImplementation(async () => {
+        events.push("ensureConfigReady");
+      });
+
+      await runPreAction({ parseArgv, processArgv });
+
+      expect(waitForDeferredGatewayActivationMock).toHaveBeenCalledTimes(1);
+      expect(prepareGatewayRunBootstrapMock).toHaveBeenCalledTimes(1);
+      const activationOrder = waitForDeferredGatewayActivationMock.mock.invocationCallOrder[0] ?? 0;
+      const prepareOrder = prepareGatewayRunBootstrapMock.mock.invocationCallOrder[0] ?? 0;
+      const ensureConfigReadyOrder = ensureConfigReadyMock.mock.invocationCallOrder[0] ?? 0;
+      expect(prepareOrder).toBeGreaterThan(activationOrder);
+      expect(ensureConfigReadyOrder).toBeGreaterThan(activationOrder);
+      expect(events.indexOf("activation:end")).toBeLessThan(events.indexOf("prepare"));
+      expect(events.indexOf("activation:end")).toBeLessThan(events.indexOf("ensureConfigReady"));
+    },
+  );
+
   it("runs gateway pre-bootstrap before full-CLI gateway bootstrap", async () => {
     prepareGatewayRunBootstrapMock.mockResolvedValueOnce(false);
     const gatewayRunCommand = resolveActionCommand(["gateway", "run"]);
@@ -302,6 +346,7 @@ describe("registerPreActionHooks", () => {
       gatewayRunCommand.setOptionValueWithSource("force", false, "default");
     }
 
+    expect(waitForDeferredGatewayActivationMock).toHaveBeenCalledTimes(1);
     expect(prepareGatewayRunBootstrapMock).toHaveBeenCalledWith({
       opts: { force: true, reset: false },
       runtime: runtimeMock,
@@ -394,6 +439,7 @@ describe("registerPreActionHooks", () => {
       processArgv: ["node", "openclaw", "channels"],
     });
 
+    expect(waitForDeferredGatewayActivationMock).not.toHaveBeenCalled();
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(setVerboseMock).not.toHaveBeenCalled();
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
@@ -531,17 +577,30 @@ describe("registerPreActionHooks", () => {
     });
   });
 
-  it("skips help/version preaction and respects banner opt-out", async () => {
+  it("skips deferred activation for help/version and non-gateway command paths", async () => {
     await runPreAction({
       parseArgv: ["status"],
-      processArgv: ["node", "openclaw", "--version"],
+      processArgv: ["node", "openclaw", "--help"],
     });
 
+    expect(waitForDeferredGatewayActivationMock).not.toHaveBeenCalled();
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(setVerboseMock).not.toHaveBeenCalled();
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
+    waitForDeferredGatewayActivationMock.mockResolvedValue({ mode: "disabled" });
+
+    await runPreAction({
+      parseArgv: ["status"],
+      processArgv: ["node", "openclaw", "--version"],
+    });
+
+    expect(waitForDeferredGatewayActivationMock).not.toHaveBeenCalled();
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    waitForDeferredGatewayActivationMock.mockResolvedValue({ mode: "disabled" });
     process.env.OPENCLAW_HIDE_BANNER = "1";
 
     await runPreAction({
@@ -549,6 +608,7 @@ describe("registerPreActionHooks", () => {
       processArgv: ["node", "openclaw", "status"],
     });
 
+    expect(waitForDeferredGatewayActivationMock).not.toHaveBeenCalled();
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
   });

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -126,6 +126,11 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (isHelpOrVersionInvocation(argv) || isBareParentDefaultHelpInvocation(actionCommand, argv)) {
       return;
     }
+    if (isGatewayRunAction(actionCommand)) {
+      const { waitForDeferredGatewayActivation } =
+        await import("../gateway-cli/deferred-activation.js");
+      await waitForDeferredGatewayActivation();
+    }
     const jsonOutputMode = isCommandJsonOutputMode(actionCommand, argv);
     const { commandPath, startupPolicy } = resolveCliExecutionStartupContext({
       argv,

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -39,6 +39,9 @@ const pinConfigDirMock = vi.hoisted(() => vi.fn());
 const pinRuntimePathsMock = vi.hoisted(() => vi.fn());
 const ensurePathMock = vi.hoisted(() => vi.fn());
 const assertRuntimeMock = vi.hoisted(() => vi.fn());
+const waitForDeferredGatewayActivationMock = vi.hoisted(() =>
+  vi.fn(async () => ({ mode: "disabled" as const })),
+);
 const closeActiveMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
 const hasMemoryRuntimeMock = vi.hoisted(() => vi.fn(() => false));
 const listRegisteredAgentHarnessesMock = vi.hoisted(() => vi.fn((): unknown[] => []));
@@ -235,6 +238,10 @@ vi.mock("../infra/runtime-guard.js", () => ({
   assertSupportedRuntime: assertRuntimeMock,
 }));
 
+vi.mock("./gateway-cli/deferred-activation.js", () => ({
+  waitForDeferredGatewayActivation: waitForDeferredGatewayActivationMock,
+}));
+
 vi.mock("../plugins/memory-runtime.js", () => ({
   closeActiveMemorySearchManagers: closeActiveMemorySearchManagersMock,
 }));
@@ -396,6 +403,7 @@ describe("runCli exit behavior", () => {
     delete process.env.OPENCLAW_GATEWAY_PASSWORD;
     delete process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV];
     vi.clearAllMocks();
+    waitForDeferredGatewayActivationMock.mockResolvedValue({ mode: "disabled" });
     readConfigFileSnapshotMock.mockResolvedValue({
       exists: true,
       valid: true,
@@ -2159,13 +2167,96 @@ describe("runCli exit behavior", () => {
     expect(startProxyMock).toHaveBeenCalledWith(undefined);
   });
 
+  it.each([
+    ["gateway run", ["node", "openclaw", "gateway", "run"]],
+    ["bare gateway", ["node", "openclaw", "gateway"]],
+  ])(
+    "waits for deferred activation before gateway startup side effects for %s",
+    async (_name, argv) => {
+      const events: string[] = [];
+      assertRuntimeMock.mockImplementation(() => {
+        events.push("runtime");
+      });
+      waitForDeferredGatewayActivationMock.mockImplementation(async () => {
+        events.push("activation:start");
+        await Promise.resolve();
+        events.push("activation:end");
+        return { mode: "disabled" };
+      });
+      loadDotEnvMock.mockImplementation(() => {
+        events.push("dotenv");
+      });
+      readConfigFileSnapshotMock.mockImplementation(async () => {
+        events.push("config-snapshot");
+        return {
+          exists: true,
+          valid: true,
+          sourceConfig: { gateway: { mode: "local" } },
+        };
+      });
+      normalizeEnvMock.mockImplementation(() => {
+        events.push("normalize");
+      });
+      loadConfigMock.mockImplementation(() => {
+        events.push("config-load");
+        return {};
+      });
+      startProxyMock.mockImplementation(async () => {
+        events.push("proxy");
+        return null;
+      });
+
+      await runCli(argv);
+
+      expect(waitForDeferredGatewayActivationMock).toHaveBeenCalledTimes(1);
+      const runtimeGuardOrder = assertRuntimeMock.mock.invocationCallOrder[0] ?? 0;
+      const activationOrder = waitForDeferredGatewayActivationMock.mock.invocationCallOrder[0] ?? 0;
+      const dotenvOrder = loadDotEnvMock.mock.invocationCallOrder[0] ?? 0;
+      const configReadOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[0] ?? 0;
+      const normalizeOrder = normalizeEnvMock.mock.invocationCallOrder[0] ?? 0;
+      const proxyOrder = startProxyMock.mock.invocationCallOrder[0] ?? 0;
+      expect(runtimeGuardOrder).toBeGreaterThan(0);
+      expect(activationOrder).toBeGreaterThan(runtimeGuardOrder);
+      expect(dotenvOrder).toBeGreaterThan(activationOrder);
+      expect(configReadOrder).toBeGreaterThan(activationOrder);
+      expect(normalizeOrder).toBeGreaterThan(activationOrder);
+      expect(proxyOrder).toBeGreaterThan(activationOrder);
+      expect(events.indexOf("activation:end")).toBeLessThan(events.indexOf("dotenv"));
+      expect(events.indexOf("activation:end")).toBeLessThan(events.indexOf("config-snapshot"));
+      expect(events.indexOf("activation:end")).toBeLessThan(events.indexOf("normalize"));
+      expect(events.indexOf("activation:end")).toBeLessThan(events.indexOf("proxy"));
+    },
+  );
+
+  it.each([
+    ["root help", ["node", "openclaw", "--help"]],
+    ["version", ["node", "openclaw", "--version"]],
+    ["non-gateway command", ["node", "openclaw", "status"]],
+  ])("skips deferred activation for %s", async (_name, argv) => {
+    if (_name === "version") {
+      buildProgramMock.mockReturnValueOnce({
+        commands: [],
+        parseAsync: vi.fn().mockResolvedValueOnce(undefined),
+      });
+    }
+    if (_name === "non-gateway command") {
+      tryRouteCliMock.mockResolvedValueOnce(true);
+    }
+
+    await runCli(argv);
+
+    expect(waitForDeferredGatewayActivationMock).not.toHaveBeenCalled();
+  });
+
   it("validates the runtime before selecting gateway config", async () => {
     await runCli(["node", "openclaw", "gateway", "run"]);
 
     const runtimeGuardOrder = assertRuntimeMock.mock.invocationCallOrder[0] ?? 0;
+    const activationOrder = waitForDeferredGatewayActivationMock.mock.invocationCallOrder[0] ?? 0;
     const configReadOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[0] ?? 0;
     expect(runtimeGuardOrder).toBeGreaterThan(0);
-    expect(configReadOrder).toBeGreaterThan(runtimeGuardOrder);
+    expect(activationOrder).toBeGreaterThan(runtimeGuardOrder);
+    expect(configReadOrder).toBeGreaterThan(activationOrder);
   });
 
   it("re-pins runtime paths after selecting gateway config", async () => {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -3194,6 +3194,26 @@ describe("runCli exit behavior", () => {
     expect(closeActiveMemorySearchManagersMock).not.toHaveBeenCalled();
   });
 
+  it("returns before deferred gateway activation for handled host container gateway runs", async () => {
+    maybeRunCliInContainerMock.mockReturnValueOnce({ handled: true, exitCode: 0 });
+
+    await runCli(["node", "openclaw", "--container", "demo", "gateway", "run"]);
+
+    expect(maybeRunCliInContainerMock).toHaveBeenCalledWith([
+      "node",
+      "openclaw",
+      "--container",
+      "demo",
+      "gateway",
+      "run",
+    ]);
+    expect(waitForDeferredGatewayActivationMock).not.toHaveBeenCalled();
+    expect(loadDotEnvMock).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    expect(loadConfigMock).not.toHaveBeenCalled();
+    expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+  });
+
   it("returns after a handled container-target invocation", async () => {
     maybeRunCliInContainerMock.mockReturnValueOnce({ handled: true, exitCode: 0 });
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2228,6 +2228,56 @@ describe("runCli exit behavior", () => {
     },
   );
 
+  it("parks gateway run startup until deferred activation resolves", async () => {
+    let resolveActivation:
+      | ((value: { mode: "activated"; activationId: string }) => void)
+      | undefined;
+    waitForDeferredGatewayActivationMock.mockImplementation(
+      () =>
+        new Promise((resolve: (value: { mode: "activated"; activationId: string }) => void) => {
+          resolveActivation = resolve;
+        }),
+    );
+
+    const runPromise = runCli(["node", "openclaw", "gateway", "run"]);
+
+    await vi.waitFor(() => {
+      expect(waitForDeferredGatewayActivationMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(loadDotEnvMock).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    expect(pinRuntimePathsMock).not.toHaveBeenCalled();
+    expect(pinConfigDirMock).not.toHaveBeenCalled();
+    expect(normalizeEnvMock).not.toHaveBeenCalled();
+    expect(startProxyMock).not.toHaveBeenCalled();
+    expect(addGatewayRunCommandMock).not.toHaveBeenCalled();
+    expect(commanderParseAsyncMock).not.toHaveBeenCalled();
+    expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+
+    if (!resolveActivation) {
+      throw new Error("deferred activation resolver was not captured");
+    }
+    resolveActivation({ mode: "activated", activationId: "lifecycle-test" });
+    await runPromise;
+
+    expect(loadDotEnvMock).toHaveBeenCalledTimes(1);
+    expect(loadDotEnvMock).toHaveBeenCalledWith({ loadGlobalEnv: false, quiet: true });
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ isolateEnv: true, observe: false });
+    expect(pinRuntimePathsMock).toHaveBeenCalledTimes(1);
+    expect(pinConfigDirMock).toHaveBeenCalledTimes(1);
+    expect(normalizeEnvMock).toHaveBeenCalled();
+    const activationOrder = waitForDeferredGatewayActivationMock.mock.invocationCallOrder[0] ?? 0;
+    const normalizeOrder = normalizeEnvMock.mock.invocationCallOrder[0] ?? 0;
+    expect(normalizeOrder).toBeGreaterThan(activationOrder);
+    expect(startProxyMock).toHaveBeenCalledTimes(1);
+    expect(startProxyMock).toHaveBeenCalledWith(undefined);
+    expect(addGatewayRunCommandMock).toHaveBeenCalledTimes(2);
+    expect(commanderParseAsyncMock).toHaveBeenCalledTimes(1);
+    expect(commanderParseAsyncMock).toHaveBeenCalledWith(["node", "openclaw", "gateway", "run"]);
+  });
+
   it.each([
     ["root help", ["node", "openclaw", "--help"]],
     ["version", ["node", "openclaw", "--version"]],

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2278,6 +2278,24 @@ describe("runCli exit behavior", () => {
     expect(commanderParseAsyncMock).toHaveBeenCalledWith(["node", "openclaw", "gateway", "run"]);
   });
 
+  it("does not start gateway when deferred activation rejects", async () => {
+    waitForDeferredGatewayActivationMock.mockRejectedValueOnce(
+      new Error("deferred activation interrupted by SIGTERM"),
+    );
+    await expect(runCli(["node", "openclaw", "gateway", "run"])).rejects.toThrow(
+      "deferred activation interrupted by SIGTERM",
+    );
+    expect(loadDotEnvMock).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    expect(pinRuntimePathsMock).not.toHaveBeenCalled();
+    expect(pinConfigDirMock).not.toHaveBeenCalled();
+    expect(normalizeEnvMock).not.toHaveBeenCalled();
+    expect(startProxyMock).not.toHaveBeenCalled();
+    expect(addGatewayRunCommandMock).not.toHaveBeenCalled();
+    expect(commanderParseAsyncMock).not.toHaveBeenCalled();
+    expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["root help", ["node", "openclaw", "--help"]],
     ["version", ["node", "openclaw", "--version"]],

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -8,6 +8,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { loggingState } from "../logging/state.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
+import type { DeferredActivationResult } from "./gateway-cli/deferred-activation.js";
 import { getGatewayRunRuntimeHooks } from "./gateway-cli/runtime-hooks.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
 import { runCli, shouldStartProxyForCli } from "./run-main.js";
@@ -40,7 +41,7 @@ const pinRuntimePathsMock = vi.hoisted(() => vi.fn());
 const ensurePathMock = vi.hoisted(() => vi.fn());
 const assertRuntimeMock = vi.hoisted(() => vi.fn());
 const waitForDeferredGatewayActivationMock = vi.hoisted(() =>
-  vi.fn(async () => ({ mode: "disabled" as const })),
+  vi.fn<() => Promise<DeferredActivationResult>>(async () => ({ mode: "disabled" as const })),
 );
 const closeActiveMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
 const hasMemoryRuntimeMock = vi.hoisted(() => vi.fn(() => false));

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -874,6 +874,14 @@ export async function runCli(argv: string[] = process.argv) {
   // Enforce the minimum supported runtime before gateway selection can read or recover config.
   assertSupportedRuntime();
 
+  if (!isHelpOrVersionInvocation && isGatewayRunInvocation) {
+    await startupTrace.measure("gateway-run-deferred-activation", async () => {
+      const { waitForDeferredGatewayActivation } =
+        await import("./gateway-cli/deferred-activation.js");
+      await waitForDeferredGatewayActivation();
+    });
+  }
+
   if (!isHelpOrVersionInvocation && (isGatewayRunInvocation || shouldLoadCliDotEnv())) {
     await startupTrace.measure("dotenv", async () => {
       if (isRemoteAgentDispatchInvocation(normalizedArgv, normalizedInvocation.primary)) {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -868,6 +868,9 @@ export async function runCli(argv: string[] = process.argv) {
   assertSupportedRuntime();
 
   if (!isHelpOrVersionInvocation && isGatewayRunInvocation) {
+    // This defensive wait intentionally runs before dotenv/config I/O.
+    // The activation control port/token must come from inherited orchestrator env,
+    // not from .env-driven CLI env selection.
     await startupTrace.measure("gateway-run-deferred-activation", async () => {
       const { waitForDeferredGatewayActivation } =
         await import("./gateway-cli/deferred-activation.js");

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -30,6 +30,7 @@ import { maybeRunCliInContainer, parseCliContainerArgs } from "./container-targe
 import {
   consumeGatewayFastPathRootOptionToken,
   consumeGatewayRunOptionToken,
+  isGatewayRunInvocationArgv,
   resolveGatewayCatalogCommandPath,
   resolveGatewayRunPreBootstrapOptions,
 } from "./gateway-run-argv.js";
@@ -134,14 +135,6 @@ export function isGatewayRunFastPathArgv(argv: string[]): boolean {
   }
 
   return sawGateway;
-}
-
-function isGatewayRunInvocationArgv(argv: string[]): boolean {
-  const commandPath = resolveGatewayCatalogCommandPath(argv);
-  return (
-    commandPath?.length === 1 ||
-    (commandPath?.length === 2 && commandPath[0] === "gateway" && commandPath[1] === "run")
-  );
 }
 
 async function tryRunGatewayRunFastPath(

--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -435,6 +435,41 @@ describe("runEntryAfterDeferredGatewayActivation", () => {
     expect(loadAfterGateCalls).toBe(1);
   });
 
+  it("waits for deferred gateway activation for profiled gateway run invocations before profile env is applied", async () => {
+    const { runEntryAfterDeferredGatewayActivation } =
+      (await import("./entry.js")) as EntryDeferredActivationModule;
+
+    expect(runEntryAfterDeferredGatewayActivation).toBeTypeOf("function");
+
+    const deferred = createDeferred<void>();
+    let waitCalls = 0;
+    let loadAfterGateCalls = 0;
+
+    const runPromise = runEntryAfterDeferredGatewayActivation!(
+      ["node", "openclaw", "--profile", "demo", "gateway", "run", "--force"],
+      async () => {
+        loadAfterGateCalls += 1;
+        return "loaded";
+      },
+      {
+        waitForDeferredGatewayActivation: async () => {
+          waitCalls += 1;
+          await deferred.promise;
+        },
+      },
+    );
+
+    await Promise.resolve();
+
+    expect(waitCalls).toBe(1);
+    expect(loadAfterGateCalls).toBe(0);
+
+    deferred.resolve();
+
+    await expect(runPromise).resolves.toBe("loaded");
+    expect(loadAfterGateCalls).toBe(1);
+  });
+
   it.each([
     {
       name: "gateway help",

--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -2,6 +2,35 @@
 import { describe, expect, it } from "vitest";
 import { tryHandlePrecomputedCommandHelpFastPath, tryHandleRootHelpFastPath } from "./entry.js";
 
+type EntryDeferredActivationModule = {
+  runEntryAfterDeferredGatewayActivation?: <T>(
+    argv: string[],
+    loadAfterGate: () => Promise<T>,
+    deps?: {
+      hasContainerTarget?: boolean;
+      isGatewayRunInvocationArgv?: (argv: string[]) => boolean;
+      isHelpOrVersionInvocation?: (argv: string[]) => boolean;
+      waitForDeferredGatewayActivation?: () => Promise<unknown>;
+    },
+  ) => Promise<T>;
+};
+
+function createDeferred<T>() {
+  let resolve: ((value: T | PromiseLike<T>) => void) | undefined;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return {
+    promise,
+    resolve(value: T) {
+      if (!resolve) {
+        throw new Error("deferred resolver was not captured");
+      }
+      resolve(value);
+    },
+  };
+}
+
 describe("entry root help fast path", () => {
   it("prefers precomputed root help text when available", async () => {
     let outputPrecomputedRootHelpTextCalls = 0;
@@ -367,5 +396,87 @@ describe("entry precomputed command help fast path", () => {
 
     expect(handled).toBe(false);
     expect(outputPrecomputedBrowserHelpTextCalls).toBe(0);
+  });
+});
+
+describe("runEntryAfterDeferredGatewayActivation", () => {
+  it("waits for deferred gateway activation before loading downstream gateway code", async () => {
+    const { runEntryAfterDeferredGatewayActivation } =
+      (await import("./entry.js")) as EntryDeferredActivationModule;
+
+    expect(runEntryAfterDeferredGatewayActivation).toBeTypeOf("function");
+
+    const deferred = createDeferred<void>();
+    let waitCalls = 0;
+    let loadAfterGateCalls = 0;
+
+    const runPromise = runEntryAfterDeferredGatewayActivation!(
+      ["node", "openclaw", "--no-color", "gateway", "run", "--force"],
+      async () => {
+        loadAfterGateCalls += 1;
+        return "loaded";
+      },
+      {
+        waitForDeferredGatewayActivation: async () => {
+          waitCalls += 1;
+          await deferred.promise;
+        },
+      },
+    );
+
+    await Promise.resolve();
+
+    expect(waitCalls).toBe(1);
+    expect(loadAfterGateCalls).toBe(0);
+
+    deferred.resolve();
+
+    await expect(runPromise).resolves.toBe("loaded");
+    expect(loadAfterGateCalls).toBe(1);
+  });
+
+  it.each([
+    {
+      name: "gateway help",
+      argv: ["node", "openclaw", "gateway", "--help"],
+    },
+    {
+      name: "gateway version",
+      argv: ["node", "openclaw", "gateway", "--version"],
+    },
+    {
+      name: "non-gateway command",
+      argv: ["node", "openclaw", "status"],
+    },
+    {
+      name: "host-side container delegation",
+      argv: ["node", "openclaw", "--container", "demo", "gateway"],
+    },
+  ])("skips deferred entry activation for $name", async ({ argv }) => {
+    const { runEntryAfterDeferredGatewayActivation } =
+      (await import("./entry.js")) as EntryDeferredActivationModule;
+
+    expect(runEntryAfterDeferredGatewayActivation).toBeTypeOf("function");
+
+    let waitCalls = 0;
+    let loadAfterGateCalls = 0;
+
+    await expect(
+      runEntryAfterDeferredGatewayActivation!(
+        argv,
+        async () => {
+          loadAfterGateCalls += 1;
+          return "loaded";
+        },
+        {
+          waitForDeferredGatewayActivation: async () => {
+            waitCalls += 1;
+          },
+        },
+      ),
+    ).resolves.toBe("loaded");
+
+    expect(waitCalls).toBe(0);
+    expect(loadAfterGateCalls).toBe(1);
   });
 });

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -3,8 +3,16 @@
 // CLI process entrypoint for OpenClaw command execution.
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { getCommandPathWithRootOptions, hasFlag, isRootHelpInvocation } from "./cli/argv.js";
+import {
+  getCommandPathWithRootOptions,
+  hasFlag,
+  isHelpOrVersionInvocation,
+  isRootHelpInvocation,
+  normalizeRootHelpTargetArgv,
+  normalizeRootNoColorArgv,
+} from "./cli/argv.js";
 import { parseCliContainerArgs, resolveCliContainerTarget } from "./cli/container-target.js";
+import { isGatewayRunInvocationArgv } from "./cli/gateway-run-argv.js";
 import {
   resolvePrecomputedSubcommandHelpCommand,
   type PrecomputedSubcommandHelpName,
@@ -71,21 +79,7 @@ if (
     process.title = "openclaw";
     ensureOpenClawExecMarkerOnProcess();
     installProcessWarningFilter();
-    normalizeEnv();
-
-    enableOpenClawCompileCache({
-      installRoot,
-    });
-    gatewayEntryStartupTrace.mark("bootstrap");
-
-    if (shouldForceReadOnlyAuthStore(process.argv)) {
-      process.env.OPENCLAW_AUTH_STORE_READONLY = "1";
-    }
-
-    if (process.argv.includes("--no-color")) {
-      process.env.NO_COLOR = "1";
-      process.env.FORCE_COLOR = "0";
-    }
+    process.argv = normalizeWindowsArgv(process.argv);
 
     function ensureCliRespawnReady(): boolean {
       const plan = buildCliRespawnPlan();
@@ -97,8 +91,6 @@ if (
       // Parent must not continue running the CLI.
       return true;
     }
-
-    process.argv = normalizeWindowsArgv(process.argv);
 
     if (!ensureCliRespawnReady()) {
       const parsedContainer = parseCliContainerArgs(process.argv);
@@ -120,6 +112,29 @@ if (
         process.exit(2);
       }
 
+      const normalizedEntryArgv = normalizeRootHelpTargetArgv(
+        normalizeRootNoColorArgv(parsed.argv),
+      );
+      await runEntryAfterDeferredGatewayActivation(normalizedEntryArgv, async () => undefined, {
+        hasContainerTarget: containerTargetName !== null,
+      });
+
+      normalizeEnv();
+
+      enableOpenClawCompileCache({
+        installRoot,
+      });
+      gatewayEntryStartupTrace.mark("bootstrap");
+
+      if (shouldForceReadOnlyAuthStore(process.argv)) {
+        process.env.OPENCLAW_AUTH_STORE_READONLY = "1";
+      }
+
+      if (process.argv.includes("--no-color")) {
+        process.env.NO_COLOR = "1";
+        process.env.FORCE_COLOR = "0";
+      }
+
       if (parsed.profile) {
         applyCliProfileEnv({ profile: parsed.profile });
         // Keep Commander and ad-hoc argv checks consistent.
@@ -132,6 +147,35 @@ if (
       }
     }
   }
+}
+
+export async function runEntryAfterDeferredGatewayActivation<T>(
+  argv: string[],
+  loadAfterGate: () => Promise<T>,
+  deps: {
+    hasContainerTarget?: boolean;
+    isGatewayRunInvocationArgv?: (argv: string[]) => boolean;
+    isHelpOrVersionInvocation?: (argv: string[]) => boolean;
+    waitForDeferredGatewayActivation?: () => Promise<unknown>;
+  } = {},
+): Promise<T> {
+  const hasContainerTarget = deps.hasContainerTarget ?? resolveCliContainerTarget(argv) !== null;
+  if (
+    hasContainerTarget ||
+    (deps.isHelpOrVersionInvocation ?? isHelpOrVersionInvocation)(argv) ||
+    !(deps.isGatewayRunInvocationArgv ?? isGatewayRunInvocationArgv)(argv)
+  ) {
+    return await loadAfterGate();
+  }
+
+  const waitForDeferredGatewayActivation =
+    deps.waitForDeferredGatewayActivation ??
+    (async () =>
+      (
+        await import("./cli/gateway-cli/deferred-activation.js")
+      ).waitForDeferredGatewayActivation());
+  await waitForDeferredGatewayActivation();
+  return await loadAfterGate();
 }
 
 export async function tryHandleRootHelpFastPath(

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -115,6 +115,8 @@ if (
       const normalizedEntryArgv = normalizeRootHelpTargetArgv(
         normalizeRootNoColorArgv(parsed.argv),
       );
+      // Deferred activation only honors inherited control env.
+      // Profile state/config selection intentionally happens after this wait.
       await runEntryAfterDeferredGatewayActivation(normalizedEntryArgv, async () => undefined, {
         hasContainerTarget: containerTargetName !== null,
       });


### PR DESCRIPTION
## What Problem This Solves

Container orchestrators can start the OpenClaw process before a user's persisted state is available, but they must not let an active Gateway read, migrate, cache, or write that state before hydration finishes. Starting the real Gateway early is unsafe for cron, sessions, SQLite-backed registries, plugins, channels, memory indexes, recovery queues, and other startup-owned state.

This PR adds an opt-in **state-free deferred activation gate**. It lets an orchestrator park the CLI process, hydrate and prepare the final state tree, then activate the unchanged canonical Gateway startup path.

## Safety Boundary

For `openclaw gateway` / `openclaw gateway run`, when both activation controls are present in the inherited process environment:

- `OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_CONTROL_PORT`
- `OPENCLAW_GATEWAY_DEFERRED_ACTIVATION_TOKEN`

OpenClaw parks **before** dotenv loading, profile state/config projection, environment normalization, managed-proxy startup, `run-main` module evaluation, config/state-path selection, migrations, SQLite, Gateway locks, boot accounting, plugin discovery, or `startGatewayServer`.

The parked process owns only a loopback control listener. It does **not** bind the real Gateway port, create a Gateway lock/boot row, or open OpenClaw state.

Activation then resumes the existing startup sequence unchanged:

1. normal environment/config selection
2. Gateway pre-bootstrap and migrations
3. boot/crash-loop lifecycle
4. `runGatewayLoop`
5. `startGatewayServer`

The defensive singleton checks in `run-main` and Commander preaction remain, but the product-launcher gate is the primary boundary. Host-side `--container` delegation, help/version, and non-Gateway commands skip parking.

Activation controls are intentionally **inherited environment only**. Reading `.env` or profile state before parking would violate the zero-state/config-I/O boundary.

## Control Protocol

The control listener binds only `127.0.0.1` and exposes:

- `GET /healthz` → parked-process liveness
- `GET /readyz` → `503` while parked
- authenticated `POST /activate` with `{ "activationId": "..." }` → `202 Accepted`

Hardening includes:

- control port/token must be configured together
- non-empty, header-safe token validation
- constant-time token comparison
- 16 KiB request-body limit
- 256-byte activation ID limit
- exact route/method handling and bounded malformed-request responses
- one accepted activation; duplicate/concurrent attempts cannot start twice
- winning 202 socket preserved through graceful delivery
- non-winning slow/partial sockets force-closed during activation
- disconnect-safe activation commit
- SIGTERM/SIGINT cleanup with correct pre-existing-listener ownership
- no activation-time environment mutation map

After `202`, callers poll the real Gateway `/readyz`.

## What Changed From The Previous PR Version

This is a current-`main` reimplementation, not a mechanical rebase of the old recursive `startGatewayServer(..., { activationMode: "deferred" })` design.

Removed from the design:

- recursive inner `startGatewayServer`
- placeholder on the real Gateway port
- deferred `GatewayServer` close/start ownership
- activation-time config/env retargeting
- arbitrary activation env payloads
- parked boot/crash-loop/lock ownership

`server.impl.ts` is unchanged.

Optional full Gateway module preload was intentionally **not** shipped: auditing showed importing `server.impl` reaches eager config/state-path filesystem probes. The safe implementation therefore parks the control process only. Whether that is valuable for Lobster's real production image is measured separately by the Lobster integration benchmark; this upstream PR makes no product-performance claim.

## Evidence

Implementation base/head:

- base: `ffc8051cacb50d1f4b39cc2c6f822083caba1f2a`
- head: `1ab4dfaaf5cabcf4087fe4d3e67ba8ddd35af257`

Focused validation:

- 11 affected test files, **404 tests passed**
- core production tsgo typecheck: PASS
- core test tsgo typecheck: PASS
- targeted oxlint across all changed TypeScript files: PASS
- targeted format check: PASS
- `pnpm build`: PASS; CLI bootstrap import guard passed; no ineffective dynamic-import warning
- shell harness syntax/self-tests: PASS
- `git diff --check origin/main...HEAD`: PASS

Linux OS-level proof used the real packaged launcher under `strace` in an approved disposable Debian 12 arm64 Colima container with current frozen-lockfile dependencies:

- run ID: `2026-07-11T03-34-50Z-279`
- parked `/healthz`: `{"status":"ok"}`
- activation: `{"status":"accepted","activationId":"state-io-proof"}`
- canonical Gateway `/readyz`: `{"ready":true,...}`
- eight pre-activation traces, 27,118 bytes
- **zero** isolated state-root accesses
- **zero** isolated config-root accesses
- **zero** `openclaw.sqlite` / `gateway.lock` accesses
- **zero** bind/connect calls to real Gateway port `18789`

Structured autoreview:

- isolated Pi engine, `github-copilot/gpt-5.4`, xhigh reasoning
- final result: `autoreview clean: no accepted/actionable findings reported`

The full local lint fan-out was intentionally not rerun after it resource-starved unrelated shards on the development machine. Targeted lint/type/build proof is green; hosted CI owns the full fan-out for this pushed head.

## User Impact

Default startup is unchanged when the two activation controls are absent. Deferred activation remains explicit and opt-in. This PR supplies the safe upstream primitive; Lobster separately owns hydration-before-activation enforcement, rollout controls, real-image benchmarks, and the decision whether the measured gain justifies keeping pre-warm complexity.
