### PR TITLE
fix(media-understanding): forward scanned PDF page images to vision models on chat channels

### DIFF
--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -59,4 +59,65 @@ describe("resolveCurrentTurnImages", () => {
       });
     });
   });
+
+  it("merges current-turn extracted images with existing inline images", async () => {
+    const existingImage = {
+      type: "image" as const,
+      data: Buffer.from("existing-image").toString("base64"),
+      mimeType: "image/jpeg",
+    };
+    const extractedPdfPage = {
+      type: "image" as const,
+      data: Buffer.from("pdf-page").toString("base64"),
+      mimeType: "image/png",
+    };
+
+    const result = await resolveCurrentTurnImages({
+      ctx: {
+        Body: "<media:document>",
+        CurrentTurnImages: [extractedPdfPage],
+        CurrentTurnImageOrder: ["inline"],
+      } satisfies MsgContext,
+      cfg: {} as OpenClawConfig,
+      images: [existingImage],
+      imageOrder: ["inline"],
+    });
+
+    expect(result).toStrictEqual({
+      images: [existingImage, extractedPdfPage],
+      imageOrder: ["inline", "inline"],
+    });
+  });
+
+  it("does not merge extracted images twice across the prepare and run passes", async () => {
+    const extractedPdfPage = {
+      type: "image" as const,
+      data: Buffer.from("pdf-page").toString("base64"),
+      mimeType: "image/png",
+    };
+    const ctx = {
+      Body: "<media:document>",
+      CurrentTurnImages: [extractedPdfPage],
+      CurrentTurnImageOrder: ["inline"],
+    } satisfies MsgContext;
+
+    const prepared = await resolveCurrentTurnImages({
+      ctx,
+      cfg: {} as OpenClawConfig,
+    });
+    const runPass = await resolveCurrentTurnImages({
+      ctx,
+      cfg: {} as OpenClawConfig,
+      images: prepared.images,
+      imageOrder: prepared.imageOrder,
+    });
+
+    expect(prepared).toStrictEqual({
+      images: [extractedPdfPage],
+      imageOrder: ["inline"],
+    });
+    expect(runPass).toStrictEqual(prepared);
+    expect(ctx.CurrentTurnImages).toBeUndefined();
+    expect(ctx.CurrentTurnImageOrder).toBeUndefined();
+  });
 });

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -89,6 +89,41 @@ function createUndescribedImageContext(
 }
 
 /** Resolves current-turn image attachments that were not already described by media understanding. */
+export function takeCurrentTurnImages(ctx: MsgContext): {
+  images?: ImageContent[];
+  imageOrder?: PromptImageOrderEntry[];
+} {
+  const images = ctx.CurrentTurnImages;
+  if (images && images.length > 0) {
+    const imageOrder = ctx.CurrentTurnImageOrder;
+    delete ctx.CurrentTurnImages;
+    delete ctx.CurrentTurnImageOrder;
+    return { images, imageOrder };
+  }
+  return {};
+}
+
+function mergeImagePayloads(params: {
+  baseImages?: ImageContent[];
+  baseImageOrder?: PromptImageOrderEntry[];
+  nextImages?: ImageContent[];
+  nextImageOrder?: PromptImageOrderEntry[];
+}): { images?: ImageContent[]; imageOrder?: PromptImageOrderEntry[] } {
+  const nextImages = params.nextImages ?? [];
+  if (nextImages.length === 0) {
+    return { images: params.baseImages, imageOrder: params.baseImageOrder };
+  }
+  const images = [...(params.baseImages ?? []), ...nextImages];
+  const nextOrder =
+    params.nextImageOrder && params.nextImageOrder.length === nextImages.length
+      ? params.nextImageOrder
+      : nextImages.map((): PromptImageOrderEntry => "inline");
+  return {
+    images,
+    imageOrder: [...(params.baseImageOrder ?? []), ...nextOrder],
+  };
+}
+
 export async function resolveCurrentTurnImages(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
@@ -98,30 +133,37 @@ export async function resolveCurrentTurnImages(params: {
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
 }> {
+  const extracted = takeCurrentTurnImages(params.ctx);
+  let merged = mergeImagePayloads({
+    baseImages: params.images,
+    baseImageOrder: params.imageOrder,
+    nextImages: extracted.images,
+    nextImageOrder: extracted.imageOrder,
+  });
   if (Array.isArray(params.images) && params.images.length > 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
+    return merged;
   }
 
   const currentImageAttachments = collectCurrentImageAttachments(params.ctx);
   if (currentImageAttachments.length === 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
+    return merged;
   }
   const describedImageIndexes = collectDescribedImageAttachmentIndexes(params.ctx);
   const undescribedImageAttachments = currentImageAttachments.filter(
     (attachment) => !describedImageIndexes.has(attachment.index),
   );
   if (undescribedImageAttachments.length === 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
+    return merged;
   }
 
   try {
     // Only send undescribed current images natively; described images already exist as text context.
-    const resolved = await resolveAgentTurnAttachments({
+    const attachmentResult = await resolveAgentTurnAttachments({
       ctx: createUndescribedImageContext(params.ctx, undescribedImageAttachments),
       cfg: params.cfg,
       includeRecentHistoryImages: false,
     });
-    const images = resolved.attachments.map(
+    const images = attachmentResult.attachments.map(
       (attachment): ImageContent => ({
         type: "image",
         data: attachment.data,
@@ -132,15 +174,22 @@ export async function resolveCurrentTurnImages(params: {
       logVerbose(
         `agent-runner: native OpenClaw media resolution produced ${images.length}/${undescribedImageAttachments.length} current image attachment(s); falling back to prompt image refs`,
       );
-      return { images: params.images, imageOrder: params.imageOrder };
+      return merged;
     }
-    return images.length > 0
-      ? { images, imageOrder: images.map(() => "inline" as const) }
-      : { images: params.images, imageOrder: params.imageOrder };
+    if (images.length === 0) {
+      return merged;
+    }
+    merged = mergeImagePayloads({
+      baseImages: merged.images,
+      baseImageOrder: merged.imageOrder,
+      nextImages: images,
+      nextImageOrder: images.map((): PromptImageOrderEntry => "inline"),
+    });
+    return merged;
   } catch (error) {
     logVerbose(
       `agent-runner: media attachment image resolution failed, proceeding without native images: ${formatErrorMessage(error)}`,
     );
-    return { images: params.images, imageOrder: params.imageOrder };
+    return merged;
   }
 }

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -37,6 +37,7 @@ import {
   resolveInlineAgentImageAttachments,
 } from "./agent-turn-attachments.js";
 import { resolveFirstContextText } from "./context-text.js";
+import { takeCurrentTurnImages } from "./current-turn-images.js";
 import {
   createAcpDispatchDeliveryCoordinator,
   type AcpDispatchDeliveryCoordinator,
@@ -563,22 +564,26 @@ export async function tryDispatchAcpReply(params: {
       cfg: params.cfg,
     });
     const mediaAttachments = resolvedTurnAttachments.attachments;
-    const inlineAttachments = resolveInlineAgentImageAttachments(params.images);
+    const inputInlineAttachments = resolveInlineAgentImageAttachments(params.images);
+    const extractedInlineAttachments = resolveInlineAgentImageAttachments(
+      takeCurrentTurnImages(params.ctx).images,
+    );
+    const inlineAttachments = [...inputInlineAttachments, ...extractedInlineAttachments];
     const mediaAttachmentsAreOnlyRecentHistory =
       mediaAttachments.length > 0 &&
       mediaAttachments.length === resolvedTurnAttachments.recentHistoryImages.length;
-    const attachments =
+    const shouldUseMediaAttachments =
       mediaAttachments.length > 0 &&
-      !(mediaAttachmentsAreOnlyRecentHistory && inlineAttachments.length > 0)
-        ? mediaAttachments
-        : inlineAttachments;
-    const turnPromptText =
-      attachments === mediaAttachments
-        ? appendRecentHistoryImageContext({
-            promptText,
-            images: resolvedTurnAttachments.recentHistoryImages,
-          })
-        : promptText;
+      !(mediaAttachmentsAreOnlyRecentHistory && inlineAttachments.length > 0);
+    const attachments = shouldUseMediaAttachments
+      ? [...mediaAttachments, ...extractedInlineAttachments]
+      : inlineAttachments;
+    const turnPromptText = shouldUseMediaAttachments
+      ? appendRecentHistoryImageContext({
+          promptText,
+          images: resolvedTurnAttachments.recentHistoryImages,
+        })
+      : promptText;
     if (!turnPromptText && attachments.length === 0) {
       const counts = params.dispatcher.getQueuedCounts();
       delivery.applyRoutedCounts(counts);

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -1,5 +1,7 @@
 /** Shared inbound message context types used by prompt templating and reply dispatch. */
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
+import type { ImageContent } from "../llm/types.js";
+import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type {
   MediaUnderstandingDecision,
   MediaUnderstandingOutput,
@@ -219,6 +221,9 @@ export type MsgContext = {
   Transcript?: string;
   MediaUnderstanding?: MediaUnderstandingOutput[];
   MediaUnderstandingDecisions?: MediaUnderstandingDecision[];
+  /** Page images extracted from scanned/image-only PDFs during media understanding, forwarded to vision models. */
+  CurrentTurnImages?: ImageContent[];
+  CurrentTurnImageOrder?: PromptImageOrderEntry[];
   LinkUnderstanding?: string[];
   Prompt?: string;
   MaxChars?: number;

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -31,6 +31,7 @@ const readRemoteMediaBufferMock = vi.hoisted(() => vi.fn());
 const runFfmpegMock = vi.hoisted(() => vi.fn());
 const convertHeicToJpegMock = vi.hoisted(() => vi.fn());
 const runExecMock = vi.hoisted(() => vi.fn());
+const extractDocumentContentMock = vi.hoisted(() => vi.fn());
 
 let applyMediaUnderstanding: typeof import("./apply.js").applyMediaUnderstanding;
 let clearMediaUnderstandingBinaryCacheForTests: typeof import("./runner.js").clearMediaUnderstandingBinaryCacheForTests;
@@ -39,6 +40,7 @@ const mockedReadRemoteMediaBuffer = readRemoteMediaBufferMock;
 const mockedRunFfmpeg = runFfmpegMock;
 const mockedConvertHeicToJpeg = convertHeicToJpegMock;
 const mockedRunExec = runExecMock;
+const mockedExtractDocumentContent = extractDocumentContentMock;
 
 const TEMP_MEDIA_PREFIX = "openclaw-media-";
 let suiteTempMediaRootDir = "";
@@ -301,6 +303,9 @@ describe("applyMediaUnderstanding", () => {
     vi.doMock("../process/exec.js", () => ({
       runExec: runExecMock,
     }));
+    vi.doMock("../media/document-extractors.runtime.js", () => ({
+      extractDocumentContent: extractDocumentContentMock,
+    }));
     vi.doMock("./provider-registry.js", async () => {
       const actual =
         await vi.importActual<typeof import("./provider-registry.js")>("./provider-registry.js");
@@ -352,6 +357,8 @@ describe("applyMediaUnderstanding", () => {
     mockedConvertHeicToJpeg.mockReset();
     mockedConvertHeicToJpeg.mockResolvedValue(Buffer.from("jpeg-normalized"));
     mockedRunExec.mockReset();
+    mockedExtractDocumentContent.mockReset();
+    mockedExtractDocumentContent.mockResolvedValue({ text: "", images: [] });
     mockedReadRemoteMediaBuffer.mockResolvedValue({
       buffer: createSafeAudioFixtureBuffer(2048),
       contentType: "audio/ogg",
@@ -1757,6 +1764,37 @@ describe("applyMediaUnderstanding", () => {
     });
 
     expectFileNotApplied({ ctx, result, body: "<media:file>" });
+  });
+
+  it("carries rendered PDF page images into current-turn image payloads", async () => {
+    const extractedImage = {
+      type: "image" as const,
+      data: Buffer.from("scanned-page").toString("base64"),
+      mimeType: "image/png",
+    };
+    mockedExtractDocumentContent.mockResolvedValueOnce({
+      text: "",
+      images: [extractedImage],
+    });
+    const pseudoPdf = Buffer.from("%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n", "utf8");
+    const filePath = await createTempMediaFile({
+      fileName: "receipt-scan.pdf",
+      content: pseudoPdf,
+    });
+
+    const { ctx, result } = await applyWithDisabledMedia({
+      body: "<media:document>",
+      mediaPath: filePath,
+      mediaType: "application/pdf",
+    });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain("[PDF content rendered to images]");
+    expect(ctx.Body).not.toContain("images not forwarded");
+    expect(ctx.CurrentTurnImages).toEqual([extractedImage]);
+    expect(ctx.CurrentTurnImageOrder).toEqual(["inline"]);
+    expect((ctx as unknown as { BodyForAgent?: string }).BodyForAgent).toBe(ctx.Body);
+    expect((ctx as unknown as { BodyForCommands?: string }).BodyForCommands).toBe(ctx.Body);
   });
 
   it("escapes XML special characters in filenames to prevent injection", async () => {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -9,9 +9,11 @@ import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
+import type { ImageContent } from "../llm/types.js";
 import { renderFileContextBlock } from "../media/file-context.js";
 import { extractFileContentFromSource, normalizeMimeType } from "../media/input-files.js";
 import { wrapExternalContent } from "../security/external-content.js";
+import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type { ActiveMediaModel } from "../../packages/media-understanding-common/src/active-model.js";
 import {
   extractMediaUserText,
@@ -109,6 +111,17 @@ function appendFileBlocks(body: string | undefined, blocks: string[]): string {
     return suffix;
   }
   return `${base}\n\n${suffix}`.trim();
+}
+
+function appendCurrentTurnImages(ctx: MsgContext, images: ImageContent[]): void {
+  if (images.length === 0) {
+    return;
+  }
+  ctx.CurrentTurnImages = [...(ctx.CurrentTurnImages ?? []), ...images];
+  ctx.CurrentTurnImageOrder = [
+    ...(ctx.CurrentTurnImageOrder ?? []),
+    ...images.map((): PromptImageOrderEntry => "inline"),
+  ];
 }
 
 function wrapUntrustedAttachmentContent(content: string): string {
@@ -383,12 +396,13 @@ async function extractFileBlocks(params: {
   cfg: OpenClawConfig;
   limits: FileExtractionLimits;
   skipAttachmentIndexes?: Set<number>;
-}): Promise<string[]> {
+}): Promise<{ blocks: string[]; images: ImageContent[] }> {
   const { attachments, cache, cfg, limits, skipAttachmentIndexes } = params;
   if (!attachments || attachments.length === 0) {
-    return [];
+    return { blocks: [], images: [] };
   }
   const blocks: string[] = [];
+  const images: ImageContent[] = [];
   for (const attachment of attachments) {
     if (!attachment) {
       continue;
@@ -493,11 +507,15 @@ async function extractFileBlocks(params: {
       }
       continue;
     }
+    const extractedImages = extracted?.images ?? [];
+    if (extractedImages.length > 0) {
+      images.push(...extractedImages);
+    }
     const text = extracted?.text?.trim() ?? "";
     let blockText = text ? wrapUntrustedAttachmentContent(text) : "";
     if (!blockText) {
-      if (extracted?.images && extracted.images.length > 0) {
-        blockText = "[PDF content rendered to images; images not forwarded to model]";
+      if (extractedImages.length > 0) {
+        blockText = "[PDF content rendered to images]";
       } else {
         blockText = "[No extractable text]";
       }
@@ -511,7 +529,7 @@ async function extractFileBlocks(params: {
       }),
     );
   }
-  return blocks;
+  return { blocks, images };
 }
 
 export async function applyMediaUnderstanding(params: {
@@ -670,20 +688,21 @@ export async function applyMediaUnderstanding(params: {
         )
         .map((output) => output.attachmentIndex),
     );
-    const fileBlocks = await extractFileBlocks({
+    const fileExtraction = await extractFileBlocks({
       attachments,
       cache,
       cfg,
       limits: resolveFileExtractionLimits(cfg),
       skipAttachmentIndexes: audioAttachmentIndexes.size > 0 ? audioAttachmentIndexes : undefined,
     });
-    if (fileBlocks.length > 0) {
-      ctx.Body = appendFileBlocks(ctx.Body, fileBlocks);
+    if (fileExtraction.blocks.length > 0) {
+      ctx.Body = appendFileBlocks(ctx.Body, fileExtraction.blocks);
     }
-    if (outputs.length > 0 || fileBlocks.length > 0) {
+    appendCurrentTurnImages(ctx, fileExtraction.images);
+    if (outputs.length > 0 || fileExtraction.blocks.length > 0) {
       finalizeInboundContext(ctx, {
         forceBodyForAgent: true,
-        forceBodyForCommands: outputs.length > 0 || fileBlocks.length > 0,
+        forceBodyForCommands: outputs.length > 0 || fileExtraction.blocks.length > 0,
       });
     }
 
@@ -693,7 +712,7 @@ export async function applyMediaUnderstanding(params: {
       appliedImage: outputs.some((output) => output.kind === "image.description"),
       appliedAudio: outputs.some((output) => output.kind === "audio.transcription"),
       appliedVideo: outputs.some((output) => output.kind === "video.description"),
-      appliedFile: fileBlocks.length > 0,
+      appliedFile: fileExtraction.blocks.length > 0,
     };
   } finally {
     await cache.cleanup();


### PR DESCRIPTION
## What Problem This Solves

Fixes #96541

Scanned / image-only PDFs attached to chat channel messages (Telegram, WhatsApp, Slack, Discord, etc.) are silently dropped: the document extractor rasterizes pages to images, but the chat media-understanding path replaces the missing text with a dead-end placeholder string (`[PDF content rendered to images; images not forwarded to model]`) and never forwards the page images to the model. The identical extractor output is forwarded correctly on the `/v1/responses` API path (`openresponses-http.ts`), so a scanned receipt/contract that works over the API is ignored on every chat channel.

## Why This Change Was Made

The chat path (`extractFileBlocks` in `src/media-understanding/apply.ts`) had no route to forward extracted page images: `extractFileBlocks` returned only `string[]` (text blocks) and `ApplyMediaUnderstandingResult` had no image-carrying field. The page images existed (the extractor returns them when extracted text is below `minTextChars`) but were discarded before reaching the model.

This adds an image channel parallel to the existing text blocks so extracted PDF page images are forwarded to vision-capable models, mirroring the API path at `openresponses-http.ts:629-630`.

## User Impact

Vision-capable models can now read scanned / image-only PDFs sent on chat channels, instead of receiving only a placeholder string. Behavior for text-extractable PDFs and non-PDF attachments is unchanged.

**Behavior addressed:** scanned / image-only PDF page images extracted on the chat channel path are dropped, leaving the model a placeholder string.

**Approach:**
- `extractFileBlocks` now returns `{ blocks, images }` alongside its text blocks, collecting extracted page images.
- `applyMediaUnderstanding` writes collected images to `ctx.CurrentTurnImages` (new optional `MsgContext` field).
- `resolveCurrentTurnImages` (non-ACP agent path) consumes `ctx.CurrentTurnImages` via `takeCurrentTurnImages` and merges them into the turn's image payload (with idempotent take-once semantics to prevent double-merge across prepare/run passes).
- `tryDispatchAcpReply` (ACP path, which bypasses `resolveCurrentTurnImages`) consumes `takeCurrentTurnImages` directly and appends extracted images to inline attachments.
- Placeholder text updated from `[PDF content rendered to images; images not forwarded to model]` → `[PDF content rendered to images]` since images are now forwarded.

## Evidence

**Real environment tested:** vitest regression tests driving the real `applyMediaUnderstanding` + `resolveCurrentTurnImages` paths with the document-extractor boundary stubbed to return one image-only page (the one true external boundary — real base64 canonicalization, real PDF MIME validation, real `extractPdfContent` orchestration run end-to-end).

**Exact steps or command run after this patch:**
`pnpm test src/media-understanding/apply.test.ts src/auto-reply/reply/current-turn-images.test.ts`

**Evidence after fix:** New regression test `carries rendered PDF page images into current-turn image payloads` asserts that `ctx.CurrentTurnImages` is populated with the extracted page image and `ctx.Body` no longer contains "images not forwarded". New test `merges current-turn extracted images with existing inline images` asserts the merge path. New test `does not merge extracted images twice across the prepare and run passes` asserts idempotent take-once semantics.

**Observed result after fix:** `result.appliedFile === true`, `ctx.CurrentTurnImages` contains the extracted `image/png` page raster, placeholder text no longer claims images are dropped. Pre-fix, `ctx.CurrentTurnImages` was never set and the only forwarded block was a text block with zero image bytes.

**What was not tested:** The live channel transport end-to-end (a real Telegram/WhatsApp send) was not exercised; the rendering boundary (`extractDocumentContent`) was stubbed rather than running clawpdf on real raster bytes.

---

AI-assisted: this PR was prepared with AI assistance. The approach was validated against a prior community attempt (closed PR that confirmed the root cause and fix direction but could not satisfy the proof gate).
