### PR TITLE
fix: surface provider authentication failures in channels

### DIFF
--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -13,6 +13,7 @@ export {
   stripThoughtSignatures,
 } from "./embedded-agent-helpers/bootstrap.js";
 export {
+  AUTH_INVALID_TOKEN_USER_TEXT,
   BILLING_ERROR_USER_MESSAGE,
   classifyAssistantFailoverReason,
   classifyProviderRuntimeFailureKind,

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -13,7 +13,6 @@ export {
   stripThoughtSignatures,
 } from "./embedded-agent-helpers/bootstrap.js";
 export {
-  AUTH_INVALID_TOKEN_USER_TEXT,
   BILLING_ERROR_USER_MESSAGE,
   classifyAssistantFailoverReason,
   classifyProviderRuntimeFailureKind,

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -75,6 +75,10 @@ export {
 const log = createSubsystemLogger("errors");
 const sandboxToolPolicyAuditMessages = new WeakSet<AssistantMessage>();
 export const GENERIC_ASSISTANT_ERROR_TEXT = "LLM request failed.";
+export const AUTH_INVALID_TOKEN_USER_TEXT =
+  "Authentication failed (provider returned HTTP 401). " +
+  "Your provider token may have expired — try the request again in a moment. " +
+  "If the failure persists, re-authenticate this provider.";
 const PROVIDER_SCHEMA_REJECTION_USER_TEXT =
   "LLM request failed: provider rejected the request schema or tool payload.";
 const MODEL_NOT_FOUND_USER_TEXT =
@@ -1419,11 +1423,7 @@ export function formatAssistantErrorText(
   }
 
   if (providerRuntimeFailureKind === "auth_invalid_token") {
-    return (
-      "Authentication failed (provider returned HTTP 401). " +
-      "Your provider token may have expired — try the request again in a moment. " +
-      "If the failure persists, re-authenticate this provider."
-    );
+    return AUTH_INVALID_TOKEN_USER_TEXT;
   }
 
   if (providerRuntimeFailureKind === "upstream_html") {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -28,6 +28,7 @@ import {
 } from "./agent-runner-execution.js";
 import { HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT } from "./agent-runner-failure-copy.js";
 import {
+  PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE,
   PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
   PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
   PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE,
@@ -6530,6 +6531,38 @@ describe("runAgentTurnWithFallback", () => {
       if (result.kind === "final") {
         expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
         expect(result.payload.text).toContain('Missing API key for provider "openai"');
+      }
+    },
+  );
+
+  it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
+    "surfaces provider authentication failures in $label chats",
+    async (testCase) => {
+      const rawError =
+        "unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses";
+      state.runEmbeddedAgentMock.mockRejectedValueOnce(
+        new FailoverError("LLM request unauthorized.", {
+          reason: "auth",
+          provider: "openai",
+          model: "gpt-5.5",
+          status: 401,
+          rawError,
+        }),
+      );
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback(
+        createMinimalRunAgentTurnParams({
+          sessionCtx: createNonDirectFailureSessionCtx(testCase),
+        }),
+      );
+
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        expect(result.payload.isError).toBe(true);
+        expect(result.payload.text).toBe(PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE);
+        expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
+        expect(result.payload.text).not.toContain(rawError);
       }
     },
   );

--- a/src/auto-reply/reply/provider-request-error-classifier.test.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.test.ts
@@ -1,13 +1,60 @@
 /** Tests provider request error classification for retry/fallback decisions. */
 import { describe, expect, it } from "vitest";
+import { FailoverError } from "../../agents/failover-error.js";
 import {
   classifyProviderRequestError,
+  PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE,
   PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
   PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
   PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE,
 } from "./provider-request-error-classifier.js";
 
 describe("provider request error classifier", () => {
+  it("classifies provider HTTP 401 authentication failures", () => {
+    const message =
+      "unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses";
+
+    expect(classifyProviderRequestError(new Error(message))).toEqual({
+      code: "provider_authentication_error",
+      userMessage: PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE,
+      technicalMessage: message,
+    });
+  });
+
+  it("classifies typed authentication failures without relying on raw provider text", () => {
+    const error = new FailoverError("LLM request unauthorized.", {
+      reason: "auth",
+      provider: "openai",
+      model: "gpt-5.5",
+      status: 401,
+    });
+
+    expect(classifyProviderRequestError(error)).toEqual({
+      code: "provider_authentication_error",
+      userMessage: PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE,
+      technicalMessage: "LLM request unauthorized.",
+    });
+  });
+
+  it("does not label typed HTTP 403 authorization failures as HTTP 401", () => {
+    const error = new FailoverError("Provider access denied.", {
+      reason: "auth_permanent",
+      provider: "openai",
+      model: "gpt-5.5",
+      status: 403,
+    });
+
+    expect(classifyProviderRequestError(error)).toBeUndefined();
+  });
+
+  it("leaves unrelated HTTP 401 failures unclassified", () => {
+    expect(
+      classifyProviderRequestError(
+        new Error("401 input item id does not belong to this conversation"),
+      ),
+    ).toBeUndefined();
+  });
+
   it.each([
     [
       "OpenAI missing custom tool output",

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -1,9 +1,14 @@
 // Classifies provider request failures into retry and user-facing categories.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  AUTH_INVALID_TOKEN_USER_TEXT,
+  classifyProviderRuntimeFailureKind,
+} from "../../agents/embedded-agent-helpers.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 
 /** Provider request error classes that get a specialized user-facing reply. */
 export type ProviderRequestErrorCode =
+  | "provider_authentication_error"
   | "provider_conversation_state_error"
   | "provider_internal_error"
   | "provider_rate_limit_or_quota_error";
@@ -25,11 +30,20 @@ export const PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE =
 export const PROVIDER_INTERNAL_ERROR_USER_MESSAGE =
   "⚠️ The model provider returned a temporary internal error before replying. Try again in a moment, or switch to another model if it keeps happening.";
 
+export const PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE = `⚠️ ${AUTH_INVALID_TOKEN_USER_TEXT}`;
+
 /** Classifies provider request failures that are actionable for users. */
 export function classifyProviderRequestError(
   err: unknown,
 ): ProviderRequestErrorClassification | undefined {
   const technicalMessage = formatErrorMessage(err);
+  if (classifyProviderRuntimeFailureKind(technicalMessage) === "auth_invalid_token") {
+    return {
+      code: "provider_authentication_error",
+      userMessage: PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE,
+      technicalMessage,
+    };
+  }
   if (
     hasHttp429Evidence(err, technicalMessage) &&
     isGenericProviderRuntimeErrorMessage(technicalMessage)

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -3,7 +3,8 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import {
   AUTH_INVALID_TOKEN_USER_TEXT,
   classifyProviderRuntimeFailureKind,
-} from "../../agents/embedded-agent-helpers.js";
+} from "../../agents/embedded-agent-helpers/errors.js";
+import { isFailoverError } from "../../agents/failover-error.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 
 /** Provider request error classes that get a specialized user-facing reply. */
@@ -37,7 +38,11 @@ export function classifyProviderRequestError(
   err: unknown,
 ): ProviderRequestErrorClassification | undefined {
   const technicalMessage = formatErrorMessage(err);
-  if (classifyProviderRuntimeFailureKind(technicalMessage) === "auth_invalid_token") {
+  const isTypedAuthFailure = isFailoverError(err) && err.reason === "auth" && err.status === 401;
+  if (
+    isTypedAuthFailure ||
+    classifyProviderRuntimeFailureKind(technicalMessage) === "auth_invalid_token"
+  ) {
     return {
       code: "provider_authentication_error",
       userMessage: PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE,


### PR DESCRIPTION
Related: #80040

## What Problem This Solves

Fixes an issue where users messaging a bot in a channel would receive no reply when the model provider rejected the request with an HTTP 401 authentication failure. The user only sees the :eyes: react, but there is not response or error message from the bot.
<img width="328" height="130" alt="Screenshot 2026-06-24 at 16 49 15" src="https://github.com/user-attachments/assets/9553d910-7f8c-4647-8a80-a5002c68b643" />


## Why This Change Was Made

Classify proven invalid-token HTTP 401 failures as actionable provider request errors and reuse the existing sanitized authentication guidance. This keeps raw provider details private while allowing the shared channel reply path to surface the failure instead of treating it as a generic, silence-eligible error.

## User Impact

Channel users now receive a concise authentication warning with retry and re-authentication guidance instead of seeing the bot silently stop.

## Evidence

- Observed failure shape: `unexpected status 401 Unauthorized: Missing bearer or basic authentication in header`.
- Before: the failure fell through to the generic runner error and became `NO_REPLY` in channels.
- After: the failure is classified and routed through the existing visible non-generic failure path.
- Focused classifier suite: 18 tests passed.
- Focused reply-runner suite: 214 tests passed, including Slack, Discord, Telegram, WhatsApp, and Microsoft Teams channel/group coverage.
- Changed-file formatting check passed.
