### PR TITLE
fix(sdk): promote streaming-byte-guard to plugin-sdk + bound 4 core streaming reads

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -306,6 +306,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/runtime-fetch` | Dispatcher-aware runtime fetch without proxy/guarded-fetch imports |
     | `plugin-sdk/inline-image-data-url-runtime` | Inline image data URL sanitizer and signature sniffing helpers without the broad media runtime surface |
     | `plugin-sdk/response-limit-runtime` | Bounded response-body reader without the broad media runtime surface |
+    | `plugin-sdk/stream-reader-with-limit` | Streaming-body SSE/NDJSON byte-cap guard for hostile unbounded responses, mirroring the response-limit-runtime pattern for chunk-by-chunk streaming reads |
     | `plugin-sdk/session-binding-runtime` | Current conversation binding state without configured binding routing or pairing stores |
     | `plugin-sdk/session-store-runtime` | Session-store helpers without broad config writes/maintenance imports |
     | `plugin-sdk/sqlite-runtime` | Focused SQLite agent-schema, path, and transaction helpers without database lifecycle controls |

--- a/package.json
+++ b/package.json
@@ -985,6 +985,10 @@
       "types": "./dist/plugin-sdk/session-binding-runtime.d.ts",
       "default": "./dist/plugin-sdk/session-binding-runtime.js"
     },
+    "./plugin-sdk/stream-reader-with-limit": {
+      "types": "./dist/plugin-sdk/stream-reader-with-limit.d.ts",
+      "default": "./dist/plugin-sdk/stream-reader-with-limit.js"
+    },
     "./plugin-sdk/session-key-runtime": {
       "types": "./dist/plugin-sdk/session-key-runtime.d.ts",
       "default": "./dist/plugin-sdk/session-key-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -216,6 +216,7 @@
   "inline-image-data-url-runtime",
   "response-limit-runtime",
   "session-binding-runtime",
+  "stream-reader-with-limit",
   "session-key-runtime",
   "session-store-runtime",
   "session-transcript-runtime",

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -307,6 +307,82 @@ describe("anthropic transport stream", () => {
     expect(cancelCount).toBe(1);
   });
 
+  it("bounds streamed Anthropic success responses without content-length", async () => {
+    // The bounded reader is configured at module load, so this test uses a
+    // hand-rolled streaming body that exceeds the configured cap (16 MiB).
+    // To keep the test fast and deterministic we drive the same SSE parser
+    // logic directly via the exported transport's stream() method, since
+    // pulling 16 MiB through a vitest mock would dwarf the test runtime.
+    const { parseAnthropicSseBodyForTest } = await import("./anthropic-transport-stream.js");
+    const encoder = new TextEncoder();
+    let pullCount = 0;
+    let cancelCount = 0;
+    let cancelReason: unknown;
+
+    const oversizedBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        // Emit 1 MiB chunks until the bounded reader cancels us. 19 chunks
+        // is enough to exceed the 16 MiB cap on the second pull after the
+        // 16 MiB threshold is crossed.
+        controller.enqueue(encoder.encode("a".repeat(1024 * 1024)));
+      },
+      cancel(reason) {
+        cancelCount += 1;
+        cancelReason = reason;
+      },
+    });
+
+    let error: Error | null = null;
+    try {
+      for await (const event of parseAnthropicSseBodyForTest(oversizedBody)) {
+        expect(event).toBeDefined();
+      }
+    } catch (caught) {
+      error = caught as Error;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toMatch(/Anthropic Messages success body exceeded/);
+    expect(error?.message).toMatch(/16777216/);
+    // The bounded reader cancelled the upstream producer after the cap was hit.
+    expect(cancelCount).toBe(1);
+    // Server-side observation: pullCount is at least 17 (16 MiB / 1 MiB per pull)
+    // and well below 20 (the test never drained a 20 MiB body).
+    expect(pullCount).toBeGreaterThanOrEqual(17);
+    expect(pullCount).toBeLessThanOrEqual(20);
+    expect(cancelReason).toBeInstanceOf(Error);
+  });
+
+  it("parses normal Anthropic success SSE responses end-to-end", async () => {
+    // The bounded reader must allow small valid SSE streams to pass through
+    // unchanged; the cap is the only change.
+    const { parseAnthropicSseBodyForTest } = await import("./anthropic-transport-stream.js");
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            'data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":1,"output_tokens":0}}}\n\n' +
+              'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+              'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}\n\n' +
+              'data: {"type":"content_block_stop","index":0}\n\n' +
+              'data: {"type":"message_stop"}\n\n',
+          ),
+        );
+        controller.close();
+      },
+    });
+
+    const events: Record<string, unknown>[] = [];
+    for await (const event of parseAnthropicSseBodyForTest(body)) {
+      events.push(event);
+    }
+    const types = events.map((e) => e.type);
+    expect(types).toContain("message_start");
+    expect(types).toContain("content_block_delta");
+    expect(types).toContain("message_stop");
+  });
+
   it("aborts stalled streamed Anthropic error responses", async () => {
     vi.useFakeTimers();
     const encoder = new TextEncoder();

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -53,6 +53,7 @@ import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
 import type { StreamFn } from "./runtime/index.js";
+import { createSseByteGuard } from "openclaw/plugin-sdk/stream-reader-with-limit";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
   coerceTransportToolCallArguments,
@@ -69,6 +70,11 @@ const CLAUDE_CODE_VERSION = "2.1.75";
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_CHARS = 400;
 const ANTHROPIC_MESSAGES_ERROR_BODY_READ_IDLE_TIMEOUT_MS = 10_000;
+// Cap on the streaming 200 success-body SSE read for Anthropic Messages.
+// Mirrors the 16 MiB provider-JSON cap from `readProviderJsonResponse` so a
+// hostile or malfunctioning Anthropic-compatible endpoint cannot exhaust
+// process memory by streaming an unbounded SSE body.
+const ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 const CLAUDE_CODE_TOOLS = [
   "Read",
   "Write",
@@ -613,7 +619,10 @@ function createAbortError(signal: AbortSignal): Error {
 }
 
 function readAnthropicSseChunk(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reader: {
+    read: () => Promise<ReadableStreamReadResult<Uint8Array>>;
+    cancel: (reason?: unknown) => Promise<void>;
+  },
   signal?: AbortSignal,
 ): Promise<ReadableStreamReadResult<Uint8Array>> {
   if (!signal) {
@@ -670,17 +679,27 @@ function parseAnthropicSseEventData(data: string): Record<string, unknown> {
   }
 }
 
-async function* parseAnthropicSseBody(
+/**
+ * Internal — exported under a separate name so production callers go through
+ * the `client.messages.stream()` entrypoint. Tests can drive it directly to
+ * exercise the bounded-reader behaviour without the surrounding client.
+ */
+export async function* parseAnthropicSseBodyForTest(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
 ): AsyncIterable<Record<string, unknown>> {
-  const reader = body.getReader();
+  const rawReader = body.getReader();
+  const guard = createSseByteGuard(rawReader, {
+    maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(`Anthropic Messages success body exceeded ${maxBytes} bytes (received ${size})`),
+  });
   const decoder = new TextDecoder();
   let buffer = "";
   let completed = false;
   try {
     while (true) {
-      const { done, value } = await readAnthropicSseChunk(reader, signal);
+      const { done, value } = await readAnthropicSseChunk(guard, signal);
       if (done) {
         completed = true;
         break;
@@ -714,9 +733,9 @@ async function* parseAnthropicSseBody(
     }
   } finally {
     if (!completed) {
-      await reader.cancel(signal?.reason).catch(() => undefined);
+      await rawReader.cancel(signal?.reason).catch(() => undefined);
     }
-    reader.releaseLock();
+    rawReader.releaseLock();
   }
 }
 
@@ -755,7 +774,7 @@ function createAnthropicMessagesClient(params: {
         if (!response.body) {
           return;
         }
-        yield* parseAnthropicSseBody(response.body, options?.signal);
+        yield* parseAnthropicSseBodyForTest(response.body, options?.signal);
       },
     },
   };

--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -189,4 +189,42 @@ describe("streamProxy", () => {
       errorMessage: "Proxy stream ended before terminal event",
     });
   });
+
+  it("bounds streamed proxy success bodies without content-length", async () => {
+    const CHUNK_SIZE = 1024 * 1024; // 1 MiB
+    const stats = { pullCount: 0, cancelled: false };
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        stats.pullCount += 1;
+        controller.enqueue(new Uint8Array(CHUNK_SIZE));
+      },
+      cancel(_reason) {
+        stats.cancelled = true;
+      },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)?.type).toBe("error");
+    const result = await stream.result();
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toMatch(/Proxy success body exceeded 16777216 bytes/);
+    // The bounded reader should have cancelled well before draining 64 MiB.
+    // With 1 MiB chunks, 17-20 pulls is the bounded range.
+    expect(stats.pullCount).toBeGreaterThanOrEqual(17);
+    expect(stats.pullCount).toBeLessThanOrEqual(20);
+    expect(stats.cancelled).toBe(true);
+  });
 });

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -15,6 +15,13 @@ import type {
 } from "../../llm/types.js";
 import { EventStream } from "../../llm/utils/event-stream.js";
 import { parseStreamingJson } from "../../llm/utils/json-parse.js";
+import { createSseByteGuard } from "openclaw/plugin-sdk/stream-reader-with-limit";
+
+// Cap on the streaming 200 success-body SSE read for the proxy stream.
+// Mirrors the 16 MiB provider-JSON cap from `readProviderJsonResponse` so a
+// hostile or malfunctioning upstream proxy cannot exhaust process memory by
+// streaming an unbounded SSE body on every proxy-streamed model call.
+const PROXY_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 
 type StreamingToolCall = ToolCall & { partialJson?: string };
 
@@ -152,9 +159,12 @@ export function streamProxy(
     };
 
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    let guard: ReturnType<typeof createSseByteGuard> | undefined;
 
     const abortHandler = () => {
-      if (reader) {
+      if (guard) {
+        guard.cancel("Request aborted by user").catch(() => {});
+      } else if (reader) {
         reader.cancel("Request aborted by user").catch(() => {});
       }
     };
@@ -192,6 +202,11 @@ export function streamProxy(
       }
 
       reader = response.body!.getReader();
+      guard = createSseByteGuard(reader, {
+        maxBytes: PROXY_SUCCESS_BODY_MAX_BYTES,
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(`Proxy success body exceeded ${maxBytes} bytes (received ${size})`),
+      });
       const decoder = new TextDecoder();
       let buffer = "";
       let terminalEventSeen = false;
@@ -214,7 +229,7 @@ export function streamProxy(
       };
 
       while (true) {
-        const { done, value } = await reader.read();
+        const { done, value } = await guard.read();
         if (done) {
           break;
         }

--- a/src/agents/streaming-byte-guard.ts
+++ b/src/agents/streaming-byte-guard.ts
@@ -1,0 +1,108 @@
+/**
+ * Bounded SSE / NDJSON stream reader guard.
+ *
+ * Wraps a `ReadableStreamDefaultReader<Uint8Array>` so the caller can keep its
+ * existing chunk-by-chunk parsing logic untouched, while accumulated bytes are
+ * tracked against a hard byte cap. On overflow the underlying reader is
+ * cancelled and an overflow error is thrown — the same shape Alix-007's
+ * non-streaming `readProviderJsonResponse` / `readResponseWithLimit` helper
+ * family uses for JSON / binary / text bodies.
+ *
+ * SSE / NDJSON streaming bodies are attacker-influenceable on every Anthropic-
+ * compatible, OpenAI, Ollama, Google, and proxy endpoint; a hostile or
+ * malfunctioning server can stream forever and exhaust process memory. This
+ * guard closes the symmetric success-path surface that the previous bounded
+ * helpers left open (they covered `response.json()` / `response.text()` for
+ * non-streaming bodies only).
+ *
+ * Internal for now: only Anthropic transport + provider call sites consume
+ * it. When an external plugin (e.g. extensions/google, extensions/ollama)
+ * needs the same byte-cap guard, promote this helper through the
+ * `openclaw/plugin-sdk/*` surface together with `scripts/lib/plugin-sdk-entrypoints.json`
+ * and the API-baseline hash so the SDK contract stays aligned.
+ */
+
+export type SseStreamOverflow = {
+  size: number;
+  maxBytes: number;
+};
+
+export type ReadSseStreamWithLimitOptions = {
+  maxBytes: number;
+  onOverflow?: (params: SseStreamOverflow) => Error;
+};
+
+export type SseByteGuard = {
+  read(): Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel(reason?: unknown): Promise<void>;
+  totalBytes(): number;
+  overflowed(): boolean;
+};
+
+/**
+ * Wrap a `ReadableStreamDefaultReader<Uint8Array>` so accumulated bytes are
+ * capped. After overflow the wrapper throws on every subsequent read and the
+ * underlying reader is cancelled so the upstream producer stops immediately.
+ *
+ * Usage:
+ *
+ *   const reader = body.getReader();
+ *   const guard = createSseByteGuard(reader, { maxBytes: 16 * 1024 * 1024 });
+ *   while (true) {
+ *     const { done, value } = await guard.read();
+ *     if (done) break;
+ *     // existing line / frame parsing logic, untouched
+ *   }
+ */
+export function createSseByteGuard(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  opts: ReadSseStreamWithLimitOptions,
+): SseByteGuard {
+  if (!Number.isFinite(opts.maxBytes) || opts.maxBytes < 0) {
+    throw new RangeError(`maxBytes must be a non-negative finite number: ${opts.maxBytes}`);
+  }
+  const onOverflow =
+    opts.onOverflow ??
+    ((params: SseStreamOverflow) =>
+      new Error(`SSE stream exceeds ${params.maxBytes} bytes (received ${params.size})`));
+
+  let total = 0;
+  let cancelled = false;
+
+  return {
+    read: async () => {
+      if (cancelled) {
+        return { done: true, value: undefined };
+      }
+      const result = await reader.read();
+      if (result.done) {
+        return result;
+      }
+      const chunk = result.value;
+      const chunkLen = chunk?.byteLength ?? 0;
+      const next = total + chunkLen;
+      if (next > opts.maxBytes) {
+        cancelled = true;
+        const err = onOverflow({ size: next, maxBytes: opts.maxBytes });
+        try {
+          await reader.cancel(err);
+        } catch {
+          // ignore cancellation failures — caller sees the overflow error
+        }
+        throw err;
+      }
+      total = next;
+      return result;
+    },
+    cancel: async (reason?: unknown) => {
+      cancelled = true;
+      try {
+        await reader.cancel(reason);
+      } catch {
+        // ignore cancellation failures
+      }
+    },
+    totalBytes: () => total,
+    overflowed: () => cancelled,
+  };
+}

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -15,6 +15,7 @@ import {
   type AnthropicProjectedToolChoice,
   type AnthropicToolProjection,
 } from "../../agents/anthropic-tool-projection.js";
+import { createSseByteGuard } from "openclaw/plugin-sdk/stream-reader-with-limit";
 import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
@@ -72,6 +73,11 @@ import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.j
 import { transformMessages } from "./transform-messages.js";
 
 const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
+// Cap on the streaming 200 success-body SSE read for Anthropic Messages.
+// Mirrors the 16 MiB provider-JSON cap from `readProviderJsonResponse` so a
+// hostile or malfunctioning Anthropic-compatible endpoint cannot exhaust
+// process memory by streaming an unbounded SSE body.
+const ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 
 function getCacheControl(
   model: Model<"anthropic-messages">,
@@ -346,7 +352,12 @@ async function* iterateSseMessages(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
 ): AsyncGenerator<ServerSentEvent> {
-  const reader = body.getReader();
+  const rawReader = body.getReader();
+  const guard = createSseByteGuard(rawReader, {
+    maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(`Anthropic Messages success body exceeded ${maxBytes} bytes (received ${size})`),
+  });
   const decoder = new TextDecoder();
   const state: SseDecoderState = { event: null, data: [], raw: [] };
   let buffer = "";
@@ -357,7 +368,7 @@ async function* iterateSseMessages(
         throw new Error("Request was aborted");
       }
 
-      const { value, done } = await reader.read();
+      const { value, done } = await guard.read();
       if (done) {
         break;
       }
@@ -397,7 +408,7 @@ async function* iterateSseMessages(
       yield trailingEvent;
     }
   } finally {
-    reader.releaseLock();
+    rawReader.releaseLock();
   }
 }
 

--- a/src/llm/providers/openai-chatgpt-responses.test.ts
+++ b/src/llm/providers/openai-chatgpt-responses.test.ts
@@ -5,6 +5,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-b
 import type { Context, Model } from "../types.js";
 import {
   extractOpenAICodexAccountId,
+  parseSSEForTest,
   resetOpenAICodexWebSocketDebugStats,
   streamOpenAICodexResponses,
 } from "./openai-chatgpt-responses.js";
@@ -559,5 +560,100 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(result.stopReason).toBe("error");
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+  });
+});
+
+describe("parseSSEForTest (streaming 200 success-body bound)", () => {
+  const CHUNK_SIZE = 1024 * 1024;
+
+  function createHostileSseBody(params: {
+    totalBytes: number;
+    onCancel: (reason: unknown) => void;
+    onPull?: () => void;
+  }): Response {
+    let pulled = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        params.onPull?.();
+        const remaining = params.totalBytes - pulled;
+        if (remaining <= 0) {
+          controller.close();
+          return;
+        }
+        const size = Math.min(CHUNK_SIZE, remaining);
+        controller.enqueue(new Uint8Array(size));
+        pulled += size;
+      },
+      cancel(reason) {
+        params.onCancel(reason);
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("bounds streamed OpenAI Codex Responses success bodies without content-length", async () => {
+    let cancelReason: unknown;
+    let pullCount = 0;
+    const body = createHostileSseBody({
+      totalBytes: 64 * 1024 * 1024,
+      onPull: () => {
+        pullCount += 1;
+      },
+      onCancel: (reason) => {
+        cancelReason = reason;
+      },
+    });
+
+    let caught: Error | null = null;
+    try {
+      for await (const event of parseSSEForTest(body)) {
+        expect(event).toBeDefined();
+      }
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).not.toBeNull();
+    expect(caught?.message).toMatch(
+      /OpenAI Codex Responses success body exceeded 16777216 bytes/,
+    );
+    expect(cancelReason).toBeInstanceOf(Error);
+    // The bounded reader should have cancelled well before draining the full 64 MiB.
+    // With 1 MiB chunks, 17-20 pulls is the bounded range (16 MiB + a couple of overshoot).
+    expect(pullCount).toBeGreaterThanOrEqual(17);
+    expect(pullCount).toBeLessThanOrEqual(20);
+  });
+
+  it("parses normal OpenAI Codex Responses SSE responses end-to-end", async () => {
+    const events = [
+      { type: "response.created", response: { id: "resp_1" } },
+      { type: "response.output_text.delta", delta: "hello" },
+      { type: "response.completed", response: { id: "resp_1" } },
+    ];
+    const body = new Response(
+      events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
+      {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      },
+    );
+
+    const collected: Record<string, unknown>[] = [];
+    for await (const event of parseSSEForTest(body)) {
+      collected.push(event);
+    }
+
+    expect(collected.map((e) => e.type)).toEqual([
+      "response.created",
+      "response.output_text.delta",
+      "response.completed",
+    ]);
   });
 });

--- a/src/llm/providers/openai-chatgpt-responses.ts
+++ b/src/llm/providers/openai-chatgpt-responses.ts
@@ -26,6 +26,7 @@ import {
   clampTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
 import { stripSystemPromptCacheBoundary } from "../../agents/system-prompt-cache-boundary.js";
+import { createSseByteGuard } from "openclaw/plugin-sdk/stream-reader-with-limit";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { clampThinkingLevel } from "../model-utils.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
@@ -62,6 +63,11 @@ import { buildBaseOptions } from "./simple-options.js";
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
+// Cap on the streaming 200 success-body SSE read for OpenAI Codex Responses.
+// Mirrors the 16 MiB provider-JSON cap from `readProviderJsonResponse` so a
+// hostile or malfunctioning ChatGPT Responses endpoint (or a proxy that does
+// not bound its stream) cannot exhaust process memory by streaming forever.
+const OPENAI_CODEX_RESPONSES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 const RETRY_AFTER_HTTP_DATE_RE =
   /^(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT|(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), \d{2}-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2} \d{2}:\d{2}:\d{2} GMT|(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [ \d]\d \d{2}:\d{2}:\d{2} \d{4})$/;
 const CODEX_TOOL_CALL_PROVIDERS = new Set(["openai", "opencode"]);
@@ -722,12 +728,19 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
   }
 
   const reader = response.body.getReader();
+  const guard = createSseByteGuard(reader, {
+    maxBytes: OPENAI_CODEX_RESPONSES_SUCCESS_BODY_MAX_BYTES,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(
+        `OpenAI Codex Responses success body exceeded ${maxBytes} bytes (received ${size})`,
+      ),
+  });
   const decoder = new TextDecoder();
   let buffer = "";
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await guard.read();
       if (done) {
         break;
       }
@@ -760,13 +773,20 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
     }
   } finally {
     try {
-      await reader.cancel();
+      await guard.cancel();
     } catch {}
     try {
       reader.releaseLock();
     } catch {}
   }
 }
+
+/**
+ * Internal-export wrapper around {@link parseSSE} so the bounded-read behavior
+ * can be driven directly from tests. Production code must continue to call
+ * `parseSSE` (the same function body).
+ */
+export const parseSSEForTest = parseSSE;
 
 // ============================================================================
 // WebSocket Parsing

--- a/src/plugin-sdk/stream-reader-with-limit.ts
+++ b/src/plugin-sdk/stream-reader-with-limit.ts
@@ -1,0 +1,16 @@
+/**
+ * Streaming-body SSE/NDJSON byte-cap guard, re-exported from core.
+ *
+ * Mirrors the `openclaw/plugin-sdk/provider-http` (re-exports
+ * `readProviderJsonResponse` from `src/agents/provider-http-errors.ts`) pattern:
+ * the implementation lives in core (`src/agents/streaming-byte-guard.ts`); this
+ * SDK subpath is a thin re-export so extensions (`extensions/google`,
+ * `extensions/ollama`, ...) can consume the helper without reaching into
+ * `src/agents/**`, which the `src/plugin-sdk/CLAUDE.md` boundary forbids.
+ */
+export {
+  createSseByteGuard,
+  type ReadSseStreamWithLimitOptions,
+  type SseByteGuard,
+  type SseStreamOverflow,
+} from "../agents/streaming-byte-guard.js";


### PR DESCRIPTION
## What Problem This Solves

Streaming-body SSE reads in OpenClaw's core runtime (Anthropic transport, Anthropic provider, OpenAI Codex Responses, internal proxy) accumulate unbounded bytes into a string buffer while waiting for frame delimiters. The companion **error-body** path (`readAnthropicMessagesErrorBodySnippet`, 8 KiB cap + 10s idle timeout) was bounded by #95108; the symmetric **200 success-body** path was left open. A hostile or malfunctioning Anthropic-compatible endpoint, ChatGPT Responses mirror, or internal proxy can return a `Content-Length`-less SSE body that streams forever, exhausting process memory on every streaming model call.

The bounded helper (`createSseByteGuard`) was previously only in core (`src/agents/streaming-byte-guard.ts`). Per `src/plugin-sdk/CLAUDE.md`, extensions cannot import `src/agents/**`, so `extensions/google` and `extensions/ollama` (the next streaming-body OOM surfaces) had no way to reuse the bounded-read helper. This PR **promotes the helper to a public plugin-SDK subpath** so the future extensions can import it without a `src/agents/**` reach-through.

## Changes

- `src/agents/streaming-byte-guard.ts` (NEW, 108 lines) — `createSseByteGuard(reader, {maxBytes, onOverflow?})` wraps a `ReadableStreamDefaultReader<Uint8Array>`, tracks accumulated bytes across the existing chunk loop, cancels the underlying reader on overflow, and throws a canonical overflow error. Exposes `read() / cancel() / totalBytes() / overflowed()` so the same guard drives both production and AbortSignal-handling code paths.
- `src/plugin-sdk/stream-reader-with-limit.ts` (NEW, 16 lines) — re-exports `createSseByteGuard` + `SseStreamOverflow` / `SseByteGuard` / `ReadSseStreamWithLimitOptions` types. Mirrors the existing `openclaw/plugin-sdk/provider-http` (re-export of `readProviderJsonResponse` from `src/agents/provider-http-errors.ts`) pattern that Alix-007 used to land the non-streaming bounded-read family.
- `src/agents/anthropic-transport-stream.ts:56` — `parseAnthropicSseBody` now wraps `response.body.getReader()` in `createSseByteGuard` with `ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024`. Existing `\n\n` frame parsing, abort propagation, and `reader.releaseLock()` cleanup unchanged. Exports the function as `parseAnthropicSseBodyForTest` for direct test access.
- `src/llm/providers/anthropic.ts:18` — `iterateSseMessages` (legacy provider's SSE parser) gets the same bound with its own constant.
- `src/llm/providers/openai-chatgpt-responses.ts:29` — `parseSSE` (ChatGPT Responses SSE parser) gets the same bound. Exports as `parseSSEForTest`.
- `src/agents/runtime/proxy.ts:18` — `streamProxy` gets the same bound. The abort handler at line 162 also routes through `guard.cancel()` so a bounded cancel propagates immediately on signal abort (with a fallback to `reader.cancel()` for the brief window before the guard is constructed).
- `scripts/lib/plugin-sdk-entrypoints.json` + `package.json` exports + `docs/plugins/sdk-subpaths.md` — register the new SDK subpath `openclaw/plugin-sdk/stream-reader-with-limit`. Regenerated via `pnpm plugin-sdk:sync-exports` (not hand-edited).
- `docs/.generated/plugin-sdk-api-baseline.sha256` — regenerated via `pnpm plugin-sdk:api:gen --write` to record the new SDK surface.
- 3 test files: `src/agents/anthropic-transport-stream.test.ts` (+76), `src/llm/providers/openai-chatgpt-responses.test.ts` (+96), `src/agents/runtime/proxy.test.ts` (+38) — inline overflow + happy-path tests for each bounded surface. No committed repro script (proof in this body, not in git — matches Alix-007's pattern in #95218 / #95417 / #96027 / #96038 / #96042 / #96607).

## Real behavior proof

The 4 bounded surfaces are exercised against an in-test `ReadableStream` mock that pulls 1 MiB chunks until the bounded reader cancels. Overflow path asserts the canonical overflow message + the bounded reader cancel call. Negative control confirms small bodies drain fully.

- **Behavior addressed**: unbounded buffering of core streaming-body SSE reads (Anthropic transport, Anthropic provider, OpenAI Codex Responses, internal proxy); after the fix all 4 reads are capped at 16 MiB and streams are cancelled on overflow.
- **Real environment tested**: vitest 4.1.7 via `scripts/run-vitest.mjs`; Node v22.
- **Exact steps**:
  - `node scripts/run-vitest.mjs anthropic-transport-stream anthropic.test openai-chatgpt-responses proxy.test --run` — 84/84 passed (4 files)
  - `node scripts/run-oxlint.mjs --tsconfig tsconfig.json <files>` — exit 0
  - `node scripts/run-tsgo.mjs` — exit 0
  - `node scripts/sync-plugin-sdk-exports.mjs --check` — `plugin-sdk exports synced.`
  - `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` — exit 0 (baseline hash matches regenerated)
  - `node scripts/plugin-sdk-surface-report.mjs --check` — public entrypoints 323 (+1, matches new `stream-reader-with-limit`), public exports 10386 (+4), callable exports 5212 (+1)
- **Observed result after fix**: bounded readers cancel upstream `ReadableStreamDefaultReader` after ~17-20 chunks (1 MiB each) before draining the full hostile body. Test pullCount assertions bounded to that range. Small valid SSE frames still parse end-to-end.
- **What was not tested**: live API calls to real Anthropic / ChatGPT Responses / proxy endpoints (in-test `ReadableStream` mock + in-memory `Response` mocks are equivalent transport behavior). No cross-platform Node 18/20 differences tested (Node 22 only, matches CI).

## Out of scope (separate PRs)

- `extensions/google/transport-stream.ts` — needs to import the new SDK subpath to bound its streaming Anthropic-compatible response. Separate PR after this lands.
- `extensions/ollama/src/{setup,stream}.ts` — same pattern for Ollama's streaming chat + model-discovery reads. Separate PR after this lands.

## Risk

- **Low**: same 16 MiB cap already used by `readProviderJsonResponse` for non-streaming Anthropic/Anthropic-Vertex success bodies. The cap is consistent across non-streaming and streaming paths.
- **Cancel propagation**: `createSseByteGuard.cancel(reason)` propagates the overflow error to the underlying reader. Tests assert `cancelReason instanceof Error` and the bounded pullCount.
- **SDK surface**: ONE new public subpath `openclaw/plugin-sdk/stream-reader-with-limit` (mirrors the Alix-007 SDK re-export pattern). Full metadata regenerated via the proper SDK sync workflow (not hand-edited).
- **Maintainer review requested**: SDK promotion needs explicit acceptance per the P1 ClawSweeper flag from the previous PR. This PR does the SDK sync properly (sync-exports + api:gen + surface:check all green) so the maintainer gate is the only outstanding concern.

## Diff stats

```
12 files changed, 419 insertions(+), 14 deletions(-)
```

Per-surface breakdown (excluding helper + SDK re-export + plumbing):
- `src/agents/anthropic-transport-stream.ts`: +26/-7 (cap constant + import + wrap)
- `src/llm/providers/anthropic.ts`: +14/-3 (cap constant + import + wrap)
- `src/llm/providers/openai-chatgpt-responses.ts`: +22/-2 (cap constant + import + wrap + export)
- `src/agents/runtime/proxy.ts`: +17/-2 (cap constant + import + wrap + abort-handler route)

Plus 1 helper (108 lines) + 1 SDK re-export (16 lines) + 1 docs row (1 line) + 2 metadata lines (entrypoints + baseline) + 3 test files (+210/-0 inline tests).