### PR TITLE
fix(media): forward scanned PDF page images as current-turn images

### DIFF
--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -98,6 +98,23 @@ export async function resolveCurrentTurnImages(params: {
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
 }> {
+  // Consume extracted current-turn images (e.g., PDF page images from file extraction).
+  const currentTurnImages = params.ctx.CurrentTurnImages;
+  if (currentTurnImages && currentTurnImages.length > 0) {
+    // Clear so they are consumed once.
+    delete params.ctx.CurrentTurnImages;
+    const mergedImages = [
+      ...(Array.isArray(params.images) ? params.images : []),
+      ...currentTurnImages,
+    ];
+    if (mergedImages.length > 0) {
+      return {
+        images: mergedImages,
+        imageOrder: mergedImages.map(() => "inline" as const),
+      };
+    }
+  }
+
   if (Array.isArray(params.images) && params.images.length > 0) {
     return { images: params.images, imageOrder: params.imageOrder };
   }

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -558,20 +558,38 @@ export async function tryDispatchAcpReply(params: {
     }
 
     const promptText = resolveAcpPromptText(params.ctx);
+
+    // Consume extracted current-turn images (e.g., PDF page images from file extraction)
+    // forwarded by applyMediaUnderstanding via ctx.CurrentTurnImages.
+    const currentTurnImages = params.ctx.CurrentTurnImages;
+    if (currentTurnImages && currentTurnImages.length > 0) {
+      delete params.ctx.CurrentTurnImages;
+    }
+
     const resolvedTurnAttachments = await resolveAgentTurnAttachments({
       ctx: params.ctx,
       cfg: params.cfg,
     });
     const mediaAttachments = resolvedTurnAttachments.attachments;
     const inlineAttachments = resolveInlineAgentImageAttachments(params.images);
+    // Merge extracted current-turn images (PDF page rasters) into inline attachments.
+    const allInlineAttachments = currentTurnImages && currentTurnImages.length > 0
+      ? [
+          ...inlineAttachments,
+          ...currentTurnImages.map((img) => ({
+            mediaType: img.mimeType,
+            data: img.data,
+          })),
+        ]
+      : inlineAttachments;
     const mediaAttachmentsAreOnlyRecentHistory =
       mediaAttachments.length > 0 &&
       mediaAttachments.length === resolvedTurnAttachments.recentHistoryImages.length;
     const attachments =
       mediaAttachments.length > 0 &&
-      !(mediaAttachmentsAreOnlyRecentHistory && inlineAttachments.length > 0)
+      !(mediaAttachmentsAreOnlyRecentHistory && allInlineAttachments.length > 0)
         ? mediaAttachments
-        : inlineAttachments;
+        : allInlineAttachments;
     const turnPromptText =
       attachments === mediaAttachments
         ? appendRecentHistoryImageContext({

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -5,6 +5,7 @@ import type {
   MediaUnderstandingOutput,
 } from "../media-understanding/types.js";
 import type { PluginHookChannelContext } from "../plugins/hook-channel-context.types.js";
+import type { ImageContent } from "../llm/types.js";
 import type { InputProvenance } from "../sessions/input-provenance.js";
 import type { CommandTurnContext } from "./command-turn-context.js";
 import type { CommandArgs } from "./commands-args.types.js";
@@ -217,6 +218,8 @@ export type MsgContext = {
   /** Remote host for SCP when media lives on a different machine (e.g., openclaw@192.168.64.3). */
   MediaRemoteHost?: string;
   Transcript?: string;
+  /** Extracted PDF page images from file extraction, forwarded as current-turn image inputs for vision-capable model paths. */
+  CurrentTurnImages?: ImageContent[];
   MediaUnderstanding?: MediaUnderstandingOutput[];
   MediaUnderstandingDecisions?: MediaUnderstandingDecision[];
   LinkUnderstanding?: string[];

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -5,19 +5,20 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
-import type { MsgContext } from "../auto-reply/templating.js";
-import type { OpenClawConfig } from "../config/types.js";
-import { logVerbose, shouldLogVerbose } from "../globals.js";
-import { renderFileContextBlock } from "../media/file-context.js";
-import { extractFileContentFromSource, normalizeMimeType } from "../media/input-files.js";
-import { wrapExternalContent } from "../security/external-content.js";
 import type { ActiveMediaModel } from "../../packages/media-understanding-common/src/active-model.js";
 import {
   extractMediaUserText,
   formatAudioTranscripts,
   formatMediaUnderstandingBody,
 } from "../../packages/media-understanding-common/src/format.js";
+import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { logVerbose, shouldLogVerbose } from "../globals.js";
+import type { ImageContent } from "../llm/types.js";
+import { renderFileContextBlock } from "../media/file-context.js";
+import { extractFileContentFromSource, normalizeMimeType } from "../media/input-files.js";
+import { wrapExternalContent } from "../security/external-content.js";
 import { resolveAttachmentKind } from "./attachments.js";
 import { runWithConcurrency } from "./concurrency.js";
 import { DEFAULT_ECHO_TRANSCRIPT_FORMAT, sendTranscriptEcho } from "./echo-transcript.js";
@@ -47,6 +48,11 @@ type ApplyMediaUnderstandingResult = {
   appliedAudio: boolean;
   appliedVideo: boolean;
   appliedFile: boolean;
+};
+
+type ExtractedFileBlocks = {
+  blocks: string[];
+  images: ImageContent[];
 };
 
 const CAPABILITY_ORDER: MediaUnderstandingCapability[] = ["image", "audio", "video"];
@@ -383,12 +389,13 @@ async function extractFileBlocks(params: {
   cfg: OpenClawConfig;
   limits: FileExtractionLimits;
   skipAttachmentIndexes?: Set<number>;
-}): Promise<string[]> {
+}): Promise<ExtractedFileBlocks> {
   const { attachments, cache, cfg, limits, skipAttachmentIndexes } = params;
   if (!attachments || attachments.length === 0) {
-    return [];
+    return { blocks: [], images: [] };
   }
   const blocks: string[] = [];
+  const images: ImageContent[] = [];
   for (const attachment of attachments) {
     if (!attachment) {
       continue;
@@ -494,21 +501,13 @@ async function extractFileBlocks(params: {
       continue;
     }
     const text = extracted?.text?.trim() ?? "";
+    if (extracted?.images && extracted.images.length > 0) {
+      images.push(...extracted.images);
+    }
     let blockText = text ? wrapUntrustedAttachmentContent(text) : "";
     if (!blockText) {
       if (extracted?.images && extracted.images.length > 0) {
-        // Forward extracted PDF page images as inline base64 data URIs so
-        // vision-capable models can read scanned documents. Mirrors the
-        // /v1/responses path behavior (openresponses-http.ts:629-630) where
-        // the same extractor output is forwarded as separate image content.
-        //
-        // Base64 data URIs are used because the chat path has no image-carrying
-        // field on ApplyMediaUnderstandingResult; embedding them in the text block
-        // ensures they reach the model without structural type changes.
-        const imageContext = extracted.images
-          .map((img, i) => `![Page ${i + 1}](data:${img.mimeType ?? "image/png"};base64,${img.base64})`)
-          .join("\n\n");
-        blockText = `[PDF content rendered to images]\n\n${imageContext}`;
+        blockText = "[PDF content rendered to images]";
       } else {
         blockText = "[No extractable text]";
       }
@@ -522,7 +521,7 @@ async function extractFileBlocks(params: {
       }),
     );
   }
-  return blocks;
+  return { blocks, images };
 }
 
 export async function applyMediaUnderstanding(params: {
@@ -681,13 +680,17 @@ export async function applyMediaUnderstanding(params: {
         )
         .map((output) => output.attachmentIndex),
     );
-    const fileBlocks = await extractFileBlocks({
+    const extractedFiles = await extractFileBlocks({
       attachments,
       cache,
       cfg,
       limits: resolveFileExtractionLimits(cfg),
       skipAttachmentIndexes: audioAttachmentIndexes.size > 0 ? audioAttachmentIndexes : undefined,
     });
+    const fileBlocks = extractedFiles.blocks;
+    if (extractedFiles.images.length > 0) {
+      ctx.CurrentTurnImages = [...(ctx.CurrentTurnImages ?? []), ...extractedFiles.images];
+    }
     if (fileBlocks.length > 0) {
       ctx.Body = appendFileBlocks(ctx.Body, fileBlocks);
     }

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -497,7 +497,18 @@ async function extractFileBlocks(params: {
     let blockText = text ? wrapUntrustedAttachmentContent(text) : "";
     if (!blockText) {
       if (extracted?.images && extracted.images.length > 0) {
-        blockText = "[PDF content rendered to images; images not forwarded to model]";
+        // Forward extracted PDF page images as inline base64 data URIs so
+        // vision-capable models can read scanned documents. Mirrors the
+        // /v1/responses path behavior (openresponses-http.ts:629-630) where
+        // the same extractor output is forwarded as separate image content.
+        //
+        // Base64 data URIs are used because the chat path has no image-carrying
+        // field on ApplyMediaUnderstandingResult; embedding them in the text block
+        // ensures they reach the model without structural type changes.
+        const imageContext = extracted.images
+          .map((img, i) => `![Page ${i + 1}](data:${img.mimeType ?? "image/png"};base64,${img.base64})`)
+          .join("\n\n");
+        blockText = `[PDF content rendered to images]\n\n${imageContext}`;
       } else {
         blockText = "[No extractable text]";
       }


### PR DESCRIPTION
## What Problem This Solves

Chat media-understanding already receives page-image payloads from image-only PDFs, but converted them into placeholder-only file blocks. Scanned PDFs in chat channels therefore did not reach vision-capable agent turns, unlike the sibling OpenResponses path.

## Summary

Carry extracted PDF page images as transient current-turn images, consumed once in normal reply and ACP dispatch.

**Changes:**
- `apply.ts`: `extractFileBlocks` returns `ExtractedFileBlocks` with `images` alongside `blocks`. Extracted page images are stored on `ctx.CurrentTurnImages`
- `templating.ts`: `MsgContext` gains optional `CurrentTurnImages?: ImageContent[]`
- `current-turn-images.ts`: `resolveCurrentTurnImages` consumes `ctx.CurrentTurnImages` and merges them into the resolved image output
- `dispatch-acp.ts`: consumes `ctx.CurrentTurnImages` and forwards as inline ACP attachments

## Linked context

Closes #96541

## Evidence

- `extractFileBlocks` now returns images alongside text blocks
- Placeholder updated from `[PDF content rendered to images; images not forwarded to model]` to just `[PDF content rendered to images]`
- Images are forwarded via the typed `ImageContent` path (not Markdown data URIs)
- Both normal reply (resolveCurrentTurnImages) and ACP dispatch handle the new field
- Local type checks, lint, and diff whitespace pass on this branch

```bash
pnpm vitest run src/media-understanding/apply.test.ts
pnpm vitest run src/auto-reply/reply/current-turn-images.test.ts
pnpm vitest run src/auto-reply/reply/dispatch-acp.test.ts
pnpm vitest run src/auto-reply/reply/get-reply.test.ts
pnpm format:check
pnpm check:changed
```

Live chat-channel proof will be supplied separately.

## Risk checklist

Did user-visible behavior change? (`Yes`) — PDF page images now reach vision-capable models on chat channels.

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`) — images that were already extracted and forwarded by the API path are now also forwarded on the chat path.

What is the highest-risk area?  
Double-consumption of CurrentTurnImages if both reply paths run in sequence.

How is that risk mitigated?  
CurrentTurnImages is deleted after consumption (delete ctx.CurrentTurnImages) so each path consumes it at most once.
