### PR TITLE
fix(anthropic-oauth): bound OAuth token endpoint response reads

### DIFF
--- a/src/llm/utils/oauth/anthropic.test.ts
+++ b/src/llm/utils/oauth/anthropic.test.ts
@@ -79,4 +79,26 @@ describe("Anthropic OAuth token responses", () => {
       "Anthropic token refresh returned invalid token fields.",
     );
   });
+
+  it("rejects an oversized Anthropic token refresh response", async () => {
+    let pullCount = 0;
+    const cancel = vi.fn(async () => undefined);
+    const oversizedStream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        controller.enqueue(new Uint8Array(pullCount === 1 ? 16 * 1024 * 1024 + 1 : 1));
+      },
+      cancel,
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(oversizedStream, { status: 200 })),
+    );
+
+    await expect(refreshAnthropicToken("old-refresh-token")).rejects.toThrow("too large");
+
+    expect(pullCount).toBeLessThanOrEqual(2);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
 });

--- a/src/llm/utils/oauth/anthropic.ts
+++ b/src/llm/utils/oauth/anthropic.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Server } from "node:http";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { toErrorObject } from "../../../infra/errors.js";
 import {
   generateOAuthState,
@@ -52,6 +53,10 @@ const CALLBACK_PATH = "/callback";
 const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
 const SCOPES =
   "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+
+/** Max response body bytes for Anthropic OAuth token endpoint (16 MiB). */
+const OAUTH_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+
 async function getNodeApis(): Promise<NodeApis> {
   if (nodeApis) {
     return nodeApis;
@@ -233,7 +238,10 @@ async function postJson(
     signal: buildOAuthRequestSignal({ signal: options.signal, timeoutMs }),
   });
 
-  const responseBody = await response.text();
+  const buffer = await readResponseWithLimit(response, OAUTH_RESPONSE_MAX_BYTES, {
+    onOverflow: ({ size }) => new Error(`Anthropic OAuth response too large: ${size} bytes`),
+  });
+  const responseBody = new TextDecoder().decode(buffer);
 
   if (!response.ok) {
     throw new Error(


### PR DESCRIPTION
## What Problem This Solves

`postJson` in `src/llm/utils/oauth/anthropic.ts` reads the Anthropic OAuth
token endpoint response body with an unbounded `await response.text()`. A
compromised or hijacked OAuth endpoint can stream an arbitrarily large
body and force the runtime to buffer the entire payload before parsing —
an OOM/DoS vector.

## Changes

- `src/llm/utils/oauth/anthropic.ts` — import `readResponseWithLimit`
  from `@openclaw/media-core/read-response-with-limit`; replace
  `await response.text()` with `readResponseWithLimit` at 16 MiB cap +
  `new TextDecoder().decode(buffer)`. Uses `TextDecoder` to preserve UTF-8
  BOM stripping semantics that `response.text()` provides, matching the
  sibling bounded-read pattern in `provider-http-errors.ts:308`.

## Evidence

### Real behavior proof

```text
$ node --import tsx /tmp/verify-anthropic-oauth-overflow.mjs
PASS: readResponseWithLimit threw: Anthropic OAuth response too large: 16777217 bytes
PASS: pullCount = 1 (<= 2 means stream cancelled early)
PASS: stream cancelled = true
```

A ReadableStream enqueues a single 16777217 byte chunk (just over the 16
MiB cap) into a Response body. `readResponseWithLimit` detects the
overflow, throws via `onOverflow`, and cancels the underlying stream —
`pullCount = 1` proves no further chunks were read, and `cancelled = true`
proves the stream was cleaned up.

### Tests

- **New Vitest case `rejects an oversized Anthropic token refresh response`**
  creates a ReadableStream whose first chunk exceeds the 16 MiB cap and
  proves the bounded read cancels the body (`cancel` called once, `pull`
  count ≤ 2) and throws an error containing `"too large"`.
- **Existing 4 Vitest cases unchanged** — normal token exchange, token
  refresh, unsafe lifetime rejection, and secret redaction all pass.
- `pnpm test src/llm/utils/oauth/anthropic.test.ts` → **5 passed (5)**