### PR TITLE
fix(terminal): wrap long wide-char words by visible width, not code-point count

### DIFF
--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -1,7 +1,7 @@
 // Terminal Core module implements note behavior.
 import { AsyncLocalStorage } from "node:async_hooks";
 import { note as clackNote } from "@clack/prompts";
-import { visibleWidth } from "./ansi.js";
+import { splitGraphemes, visibleWidth } from "./ansi.js";
 import { stylePromptTitle } from "./prompt-style.js";
 import { normalizeLowercaseStringOrEmpty } from "./string.js";
 
@@ -26,10 +26,23 @@ function splitLongWord(word: string, maxLen: number): string[] {
   if (maxLen <= 0) {
     return [word];
   }
-  const chars = Array.from(word);
+  // maxLen is a visible-column budget, so accumulate grapheme visible width (CJK/emoji count as 2
+  // columns) instead of code-point count; otherwise a wide-char run overflows the line by up to 2x.
   const parts: string[] = [];
-  for (let i = 0; i < chars.length; i += maxLen) {
-    parts.push(chars.slice(i, i + maxLen).join(""));
+  let current = "";
+  let currentWidth = 0;
+  for (const grapheme of splitGraphemes(word)) {
+    const width = visibleWidth(grapheme);
+    if (current && currentWidth + width > maxLen) {
+      parts.push(current);
+      current = "";
+      currentWidth = 0;
+    }
+    current += grapheme;
+    currentWidth += width;
+  }
+  if (current) {
+    parts.push(current);
   }
   return parts.length > 0 ? parts : [word];
 }

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -383,4 +383,16 @@ describe("wrapNoteMessage", () => {
     expect(wrapNoteMessage(new Error("boom"), { maxWidth: 20, columns: 80 })).toBe("Error: boom");
     expect(wrapNoteMessage({ message: "boom" }, { maxWidth: 20, columns: 80 })).toBe("");
   });
+
+  it("keeps wrapped lines within the visible-column budget for wide (CJK) words", () => {
+    // A long CJK run with no separators reaches splitLongWord; each fullwidth char is 2 columns,
+    // so splitting by code-point count would emit lines up to 2x the budget.
+    const input = "東京特許許可局長今日休暇許可局長今日休暇東京特許";
+    const lines = wrapNoteMessage(input, { maxWidth: 20, columns: 80 }).split("\n");
+
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(20);
+    }
+    expect(lines.join("")).toBe(input);
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

`wrapNoteMessage` (`packages/terminal-core/src/note.ts`) wraps note/diagnostic text to a visible-column budget — every fit decision in `wrapLine` is made with `visibleWidth()`. But its `splitLongWord` fallback (used when a single word is longer than the line budget, e.g. an unbroken CJK run) sliced the word into groups of `maxLen` **code points** via `Array.from(word)`. Since `maxLen` is a visible-column budget and wide characters (CJK / fullwidth / emoji) are 2 columns each, a wide-char run produced lines up to **twice** the budget — e.g. a 24-character CJK word at `maxWidth: 20` emitted a single 40-column line.

## Why This Change Was Made

`splitLongWord` was the lone place that measured in code points while the rest of `wrapLine` measures visible columns. The fix accumulates grapheme visible width (the same `splitGraphemes`/`visibleWidth` decomposition the module already uses) and starts a new segment when the next grapheme would exceed `maxLen`, so every wrapped segment fits the budget. A single grapheme wider than the budget still emits on its own (preserving loop progress). ASCII wrapping is byte-identical.

## User Impact

Note bodies containing long wide-character runs (CJK text, emoji) without separators now wrap within the requested column width instead of overflowing to ~2× and breaking terminal alignment / re-wrapping. No API change.

## Evidence

`oxfmt`, `oxlint`, `tsgo:core` pass; the full `packages/terminal-core/src/table.test.ts` suite passes with a new CJK regression test, and reverting the fix makes that test fail (fail-before).

## Real behavior proof

Behavior addressed: `wrapNoteMessage` emitted wrapped lines up to twice the visible-column budget for long wide-character words, because `splitLongWord` split by code-point count rather than visible width.

Real environment tested: Ran the exported `wrapNoteMessage` and `visibleWidth` from `packages/terminal-core/src/{note,ansi}.ts` via `tsx` on Node v22.22.1 (no mocks), before and after the patch, plus the colocated Vitest suite via `node scripts/run-vitest.mjs`.

Exact steps or command run after this patch: `wrapNoteMessage("東京特許許可局長今日休暇許可局長今日休暇東京特許", { maxWidth: 20, columns: 80 }).split("\n")`, asserting `visibleWidth(line) <= 20` for each line; then `node scripts/run-vitest.mjs packages/terminal-core/src/table.test.ts`, `node scripts/run-oxlint.mjs`, `pnpm tsgo:core`.

Evidence after fix:
```
BEFORE (origin/main):
  wrapNoteMessage(<24 CJK chars>, {maxWidth:20}) -> line[0] visibleWidth=40, line[1]=8   (40 > 20 budget)
AFTER:
  wrapNoteMessage(<24 CJK chars>, {maxWidth:20}) -> line[0]=20, line[1]=20, line[2]=8     (all <= 20; join("") == input)
  ASCII control ("a".repeat(70), maxWidth 20)    -> unchanged (lines <= 20, as before)
table.test.ts -> exit 0 (all pass, incl. new CJK regression test); fail-before (revert source) -> the new test fails
oxlint -> exit 0 ; tsgo:core -> exit 0
```

Observed result after fix: every wrapped line of the CJK input is ≤ 20 visible columns (the long word breaks into 3 lines instead of one 40-column line), content is preserved (`join("")` equals the input), and ASCII wrapping is unchanged.

What was not tested: the actual @clack/prompts terminal render of a note (no interactive terminal in this environment); the fix is a pure wrapping-math change proven at the function and unit-test level using the module's own `visibleWidth` measurement.
