### PR TITLE
test(ui-e2e): run Chromium capability probe headless with a timeout

### DIFF
--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -111,7 +111,20 @@ export function canRunPlaywrightChromium(chromiumExecutablePath: string): boolea
   if (!existsSync(chromiumExecutablePath)) {
     return false;
   }
-  return spawnSync(chromiumExecutablePath, ["--version"], { stdio: "ignore" }).status === 0;
+  // Some Chrome-for-Testing builds on Windows treat `chrome.exe --version` as a
+  // full launch that never exits, which would deadlock this synchronous probe and
+  // even pop a visible window. Run it headless with a hard timeout: a clean exit 0
+  // confirms the binary runs, and a timeout falls back to the on-disk existence
+  // check (the binary is present; Playwright's own launch will surface any real
+  // failure) instead of blocking forever.
+  const probe = spawnSync(chromiumExecutablePath, ["--headless=new", "--version"], {
+    stdio: "ignore",
+    timeout: 5000,
+  });
+  if (probe.status === 0) {
+    return true;
+  }
+  return (probe.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT";
 }
 
 export async function startControlUiE2eServer(): Promise<ControlUiE2eServer> {


### PR DESCRIPTION
## Problem

`canRunPlaywrightChromium()` in `ui/src/test-helpers/control-ui-e2e.ts` gates the
ui-e2e suites by shelling out to `chrome.exe --version` synchronously (`spawnSync`),
and the helper runs at test-module load time.

On **Chrome for Testing 148 (Playwright `chromium-1223`) on Windows**, `chrome.exe
--version` does **not** print-and-exit — it launches a full **headed** browser that
never returns. Because the probe is synchronous, the entire `vitest` ui-e2e run
**deadlocks at the `RUN` header before any test executes**, and a visible "New Tab -
Google Chrome for Testing" window appears. Playwright revision **1208**'s `--version`
exits cleanly, so this is a CFT-148 regression on Windows.

The tests themselves are not the problem: driving `chromium.launch({ headless: true })`
with the matching binary directly is fully windowless. Only the capability probe hangs.

## Fix

Run the probe **headless with a hard timeout**:

- a clean `exit 0` still confirms the binary runs — unchanged fast path on Linux/CI,
  where `--version` exits immediately;
- a timeout falls back to the on-disk existence check (the binary is present;
  Playwright's own `chromium.launch()` surfaces any genuine launch failure) instead of
  blocking forever or popping a window.

## Verification

- **Before:** a `ui/src/ui/e2e/*.e2e.test.ts` spec on Windows (chromium-1223) hangs at
  `RUN`; a headed "Chrome for Testing" window is left open (reproduced standalone with
  `chrome.exe --version`).
- **After:** the spec runs to completion and stays **windowless** — 0 headed windows
  observed across the run, no lingering Chrome-for-Testing processes.
- No behavior change on Linux/CI, where `--version` already exits 0 immediately.

Based on `dd9706e90264e272ce7f155e00fa3cc83ee69b7a`; happy to rebase onto current `main`.
