### PR TITLE
fix(media): forward scanned PDF page images

### DIFF
--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -321,7 +321,7 @@ When `mode: "all"`, outputs are labeled `[Image 1/2]`, `[Audio 2/2]`, etc.
     - The injected block uses explicit boundary markers like `<<<EXTERNAL_UNTRUSTED_CONTENT id="...">>>` / `<<<END_EXTERNAL_UNTRUSTED_CONTENT id="...">>>` and includes a `Source: External` metadata line.
     - This attachment-extraction path intentionally omits the long `SECURITY NOTICE:` banner to avoid bloating the media prompt; the boundary markers and metadata still remain.
     - If a file has no extractable text, OpenClaw injects `[No extractable text]`.
-    - If a PDF falls back to rendered page images in this path, the media prompt keeps the placeholder `[PDF content rendered to images; images not forwarded to model]` because this attachment-extraction step forwards text blocks, not the rendered PDF images.
+    - If a PDF falls back to rendered page images in this path, the media prompt includes `[PDF content rendered to images]` and forwards those page images as current-turn image inputs on vision-capable model paths. If the model path cannot consume images, the placeholder still records that PDF raster fallback occurred.
 
   </Accordion>
 </AccordionGroup>

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -23,6 +23,59 @@ describe("resolveCurrentTurnImages", () => {
     vi.restoreAllMocks();
   });
 
+  it("uses and consumes extracted current-turn images", async () => {
+    const image = {
+      type: "image" as const,
+      data: Buffer.from("rendered-pdf-page").toString("base64"),
+      mimeType: "image/png",
+    };
+    const ctx = {
+      Body: "scan",
+      CurrentTurnImages: [image],
+    } satisfies MsgContext;
+
+    const result = await resolveCurrentTurnImages({
+      ctx,
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(result).toStrictEqual({
+      images: [image],
+      imageOrder: ["inline"],
+    });
+    expect(ctx.CurrentTurnImages).toBeUndefined();
+  });
+
+  it("appends extracted current-turn images to explicit inline images", async () => {
+    const explicitImage = {
+      type: "image" as const,
+      data: Buffer.from("explicit-image").toString("base64"),
+      mimeType: "image/jpeg",
+    };
+    const extractedImage = {
+      type: "image" as const,
+      data: Buffer.from("rendered-pdf-page").toString("base64"),
+      mimeType: "image/png",
+    };
+    const ctx = {
+      Body: "scan",
+      CurrentTurnImages: [extractedImage],
+    } satisfies MsgContext;
+
+    const result = await resolveCurrentTurnImages({
+      ctx,
+      cfg: {} as OpenClawConfig,
+      images: [explicitImage],
+      imageOrder: ["offloaded"],
+    });
+
+    expect(result).toStrictEqual({
+      images: [explicitImage, extractedImage],
+      imageOrder: ["offloaded", "inline"],
+    });
+    expect(ctx.CurrentTurnImages).toBeUndefined();
+  });
+
   it("hydrates Telegram-style state-relative media into native prompt images", async () => {
     await withTempDir({ prefix: "openclaw-current-turn-images-" }, async (base) => {
       const stateDir = path.join(base, "state");

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -88,6 +88,23 @@ function createUndescribedImageContext(
   };
 }
 
+function isValidCurrentTurnImage(image: ImageContent): boolean {
+  return (
+    image.type === "image" && image.mimeType.startsWith("image/") && image.data.trim().length > 0
+  );
+}
+
+/** Returns transient current-turn image payloads and removes them from the context. */
+export function takeCurrentTurnImages(ctx: MsgContext): ImageContent[] {
+  const images = Array.isArray(ctx.CurrentTurnImages)
+    ? ctx.CurrentTurnImages.filter(isValidCurrentTurnImage)
+    : [];
+  if (Array.isArray(ctx.CurrentTurnImages)) {
+    delete ctx.CurrentTurnImages;
+  }
+  return images;
+}
+
 /** Resolves current-turn image attachments that were not already described by media understanding. */
 export async function resolveCurrentTurnImages(params: {
   ctx: MsgContext;
@@ -98,8 +115,18 @@ export async function resolveCurrentTurnImages(params: {
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
 }> {
-  if (Array.isArray(params.images) && params.images.length > 0) {
+  const explicitImages = Array.isArray(params.images) ? params.images : [];
+  const currentTurnImages = takeCurrentTurnImages(params.ctx);
+  if (explicitImages.length > 0 && currentTurnImages.length === 0) {
     return { images: params.images, imageOrder: params.imageOrder };
+  }
+  const combinedImages = [...explicitImages, ...currentTurnImages];
+  if (combinedImages.length > 0) {
+    const explicitImageOrder = params.imageOrder ?? explicitImages.map(() => "inline" as const);
+    return {
+      images: combinedImages,
+      imageOrder: [...explicitImageOrder, ...currentTurnImages.map(() => "inline" as const)],
+    };
   }
 
   const currentImageAttachments = collectCurrentImageAttachments(params.ctx);

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -1192,6 +1192,30 @@ describe("tryDispatchAcpReply", () => {
     ]);
   });
 
+  it("forwards media-understanding current-turn images into agent runtime turns", async () => {
+    setReadyAcpResolution();
+    const image = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: Buffer.from("rendered-pdf-page").toString("base64"),
+    };
+
+    await runDispatch({
+      bodyForAgent: "describe scanned pdf",
+      ctxOverrides: {
+        CurrentTurnImages: [image],
+      },
+    });
+
+    expect(runTurnCall().text).toBe("describe scanned pdf");
+    expect(runTurnCall().attachments).toEqual([
+      {
+        mediaType: "image/png",
+        data: image.data,
+      },
+    ]);
+  });
+
   it("preserves chat.send inline image attachments over recent history images", async () => {
     setReadyAcpResolution();
     const image = {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -37,6 +37,7 @@ import {
   resolveInlineAgentImageAttachments,
 } from "./agent-turn-attachments.js";
 import { resolveFirstContextText } from "./context-text.js";
+import { takeCurrentTurnImages } from "./current-turn-images.js";
 import {
   createAcpDispatchDeliveryCoordinator,
   type AcpDispatchDeliveryCoordinator,
@@ -563,22 +564,26 @@ export async function tryDispatchAcpReply(params: {
       cfg: params.cfg,
     });
     const mediaAttachments = resolvedTurnAttachments.attachments;
-    const inlineAttachments = resolveInlineAgentImageAttachments(params.images);
+    const explicitInlineAttachments = resolveInlineAgentImageAttachments(params.images);
+    const transientInlineAttachments = resolveInlineAgentImageAttachments(
+      takeCurrentTurnImages(params.ctx),
+    );
+    const inlineAttachments = [...explicitInlineAttachments, ...transientInlineAttachments];
     const mediaAttachmentsAreOnlyRecentHistory =
       mediaAttachments.length > 0 &&
       mediaAttachments.length === resolvedTurnAttachments.recentHistoryImages.length;
-    const attachments =
+    const shouldUseMediaAttachments =
       mediaAttachments.length > 0 &&
-      !(mediaAttachmentsAreOnlyRecentHistory && inlineAttachments.length > 0)
-        ? mediaAttachments
-        : inlineAttachments;
-    const turnPromptText =
-      attachments === mediaAttachments
-        ? appendRecentHistoryImageContext({
-            promptText,
-            images: resolvedTurnAttachments.recentHistoryImages,
-          })
-        : promptText;
+      !(mediaAttachmentsAreOnlyRecentHistory && inlineAttachments.length > 0);
+    const attachments = shouldUseMediaAttachments
+      ? [...mediaAttachments, ...transientInlineAttachments]
+      : inlineAttachments;
+    const turnPromptText = shouldUseMediaAttachments
+      ? appendRecentHistoryImageContext({
+          promptText,
+          images: resolvedTurnAttachments.recentHistoryImages,
+        })
+      : promptText;
     if (!turnPromptText && attachments.length === 0) {
       const counts = params.dispatcher.getQueuedCounts();
       delivery.applyRoutedCounts(counts);

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -1,5 +1,6 @@
 /** Shared inbound message context types used by prompt templating and reply dispatch. */
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
+import type { ImageContent } from "../llm/types.js";
 import type {
   MediaUnderstandingDecision,
   MediaUnderstandingOutput,
@@ -200,6 +201,8 @@ export type MsgContext = {
   MediaWorkspaceDir?: string;
   /** Attachment indexes whose audio was already transcribed before media understanding runs. */
   MediaTranscribedIndexes?: number[];
+  /** Extracted current-turn image payloads to forward once without persisting as text context. */
+  CurrentTurnImages?: ImageContent[];
   /**
    * Marker: skip downstream stageSandboxMedia. chat.send RPC sets this so
    * staging runs synchronously before respond() and surfaces 5xx to the

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -31,6 +31,7 @@ const readRemoteMediaBufferMock = vi.hoisted(() => vi.fn());
 const runFfmpegMock = vi.hoisted(() => vi.fn());
 const convertHeicToJpegMock = vi.hoisted(() => vi.fn());
 const runExecMock = vi.hoisted(() => vi.fn());
+const extractDocumentContentMock = vi.hoisted(() => vi.fn());
 
 let applyMediaUnderstanding: typeof import("./apply.js").applyMediaUnderstanding;
 let clearMediaUnderstandingBinaryCacheForTests: typeof import("./runner.js").clearMediaUnderstandingBinaryCacheForTests;
@@ -39,6 +40,7 @@ const mockedReadRemoteMediaBuffer = readRemoteMediaBufferMock;
 const mockedRunFfmpeg = runFfmpegMock;
 const mockedConvertHeicToJpeg = convertHeicToJpegMock;
 const mockedRunExec = runExecMock;
+const mockedExtractDocumentContent = extractDocumentContentMock;
 
 const TEMP_MEDIA_PREFIX = "openclaw-media-";
 let suiteTempMediaRootDir = "";
@@ -298,6 +300,9 @@ describe("applyMediaUnderstanding", () => {
       runFfmpeg: runFfmpegMock,
       convertHeicToJpeg: convertHeicToJpegMock,
     }));
+    vi.doMock("../media/document-extractors.runtime.js", () => ({
+      extractDocumentContent: extractDocumentContentMock,
+    }));
     vi.doMock("../process/exec.js", () => ({
       runExec: runExecMock,
     }));
@@ -352,6 +357,8 @@ describe("applyMediaUnderstanding", () => {
     mockedConvertHeicToJpeg.mockReset();
     mockedConvertHeicToJpeg.mockResolvedValue(Buffer.from("jpeg-normalized"));
     mockedRunExec.mockReset();
+    mockedExtractDocumentContent.mockReset();
+    mockedExtractDocumentContent.mockResolvedValue(null);
     mockedReadRemoteMediaBuffer.mockResolvedValue({
       buffer: createSafeAudioFixtureBuffer(2048),
       contentType: "audio/ogg",
@@ -1740,6 +1747,38 @@ describe("applyMediaUnderstanding", () => {
     });
 
     expectFileNotApplied({ ctx, result, body: "<media:file>" });
+  });
+
+  it("forwards rendered PDF page images as current-turn images", async () => {
+    const pseudoPdf = Buffer.from("%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n", "utf8");
+    const filePath = await createTempMediaFile({
+      fileName: "scan.pdf",
+      content: pseudoPdf,
+    });
+    const renderedPageImage = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: Buffer.from("rendered-page").toString("base64"),
+    };
+    mockedExtractDocumentContent.mockResolvedValueOnce({
+      text: "",
+      images: [renderedPageImage],
+    });
+
+    const cfg = createMediaDisabledConfigWithAllowedMimes(["application/pdf"]);
+
+    const { ctx, result } = await applyWithDisabledMedia({
+      body: "<media:file>",
+      mediaPath: filePath,
+      mediaType: "application/pdf",
+      cfg,
+    });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain('<file name="scan.pdf" mime="application/pdf">');
+    expect(ctx.Body).toContain("[PDF content rendered to images]");
+    expect(ctx.Body).not.toContain("images not forwarded");
+    expect(ctx.CurrentTurnImages).toEqual([renderedPageImage]);
   });
 
   it("respects configured allowedMimes for text-like attachments", async () => {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -5,19 +5,20 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
-import type { MsgContext } from "../auto-reply/templating.js";
-import type { OpenClawConfig } from "../config/types.js";
-import { logVerbose, shouldLogVerbose } from "../globals.js";
-import { renderFileContextBlock } from "../media/file-context.js";
-import { extractFileContentFromSource, normalizeMimeType } from "../media/input-files.js";
-import { wrapExternalContent } from "../security/external-content.js";
 import type { ActiveMediaModel } from "../../packages/media-understanding-common/src/active-model.js";
 import {
   extractMediaUserText,
   formatAudioTranscripts,
   formatMediaUnderstandingBody,
 } from "../../packages/media-understanding-common/src/format.js";
+import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { logVerbose, shouldLogVerbose } from "../globals.js";
+import type { ImageContent } from "../llm/types.js";
+import { renderFileContextBlock } from "../media/file-context.js";
+import { extractFileContentFromSource, normalizeMimeType } from "../media/input-files.js";
+import { wrapExternalContent } from "../security/external-content.js";
 import { resolveAttachmentKind } from "./attachments.js";
 import { runWithConcurrency } from "./concurrency.js";
 import { DEFAULT_ECHO_TRANSCRIPT_FORMAT, sendTranscriptEcho } from "./echo-transcript.js";
@@ -47,6 +48,11 @@ type ApplyMediaUnderstandingResult = {
   appliedAudio: boolean;
   appliedVideo: boolean;
   appliedFile: boolean;
+};
+
+type ExtractedFileBlocks = {
+  blocks: string[];
+  images: ImageContent[];
 };
 
 const CAPABILITY_ORDER: MediaUnderstandingCapability[] = ["image", "audio", "video"];
@@ -383,12 +389,13 @@ async function extractFileBlocks(params: {
   cfg: OpenClawConfig;
   limits: FileExtractionLimits;
   skipAttachmentIndexes?: Set<number>;
-}): Promise<string[]> {
+}): Promise<ExtractedFileBlocks> {
   const { attachments, cache, cfg, limits, skipAttachmentIndexes } = params;
   if (!attachments || attachments.length === 0) {
-    return [];
+    return { blocks: [], images: [] };
   }
   const blocks: string[] = [];
+  const images: ImageContent[] = [];
   for (const attachment of attachments) {
     if (!attachment) {
       continue;
@@ -494,10 +501,13 @@ async function extractFileBlocks(params: {
       continue;
     }
     const text = extracted?.text?.trim() ?? "";
+    if (extracted?.images && extracted.images.length > 0) {
+      images.push(...extracted.images);
+    }
     let blockText = text ? wrapUntrustedAttachmentContent(text) : "";
     if (!blockText) {
       if (extracted?.images && extracted.images.length > 0) {
-        blockText = "[PDF content rendered to images; images not forwarded to model]";
+        blockText = "[PDF content rendered to images]";
       } else {
         blockText = "[No extractable text]";
       }
@@ -511,7 +521,7 @@ async function extractFileBlocks(params: {
       }),
     );
   }
-  return blocks;
+  return { blocks, images };
 }
 
 export async function applyMediaUnderstanding(params: {
@@ -670,13 +680,17 @@ export async function applyMediaUnderstanding(params: {
         )
         .map((output) => output.attachmentIndex),
     );
-    const fileBlocks = await extractFileBlocks({
+    const extractedFiles = await extractFileBlocks({
       attachments,
       cache,
       cfg,
       limits: resolveFileExtractionLimits(cfg),
       skipAttachmentIndexes: audioAttachmentIndexes.size > 0 ? audioAttachmentIndexes : undefined,
     });
+    const fileBlocks = extractedFiles.blocks;
+    if (extractedFiles.images.length > 0) {
+      ctx.CurrentTurnImages = [...(ctx.CurrentTurnImages ?? []), ...extractedFiles.images];
+    }
     if (fileBlocks.length > 0) {
       ctx.Body = appendFileBlocks(ctx.Body, fileBlocks);
     }


### PR DESCRIPTION
Closes #96541.

## What Problem This Solves
Chat media-understanding already receives page-image payloads from image-only PDFs, but converted them into placeholder-only file blocks. Scanned PDFs in chat channels therefore did not reach vision-capable agent turns, unlike the sibling OpenResponses path.

## Summary
Carry extracted PDF page images as transient current-turn images, consume them once in normal reply and ACP dispatch, and update the media-understanding docs to remove the stale "images not forwarded" wording.

## Evidence
- Added source-level regressions proving rendered PDF page images are retained, consumed by current-turn image resolution, and forwarded into ACP runTurn attachments.
- Re-ran focused media-understanding, normal/ACP reply image handling, agent-runner execution, and sibling OpenResponses file-only PDF coverage before push.
- Local type, lint, docs formatting, and diff whitespace checks passed on this branch.

Live chat-channel proof will be supplied separately.