### PR TITLE
fix(ollama): remote Ollama streaming stalls at model_call:started on slow hosts

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -451,6 +451,47 @@ describe("createOllamaStreamFn thinking events", () => {
     expect(yieldedBeforeDone).toBe(true);
   });
 
+  it("refreshes the guarded-fetch idle timeout for each streamed chunk", async () => {
+    const chunks = [
+      {
+        model: "qwen3.5",
+        created_at: "2026-01-01T00:00:00Z",
+        message: { role: "assistant" as const, content: "Hello" },
+        done: false,
+      },
+      {
+        model: "qwen3.5",
+        created_at: "2026-01-01T00:00:01Z",
+        message: { role: "assistant" as const, content: " world" },
+        done: false,
+      },
+      makeOllamaResponse({ content: "" }),
+    ];
+    const body = makeNdjsonBody(chunks);
+    const refreshTimeout = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(body, { status: 200 }),
+      release: vi.fn(async () => undefined),
+      refreshTimeout,
+    });
+
+    const streamFn = createOllamaStreamFn("http://localhost:11434");
+    const stream = streamFn(
+      { api: "ollama", provider: "ollama", id: "qwen3.5", contextWindow: 65536 } as never,
+      { messages: [{ role: "user", content: "test" }] } as never,
+      {},
+    );
+
+    const events: Array<{ type: string }> = [];
+    for await (const event of stream as AsyncIterable<{ type: string }>) {
+      events.push(event);
+    }
+
+    // One refresh per consumed NDJSON chunk keeps the deadline a no-progress
+    // timeout instead of a wall-clock cap on slow remote Ollama hosts.
+    expect(refreshTimeout).toHaveBeenCalledTimes(chunks.length);
+  });
+
   it("reports caller aborts during dense native stream processing as aborted", async () => {
     const chunks = [
       ...Array.from({ length: 65 }, (_value, index) => ({

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -1195,7 +1195,7 @@ function createRawOllamaStreamFn(
           headers.Authorization = `Bearer ${options.apiKey}`;
         }
 
-        const { response, release } = await fetchWithSsrFGuard({
+        const { response, release, refreshTimeout } = await fetchWithSsrFGuard({
           url: chatUrl,
           init: {
             method: "POST",
@@ -1353,6 +1353,12 @@ function createRawOllamaStreamFn(
           };
 
           for await (const chunk of parseNdjsonStream(reader)) {
+            // Reset the guarded-fetch idle timeout on each chunk so the request
+            // deadline behaves as a no-progress timeout, not a wall-clock cap.
+            // Without this, a slow remote Ollama host (CPU-only inference) is
+            // aborted mid-stream once timeoutMs elapses, which the server sees as
+            // a client disconnect and the session stalls at model_call:started.
+            refreshTimeout?.();
             throwIfOllamaStreamAborted(options?.signal);
             const thinkingDelta = chunk.message?.thinking ?? chunk.message?.reasoning;
             if (thinkingDelta && shouldEmitThinking) {


### PR DESCRIPTION
Closes #94251

## What Problem This Solves

Fixes an issue where users running a remote Ollama provider (Ollama on a different machine than OpenClaw, especially slow CPU-only inference) would never receive a chat response. The session stalls indefinitely at `model_call:started`, and the remote Ollama host shows the model going to `Stopping...` mid-generation — the server sees the client disconnect. Direct `curl` from the same host streams fine, so the failure is specific to OpenClaw's native Ollama stream client.

## Why This Change Was Made

The native Ollama stream path (`createRawOllamaStreamFn`) requests a stream through `fetchWithSsrFGuard`, which arms an `AbortController`-based deadline (`buildTimeoutAbortSignal`) and returns a `refreshTimeout` callback. That callback is the documented contract for converting the deadline into a no-progress (idle) timeout: it must be called as the body is consumed. The OpenAI-compatible transport (`src/agents/provider-transport-fetch.ts`) and MCP HTTP fetch (`src/agents/mcp-http-fetch.ts`) both call `refreshTimeout()` on every chunk. The Ollama native path destructured only `{ response, release }` and never called it, so the configured request timeout acted as a hard wall-clock cap. Once a configured `timeoutSeconds` elapsed while a slow remote model was still streaming, the request was aborted mid-stream, the server saw a disconnect, and the run stalled. The fix calls `refreshTimeout?.()` for each consumed NDJSON chunk, matching the existing sibling contract.

## User Impact

Remote/slow Ollama hosts now stream to completion: the request deadline behaves as a no-progress timeout (reset on every chunk) rather than a total wall-clock cap. Chat sessions backed by a remote Ollama model return responses instead of hanging at `model_call:started`. No config or API changes.

## Evidence

Added a regression test asserting `refreshTimeout` is called once per streamed NDJSON chunk.

Before the production fix (test reverted), the test fails:

```
× refreshes the guarded-fetch idle timeout for each streamed chunk
AssertionError: expected "vi.fn()" to be called 3 times, but got 0 times
 ❯ extensions/ollama/src/stream.test.ts:491:28
   491| expect(refreshTimeout).toHaveBeenCalledTimes(chunks.length);
 Test Files  1 failed (1)
      Tests  1 failed | 15 passed (16)
```

After the fix:

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

Also green on the touched area: `tsgo` extensions typecheck (exit 0), oxlint (exit 0), oxfmt --check (all files correctly formatted).
