### PR TITLE
fix(line): forward FileMessage fileName to media store for audio MIME detection

### DIFF
--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -467,7 +467,14 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
 
   if (isDownloadableLineMessageType(message.type)) {
     try {
-      const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
+      const fileName =
+        message.type === "file" ? (message as webhook.FileMessageContent).fileName : undefined;
+      const media = await downloadLineMedia(
+        message.id,
+        account.channelAccessToken,
+        mediaMaxBytes,
+        fileName,
+      );
       allMedia.push({
         path: media.path,
         contentType: media.contentType,

--- a/extensions/line/src/download.integration.test.ts
+++ b/extensions/line/src/download.integration.test.ts
@@ -1,0 +1,74 @@
+// Integration proof: real saveMediaStream + mocked LINE client shows filename-based audio detection.
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMessageContentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@line/bot-sdk", () => ({
+  messagingApi: {
+    MessagingApiBlobClient: class {
+      getMessageContent(messageId: string) {
+        return getMessageContentMock(messageId);
+      }
+    },
+  },
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  createSubsystemLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }),
+  }),
+  logVerbose: () => {},
+}));
+
+let tmpHome: string;
+let originalHome: string | undefined;
+let downloadLineMedia: typeof import("./download.js").downloadLineMedia;
+
+async function* chunks(parts: Buffer[]): AsyncGenerator<Buffer> {
+  for (const part of parts) {
+    yield part;
+  }
+}
+
+describe("downloadLineMedia integration proof", () => {
+  beforeAll(async () => {
+    originalHome = process.env.OPENCLAW_HOME;
+    tmpHome = mkdtempSync(path.join(os.tmpdir(), "oc-line-proof-"));
+    process.env.OPENCLAW_HOME = tmpHome;
+    ({ downloadLineMedia } = await import("./download.js"));
+  });
+
+  afterAll(() => {
+    if (originalHome === undefined) {
+      delete process.env.OPENCLAW_HOME;
+    } else {
+      process.env.OPENCLAW_HOME = originalHome;
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getMessageContentMock.mockReset();
+  });
+
+  it("saves a LINE file-upload audio attachment with audio/mpeg MIME using the filename hint", async () => {
+    // No audio magic bytes; only the .mp3 filename hint can classify this as audio.
+    const data = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    getMessageContentMock.mockResolvedValueOnce(chunks([data]));
+
+    const result = await downloadLineMedia("mid-file", "token", 10 * 1024 * 1024, "voice.mp3");
+
+    expect(result.size).toBe(data.length);
+    expect(result.contentType).toBe("audio/mpeg");
+    expect(path.extname(result.path)).toBe(".mp3");
+    expect(existsSync(result.path)).toBe(true);
+  });
+});

--- a/extensions/line/src/download.test.ts
+++ b/extensions/line/src/download.test.ts
@@ -61,10 +61,18 @@ function detectMockContentType(
   }
   if (originalFilename) {
     const lower = originalFilename.toLowerCase();
-    if (lower.endsWith(".mp3")) return "audio/mpeg";
-    if (lower.endsWith(".m4a")) return "audio/x-m4a";
-    if (lower.endsWith(".wav")) return "audio/wav";
-    if (lower.endsWith(".ogg")) return "audio/ogg";
+    if (lower.endsWith(".mp3")) {
+      return "audio/mpeg";
+    }
+    if (lower.endsWith(".m4a")) {
+      return "audio/x-m4a";
+    }
+    if (lower.endsWith(".wav")) {
+      return "audio/wav";
+    }
+    if (lower.endsWith(".ogg")) {
+      return "audio/ogg";
+    }
   }
   return contentType;
 }

--- a/extensions/line/src/download.test.ts
+++ b/extensions/line/src/download.test.ts
@@ -48,12 +48,23 @@ function saveMediaStreamCall(): unknown[] {
   return call;
 }
 
-function detectMockContentType(buffer: Buffer, contentType?: string): string | undefined {
+function detectMockContentType(
+  buffer: Buffer,
+  contentType?: string,
+  originalFilename?: string,
+): string | undefined {
   if (buffer[0] === 0xff && buffer[1] === 0xd8) {
     return "image/jpeg";
   }
   if (buffer.toString("ascii", 4, 8) === "ftyp") {
     return buffer.toString("ascii", 8, 12) === "M4A " ? "audio/x-m4a" : "video/mp4";
+  }
+  if (originalFilename) {
+    const lower = originalFilename.toLowerCase();
+    if (lower.endsWith(".mp3")) return "audio/mpeg";
+    if (lower.endsWith(".m4a")) return "audio/x-m4a";
+    if (lower.endsWith(".wav")) return "audio/wav";
+    if (lower.endsWith(".ogg")) return "audio/ogg";
   }
   return contentType;
 }
@@ -75,7 +86,13 @@ describe("downloadLineMedia", () => {
     getMessageContentMock.mockReset();
     saveMediaStreamMock.mockReset();
     saveMediaStreamMock.mockImplementation(
-      async (stream: AsyncIterable<Buffer>, contentType?: string, subdir?: string) => {
+      async (
+        stream: AsyncIterable<Buffer>,
+        contentType?: string,
+        subdir?: string,
+        _maxBytes?: number,
+        originalFilename?: string,
+      ) => {
         const chunksLocal: Buffer[] = [];
         for await (const chunk of stream) {
           chunksLocal.push(Buffer.from(chunk));
@@ -83,7 +100,7 @@ describe("downloadLineMedia", () => {
         const buffer = Buffer.concat(chunksLocal);
         return {
           path: `/home/user/.openclaw/media/${subdir ?? "unknown"}/saved-media`,
-          contentType: detectMockContentType(buffer, contentType),
+          contentType: detectMockContentType(buffer, contentType, originalFilename),
           size: buffer.length,
         };
       },
@@ -161,5 +178,26 @@ describe("downloadLineMedia", () => {
     saveMediaStreamMock.mockRejectedValueOnce(new Error("Media exceeds 0MB limit"));
 
     await expect(downloadLineMedia("mid-bad", "token")).rejects.toThrow(/Media exceeds/i);
+  });
+
+  it("passes a LINE file message filename to saveMediaStream", async () => {
+    const data = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    getMessageContentMock.mockResolvedValueOnce(chunks([data]));
+
+    await downloadLineMedia("mid-file", "token", 10 * 1024 * 1024, "report.pdf");
+
+    expect(saveMediaStreamMock).toHaveBeenCalledTimes(1);
+    const call = saveMediaStreamCall();
+    expect(call[4]).toBe("report.pdf");
+  });
+
+  it("uses the file message filename to detect audio content type", async () => {
+    // No audio magic bytes; only the .mp3 filename hint can classify this as audio.
+    const data = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    getMessageContentMock.mockResolvedValueOnce(chunks([data]));
+
+    const result = await downloadLineMedia("mid-file", "token", 10 * 1024 * 1024, "voice.mp3");
+
+    expect(result.contentType).toBe("audio/mpeg");
   });
 });

--- a/extensions/line/src/download.ts
+++ b/extensions/line/src/download.ts
@@ -13,6 +13,7 @@ export async function downloadLineMedia(
   messageId: string,
   channelAccessToken: string,
   maxBytes = 10 * 1024 * 1024,
+  fileName?: string,
 ): Promise<DownloadResult> {
   const client = new messagingApi.MessagingApiBlobClient({
     channelAccessToken,
@@ -24,6 +25,7 @@ export async function downloadLineMedia(
     undefined,
     "inbound",
     maxBytes,
+    fileName,
   );
   logVerbose(`line: persisted media ${messageId} to ${saved.path} (${saved.size} bytes)`);
 


### PR DESCRIPTION
## What Problem This Solves

Closes the audio-detection half of #96163.

When a LINE user sends an audio file via the file upload feature, the message arrives as `type: \"file\"` (`webhook.FileMessageContent`). That content carries a `fileName` field (e.g. `voice.m4a`), but `extensions/line/src/bot-handlers.ts` discarded it before calling `downloadLineMedia`. The media store therefore received no `originalFilename` hint, so audio formats that lack reliable magic-byte detection could be saved as `.bin` and never routed to the audio transcription pipeline.

The 0-byte download half of #96163 is **not** addressed here; ClawSweeper noted that a high-confidence live repro is still needed for that part.

## Why This Change Was Made

`saveMediaStream` already accepts an `originalFilename` parameter that is used for MIME type classification and extension selection. The LINE plugin simply was not plumbing the available `fileName` metadata into it. Forwarding the existing field is the smallest, backward-compatible fix and aligns LINE file messages with other attachment paths that already provide filename hints.

## User Impact

LINE file-upload audio attachments (`.m4a`, `.mp3`, `.wav`, `.ogg`, etc.) can now be correctly classified as audio by the media store, so they are eligible for transcription by the configured `tools.media.audio` provider. No config or UI change is required.

## Evidence

- Local unit tests:
  - `node scripts/run-vitest.mjs run extensions/line/src/download.test.ts` → 8 passed
  - `node scripts/run-vitest.mjs run extensions/line/src/bot-handlers.test.ts` → 26 passed
- Integration proof using real media store:
  - `node scripts/run-vitest.mjs run extensions/line/src/download.integration.test.ts` → 1 passed
  - Confirms a `.mp3` filename hint yields `audio/mpeg` and a `.mp3` saved file path when the buffer has no audio magic bytes
- Format: `npx oxfmt --write --threads=1 extensions/line/src/download.ts extensions/line/src/bot-handlers.ts extensions/line/src/download.test.ts extensions/line/src/download.integration.test.ts`