### PR TITLE
fix(slack): keep outbound replies in thread sessions

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -475,6 +475,49 @@ describe("slackPlugin status", () => {
     });
   });
 
+  it("uses the current Slack thread session before inherited child reply ids", async () => {
+    const resolveRoute = slackPlugin.messaging?.resolveOutboundSessionRoute;
+    if (!resolveRoute) {
+      throw new Error("slack messaging.resolveOutboundSessionRoute unavailable");
+    }
+
+    const route = await resolveRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "main",
+      target: "channel:C1",
+      currentSessionKey: "agent:main:slack:channel:C1:thread:1712345678.123456",
+      replyToId: "1712345688.654321",
+    });
+
+    expectRecordFields(route, "Slack route", {
+      sessionKey: "agent:main:slack:channel:c1:thread:1712345678.123456",
+      baseSessionKey: "agent:main:slack:channel:c1",
+      threadId: "1712345678.123456",
+    });
+  });
+
+  it("keeps explicit Slack reply ids ahead of the current thread session", async () => {
+    const resolveRoute = slackPlugin.messaging?.resolveOutboundSessionRoute;
+    if (!resolveRoute) {
+      throw new Error("slack messaging.resolveOutboundSessionRoute unavailable");
+    }
+
+    const route = await resolveRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "main",
+      target: "channel:C1",
+      currentSessionKey: "agent:main:slack:channel:C1:thread:1712345678.123456",
+      replyToId: "1712345688.654321",
+      replyToIsExplicit: true,
+    });
+
+    expectRecordFields(route, "Slack route", {
+      sessionKey: "agent:main:slack:channel:c1:thread:1712345688.654321",
+      baseSessionKey: "agent:main:slack:channel:c1",
+      threadId: "1712345688.654321",
+    });
+  });
+
   it("canonicalizes bare Slack IM channel targets to direct user session routes", async () => {
     const resolveRoute = slackPlugin.messaging?.resolveOutboundSessionRoute;
     if (!resolveRoute) {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -312,6 +312,7 @@ async function resolveSlackOutboundSessionRoute(params: {
   accountId?: string | null;
   target: string;
   replyToId?: string | null;
+  replyToIsExplicit?: boolean;
   threadId?: string | number | null;
   currentSessionKey?: string | null;
 }) {
@@ -373,6 +374,9 @@ async function resolveSlackOutboundSessionRoute(params: {
     replyToId: params.replyToId,
     threadId: params.threadId,
     currentSessionKey: params.currentSessionKey,
+    precedence: params.replyToIsExplicit
+      ? ["replyToId", "threadId", "currentSession"]
+      : ["currentSession", "threadId", "replyToId"],
     canRecoverCurrentThread: () =>
       shouldRecoverSlackThreadFromCurrentSession({
         cfg: params.cfg,
@@ -661,8 +665,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
         }
         return resolveTargetsWithOptionalToken({
           token:
-            normalizeOptionalString(account.userToken) ??
-            normalizeOptionalString(account.botToken),
+            normalizeOptionalString(account.userToken) ?? normalizeOptionalString(account.botToken),
           inputs,
           missingTokenNote: "missing Slack token",
           resolveWithToken: async ({ token, inputs: inputsLocal }) =>

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -647,6 +647,8 @@ export type ChannelMessagingAdapter = {
       source: "normalized" | "directory";
     };
     replyToId?: string | null;
+    /** True when replyToId came from an explicit payload target or reply tag. */
+    replyToIsExplicit?: boolean;
     threadId?: string | number | null;
   }) => ChannelOutboundSessionRoute | Promise<ChannelOutboundSessionRoute | null> | null;
 };

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -122,6 +122,7 @@ describe("message action threading helpers", () => {
         replyToId: threadId == null ? threadId : String(threadId),
         threadId: threadId ?? null,
       }),
+      replyToIsExplicit: false,
       resolveOutboundSessionRoute,
       ensureOutboundSessionEntry,
     });
@@ -129,6 +130,7 @@ describe("message action threading helpers", () => {
     expect(resolveOutboundSessionRoute).toHaveBeenCalledOnce();
     expect(firstMockArg(resolveOutboundSessionRoute)).toMatchObject({
       replyToId: "root-42",
+      replyToIsExplicit: false,
       threadId: "root-42",
     });
   });

--- a/src/infra/outbound/message-action-threading.ts
+++ b/src/infra/outbound/message-action-threading.ts
@@ -211,6 +211,7 @@ export async function prepareOutboundMirrorRoute(params: {
           currentSessionKey: params.currentSessionKey,
           resolvedTarget: params.resolvedTarget,
           replyToId,
+          replyToIsExplicit: params.replyToIsExplicit,
           threadId: resolvedThreadId,
         })
       : null;

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -39,6 +39,7 @@ export type ResolveOutboundSessionRouteParams = {
   currentSessionKey?: string;
   resolvedTarget?: ResolvedMessagingTarget;
   replyToId?: string | null;
+  replyToIsExplicit?: boolean;
   threadId?: string | number | null;
 };
 


### PR DESCRIPTION
Closes #96535

## What Problem This Solves

Fixes an issue where Slack thread replies could create new outbound delivery-mirror sessions keyed by a child reply timestamp instead of reusing the existing thread session. This caused assistant-only mirror sessions to accumulate for one Slack conversation.

## Why This Change Was Made

Slack outbound session routing now treats inherited reply metadata differently from explicit reply targets. Inherited same-thread sends prefer the recovered/current Slack thread session, while explicit reply targets still keep the existing reply-first behavior. The generic SDK route-helper default remains unchanged for other channels.

## User Impact

Slack users should see outbound mirrored replies stay attached to the existing Slack thread session instead of producing near-empty sibling session records for each reply.

## Evidence

- Red proof before fix: `node scripts/run-vitest.mjs extensions/slack/src/channel.test.ts -t "uses the current Slack thread session before inherited child reply ids"` failed because the route used `:thread:1712345688.654321` instead of the current thread `:thread:1712345678.123456`.
- Focused proof after fix: `node scripts/run-vitest.mjs extensions/slack/src/channel.test.ts src/plugin-sdk/thread-aware-outbound-session-route.test.ts src/infra/outbound/message-action-runner.threading.test.ts` passed 3 Vitest shards / 75 tests.
- `git diff --check` passed.
- AI-assisted change. The repo-local autoreview helper was attempted, but the local approval layer blocked it because it would send the unpushed local diff to external model services. I performed a manual two-lens review instead: runtime correctness and contract/scope review found no follow-up changes needed.
