### PR TITLE
fix(failover): allow model fallback on harness transport timeout

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -68,6 +68,44 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("falls back on harness transport timeout when a fallback model chain is configured", () => {
+    // Positive: harnessOwnsTransport + timeout + fallbackConfigured → fallback_model
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        harnessOwnsTransport: true,
+        fallbackConfigured: true,
+        failoverReason: "timeout",
+        aborted: false,
+        externalAbort: false,
+        failoverFailure: false,
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "timeout",
+    });
+  });
+
+  it("surfaces harness transport timeout when no fallback model is configured", () => {
+    // Negative: harnessOwnsTransport + timeout + fallbackConfigured=false → surface_error
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        harnessOwnsTransport: true,
+        fallbackConfigured: false,
+        failoverReason: "timeout",
+        aborted: false,
+        externalAbort: false,
+        failoverFailure: false,
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "surface_error",
+      reason: "timeout",
+    });
+  });
+
   it("surfaces deterministic prompt format failures instead of rotating or falling back", () => {
     expect(
       resolveRunFailoverDecision({
@@ -563,7 +601,10 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
-  it("surfaces harness-owned prompt timeouts instead of falling back", () => {
+  it("falls back on harness-owned prompt timeouts when a fallback chain is configured", () => {
+    // With fallbackConfigured=true and a harness-owned transport timeout,
+    // the decision should route to the fallback model chain instead of
+    // surfacing the error directly — consistent with auth/billing failures.
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
@@ -576,7 +617,7 @@ describe("resolveRunFailoverDecision", () => {
         profileRotated: true,
       }),
     ).toEqual({
-      action: "surface_error",
+      action: "fallback_model",
       reason: "timeout",
     });
   });

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -179,6 +179,15 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
       };
     }
     if (params.harnessOwnsTransport && params.failoverReason === "timeout") {
+      // Timeouts from harness-owned transports (Ollama, etc.) should still
+      // attempt the configured fallback chain before surfacing the error,
+      // consistent with the behavior for auth and billing failures.
+      if (params.fallbackConfigured) {
+        return {
+          action: "fallback_model",
+          reason: "timeout",
+        };
+      }
       return {
         action: "surface_error",
         reason: params.failoverReason,


### PR DESCRIPTION
## What Problem This Solves

When a harness-owned transport (Ollama, local models) times out, route to the
configured fallback model chain instead of surfacing the error directly. This makes
timeout handling consistent with the existing behavior for auth and billing failures.

Previously, `resolveRunFailoverDecision` would immediately return `surface_error` for
harness transport timeouts, never reaching the `fallbackConfigured` check.

Closes #95574

## Changes

- **`src/agents/embedded-agent-runner/run/failover-policy.ts`** — added
  `fallbackConfigured` guard before the `surface_error` return for harness
  transport timeouts.  When a fallback chain is configured, the decision
  returns `fallback_model` instead.
- **`src/agents/embedded-agent-runner/run/failover-policy.test.ts`** — added 2
  regression tests (positive: fallbackConfigured=true → fallback_model;
  negative: fallbackConfigured=false → surface_error). Updated the existing
  harness-timeout test to expect `fallback_model` with a configured chain.

## Evidence

- **Tests**: Vitest 34/34 passed (~28s).
  `src/agents/embedded-agent-runner/run/failover-policy.test.ts`
- **Static checks**: `git diff --check` clean