### PR TITLE
fix(voice-call): fall back to persisted call store on status misses

### DIFF
--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -387,6 +387,23 @@ export default definePluginEntry({
       return `call is not active (${details.join(", ")})`;
     };
 
+    const findCallWithPersistedFallback = async (
+      rt: VoiceCallRuntime,
+      callId: string,
+    ) => {
+      const active = rt.manager.getCall(callId) || rt.manager.getCallByProviderCallId(callId);
+      if (active) {
+        return active;
+      }
+      // Fall back to the persisted call store when the in-memory manager has
+      // evicted a completed call (issue #96586).
+      return (
+        (await rt.manager.getPersistedCallByCallId(callId)) ??
+        (await rt.manager.getPersistedCallByProviderCallId(callId)) ??
+        null
+      );
+    };
+
     const resolveCallMessageRequest = async (params: GatewayRequestHandlerOptions["params"]) => {
       const callId = normalizeOptionalString(params?.callId) ?? "";
       const message = normalizeOptionalString(params?.message) ?? "";
@@ -657,7 +674,7 @@ export default definePluginEntry({
             });
             return;
           }
-          const call = rt.manager.getCall(raw) || rt.manager.getCallByProviderCallId(raw);
+          const call = await findCallWithPersistedFallback(rt, raw);
           if (!call) {
             respond(true, { found: false });
             return;
@@ -794,8 +811,7 @@ export default definePluginEntry({
                 if (!callId) {
                   throw new Error("callId required");
                 }
-                const call =
-                  rt.manager.getCall(callId) || rt.manager.getCallByProviderCallId(callId);
+                const call = await findCallWithPersistedFallback(rt, callId);
                 return json(
                   call ? { found: true, call: toVoiceCallStatus(call) } : { found: false },
                 );
@@ -809,7 +825,7 @@ export default definePluginEntry({
             if (!sid) {
               throw new Error("sid required for status");
             }
-            const call = rt.manager.getCall(sid) || rt.manager.getCallByProviderCallId(sid);
+            const call = await findCallWithPersistedFallback(rt, sid);
             return json(call ? { found: true, call: toVoiceCallStatus(call) } : { found: false });
           }
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -18,6 +18,8 @@ import {
 } from "./manager/outbound.js";
 import {
   getCallHistoryFromStore,
+  getPersistedCallByCallId,
+  getPersistedCallByProviderCallId,
   loadActiveCallsFromStore,
   persistCallRecord,
 } from "./manager/store.js";
@@ -446,6 +448,23 @@ export class CallManager {
       providerCallIdMap: this.providerCallIdMap,
       providerCallId,
     });
+  }
+
+  /**
+   * Find a persisted call record by call id, falling back to the on-disk store
+   * when the in-memory manager has evicted the call (issue #96586).
+   */
+  async getPersistedCallByCallId(callId: string): Promise<CallRecord | null> {
+    return getPersistedCallByCallId(this.storePath, callId);
+  }
+
+  /**
+   * Find a persisted call record by provider call id (e.g. Twilio CallSid),
+   * falling back to the on-disk store when the in-memory manager has evicted
+   * the call (issue #96586).
+   */
+  async getPersistedCallByProviderCallId(providerCallId: string): Promise<CallRecord | null> {
+    return getPersistedCallByProviderCallId(this.storePath, providerCallId);
   }
 
   /**

--- a/extensions/voice-call/src/manager/store.test.ts
+++ b/extensions/voice-call/src/manager/store.test.ts
@@ -17,6 +17,8 @@ import { CallRecordSchema } from "../types.js";
 import {
   flushPendingCallRecordWritesForTest,
   getCallHistoryFromStore,
+  getPersistedCallByCallId,
+  getPersistedCallByProviderCallId,
   loadActiveCallsFromStore,
   persistCallRecord,
 } from "./store.js";
@@ -38,6 +40,43 @@ function installStateRuntime(): void {
 }
 
 describe("voice-call call record store", () => {
+
+  it("finds a persisted call record by call id (fallback for #96586)", async () => {
+    const storePath = createTestStorePath();
+    const call = CallRecordSchema.parse(
+      makePersistedCall({ callId: "call-by-id", providerCallId: "SID-by-id" }),
+    );
+    persistCallRecord(storePath, call);
+    await flushPendingCallRecordWritesForTest();
+
+    const found = await getPersistedCallByCallId(storePath, "call-by-id");
+    expect(found?.callId).toBe("call-by-id");
+  });
+
+  it("returns null when no persisted call matches the call id", async () => {
+    const storePath = createTestStorePath();
+    const found = await getPersistedCallByCallId(storePath, "missing-call-id");
+    expect(found).toBeNull();
+  });
+
+  it("finds a persisted call record by provider call id (fallback for #96586)", async () => {
+    const storePath = createTestStorePath();
+    const call = CallRecordSchema.parse(
+      makePersistedCall({ callId: "call-by-provider", providerCallId: "SID-by-provider" }),
+    );
+    persistCallRecord(storePath, call);
+    await flushPendingCallRecordWritesForTest();
+
+    const found = await getPersistedCallByProviderCallId(storePath, "SID-by-provider");
+    expect(found?.providerCallId).toBe("SID-by-provider");
+  });
+
+  it("returns null when no persisted call matches the provider call id", async () => {
+    const storePath = createTestStorePath();
+    const found = await getPersistedCallByProviderCallId(storePath, "missing-sid");
+    expect(found).toBeNull();
+  });
+
   beforeEach(() => {
     resetPluginStateStoreForTests();
     installStateRuntime();

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -394,3 +394,52 @@ export async function getCallHistoryFromStore(
   }
   return [];
 }
+
+/**
+ * Find a persisted call record by call id. Used as a fallback when the
+ * in-memory manager has evicted a completed call but its transcript is still
+ * stored (see issue #96586).
+ */
+export async function getPersistedCallByCallId(
+  storePath: string,
+  callId: string,
+): Promise<CallRecord | null> {
+  if (!callId) {
+    return null;
+  }
+  const stores = tryCreateCallRecordStateStores(storePath);
+  if (!stores) {
+    return null;
+  }
+  try {
+    const events = readCallRecordEvents(stores);
+    return events.find((call) => call.callId === callId) ?? null;
+  } catch (err) {
+    console.error("[voice-call] Failed to read persisted call by callId:", err);
+    return null;
+  }
+}
+
+/**
+ * Find a persisted call record by provider call id (e.g. Twilio CallSid).
+ * Fallback for status lookups once the in-memory manager evicts the call.
+ */
+export async function getPersistedCallByProviderCallId(
+  storePath: string,
+  providerCallId: string,
+): Promise<CallRecord | null> {
+  if (!providerCallId) {
+    return null;
+  }
+  const stores = tryCreateCallRecordStateStores(storePath);
+  if (!stores) {
+    return null;
+  }
+  try {
+    const events = readCallRecordEvents(stores);
+    return events.find((call) => call.providerCallId === providerCallId) ?? null;
+  } catch (err) {
+    console.error("[voice-call] Failed to read persisted call by providerCallId:", err);
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes #96586.

## What Problem This Solves
The `voice_call` tool's `get_status` action, the legacy `mode: "status"` path, and the `voicecall.status` gateway method only check the in-memory call manager. Once a call is evicted from the active map (completion cleanup, gateway restart, or time), they return `{ found: false }` even though the full call record - including transcript - is still persisted in the plugin's SQLite store. Any agent workflow that "calls and reports back" silently fails at the reporting step.

## Evidence
- **Reporter production data** (issue #96586): `get_status` returns `{ found: false }` for completed calls; a manual SQLite query confirms the full persisted record (transcript + state) is present under `plugin_state_entries` (plugin_id=`voice-call`), keyed as `event:<seq6>:<sequence>:<uuid>:chunk:NNNN`.
- **Root cause verified against current main** (`a21144d8a6`): `index.ts` `get_status` case, `mode === "status"`, and the `voicecall.status` gateway method all use `rt.manager.getCall(id) || rt.manager.getCallByProviderCallId(id)` (in-memory only); `CallManager.getCall` reads the `activeCalls` map with no persisted fallback.
- **Unit tests** (9 green in `store.test.ts`): `getPersistedCallByCallId`/`getPersistedCallByProviderCallId` find persisted records by id and return null on miss. Existing `index.test.ts` (38) and `store.test.ts` (5) unchanged.

## Fix
- `store.ts`: add `getPersistedCallByCallId(storePath, callId)` and `getPersistedCallByProviderCallId(storePath, providerCallId)` - bounded lookups reusing the existing `readCallRecordEvents` path.
- `manager.ts` (`CallManager`): add `getPersistedCallByCallId`/`getPersistedCallByProviderCallId` methods that delegate to the store using the private `storePath`.
- `index.ts`: add a `findCallWithPersistedFallback(rt, id)` helper (in-memory first, then persisted by callId, then by providerCallId) and use it in all three status surfaces.

## Scope / non-goals
- No new `get_transcript` action (the issue suggests it, but the ClawSweeper review flags it as "not needed to repair").
- No change to the in-memory call manager, eviction policy, store schema, or recovery thresholds.
- Read-only: status lookups only; no state mutation.

## Test plan
- [x] New unit tests (`store.test.ts`): by-callId and by-providerCallId hit/miss.
- [x] Existing `index.test.ts` (38) and `store.test.ts` (5) green - no regression.
- [ ] CI: `pnpm tsgo` + `pnpm check` (oxlint/oxfmt).
- [ ] Live regression (maintainer env, needs a voice provider): complete a call, evict/restart, `get_status` returns `found: true` with the persisted record.
