### PR TITLE
fix(sessions): align reply init revision with persisted skillsSnapshot

### DIFF
--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -55,7 +55,7 @@ export async function recordInboundSession(params: {
     })
     .catch(params.onRecordError);
   params.trackSessionMetaTask?.(metaTask);
-  void metaTask;
+  await metaTask;
 
   const update = params.updateLastRoute;
   if (!update) {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1381,7 +1381,14 @@ export function loadReplySessionInitializationSnapshot(params: {
   storePath: string;
   sessionKey: string;
 }): ReplySessionInitializationSnapshot {
-  const store = loadSessionStore(params.storePath, { skipCache: true, clone: false });
+  // Use persisted shape (skills + promptRef), not hydrated in-memory prompt text.
+  // Writer-cache loads hydrate prompt blobs; comparing hydrated vs persisted revisions
+  // causes false stale-snapshot conflicts on the second inbound turn.
+  const store = loadSessionStore(params.storePath, {
+    skipCache: true,
+    clone: false,
+    hydrateSkillPromptRefs: false,
+  });
   const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
   const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
   const entries = cloneSessionEntries(store);
@@ -1422,7 +1429,20 @@ export async function commitReplySessionInitialization(params: {
     async (store): Promise<ReplySessionInitializationCommitResult> => {
       const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
       const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
-      const revision = createReplySessionInitializationRevision(currentEntry);
+      // Writer `store` may carry hydrated skillsSnapshot.prompt; revision must use the
+      // same persisted shape as loadReplySessionInitializationSnapshot().
+      const persistedStore = loadSessionStore(params.storePath, {
+        skipCache: true,
+        clone: false,
+        hydrateSkillPromptRefs: false,
+      });
+      const persistedEntry = resolveSessionStoreEntry({
+        store: persistedStore,
+        sessionKey: params.sessionKey,
+      }).existing;
+      const revision = createReplySessionInitializationRevision(
+        persistedEntry ? { ...persistedEntry } : undefined,
+      );
       if (revision !== params.expectedRevision) {
         return {
           ok: false,


### PR DESCRIPTION
## Summary

- Compare reply session initialization revisions using the on-disk `skillsSnapshot` shape (`promptRef`) instead of hydrated writer-cache `prompt` text
- Await inbound session meta recording before `updateLastRoute` to avoid concurrent session store writes

Fixes #96698

## Problem

The second inbound Discord message (and likely any channel) fails with:

```
reply session initialization conflicted for agent:main:discord:channel:<channelId>
```

`createReplySessionInitializationRevision()` serializes the full session entry, but snapshot load and commit compared different `skillsSnapshot` shapes: persisted `{ skills, promptRef }` vs hydrated `{ skills, prompt }`. This produced false `stale-snapshot` conflicts after the first agent run.

## Test plan

- [x] Send two consecutive messages in the same Discord channel; both succeed
- [x] No `stale-snapshot` / initialization conflict on second turn
- [ ] Existing session store tests pass

Made with [Cursor](https://cursor.com)