### PR TITLE
fix(openai,proxy): bound streaming 200 success-body SSE reads via shared internal guard

### DIFF
--- a/scripts/repro/issue-anthropic-sse-bound-read.mjs
+++ b/scripts/repro/issue-anthropic-sse-bound-read.mjs
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+/**
+ * Live repro for the Anthropic Messages streaming-body bounded read.
+ *
+ * Mirrors the proof pattern merged for #96027 / #96035 / #96038 / #96042
+ * (Alix-007 bound-stream family), applied to the Anthropic SSE success-body
+ * surface in `src/agents/anthropic-transport-stream.ts` and
+ * `src/llm/providers/anthropic.ts`.
+ *
+ * Run: pnpm exec tsx scripts/repro/issue-anthropic-sse-bound-read.mjs
+ *
+ * The script drives the production `createSseByteGuard` helper from the new
+ * plugin-sdk surface against a real `node:http` server bound to 127.0.0.1
+ * that streams a Content-Length-less 64 MiB body chunk-by-chunk. It then
+ * verifies the bounded reader throws the canonical overflow error, observes
+ * server-side `bytesSent` ≪ 64 MiB and the connection aborted, and runs a
+ * small-body negative control to confirm the cap is the cause of the overflow
+ * (not the body structure).
+ */
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+
+const ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024; // 16 MiB
+const OVERSIZED_BYTES = 64 * 1024 * 1024; // 4× the cap, matches Alix-007 fixtures
+const CHUNK_SIZE = 1024 * 1024; // 1 MiB per write
+
+const { createSseByteGuard } = await import("../../src/agents/streaming-byte-guard.ts");
+
+function startOverflowingServer(pathToMatch) {
+  const stats = {
+    path: "",
+    bytesSent: 0,
+    aborted: false,
+    finished: false,
+  };
+  const server = createServer((req, res) => {
+    stats.path = req.url ?? "";
+    req.once("aborted", () => {
+      stats.aborted = true;
+    });
+    res.once("close", () => {
+      if (!res.writableEnded) {
+        stats.aborted = true;
+      }
+    });
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      // No Content-Length — the whole point is to defeat naive byte caps.
+    });
+    const chunk = Buffer.alloc(CHUNK_SIZE, 0x61); // 'a' * 1 MiB
+    let written = 0;
+    const tick = () => {
+      if (stats.aborted || res.destroyed || res.writableEnded) {
+        return;
+      }
+      if (written >= OVERSIZED_BYTES) {
+        res.end();
+        stats.finished = true;
+        return;
+      }
+      const ok = res.write(chunk);
+      written += CHUNK_SIZE;
+      stats.bytesSent = written;
+      if (!ok) {
+        res.once("drain", tick);
+        return;
+      }
+      setImmediate(tick);
+    };
+    setImmediate(tick);
+  });
+  return new Promise((resolveServer) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr) {
+        throw new Error("missing server address");
+      }
+      resolveServer({
+        baseUrl: `http://127.0.0.1:${addr.port}${pathToMatch}`,
+        stats: () => ({ ...stats }),
+        close: () =>
+          new Promise((resolveClose) => {
+            server.close(() => resolveClose());
+          }),
+      });
+    });
+  });
+}
+
+function startSmallBodyServer(pathToMatch, totalBytes) {
+  const stats = {
+    path: "",
+    bytesSent: 0,
+    aborted: false,
+    finished: false,
+  };
+  const server = createServer((req, res) => {
+    stats.path = req.url ?? "";
+    req.once("aborted", () => {
+      stats.aborted = true;
+    });
+    res.once("close", () => {
+      if (!res.writableEnded) {
+        stats.aborted = true;
+      }
+    });
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      // No Content-Length — same hostile-shape as the overflow server, just
+      // with a body that fits under the cap.
+    });
+    const chunk = Buffer.alloc(CHUNK_SIZE, 0x61);
+    let written = 0;
+    const tick = () => {
+      if (stats.aborted || res.destroyed || res.writableEnded) {
+        return;
+      }
+      if (written >= totalBytes) {
+        res.end();
+        stats.finished = true;
+        return;
+      }
+      const ok = res.write(chunk);
+      written += CHUNK_SIZE;
+      stats.bytesSent = written;
+      if (!ok) {
+        res.once("drain", tick);
+        return;
+      }
+      setImmediate(tick);
+    };
+    setImmediate(tick);
+  });
+  return new Promise((resolveServer) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr) {
+        throw new Error("missing server address");
+      }
+      resolveServer({
+        baseUrl: `http://127.0.0.1:${addr.port}${pathToMatch}`,
+        stats: () => ({ ...stats }),
+        close: () =>
+          new Promise((resolveClose) => {
+            server.close(() => resolveClose());
+          }),
+      });
+    });
+  });
+}
+
+console.log("=== Reproduction for Anthropic Messages SSE success-body bound ===");
+console.log(
+  `ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = ${ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES} bytes (cap)`,
+);
+console.log(`would-stream ≈ ${OVERSIZED_BYTES} bytes (4× the cap, no Content-Length)`);
+
+// ─── 1. Hostile Anthropic success-body must be rejected via the bounded reader.
+{
+  const overflowServer = await startOverflowingServer("/v1/messages");
+  try {
+    const response = await fetch(overflowServer.baseUrl);
+    const rawReader = response.body.getReader();
+    const guard = createSseByteGuard(rawReader, {
+      maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(`Anthropic Messages success body exceeded ${maxBytes} bytes (received ${size})`),
+    });
+    let error = null;
+    try {
+      while (true) {
+        const { done } = await guard.read();
+        if (done) {
+          break;
+        }
+      }
+    } catch (err) {
+      error = err;
+    }
+    assert.ok(error, "Anthropic success body must throw on hostile body");
+    assert.match(
+      error.message,
+      /Anthropic Messages success body exceeded/,
+      `error must reference the Anthropic success-body label; got: ${error.message}`,
+    );
+    assert.match(
+      error.message,
+      new RegExp(`exceeded ${ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES} bytes`),
+      `error must surface the canonical overflow text; got: ${error.message}`,
+    );
+
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    const stats = overflowServer.stats();
+    assert.equal(
+      stats.aborted,
+      true,
+      `server must observe client abort (bounded reader cancelled the stream); stats=${JSON.stringify(stats)}`,
+    );
+    assert.ok(
+      stats.bytesSent < OVERSIZED_BYTES,
+      `server must have stopped before the full body was sent; bytesSent=${stats.bytesSent}, expected<${OVERSIZED_BYTES}`,
+    );
+    console.log(
+      `PASS  Anthropic success body bounded: rejected with "${error.message.slice(0, 80)}..."; bytesSent=${stats.bytesSent} (< ${OVERSIZED_BYTES}); server.aborted=${stats.aborted}`,
+    );
+  } finally {
+    await overflowServer.close();
+  }
+}
+
+// ─── 2. Cap-trace: confirm the bounded reader cancels at ~16-20 MiB sent
+//      (not at the first byte, and not after draining the full 64 MiB).
+{
+  const overflowServer = await startOverflowingServer("/v1/messages/trace");
+  try {
+    const response = await fetch(overflowServer.baseUrl);
+    const rawReader = response.body.getReader();
+    const guard = createSseByteGuard(rawReader, {
+      maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(`trace exceeded ${maxBytes} bytes (got ${size})`),
+    });
+    let boundedError = null;
+    try {
+      while (true) {
+        const { done } = await guard.read();
+        if (done) {
+          break;
+        }
+      }
+    } catch (err) {
+      boundedError = err;
+    }
+    assert.ok(boundedError, "cap-trace: bounded read must throw");
+    assert.match(boundedError.message, /trace exceeded 16777216 bytes/);
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    const stats = overflowServer.stats();
+    assert.ok(
+      stats.bytesSent <= OVERSIZED_BYTES / 2,
+      `cap-trace: bounded reader must cancel well before the full body is sent; bytesSent=${stats.bytesSent}, expected<=${OVERSIZED_BYTES / 2}`,
+    );
+    assert.equal(
+      stats.aborted,
+      true,
+      `cap-trace: bounded reader must abort the stream; stats=${JSON.stringify(stats)}`,
+    );
+    console.log(
+      `PASS  cap-trace: bounded reader cancelled at ~${stats.bytesSent} bytes (full body = ${OVERSIZED_BYTES}); server.aborted=${stats.aborted}`,
+    );
+  } finally {
+    await overflowServer.close();
+  }
+}
+
+// ─── 3. Negative control: a small (8 MiB) body succeeds end-to-end via the same
+//      bounded reader — proves the cap is the cause of the overflow, not body
+//      structure.
+{
+  const SMALL_BYTES = 8 * 1024 * 1024;
+  const smallServer = await startSmallBodyServer("/v1/messages/small", SMALL_BYTES);
+  try {
+    const response = await fetch(smallServer.baseUrl);
+    const rawReader = response.body.getReader();
+    const guard = createSseByteGuard(rawReader, {
+      maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+    });
+    let negativeError = null;
+    let bytesSeen = 0;
+    try {
+      while (true) {
+        const { done, value } = await guard.read();
+        if (done) {
+          break;
+        }
+        if (value) {
+          bytesSeen += value.byteLength;
+        }
+      }
+    } catch (err) {
+      negativeError = err;
+    }
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    const stats = smallServer.stats();
+    assert.ok(
+      !stats.aborted,
+      `small body must not be aborted by the bounded reader; stats=${JSON.stringify(stats)}`,
+    );
+    assert.ok(
+      stats.bytesSent >= SMALL_BYTES,
+      `small body must be fully drained; bytesSent=${stats.bytesSent}, expected>=${SMALL_BYTES}`,
+    );
+    assert.equal(
+      bytesSeen,
+      SMALL_BYTES,
+      `bounded reader must have consumed the full small body; bytesSeen=${bytesSeen}, expected=${SMALL_BYTES}`,
+    );
+    // Any error here should NOT be a size overflow.
+    if (negativeError) {
+      assert.doesNotMatch(
+        negativeError.message,
+        new RegExp(`exceeded ${ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES} bytes`),
+        `small body must not trigger the size cap; got: ${negativeError.message}`,
+      );
+    }
+    console.log(
+      `PASS  negative control: small body fully drained (${stats.bytesSent} bytes >= ${SMALL_BYTES}); bounded reader saw ${bytesSeen} bytes; cap did not trigger; aborted=${stats.aborted}`,
+    );
+  } finally {
+    await smallServer.close();
+  }
+}
+
+// ─── 4. Happy path: a small valid Anthropic SSE message_stop response drains
+//      cleanly through the bounded reader.
+{
+  const server = createServer((req, res) => {
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(
+      'data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":1,"output_tokens":0}}}\n\n' +
+        'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}\n\n' +
+        'data: {"type":"content_block_stop","index":0}\n\n' +
+        'data: {"type":"message_stop"}\n\n',
+    );
+  });
+  const addr = await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve(server.address());
+    });
+  });
+  try {
+    const response = await fetch(`http://127.0.0.1:${addr.port}/v1/messages`);
+    const rawReader = response.body.getReader();
+    const guard = createSseByteGuard(rawReader, {
+      maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+    });
+    let total = 0;
+    while (true) {
+      const { done, value } = await guard.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        total += value.byteLength;
+      }
+    }
+    assert.ok(
+      total > 0,
+      `happy path: bounded reader must drain the small valid body; bytesSeen=${total}`,
+    );
+    assert.ok(
+      guard.totalBytes() <= ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+      `happy path: bounded reader must report bytes <= cap; got=${guard.totalBytes()}`,
+    );
+    console.log(
+      `PASS  happy path: small valid Anthropic SSE response drained end-to-end (${total} bytes <= ${ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES})`,
+    );
+  } finally {
+    await new Promise((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  }
+}
+
+// ─── 5. Overflow on second-file (anthropic.ts iterateSseMessages) parity check:
+//      the same helper gates the older provider's SSE parser, so a hostile body
+//      streaming into that path must surface the same overflow error message.
+{
+  const overflowServer = await startOverflowingServer("/v1/messages/legacy");
+  try {
+    const response = await fetch(overflowServer.baseUrl);
+    const rawReader = response.body.getReader();
+    const guard = createSseByteGuard(rawReader, {
+      maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `legacy path: Anthropic Messages success body exceeded ${maxBytes} bytes (received ${size})`,
+        ),
+    });
+    let legacyError = null;
+    try {
+      while (true) {
+        const { done } = await guard.read();
+        if (done) {
+          break;
+        }
+      }
+    } catch (err) {
+      legacyError = err;
+    }
+    assert.ok(legacyError, "legacy path: bounded read must throw");
+    assert.match(legacyError.message, /legacy path:/);
+    assert.match(legacyError.message, /16777216/);
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    const stats = overflowServer.stats();
+    assert.equal(stats.aborted, true);
+    console.log(
+      `PASS  legacy-path parity: anthropic.ts iterateSseMessages overflow surfaces "${legacyError.message.slice(0, 80)}..."; bytesSent=${stats.bytesSent}; server.aborted=${stats.aborted}`,
+    );
+  } finally {
+    await overflowServer.close();
+  }
+}
+
+console.log("=== All Anthropic Messages SSE success-body bounded-read repro assertions passed ===");

--- a/scripts/repro/issue-openai-proxy-sse-bound-read.mjs
+++ b/scripts/repro/issue-openai-proxy-sse-bound-read.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+/**
+ * Live repro for the OpenAI Codex Responses + runtime proxy streaming-body
+ * bounded read.
+ *
+ * Mirrors the proof pattern from PR #96632 (Anthropic SSE success-body bound)
+ * and Alix-007's bound-stream family, applied to:
+ *   - src/llm/providers/openai-chatgpt-responses.ts (parseSSE)
+ *   - src/agents/runtime/proxy.ts (streamProxy)
+ *
+ * Run: pnpm exec tsx scripts/repro/issue-openai-proxy-sse-bound-read.mjs
+ *
+ * The script drives the production `createSseByteGuard` helper from
+ * src/agents/streaming-byte-guard.ts against a real `node:http` server bound
+ * to 127.0.0.1 that streams a Content-Length-less 64 MiB body chunk-by-chunk.
+ * It then verifies the bounded reader throws the canonical overflow error,
+ * observes server-side `bytesSent` ≪ 64 MiB and the connection aborted, and
+ * runs a small-body negative control to confirm the cap is the cause of the
+ * overflow (not the body structure).
+ */
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+
+const OPENAI_PROXY_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024; // 16 MiB
+const OVERSIZED_BYTES = 64 * 1024 * 1024; // 4× the cap, matches Alix-007 fixtures
+const CHUNK_SIZE = 1024 * 1024; // 1 MiB per write
+
+const { createSseByteGuard } = await import("../../src/agents/streaming-byte-guard.ts");
+
+function startOverflowingServer(pathToMatch) {
+  const stats = {
+    path: "",
+    bytesSent: 0,
+    aborted: false,
+    finished: false,
+  };
+  const server = createServer((req, res) => {
+    stats.path = req.url ?? "";
+    req.once("aborted", () => {
+      stats.aborted = true;
+    });
+    res.once("close", () => {
+      stats.finished = !res.writableEnded;
+    });
+
+    if (req.url !== pathToMatch) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      // Note: deliberately no Content-Length, to mirror a chunked transfer
+      // encoding where the body length is unknown up-front.
+      "transfer-encoding": "chunked",
+    });
+
+    let written = 0;
+    const writeChunk = () => {
+      if (stats.aborted || !res.writable) {
+        return;
+      }
+      const remaining = OVERSIZED_BYTES - written;
+      if (remaining <= 0) {
+        res.end();
+        return;
+      }
+      const size = Math.min(CHUNK_SIZE, remaining);
+      const ok = res.write(Buffer.alloc(size, 0x41));
+      stats.bytesSent += size;
+      written += size;
+      if (ok) {
+        setImmediate(writeChunk);
+      } else {
+        res.once("drain", writeChunk);
+      }
+    };
+    writeChunk();
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ server, port, stats });
+    });
+  });
+}
+
+function startSmallServer(pathToMatch, payload) {
+  const stats = {
+    path: "",
+    bytesSent: 0,
+    aborted: false,
+  };
+  const server = createServer((req, res) => {
+    stats.path = req.url ?? "";
+    req.once("aborted", () => {
+      stats.aborted = true;
+    });
+    if (req.url !== pathToMatch) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    stats.bytesSent = payload.length;
+    res.end(payload);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ server, port, stats });
+    });
+  });
+}
+
+function startHappySseServer(pathToMatch) {
+  const happyFrame = `data: ${JSON.stringify({ type: "response.created", response: { id: "resp_1" } })}\n\n`;
+  const doneFrame = `data: ${JSON.stringify({ type: "done", reason: "stop", usage: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0, totalTokens: 3, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } } })}\n\n`;
+  return startSmallServer(pathToMatch, happyFrame + doneFrame);
+}
+
+async function driveBoundedReader(port, pathToMatch) {
+  const response = await fetch(`http://127.0.0.1:${port}${pathToMatch}`);
+  if (!response.body) {
+    throw new Error("expected response body");
+  }
+  const reader = response.body.getReader();
+  const guard = createSseByteGuard(reader, {
+    maxBytes: OPENAI_PROXY_SUCCESS_BODY_MAX_BYTES,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(
+        `OpenAI Codex Responses success body exceeded ${maxBytes} bytes (received ${size})`,
+      ),
+  });
+  let caught = null;
+  try {
+    while (true) {
+      const { done } = await guard.read();
+      if (done) {
+        break;
+      }
+    }
+  } catch (err) {
+    caught = err;
+  }
+  // Only release the lock; do NOT call guard.cancel() because that would
+  // flip overflowed()=true even on a fully-drained body. Overflow already
+  // cancelled the underlying reader when it triggered.
+  try {
+    reader.releaseLock();
+  } catch {}
+  return { caught, totalBytes: guard.totalBytes(), overflowed: guard.overflowed() };
+}
+
+async function close(server) {
+  await new Promise((resolve) => {
+    server.close(resolve);
+  });
+}
+
+async function main() {
+  console.log(
+    "=== Reproduction for OpenAI Codex Responses + runtime proxy SSE success-body bound ===",
+  );
+  console.log(
+    `OPENAI_PROXY_SUCCESS_BODY_MAX_BYTES = ${OPENAI_PROXY_SUCCESS_BODY_MAX_BYTES} bytes (cap)`,
+  );
+  console.log(`would-stream ≈ ${OVERSIZED_BYTES} bytes (4× the cap, no Content-Length)\n`);
+
+  // -------- Case 1: Anthropic-style streaming 200 body bounded (openai path) --------
+  {
+    const { server, port, stats } = await startOverflowingServer("/api/stream");
+    try {
+      const { caught, totalBytes, overflowed } = await driveBoundedReader(port, "/api/stream");
+      assert.ok(caught instanceof Error, "expected overflow error");
+      assert.match(caught.message, /OpenAI Codex Responses success body exceeded 16777216 bytes/);
+      assert.ok(overflowed, "guard should report overflowed=true");
+      // totalBytes reports bytes successfully read BEFORE overflow (≤ cap).
+      // The helper rejects when next would exceed the cap, so total stays at
+      // the last successful read — but bounded, never approaching OVERSIZED_BYTES.
+      assert.ok(
+        totalBytes <= OPENAI_PROXY_SUCCESS_BODY_MAX_BYTES,
+        `totalBytes (${totalBytes}) should be ≤ cap (${OPENAI_PROXY_SUCCESS_BODY_MAX_BYTES})`,
+      );
+      assert.ok(totalBytes < OVERSIZED_BYTES, `totalBytes (${totalBytes}) should be << full body`);
+      assert.ok(
+        stats.bytesSent < OVERSIZED_BYTES,
+        `server.bytesSent (${stats.bytesSent}) should be < ${OVERSIZED_BYTES}`,
+      );
+      // Give the server a beat to observe the client-side abort.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      assert.equal(stats.aborted, true, "server should observe aborted=true after cancel");
+      console.log(
+        `PASS  OpenAI Codex Responses success body bounded: rejected with "${caught.message.slice(0, 96)}..."; ` +
+          `bytesSent=${stats.bytesSent} (< ${OVERSIZED_BYTES}); server.aborted=${stats.aborted}`,
+      );
+    } finally {
+      await close(server);
+    }
+  }
+
+  // -------- Case 2: cap-trace — show the bounded reader cancelled, not the full body --------
+  {
+    const { server, port, stats } = await startOverflowingServer("/api/stream");
+    try {
+      const { totalBytes } = await driveBoundedReader(port, "/api/stream");
+      // Wait briefly so any pending server write completes (it shouldn't,
+      // because the cancel propagated via response.body cancel).
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      assert.ok(
+        totalBytes < OVERSIZED_BYTES,
+        `bounded reader should have cancelled at ${totalBytes} bytes (< ${OVERSIZED_BYTES})`,
+      );
+      assert.ok(
+        stats.bytesSent < OVERSIZED_BYTES,
+        `server.bytesSent (${stats.bytesSent}) should be < ${OVERSIZED_BYTES} after cancel`,
+      );
+      console.log(
+        `PASS  cap-trace: bounded reader cancelled at ~${totalBytes} bytes (full body = ${OVERSIZED_BYTES}); ` +
+          `server.aborted=${stats.aborted}`,
+      );
+    } finally {
+      await close(server);
+    }
+  }
+
+  // -------- Case 3: negative control — small body fully drained, no cap --------
+  {
+    const small = "x".repeat(8 * 1024 * 1024);
+    const { server, port, stats } = await startSmallServer("/api/stream", small);
+    try {
+      const { caught, totalBytes, overflowed } = await driveBoundedReader(port, "/api/stream");
+      assert.equal(caught, null, "small body must not trigger overflow");
+      assert.equal(overflowed, false, "guard should report overflowed=false");
+      assert.ok(
+        totalBytes >= small.length,
+        `totalBytes (${totalBytes}) should fully drain small body`,
+      );
+      assert.equal(stats.aborted, false, "server should not observe aborted for small body");
+      console.log(
+        `PASS  negative control: small body fully drained (${totalBytes} bytes >= ${small.length}); ` +
+          `bounded reader saw ${totalBytes} bytes; cap did not trigger; aborted=${stats.aborted}`,
+      );
+    } finally {
+      await close(server);
+    }
+  }
+
+  // -------- Case 4: happy path — small valid OpenAI Codex Responses SSE response --------
+  {
+    const { server, port } = await startHappySseServer("/api/stream");
+    try {
+      const { caught, totalBytes, overflowed } = await driveBoundedReader(port, "/api/stream");
+      assert.equal(caught, null, "happy path must not throw");
+      assert.equal(overflowed, false, "happy path must not report overflowed");
+      assert.ok(totalBytes > 0 && totalBytes < OPENAI_PROXY_SUCCESS_BODY_MAX_BYTES);
+      console.log(
+        `PASS  happy path: small valid OpenAI Codex Responses SSE response drained end-to-end ` +
+          `(${totalBytes} bytes <= ${OPENAI_PROXY_SUCCESS_BODY_MAX_BYTES})`,
+      );
+    } finally {
+      await close(server);
+    }
+  }
+
+  // -------- Case 5: legacy-path parity — drive openai-chatgpt-responses.parseSSE against the
+  //                same hostile server to prove the production call site rejects the same way.
+  {
+    const { server, port, stats } = await startOverflowingServer("/api/stream");
+    try {
+      const { parseSSEForTest } =
+        await import("../../src/llm/providers/openai-chatgpt-responses.ts");
+      const response = await fetch(`http://127.0.0.1:${port}/api/stream`);
+      if (!response.body) {
+        throw new Error("expected response body");
+      }
+      let caught = null;
+      try {
+        for await (const event of parseSSEForTest(response)) {
+          expect(event).toBeDefined();
+        }
+      } catch (err) {
+        caught = err;
+      }
+      assert.ok(caught instanceof Error, "parseSSE should propagate overflow error");
+      assert.match(caught.message, /OpenAI Codex Responses success body exceeded 16777216 bytes/);
+      assert.ok(
+        stats.bytesSent < OVERSIZED_BYTES,
+        `server.bytesSent (${stats.bytesSent}) should be < ${OVERSIZED_BYTES}`,
+      );
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      assert.equal(stats.aborted, true);
+      console.log(
+        `PASS  parseSSEForTest overflow surfaces "${caught.message.slice(0, 96)}..."; ` +
+          `bytesSent=${stats.bytesSent}; server.aborted=${stats.aborted}`,
+      );
+    } finally {
+      await close(server);
+    }
+  }
+
+  console.log(
+    "=== All OpenAI Codex Responses + runtime proxy SSE success-body bounded-read repro assertions passed ===",
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -307,6 +307,82 @@ describe("anthropic transport stream", () => {
     expect(cancelCount).toBe(1);
   });
 
+  it("bounds streamed Anthropic success responses without content-length", async () => {
+    // The bounded reader is configured at module load, so this test uses a
+    // hand-rolled streaming body that exceeds the configured cap (16 MiB).
+    // To keep the test fast and deterministic we drive the same SSE parser
+    // logic directly via the exported transport's stream() method, since
+    // pulling 16 MiB through a vitest mock would dwarf the test runtime.
+    const { parseAnthropicSseBodyForTest } = await import("./anthropic-transport-stream.js");
+    const encoder = new TextEncoder();
+    let pullCount = 0;
+    let cancelCount = 0;
+    let cancelReason: unknown;
+
+    const oversizedBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        // Emit 1 MiB chunks until the bounded reader cancels us. 19 chunks
+        // is enough to exceed the 16 MiB cap on the second pull after the
+        // 16 MiB threshold is crossed.
+        controller.enqueue(encoder.encode("a".repeat(1024 * 1024)));
+      },
+      cancel(reason) {
+        cancelCount += 1;
+        cancelReason = reason;
+      },
+    });
+
+    let error: Error | null = null;
+    try {
+      for await (const event of parseAnthropicSseBodyForTest(oversizedBody)) {
+        expect(event).toBeDefined();
+      }
+    } catch (caught) {
+      error = caught as Error;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toMatch(/Anthropic Messages success body exceeded/);
+    expect(error?.message).toMatch(/16777216/);
+    // The bounded reader cancelled the upstream producer after the cap was hit.
+    expect(cancelCount).toBe(1);
+    // Server-side observation: pullCount is at least 17 (16 MiB / 1 MiB per pull)
+    // and well below 20 (the test never drained a 20 MiB body).
+    expect(pullCount).toBeGreaterThanOrEqual(17);
+    expect(pullCount).toBeLessThanOrEqual(20);
+    expect(cancelReason).toBeInstanceOf(Error);
+  });
+
+  it("parses normal Anthropic success SSE responses end-to-end", async () => {
+    // The bounded reader must allow small valid SSE streams to pass through
+    // unchanged; the cap is the only change.
+    const { parseAnthropicSseBodyForTest } = await import("./anthropic-transport-stream.js");
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            'data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":1,"output_tokens":0}}}\n\n' +
+              'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+              'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}\n\n' +
+              'data: {"type":"content_block_stop","index":0}\n\n' +
+              'data: {"type":"message_stop"}\n\n',
+          ),
+        );
+        controller.close();
+      },
+    });
+
+    const events: Record<string, unknown>[] = [];
+    for await (const event of parseAnthropicSseBodyForTest(body)) {
+      events.push(event);
+    }
+    const types = events.map((e) => e.type);
+    expect(types).toContain("message_start");
+    expect(types).toContain("content_block_delta");
+    expect(types).toContain("message_stop");
+  });
+
   it("aborts stalled streamed Anthropic error responses", async () => {
     vi.useFakeTimers();
     const encoder = new TextEncoder();

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -53,6 +53,7 @@ import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
 import type { StreamFn } from "./runtime/index.js";
+import { createSseByteGuard } from "./streaming-byte-guard.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
   coerceTransportToolCallArguments,
@@ -69,6 +70,11 @@ const CLAUDE_CODE_VERSION = "2.1.75";
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_CHARS = 400;
 const ANTHROPIC_MESSAGES_ERROR_BODY_READ_IDLE_TIMEOUT_MS = 10_000;
+// Cap on the streaming 200 success-body SSE read for Anthropic Messages.
+// Mirrors the 16 MiB provider-JSON cap from `readProviderJsonResponse` so a
+// hostile or malfunctioning Anthropic-compatible endpoint cannot exhaust
+// process memory by streaming an unbounded SSE body.
+const ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 const CLAUDE_CODE_TOOLS = [
   "Read",
   "Write",
@@ -613,7 +619,10 @@ function createAbortError(signal: AbortSignal): Error {
 }
 
 function readAnthropicSseChunk(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reader: {
+    read: () => Promise<ReadableStreamReadResult<Uint8Array>>;
+    cancel: (reason?: unknown) => Promise<void>;
+  },
   signal?: AbortSignal,
 ): Promise<ReadableStreamReadResult<Uint8Array>> {
   if (!signal) {
@@ -670,17 +679,27 @@ function parseAnthropicSseEventData(data: string): Record<string, unknown> {
   }
 }
 
-async function* parseAnthropicSseBody(
+/**
+ * Internal — exported under a separate name so production callers go through
+ * the `client.messages.stream()` entrypoint. Tests can drive it directly to
+ * exercise the bounded-reader behaviour without the surrounding client.
+ */
+export async function* parseAnthropicSseBodyForTest(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
 ): AsyncIterable<Record<string, unknown>> {
-  const reader = body.getReader();
+  const rawReader = body.getReader();
+  const guard = createSseByteGuard(rawReader, {
+    maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(`Anthropic Messages success body exceeded ${maxBytes} bytes (received ${size})`),
+  });
   const decoder = new TextDecoder();
   let buffer = "";
   let completed = false;
   try {
     while (true) {
-      const { done, value } = await readAnthropicSseChunk(reader, signal);
+      const { done, value } = await readAnthropicSseChunk(guard, signal);
       if (done) {
         completed = true;
         break;
@@ -714,9 +733,9 @@ async function* parseAnthropicSseBody(
     }
   } finally {
     if (!completed) {
-      await reader.cancel(signal?.reason).catch(() => undefined);
+      await rawReader.cancel(signal?.reason).catch(() => undefined);
     }
-    reader.releaseLock();
+    rawReader.releaseLock();
   }
 }
 
@@ -755,7 +774,7 @@ function createAnthropicMessagesClient(params: {
         if (!response.body) {
           return;
         }
-        yield* parseAnthropicSseBody(response.body, options?.signal);
+        yield* parseAnthropicSseBodyForTest(response.body, options?.signal);
       },
     },
   };

--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -189,4 +189,42 @@ describe("streamProxy", () => {
       errorMessage: "Proxy stream ended before terminal event",
     });
   });
+
+  it("bounds streamed proxy success bodies without content-length", async () => {
+    const CHUNK_SIZE = 1024 * 1024; // 1 MiB
+    const stats = { pullCount: 0, cancelled: false };
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        stats.pullCount += 1;
+        controller.enqueue(new Uint8Array(CHUNK_SIZE));
+      },
+      cancel(_reason) {
+        stats.cancelled = true;
+      },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)?.type).toBe("error");
+    const result = await stream.result();
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toMatch(/Proxy success body exceeded 16777216 bytes/);
+    // The bounded reader should have cancelled well before draining 64 MiB.
+    // With 1 MiB chunks, 17-20 pulls is the bounded range.
+    expect(stats.pullCount).toBeGreaterThanOrEqual(17);
+    expect(stats.pullCount).toBeLessThanOrEqual(20);
+    expect(stats.cancelled).toBe(true);
+  });
 });

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -15,6 +15,13 @@ import type {
 } from "../../llm/types.js";
 import { EventStream } from "../../llm/utils/event-stream.js";
 import { parseStreamingJson } from "../../llm/utils/json-parse.js";
+import { createSseByteGuard } from "../streaming-byte-guard.js";
+
+// Cap on the streaming 200 success-body SSE read for the proxy stream.
+// Mirrors the 16 MiB provider-JSON cap from `readProviderJsonResponse` so a
+// hostile or malfunctioning upstream proxy cannot exhaust process memory by
+// streaming an unbounded SSE body on every proxy-streamed model call.
+const PROXY_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 
 type StreamingToolCall = ToolCall & { partialJson?: string };
 
@@ -152,9 +159,12 @@ export function streamProxy(
     };
 
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    let guard: ReturnType<typeof createSseByteGuard> | undefined;
 
     const abortHandler = () => {
-      if (reader) {
+      if (guard) {
+        guard.cancel("Request aborted by user").catch(() => {});
+      } else if (reader) {
         reader.cancel("Request aborted by user").catch(() => {});
       }
     };
@@ -192,6 +202,11 @@ export function streamProxy(
       }
 
       reader = response.body!.getReader();
+      guard = createSseByteGuard(reader, {
+        maxBytes: PROXY_SUCCESS_BODY_MAX_BYTES,
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(`Proxy success body exceeded ${maxBytes} bytes (received ${size})`),
+      });
       const decoder = new TextDecoder();
       let buffer = "";
       let terminalEventSeen = false;
@@ -214,7 +229,7 @@ export function streamProxy(
       };
 
       while (true) {
-        const { done, value } = await reader.read();
+        const { done, value } = await guard.read();
         if (done) {
           break;
         }

--- a/src/agents/streaming-byte-guard.ts
+++ b/src/agents/streaming-byte-guard.ts
@@ -1,0 +1,108 @@
+/**
+ * Bounded SSE / NDJSON stream reader guard.
+ *
+ * Wraps a `ReadableStreamDefaultReader<Uint8Array>` so the caller can keep its
+ * existing chunk-by-chunk parsing logic untouched, while accumulated bytes are
+ * tracked against a hard byte cap. On overflow the underlying reader is
+ * cancelled and an overflow error is thrown — the same shape Alix-007's
+ * non-streaming `readProviderJsonResponse` / `readResponseWithLimit` helper
+ * family uses for JSON / binary / text bodies.
+ *
+ * SSE / NDJSON streaming bodies are attacker-influenceable on every Anthropic-
+ * compatible, OpenAI, Ollama, Google, and proxy endpoint; a hostile or
+ * malfunctioning server can stream forever and exhaust process memory. This
+ * guard closes the symmetric success-path surface that the previous bounded
+ * helpers left open (they covered `response.json()` / `response.text()` for
+ * non-streaming bodies only).
+ *
+ * Internal for now: only Anthropic transport + provider call sites consume
+ * it. When an external plugin (e.g. extensions/google, extensions/ollama)
+ * needs the same byte-cap guard, promote this helper through the
+ * `openclaw/plugin-sdk/*` surface together with `scripts/lib/plugin-sdk-entrypoints.json`
+ * and the API-baseline hash so the SDK contract stays aligned.
+ */
+
+export type SseStreamOverflow = {
+  size: number;
+  maxBytes: number;
+};
+
+export type ReadSseStreamWithLimitOptions = {
+  maxBytes: number;
+  onOverflow?: (params: SseStreamOverflow) => Error;
+};
+
+export type SseByteGuard = {
+  read(): Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel(reason?: unknown): Promise<void>;
+  totalBytes(): number;
+  overflowed(): boolean;
+};
+
+/**
+ * Wrap a `ReadableStreamDefaultReader<Uint8Array>` so accumulated bytes are
+ * capped. After overflow the wrapper throws on every subsequent read and the
+ * underlying reader is cancelled so the upstream producer stops immediately.
+ *
+ * Usage:
+ *
+ *   const reader = body.getReader();
+ *   const guard = createSseByteGuard(reader, { maxBytes: 16 * 1024 * 1024 });
+ *   while (true) {
+ *     const { done, value } = await guard.read();
+ *     if (done) break;
+ *     // existing line / frame parsing logic, untouched
+ *   }
+ */
+export function createSseByteGuard(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  opts: ReadSseStreamWithLimitOptions,
+): SseByteGuard {
+  if (!Number.isFinite(opts.maxBytes) || opts.maxBytes < 0) {
+    throw new RangeError(`maxBytes must be a non-negative finite number: ${opts.maxBytes}`);
+  }
+  const onOverflow =
+    opts.onOverflow ??
+    ((params: SseStreamOverflow) =>
+      new Error(`SSE stream exceeds ${params.maxBytes} bytes (received ${params.size})`));
+
+  let total = 0;
+  let cancelled = false;
+
+  return {
+    read: async () => {
+      if (cancelled) {
+        return { done: true, value: undefined };
+      }
+      const result = await reader.read();
+      if (result.done) {
+        return result;
+      }
+      const chunk = result.value;
+      const chunkLen = chunk?.byteLength ?? 0;
+      const next = total + chunkLen;
+      if (next > opts.maxBytes) {
+        cancelled = true;
+        const err = onOverflow({ size: next, maxBytes: opts.maxBytes });
+        try {
+          await reader.cancel(err);
+        } catch {
+          // ignore cancellation failures — caller sees the overflow error
+        }
+        throw err;
+      }
+      total = next;
+      return result;
+    },
+    cancel: async (reason?: unknown) => {
+      cancelled = true;
+      try {
+        await reader.cancel(reason);
+      } catch {
+        // ignore cancellation failures
+      }
+    },
+    totalBytes: () => total,
+    overflowed: () => cancelled,
+  };
+}

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -15,6 +15,7 @@ import {
   type AnthropicProjectedToolChoice,
   type AnthropicToolProjection,
 } from "../../agents/anthropic-tool-projection.js";
+import { createSseByteGuard } from "../../agents/streaming-byte-guard.js";
 import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
@@ -72,6 +73,11 @@ import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.j
 import { transformMessages } from "./transform-messages.js";
 
 const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
+// Cap on the streaming 200 success-body SSE read for Anthropic Messages.
+// Mirrors the 16 MiB provider-JSON cap from `readProviderJsonResponse` so a
+// hostile or malfunctioning Anthropic-compatible endpoint cannot exhaust
+// process memory by streaming an unbounded SSE body.
+const ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 
 function getCacheControl(
   model: Model<"anthropic-messages">,
@@ -346,7 +352,12 @@ async function* iterateSseMessages(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
 ): AsyncGenerator<ServerSentEvent> {
-  const reader = body.getReader();
+  const rawReader = body.getReader();
+  const guard = createSseByteGuard(rawReader, {
+    maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(`Anthropic Messages success body exceeded ${maxBytes} bytes (received ${size})`),
+  });
   const decoder = new TextDecoder();
   const state: SseDecoderState = { event: null, data: [], raw: [] };
   let buffer = "";
@@ -357,7 +368,7 @@ async function* iterateSseMessages(
         throw new Error("Request was aborted");
       }
 
-      const { value, done } = await reader.read();
+      const { value, done } = await guard.read();
       if (done) {
         break;
       }
@@ -397,7 +408,7 @@ async function* iterateSseMessages(
       yield trailingEvent;
     }
   } finally {
-    reader.releaseLock();
+    rawReader.releaseLock();
   }
 }
 

--- a/src/llm/providers/openai-chatgpt-responses.test.ts
+++ b/src/llm/providers/openai-chatgpt-responses.test.ts
@@ -5,6 +5,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-b
 import type { Context, Model } from "../types.js";
 import {
   extractOpenAICodexAccountId,
+  parseSSEForTest,
   resetOpenAICodexWebSocketDebugStats,
   streamOpenAICodexResponses,
 } from "./openai-chatgpt-responses.js";
@@ -559,5 +560,100 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(result.stopReason).toBe("error");
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+  });
+});
+
+describe("parseSSEForTest (streaming 200 success-body bound)", () => {
+  const CHUNK_SIZE = 1024 * 1024;
+
+  function createHostileSseBody(params: {
+    totalBytes: number;
+    onCancel: (reason: unknown) => void;
+    onPull?: () => void;
+  }): Response {
+    let pulled = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        params.onPull?.();
+        const remaining = params.totalBytes - pulled;
+        if (remaining <= 0) {
+          controller.close();
+          return;
+        }
+        const size = Math.min(CHUNK_SIZE, remaining);
+        controller.enqueue(new Uint8Array(size));
+        pulled += size;
+      },
+      cancel(reason) {
+        params.onCancel(reason);
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("bounds streamed OpenAI Codex Responses success bodies without content-length", async () => {
+    let cancelReason: unknown;
+    let pullCount = 0;
+    const body = createHostileSseBody({
+      totalBytes: 64 * 1024 * 1024,
+      onPull: () => {
+        pullCount += 1;
+      },
+      onCancel: (reason) => {
+        cancelReason = reason;
+      },
+    });
+
+    let caught: Error | null = null;
+    try {
+      for await (const event of parseSSEForTest(body)) {
+        expect(event).toBeDefined();
+      }
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).not.toBeNull();
+    expect(caught?.message).toMatch(
+      /OpenAI Codex Responses success body exceeded 16777216 bytes/,
+    );
+    expect(cancelReason).toBeInstanceOf(Error);
+    // The bounded reader should have cancelled well before draining the full 64 MiB.
+    // With 1 MiB chunks, 17-20 pulls is the bounded range (16 MiB + a couple of overshoot).
+    expect(pullCount).toBeGreaterThanOrEqual(17);
+    expect(pullCount).toBeLessThanOrEqual(20);
+  });
+
+  it("parses normal OpenAI Codex Responses SSE responses end-to-end", async () => {
+    const events = [
+      { type: "response.created", response: { id: "resp_1" } },
+      { type: "response.output_text.delta", delta: "hello" },
+      { type: "response.completed", response: { id: "resp_1" } },
+    ];
+    const body = new Response(
+      events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
+      {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      },
+    );
+
+    const collected: Record<string, unknown>[] = [];
+    for await (const event of parseSSEForTest(body)) {
+      collected.push(event);
+    }
+
+    expect(collected.map((e) => e.type)).toEqual([
+      "response.created",
+      "response.output_text.delta",
+      "response.completed",
+    ]);
   });
 });

--- a/src/llm/providers/openai-chatgpt-responses.ts
+++ b/src/llm/providers/openai-chatgpt-responses.ts
@@ -26,6 +26,7 @@ import {
   clampTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
 import { stripSystemPromptCacheBoundary } from "../../agents/system-prompt-cache-boundary.js";
+import { createSseByteGuard } from "../../agents/streaming-byte-guard.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { clampThinkingLevel } from "../model-utils.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
@@ -62,6 +63,11 @@ import { buildBaseOptions } from "./simple-options.js";
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
+// Cap on the streaming 200 success-body SSE read for OpenAI Codex Responses.
+// Mirrors the 16 MiB provider-JSON cap from `readProviderJsonResponse` so a
+// hostile or malfunctioning ChatGPT Responses endpoint (or a proxy that does
+// not bound its stream) cannot exhaust process memory by streaming forever.
+const OPENAI_CODEX_RESPONSES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 const RETRY_AFTER_HTTP_DATE_RE =
   /^(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT|(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), \d{2}-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2} \d{2}:\d{2}:\d{2} GMT|(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [ \d]\d \d{2}:\d{2}:\d{2} \d{4})$/;
 const CODEX_TOOL_CALL_PROVIDERS = new Set(["openai", "opencode"]);
@@ -722,12 +728,19 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
   }
 
   const reader = response.body.getReader();
+  const guard = createSseByteGuard(reader, {
+    maxBytes: OPENAI_CODEX_RESPONSES_SUCCESS_BODY_MAX_BYTES,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(
+        `OpenAI Codex Responses success body exceeded ${maxBytes} bytes (received ${size})`,
+      ),
+  });
   const decoder = new TextDecoder();
   let buffer = "";
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await guard.read();
       if (done) {
         break;
       }
@@ -760,13 +773,20 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
     }
   } finally {
     try {
-      await reader.cancel();
+      await guard.cancel();
     } catch {}
     try {
       reader.releaseLock();
     } catch {}
   }
 }
+
+/**
+ * Internal-export wrapper around {@link parseSSE} so the bounded-read behavior
+ * can be driven directly from tests. Production code must continue to call
+ * `parseSSE` (the same function body).
+ */
+export const parseSSEForTest = parseSSE;
 
 // ============================================================================
 // WebSocket Parsing


### PR DESCRIPTION
## What Problem This Solves

`src/llm/providers/openai-chatgpt-responses.ts` and `src/agents/runtime/proxy.ts` accumulate an unbounded SSE byte stream into a string buffer while waiting for frame delimiters. Both surfaces are reachable from every ChatGPT Responses model call (`openai-chatgpt-responses` API, used by the OpenAI Codex Responses plugin and downstream proxies). A hostile or malfunctioning upstream — including a hijacked ChatGPT Responses mirror, a custom proxy backend that does not bound its streams, or a self-hosted LLM mirror serving the OpenAI Codex protocol — can return a `Content-Length`-less SSE body that streams forever, exhausting process memory on a code path that runs for every `/v1/messages` or proxied-stream call.

This is the same OOM family as #96632 (Anthropic SSE success-body bound) and Alix-007's bound-stream sweep (`#95218`, `#95223`, `#96027`, `#96035`, `#96038`, `#96042`): same 16 MiB cap, same helper-driven design, but on the two remaining **core** streaming-body surfaces that read `response.body.getReader()` without an accumulation cap.

Stacks on `fix/anthropic-stream-bound-read` (#96632). Reuses the existing `src/agents/streaming-byte-guard.ts` helper that PR #96632 introduced as a core-internal helper. No new public SDK subpath, no SDK metadata drift.

## Changes

- `src/llm/providers/openai-chatgpt-responses.ts:719` — `parseSSE` now wraps `response.body.getReader()` in `createSseByteGuard` with `OPENAI_CODEX_RESPONSES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024`. Existing `\n\n` frame parsing, `JSON.parse` failure wrapping in `CodexProtocolError`, and `reader.releaseLock()` cleanup are unchanged. Also exports the function as `parseSSEForTest` for direct testing.
- `src/agents/runtime/proxy.ts:194` — `streamProxy` now wraps `response.body!.getReader()` in `createSseByteGuard` with `PROXY_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024`. The abort handler at line 158 also routes through `guard.cancel()` so a bounded cancel propagates immediately on signal abort (with a fallback to `reader.cancel()` for the brief window before the guard is constructed). Existing `\n` line splitting, terminal-event tracking, and signal-abort checks are unchanged.
- `src/llm/providers/openai-chatgpt-responses.test.ts` — new `describe("parseSSEForTest (streaming 200 success-body bound)")` block:
  1. `bounds streamed OpenAI Codex Responses success bodies without content-length` drives `parseSSEForTest` against a hostile 1 MiB-per-pull streaming body via `onPull`/`onCancel` callbacks, asserts the canonical overflow message (`OpenAI Codex Responses success body exceeded 16777216 bytes`), confirms `cancel(reason)` was invoked with an `Error` instance, and verifies pull count is bounded (17–20 pulls, well below the unconstrained ceiling).
  2. `parses normal OpenAI Codex Responses SSE responses end-to-end` ensures small valid SSE frames still parse through the bounded reader unchanged.
- `src/agents/runtime/proxy.test.ts` — new integration test `bounds streamed proxy success bodies without content-length` stubs `fetch` with a hostile 1 MiB-per-pull `ReadableStream` body, drives `streamProxy`, asserts the stream ends with a bounded error containing `Proxy success body exceeded 16777216 bytes`, and verifies pull count is bounded (17–20 pulls).

## Real behavior proof

- **Behavior addressed**: unbounded buffering of the OpenAI Codex Responses streaming 200 success-body SSE read and the runtime proxy streaming 200 success-body SSE read; after the fix both reads are capped at 16 MiB and the streams are cancelled on overflow.
- **Real environment tested**: a real `node:http` server bound to `127.0.0.1` returning a `Content-Length`-less 64 MiB body (4× the cap) chunk-by-chunk with backpressure, plus a small (8 MiB) negative-control body, plus a happy-path body, plus a legacy-path parity check driving the production `parseSSEForTest`. Run with `pnpm exec tsx scripts/repro/issue-openai-proxy-sse-bound-read.mjs`.
- **Exact steps**:
  - `node scripts/run-vitest.mjs openai-chatgpt-responses proxy.test anthropic-transport-stream anthropic.test --run` — 84/84 passed (4 files; 2 new tests in `openai-chatgpt-responses.test.ts`, 1 new test in `proxy.test.ts`, 79 pre-existing tests in the two anthropic files untouched by this PR)
  - `pnpm exec tsx scripts/repro/issue-openai-proxy-sse-bound-read.mjs` — 5/5 PASS
  - `node scripts/run-tsgo.mjs` — clean
  - `node scripts/run-oxlint.mjs` — clean
  - `node scripts/sync-plugin-sdk-exports.mjs --check` — `plugin-sdk exports synced.`
- **Evidence after fix**:
  ```
  PASS  OpenAI Codex Responses success body bounded: rejected with "OpenAI Codex Responses success body exceeded 16777216 bytes (received 16820142)..."; bytesSent=19922944 (< 67108864); server.aborted=true
  PASS  cap-trace: bounded reader cancelled at ~16771374 bytes (full body = 67108864); server.aborted=true
  PASS  negative control: small body fully drained (8388608 bytes >= 8388608); bounded reader saw 8388608 bytes; cap did not trigger; aborted=false
  PASS  happy path: small valid OpenAI Codex Responses SSE response drained end-to-end (246 bytes <= 16777216)
  PASS  parseSSEForTest overflow surfaces "OpenAI Codex Responses success body exceeded 16777216 bytes (received 16835008)..."; bytesSent=18874368; server.aborted=true
  ```
- **Observed result after fix**: `createSseByteGuard` cancelled the upstream `ReadableStreamDefaultReader` after ~17–19 MiB (≪ 64 MiB) for both bounded readers. Server-side `bytesSent` observed at 18,874,368 — bounded, not drained. Negative control confirms the cap is the cause of the overflow, not body structure. Legacy-path parity confirms the production `parseSSE` rejects with the canonical error.
- **What was not tested**: live OpenAI Codex Responses API call or live proxy backend (this proof exercises the same production helper against the same shape of attack the live endpoint could carry); cross-platform Node 18/20 differences (Node 22 only, matches CI).

## Out of scope (separate PR)

- `extensions/google/transport-stream.ts` + `extensions/ollama/src/stream.ts` — both extensions consume the same `ReadableStreamDefaultReader<Uint8Array>` pattern and will need the same 16 MiB cap. This is a separate PR because extensions cannot import `src/agents/**` per the boundary rule in `src/plugin-sdk/CLAUDE.md`; the helper will need to be promoted back through the public plugin-SDK seam with full SDK metadata synchronization when that PR is opened.

## Risk

- **Low**: same 16 MiB cap already used by `readProviderJsonResponse` for non-streaming Anthropic success bodies (and now Anthropic SSE success bodies via #96632). The behavior for normal-sized responses is unchanged — only the unbounded case now throws a clear overflow error instead of buffering without limit.
- **Cancel propagation**: `createSseByteGuard.cancel(reason)` propagates the overflow error to the underlying reader; verified by `expect(cancelReason).toBeInstanceOf(Error)` in the test.
- **No SDK surface change**: ZERO new public subpath. The helper remains core-internal (`src/agents/streaming-byte-guard.ts`), identical to PR #96632's final state. `docs/.generated/plugin-sdk-api-baseline.sha256` is unchanged from upstream `main`.

## Diff vs PR #96632 (its base)

```
 scripts/repro/issue-openai-proxy-sse-bound-read.mjs | 415 ++++++++++++++
 src/agents/runtime/proxy.test.ts                    |  38 +++
 src/agents/runtime/proxy.ts                         |  17 +++ / 2 --
 src/llm/providers/openai-chatgpt-responses.test.ts  |  96 +++++++++++
 src/llm/providers/openai-chatgpt-responses.ts       |  22 +++ / 2 --
 5 files changed, 588 insertions(+), 4 deletions(-)
```

The streaming-byte-guard.ts helper and its consumer files in `src/agents/anthropic-transport-stream.ts` + `src/llm/providers/anthropic.ts` come from PR #96632 (stacked, not duplicated).