### PR TITLE
feat: allow before-agent-run prompt transforms

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -301,9 +301,15 @@ so your plugin does not depend on a legacy combined phase.
 including prompt-local image loading and `llm_input` observation. It receives
 the current user input as `prompt`, plus loaded session history in `messages`
 and the active system prompt. Return `{ outcome: "block", reason, message? }`
-to stop the run before the model can read the prompt. `reason` is internal;
-`message` is the user-facing replacement. The only supported outcomes are
-`pass` and `block`; unsupported decision shapes fail closed.
+to stop the run before the model can read the prompt. Return
+`{ outcome: "transform", prompt }` to replace only the current model-bound user
+prompt and continue the same run. The transformed prompt is what the model and
+`llm_input` observers receive; the stored transcript prompt is not rewritten.
+`reason` is internal; `message` is the user-facing replacement for blocks.
+Supported outcomes are `pass`, `transform`, and `block`; unsupported decision
+shapes fail closed. When multiple plugins return decisions, `block` wins over
+`transform`, `transform` wins over `pass`, and the first transform at the same
+priority order is kept.
 
 When a run is blocked, OpenClaw stores only the replacement text in
 `message.content` plus non-sensitive block metadata such as the blocking plugin

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -2773,6 +2773,95 @@ describe("runCliAgent reliability", () => {
     }
   });
 
+  it("uses before_agent_run transform for CLI model input while preserving transcript text", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const sensitivePrompt = "Hi OpenClaw, my credit card is 4111111111111111";
+    const redactedPrompt = "Hi OpenClaw, my credit card is [CreditCardNumber]";
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) =>
+        ["before_agent_run", "llm_input"].includes(hookName),
+      ),
+      runBeforeAgentRun: vi.fn(async () => ({
+        pluginId: "redactor",
+        decision: {
+          outcome: "transform" as const,
+          prompt: redactedPrompt,
+          reason: "redacted payment card",
+        },
+      })),
+      runLlmInput: vi.fn(async () => undefined),
+    };
+    setHookRunnerForTest(hookRunner);
+    const { dir, sessionFile } = createSessionFile();
+
+    try {
+      const context = buildPreparedContext({
+        sessionKey: "agent:main:main",
+        runId: "run-cli-transform",
+        openClawHistoryPrompt: [
+          "Continue this conversation using the OpenClaw transcript below as prior session history.",
+          "",
+          "<conversation_history>",
+          "User: earlier context",
+          "</conversation_history>",
+          "",
+          "<next_user_message>",
+          sensitivePrompt,
+          "</next_user_message>",
+        ].join("\n"),
+      });
+      await runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          agentId: "main",
+          sessionFile,
+          workspaceDir: dir,
+          prompt: sensitivePrompt,
+          userTurnTranscriptRecorder: createCliUserTurnRecorder({
+            text: sensitivePrompt,
+            sessionFile,
+            sessionKey: "agent:main:main",
+            workspaceDir: dir,
+          }),
+        },
+      });
+
+      expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+      const beforeRunEvent = requireRecord(
+        callArg(hookRunner.runBeforeAgentRun, 0, 0, "before_agent_run event"),
+        "before_agent_run event",
+      );
+      expect(beforeRunEvent.prompt).toBe(sensitivePrompt);
+      const llmInputEvent = requireRecord(
+        callArg(hookRunner.runLlmInput, 0, 0, "llm_input event"),
+        "llm_input event",
+      );
+      expect(llmInputEvent.prompt).toBe(redactedPrompt);
+      expect(JSON.stringify(llmInputEvent)).not.toContain("4111111111111111");
+      expect(JSON.stringify(supervisorSpawnMock.mock.calls)).toContain("[CreditCardNumber]");
+      expect(JSON.stringify(supervisorSpawnMock.mock.calls)).not.toContain("4111111111111111");
+
+      const lines = fs.readFileSync(sessionFile, "utf-8").trim().split("\n");
+      const userTurnLine = JSON.parse(lines[lines.length - 1]);
+      expect(JSON.stringify(userTurnLine)).toContain(sensitivePrompt);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("forwards channel identity context to CLI before_agent_run hooks", async () => {
     supervisorSpawnMock.mockClear();
     const hookRunner = {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -123,6 +123,31 @@ function formatCliEmptyOutputDiagnostics(output: CliOutput): string | undefined 
   ].join(" ");
 }
 
+function replaceCliHistoryPromptCurrentTurn(params: {
+  historyPrompt: string | undefined;
+  prompt: string;
+}): string | undefined {
+  if (!params.historyPrompt) {
+    return undefined;
+  }
+  const start = "<next_user_message>\n";
+  const end = "\n</next_user_message>";
+  const startIndex = params.historyPrompt.indexOf(start);
+  if (startIndex === -1) {
+    return params.historyPrompt;
+  }
+  const contentStart = startIndex + start.length;
+  const endIndex = params.historyPrompt.indexOf(end, contentStart);
+  if (endIndex === -1) {
+    return params.historyPrompt;
+  }
+  return [
+    params.historyPrompt.slice(0, contentStart),
+    params.prompt,
+    params.historyPrompt.slice(endIndex),
+  ].join("");
+}
+
 /** Checks whether a Claude CLI session binding has reached its transcript file. */
 export async function isCliBindingFlushed(
   sessionId: string | undefined,
@@ -528,16 +553,18 @@ export async function runPreparedCliAgent(
         config: params.config,
       })
     : [];
-  const llmInputEvent = {
-    runId: params.runId,
-    sessionId: params.sessionId,
-    provider: params.provider,
-    model: context.modelId,
-    systemPrompt: context.systemPrompt,
-    prompt: params.prompt,
-    historyMessages,
-    imagesCount: params.images?.length ?? 0,
-  } as const;
+  let modelBoundPrompt = params.prompt;
+  const buildLlmInputEvent = () =>
+    ({
+      runId: params.runId,
+      sessionId: params.sessionId,
+      provider: params.provider,
+      model: context.modelId,
+      systemPrompt: context.systemPrompt,
+      prompt: modelBoundPrompt,
+      historyMessages,
+      imagesCount: params.images?.length ?? 0,
+    }) as const;
   const hookContext = {
     runId: params.runId,
     jobId: params.jobId,
@@ -794,7 +821,7 @@ export async function runPreparedCliAgent(
   };
 
   const executeCliAttempt = async (cliSessionIdToUse?: string, timeoutMs = params.timeoutMs) => {
-    const attemptContext =
+    const baseAttemptContext =
       timeoutMs === params.timeoutMs
         ? context
         : {
@@ -802,6 +829,20 @@ export async function runPreparedCliAgent(
             params: {
               ...context.params,
               timeoutMs,
+            },
+          };
+    const attemptContext =
+      modelBoundPrompt === params.prompt
+        ? baseAttemptContext
+        : {
+            ...baseAttemptContext,
+            openClawHistoryPrompt: replaceCliHistoryPromptCurrentTurn({
+              historyPrompt: baseAttemptContext.openClawHistoryPrompt,
+              prompt: modelBoundPrompt,
+            }),
+            params: {
+              ...baseAttemptContext.params,
+              prompt: modelBoundPrompt,
             },
           };
     const output = await executePreparedCliRun(attemptContext, cliSessionIdToUse);
@@ -1145,11 +1186,14 @@ export async function runPreparedCliAgent(
         });
         return buildBlockedBeforeAgentRunResult(blockMessage);
       }
+      if (beforeRunDecision?.outcome === "transform") {
+        modelBoundPrompt = beforeRunDecision.prompt;
+      }
     }
 
     await persistApprovedCliUserTurnTranscript(params);
     runAgentHarnessLlmInputHook({
-      event: llmInputEvent,
+      event: buildLlmInputEvent(),
       ctx: hookContext,
       hookRunner,
     });

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -12,6 +12,12 @@ import {
   registerMemoryPromptSection,
 } from "../../../plugins/memory-state.js";
 import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../../infra/diagnostic-events.js";
+import {
   type AttemptContextEngine,
   buildLoopPromptCacheInfo,
   assembleAttemptContextEngine,
@@ -1971,6 +1977,127 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(result.finalPromptText).toBeUndefined();
     expect(result.promptErrorSource).toBe("hook:before_agent_run");
     expectInitialLockReleasedBeforePostTurnWrite(lockEvents);
+  });
+
+  it("uses before_agent_run transform only at the model boundary", async () => {
+    const sensitivePrompt = "Hi OpenClaw, my credit card is 4111111111111111";
+    const redactedPrompt = "Hi OpenClaw, my credit card is [CreditCardNumber]";
+    const runBeforeAgentRun = vi.fn(async () => ({
+      pluginId: "redactor",
+      decision: {
+        outcome: "transform" as const,
+        prompt: redactedPrompt,
+        reason: "redacted payment card",
+      },
+    }));
+    const runLlmInput = vi.fn(async () => {});
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((name: string) => name === "before_agent_run" || name === "llm_input"),
+      runBeforeAgentRun,
+      runLlmInput,
+    });
+    let transcriptPrompt: string | undefined;
+    let providerMessages: unknown[] = [];
+    const contextAssembledEvents: DiagnosticEventPayload[] = [];
+    resetDiagnosticEventsForTest();
+    const stopDiagnostics = onInternalDiagnosticEvent((event) => {
+      if (event.type === "context.assembled") {
+        contextAssembledEvents.push(event);
+      }
+    });
+
+    try {
+      const result = await createContextEngineAttemptRunner({
+        contextEngine: createContextEngineBootstrapAndAssemble(),
+        sessionKey,
+        tempPaths,
+        trajectory: true,
+        attemptOverrides: {
+          prompt: sensitivePrompt,
+        },
+        sessionPrompt: async (session, prompt) => {
+          transcriptPrompt = prompt;
+          const transformContext = (
+            session.agent as {
+              transformContext?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
+            }
+          ).transformContext;
+          if (!transformContext) {
+            throw new Error("expected model prompt transform");
+          }
+          providerMessages = await transformContext([
+            ...session.messages,
+            {
+              role: "user",
+              content: [{ type: "text", text: prompt }],
+              timestamp: 2,
+            } as AgentMessage,
+          ]);
+          session.messages = [...session.messages, doneMessage];
+        },
+      });
+      await waitForDiagnosticEventsDrained();
+
+      expect(transcriptPrompt).toBe(sensitivePrompt);
+      expect(result.finalPromptText).toBe(redactedPrompt);
+      expect(JSON.stringify(result)).not.toContain("4111111111111111");
+      expect(JSON.stringify(providerMessages)).toContain(redactedPrompt);
+      const contextAssembled = findRecord(
+        contextAssembledEvents as Array<Record<string, unknown>>,
+        (event) => event.type === "context.assembled",
+        "context assembled diagnostic",
+      );
+      expect(contextAssembled.promptChars).toBe(redactedPrompt.length);
+      expect(JSON.stringify(contextAssembled)).not.toContain("4111111111111111");
+      const llmInputEvent = mockParams(runLlmInput as MockCallSource, 0, "llm_input params");
+      expect(llmInputEvent.prompt).toContain("[CreditCardNumber]");
+      expect(JSON.stringify(llmInputEvent)).not.toContain("4111111111111111");
+      const imageDetectionInput = requireRecord(
+        mockArg(hoisted.detectAndLoadPromptImagesMock, 0, 0, "image detection input"),
+        "image detection input",
+      );
+      expect(imageDetectionInput.prompt).toContain("[CreditCardNumber]");
+      expect(JSON.stringify(imageDetectionInput)).not.toContain("4111111111111111");
+      const trajectoryEvents = (
+        await fs.readFile(path.join(tempPaths[0] ?? "", "session.trajectory.jsonl"), "utf8")
+      )
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as TrajectoryEvent);
+      const modelBoundEvents = trajectoryEvents.filter((event) =>
+        ["context.compiled", "prompt.submitted", "model.completed", "trace.artifacts"].includes(
+          event.type ?? "",
+        ),
+      );
+      expect(JSON.stringify(modelBoundEvents)).toContain("[CreditCardNumber]");
+      expect(JSON.stringify(modelBoundEvents)).not.toContain("4111111111111111");
+      const contextCompiled = findRecord(
+        modelBoundEvents as Array<Record<string, unknown>>,
+        (event) => event.type === "context.compiled",
+        "context compiled event",
+      );
+      expect(requireRecord(contextCompiled.data, "context compiled data").prompt).toBe(
+        redactedPrompt,
+      );
+      const modelCompleted = findRecord(
+        modelBoundEvents as Array<Record<string, unknown>>,
+        (event) => event.type === "model.completed",
+        "model completed event",
+      );
+      expect(requireRecord(modelCompleted.data, "model completed data").finalPromptText).toBe(
+        redactedPrompt,
+      );
+      const traceArtifacts = findRecord(
+        modelBoundEvents as Array<Record<string, unknown>>,
+        (event) => event.type === "trace.artifacts",
+        "trace artifacts event",
+      );
+      expect(requireRecord(traceArtifacts.data, "trace artifacts data").finalPromptText).toBe(
+        redactedPrompt,
+      );
+    } finally {
+      stopDiagnostics();
+    }
   });
 
   it("preserves provider prompt errors when cleanup reacquire detects session takeover", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2026,7 +2026,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
             throw new Error("expected model prompt transform");
           }
           providerMessages = await transformContext([
-            ...session.messages,
+            ...(session.messages as AgentMessage[]),
             {
               role: "user",
               content: [{ type: "text", text: prompt }],

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4222,6 +4222,8 @@ export async function runEmbeddedAttempt(
             context: params.currentInboundContext,
             prompt: promptSubmission.modelPrompt ?? promptSubmission.prompt,
           });
+          let modelBoundPrompt = promptForModel;
+          let beforeAgentRunTransformedPrompt = false;
           currentUserTimestampOverride =
             !isRawModelRun && typeof preparedUserTurnMessage?.timestamp === "number"
               ? {
@@ -4260,7 +4262,7 @@ export async function runEmbeddedAttempt(
           if (systemPromptReport) {
             systemPromptReport.currentTurn = {
               ...(params.currentInboundEventKind ? { kind: params.currentInboundEventKind } : {}),
-              promptChars: promptForModel.length,
+              promptChars: modelBoundPrompt.length,
               runtimeContextChars: promptSubmission.runtimeOnly
                 ? (runtimeSystemContext?.length ?? 0)
                 : (runtimeContextForHook?.length ?? 0),
@@ -4363,7 +4365,13 @@ export async function runEmbeddedAttempt(
               promptError = new Error(blockReplacementMsg);
               promptErrorSource = "hook:before_agent_run";
               skipPromptSubmission = true;
+            } else if (beforeRunDecision?.outcome === "transform") {
+              modelBoundPrompt = beforeRunDecision.prompt;
+              beforeAgentRunTransformedPrompt = true;
             }
+          }
+          if (systemPromptReport?.currentTurn) {
+            systemPromptReport.currentTurn.promptChars = modelBoundPrompt.length;
           }
 
           if (!skipPromptSubmission) {
@@ -4409,8 +4417,10 @@ export async function runEmbeddedAttempt(
             });
           }
 
-          // Detect and load images referenced in the visible prompt for vision-capable models.
-          // Images are prompt-local only.
+          const imageDetectionPrompt =
+            modelBoundPrompt === promptForModel ? promptSubmission.prompt : modelBoundPrompt;
+          // Images are prompt-local. A transform replaces the model-bound prompt,
+          // so image refs must follow the transformed text instead of the transcript.
           const imageResult = skipPromptSubmission
             ? {
                 images: [],
@@ -4419,7 +4429,7 @@ export async function runEmbeddedAttempt(
                 skippedCount: 0,
               }
             : await detectAndLoadPromptImages({
-                prompt: promptSubmission.prompt,
+                prompt: imageDetectionPrompt,
                 workspaceDir: effectiveWorkspace,
                 model: params.model,
                 existingImages: params.images,
@@ -4436,18 +4446,18 @@ export async function runEmbeddedAttempt(
 
           if (!skipPromptSubmission) {
             cacheTrace?.recordStage("prompt:before", {
-              prompt: promptForModel,
+              prompt: modelBoundPrompt,
               messages: activeSession.messages,
             });
             cacheTrace?.recordStage("prompt:images", {
-              prompt: promptForModel,
+              prompt: modelBoundPrompt,
               messages: activeSession.messages,
               note: `images: prompt=${imageResult.images.length}`,
             });
             const trajectoryProviderVisibleTools = toTrajectoryToolDefinitions(effectiveTools);
             trajectoryRecorder?.recordEvent("context.compiled", {
               systemPrompt: systemPromptForHook,
-              prompt: promptForModel,
+              prompt: modelBoundPrompt,
               messages: activeSession.messages,
               tools: toTrajectoryToolDefinitions(
                 toolSearch.compacted ? uncompactedEffectiveTools : effectiveTools,
@@ -4465,7 +4475,7 @@ export async function runEmbeddedAttempt(
           const promptSkipReason = skipPromptSubmission
             ? null
             : resolvePromptSubmissionSkipReason({
-                prompt: promptForModel,
+                prompt: modelBoundPrompt,
                 messages: activeSession.messages,
                 runtimeOnly: promptSubmission.runtimeOnly,
                 imageCount: imageResult.images.length,
@@ -4482,7 +4492,7 @@ export async function runEmbeddedAttempt(
             }
             trajectoryRecorder?.recordEvent("prompt.skipped", {
               reason: promptSkipReason,
-              prompt: promptForModel,
+              prompt: modelBoundPrompt,
               messages: activeSession.messages,
               imagesCount: imageResult.images.length,
             });
@@ -4490,7 +4500,9 @@ export async function runEmbeddedAttempt(
 
           const msgCount = activeSession.messages.length;
           const systemLen = systemPromptText?.length ?? 0;
-          const promptLen = effectivePrompt.length;
+          const promptLen = beforeAgentRunTransformedPrompt
+            ? modelBoundPrompt.length
+            : effectivePrompt.length;
           const sessionSummary = summarizeSessionContext(activeSession.messages);
           const reserveTokens = settingsManager.getCompactionReserveTokens();
           emitTrustedDiagnosticEvent({
@@ -4536,7 +4548,7 @@ export async function runEmbeddedAttempt(
           }
 
           const llmBoundaryPromptForPrecheck = normalizeCurrentPromptTextForLlmBoundary({
-            prompt: promptForModel,
+            prompt: modelBoundPrompt,
             ...(boundaryTimezone ? { timezone: boundaryTimezone } : {}),
             ...(includeBoundaryTimestamp ? {} : { includeTimestamp: false }),
             ...(typeof preparedUserTurnMessage?.timestamp === "number"
@@ -4751,9 +4763,9 @@ export async function runEmbeddedAttempt(
                 }
               };
             };
-            finalPromptText = promptForSession;
+            finalPromptText = beforeAgentRunTransformedPrompt ? modelBoundPrompt : promptForSession;
             trajectoryRecorder?.recordEvent("prompt.submitted", {
-              prompt: promptForModel,
+              prompt: modelBoundPrompt,
               systemPrompt: systemPromptForHook,
               messages: activeSession.messages,
               imagesCount: imageResult.images.length,
@@ -4768,7 +4780,7 @@ export async function runEmbeddedAttempt(
             const cleanupModelPromptTransform = installModelPromptTransform({
               session: activeSession,
               transcriptPrompt: promptForSession,
-              modelPrompt: promptForModel,
+              modelPrompt: modelBoundPrompt,
               prependContext: promptBuildPrependContext,
               appendContext: promptBuildAppendContext,
               shouldCapturePrompt: () => captureCurrentPromptForModel,

--- a/src/plugins/hook-decision-types.test.ts
+++ b/src/plugins/hook-decision-types.test.ts
@@ -13,6 +13,7 @@ describe("HookDecision helpers", () => {
   describe("isHookDecision", () => {
     it("recognizes supported outcomes", () => {
       expect(isHookDecision({ outcome: "pass" })).toBe(true);
+      expect(isHookDecision({ outcome: "transform", prompt: "redacted prompt" })).toBe(true);
       expect(isHookDecision({ outcome: "block", reason: "policy" })).toBe(true);
     });
 
@@ -25,6 +26,10 @@ describe("HookDecision helpers", () => {
       expect(isHookDecision({ outcome: "invalid" })).toBe(false);
       expect(isHookDecision({ outcome: "pass", message: "typo" })).toBe(false);
       expect(isHookDecision({ outcome: "pass", reason: "typo" })).toBe(false);
+      expect(isHookDecision({ outcome: "transform" })).toBe(false);
+      expect(isHookDecision({ outcome: "transform", prompt: "" })).toBe(false);
+      expect(isHookDecision({ outcome: "transform", prompt: "safe", messages: [] })).toBe(false);
+      expect(isHookDecision({ outcome: "transform", prompt: "safe", metadata: [] })).toBe(false);
       expect(isHookDecision({ outcome: "block" })).toBe(false);
       expect(isHookDecision({ outcome: "block", reason: "" })).toBe(false);
       expect(isHookDecision({ outcome: "block", reason: "policy", message: "" })).toBe(false);
@@ -36,18 +41,25 @@ describe("HookDecision helpers", () => {
 
   describe("mergeHookDecisions", () => {
     const passDecision: HookDecision = { outcome: "pass" };
+    const transformDecision: HookDecision = { outcome: "transform", prompt: "redacted prompt" };
     const blockDecision: HookDecision = { outcome: "block", reason: "policy" };
 
     it("uses most-restrictive-wins ordering", () => {
       expect(mergeHookDecisions(undefined, passDecision)).toBe(passDecision);
+      expect(mergeHookDecisions(passDecision, transformDecision)).toBe(transformDecision);
+      expect(mergeHookDecisions(transformDecision, passDecision)).toBe(transformDecision);
+      expect(mergeHookDecisions(transformDecision, blockDecision)).toBe(blockDecision);
+      expect(mergeHookDecisions(blockDecision, transformDecision)).toBe(blockDecision);
       expect(mergeHookDecisions(passDecision, blockDecision)).toBe(blockDecision);
       expect(mergeHookDecisions(blockDecision, passDecision)).toBe(blockDecision);
     });
 
     it("keeps the first decision when outcomes have the same severity", () => {
       const secondBlock: HookDecision = { outcome: "block", reason: "second" };
+      const secondTransform: HookDecision = { outcome: "transform", prompt: "second" };
 
       expect(mergeHookDecisions(passDecision, { outcome: "pass" })).toBe(passDecision);
+      expect(mergeHookDecisions(transformDecision, secondTransform)).toBe(transformDecision);
       expect(mergeHookDecisions(blockDecision, secondBlock)).toBe(blockDecision);
     });
   });

--- a/src/plugins/hook-decision-types.ts
+++ b/src/plugins/hook-decision-types.ts
@@ -3,7 +3,7 @@
  * Core is outcome-agnostic — it handles the mechanics of each outcome
  * without knowing *why* the decision was made.
  */
-export type HookDecision = HookDecisionPass | HookDecisionBlock;
+export type HookDecision = HookDecisionPass | HookDecisionTransform | HookDecisionBlock;
 
 /** Content is fine. Proceed normally. */
 export type HookDecisionPass = {
@@ -29,6 +29,21 @@ export type HookDecisionBlock = {
   metadata?: Record<string, unknown>;
 };
 
+/**
+ * Content can proceed after replacing the current model-bound prompt. The
+ * replacement is sent to the model and model-input observers; it does not
+ * rewrite the stored transcript prompt.
+ */
+export type HookDecisionTransform = {
+  outcome: "transform";
+  /** Replacement text for the current model-bound user prompt. */
+  prompt: string;
+  /** Internal plugin-local reason. Do not expose verbatim. */
+  reason?: string;
+  /** Opaque metadata for the plugin's own use. Core does not interpret it. */
+  metadata?: Record<string, unknown>;
+};
+
 export function resolveBlockMessage(
   decision: HookDecisionBlock,
   params: { blockedBy?: string } = {},
@@ -48,12 +63,13 @@ export function resolveBlockMessage(
 /** Outcome severity for most-restrictive-wins merging. Higher = more restrictive. */
 export const HOOK_DECISION_SEVERITY: Record<HookDecision["outcome"], number> = {
   pass: 0,
+  transform: 1,
   block: 2,
 };
 
 /**
  * Merge two HookDecisions using most-restrictive-wins semantics.
- * `block > pass`
+ * `block > transform > pass`
  */
 export function mergeHookDecisions(a: HookDecision | undefined, b: HookDecision): HookDecision {
   if (!a) {
@@ -73,6 +89,25 @@ export function isHookDecision(value: unknown): value is HookDecision {
   const keys = Object.keys(v);
   if (v.outcome === "pass") {
     return keys.length === 1;
+  }
+  if (v.outcome === "transform") {
+    const allowedTransformKeys = new Set(["outcome", "prompt", "reason", "metadata"]);
+    if (keys.some((key) => !allowedTransformKeys.has(key))) {
+      return false;
+    }
+    if (typeof v.prompt !== "string" || !v.prompt.trim()) {
+      return false;
+    }
+    if ("reason" in v && (typeof v.reason !== "string" || !v.reason.trim())) {
+      return false;
+    }
+    if (
+      "metadata" in v &&
+      (typeof v.metadata !== "object" || v.metadata === null || Array.isArray(v.metadata))
+    ) {
+      return false;
+    }
+    return true;
   }
   if (v.outcome !== "block") {
     return false;
@@ -100,7 +135,7 @@ export function isHookDecision(value: unknown): value is HookDecision {
 }
 
 /** Outcomes valid for input gates (before_agent_run). */
-export type InputGateDecision = HookDecisionPass | HookDecisionBlock;
+export type InputGateDecision = HookDecisionPass | HookDecisionTransform | HookDecisionBlock;
 
 /**
  * A gate hook decision paired with the pluginId that produced it.

--- a/src/plugins/hook-lifecycle-gates.test.ts
+++ b/src/plugins/hook-lifecycle-gates.test.ts
@@ -107,6 +107,85 @@ describe("before_agent_run hook", () => {
     expect(calls).toEqual(["pass-plugin", "block-plugin"]);
   });
 
+  it("returns the first transform when no handler blocks", async () => {
+    const firstTransform = vi.fn(async () => ({
+      outcome: "transform" as const,
+      prompt: "Hi OpenClaw, my card is [CreditCardNumber]",
+      reason: "redacted sensitive data",
+    }));
+    const secondTransform = vi.fn(async () => ({
+      outcome: "transform" as const,
+      prompt: "second replacement",
+    }));
+    const registry = makeRegistry([
+      {
+        pluginId: "first-redactor",
+        hookName: "before_agent_run",
+        handler: firstTransform,
+        source: "test",
+        priority: 10,
+      },
+      {
+        pluginId: "second-redactor",
+        hookName: "before_agent_run",
+        handler: secondTransform,
+        source: "test",
+        priority: 5,
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentRun(
+      { prompt: "Hi OpenClaw, my card is 4111111111111111", messages: [] },
+      ctx,
+    );
+
+    expect(result).toEqual({
+      pluginId: "first-redactor",
+      decision: {
+        outcome: "transform",
+        prompt: "Hi OpenClaw, my card is [CreditCardNumber]",
+        reason: "redacted sensitive data",
+      },
+    });
+    expect(firstTransform).toHaveBeenCalledTimes(1);
+    expect(secondTransform).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets block beat an earlier transform", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "redactor",
+        hookName: "before_agent_run",
+        handler: async () => ({
+          outcome: "transform" as const,
+          prompt: "redacted prompt",
+        }),
+        source: "test",
+        priority: 10,
+      },
+      {
+        pluginId: "blocker",
+        hookName: "before_agent_run",
+        handler: async () => ({
+          outcome: "block" as const,
+          reason: "still unsafe",
+        }),
+        source: "test",
+        priority: 5,
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentRun({ prompt: "secret prompt", messages: [] }, ctx);
+
+    expect(result).toEqual({
+      pluginId: "blocker",
+      decision: {
+        outcome: "block",
+        reason: "still unsafe",
+      },
+    });
+  });
+
   it("short-circuits when the first of multiple handlers blocks", async () => {
     const blockHandler = vi.fn(async () => ({
       outcome: "block" as const,
@@ -210,6 +289,26 @@ describe("before_agent_run hook", () => {
         reason: "before_agent_run returned an invalid decision",
       },
       pluginId: "malformed-block-plugin",
+    });
+  });
+
+  it("fails closed on malformed transform decisions", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "malformed-transform-plugin",
+        hookName: "before_agent_run",
+        handler: async () => ({ outcome: "transform", prompt: "" }) as never,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentRun({ prompt: "test", messages: [] }, ctx);
+    expect(result).toEqual({
+      decision: {
+        outcome: "block",
+        reason: "before_agent_run returned an invalid decision",
+      },
+      pluginId: "malformed-transform-plugin",
     });
   });
 

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -1066,7 +1066,7 @@ export type PluginHookBeforeAgentRunEvent = {
   senderIsOwner?: boolean;
 };
 
-/** Result type for before_agent_run. Returns pass/block or void (= pass). */
+/** Result type for before_agent_run. Returns pass/transform/block or void (= pass). */
 export type PluginHookBeforeAgentRunResult = InputGateDecision | void;
 
 export type PluginHookResolveExecEnvEvent = {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -14,6 +14,7 @@ import {
   type GateHookResult,
   type InputGateDecision,
   isHookDecision,
+  mergeHookDecisions,
 } from "./hook-decision-types.js";
 import type { GlobalHookRunnerRegistry, HookRunnerRegistry } from "./hook-registry.types.js";
 import type {
@@ -1201,7 +1202,7 @@ export function createHookRunner(
   /**
    * Run before_agent_run gate hook.
    * Fires after session resolution and workspace preparation, before model inference.
-   * Returns the most-restrictive pass/block decision from all handlers.
+   * Returns the most-restrictive pass/transform/block decision from all handlers.
    * Handlers that return void are treated as pass.
    */
   async function runBeforeAgentRun(
@@ -1229,10 +1230,7 @@ export function createHookRunner(
                 outcome: "block",
                 reason: "before_agent_run returned an invalid decision",
               };
-          const merged =
-            !_acc || (normalized.outcome === "block" && _acc.outcome !== "block")
-              ? normalized
-              : _acc;
+          const merged = mergeHookDecisions(_acc, normalized) as InputGateDecision;
           if (merged === normalized) {
             winningPluginId = reg.pluginId;
           }


### PR DESCRIPTION
## What Problem This Solves

Plugins can currently allow or block `before_agent_run`, but they cannot safely rewrite the prompt that is sent to the model. That makes redaction-style plugins choose between blocking the run or letting sensitive input reach model-bound surfaces.

## Why This Change Was Made

This adds a `transform` hook decision for `before_agent_run`. A plugin can now return `{ outcome: "transform", prompt }` to replace the prompt at model-bound surfaces while preserving the local transcript prompt.

The implementation routes the transformed prompt through the CLI and embedded model boundaries, `llm_input`, prompt/image handling, trajectory events, final prompt metadata, and context diagnostics. Hook merging keeps `block` as the strongest decision, then `transform`, then `pass`.

## User Impact

Users can install plugins that redact sensitive information before a prompt reaches model providers. Local transcript/history behavior remains unchanged, so users still see the prompt they originally submitted.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `node scripts/run-vitest.mjs src/plugins/hook-decision-types.test.ts src/plugins/hook-lifecycle-gates.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/cli-runner.reliability.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

### Real-run proof — `before_agent_run` transform

Ran a real `openclaw agent --local` turn on this PR branch with a minimal local plugin that returns `{ outcome: "transform", prompt }` from `before_agent_run` and also registers an `llm_input` observer. Provider: LiteLLM (`openai-completions`) with a real `status=200` model response. All runtime state isolated via `OPENCLAW_HOME`.

**Input prompt:** `My project codename is CONFIDENTIAL-ABC123. Please acknowledge and remember it.`

Plugin + model boundary (stderr):

```
[transform-proof] before_agent_run original    = "My project codename is CONFIDENTIAL-ABC123. Please acknowledge and remember it."
[transform-proof] before_agent_run replacement = "My project codename is [REDACTED-SECRET]. Please acknowledge and remember it."
[transform-proof] llm_input.prompt (model-bound) = "...My project codename is [REDACTED-SECRET]. Please acknowledge and remember it."
[provider-transport-fetch] [model-fetch] response provider=litellm api=openai-completions model=... status=200
```

Model reply (the model received the transformed prompt and echoed it back):

```
Acknowledged. I'll remember that your project codename is [REDACTED-SECRET].
```

Stored canonical transcript (`agents/default/sessions/<id>.jsonl`):

```json
{ "role": "user", "content": [{ "type": "text",
  "text": "My project codename is CONFIDENTIAL-ABC123. Please acknowledge and remember it." }] }
```

The transformed prompt (`[REDACTED-SECRET]`) is what the `llm_input` observer, the outbound model request, and the model's own reply carry. The stored canonical transcript keeps the original prompt verbatim — `[REDACTED-SECRET]` never appears in the transcript jsonl (only in the model-bound path and the diagnostic trajectory). This confirms `transform` replaces the model-bound prompt without rewriting stored transcript text, matching the documented contract.
