### PR TITLE
Fix MSTeams card actions with durable receive before ACK

### DIFF
--- a/extensions/msteams/src/card-action-ingress.test.ts
+++ b/extensions/msteams/src/card-action-ingress.test.ts
@@ -1,24 +1,33 @@
 // Msteams tests cover durable card-action admission, replay, retry, and dedupe.
-import { mkdtemp, realpath, rm } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  createMSTeamsCardActionIngress,
-  type MSTeamsCardActionIngressPayload,
-} from "./card-action-ingress.js";
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createMSTeamsCardActionIngress } from "./card-action-ingress.js";
 import type { MSTeamsApp } from "./sdk.js";
 import type { MSTeamsActivity } from "./sdk-types.js";
 
-const stateDirs: string[] = [];
-const disposers: Array<() => void> = [];
+type MSTeamsCardActionIngressPayload = {
+  version: 1;
+  receivedAt: number;
+  activity: MSTeamsActivity;
+};
 
-async function createStateDir(): Promise<string> {
-  const created = await mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-card-action-"));
-  const resolved = await realpath(created);
-  stateDirs.push(resolved);
-  return resolved;
+const disposers: Array<() => void> = [];
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(() => {
+    for (const dispose of disposers.splice(0).toReversed()) {
+      dispose();
+    }
+    closeOpenClawStateDatabaseForTest();
+    cleanup();
+  }),
+);
+
+function createStateDir(): string {
+  return tempDirs.make("openclaw-msteams-card-action-");
 }
 
 function createQueue(stateDir: string) {
@@ -73,18 +82,9 @@ async function drain(ingress: ReturnType<typeof createMSTeamsCardActionIngress>)
   await ingress.waitForIdle();
 }
 
-afterEach(async () => {
-  for (const dispose of disposers.splice(0).toReversed()) {
-    dispose();
-  }
-  for (const stateDir of stateDirs.splice(0).toReversed()) {
-    await rm(stateDir, { recursive: true, force: true });
-  }
-});
-
 describe("createMSTeamsCardActionIngress", () => {
   it("commits a pending SQLite row before enqueue resolves", async () => {
-    const stateDir = await createStateDir();
+    const stateDir = createStateDir();
     const queue = createQueue(stateDir);
     const { app } = createApp();
     const ingress = createMSTeamsCardActionIngress({
@@ -107,7 +107,7 @@ describe("createMSTeamsCardActionIngress", () => {
   });
 
   it("recovers after restart and targets the original Teams thread proactively", async () => {
-    const stateDir = await createStateDir();
+    const stateDir = createStateDir();
     const firstApp = createApp();
     const first = createMSTeamsCardActionIngress({
       app: firstApp.app,
@@ -143,7 +143,7 @@ describe("createMSTeamsCardActionIngress", () => {
   });
 
   it("retries a transient dispatch failure without a restart", async () => {
-    const stateDir = await createStateDir();
+    const stateDir = createStateDir();
     const { app } = createApp();
     let now = 1_000;
     const dispatch = vi
@@ -168,7 +168,7 @@ describe("createMSTeamsCardActionIngress", () => {
   });
 
   it("does not retry an error after the reply lane durably adopts the turn", async () => {
-    const stateDir = await createStateDir();
+    const stateDir = createStateDir();
     const { app } = createApp();
     const dispatch = vi.fn(async (_context, lifecycle) => {
       await lifecycle.onAdopted();
@@ -190,7 +190,7 @@ describe("createMSTeamsCardActionIngress", () => {
   });
 
   it("claim-fences duplicate delivery across concurrent drain instances", async () => {
-    const stateDir = await createStateDir();
+    const stateDir = createStateDir();
     const { app } = createApp();
     const dispatch = vi.fn(async () => {});
     const first = createMSTeamsCardActionIngress({

--- a/extensions/msteams/src/card-action-ingress.test.ts
+++ b/extensions/msteams/src/card-action-ingress.test.ts
@@ -1,13 +1,15 @@
 // Msteams tests cover durable card-action admission, replay, retry, and dedupe.
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { createMSTeamsCardActionIngress } from "./card-action-ingress.js";
-import type { MSTeamsApp } from "./sdk.js";
 import type { MSTeamsActivity } from "./sdk-types.js";
+import type { MSTeamsApp } from "./sdk.js";
 
 type MSTeamsCardActionIngressPayload = {
   version: 1;
@@ -16,18 +18,13 @@ type MSTeamsCardActionIngressPayload = {
 };
 
 const disposers: Array<() => void> = [];
-const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
-  afterEach(() => {
-    for (const dispose of disposers.splice(0).toReversed()) {
-      dispose();
-    }
-    closeOpenClawStateDatabaseForTest();
-    cleanup();
-  }),
-);
+const stateDirs: string[] = [];
 
-function createStateDir(): string {
-  return tempDirs.make("openclaw-msteams-card-action-");
+async function createStateDir(): Promise<string> {
+  const created = await mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-card-action-"));
+  const resolved = await realpath(created);
+  stateDirs.push(resolved);
+  return resolved;
 }
 
 function createQueue(stateDir: string) {
@@ -82,9 +79,19 @@ async function drain(ingress: ReturnType<typeof createMSTeamsCardActionIngress>)
   await ingress.waitForIdle();
 }
 
+afterEach(async () => {
+  for (const dispose of disposers.splice(0).toReversed()) {
+    dispose();
+  }
+  closeOpenClawStateDatabaseForTest();
+  for (const stateDir of stateDirs.splice(0).toReversed()) {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
 describe("createMSTeamsCardActionIngress", () => {
   it("commits a pending SQLite row before enqueue resolves", async () => {
-    const stateDir = createStateDir();
+    const stateDir = await createStateDir();
     const queue = createQueue(stateDir);
     const { app } = createApp();
     const ingress = createMSTeamsCardActionIngress({
@@ -107,7 +114,7 @@ describe("createMSTeamsCardActionIngress", () => {
   });
 
   it("recovers after restart and targets the original Teams thread proactively", async () => {
-    const stateDir = createStateDir();
+    const stateDir = await createStateDir();
     const firstApp = createApp();
     const first = createMSTeamsCardActionIngress({
       app: firstApp.app,
@@ -131,9 +138,7 @@ describe("createMSTeamsCardActionIngress", () => {
     await drain(recovered);
 
     expect(dispatch).toHaveBeenCalledOnce();
-    expect(secondApp.activities).toHaveBeenCalledWith(
-      "19:conversation;messageid=thread-root",
-    );
+    expect(secondApp.activities).toHaveBeenCalledWith("19:conversation;messageid=thread-root");
     expect(secondApp.create).toHaveBeenCalledWith(
       expect.objectContaining({
         conversation: expect.objectContaining({ id: "19:conversation;messageid=thread-root" }),
@@ -143,7 +148,7 @@ describe("createMSTeamsCardActionIngress", () => {
   });
 
   it("retries a transient dispatch failure without a restart", async () => {
-    const stateDir = createStateDir();
+    const stateDir = await createStateDir();
     const { app } = createApp();
     let now = 1_000;
     const dispatch = vi
@@ -168,7 +173,7 @@ describe("createMSTeamsCardActionIngress", () => {
   });
 
   it("does not retry an error after the reply lane durably adopts the turn", async () => {
-    const stateDir = createStateDir();
+    const stateDir = await createStateDir();
     const { app } = createApp();
     const dispatch = vi.fn(async (_context, lifecycle) => {
       await lifecycle.onAdopted();
@@ -190,7 +195,7 @@ describe("createMSTeamsCardActionIngress", () => {
   });
 
   it("claim-fences duplicate delivery across concurrent drain instances", async () => {
-    const stateDir = createStateDir();
+    const stateDir = await createStateDir();
     const { app } = createApp();
     const dispatch = vi.fn(async () => {});
     const first = createMSTeamsCardActionIngress({

--- a/extensions/msteams/src/card-action-ingress.test.ts
+++ b/extensions/msteams/src/card-action-ingress.test.ts
@@ -1,0 +1,215 @@
+// Msteams tests cover durable card-action admission, replay, retry, and dedupe.
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createMSTeamsCardActionIngress,
+  type MSTeamsCardActionIngressPayload,
+} from "./card-action-ingress.js";
+import type { MSTeamsApp } from "./sdk.js";
+import type { MSTeamsActivity } from "./sdk-types.js";
+
+const stateDirs: string[] = [];
+const disposers: Array<() => void> = [];
+
+async function createStateDir(): Promise<string> {
+  const created = await mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-card-action-"));
+  const resolved = await realpath(created);
+  stateDirs.push(resolved);
+  return resolved;
+}
+
+function createQueue(stateDir: string) {
+  return createChannelIngressQueueForTests<MSTeamsCardActionIngressPayload>({
+    channelId: "msteams",
+    accountId: "default",
+    stateDir,
+  });
+}
+
+function createActivity(id = "invoke-1"): MSTeamsActivity {
+  return {
+    type: "invoke",
+    name: "adaptiveCard/action",
+    id,
+    timestamp: "2026-07-17T08:00:00.000Z",
+    serviceUrl: "https://smba.trafficmanager.net/emea",
+    channelId: "msteams",
+    from: { id: "29:user", aadObjectId: "aad-user", name: "Ada" },
+    recipient: { id: "28:bot", name: "OpenClaw" },
+    conversation: {
+      id: "19:conversation;messageid=thread-root",
+      conversationType: "channel",
+    },
+    channelData: {
+      team: { id: "team-1" },
+      tenant: { id: "tenant-1" },
+    },
+    value: { action: { data: { action: "approve" } } },
+  };
+}
+
+function createApp() {
+  const create = vi.fn(async () => ({ id: "reply-1" }));
+  const activities = vi.fn(() => ({
+    create,
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  }));
+  const app = {
+    api: {
+      serviceUrl: "https://smba.trafficmanager.net/emea",
+      teams: { getById: vi.fn(async () => ({ aadGroupId: "group-1" })) },
+      conversations: { activities },
+    },
+  } as unknown as MSTeamsApp;
+  return { app, activities, create };
+}
+
+async function drain(ingress: ReturnType<typeof createMSTeamsCardActionIngress>) {
+  await ingress.drainOnce();
+  await ingress.waitForIdle();
+}
+
+afterEach(async () => {
+  for (const dispose of disposers.splice(0).toReversed()) {
+    dispose();
+  }
+  for (const stateDir of stateDirs.splice(0).toReversed()) {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+describe("createMSTeamsCardActionIngress", () => {
+  it("commits a pending SQLite row before enqueue resolves", async () => {
+    const stateDir = await createStateDir();
+    const queue = createQueue(stateDir);
+    const { app } = createApp();
+    const ingress = createMSTeamsCardActionIngress({
+      app,
+      queue,
+      dispatch: vi.fn(async () => {}),
+    });
+    disposers.push(ingress.dispose);
+
+    await expect(ingress.enqueue(createActivity())).resolves.toMatchObject({
+      kind: "accepted",
+      duplicate: false,
+    });
+    await expect(queue.listPending()).resolves.toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({ version: 1 }),
+        laneKey: "conversation:19:conversation",
+      }),
+    ]);
+  });
+
+  it("recovers after restart and targets the original Teams thread proactively", async () => {
+    const stateDir = await createStateDir();
+    const firstApp = createApp();
+    const first = createMSTeamsCardActionIngress({
+      app: firstApp.app,
+      queue: createQueue(stateDir),
+      dispatch: vi.fn(async () => {}),
+    });
+    disposers.push(first.dispose);
+    await first.enqueue(createActivity("invoke-restart"));
+    first.dispose();
+
+    const secondApp = createApp();
+    const dispatch = vi.fn(async (context) => {
+      await context.sendActivity("recovered");
+    });
+    const recovered = createMSTeamsCardActionIngress({
+      app: secondApp.app,
+      queue: createQueue(stateDir),
+      dispatch,
+    });
+    disposers.push(recovered.dispose);
+    await drain(recovered);
+
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(secondApp.activities).toHaveBeenCalledWith(
+      "19:conversation;messageid=thread-root",
+    );
+    expect(secondApp.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation: expect.objectContaining({ id: "19:conversation;messageid=thread-root" }),
+        channelData: expect.objectContaining({ tenant: { id: "tenant-1" } }),
+      }),
+    );
+  });
+
+  it("retries a transient dispatch failure without a restart", async () => {
+    const stateDir = await createStateDir();
+    const { app } = createApp();
+    let now = 1_000;
+    const dispatch = vi
+      .fn<(context: unknown) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("temporary dispatch failure"))
+      .mockResolvedValue(undefined);
+    const ingress = createMSTeamsCardActionIngress({
+      app,
+      queue: createQueue(stateDir),
+      dispatch,
+      now: () => now,
+      retryPolicy: { baseMs: 10, maxMs: 10 },
+    });
+    disposers.push(ingress.dispose);
+    await ingress.enqueue(createActivity("invoke-retry"));
+
+    await drain(ingress);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    now += 10;
+    await drain(ingress);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry an error after the reply lane durably adopts the turn", async () => {
+    const stateDir = await createStateDir();
+    const { app } = createApp();
+    const dispatch = vi.fn(async (_context, lifecycle) => {
+      await lifecycle.onAdopted();
+      throw new Error("post-adoption failure");
+    });
+    const ingress = createMSTeamsCardActionIngress({
+      app,
+      queue: createQueue(stateDir),
+      dispatch,
+      retryPolicy: { baseMs: 0, maxMs: 0 },
+    });
+    disposers.push(ingress.dispose);
+    await ingress.enqueue(createActivity("invoke-adopted"));
+
+    await drain(ingress);
+    await drain(ingress);
+
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("claim-fences duplicate delivery across concurrent drain instances", async () => {
+    const stateDir = await createStateDir();
+    const { app } = createApp();
+    const dispatch = vi.fn(async () => {});
+    const first = createMSTeamsCardActionIngress({
+      app,
+      queue: createQueue(stateDir),
+      dispatch,
+    });
+    const second = createMSTeamsCardActionIngress({
+      app,
+      queue: createQueue(stateDir),
+      dispatch,
+    });
+    disposers.push(first.dispose, second.dispose);
+
+    await first.enqueue(createActivity("invoke-duplicate"));
+    await second.enqueue(createActivity("invoke-duplicate"));
+    await Promise.all([first.drainOnce(), second.drainOnce()]);
+    await Promise.all([first.waitForIdle(), second.waitForIdle()]);
+
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/msteams/src/card-action-ingress.ts
+++ b/extensions/msteams/src/card-action-ingress.ts
@@ -28,7 +28,7 @@ const CARD_ACTION_COMPLETED_MAX_ENTRIES = 10_000;
 const CARD_ACTION_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const CARD_ACTION_FAILED_MAX_ENTRIES = 1_000;
 
-export type MSTeamsCardActionIngressPayload = {
+type MSTeamsCardActionIngressPayload = {
   version: typeof CARD_ACTION_INGRESS_VERSION;
   receivedAt: number;
   activity: MSTeamsActivity;
@@ -41,10 +41,10 @@ type MSTeamsCardActionTurnAdoptionLifecycle = ReturnType<
 class MSTeamsCardActionIngressPermanentError extends Error {}
 
 function cloneActivity(activity: MSTeamsActivity): MSTeamsActivity {
-  return JSON.parse(JSON.stringify(activity)) as MSTeamsActivity;
+  return structuredClone(activity);
 }
 
-export function resolveMSTeamsCardActionEventId(activity: MSTeamsActivity): string {
+function resolveMSTeamsCardActionEventId(activity: MSTeamsActivity): string {
   const conversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
   const stableIdentity = activity.id?.trim()
     ? [conversationId, activity.id.trim()]

--- a/extensions/msteams/src/card-action-ingress.ts
+++ b/extensions/msteams/src/card-action-ingress.ts
@@ -1,0 +1,211 @@
+// Msteams plugin owns durable admission and replay for non-poll card actions.
+import { createHash } from "node:crypto";
+import {
+  bindIngressLifecycleToReplyOptions,
+  createChannelIngressDrain,
+  type ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { DEFAULT_ACCOUNT_ID } from "../runtime-api.js";
+import type { MSTeamsSdkCloudOptions } from "./cloud.js";
+import { buildStoredConversationReference } from "./conversation-reference.js";
+import { formatUnknownError } from "./errors.js";
+import {
+  extractMSTeamsConversationMessageId,
+  normalizeMSTeamsConversationId,
+} from "./inbound.js";
+import { getMSTeamsRuntime } from "./runtime.js";
+import {
+  deleteMSTeamsActivityWithReference,
+  sendMSTeamsActivityWithReference,
+  updateMSTeamsActivityWithReference,
+} from "./sdk-proactive.js";
+import type { MSTeamsApp } from "./sdk.js";
+import type { MSTeamsActivity, MSTeamsTurnContext } from "./sdk-types.js";
+
+const CARD_ACTION_INGRESS_VERSION = 1;
+const CARD_ACTION_COMPLETED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const CARD_ACTION_COMPLETED_MAX_ENTRIES = 10_000;
+const CARD_ACTION_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const CARD_ACTION_FAILED_MAX_ENTRIES = 1_000;
+
+export type MSTeamsCardActionIngressPayload = {
+  version: typeof CARD_ACTION_INGRESS_VERSION;
+  receivedAt: number;
+  activity: MSTeamsActivity;
+};
+
+type MSTeamsCardActionTurnAdoptionLifecycle = ReturnType<
+  typeof bindIngressLifecycleToReplyOptions
+>["turnAdoptionLifecycle"];
+
+class MSTeamsCardActionIngressPermanentError extends Error {}
+
+function cloneActivity(activity: MSTeamsActivity): MSTeamsActivity {
+  return JSON.parse(JSON.stringify(activity)) as MSTeamsActivity;
+}
+
+export function resolveMSTeamsCardActionEventId(activity: MSTeamsActivity): string {
+  const conversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
+  const stableIdentity = activity.id?.trim()
+    ? [conversationId, activity.id.trim()]
+    : [
+        conversationId,
+        activity.from?.aadObjectId ?? activity.from?.id ?? "",
+        activity.timestamp ?? activity.localTimestamp ?? "",
+        activity.name ?? "",
+        activity.value ?? null,
+      ];
+  return createHash("sha256").update(JSON.stringify(stableIdentity)).digest("hex");
+}
+
+function resolveMSTeamsCardActionLaneKey(activity: MSTeamsActivity, eventId: string): string {
+  const conversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
+  return conversationId ? `conversation:${conversationId}` : `event:${eventId}`;
+}
+
+function parsePayload(payload: MSTeamsCardActionIngressPayload): MSTeamsActivity {
+  if (
+    payload.version !== CARD_ACTION_INGRESS_VERSION ||
+    !payload.activity ||
+    typeof payload.activity !== "object" ||
+    payload.activity.type !== "invoke" ||
+    payload.activity.name !== "adaptiveCard/action"
+  ) {
+    throw new MSTeamsCardActionIngressPermanentError(
+      "Microsoft Teams card-action ingress payload is invalid.",
+    );
+  }
+  return payload.activity;
+}
+
+function createReplayContext(params: {
+  app: MSTeamsApp;
+  activity: MSTeamsActivity;
+  serviceUrlBoundary?: MSTeamsSdkCloudOptions;
+}): MSTeamsTurnContext {
+  const { app, activity, serviceUrlBoundary } = params;
+  const rawConversationId = activity.conversation?.id ?? "";
+  const conversationId = normalizeMSTeamsConversationId(rawConversationId);
+  const conversationType = activity.conversation?.conversationType ?? "personal";
+  const threadId =
+    conversationType === "channel"
+      ? (extractMSTeamsConversationMessageId(rawConversationId) ?? activity.replyToId)
+      : undefined;
+  const reference = buildStoredConversationReference({
+    activity,
+    conversationId,
+    conversationType,
+    teamId: activity.channelData?.team?.id,
+    threadId,
+  });
+  const proactiveOptions = {
+    ...(threadId ? { threadActivityId: threadId } : {}),
+    ...(serviceUrlBoundary ? { serviceUrlBoundary } : {}),
+  };
+  const sendActivity = (outbound: unknown) =>
+    sendMSTeamsActivityWithReference(app, reference, outbound, proactiveOptions);
+  return {
+    activity,
+    sendActivity,
+    sendActivities: async (activities) => {
+      const results: unknown[] = [];
+      for (const outbound of activities) {
+        results.push(await sendActivity(outbound));
+      }
+      return results;
+    },
+    updateActivity: async (outbound) => {
+      const activityId = typeof outbound.id === "string" ? outbound.id : "";
+      return (await updateMSTeamsActivityWithReference(
+        app,
+        reference,
+        activityId,
+        outbound,
+        proactiveOptions,
+      )) as { id?: string } | void;
+    },
+    deleteActivity: async (activityId) => {
+      await deleteMSTeamsActivityWithReference(
+        app,
+        reference,
+        activityId,
+        proactiveOptions,
+      );
+    },
+    getTeamDetails: (teamId) => app.api.teams.getById(teamId),
+  };
+}
+
+export function createMSTeamsCardActionIngress(params: {
+  app: MSTeamsApp;
+  dispatch: (
+    context: MSTeamsTurnContext,
+    turnAdoptionLifecycle: MSTeamsCardActionTurnAdoptionLifecycle,
+  ) => Promise<void>;
+  queue?: ChannelIngressQueue<MSTeamsCardActionIngressPayload>;
+  abortSignal?: AbortSignal;
+  serviceUrlBoundary?: MSTeamsSdkCloudOptions;
+  onLog?: (message: string) => void;
+  now?: () => number;
+  retryPolicy?: { maxAttempts?: number; deadLetterMinAgeMs?: number; baseMs?: number; maxMs?: number };
+}) {
+  const queue =
+    params.queue ??
+    getMSTeamsRuntime().state.openChannelIngressQueue<MSTeamsCardActionIngressPayload>({
+      accountId: DEFAULT_ACCOUNT_ID,
+    });
+  const drain = createChannelIngressDrain<MSTeamsCardActionIngressPayload>({
+    queue,
+    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+    ...(params.onLog ? { onLog: params.onLog } : {}),
+    ...(params.now ? { now: params.now } : {}),
+    ...(params.retryPolicy ? { retryPolicy: params.retryPolicy } : {}),
+    resolveNonRetryableFailure: (error) =>
+      error instanceof MSTeamsCardActionIngressPermanentError
+        ? { reason: "invalid-payload", message: error.message }
+        : null,
+    dispatchClaimedEvent: async (event, lifecycle) => {
+      const activity = parsePayload(event.payload);
+      await params.dispatch(
+        createReplayContext({
+          app: params.app,
+          activity,
+          serviceUrlBoundary: params.serviceUrlBoundary,
+        }),
+        bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle,
+      );
+    },
+    formatError: formatUnknownError,
+  });
+
+  return {
+    enqueue: async (activity: MSTeamsActivity) => {
+      const receivedAt = params.now?.() ?? Date.now();
+      const storedActivity = cloneActivity(activity);
+      const eventId = resolveMSTeamsCardActionEventId(storedActivity);
+      await queue.prune({
+        completedTtlMs: CARD_ACTION_COMPLETED_TTL_MS,
+        completedMaxEntries: CARD_ACTION_COMPLETED_MAX_ENTRIES,
+        failedTtlMs: CARD_ACTION_FAILED_TTL_MS,
+        failedMaxEntries: CARD_ACTION_FAILED_MAX_ENTRIES,
+        ...(params.now ? { now: receivedAt } : {}),
+      });
+      const result = await queue.enqueue(
+        eventId,
+        {
+          version: CARD_ACTION_INGRESS_VERSION,
+          receivedAt,
+          activity: storedActivity,
+        },
+        {
+          receivedAt,
+          laneKey: resolveMSTeamsCardActionLaneKey(storedActivity, eventId),
+        },
+      );
+      return { kind: result.kind, duplicate: result.duplicate };
+    },
+    drainOnce: drain.drainOnce,
+    waitForIdle: drain.waitForIdle,
+    dispose: drain.dispose,
+  };
+}

--- a/extensions/msteams/src/card-action-ingress.ts
+++ b/extensions/msteams/src/card-action-ingress.ts
@@ -9,18 +9,15 @@ import { DEFAULT_ACCOUNT_ID } from "../runtime-api.js";
 import type { MSTeamsSdkCloudOptions } from "./cloud.js";
 import { buildStoredConversationReference } from "./conversation-reference.js";
 import { formatUnknownError } from "./errors.js";
-import {
-  extractMSTeamsConversationMessageId,
-  normalizeMSTeamsConversationId,
-} from "./inbound.js";
+import { extractMSTeamsConversationMessageId, normalizeMSTeamsConversationId } from "./inbound.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import {
   deleteMSTeamsActivityWithReference,
   sendMSTeamsActivityWithReference,
   updateMSTeamsActivityWithReference,
 } from "./sdk-proactive.js";
-import type { MSTeamsApp } from "./sdk.js";
 import type { MSTeamsActivity, MSTeamsTurnContext } from "./sdk-types.js";
+import type { MSTeamsApp } from "./sdk.js";
 
 const CARD_ACTION_INGRESS_VERSION = 1;
 const CARD_ACTION_COMPLETED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -125,12 +122,7 @@ function createReplayContext(params: {
       )) as { id?: string } | void;
     },
     deleteActivity: async (activityId) => {
-      await deleteMSTeamsActivityWithReference(
-        app,
-        reference,
-        activityId,
-        proactiveOptions,
-      );
+      await deleteMSTeamsActivityWithReference(app, reference, activityId, proactiveOptions);
     },
     getTeamDetails: (teamId) => app.api.teams.getById(teamId),
   };
@@ -147,7 +139,12 @@ export function createMSTeamsCardActionIngress(params: {
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
   onLog?: (message: string) => void;
   now?: () => number;
-  retryPolicy?: { maxAttempts?: number; deadLetterMinAgeMs?: number; baseMs?: number; maxMs?: number };
+  retryPolicy?: {
+    maxAttempts?: number;
+    deadLetterMinAgeMs?: number;
+    baseMs?: number;
+    maxMs?: number;
+  };
 }) {
   const queue =
     params.queue ??

--- a/extensions/msteams/src/conversation-reference.ts
+++ b/extensions/msteams/src/conversation-reference.ts
@@ -1,0 +1,44 @@
+// Msteams plugin module builds the canonical proactive conversation reference.
+import { tryNormalizeBotFrameworkServiceUrl } from "./bot-framework-service-url.js";
+import type { StoredConversationReference } from "./conversation-store.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+export function buildStoredConversationReference(params: {
+  activity: MSTeamsTurnContext["activity"];
+  conversationId: string;
+  conversationType: string;
+  teamId?: string;
+  /** Thread root message ID for channel thread messages. */
+  threadId?: string;
+}): StoredConversationReference {
+  const { activity, conversationId, conversationType, teamId, threadId } = params;
+  const from = activity.from;
+  const conversation = activity.conversation;
+  const agent = activity.recipient;
+  const clientInfo = activity.entities?.find((entity) => entity.type === "clientInfo") as
+    | { timezone?: string }
+    | undefined;
+  // Bot Framework requires tenantId on proactive activities. Channel invokes
+  // commonly expose it only through channelData, not conversation.tenantId.
+  const tenantId = activity.channelData?.tenant?.id ?? conversation?.tenantId;
+  const aadObjectId = from?.aadObjectId;
+  const serviceUrl = tryNormalizeBotFrameworkServiceUrl(activity.serviceUrl);
+  return {
+    activityId: activity.id,
+    user: from ? { id: from.id, name: from.name, aadObjectId: from.aadObjectId } : undefined,
+    agent,
+    conversation: {
+      id: conversationId,
+      conversationType,
+      tenantId,
+    },
+    ...(tenantId ? { tenantId } : {}),
+    ...(aadObjectId ? { aadObjectId } : {}),
+    teamId,
+    channelId: activity.channelId,
+    ...(serviceUrl ? { serviceUrl } : {}),
+    locale: activity.locale,
+    ...(clientInfo?.timezone ? { timezone: clientInfo.timezone } : {}),
+    ...(threadId ? { threadId } : {}),
+  };
+}

--- a/extensions/msteams/src/conversation-reference.ts
+++ b/extensions/msteams/src/conversation-reference.ts
@@ -10,7 +10,9 @@ export function buildStoredConversationReference(params: {
   teamId?: string;
   /** Thread root message ID for channel thread messages. */
   threadId?: string;
-}): StoredConversationReference {
+}): StoredConversationReference & {
+  conversation: { id: string; conversationType?: string; tenantId?: string };
+} {
   const { activity, conversationId, conversationType, teamId, threadId } = params;
   const from = activity.from;
   const conversation = activity.conversation;

--- a/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
+++ b/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
@@ -199,6 +199,23 @@ describe("msteams adaptive card action invoke", () => {
     expect(ctxPayload.SenderId).toBe("user-aad");
   });
 
+  it("propagates durable card-action dispatch failures for queue retry", async () => {
+    const deps = createDeps();
+    const handler = createActivityHandler();
+    const registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+    runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mockRejectedValueOnce(
+      new Error("temporary dispatch failure"),
+    );
+
+    await expect(
+      runAdaptiveCardInvoke(registered, {
+        action: { type: "Action.Submit", data: { intent: "retry-me" } },
+      }),
+    ).rejects.toThrow("temporary dispatch failure");
+  });
+
   it("routes Teams imBack actions as the submitted message text", async () => {
     const deps = createDeps();
     const handler = createActivityHandler();

--- a/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
+++ b/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
@@ -71,6 +71,7 @@ async function runAdaptiveCardInvoke(
     run: NonNullable<MSTeamsActivityHandler["run"]>;
   },
   value: unknown,
+  sendActivity = vi.fn(async () => ({ id: "activity-id" })),
 ) {
   await registered.run({
     activity: {
@@ -96,7 +97,7 @@ async function runAdaptiveCardInvoke(
       attachments: [],
       value,
     },
-    sendActivity: vi.fn(async () => ({ id: "activity-id" })),
+    sendActivity,
     sendActivities: async () => [],
   } as unknown as MSTeamsTurnContext);
 }
@@ -208,12 +209,18 @@ describe("msteams adaptive card action invoke", () => {
     runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mockRejectedValueOnce(
       new Error("temporary dispatch failure"),
     );
+    const sendActivity = vi.fn(async () => ({ id: "activity-id" }));
 
     await expect(
-      runAdaptiveCardInvoke(registered, {
-        action: { type: "Action.Submit", data: { intent: "retry-me" } },
-      }),
+      runAdaptiveCardInvoke(
+        registered,
+        {
+          action: { type: "Action.Submit", data: { intent: "retry-me" } },
+        },
+        sendActivity,
+      ),
     ).rejects.toThrow("temporary dispatch failure");
+    expect(sendActivity).not.toHaveBeenCalled();
   });
 
   it("routes Teams imBack actions as the submitted message text", async () => {

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -4,7 +4,10 @@ import { serializeMSTeamsAdaptiveCardActionValue } from "./adaptive-card-submit.
 import { formatUnknownError } from "./errors.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
 import { resolveMSTeamsSenderAccess } from "./monitor-handler/access.js";
-import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.js";
+import {
+  createMSTeamsMessageHandler,
+  type MSTeamsTurnAdoptionLifecycle,
+} from "./monitor-handler/message-handler.js";
 import { createMSTeamsReactionHandler } from "./monitor-handler/reaction-handler.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 import { buildGroupWelcomeText, buildWelcomeCard } from "./welcome-card.js";
@@ -23,6 +26,10 @@ export type MSTeamsActivityHandler = {
     handler: (context: unknown, next: () => Promise<void>) => Promise<void>,
   ) => MSTeamsActivityHandler;
   run?: (context: unknown) => Promise<void>;
+  runCardAction?: (
+    context: MSTeamsTurnContext,
+    turnAdoptionLifecycle?: MSTeamsTurnAdoptionLifecycle,
+  ) => Promise<void>;
 };
 
 async function isInvokeAuthorized(params: {
@@ -136,6 +143,27 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
   const handleTeamsMessage = createMSTeamsMessageHandler(deps);
   const handleReaction = createMSTeamsReactionHandler(deps);
 
+  handler.runCardAction = async (
+    ctx: MSTeamsTurnContext,
+    turnAdoptionLifecycle?: MSTeamsTurnAdoptionLifecycle,
+  ) => {
+    const text = serializeMSTeamsAdaptiveCardActionValue(ctx.activity?.value);
+    if (!text) {
+      return;
+    }
+    await handleTeamsMessage.runImmediate(
+      {
+        ...ctx,
+        activity: {
+          ...ctx.activity,
+          type: "message",
+          text,
+        },
+      },
+      turnAdoptionLifecycle,
+    );
+  };
+
   // Wrap the original run method to intercept invokes
   const originalRun = handler.run;
   if (originalRun) {
@@ -145,18 +173,7 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       // agent can react. Poll votes are intercepted in monitor.ts's
       // app.on("card.action") handler which returns the InvokeResponse to Teams.
       if (ctx.activity?.type === "invoke" && ctx.activity?.name === "adaptiveCard/action") {
-        const text = serializeMSTeamsAdaptiveCardActionValue(ctx.activity?.value);
-        if (text) {
-          await handleTeamsMessage({
-            ...ctx,
-            activity: {
-              ...ctx.activity,
-              type: "message",
-              text,
-            },
-          });
-        }
-        return;
+        return handler.runCardAction?.(ctx);
       }
 
       return originalRun.call(handler, context);

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -976,12 +976,12 @@ describe("msteams monitor handler authz", () => {
     );
 
     const ctx = recordFromMockCall(ctxPayload);
-    expect(ctx.SupplementalContext).toMatchObject({
-      quote: {
-        body: "Quoted body",
-        sender: "Alice",
-      },
+    expect(ctx).toMatchObject({
+      ReplyToBody: "Quoted body",
+      ReplyToSender: "Alice",
+      ReplyToIsQuote: true,
     });
+    expect(ctx).not.toHaveProperty("SupplementalContext");
   });
 
   it("drops quote context when attachment metadata disagrees with a blocked parent sender", async () => {
@@ -994,7 +994,8 @@ describe("msteams monitor handler authz", () => {
     );
 
     const ctx = recordFromMockCall(ctxPayload);
-    expect(ctx.SupplementalContext).toEqual({});
+    expect(ctx.ReplyToBody).toBeUndefined();
+    expect(ctx.ReplyToSender).toBeUndefined();
     expect(ctx.BodyForAgent).toBe("Current message");
   });
 
@@ -1027,7 +1028,11 @@ describe("msteams monitor handler authz", () => {
     // group chat: the fetched body would bypass the supplemental-quote visibility
     // allowlist. Only 1:1 DMs may fetch full text.
     const ctx = recordFromMockCall(firstSettledDispatch().ctxPayload);
-    expect(ctx.SupplementalContext).toMatchObject({ quote: { body: "secret snippet…" } });
+    expect(ctx).toMatchObject({
+      ReplyToBody: "secret snippet…",
+      ReplyToSender: "Victim",
+      ReplyToIsQuote: true,
+    });
     expect(graphThreadMockState.fetchChatMessageText).not.toHaveBeenCalled();
   });
 
@@ -1067,10 +1072,11 @@ describe("msteams monitor handler authz", () => {
         timeoutMs: 10_000,
       }),
     );
-    expect(recordFromMockCall(firstSettledDispatch().ctxPayload).SupplementalContext).toMatchObject(
-      {
-        quote: { id: "message-1", body: "complete quoted message", sender: "Bot" },
-      },
-    );
+    expect(recordFromMockCall(firstSettledDispatch().ctxPayload)).toMatchObject({
+      ReplyToId: "message-1",
+      ReplyToBody: "complete quoted message",
+      ReplyToSender: "Bot",
+      ReplyToIsQuote: true,
+    });
   });
 });

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -1061,9 +1061,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     },
   });
 
-  const buildDebounceEntry = async (
-    context: MSTeamsTurnContext,
-  ): Promise<MSTeamsDebounceEntry> => {
+  const buildDebounceEntry = async (context: MSTeamsTurnContext): Promise<MSTeamsDebounceEntry> => {
     const activity = context.activity;
     const attachments = Array.isArray(activity.attachments)
       ? (activity.attachments as unknown as MSTeamsAttachmentLike[])
@@ -1093,9 +1091,35 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     };
   };
 
-  const handleTeamsMessage = async (context: MSTeamsTurnContext) => {
-    await inboundDebouncer.enqueue(await buildDebounceEntry(context));
-  };
+  async function handleTeamsMessage(context: MSTeamsTurnContext) {
+    const activity = context.activity;
+    const attachments = Array.isArray(activity.attachments)
+      ? (activity.attachments as unknown as MSTeamsAttachmentLike[])
+      : [];
+    const rawText = activity.text?.trim() ?? "";
+    const htmlText = extractTextFromHtmlAttachments(attachments);
+    const valueText =
+      rawText || htmlText ? "" : serializeMSTeamsAdaptiveCardActionValue(activity.value);
+    const text = stripMSTeamsMentionTags(rawText || htmlText || valueText || "");
+    const wasMentioned = wasMSTeamsBotMentioned(activity);
+    const conversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
+    const replyToId = activity.replyToId ?? undefined;
+    const implicitMentionKinds: Array<"reply_to_bot"> =
+      conversationId &&
+      replyToId &&
+      (await wasMSTeamsMessageSentWithPersistence({ conversationId, messageId: replyToId }))
+        ? ["reply_to_bot"]
+        : [];
+
+    await inboundDebouncer.enqueue({
+      context,
+      rawText,
+      text,
+      attachments,
+      wasMentioned,
+      implicitMentionKinds,
+    });
+  }
 
   return Object.assign(handleTeamsMessage, {
     // Durable replays surface pre-adoption failures to the queue and bypass

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -31,7 +31,8 @@ import {
   type MSTeamsAttachmentLike,
 } from "../attachments.js";
 import { extractHtmlFromAttachment } from "../attachments/shared.js";
-import { buildStoredConversationReference } from "../conversation-reference.js";
+import { tryNormalizeBotFrameworkServiceUrl } from "../bot-framework-service-url.js";
+import type { StoredConversationReference } from "../conversation-store.js";
 import { formatUnknownError } from "../errors.js";
 import {
   fetchChannelMessage,
@@ -133,6 +134,49 @@ function formatMSTeamsSenderReason(params: {
     default:
       return params.reasonCode;
   }
+}
+
+function buildStoredConversationReference(params: {
+  activity: MSTeamsTurnContext["activity"];
+  conversationId: string;
+  conversationType: string;
+  teamId?: string;
+  /** Thread root message ID for channel thread messages. */
+  threadId?: string;
+}): StoredConversationReference {
+  const { activity, conversationId, conversationType, teamId, threadId } = params;
+  const from = activity.from;
+  const conversation = activity.conversation;
+  const agent = activity.recipient;
+  const clientInfo = activity.entities?.find((e) => e.type === "clientInfo") as
+    | { timezone?: string }
+    | undefined;
+  // Bot Framework requires `tenantId` on outbound proactive activities so the
+  // connector can route them to the correct Azure AD tenant; missing it causes
+  // HTTP 403. Channel activities often leave `conversation.tenantId` unset, so
+  // prefer the canonical `channelData.tenant.id` source when available.
+  const channelDataTenantId = activity.channelData?.tenant?.id;
+  const tenantId = channelDataTenantId ?? conversation?.tenantId;
+  const aadObjectId = from?.aadObjectId;
+  const serviceUrl = tryNormalizeBotFrameworkServiceUrl(activity.serviceUrl);
+  return {
+    activityId: activity.id,
+    user: from ? { id: from.id, name: from.name, aadObjectId: from.aadObjectId } : undefined,
+    agent,
+    conversation: {
+      id: conversationId,
+      conversationType,
+      tenantId,
+    },
+    ...(tenantId ? { tenantId } : {}),
+    ...(aadObjectId ? { aadObjectId } : {}),
+    teamId,
+    channelId: activity.channelId,
+    ...(serviceUrl ? { serviceUrl } : {}),
+    locale: activity.locale,
+    ...(clientInfo?.timezone ? { timezone: clientInfo.timezone } : {}),
+    ...(threadId ? { threadId } : {}),
+  };
 }
 
 export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -12,6 +12,7 @@ import {
   hasFinalInboundReplyDispatch,
   resolveInboundReplyDispatchCounts,
 } from "openclaw/plugin-sdk/channel-inbound";
+import type { bindIngressLifecycleToReplyOptions } from "openclaw/plugin-sdk/channel-outbound";
 import {
   filterSupplementalContextItems,
   resolveChannelContextVisibilityMode,
@@ -30,8 +31,7 @@ import {
   type MSTeamsAttachmentLike,
 } from "../attachments.js";
 import { extractHtmlFromAttachment } from "../attachments/shared.js";
-import { tryNormalizeBotFrameworkServiceUrl } from "../bot-framework-service-url.js";
-import type { StoredConversationReference } from "../conversation-store.js";
+import { buildStoredConversationReference } from "../conversation-reference.js";
 import { formatUnknownError } from "../errors.js";
 import {
   fetchChannelMessage,
@@ -99,6 +99,10 @@ import {
 } from "./inbound-media.js";
 import { resolveMSTeamsRouteSessionKey } from "./thread-session.js";
 
+export type MSTeamsTurnAdoptionLifecycle = ReturnType<
+  typeof bindIngressLifecycleToReplyOptions
+>["turnAdoptionLifecycle"];
+
 function formatMSTeamsSenderReason(params: {
   reasonCode: string;
   dmPolicy?: string;
@@ -129,49 +133,6 @@ function formatMSTeamsSenderReason(params: {
     default:
       return params.reasonCode;
   }
-}
-
-function buildStoredConversationReference(params: {
-  activity: MSTeamsTurnContext["activity"];
-  conversationId: string;
-  conversationType: string;
-  teamId?: string;
-  /** Thread root message ID for channel thread messages. */
-  threadId?: string;
-}): StoredConversationReference {
-  const { activity, conversationId, conversationType, teamId, threadId } = params;
-  const from = activity.from;
-  const conversation = activity.conversation;
-  const agent = activity.recipient;
-  const clientInfo = activity.entities?.find((e) => e.type === "clientInfo") as
-    | { timezone?: string }
-    | undefined;
-  // Bot Framework requires `tenantId` on outbound proactive activities so the
-  // connector can route them to the correct Azure AD tenant; missing it causes
-  // HTTP 403. Channel activities often leave `conversation.tenantId` unset, so
-  // prefer the canonical `channelData.tenant.id` source when available.
-  const channelDataTenantId = activity.channelData?.tenant?.id;
-  const tenantId = channelDataTenantId ?? conversation?.tenantId;
-  const aadObjectId = from?.aadObjectId;
-  const serviceUrl = tryNormalizeBotFrameworkServiceUrl(activity.serviceUrl);
-  return {
-    activityId: activity.id,
-    user: from ? { id: from.id, name: from.name, aadObjectId: from.aadObjectId } : undefined,
-    agent,
-    conversation: {
-      id: conversationId,
-      conversationType,
-      tenantId,
-    },
-    ...(tenantId ? { tenantId } : {}),
-    ...(aadObjectId ? { aadObjectId } : {}),
-    teamId,
-    channelId: activity.channelId,
-    ...(serviceUrl ? { serviceUrl } : {}),
-    locale: activity.locale,
-    ...(clientInfo?.timezone ? { timezone: clientInfo.timezone } : {}),
-    ...(threadId ? { threadId } : {}),
-  };
 }
 
 export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
@@ -219,7 +180,14 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     implicitMentionKinds: Array<"reply_to_bot">;
   };
 
-  const handleTeamsMessageNow = async (params: MSTeamsDebounceEntry) => {
+  const handleTeamsMessageNow = async (
+    params: MSTeamsDebounceEntry,
+    options?: {
+      rethrowDispatchFailure?: boolean;
+      notifyDispatchFailure?: boolean;
+      turnAdoptionLifecycle?: MSTeamsTurnAdoptionLifecycle;
+    },
+  ) => {
     const context = params.context;
     const activity = context.activity;
     const rawText = params.rawText;
@@ -997,7 +965,9 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
                 ctxPayload,
                 dispatcher,
                 onSettled: () => markDispatchIdle(),
-                replyOptions,
+                replyOptions: options?.turnAdoptionLifecycle
+                  ? { ...replyOptions, turnAdoptionLifecycle: options.turnAdoptionLifecycle }
+                  : replyOptions,
                 configOverride,
               }),
           }),
@@ -1020,10 +990,15 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     } catch (err) {
       log.error("dispatch failed", { error: formatUnknownError(err) });
       runtime.error(`msteams dispatch failed: ${formatUnknownError(err)}`);
-      try {
-        await context.sendActivity("⚠️ Something went wrong. Please try again.");
-      } catch {
-        // Best effort.
+      if (options?.notifyDispatchFailure !== false) {
+        try {
+          await context.sendActivity("⚠️ Something went wrong. Please try again.");
+        } catch {
+          // Best effort.
+        }
+      }
+      if (options?.rethrowDispatchFailure) {
+        throw err;
       }
     }
   };
@@ -1086,7 +1061,9 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     },
   });
 
-  return async function handleTeamsMessage(context: MSTeamsTurnContext) {
+  const buildDebounceEntry = async (
+    context: MSTeamsTurnContext,
+  ): Promise<MSTeamsDebounceEntry> => {
     const activity = context.activity;
     const attachments = Array.isArray(activity.attachments)
       ? (activity.attachments as unknown as MSTeamsAttachmentLike[])
@@ -1106,14 +1083,33 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         ? ["reply_to_bot"]
         : [];
 
-    await inboundDebouncer.enqueue({
+    return {
       context,
       rawText,
       text,
       attachments,
       wasMentioned,
       implicitMentionKinds,
-    });
+    };
   };
+
+  const handleTeamsMessage = async (context: MSTeamsTurnContext) => {
+    await inboundDebouncer.enqueue(await buildDebounceEntry(context));
+  };
+
+  return Object.assign(handleTeamsMessage, {
+    // Durable replays surface pre-adoption failures to the queue and bypass
+    // debounce so an enqueue cannot hide a later dispatch failure.
+    runImmediate: async (
+      context: MSTeamsTurnContext,
+      turnAdoptionLifecycle?: MSTeamsTurnAdoptionLifecycle,
+    ) => {
+      await handleTeamsMessageNow(await buildDebounceEntry(context), {
+        rethrowDispatchFailure: true,
+        notifyDispatchFailure: false,
+        turnAdoptionLifecycle,
+      });
+    },
+  });
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -129,10 +129,20 @@ vi.mock("express", () => {
 });
 
 const registerMSTeamsHandlers = vi.hoisted(() =>
-  vi.fn<RegisterMSTeamsHandlersMock>((handler) => handler),
+  vi.fn<RegisterMSTeamsHandlersMock>((handler) => {
+    handler.runCardAction = vi.fn(async () => {});
+    return handler;
+  }),
 );
 const isSigninInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
 const isCardActionInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
+const cardActionIngress = vi.hoisted(() => ({
+  enqueue: vi.fn(async () => ({ kind: "accepted", duplicate: false })),
+  drainOnce: vi.fn(async () => ({ started: 0 })),
+  waitForIdle: vi.fn(async () => {}),
+  dispose: vi.fn(),
+}));
+const createMSTeamsCardActionIngress = vi.hoisted(() => vi.fn(() => cardActionIngress));
 const runMSTeamsFileConsentInvokeHandler = vi.hoisted(() => vi.fn(async () => {}));
 const loadMSTeamsSdkWithAuth = vi.hoisted(() =>
   vi.fn(async (_creds?: unknown, _options?: unknown) => ({
@@ -164,6 +174,10 @@ vi.mock("./monitor-handler.js", () => ({
   isCardActionInvokeAuthorized,
   isSigninInvokeAuthorized,
   registerMSTeamsHandlers,
+}));
+
+vi.mock("./card-action-ingress.js", () => ({
+  createMSTeamsCardActionIngress,
 }));
 
 vi.mock("./file-consent-invoke.js", () => ({
@@ -296,6 +310,13 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     resolveAllowlistMocks.resolveMSTeamsUserAllowlist.mockReset().mockResolvedValue([]);
     isSigninInvokeAuthorized.mockReset().mockResolvedValue(true);
     isCardActionInvokeAuthorized.mockReset().mockResolvedValue(true);
+    cardActionIngress.enqueue
+      .mockReset()
+      .mockResolvedValue({ kind: "accepted", duplicate: false });
+    cardActionIngress.drainOnce.mockReset().mockResolvedValue({ started: 0 });
+    cardActionIngress.waitForIdle.mockReset().mockResolvedValue(undefined);
+    cardActionIngress.dispose.mockReset();
+    createMSTeamsCardActionIngress.mockClear();
     runMSTeamsFileConsentInvokeHandler.mockReset().mockResolvedValue(undefined);
     ssoTokenStore.get.mockClear();
     ssoTokenStore.save.mockClear();
@@ -761,7 +782,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     await task;
   });
 
-  it("acks non-poll card actions before agent dispatch settles", async () => {
+  it("acks non-poll card actions after the durable commit without waiting for dispatch", async () => {
     const abort = new AbortController();
     const task = monitorMSTeamsProvider({
       cfg: createConfig(0),
@@ -786,28 +807,82 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     if (typeof cardActionHandler !== "function") {
       throw new Error("expected card.action handler");
     }
-    const registeredHandler = registerMSTeamsHandlers.mock.calls[0]?.[0];
-    if (!registeredHandler) {
-      throw new Error("expected registered Teams handler");
-    }
-    let releaseDispatch: (() => void) | undefined;
-    const dispatchWork = new Promise<void>((resolve) => {
-      releaseDispatch = resolve;
+    let releaseCommit: (() => void) | undefined;
+    const commitWork = new Promise<{ kind: "accepted"; duplicate: false }>((resolve) => {
+      releaseCommit = () => resolve({ kind: "accepted", duplicate: false });
     });
-    const run = vi.spyOn(registeredHandler, "run").mockReturnValueOnce(dispatchWork);
+    let releaseDrain: (() => void) | undefined;
+    const drainWork = new Promise<{ started: number }>((resolve) => {
+      releaseDrain = () => resolve({ started: 1 });
+    });
+    cardActionIngress.enqueue.mockReturnValueOnce(commitWork);
+    cardActionIngress.drainOnce.mockReturnValueOnce(drainWork);
+
+    const responsePromise = cardActionHandler({
+      activity: {
+        type: "invoke",
+        name: "adaptiveCard/action",
+        id: "invoke-1",
+        value: { action: { data: { action: "nonPoll" } } },
+      },
+    });
+
+    await vi.waitFor(() => expect(cardActionIngress.enqueue).toHaveBeenCalledTimes(1));
+    let acked = false;
+    void responsePromise.then(() => {
+      acked = true;
+    });
+    await Promise.resolve();
+    expect(acked).toBe(false);
+
+    releaseCommit?.();
+    const response = await responsePromise;
+    expect(response).toMatchObject({ statusCode: 200, value: "OK" });
+    expect(cardActionIngress.drainOnce).toHaveBeenCalled();
+    releaseDrain?.();
+    await drainWork;
+
+    abort.abort();
+    await task;
+  });
+
+  it("does not persist unauthorized non-poll card actions", async () => {
+    const abort = new AbortController();
+    isCardActionInvokeAuthorized.mockResolvedValueOnce(false);
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await waitForMSTeamsTestState(() => {
+      expect(registerMSTeamsHandlers).toHaveBeenCalled();
+    });
+    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
+    if (!sdkResultPromise) {
+      throw new Error("expected loadMSTeamsSdkWithAuth result");
+    }
+    const app = (await sdkResultPromise).app;
+    const cardActionHandler = app.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === "card.action",
+    )?.[1];
+    if (typeof cardActionHandler !== "function") {
+      throw new Error("expected card.action handler");
+    }
 
     const response = await cardActionHandler({
       activity: {
         type: "invoke",
         name: "adaptiveCard/action",
+        id: "invoke-denied",
         value: { action: { data: { action: "nonPoll" } } },
       },
     });
 
-    expect(response).toMatchObject({ statusCode: 200, value: "OK" });
-    expect(run).toHaveBeenCalledTimes(1);
-    releaseDispatch?.();
-    await dispatchWork;
+    expect(response).toMatchObject({ statusCode: 200, value: "Not authorized." });
+    expect(cardActionIngress.enqueue).not.toHaveBeenCalled();
 
     abort.abort();
     await task;

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -772,7 +772,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     await task;
   });
 
-  it("acks non-poll card actions after the durable commit without waiting for dispatch", async () => {
+  it("acks non-poll card actions after the durable commit", async () => {
     const abort = new AbortController();
     const task = monitorMSTeamsProvider({
       cfg: createConfig(0),
@@ -786,15 +786,17 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     const cardActionHandler = app.on.mock.calls.find(
       (call: [string, unknown]) => call[0] === "card.action",
     )?.[1] as (event: unknown) => Promise<unknown>;
-    const commit = Promise.withResolvers<{ kind: "accepted"; duplicate: false }>();
-    const drain = Promise.withResolvers<{ started: number }>();
-    cardActionIngress.enqueue.mockReturnValueOnce(commit.promise);
-    cardActionIngress.drainOnce.mockReturnValueOnce(drain.promise);
+    let releaseCommit: (() => void) | undefined;
+    cardActionIngress.enqueue.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseCommit = () => resolve({ kind: "accepted", duplicate: false });
+        }),
+    );
     const responsePromise = cardActionHandler({
       activity: {
         type: "invoke",
         name: "adaptiveCard/action",
-        id: "invoke-1",
         value: { action: { data: { action: "nonPoll" } } },
       },
     });
@@ -805,10 +807,8 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     });
     await Promise.resolve();
     expect(acked).toBe(false);
-    commit.resolve({ kind: "accepted", duplicate: false });
+    releaseCommit?.();
     expect(await responsePromise).toMatchObject({ statusCode: 200, value: "OK" });
-    expect(cardActionIngress.drainOnce).toHaveBeenCalled();
-    drain.resolve({ started: 1 });
     abort.abort();
     await task;
   });

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -129,10 +129,9 @@ vi.mock("express", () => {
 });
 
 const registerMSTeamsHandlers = vi.hoisted(() =>
-  vi.fn<RegisterMSTeamsHandlersMock>((handler) => {
-    handler.runCardAction = vi.fn(async () => {});
-    return handler;
-  }),
+  vi.fn<RegisterMSTeamsHandlersMock>((handler) =>
+    Object.assign(handler, { runCardAction: vi.fn(async () => {}) }),
+  ),
 );
 const isSigninInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
 const isCardActionInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
@@ -176,9 +175,7 @@ vi.mock("./monitor-handler.js", () => ({
   registerMSTeamsHandlers,
 }));
 
-vi.mock("./card-action-ingress.js", () => ({
-  createMSTeamsCardActionIngress,
-}));
+vi.mock("./card-action-ingress.js", () => ({ createMSTeamsCardActionIngress }));
 
 vi.mock("./file-consent-invoke.js", () => ({
   runMSTeamsFileConsentInvokeHandler,
@@ -310,13 +307,6 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     resolveAllowlistMocks.resolveMSTeamsUserAllowlist.mockReset().mockResolvedValue([]);
     isSigninInvokeAuthorized.mockReset().mockResolvedValue(true);
     isCardActionInvokeAuthorized.mockReset().mockResolvedValue(true);
-    cardActionIngress.enqueue
-      .mockReset()
-      .mockResolvedValue({ kind: "accepted", duplicate: false });
-    cardActionIngress.drainOnce.mockReset().mockResolvedValue({ started: 0 });
-    cardActionIngress.waitForIdle.mockReset().mockResolvedValue(undefined);
-    cardActionIngress.dispose.mockReset();
-    createMSTeamsCardActionIngress.mockClear();
     runMSTeamsFileConsentInvokeHandler.mockReset().mockResolvedValue(undefined);
     ssoTokenStore.get.mockClear();
     ssoTokenStore.save.mockClear();
@@ -791,33 +781,15 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       conversationStore: createStores().conversationStore,
       pollStore: createStores().pollStore,
     });
-
-    await waitForMSTeamsTestState(() => {
-      expect(registerMSTeamsHandlers).toHaveBeenCalled();
-    });
-
-    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
-    if (!sdkResultPromise) {
-      throw new Error("expected loadMSTeamsSdkWithAuth result");
-    }
-    const app = (await sdkResultPromise).app;
+    await waitForMSTeamsTestState(() => expect(registerMSTeamsHandlers).toHaveBeenCalled());
+    const app = (await loadMSTeamsSdkWithAuth.mock.results[0]!.value).app;
     const cardActionHandler = app.on.mock.calls.find(
       (call: [string, unknown]) => call[0] === "card.action",
-    )?.[1];
-    if (typeof cardActionHandler !== "function") {
-      throw new Error("expected card.action handler");
-    }
-    let releaseCommit: (() => void) | undefined;
-    const commitWork = new Promise<{ kind: "accepted"; duplicate: false }>((resolve) => {
-      releaseCommit = () => resolve({ kind: "accepted", duplicate: false });
-    });
-    let releaseDrain: (() => void) | undefined;
-    const drainWork = new Promise<{ started: number }>((resolve) => {
-      releaseDrain = () => resolve({ started: 1 });
-    });
-    cardActionIngress.enqueue.mockReturnValueOnce(commitWork);
-    cardActionIngress.drainOnce.mockReturnValueOnce(drainWork);
-
+    )?.[1] as (event: unknown) => Promise<unknown>;
+    const commit = Promise.withResolvers<{ kind: "accepted"; duplicate: false }>();
+    const drain = Promise.withResolvers<{ started: number }>();
+    cardActionIngress.enqueue.mockReturnValueOnce(commit.promise);
+    cardActionIngress.drainOnce.mockReturnValueOnce(drain.promise);
     const responsePromise = cardActionHandler({
       activity: {
         type: "invoke",
@@ -826,7 +798,6 @@ describe("monitorMSTeamsProvider lifecycle", () => {
         value: { action: { data: { action: "nonPoll" } } },
       },
     });
-
     await vi.waitFor(() => expect(cardActionIngress.enqueue).toHaveBeenCalledTimes(1));
     let acked = false;
     void responsePromise.then(() => {
@@ -834,27 +805,10 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     });
     await Promise.resolve();
     expect(acked).toBe(false);
-
-    releaseCommit?.();
-    const response = await responsePromise;
-    expect(response).toMatchObject({ statusCode: 200, value: "OK" });
+    commit.resolve({ kind: "accepted", duplicate: false });
+    expect(await responsePromise).toMatchObject({ statusCode: 200, value: "OK" });
     expect(cardActionIngress.drainOnce).toHaveBeenCalled();
-    releaseDrain?.();
-    await drainWork;
-
-    cardActionIngress.enqueue.mockClear();
-    isCardActionInvokeAuthorized.mockResolvedValueOnce(false);
-    const deniedResponse = await cardActionHandler({
-      activity: {
-        type: "invoke",
-        name: "adaptiveCard/action",
-        id: "invoke-denied",
-        value: { action: { data: { action: "nonPoll" } } },
-      },
-    });
-    expect(deniedResponse).toMatchObject({ statusCode: 200, value: "Not authorized." });
-    expect(cardActionIngress.enqueue).not.toHaveBeenCalled();
-
+    drain.resolve({ started: 1 });
     abort.abort();
     await task;
   });
@@ -1149,4 +1103,3 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     await task;
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -842,37 +842,9 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     releaseDrain?.();
     await drainWork;
 
-    abort.abort();
-    await task;
-  });
-
-  it("does not persist unauthorized non-poll card actions", async () => {
-    const abort = new AbortController();
+    cardActionIngress.enqueue.mockClear();
     isCardActionInvokeAuthorized.mockResolvedValueOnce(false);
-    const task = monitorMSTeamsProvider({
-      cfg: createConfig(0),
-      runtime: createRuntime(),
-      abortSignal: abort.signal,
-      conversationStore: createStores().conversationStore,
-      pollStore: createStores().pollStore,
-    });
-
-    await waitForMSTeamsTestState(() => {
-      expect(registerMSTeamsHandlers).toHaveBeenCalled();
-    });
-    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
-    if (!sdkResultPromise) {
-      throw new Error("expected loadMSTeamsSdkWithAuth result");
-    }
-    const app = (await sdkResultPromise).app;
-    const cardActionHandler = app.on.mock.calls.find(
-      (call: [string, unknown]) => call[0] === "card.action",
-    )?.[1];
-    if (typeof cardActionHandler !== "function") {
-      throw new Error("expected card.action handler");
-    }
-
-    const response = await cardActionHandler({
+    const deniedResponse = await cardActionHandler({
       activity: {
         type: "invoke",
         name: "adaptiveCard/action",
@@ -880,8 +852,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
         value: { action: { data: { action: "nonPoll" } } },
       },
     });
-
-    expect(response).toMatchObject({ statusCode: 200, value: "Not authorized." });
+    expect(deniedResponse).toMatchObject({ statusCode: 200, value: "Not authorized." });
     expect(cardActionIngress.enqueue).not.toHaveBeenCalled();
 
     abort.abort();
@@ -1178,3 +1149,4 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     await task;
   });
 });
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -10,6 +10,7 @@ import {
   type OpenClawConfig,
   type RuntimeEnv,
 } from "../runtime-api.js";
+import { createMSTeamsCardActionIngress } from "./card-action-ingress.js";
 import { resolveMSTeamsSdkCloudOptions } from "./cloud.js";
 import { createMSTeamsConversationStoreState } from "./conversation-store-state.js";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
@@ -224,8 +225,9 @@ export async function monitorMSTeamsProvider(
   // Lazy-load the SDK and create the App with ExpressAdapter. The SDK
   // registers POST /api/messages (or configured path) and handles JWT
   // validation + body parsing internally.
+  const sdkCloudOptions = resolveMSTeamsSdkCloudOptions(msteamsCfg);
   const { app } = await loadMSTeamsSdkWithAuth(creds, {
-    ...resolveMSTeamsSdkCloudOptions(msteamsCfg),
+    ...sdkCloudOptions,
     httpServerAdapter: await createMSTeamsExpressAdapter(expressApp),
     messagingEndpoint: configuredPath,
     ...(ssoConnectionName ? { oauthDefaultConnectionName: ssoConnectionName } : {}),
@@ -291,6 +293,42 @@ export async function monitorMSTeamsProvider(
     log,
   };
   registerMSTeamsHandlers(handler, handlerDeps);
+  const runCardAction = handler.runCardAction;
+  if (!runCardAction) {
+    throw new Error("Microsoft Teams card-action handler registration failed");
+  }
+  const cardActionIngress = createMSTeamsCardActionIngress({
+    app,
+    abortSignal: opts.abortSignal,
+    serviceUrlBoundary: sdkCloudOptions,
+    dispatch: async (context, turnAdoptionLifecycle) => {
+      await runCardAction(context, turnAdoptionLifecycle);
+    },
+    onLog: (message) => log.warn?.(`msteams ${message}`),
+  });
+  let cardActionDrainPass: Promise<void> | undefined;
+  let cardActionDrainRequested = false;
+  let cardActionDrainTimer: ReturnType<typeof setInterval> | undefined;
+  const requestCardActionDrain = () => {
+    cardActionDrainRequested = true;
+    if (!cardActionDrainPass) {
+      cardActionDrainPass = (async () => {
+        while (cardActionDrainRequested) {
+          cardActionDrainRequested = false;
+          await cardActionIngress.drainOnce();
+        }
+      })()
+        .catch((err: unknown) => {
+          runtime.error(`msteams card-action drain failed: ${formatUnknownError(err)}`);
+        })
+        .finally(() => {
+          cardActionDrainPass = undefined;
+          if (cardActionDrainRequested) {
+            requestCardActionDrain();
+          }
+        });
+    }
+  };
 
   // Handle adaptiveCard/action invokes (Action.Execute Universal Action Model).
   // We must return an InvokeResponse-shaped value so Teams updates the card UI;
@@ -300,18 +338,17 @@ export async function monitorMSTeamsProvider(
     const adaptedCtx = adaptSdkContext(ctx, app);
     try {
       const activity = adaptedCtx.activity;
+      if (!(await isCardActionInvokeAuthorized(adaptedCtx, handlerDeps))) {
+        return {
+          statusCode: 200,
+          type: "application/vnd.microsoft.activity.message",
+          value: "Not authorized.",
+        };
+      }
       const vote = extractMSTeamsPollVote(activity);
       if (vote) {
         const voterId = activity?.from?.aadObjectId ?? activity?.from?.id ?? "unknown";
         try {
-          if (!(await isCardActionInvokeAuthorized(adaptedCtx, handlerDeps))) {
-            return {
-              statusCode: 200,
-              type: "application/vnd.microsoft.activity.message",
-              value: "Not authorized.",
-            };
-          }
-
           const existingPoll = await pollStore.getPoll(vote.pollId);
           if (!existingPoll) {
             log.debug?.("poll vote ignored (poll not found)", { pollId: vote.pollId });
@@ -375,11 +412,10 @@ export async function monitorMSTeamsProvider(
           };
         }
       }
-      // Non-poll card actions may dispatch into the agent. Acknowledge the
-      // invoke immediately so Teams does not time out while that work runs.
-      void handler.run!(adaptedCtx).catch((err: unknown) => {
-        log.error("msteams card.action dispatch failed", { error: formatUnknownError(err) });
-      });
+      // Commit before ACK. The drain owns claim fencing, bounded retries, and
+      // recovery after a process stop between this response and dispatch.
+      await cardActionIngress.enqueue(activity);
+      requestCardActionDrain();
       return {
         statusCode: 200,
         type: "application/vnd.microsoft.activity.message",
@@ -535,12 +571,18 @@ export async function monitorMSTeamsProvider(
 
   // Initialize the SDK App — registers the POST route on Express and sets up
   // JWT validation middleware internally.
-  await app.initialize();
+  try {
+    await app.initialize();
+  } catch (err) {
+    cardActionIngress.dispose();
+    throw err;
+  }
 
   // Start listening and fail fast if bind/listen fails.
   const httpServer = await new Promise<Server>((resolve, reject) => {
     const server = expressApp.listen(port, (err) => (err ? reject(err) : resolve(server)));
   }).catch((err: unknown) => {
+    cardActionIngress.dispose();
     log.error("msteams server error", { error: formatUnknownError(err) });
     throw err;
   });
@@ -550,9 +592,17 @@ export async function monitorMSTeamsProvider(
   httpServer.on("error", (err) => {
     log.error("msteams server error", { error: formatUnknownError(err) });
   });
+  requestCardActionDrain();
+  cardActionDrainTimer = setInterval(requestCardActionDrain, 1_000);
+  cardActionDrainTimer.unref?.();
 
   const shutdown = async () => {
     log.info("shutting down msteams provider");
+    if (cardActionDrainTimer) {
+      clearInterval(cardActionDrainTimer);
+      cardActionDrainTimer = undefined;
+    }
+    cardActionIngress.dispose();
     return new Promise<void>((resolve) => {
       httpServer.close((err) => {
         if (err) {

--- a/extensions/msteams/src/sdk-types.ts
+++ b/extensions/msteams/src/sdk-types.ts
@@ -7,7 +7,7 @@
  * objects), so we model the minimal structural shape we rely on.
  */
 
-type MSTeamsActivity = {
+export type MSTeamsActivity = {
   type: string;
   id?: string;
   timestamp?: string;


### PR DESCRIPTION
## What problem this solves

Microsoft Teams adaptive-card actions were acknowledged before OpenClaw had durably recorded them. If the Gateway stopped after the invoke ACK but before asynchronous dispatch completed, the user saw a successful click while the action could be lost permanently.

## What changed

- Authenticate and normalize non-poll card actions before admitting them.
- Commit the action to the shared SQLite-backed channel ingress queue before returning the invoke ACK.
- Drain the queue asynchronously with bounded retry, dead-letter handling, claim fencing, and startup recovery.
- Derive stable event and conversation-lane identities so duplicate delivery cannot dispatch concurrently.
- Rebuild the Bot Framework conversation reference for proactive replay to the original conversation/thread.
- Keep queue-owned retry attempts silent: dispatch failures are rethrown to the queue without sending a generic failure reply on every attempt.

Normal messages and poll actions keep their existing paths; this change is limited to non-poll adaptive-card actions.

## Evidence

- Real SQLite lifecycle tests cover commit-before-return, restart recovery, bounded transient retry, post-adoption terminal handling, duplicate fencing, and correct conversation/thread replay.
- Focused Teams handler tests cover normal card completion, error propagation to the queue, and verify that retryable failures do not call `sendActivity`.
- The branch is refreshed onto current `main` at `907f5552f5f076f8ae2d50e16a707e4a7258f8c9`.
- [GitHub Actions CI run 29577503313](https://github.com/openclaw/openclaw/actions/runs/29577503313) is green, including changed Node tests, production/test type checks, lint, dependency and package-boundary checks, build artifacts, and `openclaw/ci-gate`.
- The implementation was checked against the pinned `@microsoft/teams.apps` 2.0.13 invoke-response, proactive conversation, and activity-send contracts.

## Live Teams validation limitation

I cannot currently provide redacted live Microsoft Teams evidence because I do not have access to a Microsoft 365 tenant that permits custom Teams app upload.

I attempted to provision a Teams/Microsoft 365 trial, but the required payment-method verification was unsuccessful. The Microsoft 365 E5 developer sandbox is also eligibility-restricted and is not generally available to individual contributors.

After the branch refresh and review fixes above, complete reproduction steps and diagnostics are available, but a maintainer or contributor with an existing Teams development tenant is needed for the final live validation. I have requested maintainer-assisted validation in a PR comment.

Requested live scenarios:

1. Confirm the durable ingress record is committed before the invoke ACK.
2. Confirm a normal non-poll card action completes successfully.
3. Stop the Gateway after ACK and verify recovery after restart.
4. Inject a transient dispatch failure and verify bounded retry without duplicate user-visible failure replies.
5. Confirm duplicate delivery does not cause concurrent duplicate dispatch.
6. Confirm the proactive reply targets the correct conversation/thread.

All logs and recordings must redact tenant IDs, user IDs, service URLs, tokens, credentials, IP addresses, and message content.
