### PR TITLE
fix(cron): engage model fallback on result-level failures in isolated cron runs (fixes #96525) (AI-assisted)

### DIFF
--- a/src/cron/isolated-agent/run-execution.runtime.ts
+++ b/src/cron/isolated-agent/run-execution.runtime.ts
@@ -8,6 +8,10 @@ export { resolveCronAgentLane } from "../../agents/lanes.js";
 export { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
 export { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 export { runWithModelFallback } from "../../agents/model-fallback.js";
+export {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 export { isCliProvider } from "../../agents/model-selection-cli.js";
 export { normalizeVerboseLevel } from "../../auto-reply/thinking.shared.js";
 export { resolveSessionTranscriptPath } from "../../config/sessions/paths.js";

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -31,6 +31,8 @@ import {
   resolveSessionTranscriptPath,
   runCliAgent,
   runWithModelFallback,
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
 } from "./run-execution.runtime.js";
 import { resolveCronFallbacksOverride } from "./run-fallback-policy.js";
 import type {
@@ -295,6 +297,18 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      // Classify returned result-level terminal failures (reasoning-only /
+      // empty-visible / fallback-safe incomplete_turn) so the configured
+      // fallback chain engages, matching the interactive and auto-reply
+      // callers. Non-embedded (CLI) results classify to null, so CLI cron runs
+      // are unaffected. (#96525)
+      classifyResult: ({ provider: providerLocal, model: modelLocal, result: resultLocal }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider: providerLocal,
+          model: modelLocal,
+          result: resultLocal,
+        }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());

--- a/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
@@ -1,5 +1,7 @@
+import { createContractRunResult } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 // Cron model override forwarding tests cover passing overrides into agent runs.
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import {
   clearCliSessionMock,
   clearFastTestEnv,
@@ -664,5 +666,49 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
     await runCronIsolatedAgentTurn(makeParams({ job: jobWithFallbacks }));
 
     expect(capturedFallbacksOverride).toEqual(["openai/gpt-4o"]);
+  });
+
+  it("forwards a working result classifier and merge helper so result-level failures engage the fallback chain (#96525)", async () => {
+    let captured: Record<string, unknown> | undefined;
+    runWithModelFallbackMock.mockImplementation(async (params: Record<string, unknown>) => {
+      captured = params;
+      return makeSuccessfulRunResult();
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeParams());
+    expect(result.status).toBe("ok");
+
+    // Cron must forward both, exactly like the interactive (agent-command) and
+    // auto-reply callers, so a returned result-level terminal failure advances
+    // the configured fallback chain instead of being delivered as the answer.
+    expect(typeof captured?.classifyResult).toBe("function");
+    expect(captured?.mergeExhaustedResult).toBe(
+      mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+    );
+
+    const classify = captured?.classifyResult as (input: {
+      provider: string;
+      model: string;
+      result: unknown;
+    }) => unknown;
+
+    // A fallback-safe incomplete_turn (reasoning-only) embedded result classifies
+    // non-null, which is what makes runWithModelFallback try the next candidate.
+    const reasoningOnly = createContractRunResult({
+      payloads: [{ text: "Agent couldn't generate a response.", isError: true }],
+      meta: {
+        durationMs: 1,
+        agentHarnessResultClassification: "reasoning-only",
+        error: {
+          kind: "incomplete_turn",
+          message: "Agent couldn't generate a response.",
+          fallbackSafe: true,
+          terminalPresentation: false,
+        },
+      },
+    });
+    expect(
+      classify({ provider: "anthropic", model: "claude-opus-4-6", result: reasoningOnly }),
+    ).not.toBeNull();
   });
 });

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -1,6 +1,10 @@
 // Isolated run test harness builds cron run inputs, mocks, and assertions.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { vi, type Mock } from "vitest";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { resolveFastModeState as resolveFastModeStateImpl } from "../../agents/fast-mode.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
@@ -238,6 +242,8 @@ vi.mock("./run-execution.runtime.js", () => ({
   resolveCronAgentLane: resolveCronAgentLaneMock,
   LiveSessionModelSwitchError,
   runWithModelFallback: runWithModelFallbackMock,
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
   isCliProvider: isCliProviderMock,
   runEmbeddedAgent: runEmbeddedAgentMock,
   countActiveDescendantRuns: countActiveDescendantRunsMock,


### PR DESCRIPTION
Fixes #96525.

## Summary
Isolated cron `agentTurn` jobs on embedded (non-CLI) providers silently dropped the answer when the primary model returned a **result-level** terminal failure (reasoning-only, empty-visible, or fallback-safe `incomplete_turn`). The configured model-fallback chain never engaged, the run was recorded as `status: "error"`, and the operator received the generic `"Agent couldn't generate a response."` payload — even though a healthy fallback model was configured and would have produced the real answer. Because cron fires repeatedly, the failure recurs every run until a human notices.

## Root cause
The cron embedded-run path calls `runWithModelFallback` **without** a `classifyResult` or `mergeExhaustedResult` (`src/cron/isolated-agent/run-executor.ts`). Every other answer-bearing caller passes both — `src/agents/agent-command.ts` and `src/auto-reply/reply/agent-runner-execution.ts`. With `classifyResult` undefined, a returned (non-thrown) result-level failure is treated as a success, so the chain never advances to the next candidate. Thrown `FailoverError`s (auth/rate-limit/overload) still engage the chain via the catch path; only the returned result-level failure class was missed. This also contradicts the documented contract (`docs/automation/cron-jobs.md`) that configured fallback chains still apply when the job primary fails.

## Changes
- **`src/cron/isolated-agent/run-executor.ts`** — pass the existing `classifyEmbeddedAgentRunResultForModelFallback` and `mergeEmbeddedAgentRunResultForModelFallbackExhaustion` to the cron `runWithModelFallback` call, mirroring the interactive and auto-reply callers. Non-embedded (CLI) results classify to `null` via the classifier's `isEmbeddedAgentRunResult` gate, so CLI cron runs are unaffected.
- **`src/cron/isolated-agent/run-execution.runtime.ts`** — re-export the two helpers through the cron runtime facade, consistent with how `runWithModelFallback` is already exposed there.
- **tests** — regression coverage asserting the cron path forwards a working result classifier and the merge helper to `runWithModelFallback`.

## Testing
- `node scripts/run-vitest.mjs run src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts` → **15 passing** (incl. the new #96525 case)
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental false` → clean
- `oxlint` + `oxfmt --check` on the changed files → clean

## AI-assisted disclosure
Prepared with AI assistance. Per `CONTRIBUTING.md`, the automated tests/typecheck/lint above are supplemental; the real-behavior proof below is a direct run of the production `runWithModelFallback` + classifier. `CHANGELOG.md` intentionally left untouched per the contributor guidelines.

## Real behavior proof

**Behavior or issue addressed:** Isolated cron `agentTurn` runs on embedded providers dropped the answer on a result-level terminal failure (reasoning-only / fallback-safe `incomplete_turn`) because the configured model-fallback chain never engaged; this change makes cron forward the result classifier so the chain advances to a healthy fallback model (#96525).

**Real environment tested:** Clean checkout at the current PR head `fe7ea842` on Windows 11, Node `v24.13.0`. A harness drove the real exported `runWithModelFallback` (`src/agents/model-fallback.ts`) together with the real `classifyEmbeddedAgentRunResultForModelFallback` / `mergeEmbeddedAgentRunResultForModelFallbackExhaustion` (`src/agents/embedded-agent-runner/result-fallback-classifier.ts`) — the exact production functions the cron path uses — comparing the prior cron wiring (no classifier) against the wiring this change adds. The model `run()` outcomes are synthetic (a reasoning-only primary plus a healthy fallback) because reproducing a live reasoning-only outcome on demand is non-deterministic; the fallback orchestration and classifier under observation are the real production code.

**Exact steps or command run after this patch:** `node --import tsx proof-96525.mts`. The harness builds a primary result with `meta.error.kind = "incomplete_turn"`, `fallbackSafe: true`, `agentHarnessResultClassification: "reasoning-only"`, plus a healthy fallback result, then calls `runWithModelFallback` once with the prior cron options and once with the classifier + merge helper this change wires in.

**Evidence after fix:** Copied console output from the current-head (`fe7ea842`) run:

```text
=== classifier decision on the primary result (the trigger) ===
reasoning-only / fallback-safe incomplete_turn -> classification: {"message":"Agent couldn't generate a response.","reason":"format","code":"incomplete_result","preserveResultOnExhaustion":true,"preserveResultPriority":0}
healthy result -> classification: null

=== runWithModelFallback behavior ===
--- OLD cron wiring (no classifier) — answer dropped
  run() calls: 1
  selected provider/model: openai/gpt-5.4
  delivered answer: "Agent couldn't generate a response."

--- NEW cron wiring (this change: classifier + merge) — fallback engaged
  run() calls: 2
  selected provider/model: anthropic/claude-haiku-3-5
  delivered answer: "Workspace cleaned up: removed 12 stale files."
```

**Observed result after fix:** With the prior cron wiring the primary's reasoning-only failure is returned as-is (`run()` called once, the error payload delivered). With the classifier + merge helper this change adds, the real classifier flags the result as a fallback-safe `incomplete_result`, `runWithModelFallback` advances to the configured fallback (`run()` called twice), and the healthy fallback answer is delivered. The classifier returns `null` for a healthy result, so no needless fallback occurs.

**What was not tested:** A full end-to-end run through the live cron daemon against a real provider returning a genuine reasoning-only / incomplete turn was not exercised (that outcome is non-deterministic to trigger live); verification drives the production fallback orchestration and classifier directly with representative results.
