### PR TITLE
feat: show live session activity for running tasks

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c5220c8ccb7c2c57fb62f689bba49fa34a062546bcac909f7d38bba61e99a585  plugin-sdk-api-baseline.json
-41ed9c28192c9f9c47de551b854a880225212c441f92e527681462b7fc3a9bab  plugin-sdk-api-baseline.jsonl
+63c7f46b6e9fad7c6e862b5411afb8f43a30e31b51241ac0b8dbf44a9bd76496  plugin-sdk-api-baseline.json
+103607db80471c884b05dceb8c6ea9d36017ee97650fe3a3a097a3c531bef170  plugin-sdk-api-baseline.jsonl

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -445,6 +445,7 @@ enumeration of `src/gateway/server-methods/*.ts`.
 
   <Accordion title="Session control">
     - `sessions.list` returns the current session index, including per-row `agentRuntime` metadata when an agent runtime backend is configured.
+    - `sessions.activity` returns active detached tasks and live tool executions for a session. Descendant session activity is included by default so parent-session views can show subagent work without polling every child session separately.
     - `sessions.subscribe` and `sessions.unsubscribe` toggle session change event subscriptions for the current WS client.
     - `sessions.messages.subscribe` and `sessions.messages.unsubscribe` toggle transcript/message event subscriptions for one session.
     - `sessions.preview` returns bounded transcript previews for specific session keys.
@@ -511,9 +512,9 @@ enumeration of `src/gateway/server-methods/*.ts`.
   events. In protocol v4, delta payloads carry `deltaText`; `message` remains
   the cumulative assistant snapshot. Non-prefix replacements set `replace=true`
   and use `deltaText` as the replacement text.
-- `session.message`, `session.operation`, and `session.tool`: transcript,
-  in-flight session operation, and event-stream updates for a subscribed
-  session.
+- `session.message`, `session.operation`, `session.tool`, and
+  `session.activity`: transcript, in-flight session operation, live tool
+  stream, and active task/tool activity updates for subscribed sessions.
 - `sessions.changed`: session index or metadata changed.
 - `presence`: system presence snapshot updates.
 - `tick`: periodic keepalive / liveness event.

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -444,6 +444,8 @@ cover CLI and Gateway-backed install or update paths.
 - `message_sending`: returning `{ cancel: false }` is treated as no decision (same as omitting `cancel`), not as an override.
 - `message_received`: use the typed `threadId` field when you need inbound thread/topic routing. Keep `metadata` for channel-specific extras.
 - `message_sending`: use typed `replyToId` / `threadId` routing fields before falling back to channel-specific `metadata`.
+- `task_created`, `task_updated`, `task_finished`, and `task_deleted`: observe metadata-only Gateway task lifecycle changes without raw task payloads or transcript contents.
+- `tool_started`, `tool_updated`, and `tool_finished`: observe metadata-only live tool activity without tool arguments or results.
 - `gateway_start`: use `ctx.config`, `ctx.workspaceDir`, and `ctx.getCron?.()` for gateway-owned startup state instead of relying on internal `gateway:startup` hooks.
 - `cron_changed`: observe gateway-owned cron lifecycle changes. Use `event.job?.state?.nextRunAtMs` and `ctx.getCron?.()` when syncing external wake schedulers, and keep OpenClaw as the source of truth for due checks and execution.
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -134,7 +134,7 @@ Imported themes are stored only in the current browser profile. They are not wri
     - Chat history refreshes request a bounded recent window with per-message text caps so large sessions do not force the browser to render a full transcript payload before the chat becomes usable.
     - Talk through browser realtime sessions. OpenAI uses direct WebRTC, Google Live uses a constrained one-use browser token over WebSocket, and backend-only realtime voice plugins use the Gateway relay transport. Client-owned provider sessions start with `talk.client.create`; Gateway relay sessions start with `talk.session.create`. The relay keeps provider credentials on the Gateway while the browser streams microphone PCM through `talk.session.appendAudio`, forwards `openclaw_agent_consult` provider tool calls through `talk.client.toolCall` for Gateway policy and the larger configured OpenClaw model, and routes active-run voice steering through `talk.client.steer` or `talk.session.steer`.
     - Stream tool calls + live tool output cards in Chat (agent events).
-    - Activity tab with browser-local, redaction-first summaries of live tool activity from existing `session.tool` / tool event delivery.
+    - Chat running-work strip for active background tasks and live tools, including descendant-session work (`sessions.activity`, `session.activity`, and `session.tool`).
 
   </Accordion>
   <Accordion title="Channels, instances, sessions, dreams">
@@ -201,11 +201,11 @@ Typical workflow:
 
 The page redacts credential-bearing URL-like values before rendering and quotes server names in command snippets so copied commands still work with spaces or shell metacharacters. The full CLI and config reference lives in [MCP](/cli/mcp).
 
-## Activity tab
+## Activity tab and chat activity strip
 
-The Activity tab is an ephemeral browser-local observer for live tool activity. It is derived from the same Gateway `session.tool` / tool event stream that powers Chat tool cards; it does not add another Gateway event family, endpoint, durable activity store, metrics feed, or external observer stream.
+The Chat view shows a running-work strip for active session work. It loads the current snapshot with `sessions.activity`, refreshes from `session.activity` events, and still uses the same `session.tool` / tool event stream that powers Chat tool cards for detailed live tool rendering.
 
-Activity entries keep only sanitized summaries and redacted, truncated output previews. Tool argument values are not stored in Activity state; the UI shows that arguments are hidden and records only the argument field count. The in-memory list follows the current browser tab, survives navigation within the Control UI, and resets on page reload, session switch, or **Clear**.
+The Activity tab remains a redaction-first tool activity log. Activity entries keep only sanitized summaries and redacted, truncated output previews. Tool argument values are not stored in Activity state; the UI shows that arguments are hidden and records only the argument field count. Running detached tasks and live tools are session-scoped in the Chat strip, include descendant sessions by default, and clear from the list when the Gateway reports completion.
 
 ## Operator terminal
 

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -352,6 +352,10 @@ import {
   SecretsResolveResultSchema,
   type SessionsAbortParams,
   SessionsAbortParamsSchema,
+  type SessionsActivityParams,
+  SessionsActivityParamsSchema,
+  type SessionsActivityResult,
+  SessionsActivityResultSchema,
   type SessionsCompactParams,
   SessionsCompactParamsSchema,
   type SessionsCleanupParams,
@@ -681,6 +685,9 @@ export const validateSecretsResolveResult = lazyCompile<SecretsResolveResult>(
 export const validateSessionsListParams = lazyCompile<SessionsListParams>(SessionsListParamsSchema);
 export const validateSessionsCleanupParams = lazyCompile<SessionsCleanupParams>(
   SessionsCleanupParamsSchema,
+);
+export const validateSessionsActivityParams = lazyCompile<SessionsActivityParams>(
+  SessionsActivityParamsSchema,
 );
 export const validateSessionsPreviewParams = lazyCompile<SessionsPreviewParams>(
   SessionsPreviewParamsSchema,
@@ -1088,6 +1095,8 @@ export {
   NodePendingEnqueueResultSchema,
   SessionsListParamsSchema,
   SessionsCleanupParamsSchema,
+  SessionsActivityParamsSchema,
+  SessionsActivityResultSchema,
   SessionsPreviewParamsSchema,
   SessionsDescribeParamsSchema,
   SessionsResolveParamsSchema,
@@ -1441,6 +1450,8 @@ export type {
   NodePendingEnqueueResult,
   SessionsListParams,
   SessionsCleanupParams,
+  SessionsActivityParams,
+  SessionsActivityResult,
   SessionsPreviewParams,
   SessionsDescribeParams,
   SessionsResolveParams,

--- a/packages/gateway-protocol/src/schema/protocol-schemas.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schemas.ts
@@ -255,6 +255,8 @@ import {
 } from "./secrets.js";
 import {
   SessionsAbortParamsSchema,
+  SessionsActivityParamsSchema,
+  SessionsActivityResultSchema,
   SessionsCompactParamsSchema,
   SessionsCompactionBranchParamsSchema,
   SessionsCompactionBranchResultSchema,
@@ -394,6 +396,8 @@ export const ProtocolSchemas = {
   // Session lifecycle, message routing, compaction, and usage accounting.
   SessionsListParams: SessionsListParamsSchema,
   SessionsCleanupParams: SessionsCleanupParamsSchema,
+  SessionsActivityParams: SessionsActivityParamsSchema,
+  SessionsActivityResult: SessionsActivityResultSchema,
   SessionsPreviewParams: SessionsPreviewParamsSchema,
   SessionsDescribeParams: SessionsDescribeParamsSchema,
   SessionsResolveParams: SessionsResolveParamsSchema,

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -204,6 +204,73 @@ export const SessionsCleanupParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+const SessionActivityTaskStatusSchema = Type.Union([
+  Type.Literal("queued"),
+  Type.Literal("running"),
+]);
+
+export const SessionActivityTaskSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    sessionKey: NonEmptyString,
+    runtime: Type.Union([
+      Type.Literal("subagent"),
+      Type.Literal("acp"),
+      Type.Literal("cli"),
+      Type.Literal("cron"),
+    ]),
+    title: Type.String(),
+    status: SessionActivityTaskStatusSchema,
+    createdAt: Type.Integer({ minimum: 0 }),
+    startedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+    lastEventAt: Type.Optional(Type.Integer({ minimum: 0 })),
+    childSessionKey: Type.Optional(NonEmptyString),
+    runId: Type.Optional(NonEmptyString),
+    label: Type.Optional(Type.String()),
+    progressSummary: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const SessionActivityToolSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    sessionKey: NonEmptyString,
+    runId: NonEmptyString,
+    toolCallId: NonEmptyString,
+    name: NonEmptyString,
+    title: NonEmptyString,
+    status: Type.Literal("running"),
+    startedAt: Type.Integer({ minimum: 0 }),
+    updatedAt: Type.Integer({ minimum: 0 }),
+  },
+  { additionalProperties: false },
+);
+
+export const SessionsActivityParamsSchema = Type.Object(
+  {
+    key: NonEmptyString,
+    /** Include work running in recursively spawned child sessions. Defaults to true. */
+    includeDescendants: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
+
+export const SessionsActivityResultSchema = Type.Object(
+  {
+    key: NonEmptyString,
+    /** Monotonic best-effort version for this session activity view. */
+    revision: Type.Integer({ minimum: 0 }),
+    /** The root session and any child sessions represented in this snapshot. */
+    includedSessionKeys: Type.Array(NonEmptyString),
+    /** True when descendant traversal reached the implementation safety limit. */
+    truncated: Type.Boolean(),
+    tasks: Type.Array(SessionActivityTaskSchema),
+    tools: Type.Array(SessionActivityToolSchema),
+  },
+  { additionalProperties: false },
+);
+
 /** Reads short previews for selected session keys. */
 export const SessionsPreviewParamsSchema = Type.Object(
   {

--- a/packages/gateway-protocol/src/schema/types.ts
+++ b/packages/gateway-protocol/src/schema/types.ts
@@ -70,6 +70,8 @@ export type PushTestResult = SchemaType<"PushTestResult">;
 /** Session lifecycle, message routing, compaction, patch, and usage payloads. */
 export type SessionsListParams = SchemaType<"SessionsListParams">;
 export type SessionsCleanupParams = SchemaType<"SessionsCleanupParams">;
+export type SessionsActivityParams = SchemaType<"SessionsActivityParams">;
+export type SessionsActivityResult = SchemaType<"SessionsActivityResult">;
 export type SessionsPreviewParams = SchemaType<"SessionsPreviewParams">;
 export type SessionsDescribeParams = SchemaType<"SessionsDescribeParams">;
 export type SessionsResolveParams = SchemaType<"SessionsResolveParams">;

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -140,6 +140,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "voicewake.routing.get", scope: "operator.read" },
   { name: "voicewake.routing.set", scope: "operator.write" },
   { name: "sessions.list", scope: "operator.read", startup: true },
+  { name: "sessions.activity", scope: "operator.read" },
   { name: "sessions.subscribe", scope: "operator.read" },
   { name: "sessions.unsubscribe", scope: "operator.read" },
   { name: "sessions.messages.subscribe", scope: "operator.read" },

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -48,6 +48,7 @@ const EVENT_SCOPE_GUARDS: Record<string, string[]> = {
   "session.message": [READ_SCOPE],
   "session.operation": [READ_SCOPE],
   "session.tool": [READ_SCOPE],
+  "session.activity": [READ_SCOPE],
   // Operator terminal byte/exit streams. Admin-gated to match the terminal.*
   // methods; also targeted to the owning connection at broadcast time.
   "terminal.data": [ADMIN_SCOPE],

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -56,6 +56,10 @@ import {
   type AgentEventHandlerOptions,
 } from "./server-chat.js";
 import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.runtime.js";
+import {
+  clearSessionToolActivitiesForRun,
+  getSessionActivitySnapshot,
+} from "./session-activity.js";
 import { loadSessionEntry } from "./session-utils.js";
 
 describe("agent event handler", () => {
@@ -1600,9 +1604,19 @@ describe("agent event handler", () => {
       },
     });
 
-    expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
-    expect(requireMockArg(broadcastToConnIds, 0, 0, "session tool event")).toBe("session.tool");
-    const sessionToolPayload = requireMockPayload(broadcastToConnIds, 0, 1, "session tool payload");
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(2);
+    expect(requireMockArg(broadcastToConnIds, 0, 0, "session activity event")).toBe(
+      "session.activity",
+    );
+    expect(requireMockPayload(broadcastToConnIds, 0, 1, "session activity payload")).toEqual(
+      expect.objectContaining({
+        sessionKey: "session-1",
+        sourceSessionKey: "session-1",
+        reason: "tool",
+      }),
+    );
+    expect(requireMockArg(broadcastToConnIds, 1, 0, "session tool event")).toBe("session.tool");
+    const sessionToolPayload = requireMockPayload(broadcastToConnIds, 1, 1, "session tool payload");
     expectRecordFields(sessionToolPayload, {
       runId: "run-session-tool",
       sessionKey: "session-1",
@@ -1624,10 +1638,10 @@ describe("agent event handler", () => {
       toolCallId: "tool-session-1",
       args: { command: "echo hi" },
     });
-    expect(requireMockArg(broadcastToConnIds, 0, 2, "session tool recipients")).toEqual(
+    expect(requireMockArg(broadcastToConnIds, 1, 2, "session tool recipients")).toEqual(
       new Set(["conn-session"]),
     );
-    expect(requireMockArg(broadcastToConnIds, 0, 3, "session tool options")).toEqual({
+    expect(requireMockArg(broadcastToConnIds, 1, 3, "session tool options")).toEqual({
       dropIfSlow: true,
     });
     resetAgentRunContextForTest();
@@ -1669,8 +1683,11 @@ describe("agent event handler", () => {
     });
 
     expect(loadGatewaySessionRow).toHaveBeenCalledWith("global", { agentId: "work" });
-    expect(requireMockArg(broadcastToConnIds, 0, 0, "session tool event")).toBe("session.tool");
-    expect(requireMockPayload(broadcastToConnIds, 0, 1, "session tool payload")).toEqual(
+    expect(requireMockArg(broadcastToConnIds, 0, 0, "session activity event")).toBe(
+      "session.activity",
+    );
+    expect(requireMockArg(broadcastToConnIds, 1, 0, "session tool event")).toBe("session.tool");
+    expect(requireMockPayload(broadcastToConnIds, 1, 1, "session tool payload")).toEqual(
       expect.objectContaining({
         sessionKey: "global",
         agentId: "work",
@@ -1712,19 +1729,23 @@ describe("agent event handler", () => {
       },
     });
 
-    expect(broadcastToConnIds).toHaveBeenCalledTimes(2);
-    expect(requireMockArg(broadcastToConnIds, 0, 0, "run tool event")).toBe("agent");
-    expect(requireMockArg(broadcastToConnIds, 0, 2, "run tool recipients")).toEqual(
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(3);
+    expect(requireMockArg(broadcastToConnIds, 0, 0, "session activity event")).toBe(
+      "session.activity",
+    );
+    expect(requireMockArg(broadcastToConnIds, 1, 0, "run tool event")).toBe("agent");
+    expect(requireMockArg(broadcastToConnIds, 1, 2, "run tool recipients")).toEqual(
       new Set(["conn-overlap", "conn-run-only"]),
     );
-    expect(requireMockArg(broadcastToConnIds, 1, 0, "session tool event")).toBe("session.tool");
-    expect(requireMockArg(broadcastToConnIds, 1, 2, "session tool recipients")).toEqual(
+    expect(requireMockArg(broadcastToConnIds, 2, 0, "session tool event")).toBe("session.tool");
+    expect(requireMockArg(broadcastToConnIds, 2, 2, "session tool recipients")).toEqual(
       new Set(["conn-session-only"]),
     );
   });
 
   it("suppresses heartbeat tool events for Control UI and verbose node subscribers", () => {
     const {
+      broadcast,
       broadcastToConnIds,
       nodeSendToSession,
       sessionEventSubscribers,
@@ -1756,6 +1777,7 @@ describe("agent event handler", () => {
     });
 
     expect(broadcastToConnIds).not.toHaveBeenCalled();
+    expect(broadcast.mock.calls.filter(([event]) => event === "session.activity")).toHaveLength(0);
     const nodeToolCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "agent");
     expect(nodeToolCalls).toHaveLength(0);
     resetAgentRunContextForTest();
@@ -3958,7 +3980,13 @@ describe("agent event handler", () => {
   });
 
   it("remaps chat-linked tool runId for non-full verbose payloads", () => {
-    const { broadcastToConnIds, chatRunState, toolEventRecipients, handler } = createHarness({
+    const {
+      broadcastToConnIds,
+      chatRunState,
+      sessionEventSubscribers,
+      toolEventRecipients,
+      handler,
+    } = createHarness({
       resolveSessionKeyForRun: () => "session-tool-remap",
     });
 
@@ -3970,6 +3998,7 @@ describe("agent event handler", () => {
       sessionKey: "session-tool-remap",
       verboseLevel: "on",
     });
+    sessionEventSubscribers.subscribe("conn-session");
     toolEventRecipients.add("run-tool-internal", "conn-1");
 
     handler({
@@ -3978,18 +4007,46 @@ describe("agent event handler", () => {
       stream: "tool",
       ts: Date.now(),
       data: {
-        phase: "result",
+        phase: "start",
         name: "exec",
         toolCallId: "tool-remap-1",
         result: { content: [{ type: "text", text: "secret" }] },
       },
     });
 
-    expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
-    const payload = requireMockArg(broadcastToConnIds, 0, 1, "remapped tool payload") as {
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(3);
+    expect(requireMockArg(broadcastToConnIds, 0, 0, "remapped activity event")).toBe(
+      "session.activity",
+    );
+    const payload = requireMockArg(broadcastToConnIds, 1, 1, "remapped tool payload") as {
       runId?: string;
     };
     expect(payload.runId).toBe("run-tool-client");
+    expect(getSessionActivitySnapshot({ key: "session-tool-remap" }).tools[0]).toMatchObject({
+      id: "run-tool-client:tool-remap-1",
+      runId: "run-tool-client",
+      toolCallId: "tool-remap-1",
+    });
+
+    handler({
+      runId: "run-tool-internal",
+      seq: 2,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "end" },
+    });
+
+    expect(getSessionActivitySnapshot({ key: "session-tool-remap" }).tools).toEqual([]);
+    expect(
+      broadcastToConnIds.mock.calls.some(
+        ([event, eventPayload]) =>
+          event === "session.activity" &&
+          typeof eventPayload === "object" &&
+          eventPayload !== null &&
+          (eventPayload as { reason?: unknown }).reason === "tool-clear",
+      ),
+    ).toBe(true);
+    clearSessionToolActivitiesForRun("run-tool-client");
     resetAgentRunContextForTest();
   });
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -31,6 +31,12 @@ import type {
 import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.runtime.js";
 import { persistGatewaySessionLifecycleEvent } from "./server-chat.persist-session-lifecycle.runtime.js";
 import {
+  clearSessionToolActivitiesForRun,
+  expandSessionActivityMutation,
+  recordSessionToolActivity,
+  type SessionActivityMutation,
+} from "./session-activity.js";
+import {
   deriveGatewaySessionLifecycleProjectionPatch,
   isRestartRecoveryLifecycleEvent,
   isStaleLifecycleEventForSession,
@@ -519,6 +525,26 @@ export function createAgentEventHandler({
     }
   };
 
+  const broadcastSessionActivityMutation = (mutation: SessionActivityMutation, reason: string) => {
+    const connIds = sessionEventSubscribers.getAll();
+    if (connIds.size === 0) {
+      return;
+    }
+    for (const expanded of expandSessionActivityMutation(mutation)) {
+      broadcastToConnIds(
+        "session.activity",
+        {
+          sessionKey: expanded.sessionKey,
+          ...(expanded.sourceSessionKey ? { sourceSessionKey: expanded.sourceSessionKey } : {}),
+          revision: expanded.revision,
+          reason,
+        },
+        connIds,
+        { dropIfSlow: true },
+      );
+    }
+  };
+
   const emitFirstAssistantChatSendTiming = (chatLink: ChatRunEntry | undefined) => {
     const timing = chatLink?.chatSendTiming;
     if (!timing || timing.firstAssistantEventSent) {
@@ -601,6 +627,13 @@ export function createAgentEventHandler({
       );
     if (isSupersededRestartRecoveryEvent) {
       return;
+    }
+
+    const toolActivityCleanupRunIds = new Set([evt.runId, clientRunId]);
+    for (const runId of toolActivityCleanupRunIds) {
+      for (const mutation of clearSessionToolActivitiesForRun(runId)) {
+        broadcastSessionActivityMutation(mutation, "tool-clear");
+      }
     }
 
     if (
@@ -1224,6 +1257,13 @@ export function createAgentEventHandler({
             return { ...agentPayload, data };
           })()
         : agentPayload;
+    const toolActivityMutation =
+      isToolEvent && !suppressHeartbeatToolEvents
+        ? recordSessionToolActivity({ event: eventForClients, sessionKey })
+        : undefined;
+    if (toolActivityMutation) {
+      broadcastSessionActivityMutation(toolActivityMutation, "tool");
+    }
     if (last > 0 && evt.seq !== last + 1 && isControlUiVisible) {
       flushBufferedAgentDeltaIfNeeded(clientRunId);
       broadcast("agent", {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -691,6 +691,7 @@ export function createGatewayCloseHandler(
     heartbeatUnsub: (() => void) | null;
     transcriptUnsub: (() => void) | null;
     lifecycleUnsub: (() => void) | null;
+    taskActivityUnsub?: (() => void) | null;
     getPendingReplyCount?: () => number;
     clients: Set<{ socket: { close: (code: number, reason: string) => void } }>;
     configReloader: { stop: () => Promise<void> };
@@ -904,6 +905,9 @@ export function createGatewayCloseHandler(
       }
       if (params.lifecycleUnsub) {
         await shutdownStep("lifecycle-unsub", () => params.lifecycleUnsub!(), warnings);
+      }
+      if (params.taskActivityUnsub) {
+        await shutdownStep("task-activity-unsub", () => params.taskActivityUnsub!(), warnings);
       }
       params.chatRunState.clear();
       let clientCloseFailures = 0;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -43,6 +43,7 @@ export const GATEWAY_EVENTS = [
   "session.message",
   "session.operation",
   "session.tool",
+  "session.activity",
   "sessions.changed",
   "presence",
   "tick",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -182,6 +182,10 @@ const loadSessionsHandlers = lazyHandlerModule(
   () => import("./server-methods/sessions.js"),
   (module) => module.sessionsHandlers,
 );
+const loadSessionActivityHandlers = lazyHandlerModule(
+  () => import("./server-methods/session-activity.js"),
+  (module) => module.sessionActivityHandlers,
+);
 const loadSkillsHandlers = lazyHandlerModule(
   () => import("./server-methods/skills.js"),
   (module) => module.skillsHandlers,
@@ -533,6 +537,10 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
       "sessions.compact",
     ],
     loadHandlers: loadSessionsHandlers,
+  }),
+  ...createLazyCoreHandlers({
+    methods: ["sessions.activity"],
+    loadHandlers: loadSessionActivityHandlers,
   }),
   ...createLazyCoreHandlers({
     methods: [

--- a/src/gateway/server-methods/session-activity.test.ts
+++ b/src/gateway/server-methods/session-activity.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSessionActivitySnapshot: vi.fn(),
+}));
+
+vi.mock("../session-activity.js", () => ({
+  getSessionActivitySnapshot: mocks.getSessionActivitySnapshot,
+}));
+
+import { sessionActivityHandlers } from "./session-activity.js";
+
+describe("sessions.activity", () => {
+  it("returns active durable tasks and live tools for one session", async () => {
+    mocks.getSessionActivitySnapshot.mockReturnValue({
+      key: "agent:main:main",
+      revision: 4,
+      includedSessionKeys: ["agent:main:main", "agent:main:subagent:child"],
+      truncated: false,
+      tasks: [
+        {
+          taskId: "task-running",
+          requesterSessionKey: "agent:main:main",
+          runtime: "subagent",
+          task: "Investigate issue",
+          status: "running",
+          createdAt: 100,
+          startedAt: 120,
+          lastEventAt: 130,
+          childSessionKey: "agent:main:subagent:child",
+          runId: "run-subagent",
+          deliveryStatus: "pending",
+          notifyPolicy: "done_only",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+        },
+        {
+          taskId: "task-done",
+          requesterSessionKey: "agent:main:main",
+          runtime: "cron",
+          task: "Completed job",
+          status: "succeeded",
+          createdAt: 10,
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+        },
+      ],
+      tools: [
+        {
+          id: "run-exec:call-exec",
+          sessionKey: "agent:main:main",
+          runId: "run-exec",
+          toolCallId: "call-exec",
+          name: "exec",
+          title: "exec",
+          status: "running",
+          startedAt: 150,
+          updatedAt: 160,
+        },
+      ],
+    });
+    const respond = vi.fn();
+
+    await sessionActivityHandlers["sessions.activity"]({
+      params: { key: "agent:main:main" },
+      respond,
+    } as never);
+
+    expect(respond).toHaveBeenCalledWith(true, {
+      key: "agent:main:main",
+      revision: 4,
+      includedSessionKeys: ["agent:main:main", "agent:main:subagent:child"],
+      truncated: false,
+      tasks: [
+        expect.objectContaining({
+          id: "task-running",
+          runtime: "subagent",
+          status: "running",
+          childSessionKey: "agent:main:subagent:child",
+        }),
+      ],
+      tools: [expect.objectContaining({ name: "exec", status: "running" })],
+    });
+    expect(mocks.getSessionActivitySnapshot).toHaveBeenCalledWith({
+      key: "agent:main:main",
+      includeDescendants: undefined,
+    });
+  });
+});

--- a/src/gateway/server-methods/session-activity.ts
+++ b/src/gateway/server-methods/session-activity.ts
@@ -1,0 +1,56 @@
+import type { TaskRecord } from "../../tasks/task-registry.types.js";
+import {
+  ErrorCodes,
+  errorShape,
+  validateSessionsActivityParams,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { getSessionActivitySnapshot } from "../session-activity.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+function isActiveTask(task: TaskRecord): task is TaskRecord & { status: "queued" | "running" } {
+  return task.status === "queued" || task.status === "running";
+}
+
+function mapActiveTask(task: TaskRecord) {
+  return {
+    id: task.taskId,
+    sessionKey: task.requesterSessionKey,
+    runtime: task.runtime,
+    title: task.task,
+    status: task.status,
+    createdAt: task.createdAt,
+    ...(task.startedAt !== undefined ? { startedAt: task.startedAt } : {}),
+    ...(task.lastEventAt !== undefined ? { lastEventAt: task.lastEventAt } : {}),
+    ...(task.childSessionKey ? { childSessionKey: task.childSessionKey } : {}),
+    ...(task.runId ? { runId: task.runId } : {}),
+    ...(task.label ? { label: task.label } : {}),
+    ...(task.progressSummary ? { progressSummary: task.progressSummary } : {}),
+  };
+}
+
+export const sessionActivityHandlers: GatewayRequestHandlers = {
+  "sessions.activity": ({ params, respond }) => {
+    if (!assertValidParams(params, validateSessionsActivityParams, "sessions.activity", respond)) {
+      return;
+    }
+    const key = params.key.trim();
+    if (!key) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "key required"));
+      return;
+    }
+    const activity = getSessionActivitySnapshot({
+      key,
+      includeDescendants: params.includeDescendants,
+    });
+    const tasks = activity.tasks.filter(isActiveTask).map(mapActiveTask);
+    respond(true, {
+      key,
+      revision: activity.revision,
+      includedSessionKeys: activity.includedSessionKeys,
+      truncated: activity.truncated,
+      tasks,
+      tools: activity.tools,
+    });
+  },
+};

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -34,6 +34,7 @@ export type GatewayServerMutableState = {
   heartbeatUnsub: (() => void) | null;
   transcriptUnsub: (() => void) | null;
   lifecycleUnsub: (() => void) | null;
+  taskActivityUnsub: (() => void) | null;
 };
 
 /** Creates gateway mutable state with inert handles that are safe to stop before startup finishes. */
@@ -70,5 +71,6 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
     heartbeatUnsub: null as (() => void) | null,
     transcriptUnsub: null as (() => void) | null,
     lifecycleUnsub: null as (() => void) | null,
+    taskActivityUnsub: null as (() => void) | null,
   };
 }

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -4,6 +4,7 @@ import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
+import { onTaskRegistryEvent } from "../tasks/task-registry.js";
 import {
   type ChatAbortControllerEntry,
   removeChatAbortControllerEntry,
@@ -15,6 +16,7 @@ import type {
   SessionMessageSubscriberRegistry,
   ToolEventRecipientRegistry,
 } from "./server-chat-state.js";
+import { bumpSessionActivityRevision, listRelatedSessionActivityKeys } from "./session-activity.js";
 
 /** Register gateway runtime event subscriptions and return unsubscribe handles. */
 export function startGatewayEventSubscriptions(params: {
@@ -241,10 +243,36 @@ export function startGatewayEventSubscriptions(params: {
     void getLifecycleEventHandler().then((handler) => handler(evt));
   });
 
+  const taskActivityUnsub = onTaskRegistryEvent((event) => {
+    const task =
+      event.kind === "deleted"
+        ? event.previous
+        : event.kind === "upserted"
+          ? event.task
+          : undefined;
+    if (!task) {
+      return;
+    }
+    const connIds = params.sessionEventSubscribers.getAll();
+    if (connIds.size === 0) {
+      return;
+    }
+    for (const sessionKey of listRelatedSessionActivityKeys(task)) {
+      const revision = bumpSessionActivityRevision(sessionKey) ?? 0;
+      params.broadcastToConnIds(
+        "session.activity",
+        { sessionKey, revision, reason: "task" },
+        connIds,
+        { dropIfSlow: true },
+      );
+    }
+  });
+
   return {
     agentUnsub,
     heartbeatUnsub,
     transcriptUnsub,
     lifecycleUnsub,
+    taskActivityUnsub,
   };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1064,6 +1064,7 @@ export async function startGatewayServer(
       heartbeatUnsub: runtimeState.heartbeatUnsub,
       transcriptUnsub: runtimeState.transcriptUnsub,
       lifecycleUnsub: runtimeState.lifecycleUnsub,
+      taskActivityUnsub: runtimeState.taskActivityUnsub,
       chatRunState,
       chatAbortControllers,
       chatQueuedTurns,

--- a/src/gateway/session-activity.snapshot.test.ts
+++ b/src/gateway/session-activity.snapshot.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listTasksForRelatedSessionKey: vi.fn(),
+}));
+
+vi.mock("../tasks/task-registry.js", () => ({
+  listTasksForRelatedSessionKey: mocks.listTasksForRelatedSessionKey,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => null,
+}));
+
+import {
+  expandSessionActivityMutation,
+  getSessionActivitySnapshot,
+  recordSessionToolActivity,
+  resetSessionToolActivitiesForTests,
+} from "./session-activity.js";
+
+function task(params: {
+  taskId: string;
+  ownerKey: string;
+  childSessionKey?: string;
+  status?: "queued" | "running" | "succeeded";
+  createdAt?: number;
+}) {
+  return {
+    taskId: params.taskId,
+    runtime: "subagent" as const,
+    requesterSessionKey: params.ownerKey,
+    ownerKey: params.ownerKey,
+    scopeKind: "session" as const,
+    ...(params.childSessionKey ? { childSessionKey: params.childSessionKey } : {}),
+    task: params.taskId,
+    status: params.status ?? "running",
+    deliveryStatus: "pending" as const,
+    notifyPolicy: "done_only" as const,
+    createdAt: params.createdAt ?? 1,
+  };
+}
+
+describe("session activity snapshots", () => {
+  afterEach(() => {
+    mocks.listTasksForRelatedSessionKey.mockReset();
+    resetSessionToolActivitiesForTests();
+  });
+
+  it("includes active descendant tasks and live exec work", () => {
+    const root = "agent:main:main";
+    const child = "agent:main:subagent:child";
+    const grandchild = "agent:main:subagent:grandchild";
+    const rootTask = task({ taskId: "task-root", ownerKey: root, childSessionKey: child });
+    const childTask = task({
+      taskId: "task-child",
+      ownerKey: child,
+      childSessionKey: grandchild,
+      createdAt: 2,
+    });
+    const grandchildTask = task({ taskId: "task-grandchild", ownerKey: grandchild, createdAt: 3 });
+    mocks.listTasksForRelatedSessionKey.mockImplementation((key: string) => {
+      if (key === root) {
+        return [rootTask];
+      }
+      if (key === child) {
+        return [rootTask, childTask];
+      }
+      if (key === grandchild) {
+        return [childTask, grandchildTask];
+      }
+      return [];
+    });
+
+    const mutation = recordSessionToolActivity({
+      sessionKey: grandchild,
+      event: {
+        runId: "run-exec",
+        seq: 1,
+        stream: "tool",
+        ts: 100,
+        data: { phase: "start", name: "exec", toolCallId: "call-exec" },
+      },
+    });
+    expect(mutation).toBeDefined();
+    expect(expandSessionActivityMutation(mutation!)).toEqual([
+      expect.objectContaining({ sessionKey: root }),
+      expect.objectContaining({ sessionKey: child }),
+      expect.objectContaining({ sessionKey: grandchild, revision: 1 }),
+    ]);
+
+    expect(getSessionActivitySnapshot({ key: root })).toMatchObject({
+      key: root,
+      revision: 1,
+      includedSessionKeys: [root, child, grandchild],
+      truncated: false,
+      tasks: [
+        expect.objectContaining({ taskId: "task-grandchild" }),
+        expect.objectContaining({ taskId: "task-child" }),
+        expect.objectContaining({ taskId: "task-root" }),
+      ],
+      tools: [expect.objectContaining({ sessionKey: grandchild, name: "exec" })],
+    });
+  });
+
+  it("can restrict the snapshot to direct session activity", () => {
+    const root = "agent:main:main";
+    const child = "agent:main:subagent:child";
+    const rootTask = task({ taskId: "task-root", ownerKey: root, childSessionKey: child });
+    mocks.listTasksForRelatedSessionKey.mockImplementation((key: string) =>
+      key === root ? [rootTask] : [],
+    );
+
+    expect(getSessionActivitySnapshot({ key: root, includeDescendants: false })).toMatchObject({
+      includedSessionKeys: [root],
+      tasks: [expect.objectContaining({ taskId: "task-root" })],
+      tools: [],
+    });
+  });
+});

--- a/src/gateway/session-activity.test.ts
+++ b/src/gateway/session-activity.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
+import {
+  clearSessionToolActivitiesForRun,
+  listSessionToolActivities,
+  recordSessionToolActivity,
+  resetSessionToolActivitiesForTests,
+} from "./session-activity.js";
+
+describe("session tool activity registry", () => {
+  afterEach(() => {
+    resetSessionToolActivitiesForTests();
+    resetGlobalHookRunner();
+  });
+
+  it("tracks live exec work until the tool result arrives", () => {
+    recordSessionToolActivity({
+      sessionKey: "agent:main:main",
+      event: {
+        runId: "run-exec",
+        seq: 1,
+        stream: "tool",
+        ts: 100,
+        data: {
+          phase: "start",
+          name: "exec",
+          toolCallId: "call-exec",
+        },
+      },
+    });
+
+    expect(listSessionToolActivities("agent:main:main")).toEqual([
+      expect.objectContaining({
+        id: "run-exec:call-exec",
+        name: "exec",
+        status: "running",
+        startedAt: 100,
+      }),
+    ]);
+
+    recordSessionToolActivity({
+      sessionKey: "agent:main:main",
+      event: {
+        runId: "run-exec",
+        seq: 2,
+        stream: "tool",
+        ts: 200,
+        data: {
+          phase: "result",
+          name: "exec",
+          toolCallId: "call-exec",
+        },
+      },
+    });
+
+    expect(listSessionToolActivities("agent:main:main")).toEqual([]);
+  });
+
+  it("clears every live tool when its agent run ends", () => {
+    for (const toolCallId of ["call-one", "call-two"]) {
+      recordSessionToolActivity({
+        sessionKey: "agent:main:main",
+        event: {
+          runId: "run-tools",
+          seq: 1,
+          stream: "tool",
+          ts: 100,
+          data: { phase: "start", name: "exec", toolCallId },
+        },
+      });
+    }
+
+    clearSessionToolActivitiesForRun("run-tools");
+
+    expect(listSessionToolActivities("agent:main:main")).toEqual([]);
+  });
+
+  it("emits metadata-only typed plugin hooks for live tools", async () => {
+    const started = vi.fn();
+    const finished = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "tool_started", handler: started },
+        { hookName: "tool_finished", handler: finished },
+      ]),
+    );
+    const event = {
+      runId: "run-exec",
+      seq: 1,
+      stream: "tool" as const,
+      ts: 100,
+      data: {
+        phase: "start",
+        name: "exec",
+        toolCallId: "call-exec",
+        args: { command: "secret" },
+      },
+    };
+
+    recordSessionToolActivity({ sessionKey: "agent:main:main", event });
+    recordSessionToolActivity({
+      sessionKey: "agent:main:main",
+      event: { ...event, seq: 2, data: { ...event.data, phase: "result" } },
+    });
+    await Promise.resolve();
+
+    expect(started).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "started",
+        activity: expect.objectContaining({ name: "exec" }),
+      }),
+      expect.objectContaining({ sessionKey: "agent:main:main", toolCallId: "call-exec" }),
+    );
+    expect(finished).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: "finished" }),
+      expect.anything(),
+    );
+    expect(started.mock.calls[0]?.[0]).not.toHaveProperty("args");
+  });
+});

--- a/src/gateway/session-activity.ts
+++ b/src/gateway/session-activity.ts
@@ -1,0 +1,313 @@
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { listTasksForRelatedSessionKey } from "../tasks/task-registry.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+
+export type SessionToolActivity = {
+  id: string;
+  sessionKey: string;
+  runId: string;
+  toolCallId: string;
+  name: string;
+  title: string;
+  status: "running";
+  startedAt: number;
+  updatedAt: number;
+};
+
+type SessionActivityState = {
+  toolsById: Map<string, SessionToolActivity>;
+  revisionsBySessionKey: Map<string, number>;
+};
+
+const SESSION_ACTIVITY_STATE_KEY = Symbol.for("openclaw.gateway.sessionActivity");
+
+function getSessionActivityState(): SessionActivityState {
+  return resolveGlobalSingleton<SessionActivityState>(SESSION_ACTIVITY_STATE_KEY, () => ({
+    toolsById: new Map(),
+    revisionsBySessionKey: new Map(),
+  }));
+}
+
+const MAX_SESSION_ACTIVITY_DESCENDANTS = 128;
+
+export type SessionActivityMutation = {
+  sessionKey: string;
+  revision: number;
+  sourceSessionKey?: string;
+};
+
+export type SessionActivitySnapshot = {
+  key: string;
+  revision: number;
+  includedSessionKeys: string[];
+  truncated: boolean;
+  tasks: TaskRecord[];
+  tools: SessionToolActivity[];
+};
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function compareTaskActivityNewestFirst(left: TaskRecord, right: TaskRecord): number {
+  const leftAt = left.lastEventAt ?? left.startedAt ?? left.createdAt;
+  const rightAt = right.lastEventAt ?? right.startedAt ?? right.createdAt;
+  return rightAt - leftAt || left.taskId.localeCompare(right.taskId);
+}
+
+function toPluginToolActivity(activity: SessionToolActivity) {
+  return {
+    id: activity.id,
+    name: activity.name,
+    title: activity.title,
+    startedAt: activity.startedAt,
+    updatedAt: activity.updatedAt,
+  };
+}
+
+function emitPluginToolActivity(params: {
+  activity: SessionToolActivity;
+  phase: "started" | "updated" | "finished";
+}) {
+  const runner = getGlobalHookRunner();
+  if (!runner) {
+    return;
+  }
+  const event = {
+    phase: params.phase,
+    activity: toPluginToolActivity(params.activity),
+  };
+  const context = {
+    sessionKey: params.activity.sessionKey,
+    runId: params.activity.runId,
+    toolCallId: params.activity.toolCallId,
+  };
+  if (params.phase === "started" && runner.hasHooks("tool_started")) {
+    void runner.runToolStarted(event, context).catch(() => {});
+  } else if (params.phase === "updated" && runner.hasHooks("tool_updated")) {
+    void runner.runToolUpdated(event, context).catch(() => {});
+  } else if (params.phase === "finished" && runner.hasHooks("tool_finished")) {
+    void runner.runToolFinished(event, context).catch(() => {});
+  }
+}
+
+/** Advance a best-effort per-session activity version after a visible mutation. */
+export function bumpSessionActivityRevision(sessionKey: string): number | undefined {
+  const normalizedSessionKey = sessionKey.trim();
+  if (!normalizedSessionKey) {
+    return undefined;
+  }
+  const state = getSessionActivityState();
+  const next = (state.revisionsBySessionKey.get(normalizedSessionKey) ?? 0) + 1;
+  state.revisionsBySessionKey.set(normalizedSessionKey, next);
+  return next;
+}
+
+export function getSessionActivityRevision(sessionKey: string): number {
+  const normalizedSessionKey = sessionKey.trim();
+  return normalizedSessionKey
+    ? (getSessionActivityState().revisionsBySessionKey.get(normalizedSessionKey) ?? 0)
+    : 0;
+}
+
+/**
+ * Return every session key whose activity view includes this task. This walks
+ * parent task links backwards so a root session is invalidated for a nested
+ * child task update.
+ */
+export function listRelatedSessionActivityKeys(task: TaskRecord): string[] {
+  return listSessionActivityAncestorKeys([
+    task.ownerKey,
+    task.requesterSessionKey,
+    task.childSessionKey,
+  ]);
+}
+
+/** Return a session and every ancestor session that includes it as a descendant. */
+export function listSessionActivityAncestorKeys(sessionKeys: Array<string | undefined>): string[] {
+  const keys = new Set<string>();
+  const pending = sessionKeys
+    .map(readNonEmptyString)
+    .filter((value): value is string => Boolean(value));
+
+  while (pending.length > 0 && keys.size < MAX_SESSION_ACTIVITY_DESCENDANTS) {
+    const sessionKey = pending.shift();
+    if (!sessionKey || keys.has(sessionKey)) {
+      continue;
+    }
+    keys.add(sessionKey);
+    for (const candidate of listTasksForRelatedSessionKey(sessionKey)) {
+      if (candidate.childSessionKey?.trim() !== sessionKey) {
+        continue;
+      }
+      for (const ancestorKey of [candidate.ownerKey, candidate.requesterSessionKey]) {
+        const normalized = readNonEmptyString(ancestorKey);
+        if (normalized && !keys.has(normalized)) {
+          pending.push(normalized);
+        }
+      }
+    }
+  }
+
+  return [...keys].toSorted();
+}
+
+/** Expand a direct mutation to every ancestor session activity view it affects. */
+export function expandSessionActivityMutation(
+  mutation: SessionActivityMutation,
+): SessionActivityMutation[] {
+  return listSessionActivityAncestorKeys([mutation.sessionKey]).map((sessionKey) =>
+    sessionKey === mutation.sessionKey
+      ? mutation
+      : Object.assign(
+          {
+            sessionKey,
+            revision: bumpSessionActivityRevision(sessionKey) ?? 0,
+          },
+          mutation.sourceSessionKey ? { sourceSessionKey: mutation.sourceSessionKey } : {},
+        ),
+  );
+}
+
+/**
+ * Build a self-contained activity snapshot. Descendant traversal includes
+ * terminal parent records so active grandchildren remain visible after an
+ * intermediate parent task has finished.
+ */
+export function getSessionActivitySnapshot(params: {
+  key: string;
+  includeDescendants?: boolean;
+}): SessionActivitySnapshot {
+  const key = params.key.trim();
+  const includeDescendants = params.includeDescendants !== false;
+  const includedSessionKeys = new Set<string>();
+  const taskById = new Map<string, TaskRecord>();
+  const pending = key ? [key] : [];
+  let truncated = false;
+
+  while (pending.length > 0) {
+    const sessionKey = pending.shift();
+    if (!sessionKey || includedSessionKeys.has(sessionKey)) {
+      continue;
+    }
+    if (includedSessionKeys.size >= MAX_SESSION_ACTIVITY_DESCENDANTS) {
+      truncated = true;
+      break;
+    }
+    includedSessionKeys.add(sessionKey);
+    for (const task of listTasksForRelatedSessionKey(sessionKey)) {
+      taskById.set(task.taskId, task);
+      const childSessionKey = readNonEmptyString(task.childSessionKey);
+      if (includeDescendants && childSessionKey && !includedSessionKeys.has(childSessionKey)) {
+        pending.push(childSessionKey);
+      }
+    }
+  }
+
+  const sessionKeys = [...includedSessionKeys].toSorted();
+  const tools = sessionKeys
+    .flatMap((sessionKey) => listSessionToolActivities(sessionKey))
+    .toSorted((left, right) => right.updatedAt - left.updatedAt || left.id.localeCompare(right.id));
+
+  return {
+    key,
+    revision: getSessionActivityRevision(key),
+    includedSessionKeys: sessionKeys,
+    truncated,
+    tasks: [...taskById.values()].toSorted(compareTaskActivityNewestFirst),
+    tools,
+  };
+}
+
+/** Track live tool work separately from the durable detached-task ledger. */
+export function recordSessionToolActivity(params: {
+  event: AgentEventPayload;
+  sessionKey: string | undefined;
+}): SessionActivityMutation | undefined {
+  if (params.event.stream !== "tool" || !params.sessionKey) {
+    return undefined;
+  }
+  const sessionKey = params.sessionKey.trim();
+  const data = params.event.data ?? {};
+  const toolCallId = readNonEmptyString(data.toolCallId);
+  if (!sessionKey || !toolCallId) {
+    return undefined;
+  }
+  const id = `${params.event.runId}:${toolCallId}`;
+  const phase = readNonEmptyString(data.phase);
+  const state = getSessionActivityState();
+  if (phase === "result") {
+    const previous = state.toolsById.get(id);
+    if (!previous) {
+      return undefined;
+    }
+    state.toolsById.delete(id);
+    emitPluginToolActivity({ activity: previous, phase: "finished" });
+    return {
+      sessionKey,
+      revision: bumpSessionActivityRevision(sessionKey) ?? 0,
+      sourceSessionKey: sessionKey,
+    };
+  }
+  const previous = state.toolsById.get(id);
+  const name = readNonEmptyString(data.name) ?? previous?.name ?? "tool";
+  const now = typeof params.event.ts === "number" ? params.event.ts : Date.now();
+  const activity: SessionToolActivity = {
+    id,
+    sessionKey,
+    runId: params.event.runId,
+    toolCallId,
+    name,
+    title: name,
+    status: "running",
+    startedAt: previous?.startedAt ?? now,
+    updatedAt: now,
+  };
+  state.toolsById.set(id, activity);
+  emitPluginToolActivity({ activity, phase: previous ? "updated" : "started" });
+  return {
+    sessionKey,
+    revision: bumpSessionActivityRevision(sessionKey) ?? 0,
+    sourceSessionKey: sessionKey,
+  };
+}
+
+export function clearSessionToolActivitiesForRun(runId: string): SessionActivityMutation[] {
+  const normalizedRunId = runId.trim();
+  if (!normalizedRunId) {
+    return [];
+  }
+  const state = getSessionActivityState();
+  const changedSessionKeys = new Set<string>();
+  for (const [id, activity] of state.toolsById) {
+    if (activity.runId === normalizedRunId) {
+      state.toolsById.delete(id);
+      changedSessionKeys.add(activity.sessionKey);
+      emitPluginToolActivity({ activity, phase: "finished" });
+    }
+  }
+  return [...changedSessionKeys].toSorted().map((sessionKey) => ({
+    sessionKey,
+    revision: bumpSessionActivityRevision(sessionKey) ?? 0,
+    sourceSessionKey: sessionKey,
+  }));
+}
+
+export function listSessionToolActivities(sessionKey: string): SessionToolActivity[] {
+  const normalizedSessionKey = sessionKey.trim();
+  if (!normalizedSessionKey) {
+    return [];
+  }
+  return [...getSessionActivityState().toolsById.values()]
+    .filter((activity) => activity.sessionKey === normalizedSessionKey)
+    .toSorted((left, right) => right.updatedAt - left.updatedAt || left.id.localeCompare(right.id))
+    .map((activity) => Object.assign({}, activity));
+}
+
+export function resetSessionToolActivitiesForTests(): void {
+  const state = getSessionActivityState();
+  state.toolsById.clear();
+  state.revisionsBySessionKey.clear();
+}

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -115,6 +115,13 @@ export type PluginHookName =
   | "subagent_ended"
   /** @deprecated Use gateway_stop. */
   | "deactivate"
+  | "task_created"
+  | "task_updated"
+  | "task_finished"
+  | "task_deleted"
+  | "tool_started"
+  | "tool_updated"
+  | "tool_finished"
   | "gateway_start"
   | "gateway_stop"
   | "heartbeat_prompt_contribution"
@@ -156,6 +163,13 @@ export const PLUGIN_HOOK_NAMES = [
   "subagent_spawned",
   "subagent_ended",
   "deactivate",
+  "task_created",
+  "task_updated",
+  "task_finished",
+  "task_deleted",
+  "tool_started",
+  "tool_updated",
+  "tool_finished",
   "gateway_start",
   "gateway_stop",
   "heartbeat_prompt_contribution",
@@ -656,6 +670,54 @@ export type PluginHookAfterToolCallEvent = {
   result?: unknown;
   error?: string;
   durationMs?: number;
+};
+
+/** Metadata-only task record exposed to passive lifecycle hooks. */
+export type PluginHookTaskActivity = {
+  id: string;
+  runtime: "subagent" | "acp" | "cli" | "cron";
+  status: "queued" | "running" | "succeeded" | "failed" | "timed_out" | "cancelled" | "lost";
+  title: string;
+  createdAt: number;
+  startedAt?: number;
+  endedAt?: number;
+  updatedAt?: number;
+  label?: string;
+  progressSummary?: string;
+  runId?: string;
+  childSessionKey?: string;
+};
+
+export type PluginHookTaskActivityContext = {
+  requesterSessionKey: string;
+  ownerKey: string;
+  childSessionKey?: string;
+  parentTaskId?: string;
+  agentId?: string;
+};
+
+export type PluginHookTaskActivityEvent = {
+  task: PluginHookTaskActivity;
+  previous?: PluginHookTaskActivity;
+};
+
+export type PluginHookToolActivity = {
+  id: string;
+  name: string;
+  title: string;
+  startedAt: number;
+  updatedAt: number;
+};
+
+export type PluginHookToolActivityEvent = {
+  phase: "started" | "updated" | "finished";
+  activity: PluginHookToolActivity;
+};
+
+export type PluginHookToolActivityContext = {
+  sessionKey: string;
+  runId: string;
+  toolCallId: string;
 };
 
 export type PluginHookToolResultPersistContext = {
@@ -1178,6 +1240,34 @@ export type PluginHookHandlerMap = {
   after_tool_call: (
     event: PluginHookAfterToolCallEvent,
     ctx: PluginHookToolContext,
+  ) => Promise<void> | void;
+  task_created: (
+    event: PluginHookTaskActivityEvent,
+    ctx: PluginHookTaskActivityContext,
+  ) => Promise<void> | void;
+  task_updated: (
+    event: PluginHookTaskActivityEvent,
+    ctx: PluginHookTaskActivityContext,
+  ) => Promise<void> | void;
+  task_finished: (
+    event: PluginHookTaskActivityEvent,
+    ctx: PluginHookTaskActivityContext,
+  ) => Promise<void> | void;
+  task_deleted: (
+    event: PluginHookTaskActivityEvent,
+    ctx: PluginHookTaskActivityContext,
+  ) => Promise<void> | void;
+  tool_started: (
+    event: PluginHookToolActivityEvent,
+    ctx: PluginHookToolActivityContext,
+  ) => Promise<void> | void;
+  tool_updated: (
+    event: PluginHookToolActivityEvent,
+    ctx: PluginHookToolActivityContext,
+  ) => Promise<void> | void;
+  tool_finished: (
+    event: PluginHookToolActivityEvent,
+    ctx: PluginHookToolActivityContext,
   ) => Promise<void> | void;
   tool_result_persist: (
     event: PluginHookToolResultPersistEvent,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -19,6 +19,10 @@ import type { GlobalHookRunnerRegistry, HookRunnerRegistry } from "./hook-regist
 import type {
   PluginHookAfterCompactionEvent,
   PluginHookAfterToolCallEvent,
+  PluginHookTaskActivityContext,
+  PluginHookTaskActivityEvent,
+  PluginHookToolActivityContext,
+  PluginHookToolActivityEvent,
   PluginHookAgentContext,
   PluginHookAgentEndEvent,
   PluginHookBeforeAgentFinalizeEvent,
@@ -61,6 +65,7 @@ import type {
   PluginHookGatewayCronDeliveryStatus,
   PluginHookGatewayCronJobState,
   PluginHookGatewayCronRunStatus,
+  PluginHookToolContext,
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
@@ -81,7 +86,6 @@ import type {
   PluginHookSubagentSpawningResult,
   PluginHookSubagentEndedEvent,
   PluginHookSubagentSpawnedEvent,
-  PluginHookToolContext,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
@@ -138,6 +142,10 @@ export type {
   PluginHookBeforeToolCallResult,
   PluginHookBeforeAgentRunEvent,
   PluginHookAfterToolCallEvent,
+  PluginHookTaskActivityContext,
+  PluginHookTaskActivityEvent,
+  PluginHookToolActivityContext,
+  PluginHookToolActivityEvent,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
@@ -1303,6 +1311,55 @@ export function createHookRunner(
     return runVoidHook("after_tool_call", event, ctx);
   }
 
+  async function runTaskCreated(
+    event: PluginHookTaskActivityEvent,
+    ctx: PluginHookTaskActivityContext,
+  ): Promise<void> {
+    return runVoidHook("task_created", event, ctx);
+  }
+
+  async function runTaskUpdated(
+    event: PluginHookTaskActivityEvent,
+    ctx: PluginHookTaskActivityContext,
+  ): Promise<void> {
+    return runVoidHook("task_updated", event, ctx);
+  }
+
+  async function runTaskFinished(
+    event: PluginHookTaskActivityEvent,
+    ctx: PluginHookTaskActivityContext,
+  ): Promise<void> {
+    return runVoidHook("task_finished", event, ctx);
+  }
+
+  async function runTaskDeleted(
+    event: PluginHookTaskActivityEvent,
+    ctx: PluginHookTaskActivityContext,
+  ): Promise<void> {
+    return runVoidHook("task_deleted", event, ctx);
+  }
+
+  async function runToolStarted(
+    event: PluginHookToolActivityEvent,
+    ctx: PluginHookToolActivityContext,
+  ): Promise<void> {
+    return runVoidHook("tool_started", event, ctx);
+  }
+
+  async function runToolUpdated(
+    event: PluginHookToolActivityEvent,
+    ctx: PluginHookToolActivityContext,
+  ): Promise<void> {
+    return runVoidHook("tool_updated", event, ctx);
+  }
+
+  async function runToolFinished(
+    event: PluginHookToolActivityEvent,
+    ctx: PluginHookToolActivityContext,
+  ): Promise<void> {
+    return runVoidHook("tool_finished", event, ctx);
+  }
+
   /**
    * Run tool_result_persist hook.
    *
@@ -1652,6 +1709,13 @@ export function createHookRunner(
     // Tool hooks
     runBeforeToolCall,
     runAfterToolCall,
+    runTaskCreated,
+    runTaskUpdated,
+    runTaskFinished,
+    runTaskDeleted,
+    runToolStarted,
+    runToolUpdated,
+    runToolFinished,
     runToolResultPersist,
     // Message write hooks
     runBeforeMessageWrite,

--- a/src/tasks/task-activity-hooks.ts
+++ b/src/tasks/task-activity-hooks.ts
@@ -1,0 +1,94 @@
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+function toTaskActivity(task: TaskRecord) {
+  return {
+    id: task.taskId,
+    runtime: task.runtime,
+    status: task.status,
+    title: task.label ?? `${task.runtime} task`,
+    createdAt: task.createdAt,
+    ...(task.startedAt !== undefined ? { startedAt: task.startedAt } : {}),
+    ...(task.endedAt !== undefined ? { endedAt: task.endedAt } : {}),
+    ...(task.lastEventAt !== undefined ? { updatedAt: task.lastEventAt } : {}),
+    ...(task.label ? { label: task.label } : {}),
+    ...(task.progressSummary ? { progressSummary: task.progressSummary } : {}),
+    ...(task.runId ? { runId: task.runId } : {}),
+    ...(task.childSessionKey ? { childSessionKey: task.childSessionKey } : {}),
+  };
+}
+
+function toTaskActivityContext(task: TaskRecord) {
+  return {
+    requesterSessionKey: task.requesterSessionKey,
+    ownerKey: task.ownerKey,
+    ...(task.childSessionKey ? { childSessionKey: task.childSessionKey } : {}),
+    ...(task.parentTaskId ? { parentTaskId: task.parentTaskId } : {}),
+    ...(task.agentId ? { agentId: task.agentId } : {}),
+  };
+}
+
+function isTerminalStatus(task: TaskRecord): boolean {
+  return (
+    task.status === "succeeded" ||
+    task.status === "failed" ||
+    task.status === "timed_out" ||
+    task.status === "cancelled" ||
+    task.status === "lost"
+  );
+}
+
+/** Emit metadata-only task lifecycle hooks without delaying task registry writes. */
+export function emitTaskCreatedHook(task: TaskRecord): void {
+  const runner = getGlobalHookRunner();
+  if (!runner?.hasHooks("task_created")) {
+    return;
+  }
+  void runner
+    .runTaskCreated({ task: toTaskActivity(task) }, toTaskActivityContext(task))
+    .catch(() => {});
+}
+
+export function emitTaskUpdatedHook(params: { task: TaskRecord; previous: TaskRecord }): void {
+  const runner = getGlobalHookRunner();
+  if (!runner) {
+    return;
+  }
+  const event = {
+    task: toTaskActivity(params.task),
+    previous: toTaskActivity(params.previous),
+  };
+  const context = toTaskActivityContext(params.task);
+  if (runner.hasHooks("task_updated")) {
+    void runner.runTaskUpdated(event, context).catch(() => {});
+  }
+  if (!isTerminalStatus(params.previous) && isTerminalStatus(params.task)) {
+    emitTaskFinishedHook(params.task, params.previous);
+  }
+}
+
+export function emitTaskFinishedHook(task: TaskRecord, previous?: TaskRecord): void {
+  const runner = getGlobalHookRunner();
+  if (!runner?.hasHooks("task_finished")) {
+    return;
+  }
+  void runner
+    .runTaskFinished(
+      {
+        task: toTaskActivity(task),
+        ...(previous ? { previous: toTaskActivity(previous) } : {}),
+      },
+      toTaskActivityContext(task),
+    )
+    .catch(() => {});
+}
+
+export function emitTaskDeletedHook(task: TaskRecord): void {
+  const runner = getGlobalHookRunner();
+  if (!runner?.hasHooks("task_deleted")) {
+    return;
+  }
+  void runner
+    .runTaskDeleted({ task: toTaskActivity(task) }, toTaskActivityContext(task))
+    .catch(() => {});
+}

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -7,6 +7,11 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
@@ -28,6 +33,7 @@ import {
   listFreshTasksForOwnerKey,
   markTaskTerminalById,
   maybeDeliverTaskStateChangeUpdate,
+  onTaskRegistryEvent,
   resetTaskRegistryForTests,
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
@@ -112,6 +118,7 @@ describe("task-registry store runtime", () => {
     ORIGINAL_ENV.restore();
     resetTaskRegistryForTests();
     resetTaskFlowRegistryForTests({ persist: false });
+    resetGlobalHookRunner();
   });
 
   it("uses the configured task store for restore and save", () => {
@@ -306,6 +313,83 @@ describe("task-registry store runtime", () => {
       kind: "deleted",
       taskId: created.taskId,
     });
+  });
+
+  it("notifies runtime task listeners without replacing configured observers", () => {
+    const events: TaskRegistryObserverEvent[] = [];
+    const stop = onTaskRegistryEvent((event) => events.push(event));
+
+    const created = createTaskRecord({
+      runtime: "acp",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:codex:acp:listener",
+      runId: "run-listener",
+      task: "Listener task",
+      status: "running",
+      deliveryStatus: "pending",
+    });
+    stop();
+    deleteTaskRecordById(created.taskId);
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "upserted",
+        task: expect.objectContaining({ taskId: created.taskId }),
+      }),
+    ]);
+  });
+
+  it("emits metadata-only typed plugin hooks for task lifecycle changes", async () => {
+    const createdHook = vi.fn();
+    const updatedHook = vi.fn();
+    const finishedHook = vi.fn();
+    const deletedHook = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "task_created", handler: createdHook },
+        { hookName: "task_updated", handler: updatedHook },
+        { hookName: "task_finished", handler: finishedHook },
+        { hookName: "task_deleted", handler: deletedHook },
+      ]),
+    );
+    configureTaskRegistryRuntime({
+      store: {
+        loadSnapshot: () => ({ tasks: new Map(), deliveryStates: new Map() }),
+        saveSnapshot: () => {},
+      },
+    });
+
+    const created = createTaskRecord({
+      runtime: "subagent",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:hook",
+      runId: "run-hook",
+      task: "Sensitive prompt must not be exposed",
+      status: "running",
+      deliveryStatus: "pending",
+    });
+    markTaskTerminalById({ taskId: created.taskId, status: "succeeded", endedAt: 200 });
+    deleteTaskRecordById(created.taskId);
+    await Promise.resolve();
+
+    expect(createdHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({ title: "subagent task", runtime: "subagent" }),
+      }),
+      expect.objectContaining({ ownerKey: "agent:main:main" }),
+    );
+    expect(updatedHook).toHaveBeenCalledWith(
+      expect.objectContaining({ task: expect.objectContaining({ status: "succeeded" }) }),
+      expect.anything(),
+    );
+    expect(finishedHook).toHaveBeenCalledTimes(1);
+    expect(deletedHook).toHaveBeenCalledTimes(1);
+    expect(createdHook.mock.calls[0]?.[0]).not.toHaveProperty("task.task");
+    expect(JSON.stringify(createdHook.mock.calls[0]?.[0])).not.toContain(
+      "Sensitive prompt must not be exposed",
+    );
   });
 
   it("uses atomic task-plus-delivery store methods when available", async () => {

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -21,6 +21,12 @@ import { isDeliverableMessageChannel } from "../utils/message-channel.js";
 import { cancelActiveCronTaskRun } from "./cron-task-cancel.js";
 import { isChildlessNativeSubagentTask } from "./native-subagent-task.js";
 import {
+  emitTaskCreatedHook,
+  emitTaskDeletedHook,
+  emitTaskFinishedHook,
+  emitTaskUpdatedHook,
+} from "./task-activity-hooks.js";
+import {
   formatTaskBlockedFollowupMessage,
   formatTaskStateChangeMessage,
   formatTaskTerminalMessage,
@@ -69,6 +75,7 @@ const taskIdsByOwnerKey = taskRegistryProcessState.taskIdsByOwnerKey;
 const taskIdsByParentFlowId = taskRegistryProcessState.taskIdsByParentFlowId;
 const taskIdsByRelatedSessionKey = taskRegistryProcessState.taskIdsByRelatedSessionKey;
 const tasksWithPendingDelivery = taskRegistryProcessState.tasksWithPendingDelivery;
+const taskRegistryEventListeners = new Set<(event: TaskRegistryObserverEvent) => void>();
 let listenerStarted = false;
 let listenerStop: (() => void) | null = null;
 let restoreAttempted = false;
@@ -266,17 +273,36 @@ function snapshotTaskRecords(source: ReadonlyMap<string, TaskRecord>): TaskRecor
 
 function emitTaskRegistryObserverEvent(createEvent: () => TaskRegistryObserverEvent): void {
   const observers = getTaskRegistryObservers();
-  if (!observers?.onEvent) {
+  if (!observers?.onEvent && taskRegistryEventListeners.size === 0) {
     return;
   }
-  try {
-    observers.onEvent(createEvent());
-  } catch (error) {
-    log.warn("Task registry observer failed", {
-      event: "task-registry",
-      error,
-    });
+  const event = createEvent();
+  if (observers?.onEvent) {
+    try {
+      observers.onEvent(event);
+    } catch (error) {
+      log.warn("Task registry observer failed", {
+        event: "task-registry",
+        error,
+      });
+    }
   }
+  for (const listener of taskRegistryEventListeners) {
+    try {
+      listener(event);
+    } catch (error) {
+      log.warn("Task registry event listener failed", {
+        event: "task-registry",
+        error,
+      });
+    }
+  }
+}
+
+/** Subscribe to best-effort task registry changes. Snapshot reads remain authoritative. */
+export function onTaskRegistryEvent(listener: (event: TaskRegistryObserverEvent) => void) {
+  taskRegistryEventListeners.add(listener);
+  return () => taskRegistryEventListeners.delete(listener);
 }
 
 function persistTaskRegistry(): boolean {
@@ -1233,6 +1259,7 @@ function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskRecord | nu
     task: cloneTaskRecord(next),
     previous: cloneTaskRecord(current),
   }));
+  emitTaskUpdatedHook({ task: next, previous: current });
   return cloneTaskRecord(next);
 }
 
@@ -1842,7 +1869,9 @@ export function createTaskRecord(params: {
     kind: "upserted",
     task: cloneTaskRecord(record),
   }));
+  emitTaskCreatedHook(record);
   if (isTerminalTaskStatus(record.status)) {
+    emitTaskFinishedHook(record);
     void maybeDeliverTaskTerminalUpdate(taskId);
   }
   return cloneTaskRecord(record);
@@ -2396,11 +2425,13 @@ export function deleteTaskRecordById(taskId: string): boolean {
     taskId: current.taskId,
     previous: cloneTaskRecord(current),
   }));
+  emitTaskDeletedHook(current);
   return true;
 }
 
 export function resetTaskRegistryForTests(opts?: { persist?: boolean }) {
   clearTaskRegistryMemory();
+  taskRegistryEventListeners.clear();
   restoreAttempted = false;
   resetTaskRegistryRuntimeForTests();
   if (listenerStop) {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -15,6 +15,42 @@ export type { ConfigUiHint, ConfigUiHints } from "../../../src/shared/config-ui-
 export type { SessionGoal } from "../../../src/config/sessions/types.js";
 export type { FastMode } from "@openclaw/normalization-core/string-coerce";
 
+export type SessionActivityTask = {
+  id: string;
+  sessionKey: string;
+  runtime: "subagent" | "acp" | "cli" | "cron";
+  title: string;
+  status: "queued" | "running";
+  createdAt: number;
+  startedAt?: number;
+  lastEventAt?: number;
+  childSessionKey?: string;
+  runId?: string;
+  label?: string;
+  progressSummary?: string;
+};
+
+export type SessionActivityTool = {
+  id: string;
+  sessionKey: string;
+  runId: string;
+  toolCallId: string;
+  name: string;
+  title: string;
+  status: "running";
+  startedAt: number;
+  updatedAt: number;
+};
+
+export type SessionActivityResult = {
+  key: string;
+  revision: number;
+  includedSessionKeys: string[];
+  truncated: boolean;
+  tasks: SessionActivityTask[];
+  tools: SessionActivityTool[];
+};
+
 export type ChannelsStatusSnapshot = {
   ts: number;
   channelOrder: string[];

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -288,6 +288,119 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("renders active session tasks and tools from Gateway activity updates", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const now = Date.now();
+    const runId = "activity-run";
+    const toolCallId = "activity-tool";
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ text: "Ready for activity check.", type: "text" }],
+          role: "assistant",
+          timestamp: now - 60_000,
+        },
+      ],
+      methodResponses: {
+        "sessions.activity": {
+          key: "main",
+          revision: 4,
+          includedSessionKeys: ["main", "main/subagent-proof"],
+          truncated: false,
+          tasks: [
+            {
+              id: "task-subagent-proof",
+              sessionKey: "main",
+              runtime: "subagent",
+              title: "Investigate session activity",
+              status: "running",
+              createdAt: now - 30_000,
+              startedAt: now - 29_000,
+              lastEventAt: now - 1_000,
+              childSessionKey: "main/subagent-proof",
+              runId: "subagent-run-proof",
+              label: "Subagent: investigate session activity",
+            },
+          ],
+          tools: [
+            {
+              id: `${runId}:${toolCallId}`,
+              sessionKey: "main",
+              runId,
+              toolCallId,
+              name: "exec",
+              title: "exec: pnpm test session activity",
+              status: "running",
+              startedAt: now - 5_000,
+              updatedAt: now - 1_000,
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByText("Ready for activity check.").waitFor({ timeout: 10_000 });
+
+      const activityRequest = await gateway.waitForRequest("sessions.activity");
+      expect(activityRequest.params).toEqual({ key: "main", includeDescendants: true });
+      await page.locator(".chat-activity").getByText("Running (2)").waitFor({
+        timeout: 10_000,
+      });
+      await page.getByText("Subagent: investigate session activity").waitFor({
+        timeout: 10_000,
+      });
+      await page.getByText("exec: pnpm test session activity").waitFor({ timeout: 10_000 });
+
+      await gateway.emitGatewayEvent("session.tool", {
+        sessionKey: "main",
+        runId,
+        ts: now + 1_000,
+        data: {
+          name: "exec",
+          phase: "result",
+          toolCallId,
+        },
+      });
+
+      await page.locator(".chat-activity").getByText("Running (1)").waitFor({
+        timeout: 10_000,
+      });
+      await page.getByText("exec: pnpm test session activity").waitFor({
+        state: "detached",
+        timeout: 10_000,
+      });
+      expect(await gateway.getRequests("sessions.activity")).toHaveLength(1);
+
+      await gateway.deferNext("sessions.activity");
+      await gateway.emitGatewayEvent("session.activity", {
+        sessionKey: "main",
+        sourceSessionKey: "main/subagent-proof",
+        reason: "task",
+      });
+      const activityRequests = await waitForRequests(gateway, "sessions.activity", 2);
+      expect(activityRequests[1]?.params).toEqual({ key: "main", includeDescendants: true });
+
+      await gateway.resolveDeferred("sessions.activity", {
+        key: "main",
+        revision: 5,
+        includedSessionKeys: ["main"],
+        truncated: false,
+        tasks: [],
+        tools: [],
+      });
+      await page.locator(".chat-activity").waitFor({ state: "detached", timeout: 10_000 });
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("keeps the composer clear when a stale native input replay arrives after send", async () => {
     const context = await newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -73,6 +73,7 @@ import {
 import { exportChatMarkdown } from "./export.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
+import { loadSessionActivity } from "./session-activity.ts";
 import { clearChatMessagesFromCache } from "./session-message-cache.ts";
 
 type ChatRouteData = {
@@ -142,6 +143,7 @@ export class ChatPage extends LitElement {
     });
     const subscriptionSync = syncSelectedSessionMessageSubscription(state);
     const historyLoad = loadChatHistory(state);
+    const activityLoad = loadSessionActivity(state);
     state.requestUpdate();
     const scheduleHistoryScroll = () => {
       if (state.sessionKey !== nextSessionKey) {
@@ -166,6 +168,7 @@ export class ChatPage extends LitElement {
     );
     void subscriptionSync;
     void historyLoad;
+    void activityLoad;
     void sessionsRefresh;
   }
 
@@ -589,6 +592,7 @@ export class ChatPage extends LitElement {
       };
       this.connectedClient = startupClient;
       void syncSelectedSessionMessageSubscription(state, { force: true });
+      void loadSessionActivity(state).finally(() => state.requestUpdate?.());
       void retryReconnectableQueuedChatSends(state);
       void refreshPageChat(state, { startup: true, awaitHistory: true }).finally(() => {
         void finishStartup();
@@ -638,6 +642,8 @@ export class ChatPage extends LitElement {
       streamSegments: state.chatStreamSegments,
       stream: state.chatStream,
       streamStartedAt: state.chatStreamStartedAt,
+      activity: state.sessionActivity,
+      activityLoading: state.sessionActivityLoading,
       assistantAvatarUrl: resolveChatAvatarUrl(state),
       draft: state.chatMessage,
       queue: state.chatQueue,

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -97,6 +97,11 @@ import {
   reconcileChatRunLifecycle,
 } from "./run-lifecycle.ts";
 import { scheduleChatScroll, handleChatScroll, resetChatScroll } from "./scroll.ts";
+import {
+  applySessionToolActivityEvent,
+  loadSessionActivity,
+  type SessionActivityState,
+} from "./session-activity.ts";
 import { cacheChatMessages, readChatMessagesFromCache } from "./session-message-cache.ts";
 import {
   handleAgentEvent,
@@ -150,6 +155,8 @@ export type ChatPageHost = ChatHost &
     sessionsResult: SessionsListResult | null;
     sessionsResultAgentId: string | null;
     sessionsError: string | null;
+    sessionActivityLoading: boolean;
+    sessionActivity: import("../../api/types.ts").SessionActivityResult | null;
     sessionsShowArchived: boolean;
     selectedChatSessionArchived: boolean;
     agentsList: AgentsListResult | null;
@@ -333,6 +340,8 @@ export function resetChatStateForRouteSession(state: ChatPageHost, sessionKey: s
   state.chatReplyTarget = null;
   state.chatMessages = restoreChatMessagesForSession(state, sessionKey);
   state.chatToolMessages = [];
+  state.sessionActivity = null;
+  state.sessionActivityLoading = false;
   state.chatStreamSegments = [];
   state.chatThinkingLevel = null;
   state.chatVerboseLevel = null;
@@ -931,6 +940,8 @@ export function createPageState(
     sessionsResultAgentId: null,
     sessionsLoading: false,
     sessionsError: null,
+    sessionActivityLoading: false,
+    sessionActivity: null,
     sessionsShowArchived: false,
     selectedChatSessionArchived: false,
     agentsList: context.agents.state.agentsList,
@@ -1082,8 +1093,25 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
     return;
   }
   if (event.event === "agent" || event.event === "session.tool") {
+    applySessionToolActivityEvent(
+      state as unknown as SessionActivityState,
+      event.payload as Parameters<typeof applySessionToolActivityEvent>[1],
+    );
     handleAgentEvent(state as never, event.payload as never);
     requestPageUpdate(state);
+    return;
+  }
+  if (event.event === "session.activity") {
+    const payload = event.payload as
+      | { sessionKey?: unknown; sourceSessionKey?: unknown; reason?: unknown }
+      | undefined;
+    const isDirectLiveToolUpdate =
+      payload?.reason === "tool" && payload.sourceSessionKey === state.sessionKey;
+    if (payload?.sessionKey === state.sessionKey && !isDirectLiveToolUpdate) {
+      void loadSessionActivity(state as unknown as SessionActivityState).finally(() =>
+        requestPageUpdate(state),
+      );
+    }
     return;
   }
   if (event.event === "session.operation") {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -2,7 +2,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { styleMap } from "lit/directives/style-map.js";
-import type { SessionsListResult } from "../../api/types.ts";
+import type { SessionActivityResult, SessionsListResult } from "../../api/types.ts";
 import { icons } from "../../components/icons.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
@@ -63,6 +63,8 @@ export type ChatProps = {
   streamSegments: ChatStreamSegment[];
   stream: string | null;
   streamStartedAt: number | null;
+  activity?: SessionActivityResult | null;
+  activityLoading?: boolean;
   assistantAvatarUrl?: string | null;
   draft: string;
   queue: ChatQueueItem[];
@@ -158,6 +160,18 @@ export function renderChat(props: ChatProps) {
   const sidebarOpen = Boolean(props.sidebarOpen && props.onCloseSidebar);
   const canCompose = props.connected && props.canSend;
   let chatSection: HTMLElement | null = null;
+  const activityItems = [
+    ...(props.activity?.tasks ?? []).map((task) => ({
+      id: `task:${task.id}`,
+      label: task.label ?? task.title,
+      detail: task.runtime,
+    })),
+    ...(props.activity?.tools ?? []).map((tool) => ({
+      id: `tool:${tool.id}`,
+      label: tool.title,
+      detail: "tool",
+    })),
+  ];
 
   const thread = renderChatThread({
     sessionKey: props.sessionKey,
@@ -344,7 +358,38 @@ export function renderChat(props: ChatProps) {
               class="chat-main"
               style="flex: ${sidebarOpen ? `0 1 ${splitRatio * 100}%` : "1 1 100%"}"
             >
-              ${thread} ${chatColumnFooter}
+              ${thread}
+              ${props.activityLoading || activityItems.length
+                ? html`
+                    <div class="chat-queue chat-activity" role="status" aria-live="polite">
+                      <div class="chat-queue__title">
+                        ${props.activityLoading
+                          ? html`<span
+                              class="usage-loading-spinner"
+                              aria-label="Loading activity"
+                              style="display: inline-block; margin-right: 6px; vertical-align: -1px"
+                            ></span>`
+                          : nothing}
+                        Running${activityItems.length ? ` (${activityItems.length})` : ""}
+                      </div>
+                      ${activityItems.length
+                        ? html`
+                            <div class="chat-queue__list">
+                              ${activityItems.map(
+                                (item) => html`
+                                  <div class="chat-queue__item" title=${item.label}>
+                                    <div class="chat-queue__text">${item.label}</div>
+                                    <span class="chat-queue__state">${item.detail}</span>
+                                  </div>
+                                `,
+                              )}
+                            </div>
+                          `
+                        : nothing}
+                    </div>
+                  `
+                : nothing}
+              ${chatColumnFooter}
             </div>
 
             ${sidebarOpen

--- a/ui/src/pages/chat/session-activity.test.ts
+++ b/ui/src/pages/chat/session-activity.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applySessionToolActivityEvent,
+  loadSessionActivity,
+  type SessionActivityState,
+} from "./session-activity.ts";
+
+function createState(overrides: Partial<SessionActivityState> = {}): SessionActivityState {
+  return {
+    client: null,
+    connected: true,
+    sessionKey: "agent:main:main",
+    sessionActivityLoading: false,
+    sessionActivity: null,
+    ...overrides,
+  };
+}
+
+describe("session activity controller", () => {
+  it("loads the active task and tool snapshot for the selected session", async () => {
+    const request = vi.fn(async () => ({
+      key: "agent:main:main",
+      revision: 3,
+      includedSessionKeys: ["agent:main:main"],
+      truncated: false,
+      tasks: [],
+      tools: [],
+    }));
+    const state = createState({ client: { request } as never });
+
+    await loadSessionActivity(state);
+
+    expect(request).toHaveBeenCalledWith("sessions.activity", {
+      key: "agent:main:main",
+      includeDescendants: true,
+    });
+    expect(state.sessionActivity).toEqual({
+      key: "agent:main:main",
+      revision: 3,
+      includedSessionKeys: ["agent:main:main"],
+      truncated: false,
+      tasks: [],
+      tools: [],
+    });
+    expect(state.sessionActivityLoading).toBe(false);
+  });
+
+  it("adds and removes live exec activity from session tool events", () => {
+    const state = createState({
+      sessionActivity: {
+        key: "agent:main:main",
+        revision: 0,
+        includedSessionKeys: ["agent:main:main"],
+        truncated: false,
+        tasks: [],
+        tools: [],
+      },
+    });
+    const start = {
+      sessionKey: "agent:main:main",
+      runId: "run-exec",
+      ts: 100,
+      data: { phase: "start", name: "exec", toolCallId: "call-exec" },
+    };
+
+    applySessionToolActivityEvent(state, start);
+    expect(state.sessionActivity?.tools).toEqual([
+      expect.objectContaining({ id: "run-exec:call-exec", name: "exec" }),
+    ]);
+
+    applySessionToolActivityEvent(state, {
+      ...start,
+      ts: 200,
+      data: { ...start.data, phase: "result" },
+    });
+    expect(state.sessionActivity?.tools).toEqual([]);
+  });
+});

--- a/ui/src/pages/chat/session-activity.ts
+++ b/ui/src/pages/chat/session-activity.ts
@@ -1,0 +1,84 @@
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionActivityResult, SessionActivityTool } from "../../api/types.ts";
+
+export type SessionActivityState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  sessionKey: string;
+  sessionActivityLoading: boolean;
+  sessionActivity: SessionActivityResult | null;
+};
+
+export async function loadSessionActivity(state: SessionActivityState) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  const sessionKey = state.sessionKey;
+  state.sessionActivityLoading = true;
+  try {
+    const result = await state.client.request<SessionActivityResult>("sessions.activity", {
+      key: sessionKey,
+      includeDescendants: true,
+    });
+    if (state.sessionKey === sessionKey) {
+      state.sessionActivity = result;
+    }
+  } finally {
+    if (state.sessionKey === sessionKey) {
+      state.sessionActivityLoading = false;
+    }
+  }
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function applySessionToolActivityEvent(
+  state: SessionActivityState,
+  payload: { runId?: unknown; sessionKey?: unknown; ts?: unknown; data?: unknown } | undefined,
+) {
+  const sessionKey = readNonEmptyString(payload?.sessionKey);
+  const runId = readNonEmptyString(payload?.runId);
+  const data = payload?.data && typeof payload.data === "object" ? payload.data : {};
+  const toolCallId = readNonEmptyString((data as Record<string, unknown>).toolCallId);
+  const phase = readNonEmptyString((data as Record<string, unknown>).phase);
+  if (!sessionKey || sessionKey !== state.sessionKey || !runId || !toolCallId) {
+    return;
+  }
+  const id = `${runId}:${toolCallId}`;
+  const existing = state.sessionActivity;
+  const tools = existing?.tools ?? [];
+  const base = {
+    key: sessionKey,
+    revision: existing?.revision ?? 0,
+    includedSessionKeys: existing?.includedSessionKeys ?? [sessionKey],
+    truncated: existing?.truncated ?? false,
+    tasks: existing?.tasks ?? [],
+  };
+  if (phase === "result") {
+    state.sessionActivity = {
+      ...base,
+      tools: tools.filter((tool) => tool.id !== id),
+    };
+    return;
+  }
+  const name = readNonEmptyString((data as Record<string, unknown>).name) ?? "tool";
+  const now = typeof payload?.ts === "number" ? payload.ts : Date.now();
+  const previous = tools.find((tool) => tool.id === id);
+  const next: SessionActivityTool = {
+    id,
+    sessionKey,
+    runId,
+    toolCallId,
+    name,
+    title: name,
+    status: "running",
+    startedAt: previous?.startedAt ?? now,
+    updatedAt: now,
+  };
+  state.sessionActivity = {
+    ...base,
+    tools: [next, ...tools.filter((tool) => tool.id !== id)],
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

  Resolves a problem where the control UI could not reliably know which background work was active for a session, making it hard to show loading state, running task details, or polling-style progress for exec calls, subagents, and other session-scoped work.

  ## Why This Change Was Made

  This adds a live session activity surface over the existing gateway WebSocket protocol instead of introducing a separate REST endpoint, so the UI can subscribe to activity changes using the same session state channel. The snapshot aggregates active task-registry entries and live tool calls, includes descendant sessions by default, and exposes metadata-only plugin hooks for other integrations to build on without leaking tool arguments or results.

  ## User Impact

  Users can now see when a session has active background work, including exec/tool activity and task activity from subagents or related session work. The control UI can show a loading controller and running task list from the new session activity stream, while plugin authors get hook events for task and tool lifecycle changes.

  ## Evidence

  Focused validation passed:

  ```text
  OPENCLAW_LOCAL_CHECK=0 PATH=/Users/gauravprasad/.nvm/versions/node/v22.22.2/bin:$PATH corepack pnpm test src/gateway/session-activity.test.ts src/gateway/session-activity.snapshot.test.ts src/gateway/server-methods/session-activity.test.ts src/tasks/task-registry.store.test.ts ui/src/ui/controllers/session-activity.test.ts ui/src/ui/app-gateway.node.test.ts

  Results covered:

  gateway: 3 files / 6 tests passed
  tasks: 1 file / 12 tests passed
  ui: 2 files / 36 tests passed

  Additional checks passed:

  pnpm plugin-sdk:api:check
  git diff --check

  pnpm check:changed completed the static lanes successfully during local validation; I would let CI provide the final full-gate confirmation.
