### PR TITLE
fix(slack): fail unconfirmed threaded deliveries

### DIFF
--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -332,6 +332,39 @@ describe("handleSlackAction", () => {
     });
   });
 
+  it("does not mark first reply used when threaded send confirmation fails", async () => {
+    const cfg = slackConfig();
+    const hasRepliedRef = { value: false };
+    sendSlackMessage.mockRejectedValueOnce(
+      new Error("Slack delivery did not confirm thread 1234567890.123456 for channel:C123"),
+    );
+
+    await expect(
+      handleSlackAction(
+        {
+          action: "sendMessage",
+          to: "channel:C123",
+          content: "Hello thread",
+          threadTs: "1234567890.123456",
+        },
+        cfg,
+        {
+          currentChannelId: "C123",
+          replyToMode: "first",
+          hasRepliedRef,
+        },
+      ),
+    ).rejects.toThrow(/did not confirm thread 1234567890\.123456/i);
+
+    expectSlackSendCall(0, "channel:C123", "Hello thread", {
+      cfg,
+      mediaUrl: undefined,
+      threadTs: "1234567890.123456",
+      blocks: undefined,
+    });
+    expect(hasRepliedRef.value).toBe(false);
+  });
+
   it("passes replyBroadcast to sendSlackMessage for thread replies", async () => {
     const cfg = slackConfig();
     await handleSlackAction(

--- a/extensions/slack/src/channel.message-adapter.test.ts
+++ b/extensions/slack/src/channel.message-adapter.test.ts
@@ -136,6 +136,12 @@ describe("slack channel message adapter", () => {
 
     const proveReplyThread = async () => {
       sendSlack.mockClear();
+      sendSlack.mockResolvedValueOnce({
+        messageId: "msg-1",
+        channelId: "C123",
+        threadTs: "1712000000.000001",
+        confirmedThreadTs: "1712000000.000001",
+      });
       const result = await sendText({
         cfg,
         to: "C123",
@@ -155,6 +161,12 @@ describe("slack channel message adapter", () => {
 
     const proveThreadFallback = async () => {
       sendSlack.mockClear();
+      sendSlack.mockResolvedValueOnce({
+        messageId: "msg-1",
+        channelId: "C123",
+        threadTs: "1712345678.123456",
+        confirmedThreadTs: "1712345678.123456",
+      });
       const result = await sendText({
         cfg,
         to: "C123",

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -677,7 +677,11 @@ describe("slackPlugin outbound", () => {
   });
 
   it("uses threadId as threadTs fallback for sendText", async () => {
-    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-text" });
+    const sendSlack = vi.fn().mockResolvedValue({
+      messageId: "m-text",
+      threadTs: "1712345678.123456",
+      confirmedThreadTs: "1712345678.123456",
+    });
     const sendText = requireSlackSendText();
 
     const result = await sendText({
@@ -692,7 +696,34 @@ describe("slackPlugin outbound", () => {
     expect(requireMockCallArgValue(sendSlack, 0, 0)).toBe("C123");
     expect(requireMockCallArgValue(sendSlack, 0, 1)).toBe("hello");
     expect(requireMockCallArg(sendSlack, 0, 2).threadTs).toBe("1712345678.123456");
-    expect(result).toEqual({ channel: "slack", messageId: "m-text" });
+    expect(result).toEqual({
+      channel: "slack",
+      messageId: "m-text",
+      threadTs: "1712345678.123456",
+      confirmedThreadTs: "1712345678.123456",
+    });
+  });
+
+  it("fails sendText when Slack does not confirm the requested thread", async () => {
+    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-text" });
+    const sendText = requireSlackSendText();
+
+    await expect(
+      sendText({
+        cfg,
+        to: "C123",
+        text: "hello",
+        accountId: "default",
+        threadId: "1712345678.123456",
+        deps: { sendSlack },
+      }),
+    ).rejects.toThrow(
+      "Slack delivery did not confirm thread 1712345678.123456 for C123; delivered message m-text",
+    );
+
+    expect(requireMockCallArgValue(sendSlack, 0, 0)).toBe("C123");
+    expect(requireMockCallArgValue(sendSlack, 0, 1)).toBe("hello");
+    expect(requireMockCallArg(sendSlack, 0, 2).threadTs).toBe("1712345678.123456");
   });
 
   it("prefers replyToId over threadId for sendMedia", async () => {
@@ -720,7 +751,11 @@ describe("slackPlugin outbound", () => {
   });
 
   it("falls back to threadId when replyToId is not a Slack thread timestamp", async () => {
-    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-text" });
+    const sendSlack = vi.fn().mockResolvedValue({
+      messageId: "m-text",
+      threadTs: "1712345678.123456",
+      confirmedThreadTs: "1712345678.123456",
+    });
     const sendText = requireSlackSendText();
 
     const result = await sendText({
@@ -736,7 +771,12 @@ describe("slackPlugin outbound", () => {
     expect(requireMockCallArgValue(sendSlack, 0, 0)).toBe("C123");
     expect(requireMockCallArgValue(sendSlack, 0, 1)).toBe("hello");
     expect(requireMockCallArg(sendSlack, 0, 2).threadTs).toBe("1712345678.123456");
-    expect(result).toEqual({ channel: "slack", messageId: "m-text" });
+    expect(result).toEqual({
+      channel: "slack",
+      messageId: "m-text",
+      threadTs: "1712345678.123456",
+      confirmedThreadTs: "1712345678.123456",
+    });
   });
 
   it("does not stringify numeric Slack thread ids", async () => {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -72,6 +72,7 @@ import {
 } from "./shared.js";
 import { parseSlackTarget } from "./target-parsing.js";
 import { slackContextTargetsMatch } from "./targets.js";
+import { assertSlackThreadDeliveryResult } from "./thread-delivery-confirmation.js";
 import { normalizeSlackThreadTsCandidate, resolveSlackThreadTsValue } from "./thread-ts.js";
 import { buildSlackThreadingToolContext } from "./threading-tool-context.js";
 
@@ -481,12 +482,14 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
         replyToId,
         threadId,
       });
-      return await send(to, text, {
+      const result = await send(to, text, {
         cfg,
         threadTs: threadTsValue,
         accountId: accountId ?? undefined,
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });
+      assertSlackThreadDeliveryResult({ result, to, threadTs: threadTsValue });
+      return result;
     },
     sendMedia: async ({
       to,
@@ -661,8 +664,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
         }
         return resolveTargetsWithOptionalToken({
           token:
-            normalizeOptionalString(account.userToken) ??
-            normalizeOptionalString(account.botToken),
+            normalizeOptionalString(account.userToken) ?? normalizeOptionalString(account.botToken),
           inputs,
           missingTokenNote: "missing Slack token",
           resolveWithToken: async ({ token, inputs: inputsLocal }) =>

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -179,6 +179,25 @@ describe("deliverReplies identity passthrough", () => {
     expect(blocks[1]?.elements?.[0]?.value).toBe("approve");
   });
 
+  it("propagates threaded text delivery confirmation failures", async () => {
+    sendMock.mockRejectedValueOnce(
+      new Error("Slack delivery did not confirm thread 1712345678.123456 for C123"),
+    );
+
+    await expect(
+      deliverReplies(
+        baseParams({
+          replies: [{ text: "threaded update" }],
+          replyThreadTs: "1712345678.123456",
+          replyToMode: "all",
+        }),
+      ),
+    ).rejects.toThrow(/did not confirm thread 1712345678\.123456/i);
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(requireSendCall()[2].threadTs).toBe("1712345678.123456");
+  });
+
   it("rejects replies when merged Slack blocks exceed the platform limit", async () => {
     sendMock.mockResolvedValue(undefined);
 

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -110,7 +110,10 @@ describe("slackOutbound", () => {
   });
 
   it("falls back to threadId when payload replyToId is not a Slack thread timestamp", async () => {
-    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-blocks" });
+    sendMessageSlackMock.mockResolvedValueOnce({
+      messageId: "m-blocks",
+      threadTs: "1712345678.123456",
+    });
 
     await slackOutbound.sendPayload!({
       cfg,
@@ -162,6 +165,86 @@ describe("slackOutbound", () => {
       threadTs: undefined,
       accountId: "default",
       blocks: [{ type: "divider" }],
+    });
+  });
+
+  it("fails threaded payload delivery when Slack does not confirm the origin thread", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "1712349999.000001" });
+
+    await expect(
+      slackOutbound.sendPayload!({
+        cfg,
+        to: "C123",
+        text: "",
+        threadId: "1712345678.123456",
+        payload: {
+          text: "fallback text",
+          channelData: {
+            slack: {
+              blocks: [{ type: "divider" }],
+            },
+          },
+        },
+        accountId: "default",
+      }),
+    ).rejects.toThrow(
+      "Slack delivery did not confirm thread 1712345678.123456 for C123; delivered message 1712349999.000001",
+    );
+  });
+
+  it("fails threaded payload delivery when Slack confirms a different thread", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({
+      messageId: "1712349999.000001",
+      threadTs: "1712340000.000001",
+    });
+
+    await expect(
+      slackOutbound.sendPayload!({
+        cfg,
+        to: "C123",
+        text: "",
+        threadId: "1712345678.123456",
+        payload: {
+          text: "fallback text",
+          channelData: {
+            slack: {
+              blocks: [{ type: "divider" }],
+            },
+          },
+        },
+        accountId: "default",
+      }),
+    ).rejects.toThrow(
+      "Slack delivery did not confirm thread 1712345678.123456 for C123; delivered thread 1712340000.000001",
+    );
+  });
+
+  it("accepts threaded payload delivery when Slack confirms the origin thread", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({
+      messageId: "1712349999.000001",
+      threadTs: "1712345678.123456",
+    });
+
+    const result = await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      threadId: "1712345678.123456",
+      payload: {
+        text: "fallback text",
+        channelData: {
+          slack: {
+            blocks: [{ type: "divider" }],
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(result).toEqual({
+      channel: "slack",
+      messageId: "1712349999.000001",
+      threadTs: "1712345678.123456",
     });
   });
 });

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -278,4 +278,35 @@ describe("slackOutbound", () => {
       confirmedThreadTs: "1712345678.123456",
     });
   });
+
+  it("preserves threaded media delivery when upload results only echo the requested thread", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({
+      messageId: "1712349999.000001",
+      threadTs: "1712345678.123456",
+    });
+
+    const result = await slackOutbound.sendMedia!({
+      cfg,
+      to: "C123",
+      text: "caption",
+      mediaUrl: "https://example.com/threaded.png",
+      threadId: "1712345678.123456",
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledWith("C123", "caption", {
+      cfg,
+      threadTs: "1712345678.123456",
+      accountId: "default",
+      mediaUrl: "https://example.com/threaded.png",
+      mediaAccess: undefined,
+      mediaLocalRoots: undefined,
+      mediaReadFile: undefined,
+    });
+    expect(result).toEqual({
+      channel: "slack",
+      messageId: "1712349999.000001",
+      threadTs: "1712345678.123456",
+    });
+  });
 });

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -113,6 +113,7 @@ describe("slackOutbound", () => {
     sendMessageSlackMock.mockResolvedValueOnce({
       messageId: "m-blocks",
       threadTs: "1712345678.123456",
+      confirmedThreadTs: "1712345678.123456",
     });
 
     await slackOutbound.sendPayload!({
@@ -196,6 +197,7 @@ describe("slackOutbound", () => {
     sendMessageSlackMock.mockResolvedValueOnce({
       messageId: "1712349999.000001",
       threadTs: "1712340000.000001",
+      confirmedThreadTs: "1712340000.000001",
     });
 
     await expect(
@@ -219,10 +221,38 @@ describe("slackOutbound", () => {
     );
   });
 
+  it("fails threaded payload delivery when only the requested thread is echoed", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({
+      messageId: "1712349999.000001",
+      threadTs: "1712345678.123456",
+    });
+
+    await expect(
+      slackOutbound.sendPayload!({
+        cfg,
+        to: "C123",
+        text: "",
+        threadId: "1712345678.123456",
+        payload: {
+          text: "fallback text",
+          channelData: {
+            slack: {
+              blocks: [{ type: "divider" }],
+            },
+          },
+        },
+        accountId: "default",
+      }),
+    ).rejects.toThrow(
+      "Slack delivery did not confirm thread 1712345678.123456 for C123; delivered message 1712349999.000001",
+    );
+  });
+
   it("accepts threaded payload delivery when Slack confirms the origin thread", async () => {
     sendMessageSlackMock.mockResolvedValueOnce({
       messageId: "1712349999.000001",
       threadTs: "1712345678.123456",
+      confirmedThreadTs: "1712345678.123456",
     });
 
     const result = await slackOutbound.sendPayload!({
@@ -245,6 +275,7 @@ describe("slackOutbound", () => {
       channel: "slack",
       messageId: "1712349999.000001",
       threadTs: "1712345678.123456",
+      confirmedThreadTs: "1712345678.123456",
     });
   });
 });

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -27,6 +27,7 @@ import {
 import { compileSlackInteractiveReplies } from "./interactive-replies.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
 import type { SlackSendIdentity } from "./send.js";
+import { assertSlackThreadDeliveryResult } from "./thread-delivery-confirmation.js";
 import { resolveSlackThreadTsValue } from "./thread-ts.js";
 
 const SLACK_MAX_BLOCKS = 50;
@@ -65,29 +66,6 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
     return undefined;
   }
   return { username, iconUrl, iconEmoji };
-}
-
-function assertSlackThreadDeliveryResult(params: {
-  result: Awaited<ReturnType<SlackSendFn>>;
-  to: string;
-  threadTs?: string;
-}) {
-  if (!params.threadTs) {
-    return;
-  }
-  const deliveredThreadTs = normalizeOptionalString(params.result?.confirmedThreadTs);
-  if (deliveredThreadTs === params.threadTs) {
-    return;
-  }
-  const deliveredMessageId = normalizeOptionalString(params.result?.messageId);
-  const suffix = deliveredThreadTs
-    ? `; delivered thread ${deliveredThreadTs}`
-    : deliveredMessageId
-      ? `; delivered message ${deliveredMessageId}`
-      : "";
-  throw new Error(
-    `Slack delivery did not confirm thread ${params.threadTs} for ${params.to}${suffix}`,
-  );
 }
 
 async function sendSlackOutboundMessage(params: {

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -67,6 +67,29 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
   return { username, iconUrl, iconEmoji };
 }
 
+function assertSlackThreadDeliveryResult(params: {
+  result: Awaited<ReturnType<SlackSendFn>>;
+  to: string;
+  threadTs?: string;
+}) {
+  if (!params.threadTs) {
+    return;
+  }
+  const deliveredThreadTs = normalizeOptionalString(params.result?.threadTs);
+  if (deliveredThreadTs === params.threadTs) {
+    return;
+  }
+  const deliveredMessageId = normalizeOptionalString(params.result?.messageId);
+  const suffix = deliveredThreadTs
+    ? `; delivered thread ${deliveredThreadTs}`
+    : deliveredMessageId
+      ? `; delivered message ${deliveredMessageId}`
+      : "";
+  throw new Error(
+    `Slack delivery did not confirm thread ${params.threadTs} for ${params.to}${suffix}`,
+  );
+}
+
 async function sendSlackOutboundMessage(params: {
   cfg: NonNullable<NonNullable<Parameters<SlackSendFn>[2]>["cfg"]>;
   to: string;
@@ -108,6 +131,7 @@ async function sendSlackOutboundMessage(params: {
     ...(params.blocks ? { blocks: params.blocks } : {}),
     ...(slackIdentity ? { identity: slackIdentity } : {}),
   });
+  assertSlackThreadDeliveryResult({ result, to: params.to, threadTs });
   return result;
 }
 

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -131,7 +131,9 @@ async function sendSlackOutboundMessage(params: {
     ...(params.blocks ? { blocks: params.blocks } : {}),
     ...(slackIdentity ? { identity: slackIdentity } : {}),
   });
-  assertSlackThreadDeliveryResult({ result, to: params.to, threadTs });
+  if (!params.mediaUrl) {
+    assertSlackThreadDeliveryResult({ result, to: params.to, threadTs });
+  }
   return result;
 }
 

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -75,7 +75,7 @@ function assertSlackThreadDeliveryResult(params: {
   if (!params.threadTs) {
     return;
   }
-  const deliveredThreadTs = normalizeOptionalString(params.result?.threadTs);
+  const deliveredThreadTs = normalizeOptionalString(params.result?.confirmedThreadTs);
   if (deliveredThreadTs === params.threadTs) {
     return;
   }

--- a/extensions/slack/src/outbound-delivery.test.ts
+++ b/extensions/slack/src/outbound-delivery.test.ts
@@ -58,6 +58,12 @@ describe("slack outbound shared hook wiring", () => {
   });
 
   it("fires message_sending once with shared routing fields", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({
+      messageId: "m1",
+      channelId: "C123",
+      threadTs: "1712000000.000001",
+      confirmedThreadTs: "1712000000.000001",
+    });
     const hookRegistry = createEmptyPluginRegistry();
     const handler = vi.fn().mockResolvedValue(undefined);
     addTestHook({
@@ -99,6 +105,12 @@ describe("slack outbound shared hook wiring", () => {
   });
 
   it("passes replyToId as Slack threadTs for threaded outbound delivery", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({
+      messageId: "m1",
+      channelId: "C123",
+      threadTs: "1712000000.000001",
+      confirmedThreadTs: "1712000000.000001",
+    });
     await deliverOutboundPayloads({
       cfg,
       channel: "slack",

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -99,6 +99,14 @@ describe("sendMessageSlack thread participation", () => {
   it("records participation after a successful threaded send", async () => {
     clearSlackThreadParticipationCache();
     const client = createSlackSendTestClient();
+    client.chat.postMessage.mockResolvedValueOnce({
+      ts: "171234.567",
+      channel: "C123",
+      message: {
+        ts: "171234.567",
+        thread_ts: "1712345678.123456",
+      },
+    });
 
     const result = await sendMessageSlack("channel:C123", "hello thread", {
       token: "xoxb-test",
@@ -108,12 +116,12 @@ describe("sendMessageSlack thread participation", () => {
     });
 
     expect(result.threadTs).toBe("1712345678.123456");
-    expect(result.confirmedThreadTs).toBeUndefined();
+    expect(result.confirmedThreadTs).toBe("1712345678.123456");
     expect(result.receipt.threadId).toBe("1712345678.123456");
     expect(hasSlackThreadParticipation("default", "C123", "1712345678.123456")).toBe(true);
   });
 
-  it("records canonical Slack response thread participation instead of requested child thread", async () => {
+  it("rejects threaded sends when Slack confirms a different thread", async () => {
     clearSlackThreadParticipationCache();
     const client = createSlackSendTestClient();
     client.chat.postMessage.mockResolvedValueOnce({
@@ -125,19 +133,34 @@ describe("sendMessageSlack thread participation", () => {
       },
     });
 
-    const result = await sendMessageSlack("channel:C123", "hello thread", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      threadTs: "1781932168.648159",
-    });
+    await expect(
+      sendMessageSlack("channel:C123", "hello thread", {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+        threadTs: "1781932168.648159",
+      }),
+    ).rejects.toThrow(/did not confirm thread 1781932168\.648159/i);
 
-    expect(postedMessage(client).thread_ts).toBe("1781932168.648159");
-    expect(result.threadTs).toBe("1781803536.235489");
-    expect(result.confirmedThreadTs).toBe("1781803536.235489");
-    expect(result.receipt.threadId).toBe("1781803536.235489");
-    expect(hasSlackThreadParticipation("default", "C123", "1781803536.235489")).toBe(true);
     expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(false);
+    expect(hasSlackThreadParticipation("default", "C123", "1781803536.235489")).toBe(false);
+  });
+
+  it("rejects threaded sends when Slack omits confirmed thread evidence", async () => {
+    clearSlackThreadParticipationCache();
+    const client = createSlackSendTestClient();
+
+    await expect(
+      sendMessageSlack("channel:C123", "hello thread", {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+        threadTs: "1712345678.123456",
+      }),
+    ).rejects.toThrow(/did not confirm thread 1712345678\.123456/i);
+
+    expect(postedMessage(client).thread_ts).toBe("1712345678.123456");
+    expect(hasSlackThreadParticipation("default", "C123", "1712345678.123456")).toBe(false);
   });
 
   it("does not record participation for unthreaded sends", async () => {
@@ -157,12 +180,14 @@ describe("sendMessageSlack thread participation", () => {
     clearSlackThreadParticipationCache();
     const client = createSlackSendTestClient();
 
-    await sendMessageSlack("channel:C123", "hello invalid thread", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      threadTs: "not-a-slack-thread",
-    });
+    await expect(
+      sendMessageSlack("channel:C123", "hello invalid thread", {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+        threadTs: "not-a-slack-thread",
+      }),
+    ).rejects.toThrow(/did not confirm thread not-a-slack-thread/i);
 
     expect(hasSlackThreadParticipation("default", "C123", "not-a-slack-thread")).toBe(false);
   });
@@ -214,7 +239,7 @@ describe("sendMessageSlack chunking", () => {
         channel: "C123",
         message: {
           ts: "1781932190.115869",
-          thread_ts: "1781803536.235489",
+          thread_ts: "1781932168.648159",
         },
       })
       .mockResolvedValueOnce({
@@ -233,11 +258,10 @@ describe("sendMessageSlack chunking", () => {
     expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
     expect(postedMessage(client).thread_ts).toBe("1781932168.648159");
     expect(postedMessage(client, 1).thread_ts).toBe("1781932168.648159");
-    expect(result.threadTs).toBe("1781803536.235489");
-    expect(result.confirmedThreadTs).toBe("1781803536.235489");
-    expect(result.receipt.threadId).toBe("1781803536.235489");
-    expect(hasSlackThreadParticipation("default", "C123", "1781803536.235489")).toBe(true);
-    expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(false);
+    expect(result.threadTs).toBe("1781932168.648159");
+    expect(result.confirmedThreadTs).toBe("1781932168.648159");
+    expect(result.receipt.threadId).toBe("1781932168.648159");
+    expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(true);
   });
 });
 
@@ -267,7 +291,7 @@ describe("sendMessageSlack blocks", () => {
     expect((receiptPart?.raw as Record<string, unknown> | undefined)?.channelId).toBe("C123");
   });
 
-  it("uses canonical Slack response thread for block receipts and participation", async () => {
+  it("uses confirmed Slack response thread for block receipts and participation", async () => {
     clearSlackThreadParticipationCache();
     const client = createSlackSendTestClient();
     client.chat.postMessage.mockResolvedValueOnce({
@@ -275,7 +299,7 @@ describe("sendMessageSlack blocks", () => {
       channel: "C123",
       message: {
         ts: "1781932190.115869",
-        thread_ts: "1781803536.235489",
+        thread_ts: "1781932168.648159",
       },
     });
 
@@ -288,12 +312,11 @@ describe("sendMessageSlack blocks", () => {
     });
 
     expect(postedMessage(client).thread_ts).toBe("1781932168.648159");
-    expect(result.threadTs).toBe("1781803536.235489");
-    expect(result.confirmedThreadTs).toBe("1781803536.235489");
-    expect(result.receipt.threadId).toBe("1781803536.235489");
+    expect(result.threadTs).toBe("1781932168.648159");
+    expect(result.confirmedThreadTs).toBe("1781932168.648159");
+    expect(result.receipt.threadId).toBe("1781932168.648159");
     expect(result.receipt.parts[0]?.kind).toBe("card");
-    expect(hasSlackThreadParticipation("default", "C123", "1781803536.235489")).toBe(true);
-    expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(false);
+    expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(true);
   });
 
   it("posts user-target block messages directly without conversations.open", async () => {
@@ -341,6 +364,14 @@ describe("sendMessageSlack blocks", () => {
     client.conversations.open
       .mockRejectedValueOnce(slackDnsRequestError())
       .mockResolvedValueOnce({ channel: { id: "D123" } });
+    client.chat.postMessage.mockResolvedValueOnce({
+      ts: "171234.567",
+      channel: "D123",
+      message: {
+        ts: "171234.567",
+        thread_ts: "171234.100",
+      },
+    });
 
     const result = await sendMessageSlack("user:U123", "hello", {
       token: "xoxb-test",
@@ -355,11 +386,19 @@ describe("sendMessageSlack blocks", () => {
     expect(result.messageId).toBe("171234.567");
     expect(result.channelId).toBe("D123");
     expect(result.receipt.threadId).toBe("171234.100");
-    expect(result.confirmedThreadTs).toBeUndefined();
+    expect(result.confirmedThreadTs).toBe("171234.100");
   });
 
   it("passes reply_broadcast for threaded text sends only on the first chunk", async () => {
     const client = createSlackSendTestClient();
+    client.chat.postMessage.mockResolvedValueOnce({
+      ts: "171234.567",
+      channel: "C123",
+      message: {
+        ts: "171234.567",
+        thread_ts: "171234.100",
+      },
+    });
 
     await sendMessageSlack("channel:C123", "a".repeat(8500), {
       token: "xoxb-test",

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -108,6 +108,7 @@ describe("sendMessageSlack thread participation", () => {
     });
 
     expect(result.threadTs).toBe("1712345678.123456");
+    expect(result.confirmedThreadTs).toBeUndefined();
     expect(result.receipt.threadId).toBe("1712345678.123456");
     expect(hasSlackThreadParticipation("default", "C123", "1712345678.123456")).toBe(true);
   });
@@ -133,6 +134,7 @@ describe("sendMessageSlack thread participation", () => {
 
     expect(postedMessage(client).thread_ts).toBe("1781932168.648159");
     expect(result.threadTs).toBe("1781803536.235489");
+    expect(result.confirmedThreadTs).toBe("1781803536.235489");
     expect(result.receipt.threadId).toBe("1781803536.235489");
     expect(hasSlackThreadParticipation("default", "C123", "1781803536.235489")).toBe(true);
     expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(false);
@@ -232,6 +234,7 @@ describe("sendMessageSlack chunking", () => {
     expect(postedMessage(client).thread_ts).toBe("1781932168.648159");
     expect(postedMessage(client, 1).thread_ts).toBe("1781932168.648159");
     expect(result.threadTs).toBe("1781803536.235489");
+    expect(result.confirmedThreadTs).toBe("1781803536.235489");
     expect(result.receipt.threadId).toBe("1781803536.235489");
     expect(hasSlackThreadParticipation("default", "C123", "1781803536.235489")).toBe(true);
     expect(hasSlackThreadParticipation("default", "C123", "1781932168.648159")).toBe(false);
@@ -286,6 +289,7 @@ describe("sendMessageSlack blocks", () => {
 
     expect(postedMessage(client).thread_ts).toBe("1781932168.648159");
     expect(result.threadTs).toBe("1781803536.235489");
+    expect(result.confirmedThreadTs).toBe("1781803536.235489");
     expect(result.receipt.threadId).toBe("1781803536.235489");
     expect(result.receipt.parts[0]?.kind).toBe("card");
     expect(hasSlackThreadParticipation("default", "C123", "1781803536.235489")).toBe(true);
@@ -351,6 +355,7 @@ describe("sendMessageSlack blocks", () => {
     expect(result.messageId).toBe("171234.567");
     expect(result.channelId).toBe("D123");
     expect(result.receipt.threadId).toBe("171234.100");
+    expect(result.confirmedThreadTs).toBeUndefined();
   });
 
   it("passes reply_broadcast for threaded text sends only on the first chunk", async () => {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -35,6 +35,7 @@ import { SLACK_TEXT_LIMIT } from "./limits.js";
 import { loadOutboundMediaFromUrl } from "./runtime-api.js";
 import { recordSlackThreadParticipation } from "./sent-thread-cache.js";
 import { parseSlackTarget } from "./targets.js";
+import { assertSlackThreadDeliveryResult } from "./thread-delivery-confirmation.js";
 import { normalizeSlackThreadTsCandidate } from "./thread-ts.js";
 import { resolveSlackBotToken } from "./token.js";
 import { truncateSlackText } from "./truncate.js";
@@ -718,6 +719,9 @@ export async function sendMessageSlack(
       blocks,
     }),
   );
+  if (!opts.mediaUrl) {
+    assertSlackThreadDeliveryResult({ result, to, threadTs: opts.threadTs });
+  }
   const threadTs = result.threadTs ?? normalizeSlackThreadTsCandidate(opts.threadTs);
   if (threadTs && result.channelId && account.accountId) {
     recordSlackThreadParticipation(account.accountId, result.channelId, threadTs);

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -413,6 +413,7 @@ export type SlackSendResult = {
   channelId: string;
   receipt: MessageReceipt;
   threadTs?: string;
+  confirmedThreadTs?: string;
 };
 
 function createSlackSendReceipt(params: {
@@ -794,12 +795,13 @@ async function sendMessageSlackQueuedInner(params: {
     });
     const messageId = response.ts ?? "unknown";
     const deliveredChannelId = resolvePostedMessageChannelId(response, channelId);
-    const deliveredThreadTs =
-      resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
+    const confirmedThreadTs = resolvePostedMessageThreadTs(response);
+    const deliveredThreadTs = confirmedThreadTs ?? normalizeSlackThreadTsCandidate(opts.threadTs);
     return {
       messageId,
       channelId: deliveredChannelId,
       threadTs: deliveredThreadTs,
+      ...(confirmedThreadTs ? { confirmedThreadTs } : {}),
       receipt: createSlackSendReceipt({
         platformMessageIds: [messageId],
         channelId: deliveredChannelId,
@@ -834,7 +836,7 @@ async function sendMessageSlackQueuedInner(params: {
   const sentMessageIds: string[] = [];
   let lastMessageId = "";
   let deliveredChannelId = channelId;
-  let canonicalDeliveredThreadTs: string | undefined;
+  let confirmedDeliveredThreadTs: string | undefined;
   let chunksToPost: string[];
   if (opts.mediaUrl) {
     const [firstChunk, ...rest] = resolvedChunks;
@@ -870,7 +872,7 @@ async function sendMessageSlackQueuedInner(params: {
     });
     lastMessageId = response.ts ?? lastMessageId;
     deliveredChannelId = resolvePostedMessageChannelId(response, deliveredChannelId);
-    canonicalDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);
+    confirmedDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);
     if (response.ts) {
       sentMessageIds.push(response.ts);
     }
@@ -878,11 +880,12 @@ async function sendMessageSlackQueuedInner(params: {
 
   const messageId = lastMessageId || "unknown";
   const deliveredThreadTs =
-    canonicalDeliveredThreadTs ?? normalizeSlackThreadTsCandidate(opts.threadTs);
+    confirmedDeliveredThreadTs ?? normalizeSlackThreadTsCandidate(opts.threadTs);
   return {
     messageId,
     channelId: deliveredChannelId,
     threadTs: deliveredThreadTs,
+    ...(confirmedDeliveredThreadTs ? { confirmedThreadTs: confirmedDeliveredThreadTs } : {}),
     receipt: createSlackSendReceipt({
       platformMessageIds: sentMessageIds.length ? sentMessageIds : [messageId],
       channelId: deliveredChannelId,

--- a/extensions/slack/src/thread-delivery-confirmation.ts
+++ b/extensions/slack/src/thread-delivery-confirmation.ts
@@ -1,0 +1,26 @@
+// Slack plugin module implements threaded delivery confirmation.
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { SlackSendResult } from "./send.js";
+
+export function assertSlackThreadDeliveryResult(params: {
+  result: Pick<SlackSendResult, "confirmedThreadTs" | "messageId">;
+  to: string;
+  threadTs?: string;
+}) {
+  if (!params.threadTs) {
+    return;
+  }
+  const deliveredThreadTs = normalizeOptionalString(params.result.confirmedThreadTs);
+  if (deliveredThreadTs === params.threadTs) {
+    return;
+  }
+  const deliveredMessageId = normalizeOptionalString(params.result.messageId);
+  const suffix = deliveredThreadTs
+    ? `; delivered thread ${deliveredThreadTs}`
+    : deliveredMessageId
+      ? `; delivered message ${deliveredMessageId}`
+      : "";
+  throw new Error(
+    `Slack delivery did not confirm thread ${params.threadTs} for ${params.to}${suffix}`,
+  );
+}

--- a/extensions/slack/src/thread-delivery-confirmation.ts
+++ b/extensions/slack/src/thread-delivery-confirmation.ts
@@ -1,9 +1,11 @@
 // Slack plugin module implements threaded delivery confirmation.
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { SlackSendResult } from "./send.js";
 
 export function assertSlackThreadDeliveryResult(params: {
-  result: Pick<SlackSendResult, "confirmedThreadTs" | "messageId">;
+  result: {
+    confirmedThreadTs?: string;
+    messageId?: string;
+  };
   to: string;
   threadTs?: string;
 }) {


### PR DESCRIPTION
## What Problem This Solves
Slack threaded outbound sends could report success even when Slack did not confirm delivery into the requested thread. The send layer previously exposed `threadTs` by falling back to the requested value, so callers could not distinguish a real Slack-confirmed thread from an echoed request.

The earlier repair only guarded selected caller paths, which left direct reply delivery and Slack action sends able to call `sendMessageSlack` with `threadTs` and still treat missing or mismatched Slack thread evidence as success. It also allowed the sent-thread participation cache to be updated from the fallback thread before a caller-side guard could throw.

## Why This Change Was Made
This change separates requested thread fallback from Slack-confirmed thread evidence on text/block sends, then enforces the confirmation invariant at the Slack send boundary before thread participation is recorded. `sendMessageSlack` now fails non-media threaded text/block sends unless Slack returns `message.thread_ts` matching the requested target thread.

The existing caller-side guards remain for injected/test send functions, but the production invariant now lives in one canonical place. Threaded media uploads remain exempt because Slack media uploads preserve the requested thread through the upload flow rather than the text-message confirmation field.

## User Impact
When Slack omits or changes the destination thread for a text or block message, OpenClaw now surfaces a delivery failure instead of silently marking the reply as delivered to the original thread. Direct Slack replies, Slack action sends, outbound payloads, and channel text sends all share that fail-closed behavior.

Successful threaded Slack text/block sends are unchanged when Slack confirms the requested thread. Threaded Slack file/media uploads keep working and are not rejected just because the text-message confirmation field is absent.

## Evidence
Head commit: `73c22c6e377f8558023a65e97d3457a9a0648ca6`.

- `node scripts/run-vitest.mjs run extensions/slack/src/send.blocks.test.ts extensions/slack/src/monitor/replies.test.ts extensions/slack/src/action-runtime.test.ts extensions/slack/src/outbound-adapter.test.ts extensions/slack/src/channel.test.ts extensions/slack/src/channel.message-adapter.test.ts extensions/slack/src/outbound-delivery.test.ts` passed: 7 files, 187 tests.
- `pnpm oxfmt --check extensions/slack/src/thread-delivery-confirmation.ts extensions/slack/src/send.ts extensions/slack/src/send.blocks.test.ts extensions/slack/src/monitor/replies.test.ts extensions/slack/src/action-runtime.test.ts` passed.
- `pnpm tsgo:extensions:test` passed.
- `pnpm check:madge-import-cycles` passed: 0 cycles.
- `git diff --check` passed.

Regression coverage now includes:

- `sendMessageSlack` rejects requested threaded text sends when Slack omits confirmed thread evidence;
- `sendMessageSlack` rejects requested threaded text sends when Slack confirms a different thread;
- thread participation is not recorded after either confirmation failure;
- successful threaded text/block sends continue to record participation only from matching confirmed thread evidence;
- chunked threaded text sends continue to carry the requested `thread_ts` and preserve confirmed thread receipts;
- direct `deliverReplies` threaded text delivery propagates send-boundary confirmation failures;
- Slack action `sendMessage` does not mark `replyToMode: "first"` as used when threaded delivery confirmation fails;
- threaded media uploads preserve the requested `thread_ts` path and are not rejected by the text-send confirmation guard.

Live Slack proof is still not included from this environment because no redacted Slack workspace credentials are available here.
