### PR TITLE
fix(qqbot): keep empty cells when flushing a partial table row

### DIFF
--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
@@ -156,6 +156,22 @@ describe("chunkQQBotMarkdownText", () => {
     expect(chunker.flushPendingText(160)).toEqual(["5 reportbuilder.ts generatemonthly_sales"]);
   });
 
+  it("preserves an empty cell when flushing a partial table row so columns stay aligned", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    chunker.chunkText(
+      ["| Id | Status | Note |", "|---|---|---|", "| 1 | ok | first |"].join("\n"),
+      160,
+    );
+    // Streamed incomplete row with an empty middle (Status) cell and no trailing pipe; the empty
+    // cell must be kept so "needs review" stays in the Note column rather than shifting into Status.
+    expect(chunker.chunkText("| 2 |  | needs review", 160)).toEqual([]);
+
+    expect(chunker.flushPendingText(160)).toEqual([
+      ["Id: 2", "Status: ", "Note: needs review"].join("\n"),
+    ]);
+  });
+
   it("keeps fenced code blocks self-contained across streaming block flushes", () => {
     const chunker = createQQBotMarkdownChunker((text) => [text]);
 

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -448,12 +448,13 @@ function splitTableCells(line: string): string[] {
 }
 
 function splitPartialTableCells(line: string): string[] {
+  // Keep empty cells: renderTableRowAsFields maps cells to headers positionally, so dropping a
+  // blank cell would shift every later value into the wrong column. Mirrors splitTableCells.
   const trimmed = line.trim();
   return trimmed
     .replace(/^\|/, "")
     .split("|")
-    .map((cell) => cell.trim())
-    .filter((cell) => cell.length > 0);
+    .map((cell) => cell.trim());
 }
 
 function mergeRowFragments(pending: string | null, next: string): string {


### PR DESCRIPTION
## What Problem This Solves

When QQ Bot streams a markdown table and a row arrives incomplete (split across stream blocks), the chunker buffers the fragment and later renders it with `renderTableRowAsFields`, which maps cells to header columns **positionally**. But `splitPartialTableCells` ran `.filter(cell => cell.length > 0)`, dropping empty cells. So a streamed row with a blank interior cell — e.g. `| 2 |  | needs review` for a `[Id, Status, Note]` table — lost the empty `Status` cell, shifting `needs review` into the `Status` column and dropping the `Note` column entirely.

The sibling `splitTableCells` (used for complete rows) deliberately keeps empty cells, so the same logical row rendered correctly when delivered whole (`| 2 |  | needs review |` → `Id: 2 / Status:  / Note: needs review`). Identical input, divergent output — isolating the `.filter` as the defect.

## Why This Change Was Made

Remove the `.filter` so partial rows preserve empty cells, matching `splitTableCells` and the positional-mapping contract. As a bonus, a fragment beginning with an empty cell (`|  | x`) now reaches the `>= 2` cell count in `isIncompleteTableRowFragment`, so it is buffered to await completion instead of being emitted immediately as malformed text.

## User Impact

Streamed QQ Bot tables with blank cells (common in LLM-generated tables with missing values) now keep their columns aligned. No API change. Existing behavior for non-empty cells is unchanged.

## Evidence

`oxfmt`, `oxlint`, `tsgo:extensions` pass; the full `markdown-table-chunking.test.ts` suite passes with a new regression test, and reverting the one-line change makes that test fail (fail-before).

## Real behavior proof

Behavior addressed: a streamed incomplete table row with a blank interior cell (e.g. `| 2 |  | needs review`) had its empty cell dropped by `splitPartialTableCells`, so positional rendering shifted later values into the wrong column and dropped the last column.

Real environment tested: Ran the exported `createQQBotMarkdownChunker` from `extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts` via the colocated Vitest suite (`node scripts/run-vitest.mjs`) on Node v22.22.1 — real streaming `chunkText`/`flushPendingText` calls, no mocks — before and after the patch.

Exact steps or command run after this patch: establish an active 3-column table `[Id, Status, Note]`, then `chunker.chunkText("| 2 |  | needs review", 160)` (buffered → `[]`) and `chunker.flushPendingText(160)`; plus `node scripts/run-vitest.mjs <table-chunking>.test.ts`, `node scripts/run-oxlint.mjs`, `pnpm tsgo:extensions`.

Evidence after fix:
```
BEFORE (origin/main):
  flushPendingText(...) -> ["Id: 2\nStatus: needs review"]   (empty cell dropped; "needs review" wrongly in Status, Note lost)
AFTER:
  flushPendingText(...) -> ["Id: 2\nStatus: \nNote: needs review"]   (empty Status kept; Note aligned)
full markdown-table-chunking.test.ts -> exit 0 (all pass, incl. new regression test)
fail-before (revert source) -> the new test fails
oxlint -> exit 0 ; tsgo:extensions -> exit 0
```

Observed result after fix: the empty cell is preserved, so every value stays under its correct header; all pre-existing table-chunking tests (which use non-empty cells) are unaffected.

What was not tested: a live QQ Bot channel render of a streamed table with a blank cell (no live QQ Bot workspace in this environment); the fix is a pure parsing change proven at the chunker API and unit-test level.
