### PR TITLE
fix: use numeric sort for model alias resolution

### DIFF
--- a/src/agents/sessions/model-resolver.test.ts
+++ b/src/agents/sessions/model-resolver.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { Model } from "../../llm/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
-import { findInitialModel, restoreModelFromSession } from "./model-resolver.js";
+import { findInitialModel, parseModelPattern, restoreModelFromSession } from "./model-resolver.js";
 
 function model(provider: string, id: string): Model {
   return {
@@ -55,5 +55,16 @@ describe("model resolver fallback selection", () => {
     );
 
     expect(result.model).toBe(firstAvailable);
+  });
+});
+
+describe("parseModelPattern numeric model ids", () => {
+  it("uses numeric ordering when resolving version-like aliases", () => {
+    const result = parseModelPattern("opus", [
+      model("anthropic", "claude-opus-4-9"),
+      model("anthropic", "claude-opus-4-10"),
+    ]);
+
+    expect(result.model?.id).toBe("claude-opus-4-10");
   });
 });

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -116,11 +116,11 @@ function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | 
 
   if (aliases.length > 0) {
     // Prefer alias - if multiple aliases, pick the one that sorts highest
-    aliases.sort((a, b) => b.id.localeCompare(a.id));
+    aliases.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
     return aliases[0];
   }
   // No alias found, pick latest dated version
-  datedVersions.sort((a, b) => b.id.localeCompare(a.id));
+  datedVersions.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
   return datedVersions[0];
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes alias model resolution for version-like model ids that cross into double-digit minor versions.

Previously, `tryMatchModel` sorted candidate model ids with plain lexicographic `localeCompare`, so ids like `claude-opus-4-9` could sort above `claude-opus-4-10`. This caused partial aliases such as `opus` to resolve to an older model.

This PR updates model candidate sorting to use numeric-aware collation and adds a regression test for the `4-9` vs `4-10` case.

Fixes #96588.

## Evidence

- `node scripts/run-vitest.mjs run src/agents/sessions/model-resolver.test.ts` → **Test Files 1 passed, Tests 3 passed**
- `pnpm exec oxfmt --check --threads=1 src/agents/sessions/model-resolver.ts src/agents/sessions/model-resolver.test.ts` → **All matched files use the correct format**
- Observed behavior: `parseModelPattern("opus", ...)` selects `claude-opus-4-10` over `claude-opus-4-9` after the numeric-aware sort fix