### PR TITLE
fix(models): preserve custom google-vertex models in the model list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Docs: https://docs.openclaw.ai
 - Commands/config writes: enforce `configWrites` against both the originating account and the targeted account scope for `/config` and config-backed `/allowlist` edits, blocking sibling-account mutations while preserving gateway `operator.admin` flows. Thanks @tdjackey for reporting.
 - Security/system.run: fail closed for approval-backed interpreter/runtime commands when OpenClaw cannot bind exactly one concrete local file operand, while extending best-effort direct-file binding to additional runtime forms. Thanks @tdjackey for reporting.
 - Gateway/session reset auth: split conversation `/new` and `/reset` handling away from the admin-only `sessions.reset` control-plane RPC so write-scoped gateway callers can no longer reach the privileged reset path through `agent`. Thanks @tdjackey for reporting.
+- Models/custom providers: backfill the built-in `baseUrl` and a sentinel apiKey for known native providers (e.g. `google-vertex`) that define custom models without an API key, so the entry passes model-registry validation instead of silently dropping every custom model from the model list. Fixes #96600.
 
 ## 2026.3.8
 

--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -4,6 +4,11 @@ import { listKnownProviderEnvApiKeyNames } from "./model-auth-env-vars.js";
 export const MINIMAX_OAUTH_MARKER = "minimax-oauth";
 export const QWEN_OAUTH_MARKER = "qwen-oauth";
 export const OLLAMA_LOCAL_AUTH_MARKER = "ollama-local";
+// Sentinel apiKey for native providers (e.g. google-vertex) that authenticate
+// via an SDK/ADC credential chain rather than a plain API key. Persisted so
+// pi's ModelRegistry accepts custom models for these providers; the real
+// credentials are resolved by the provider at request time.
+export const SDK_AUTH_API_KEY_MARKER = "sdk-auth";
 export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
 export const SECRETREF_ENV_HEADER_MARKER_PREFIX = "secretref-env:"; // pragma: allowlist secret
 
@@ -71,6 +76,7 @@ export function isNonSecretApiKeyMarker(
     trimmed === MINIMAX_OAUTH_MARKER ||
     trimmed === QWEN_OAUTH_MARKER ||
     trimmed === OLLAMA_LOCAL_AUTH_MARKER ||
+    trimmed === SDK_AUTH_API_KEY_MARKER ||
     trimmed === NON_ENV_SECRETREF_MARKER ||
     isAwsSdkAuthMarker(trimmed);
   if (isKnownMarker) {

--- a/src/agents/models-config.providers.google-vertex.test.ts
+++ b/src/agents/models-config.providers.google-vertex.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { normalizeProviders, type ProviderConfig } from "./models-config.providers.js";
+import { discoverAuthStorage, discoverModels } from "./pi-model-discovery.js";
+
+// Regression coverage for issue #96600: custom models added to a native
+// provider (google-vertex) via config were silently dropped from the model
+// list. google-vertex authenticates via gcloud ADC and has no plain apiKey, but
+// pi's ModelRegistry rejects a custom-model provider lacking baseUrl OR apiKey,
+// and that rejection drops ALL custom models from models.json. normalizeProviders
+// now backfills the built-in baseUrl and a sentinel apiKey for known providers so
+// the entry survives validation.
+
+function buildVertexModel(): NonNullable<ProviderConfig["models"]>[number] {
+  return {
+    id: "gemini-3.5-flash",
+    name: "Gemini 3.5 Flash (Vertex AI)",
+    input: ["text"] as Array<"text" | "image">,
+    reasoning: false,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_048_576,
+    maxTokens: 65536,
+  };
+}
+
+describe("google-vertex provider normalization", () => {
+  it("backfills a sentinel apiKey for a custom google-vertex model with a baseUrl", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-vertex-"));
+    // Schema-valid shape: api maps to google-generative-ai, baseUrl present, but
+    // no apiKey because Vertex uses ADC.
+    const providers = {
+      "google-vertex": {
+        api: "google-generative-ai",
+        baseUrl: "https://{location}-aiplatform.googleapis.com",
+        models: [buildVertexModel()],
+      } as ProviderConfig,
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    const vertex = normalized?.["google-vertex"];
+    expect(vertex).toBeDefined();
+    expect(vertex?.baseUrl).toBe("https://{location}-aiplatform.googleapis.com");
+    expect(vertex?.apiKey).toBeTruthy();
+    expect(vertex?.models.map((model) => model.id)).toEqual(["gemini-3.5-flash"]);
+  });
+
+  it("backfills a built-in baseUrl when a known provider omits it", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-vertex-"));
+    const providers = {
+      "google-vertex": {
+        api: "google-generative-ai",
+        models: [buildVertexModel()],
+      } as unknown as ProviderConfig,
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    const vertex = normalized?.["google-vertex"];
+    expect(typeof vertex?.baseUrl).toBe("string");
+    expect(vertex?.baseUrl).toContain("aiplatform.googleapis.com");
+    expect(vertex?.apiKey).toBeTruthy();
+  });
+
+  it("does not override a user-provided apiKey", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-vertex-"));
+    const providers = {
+      "google-vertex": {
+        api: "google-generative-ai",
+        baseUrl: "https://{location}-aiplatform.googleapis.com",
+        apiKey: "MY_VERTEX_KEY", // pragma: allowlist secret
+        models: [buildVertexModel()],
+      } as ProviderConfig,
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    expect(normalized?.["google-vertex"]?.apiKey).toBe("MY_VERTEX_KEY");
+  });
+
+  it("leaves unknown custom providers untouched", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-vertex-"));
+    const providers = {
+      "totally-unknown-provider": {
+        api: "openai-completions",
+        models: [{ ...buildVertexModel(), id: "some-model" }],
+      } as unknown as ProviderConfig,
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    // No baseUrl/apiKey backfill for non-built-in providers.
+    expect(normalized?.["totally-unknown-provider"]?.baseUrl).toBeUndefined();
+    expect(normalized?.["totally-unknown-provider"]?.apiKey).toBeUndefined();
+  });
+
+  it("keeps the custom vertex model visible through pi's ModelRegistry", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-vertex-"));
+    const providers = {
+      "google-vertex": {
+        api: "google-generative-ai",
+        baseUrl: "https://{location}-aiplatform.googleapis.com",
+        models: [buildVertexModel()],
+      } as ProviderConfig,
+    };
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    writeFileSync(
+      join(agentDir, "models.json"),
+      JSON.stringify({ providers: normalized }, null, 2),
+      "utf8",
+    );
+
+    const registry = discoverModels(discoverAuthStorage(agentDir), agentDir);
+    const ids = registry
+      .getAll()
+      .filter((model) => model.provider === "google-vertex")
+      .map((model) => model.id);
+
+    expect(ids).toContain("gemini-3.5-flash");
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -1,3 +1,4 @@
+import { getModels, getProviders, type KnownProvider } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../config/config.js";
 import { coerceSecretRef, resolveSecretInputRef } from "../config/types.secrets.js";
 import {
@@ -60,6 +61,7 @@ import {
   MINIMAX_OAUTH_MARKER,
   OLLAMA_LOCAL_AUTH_MARKER,
   QWEN_OAUTH_MARKER,
+  SDK_AUTH_API_KEY_MARKER,
   isNonSecretApiKeyMarker,
   resolveNonEnvSecretRefApiKeyMarker,
   resolveNonEnvSecretRefHeaderValueMarker,
@@ -72,6 +74,39 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
 const ENV_VAR_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+let cachedKnownProviders: Set<string> | undefined;
+
+function getKnownProviderSet(): Set<string> {
+  if (!cachedKnownProviders) {
+    try {
+      cachedKnownProviders = new Set(getProviders());
+    } catch {
+      cachedKnownProviders = new Set();
+    }
+  }
+  return cachedKnownProviders;
+}
+
+// Resolve the canonical baseUrl that pi-ai uses for a built-in provider so that
+// custom models defined for that provider inherit the same endpoint. Returns
+// undefined for unknown/custom providers (which must declare their own baseUrl).
+function resolveBuiltInProviderBaseUrl(provider: string): string | undefined {
+  if (!getKnownProviderSet().has(provider)) {
+    return undefined;
+  }
+  try {
+    for (const model of getModels(provider as KnownProvider)) {
+      const baseUrl = model.baseUrl?.trim();
+      if (baseUrl) {
+        return baseUrl;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
 
 function normalizeApiKeyConfig(value: string): string {
   const trimmed = value.trim();
@@ -400,6 +435,37 @@ export function normalizeProviders(params: {
           mutated = true;
           normalizedProvider = { ...normalizedProvider, apiKey };
         }
+      }
+    }
+
+    // pi's ModelRegistry rejects a provider that defines custom models without
+    // BOTH a baseUrl and an apiKey, and a single rejected provider drops ALL
+    // custom models from models.json. Native providers like google-vertex
+    // authenticate via an SDK/ADC credential chain (no plain API key) and may
+    // have no user-supplied baseUrl, so for known built-in providers backfill
+    // the catalog baseUrl and a sentinel apiKey when none could be resolved.
+    // The real credentials are still resolved by the provider at request time.
+    // Without this, custom/newer google-vertex models silently disappear from
+    // the model list (see issue #96600). Scoped to known providers so arbitrary
+    // custom endpoints keep requiring an explicit baseUrl/apiKey.
+    if (hasModels && getKnownProviderSet().has(normalizedKey)) {
+      const hasBaseUrl =
+        typeof normalizedProvider.baseUrl === "string" && normalizedProvider.baseUrl.trim() !== "";
+      if (!hasBaseUrl) {
+        const builtInBaseUrl = resolveBuiltInProviderBaseUrl(normalizedKey);
+        if (builtInBaseUrl) {
+          mutated = true;
+          normalizedProvider = { ...normalizedProvider, baseUrl: builtInBaseUrl };
+        }
+      }
+      const stillMissingApiKey = !(
+        normalizeOptionalSecretInput(normalizedProvider.apiKey) || normalizedProvider.apiKey
+      );
+      const baseUrlNowPresent =
+        typeof normalizedProvider.baseUrl === "string" && normalizedProvider.baseUrl.trim() !== "";
+      if (stillMissingApiKey && baseUrlNowPresent) {
+        mutated = true;
+        normalizedProvider = { ...normalizedProvider, apiKey: SDK_AUTH_API_KEY_MARKER };
       }
     }
 


### PR DESCRIPTION
## Summary

- Problem: Adding a custom model to a native provider that authenticates without a plain API key (e.g. `google-vertex`, which uses gcloud ADC) silently removes the model — and every other custom model — from `openclaw models list`.
- Why it matters: pi's `ModelRegistry` rejects a custom-model provider entry that lacks a `baseUrl` *or* an `apiKey`, and a single rejected provider causes `loadCustomModels` to discard the entire `models.json` (`emptyCustomModelsResult`). Users cannot register newer/custom Vertex models at all.
- What changed: In `normalizeProviders`, when a **known built-in** provider defines custom `models` but has no `baseUrl` and/or no resolvable `apiKey`, backfill the built-in catalog `baseUrl` and a `sdk-auth` sentinel apiKey so the entry passes registry validation. Real credentials are still resolved by the provider at request time.
- What did NOT change (scope boundary): Unknown/custom providers are untouched (they still must declare their own `baseUrl`/`apiKey`). User-provided `baseUrl`/`apiKey` are never overridden. No schema or network behavior changes.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] API / contracts
- [x] Auth / tokens

## Linked Issue/PR

- Closes #96600

## User-visible / Behavior Changes

Custom models configured for native providers that use SDK/ADC auth (e.g. `google-vertex`) now appear in `openclaw models list` and resolve, instead of being silently dropped along with all other custom models. No config or default changes are required.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — the `sdk-auth` value is a non-secret sentinel registered alongside the other non-secret auth markers (`ollama-local`, etc.); real credentials still come from the provider's own auth resolution.
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (also reported on Ubuntu in the issue)
- Runtime/container: Node 22, source build
- Model/provider: `google-vertex` custom model (`gemini-3.5-flash`)
- Relevant config (redacted):

```json
{
  "models": {
    "mode": "merge",
    "providers": {
      "google-vertex": {
        "api": "google-generative-ai",
        "baseUrl": "https://{location}-aiplatform.googleapis.com",
        "models": [{ "id": "gemini-3.5-flash", "name": "Gemini 3.5 Flash (Vertex AI)" }]
      }
    }
  }
}
```

### Steps

1. Configure a custom `google-vertex` model (no API key, since Vertex uses ADC).
2. Let OpenClaw materialize `models.json` and build the model registry (the path used by `openclaw models list`).
3. Inspect the google-vertex models the registry returns.

### Expected

- The custom `gemini-3.5-flash` model appears in the model list.

### Actual (before fix)

- The registry fails to load `models.json` (`Provider google-vertex: "apiKey" is required when defining custom models.`) and drops every custom model. `gemini-3.5-flash` never appears.

## Evidence

Reproduced the exact failure on current `main` by driving the real `planOpenClawModelsJson` → `models.json` → pi `ModelRegistry` path:

Before fix:
```
=== registry load error: Failed to load models.json: Provider google-vertex: "baseUrl" is required when defining custom models.
=== custom gemini-3.5-flash present? false
```

For a schema-valid config that supplies `baseUrl` but no apiKey (Vertex ADC), the failure persists before the fix:
```
error: Failed to load models.json: Provider google-vertex: "apiKey" is required when defining custom models.
custom present? false
```

After fix:
```
=== registry load error: (none)
=== custom gemini-3.5-flash present? true
```

Regression test (`src/agents/models-config.providers.google-vertex.test.ts`) — fails before the fix (3 failing, incl. the registry-visibility case), passes after:
```
$ npx vitest run src/agents/models-config.providers.google-vertex.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Full surrounding suites stay green, and typecheck/lint are clean:
```
$ npx vitest run src/agents/models-config src/agents/model-auth
 Test Files  34 passed (34)
      Tests  166 passed (166)

$ npx vitest run src/commands/models/list
 Test Files  5 passed (5)
      Tests  26 passed (26)

$ pnpm tsgo            # no errors
$ npx oxlint <touched files>   # 0 warnings, 0 errors
```

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: Custom `google-vertex` model with no apiKey now loads through the same `models.json` → pi `ModelRegistry` path that backs `openclaw models list`; confirmed both the raw registry-load error disappears and the model becomes visible.
- Edge cases checked: user-provided `apiKey` is preserved (not overwritten); user-provided `baseUrl` is preserved; unknown/custom providers get no backfill and keep prior behavior.
- What I did **not** verify: a live request against a real Google Vertex/ADC endpoint (no GCP credentials available). The fix targets model-list visibility/registry validation; request-time auth resolution is unchanged.

Note on the issue's example config: it uses `api: "google-vertex"` (not a valid `ModelApi`) and omits the schema-required `baseUrl`, so that exact snippet fails config validation. The underlying defect is real and reproduces with a schema-valid config (shown above), where the missing apiKey alone is enough to drop all custom models.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; behavior returns to requiring an explicit `apiKey` for custom models on these providers.
- Files/config to restore: `src/agents/models-config.providers.ts`, `src/agents/model-auth-markers.ts`.
- Known bad symptoms reviewers should watch for: a real provider apiKey being unexpectedly replaced by `sdk-auth` (guarded against — backfill only runs when no apiKey is resolvable), or custom models for unknown providers gaining an unexpected baseUrl (guarded — scoped to known providers).

## Risks and Mitigations

- Risk: The `sdk-auth` sentinel could be sent as a bearer token to an endpoint that expects a real key.
  - Mitigation: It is only added when the user supplied no apiKey at all, scoped to known native providers whose real auth (ADC/SDK) is resolved separately; this matches the existing `ollama-local`/AWS-SDK marker pattern.
