### PR TITLE
fix(qwen): bound video description success response reads

### DIFF
--- a/extensions/qwen/media-understanding-provider.test.ts
+++ b/extensions/qwen/media-understanding-provider.test.ts
@@ -8,6 +8,39 @@ import { describeQwenVideo } from "./media-understanding-provider.js";
 
 installPinnedHostnameTestHooks();
 
+function oversizedJsonResponse(params: { chunkCount: number; chunkSize: number }): {
+  response: Response;
+  getReadCount: () => number;
+  wasCanceled: () => boolean;
+} {
+  const chunk = new Uint8Array(params.chunkSize);
+  let readCount = 0;
+  let canceled = false;
+  return {
+    response: new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (readCount >= params.chunkCount) {
+            controller.close();
+            return;
+          }
+          readCount += 1;
+          controller.enqueue(chunk);
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    ),
+    getReadCount: () => readCount,
+    wasCanceled: () => canceled,
+  };
+}
+
 describe("describeQwenVideo", () => {
   it("builds the expected OpenAI-compatible video payload", async () => {
     const { fetchFn, getRequest } = createRequestCaptureJsonFetch({
@@ -73,5 +106,43 @@ describe("describeQwenVideo", () => {
     expect(videoContent.video_url.url).toBe(
       `data:video/mp4;base64,${Buffer.from("video-bytes").toString("base64")}`,
     );
+  });
+
+  it("bounds successful Qwen video JSON bodies instead of buffering the whole response", async () => {
+    const streamed = oversizedJsonResponse({ chunkCount: 64, chunkSize: 1024 * 1024 });
+
+    await expect(
+      describeQwenVideo({
+        buffer: Buffer.from("video-bytes"),
+        fileName: "clip.mp4",
+        mime: "video/mp4",
+        apiKey: "test-key",
+        timeoutMs: 1500,
+        baseUrl: "https://example.com/v1",
+        fetchFn: async () => streamed.response,
+      }),
+    ).rejects.toThrow("Qwen video description failed: JSON response exceeds 16777216 bytes");
+
+    expect(streamed.getReadCount()).toBeLessThan(64);
+    expect(streamed.wasCanceled()).toBe(true);
+  });
+
+  it("reports malformed Qwen video JSON with a provider-owned error", async () => {
+    const response = new Response("not-json{", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await expect(
+      describeQwenVideo({
+        buffer: Buffer.from("video-bytes"),
+        fileName: "clip.mp4",
+        mime: "video/mp4",
+        apiKey: "test-key",
+        timeoutMs: 1500,
+        baseUrl: "https://example.com/v1",
+        fetchFn: async () => response,
+      }),
+    ).rejects.toThrow("Qwen video description failed: malformed JSON response");
   });
 });

--- a/extensions/qwen/media-understanding-provider.ts
+++ b/extensions/qwen/media-understanding-provider.ts
@@ -13,6 +13,7 @@ import {
 import {
   assertOkOrThrowHttpError,
   postJsonRequest,
+  readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
 import { QWEN_STANDARD_GLOBAL_BASE_URL } from "./models.js";
@@ -60,7 +61,14 @@ export async function describeQwenVideo(
 
   try {
     await assertOkOrThrowHttpError(res, "Qwen video description failed");
-    const payload = (await res.json()) as OpenAiCompatibleVideoPayload;
+    // Read the success body through the shared byte-bounded JSON reader (16 MiB cap +
+    // stream cancel on overflow) so a hostile or buggy endpoint cannot force the runtime
+    // to buffer an unbounded body. Malformed JSON keeps the
+    // `Qwen video description failed: malformed JSON response` wrapping.
+    const payload = await readProviderJsonResponse<OpenAiCompatibleVideoPayload>(
+      res,
+      "Qwen video description failed",
+    );
     const text = coerceOpenAiCompatibleVideoText(payload);
     if (!text) {
       throw new Error("Qwen video description response missing content");


### PR DESCRIPTION
## What Problem This Solves

On the **success** path, `describeQwenVideo`
(`extensions/qwen/media-understanding-provider.ts`) read the video-description
response with an unbounded `await res.json()`. `res.json()` buffers the **entire**
body into memory before parsing — no byte ceiling, with or without a
`Content-Length` header. The Qwen OpenAI-compatible endpoint is untrusted external
input: a hostile, misconfigured, or SSRF-reachable `baseUrl` can stream an
arbitrarily large or never-ending JSON body and force the runtime to buffer it
all, causing memory pressure or a hang on the media-understanding path. This is
the success-JSON-side companion to the `#95103` / `#95108` response-limit campaign
(and to the already-merged `#95218` / `#96027` / `#96038` bounded-reader PRs).

## Changes

- Read the success body through the shared byte-bounded reader
  `readProviderJsonResponse` (16 MiB cap, re-exported via
  `openclaw/plugin-sdk/provider-http`), then `JSON.parse` the decoded prefix —
  the exact pattern merged in `#96027` / `#96038`. Plugin-scoped, no new
  abstraction.
- On overflow the reader cancels the underlying stream and throws a bounded error
  (`Qwen video description failed: JSON response exceeds 16777216 bytes`).
- Malformed JSON is normalized to a stable
  `Qwen video description failed: malformed JSON response` (previously a raw
  `SyntaxError`); the OpenAI-compatible payload extraction is unchanged.

## Real behavior proof

- **Behavior addressed**: An untrusted Qwen video-description success response
  with no `Content-Length` and an oversized / never-ending body must not be
  buffered whole; the read must stop at the 16 MiB cap, cancel the stream, and
  throw a bounded error — while valid small responses still parse unchanged.
- **Real environment tested**: A real `node:http` server (`createServer`) bound
  to `127.0.0.1`, streaming a JSON body in 1 MiB chunks with **no
  `Content-Length`** header (would total ~64 MiB, 4× the cap), driving the **real
  exported** `describeQwenVideo` over a **real loopback socket** — through the
  real `postJsonRequest` / SSRF-guarded undici dispatcher and the real
  `readProviderJsonResponse` reader. Loopback is allowed via the provider's own
  `request: { allowPrivateNetwork: true }` override (the same mechanism Ollama
  uses via `buildOllamaBaseUrlSsrFPolicy`). Node v22.22.0. No mock fetch, no
  in-process `ReadableStream` fixture — the bytes cross a real socket.
- **Exact steps**: `node --import tsx __qwen_bound_proof.mts` — start the
  streaming server → drive the real `describeQwenVideo` against it and assert it
  rejects with the bounded error + the server observed an early socket abort
  (stream cancelled) with bytes-on-wire near the cap → run a **negative control**
  (old unbounded `fetch().arrayBuffer()` of the same endpoint) → drive the real
  function against a second server returning a small valid payload.
- **Evidence after fix**:
  - Bounded case: threw `Qwen video description failed: JSON response exceeds
    16777216 bytes`; the server saw the socket aborted after **18,874,369 bytes**
    (≈18 MiB, ≪ the ~64 MiB it would have sent), confirming the stream was
    **cancelled**, not drained.
  - Negative control: an unbounded read of the same endpoint pulled the **full
    67,108,866 bytes** (>3.5× the bounded read), proving the cap is load-bearing
    (without it the body keeps accumulating past 16 MiB).
  - Small case: parsed into the expected text intact, no truncation.
- **What was not tested**: I did not hit a live DashScope / Qwen endpoint (no key,
  would not reproduce a hostile oversized body); the proof reproduces the exact
  untrusted-body transport shape with a local streaming server over a real
  socket. The proof drives the bytes-on-wire + early-socket-close signal (the
  load-bearing signal) rather than driving the runtime to actual OOM. The proof
  script is not committed.

## Evidence

Real `node:http` terminal proof (real loopback socket, real exported
`describeQwenVideo`, real SSRF dispatcher + `readProviderJsonResponse`):

```
[proof] huge server http://127.0.0.1:44351, small server http://127.0.0.1:41785, cap=16777216 bytes, would-stream≈67108864 bytes

PASS  describeQwenVideo throws bounded error on unbounded streamed JSON body :: threw=true msg="Qwen video description failed: JSON response exceeds 16777216 bytes"
PASS  stream cancelled: server saw socket abort before sending the full ~64MiB :: aborted=true bytesSent=18874369 (<67108864)
PASS  stream cancelled near the 16 MiB cap (bytesSent ≈ cap, ≪ 64 MiB) :: bytesSent=18874369 (<33554432)
PASS  negative control: unbounded read buffers the FULL body PAST the 16 MiB cap :: buffered=67108866 bytes (>16777216) — cap is load-bearing
PASS  negative control consumed far more than the bounded read :: unbounded buffered=67108866 vs bounded sent≈18874369
PASS  happy path: small valid /chat/completions JSON still parsed :: text="a calm beach at sunset" model="qwen-vl-max-latest"

[proof] ALL PASS
```

In-repo Vitest suite (bounded-overflow streaming regression + malformed-JSON +
the unchanged happy-path payload test) passes 3/3:

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Checks on the changed files:
- `node scripts/run-vitest.mjs extensions/qwen/media-understanding-provider.test.ts --run` → **3/3 passed**
- `tsgo` (extensions test project) → clean on `extensions/qwen`. This revision
  also fixes the two new `describeQwenVideo` test calls that were missing the
  required `fileName` / `timeoutMs` fields of `VideoDescriptionRequest`
  (`error TS2739`), which would otherwise fail `check-test-types`.
- `oxlint extensions/qwen/media-understanding-provider.ts extensions/qwen/media-understanding-provider.test.ts` → exit 0, clean

**Label**: security

_AI-assisted._