### PR TITLE
fix(cli): keep built-in nodes commands off the plugin load path

### DIFF
--- a/src/cli/nodes-cli.plugin-registration.test.ts
+++ b/src/cli/nodes-cli.plugin-registration.test.ts
@@ -1,30 +1,15 @@
 // Nodes CLI plugin registration tests cover node command plugin registration.
+// Built-in node command registration runs for real so the guard is exercised against the actual
+// registered subcommand names; only the plugin-loader boundary is stubbed.
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loggingState } from "../logging/state.js";
 
 const registerPluginCliCommandsFromValidatedConfig = vi.fn(async () => ({}));
-const registerNodesCameraCommands = vi.fn();
-const registerNodesInvokeCommands = vi.fn();
-const registerNodesLocationCommands = vi.fn();
-const registerNodesNotifyCommand = vi.fn();
-const registerNodesPairingCommands = vi.fn();
-const registerNodesPushCommand = vi.fn();
-const registerNodesScreenCommands = vi.fn();
-const registerNodesStatusCommands = vi.fn();
 
 vi.mock("../plugins/cli.js", () => ({
   registerPluginCliCommandsFromValidatedConfig,
 }));
-
-vi.mock("./nodes-cli/register.camera.js", () => ({ registerNodesCameraCommands }));
-vi.mock("./nodes-cli/register.invoke.js", () => ({ registerNodesInvokeCommands }));
-vi.mock("./nodes-cli/register.location.js", () => ({ registerNodesLocationCommands }));
-vi.mock("./nodes-cli/register.notify.js", () => ({ registerNodesNotifyCommand }));
-vi.mock("./nodes-cli/register.pairing.js", () => ({ registerNodesPairingCommands }));
-vi.mock("./nodes-cli/register.push.js", () => ({ registerNodesPushCommand }));
-vi.mock("./nodes-cli/register.screen.js", () => ({ registerNodesScreenCommands }));
-vi.mock("./nodes-cli/register.status.js", () => ({ registerNodesStatusCommands }));
 
 const { registerNodesCli } = await import("./nodes-cli/register.js");
 
@@ -50,14 +35,29 @@ describe("registerNodesCli plugin registration", () => {
     return program;
   }
 
-  it("routes plugin registration logs to stderr for nodes --json commands", async () => {
+  it("skips plugin CLI/runtime registration for built-in nodes subcommands", async () => {
+    for (const subcommand of ["status", "list", "describe", "invoke", "pending", "camera"]) {
+      registerPluginCliCommandsFromValidatedConfig.mockClear();
+      await registerWithArgv(["node", "openclaw", "nodes", subcommand, "--json"]);
+      expect(registerPluginCliCommandsFromValidatedConfig).not.toHaveBeenCalled();
+    }
+  });
+
+  it("registers plugin-provided node subcommands lazily and routes their logs to stderr", async () => {
     let forceStderrDuringRegistration = false;
     registerPluginCliCommandsFromValidatedConfig.mockImplementationOnce(async () => {
       forceStderrDuringRegistration = loggingState.forceConsoleToStderr;
       return {};
     });
 
-    const program = await registerWithArgv(["node", "openclaw", "nodes", "list", "--json"]);
+    const program = await registerWithArgv([
+      "node",
+      "openclaw",
+      "nodes",
+      "canvas",
+      "snapshot",
+      "--json",
+    ]);
 
     expect(registerPluginCliCommandsFromValidatedConfig).toHaveBeenCalledWith(
       program,
@@ -69,6 +69,16 @@ describe("registerNodesCli plugin registration", () => {
     expect(loggingState.forceConsoleToStderr).toBe(false);
   });
 
+  it("surfaces plugin subcommands for bare `nodes` listing", async () => {
+    const program = await registerWithArgv(["node", "openclaw", "nodes"]);
+    expect(registerPluginCliCommandsFromValidatedConfig).toHaveBeenCalledWith(
+      program,
+      undefined,
+      undefined,
+      { mode: "lazy", primary: "nodes" },
+    );
+  });
+
   it("does not route pass-through --json after the terminator", async () => {
     let forceStderrDuringRegistration = true;
     registerPluginCliCommandsFromValidatedConfig.mockImplementationOnce(async () => {
@@ -76,7 +86,7 @@ describe("registerNodesCli plugin registration", () => {
       return {};
     });
 
-    await registerWithArgv(["node", "openclaw", "nodes", "invoke", "--", "--json"]);
+    await registerWithArgv(["node", "openclaw", "nodes", "canvas", "--", "--json"]);
 
     expect(forceStderrDuringRegistration).toBe(false);
     expect(loggingState.forceConsoleToStderr).toBe(false);

--- a/src/cli/nodes-cli/register.ts
+++ b/src/cli/nodes-cli/register.ts
@@ -2,6 +2,7 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { resolveCliArgvInvocation } from "../argv-invocation.js";
 import { formatHelpExamples } from "../help-format.js";
 import { withConsoleLogsRoutedToStderrForJson } from "../json-output-mode.js";
 import { registerNodesCameraCommands } from "./register.camera.js";
@@ -42,6 +43,13 @@ export async function registerNodesCli(program: Command, argv: readonly string[]
   registerNodesScreenCommands(nodes);
   registerNodesLocationCommands(nodes);
 
+  // Built-in `nodes` subcommands (status/list/pairing/invoke/...) must stay on the lightweight
+  // path: loading plugin CLI/runtime to resolve them only adds startup cost. Plugin-provided node
+  // subcommands (e.g. `nodes canvas`) are not registered above, so only pay the plugin load when
+  // the invoked subcommand is not already a built-in.
+  if (!shouldRegisterNodesPluginCommands(nodes, argv)) {
+    return;
+  }
   const { registerPluginCliCommandsFromValidatedConfig } = await import("../../plugins/cli.js");
   await withConsoleLogsRoutedToStderrForJson(
     argv,
@@ -51,4 +59,20 @@ export async function registerNodesCli(program: Command, argv: readonly string[]
         primary: "nodes",
       }),
   );
+}
+
+/** Plugin node subcommands are only resolved when the invocation is not a built-in nodes command. */
+function shouldRegisterNodesPluginCommands(nodes: Command, argv: readonly string[]): boolean {
+  const { commandPath } = resolveCliArgvInvocation([...argv]);
+  if (commandPath[0] !== "nodes") {
+    // Eager registration (root help/completion) needs the full command tree, plugins included.
+    return true;
+  }
+  const requestedSubcommand = commandPath[1];
+  if (!requestedSubcommand) {
+    // Bare `openclaw nodes` listing should still surface plugin-provided subcommands.
+    return true;
+  }
+  const builtInSubcommands = new Set(nodes.commands.map((command) => command.name()));
+  return !builtInSubcommands.has(requestedSubcommand);
 }


### PR DESCRIPTION
## What Problem This Solves

`openclaw nodes status` / `openclaw nodes list` are lightweight built-in CLI commands, but on recent versions they load the full plugin CLI/runtime during command registration. `registerNodesCli` (`src/cli/nodes-cli/register.ts`) unconditionally calls `registerPluginCliCommandsFromValidatedConfig(program, undefined, undefined, { mode: "lazy", primary: "nodes" })`, so enabled plugins initialize even for these built-in commands.

This is a regression: the reporter observed `openclaw nodes status --json --connected` taking ~10.5s on 2026.5.28 vs ~1.3s on 2026.5.7, and confirmed that removing the unconditional plugin registration drops it to ~0.95s. The `nodes` command family resolves to `loadPlugins: "never"` under the command-path policy, so it should stay on the no-plugin path. Fixes #96697.

## Why This Change Was Made

The unconditional plugin registration block was introduced when canvas moved from a built-in node command to a plugin surface (commit `330ba1fa31`), so that plugin-provided node subcommands such as `nodes canvas` still register under `nodes`. Simply removing the block (or hard-guarding it on the `nodes` path policy, which is always `"never"`) would also drop plugin-provided node subcommands.

The fix keeps both properties: built-in node subcommands stay fast, and plugin-provided subcommands still resolve. After the built-in commands are registered, `registerNodesCli` now skips the plugin CLI/runtime load when the invoked subcommand is already a registered built-in (`status`, `list`, `describe`, `invoke`, `pending`, `camera`, …). Plugin load is only paid when the invoked subcommand is not a built-in (e.g. `nodes canvas`), for bare `nodes` listing, and during eager/root-help registration — preserving the full command tree where it matters.

Reading the actually-registered `nodes.commands` (rather than a hardcoded name list) means future built-in subcommand additions stay on the fast path automatically.

## User Impact

- `openclaw nodes status` / `nodes list` and other built-in node subcommands no longer trigger plugin CLI/runtime initialization, restoring fast startup for node discovery and health-check automation.
- Plugin-provided node subcommands (e.g. `nodes canvas`) and `nodes` help/listing are unchanged.
- No config, schema, or public CLI surface changes.

## Evidence

### Real behavior proof

Ran the actual CLI from source (`node --import tsx` → `runCli`) with bundled plugins present. The "Config warnings: plugins: …" line is emitted only when the plugin CLI/runtime load path runs during registration, so it is a direct signal of whether plugins were loaded.

**Before fix** (parent commit, unconditional registration) — `nodes status` loads plugins:

```
$ openclaw nodes status --json --connected
Config warnings:
- plugins: plugin: OpenClaw source checkout detected without pnpm workspace dependencies; run `pnpm install` from the repo root so bundled plugins can load package-local dependencies.
>>> PLUGINS LOADED (warning present, before any gateway call)
```

**After fix** — the same built-in command stays on the clean no-plugin path:

```
$ openclaw nodes status --json --connected
>>> NO plugin output (no plugin CLI/runtime load); command proceeds straight to the gateway call
```

**After fix** — plugin-provided `nodes canvas` still resolves on demand (plugins loaded only here):

```
$ openclaw nodes canvas --help
Config warnings:
- plugins: plugin: OpenClaw source checkout detected without pnpm workspace dependencies; ...
Usage: openclaw nodes canvas [options] [command]
Commands:
  a2ui        Render A2UI content on the canvas
  eval        Evaluate JavaScript in the canvas
  snapshot    Capture a canvas snapshot (prints the saved path)
  ...
```

`openclaw nodes --help` (bare) still lists `canvas` alongside the built-ins, confirming plugin extensions are preserved.

### Tests

`src/cli/nodes-cli.plugin-registration.test.ts` drives the **real** built-in node command registration (only the plugin-loader boundary is stubbed), so the guard is exercised against the actual registered subcommand names:

- Built-in subcommands (`status`, `list`, `describe`, `invoke`, `pending`, `camera`) → `registerPluginCliCommandsFromValidatedConfig` is **not** called.
- Plugin-provided subcommand (`nodes canvas snapshot --json`) → plugin commands registered lazily with `{ mode: "lazy", primary: "nodes" }`, and registration logs are routed to stderr in JSON mode.
- Bare `nodes` listing → plugin subcommands still surfaced.
- Pass-through `nodes canvas -- --json` → terminator still suppresses JSON-mode stderr routing.

```
$ node scripts/run-vitest.mjs src/cli/nodes-cli.plugin-registration.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ node scripts/run-vitest.mjs src/cli/program.nodes-basic.e2e.test.ts
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

`oxfmt` and `oxlint` clean on the changed files. Full typecheck/build run in CI (all green).

---
AI-assisted.
