### PR TITLE
fix(telegram): fall back to plain text when rich message entity validation fails

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -5,7 +5,7 @@ import { createTelegramRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
-import { markdownToTelegramHtml } from "../format.js";
+import { markdownToTelegramHtml, telegramHtmlToPlainTextFallback } from "../format.js";
 import { isSafeToRetrySendError, isTelegramRateLimitError } from "../network-errors.js";
 import {
   buildTelegramSendParams,
@@ -26,6 +26,8 @@ export { buildTelegramSendParams } from "../reply-parameters.js";
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const EMPTY_TEXT_ERR_RE = /message text is empty/i;
 const QUOTE_PARAM_RE = /\bquote not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
+const RICH_ENTITY_INVALID_RE =
+  /RICH_MESSAGE_(?:EMAIL|URL|MENTION|HASHTAG|CASHTAG|BOT_COMMAND|PHONE|BANK_CARD)_INVALID/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
 
@@ -121,42 +123,20 @@ export async function sendTelegramText(
     silent: opts?.silent,
   });
   const textMode = opts?.textMode ?? "markdown";
-  if (opts?.richMessages === true) {
-    const richMessage = buildTelegramRichMessage(text, textMode, {
-      skipEntityDetection: opts.linkPreview === false,
-      tableMode: opts.tableMode,
-    });
-    const res = await sendTelegramWithThreadFallback({
-      operation: "sendRichMessage",
-      runtime,
-      thread: opts.thread,
-      requestParams: toTelegramRichMessageContextParams(baseParams),
-      removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
-      send: (effectiveParams) =>
-        getTelegramRichRawApi(bot.api).sendRichMessage({
-          chat_id: chatId,
-          rich_message: richMessage,
-          ...(opts.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-          ...effectiveParams,
-        }),
-    });
-    runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
-    return res.message_id;
-  }
   // Add link_preview_options when link preview is disabled.
   const linkPreviewEnabled = opts?.linkPreview ?? true;
   const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
   const htmlText = textMode === "html" ? text : markdownToTelegramHtml(text);
   const fallbackText = opts?.plainText ?? text;
   const hasFallbackText = fallbackText.trim().length > 0;
-  const sendPlainFallback = async () => {
+  const sendPlainFallback = async (plainText: string = fallbackText) => {
     const res = await sendTelegramWithThreadFallback({
       operation: "sendMessage",
       runtime,
       thread: opts?.thread,
       requestParams: baseParams,
       send: (effectiveParams) =>
-        bot.api.sendMessage(chatId, fallbackText, {
+        bot.api.sendMessage(chatId, plainText, {
           ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
           ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
           ...effectiveParams,
@@ -165,6 +145,42 @@ export async function sendTelegramText(
     runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id} (plain)`);
     return res.message_id;
   };
+
+  if (opts?.richMessages === true) {
+    const richMessage = buildTelegramRichMessage(text, textMode, {
+      skipEntityDetection: opts.linkPreview === false,
+      tableMode: opts.tableMode,
+    });
+    try {
+      const res = await sendTelegramWithThreadFallback({
+        operation: "sendRichMessage",
+        runtime,
+        thread: opts.thread,
+        requestParams: toTelegramRichMessageContextParams(baseParams),
+        removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
+        send: (effectiveParams) =>
+          getTelegramRichRawApi(bot.api).sendRichMessage({
+            chat_id: chatId,
+            rich_message: richMessage,
+            ...(opts.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+            ...effectiveParams,
+          }),
+      });
+      runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
+      return res.message_id;
+    } catch (err) {
+      const errText = formatErrorMessage(err);
+      if (!RICH_ENTITY_INVALID_RE.test(errText) || !hasFallbackText) {
+        throw err;
+      }
+      const richFallbackText =
+        opts?.plainText ?? (textMode === "html" ? telegramHtmlToPlainTextFallback(text) : text);
+      runtime.log?.(
+        `telegram sendRichMessage rejected invalid entity; falling back to plain text: ${errText}`,
+      );
+      return await sendPlainFallback(richFallbackText);
+    }
+  }
 
   // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
   if (!htmlText.trim()) {

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -206,6 +206,12 @@ function createNormalizedQuoteTextInvalidError(operation = "sendMessage") {
   );
 }
 
+function createRichEntityInvalidError(entity = "EMAIL", operation = "sendRichMessage") {
+  return new Error(
+    `GrammyError: Call to '${operation}' failed! (400: Bad Request: RICH_MESSAGE_${entity}_INVALID)`,
+  );
+}
+
 function createWrappedPreConnectHttpError(operation = "sendMessage") {
   const root = Object.assign(new Error("getaddrinfo ENOTFOUND api.telegram.org"), {
     code: "ENOTFOUND",
@@ -1264,6 +1270,78 @@ describe("deliverReplies", () => {
       html: oauthProfileText,
       skip_entity_detection: true,
     });
+  });
+
+  it("falls back to plain text when a rich message is rejected for an invalid entity", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 12,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+    (bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> }).sendRichMessage = vi
+      .fn()
+      .mockRejectedValue(createRichEntityInvalidError("EMAIL"));
+    const text = "Status includes openai:owner@example.com";
+
+    await deliverWith({
+      replies: [{ text }],
+      runtime,
+      bot,
+      richMessages: true,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(firstMockCallArg(sendMessage, 0)).toBe("123");
+    expect(firstMockCallArg(sendMessage, 1)).toBe(text);
+    expect(mockCallArg(sendMessage, 0, 2)).not.toHaveProperty("parse_mode");
+  });
+
+  it("falls back to plain text for other invalid rich entity validation errors", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 13,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+    (bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> }).sendRichMessage = vi
+      .fn()
+      .mockRejectedValue(createRichEntityInvalidError("URL"));
+    const text = "Status with a rejected URL entity";
+
+    await deliverWith({
+      replies: [{ text }],
+      runtime,
+      bot,
+      richMessages: true,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(firstMockCallArg(sendMessage, 1)).toBe(text);
+  });
+
+  it("does not fall back to plain text for non-validation rich message errors", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 14,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+    (bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> }).sendRichMessage = vi
+      .fn()
+      .mockRejectedValue(new Error("network error"));
+    const text = "Status text";
+
+    await expect(
+      deliverWith({
+        replies: [{ text }],
+        runtime,
+        bot,
+        richMessages: true,
+      }),
+    ).rejects.toThrow("network error");
+
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("uses legacy reply id when selected reply target differs from quote source", async () => {


### PR DESCRIPTION
Fixes #96363

## What Problem This Solves

When `channels.telegram.richMessages = true`, Telegram can reject rich messages with `RICH_MESSAGE_*_INVALID` (for example `RICH_MESSAGE_EMAIL_INVALID` on `/status` replies that contain provider-prefixed email-like strings). Today the reply is dropped and the user sees nothing.

## Why This Change Was Made

`sendTelegramText` already falls back from HTML formatting to plain text for parse errors, but the rich-message branch had no equivalent safety net for rich-entity validation failures. This change adds a catch around `sendRichMessage` that detects `RICH_MESSAGE_*_INVALID` errors and resends the text as a plain `sendMessage`.

## User Impact

Telegram users with rich messages enabled now receive a plain-text reply instead of a dropped message when a rich entity is rejected by Telegram.

## Evidence

- Added focused regression tests in `extensions/telegram/src/bot/delivery.test.ts` covering:
  - `RICH_MESSAGE_EMAIL_INVALID` triggers plain-text fallback
  - Other `RICH_MESSAGE_*_INVALID` errors trigger fallback
  - Non-validation errors do not trigger fallback
- `node scripts/run-vitest.mjs run extensions/telegram/src/bot/delivery.test.ts` passes (62 tests)
- `node scripts/run-vitest.mjs run extensions/telegram/src/send.test.ts extensions/telegram/src/bot/delivery.test.ts` passes (197 tests)
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` pass
- `pnpm exec oxfmt --check` and `pnpm exec oxlint` pass on touched files