### PR TITLE
fix(github-copilot): bound usage response reads

### DIFF
--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -267,6 +267,47 @@ describe("fetchCopilotUsage", () => {
       plan: "free",
     });
   });
+
+  it("bounds the usage read and cancels the stream when the body exceeds the JSON byte cap", async () => {
+    // Larger than the shared 16 MiB readProviderJsonResponse cap so the bounded reader cancels the
+    // stream mid-flight; if the cap were removed the unbounded res.json() would buffer the whole body.
+    const ONE_MIB = 1024 * 1024;
+    const TOTAL_CHUNKS = 32; // 32 MiB advertised body, double the cap.
+    const chunk = new Uint8Array(ONE_MIB);
+
+    let bytesPulled = 0;
+    let canceled = false;
+    const makeOversizedJsonResponse = (): Response => {
+      let pulled = 0;
+      const body = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (pulled >= TOTAL_CHUNKS) {
+            controller.close();
+            return;
+          }
+          pulled += 1;
+          bytesPulled += chunk.length;
+          controller.enqueue(chunk);
+        },
+        cancel() {
+          canceled = true;
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const mockFetch = createProviderUsageFetch(async () => makeOversizedJsonResponse());
+
+    await expect(fetchCopilotUsage("token", 5000, mockFetch)).rejects.toThrow(
+      /github-copilot-usage: JSON response exceeds/,
+    );
+    // The bounded reader cancels the body and never pulls the full advertised 32 MiB stream.
+    expect(canceled).toBe(true);
+    expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
+  });
 });
 
 describe("github-copilot token", () => {

--- a/extensions/github-copilot/usage.ts
+++ b/extensions/github-copilot/usage.ts
@@ -1,5 +1,6 @@
 // Github Copilot plugin module implements usage behavior.
 import { buildCopilotIdeHeaders } from "openclaw/plugin-sdk/provider-auth";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   buildUsageHttpErrorSnapshot,
   fetchJson,
@@ -41,7 +42,10 @@ export async function fetchCopilotUsage(
     });
   }
 
-  const data = (await res.json()) as CopilotUsageResponse;
+  const data = await readProviderJsonResponse<CopilotUsageResponse>(
+    res,
+    "github-copilot-usage",
+  );
   const windows: UsageWindow[] = [];
 
   if (data.quota_snapshots?.premium_interactions) {


### PR DESCRIPTION
## What Problem This Solves

`fetchCopilotUsage` in `extensions/github-copilot/usage.ts` read the success response with an
unbounded `await res.json()`. The shared fetch layer enforces an abort timeout but does **not**
bound body size, so a misbehaving or compromised `api.github.com/copilot_internal/user` endpoint
can stream an arbitrarily large (or `Content-Length`-less, never-ending) JSON body that
`res.json()` buffers whole into memory — an OOM / hang vector on the usage-accounting path.

## Changes

- Read the success body through the shared bounded reader `readProviderJsonResponse`
  (re-exported via `openclaw/plugin-sdk/provider-http`): it reads under the shared 16 MiB
  `PROVIDER_JSON_RESPONSE_MAX_BYTES` cap, **cancels the underlying stream on overflow**, and
  throws `github-copilot-usage: JSON response exceeds <N> bytes`.
- No new abstraction — reuses the same bounded reader as the recently merged provider
  response-limit PRs (#95218 / #96027 / #96038), bringing GitHub Copilot usage in line with the
  other providers' bounded JSON reads.

## Real behavior proof

- **Behavior addressed**: An untrusted Copilot usage success response with no
  `Content-Length` and an oversized / never-ending body must not be buffered whole; the
  read must stop at the cap, cancel the stream, and throw a bounded error — while valid
  small responses still parse unchanged.
- **Real environment tested**: A real local `node:http` server (`http.createServer`) bound
  to `127.0.0.1`, streaming a `Content-Length`-less JSON body in 64 KiB chunks (advertised
  ~64 MiB, 4× the 16 MiB cap). The **real exported** `fetchCopilotUsage` was driven against
  it over a **real TCP socket** — the supplied `fetchFn` rewrites the `api.github.com` URL
  to the loopback server and calls the global undici `fetch`, so the real
  `fetchCopilotUsage` → `fetchJson` → real `fetch` → real socket →
  `readProviderJsonResponse` path runs. Not an in-process `Response`. Node v22.22.0.
- **Exact steps**: `node --import tsx _proof_copilot_usage_bound.mts` — start the server →
  drive the **real** `fetchCopilotUsage` against `/huge` and assert it rejects + the server
  observed the socket abort + bytes-on-wire ≪ the full body → run a negative control (the
  OLD unbounded full-body read against the same `/huge` endpoint) → drive the real
  `fetchCopilotUsage` against `/small` (a valid usage object) and assert it still parses.
- **Evidence after fix**:
  - Oversized case: `fetchCopilotUsage` threw exactly
    `github-copilot-usage: JSON response exceeds 16777216 bytes`; the server observed the
    socket aborted after **18,743,305 bytes** (≪ the ~67 MiB it would have streamed),
    confirming the stream was **cancelled**, not drained.
  - Negative control: the OLD unbounded read pulled the **full 67,108,875 bytes** (> the
    16 MiB cap), proving the cap is load-bearing — without it the body keeps accumulating
    past 16 MiB.
  - Small case: `fetchCopilotUsage` parsed the valid usage JSON intact
    (`plan=individual`, Premium used 27%, Chat used 9%).
- **What was not tested**: Did not hit the live `api.github.com` endpoint (would not
  reproduce a hostile oversized body); the untrusted-body behavior is fully reproduced with
  a local streaming server over the same transport. The proof script is not committed.

## Evidence

```
[proof] real node:http server on http://127.0.0.1:40987, cap=16777216 bytes, would-stream≈67108864 bytes

PASS  oversized body: real fetchCopilotUsage throws the bounded cap error :: msg="github-copilot-usage: JSON response exceeds 16777216 bytes"
PASS  stream cancelled: server observed the socket abort (body not drained) :: socketAborted=true
PASS  bytes on wire stayed near the cap, not the full ~64 MiB body :: bytesSent=18743305 (< 67108864)
PASS  negative control: unbounded read buffers PAST the 16 MiB cap (cap is load-bearing) :: buffered=67108875 bytes (> 16777216)
PASS  happy path: small valid usage JSON still parsed by real fetchCopilotUsage :: plan=individual Premium.used=27 Chat.used=9

[proof] ALL PASS (pass=5 fail=0)
```

Regression suite + checks (worktree on `upstream/main`):
- `node scripts/run-vitest.mjs extensions/github-copilot/models.test.ts --run` → **29/29 passed**
  (includes a streaming-fixture regression test asserting the oversized read cancels the
  stream and never pulls the full advertised body)
- `oxlint extensions/github-copilot/usage.ts extensions/github-copilot/models.test.ts` → exit 0, clean
- `tsgo -p tsconfig.extensions.json` → exit 0, no errors

**Label**: security

_AI-assisted._

