### PR TITLE
perf(gateway): cache transcript field regexes

### DIFF
--- a/src/gateway/session-transcript-json.ts
+++ b/src/gateway/session-transcript-json.ts
@@ -5,8 +5,34 @@ export function normalizeOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
+// Transcript readers repeatedly extract a fixed set of metadata fields from
+// oversized JSONL prefixes. Keep the compiled regexes process-local instead of
+// rebuilding them for every field on every oversized record.
+const TRANSCRIPT_FIELD_REGEX_CACHE = new Map<
+  string,
+  { stringRe: RegExp; nullRe: RegExp; numberRe: RegExp }
+>();
+
+function getTranscriptFieldRegexes(field: string): {
+  stringRe: RegExp;
+  nullRe: RegExp;
+  numberRe: RegExp;
+} {
+  let cached = TRANSCRIPT_FIELD_REGEX_CACHE.get(field);
+  if (!cached) {
+    const escapedField = escapeRegExp(field);
+    cached = {
+      stringRe: new RegExp(`"${escapedField}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`),
+      nullRe: new RegExp(`"${escapedField}"\\s*:\\s*null`),
+      numberRe: new RegExp(`"${escapedField}"\\s*:\\s*(-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)`),
+    };
+    TRANSCRIPT_FIELD_REGEX_CACHE.set(field, cached);
+  }
+  return cached;
+}
+
 export function extractJsonStringFieldPrefix(prefix: string, field: string): string | undefined {
-  const match = new RegExp(`"${escapeRegExp(field)}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`).exec(prefix);
+  const match = getTranscriptFieldRegexes(field).stringRe.exec(prefix);
   if (!match) {
     return undefined;
   }
@@ -22,16 +48,14 @@ export function extractJsonNullableStringFieldPrefix(
   prefix: string,
   field: string,
 ): string | null | undefined {
-  if (new RegExp(`"${escapeRegExp(field)}"\\s*:\\s*null`).test(prefix)) {
+  if (getTranscriptFieldRegexes(field).nullRe.test(prefix)) {
     return null;
   }
   return extractJsonStringFieldPrefix(prefix, field);
 }
 
 export function extractJsonNumberFieldPrefix(prefix: string, field: string): number | undefined {
-  const match = new RegExp(
-    `"${escapeRegExp(field)}"\\s*:\\s*(-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)`,
-  ).exec(prefix);
+  const match = getTranscriptFieldRegexes(field).numberRe.exec(prefix);
   if (!match) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

The oversized transcript metadata parser rebuilt the same field-matching regular expressions for every extracted field on every oversized JSONL record. The original contributor PR #83043 targeted this hot path, but `main` has since moved the helpers from `src/gateway/session-utils.fs.ts` into `src/gateway/session-transcript-json.ts`, leaving the contributor branch stale and conflicting.

## Why This Change Was Made

This keeps the contributor's optimization but applies it at the current helper owner. The cache is process-local, bounded by the small fixed set of internal transcript metadata field names, and uses the same non-global regex patterns as before.

Credit: based on the optimization proposed by @YonganZhang in #83043.

## User Impact

Gateway transcript history paths avoid repeated regex construction when summarizing oversized transcript rows. Behavior, escaping, JSON decoding, and numeric validation stay unchanged.

## Evidence

- `git diff --check origin/main...HEAD`
- `pnpm test:serial src/gateway/session-utils.fs.test.ts -- --testNamePattern "oversized transcript line guards"` passed: 4 files, 32 tests, 336 skipped.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings.
- `OPENCLAW_TESTBOX=1 pnpm check:changed` passed on Blacksmith Testbox-through-Crabbox `tbx_01kvyxkm46rmt8frkr8ffdbgm6`, Actions run `28156562700`, lanes `core, coreTests`.
