### PR TITLE
fix: allow MiniMax M3 multimodal model for native image understanding

### DIFF
--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -79,6 +79,20 @@ export function isMinimaxVlmModel(provider: string, modelId: string): boolean {
   return isMinimaxVlmProvider(provider) && modelId.trim() === "MiniMax-VL-01";
 }
 
+/**
+ * MiniMax multimodal models that natively support image input via chat completion.
+ * These models do NOT need the VL-01 fallback path; they can process images
+ * directly through the standard OpenAI-compatible chat endpoint.
+ */
+const MINIMAX_MULTIMODAL_MODEL_IDS = new Set([
+  "minimax-m3",
+]);
+
+export function isMinimaxMultimodalModel(modelId: string): boolean {
+  return MINIMAX_MULTIMODAL_MODEL_IDS.has(modelId.trim().toLowerCase());
+}
+
+
 function isMinimaxCnProvider(provider: string | undefined): boolean {
   const normalized = provider?.trim().toLowerCase();
   return normalized === "minimax-cn" || normalized === "minimax-portal-cn";

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -45,7 +45,7 @@ import {
   bundledStaticCatalogProviderUsesRuntimeAugment,
   resolveBundledStaticCatalogModel,
 } from "../embedded-agent-runner/model.static-catalog.js";
-import { isMinimaxVlmProvider } from "../minimax-vlm.js";
+import { isMinimaxMultimodalModel, isMinimaxVlmProvider } from "../minimax-vlm.js";
 import {
   resolveImageFallbackCandidates,
   resolveImageFallbackDefaultProvider,
@@ -265,7 +265,12 @@ export function resolveImageModelConfigForTool(params: {
     if (providerDefault) {
       return [`${primary.provider}/${providerDefault}`];
     }
-    if (isMinimaxVlmProvider(primary.provider)) {
+    // Non-multimodal MiniMax models fall back to VL-01; multimodal models (e.g. M3)
+    // support image natively and should use the primary model directly.
+    if (
+      isMinimaxVlmProvider(primary.provider) &&
+      !isMinimaxMultimodalModel(primary.model)
+    ) {
       return [`${primary.provider}/MiniMax-VL-01`];
     }
     return [];

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -15,7 +15,7 @@ import {
   normalizeStringEntries,
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
-import { isMinimaxVlmModel, isMinimaxVlmProvider } from "../agents/minimax-vlm.js";
+import { isMinimaxMultimodalModel, isMinimaxVlmModel, isMinimaxVlmProvider } from "../agents/minimax-vlm.js";
 import {
   buildModelAliasIndex,
   inferUniqueProviderFromConfiguredModels,
@@ -139,8 +139,14 @@ function resolveConfiguredKeyProviderOrder(params: {
 function resolveConfiguredImageModelId(params: {
   cfg: OpenClawConfig;
   providerId: string;
+  modelId?: string;
 }): string | undefined {
-  if (isMinimaxVlmProvider(params.providerId)) {
+  // MiniMax multimodal models can use their configured image model directly.
+  // Only non-multimodal MiniMax models should skip this resolution (they need VL-01 fallback).
+  if (
+    isMinimaxVlmProvider(params.providerId) &&
+    !(params.modelId && isMinimaxMultimodalModel(params.modelId))
+  ) {
     return undefined;
   }
   const configured = resolveConfiguredImageModel(params);
@@ -233,9 +239,12 @@ async function explicitImageModelVisionStatus(params: {
 }): Promise<"supported" | "unsupported" | "unknown"> {
   // Explicit model overrides should survive unknown catalog state, but known
   // text-only models must not be routed into image understanding.
+  // MiniMax multimodal models (e.g. M3) support image input natively via
+  // chat completion, so they should not be rejected here.
   if (
     isMinimaxVlmProvider(params.providerId) &&
-    !isMinimaxVlmModel(params.providerId, params.model)
+    !isMinimaxVlmModel(params.providerId, params.model) &&
+    !isMinimaxMultimodalModel(params.model)
   ) {
     return "unsupported";
   }
@@ -270,10 +279,16 @@ async function resolveAutoImageModelId(params: {
       return explicit;
     }
   }
-  if (isMinimaxVlmProvider(params.providerId)) {
+  // Non-multimodal MiniMax models (e.g. M2.7) fall back to VL-01 for image understanding.
+  // Multimodal MiniMax models (e.g. M3) are already handled by explicitImageModelVisionStatus
+  // above — if they reach here, the explicit model was unsupported and should still try VL-01.
+  if (isMinimaxVlmProvider(params.providerId) && !isMinimaxMultimodalModel(explicit ?? "")) {
     return "MiniMax-VL-01";
   }
-  const configuredModel = resolveConfiguredImageModelId(params);
+  const configuredModel = resolveConfiguredImageModelId({
+    ...params,
+    modelId: explicit,
+  });
   if (configuredModel) {
     return configuredModel;
   }
@@ -1036,11 +1051,15 @@ export async function runCapability(params: {
 
   // Skip image understanding when the primary model supports vision natively.
   // The image will be injected directly into the model context instead.
+  // MiniMax multimodal models (e.g. M3) also benefit from this optimization.
   const activeProvider = params.activeModel?.provider?.trim();
+  const activeModelId = params.activeModel?.model?.trim();
+  const activeProviderIsMinimaxNonMultimodal =
+    activeProvider && isMinimaxVlmProvider(activeProvider) && !isMinimaxMultimodalModel(activeModelId ?? "");
   if (
     capability === "image" &&
     activeProvider &&
-    !isMinimaxVlmProvider(activeProvider) &&
+    !activeProviderIsMinimaxNonMultimodal &&
     !hasExplicitImageUnderstandingConfig({
       cfg,
       config,


### PR DESCRIPTION
## Summary

MiniMax M3 is a multimodal model that supports image input natively via the standard OpenAI-compatible chat completion endpoint. Previously, all MiniMax models were unconditionally rejected for image understanding (unless the model ID was exactly `MiniMax-VL-01`), and then forced through the VL-01 fallback path (`/v1/coding_plan/vlm`). This fallback requires a Coding Plan subscription and uses a separate VLM endpoint.

For multimodal MiniMax models like M3, this is unnecessary — they can process images directly through the same chat completion API used for text.

## Changes

### New function: `isMinimaxMultimodalModel()` (`src/agents/minimax-vlm.ts`)
- Identifies MiniMax models that support native multimodal input (currently M3).
- Uses a `Set<string>` for O(1) lookup with case-insensitive matching.

### Four code paths updated:

1. **`explicitImageModelVisionStatus()`** (`runner.ts`): M3 is no longer rejected as `"unsupported"` for image understanding. Previously, any MiniMax model that wasn't `MiniMax-VL-01` was marked unsupported.

2. **`resolveAutoImageModelId()`** (`runner.ts`): M3 no longer falls back to `MiniMax-VL-01`. Non-multimodal MiniMax models (e.g. M2.7) still fall back to VL-01 as before.

3. **`resolveConfiguredImageModelId()`** (`runner.ts`): M3 can use configured image models directly instead of being skipped for all MiniMax providers.

4. **Vision-skip optimization** (`runner.ts`): M3 now benefits from the native vision skip (image injected directly into model context), just like other multimodal providers. Previously, all MiniMax providers were excluded from this optimization.

### `image-tool.ts`
- Updated VL-01 fallback guard: only non-multimodal MiniMax models fall back to VL-01 when no provider default is found.

## Backward compatibility

- Non-multimodal MiniMax models (e.g. M2.7, M2.7-highspeed) continue to fall back to `MiniMax-VL-01` as before.
- The `MiniMax-VL-01` specific path (`minimaxUnderstandImage()` → `/v1/coding_plan/vlm`) is unchanged.
- All existing tests pass (minimax-vlm: 20, runner.vision-skip: 15, image-tool: 158).

## Testing

- `src/agents/minimax-vlm.normalizes-api-key.test.ts` — 20 tests ✅
- `src/media-understanding/runner.vision-skip.test.ts` — 15 tests ✅
- `src/agents/tools/image-tool.test.ts` — 158 tests ✅

Closes #66625