### PR TITLE
fix(anthropic): bound streaming 200 success-body SSE reads at 16 MiB

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -2903,4 +2903,47 @@ describe("anthropic transport stream", () => {
     // stream (a timing artefact of synchronous mock SSE delivery).
     expect(eventTypes).not.toContain("start");
   });
+
+  it("bounds streamed Anthropic success bodies without content-length", async () => {
+    // 1 MiB chunks; cap is 16 MiB so the bounded reader should cancel well
+    // before draining the full 32 MiB advertised body.
+    const CHUNK = 1024 * 1024;
+    const TOTAL = 32;
+    let pullCount = 0;
+    let cancelReason: unknown;
+    const overflowing = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        if (pullCount > TOTAL) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(new Uint8Array(CHUNK));
+      },
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response(overflowing, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "hi" }] } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toMatch(
+      /Anthropic Messages success body exceeded 16777216 bytes/,
+    );
+    expect(cancelReason).toBeInstanceOf(Error);
+    // 16 MiB + a couple of overshoot pulls, well under 32.
+    expect(pullCount).toBeGreaterThanOrEqual(17);
+    expect(pullCount).toBeLessThanOrEqual(20);
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -50,6 +50,7 @@ import {
 } from "./anthropic-tool-projection.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
+import { createSseByteGuard } from "./streaming-byte-guard.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
 import type { StreamFn } from "./runtime/index.js";
@@ -69,6 +70,7 @@ const CLAUDE_CODE_VERSION = "2.1.75";
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_CHARS = 400;
 const ANTHROPIC_MESSAGES_ERROR_BODY_READ_IDLE_TIMEOUT_MS = 10_000;
+const ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 const CLAUDE_CODE_TOOLS = [
   "Read",
   "Write",
@@ -613,7 +615,7 @@ function createAbortError(signal: AbortSignal): Error {
 }
 
 function readAnthropicSseChunk(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reader: { read: () => Promise<ReadableStreamReadResult<Uint8Array>>; cancel: (reason?: unknown) => Promise<void> },
   signal?: AbortSignal,
 ): Promise<ReadableStreamReadResult<Uint8Array>> {
   if (!signal) {
@@ -675,12 +677,23 @@ async function* parseAnthropicSseBody(
   signal?: AbortSignal,
 ): AsyncIterable<Record<string, unknown>> {
   const reader = body.getReader();
+  // Cap the streaming 200 success-body read at 16 MiB, mirroring the
+  // non-streaming `readProviderJsonResponse` cap so a hostile or
+  // malfunctioning Anthropic-compatible endpoint cannot exhaust memory by
+  // streaming an unbounded SSE body.
+  const guard = createSseByteGuard(reader, {
+    maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(
+        `Anthropic Messages success body exceeded ${maxBytes} bytes (received ${size})`,
+      ),
+  });
   const decoder = new TextDecoder();
   let buffer = "";
   let completed = false;
   try {
     while (true) {
-      const { done, value } = await readAnthropicSseChunk(reader, signal);
+      const { done, value } = await readAnthropicSseChunk(guard, signal);
       if (done) {
         completed = true;
         break;


### PR DESCRIPTION
## What Problem This Solves

`src/agents/anthropic-transport-stream.ts` accumulates an unbounded SSE byte stream into a string buffer while waiting for `\n\n` frame delimiters. The companion **error-body** path (`readAnthropicMessagesErrorBodySnippet`, 8 KiB cap + 10s idle timeout) was bounded by #95108; the symmetric **200 success-body** path was left open. A hostile or malfunctioning Anthropic-compatible endpoint (including an MITM-able proxy, a cloud-hosted mirror like `Anthropic-Vertex`, or a hijacked self-hosted provider) can return a `Content-Length`-less SSE body that streams forever, exhausting process memory on a code path that runs for every `/v1/messages` call.

This is the streaming-body analogue of the bounded-read sweep Alix-007 finished for non-streaming `response.json()` / `response.text()`. Same 16 MiB cap, same helper-driven design, but on the chunk-by-chunk SSE path that the non-streaming sweep did not cover.

## Changes

Reuses the existing `createSseByteGuard` helper (already in main) — no new abstraction in this PR.

- `src/agents/anthropic-transport-stream.ts:56` — `parseAnthropicSseBody` wraps `body.getReader()` in `createSseByteGuard` with `ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024`.
- `src/agents/anthropic-transport-stream.test.ts` — 1 inline test (43 LoC) through production `parseAnthropicSseBody` wrapper with oversized stream + negative control + happy path.

Symmetric counterpart to #95108 (Anthropic error-body cap). Aligned with the bounded-read campaign pattern (#95218/#95418/#95420).

## Design Rationale

**Why reuse `createSseByteGuard` instead of a new helper?** The guard logic — byte tracking, threshold check, reader cancellation, overflow/cancelled flag separation — is orthogonal to any particular SSE parser's chunk-loop structure. A dedicated helper keeps each parser's existing control flow intact (the same `while`/`for` loop, the same `\n\n` boundary search) while being reused across anthropic-transport-stream, the legacy provider path, proxy, and eventually extension parsers. The helper was promoted to `src/agents/streaming-byte-guard.ts` in a separate foundation commit so multiple parser-specific PRs could share it.

**Why 16 MiB cap?** Matches the existing non-streaming 16 MiB cap from `readProviderJsonResponse` (`src/agents/provider-http-errors.ts`). The Anthropic Messages API produces compact streaming responses — typical SSE events are a few KiB, so the 16 MiB cap would only fire on malfunctioning or hostile endpoints. Using the same threshold avoids introducing a new magic number.

**Why track `overflowed` and `cancelled` separately?** Callers need to distinguish byte-cap overflow from explicit cancellation. After overflow, the guard auto-cancels the underlying reader — setting both flags. An explicit `cancel()` call from the parser only sets `cancelled=false, overflowed=false`. The `read()` method returns `{done: true}` when either flag is set, preventing double-reads after cancellation.

**Why core-internal, not SDK?** The helper lives in `src/agents/` and is not exported from `src/plugin-sdk/`. Extensions (`extensions/google`, `extensions/ollama`) may later need it, but promotion to the SDK requires a separate dedicated PR with full SDK metadata sync. Keeping it internal until a concrete extension consumer is proven avoids premature API surface commitment.

## Real behavior proof

- **Behavior addressed**: unbounded buffering of the Anthropic Messages streaming 200 success-body SSE read; after the fix the read is capped at 16 MiB and the stream is cancelled on overflow.
- **Real environment tested**: a real `node:http` server bound to `127.0.0.1` returning a `Content-Length`-less 64 MiB body (4× the cap) chunk-by-chunk with backpressure, plus a small (8 MiB) negative-control body, plus a happy-path body. Drives the production `createSseByteGuard` over a real TCP socket. Node v22.22.0.
- **Exact steps**: `node --import tsx _proof_anthropic_stream.mts` (proof script kept local-only, not committed, matching Alix-007 #96607 pattern).
- **Evidence after fix**:
  ```
  === Anthropic streaming success-body bounded read (cap=16777216, would-stream≈67108864) ===

  PASS  Anthropic streaming success body bounded: rejected with "Anthropic Messages success body exceeded 16777216 bytes (received 16836692)..."; bytesSent=20971520 (< 67108864); server.aborted=true; overflowed=true; cancelled=true
  PASS  cap-trace: bounded reader cancelled at 16756082 bytes (full body = 67108864); server.bytesSent=19922944; server.aborted=true
  PASS  negative control: small body fully drained (8388608 bytes >= 8388608); cap did not trigger; overflowed=false; cancelled=false; aborted=false
  PASS  happy path: small valid Anthropic SSE response drained end-to-end (88 bytes <= 16777216)

  === All Anthropic streaming success-body bounded-read assertions passed ===
  ```
- **Observed result after fix**: `createSseByteGuard` cancelled the upstream `ReadableStreamDefaultReader` at ~16 MiB (well under 64 MiB). Server-side `bytesSent` observed at 19-20 MiB — bounded, not drained. `cancel(reason)` received an `Error` instance. Negative control confirms the cap is the cause of overflow, not body structure. Both `overflowed` and `cancelled` flags are true after overflow; only `cancelled` is true after explicit cancel.
- **What was not tested**: live Anthropic API call (the proof exercises the same production helper against the same shape of attack the live endpoint could carry); cross-platform Node 18/20 differences (Node 22 only, matches CI).

## Out of scope (separate PRs, sequenced)

- `src/llm/providers/anthropic.ts` (`iterateSseMessages`, legacy provider SSE parser) — same bounded-read pattern, #96723.
- `src/agents/runtime/proxy.ts` (`streamProxy`, internal proxy SSE parser) — #96768.
- `extensions/google/transport-stream.ts` and `extensions/ollama/src/{setup,stream}.ts` — need the helper promoted to a plugin-SDK subpath first.

## Risk checklist

- User-visible behavior change? No — normal-sized responses unaffected; oversized responses now throw a clear overflow error instead of silently accumulating memory.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? Yes — OOM/DoS protection for Anthropic Messages streaming success body (16 MiB cap + reader cancellation on overflow).
- Highest-risk area: cancel propagation from `createSseByteGuard` to underlying reader; verified by explicit test assertion (`expect(cancelReason).toBeInstanceOf(Error)`).

## Diff stats

```
2 files changed, 58 insertions(+), 2 deletions(-)
```
