### PR TITLE
fix(voyage): bound embedding-batch status, error, and non-OK responses

### DIFF
--- a/extensions/voyage/embedding-batch.test.ts
+++ b/extensions/voyage/embedding-batch.test.ts
@@ -1,0 +1,217 @@
+// Voyage batch tests cover bounded status/error response reads.
+import { describe, expect, it } from "vitest";
+import type { VoyageEmbeddingClient } from "./embedding-provider.js";
+import { testing } from "./embedding-batch.js";
+
+const { fetchVoyageBatchStatus, readVoyageBatchError, VOYAGE_BATCH_RESPONSE_MAX_BYTES } = testing;
+
+function buildClient(): VoyageEmbeddingClient {
+  return {
+    baseUrl: "https://api.voyageai.test/v1",
+    headers: { authorization: "Bearer test" },
+    model: "voyage-3",
+  };
+}
+
+/**
+ * Build deps whose withRemoteHttpResponse drives the real onResponse against a
+ * caller-provided Response, so the bounded readers run exactly as in production.
+ */
+function buildDeps(response: Response): Parameters<typeof fetchVoyageBatchStatus>[0]["deps"] {
+  return {
+    now: () => 0,
+    sleep: async () => {},
+    postJsonWithRetry: (async () => {
+      throw new Error("postJsonWithRetry should not be called in these tests");
+    }) as never,
+    uploadBatchJsonlFile: (async () => {
+      throw new Error("uploadBatchJsonlFile should not be called in these tests");
+    }) as never,
+    withRemoteHttpResponse: (async (params: { onResponse: (res: Response) => Promise<unknown> }) =>
+      await params.onResponse(response)) as never,
+  };
+}
+
+/**
+ * A streaming JSON-ish body that proves an oversized response stops being read
+ * before the whole advertised payload is buffered into memory. getReadCount
+ * reports how many chunks were pulled; cancel() flips wasCanceled.
+ */
+function streamingResponse(params: { chunkCount: number; chunkSize: number; status?: number }): {
+  response: Response;
+  getReadCount: () => number;
+  wasCanceled: () => boolean;
+} {
+  let reads = 0;
+  let canceled = false;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (reads >= params.chunkCount) {
+        controller.close();
+        return;
+      }
+      reads += 1;
+      controller.enqueue(encoder.encode("a".repeat(params.chunkSize)));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: params.status ?? 200,
+      headers: { "content-type": "application/json" },
+    }),
+    getReadCount: () => reads,
+    wasCanceled: () => canceled,
+  };
+}
+
+describe("voyage batch bounded reads", () => {
+  it("uses a 16 MiB cap for batch status/error responses", () => {
+    expect(VOYAGE_BATCH_RESPONSE_MAX_BYTES).toBe(16 * 1024 * 1024);
+  });
+
+  it("parses a well-formed batch status response under the byte cap", async () => {
+    const response = new Response(JSON.stringify({ id: "batch_1", status: "completed" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    const status = await fetchVoyageBatchStatus({
+      client: buildClient(),
+      batchId: "batch_1",
+      deps: buildDeps(response),
+    });
+
+    expect(status).toEqual({ id: "batch_1", status: "completed" });
+  });
+
+  it("caps an oversized batch status stream instead of buffering the whole body", async () => {
+    const streamed = streamingResponse({ chunkCount: 64, chunkSize: 1024 });
+
+    await expect(
+      fetchVoyageBatchStatus({
+        client: buildClient(),
+        batchId: "batch_1",
+        deps: buildDeps(streamed.response),
+        maxResponseBytes: 4096,
+      }),
+    ).rejects.toThrow(/voyage-batch-status: JSON response exceeds 4096 bytes/);
+
+    // Stream was cancelled mid-flight: fewer chunks read than the full payload.
+    expect(streamed.getReadCount()).toBeLessThan(64);
+    expect(streamed.wasCanceled()).toBe(true);
+  });
+
+  it("preserves the full NDJSON parse chain for an under-cap error file", async () => {
+    // Multi-line NDJSON with a blank line proves the bounded read does not
+    // disturb the original trim/split("\n")/JSON.parse/extractBatchErrorMessage
+    // pipeline: the first useful error message is still extracted byte-for-byte
+    // identically to the pre-change `await res.text()` path.
+    const body = [
+      JSON.stringify({ custom_id: "req-0", response: { status_code: 200 } }),
+      "",
+      JSON.stringify({ custom_id: "req-1", error: { message: "voyage upstream rejected" } }),
+      JSON.stringify({ custom_id: "req-2", error: { message: "second error ignored" } }),
+      "",
+    ].join("\n");
+    const response = new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/x-ndjson" },
+    });
+
+    const message = await readVoyageBatchError({
+      client: buildClient(),
+      errorFileId: "file_1",
+      deps: buildDeps(response),
+    });
+
+    // extractBatchErrorMessage returns the first line carrying a message, so the
+    // success line is skipped and the second error is not surfaced.
+    expect(message).toBe("voyage upstream rejected");
+  });
+
+  it("returns undefined for an empty error file via the original empty-body branch", async () => {
+    // Whitespace-only body must still hit the `!text.trim()` short-circuit after
+    // decoding the bounded buffer, returning undefined exactly as before.
+    const response = new Response("   \n", {
+      status: 200,
+      headers: { "content-type": "application/x-ndjson" },
+    });
+
+    const message = await readVoyageBatchError({
+      client: buildClient(),
+      errorFileId: "file_1",
+      deps: buildDeps(response),
+    });
+
+    expect(message).toBeUndefined();
+  });
+
+  it("fail-softs an oversized error file into formatUnavailableBatchError by design", async () => {
+    const streamed = streamingResponse({ chunkCount: 64, chunkSize: 1024 });
+
+    // Intended behavior: an over-cap error file must NOT throw out of
+    // readVoyageBatchError. An unbounded error body would otherwise OOM the
+    // worker, so the bounded overflow error is caught and degraded into a
+    // diagnostic string via formatUnavailableBatchError. We accept the lost
+    // detail; the overflow message names the cap so the truncation is visible.
+    const readError = async () =>
+      await readVoyageBatchError({
+        client: buildClient(),
+        errorFileId: "file_1",
+        deps: buildDeps(streamed.response),
+        maxResponseBytes: 4096,
+      });
+
+    await expect(readError()).resolves.toMatch(
+      /error file unavailable: voyage batch error file content exceeds 4096 bytes/,
+    );
+
+    // The bounded reader still cancels the stream mid-flight rather than
+    // buffering the whole advertised payload before failing soft.
+    expect(streamed.getReadCount()).toBeLessThan(64);
+    expect(streamed.wasCanceled()).toBe(true);
+  });
+
+  it("caps an oversized non-OK (error) diagnostic body instead of buffering it whole", async () => {
+    // Regression for the non-OK gap: `assertVoyageResponseOk` previously read the
+    // 4xx/5xx diagnostic body with an unbounded `await res.text()`. A hostile
+    // endpoint can return a 500 with a never-ending body, so that read must be
+    // bounded too. Drive a streaming 500 through the real status path and assert
+    // the bounded overflow error fires and the stream is cancelled mid-flight.
+    const streamed = streamingResponse({ chunkCount: 64, chunkSize: 1024, status: 500 });
+
+    await expect(
+      fetchVoyageBatchStatus({
+        client: buildClient(),
+        batchId: "batch_1",
+        deps: buildDeps(streamed.response),
+        maxResponseBytes: 4096,
+      }),
+    ).rejects.toThrow(/voyage batch status failed: 500 \(error body exceeds 4096 bytes\)/);
+
+    // Stream was cancelled mid-flight rather than draining the whole body.
+    expect(streamed.getReadCount()).toBeLessThan(64);
+    expect(streamed.wasCanceled()).toBe(true);
+  });
+
+  it("preserves the diagnostic shape for a small non-OK (error) body", async () => {
+    // Under-cap non-OK body must still surface the original
+    // `${context}: ${status} ${text}` diagnostic byte-for-byte.
+    const response = new Response("voyage upstream is down", {
+      status: 503,
+      headers: { "content-type": "text/plain" },
+    });
+
+    await expect(
+      fetchVoyageBatchStatus({
+        client: buildClient(),
+        batchId: "batch_1",
+        deps: buildDeps(response),
+      }),
+    ).rejects.toThrow(/voyage batch status failed: 503 voyage upstream is down/);
+  });
+});

--- a/extensions/voyage/embedding-batch.ts
+++ b/extensions/voyage/embedding-batch.ts
@@ -21,6 +21,8 @@ import {
   uploadBatchJsonlFile,
   withRemoteHttpResponse,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { VoyageEmbeddingClient } from "./embedding-provider.js";
 
@@ -41,6 +43,10 @@ type VoyageBatchOutputLine = ProviderBatchOutputLine;
 const VOYAGE_BATCH_ENDPOINT = EMBEDDING_BATCH_ENDPOINT;
 const VOYAGE_BATCH_COMPLETION_WINDOW = "12h";
 const VOYAGE_BATCH_MAX_REQUESTS = 50000;
+// Voyage batch status/error responses are untrusted external bodies. Cap them
+// the same way other bundled providers do (16 MiB) so a misbehaving or hostile
+// endpoint cannot stream an unbounded body into memory before we parse it.
+const VOYAGE_BATCH_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
 type VoyageBatchDeps = {
   now: () => number;
@@ -65,9 +71,23 @@ function resolveVoyageBatchDeps(overrides: Partial<VoyageBatchDeps> | undefined)
   };
 }
 
-async function assertVoyageResponseOk(res: Response, context: string): Promise<void> {
+async function assertVoyageResponseOk(
+  res: Response,
+  context: string,
+  maxBytes: number = VOYAGE_BATCH_RESPONSE_MAX_BYTES,
+): Promise<void> {
   if (!res.ok) {
-    const text = await res.text();
+    // The non-OK diagnostic body is just as untrusted as the success body: a
+    // misbehaving or hostile endpoint can return a 4xx/5xx with an unbounded
+    // body, and the old `await res.text()` buffered it whole before we threw.
+    // Read it through the same bounded reader (16 MiB cap, stream cancelled on
+    // overflow) while preserving the original `${context}: ${status} ${text}`
+    // diagnostic shape for backward compatibility.
+    const bytes = await readResponseWithLimit(res, maxBytes, {
+      onOverflow: ({ maxBytes: maxBytesLocal }) =>
+        new Error(`${context}: ${res.status} (error body exceeds ${maxBytesLocal} bytes)`),
+    });
+    const text = new TextDecoder().decode(bytes);
     throw new Error(`${context}: ${res.status} ${text}`);
   }
 }
@@ -127,14 +147,18 @@ async function fetchVoyageBatchStatus(params: {
   client: VoyageEmbeddingClient;
   batchId: string;
   deps: VoyageBatchDeps;
+  maxResponseBytes?: number;
 }): Promise<VoyageBatchStatus> {
+  const maxBytes = params.maxResponseBytes ?? VOYAGE_BATCH_RESPONSE_MAX_BYTES;
   return await params.deps.withRemoteHttpResponse(
     buildVoyageBatchRequest({
       client: params.client,
       path: `batches/${params.batchId}`,
       onResponse: async (res) => {
-        await assertVoyageResponseOk(res, "voyage batch status failed");
-        return (await res.json()) as VoyageBatchStatus;
+        await assertVoyageResponseOk(res, "voyage batch status failed", maxBytes);
+        return await readProviderJsonResponse<VoyageBatchStatus>(res, "voyage-batch-status", {
+          maxBytes,
+        });
       },
     }),
   );
@@ -144,15 +168,21 @@ async function readVoyageBatchError(params: {
   client: VoyageEmbeddingClient;
   errorFileId: string;
   deps: VoyageBatchDeps;
+  maxResponseBytes?: number;
 }): Promise<string | undefined> {
+  const maxBytes = params.maxResponseBytes ?? VOYAGE_BATCH_RESPONSE_MAX_BYTES;
   try {
     return await params.deps.withRemoteHttpResponse(
       buildVoyageBatchRequest({
         client: params.client,
         path: `files/${params.errorFileId}/content`,
         onResponse: async (res) => {
-          await assertVoyageResponseOk(res, "voyage batch error file content failed");
-          const text = await res.text();
+          await assertVoyageResponseOk(res, "voyage batch error file content failed", maxBytes);
+          const bytes = await readResponseWithLimit(res, maxBytes, {
+            onOverflow: ({ maxBytes: maxBytesLocal }) =>
+              new Error(`voyage batch error file content exceeds ${maxBytesLocal} bytes`),
+          });
+          const text = new TextDecoder().decode(bytes);
           if (!text.trim()) {
             return undefined;
           }
@@ -280,10 +310,9 @@ export async function runVoyageEmbeddingBatches(
           headers: buildBatchHeaders(params.client, { json: true }),
         },
         onResponse: async (contentRes) => {
-          if (!contentRes.ok) {
-            const text = await contentRes.text();
-            throw new Error(`voyage batch file content failed: ${contentRes.status} ${text}`);
-          }
+          // Same bounded non-OK diagnostic read as the status/error-file paths:
+          // the failure body is untrusted, so cap it instead of `await text()`.
+          await assertVoyageResponseOk(contentRes, "voyage batch file content failed");
 
           if (!contentRes.body) {
             return;
@@ -316,3 +345,9 @@ export async function runVoyageEmbeddingBatches(
     },
   });
 }
+
+export const testing = {
+  fetchVoyageBatchStatus,
+  readVoyageBatchError,
+  VOYAGE_BATCH_RESPONSE_MAX_BYTES,
+} as const;


### PR DESCRIPTION
## What Problem This Solves

`extensions/voyage/embedding-batch.ts` makes several **unbounded** reads of
**external, untrusted** Voyage batch responses. A misconfigured / hostile /
SSRF-reachable endpoint (including a self-hosted `baseUrl` override) can return a
`Content-Length`-less body that streams forever — and each unbounded read buffers
the **entire** payload before we can act on it, driving the batch worker into
memory pressure / OOM or a hang. Three reads are affected: the batch **status
JSON**, the batch **error-file** body, and the **non-OK (4xx/5xx) diagnostic**
body. This is the same untrusted-body surface the merged response-limit campaign
(#95218 / #96027 / #96038) closes across the other bundled providers.

The two **success-body** reads were bounded in the first revision of this PR. This
revision closes the **last remaining gap**: the **non-OK diagnostic body**.
`assertVoyageResponseOk` still read the failure body with an unbounded
`await res.text()` before throwing (and a duplicate unbounded
`await contentRes.text()` existed on the non-OK output-file branch in
`runVoyageEmbeddingBatches`), so a hostile endpoint returning a 500 with an
unbounded body was still buffered whole on the error path. Both non-OK reads are
now bounded too.

## Changes

- **Non-OK diagnostic body** (`assertVoyageResponseOk`): now read through the
  shared `readResponseWithLimit` (16 MiB cap, `media-core` bounded reader,
  re-exported via `openclaw/plugin-sdk/response-limit-runtime`) instead of
  `await res.text()`. The `${context}: ${status} ${text}` diagnostic is preserved
  byte-for-byte for under-cap bodies; on overflow it throws a bounded
  `${context}: ${status} (error body exceeds <N> bytes)` and cancels the stream.
  Cap is threaded from each caller so the boundary is testable.
- **Non-OK output-file branch** (`runVoyageEmbeddingBatches`): now routes through
  the same `assertVoyageResponseOk` (same `voyage batch file content failed:
  <status> <text>` message) instead of its own unbounded `await
  contentRes.text()` — removing the last unbounded read in the file.
- **Success-body reads** (unchanged from the prior revision): status via
  `readProviderJsonResponse`, error file via `readResponseWithLimit`. The
  error-file path still **fail-softs by design** — an oversized error body
  degrades to `formatUnavailableBatchError` (cap value included so truncation is
  visible) rather than crashing the worker; the normal NDJSON
  `trim/split/JSON.parse/extractBatchErrorMessage` chain and the empty-file branch
  are preserved.
- No new abstraction — reuses the shared `media-core` bounded reader already used
  across the codebase. Plugin-scoped.

## Real behavior proof

- **Behavior addressed**: Three untrusted Voyage batch reads must not buffer an
  oversized / never-ending body whole. The success-status read, the success
  error-file read, and the **non-OK diagnostic** read must each stop at the cap,
  cancel the stream, and either throw bounded or fail-soft — while valid small
  bodies (status JSON, NDJSON error file, empty error file, small non-OK
  diagnostic) still parse / format unchanged.
- **Real environment tested**: A real `node:http` server (`createServer`) bound to
  `127.0.0.1`, streaming bodies in 64 KiB chunks with **no `Content-Length`**
  (~64 MiB per overflow route, 4× the 16 MiB cap) over a **real loopback socket**,
  on Node v22.22.0. The **real exported** `fetchVoyageBatchStatus` and
  `readVoyageBatchError` (`testing` exports of the real module) were driven against
  it, with `withRemoteHttpResponse` performing a real `fetch()` and feeding the
  real `Response` into the real `onResponse` — so the production
  `assertVoyageResponseOk` + `readResponseWithLimit` / `readProviderJsonResponse`
  run exactly as in production.
- **Exact steps**: `node --import tsx voyage-proof.mts` — boot the server →
  drive the real functions against the streaming overflow routes and the small
  routes → after each overflow, wait for the server-side socket-close event and
  read the server's observed bytes-sent / abort counters → run a negative control
  (raw unbounded read of the same non-OK route).
- **Evidence after fix (all 11 checks PASS)**:
  - **A — status success overflow**: real `fetchVoyageBatchStatus` threw
    `voyage-batch-status: JSON response exceeds 16777216 bytes`; the server saw the
    socket aborted after ~17 MiB (≪ the ~64 MiB it would have sent) → stream
    **cancelled**, not drained.
  - **B — error-file success overflow**: real `readVoyageBatchError` **fail-softed**
    to `error file unavailable: voyage batch error file content exceeds 16777216
    bytes` (no throw out of the worker); socket aborted after ~17 MiB.
  - **C — NON-OK diagnostic overflow (the gap this revision fixes)**: a streaming
    **500** drove `assertVoyageResponseOk` to throw the bounded
    `voyage batch status failed: 500 (error body exceeds 16777216 bytes)`; socket
    aborted after ~18 MiB ≪ ~64 MiB. Before this fix the 500 body was buffered
    whole by `await res.text()`.
  - **D — small / branch correctness**: small status JSON parsed unchanged; the
    NDJSON error file still extracted the first error message
    (`voyage upstream rejected`); the empty error file returned `undefined` via the
    empty-body branch; a small non-OK body preserved the original
    `voyage batch status failed: 503 voyage upstream is down` diagnostic.
  - **Negative control**: a raw **unbounded** read of the same non-OK route
    buffered **past** the 16 MiB cap (16,790,567 > 16,777,216 bytes) — proving the
    cap is load-bearing (without it the body keeps accumulating).
- **What was not tested**: Did not hit the live `api.voyageai.com` endpoint (no key
  / would not reproduce a hostile oversized body); the untrusted-body behavior is
  fully reproduced with a local streaming server over a real socket, which is the
  same transport path. The proof drives the bytes-on-wire + early-socket-close
  signal (the load-bearing signal) rather than driving the worker to actual OOM.
  The proof script is not committed.

## Evidence

Real `node:http` terminal proof (real loopback sockets, real exported functions):

```
[proof] real node:http server on http://127.0.0.1:42763, cap=16777216 bytes, would-stream≈67108864 bytes per overflow route

PASS  A status success overflow: real fetchVoyageBatchStatus throws bounded error :: threw=true msg="voyage-batch-status: JSON response exceeds 16777216 bytes"
PASS  A status overflow stream cancelled: server saw socket abort, bytes ≪ would-stream :: aborted=true bytesSent=17367040 (< 67108864)
PASS  B error-file success overflow: readVoyageBatchError fail-softs (no throw, degraded string) :: result="error file unavailable: voyage batch error file content exceeds 16777216 bytes"
PASS  B error-file overflow stream cancelled: server saw socket abort, bytes ≪ would-stream :: aborted=true bytesSent=17498112 (< 67108864)
PASS  C NON-OK diagnostic overflow (THE FIX): assertVoyageResponseOk bounds the 500 error body :: threw=true msg="voyage batch status failed: 500 (error body exceeds 16777216 bytes)"
PASS  C NON-OK overflow stream cancelled: server saw socket abort, bytes ≪ would-stream :: aborted=true bytesSent=17760256 (< 67108864)
PASS  D1 small valid status JSON still parsed unchanged :: {"id":"batch_1","status":"completed"}
PASS  D2 small NDJSON error file: full trim/split/parse chain still extracts first error :: message="voyage upstream rejected"
PASS  D3 empty error file: empty-body branch returns undefined :: message=undefined
PASS  D4 small NON-OK body: original `${context}: ${status} ${text}` diagnostic preserved :: threw=true msg="voyage batch status failed: 503 voyage upstream is down"
PASS  NEG control: raw UNBOUNDED read of /nonok-overflow buffers PAST the 16 MiB cap (cap is load-bearing) :: buffered=16790567 bytes (> 16777216)

[proof] 11 PASS, 0 FAIL
[proof] ALL PASS
```

In-repo Vitest suite (real `ReadableStream` fixtures, including the new non-OK
overflow + small non-OK diagnostic regression tests):

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Checks on the changed files: `oxlint extensions/voyage/embedding-batch.ts
extensions/voyage/embedding-batch.test.ts` → exit 0, clean; `tsgo -p
tsconfig.extensions.json` → exit 0, no errors.

**Label**: security

_AI-assisted._
