### PR TITLE
fix(cron): classify result-level failures so the model fallback chain engages (#96525)

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -2,6 +2,10 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { wrapUntrustedPromptDataBlock } from "../../agents/sanitize-for-prompt.js";
@@ -284,6 +288,18 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      // Classify returned result-level failures (reasoning-only / empty /
+      // fallback-safe incomplete_turn) so a configured fallback chain still
+      // engages, matching the interactive and auto-reply paths. The classifier
+      // only fires on embedded-runner result shapes and returns null for CLI
+      // provider results, so runCliAgent terminal handling is unchanged (#96525).
+      classifyResult: ({ provider: providerLocal, model: modelLocal, result: resultLocal }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider: providerLocal,
+          model: modelLocal,
+          result: resultLocal,
+        }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -1,4 +1,5 @@
 // Payload fallback tests cover fallback prompt payloads for isolated cron runs.
+import { createContractRunResult } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { describe, expect, it } from "vitest";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
@@ -186,5 +187,58 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
     expect(runEmbeddedAgentMock.mock.calls[0]?.[0]).toMatchObject({
       modelFallbacksOverride: ["openai/gpt-5.2", "zai/glm-5"],
     });
+  });
+
+  it("classifies returned result-level failures so the configured fallback chain still engages (#96525)", async () => {
+    mockRunCronFallbackPassthrough();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          payload: { kind: "agentTurn", message: "test", fallbacks: ["openai/gpt-5.5"] },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+
+    // Cron must classify returned result-level failures; without the classifier
+    // runWithModelFallback accepts the failed primary and never advances to the
+    // configured fallback model (#96525), the same contract the interactive and
+    // auto-reply paths already pass.
+    const request = runWithModelFallbackMock.mock.calls[0]?.[0] as {
+      classifyResult?: (params: {
+        provider: string;
+        model: string;
+        result: ReturnType<typeof createContractRunResult>;
+      }) => unknown;
+      mergeExhaustedResult?: unknown;
+    };
+    expect(typeof request.classifyResult).toBe("function");
+    expect(typeof request.mergeExhaustedResult).toBe("function");
+
+    // The wired classifier flags the reported fallback-safe reasoning-only /
+    // incomplete_turn result class, so the chain advances instead of accepting
+    // the failed primary.
+    const reasoningOnlyPrimary = createContractRunResult({
+      payloads: [{ text: "Agent couldn't generate a response.", isError: true }],
+      meta: {
+        durationMs: 1,
+        agentHarnessResultClassification: "reasoning-only",
+        error: {
+          kind: "incomplete_turn",
+          message: "Agent couldn't generate a response.",
+          fallbackSafe: true,
+          terminalPresentation: false,
+        },
+      },
+    });
+    const classified = request.classifyResult?.({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      result: reasoningOnlyPrimary,
+    });
+    expect(classified).not.toBeNull();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Closes #96525. Isolated cron / scheduled `agentTurn` jobs on embedded (non-CLI) providers with a configured model fallback chain silently dropped the answer when the primary model returned a result-level terminal failure (reasoning-only, empty-visible, or fallback-safe `incomplete_turn`). The configured fallback model was never called, the run was recorded as `status: "error"`, and the operator received the generic "Agent couldn't generate a response." text — contradicting the documented fallback contract (`docs/automation/cron-jobs.md`).

## Why This Change Was Made

The cron embedded-run path called `runWithModelFallback` (`src/cron/isolated-agent/run-executor.ts`) without `classifyResult` or `mergeExhaustedResult`. `runEmbeddedAgent` does not throw for a fallback-safe incomplete turn — it returns a result carrying `meta.error.kind = "incomplete_turn"`, `fallbackSafe: true`, and `meta.agentHarnessResultClassification`. With `classifyResult` undefined, `runWithModelFallback` treats the returned result as a success and never advances to the next candidate, so the exhaustion-preserve branch (gated on `mergeExhaustedResult`) is dead for cron. The interactive (`agent-command.ts`) and auto-reply (`agent-runner-execution.ts`) paths already pass both helpers and engage the fallback for the same returned-result failure class.

This wires the existing embedded classifier and exhausted-result merge helper into the cron call. The classifier only fires on embedded-runner result shapes (`agentHarnessResultClassification` / `meta.error.kind`) and returns `null` for CLI provider results, so `runCliAgent` terminal handling is unchanged — the fix is scoped to the embedded branch as the issue requests.

## User Impact

A cron job whose primary model returns reasoning-only / empty / incomplete output now advances to the configured fallback model and delivers the real answer, instead of recording an error every run. No change when no fallback chain is configured, and no change to CLI-provider cron runs.

## Evidence

- **Behavior addressed:** Cron embedded `runWithModelFallback` never classified returned result-level failures, so the configured fallback model was never called for reasoning-only / empty / fallback-safe `incomplete_turn` primaries.
- **Real environment tested:** `node scripts/run-vitest.mjs src/cron/isolated-agent/run.payload-fallbacks.test.ts` — drives the real `runCronIsolatedAgentTurn` cron path (mocking only `runWithModelFallback`) and asserts the cron call now passes `classifyResult` + `mergeExhaustedResult`, and that the wired classifier flags a real fallback-safe reasoning-only / `incomplete_turn` result (built with `createContractRunResult`).
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs src/cron/isolated-agent/run.payload-fallbacks.test.ts`; `./node_modules/.bin/oxlint --type-aware src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts`; `./node_modules/.bin/oxfmt --write`.
- **Evidence after fix:** The cron `runWithModelFallback` request now carries `classifyResult` (function) and `mergeExhaustedResult` (function); the wired classifier returns a non-null classification for a `reasoning-only` + fallback-safe `incomplete_turn` result, so the chain advances to the configured fallback.
- **Observed result after fix:** 7 passed. oxlint exit 0, format clean.
- **What was not tested:** A full live scheduled cron run against a real embedded provider returning a reasoning-only result end-to-end (no local multi-provider credentials). The bug is source-reproducible (per the issue's failing repro and the ClawSweeper source review); the regression is proven through the real cron executor path with the real classifier. Per the AGENTS.md skip clause, requesting maintainer skip / Crabbox if a live run is required.
