### PR TITLE
fix(heartbeat): remove static iteration cap in seekNextActivePhaseDueMs

### DIFF
--- a/src/infra/heartbeat-active-hours.test.ts
+++ b/src/infra/heartbeat-active-hours.test.ts
@@ -1,7 +1,7 @@
 // Covers heartbeat active-hours evaluation.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { isWithinActiveHours } from "./heartbeat-active-hours.js";
+import { createActiveHoursPredicate, isWithinActiveHours } from "./heartbeat-active-hours.js";
 
 function cfgWithUserTimezone(userTimezone = "UTC"): OpenClawConfig {
   return {
@@ -75,6 +75,16 @@ describe("isWithinActiveHours", () => {
 
     expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 15, 0, 0))).toBe(true);
     expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 23, 30, 0))).toBe(false);
+  });
+
+  it("evaluates repeated schedule probes with a prepared predicate", () => {
+    const isActive = createActiveHoursPredicate(
+      cfgWithUserTimezone("UTC"),
+      heartbeatWindow("09:00", "17:00", "America/New_York"),
+    );
+
+    expect(isActive(Date.UTC(2025, 0, 1, 15, 0, 0))).toBe(true);
+    expect(isActive(Date.UTC(2025, 0, 1, 23, 30, 0))).toBe(false);
   });
 
   it("falls back to user timezone when activeHours timezone is invalid", () => {

--- a/src/infra/heartbeat-active-hours.ts
+++ b/src/infra/heartbeat-active-hours.ts
@@ -46,14 +46,9 @@ function parseActiveHoursTime(opts: { allow24: boolean }, raw?: string): number 
   return hour * 60 + minute;
 }
 
-function resolveMinutesInTimeZone(nowMs: number, timeZone: string): number | null {
+function resolveMinutesInTimeZone(nowMs: number, formatter: Intl.DateTimeFormat): number | null {
   try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      hour: "2-digit",
-      minute: "2-digit",
-      hourCycle: "h23",
-    }).formatToParts(new Date(nowMs));
+    const parts = formatter.formatToParts(new Date(nowMs));
     const map: Record<string, string> = {};
     for (const part of parts) {
       if (part.type !== "literal") {
@@ -71,34 +66,57 @@ function resolveMinutesInTimeZone(nowMs: number, timeZone: string): number | nul
   }
 }
 
+/** Prepare one active-hours predicate for repeated schedule probes. */
+export function createActiveHoursPredicate(
+  cfg: OpenClawConfig,
+  heartbeat?: HeartbeatConfig,
+): (nowMs: number) => boolean {
+  const active = heartbeat?.activeHours;
+  if (!active) {
+    return () => true;
+  }
+
+  const startMin = parseActiveHoursTime({ allow24: false }, active.start);
+  const endMin = parseActiveHoursTime({ allow24: true }, active.end);
+  if (startMin === null || endMin === null) {
+    return () => true;
+  }
+  if (startMin === endMin) {
+    return () => false;
+  }
+
+  const timeZone = resolveActiveHoursTimezone(cfg, active.timezone);
+  let formatter: Intl.DateTimeFormat;
+  try {
+    // Schedule seeking can call this predicate thousands of times. Reusing the
+    // formatter avoids blocking the event loop on repeated Intl construction.
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    });
+  } catch {
+    return () => true;
+  }
+
+  return (nowMs: number) => {
+    const currentMin = resolveMinutesInTimeZone(nowMs, formatter);
+    if (currentMin === null) {
+      return true;
+    }
+    if (endMin > startMin) {
+      return currentMin >= startMin && currentMin < endMin;
+    }
+    return currentMin >= startMin || currentMin < endMin;
+  };
+}
+
 /** Return true when the current time is inside the configured heartbeat window. */
 export function isWithinActiveHours(
   cfg: OpenClawConfig,
   heartbeat?: HeartbeatConfig,
   nowMs?: number,
 ): boolean {
-  const active = heartbeat?.activeHours;
-  if (!active) {
-    return true;
-  }
-
-  const startMin = parseActiveHoursTime({ allow24: false }, active.start);
-  const endMin = parseActiveHoursTime({ allow24: true }, active.end);
-  if (startMin === null || endMin === null) {
-    return true;
-  }
-  if (startMin === endMin) {
-    return false;
-  }
-
-  const timeZone = resolveActiveHoursTimezone(cfg, active.timezone);
-  const currentMin = resolveMinutesInTimeZone(nowMs ?? Date.now(), timeZone);
-  if (currentMin === null) {
-    return true;
-  }
-
-  if (endMin > startMin) {
-    return currentMin >= startMin && currentMin < endMin;
-  }
-  return currentMin >= startMin || currentMin < endMin;
+  return createActiveHoursPredicate(cfg, heartbeat)(nowMs ?? Date.now());
 }

--- a/src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
+++ b/src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
@@ -112,6 +112,34 @@ describe("heartbeat scheduler: activeHours-aware scheduling (#75487)", () => {
     runner.stop();
   });
 
+  it("reaches a narrow active window with a sub-minute interval", async () => {
+    const startMs = Date.parse("2026-06-15T17:00:00.000Z");
+    useFakeHeartbeatTime(startMs);
+
+    const callTimes: number[] = [];
+    const runSpy: RunOnce = vi.fn().mockImplementation(async () => {
+      callTimes.push(Date.now());
+      return { status: "ran", durationMs: 1 };
+    });
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig({
+        every: "30s",
+        activeHours: { start: "09:00", end: "09:01", timezone: "UTC" },
+      }),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    await vi.advanceTimersByTimeAsync(16 * 60 * 60_000 + 60_000);
+
+    expect(callTimes.length).toBeGreaterThan(0);
+    for (const callTime of callTimes) {
+      const call = new Date(callTime);
+      expect(call.getUTCHours()).toBe(9);
+      expect(call.getUTCMinutes()).toBe(0);
+    }
+    runner.stop();
+  });
   it("seeks forward correctly with a non-UTC timezone (e.g. America/New_York)", async () => {
     // 09:00–17:00 ET (EDT = UTC-4 in June) → 13:00–21:00 UTC.
     // Start at 21:30 UTC (17:30 ET = outside window).

--- a/src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
+++ b/src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
@@ -112,75 +112,6 @@ describe("heartbeat scheduler: activeHours-aware scheduling (#75487)", () => {
     runner.stop();
   });
 
-  it("runs a bounded real scheduler with active-hours enabled", async () => {
-    const startedAt = Date.now();
-    let resolveRun: (() => void) | undefined;
-    const ran = new Promise<void>((resolve) => {
-      resolveRun = resolve;
-    });
-    const runSpy: RunOnce = vi.fn().mockImplementation(async () => {
-      resolveRun?.();
-      return { status: "ran", durationMs: 1 };
-    });
-    const runner = startHeartbeatRunner({
-      cfg: heartbeatConfig({
-        every: "50ms",
-        activeHours: { start: "00:00", end: "24:00", timezone: "UTC" },
-      }),
-      runOnce: runSpy,
-      stableSchedulerSeed: TEST_SCHEDULER_SEED,
-    });
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-
-    try {
-      await Promise.race([
-        ran,
-        new Promise<never>((_, reject) => {
-          timeout = setTimeout(
-            () => reject(new Error("real heartbeat scheduler did not fire")),
-            2_000,
-          );
-        }),
-      ]);
-      expect(runSpy).toHaveBeenCalled();
-      expect(Date.now() - startedAt).toBeLessThan(2_000);
-    } finally {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-      runner.stop();
-    }
-  });
-
-  it("reaches a narrow active window with a sub-minute interval", async () => {
-    const startMs = Date.parse("2026-06-15T17:00:00.000Z");
-    useFakeHeartbeatTime(startMs);
-
-    const callTimes: number[] = [];
-    const runSpy: RunOnce = vi.fn().mockImplementation(async () => {
-      callTimes.push(Date.now());
-      return { status: "ran", durationMs: 1 };
-    });
-    const runner = startHeartbeatRunner({
-      cfg: heartbeatConfig({
-        every: "30s",
-        activeHours: { start: "09:00", end: "09:01", timezone: "UTC" },
-      }),
-      runOnce: runSpy,
-      stableSchedulerSeed: TEST_SCHEDULER_SEED,
-    });
-
-    await vi.advanceTimersByTimeAsync(16 * 60 * 60_000 + 60_000);
-
-    expect(callTimes.length).toBeGreaterThan(0);
-    for (const callTime of callTimes) {
-      const call = new Date(callTime);
-      expect(call.getUTCHours()).toBe(9);
-      expect(call.getUTCMinutes()).toBe(0);
-    }
-    runner.stop();
-  });
-
   it("seeks forward correctly with a non-UTC timezone (e.g. America/New_York)", async () => {
     // 09:00–17:00 ET (EDT = UTC-4 in June) → 13:00–21:00 UTC.
     // Start at 21:30 UTC (17:30 ET = outside window).
@@ -353,6 +284,35 @@ describe("heartbeat scheduler: activeHours-aware scheduling (#75487)", () => {
     expect(firstCall.getUTCHours()).toBe(16);
     expect(firstCall.getUTCDate()).toBe(15);
 
+    runner.stop();
+  });
+
+  it("reaches a narrow active window with a sub-minute interval", async () => {
+    const startMs = Date.parse("2026-06-15T17:00:00.000Z");
+    useFakeHeartbeatTime(startMs);
+
+    const callTimes: number[] = [];
+    const runSpy: RunOnce = vi.fn().mockImplementation(async () => {
+      callTimes.push(Date.now());
+      return { status: "ran", durationMs: 1 };
+    });
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig({
+        every: "30s",
+        activeHours: { start: "09:00", end: "09:01", timezone: "UTC" },
+      }),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    await vi.advanceTimersByTimeAsync(16 * 60 * 60_000 + 60_000);
+
+    expect(callTimes.length).toBeGreaterThan(0);
+    for (const callTime of callTimes) {
+      const call = new Date(callTime);
+      expect(call.getUTCHours()).toBe(9);
+      expect(call.getUTCMinutes()).toBe(0);
+    }
     runner.stop();
   });
 });

--- a/src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
+++ b/src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
@@ -112,6 +112,46 @@ describe("heartbeat scheduler: activeHours-aware scheduling (#75487)", () => {
     runner.stop();
   });
 
+  it("runs a bounded real scheduler with active-hours enabled", async () => {
+    const startedAt = Date.now();
+    let resolveRun: (() => void) | undefined;
+    const ran = new Promise<void>((resolve) => {
+      resolveRun = resolve;
+    });
+    const runSpy: RunOnce = vi.fn().mockImplementation(async () => {
+      resolveRun?.();
+      return { status: "ran", durationMs: 1 };
+    });
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig({
+        every: "50ms",
+        activeHours: { start: "00:00", end: "24:00", timezone: "UTC" },
+      }),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      await Promise.race([
+        ran,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("real heartbeat scheduler did not fire")),
+            2_000,
+          );
+        }),
+      ]);
+      expect(runSpy).toHaveBeenCalled();
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      runner.stop();
+    }
+  });
+
   it("reaches a narrow active window with a sub-minute interval", async () => {
     const startMs = Date.parse("2026-06-15T17:00:00.000Z");
     useFakeHeartbeatTime(startMs);
@@ -140,6 +180,7 @@ describe("heartbeat scheduler: activeHours-aware scheduling (#75487)", () => {
     }
     runner.stop();
   });
+
   it("seeks forward correctly with a non-UTC timezone (e.g. America/New_York)", async () => {
     // 09:00–17:00 ET (EDT = UTC-4 in June) → 13:00–21:00 UTC.
     // Start at 21:30 UTC (17:30 ET = outside window).

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -7,6 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   hasOutboundReplyContent,
   isReasoningReplyPayload,
@@ -26,6 +27,7 @@ import { formatReasoningMessage } from "../agents/embedded-agent-utils.js";
 import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { resolveModelRefFromString, type ModelRef } from "../agents/model-selection.js";
 import { resolvePersistedSessionRuntimeId } from "../agents/session-runtime-compat.js";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
@@ -105,6 +107,7 @@ import {
   toAgentStoreSessionKey,
 } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { escapeRegExp } from "../utils.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
@@ -124,6 +127,7 @@ import {
   isRelayableExecCompletionEvent,
 } from "./heartbeat-events-filter.js";
 import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js";
+import { HEARTBEAT_RUN_SCOPE, type HeartbeatRunScope } from "./heartbeat-run-scope.js";
 import {
   computeNextHeartbeatPhaseDueMs,
   resolveHeartbeatPhaseMs,
@@ -149,6 +153,7 @@ import {
   setHeartbeatWakeHandler,
 } from "./heartbeat-wake.js";
 import type { OutboundSendDeps } from "./outbound/deliver.js";
+import { resolveAgentOutboundIdentity } from "./outbound/identity.js";
 import { buildOutboundSessionContext } from "./outbound/session-context.js";
 import {
   resolveHeartbeatDeliveryTargetWithSessionRoute,
@@ -174,13 +179,10 @@ export type HeartbeatDeps = OutboundSendDeps &
   };
 
 const log = createSubsystemLogger("gateway/heartbeat");
-let heartbeatRunnerRuntimePromise: Promise<typeof import("./heartbeat-runner.runtime.js")> | null =
-  null;
 
-function loadHeartbeatRunnerRuntime() {
-  heartbeatRunnerRuntimePromise ??= import("./heartbeat-runner.runtime.js");
-  return heartbeatRunnerRuntimePromise;
-}
+const loadHeartbeatRunnerRuntime = createLazyRuntimeModule(
+  () => import("./heartbeat-runner.runtime.js"),
+);
 
 const HEARTBEAT_ALWAYS_BUSY_LANES = [CommandLane.Cron, CommandLane.CronNested] as const;
 const DEFAULT_HEARTBEAT_TIMEOUT_SECONDS = 10 * 60;
@@ -843,11 +845,45 @@ function stripLeadingHeartbeatResponsePrefix(
   return text.replace(prefixPattern, "");
 }
 
+type NormalizedHeartbeatDelivery = {
+  shouldSkip: boolean;
+  text: string;
+  hasMedia: boolean;
+  isInternalPlaceholderOnly: boolean;
+  silent?: boolean;
+};
+
+function isStreamErrorFallbackPlaceholderOnly(text: string): boolean {
+  let remaining = text.trim();
+  if (!remaining) {
+    return false;
+  }
+
+  while (remaining.startsWith(STREAM_ERROR_FALLBACK_TEXT)) {
+    remaining = remaining.slice(STREAM_ERROR_FALLBACK_TEXT.length).trimStart();
+  }
+  return remaining.length === 0;
+}
+
+const TRAILING_HEARTBEAT_NOTIFY_FALSE_RE = /(?:^|[\r\n])[ \t]*notify=false[ \t]*(?:\r?\n[ \t]*)*$/i;
+
+function truncateHeartbeatPreview(value: string | undefined): string | undefined {
+  return value ? truncateUtf16Safe(value, 200) : undefined;
+}
+
+function stripTrailingHeartbeatNotifyFalse(text: string): { text: string; silent: boolean } {
+  const match = TRAILING_HEARTBEAT_NOTIFY_FALSE_RE.exec(text);
+  if (!match) {
+    return { text, silent: false };
+  }
+  return { text: text.slice(0, match.index).trimEnd(), silent: true };
+}
+
 function normalizeHeartbeatReply(
   payload: ReplyPayload,
   responsePrefix: string | undefined,
   ackMaxChars: number,
-) {
+): NormalizedHeartbeatDelivery {
   const rawText = typeof payload.text === "string" ? payload.text : "";
   const textForStrip = stripLeadingHeartbeatResponsePrefix(rawText, responsePrefix);
   const stripped = stripHeartbeatToken(textForStrip, {
@@ -855,29 +891,45 @@ function normalizeHeartbeatReply(
     maxAckChars: ackMaxChars,
   });
   const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
-  if (stripped.shouldSkip && !hasMedia) {
+  const notifyFalse = stripTrailingHeartbeatNotifyFalse(stripped.text);
+  const isInternalPlaceholderOnly = isStreamErrorFallbackPlaceholderOnly(notifyFalse.text);
+  if ((stripped.shouldSkip || isInternalPlaceholderOnly) && !hasMedia) {
     return {
       shouldSkip: true,
       text: "",
       hasMedia,
+      isInternalPlaceholderOnly,
+      ...(notifyFalse.silent ? { silent: true } : {}),
     };
   }
-  let finalText = stripped.text;
+  let finalText = isInternalPlaceholderOnly ? "" : notifyFalse.text;
   if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
     finalText = `${responsePrefix} ${finalText}`;
   }
-  return { shouldSkip: false, text: finalText, hasMedia };
+  const shouldSkip = !hasMedia && finalText.trim().length === 0;
+  return {
+    shouldSkip,
+    text: finalText,
+    hasMedia,
+    isInternalPlaceholderOnly,
+    ...(notifyFalse.silent ? { silent: true } : {}),
+  };
 }
 
 function normalizeHeartbeatToolNotification(
   response: HeartbeatToolResponse,
   responsePrefix: string | undefined,
-) {
+): NormalizedHeartbeatDelivery {
   let finalText = getHeartbeatToolNotificationText(response);
   if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
     finalText = `${responsePrefix} ${finalText}`;
   }
-  return { shouldSkip: false, text: finalText, hasMedia: false };
+  return {
+    shouldSkip: false,
+    text: finalText,
+    hasMedia: false,
+    isInternalPlaceholderOnly: false,
+  };
 }
 
 type HeartbeatWakePayloadFlags = {
@@ -992,6 +1044,7 @@ async function resolveHeartbeatPreflight(params: {
   cfg: OpenClawConfig;
   agentId: string;
   heartbeat?: HeartbeatConfig;
+  runScope: HeartbeatRunScope;
   forcedSessionKey?: string;
   reason?: string;
   source?: HeartbeatWakeSource;
@@ -1007,7 +1060,8 @@ async function resolveHeartbeatPreflight(params: {
     params.heartbeat,
     params.forcedSessionKey,
   );
-  const pendingEventEntries = peekSystemEventEntries(session.sessionKey);
+  const pendingEventEntries =
+    params.runScope === "commitment-only" ? [] : peekSystemEventEntries(session.sessionKey);
   const dueCommitments = canHeartbeatDeliverCommitments(params.heartbeat)
     ? selectCommitmentDeliveryBatch(
         await listDueCommitmentsForSession({
@@ -1045,6 +1099,7 @@ async function resolveHeartbeatPreflight(params: {
     shouldInspectWakePendingEvents ||
     hasTaggedCronEvents;
   const shouldBypassFileGates =
+    params.runScope === "commitment-only" ||
     wakeFlags.isExecEventWake ||
     wakeFlags.isCronWake ||
     wakeFlags.isWakePayload ||
@@ -1198,6 +1253,7 @@ function resolveHeartbeatRunPrompt(params: {
   dueTasks: HeartbeatTask[];
   heartbeatFileContent?: string;
   useHeartbeatResponseTool: boolean;
+  runScope: HeartbeatRunScope;
 }): HeartbeatPromptResolution {
   const pendingEventEntries = params.preflight.pendingEventEntries;
   const cronEvents = pendingEventEntries
@@ -1221,6 +1277,26 @@ function resolveHeartbeatRunPrompt(params: {
     useHeartbeatResponseTool: false,
   });
   const hasDueCommitments = Boolean(commitmentPrompt);
+  if (params.runScope === "commitment-only") {
+    if (commitmentPrompt) {
+      return {
+        prompt: commitmentPrompt,
+        hasExecCompletion: false,
+        hasRelayableExecCompletion: false,
+        hasCronEvents: false,
+        hasDueCommitments,
+        usesHeartbeatResponseTool: false,
+      };
+    }
+    return {
+      prompt: null,
+      hasExecCompletion: false,
+      hasRelayableExecCompletion: false,
+      hasCronEvents: false,
+      hasDueCommitments: false,
+      usesHeartbeatResponseTool: false,
+    };
+  }
 
   if (params.preflight.tasks && params.preflight.tasks.length > 0) {
     const dueTasks = params.dueTasks;
@@ -1320,6 +1396,32 @@ function selectSystemEventsConsumedByHeartbeat(params: {
   return preflight.pendingEventEntries;
 }
 
+// Recovery fields a completed heartbeat delivery must clear. Mirrors the
+// canonical clearPendingFinalDeliveryAfterSuccess in dispatch-from-config.ts so
+// the send-success and duplicate-skip paths drop the exact same set; leaving any
+// behind keeps the session stuck on a delivery that already happened.
+const CLEARED_PENDING_FINAL_DELIVERY_FIELDS = {
+  pendingFinalDelivery: undefined,
+  pendingFinalDeliveryText: undefined,
+  pendingFinalDeliveryCreatedAt: undefined,
+  pendingFinalDeliveryLastAttemptAt: undefined,
+  pendingFinalDeliveryAttemptCount: undefined,
+  pendingFinalDeliveryLastError: undefined,
+  pendingFinalDeliveryContext: undefined,
+  pendingFinalDeliveryIntentId: undefined,
+} as const;
+
+// Clear pending-final only when this run produced it: the agent run stamps
+// createdAt during the run, so createdAt >= run start means we own it. An older
+// final (e.g. one a message_tool_only run never refreshed) must keep its recovery path.
+function heartbeatRunOwnsPendingFinalDelivery(
+  entry: SessionEntry | undefined,
+  runStartedAt: number,
+): boolean {
+  const createdAt = entry?.pendingFinalDeliveryCreatedAt;
+  return typeof createdAt === "number" && createdAt >= runStartedAt;
+}
+
 export async function runHeartbeatOnce(opts: {
   cfg?: OpenClawConfig;
   agentId?: string;
@@ -1328,6 +1430,7 @@ export async function runHeartbeatOnce(opts: {
   source?: HeartbeatWakeSource;
   intent?: HeartbeatWakeIntent;
   reason?: string;
+  runScope?: HeartbeatRunScope;
   deps?: HeartbeatDeps;
 }): Promise<HeartbeatRunResult> {
   const cfg = opts.cfg ?? getRuntimeConfig();
@@ -1344,6 +1447,7 @@ export async function runHeartbeatOnce(opts: {
     source: opts.source,
     mergeRequestedHeartbeat: opts.source === "cron",
   });
+  const runScope = opts.runScope ?? "global";
   if (!areHeartbeatsEnabled()) {
     return { status: "skipped", reason: "disabled" };
   }
@@ -1435,6 +1539,7 @@ export async function runHeartbeatOnce(opts: {
     cfg,
     agentId,
     heartbeat,
+    runScope,
     forcedSessionKey: opts.sessionKey,
     source: opts.source,
     reason: opts.reason,
@@ -1474,7 +1579,8 @@ export async function runHeartbeatOnce(opts: {
   }
 
   const previousUpdatedAt = entry?.updatedAt;
-  const dueHeartbeatTasks = resolveDueHeartbeatTasks(preflight, startedAt);
+  const dueHeartbeatTasks =
+    runScope === "commitment-only" ? [] : resolveDueHeartbeatTasks(preflight, startedAt);
 
   // When isolatedSession is enabled, create a fresh session via the same
   // pattern as cron sessionTarget: "isolated". This gives the heartbeat
@@ -1570,6 +1676,7 @@ export async function runHeartbeatOnce(opts: {
     dueTasks: dueHeartbeatTasks,
     heartbeatFileContent: preflight.heartbeatFileContent,
     useHeartbeatResponseTool: useHeartbeatResponseToolPrompt,
+    runScope,
   });
   const dueCommitmentIds = hasDueCommitments
     ? preflight.dueCommitments.map((commitment) => commitment.id)
@@ -1673,10 +1780,11 @@ export async function runHeartbeatOnce(opts: {
   }
   // Update task last run times AFTER successful heartbeat completion
   const updateTaskTimestamps = async () => {
-    if (!preflight.tasks || preflight.tasks.length === 0) {
+    if (!preflight.tasks || preflight.tasks.length === 0 || dueHeartbeatTasks.length === 0) {
       return;
     }
     const tasks = preflight.tasks;
+    const dueTaskNames = new Set(dueHeartbeatTasks.map((task) => task.name));
 
     await updateSessionStore(storePath, (store) => {
       const current = store[sessionKey];
@@ -1693,13 +1801,40 @@ export async function runHeartbeatOnce(opts: {
       const taskState = { ...base.heartbeatTaskState };
 
       for (const task of tasks) {
-        if (isTaskDue(taskState[task.name], task.interval, startedAt)) {
+        if (dueTaskNames.has(task.name)) {
           taskState[task.name] = startedAt;
         }
       }
 
       store[sessionKey] = { ...base, heartbeatTaskState: taskState };
     });
+  };
+
+  // The duplicate-suppression branch returns before any send, so it never hits
+  // the send-success clear. A duplicate means this run's own output was already
+  // delivered within the dedupe window, so this run's pending-final is satisfied
+  // and gets cleared the same way the send-success path does. We must not
+  // text-match the pending against the delivered text: agent-runner stores it
+  // pre-normalization (no responsePrefix), so a byte compare would leave
+  // prefixed agents permanently stuck. Ownership is gated on createdAt instead,
+  // so an older final this run did not produce is preserved, not erased.
+  const clearSatisfiedPendingFinalDelivery = async () => {
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        const current = store[sessionKey];
+        if (current?.pendingFinalDelivery !== true && !current?.pendingFinalDeliveryText) {
+          return false;
+        }
+        if (!heartbeatRunOwnsPendingFinalDelivery(current, startedAt)) {
+          return false;
+        }
+        store[sessionKey] = { ...current, ...CLEARED_PENDING_FINAL_DELIVERY_FIELDS };
+        return true;
+      },
+      // No pending to clear is the common case; avoid rewriting the store then.
+      { skipSaveWhenResult: (cleared) => !cleared },
+    );
   };
 
   const consumeInspectedSystemEvents = () => {
@@ -1752,6 +1887,7 @@ export async function runHeartbeatOnce(opts: {
     sessionKey: runSessionKey,
     policySessionKey: outboundPolicySessionKey,
   });
+  const outboundIdentity = resolveAgentOutboundIdentity(cfg, agentId);
   const canAttemptHeartbeatOk = Boolean(
     !hasDueCommitments && visibility.showOk && delivery.channel !== "none" && delivery.to,
   );
@@ -1787,31 +1923,37 @@ export async function runHeartbeatOnce(opts: {
     if (!canAttemptHeartbeatOk || delivery.channel === "none" || !delivery.to) {
       return false;
     }
-    const heartbeatPlugin = resolveHeartbeatChannelPlugin(delivery.channel);
-    if (heartbeatPlugin?.heartbeat?.checkReady) {
-      const readiness = await heartbeatPlugin.heartbeat.checkReady({
+    try {
+      const heartbeatPlugin = resolveHeartbeatChannelPlugin(delivery.channel);
+      if (heartbeatPlugin?.heartbeat?.checkReady) {
+        const readiness = await heartbeatPlugin.heartbeat.checkReady({
+          cfg,
+          accountId: delivery.accountId,
+          deps: opts.deps,
+        });
+        if (!readiness.ok) {
+          return false;
+        }
+      }
+      const send = await sendDurableMessageBatch({
         cfg,
+        channel: delivery.channel,
+        to: delivery.to,
         accountId: delivery.accountId,
+        threadId: delivery.threadId,
+        payloads: [{ text: resolveHeartbeatOkText() }],
+        session: outboundSession,
+        identity: outboundIdentity,
         deps: opts.deps,
       });
-      if (!readiness.ok) {
-        return false;
+      if (send.status === "failed" || send.status === "partial_failed") {
+        throw send.error;
       }
+      return true;
+    } catch (err) {
+      log.warn(`heartbeat: HEARTBEAT_OK delivery failed: ${formatErrorMessage(err)}`);
+      return false;
     }
-    const send = await sendDurableMessageBatch({
-      cfg,
-      channel: delivery.channel,
-      to: delivery.to,
-      accountId: delivery.accountId,
-      threadId: delivery.threadId,
-      payloads: [{ text: resolveHeartbeatOkText() }],
-      session: outboundSession,
-      deps: opts.deps,
-    });
-    if (send.status === "failed" || send.status === "partial_failed") {
-      throw send.error;
-    }
-    return true;
   };
 
   try {
@@ -1824,6 +1966,7 @@ export async function runHeartbeatOnce(opts: {
     const replyOperationRunState: ReplyOperationRunState = {};
     const replyOpts = {
       isHeartbeat: true,
+      [HEARTBEAT_RUN_SCOPE]: runScope,
       [REPLY_OPERATION_RUN_STATE]: replyOperationRunState,
       ...(heartbeatModelOverride ? { heartbeatModelOverride } : {}),
       suppressToolErrorWarnings,
@@ -1873,7 +2016,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "ok-token",
         reason: opts.reason,
-        preview: heartbeatToolResponse.summary.slice(0, 200),
+        preview: truncateHeartbeatPreview(heartbeatToolResponse.summary),
         durationMs: Date.now() - startedAt,
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
         accountId: delivery.accountId,
@@ -1931,7 +2074,12 @@ export async function runHeartbeatOnce(opts: {
       ? normalizeHeartbeatToolNotification(heartbeatToolResponse, responsePrefix)
       : replyPayload
         ? normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars)
-        : { shouldSkip: true, text: "", hasMedia: false };
+        : {
+            shouldSkip: true,
+            text: "",
+            hasMedia: false,
+            isInternalPlaceholderOnly: false,
+          };
     // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
     // The model should be responding with exec results, not ack tokens.
     // Also, if normalized.text is empty due to token stripping but we have exec completion,
@@ -1940,12 +2088,17 @@ export async function runHeartbeatOnce(opts: {
       !heartbeatToolResponse &&
       hasRelayableExecCompletion &&
       !normalized.text.trim() &&
+      !normalized.isInternalPlaceholderOnly &&
       replyPayload?.text?.trim()
         ? replyPayload.text.trim()
         : null;
     if (execFallbackText) {
-      normalized.text = execFallbackText;
-      normalized.shouldSkip = false;
+      const execNotifyFalse = stripTrailingHeartbeatNotifyFalse(execFallbackText);
+      normalized.text = execNotifyFalse.text;
+      normalized.shouldSkip = !normalized.hasMedia && !normalized.text.trim();
+      if (execNotifyFalse.silent) {
+        normalized.silent = true;
+      }
     }
     const replacement = !heartbeatToolResponse
       ? replaceGenericExternalRunFailureText(normalized.text)
@@ -1956,7 +2109,9 @@ export async function runHeartbeatOnce(opts: {
       normalized.shouldSkip = false;
     }
     const shouldSkipMain =
-      normalized.shouldSkip && !normalized.hasMedia && !hasRelayableExecCompletion;
+      normalized.shouldSkip &&
+      !normalized.hasMedia &&
+      (!hasRelayableExecCompletion || normalized.isInternalPlaceholderOnly);
     if (shouldSkipMain && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({
         storePath,
@@ -1964,7 +2119,7 @@ export async function runHeartbeatOnce(opts: {
         updatedAt: previousUpdatedAt,
       });
 
-      const okSent = await maybeSendHeartbeatOk();
+      const okSent = normalized.silent ? false : await maybeSendHeartbeatOk();
       emitHeartbeatEvent({
         status: "ok-token",
         reason: opts.reason,
@@ -2010,11 +2165,12 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
+      await clearSatisfiedPendingFinalDelivery();
 
       emitHeartbeatEvent({
         status: "skipped",
         reason: "duplicate",
-        preview: normalized.text.slice(0, 200),
+        preview: truncateHeartbeatPreview(normalized.text),
         durationMs: Date.now() - startedAt,
         hasMedia: false,
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
@@ -2043,7 +2199,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "skipped",
         reason: delivery.reason ?? "no-target",
-        preview: previewText?.slice(0, 200),
+        preview: truncateHeartbeatPreview(previewText),
         durationMs: Date.now() - startedAt,
         hasMedia: mediaUrls.length > 0,
         accountId: delivery.accountId,
@@ -2063,7 +2219,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "alerts-disabled",
-        preview: previewText?.slice(0, 200),
+        preview: truncateHeartbeatPreview(previewText),
         durationMs: Date.now() - startedAt,
         channel: delivery.channel,
         hasMedia: mediaUrls.length > 0,
@@ -2086,7 +2242,7 @@ export async function runHeartbeatOnce(opts: {
         emitHeartbeatEvent({
           status: "skipped",
           reason: readiness.reason,
-          preview: previewText?.slice(0, 200),
+          preview: truncateHeartbeatPreview(previewText),
           durationMs: Date.now() - startedAt,
           hasMedia: mediaUrls.length > 0,
           channel: delivery.channel,
@@ -2106,6 +2262,7 @@ export async function runHeartbeatOnce(opts: {
       to: delivery.to,
       accountId: deliveryAccountId,
       session: outboundSession,
+      identity: outboundIdentity,
       threadId: delivery.threadId,
       payloads: [
         ...reasoningPayloads,
@@ -2119,6 +2276,7 @@ export async function runHeartbeatOnce(opts: {
             ]),
       ],
       deps: opts.deps,
+      silent: normalized.silent,
     });
     if (send.status === "failed" || send.status === "partial_failed") {
       throw send.error;
@@ -2142,10 +2300,18 @@ export async function runHeartbeatOnce(opts: {
         if (!current) {
           return;
         }
+        // A heartbeat-driven agent run can leave its own pendingFinalDelivery
+        // set; a successful send completes it, so clear the recovery fields.
+        // Only clear the pending-final this run owns — an older final the run
+        // did not produce keeps its own recovery path.
+        const clearedRecoveryFields = heartbeatRunOwnsPendingFinalDelivery(current, startedAt)
+          ? CLEARED_PENDING_FINAL_DELIVERY_FIELDS
+          : {};
         store[sessionKey] = {
           ...current,
           lastHeartbeatText: normalized.text,
           lastHeartbeatSentAt: startedAt,
+          ...clearedRecoveryFields,
         };
       });
     }
@@ -2160,11 +2326,12 @@ export async function runHeartbeatOnce(opts: {
       to: delivery.to,
       ...(deliveredAgentRunFailure ? { reason: "agent-runner-failure" } : {}),
       ...(!deliveredAgentRunFailure && !visibleSendSucceeded ? { reason: send.reason } : {}),
-      preview: previewText?.slice(0, 200),
+      preview: truncateHeartbeatPreview(previewText),
       durationMs: Date.now() - startedAt,
       hasMedia: mediaUrls.length > 0,
       channel: delivery.channel,
       accountId: delivery.accountId,
+      ...(normalized.silent === true ? { silent: true } : {}),
       indicatorType: visibility.useIndicator ? resolveIndicatorType(eventStatus) : undefined,
     });
     await updateTaskTimestamps();
@@ -2187,8 +2354,11 @@ export async function runHeartbeatOnce(opts: {
   }
 }
 
+export const testing = { truncateHeartbeatPreview };
+
 export function startHeartbeatRunner(opts: {
   cfg?: OpenClawConfig;
+  readCurrentConfig?: () => OpenClawConfig;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   runOnce?: typeof runHeartbeatOnce;
@@ -2204,6 +2374,7 @@ export function startHeartbeatRunner(opts: {
     timer: null as NodeJS.Timeout | null,
     stopped: false,
   };
+  const readCurrentConfig = opts.readCurrentConfig ?? (() => state.cfg);
   let initialized = false;
   let heartbeatTimeoutOverflowWarned = false;
 
@@ -2446,6 +2617,7 @@ export function startHeartbeatRunner(opts: {
     const isInterval = reason === "interval";
     const startedAt = Date.now();
     const now = startedAt;
+    const wakeConfig = readCurrentConfig();
     let ran = false;
     // Track retryable busy skips so we can skip re-arm in finally — the wake
     // layer handles retry for this case (DEFAULT_RETRY_MS = 1 s).
@@ -2465,10 +2637,10 @@ export function startHeartbeatRunner(opts: {
         }
         try {
           const res = await runOnce({
-            cfg: state.cfg,
+            cfg: wakeConfig,
             agentId: targetAgent.agentId,
             heartbeat: resolveHeartbeatForWake({
-              cfg: state.cfg,
+              cfg: wakeConfig,
               agentId: targetAgent.agentId,
               configuredHeartbeat: targetAgent.heartbeat,
               requestedHeartbeat,
@@ -2478,6 +2650,7 @@ export function startHeartbeatRunner(opts: {
             source: params.source,
             intent,
             reason,
+            runScope: "global",
             sessionKey: requestedSessionKey,
             deps: { runtime: state.runtime },
           });
@@ -2529,12 +2702,13 @@ export function startHeartbeatRunner(opts: {
         let res: HeartbeatRunResult;
         try {
           res = await runOnce({
-            cfg: state.cfg,
+            cfg: wakeConfig,
             agentId: agent.agentId,
             heartbeat: agent.heartbeat,
             source: params.source,
             intent,
             reason,
+            runScope: "global",
             deps: { runtime: state.runtime },
           });
         } catch (err) {
@@ -2561,13 +2735,13 @@ export function startHeartbeatRunner(opts: {
         let agentRan = res.status === "ran";
 
         const defaultSessionKey = resolveHeartbeatSession(
-          state.cfg,
+          wakeConfig,
           agent.agentId,
           agent.heartbeat,
         ).sessionKey;
         const dueSessionKeys = canHeartbeatDeliverCommitments(agent.heartbeat)
           ? await listDueCommitmentSessionKeys({
-              cfg: state.cfg,
+              cfg: wakeConfig,
               agentId: agent.agentId,
               nowMs: now,
               limit: 10,
@@ -2580,10 +2754,10 @@ export function startHeartbeatRunner(opts: {
           let commitmentRes: HeartbeatRunResult;
           try {
             commitmentRes = await runOnce({
-              cfg: state.cfg,
+              cfg: wakeConfig,
               agentId: agent.agentId,
               heartbeat: agent.heartbeat,
-              reason: "commitment",
+              runScope: "commitment-only",
               sessionKey: dueSessionKey,
               deps: { runtime: state.runtime },
             });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -110,7 +110,11 @@ import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/t
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
 import { formatErrorMessage, hasErrnoCode } from "./errors.js";
 import { resolveMainScopedEventSessionKey } from "./event-session-routing.js";
-import { isWithinActiveHours, resolveActiveHoursTimezone } from "./heartbeat-active-hours.js";
+import {
+  createActiveHoursPredicate,
+  isWithinActiveHours,
+  resolveActiveHoursTimezone,
+} from "./heartbeat-active-hours.js";
 import { recordRunStart, shouldDeferWake, type DeferDecision } from "./heartbeat-cooldown.js";
 import {
   buildCronEventPrompt,
@@ -2222,13 +2226,15 @@ export function startHeartbeatRunner(opts: {
         : undefined,
     });
 
-  const seekActiveSlotForAgent = (agent: HeartbeatAgentState, rawDueMs: number) =>
-    seekNextActivePhaseDueMs({
+  const seekActiveSlotForAgent = (agent: HeartbeatAgentState, rawDueMs: number) => {
+    const isActive = createActiveHoursPredicate(state.cfg, agent.heartbeat);
+    return seekNextActivePhaseDueMs({
       startMs: rawDueMs,
       intervalMs: agent.intervalMs,
       phaseMs: agent.phaseMs,
-      isActive: (ms) => isWithinActiveHours(state.cfg, agent.heartbeat, ms),
+      isActive,
     });
+  };
 
   const advanceAgentSchedule = (agent: HeartbeatAgentState, now: number, reason?: string) => {
     const rawDueMs =
@@ -2371,11 +2377,12 @@ export function startHeartbeatRunner(opts: {
         phaseMs,
         ahChanged ? undefined : prevState,
       );
+      const isActive = createActiveHoursPredicate(cfg, agent.heartbeat);
       const nextDueMs = seekNextActivePhaseDueMs({
         startMs: rawNextDueMs,
         intervalMs,
         phaseMs,
-        isActive: (ms) => isWithinActiveHours(cfg, agent.heartbeat, ms),
+        isActive,
       });
       nextAgents.set(agent.agentId, {
         agentId: agent.agentId,

--- a/src/infra/heartbeat-schedule.test.ts
+++ b/src/infra/heartbeat-schedule.test.ts
@@ -262,7 +262,7 @@ describe("seekNextActivePhaseDueMs", () => {
     expect(steps).toBe(977);
   });
 
-  it("event-loop-safe for 1ms interval with never-active window", () => {
+  it("bounded at 604k iterations for 1ms interval with never-active window", () => {
     const startMs = Date.parse("2026-01-01T12:00:00.000Z");
     const t0 = performance.now();
     const result = seekNextActivePhaseDueMs({
@@ -274,8 +274,58 @@ describe("seekNextActivePhaseDueMs", () => {
     const elapsedMs = performance.now() - t0;
 
     expect(result).toBe(startMs);
-    // 1M iterations in V8 should complete well within 50ms
+    // Batched at 1s steps → 604,800 iterations. Trivial predicate: ~3ms.
     expect(elapsedMs).toBeLessThan(50);
+  });
+
+  it("returns startMs directly when already active for sub-second intervals", () => {
+    // 500ms interval, batched at 1s (multiplier=2). startMs at 16:59:59.500
+    // is within the 09-17 active window — function returns it without
+    // backward walk because the first candidate is already active.
+    const startMs = Date.parse("2026-01-01T16:59:59.500Z");
+    const intervalMs = 500;
+    const isActive = (ms: number) => {
+      const hour = new Date(ms).getUTCHours();
+      return hour >= 9 && hour < 17;
+    };
+
+    const result = seekNextActivePhaseDueMs({
+      startMs,
+      intervalMs,
+      phaseMs: 0,
+      isActive,
+    });
+
+    // startMs itself is active → return it directly (no backward walk)
+    expect(result).toBe(startMs);
+    const steps = (result - startMs) / intervalMs;
+    expect(Number.isInteger(steps)).toBe(true);
+  });
+
+  it("backward walk returns earliest active slot for sub-second batch transition", () => {
+    // 500ms interval, batched at 1s. Start at 08:59:59.500 (inactive).
+    // Next batch candidate at 09:00:00.500 is active — backward walk
+    // over the gap finds the true first active slot at 09:00:00.000.
+    const startMs = Date.parse("2026-01-01T08:59:59.500Z");
+    const intervalMs = 500;
+    const isActive = (ms: number) => {
+      const hour = new Date(ms).getUTCHours();
+      return hour >= 9 && hour < 17;
+    };
+
+    const result = seekNextActivePhaseDueMs({
+      startMs,
+      intervalMs,
+      phaseMs: 0,
+      isActive,
+    });
+
+    // The first active phase slot is the first phase candidate >= 09:00
+    // 09:00:00.000 - 08:59:59.500 = 500ms = 1 * intervalMs
+    expect(result).toBe(Date.parse("2026-01-01T09:00:00.000Z"));
+    const steps = (result - startMs) / intervalMs;
+    expect(Number.isInteger(steps)).toBe(true);
+    expect(steps).toBe(1);
   });
 
   it("falls back to startMs after 7-day horizon for intervals without active slot", () => {

--- a/src/infra/heartbeat-schedule.test.ts
+++ b/src/infra/heartbeat-schedule.test.ts
@@ -212,6 +212,46 @@ describe("seekNextActivePhaseDueMs", () => {
     expect(result).toBe(Date.parse("2026-01-02T09:00:00.000Z"));
   });
 
+  it("finds the next active slot for sub-minute intervals without unbounded iteration", () => {
+    // 30s interval, 09:00–17:00. Start at 17:00 (quiet) → 09:00 next day.
+    const startMs = Date.parse("2026-01-01T17:00:00.000Z");
+    const intervalMs = 30_000;
+    const isActive = (ms: number) => {
+      const hour = new Date(ms).getUTCHours();
+      return hour >= 9 && hour < 17;
+    };
+
+    const t0 = performance.now();
+    const result = seekNextActivePhaseDueMs({
+      startMs,
+      intervalMs,
+      phaseMs: 0,
+      isActive,
+    });
+    const elapsedMs = performance.now() - t0;
+
+    // Finds the first active slot at 09:00 the next day
+    expect(result).toBe(Date.parse("2026-01-02T09:00:00.000Z"));
+    // Must be near-instant — not stall on unbounded iteration
+    expect(elapsedMs).toBeLessThan(100);
+  });
+
+  it("stays bounded for 1ms interval with never-active window", () => {
+    const startMs = Date.parse("2026-01-01T12:00:00.000Z");
+    const t0 = performance.now();
+    const result = seekNextActivePhaseDueMs({
+      startMs,
+      intervalMs: 1,
+      phaseMs: 0,
+      isActive: () => false,
+    });
+    const elapsedMs = performance.now() - t0;
+
+    expect(result).toBe(startMs);
+    // With 60s seek floor, max ~10,080 iterations — sub-millisecond
+    expect(elapsedMs).toBeLessThan(50);
+  });
+
   it("falls back to startMs after 7-day horizon for intervals without active slot", () => {
     const startMs = Date.parse("2026-01-01T12:00:00.000Z");
     const t0 = performance.now();

--- a/src/infra/heartbeat-schedule.test.ts
+++ b/src/infra/heartbeat-schedule.test.ts
@@ -234,9 +234,41 @@ describe("seekNextActivePhaseDueMs", () => {
     expect(result).toBe(Date.parse("2026-01-02T09:00:00.000Z"));
     // Must be near-instant — not stall on unbounded iteration
     expect(elapsedMs).toBeLessThan(100);
+    // Returned candidate must be reachable from startMs by whole intervalMs steps
+    const steps = (result - startMs) / intervalMs;
+    expect(Number.isInteger(steps)).toBe(true);
   });
 
-  it("stays bounded for 1ms interval with never-active window", () => {
+  it("preserves phase alignment for non-divisor sub-minute intervals (45s)", () => {
+    // 45s interval — MIN_SEEK_STEP_MS (60s) is NOT a multiple of 45s.
+    // The seek must batch in multiples of 45s (90s = 2×45s) so every
+    // candidate remains on the phase-aligned sequence.
+    const startMs = Date.parse("2026-01-01T17:00:00.000Z");
+    const intervalMs = 45_000;
+    const isActive = (ms: number) => {
+      const hour = new Date(ms).getUTCHours();
+      return hour >= 9 && hour < 17;
+    };
+
+    const t0 = performance.now();
+    const result = seekNextActivePhaseDueMs({
+      startMs,
+      intervalMs,
+      phaseMs: 0,
+      isActive,
+    });
+    const elapsedMs = performance.now() - t0;
+
+    // First active slot at 09:00 next day
+    expect(result).toBe(Date.parse("2026-01-02T09:00:00.000Z"));
+    // Must be bounded despite non-divisor step floor
+    expect(elapsedMs).toBeLessThan(100);
+    // Must be reachable by whole 45s steps from startMs (09:00 - 17:00 = 16h = 960min = 57,600s)
+    const steps = (result - startMs) / intervalMs;
+    expect(Number.isInteger(steps)).toBe(true);
+  });
+
+  it("returns a phase-aligned candidate for 1ms interval with never-active window", () => {
     const startMs = Date.parse("2026-01-01T12:00:00.000Z");
     const t0 = performance.now();
     const result = seekNextActivePhaseDueMs({
@@ -248,7 +280,7 @@ describe("seekNextActivePhaseDueMs", () => {
     const elapsedMs = performance.now() - t0;
 
     expect(result).toBe(startMs);
-    // With 60s seek floor, max ~10,080 iterations — sub-millisecond
+    // With batched 60s steps, max ~10,080 iterations — sub-millisecond
     expect(elapsedMs).toBeLessThan(50);
   });
 

--- a/src/infra/heartbeat-schedule.test.ts
+++ b/src/infra/heartbeat-schedule.test.ts
@@ -212,19 +212,21 @@ describe("seekNextActivePhaseDueMs", () => {
     expect(result).toBe(Date.parse("2026-01-02T09:00:00.000Z"));
   });
 
-  it("caps iterations for pathological sub-second intervals", () => {
+  it("falls back to startMs after 7-day horizon for intervals without active slot", () => {
     const startMs = Date.parse("2026-01-01T12:00:00.000Z");
     const t0 = performance.now();
     const result = seekNextActivePhaseDueMs({
       startMs,
-      intervalMs: 1, // 1ms — pathological
+      intervalMs: HOUR, // 1h interval — only 168 checks in the 7-day horizon
       phaseMs: 0,
       isActive: () => false,
     });
     const elapsedMs = performance.now() - t0;
 
+    // No active slot within 7 days → fallback to startMs
     expect(result).toBe(startMs);
-    expect(elapsedMs).toBeLessThan(500);
+    // With only 168 iterations, this is near-instant
+    expect(elapsedMs).toBeLessThan(100);
   });
 
   it("handles intervalMs larger than the seek horizon", () => {

--- a/src/infra/heartbeat-schedule.test.ts
+++ b/src/infra/heartbeat-schedule.test.ts
@@ -212,8 +212,7 @@ describe("seekNextActivePhaseDueMs", () => {
     expect(result).toBe(Date.parse("2026-01-02T09:00:00.000Z"));
   });
 
-  it("finds the next active slot for sub-minute intervals without unbounded iteration", () => {
-    // 30s interval, 09:00–17:00. Start at 17:00 (quiet) → 09:00 next day.
+  it("finds the next active slot for 30s intervals", () => {
     const startMs = Date.parse("2026-01-01T17:00:00.000Z");
     const intervalMs = 30_000;
     const isActive = (ms: number) => {
@@ -230,45 +229,40 @@ describe("seekNextActivePhaseDueMs", () => {
     });
     const elapsedMs = performance.now() - t0;
 
-    // Finds the first active slot at 09:00 the next day
     expect(result).toBe(Date.parse("2026-01-02T09:00:00.000Z"));
-    // Must be near-instant — not stall on unbounded iteration
     expect(elapsedMs).toBeLessThan(100);
-    // Returned candidate must be reachable from startMs by whole intervalMs steps
+    // Phase-aligned: reachable by whole 30s steps
     const steps = (result - startMs) / intervalMs;
     expect(Number.isInteger(steps)).toBe(true);
   });
 
-  it("preserves phase alignment for non-divisor sub-minute intervals (45s)", () => {
-    // 45s interval — MIN_SEEK_STEP_MS (60s) is NOT a multiple of 45s.
-    // The seek must batch in multiples of 45s (90s = 2×45s) so every
-    // candidate remains on the phase-aligned sequence.
+  it("does not skip phase slots inside narrow active windows (59s / 1min window)", () => {
+    // With 59s interval and a 1-minute active window at 09:00-09:01,
+    // the first phase-aligned slot inside the window is 09:00:43.
+    // Batched stepping (≥118s) would skip from 08:59:44 to 09:01:42,
+    // missing 09:00:43 entirely.
     const startMs = Date.parse("2026-01-01T17:00:00.000Z");
-    const intervalMs = 45_000;
+    const intervalMs = 59_000;
     const isActive = (ms: number) => {
-      const hour = new Date(ms).getUTCHours();
-      return hour >= 9 && hour < 17;
+      const d = new Date(ms);
+      return d.getUTCHours() === 9 && d.getUTCMinutes() === 0;
     };
 
-    const t0 = performance.now();
     const result = seekNextActivePhaseDueMs({
       startMs,
       intervalMs,
       phaseMs: 0,
       isActive,
     });
-    const elapsedMs = performance.now() - t0;
 
-    // First active slot at 09:00 next day
-    expect(result).toBe(Date.parse("2026-01-02T09:00:00.000Z"));
-    // Must be bounded despite non-divisor step floor
-    expect(elapsedMs).toBeLessThan(100);
-    // Must be reachable by whole 45s steps from startMs (09:00 - 17:00 = 16h = 960min = 57,600s)
+    expect(result).toBe(Date.parse("2026-01-02T09:00:43.000Z"));
+    // Phase-aligned
     const steps = (result - startMs) / intervalMs;
     expect(Number.isInteger(steps)).toBe(true);
+    expect(steps).toBe(977);
   });
 
-  it("returns a phase-aligned candidate for 1ms interval with never-active window", () => {
+  it("event-loop-safe for 1ms interval with never-active window", () => {
     const startMs = Date.parse("2026-01-01T12:00:00.000Z");
     const t0 = performance.now();
     const result = seekNextActivePhaseDueMs({
@@ -280,7 +274,7 @@ describe("seekNextActivePhaseDueMs", () => {
     const elapsedMs = performance.now() - t0;
 
     expect(result).toBe(startMs);
-    // With batched 60s steps, max ~10,080 iterations — sub-millisecond
+    // 1M iterations in V8 should complete well within 50ms
     expect(elapsedMs).toBeLessThan(50);
   });
 

--- a/src/infra/heartbeat-schedule.test.ts
+++ b/src/infra/heartbeat-schedule.test.ts
@@ -262,26 +262,25 @@ describe("seekNextActivePhaseDueMs", () => {
     expect(steps).toBe(977);
   });
 
-  it("bounded at 604k iterations for 1ms interval with never-active window", () => {
+  it("bounds a 1ms never-active scan at 20,160 forward probes", () => {
     const startMs = Date.parse("2026-01-01T12:00:00.000Z");
-    const t0 = performance.now();
+    let predicateCalls = 0;
     const result = seekNextActivePhaseDueMs({
       startMs,
       intervalMs: 1,
       phaseMs: 0,
-      isActive: () => false,
+      isActive: () => {
+        predicateCalls += 1;
+        return false;
+      },
     });
-    const elapsedMs = performance.now() - t0;
 
     expect(result).toBe(startMs);
-    // Batched at 1s steps → 604,800 iterations. Trivial predicate: ~3ms.
-    expect(elapsedMs).toBeLessThan(50);
+    expect(predicateCalls).toBe(20_160);
   });
 
   it("returns startMs directly when already active for sub-second intervals", () => {
-    // 500ms interval, batched at 1s (multiplier=2). startMs at 16:59:59.500
-    // is within the 09-17 active window — function returns it without
-    // backward walk because the first candidate is already active.
+    // startMs at 16:59:59.500 is already active, so no batch recovery is needed.
     const startMs = Date.parse("2026-01-01T16:59:59.500Z");
     const intervalMs = 500;
     const isActive = (ms: number) => {
@@ -302,13 +301,14 @@ describe("seekNextActivePhaseDueMs", () => {
     expect(Number.isInteger(steps)).toBe(true);
   });
 
-  it("backward walk returns earliest active slot for sub-second batch transition", () => {
-    // 500ms interval, batched at 1s. Start at 08:59:59.500 (inactive).
-    // Next batch candidate at 09:00:00.500 is active — backward walk
-    // over the gap finds the true first active slot at 09:00:00.000.
+  it("finds the earliest sub-second slot with bounded transition probes", () => {
+    // 500ms interval batches at 30s. Start at 08:59:59.500 (inactive), then
+    // binary-search the sampled transition to the first active phase slot.
     const startMs = Date.parse("2026-01-01T08:59:59.500Z");
     const intervalMs = 500;
+    let predicateCalls = 0;
     const isActive = (ms: number) => {
+      predicateCalls += 1;
       const hour = new Date(ms).getUTCHours();
       return hour >= 9 && hour < 17;
     };
@@ -326,23 +326,24 @@ describe("seekNextActivePhaseDueMs", () => {
     const steps = (result - startMs) / intervalMs;
     expect(Number.isInteger(steps)).toBe(true);
     expect(steps).toBe(1);
+    expect(predicateCalls).toBeLessThanOrEqual(8);
   });
 
   it("falls back to startMs after 7-day horizon for intervals without active slot", () => {
     const startMs = Date.parse("2026-01-01T12:00:00.000Z");
-    const t0 = performance.now();
+    let predicateCalls = 0;
     const result = seekNextActivePhaseDueMs({
       startMs,
       intervalMs: HOUR, // 1h interval — only 168 checks in the 7-day horizon
       phaseMs: 0,
-      isActive: () => false,
+      isActive: () => {
+        predicateCalls += 1;
+        return false;
+      },
     });
-    const elapsedMs = performance.now() - t0;
 
-    // No active slot within 7 days → fallback to startMs
     expect(result).toBe(startMs);
-    // With only 168 iterations, this is near-instant
-    expect(elapsedMs).toBeLessThan(100);
+    expect(predicateCalls).toBe(168);
   });
 
   it("handles intervalMs larger than the seek horizon", () => {

--- a/src/infra/heartbeat-schedule.ts
+++ b/src/infra/heartbeat-schedule.ts
@@ -80,6 +80,9 @@ export function resolveNextHeartbeatDueMs(params: {
  * `startMs` is already phase-aligned and `intervalMs` addition maintains it.
  */
 const MAX_SEEK_HORIZON_MS = 7 * 24 * 60 * 60_000;
+// Active-hours windows are minute-granular, so finer steps add no
+// precision but risk unbounded iteration when intervalMs is sub-minute.
+const MIN_SEEK_STEP_MS = 60_000;
 
 export function seekNextActivePhaseDueMs(params: {
   startMs: number;
@@ -92,13 +95,16 @@ export function seekNextActivePhaseDueMs(params: {
     return params.startMs;
   }
   const intervalMs = resolvePositiveIntervalMs(params.intervalMs);
+  // Step at the configured interval but never finer than 60s so the
+  // seek is always bounded by MAX_SEEK_HORIZON_MS / MIN_SEEK_STEP_MS.
+  const seekStepMs = Math.max(intervalMs, MIN_SEEK_STEP_MS);
   const horizonMs = params.startMs + MAX_SEEK_HORIZON_MS;
   let candidateMs = params.startMs;
   while (candidateMs <= horizonMs) {
     if (isActive(candidateMs)) {
       return candidateMs;
     }
-    candidateMs += intervalMs;
+    candidateMs += seekStepMs;
   }
   // No in-window slot found; fall back so the runtime guard can gate it.
   return params.startMs;

--- a/src/infra/heartbeat-schedule.ts
+++ b/src/infra/heartbeat-schedule.ts
@@ -80,10 +80,13 @@ export function resolveNextHeartbeatDueMs(params: {
  * `startMs` is already phase-aligned and `intervalMs` addition maintains it.
  */
 const MAX_SEEK_HORIZON_MS = 7 * 24 * 60 * 60_000;
-// Upper bound to prevent event-loop stalls from sub-ms intervals while
-// still covering the full 7-day horizon for any intervalMs >= 605ms.
-// 1M iterations takes < 2 ms in V8 for this loop body.
-const MAX_SEEK_ITERATIONS = 1_000_000;
+// When intervalMs is sub-second the production isWithinActiveHours predicate
+// (Intl.DateTimeFormat per call) would be too expensive for per-candidate
+// scanning.  Batch in whole-interval multiples ≥ 1 s so the iteration count
+// stays ≤ 604,800 (~10 ms for trivial predicates, still reasonable for the
+// production predicate at ~0.6–6 s worst case).  For intervalMs ≥ 1 s we
+// check every phase candidate directly — 60 s+ intervals stay ≤ 10,080.
+const MIN_SEEK_STEP_MS = 1_000;
 
 export function seekNextActivePhaseDueMs(params: {
   startMs: number;
@@ -97,15 +100,43 @@ export function seekNextActivePhaseDueMs(params: {
   }
   const intervalMs = resolvePositiveIntervalMs(params.intervalMs);
   const horizonMs = params.startMs + MAX_SEEK_HORIZON_MS;
-  let candidateMs = params.startMs;
-  let iterations = 0;
-  while (candidateMs <= horizonMs && iterations < MAX_SEEK_ITERATIONS) {
-    if (isActive(candidateMs)) {
-      return candidateMs;
+
+  if (intervalMs >= MIN_SEEK_STEP_MS) {
+    // Per-candidate scan — naturally bounded by horizon.
+    let candidateMs = params.startMs;
+    while (candidateMs <= horizonMs) {
+      if (isActive(candidateMs)) return candidateMs;
+      candidateMs += intervalMs;
     }
-    candidateMs += intervalMs;
-    iterations++;
+  } else {
+    // Sub-second: batch in whole-interval multiples ≥ 1 s.
+    const multiplier = Math.ceil(MIN_SEEK_STEP_MS / intervalMs);
+    const batchStepMs = intervalMs * multiplier;
+    let candidateMs = params.startMs;
+    let prevWasActive: boolean | null = null;
+    while (candidateMs <= horizonMs) {
+      const active = isActive(candidateMs);
+      if (active) {
+        if (prevWasActive === false) {
+          // Inactive→active transition: walk backward to find the
+          // earliest phase-aligned slot inside the window.
+          let first = candidateMs;
+          let probe = candidateMs - intervalMs;
+          // Don't walk past startMs or the previous batch candidate.
+          const limit = Math.max(params.startMs, candidateMs - batchStepMs);
+          while (probe > limit && isActive(probe)) {
+            first = probe;
+            probe -= intervalMs;
+          }
+          return first;
+        }
+        return candidateMs;
+      }
+      prevWasActive = active;
+      candidateMs += batchStepMs;
+    }
   }
+
   // No in-window slot found; fall back so the runtime guard can gate it.
   return params.startMs;
 }

--- a/src/infra/heartbeat-schedule.ts
+++ b/src/infra/heartbeat-schedule.ts
@@ -80,13 +80,12 @@ export function resolveNextHeartbeatDueMs(params: {
  * `startMs` is already phase-aligned and `intervalMs` addition maintains it.
  */
 const MAX_SEEK_HORIZON_MS = 7 * 24 * 60 * 60_000;
-// When intervalMs is sub-second the production isWithinActiveHours predicate
-// (Intl.DateTimeFormat per call) would be too expensive for per-candidate
-// scanning.  Batch in whole-interval multiples ≥ 1 s so the iteration count
-// stays ≤ 604,800 (~10 ms for trivial predicates, still reasonable for the
-// production predicate at ~0.6–6 s worst case).  For intervalMs ≥ 1 s we
-// check every phase candidate directly — 60 s+ intervals stay ≤ 10,080.
-const MIN_SEEK_STEP_MS = 1_000;
+// Batch in whole-interval multiples ≥ 30 s so the iteration count stays
+// ≤ 20,160 for every accepted interval.  The production isWithinActiveHours
+// predicate does Intl.DateTimeFormat work per call; 20,160 calls ≈ 20–200 ms.
+// Checking every phase candidate would cost up to 604,800 calls (0.6–6 s) for
+// 1 s intervals — still tolerable once, but risky on startup/hot-reload.
+const MIN_SEEK_STEP_MS = 30_000;
 
 export function seekNextActivePhaseDueMs(params: {
   startMs: number;
@@ -101,40 +100,34 @@ export function seekNextActivePhaseDueMs(params: {
   const intervalMs = resolvePositiveIntervalMs(params.intervalMs);
   const horizonMs = params.startMs + MAX_SEEK_HORIZON_MS;
 
-  if (intervalMs >= MIN_SEEK_STEP_MS) {
-    // Per-candidate scan — naturally bounded by horizon.
-    let candidateMs = params.startMs;
-    while (candidateMs <= horizonMs) {
-      if (isActive(candidateMs)) return candidateMs;
-      candidateMs += intervalMs;
-    }
-  } else {
-    // Sub-second: batch in whole-interval multiples ≥ 1 s.
-    const multiplier = Math.ceil(MIN_SEEK_STEP_MS / intervalMs);
-    const batchStepMs = intervalMs * multiplier;
-    let candidateMs = params.startMs;
-    let prevWasActive: boolean | null = null;
-    while (candidateMs <= horizonMs) {
-      const active = isActive(candidateMs);
-      if (active) {
-        if (prevWasActive === false) {
-          // Inactive→active transition: walk backward to find the
-          // earliest phase-aligned slot inside the window.
-          let first = candidateMs;
-          let probe = candidateMs - intervalMs;
-          // Don't walk past startMs or the previous batch candidate.
-          const limit = Math.max(params.startMs, candidateMs - batchStepMs);
-          while (probe > limit && isActive(probe)) {
-            first = probe;
-            probe -= intervalMs;
-          }
-          return first;
+  // Step in whole-interval multiples ≥ 30 s.  For intervalMs ≥ 30 s the
+  // multiplier is 1 (effectively per-candidate).  For sub-30 s intervals
+  // the batch step stays phase-aligned while keeping predicate calls ≤ 20,160.
+  const multiplier = Math.max(1, Math.ceil(MIN_SEEK_STEP_MS / intervalMs));
+  const batchStepMs = intervalMs * multiplier;
+
+  let candidateMs = params.startMs;
+  let prevWasActive: boolean | null = null;
+
+  while (candidateMs <= horizonMs) {
+    const active = isActive(candidateMs);
+    if (active) {
+      if (prevWasActive === false) {
+        // Inactive→active transition: walk backward one batch step
+        // to find the earliest phase-aligned slot inside the window.
+        let first = candidateMs;
+        let probe = candidateMs - intervalMs;
+        const limit = Math.max(params.startMs, candidateMs - batchStepMs);
+        while (probe > limit && isActive(probe)) {
+          first = probe;
+          probe -= intervalMs;
         }
-        return candidateMs;
+        return first;
       }
-      prevWasActive = active;
-      candidateMs += batchStepMs;
+      return candidateMs;
     }
+    prevWasActive = active;
+    candidateMs += batchStepMs;
   }
 
   // No in-window slot found; fall back so the runtime guard can gate it.

--- a/src/infra/heartbeat-schedule.ts
+++ b/src/infra/heartbeat-schedule.ts
@@ -80,8 +80,6 @@ export function resolveNextHeartbeatDueMs(params: {
  * `startMs` is already phase-aligned and `intervalMs` addition maintains it.
  */
 const MAX_SEEK_HORIZON_MS = 7 * 24 * 60 * 60_000;
-// Prevent pathological sub-minute intervals from blocking the event loop.
-const MAX_SEEK_ITERATIONS = 10_080; // 7 days at 1-minute steps
 
 export function seekNextActivePhaseDueMs(params: {
   startMs: number;
@@ -96,13 +94,11 @@ export function seekNextActivePhaseDueMs(params: {
   const intervalMs = resolvePositiveIntervalMs(params.intervalMs);
   const horizonMs = params.startMs + MAX_SEEK_HORIZON_MS;
   let candidateMs = params.startMs;
-  let iterations = 0;
-  while (candidateMs <= horizonMs && iterations < MAX_SEEK_ITERATIONS) {
+  while (candidateMs <= horizonMs) {
     if (isActive(candidateMs)) {
       return candidateMs;
     }
     candidateMs += intervalMs;
-    iterations++;
   }
   // No in-window slot found; fall back so the runtime guard can gate it.
   return params.startMs;

--- a/src/infra/heartbeat-schedule.ts
+++ b/src/infra/heartbeat-schedule.ts
@@ -80,11 +80,10 @@ export function resolveNextHeartbeatDueMs(params: {
  * `startMs` is already phase-aligned and `intervalMs` addition maintains it.
  */
 const MAX_SEEK_HORIZON_MS = 7 * 24 * 60 * 60_000;
-// Active-hours windows are minute-granular, so sub-minute intervals can
-// produce unbounded iteration across the 7-day horizon.  Batch steps in
-// whole-interval multiples that are ≥ 60s so the seek stays bounded and
-// every candidate remains reachable by whole intervalMs steps from startMs.
-const MIN_SEEK_STEP_MS = 60_000;
+// Upper bound to prevent event-loop stalls from sub-ms intervals while
+// still covering the full 7-day horizon for any intervalMs >= 605ms.
+// 1M iterations takes < 2 ms in V8 for this loop body.
+const MAX_SEEK_ITERATIONS = 1_000_000;
 
 export function seekNextActivePhaseDueMs(params: {
   startMs: number;
@@ -97,18 +96,15 @@ export function seekNextActivePhaseDueMs(params: {
     return params.startMs;
   }
   const intervalMs = resolvePositiveIntervalMs(params.intervalMs);
-  // Use the smallest multiple of intervalMs that is ≥ 60s so every
-  // candidate is phase-aligned while the total iteration count is
-  // bounded by MAX_SEEK_HORIZON_MS / 60_000 ≈ 10,080.
-  const multiplier = Math.max(1, Math.ceil(MIN_SEEK_STEP_MS / intervalMs));
-  const seekStepMs = intervalMs * multiplier;
   const horizonMs = params.startMs + MAX_SEEK_HORIZON_MS;
   let candidateMs = params.startMs;
-  while (candidateMs <= horizonMs) {
+  let iterations = 0;
+  while (candidateMs <= horizonMs && iterations < MAX_SEEK_ITERATIONS) {
     if (isActive(candidateMs)) {
       return candidateMs;
     }
-    candidateMs += seekStepMs;
+    candidateMs += intervalMs;
+    iterations++;
   }
   // No in-window slot found; fall back so the runtime guard can gate it.
   return params.startMs;

--- a/src/infra/heartbeat-schedule.ts
+++ b/src/infra/heartbeat-schedule.ts
@@ -80,8 +80,10 @@ export function resolveNextHeartbeatDueMs(params: {
  * `startMs` is already phase-aligned and `intervalMs` addition maintains it.
  */
 const MAX_SEEK_HORIZON_MS = 7 * 24 * 60 * 60_000;
-// Active-hours windows are minute-granular, so finer steps add no
-// precision but risk unbounded iteration when intervalMs is sub-minute.
+// Active-hours windows are minute-granular, so sub-minute intervals can
+// produce unbounded iteration across the 7-day horizon.  Batch steps in
+// whole-interval multiples that are ≥ 60s so the seek stays bounded and
+// every candidate remains reachable by whole intervalMs steps from startMs.
 const MIN_SEEK_STEP_MS = 60_000;
 
 export function seekNextActivePhaseDueMs(params: {
@@ -95,9 +97,11 @@ export function seekNextActivePhaseDueMs(params: {
     return params.startMs;
   }
   const intervalMs = resolvePositiveIntervalMs(params.intervalMs);
-  // Step at the configured interval but never finer than 60s so the
-  // seek is always bounded by MAX_SEEK_HORIZON_MS / MIN_SEEK_STEP_MS.
-  const seekStepMs = Math.max(intervalMs, MIN_SEEK_STEP_MS);
+  // Use the smallest multiple of intervalMs that is ≥ 60s so every
+  // candidate is phase-aligned while the total iteration count is
+  // bounded by MAX_SEEK_HORIZON_MS / 60_000 ≈ 10,080.
+  const multiplier = Math.max(1, Math.ceil(MIN_SEEK_STEP_MS / intervalMs));
+  const seekStepMs = intervalMs * multiplier;
   const horizonMs = params.startMs + MAX_SEEK_HORIZON_MS;
   let candidateMs = params.startMs;
   while (candidateMs <= horizonMs) {

--- a/src/infra/heartbeat-schedule.ts
+++ b/src/infra/heartbeat-schedule.ts
@@ -1,6 +1,6 @@
 // Computes deterministic heartbeat schedule phases and due times.
 import { createHash } from "node:crypto";
-import { resolveIntegerOption } from "./numeric-options.js";
+import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 
 function resolvePositiveIntervalMs(value: number): number {
   return resolveIntegerOption(value, 1, { min: 1 });

--- a/src/infra/heartbeat-schedule.ts
+++ b/src/infra/heartbeat-schedule.ts
@@ -80,11 +80,9 @@ export function resolveNextHeartbeatDueMs(params: {
  * `startMs` is already phase-aligned and `intervalMs` addition maintains it.
  */
 const MAX_SEEK_HORIZON_MS = 7 * 24 * 60 * 60_000;
-// Batch in whole-interval multiples ≥ 30 s so the iteration count stays
-// ≤ 20,160 for every accepted interval.  The production isWithinActiveHours
-// predicate does Intl.DateTimeFormat work per call; 20,160 calls ≈ 20–200 ms.
-// Checking every phase candidate would cost up to 604,800 calls (0.6–6 s) for
-// 1 s intervals — still tolerable once, but risky on startup/hot-reload.
+// Batch in whole-interval multiples of at least 30 seconds. Active-hours
+// boundaries have minute granularity, while each sub-30-second batch is less
+// than one minute, so every possible active window still contains a probe.
 const MIN_SEEK_STEP_MS = 30_000;
 
 export function seekNextActivePhaseDueMs(params: {
@@ -100,33 +98,37 @@ export function seekNextActivePhaseDueMs(params: {
   const intervalMs = resolvePositiveIntervalMs(params.intervalMs);
   const horizonMs = params.startMs + MAX_SEEK_HORIZON_MS;
 
-  // Step in whole-interval multiples ≥ 30 s.  For intervalMs ≥ 30 s the
-  // multiplier is 1 (effectively per-candidate).  For sub-30 s intervals
-  // the batch step stays phase-aligned while keeping predicate calls ≤ 20,160.
+  // For intervals of at least 30 seconds, inspect every phase candidate. For
+  // shorter intervals, phase-aligned batches bound the forward scan at 20,160
+  // predicate calls across the exclusive seven-day horizon.
   const multiplier = Math.max(1, Math.ceil(MIN_SEEK_STEP_MS / intervalMs));
   const batchStepMs = intervalMs * multiplier;
 
   let candidateMs = params.startMs;
-  let prevWasActive: boolean | null = null;
+  let previousInactiveMs: number | undefined;
 
-  while (candidateMs <= horizonMs) {
-    const active = isActive(candidateMs);
-    if (active) {
-      if (prevWasActive === false) {
-        // Inactive→active transition: walk backward one batch step
-        // to find the earliest phase-aligned slot inside the window.
-        let first = candidateMs;
-        let probe = candidateMs - intervalMs;
-        const limit = Math.max(params.startMs, candidateMs - batchStepMs);
-        while (probe > limit && isActive(probe)) {
-          first = probe;
-          probe -= intervalMs;
+  while (candidateMs < horizonMs) {
+    if (isActive(candidateMs)) {
+      if (previousInactiveMs !== undefined && multiplier > 1) {
+        // A sub-minute batch cannot contain a complete minute-granular active
+        // window. Binary-search its single inactive→active transition instead
+        // of walking every sub-second phase slot backward.
+        let inactiveMs = previousInactiveMs;
+        let activeMs = candidateMs;
+        while (activeMs - inactiveMs > intervalMs) {
+          const remainingSteps = (activeMs - inactiveMs) / intervalMs;
+          const probeMs = inactiveMs + Math.floor(remainingSteps / 2) * intervalMs;
+          if (isActive(probeMs)) {
+            activeMs = probeMs;
+          } else {
+            inactiveMs = probeMs;
+          }
         }
-        return first;
+        return activeMs;
       }
       return candidateMs;
     }
-    prevWasActive = active;
+    previousInactiveMs = candidateMs;
     candidateMs += batchStepMs;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes heartbeat starvation when a sub-minute heartbeat interval is combined
with active hours. The old static 10,080-iteration cap was calibrated for a
one-minute cadence, so shorter accepted intervals could stop before reaching
the next active window.

## Why This Change Was Made

The scheduler now:

- probes phase-aligned candidates in whole-interval batches of at least 30
  seconds, bounding the seven-day forward scan at 20,160 predicate calls;
- binary-searches the single inactive-to-active transition inside a
  sub-minute batch, avoiding a linear walk for sub-second intervals; and
- prepares the active-hours predicate once per seek, reusing its
  `Intl.DateTimeFormat` instead of rebuilding formatters for every probe.

Active-hours boundaries have minute granularity and every sub-30-second
interval produces a batch shorter than one minute, so each possible active
window is still probed. Intervals of at least 30 seconds continue to inspect
every phase candidate.

## User Impact

Users with sub-minute heartbeat intervals and active hours now reach the next
active window instead of silently falling back to an inactive candidate.
Normal minute-or-larger scheduling behavior is unchanged.

## Evidence

- Focused unit suite: 27 tests passed.
- Runner active-hours E2E suite: 9 tests passed, including a 30-second cadence
  with a one-minute active window reached from an inactive start.
- Deterministic bounds cover exactly 20,160 forward probes across the exclusive
  seven-day horizon and logarithmic transition recovery for a 1 ms cadence.
- Production-shaped benchmark: 20,160 prepared active-hours checks complete in
  about 25 ms locally; rebuilding the formatter per call took about 2.8 s.
- `pnpm build` and `pnpm check` pass under Node 24/npm 11.

Focused command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  src/infra/heartbeat-schedule.test.ts \
  src/infra/heartbeat-active-hours.test.ts \
  src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
```
