### PR TITLE
fix(telegram): fall back to plain text when rich message send fails

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -126,22 +126,28 @@ export async function sendTelegramText(
       skipEntityDetection: opts.linkPreview === false,
       tableMode: opts.tableMode,
     });
-    const res = await sendTelegramWithThreadFallback({
-      operation: "sendRichMessage",
-      runtime,
-      thread: opts.thread,
-      requestParams: toTelegramRichMessageContextParams(baseParams),
-      removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
-      send: (effectiveParams) =>
-        getTelegramRichRawApi(bot.api).sendRichMessage({
-          chat_id: chatId,
-          rich_message: richMessage,
-          ...(opts.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-          ...effectiveParams,
-        }),
-    });
-    runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
-    return res.message_id;
+    try {
+      const res = await sendTelegramWithThreadFallback({
+        operation: "sendRichMessage",
+        runtime,
+        thread: opts.thread,
+        requestParams: toTelegramRichMessageContextParams(baseParams),
+        removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
+        send: (effectiveParams) =>
+          getTelegramRichRawApi(bot.api).sendRichMessage({
+            chat_id: chatId,
+            rich_message: richMessage,
+            ...(opts.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+            ...effectiveParams,
+          }),
+      });
+      runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
+      return res.message_id;
+    } catch (err) {
+      runtime.error?.(
+        `telegram sendRichMessage failed, falling back to plain text: ${formatErrorMessage(err)}`,
+      );
+    }
   }
   // Add link_preview_options when link preview is disabled.
   const linkPreviewEnabled = opts?.linkPreview ?? true;


### PR DESCRIPTION
Closes #96363

## What Problem This Solves

Fixes an issue where users sending `/status` (or other slash commands) to a Telegram bot with `richMessages=true` would receive no response. Telegram rejects the rich message with `RICH_MESSAGE_EMAIL_INVALID` when the status text contains `@` symbols (e.g. model names, usernames) that the rich message parser misinterprets as email entities.

## Why This Change Was Made

The `sendTelegramText` function in `delivery.send.ts` had no error recovery for the rich message path. When `sendRichMessage` failed, the error propagated up and the reply was silently dropped. The non-rich path already had a plain text fallback mechanism. This change wraps the rich message send in a try/catch so that on failure, execution falls through to the existing plain text delivery path.

## User Impact

Users with `richMessages=true` will no longer lose slash command replies when Telegram rejects the rich message payload. The reply is delivered as plain text instead of being silently dropped.

## Evidence

All 135 existing Telegram dispatch tests pass. Build succeeds with no errors.
