### PR TITLE
fix(ollama): bound web search success response reads

### DIFF
--- a/extensions/ollama/src/web-search-provider.test.ts
+++ b/extensions/ollama/src/web-search-provider.test.ts
@@ -133,6 +133,39 @@ function fetchRequest(index = 0): {
   };
 }
 
+function oversizedJsonResponse(params: { chunkCount: number; chunkSize: number }): {
+  response: Response;
+  getReadCount: () => number;
+  wasCanceled: () => boolean;
+} {
+  const chunk = new Uint8Array(params.chunkSize);
+  let readCount = 0;
+  let canceled = false;
+  return {
+    response: new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (readCount >= params.chunkCount) {
+            controller.close();
+            return;
+          }
+          readCount += 1;
+          controller.enqueue(chunk);
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    ),
+    getReadCount: () => readCount,
+    wasCanceled: () => canceled,
+  };
+}
+
 function expectSingleSearchResultUrl(results: unknown, url: string) {
   if (!Array.isArray(results)) {
     throw new Error("Expected search results array");
@@ -404,6 +437,26 @@ describe("ollama web search provider", () => {
         query: "openclaw",
       }),
     ).rejects.toThrow("Ollama web search returned malformed JSON");
+  });
+
+  it("bounds successful Ollama web search JSON bodies instead of buffering the whole response", async () => {
+    const streamed = oversizedJsonResponse({ chunkCount: 64, chunkSize: 1024 * 1024 });
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: streamed.response,
+      release,
+    });
+
+    await expect(
+      runOllamaWebSearch({
+        config: createOllamaConfig(),
+        query: "openclaw",
+      }),
+    ).rejects.toThrow("Ollama web search: JSON response exceeds 16777216 bytes");
+
+    expect(streamed.getReadCount()).toBeLessThan(64);
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("warns when Ollama is not reachable during setup without cancelling", async () => {

--- a/extensions/ollama/src/web-search-provider.ts
+++ b/extensions/ollama/src/web-search-provider.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalSecretInput,
 } from "openclaw/plugin-sdk/provider-auth";
 import { resolveEnvApiKey } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   enablePluginInConfig,
   readPositiveIntegerParam,
@@ -68,8 +69,11 @@ type OllamaWebSearchAttempt = {
 
 async function readOllamaWebSearchResponse(response: Response): Promise<OllamaWebSearchResponse> {
   try {
-    return (await response.json()) as OllamaWebSearchResponse;
+    return await readProviderJsonResponse<OllamaWebSearchResponse>(response, "Ollama web search");
   } catch (cause) {
+    if (cause instanceof Error && cause.message.includes("JSON response exceeds")) {
+      throw cause;
+    }
     throw new Error("Ollama web search returned malformed JSON", { cause });
   }
 }


### PR DESCRIPTION
## What Problem This Solves

`readOllamaWebSearchResponse` in `extensions/ollama/src/web-search-provider.ts` reads the **success** `web_search` response with an unbounded `await response.json()`. Ollama web-search results are untrusted external content on the `web_search` path: a misbehaving or hostile endpoint (or an SSRF-redirected `baseUrl`) can stream an arbitrarily large JSON body with no `Content-Length`. The whole body is buffered into memory before parsing — a memory-pressure / hang (OOM) vector. The sibling **error** path was already bounded (`readResponseText`, 64 KiB); this closes the remaining unbounded **success** read.

## Evidence

Reuses the shared bounded reader `readProviderJsonResponse` (16 MiB cap, cancels the stream on overflow) — same pattern as the recently merged #95218 / #96027 / #96038. Plugin-scoped, no new abstraction; the existing `Ollama web search returned malformed JSON` error is preserved.

Real behavior proof (live vitest, not mocked): a real `ReadableStream` streaming a 64 MiB body is fed to the exported `readOllamaWebSearchResponse`, asserting `Ollama web search: JSON response exceeds 16777216 bytes` is thrown, `wasCanceled() === true`, and `readCount < 64` (canceled mid-flight, not fully buffered).

```
Tests  15 passed (15)
```
