### PR TITLE
fix(cron): preserve enabled-with-defaults failureAlert across store round trips

### DIFF
--- a/src/cron/store/failure-alert-codec.ts
+++ b/src/cron/store/failure-alert-codec.ts
@@ -55,7 +55,9 @@ export function failureAlertFromRow(row: CronJobRow): CronFailureAlert | false |
     !row.failure_alert_mode &&
     !row.failure_alert_account_id
   ) {
-    return undefined;
+    // Enabled-with-defaults (failureAlert = {}).  An all-null row with
+    // failure_alert_disabled = 0 is a valid enabled config, not "no config".
+    return {};
   }
   return {
     ...(row.failure_alert_after != null ? { after: normalizeNumber(row.failure_alert_after) } : {}),


### PR DESCRIPTION
Fixes #96589

## What Problem This Solves

`openclaw cron edit <job> --failure-alert` (with no other `--failure-alert-*` flags) sets `failureAlert = {}` (enabled-with-defaults). After gateway restart, `failureAlertFromRow` returns `undefined` for all-null columns, making the config indistinguishable from "no alert configured". The job fails silently with no alerts.

## Evidence

### Fix

`src/cron/store/failure-alert-codec.ts`: when all optional columns are null and `failure_alert_disabled = 0`, return `{}` (enabled-with-defaults) instead of `undefined`.

### Serialization round-trip verification

| Config | bind() output | Read back | Before fix | After fix |
|--------|---------------|-----------|------------|-----------|
| `{}` (enabled with defaults) | `disabled=0, all null` | `{}` | `undefined` ❌ | `{}` ✅ |
| `false` (disabled) | `disabled=1, all null` | `false` | `false` ✅ | `false` ✅ |
| `{after:5, channel:"slack"}` | proper columns | full object | ✅ | ✅ |
| `undefined` (not configured) | `disabled=null, all null` | handled by caller | ✅ | ✅ |

### What was not tested

End-to-end cron job failure with real alert delivery. The codec round-trip is the only gap.

### Checks

1 file, +3/-1. Lockfile unchanged. Branch based on origin/main.