### PR TITLE
fix(openai-completions): relocate dynamic cache-boundary suffix for implicit prefix-cache providers

### DIFF
--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -381,7 +381,7 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedRetention).toBe("24h");
   });
 
-  it("strips the internal cache boundary from OpenAI-compatible system prompts", async () => {
+  it("relocates dynamic cache-boundary suffix to trailing message for implicit prefix-cache providers", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(
       createModel(32_000),
@@ -402,9 +402,15 @@ describe("OpenAI-compatible completions params", () => {
 
     expect(result.stopReason).toBe("error");
     const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    // Stable prefix stays as the leading system message (byte-identical across turns).
     expect(messages[0]).toEqual({
       role: "system",
-      content: "Stable prefix\nDynamic suffix",
+      content: "Stable prefix",
+    });
+    // Dynamic suffix is relocated to a trailing system message after user turns.
+    expect(messages[2]).toEqual({
+      role: "system",
+      content: "Dynamic suffix",
     });
   });
 

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -956,16 +956,48 @@ export function convertMessages(
     normalizeToolCallId(id),
   );
 
+  // Set when the system prompt's dynamic below-boundary suffix is relocated to a
+  // trailing message (implicit prefix-cache path); appended after the loop.
+  let trailingSystemSuffixMessage:
+    | OpenAI.Chat.Completions.ChatCompletionMessageParam
+    | undefined;
+
   if (context.systemPrompt) {
     const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
     const role = useDeveloperRole ? "developer" : "system";
-    const systemPrompt = options.preserveSystemPromptCacheBoundary
-      ? context.systemPrompt
-      : stripSystemPromptCacheBoundary(context.systemPrompt);
-    params.push({
-      role,
-      content: sanitizeSurrogates(systemPrompt),
-    });
+    if (options.preserveSystemPromptCacheBoundary) {
+      // Explicit cache_control path keeps the boundary marker; a later pass splits
+      // it into cached prefix + uncached suffix content parts on the same message.
+      params.push({
+        role,
+        content: sanitizeSurrogates(context.systemPrompt),
+      });
+    } else {
+      // Implicit prefix-cache providers (e.g. DeepSeek) cache the literal request
+      // prefix from token 0, so per-turn-volatile content placed in the leading
+      // system message invalidates the cache for the whole conversation that
+      // follows it. Keep the stable prefix as a byte-identical leading message and
+      // relocate the dynamic below-boundary suffix to a trailing message so the
+      // cached prefix + history stay stable while the runtime context still
+      // reaches the model. (#94518)
+      const split = splitSystemPromptCacheBoundary(context.systemPrompt);
+      if (split) {
+        if (split.stablePrefix) {
+          params.push({ role, content: sanitizeSurrogates(split.stablePrefix) });
+        }
+        if (split.dynamicSuffix) {
+          trailingSystemSuffixMessage = {
+            role,
+            content: sanitizeSurrogates(split.dynamicSuffix),
+          };
+        }
+      } else {
+        params.push({
+          role,
+          content: sanitizeSurrogates(stripSystemPromptCacheBoundary(context.systemPrompt)),
+        });
+      }
+    }
   }
 
   let lastRole: string | null = null;
@@ -1189,6 +1221,10 @@ export function convertMessages(
     }
 
     lastRole = msg.role;
+  }
+
+  if (trailingSystemSuffixMessage) {
+    params.push(trailingSystemSuffixMessage);
   }
 
   return params;


### PR DESCRIPTION
## What Problem This Solves

The system prompt contains a cache boundary marker separating stable content from volatile Runtime block content. For providers with implicit prefix caching (DeepSeek, z.ai), any change in the leading system message invalidates the cache. The volatile Runtime block changes every turn, destroying cache effectiveness. Builds on #94945, rebased onto current main.

## Evidence

Fix deployed to running OpenClaw gateway (aa69b12) using z.ai glm-5-turbo. This entire 3h+ session ran on the patched code.

Cache metrics from session_status (long session, prefix cache warm):
- Cache: 63% hit, 62k cached tokens, 0 new
- Context: 88k/203k (43%)

The 63% hit rate confirms the stable prefix (AGENTS.md, SOUL.md, USER.md, tool definitions) is being served from cache. The dynamic suffix is sent as a trailing system message and does not invalidate the prefix cache. Before this fix, the volatile Runtime block was part of the leading message and every turn change would shift the byte prefix, destroying cache hits. The 62k cached tokens demonstrate the stable portion is cached across turns despite Runtime changes.

Provider: z.ai (OpenAI-compatible, openai-completions). Model: glm-5-turbo. Session: agent:main:node-c955ad5b83f8.

Fixes #94518. Test plan: pnpm test src/llm/providers/openai-completions.test.ts