### PR TITLE
fix(model-resolver): use numeric-aware version comparison for model alias resolution

### DIFF
--- a/src/agents/sessions/model-resolver.test.ts
+++ b/src/agents/sessions/model-resolver.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { Model } from "../../llm/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
-import { findInitialModel, restoreModelFromSession } from "./model-resolver.js";
+import { findInitialModel, parseModelPattern, restoreModelFromSession } from "./model-resolver.js";
 
 function model(provider: string, id: string): Model {
   return {
@@ -55,5 +55,17 @@ describe("model resolver fallback selection", () => {
     );
 
     expect(result.model).toBe(firstAvailable);
+  });
+});
+
+describe("parseModelPattern version sorting", () => {
+  it("selects the numerically highest version when aliases span double-digit minors", () => {
+    const models = [
+      model("anthropic", "claude-opus-4-9"),
+      model("anthropic", "claude-opus-4-10"),
+      model("anthropic", "claude-opus-4-11"),
+    ];
+    const result = parseModelPattern("opus", models);
+    expect(result.model?.id).toBe("claude-opus-4-11");
   });
 });

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -93,26 +93,6 @@ export function findExactModelReferenceMatch(
  * Try to match a pattern to a model from the available models list.
  * Returns the matched model or undefined if no match found.
  */
-function compareModelIds(a: string, b: string): number {
-  // Numeric segment comparison for model IDs like "claude-opus-4-10".
-  // Compare each numeric part numerically so 4-10 > 4-9.
-  const aNums = a
-    .split(/-/)
-    .map(Number)
-    .filter((n) => Number.isFinite(n));
-  const bNums = b
-    .split(/-/)
-    .map(Number)
-    .filter((n) => Number.isFinite(n));
-  const len = Math.min(aNums.length, bNums.length);
-  for (let i = 0; i < len; i++) {
-    if (aNums[i] !== bNums[i]) {
-      return aNums[i] - bNums[i];
-    }
-  }
-  return aNums.length - bNums.length;
-}
-
 function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | undefined {
   const exactMatch = findExactModelReferenceMatch(modelPattern, availableModels);
   if (exactMatch) {
@@ -136,11 +116,11 @@ function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | 
 
   if (aliases.length > 0) {
     // Prefer alias - if multiple aliases, pick the one that sorts highest
-    aliases.sort((a, b) => compareModelIds(b.id, a.id));
+    aliases.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
     return aliases[0];
   }
   // No alias found, pick latest dated version
-  datedVersions.sort((a, b) => compareModelIds(b.id, a.id));
+  datedVersions.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
   return datedVersions[0];
 }
 

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -93,6 +93,24 @@ export function findExactModelReferenceMatch(
  * Try to match a pattern to a model from the available models list.
  * Returns the matched model or undefined if no match found.
  */
+function compareModelIds(a: string, b: string): number {
+  // Numeric segment comparison for model IDs like "claude-opus-4-10".
+  // Compare each numeric part numerically so 4-10 > 4-9.
+  const aNums = a
+    .split(/-/)
+    .map(Number)
+    .filter((n) => Number.isFinite(n));
+  const bNums = b
+    .split(/-/)
+    .map(Number)
+    .filter((n) => Number.isFinite(n));
+  const len = Math.min(aNums.length, bNums.length);
+  for (let i = 0; i < len; i++) {
+    if (aNums[i] !== bNums[i]) return aNums[i] - bNums[i];
+  }
+  return aNums.length - bNums.length;
+}
+
 function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | undefined {
   const exactMatch = findExactModelReferenceMatch(modelPattern, availableModels);
   if (exactMatch) {
@@ -116,11 +134,11 @@ function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | 
 
   if (aliases.length > 0) {
     // Prefer alias - if multiple aliases, pick the one that sorts highest
-    aliases.sort((a, b) => b.id.localeCompare(a.id));
+    aliases.sort((a, b) => compareModelIds(b.id, a.id));
     return aliases[0];
   }
   // No alias found, pick latest dated version
-  datedVersions.sort((a, b) => b.id.localeCompare(a.id));
+  datedVersions.sort((a, b) => compareModelIds(b.id, a.id));
   return datedVersions[0];
 }
 

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -106,7 +106,9 @@ function compareModelIds(a: string, b: string): number {
     .filter((n) => Number.isFinite(n));
   const len = Math.min(aNums.length, bNums.length);
   for (let i = 0; i < len; i++) {
-    if (aNums[i] !== bNums[i]) return aNums[i] - bNums[i];
+    if (aNums[i] !== bNums[i]) {
+      return aNums[i] - bNums[i];
+    }
   }
   return aNums.length - bNums.length;
 }


### PR DESCRIPTION
Fixes #96588

## What Problem This Solves

`tryMatchModel` sorts candidate model ids with plain lexicographic `localeCompare`, so ids like `claude-opus-4-9` sort above `claude-opus-4-10`. When version numbers cross into double digits, partial aliases such as `opus` resolve to an older model.

## Evidence

### Fix

`src/agents/sessions/model-resolver.ts`: replaced two `localeCompare()` sort calls with `localeCompare(undefined, { numeric: true })`, which natively compares numeric segments correctly.

### Regression test

Added `parseModelPattern("opus", [claude-opus-4-9, claude-opus-4-10, claude-opus-4-11])` → selects `claude-opus-4-11`.

### Terminal output (patched resolver)

```
========================================
  PR #96609 — Numerical Version Sort
========================================
  Input models: claude-opus-4-9, claude-opus-4-10, claude-opus-4-11
  Pattern:      "opus"
  Before fix:   claude-opus-4-9  ❌ (localeCompare picks wrong)
  After fix:    claude-opus-4-11  ✅ (numeric-aware picks correct)
  Status:       PASS
========================================
```

### What was not tested

Single-digit versions only (lexicographic and numeric ordering agree — no behavioral change). Custom model catalogs where version numbering does not follow `-N-N` patterns.

## AI Assistance
- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>

## Changes

2 files, +15/-3. Lockfile unchanged.