### PR TITLE
fix(model-resolver): use numeric-aware collation for alias/version sort

### DIFF
--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -116,11 +116,11 @@ function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | 
 
   if (aliases.length > 0) {
     // Prefer alias - if multiple aliases, pick the one that sorts highest
-    aliases.sort((a, b) => b.id.localeCompare(a.id));
+    aliases.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
     return aliases[0];
   }
   // No alias found, pick latest dated version
-  datedVersions.sort((a, b) => b.id.localeCompare(a.id));
+  datedVersions.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
   return datedVersions[0];
 }
 


### PR DESCRIPTION
## Summary

**Problem**: When a user runs `/model opus` or a scope specifies `--model opus`, the alias `opus` matches multiple version-suffixed model ids like `claude-opus-4-9` and `claude-opus-4-10`. The `tryMatchModel` function in `src/agents/sessions/model-resolver.ts:117-124` sorts candidates using plain `String.localeCompare`, which compares character by character using Unicode code points. Because '9' (code point 57) is lexicographically greater than '1' (code point 49), `"claude-opus-4-9"` sorts above `"claude-opus-4-10"` — the resolver silently selects the older, weaker model. This defect is latent today because all shipped model families use single-digit minor versions where lexicographic and numeric ordering agree, but it becomes wrong the moment any family crosses into double-digit minor versions.

**Solution**: Add the standard ECMAScript `{ numeric: true }` option to both `localeCompare` calls. This option, available since ES2020, instructs the comparator to treat embedded numeric substrings as numbers rather than character sequences. With `{ numeric: true }`, `"4-10"` correctly ranks above `"4-9"` because 10 > 9 as integers.

**What changed**: `src/agents/sessions/model-resolver.ts` — exactly 2 lines (119 and 123), changing `b.id.localeCompare(a.id)` to `b.id.localeCompare(a.id, undefined, { numeric: true })` in both the alias bucket comparator and the dated-version bucket comparator

**What did NOT change**: The `isAlias` classifier (which determines whether an id ends in an 8-digit date stamp), the match pipeline, the return path, the fallback model resolution logic in `parseModelPattern`, or any other model selection code path. Only the two sort comparison callbacks were modified. No tests were added because the existing test models all have single-digit versions where numeric and lexicographic collation are identical.

Fixes #96588

## Real behavior proof (required for external PRs)

**Behavior addressed**: Model alias resolution via `parseModelPattern` and `tryMatchModel` selects the lexicographically highest model id rather than the numerically newest version when minor versions reach double digits. With models `claude-opus-4-9` and `claude-opus-4-10`, resolving the alias `opus` incorrectly selects the older `4-9` variant. The `/model` slash command and CLI scope parsing both route through this same code path, so any user-facing model selection via alias or partial id match is affected.

**Real setup tested**:
- **Runtime**: Node 24.13, Linux x86_64
- **Branch**: `fix/issue-96588-model-alias-ordering` at `a95eabb2b5`, based on upstream/main
- **Method**: Direct TypeScript import of `parseModelPattern` from `model-resolver.ts` via `node --import tsx/esm`, exercising the same runtime code path used in production by `/model` and CLI `--model` parsing

**Root cause**: The `tryMatchModel` function is called by `parseModelPattern` to resolve a model pattern (which could be an alias, partial id, or exact id) against the list of available models. It first tries exact match, then splits candidates into alias-matching and dated-version buckets. Both buckets are sorted descending with `localeCompare` to pick the "highest" match. Without `{ numeric: true }`, the comparator treats all characters as opaque code points. The model id `"claude-opus-4-9"` compared to `"claude-opus-4-10"` shares the prefix `"claude-opus-4-"`, then compares '9' against '1' — and '9' wins lexicographically, producing a reverse-numeric ordering. The resolver takes `aliases[0]` (the sort-highest entry) and returns it as the match.

The `isAlias` function at line 30-39 classifies model ids that do not end in 8-digit `-YYYYMMDD` date stamps as aliases. This means version-suffixed ids like `claude-opus-4-10` fall into the alias bucket and hit the line 119 comparator. The dated-version bucket (line 123) handles `-YYYYMMDD` suffixed ids where the date stamps are fixed-width and lexicographic ordering already works, but receives the same fix for consistency and correctness.

**Exact steps or command run after this patch**: Imported `parseModelPattern` via `node --import tsx/esm` and called it against four scenarios: (1) double-digit alias resolution, (2) single-digit alias regression check, (3) exact id match, and (4) non-matching alias

**After-fix evidence**:
```
1. opus double-digit: claude-opus-4-10 ✅
   (available: claude-opus-4-9, claude-opus-4-10)

2. sonnet single-digit: claude-sonnet-4-6 ✅
   (available: claude-sonnet-4-5, claude-sonnet-4-6)
   — regression check: single-digit ordering identical to before

3. exact match: claude-opus-4-9 ✅
   — exact id match returns before reaching the sort step

4. no match: (none) ✅
   — non-matching alias returns undefined with warning, unchanged
```

Before the fix (pristine upstream/main), the same alias `opus` against the same two-version list selects `claude-opus-4-9` — the older version. After applying `{ numeric: true }` to both `localeCompare` calls, the same input selects `claude-opus-4-10` — the numerically newest version.

**Observed result after the fix**: Both comparator lines now produce correct numeric ordering for multi-digit version substrings. The alias bucket correctly picks the numerically highest versioned model. The dated-version bucket behavior is unchanged because `-YYYYMMDD` date suffixes are fixed-width. The existing unit tests continue to pass (2/2, no modifications needed) because they use single-digit model versions. Single-digit version ordering is preserved because numeric collation produces the same result as lexicographic for single-digit numeric substrings.

**What was not tested**: Live provider catalog with actual double-digit minor versions. No shipped model family currently has double-digit minor versions — this is a latent, forward-looking fix. The verification uses the real `parseModelPattern` function imported from the PR head with synthetic two-version model lists constructed using the same `Model` type used in the existing test suite. The models are valid `Model` objects with all required fields (id, name, provider, api, baseUrl, reasoning, input, cost, contextWindow, maxTokens).

**Evidence provenance**: `node --import tsx/esm` directly importing and calling `parseModelPattern` on the PR head commit `a95eabb2b5` at Node 24.13 / Linux x86_64, 2026-06-25.

## Tests and validation
| Test Type | Result | Details |
|-----------|--------|---------|
| Unit Tests | ✅ 2/2 | model-resolver.test.ts — unchanged, zero regressions |
| Proof Script | ✅ 4/4 | double-digit + single-digit + exact match + no match |

## Design decisions

**Why `{ numeric: true }` instead of a custom numeric sort or semver parser?**

The standard `{ numeric: true }` collation option is precisely designed for this use case — sorting strings that contain embedded numeric substrings in natural order. It avoids introducing a dependency on semver parsing or a custom comparator function. The option is maximally simple: it is one additional argument to an already-existing function call. Semver parsing would be overkill here because model ids like `claude-opus-4-10` are not semver strings — they are provider-specific identifiers that happen to carry numeric version suffixes. A general numeric collation handles this without needing to know the exact version scheme of every provider.

**Why apply the fix to the dated-version bucket (line 123) when it currently compares fixed-width YYYYMMDD suffixes?**

The dated-version bucket already produces correct ordering because `-YYYYMMDD` suffixes are fixed-width and lexicographic ordering happens to match chronological ordering. However, applying `{ numeric: true }` to both comparator lines ensures consistency if the dated-version classification logic ever changes or if future model ids use non-fixed-width numeric suffixes in the dated bucket. The cost is zero — numeric collation on fixed-width digit strings produces identical results to lexicographic collation — and the benefit is defense against future drift. It also means a code reader who looks at either line doesn't have to wonder why only one comparator has the option.

**Why not add new test cases for double-digit versions?**

The existing test models use single-digit versions (e.g., `claude-sonnet-4-6`). Adding a double-digit test case would require constructing synthetic model ids that don't exist in any shipped catalog, which would be confusing for future maintainers who might wonder where those models came from. The proof script above provides the behavioral verification without polluting the test suite with invented model versions. When the first real double-digit model ships, its natural inclusion in the test catalog will serve as the regression test. The fix is so simple (two lines, one standard option) that the proof script verification is sufficient.

**Why the `undefined` second argument to `localeCompare`?**

The `localeCompare` signature is `localeCompare(compareString, locales?, options?)`. Passing `undefined` for locales means "use the default locale," which is the same behavior as the original two-argument `localeCompare(a.id)` call where locales was implicitly `undefined`. The `{ numeric: true }` option is independent of locale — it controls how embedded numeric substrings are compared, not language-specific ordering. This means the fix is locale-agnostic and works identically across all runtime environments.

## Risk checklist

**What is the highest-risk area of this change?**

Model resolution ordering changes for all alias and dated-version lookups. If any downstream code or user workflow depends on the specific lexicographic ordering produced by the old comparator (e.g., by always selecting the first model a particular alias resolves to), the model selection could silently change once a family reaches double-digit versions.

**Risk level**: Low risk — the `{ numeric: true }` option only changes ordering when model ids contain multi-digit numeric substrings where digit counts differ (e.g., comparing 9 against 10). For single-digit versions — the only state that has ever been shipped — lexicographic and numeric ordering produce identical results, so the fix has zero behavioral effect on today's catalogs. The `localeCompare` `{ numeric: true }` option is standardized in ECMAScript 2020 and available in Node.js 14+. The project requires Node 22.19+, well above this threshold.

**Mitigation**: The proof script above demonstrates that single-digit version ordering (scenario 2) is unchanged. Exact match lookup (scenario 3) bypasses the sort entirely and is unaffected. No other model-id comparator using `localeCompare` exists in `src/agents/sessions` or `src/llm`. The existing 2 unit tests pass without modification, confirming no behavioral regression for the single-digit case.

**Merge risk declaration**: No merge risk — latent fix with zero behavioral effect on current shipped model catalogs. The change becomes active only when a model family's minor version reaches double digits, at which point it prevents incorrect alias resolution rather than introducing a new problem.