### PR TITLE
fix(agents): keep lightContext cron prompts within small-context budget

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4605,6 +4605,7 @@ export async function runEmbeddedAttempt(
                   : {}),
                 systemPrompt: systemPromptForHook,
                 prompt: llmBoundaryPromptForPrecheck,
+                contextMode: params.bootstrapContextMode,
                 contextTokenBudget,
                 reserveTokens,
                 toolResultMaxChars: promptToolResultMaxChars,

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -346,6 +346,26 @@ describe("preemptive-compaction", () => {
     expect(result.route).toBe("fits");
   });
 
+  it("keeps lightweight tiny-context prompts out of no-op compact-only recovery", () => {
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [],
+      systemPrompt: "sys",
+      prompt: "daily cron briefing",
+      contextMode: "lightweight",
+      contextTokenBudget: 4_096,
+      reserveTokens: 20_000,
+      llmBoundaryTokenPressure: {
+        estimatedPromptTokens: 3_544,
+        source: "test_lightweight_cron_boundary",
+      },
+    });
+
+    expect(result.route).toBe("fits");
+    expect(result.shouldCompact).toBe(false);
+    expect(result.promptBudgetBeforeReserve).toBeGreaterThanOrEqual(3_544);
+    expect(result.effectiveReserveTokens).toBeLessThan(1_000);
+  });
+
   it("keeps the requested reserve when it leaves enough prompt budget", () => {
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages: [makeAssistantHistory("short history")],

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -23,6 +23,11 @@ const MESSAGE_BOUNDARY_OVERHEAD_TOKENS = 12;
 const CONTENT_BLOCK_OVERHEAD_TOKENS = 6;
 const IMAGE_BLOCK_TOKENS = 2_000;
 const TRUNCATION_ROUTE_BUFFER_TOKENS = 512;
+// Lightweight cron/bootstrap runs have a tiny deterministic prompt but inherit the shared ~20k
+// reserve floor; on small-context models that floor starves the prompt budget and routes to a
+// no-op compact_only (nothing to compact), failing the run. Reserve most of a small window for the
+// prompt instead. The clamp below still leaves large-context lightweight runs at full reserve.
+const LIGHTWEIGHT_MIN_PROMPT_BUDGET_RATIO = 0.875;
 
 /** Pre-prompt routing decision plus the budget facts used to explain it in logs and session state. */
 export type PreemptiveCompactionDecision = {
@@ -250,6 +255,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   unwindowedMessages?: AgentMessage[];
   systemPrompt?: string;
   prompt: string;
+  contextMode?: "full" | "lightweight";
   contextTokenBudget: number;
   reserveTokens: number;
   toolResultMaxChars?: number;
@@ -281,10 +287,17 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   }
   const contextTokenBudget = Math.max(1, Math.floor(params.contextTokenBudget));
   const requestedReserveTokens = Math.max(0, Math.floor(params.reserveTokens));
-  const minPromptBudget = Math.min(
+  const baseMinPromptBudget = Math.min(
     MIN_PROMPT_BUDGET_TOKENS,
     Math.max(1, Math.floor(contextTokenBudget * MIN_PROMPT_BUDGET_RATIO)),
   );
+  const minPromptBudget =
+    params.contextMode === "lightweight"
+      ? Math.max(
+          baseMinPromptBudget,
+          Math.max(1, Math.floor(contextTokenBudget * LIGHTWEIGHT_MIN_PROMPT_BUDGET_RATIO)),
+        )
+      : baseMinPromptBudget;
   // Keep a minimum prompt budget even when reserveTokens asks for most of the context window.
   const effectiveReserveTokens = Math.min(
     requestedReserveTokens,


### PR DESCRIPTION
Closes #96658

> AI-assisted PR (Claude). The author has reviewed and owns the final diff.

## What Problem This Solves

Fixes an issue where isolated cron jobs running with `lightContext: true` on small-context
models fail with **"Context overflow: prompt too large for the model"** even when the session
has essentially no history. The Morning Briefing / contribution-scout style cron jobs become
unrunnable on small-context models (e.g. `ollama/phi3:mini`, 4,096-token window); the only
workaround today is disabling `lightContext`.

## Why This Change Was Made

The pre-prompt precheck `shouldPreemptivelyCompactBeforePrompt` clamps `reserveTokens` against a
minimum prompt budget, but that floor (`min(MIN_PROMPT_BUDGET_TOKENS, contextTokenBudget *
MIN_PROMPT_BUDGET_RATIO)` = `min(8000, 0.5 * ctx)`) is far too small for tiny context windows.
On a 4,096-token model the hardcoded ~20k `reserveTokens` floor clamps the prompt budget down to
~2,048 tokens, so a deterministic ~3,544-token bootstrap prompt overflows and routes to
`compact_only` — but a lightweight session has nothing to compact, so recovery is a no-op and the
run fails.

This is exactly the maintainer-flagged fix shape ("Option 2" in the issue): thread the existing
`bootstrapContextMode` into the precheck and, for `contextMode === "lightweight"`, reserve most of
a small context window for the prompt (`LIGHTWEIGHT_MIN_PROMPT_BUDGET_RATIO = 0.875`) so the
*reserve* shrinks instead of the prompt. Net effect for lightweight runs: effective reserve becomes
`min(requestedReserve, ~12.5% of context)`. The existing clamp means **large-context lightweight
runs keep their full requested reserve** (for a 20k reserve, the cap only bites below ~160k context),
and **non-lightweight ("full") runs are unchanged**.

Scope / boundaries:
- Only the pre-prompt precheck call in `runEmbeddedAttempt` receives `contextMode`. The sibling
  callers `shouldPreemptivelyCompactBeforePrompt` has — the mid-turn tool-result context guard
  (`tool-result-context-guard.ts`) and the CLI precheck (`cli-compaction.ts`) — are intentionally
  left as-is: the catastrophic *no-op* failure is specific to the pre-prompt path with an empty
  lightweight bootstrap (nothing to compact). Mid-turn there are accumulated tool results that give
  the guard real reducible content, and the CLI path is not a `lightContext` surface. Threading
  `contextMode` into the mid-turn guard is a reasonable follow-up if small-context lightweight
  sessions are observed overflowing mid-tool-loop.

## User Impact

`lightContext: true` cron jobs run successfully on small-context models again, with no config
change required and no `lightContext: false` workaround. No behavior change for full-context runs
or for non-lightweight sessions.

## Evidence

Deterministic source-level red→green via the repo runner (the accepted proof for this routing
logic), exact command:

```
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts \
  --testNamePattern lightweight --reporter verbose --maxWorkers 1
```

New regression `keeps lightweight tiny-context prompts out of no-op compact-only recovery`
(4096 ctx / 20000 reserve / 3544 estimated prompt):

- **RED** (without the source change): `expected 'compact_only' to be 'fits'` — 2 failed, exit 1.
- **GREEN** (with the fix): `route='fits'`, `shouldCompact=false`, `promptBudgetBeforeReserve=3584`
  (≥ 3544), `effectiveReserveTokens=512` (< 1000) — 2 passed | 32 skipped, exit 0.

**Proof gap (honest):** the full real-behavior repro is a live isolated cron run on a small-context
model (e.g. `ollama/phi3:mini`) failing then succeeding end-to-end. That is a live-service scenario
I could not run locally, so it was **not** performed here. The fix is proven at the deterministic
precheck-routing boundary that produces the reported `route=compact_only` / `overflowTokens` log
line in the issue.
