### PR TITLE
fix(googlechat): throw on non-ok response instead of parsing error body as success

### DIFF
--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -12,7 +12,7 @@ import type { GoogleChatCardV2, GoogleChatReaction } from "./types.js";
 const CHAT_API_BASE = "https://chat.googleapis.com/v1";
 const CHAT_UPLOAD_BASE = "https://chat.googleapis.com/upload/v1";
 
-async function readGoogleChatJsonResponse<T>(response: Response, label: string): Promise<T> {
+export async function readGoogleChatJsonResponse<T>(response: Response, label: string): Promise<T> {
   if (!response.ok) {
     const body = await response.text().catch(() => "");
     throw new Error(`${label}: HTTP ${response.status}${body ? ` — ${body.slice(0, 200)}` : ""}`);

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -13,6 +13,10 @@ const CHAT_API_BASE = "https://chat.googleapis.com/v1";
 const CHAT_UPLOAD_BASE = "https://chat.googleapis.com/upload/v1";
 
 async function readGoogleChatJsonResponse<T>(response: Response, label: string): Promise<T> {
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`${label}: HTTP ${response.status}${body ? ` — ${body.slice(0, 200)}` : ""}`);
+  }
   try {
     return (await response.json()) as T;
   } catch (cause) {


### PR DESCRIPTION
## What Problem This Solves

The `readGoogleChatJsonResponse` helper in `extensions/googlechat/src/api.ts` is used by every Google Chat API call to parse JSON responses. It calls `response.json()` without checking `response.ok` first. When the Google Chat API returns a 4xx/5xx status with a JSON error body (e.g. `{"error":{"message":"Invalid credentials","code":401}}`), `response.json()` succeeds — it parses the error payload as the success type `T`. The caller receives a type-valid "success" response where the actual data is the error object.

The downstream impact: a caller processing a 401 response sees `result.message → undefined` (because the response shape is `{error: ...}` not `{message: ...}`) and has no way to distinguish "API returned a success" from "API returned an error but it got parsed as success." The actual error details (`{"message":"Invalid credentials"}`) are silently embedded in the payload without any signal that an error occurred.

This pattern affects all callers of `withGoogleChatResponse` — send, upload, and any future Google Chat API operations. Every Google Chat API error today gets silently swallowed and replaced with confusing `undefined` values at the call site.

## Changes

- `extensions/googlechat/src/api.ts`: add `response.ok` check before `response.json()` in `readGoogleChatJsonResponse`. On non-ok responses, read the response body text and throw with HTTP status code + body so callers receive a clear error instead of a silently parsed error payload. Export the function for reuse.

## Real behavior proof

- **Behavior addressed**: Google Chat API error responses are parsed as success, hiding HTTP status and error message from callers.
- **Real function used**: `readGoogleChatJsonResponse` (exported from `extensions/googlechat/src/api.ts`, tested via `npx tsx -e` with real `Response` objects).
- **Exact steps**: call `readGoogleChatJsonResponse` with (1) a 401 response carrying an error JSON body, (2) a 200 OK response carrying a success payload.
- **Evidence after fix**:

```
--- Negative control: API returns 401 ---
  Before fix (no ok check):
    result = {"error":{"message":"Invalid credentials","code":401}}
    result.message => undefined (caller thinks it succeeded!)
    result.error   => {"message":"Invalid credentials","code":401}

  After fix (with response.ok check):
    threw => Google Chat send: HTTP 401 — {"error":{"message":"Invalid credentials","code":401}}
             → Clear status + error body for caller to handle

--- Verification: 200 OK unchanged (backward compatible) ---
  After fix: parsed as {"message":"sent","id":"123"} (unchanged)
```
- **Observed result**: error responses now throw with HTTP status + body instead of silently masquerading as success. Normal 200 responses are unchanged.

## Evidence

```
$ node --import tsx -e ...

=== readGoogleChatJsonResponse: add response.ok check ===

--- Negative control: API returns 401 ---
  Before fix (no ok check):
    result = {"error":{"message":"Invalid credentials","code":401}}
    result.message => undefined (caller thinks it succeeded!)
    result.error   => {"message":"Invalid credentials","code":401}

  After fix (with response.ok check):
    threw => Google Chat send: HTTP 401 — {"error":{"message":"Invalid credentials","code":401}}
             → Clear status + error body for caller to handle

--- Verification: 200 OK unchanged (backward compatible) ---
  After fix: parsed as {"message":"sent","id":"123"} (unchanged)
```

**What was not tested**: End-to-end with a real Google Chat API (requires credentials).

---

This is the first PR in a response-ok-check campaign across extensions that call `response.json()` without verifying the HTTP status first. The same pattern exists in ~30 other extensions (firecrawl, feishu, elevenlabs, ollama, openai, etc.) and will be addressed in follow-up PRs.