### PR TITLE
fix(telegram): use idempotent retry context for delete/reaction

### DIFF
--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -139,6 +139,16 @@ describe("isRecoverableTelegramNetworkError", () => {
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "polling" })).toBe(true);
   });
 
+  it("treats delete/react (idempotent) contexts like polling, not send", () => {
+    const undiciSnippetErr = new Error("Undici: socket failure");
+    // delete and react are idempotent Telegram operations; a transient
+    // snippet-only error must be retried (allowMessageMatch defaults true),
+    // matching polling/webhook. send stays strict as the regression guard.
+    expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "delete" })).toBe(true);
+    expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "react" })).toBe(true);
+    expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "send" })).toBe(false);
+  });
+
   it("treats grammY failed-after envelope errors as recoverable in send context", () => {
     expect(
       isRecoverableTelegramNetworkError(

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -141,7 +141,13 @@ export function isTelegramMisdirectedRequestError(err: unknown): boolean {
   return false;
 }
 
-export type TelegramNetworkErrorContext = "polling" | "send" | "webhook" | "unknown";
+export type TelegramNetworkErrorContext =
+  | "polling"
+  | "send"
+  | "webhook"
+  | "delete"
+  | "react"
+  | "unknown";
 export type TelegramNetworkErrorOrigin = {
   method?: string | null;
   url?: string | null;

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1219,7 +1219,7 @@ export async function reactMessageTelegram(
     account,
     retry: opts.retry,
     verbose: opts.verbose,
-    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "react" }),
   });
   const remove = opts.remove === true;
   const trimmedEmoji = emoji.trim();
@@ -1276,7 +1276,7 @@ export async function deleteMessageTelegram(
     account,
     retry: opts.retry,
     verbose: opts.verbose,
-    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "delete" }),
   });
   try {
     await requestWithDiag(() => api.deleteMessage(chatId, messageId), "deleteMessage", {


### PR DESCRIPTION
## What Problem This Solves

`reactMessageTelegram` and `deleteMessageTelegram` (extensions/telegram/src/send.ts) passed `context: "send"` to `isRecoverableTelegramNetworkError`. The "send" context is the only one that defaults `allowMessageMatch` to `false`, disabling message-snippet matching. Both operations are idempotent (`api.setMessageReaction` / `api.deleteMessage` are safe to repeat), so a transient error recognizable only by message snippet (e.g. `socket hang up`, `undici network error` with no error `code`) was NOT retried — stricter than every sibling context (`polling`, `webhook`, `unknown` all default `allowMessageMatch` to true). Users saw spurious reaction/delete failures on transient network blips.

## Why This Change Was Made

`isRecoverableTelegramNetworkError`'s `context` encodes whether the caller is a non-idempotent write; only `"send"` opts into the strict path (`options.context !== "send"` at network-errors.ts:309). Grouping idempotent delete/reaction under "send" is a classification error. The existing test "skips broad message matches for send context" already locks the send-vs-polling contract, confirming the semantics are intentional — delete/react were simply mislabeled.

## User Impact

Transient network errors during emoji reactions (approval bubbles, user-feedback reactions) and message cleanup deletes now retry like polling instead of failing immediately. sendMessage behavior is unchanged (still strict, no duplicate-message risk).

## Real behavior proof

- **Behavior addressed:** `reactMessageTelegram` / `deleteMessageTelegram` used `context: "send"`, so transient snippet-only network errors were not retried even though both operations are idempotent.
- **Real environment tested:** Linux x86_64, Node 22, commit `a85f1d59c3` on branch `fix/telegram-idempotent-retry-context`.
- **Exact steps or command run after this patch:** `node --import tsx /tmp/verify-telegram-retry-context.mjs` — imports the real `isRecoverableTelegramNetworkError` and checks snippet-only transient errors across retry contexts.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```text
  Terminal capture of node runtime verification (live stdout):
    scenario: transient snippet-only network errors (no error code)
    fix: idempotent react/delete must retry like polling, not send

    err="socket hang up"
      send    (non-idempotent) : false
      react   (idempotent FIX) : true
      delete  (idempotent FIX) : true
      polling (sibling)        : true
      => react/delete retry like polling AND send stays strict: PASS

    err="Undici: network error"
      send    (non-idempotent) : false
      react   (idempotent FIX) : true
      delete  (idempotent FIX) : true
      polling (sibling)        : true
      => react/delete retry like polling AND send stays strict: PASS

  Verdict: PASS
  ```

- **Observed result after fix:** For snippet-only transient errors, `react`/`delete` now return recoverable (retry), matching `polling`; `send` stays non-recoverable.
- **What was not tested:** Live end-to-end against a real Telegram bot under an injected transient socket error (function-level proof covers the retry predicate directly); `sendChatAction` also uses `context: "send"` but is out of scope here.

## Tests and validation

```text
$ pnpm test extensions/telegram/src/network-errors.test.ts
Test Files  1 passed (1)
Tests       52 passed (52)

$ pnpm tsgo:extensions:test
EXIT=0 (type check passed)
```

Added one regression case to `network-errors.test.ts`: delete/react contexts treat a snippet-only error as recoverable (like polling), while send stays strict.

## Risk checklist

- User-visible behavior: Yes - transient network errors during reaction/delete now retry instead of surfacing as immediate failures; intended for idempotent ops, adds no duplicate-message risk.
- Config/env/migration behavior: No - no config or env surface touched.
- Security/auth/secrets/network/tool execution: No - only the retry predicate's context label changes; no new command execution, credential, or network path.
- Plugins/providers/channels/SDK: No - internal to the telegram plugin; TelegramNetworkErrorContext gains two additive enum values, helper default logic unchanged.
- Highest-risk area: slightly more retry traffic on reaction/delete under flaky networks, but both are idempotent Telegram API calls with no correctness impact.
- Mitigation: sendMessage keeps "send" (strict); existing send-vs-polling contract test plus the new delete/react regression case guard the semantics.

Closes: N/A (no existing issue)
