### PR TITLE
fix(discord,telegram,github-copilot,google-meet): bound JSON response reads to prevent OOM

### DIFF
--- a/extensions/discord/src/pluralkit.ts
+++ b/extensions/discord/src/pluralkit.ts
@@ -1,6 +1,9 @@
 // Discord plugin module implements pluralkit behavior.
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 
 const PLURALKIT_API_BASE = "https://api.pluralkit.me/v2";
 const PLURALKIT_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
@@ -59,5 +62,5 @@ export async function fetchPluralKitMessageInfo(params: {
     const detail = text.trim() ? `: ${text.trim()}` : "";
     throw new Error(`PluralKit API failed (${res.status})${detail}`);
   }
-  return (await res.json()) as PluralKitMessageInfo;
+  return await readProviderJsonResponse<PluralKitMessageInfo>(res, "discord.pluralkit");
 }

--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -1,7 +1,10 @@
 // Discord plugin module implements send.webhook behavior.
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveDiscordClientAccountContext } from "./client.js";
 import {
@@ -120,7 +123,9 @@ export async function sendWebhookMessageDiscord(
     await throwWebhookResponseError(response);
   }
 
-  const payload = (await response.json().catch(() => ({}))) as {
+  const payload = (await readProviderJsonResponse(response, "discord.webhook").catch(
+    () => ({}),
+  )) as {
     id?: string;
     channel_id?: string;
   };

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -22,7 +22,10 @@ import {
 import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS } from "openclaw/plugin-sdk/media-runtime";
 import { unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
 import { parseStrictFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readResponseTextLimited,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import type { RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -351,7 +354,7 @@ async function requestVoiceUploadUrl(params: {
     if (!res.ok) {
       throw await createVoiceRequestError(res, "Upload URL request failed");
     }
-    return (await res.json()) as UploadUrlResponse;
+    return await readProviderJsonResponse<UploadUrlResponse>(res, "discord.voice-message");
   } finally {
     await release();
   }


### PR DESCRIPTION
## What Problem This Solves

Replace unbounded `await response.json()` with `readResponseWithLimit` (1 MiB cap)
across  bound JSON response reads to prevent OOM:4 extensions, preventing OOM from oversized upstream HTTP responses.

## Evidence

### Real HTTP bounded-read proof

```
node --import tsx test/_proof_bounded_json.mts

[proof] real server on :58033, cap=1048576 bytes, would-stream≈67108864 bytes
[proof] small server on :58034

PASS  oversized body: throws bounded cap error :: threw=true msg="Error: JSON response exceeds 1048576 bytes"
PASS  stream cancelled at cap: server sent ≈ cap bytes, not ~64 MiB :: bytesSent=1048576 (cap=1048576, would-stream=67108864)
PASS  happy path: small JSON parsed correctly :: status=ok id=batch-1
PASS  negative control: unbounded read buffers PAST cap :: buffered=33554457 bytes (> 1048576)

[proof] 4 PASS, 0 FAIL
```

The proof harness starts a real `node:http` server with no Content-Length, streams ~64 MiB of JSON, and verifies `readResponseWithLimit` cancels the stream at the 1 MiB cap.

_AI-assisted._