### PR TITLE
fix(telegram): strip media-store cache suffix from outbound filenames

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -18,6 +18,7 @@ import type { ReplyPayloadDelivery } from "openclaw/plugin-sdk/interactive-runti
 import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   buildOutboundMediaLoadOptions,
+  extractOriginalFilename,
   isGifMedia,
   kindFromMime,
   probeVideoDimensions,
@@ -402,7 +403,11 @@ async function deliverMediaReply(params: {
       contentType: media.contentType,
       fileName: media.fileName,
     });
-    const fileName = media.fileName ?? (isGif ? "animation.gif" : "file");
+    const fileName = media.fileName
+      ? extractOriginalFilename(media.fileName)
+      : isGif
+        ? "animation.gif"
+        : "file";
     const file = new InputFile(media.buffer, fileName);
     const { caption, followUpText } = splitTelegramCaption(
       isFirstMedia ? (params.reply.text ?? undefined) : undefined,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -804,6 +804,29 @@ describe("deliverReplies", () => {
     });
   });
 
+  it("strips internal media-store cache suffix from outbound filenames", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 2,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendPhoto });
+
+    mockMediaLoad("photo---a1b2c3d4-e5f6-7890-abcd-ef1234567890.jpg", "image/jpeg", "image");
+
+    await deliverWith({
+      replies: [{ mediaUrl: "/media/store/photo---a1b2c3d4-e5f6-7890-abcd-ef1234567890.jpg" }],
+      runtime,
+      bot,
+    });
+
+    const media = firstMockCallArg(sendPhoto, 1);
+    if (media === undefined) {
+      throw new Error("Expected Telegram photo media");
+    }
+    expect((media as { fileName?: string }).fileName).toBe("photo.jpg");
+  });
+
   it("passes probed dimensions to video reply sends", async () => {
     const runtime = createRuntime();
     const sendVideo = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/send.runtime.ts
+++ b/extensions/telegram/src/send.runtime.ts
@@ -5,6 +5,7 @@ export type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 export type { PollInput, MediaKind } from "openclaw/plugin-sdk/media-runtime";
 export {
   buildOutboundMediaLoadOptions,
+  extractOriginalFilename,
   getImageMetadata,
   isGifMedia,
   kindFromMime,

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -2,6 +2,7 @@
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import {
   buildOutboundMediaLoadOptions,
+  extractOriginalFilename,
   isGifMedia,
   kindFromMime,
   normalizePollInput,
@@ -145,7 +146,9 @@ vi.mock("grammy", () => ({
   GrammyError: class GrammyError extends Error {
     description = "";
   },
-  InputFile: function InputFile() {},
+  InputFile: function InputFile(this: { fileName?: string }, _buffer: unknown, fileName?: string) {
+    this.fileName = fileName;
+  },
 }));
 
 vi.mock("undici", async () => {
@@ -172,6 +175,7 @@ vi.mock("openclaw/plugin-sdk/plugin-config-runtime", async () => {
 
 vi.mock("./send.runtime.js", () => ({
   buildOutboundMediaLoadOptions,
+  extractOriginalFilename,
   getImageMetadata: vi.fn(async () => ({ ...imageMetadata })),
   isGifMedia,
   kindFromMime,

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -258,6 +258,14 @@ function firstMockCall(mock: ReturnType<typeof vi.fn>, label: string): unknown[]
   return mockCall(mock, 0, label);
 }
 
+function firstMockCallArg(mock: ReturnType<typeof vi.fn>, argIndex: number) {
+  const call = mock.mock.calls[0];
+  if (call === undefined) {
+    throw new Error("expected mock call");
+  }
+  return call[argIndex];
+}
+
 function requireString(value: unknown, label: string): string {
   if (typeof value !== "string") {
     throw new Error(`expected ${label} to be a string`);
@@ -1609,6 +1617,36 @@ describe("sendMessageTelegram", () => {
       parse_mode: "HTML",
       message_thread_id: 99,
     });
+  });
+
+  it("strips internal media-store cache suffix from outbound filenames", async () => {
+    const chatId = "123";
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 59,
+      chat: { id: chatId },
+    });
+    const api = { sendPhoto } as unknown as {
+      sendPhoto: typeof sendPhoto;
+    };
+
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/jpeg",
+      fileName: "photo---a1b2c3d4-e5f6-7890-abcd-ef1234567890.jpg",
+    });
+
+    await sendMessageTelegram(chatId, "cached photo", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrl: "/media/store/photo---a1b2c3d4-e5f6-7890-abcd-ef1234567890.jpg",
+    });
+
+    const media = firstMockCallArg(sendPhoto, 1);
+    if (media === undefined) {
+      throw new Error("Expected Telegram photo media");
+    }
+    expect((media as { fileName?: string }).fileName).toBe("photo.jpg");
   });
 
   it("splits long captions into media + text messages when text exceeds 1024 chars", async () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -52,6 +52,7 @@ import {
 } from "./rich-message.js";
 import {
   buildOutboundMediaLoadOptions,
+  extractOriginalFilename,
   getImageMetadata,
   isGifMedia,
   kindFromMime,
@@ -981,8 +982,9 @@ export async function sendMessageTelegram(
       sendImageAsPhoto = await shouldSendTelegramImageAsPhoto(media.buffer);
     }
     const isVideoNote = deliveryKind === "video" && opts.asVideoNote === true;
-    const fileName =
-      media.fileName ?? (isGif ? "animation.gif" : inferFilename(kind ?? "document")) ?? "file";
+    const fileName = media.fileName
+      ? extractOriginalFilename(media.fileName)
+      : ((isGif ? "animation.gif" : inferFilename(kind ?? "document")) ?? "file");
     const file = new InputFileCtor(media.buffer, fileName);
     let caption: string | undefined;
     let followUpText: string | undefined;


### PR DESCRIPTION
Fixes #96538

## What Problem This Solves

When OpenClaw sends file attachments outbound via Telegram, the delivered filename includes an internal media-store cache suffix in the form `---<uuid>` (for example, `photo---a1b2c3d4-e5f6-7890-abcd-ef1234567890.jpg` arrives as-is). This leaks internal cache implementation details to end users and differs from the original filename.

## Why This Change Was Made

`loadWebMedia` derives `fileName` from the local media-store path basename, which embeds the cache UUID. The Telegram send paths in `sendMessageTelegram` and `deliverReplies` passed that basename directly to grammy `InputFile`.

This change strips the cache suffix using the shared `extractOriginalFilename` helper (already used by MSTeams) before constructing the `InputFile` in both Telegram outbound send paths.

## User Impact

Telegram recipients now see the original filename (for example, `photo.jpg`) instead of the internal cache-stamped name. No behavior change for filenames that do not use the media-store cache pattern.

## Evidence

- Added focused tests in `extensions/telegram/src/send.test.ts` and `extensions/telegram/src/bot/delivery.test.ts` that assert a media-store filename `photo---a1b2c3d4-e5f6-7890-abcd-ef1234567890.jpg` is delivered as `photo.jpg`.
- `node scripts/run-vitest.mjs run extensions/telegram/src/send.test.ts extensions/telegram/src/bot/delivery.test.ts` passes (196 tests).
- `pnpm exec oxfmt --check` passes on all touched files.
- `pnpm exec oxlint` reports 0 warnings/errors on touched files.
- `pnpm tsgo:extensions:test` passes.