### PR TITLE
Harden embedded memory flush isolation

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -459,6 +459,8 @@ export interface OpenAIResponsesCompat {
   sendSessionIdHeader?: boolean;
   /** Whether the provider supports `prompt_cache_retention: "24h"`. Default: true. */
   supportsLongCacheRetention?: boolean;
+  /** Where to place the runtime system prompt. Default: `message` (developer/system message). */
+  systemPromptMode?: "message" | "instructions" | "user";
 }
 
 /** Compatibility settings for Anthropic Messages-compatible APIs. */

--- a/src/agents/embedded-agent-runner/memory-flush.test.ts
+++ b/src/agents/embedded-agent-runner/memory-flush.test.ts
@@ -1,0 +1,252 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { setAgentRunnerMemoryTestDeps } from "../../auto-reply/reply/agent-runner-memory.js";
+import { writeTestSessionStore } from "../../auto-reply/reply/agent-runner.test-fixtures.js";
+import type { ReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  clearMemoryPluginState,
+  registerMemoryCapability,
+  type MemoryFlushPlanResolver,
+} from "../../plugins/memory-state.js";
+import { runEmbeddedPreAttemptMemoryFlushIfNeeded } from "./memory-flush.js";
+import type { RunEmbeddedAgentParams } from "./run/params.js";
+
+const runWithModelFallbackMock = vi.fn();
+const runEmbeddedAgentMock = vi.fn();
+const ensureMemoryFlushTargetFileMock = vi.fn();
+const ensureSelectedAgentHarnessPluginMock = vi.fn();
+const refreshQueuedFollowupSessionMock = vi.fn();
+const incrementCompactionCountMock = vi.fn();
+const emitAgentEventMock = vi.fn();
+const updateSessionEntryMock = vi.fn();
+
+function registerMemoryFlushPlanResolverForTest(resolver: MemoryFlushPlanResolver): void {
+  registerMemoryCapability("memory-core", { flushPlanResolver: resolver });
+}
+
+type TestReplyOperation = ReplyOperation & {
+  setPhase: ReturnType<typeof vi.fn<ReplyOperation["setPhase"]>>;
+  updateSessionId: ReturnType<typeof vi.fn<ReplyOperation["updateSessionId"]>>;
+};
+
+function createReplyOperation(): TestReplyOperation {
+  return {
+    key: "test",
+    sessionId: "session",
+    abortSignal: new AbortController().signal,
+    resetTriggered: false,
+    phase: "queued",
+    result: null,
+    setPhase: vi.fn<ReplyOperation["setPhase"]>(),
+    updateSessionId: vi.fn<ReplyOperation["updateSessionId"]>(),
+    attachBackend: vi.fn(),
+    detachBackend: vi.fn(),
+    retainFailureUntilComplete: vi.fn(),
+    complete: vi.fn(),
+    completeThen: vi.fn((afterClear: () => void) => {
+      afterClear();
+    }),
+    completeWithAfterClearBarrier: vi.fn(),
+    fail: vi.fn(),
+    abortByUser: vi.fn(),
+    abortForRestart: vi.fn(),
+  };
+}
+
+function createRunParams(params: {
+  rootDir: string;
+  storePath: string;
+  replyOperation?: ReplyOperation;
+  trigger?: RunEmbeddedAgentParams["trigger"];
+}): RunEmbeddedAgentParams {
+  return {
+    sessionId: "session",
+    sessionKey: "main",
+    sessionFile: path.join(params.rootDir, "session.jsonl"),
+    workspaceDir: params.rootDir,
+    agentDir: path.join(params.rootDir, "agent"),
+    agentId: "main",
+    config: {
+      session: { store: params.storePath },
+      agents: { defaults: { compaction: { memoryFlush: {} } } },
+    },
+    prompt: "hello from embedded",
+    transcriptPrompt: "hello from embedded",
+    provider: "anthropic",
+    model: "claude",
+    trigger: params.trigger ?? "user",
+    messageProvider: "whatsapp",
+    messageTo: "+15551234567",
+    chatType: "direct",
+    timeoutMs: 1_000,
+    runId: "run-1",
+    replyOperation: params.replyOperation,
+    verboseLevel: "off",
+  } as unknown as RunEmbeddedAgentParams;
+}
+
+describe("embedded pre-attempt memory flush adapter", () => {
+  const tempDirs: string[] = [];
+  let rootDir = "";
+  let storePath = "";
+
+  beforeEach(() => {
+    rootDir = makeTempDir(tempDirs, "openclaw-embedded-memory-unit-");
+    storePath = path.join(rootDir, "sessions.json");
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 20_000,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    runWithModelFallbackMock.mockReset().mockImplementation(async ({ provider, model, run }) => ({
+      result: await run(provider, model),
+      provider,
+      model,
+      attempts: [],
+    }));
+    runEmbeddedAgentMock.mockReset().mockResolvedValue({ payloads: [], meta: {} });
+    ensureMemoryFlushTargetFileMock.mockReset().mockResolvedValue(undefined);
+    ensureSelectedAgentHarnessPluginMock.mockReset().mockResolvedValue(undefined);
+    refreshQueuedFollowupSessionMock.mockReset();
+    incrementCompactionCountMock.mockReset();
+    emitAgentEventMock.mockReset();
+    updateSessionEntryMock.mockReset().mockImplementation(async (_params, update) => {
+      const current: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 80_000,
+        totalTokensFresh: true,
+        compactionCount: 1,
+      };
+      const patch = await update(current);
+      return patch ? { ...current, ...patch } : current;
+    });
+    setAgentRunnerMemoryTestDeps({
+      runWithModelFallback: runWithModelFallbackMock as never,
+      runEmbeddedAgent: runEmbeddedAgentMock as never,
+      ensureMemoryFlushTargetFile: ensureMemoryFlushTargetFileMock as never,
+      ensureSelectedAgentHarnessPlugin: ensureSelectedAgentHarnessPluginMock as never,
+      refreshQueuedFollowupSession: refreshQueuedFollowupSessionMock as never,
+      incrementCompactionCount: incrementCompactionCountMock as never,
+      updateSessionEntry: updateSessionEntryMock as never,
+      registerAgentRunContext: vi.fn() as never,
+      emitAgentEvent: emitAgentEventMock as never,
+      randomUUID: () => "00000000-0000-0000-0000-000000000001",
+      now: () => 1_700_000_000_000,
+    });
+  });
+
+  afterEach(() => {
+    setAgentRunnerMemoryTestDeps();
+    clearMemoryPluginState();
+    cleanupTempDirs(tempDirs);
+  });
+
+  it("runs the existing memory flush machinery before an embedded attempt", async () => {
+    const replyOperation = createReplyOperation();
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      totalTokensFresh: true,
+      compactionCount: 1,
+    };
+    await writeTestSessionStore(storePath, "main", sessionEntry);
+    const runParams = createRunParams({ rootDir, storePath, replyOperation });
+
+    const result = await runEmbeddedPreAttemptMemoryFlushIfNeeded({
+      runParams,
+      cfg: runParams.config!,
+      sessionId: runParams.sessionId,
+      sessionFile: runParams.sessionFile,
+      sessionKey: runParams.sessionKey,
+      agentId: "main",
+      agentDir: runParams.agentDir!,
+      provider: "anthropic",
+      model: "claude",
+      contextWindowTokens: 100_000,
+    });
+
+    expect(result.sessionEntry?.sessionId).toBe("session");
+    expect(runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    const flushCall = runEmbeddedAgentMock.mock.calls[0]?.[0] as RunEmbeddedAgentParams;
+    expect(flushCall.trigger).toBe("memory");
+    expect(flushCall.prompt).toContain("Pre-compaction memory flush.");
+    expect(flushCall.memoryFlushWritePath).toBe("memory/2023-11-14.md");
+    expect(flushCall.silentExpected).toBe(true);
+    expect(flushCall.sessionKey).toBe("main");
+    expect(flushCall.messageProvider).toBe("whatsapp");
+    expect(ensureMemoryFlushTargetFileMock).toHaveBeenCalledWith({
+      workspaceDir: rootDir,
+      relativePath: "memory/2023-11-14.md",
+    });
+    expect(replyOperation.setPhase).toHaveBeenCalledWith("memory_flushing");
+  });
+
+  it("skips recursive memory-triggered embedded runs", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      totalTokensFresh: true,
+      compactionCount: 1,
+    };
+    await writeTestSessionStore(storePath, "main", sessionEntry);
+    const runParams = createRunParams({
+      rootDir,
+      storePath,
+      replyOperation: createReplyOperation(),
+      trigger: "memory",
+    });
+
+    const result = await runEmbeddedPreAttemptMemoryFlushIfNeeded({
+      runParams,
+      cfg: runParams.config!,
+      sessionId: runParams.sessionId,
+      sessionFile: runParams.sessionFile,
+      sessionKey: runParams.sessionKey,
+      agentId: "main",
+      agentDir: runParams.agentDir!,
+      provider: "anthropic",
+      model: "claude",
+      contextWindowTokens: 100_000,
+    });
+
+    expect(result.attempted).toBe(false);
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when no reply operation is available", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      totalTokensFresh: true,
+      compactionCount: 1,
+    };
+    await writeTestSessionStore(storePath, "main", sessionEntry);
+    const runParams = createRunParams({ rootDir, storePath });
+
+    const result = await runEmbeddedPreAttemptMemoryFlushIfNeeded({
+      runParams,
+      cfg: runParams.config!,
+      sessionId: runParams.sessionId,
+      sessionFile: runParams.sessionFile,
+      sessionKey: runParams.sessionKey,
+      agentId: "main",
+      agentDir: runParams.agentDir!,
+      provider: "anthropic",
+      model: "claude",
+      contextWindowTokens: 100_000,
+    });
+
+    expect(result.attempted).toBe(false);
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-runner/memory-flush.test.ts
+++ b/src/agents/embedded-agent-runner/memory-flush.test.ts
@@ -157,7 +157,18 @@ describe("embedded pre-attempt memory flush adapter", () => {
       compactionCount: 1,
     };
     await writeTestSessionStore(storePath, "main", sessionEntry);
-    const runParams = createRunParams({ rootDir, storePath, replyOperation });
+    const runParams = {
+      ...createRunParams({ rootDir, storePath, replyOperation }),
+      prompt:
+        "SECRET pending user prompt that should not enter the synthetic flush route " +
+        "x".repeat(1_000),
+      transcriptPrompt: "SECRET transcript prompt that should not enter the flush route",
+      currentInboundEventKind: "message",
+      currentInboundAudio: true,
+      currentInboundContext: { text: "SECRET room context" },
+      images: [{ type: "image", data: "SECRET_IMAGE_BYTES", mimeType: "image/png" }],
+      imageOrder: ["inline"],
+    } as RunEmbeddedAgentParams;
 
     const result = await runEmbeddedPreAttemptMemoryFlushIfNeeded({
       runParams,
@@ -178,6 +189,13 @@ describe("embedded pre-attempt memory flush adapter", () => {
     const flushCall = runEmbeddedAgentMock.mock.calls[0]?.[0] as RunEmbeddedAgentParams;
     expect(flushCall.trigger).toBe("memory");
     expect(flushCall.prompt).toContain("Pre-compaction memory flush.");
+    expect(flushCall.prompt).not.toContain("SECRET pending user prompt");
+    expect(flushCall.transcriptPrompt).toBe("");
+    expect(flushCall.currentInboundContext).toBeUndefined();
+    expect(flushCall.currentInboundEventKind).toBeUndefined();
+    expect(flushCall.currentInboundAudio).toBe(false);
+    expect(flushCall.images).toBeUndefined();
+    expect(flushCall.imageOrder).toBeUndefined();
     expect(flushCall.memoryFlushWritePath).toBe("memory/2023-11-14.md");
     expect(flushCall.silentExpected).toBe(true);
     expect(flushCall.sessionKey).toBe("main");

--- a/src/agents/embedded-agent-runner/memory-flush.ts
+++ b/src/agents/embedded-agent-runner/memory-flush.ts
@@ -46,15 +46,13 @@ function buildEmbeddedMemoryFlushFollowupRun(params: {
 }): FollowupRun {
   const runParams = params.runParams;
   return {
-    prompt: runParams.prompt,
-    transcriptPrompt: runParams.transcriptPrompt,
-    currentInboundEventKind: runParams.currentInboundEventKind,
-    currentInboundAudio: runParams.currentInboundAudio,
-    currentInboundContext: runParams.currentInboundContext,
+    // Keep the synthetic flush route free of pending-turn user content/media. The
+    // live prompt is passed separately as promptForEstimate for threshold math;
+    // the actual model call is driven by the memory flush plan prompt.
+    prompt: "",
+    transcriptPrompt: "",
     abortSignal: runParams.abortSignal,
     enqueuedAt: Date.now(),
-    images: runParams.images,
-    imageOrder: runParams.imageOrder,
     originatingChannel: runParams.messageProvider,
     originatingTo: runParams.messageTo,
     originatingAccountId: runParams.agentAccountId,

--- a/src/agents/embedded-agent-runner/memory-flush.ts
+++ b/src/agents/embedded-agent-runner/memory-flush.ts
@@ -1,0 +1,188 @@
+import type { runMemoryFlushIfNeeded as runMemoryFlushIfNeededType } from "../../auto-reply/reply/agent-runner-memory.js";
+import type { FollowupRun } from "../../auto-reply/reply/queue.js";
+import type { TemplateContext } from "../../auto-reply/templating.js";
+import type { VerboseLevel } from "../../auto-reply/thinking.js";
+import { getSessionEntry, resolveStorePath, type SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { RunEmbeddedAgentParams } from "./run/params.js";
+
+export type EmbeddedPreAttemptMemoryFlushResult = {
+  attempted: boolean;
+  sessionEntry?: SessionEntry;
+};
+
+function buildEmbeddedMemoryFlushTemplateContext(params: RunEmbeddedAgentParams): TemplateContext {
+  return {
+    Provider: params.messageProvider,
+    OriginatingChannel: params.messageProvider,
+    OriginatingTo: params.messageTo,
+    To: params.messageTo,
+    AccountId: params.agentAccountId,
+    ChatType: params.chatType,
+    MessageThreadId: params.messageThreadId,
+    SenderId: params.senderId ?? undefined,
+    SenderName: params.senderName ?? undefined,
+    SenderUsername: params.senderUsername ?? undefined,
+    SenderE164: params.senderE164 ?? undefined,
+    MemberRoleIds: params.memberRoleIds,
+    MessageSid: params.currentMessageId,
+    MessageSidFull: params.currentMessageId,
+    ReplyToId: params.currentMessageId,
+    InputProvenance: params.inputProvenance,
+  } as TemplateContext;
+}
+
+function buildEmbeddedMemoryFlushFollowupRun(params: {
+  runParams: RunEmbeddedAgentParams;
+  cfg: OpenClawConfig;
+  sessionId: string;
+  sessionFile: string;
+  sessionKey: string;
+  runtimePolicySessionKey?: string;
+  agentId: string;
+  agentDir: string;
+  provider: string;
+  model: string;
+}): FollowupRun {
+  const runParams = params.runParams;
+  return {
+    prompt: runParams.prompt,
+    transcriptPrompt: runParams.transcriptPrompt,
+    currentInboundEventKind: runParams.currentInboundEventKind,
+    currentInboundAudio: runParams.currentInboundAudio,
+    currentInboundContext: runParams.currentInboundContext,
+    abortSignal: runParams.abortSignal,
+    enqueuedAt: Date.now(),
+    images: runParams.images,
+    imageOrder: runParams.imageOrder,
+    originatingChannel: runParams.messageProvider,
+    originatingTo: runParams.messageTo,
+    originatingAccountId: runParams.agentAccountId,
+    originatingThreadId: runParams.messageThreadId,
+    originatingChatType: runParams.chatType,
+    run: {
+      agentId: params.agentId,
+      agentDir: params.agentDir,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      runtimePolicySessionKey: params.runtimePolicySessionKey,
+      messageProvider: runParams.messageProvider,
+      chatType: runParams.chatType,
+      agentAccountId: runParams.agentAccountId,
+      groupId: runParams.groupId ?? undefined,
+      groupChannel: runParams.groupChannel ?? undefined,
+      groupSpace: runParams.groupSpace ?? undefined,
+      senderId: runParams.senderId ?? undefined,
+      senderName: runParams.senderName ?? undefined,
+      senderUsername: runParams.senderUsername ?? undefined,
+      senderE164: runParams.senderE164 ?? undefined,
+      senderIsOwner: runParams.senderIsOwner,
+      approvalReviewerDeviceId: runParams.approvalReviewerDeviceId,
+      sessionFile: params.sessionFile,
+      workspaceDir: runParams.workspaceDir,
+      cwd: runParams.cwd,
+      config: params.cfg,
+      skillsSnapshot: runParams.skillsSnapshot,
+      provider: params.provider,
+      model: params.model,
+      authProfileId: runParams.authProfileId,
+      authProfileIdSource: runParams.authProfileIdSource,
+      thinkLevel: runParams.thinkLevel,
+      fastMode: runParams.fastMode,
+      fastModeAutoOnSeconds: runParams.fastModeAutoOnSeconds,
+      verboseLevel: runParams.verboseLevel,
+      reasoningLevel: runParams.reasoningLevel,
+      execOverrides: runParams.execOverrides,
+      bashElevated: runParams.bashElevated,
+      timeoutMs: runParams.timeoutMs,
+      runTimeoutOverrideMs: runParams.runTimeoutOverrideMs,
+      blockReplyBreak: runParams.blockReplyBreak ?? "text_end",
+      ownerNumbers: runParams.ownerNumbers,
+      inputProvenance: runParams.inputProvenance,
+      extraSystemPrompt: runParams.extraSystemPrompt,
+      sourceReplyDeliveryMode: runParams.sourceReplyDeliveryMode,
+      silentReplyPromptMode: runParams.silentReplyPromptMode,
+      enforceFinalTag: runParams.enforceFinalTag,
+      silentExpected: true,
+      suppressNextUserMessagePersistence: runParams.suppressNextUserMessagePersistence,
+      suppressTranscriptOnlyAssistantPersistence:
+        runParams.suppressTranscriptOnlyAssistantPersistence,
+      skipProviderRuntimeHints: true,
+    },
+  };
+}
+
+export async function runEmbeddedPreAttemptMemoryFlushIfNeeded(params: {
+  runParams: RunEmbeddedAgentParams;
+  cfg: OpenClawConfig;
+  sessionId: string;
+  sessionFile: string;
+  sessionKey?: string;
+  runtimePolicySessionKey?: string;
+  agentId: string;
+  agentDir: string;
+  provider: string;
+  model: string;
+  contextWindowTokens?: number;
+  attemptedThisRun?: boolean;
+  verboseLevel?: VerboseLevel;
+}): Promise<EmbeddedPreAttemptMemoryFlushResult> {
+  if (params.runParams.trigger === "memory" || params.attemptedThisRun === true) {
+    return { attempted: false };
+  }
+  if (!params.sessionKey || !params.runParams.replyOperation) {
+    return { attempted: false };
+  }
+
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
+  const sessionEntry = getSessionEntry({
+    storePath,
+    sessionKey: params.sessionKey,
+  });
+  if (!sessionEntry) {
+    return { attempted: false };
+  }
+
+  const sessionStore: Record<string, SessionEntry> = {
+    [params.sessionKey]: sessionEntry,
+  };
+  const followupRun = buildEmbeddedMemoryFlushFollowupRun({
+    runParams: params.runParams,
+    cfg: params.cfg,
+    sessionId: params.sessionId,
+    sessionFile: params.sessionFile,
+    sessionKey: params.sessionKey,
+    runtimePolicySessionKey: params.runtimePolicySessionKey,
+    agentId: params.agentId,
+    agentDir: params.agentDir,
+    provider: params.provider,
+    model: params.model,
+  });
+
+  const { runMemoryFlushIfNeeded } =
+    (await import("../../auto-reply/reply/agent-runner-memory.js")) as {
+      runMemoryFlushIfNeeded: typeof runMemoryFlushIfNeededType;
+    };
+
+  const updatedEntry = await runMemoryFlushIfNeeded({
+    cfg: params.cfg,
+    followupRun,
+    promptForEstimate: params.runParams.prompt,
+    sessionCtx: buildEmbeddedMemoryFlushTemplateContext(params.runParams),
+    defaultModel: params.model,
+    agentCfgContextTokens: params.contextWindowTokens,
+    resolvedVerboseLevel: params.verboseLevel ?? params.runParams.verboseLevel ?? "off",
+    sessionEntry,
+    sessionStore,
+    sessionKey: params.sessionKey,
+    runtimePolicySessionKey: params.runtimePolicySessionKey,
+    storePath,
+    isHeartbeat: params.runParams.trigger === "heartbeat",
+    replyOperation: params.runParams.replyOperation,
+  });
+
+  return {
+    attempted: updatedEntry !== sessionEntry,
+    sessionEntry: updatedEntry ?? sessionStore[params.sessionKey],
+  };
+}

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -118,6 +118,9 @@ export const mockedResolveContextEngine = vi.fn(async () => mockedContextEngine)
 export const mockedResolveContextEngineOwnerPluginId = vi.fn(() => undefined);
 export const mockedBuildAgentRuntimePlan = vi.fn(() => ({}));
 export const mockedRunPostCompactionSideEffects = vi.fn(async () => {});
+export const mockedRunEmbeddedPreAttemptMemoryFlushIfNeeded = vi.fn(async () => ({
+  attempted: false,
+}));
 export const mockedSleepWithAbort = vi.fn(
   async (_ms: number, _abortSignal?: AbortSignal) => undefined,
 );
@@ -492,6 +495,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedShouldPreferExplicitConfigApiKeyAuth.mockReturnValue(false);
   mockedRunPostCompactionSideEffects.mockReset();
   mockedRunPostCompactionSideEffects.mockResolvedValue(undefined);
+  mockedRunEmbeddedPreAttemptMemoryFlushIfNeeded.mockReset();
+  mockedRunEmbeddedPreAttemptMemoryFlushIfNeeded.mockResolvedValue({ attempted: false });
   mockedSleepWithAbort.mockReset();
   mockedSleepWithAbort.mockResolvedValue(undefined);
 }
@@ -739,6 +744,10 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("./compaction-hooks.js", () => ({
     runPostCompactionSideEffects: mockedRunPostCompactionSideEffects,
+  }));
+
+  vi.doMock("./memory-flush.js", () => ({
+    runEmbeddedPreAttemptMemoryFlushIfNeeded: mockedRunEmbeddedPreAttemptMemoryFlushIfNeeded,
   }));
 
   vi.doMock("./utils.js", () => ({

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -45,6 +45,7 @@ import {
   mockedResolveModelAsync,
   mockedRunContextEngineMaintenance,
   mockedRunEmbeddedAttempt,
+  mockedRunEmbeddedPreAttemptMemoryFlushIfNeeded,
   mockedSessionLikelyHasOversizedToolResults,
   mockedTruncateOversizedToolResultsInSession,
   mockedWaitForDeferredTurnMaintenanceForSession,
@@ -255,6 +256,36 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
   beforeEach(() => {
     resetRunOverflowCompactionHarnessMocks();
     mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "ok" }]);
+  });
+
+  it("runs embedded pre-attempt memory flush before the backend attempt", async () => {
+    mockedRunEmbeddedPreAttemptMemoryFlushIfNeeded.mockResolvedValueOnce({ attempted: true });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-pre-attempt-memory-flush-order",
+    });
+
+    expect(mockedRunEmbeddedPreAttemptMemoryFlushIfNeeded).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedPreAttemptMemoryFlushIfNeeded.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedRunEmbeddedAttempt.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+    );
+    const flushParams = mockCallArg(mockedRunEmbeddedPreAttemptMemoryFlushIfNeeded) as {
+      sessionId?: string;
+      sessionKey?: string;
+      provider?: string;
+      model?: string;
+      contextWindowTokens?: number;
+      runParams?: RunEmbeddedAgentParams;
+    };
+    expect(flushParams.sessionId).toBe("test-session");
+    expect(flushParams.sessionKey).toBe("test-key");
+    expect(flushParams.provider).toBe("anthropic");
+    expect(flushParams.model).toBe("test-model");
+    expect(flushParams.contextWindowTokens).toBe(200000);
+    expect(flushParams.runParams?.runId).toBe("run-pre-attempt-memory-flush-order");
   });
 
   it("passes precomputed before_agent_start result into the attempt", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -155,6 +155,7 @@ import {
 import { resolveEmbeddedRunFailureSignal } from "./failure-signal.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
+import { runEmbeddedPreAttemptMemoryFlushIfNeeded } from "./memory-flush.js";
 import { resolveModelAsync } from "./model.js";
 import {
   createPostCompactionLoopGuard,
@@ -1866,6 +1867,7 @@ async function runEmbeddedAgentInternal(
           }
         };
         let authRetryPending = false;
+        let preAttemptMemoryFlushAttempted = false;
         let accumulatedReplayState = createEmbeddedRunReplayState();
         // Hoisted so the retry-limit error path can use the most recent API total.
         let lastTurnTotal: number | undefined;
@@ -2028,6 +2030,38 @@ async function runEmbeddedAgentInternal(
             );
             timeoutReleaseTimer.unref?.();
           };
+          if (!preAttemptMemoryFlushAttempted) {
+            try {
+              const flushResult = await runEmbeddedPreAttemptMemoryFlushIfNeeded({
+                runParams: params,
+                cfg: params.config ?? {},
+                sessionId: activeSessionId,
+                sessionFile: activeSessionFile,
+                sessionKey: resolvedSessionKey,
+                runtimePolicySessionKey: params.sandboxSessionKey ?? params.sessionKey,
+                agentId: workspaceResolution.agentId,
+                agentDir,
+                provider,
+                model: modelId,
+                contextWindowTokens: ctxInfo.tokens,
+                attemptedThisRun: preAttemptMemoryFlushAttempted,
+                verboseLevel: params.verboseLevel,
+              });
+              preAttemptMemoryFlushAttempted =
+                flushResult.attempted || preAttemptMemoryFlushAttempted;
+              if (flushResult.sessionEntry?.sessionId) {
+                activeSessionId = flushResult.sessionEntry.sessionId;
+              }
+              if (flushResult.sessionEntry?.sessionFile) {
+                activeSessionFile = flushResult.sessionEntry.sessionFile;
+              }
+            } catch (memoryFlushErr) {
+              preAttemptMemoryFlushAttempted = true;
+              log.warn(
+                `embedded pre-attempt memory flush failed; continuing without flush: ${String(memoryFlushErr)}`,
+              );
+            }
+          }
           const rawAttempt = await runEmbeddedAttemptWithBackend({
             sessionId: activeSessionId,
             sessionKey: resolvedSessionKey,

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3198,6 +3198,54 @@ describe("openai transport stream", () => {
     expect(params.input?.[0]?.role).toBe("system");
   });
 
+  it("moves Responses system prompts into a first user message when compat requires user mode", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "newapi",
+        baseUrl: "https://api.clawplan.ai/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 131072,
+        compat: { systemPromptMode: "user" },
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: `Stable${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic`,
+        messages: [{ role: "user", content: "hello" }],
+        tools: [],
+      } as never,
+      undefined,
+    ) as {
+      input?: Array<{ type?: string; role?: string; content?: unknown }>;
+      instructions?: string;
+    };
+
+    expect(params).not.toHaveProperty("instructions");
+    expect(params.input?.map((item) => item.role)).toEqual(["user", "user"]);
+    expect(params.input?.some((item) => item.role === "system" || item.role === "developer")).toBe(
+      false,
+    );
+    expect(params.input?.[0]).toMatchObject({
+      type: "message",
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: "System instructions for this run:\n\nStable\nDynamic",
+        },
+      ],
+    });
+    expect(params.input?.[1]).toMatchObject({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "hello" }],
+    });
+  });
+
   it("adds explicit message item types for Responses system and user input items", () => {
     const params = buildOpenAIResponsesParams(
       createAzureResponsesModel(),

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2347,6 +2347,8 @@ export function buildOpenAIResponsesParams(
   const compat = getCompat(model as OpenAIModeModel);
   const supportsDeveloperRole =
     typeof compat.supportsDeveloperRole === "boolean" ? compat.supportsDeveloperRole : undefined;
+  const systemPromptMode = model.compat?.systemPromptMode ?? "message";
+  const includeSystemPrompt = systemPromptMode !== "instructions" && systemPromptMode !== "user";
   const payloadPolicy = resolveOpenAIResponsesPayloadPolicy(model, {
     storeMode: "disable",
   });
@@ -2359,7 +2361,7 @@ export function buildOpenAIResponsesParams(
     context,
     new Set(["openai", "opencode", "azure-openai-responses", "github-copilot"]),
     {
-      includeSystemPrompt: !isCodexResponses,
+      includeSystemPrompt: includeSystemPrompt && !isCodexResponses,
       supportsDeveloperRole,
       replayReasoningItems: true,
       replayResponsesItemIds,
@@ -2372,15 +2374,37 @@ export function buildOpenAIResponsesParams(
   }
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
   const promptCacheKey = resolvePromptCacheKey(options, cacheRetention);
+  const instructions =
+    systemPromptMode === "instructions" && context.systemPrompt
+      ? sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt))
+      : undefined;
+  const input =
+    systemPromptMode === "user" && context.systemPrompt
+      ? [
+          {
+            type: "message",
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: `System instructions for this run:\n\n${sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt))}`,
+              },
+            ],
+          } satisfies ResponseInputItem,
+          ...(messages as ResponseInputItem[]),
+        ]
+      : messages;
   const params: OpenAIResponsesRequestParams = {
     model: model.id,
-    input: messages,
+    input,
     stream: true,
     prompt_cache_key: promptCacheKey,
     prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
     ...(isCodexResponses
       ? { instructions: resolveOpenAICodexResponsesInstructions(model, context) }
-      : {}),
+      : instructions
+        ? { instructions }
+        : {}),
     ...(metadata ? { metadata } : {}),
   };
   const effectiveMaxTokens = options?.maxTokens || model.maxTokens;

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -49,11 +49,10 @@ import {
 } from "./agent-runner-utils.js";
 import type { CompactionNoticePhase } from "./compaction-notice.js";
 import {
-  hasAlreadyFlushedForCurrentCompaction,
   resolveMaxActiveTranscriptBytes,
   resolveMemoryFlushContextWindowTokens,
   resolveResponsesServerCompactionThreshold,
-  shouldRunMemoryFlush,
+  shouldRunPreCompactionMemoryFlush,
   shouldRunPreflightCompaction,
 } from "./memory-flush.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
@@ -1247,20 +1246,16 @@ export async function runMemoryFlushIfNeeded(params: {
       `forceFlushTranscriptBytes=${forceFlushTranscriptBytes} forceFlushByTranscriptSize=${shouldForceFlushByTranscriptSize}`,
   );
 
-  const shouldFlushMemory =
-    (memoryFlushWritable &&
-      !params.isHeartbeat &&
-      !isCli &&
-      shouldRunMemoryFlush({
-        entry,
-        tokenCount: tokenCountForFlush,
-        contextWindowTokens,
-        reserveTokensFloor: memoryFlushPlan.reserveTokensFloor,
-        softThresholdTokens: memoryFlushPlan.softThresholdTokens,
-      })) ||
-    (shouldForceFlushByTranscriptSize &&
-      entry != null &&
-      !hasAlreadyFlushedForCurrentCompaction(entry));
+  const shouldFlushMemory = shouldRunPreCompactionMemoryFlush({
+    entry,
+    tokenCount: tokenCountForFlush,
+    contextWindowTokens,
+    reserveTokensFloor: memoryFlushPlan.reserveTokensFloor,
+    softThresholdTokens: memoryFlushPlan.softThresholdTokens,
+    memoryFlushWritable: memoryFlushWritable && !params.isHeartbeat && !isCli,
+    memoryFlushEnabled: true,
+    forceFlushByTranscriptSize: shouldForceFlushByTranscriptSize && entry != null,
+  });
 
   if (!shouldFlushMemory) {
     return entry ?? params.sessionEntry;

--- a/src/auto-reply/reply/memory-flush.embedded-preattempt.test.ts
+++ b/src/auto-reply/reply/memory-flush.embedded-preattempt.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { shouldRunEmbeddedPreAttemptMemoryFlush } from "./memory-flush.js";
+
+describe("embedded pre-attempt memory flush gating", () => {
+  const base = {
+    trigger: "message",
+    entry: {
+      totalTokens: 9_200,
+      totalTokensFresh: true,
+      compactionCount: 2,
+    },
+    contextWindowTokens: 10_000,
+    reserveTokensFloor: 500,
+    softThresholdTokens: 500,
+  } as const;
+
+  it("runs before an embedded attempt when projected tokens cross the memory-flush threshold", () => {
+    expect(shouldRunEmbeddedPreAttemptMemoryFlush(base)).toBe(true);
+  });
+
+  it("does not recurse into memory-triggered flush attempts", () => {
+    expect(
+      shouldRunEmbeddedPreAttemptMemoryFlush({
+        ...base,
+        trigger: "memory",
+      }),
+    ).toBe(false);
+  });
+
+  it("only attempts once per outer embedded run", () => {
+    expect(
+      shouldRunEmbeddedPreAttemptMemoryFlush({
+        ...base,
+        attemptedThisRun: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not rerun after the current compaction cycle already flushed", () => {
+    expect(
+      shouldRunEmbeddedPreAttemptMemoryFlush({
+        ...base,
+        entry: {
+          ...base.entry,
+          memoryFlushCompactionCount: 2,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("supports transcript-size forced flushes without requiring a fresh token count", () => {
+    expect(
+      shouldRunEmbeddedPreAttemptMemoryFlush({
+        ...base,
+        entry: {
+          compactionCount: 3,
+          totalTokensFresh: false,
+        },
+        forceFlushByTranscriptSize: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("respects disabled and unwritable flush state", () => {
+    expect(
+      shouldRunEmbeddedPreAttemptMemoryFlush({
+        ...base,
+        memoryFlushEnabled: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRunEmbeddedPreAttemptMemoryFlush({
+        ...base,
+        memoryFlushWritable: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -177,6 +177,57 @@ export function shouldRunPreflightCompaction(params: {
   return Boolean(state && state.totalTokens >= state.threshold);
 }
 
+export function shouldRunPreCompactionMemoryFlush(params: {
+  trigger?: string;
+  attemptedThisRun?: boolean;
+  memoryFlushEnabled?: boolean;
+  memoryFlushWritable?: boolean;
+  entry?: Pick<
+    SessionEntry,
+    "totalTokens" | "totalTokensFresh" | "compactionCount" | "memoryFlushCompactionCount"
+  >;
+  /**
+   * Optional token count override for pre-compaction flush gating. When provided,
+   * this value is treated as the best available projected context snapshot.
+   */
+  tokenCount?: number;
+  contextWindowTokens: number;
+  reserveTokensFloor: number;
+  softThresholdTokens: number;
+  forceFlushByTranscriptSize?: boolean;
+}): boolean {
+  if (params.trigger === "memory") {
+    return false;
+  }
+  if (params.attemptedThisRun === true) {
+    return false;
+  }
+  if (params.memoryFlushEnabled === false) {
+    return false;
+  }
+  if (params.memoryFlushWritable === false) {
+    return false;
+  }
+  if (!params.entry) {
+    return false;
+  }
+  if (hasAlreadyFlushedForCurrentCompaction(params.entry)) {
+    return false;
+  }
+  if (params.forceFlushByTranscriptSize === true) {
+    return true;
+  }
+  return shouldRunMemoryFlush({
+    entry: params.entry,
+    tokenCount: params.tokenCount,
+    contextWindowTokens: params.contextWindowTokens,
+    reserveTokensFloor: params.reserveTokensFloor,
+    softThresholdTokens: params.softThresholdTokens,
+  });
+}
+
+export const shouldRunEmbeddedPreAttemptMemoryFlush = shouldRunPreCompactionMemoryFlush;
+
 /**
  * Returns true when a memory flush has already been performed for the current
  * compaction cycle. This prevents repeated flush runs within the same cycle —

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -47,7 +47,7 @@ type SupportedOpenAICompatFields = Pick<
 
 type SupportedOpenAIResponsesCompatFields = Pick<
   OpenAIResponsesCompat,
-  "sendSessionIdHeader" | "supportsLongCacheRetention"
+  "sendSessionIdHeader" | "supportsLongCacheRetention" | "systemPromptMode"
 >;
 
 type SupportedAnthropicMessagesCompatFields = Pick<

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -231,6 +231,9 @@ const ModelCompatSchema = z
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),
     requiresReasoningContentOnAssistantMessages: z.boolean().optional(),
+    systemPromptMode: z
+      .union([z.literal("message"), z.literal("instructions"), z.literal("user")])
+      .optional(),
     toolSchemaProfile: z.string().optional(),
     unsupportedToolSchemaKeywords: z.array(z.string().min(1)).optional(),
     nativeWebSearchTool: z.boolean().optional(),

--- a/src/llm/providers/openai-compatible-auth.test.ts
+++ b/src/llm/providers/openai-compatible-auth.test.ts
@@ -1,5 +1,6 @@
 // OpenAI-compatible auth tests cover API key and base URL normalization.
 import { afterEach, describe, expect, it } from "vitest";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-boundary.js";
 import { captureEnv } from "../../test-utils/env.js";
 import type { Context, Model } from "../types.js";
 import { streamOpenAICompletions } from "./openai-completions.js";
@@ -51,6 +52,91 @@ describe("OpenAI-compatible provider credentials", () => {
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe("No API key for provider: custom-openai-compatible");
+  });
+
+  it("can place Responses system prompts in top-level instructions for compatible providers", async () => {
+    let capturedPayload:
+      | { instructions?: string; input?: Array<{ role?: string; type?: string }> }
+      | undefined;
+    const model = {
+      ...createBaseModel("openai-responses"),
+      reasoning: true,
+      compat: { systemPromptMode: "instructions" },
+    } satisfies Model<"openai-responses">;
+    const stream = streamOpenAIResponses(
+      model,
+      {
+        systemPrompt: `Stable${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        onPayload: (payload) => {
+          capturedPayload = payload as typeof capturedPayload;
+          throw new Error("stop after payload");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("stop after payload");
+    expect(capturedPayload?.instructions).toBe("Stable\nDynamic");
+    expect(capturedPayload?.input?.some((item) => item.role === "developer")).toBe(false);
+    expect(capturedPayload?.input?.some((item) => item.role === "system")).toBe(false);
+    expect(capturedPayload?.input?.find((item) => item.role === "user")).toMatchObject({
+      type: "message",
+      role: "user",
+    });
+  });
+
+  it("can place Responses system prompts in a first user message for providers that reject system fields", async () => {
+    let capturedPayload:
+      | {
+          instructions?: string;
+          input?: Array<{ role?: string; type?: string; content?: unknown }>;
+        }
+      | undefined;
+    const model = {
+      ...createBaseModel("openai-responses"),
+      reasoning: true,
+      compat: { systemPromptMode: "user" },
+    } satisfies Model<"openai-responses">;
+    const stream = streamOpenAIResponses(
+      model,
+      {
+        systemPrompt: `Stable${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        onPayload: (payload) => {
+          capturedPayload = payload as typeof capturedPayload;
+          throw new Error("stop after payload");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("stop after payload");
+    expect(capturedPayload?.instructions).toBeUndefined();
+    expect(capturedPayload?.input?.some((item) => item.role === "developer")).toBe(false);
+    expect(capturedPayload?.input?.some((item) => item.role === "system")).toBe(false);
+    expect(capturedPayload?.input?.[0]).toMatchObject({
+      type: "message",
+      role: "user",
+      content: [
+        { type: "input_text", text: "System instructions for this run:\n\nStable\nDynamic" },
+      ],
+    });
+    expect(capturedPayload?.input?.[1]).toMatchObject({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "hi" }],
+    });
   });
 
   it("does not replay Responses item ids for direct store-disabled requests", async () => {

--- a/src/llm/providers/openai-responses.ts
+++ b/src/llm/providers/openai-responses.ts
@@ -1,6 +1,10 @@
 // OpenAI Responses provider adapts OpenAI response streams to the agent runtime.
 import OpenAI from "openai";
-import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
+import type {
+  ResponseCreateParamsStreaming,
+  ResponseInputItem,
+} from "openai/resources/responses/responses.js";
+import { stripSystemPromptCacheBoundary } from "../../agents/system-prompt-cache-boundary.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import type {
   CacheRetention,
@@ -13,6 +17,7 @@ import type {
   Usage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { resolveCacheRetention } from "./cache-retention.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
@@ -32,6 +37,7 @@ function getCompat(model: Model<"openai-responses">): Required<OpenAIResponsesCo
   return {
     sendSessionIdHeader: model.compat?.sendSessionIdHeader ?? true,
     supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
+    systemPromptMode: model.compat?.systemPromptMode ?? "message",
   };
 }
 
@@ -180,15 +186,38 @@ function buildParams(
   context: Context,
   options?: OpenAIResponsesOptions,
 ) {
+  const compat = getCompat(model);
+  const systemPromptAsInstructions = compat.systemPromptMode === "instructions";
+  const systemPromptAsUserMessage = compat.systemPromptMode === "user";
   const messages = convertResponsesMessages(model, context, OPENAI_TOOL_CALL_PROVIDERS, {
+    includeSystemPrompt: !systemPromptAsInstructions && !systemPromptAsUserMessage,
     replayResponsesItemIds: options?.replayResponsesItemIds ?? false,
   });
+  const systemPrompt =
+    (systemPromptAsInstructions || systemPromptAsUserMessage) && context.systemPrompt
+      ? sanitizeSurrogates(stripSystemPromptCacheBoundary(context.systemPrompt))
+      : undefined;
+  const input =
+    systemPromptAsUserMessage && systemPrompt
+      ? [
+          {
+            type: "message",
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: `System instructions for this run:\n\n${systemPrompt}`,
+              },
+            ],
+          } satisfies ResponseInputItem,
+          ...(messages as ResponseInputItem[]),
+        ]
+      : messages;
 
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
-  const compat = getCompat(model);
   const params: ResponseCreateParamsStreaming = {
     model: model.id,
-    input: messages,
+    input,
     stream: true,
     prompt_cache_key:
       cacheRetention === "none"
@@ -197,6 +226,10 @@ function buildParams(
     prompt_cache_retention: getPromptCacheRetention(compat, cacheRetention),
     store: false,
   };
+
+  if (systemPromptAsInstructions && systemPrompt) {
+    params.instructions = systemPrompt;
+  }
 
   if (options?.maxTokens) {
     params.max_output_tokens = options?.maxTokens;


### PR DESCRIPTION
## Summary

This PR hardens embedded pre-attempt memory flush behavior and adds provider compatibility support for Responses system prompt placement.

Memory lifecycle focus:

- This stage targets the **memory write/update** and **pre-compaction flush** boundary.
- The synthetic memory flush route now avoids carrying pending-turn user content/media.
- The flush keeps the routing/session/policy metadata needed for the memory operation, while the actual model input is driven by the memory flush plan prompt.
- This helps separate memory lifecycle work from live conversation context, especially around which context should be isolated vs shared.

Implementation changes:

- Strips pending-turn content/media from embedded synthetic flush routes:
  - `prompt`
  - `transcriptPrompt`
  - inbound event/audio/context fields
  - `images`
  - `imageOrder`
- Keeps the pending prompt available separately only for flush threshold estimation.
- Adds regression coverage with fake sensitive pending-turn content to ensure it does not ride along into the flush route.
- Adds `systemPromptMode` compatibility for OpenAI Responses-style providers:
  - default `message`
  - top-level `instructions`
  - first `user` message for providers that reject system/developer fields
- Extends config/schema/types coverage for the new compat field.

## Validation

Focused tests passed:

- `src/agents/embedded-agent-runner/memory-flush.test.ts`
- `src/auto-reply/reply/memory-flush.embedded-preattempt.test.ts`
- `src/agents/openai-transport-stream.test.ts -t "moves Responses system prompts into a first user message when compat requires user mode"`
- `src/llm/providers/openai-compatible-auth.test.ts -t "Responses system prompts"`
- `git diff --check`

## Known caveat

A full run of the large `openai-transport-stream.test.ts` file still shows unrelated existing failures in ModelStudio/DeepSeek/DashScope compatibility sections. The focused tests covering this PR's changed transport behavior pass.

## Follow-up

Next lifecycle stage after this PR: validate memory retrieval when a user starts a new conversation, including source selection, session boundaries, private/group isolation, and how retrieved memory relates to conversation context.
