### PR TITLE
fix(agents): use numeric collation for alias/dated model version sorting

### DIFF
--- a/src/agents/sessions/model-resolver.test.ts
+++ b/src/agents/sessions/model-resolver.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { Model } from "../../llm/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
-import { findInitialModel, restoreModelFromSession } from "./model-resolver.js";
+import { findInitialModel, parseModelPattern, restoreModelFromSession } from "./model-resolver.js";
 
 function model(provider: string, id: string): Model {
   return {
@@ -55,5 +55,43 @@ describe("model resolver fallback selection", () => {
     );
 
     expect(result.model).toBe(firstAvailable);
+  });
+});
+
+describe("parseModelPattern alias resolution", () => {
+  it("selects the numerically newest alias when minor versions reach double digits", () => {
+    const models = [model("anthropic", "claude-opus-4-9"), model("anthropic", "claude-opus-4-10")];
+    const result = parseModelPattern("opus", models);
+
+    expect(result.model).toBe(models[1]);
+    expect(result.model?.id).toBe("claude-opus-4-10");
+  });
+
+  it("selects the numerically newest alias across mixed single and double digits", () => {
+    const models = [
+      model("anthropic", "claude-opus-4-2"),
+      model("anthropic", "claude-opus-4-10"),
+      model("anthropic", "claude-opus-4-9"),
+    ];
+    const result = parseModelPattern("opus", models);
+
+    expect(result.model?.id).toBe("claude-opus-4-10");
+  });
+
+  it("keeps single-digit alias ordering unchanged", () => {
+    const models = [model("anthropic", "claude-opus-4-2"), model("anthropic", "claude-opus-4-9")];
+    const result = parseModelPattern("opus", models);
+
+    expect(result.model?.id).toBe("claude-opus-4-9");
+  });
+
+  it("uses numeric ordering for dated version buckets too", () => {
+    const models = [
+      model("anthropic", "claude-opus-4-9-20251001"),
+      model("anthropic", "claude-opus-4-10-20250901"),
+    ];
+    const result = parseModelPattern("opus", models);
+
+    expect(result.model?.id).toBe("claude-opus-4-10-20250901");
   });
 });

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -115,12 +115,16 @@ function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | 
   const datedVersions = matches.filter((m) => !isAlias(m.id));
 
   if (aliases.length > 0) {
-    // Prefer alias - if multiple aliases, pick the one that sorts highest
-    aliases.sort((a, b) => b.id.localeCompare(a.id));
+    // Prefer alias - if multiple aliases, pick the one that sorts highest.
+    // Use numeric collation so version segments like "4-10" sort above "4-9"
+    // instead of being ordered lexicographically.
+    aliases.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
     return aliases[0];
   }
-  // No alias found, pick latest dated version
-  datedVersions.sort((a, b) => b.id.localeCompare(a.id));
+  // No alias found, pick latest dated version. Numeric collation keeps the
+  // comparator consistent with the alias branch even though -YYYYMMDD suffixes
+  // currently make lexicographic and numeric ordering coincide.
+  datedVersions.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
   return datedVersions[0];
 }
 


### PR DESCRIPTION
Fixes #96588

## What Problem This Solves

When an alias such as `opus` matched multiple versioned model ids, `tryMatchModel` in `src/agents/sessions/model-resolver.ts` sorted candidates with plain `String.localeCompare`. Lexicographic ordering treats `claude-opus-4-9` as greater than `claude-opus-4-10`, so once a model family reaches double-digit minor versions the resolver silently selects the older version.

## Why This Change Was Made

Changed both the alias bucket and dated-version bucket comparators to use `localeCompare(..., undefined, { numeric: true })`. Numeric collation orders version segments correctly (`4-10` > `4-9`), and applies consistently to both branches even though the fixed-width `-YYYYMMDD` suffix currently makes the dated-version bucket safe either way.

## User Impact

Aliases and partial model patterns now resolve to the numerically newest matching model version instead of the lexicographically highest id. This is forward-fixing: no shipped model family currently has double-digit minor versions, so the bug is latent today but would trigger on the first rollover.

## Evidence

- Added regression tests in `src/agents/sessions/model-resolver.test.ts` covering:
  - double-digit minor versions (`claude-opus-4-9` vs `claude-opus-4-10`)
  - mixed single/double-digit versions
  - preserved single-digit ordering
  - numeric ordering in the dated-version bucket
- `pnpm test src/agents/sessions/model-resolver.test.ts` passes (6/6).
