### PR TITLE
fix(agent): surface non_deliverable_terminal_turn with a specific retry message

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3691,6 +3691,7 @@ async function runEmbeddedAgentInternal(
                 toolSummary: attemptToolSummary,
                 ...(failureSignal ? { failureSignal } : {}),
                 agentHarnessResultClassification: attempt.agentHarnessResultClassification,
+                ...(attempt.terminalError ? { terminalError: attempt.terminalError } : {}),
               },
               didSendViaMessagingTool: attempt.didSendViaMessagingTool,
               didDeliverSourceReplyViaMessageTool:
@@ -3902,6 +3903,7 @@ async function runEmbeddedAgentInternal(
                 toolSummary: attemptToolSummary,
                 ...(failureSignal ? { failureSignal } : {}),
                 agentHarnessResultClassification: attempt.agentHarnessResultClassification,
+                ...(attempt.terminalError ? { terminalError: attempt.terminalError } : {}),
               },
               didSendViaMessagingTool: attempt.didSendViaMessagingTool,
               didDeliverSourceReplyViaMessageTool:
@@ -3993,6 +3995,7 @@ async function runEmbeddedAgentInternal(
                 toolSummary: attemptToolSummary,
                 ...(failureSignal ? { failureSignal } : {}),
                 agentHarnessResultClassification: attempt.agentHarnessResultClassification,
+                ...(attempt.terminalError ? { terminalError: attempt.terminalError } : {}),
               },
               didSendViaMessagingTool: attempt.didSendViaMessagingTool,
               didDeliverSourceReplyViaMessageTool:

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5673,6 +5673,7 @@ export async function runEmbeddedAttempt(
         // truthiness predicates keep working without a `.length` check.
         clientToolCalls: completedClientToolCalls.length > 0 ? completedClientToolCalls : undefined,
         yieldDetected: yieldDetected || undefined,
+        terminalError: attemptTrajectoryTerminal.terminalError,
       };
     } finally {
       if (trajectoryRecorder && !trajectoryEndRecorded) {

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -237,6 +237,8 @@ export type EmbeddedRunAttemptResult = {
   clientToolCalls?: Array<{ name: string; params: Record<string, unknown> }>;
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
+  /** Reason when the attempt ended with a terminal classification, e.g. non_deliverable_terminal_turn. */
+  terminalError?: string;
   replayMetadata: EmbeddedRunReplayMetadata;
   itemLifecycle: {
     startedCount: number;

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -148,6 +148,7 @@ export type EmbeddedAgentRunMeta = {
   finalAssistantRawText?: string;
   replayInvalid?: boolean;
   livenessState?: EmbeddedRunLivenessState;
+  terminalError?: string;
   timeoutPhase?: AgentRunTimeoutPhase;
   providerStarted?: boolean;
   agentHarnessResultClassification?: "empty" | "reasoning-only" | "planning-only";

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -21,6 +21,7 @@ const DEFERRED_TERMINAL_METADATA_KEYS = [
   "aborted",
   "livenessState",
   "replayInvalid",
+  "terminalError",
 ] as const;
 
 export function resolveAgentLifecycleTerminalMetadata(meta: unknown): Record<string, unknown> {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -120,6 +120,7 @@ import {
 import {
   GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+  resolveExternalRunFailureTextForTerminalError,
 } from "./agent-runner-failure-copy.js";
 import {
   buildEmbeddedRunExecutionParams,
@@ -947,7 +948,7 @@ function formatForwardedExternalRunFailureText(message: string): string {
 
 function buildExternalRunFailureReply(
   input: ExternalRunFailureInput,
-  options?: { includeDetails?: boolean; isHeartbeat?: boolean },
+  options?: { includeDetails?: boolean; isHeartbeat?: boolean; terminalError?: string },
 ): ExternalRunFailureReply {
   const message = typeof input === "string" ? input : input.message;
   const error = typeof input === "string" ? undefined : input.error;
@@ -995,6 +996,10 @@ function buildExternalRunFailureReply(
   const codexAppServerFailure = buildCodexAppServerFailureText(normalizedMessage);
   if (codexAppServerFailure) {
     return { text: codexAppServerFailure, isGenericRunnerFailure: false };
+  }
+  const terminalErrorText = resolveExternalRunFailureTextForTerminalError(options?.terminalError);
+  if (terminalErrorText) {
+    return { text: terminalErrorText, isGenericRunnerFailure: false };
   }
   return {
     text: options?.includeDetails

--- a/src/auto-reply/reply/agent-runner-failure-copy.ts
+++ b/src/auto-reply/reply/agent-runner-failure-copy.ts
@@ -37,3 +37,16 @@ export function replaceGenericExternalRunFailureText(text: string): {
     replaced: true,
   };
 }
+
+export const NON_DELIVERABLE_TERMINAL_TURN_REASON = "non_deliverable_terminal_turn";
+
+export const NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT =
+  "⚠️ The model stopped between tool calls without producing a reply. Please try the same message again — this usually resolves on retry. If it persists, use /new or a lighter model.";
+
+export function resolveExternalRunFailureTextForTerminalError(
+  terminalError: string | undefined,
+): string | undefined {
+  return terminalError === NON_DELIVERABLE_TERMINAL_TURN_REASON
+    ? NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT
+    : undefined;
+}


### PR DESCRIPTION
## What Problem This Solves

Surfaces `non_deliverable_terminal_turn` with specific retry guidance
instead of the generic fallback text.

## Changes

7 files: propagate terminalError through attempt result → run meta →
lifecycle metadata → failure-copy resolver → buildExternalRunFailureReply.

## Evidence

### Unit tests: terminal error propagation + fallback routing

```
pnpm exec vitest run src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts src/auto-reply/reply/agent-runner-execution.test.ts

 Test Files  2 passed (2)
      Tests  233 passed (233)
   Duration  98.06s
```

_AI-assisted._