### PR TITLE
ci: default maturity evidence to all profile

### DIFF
--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -134,7 +134,7 @@ jobs:
     with:
       ref: ${{ inputs.ref }}
       expected_sha: ${{ needs.validate_selected_ref.outputs.selected_revision }}
-      qa_profile: release
+      qa_profile: all
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
@@ -238,8 +238,8 @@ jobs:
           }
 
           const evidence = JSON.parse(fs.readFileSync(evidencePath, "utf8"));
-          if (evidence.profile !== "release") {
-            throw new Error(`qa-evidence.json profile must be release, got ${JSON.stringify(evidence.profile)}`);
+          if (evidence.profile !== "all") {
+            throw new Error(`qa-evidence.json profile must be all, got ${JSON.stringify(evidence.profile)}`);
           }
 
           const artifactDir = path.dirname(evidencePath);
@@ -256,8 +256,8 @@ jobs:
           const manifestPath = path.join(artifactDir, manifestNames[0]);
           const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
           const manifestProfile = manifest.qaProfile ?? evidence.profile;
-          if (manifestProfile !== "release") {
-            throw new Error(`QA evidence manifest profile must be release, got ${JSON.stringify(manifestProfile)}`);
+          if (manifestProfile !== "all") {
+            throw new Error(`QA evidence manifest profile must be all, got ${JSON.stringify(manifestProfile)}`);
           }
           if (manifest.targetSha !== targetSha) {
             throw new Error(`QA evidence manifest targetSha ${manifest.targetSha} does not match selected ref ${targetSha}`);
@@ -428,14 +428,14 @@ jobs:
           cat > "$body_file" <<BODY
           ## Summary
 
-          - render maturity scorecard docs from \`qa/maturity-scores.yaml\` and release QA evidence
+          - render maturity scorecard docs from \`qa/maturity-scores.yaml\` and full taxonomy QA evidence
           - maturity source ref: ${REF_INPUT}
           - QA evidence run: ${evidence_run_id}
 
           ## Verification
 
           - QA Lab maturity score validation passed
-          - Maturity scorecard workflow rendered docs from release profile qa-evidence.json artifacts with strict inputs
+          - Maturity scorecard workflow rendered docs from all profile qa-evidence.json artifacts with strict inputs
           BODY
 
           pr_url="$(gh pr list --head "$branch" --state open --json url --jq '.[0].url // ""')"

--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -18,7 +18,7 @@ on:
       qa_profile:
         description: Taxonomy QA profile id to run (for example release or all)
         required: true
-        default: release
+        default: all
         type: string
   workflow_call:
     inputs:

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -664,6 +664,7 @@ describe("ci workflow guards", () => {
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs).not.toHaveProperty("fail_on_qa_failure");
     expect(qaEvidenceWorkflow.on.workflow_call.inputs).not.toHaveProperty("fail_on_qa_failure");
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile).not.toHaveProperty("options");
+    expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile.default).toBe("all");
     expect(qaEvidenceWorkflow.on.workflow_call.inputs.qa_profile.type).toBe("string");
     const validateProfileStep = qaRunJob.steps.find(
       (step) => step.name === "Validate QA profile input",
@@ -682,7 +683,7 @@ describe("ci workflow guards", () => {
       // Keep the caller's ref while the callee verifies it against expected_sha.
       ref: "${{ inputs.ref }}",
       expected_sha: "${{ needs.validate_selected_ref.outputs.selected_revision }}",
-      qa_profile: "release",
+      qa_profile: "all",
     });
     expect(generateJob.with).not.toHaveProperty("fail_on_qa_failure");
 
@@ -713,6 +714,8 @@ describe("ci workflow guards", () => {
       (step) => step.name === "Validate QA evidence manifest",
     );
     expect(validateManifestStep.run).toContain("qa-profile-evidence-manifest.json");
+    expect(validateManifestStep.run).toContain("qa-evidence.json profile must be all");
+    expect(validateManifestStep.run).toContain("QA evidence manifest profile must be all");
     expect(validateManifestStep.run).toContain("manifest.targetSha !== targetSha");
 
     expect(qaRunJob.outputs.artifact_name).toBe("${{ steps.evidence.outputs.artifact_name }}");


### PR DESCRIPTION
## What Problem This Solves

The QA Profile Evidence workflow defaulted manual dispatches to the narrower `release` profile, while the maturity scorecard refresh path is intended to use full taxonomy evidence.

## Why This Change Was Made

- Default manual QA Profile Evidence dispatches to `all`.
- Have the maturity scorecard workflow generate and validate `all` profile evidence.
- Update workflow guard tests so generated evidence and manifest validation stay aligned.

## User Impact

Maintainers refreshing the maturity scorecard get full taxonomy QA evidence by default instead of accidentally rendering from the narrower release profile.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`
- `pnpm exec oxfmt --check --threads=1 test/scripts/ci-workflow-guards.test.ts`
- `actionlint .github/workflows/qa-profile-evidence.yml .github/workflows/maturity-scorecard.yml`
- `git diff --check`
