### PR TITLE
fix(feishu,browser,msteams,azure-speech,bedrock-mantle,googlechat,huggingface,perplexity): bound JSON response reads

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -302,7 +302,7 @@ export async function discoverMantleModels(params: {
       return cached?.models ?? [];
     }
 
-    const body = (await response.json()) as OpenAIModelsResponse;
+    const body = (await readProviderJsonResponse(response, "discovery")) as OpenAIModelsResponse;
     const rawModels = body.data ?? [];
 
     const models = rawModels

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -306,7 +306,7 @@ export async function fetchJson<T>(
 ): Promise<T> {
   const { response, release } = await fetchCdpChecked(url, timeoutMs, init, ssrfPolicy);
   try {
-    return (await response.json()) as T;
+    return (await readProviderJsonResponse(response, "cdp.helpers")) as T;
   } finally {
     await release();
   }

--- a/extensions/browser/src/browser/chrome.diagnostics.ts
+++ b/extensions/browser/src/browser/chrome.diagnostics.ts
@@ -110,7 +110,10 @@ export async function readChromeVersion(
       ssrfPolicy,
     );
     try {
-      const data = (await response.json()) as ChromeVersion;
+      const data = (await readProviderJsonResponse(
+        response,
+        "chrome.diagnostics",
+      )) as ChromeVersion;
       if (!data || typeof data !== "object") {
         throw new Error("CDP /json/version returned non-object JSON");
       }

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -270,7 +270,7 @@ async function fetchHttpJson<T>(
       const text = await res.text().catch(() => "");
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
-    return (await res.json()) as T;
+    return (await readProviderJsonResponse(res, "client-fetch")) as T;
   } finally {
     clearTimeout(t);
     await release?.();

--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -109,7 +109,7 @@ async function fetchFeishuJson<T>(params: {
   });
   try {
     // Registration poll returns 4xx for pending/error states with a JSON body.
-    return (await response.json()) as T;
+    return (await readProviderJsonResponse(response, "app-registration")) as T;
   } finally {
     await release();
   }

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -116,7 +116,7 @@ async function getToken(creds: Credentials): Promise<string> {
     await release();
     throw new Error(`Token request failed with HTTP ${response.status}`);
   }
-  const data = (await response.json()) as {
+  const data = (await readProviderJsonResponse(response, "streaming-card")) as {
     code: number;
     msg: string;
     tenant_access_token?: string;
@@ -276,7 +276,7 @@ export class FeishuStreamingSession {
       await releaseCreate();
       throw new Error(`Create card request failed with HTTP ${createRes.status}`);
     }
-    const createData = (await createRes.json()) as {
+    const createData = (await readProviderJsonResponse(createRes, "streaming-card")) as {
       code: number;
       msg: string;
       data?: { card_id: string };

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -165,7 +165,7 @@ export async function discoverHuggingfaceModels(
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);
       }
 
-      const body = (await response.json()) as OpenAIListModelsResponse;
+      const body = (await readProviderJsonResponse(response, "models")) as OpenAIListModelsResponse;
       const data = body?.data;
       if (!Array.isArray(data) || data.length === 0) {
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);

--- a/extensions/msteams/src/attachments/bot-framework.ts
+++ b/extensions/msteams/src/attachments/bot-framework.ts
@@ -112,7 +112,10 @@ async function fetchBotFrameworkAttachmentInfo(params: {
     return undefined;
   }
   try {
-    return (await response.json()) as BotFrameworkAttachmentInfo;
+    return (await readProviderJsonResponse(
+      response,
+      "bot-framework",
+    )) as BotFrameworkAttachmentInfo;
   } catch (err) {
     params.logger?.warn?.("msteams botFramework attachmentInfo parse failed", {
       error: err instanceof Error ? err.message : String(err),

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -143,7 +143,7 @@ async function fetchGraphCollection(params: {
       return { status, items: [] };
     }
     try {
-      const data = (await response.json()) as { value?: unknown[] };
+      const data = (await readProviderJsonResponse(response, "graph")) as { value?: unknown[] };
       return { status, items: Array.isArray(data.value) ? data.value : [] };
     } catch {
       return { status, items: [] };
@@ -345,7 +345,7 @@ export async function downloadMSTeamsGraphMedia(params: {
           attachments?: GraphAttachment[];
         };
         try {
-          msgData = (await msgRes.json()) as typeof msgData;
+          msgData = (await readProviderJsonResponse(msgRes, "graph")) as typeof msgData;
         } catch (err) {
           debugLog?.debug?.("graph media message parse failed", {
             messageUrl,

--- a/extensions/msteams/src/graph-upload.ts
+++ b/extensions/msteams/src/graph-upload.ts
@@ -54,7 +54,7 @@ export async function uploadToOneDrive(params: {
     throw await createMSTeamsHttpError(res, "OneDrive upload failed");
   }
 
-  const data = (await res.json()) as {
+  const data = (await readProviderJsonResponse(res, "graph-upload")) as {
     id?: string;
     webUrl?: string;
     name?: string;
@@ -106,7 +106,7 @@ async function createSharingLink(params: {
     throw await createMSTeamsHttpError(res, "Create sharing link failed");
   }
 
-  const data = (await res.json()) as {
+  const data = (await readProviderJsonResponse(res, "graph-upload")) as {
     link?: { webUrl?: string };
   };
 
@@ -200,7 +200,7 @@ export async function uploadToSharePoint(params: {
     throw await createMSTeamsHttpError(res, "SharePoint upload failed");
   }
 
-  const data = (await res.json()) as {
+  const data = (await readProviderJsonResponse(res, "graph-upload")) as {
     id?: string;
     webUrl?: string;
     name?: string;
@@ -260,7 +260,7 @@ export async function getDriveItemProperties(params: {
     throw await createMSTeamsHttpError(res, "Get driveItem properties failed");
   }
 
-  const data = (await res.json()) as {
+  const data = (await readProviderJsonResponse(res, "graph-upload")) as {
     eTag?: string;
     webDavUrl?: string;
     name?: string;
@@ -331,7 +331,7 @@ export async function resolveGraphChatId(params: {
     return null;
   }
 
-  const data = (await res.json()) as {
+  const data = (await readProviderJsonResponse(res, "graph-upload")) as {
     value?: Array<{ id?: string }>;
   };
 
@@ -371,7 +371,7 @@ async function getChatMembers(params: {
     throw await createMSTeamsHttpError(res, "Get chat members failed");
   }
 
-  const data = (await res.json()) as {
+  const data = (await readProviderJsonResponse(res, "graph-upload")) as {
     value?: Array<{
       userId?: string;
       displayName?: string;
@@ -435,7 +435,7 @@ async function createSharePointSharingLink(params: {
     throw await createMSTeamsHttpError(res, "Create SharePoint sharing link failed");
   }
 
-  const data = (await res.json()) as {
+  const data = (await readProviderJsonResponse(res, "graph-upload")) as {
     link?: { webUrl?: string };
   };
 

--- a/extensions/msteams/src/sso.ts
+++ b/extensions/msteams/src/sso.ts
@@ -130,7 +130,7 @@ async function callUserTokenService(
   }
   let parsed: unknown;
   try {
-    parsed = await response.json();
+    parsed = await readProviderJsonResponse(response, "sso");
   } catch {
     return { error: "invalid JSON from User Token service", status: response.status };
   }


### PR DESCRIPTION
## What Problem This Solves

Replace unbounded `await response.json()` with `readResponseWithLimit` (1 MiB cap)
across  bound JSON response reads to prevent OOM:8 extensions, preventing OOM from oversized upstream HTTP responses.

## Evidence

### Real HTTP bounded-read proof

```
node --import tsx test/_proof_bounded_json.mts

[proof] real server on :58033, cap=1048576 bytes, would-stream≈67108864 bytes
[proof] small server on :58034

PASS  oversized body: throws bounded cap error :: threw=true msg="Error: JSON response exceeds 1048576 bytes"
PASS  stream cancelled at cap: server sent ≈ cap bytes, not ~64 MiB :: bytesSent=1048576 (cap=1048576, would-stream=67108864)
PASS  happy path: small JSON parsed correctly :: status=ok id=batch-1
PASS  negative control: unbounded read buffers PAST cap :: buffered=33554457 bytes (> 1048576)

[proof] 4 PASS, 0 FAIL
```

The proof harness starts a real `node:http` server with no Content-Length, streams ~64 MiB of JSON, and verifies `readResponseWithLimit` cancels the stream at the 1 MiB cap.

_AI-assisted._