### PR TITLE
improve(diagnostics-otel): make agent-duration histograms usable beyond 10s

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2348,13 +2348,17 @@ describe("diagnostics-otel service", () => {
   test("advertises explicit duration buckets on the openclaw run/harness/context histograms", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
+    const priorSdkBoundaries = [
+      0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000,
+    ];
     try {
       await service.start(ctx);
 
       const runDurationOptions = histogramCreateOptions("openclaw.run.duration_ms");
       expect(runDurationOptions?.unit).toBe("ms");
       const runBoundaries = runDurationOptions?.advice?.explicitBucketBoundaries;
-      for (const boundary of [1000, 60000, 3_600_000]) {
+      expect(runBoundaries).toEqual(expect.arrayContaining(priorSdkBoundaries));
+      for (const boundary of [60000, 3_600_000]) {
         expect(runBoundaries).toContain(boundary);
       }
 
@@ -2364,7 +2368,8 @@ describe("diagnostics-otel service", () => {
 
       const contextOptions = histogramCreateOptions("openclaw.context.tokens");
       const contextBoundaries = contextOptions?.advice?.explicitBucketBoundaries;
-      for (const boundary of [8000, 128000, 1_000_000]) {
+      expect(contextBoundaries).toEqual(expect.arrayContaining(priorSdkBoundaries));
+      for (const boundary of [128000, 1_000_000]) {
         expect(contextBoundaries).toContain(boundary);
       }
     } finally {

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2345,6 +2345,33 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("advertises explicit duration buckets on the openclaw run/harness/context histograms", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
+    try {
+      await service.start(ctx);
+
+      const runDurationOptions = histogramCreateOptions("openclaw.run.duration_ms");
+      expect(runDurationOptions?.unit).toBe("ms");
+      const runBoundaries = runDurationOptions?.advice?.explicitBucketBoundaries;
+      for (const boundary of [1000, 60000, 3_600_000]) {
+        expect(runBoundaries).toContain(boundary);
+      }
+
+      const harnessDurationOptions = histogramCreateOptions("openclaw.harness.duration_ms");
+      const harnessBoundaries = harnessDurationOptions?.advice?.explicitBucketBoundaries;
+      expect(harnessBoundaries).toEqual(runBoundaries);
+
+      const contextOptions = histogramCreateOptions("openclaw.context.tokens");
+      const contextBoundaries = contextOptions?.advice?.explicitBucketBoundaries;
+      for (const boundary of [8000, 128000, 1_000_000]) {
+        expect(contextBoundaries).toContain(boundary);
+      }
+    } finally {
+      await service.stop?.(ctx);
+    }
+  });
+
   test("bounds agent identifiers on model usage metric attributes", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -107,18 +107,42 @@ const GEN_AI_TOKEN_USAGE_BUCKETS = [
 const GEN_AI_OPERATION_DURATION_BUCKETS = [
   0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 ];
-// Agent run / harness durations span seconds to ~an hour; the SDK default
-// boundaries top out at 10s, collapsing everything slower into +Inf. Spread
-// resolution across 1s … 1h so p50/p95/p99 stay meaningful for long runs.
+// Preserve the SDK's existing finite boundaries so upgrades do not remove
+// exported bucket series that dashboards or alerts may already reference.
+const OTEL_DEFAULT_HISTOGRAM_BUCKETS = [
+  0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000,
+];
+// Agent run / harness durations routinely exceed the SDK default's 10s ceiling.
+// Extend the existing layout through one hour without changing prior buckets.
 const AGENT_DURATION_MS_BUCKETS = [
-  1000, 2500, 5000, 10000, 15000, 20000, 30000, 45000, 60000, 120000, 180000, 240000, 300000,
-  600000, 900000, 1_800_000, 3_600_000,
+  ...OTEL_DEFAULT_HISTOGRAM_BUCKETS,
+  15000,
+  20000,
+  30000,
+  45000,
+  60000,
+  120000,
+  180000,
+  240000,
+  300000,
+  600000,
+  900000,
+  1_800_000,
+  3_600_000,
 ];
 // openclaw.context.tokens records context window limit/used token counts, which
-// range from a few thousand to >1M for large-context models. Bucket on a token
-// scale so realistic context sizes don't collapse into the +Inf overflow bucket.
+// range from a few thousand to >1M for large-context models. Keep the prior
+// layout and add common context-window sizes above it.
 const CONTEXT_TOKENS_BUCKETS = [
-  1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000, 200000, 400000, 1_000_000, 2_000_000,
+  ...OTEL_DEFAULT_HISTOGRAM_BUCKETS,
+  16000,
+  32000,
+  64000,
+  128000,
+  200000,
+  400000,
+  1_000_000,
+  2_000_000,
 ];
 const MAX_RETAINED_TRUSTED_SPAN_CONTEXTS = 1024;
 const RETAINED_TRUSTED_SPAN_CONTEXT_TIMEOUT_MS = 5_000;

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -107,6 +107,19 @@ const GEN_AI_TOKEN_USAGE_BUCKETS = [
 const GEN_AI_OPERATION_DURATION_BUCKETS = [
   0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 ];
+// Agent run / harness durations span seconds to ~an hour; the SDK default
+// boundaries top out at 10s, collapsing everything slower into +Inf. Spread
+// resolution across 1s … 1h so p50/p95/p99 stay meaningful for long runs.
+const AGENT_DURATION_MS_BUCKETS = [
+  1000, 2500, 5000, 10000, 15000, 20000, 30000, 45000, 60000, 120000, 180000, 240000, 300000,
+  600000, 900000, 1_800_000, 3_600_000,
+];
+// openclaw.context.tokens records context window limit/used token counts, which
+// range from a few thousand to >1M for large-context models. Bucket on a token
+// scale so realistic context sizes don't collapse into the +Inf overflow bucket.
+const CONTEXT_TOKENS_BUCKETS = [
+  1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000, 200000, 400000, 1_000_000, 2_000_000,
+];
 const MAX_RETAINED_TRUSTED_SPAN_CONTEXTS = 1024;
 const RETAINED_TRUSTED_SPAN_CONTEXT_TIMEOUT_MS = 5_000;
 
@@ -1797,14 +1810,17 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const durationHistogram = meter.createHistogram("openclaw.run.duration_ms", {
         unit: "ms",
         description: "Agent run duration",
+        advice: { explicitBucketBoundaries: AGENT_DURATION_MS_BUCKETS },
       });
       const harnessDurationHistogram = meter.createHistogram("openclaw.harness.duration_ms", {
         unit: "ms",
         description: "Agent harness lifecycle duration",
+        advice: { explicitBucketBoundaries: AGENT_DURATION_MS_BUCKETS },
       });
       const contextHistogram = meter.createHistogram("openclaw.context.tokens", {
         unit: "1",
         description: "Context window size and usage",
+        advice: { explicitBucketBoundaries: CONTEXT_TOKENS_BUCKETS },
       });
       const webhookReceivedCounter = meter.createCounter("openclaw.webhook.received", {
         unit: "1",


### PR DESCRIPTION
## What Problem This Solves

The `openclaw.run.duration_ms`, `openclaw.harness.duration_ms`, and
`openclaw.context.tokens` histograms used the OTel SDK default bucket
boundaries. The default duration buckets top out at 10s, but agent runs
routinely take minutes — so nearly every run lands in the `+Inf` overflow
bucket. Anyone reading p50/p95/p99 latency for agent runs sees a flat,
meaningless distribution unless they reconfigure buckets at the collector.

## Why This Change Was Made

Attach `explicit_bucket_boundaries` advice via named constants, matching the
existing `GEN_AI_*_BUCKETS` convention already in this file:
- `AGENT_DURATION_MS_BUCKETS` (1s … 1h) for the run and harness duration
  histograms, which share the same latency range.
- `CONTEXT_TOKENS_BUCKETS` for the small-integer context-size histogram.

Histogram bucket advice only affects how new data is aggregated; it changes
no recorded values and no public API.

## User Impact

Operators get meaningful latency percentiles for agent runs and harness
lifecycle out of the box, across the full seconds-to-an-hour range, without
any collector-side bucket configuration.

## Evidence

- New unit test asserts all three histograms advertise the expected bucket
  boundaries and that run/harness share the same set.
- `extensions/diagnostics-otel` test suite: **96 passed**.
- Typecheck (`tsgo:extensions`, `tsgo:extensions:test`), lint
  (`lint:extensions`), and format (`oxfmt --check`) all pass on the changed
  files.