### PR TITLE
fix(cron): preserve enabled-with-defaults failure alert through store roundtrip (fixes #96589) (AI-assisted)

### DIFF
--- a/src/cron/store/failure-alert-codec.test.ts
+++ b/src/cron/store/failure-alert-codec.test.ts
@@ -1,0 +1,55 @@
+// Unit tests for failure-alert SQLite column codec roundtrip.
+import { describe, expect, it } from "vitest";
+import { bindFailureAlertColumns, failureAlertFromRow } from "./failure-alert-codec.js";
+import type { CronJobRow } from "./schema.js";
+
+function roundtrip(
+  input: Parameters<typeof bindFailureAlertColumns>[0],
+): ReturnType<typeof failureAlertFromRow> {
+  const columns = bindFailureAlertColumns(input);
+  return failureAlertFromRow(columns as CronJobRow);
+}
+
+describe("failureAlertFromRow", () => {
+  it("round-trips disabled config (false)", () => {
+    expect(roundtrip(false)).toBe(false);
+  });
+
+  it("round-trips undefined (no alert config) as undefined", () => {
+    expect(roundtrip(undefined)).toBeUndefined();
+  });
+
+  it("round-trips enabled-with-defaults ({}) as {}", () => {
+    const result = roundtrip({});
+    expect(result).toEqual({});
+  });
+
+  it("round-trips populated config with all fields", () => {
+    const config = {
+      after: 3,
+      cooldownMs: 120_000,
+      channel: "telegram" as const,
+      to: "@user",
+      mode: "announce" as const,
+      accountId: "acc-1",
+      includeSkipped: true,
+    };
+    expect(roundtrip(config)).toEqual(config);
+  });
+
+  it("round-trips partial config (only after)", () => {
+    expect(roundtrip({ after: 5 })).toEqual({ after: 5 });
+  });
+
+  it("enabled-with-defaults does not collapse to undefined on read", () => {
+    // Simulates the exact bug: write {}, read back should be {} not undefined
+    const columns = bindFailureAlertColumns({});
+    const row = columns as CronJobRow;
+    expect(row.failure_alert_disabled).toBe(0);
+    expect(row.failure_alert_after).toBeNull();
+    const decoded = failureAlertFromRow(row);
+    expect(decoded).toEqual({});
+    // The critical assertion: {} is truthy, so resolveFailureAlert will use it
+    expect(decoded).toBeTruthy();
+  });
+});

--- a/src/cron/store/failure-alert-codec.ts
+++ b/src/cron/store/failure-alert-codec.ts
@@ -53,7 +53,8 @@ export function failureAlertFromRow(row: CronJobRow): CronFailureAlert | false |
     row.failure_alert_cooldown_ms == null &&
     row.failure_alert_include_skipped == null &&
     !row.failure_alert_mode &&
-    !row.failure_alert_account_id
+    !row.failure_alert_account_id &&
+    row.failure_alert_disabled !== 0
   ) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Enabling cron failure alerts with defaults only (`openclaw cron edit <job> --failure-alert` with no `--failure-alert-*` flags) works until the next gateway restart, then silently stops firing forever. The store codec persists the enabled-with-defaults state but cannot read it back, so on reload the job's `failureAlert` becomes `undefined` and failing jobs fail invisibly.

## Why This Change Was Made

`failureAlertFromRow` in `src/cron/store/failure-alert-codec.ts` checks whether all explicit config columns are null to decide if there is no alert config. But when `failure_alert_disabled === 0` (the enabled-with-defaults sentinel), all explicit columns are also null, so the empty-check returns `undefined` instead of `{}`. This collapses three intended states (disabled / enabled-with-defaults / populated) into two on read.

The fix adds `row.failure_alert_disabled !== 0` to the empty-column guard so the enabled sentinel survives the SQLite round-trip.

## User Impact

Operators who enable per-job failure alerts with default settings will no longer silently lose alert coverage after a gateway restart. This is a data-roundtrip correctness fix with no config surface or behavioral change for alerts that were already configured with explicit fields.

## Evidence

- **Behavior addressed:** Cron failure-alert enabled-with-defaults (`{}`) collapses to `undefined` on SQLite store roundtrip, silencing alerts after gateway restart.
- **Environment tested:** macOS 26.4.1, Node 22.22.3, OpenClaw repo at `0a042f68`.
- **Steps run after the patch:** Ran codec roundtrip verification importing `bindFailureAlertColumns` and `failureAlertFromRow` from `src/cron/store/failure-alert-codec.ts` with tsx.
- **Evidence after fix:**

```
PASS: disabled (false) → false
PASS: undefined (no config) → undefined
PASS: enabled-with-defaults ({}) → {}
PASS: populated config → {"after":3,"channel":"telegram"}

4/4 passed
```

- **Observed result after fix:** `roundtrip({})` now returns `{}` (truthy, alert active) instead of `undefined` (falsy, alert silenced). The `resolveFailureAlert` function at `src/cron/service/failure-alerts.ts:75` will proceed with defaults when `jobConfig` is `{}`.
- **What was not tested:** Live gateway restart cycle (requires full gateway orchestration); the fix is validated at the codec layer where the bug resides.

## Real behavior proof

- **Behavior addressed:** Cron failure-alert enabled-with-defaults (`{}`) collapses to `undefined` on SQLite store roundtrip, silencing alerts after gateway restart.
- **Environment tested:** macOS 26.4.1, Node 22.22.3, OpenClaw repo at `0a042f68`.
- **Steps run after the patch:** Ran codec roundtrip verification importing `bindFailureAlertColumns` and `failureAlertFromRow` from `src/cron/store/failure-alert-codec.ts` with tsx.
- **Evidence after fix:**

```
PASS: disabled (false) → false
PASS: undefined (no config) → undefined
PASS: enabled-with-defaults ({}) → {}
PASS: populated config → {"after":3,"channel":"telegram"}

4/4 passed
```

- **Observed result after fix:** `roundtrip({})` now returns `{}` (truthy, alert active) instead of `undefined` (falsy, alert silenced). The `resolveFailureAlert` function at `src/cron/service/failure-alerts.ts:75` will proceed with defaults when `jobConfig` is `{}`.
- **What was not tested:** Live gateway restart cycle (requires full gateway orchestration); the fix is validated at the codec layer where the bug resides.

- [x] AI-assisted (Hermes Agent)
