### PR TITLE
fix(agents): isolated cron busts prompt prefix cache via per-run session id

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1315,6 +1315,40 @@ describe("buildAgentSystemPrompt", () => {
     expect(line).toContain("thinking=low");
   });
 
+  it("keeps the runtime line cache-stable across isolated cron runs", () => {
+    // Isolated cron run-scoped keys carry a fresh per-run id every run (forceNew). Rendering it
+    // verbatim re-busts byte-exact prefix caching for the tool catalog after it (#96677 / #43148).
+    const buildForRun = (runId: string) =>
+      buildRuntimeLine({
+        agentId: "work",
+        sessionKey: `agent:work:cron:nightly-job:run:${runId}`,
+        sessionId: runId,
+        host: "host",
+        os: "linux",
+      });
+    const lineA = buildForRun("11111111-1111-1111-1111-111111111111");
+    const lineB = buildForRun("22222222-2222-2222-2222-222222222222");
+
+    expect(lineA).toContain("session=agent:work:cron:nightly-job");
+    expect(lineA).not.toContain(":run:");
+    expect(lineA).not.toContain("sessionId=");
+    // Two runs of the same job render identical bytes, so the cached prefix is reused.
+    expect(lineA).toBe(lineB);
+  });
+
+  it("preserves a stable session id that is not the run-scope id", () => {
+    const line = buildRuntimeLine({
+      agentId: "work",
+      sessionKey: "agent:main:main",
+      sessionId: "23ae7fce-3c27-4a51-b58e-d800d8ca091f",
+      host: "host",
+      os: "linux",
+    });
+
+    expect(line).toContain("session=agent:main:main");
+    expect(line).toContain("sessionId=23ae7fce-3c27-4a51-b58e-d800d8ca091f");
+  });
+
   it("renders extra system prompt exactly once", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1339,14 +1339,14 @@ describe("buildAgentSystemPrompt", () => {
   it("preserves a stable session id that is not the run-scope id", () => {
     const line = buildRuntimeLine({
       agentId: "work",
-      sessionKey: "agent:main:main",
-      sessionId: "23ae7fce-3c27-4a51-b58e-d800d8ca091f",
+      sessionKey: "agent:work:cron:nightly-job:run:run-id",
+      sessionId: "stable-session-id",
       host: "host",
       os: "linux",
     });
 
-    expect(line).toContain("session=agent:main:main");
-    expect(line).toContain("sessionId=23ae7fce-3c27-4a51-b58e-d800d8ca091f");
+    expect(line).toContain("session=agent:work:cron:nightly-job");
+    expect(line).toContain("sessionId=stable-session-id");
   });
 
   it("renders extra system prompt exactly once", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -30,6 +30,7 @@ import type { SubagentDelegationMode } from "../config/types.agent-defaults.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
 import { buildMemoryPromptSection } from "../plugins/memory-state.js";
 import type { AgentPromptSurfaceKind } from "../plugins/types.js";
+import { parseCronRunScopeSuffix } from "../sessions/session-key-utils.js";
 import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import type { ActiveProcessSessionReference } from "./bash-process-references.js";
 import type { BootstrapMode } from "./bootstrap-mode.js";
@@ -1395,10 +1396,16 @@ export function buildRuntimeLine(
   defaultThinkLevel?: ThinkLevel,
 ): string {
   const normalizedRuntimeCapabilities = normalizePromptCapabilityIds(runtimeCapabilities);
+  // Runtime line sits in the cached prompt prefix; isolated cron's volatile per-run `:run:<id>`
+  // scope (#91685) rendered verbatim re-busts byte-exact prefix caching for the tool catalog
+  // after it (#43148 class). Render the stable base key and drop the per-run id it duplicates.
+  const { baseSessionKey, runId } = parseCronRunScopeSuffix(runtimeInfo?.sessionKey);
+  const stableSessionId =
+    runtimeInfo?.sessionId && runtimeInfo.sessionId !== runId ? runtimeInfo.sessionId : undefined;
   return `Runtime: ${[
     runtimeInfo?.agentId ? `agent=${runtimeInfo.agentId}` : "",
-    runtimeInfo?.sessionKey ? `session=${sanitizeForPromptLiteral(runtimeInfo.sessionKey)}` : "",
-    runtimeInfo?.sessionId ? `sessionId=${sanitizeForPromptLiteral(runtimeInfo.sessionId)}` : "",
+    baseSessionKey ? `session=${sanitizeForPromptLiteral(baseSessionKey)}` : "",
+    stableSessionId ? `sessionId=${sanitizeForPromptLiteral(stableSessionId)}` : "",
     runtimeInfo?.host ? `host=${runtimeInfo.host}` : "",
     runtimeInfo?.repoRoot ? `repo=${runtimeInfo.repoRoot}` : "",
     runtimeInfo?.os

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1396,9 +1396,9 @@ export function buildRuntimeLine(
   defaultThinkLevel?: ThinkLevel,
 ): string {
   const normalizedRuntimeCapabilities = normalizePromptCapabilityIds(runtimeCapabilities);
-  // Runtime line sits in the cached prompt prefix; isolated cron's volatile per-run `:run:<id>`
-  // scope (#91685) rendered verbatim re-busts byte-exact prefix caching for the tool catalog
-  // after it (#43148 class). Render the stable base key and drop the per-run id it duplicates.
+  // Automatic literal-prefix caches include Runtime before the tool catalog. Rendering an
+  // isolated cron's volatile `:run:<id>` scope there defeats reuse across runs of the same job.
+  // Render the stable base key and drop the per-run session id it duplicates.
   const { baseSessionKey, runId } = parseCronRunScopeSuffix(runtimeInfo?.sessionKey);
   const stableSessionId =
     runtimeInfo?.sessionId && runtimeInfo.sessionId !== runId ? runtimeInfo.sessionId : undefined;

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -211,6 +211,13 @@ describe("cron run scope suffix parsing", () => {
     });
   });
 
+  it("parses mixed-case run markers without lowercasing the stored key", () => {
+    expect(parseCronRunScopeSuffix("AGENT:Work:CRON:Nightly-Job:RUN:ABC-123")).toEqual({
+      baseSessionKey: "AGENT:Work:CRON:Nightly-Job",
+      runId: "ABC-123",
+    });
+  });
+
   it("leaves keys without a run scope untouched", () => {
     expect(parseCronRunScopeSuffix("agent:main:main")).toEqual({
       baseSessionKey: "agent:main:main",

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -5,6 +5,7 @@ import { deriveSessionChatTypeFromKey } from "../sessions/session-chat-type-shar
 import {
   getSubagentDepth,
   isCronSessionKey,
+  parseCronRunScopeSuffix,
   parseThreadSessionSuffix,
 } from "../sessions/session-key-utils.js";
 import {
@@ -198,6 +199,45 @@ describe("thread session suffix parsing", () => {
     ).toEqual({
       baseSessionKey: "agent:main:slack:channel:General",
       threadId: "1699999999.0001",
+    });
+  });
+});
+
+describe("cron run scope suffix parsing", () => {
+  it("splits the per-run scope off an isolated cron key", () => {
+    expect(parseCronRunScopeSuffix("agent:work:cron:nightly-job:run:abc-123")).toEqual({
+      baseSessionKey: "agent:work:cron:nightly-job",
+      runId: "abc-123",
+    });
+  });
+
+  it("leaves keys without a run scope untouched", () => {
+    expect(parseCronRunScopeSuffix("agent:main:main")).toEqual({
+      baseSessionKey: "agent:main:main",
+      runId: undefined,
+    });
+  });
+
+  it("does not strip a :run: segment from a non-cron key", () => {
+    // The run scope is only ever appended to cron keys; a channel id that embeds
+    // `:run:` must keep its identity intact.
+    expect(parseCronRunScopeSuffix("agent:main:slack:channel:general:run:42")).toEqual({
+      baseSessionKey: "agent:main:slack:channel:general:run:42",
+      runId: undefined,
+    });
+  });
+
+  it("does not treat a non-terminal cron :run: as a run scope", () => {
+    expect(parseCronRunScopeSuffix("agent:main:cron:run:job:run:abc:extra")).toEqual({
+      baseSessionKey: "agent:main:cron:run:job:run:abc:extra",
+      runId: undefined,
+    });
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(parseCronRunScopeSuffix(undefined)).toEqual({
+      baseSessionKey: undefined,
+      runId: undefined,
     });
   });
 });

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -296,7 +296,7 @@ export function isCronRunSessionKey(sessionKey: string | undefined | null): bool
 
 /**
  * Splits the terminal per-run `:run:<id>` scope off an isolated cron session key
- * (`agent:<id>:cron:<job>:run:<runId>`, #91685), yielding the cache-stable base key.
+ * (`agent:<id>:cron:<job>:run:<runId>`), yielding the cache-stable base key.
  * The run scope is only ever appended to cron keys, so this is gated to that exact
  * shape: any other key (including channel ids that embed a `:run:` segment) is returned
  * unchanged with `runId` undefined, never truncating an unrelated session identity.

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -23,6 +23,11 @@ export type ParsedSessionDeliveryRoute = {
   threadId?: string;
 };
 
+export type ParsedCronRunScopeSuffix = {
+  baseSessionKey: string | undefined;
+  runId: string | undefined;
+};
+
 export type RawSessionConversationRef = {
   channel: string;
   kind: "group" | "channel";
@@ -287,6 +292,32 @@ export function isCronRunSessionKey(sessionKey: string | undefined | null): bool
     return false;
   }
   return /^cron:[^:]+:run:[^:]+(?::|$)/.test(parsed.rest);
+}
+
+/**
+ * Splits the terminal per-run `:run:<id>` scope off an isolated cron session key
+ * (`agent:<id>:cron:<job>:run:<runId>`, #91685), yielding the cache-stable base key.
+ * The run scope is only ever appended to cron keys, so this is gated to that exact
+ * shape: any other key (including channel ids that embed a `:run:` segment) is returned
+ * unchanged with `runId` undefined, never truncating an unrelated session identity.
+ */
+export function parseCronRunScopeSuffix(
+  sessionKey: string | undefined | null,
+): ParsedCronRunScopeSuffix {
+  const raw = normalizeOptionalString(sessionKey);
+  if (!raw) {
+    return { baseSessionKey: undefined, runId: undefined };
+  }
+  const parsed = parseAgentSessionKey(raw);
+  if (!parsed || !/^cron:[^:]+:run:[^:]+$/.test(parsed.rest)) {
+    return { baseSessionKey: raw, runId: undefined };
+  }
+  const runMarker = ":run:";
+  const markerIndex = raw.lastIndexOf(runMarker);
+  return {
+    baseSessionKey: raw.slice(0, markerIndex),
+    runId: raw.slice(markerIndex + runMarker.length),
+  };
 }
 
 export function isCronSessionKey(sessionKey: string | undefined | null): boolean {

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -313,7 +313,7 @@ export function parseCronRunScopeSuffix(
     return { baseSessionKey: raw, runId: undefined };
   }
   const runMarker = ":run:";
-  const markerIndex = raw.lastIndexOf(runMarker);
+  const markerIndex = raw.toLowerCase().lastIndexOf(runMarker);
   return {
     baseSessionKey: raw.slice(0, markerIndex),
     runId: raw.slice(markerIndex + runMarker.length),


### PR DESCRIPTION
### Summary

- **Problem**: isolated cron runs use a fresh run-scoped session key (`agent:<agent>:cron:<job>:run:<runId>`). `buildRuntimeLine` rendered that key and the matching session id into the prompt-facing `Runtime:` line. Transports that strip the explicit cache-boundary marker and rely on automatic literal-prefix caching therefore received different prompt bytes for every run, invalidating reuse before the tool catalog.
- **Root cause**: #72292 threaded the run-scoped key into embedded cron execution to prevent cross-run context leakage. #92468 later exposed the execution key and id in `Runtime:`. Their interaction made prompt identity volatile. #91685 changed delivery-target resolution, but did not introduce or render the run-scoped key. The issue reporter's measured 2026.6.8/2026.6.9 boundary is useful runtime evidence, but that exact version boundary is not source-verifiable because v2026.6.8 already contains both source changes.
- **Fix**: normalize only the model-visible identity. `parseCronRunScopeSuffix` recognizes the terminal canonical cron-run shape, `buildRuntimeLine` renders the stable job key, and a `sessionId` is omitted only when it duplicates the parsed run id. Execution, transcripts, routing, delivery, registry, and cleanup remain run-scoped.

### Scope and behavior

- Two different runs of one cron job now render byte-identical runtime lines.
- A distinct rotated or stable `sessionId` is preserved.
- Non-cron keys, malformed/nonterminal `:run:` segments, and channel-owned `:run:` data remain unchanged.
- Structural markers remain case-insensitive while the stored key's original casing is preserved.
- The parser is intentionally terminal-only; descendant session keys are outside this fix's scope.
- Config, plugin SDK, and gateway protocol surfaces are unchanged.

The tradeoff is deliberate: the model sees stable cron-job identity instead of the concrete run key, while every operational identity path still uses the concrete run-scoped key.

### Proof

Exact reviewed head: `a32fa8912f9bffd23310f851ab41141d1a6e925f`

Sanitized untrusted-source AWS Crabbox proof (`cbx_b3d9e9da2799`, run `run_a702d09110a3`, Linux/Node 24) ran:

```text
pnpm test \
  src/agents/system-prompt.test.ts \
  src/routing/session-key.test.ts \
  src/cron/isolated-agent/run.session-key-isolation.test.ts \
  src/agents/embedded-agent-runner/prompt-cache-observability.test.ts \
  packages/ai/src/providers/openai-completions.test.ts \
  packages/ai/src/providers/openai-responses-shared.test.ts \
  src/agents/openai-transport-stream.test.ts
```

Result: 7 files across 4 Vitest shards, 579 tests passed. Fresh maintainer autoreview found no actionable findings. Exact-head hosted CI is required before merge; an Opengrep installer network-fetch failure was rerun successfully.

Not independently tested: live metered-provider token telemetry. The cache-stability mechanism is covered deterministically at the renderer, cron execution, observability, and affected transport boundaries.

### Release note

Fix isolated cron prompt-cache stability by keeping per-run UUIDs out of the prompt-facing runtime identity.

### Change type

- [x] Bug fix

### Scope

- [x] Gateway / orchestration

Fixes #96677
