### PR TITLE
fix(byteplus): bound video-generation success response reads

### DIFF
--- a/extensions/byteplus/video-generation-provider.test.ts
+++ b/extensions/byteplus/video-generation-provider.test.ts
@@ -1,12 +1,70 @@
 // Byteplus tests cover video generation provider plugin behavior.
-import {
-  getProviderHttpMocks,
-  installProviderHttpMockCleanup,
-} from "openclaw/plugin-sdk/provider-http-test-mocks";
 import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-const { postJsonRequestMock, fetchWithTimeoutMock } = getProviderHttpMocks();
+// Submit/poll transport is mocked locally so each test can inject the BytePlus task JSON
+// bodies, while readProviderJsonResponse is kept REAL (via importActual) so the byte-bounded
+// reader actually streams and cancels oversized bodies under test instead of a stub.
+const { postJsonRequestMock, fetchWithTimeoutMock, resolveApiKeyForProviderMock } = vi.hoisted(
+  () => ({
+    postJsonRequestMock: vi.fn(),
+    fetchWithTimeoutMock: vi.fn(),
+    resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
+  }),
+);
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
+  const actual = await importActual<typeof import("openclaw/plugin-sdk/provider-http")>();
+  const resolveTimeoutMs = (timeoutMs: unknown): number =>
+    typeof timeoutMs === "function" ? (timeoutMs() as number) : ((timeoutMs as number) ?? 60_000);
+  return {
+    // REAL byte-bounded JSON reader under test — not stubbed.
+    readProviderJsonResponse: actual.readProviderJsonResponse,
+    postJsonRequest: postJsonRequestMock,
+    fetchProviderOperationResponse: async (params: {
+      url: string;
+      init?: RequestInit;
+      timeoutMs?: unknown;
+      fetchFn: typeof fetch;
+    }) => fetchWithTimeoutMock(params.url, params.init ?? {}, resolveTimeoutMs(params.timeoutMs)),
+    fetchProviderDownloadResponse: async (params: {
+      url: string;
+      init?: RequestInit;
+      timeoutMs?: unknown;
+      fetchFn: typeof fetch;
+    }) => fetchWithTimeoutMock(params.url, params.init ?? {}, resolveTimeoutMs(params.timeoutMs)),
+    assertOkOrThrowHttpError: async () => {},
+    createProviderOperationDeadline: ({
+      label,
+      timeoutMs,
+    }: {
+      label: string;
+      timeoutMs?: number;
+    }) => ({ label, timeoutMs }),
+    createProviderOperationTimeoutResolver:
+      ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
+      () =>
+        defaultTimeoutMs,
+    resolveProviderOperationTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
+      defaultTimeoutMs,
+    resolveProviderHttpRequestConfig: (params: {
+      baseUrl?: string;
+      defaultBaseUrl: string;
+      allowPrivateNetwork?: boolean;
+      defaultHeaders?: Record<string, string>;
+    }) => ({
+      baseUrl: params.baseUrl ?? params.defaultBaseUrl,
+      allowPrivateNetwork: params.allowPrivateNetwork === true,
+      headers: new Headers(params.defaultHeaders),
+      dispatcherPolicy: undefined,
+    }),
+    waitProviderOperationPollInterval: async () => {},
+  };
+});
 
 let buildBytePlusVideoGenerationProvider: typeof import("./video-generation-provider.js").buildBytePlusVideoGenerationProvider;
 
@@ -14,20 +72,22 @@ beforeAll(async () => {
   ({ buildBytePlusVideoGenerationProvider } = await import("./video-generation-provider.js"));
 });
 
-installProviderHttpMockCleanup();
+afterEach(() => {
+  postJsonRequestMock.mockReset();
+  fetchWithTimeoutMock.mockReset();
+  resolveApiKeyForProviderMock.mockClear();
+});
 
 function mockSuccessfulBytePlusTask(params?: { model?: string }) {
   postJsonRequestMock.mockResolvedValue({
-    response: {
-      json: async () => ({
-        id: "task_123",
-      }),
-    },
+    response: streamedJsonResponse({
+      id: "task_123",
+    }),
     release: vi.fn(async () => {}),
   });
   fetchWithTimeoutMock
-    .mockResolvedValueOnce({
-      json: async () => ({
+    .mockResolvedValueOnce(
+      streamedJsonResponse({
         id: "task_123",
         status: "succeeded",
         content: {
@@ -35,7 +95,7 @@ function mockSuccessfulBytePlusTask(params?: { model?: string }) {
         },
         model: params?.model ?? "seedance-1-0-lite-t2v-250428",
       }),
-    })
+    )
     .mockResolvedValueOnce({
       headers: new Headers({ "content-type": "video/webm" }),
       arrayBuffer: async () => Buffer.from("webm-bytes"),
@@ -77,6 +137,53 @@ function streamedVideoResponse(bytes: string): Response {
   );
 }
 
+// BytePlus submit/poll task JSON is now read through the byte-bounded reader, so the
+// mocked responses must expose a real readable body (not just a json() shortcut).
+function streamedJsonResponse(payload: unknown): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(JSON.stringify(payload)));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+// Builds a JSON body larger than the shared 16 MiB readProviderJsonResponse cap so the
+// bounded reader cancels the stream mid-flight; if the cap were removed the reader would
+// buffer the whole advertised payload before parsing. Tracks how many bytes were pulled
+// and whether the stream was canceled so callers can assert the body was not fully read.
+function makeOversizedJsonStream(): {
+  body: ReadableStream<Uint8Array>;
+  maxBytes: number;
+  totalBytes: number;
+  state: { bytesPulled: number; canceled: boolean };
+} {
+  const maxBytes = 16 * 1024 * 1024; // matches PROVIDER_JSON_RESPONSE_MAX_BYTES.
+  const ONE_MIB = 1024 * 1024;
+  const TOTAL_CHUNKS = 32; // 32 MiB advertised body, double the cap.
+  const chunk = new Uint8Array(ONE_MIB);
+  const state = { bytesPulled: 0, canceled: false };
+  let pulled = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= TOTAL_CHUNKS) {
+        controller.close();
+        return;
+      }
+      pulled += 1;
+      state.bytesPulled += chunk.length;
+      controller.enqueue(chunk);
+    },
+    cancel() {
+      state.canceled = true;
+    },
+  });
+  return { body, maxBytes, totalBytes: TOTAL_CHUNKS * ONE_MIB, state };
+}
+
 describe("byteplus video generation provider", () => {
   it("declares explicit mode capabilities", () => {
     expectExplicitVideoGenerationCapabilities(buildBytePlusVideoGenerationProvider());
@@ -110,21 +217,19 @@ describe("byteplus video generation provider", () => {
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({ id: "task_too_large" }),
-      },
+      response: streamedJsonResponse({ id: "task_too_large" }),
       release: vi.fn(async () => {}),
     });
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
           id: "task_too_large",
           status: "succeeded",
           content: {
             video_url: "https://example.com/too-large.mp4",
           },
         }),
-      })
+      )
       .mockResolvedValueOnce(streamedVideoResponse("too-large"));
 
     const provider = buildBytePlusVideoGenerationProvider();
@@ -222,16 +327,14 @@ describe("byteplus video generation provider", () => {
 
   it("drops malformed response duration metadata", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "task_123",
-        }),
-      },
+      response: streamedJsonResponse({
+        id: "task_123",
+      }),
       release: vi.fn(async () => {}),
     });
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
           id: "task_123",
           status: "succeeded",
           content: {
@@ -239,7 +342,7 @@ describe("byteplus video generation provider", () => {
           },
           duration: 1.5,
         }),
-      })
+      )
       .mockResolvedValueOnce({
         headers: new Headers({ "content-type": "video/mp4" }),
         arrayBuffer: async () => Buffer.from("mp4-bytes"),
@@ -259,11 +362,15 @@ describe("byteplus video generation provider", () => {
   it("reports malformed create JSON with a provider-owned error", async () => {
     const release = vi.fn(async () => {});
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => {
-          throw new SyntaxError("bad json");
-        },
-      },
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("{ not valid json"));
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
       release,
     });
 
@@ -281,19 +388,17 @@ describe("byteplus video generation provider", () => {
 
   it("rejects status responses missing a task status", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({ id: "task_missing_status" }),
-      },
+      response: streamedJsonResponse({ id: "task_missing_status" }),
       release: vi.fn(async () => {}),
     });
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      streamedJsonResponse({
         id: "task_missing_status",
         content: {
           video_url: "https://example.com/byteplus.mp4",
         },
       }),
-    });
+    );
 
     const provider = buildBytePlusVideoGenerationProvider();
     await expect(
@@ -308,18 +413,16 @@ describe("byteplus video generation provider", () => {
 
   it("rejects malformed completed content", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({ id: "task_malformed_content" }),
-      },
+      response: streamedJsonResponse({ id: "task_malformed_content" }),
       release: vi.fn(async () => {}),
     });
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      streamedJsonResponse({
         id: "task_malformed_content",
         status: "succeeded",
         content: ["https://example.com/byteplus.mp4"],
       }),
-    });
+    );
 
     const provider = buildBytePlusVideoGenerationProvider();
     await expect(
@@ -330,5 +433,62 @@ describe("byteplus video generation provider", () => {
         cfg: {},
       }),
     ).rejects.toThrow("BytePlus video generation completed with malformed content");
+  });
+
+  it("bounds the submit task JSON body and cancels an oversized stream", async () => {
+    const stream = makeOversizedJsonStream();
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(stream.body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release,
+    });
+
+    const provider = buildBytePlusVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "byteplus",
+        model: "seedance-1-0-lite-t2v-250428",
+        prompt: "oversized submit response",
+        cfg: {},
+      }),
+    ).rejects.toThrow(
+      `BytePlus video generation failed: JSON response exceeds ${stream.maxBytes} bytes`,
+    );
+    expect(stream.state.canceled).toBe(true);
+    // Only the bounded prefix is pulled, never the full advertised stream.
+    expect(stream.state.bytesPulled).toBeLessThan(stream.totalBytes);
+    // The submit request must still be released even though the body overflowed.
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("bounds the poll status JSON body and cancels an oversized stream", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task_oversized_poll" }),
+      release: vi.fn(async () => {}),
+    });
+    const stream = makeOversizedJsonStream();
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      new Response(stream.body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const provider = buildBytePlusVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "byteplus",
+        model: "seedance-1-0-lite-t2v-250428",
+        prompt: "oversized poll response",
+        cfg: {},
+      }),
+    ).rejects.toThrow(
+      `BytePlus video status request failed: JSON response exceeds ${stream.maxBytes} bytes`,
+    );
+    expect(stream.state.canceled).toBe(true);
+    expect(stream.state.bytesPulled).toBeLessThan(stream.totalBytes);
   });
 });

--- a/extensions/byteplus/video-generation-provider.ts
+++ b/extensions/byteplus/video-generation-provider.ts
@@ -11,6 +11,7 @@ import {
   fetchProviderDownloadResponse,
   fetchProviderOperationResponse,
   postJsonRequest,
+  readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
   waitProviderOperationPollInterval,
@@ -55,16 +56,13 @@ type BytePlusTaskResponse = {
 
 type BytePlusTaskStatus = "running" | "failed" | "queued" | "succeeded" | "cancelled";
 
-async function readBytePlusJsonResponse<T>(
-  response: Pick<Response, "json">,
-  label: string,
-): Promise<T> {
-  let payload: unknown;
-  try {
-    payload = await response.json();
-  } catch (cause) {
-    throw new Error(`${label}: malformed JSON response`, { cause });
-  }
+async function readBytePlusJsonResponse<T>(response: Response, label: string): Promise<T> {
+  // BytePlus submit/poll task bodies are read through the shared byte-bounded reader
+  // (readResponseWithLimit, via readProviderJsonResponse) so a hostile or buggy endpoint
+  // that streams an unbounded JSON body cannot force the runtime to buffer the whole
+  // payload before parsing. Overflow cancels the stream and throws a bounded error;
+  // malformed JSON keeps the existing `${label}: malformed JSON response` wrapping.
+  const payload = await readProviderJsonResponse<unknown>(response, label);
   if (!isRecord(payload)) {
     throw new Error(`${label}: malformed JSON response`);
   }


### PR DESCRIPTION
## What Problem This Solves

The BytePlus video provider read two untrusted success responses with an unbounded `await response.json()`, exposing the create + poll loop to OOM / hang.

`readBytePlusJsonResponse` in `extensions/byteplus/video-generation-provider.ts` parses both the **submit task** (`/contents/generations/tasks`) and **poll status** (`/contents/generations/tasks/{id}`) success bodies. The BytePlus `baseUrl` is user-supplied and the endpoint is untrusted external content, so a hostile or misconfigured host can stream an arbitrarily large (or `Content-Length`-less, never-ending) JSON body on **either** path. `response.json()` buffers the whole payload before parsing, driving the video-generation create + poll loop into memory pressure / OOM or a hang. The sibling video **buffer download** in the same file was already bounded with `readResponseWithLimit`; this closes the two remaining unbounded JSON reads.

## Changes

- Route both success reads through the shared byte-bounded reader `readProviderJsonResponse` (16 MiB cap = `PROVIDER_JSON_RESPONSE_MAX_BYTES`, re-exported via `openclaw/plugin-sdk/provider-http`) instead of `await response.json()` — it streams the body, cancels the underlying stream on overflow, and `JSON.parse`s the decoded prefix. No new abstraction: this reuses the `readResponseWithLimit`-backed reader already merged in #95218 / #96027 / #96038.
- Applies to the **submit** read (`label: "BytePlus video generation failed"`) and the **poll** read (`label: "BytePlus video status request failed"`).
- **Error semantics preserved**: malformed JSON still surfaces `${label}: malformed JSON response`; overflow throws `${label}: JSON response exceeds 16777216 bytes`. Plugin-scoped — only `extensions/byteplus` changes.

## Real behavior proof

- **Behavior addressed**: An untrusted BytePlus submit or poll success response with no
  `Content-Length` and an oversized/never-ending body must not be buffered whole; the
  read must stop at the 16 MiB cap, cancel the stream (tear down the socket), and throw a
  bounded error — while valid small submit/poll bodies still parse unchanged.
- **Real environment tested**: A real local `node:http` server (`createServer`) bound to
  `127.0.0.1`, returning a `Content-Length`-less body that streams 1 MiB chunks up to a
  ~32 MiB advertised payload (2× the cap). The **real exported** `readProviderJsonResponse`
  — the exact byte-bounded reader `readBytePlusJsonResponse` calls for **both** the submit
  and poll success-JSON paths — was driven against it over a **real TCP socket** via the
  real `fetch`, using the two real provider labels verbatim. Node v22.22.0.
- **Exact steps**: `node --import tsx <paths-loader> proof.mts` — start server → drive the
  real reader against `/oversized` with the **submit** label → repeat with the **poll**
  label → read back the server's observed bytes-on-wire / socket-abort per request → run a
  negative control (the OLD unbounded `response.json()`-style whole-body read of the same
  endpoint) → drive the real reader against small valid `/small-submit` and `/small-poll`
  bodies.
- **Evidence after fix**: For both submit and poll, `readProviderJsonResponse` threw
  `... JSON response exceeds 16777216 bytes`; the server observed the socket **aborted**
  after ~17–20 MiB (submit `bytesSent=19922944`, poll `bytesSent=17825792`, both ≪ the
  ~32 MiB it would have sent), confirming the stream was **cancelled**, not drained. The
  negative control's old unbounded read pulled the **full 33554432 bytes** (proving the cap
  is load-bearing). The small submit body parsed to `{ id: "task_real_submit" }` and the
  small poll body parsed to `status: "succeeded"` with the `video_url` intact.
- **What was not tested**: Did not hit a live `byteplus`/`ark` endpoint (no key; would not
  reproduce a hostile oversized body); the untrusted-body behavior is fully reproduced with
  a local streaming server over the same transport. The proof script is not committed.

## Evidence

Real `node:http` terminal proof (real socket, not a vitest in-process fixture):

```
[proof] real node:http server on http://127.0.0.1:37321, cap=16777216 bytes, oversized-body≈33554432 bytes (no content-length)

PASS  submit: oversized JSON throws bounded error :: threw=true msg="BytePlus video generation failed: JSON response exceeds 16777216 bytes"
PASS  submit: stream cancelled — server saw socket abort :: aborted=true
PASS  submit: bytes on wire stayed under the full advertised body (cancelled, not drained) :: bytesSent=19922944 (< 33554432)
PASS  poll: oversized JSON throws bounded error :: threw=true msg="BytePlus video status request failed: JSON response exceeds 16777216 bytes"
PASS  poll: stream cancelled — server saw socket abort :: aborted=true
PASS  poll: bytes on wire stayed under the full advertised body (cancelled, not drained) :: bytesSent=17825792 (< 33554432)
PASS  negative control: OLD unbounded read buffers the WHOLE body past the cap (cap is load-bearing) :: buffered=33554432 bytes serverSent=33554432 (>= 33554432, > cap 16777216)
PASS  happy path: small submit JSON still parsed :: id="task_real_submit"
PASS  happy path: small poll JSON still parsed :: status="succeeded" video_url="https://example.com/byteplus.mp4"

[proof] 9 PASS / 0 FAIL
[proof] ALL PASS
```

The in-repo Vitest suite for this provider still passes (it keeps `readProviderJsonResponse`
**real** via `importActual`, so the byte-bounded reader actually streams and cancels under
test rather than being stubbed — two real-`ReadableStream` overflow tests for submit and
poll assert the bounded error + that the body is not fully pulled):

```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

`oxlint` (exit 0) and `tsgo -p tsconfig.extensions.json` (no errors in `extensions/byteplus`)
are clean on the changed files.

This is the BytePlus video-generation counterpart to the #96027 / #96038 response-limit
campaign, applying the same `readResponseWithLimit`-backed bounded reader to the two
provider-discovery success-JSON reads.

**Label**: security

_AI-assisted._
