### PR TITLE
fix(tui): recognize DEL (0x7f) as backspace alongside BS (0x08)

### DIFF
--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -250,7 +250,7 @@ export function createBackspaceDeduper(params?: { dedupeWindowMs?: number; now?:
   let lastBackspaceAt = -1;
 
   return (data: string): string => {
-    if (data !== "\x08" && !matchesKey(data, Key.backspace)) {
+    if (data !== "\x08" && data !== "\x7f" && !matchesKey(data, Key.backspace)) {
       return data;
     }
     const ts = now();


### PR DESCRIPTION
## What Problem This Solves

Linux/WSL2 terminals send the DEL character (0x7f) for the backspace key
instead of BS (0x08). The backspace deduper only recognised BS, causing
DEL-based backspace input to be lost after the dedupe window closed.

Closes #92777

## Changes

- **`src/tui/tui.ts`** — added `data !== "\x7f"` to the backspace deduper
  guard so DEL characters are treated the same as BS characters.

## Evidence

- **Tests**: Vitest 63/63 passed (~37s).
  `src/tui/tui.test.ts` — existing tests already cover `\x7f` (DEL) as a
  recognised backspace; this fix ensures they are properly deduped.