### PR TITLE
fix(google): bound Veo video operation response reads

### DIFF
--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -94,6 +94,39 @@ function fetchInputUrl(fetchMock: ReturnType<typeof vi.fn>, index: number): stri
   return input.url;
 }
 
+function oversizedJsonResponse(params: { chunkCount: number; chunkSize: number }): {
+  response: Response;
+  getReadCount: () => number;
+  wasCanceled: () => boolean;
+} {
+  const chunk = new Uint8Array(params.chunkSize);
+  let readCount = 0;
+  let canceled = false;
+  return {
+    response: new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (readCount >= params.chunkCount) {
+            controller.close();
+            return;
+          }
+          readCount += 1;
+          controller.enqueue(chunk);
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    ),
+    getReadCount: () => readCount,
+    wasCanceled: () => canceled,
+  };
+}
+
 let ssrfMock: { mockRestore: () => void } | undefined;
 
 describe("google video generation provider", () => {
@@ -484,6 +517,33 @@ describe("google video generation provider", () => {
     );
     expect(downloadMock).not.toHaveBeenCalled();
     expect(result.videos[0]?.buffer).toEqual(Buffer.from("rest-video"));
+  });
+
+  it("bounds successful Google REST operation JSON bodies instead of buffering the whole response", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockRejectedValue(Object.assign(new Error("sdk 404"), { status: 404 }));
+    const streamed = oversizedJsonResponse({ chunkCount: 64, chunkSize: 1024 * 1024 });
+    const fetchMock = vi.fn(async () => streamed.response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = buildGoogleVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "google",
+        model: "veo-3.1-fast-generate-preview",
+        prompt: "A tiny robot watering a windowsill garden",
+        cfg: {},
+        durationSeconds: 3,
+      }),
+    ).rejects.toThrow("Google video operation response exceeds 16777216 bytes");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(streamed.getReadCount()).toBeLessThan(64);
+    expect(streamed.wasCanceled()).toBe(true);
   });
 
   it("retries transient Google REST poll failures with empty bodies", async () => {

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -28,6 +28,7 @@ const DEFAULT_TIMEOUT_MS = 180_000;
 const POLL_INTERVAL_MS = 10_000;
 const MAX_POLL_ATTEMPTS = 120;
 const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
+const GOOGLE_VIDEO_OPERATION_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE =
   "Google video generation response missing generated videos";
 
@@ -349,7 +350,15 @@ async function requestGoogleVideoJson(params: {
           signal: controller.signal,
         });
         try {
-          const text = await response.text();
+          const buffer = await readResponseWithLimit(
+            response,
+            GOOGLE_VIDEO_OPERATION_RESPONSE_MAX_BYTES,
+            {
+              onOverflow: ({ maxBytes }) =>
+                new Error(`Google video operation response exceeds ${maxBytes} bytes`),
+            },
+          );
+          const text = new TextDecoder().decode(buffer);
           if (!response.ok) {
             let detail: unknown = text;
             if (text) {


### PR DESCRIPTION
## What Problem This Solves

The Google **Veo video** REST operation read in `extensions/google/video-generation-provider.ts`
(`requestGoogleVideoJson`) buffers the entire external response via an unbounded
`await response.text()` before checking `response.ok`. The Veo create/poll response is untrusted
provider content: a hostile or misconfigured endpoint can stream an arbitrarily large,
`Content-Length`-less body that is fully read into memory before parsing — a memory-pressure / hang
(OOM) vector on the video-generation path.

Scope is the **video-generation operation JSON only**. This is distinct from #96324, which covers
Google embedding/image/media/oauth/speech and does not touch `video-generation-provider.ts`.

## Changes

- Route the Veo REST operation read through the shared bounded reader `readResponseWithLimit`
  (re-exported via `openclaw/plugin-sdk/response-limit-runtime`, from `@openclaw/media-core`)
  instead of `await response.text()`, capped at a new `GOOGLE_VIDEO_OPERATION_RESPONSE_MAX_BYTES`
  (16 MiB, aligned with merged provider bound-stream PRs #95218 / #96027 / #96038). The result is
  `TextDecoder().decode`d before the existing `response.ok` / HTTP-detail / `JSON.parse` flow.
- On overflow the reader cancels the underlying stream and throws a bounded error
  (`Google video operation response exceeds 16777216 bytes`). The `response.ok` error-detail path
  and the success `JSON.parse` shape are otherwise unchanged.
- Both **create and poll** share `requestGoogleVideoJson` (`generateGoogleVideoViaRest` calls it for
  the `:predictLongRunning` create POST and for each `GET <operation name>` poll), so the single
  bounded read covers both verbs.
- No new abstraction — reuses the `media-core` bounded reader already used across the codebase.

## Real behavior proof

- **Behavior addressed**: The unbounded `await response.text()` on the Veo REST operation read let
  an untrusted endpoint stream an unbounded, `Content-Length`-less JSON body fully into memory. The
  read must instead stop at the 16 MiB cap, cancel the stream, and throw a bounded error — while
  small valid operation JSON still parses unchanged.
- **Real environment tested**: A real local `node:http` server (`createServer`) bound to
  `127.0.0.1`, streaming a JSON operation body in 64 KiB chunks with **no `Content-Length`** header
  (would total ~64 MiB, 4× the 16 MiB cap), reached over the **real global `fetch` + real TCP
  socket** (not an in-process `ReadableStream` fixture, not a mocked `fetch`). The proof drives the
  **exact post-fix `requestGoogleVideoJson` read body** — `readResponseWithLimit(response,
  GOOGLE_VIDEO_OPERATION_RESPONSE_MAX_BYTES, { onOverflow })` → `TextDecoder().decode` →
  `response.ok` branch → `JSON.parse` — against that real socket, for **both the create POST and the
  poll GET** verbs that share the helper. `readResponseWithLimit` is the real `@openclaw/media-core`
  function the changed line calls. Node v22.22.0.
- **Exact steps**: `node --import tsx proof.mts` — start the real server → drive the shared read path
  against `POST /create-huge` and `GET /poll-huge` (oversized, no Content-Length) and assert each
  throws the bounded error + the server observed the socket aborted with bytes-on-wire ≪ the full
  ~64 MiB → run a negative control (the OLD unbounded read of the same body, measuring it buffers
  past the cap) → drive the shared read path against small valid create/poll operation JSON and
  assert they still parse.
- **Evidence after fix**: For both create and poll, `readResponseWithLimit` threw
  `Google video operation response exceeds 16777216 bytes`; the server observed the socket aborted
  after ~17–18 MiB (≪ the ~64 MiB it would have sent), confirming the stream was **cancelled**, not
  drained. Small create/poll operation JSON parsed back into intact operation objects
  (`name`/`done`, and the polled `done:true` result with one generated sample).
- **Observed result (all 7 checks PASS)**:
  - `create POST shared path: overflow throws bounded error` → threw, msg `exceeds 16777216 bytes`
  - `create POST shared path: stream cancelled near 16MiB` → aborted=true, bytesSent=18284544 (< 33554432)
  - `poll GET shared path: overflow throws bounded error` → threw, msg `exceeds 16777216 bytes`
  - `poll GET shared path: stream cancelled near 16MiB` → aborted=true, bytesSent=17825792 (< 33554432)
  - `negative control: OLD unbounded read buffers PAST the 16MiB cap` → buffered 16799559 bytes (> cap)
    — proves the cap is load-bearing (without it the body keeps accumulating past 16 MiB).
  - `happy path: small create operation JSON still parsed` → `name=operations/veo-abc done=false`
  - `happy path: small poll operation JSON still parsed` → `done=true samples=1`
- **What was not tested**: Did not hit the live `generativelanguage.googleapis.com` Veo endpoint
  (no key / would not reproduce a hostile oversized body); the untrusted-body behavior is fully
  reproduced with a local streaming server over the same transport. The proof did not drive the read
  to actual OOM — it measures bytes-on-wire + early socket abort, which is the load-bearing signal.
  The proof script is not committed.

## Evidence

Real `node:http` terminal proof (`node --import tsx proof.mts`):

```
[proof] real node:http server on http://127.0.0.1:41913, cap=16777216 bytes, would-stream≈67108864 bytes

PASS  create POST shared path: overflow throws bounded error :: threw=true msg="Google video operation response exceeds 16777216 bytes"
PASS  create POST shared path: stream cancelled near 16MiB (socket aborted, bytes ≪ 64MiB) :: aborted=true bytesSent=18284544 (< 33554432)
PASS  poll GET shared path: overflow throws bounded error :: threw=true msg="Google video operation response exceeds 16777216 bytes"
PASS  poll GET shared path: stream cancelled near 16MiB (socket aborted, bytes ≪ 64MiB) :: aborted=true bytesSent=17825792 (< 33554432)
PASS  negative control: OLD unbounded read buffers PAST the 16MiB cap (cap is load-bearing) :: buffered=16799559 bytes (> 16777216)
PASS  happy path: small create operation JSON still parsed (name, done:false) :: name=operations/veo-abc done=false
PASS  happy path: small poll operation JSON still parsed (done:true, 1 generated sample) :: done=true samples=1

[proof] 7 PASS / 0 FAIL
[proof] ALL PASS
```

In-repo Vitest suite for this provider (`node scripts/run-vitest.mjs
extensions/google/video-generation-provider.test.ts --run`) — includes a streaming-fixture
regression test asserting the oversized read stops before consuming all chunks and cancels the
stream:

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

`oxlint extensions/google/video-generation-provider.ts` → exit 0, clean.

This is the Google Veo video-operation counterpart to the #95103 / #95108 response-limit campaign,
applying the same `@openclaw/media-core` bounded reader to the remaining unbounded provider read.

**Label**: security

_AI-assisted._

