### PR TITLE
test: prefer shared temp dir helpers in config, gateway, cron, crestodian, and state tests

### DIFF
--- a/src/config/logging.test.ts
+++ b/src/config/logging.test.ts
@@ -1,8 +1,8 @@
 // Verifies logging config parsing and file path handling.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempDirSync } from "../test-helpers/temp-dir.js";
 
 const mocks = vi.hoisted(() => ({
   createConfigIO: vi.fn().mockReturnValue({
@@ -39,15 +39,16 @@ describe("config logging", () => {
   });
 
   it("formats backup as an indented detail when present", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-log-"));
-    const configPath = path.join(dir, "openclaw.json");
-    const backupPath = `${configPath}.bak`;
-    fs.writeFileSync(backupPath, "{}", "utf8");
+    withTempDirSync({ prefix: "openclaw-config-log-" }, (dir) => {
+      const configPath = path.join(dir, "openclaw.json");
+      const backupPath = `${configPath}.bak`;
+      fs.writeFileSync(backupPath, "{}", "utf8");
 
-    expect(
-      formatConfigUpdatedMessage(configPath, {
-        backupPath,
-      }),
-    ).toBe(`Updated config: ${configPath}\n  Backup: ${backupPath}`);
+      expect(
+        formatConfigUpdatedMessage(configPath, {
+          backupPath,
+        }),
+      ).toBe(`Updated config: ${configPath}\n  Backup: ${backupPath}`);
+    });
   });
 });

--- a/src/crestodian/audit.test.ts
+++ b/src/crestodian/audit.test.ts
@@ -1,8 +1,8 @@
 // Crestodian audit tests cover filesystem-backed rescue audit scenarios.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../test-helpers/temp-dir.js";
 import { appendCrestodianAuditEntry, resolveCrestodianAuditPath } from "./audit.js";
 
 describe("Crestodian audit log", () => {
@@ -17,23 +17,24 @@ describe("Crestodian audit log", () => {
   });
 
   it("writes jsonl records under the OpenClaw audit dir", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-audit-"));
-    vi.stubEnv("OPENCLAW_STATE_DIR", tempDir);
+    await withTempDir({ prefix: "crestodian-audit-" }, async (tempDir) => {
+      vi.stubEnv("OPENCLAW_STATE_DIR", tempDir);
 
-    const auditPath = await appendCrestodianAuditEntry({
-      operation: "config.setDefaultModel",
-      summary: "Set default model to openai/gpt-5.2",
-      configHashBefore: "before",
-      configHashAfter: "after",
+      const auditPath = await appendCrestodianAuditEntry({
+        operation: "config.setDefaultModel",
+        summary: "Set default model to openai/gpt-5.2",
+        configHashBefore: "before",
+        configHashAfter: "after",
+      });
+
+      expect(auditPath).toBe(resolveCrestodianAuditPath());
+      const lines = (await fs.readFile(auditPath, "utf8")).trim().split("\n");
+      expect(lines).toHaveLength(1);
+      const entry = JSON.parse(lines[0] ?? "{}") as Record<string, unknown>;
+      expect(entry.operation).toBe("config.setDefaultModel");
+      expect(entry.summary).toBe("Set default model to openai/gpt-5.2");
+      expect(entry.configHashBefore).toBe("before");
+      expect(entry.configHashAfter).toBe("after");
     });
-
-    expect(auditPath).toBe(resolveCrestodianAuditPath());
-    const lines = (await fs.readFile(auditPath, "utf8")).trim().split("\n");
-    expect(lines).toHaveLength(1);
-    const entry = JSON.parse(lines[0] ?? "{}") as Record<string, unknown>;
-    expect(entry.operation).toBe("config.setDefaultModel");
-    expect(entry.summary).toBe("Set default model to openai/gpt-5.2");
-    expect(entry.configHashBefore).toBe("before");
-    expect(entry.configHashAfter).toBe("after");
   });
 });

--- a/src/crestodian/audit.test.ts
+++ b/src/crestodian/audit.test.ts
@@ -1,6 +1,5 @@
 // Crestodian audit tests cover filesystem-backed rescue audit scenarios.
 import fs from "node:fs/promises";
-import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { appendCrestodianAuditEntry, resolveCrestodianAuditPath } from "./audit.js";

--- a/src/crestodian/operations.test.ts
+++ b/src/crestodian/operations.test.ts
@@ -1,8 +1,8 @@
 // Crestodian operation tests cover rescue operation planning and execution.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { createCrestodianTestRuntime } from "./crestodian.test-helpers.js";
@@ -194,14 +194,8 @@ vi.mock("../config/model-input.js", () => ({
 
 const _opTempDirs: string[] = [];
 
-async function createOpTempDir(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  _opTempDirs.push(dir);
-  return dir;
-}
-
-afterAll(async () => {
-  await Promise.all(_opTempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+afterAll(() => {
+  cleanupTempDirs(_opTempDirs);
 });
 
 describe("parseCrestodianOperation", () => {
@@ -337,7 +331,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("applies config set through typed deps and writes an audit entry", async () => {
-    const tempDir = await createOpTempDir("crestodian-config-set-");
+    const tempDir = makeTempDir(_opTempDirs, "crestodian-config-set-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runConfigSet = vi.fn(async () => {});
@@ -373,7 +367,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("applies SecretRef config set through typed deps and writes an audit entry", async () => {
-    const tempDir = await createOpTempDir("crestodian-config-ref-");
+    const tempDir = makeTempDir(_opTempDirs, "crestodian-config-ref-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runConfigSet = vi.fn(async () => {});
@@ -451,7 +445,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("installs plugins only after approval and audits the write", async () => {
-    const tempDir = await createOpTempDir("crestodian-plugin-install-");
+    const tempDir = makeTempDir(_opTempDirs, "crestodian-plugin-install-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runPluginInstall = vi.fn(async (spec: string, pluginRuntime: RuntimeEnv) => {
@@ -497,7 +491,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("uninstalls plugins only after approval and audits the write", async () => {
-    const tempDir = await createOpTempDir("crestodian-plugin-uninstall-");
+    const tempDir = makeTempDir(_opTempDirs, "crestodian-plugin-uninstall-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runPluginUninstall = vi.fn(async (pluginId: string, pluginRuntime: RuntimeEnv) => {
@@ -543,7 +537,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("runs setup bootstrap only after approval and audits it", async () => {
-    const tempDir = await createOpTempDir("crestodian-setup-");
+    const tempDir = makeTempDir(_opTempDirs, "crestodian-setup-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     vi.stubEnv("OPENAI_API_KEY", "test-key");
     const { runtime, lines } = createCrestodianTestRuntime();
@@ -592,7 +586,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("runs doctor repairs only after approval and audits them", async () => {
-    const tempDir = await createOpTempDir("crestodian-doctor-fix-");
+    const tempDir = makeTempDir(_opTempDirs, "crestodian-doctor-fix-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runDoctor = vi.fn(async () => {});

--- a/src/crestodian/operations.test.ts
+++ b/src/crestodian/operations.test.ts
@@ -192,10 +192,10 @@ vi.mock("../config/model-input.js", () => ({
     typeof model === "string" ? model : model?.primary,
 }));
 
-const _opTempDirs: string[] = [];
+const opTempDirs: string[] = [];
 
 afterAll(() => {
-  cleanupTempDirs(_opTempDirs);
+  cleanupTempDirs(opTempDirs);
 });
 
 describe("parseCrestodianOperation", () => {
@@ -331,7 +331,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("applies config set through typed deps and writes an audit entry", async () => {
-    const tempDir = makeTempDir(_opTempDirs, "crestodian-config-set-");
+    const tempDir = makeTempDir(opTempDirs, "crestodian-config-set-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runConfigSet = vi.fn(async () => {});
@@ -367,7 +367,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("applies SecretRef config set through typed deps and writes an audit entry", async () => {
-    const tempDir = makeTempDir(_opTempDirs, "crestodian-config-ref-");
+    const tempDir = makeTempDir(opTempDirs, "crestodian-config-ref-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runConfigSet = vi.fn(async () => {});
@@ -445,7 +445,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("installs plugins only after approval and audits the write", async () => {
-    const tempDir = makeTempDir(_opTempDirs, "crestodian-plugin-install-");
+    const tempDir = makeTempDir(opTempDirs, "crestodian-plugin-install-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runPluginInstall = vi.fn(async (spec: string, pluginRuntime: RuntimeEnv) => {
@@ -491,7 +491,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("uninstalls plugins only after approval and audits the write", async () => {
-    const tempDir = makeTempDir(_opTempDirs, "crestodian-plugin-uninstall-");
+    const tempDir = makeTempDir(opTempDirs, "crestodian-plugin-uninstall-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runPluginUninstall = vi.fn(async (pluginId: string, pluginRuntime: RuntimeEnv) => {
@@ -537,7 +537,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("runs setup bootstrap only after approval and audits it", async () => {
-    const tempDir = makeTempDir(_opTempDirs, "crestodian-setup-");
+    const tempDir = makeTempDir(opTempDirs, "crestodian-setup-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     vi.stubEnv("OPENAI_API_KEY", "test-key");
     const { runtime, lines } = createCrestodianTestRuntime();
@@ -586,7 +586,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("runs doctor repairs only after approval and audits them", async () => {
-    const tempDir = makeTempDir(_opTempDirs, "crestodian-doctor-fix-");
+    const tempDir = makeTempDir(opTempDirs, "crestodian-doctor-fix-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runDoctor = vi.fn(async () => {});

--- a/src/crestodian/operations.test.ts
+++ b/src/crestodian/operations.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { createCrestodianTestRuntime } from "./crestodian.test-helpers.js";
@@ -192,6 +192,18 @@ vi.mock("../config/model-input.js", () => ({
     typeof model === "string" ? model : model?.primary,
 }));
 
+const _opTempDirs: string[] = [];
+
+async function createOpTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  _opTempDirs.push(dir);
+  return dir;
+}
+
+afterAll(async () => {
+  await Promise.all(_opTempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
 describe("parseCrestodianOperation", () => {
   let stateDirSnapshot: ReturnType<typeof captureEnv> | undefined;
 
@@ -325,7 +337,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("applies config set through typed deps and writes an audit entry", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-config-set-"));
+    const tempDir = await createOpTempDir("crestodian-config-set-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runConfigSet = vi.fn(async () => {});
@@ -361,7 +373,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("applies SecretRef config set through typed deps and writes an audit entry", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-config-ref-"));
+    const tempDir = await createOpTempDir("crestodian-config-ref-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runConfigSet = vi.fn(async () => {});
@@ -439,7 +451,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("installs plugins only after approval and audits the write", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-plugin-install-"));
+    const tempDir = await createOpTempDir("crestodian-plugin-install-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runPluginInstall = vi.fn(async (spec: string, pluginRuntime: RuntimeEnv) => {
@@ -485,7 +497,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("uninstalls plugins only after approval and audits the write", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-plugin-uninstall-"));
+    const tempDir = await createOpTempDir("crestodian-plugin-uninstall-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runPluginUninstall = vi.fn(async (pluginId: string, pluginRuntime: RuntimeEnv) => {
@@ -531,7 +543,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("runs setup bootstrap only after approval and audits it", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-setup-"));
+    const tempDir = await createOpTempDir("crestodian-setup-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     vi.stubEnv("OPENAI_API_KEY", "test-key");
     const { runtime, lines } = createCrestodianTestRuntime();
@@ -580,7 +592,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("runs doctor repairs only after approval and audits them", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-doctor-fix-"));
+    const tempDir = await createOpTempDir("crestodian-doctor-fix-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runDoctor = vi.fn(async () => {});

--- a/src/crestodian/rescue-channel.live.test.ts
+++ b/src/crestodian/rescue-channel.live.test.ts
@@ -1,7 +1,7 @@
 // Crestodian live rescue channel tests cover live-channel rescue message delivery.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { CommandContext } from "../auto-reply/reply/commands-types.js";
 import { clearConfigCache } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";

--- a/src/crestodian/rescue-channel.live.test.ts
+++ b/src/crestodian/rescue-channel.live.test.ts
@@ -1,11 +1,11 @@
 // Crestodian live rescue channel tests cover live-channel rescue message delivery.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CommandContext } from "../auto-reply/reply/commands-types.js";
 import { clearConfigCache } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { runCrestodianRescueMessage } from "./rescue-message.js";
 
@@ -67,48 +67,49 @@ describeLive("Crestodian live rescue channel smoke", () => {
   });
 
   it("handles /crestodian status and a persistent approval roundtrip", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-live-rescue-"));
-    const configPath = path.join(tempDir, "openclaw.json");
-    setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    await fs.writeFile(
-      configPath,
-      JSON.stringify(
-        {
-          meta: { lastTouchedVersion: "live-test", lastTouchedAt: new Date(0).toISOString() },
-          agents: { defaults: {} },
-          tools: { exec: { security: "full", ask: "off" } },
-        },
-        null,
-        2,
-      ),
-    );
+    await withTempDir({ prefix: "crestodian-live-rescue-" }, async (tempDir) => {
+      const configPath = path.join(tempDir, "openclaw.json");
+      setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            meta: { lastTouchedVersion: "live-test", lastTouchedAt: new Date(0).toISOString() },
+            agents: { defaults: {} },
+            tools: { exec: { security: "full", ask: "off" } },
+          },
+          null,
+          2,
+        ),
+      );
 
-    const cfg: OpenClawConfig = {
-      crestodian: { rescue: { enabled: true } },
-      tools: { exec: { security: "full", ask: "off" } },
-    };
+      const cfg: OpenClawConfig = {
+        crestodian: { rescue: { enabled: true } },
+        tools: { exec: { security: "full", ask: "off" } },
+      };
 
-    await expect(runRescue({ commandBody: "/crestodian status", cfg })).resolves.toContain(
-      "[crestodian] done: status.check",
-    );
-    await expect(
-      runRescue({ commandBody: "/crestodian set default model openai/gpt-5.5", cfg }),
-    ).resolves.toContain("Reply /crestodian yes to apply");
-    await expect(runRescue({ commandBody: "/crestodian yes", cfg })).resolves.toContain(
-      "Default model: openai/gpt-5.5",
-    );
+      await expect(runRescue({ commandBody: "/crestodian status", cfg })).resolves.toContain(
+        "[crestodian] done: status.check",
+      );
+      await expect(
+        runRescue({ commandBody: "/crestodian set default model openai/gpt-5.5", cfg }),
+      ).resolves.toContain("Reply /crestodian yes to apply");
+      await expect(runRescue({ commandBody: "/crestodian yes", cfg })).resolves.toContain(
+        "Default model: openai/gpt-5.5",
+      );
 
-    const config = JSON.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig;
-    const defaultModel = config.agents?.defaults?.model;
-    if (!defaultModel || typeof defaultModel !== "object") {
-      throw new Error("expected default model object");
-    }
-    expect(defaultModel.primary).toBe("openai/gpt-5.5");
-    const auditPath = path.join(tempDir, "audit", "crestodian.jsonl");
-    const auditLines = (await fs.readFile(auditPath, "utf8")).trim().split("\n");
-    expect(auditLines.some((line) => line.includes('"operation":"config.setDefaultModel"'))).toBe(
-      true,
-    );
+      const config = JSON.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig;
+      const defaultModel = config.agents?.defaults?.model;
+      if (!defaultModel || typeof defaultModel !== "object") {
+        throw new Error("expected default model object");
+      }
+      expect(defaultModel.primary).toBe("openai/gpt-5.5");
+      const auditPath = path.join(tempDir, "audit", "crestodian.jsonl");
+      const auditLines = (await fs.readFile(auditPath, "utf8")).trim().split("\n");
+      expect(auditLines.some((line) => line.includes('"operation":"config.setDefaultModel"'))).toBe(
+        true,
+      );
+    });
   });
 });

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   adoptCronRunSessionMetadata,
@@ -219,15 +220,12 @@ describe("createPersistCronSessionEntry", () => {
 const _cronSessionTempDirs: string[] = [];
 
 async function createTranscriptFile(): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-session-"));
-  _cronSessionTempDirs.push(dir);
+  const dir = makeTempDir(_cronSessionTempDirs, "openclaw-cron-session-");
   const file = path.join(dir, "session.jsonl");
   await fs.writeFile(file, `${JSON.stringify({ type: "session", sessionId: "run-session-id" })}\n`);
   return file;
 }
 
-afterAll(async () => {
-  await Promise.all(
-    _cronSessionTempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })),
-  );
+afterAll(() => {
+  cleanupTempDirs(_cronSessionTempDirs);
 });

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -217,15 +217,15 @@ describe("createPersistCronSessionEntry", () => {
   });
 });
 
-const _cronSessionTempDirs: string[] = [];
+const cronSessionTempDirs: string[] = [];
 
 async function createTranscriptFile(): Promise<string> {
-  const dir = makeTempDir(_cronSessionTempDirs, "openclaw-cron-session-");
+  const dir = makeTempDir(cronSessionTempDirs, "openclaw-cron-session-");
   const file = path.join(dir, "session.jsonl");
   await fs.writeFile(file, `${JSON.stringify({ type: "session", sessionId: "run-session-id" })}\n`);
   return file;
 }
 
 afterAll(() => {
-  cleanupTempDirs(_cronSessionTempDirs);
+  cleanupTempDirs(cronSessionTempDirs);
 });

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   adoptCronRunSessionMetadata,
@@ -216,9 +216,18 @@ describe("createPersistCronSessionEntry", () => {
   });
 });
 
+const _cronSessionTempDirs: string[] = [];
+
 async function createTranscriptFile(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-session-"));
+  _cronSessionTempDirs.push(dir);
   const file = path.join(dir, "session.jsonl");
   await fs.writeFile(file, `${JSON.stringify({ type: "session", sessionId: "run-session-id" })}\n`);
   return file;
 }
+
+afterAll(async () => {
+  await Promise.all(
+    _cronSessionTempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});

--- a/src/cron/run-log.error-reason.test.ts
+++ b/src/cron/run-log.error-reason.test.ts
@@ -1,27 +1,21 @@
 // Cron run log error tests cover persisted failure reasons and summaries.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { migrateLegacyCronRunLogsToSqlite } from "../commands/doctor/cron/legacy-run-log-migration.js";
 import { appendCronRunLog, readCronRunLogEntriesPage, type CronRunLogEntry } from "./run-log.js";
 
 const _runLogTempDirs: string[] = [];
 
-async function _trackRunLogTempDir(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  _runLogTempDirs.push(dir);
-  return dir;
-}
-
-afterAll(async () => {
-  await Promise.all(_runLogTempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+afterAll(() => {
+  cleanupTempDirs(_runLogTempDirs);
 });
 
 async function writeLegacyRunLogAndMigrate(
   entries: Array<Record<string, unknown>>,
 ): Promise<string> {
-  const dir = await _trackRunLogTempDir("cron-run-log-");
+  const dir = makeTempDir(_runLogTempDirs, "cron-run-log-");
   const storePath = path.join(dir, "cron", "jobs.json");
   const file = path.join(dir, "cron", "runs", "job-1.jsonl");
   await fs.mkdir(path.dirname(file), { recursive: true });
@@ -55,7 +49,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("validates persisted errorReason against the full failover reason set", async () => {
-    const dir = await _trackRunLogTempDir("cron-run-log-");
+    const dir = makeTempDir(_runLogTempDirs, "cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     const reasons = [
       "auth",
@@ -116,7 +110,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("uses provider context when deriving persisted run-log reasons", async () => {
-    const dir = await _trackRunLogTempDir("cron-run-log-");
+    const dir = makeTempDir(_runLogTempDirs, "cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     await appendCronRunLog({
       storePath,
@@ -135,7 +129,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("includes derived errorReason values in run-log search", async () => {
-    const dir = await _trackRunLogTempDir("cron-run-log-");
+    const dir = makeTempDir(_runLogTempDirs, "cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     await appendCronRunLog({
       storePath,

--- a/src/cron/run-log.error-reason.test.ts
+++ b/src/cron/run-log.error-reason.test.ts
@@ -6,16 +6,16 @@ import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { migrateLegacyCronRunLogsToSqlite } from "../commands/doctor/cron/legacy-run-log-migration.js";
 import { appendCronRunLog, readCronRunLogEntriesPage, type CronRunLogEntry } from "./run-log.js";
 
-const _runLogTempDirs: string[] = [];
+const runLogTempDirs: string[] = [];
 
 afterAll(() => {
-  cleanupTempDirs(_runLogTempDirs);
+  cleanupTempDirs(runLogTempDirs);
 });
 
 async function writeLegacyRunLogAndMigrate(
   entries: Array<Record<string, unknown>>,
 ): Promise<string> {
-  const dir = makeTempDir(_runLogTempDirs, "cron-run-log-");
+  const dir = makeTempDir(runLogTempDirs, "cron-run-log-");
   const storePath = path.join(dir, "cron", "jobs.json");
   const file = path.join(dir, "cron", "runs", "job-1.jsonl");
   await fs.mkdir(path.dirname(file), { recursive: true });
@@ -49,7 +49,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("validates persisted errorReason against the full failover reason set", async () => {
-    const dir = makeTempDir(_runLogTempDirs, "cron-run-log-");
+    const dir = makeTempDir(runLogTempDirs, "cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     const reasons = [
       "auth",
@@ -110,7 +110,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("uses provider context when deriving persisted run-log reasons", async () => {
-    const dir = makeTempDir(_runLogTempDirs, "cron-run-log-");
+    const dir = makeTempDir(runLogTempDirs, "cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     await appendCronRunLog({
       storePath,
@@ -129,7 +129,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("includes derived errorReason values in run-log search", async () => {
-    const dir = makeTempDir(_runLogTempDirs, "cron-run-log-");
+    const dir = makeTempDir(runLogTempDirs, "cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     await appendCronRunLog({
       storePath,

--- a/src/cron/run-log.error-reason.test.ts
+++ b/src/cron/run-log.error-reason.test.ts
@@ -2,14 +2,26 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { migrateLegacyCronRunLogsToSqlite } from "../commands/doctor/cron/legacy-run-log-migration.js";
 import { appendCronRunLog, readCronRunLogEntriesPage, type CronRunLogEntry } from "./run-log.js";
+
+const _runLogTempDirs: string[] = [];
+
+async function _trackRunLogTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  _runLogTempDirs.push(dir);
+  return dir;
+}
+
+afterAll(async () => {
+  await Promise.all(_runLogTempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
 
 async function writeLegacyRunLogAndMigrate(
   entries: Array<Record<string, unknown>>,
 ): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cron-run-log-"));
+  const dir = await _trackRunLogTempDir("cron-run-log-");
   const storePath = path.join(dir, "cron", "jobs.json");
   const file = path.join(dir, "cron", "runs", "job-1.jsonl");
   await fs.mkdir(path.dirname(file), { recursive: true });
@@ -43,7 +55,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("validates persisted errorReason against the full failover reason set", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cron-run-log-"));
+    const dir = await _trackRunLogTempDir("cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     const reasons = [
       "auth",
@@ -104,7 +116,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("uses provider context when deriving persisted run-log reasons", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cron-run-log-"));
+    const dir = await _trackRunLogTempDir("cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     await appendCronRunLog({
       storePath,
@@ -123,7 +135,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("includes derived errorReason values in run-log search", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cron-run-log-"));
+    const dir = await _trackRunLogTempDir("cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     await appendCronRunLog({
       storePath,

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -6,10 +6,10 @@ import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
-const _hooksTempDirs: string[] = [];
+const hooksTempDirs: string[] = [];
 
 afterAll(() => {
-  cleanupTempDirs(_hooksTempDirs);
+  cleanupTempDirs(hooksTempDirs);
 });
 import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
 
@@ -125,7 +125,7 @@ describe("hooks mapping", () => {
     payload?: Record<string, unknown>;
     sessionKey?: string;
   }) {
-    const configDir = makeTempDir(_hooksTempDirs, params.tempPrefix);
+    const configDir = makeTempDir(hooksTempDirs, params.tempPrefix);
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     fs.writeFileSync(path.join(transformsRoot, "transform.mjs"), params.transformLines.join("\n"));
@@ -237,7 +237,7 @@ describe("hooks mapping", () => {
   });
 
   it("runs transform module", async () => {
-    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-");
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "transform.mjs");
@@ -348,7 +348,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transform module traversal outside transformsDir", () => {
-    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-traversal-");
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-traversal-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -368,7 +368,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects absolute transform module path outside transformsDir", () => {
-    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-abs-");
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const outside = path.join(os.tmpdir(), "evil.mjs");
@@ -389,7 +389,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir traversal outside the transforms root", () => {
-    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-xformdir-trav-");
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-xformdir-trav-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -410,7 +410,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir absolute path outside the transforms root", () => {
-    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-xformdir-abs-");
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-xformdir-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -431,7 +431,7 @@ describe("hooks mapping", () => {
   });
 
   it("accepts transformsDir subdirectory within the transforms root", async () => {
-    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-xformdir-ok-");
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-xformdir-ok-");
     const result = await applyNullTransformFromTempConfig({ configDir, transformsDir: "subdir" });
     expectSkippedTransformResult(result);
   });
@@ -439,10 +439,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transform module symlink escape outside transformsDir",
     () => {
-      const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-symlink-module-");
+      const configDir = makeTempDir(hooksTempDirs, "openclaw-config-symlink-module-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = makeTempDir(_hooksTempDirs, "openclaw-outside-module-");
+      const outsideDir = makeTempDir(hooksTempDirs, "openclaw-outside-module-");
       const outsideModule = path.join(outsideDir, "evil.mjs");
       fs.writeFileSync(outsideModule, 'export default () => ({ kind: "wake", text: "owned" });');
       fs.symlinkSync(outsideModule, path.join(transformsRoot, "linked.mjs"));
@@ -466,10 +466,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transformsDir symlink escape outside transforms root",
     () => {
-      const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-symlink-dir-");
+      const configDir = makeTempDir(hooksTempDirs, "openclaw-config-symlink-dir-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = makeTempDir(_hooksTempDirs, "openclaw-outside-dir-");
+      const outsideDir = makeTempDir(hooksTempDirs, "openclaw-outside-dir-");
       fs.writeFileSync(path.join(outsideDir, "transform.mjs"), "export default () => null;");
       fs.symlinkSync(outsideDir, path.join(transformsRoot, "escape"), "dir");
       expect(() =>
@@ -491,7 +491,7 @@ describe("hooks mapping", () => {
   );
 
   it.runIf(process.platform !== "win32")("accepts in-root transform module symlink", async () => {
-    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-symlink-ok-");
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-symlink-ok-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     const nestedDir = path.join(transformsRoot, "nested");
     fs.mkdirSync(nestedDir, { recursive: true });
@@ -522,7 +522,7 @@ describe("hooks mapping", () => {
   });
 
   it("treats null transform as a handled skip", async () => {
-    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-skip-");
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-skip-");
     const result = await applyNullTransformFromTempConfig({ configDir });
     expectSkippedTransformResult(result);
   });
@@ -572,7 +572,7 @@ describe("hooks mapping", () => {
   });
 
   it("caches transform functions by module path and export name", async () => {
-    const configDir = makeTempDir(_hooksTempDirs, "openclaw-hooks-export-");
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-hooks-export-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "multi-export.mjs");

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -4,19 +4,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
 const _hooksTempDirs: string[] = [];
 
-function _mksync(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  _hooksTempDirs.push(dir);
-  return dir;
-}
-
 afterAll(() => {
-  for (const dir of _hooksTempDirs) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  cleanupTempDirs(_hooksTempDirs);
 });
 import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
 
@@ -132,7 +125,7 @@ describe("hooks mapping", () => {
     payload?: Record<string, unknown>;
     sessionKey?: string;
   }) {
-    const configDir = _mksync(params.tempPrefix);
+    const configDir = makeTempDir(_hooksTempDirs, params.tempPrefix);
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     fs.writeFileSync(path.join(transformsRoot, "transform.mjs"), params.transformLines.join("\n"));
@@ -244,7 +237,7 @@ describe("hooks mapping", () => {
   });
 
   it("runs transform module", async () => {
-    const configDir = _mksync("openclaw-config-");
+    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "transform.mjs");
@@ -355,7 +348,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transform module traversal outside transformsDir", () => {
-    const configDir = _mksync("openclaw-config-traversal-");
+    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-traversal-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -375,7 +368,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects absolute transform module path outside transformsDir", () => {
-    const configDir = _mksync("openclaw-config-abs-");
+    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const outside = path.join(os.tmpdir(), "evil.mjs");
@@ -396,7 +389,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir traversal outside the transforms root", () => {
-    const configDir = _mksync("openclaw-config-xformdir-trav-");
+    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-xformdir-trav-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -417,7 +410,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir absolute path outside the transforms root", () => {
-    const configDir = _mksync("openclaw-config-xformdir-abs-");
+    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-xformdir-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -438,7 +431,7 @@ describe("hooks mapping", () => {
   });
 
   it("accepts transformsDir subdirectory within the transforms root", async () => {
-    const configDir = _mksync("openclaw-config-xformdir-ok-");
+    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-xformdir-ok-");
     const result = await applyNullTransformFromTempConfig({ configDir, transformsDir: "subdir" });
     expectSkippedTransformResult(result);
   });
@@ -446,10 +439,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transform module symlink escape outside transformsDir",
     () => {
-      const configDir = _mksync("openclaw-config-symlink-module-");
+      const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-symlink-module-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = _mksync("openclaw-outside-module-");
+      const outsideDir = makeTempDir(_hooksTempDirs, "openclaw-outside-module-");
       const outsideModule = path.join(outsideDir, "evil.mjs");
       fs.writeFileSync(outsideModule, 'export default () => ({ kind: "wake", text: "owned" });');
       fs.symlinkSync(outsideModule, path.join(transformsRoot, "linked.mjs"));
@@ -473,10 +466,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transformsDir symlink escape outside transforms root",
     () => {
-      const configDir = _mksync("openclaw-config-symlink-dir-");
+      const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-symlink-dir-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = _mksync("openclaw-outside-dir-");
+      const outsideDir = makeTempDir(_hooksTempDirs, "openclaw-outside-dir-");
       fs.writeFileSync(path.join(outsideDir, "transform.mjs"), "export default () => null;");
       fs.symlinkSync(outsideDir, path.join(transformsRoot, "escape"), "dir");
       expect(() =>
@@ -498,7 +491,7 @@ describe("hooks mapping", () => {
   );
 
   it.runIf(process.platform !== "win32")("accepts in-root transform module symlink", async () => {
-    const configDir = _mksync("openclaw-config-symlink-ok-");
+    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-symlink-ok-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     const nestedDir = path.join(transformsRoot, "nested");
     fs.mkdirSync(nestedDir, { recursive: true });
@@ -529,7 +522,7 @@ describe("hooks mapping", () => {
   });
 
   it("treats null transform as a handled skip", async () => {
-    const configDir = _mksync("openclaw-config-skip-");
+    const configDir = makeTempDir(_hooksTempDirs, "openclaw-config-skip-");
     const result = await applyNullTransformFromTempConfig({ configDir });
     expectSkippedTransformResult(result);
   });
@@ -579,7 +572,7 @@ describe("hooks mapping", () => {
   });
 
   it("caches transform functions by module path and export name", async () => {
-    const configDir = _mksync("openclaw-hooks-export-");
+    const configDir = makeTempDir(_hooksTempDirs, "openclaw-hooks-export-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "multi-export.mjs");

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -3,7 +3,21 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
+
+const _hooksTempDirs: string[] = [];
+
+function _mksync(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  _hooksTempDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of _hooksTempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
 
 const baseUrl = new URL("http://127.0.0.1:18789/hooks/gmail");
@@ -118,7 +132,7 @@ describe("hooks mapping", () => {
     payload?: Record<string, unknown>;
     sessionKey?: string;
   }) {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), params.tempPrefix));
+    const configDir = _mksync(params.tempPrefix);
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     fs.writeFileSync(path.join(transformsRoot, "transform.mjs"), params.transformLines.join("\n"));
@@ -230,7 +244,7 @@ describe("hooks mapping", () => {
   });
 
   it("runs transform module", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-"));
+    const configDir = _mksync("openclaw-config-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "transform.mjs");
@@ -341,7 +355,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transform module traversal outside transformsDir", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-traversal-"));
+    const configDir = _mksync("openclaw-config-traversal-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -361,7 +375,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects absolute transform module path outside transformsDir", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-abs-"));
+    const configDir = _mksync("openclaw-config-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const outside = path.join(os.tmpdir(), "evil.mjs");
@@ -382,7 +396,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir traversal outside the transforms root", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-trav-"));
+    const configDir = _mksync("openclaw-config-xformdir-trav-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -403,7 +417,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir absolute path outside the transforms root", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-abs-"));
+    const configDir = _mksync("openclaw-config-xformdir-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -424,7 +438,7 @@ describe("hooks mapping", () => {
   });
 
   it("accepts transformsDir subdirectory within the transforms root", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-ok-"));
+    const configDir = _mksync("openclaw-config-xformdir-ok-");
     const result = await applyNullTransformFromTempConfig({ configDir, transformsDir: "subdir" });
     expectSkippedTransformResult(result);
   });
@@ -432,10 +446,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transform module symlink escape outside transformsDir",
     () => {
-      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-module-"));
+      const configDir = _mksync("openclaw-config-symlink-module-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-module-"));
+      const outsideDir = _mksync("openclaw-outside-module-");
       const outsideModule = path.join(outsideDir, "evil.mjs");
       fs.writeFileSync(outsideModule, 'export default () => ({ kind: "wake", text: "owned" });');
       fs.symlinkSync(outsideModule, path.join(transformsRoot, "linked.mjs"));
@@ -459,10 +473,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transformsDir symlink escape outside transforms root",
     () => {
-      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-dir-"));
+      const configDir = _mksync("openclaw-config-symlink-dir-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-dir-"));
+      const outsideDir = _mksync("openclaw-outside-dir-");
       fs.writeFileSync(path.join(outsideDir, "transform.mjs"), "export default () => null;");
       fs.symlinkSync(outsideDir, path.join(transformsRoot, "escape"), "dir");
       expect(() =>
@@ -484,7 +498,7 @@ describe("hooks mapping", () => {
   );
 
   it.runIf(process.platform !== "win32")("accepts in-root transform module symlink", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-ok-"));
+    const configDir = _mksync("openclaw-config-symlink-ok-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     const nestedDir = path.join(transformsRoot, "nested");
     fs.mkdirSync(nestedDir, { recursive: true });
@@ -515,7 +529,7 @@ describe("hooks mapping", () => {
   });
 
   it("treats null transform as a handled skip", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-skip-"));
+    const configDir = _mksync("openclaw-config-skip-");
     const result = await applyNullTransformFromTempConfig({ configDir });
     expectSkippedTransformResult(result);
   });
@@ -565,7 +579,7 @@ describe("hooks mapping", () => {
   });
 
   it("caches transform functions by module path and export name", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-export-"));
+    const configDir = _mksync("openclaw-hooks-export-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "multi-export.mjs");

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -164,10 +164,10 @@ function setMockSessionEntry(transcriptPath: string, sessionId: string, hasEntry
   sessionEntryState.loadCalls = [];
 }
 
-const _abortTempDirs: string[] = [];
+const abortTempDirs: string[] = [];
 
 async function createTranscriptFixture(prefix: string) {
-  const dir = makeTempDir(_abortTempDirs, prefix);
+  const dir = makeTempDir(abortTempDirs, prefix);
   const sessionId = "sess-main";
   const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
   await writeTranscriptHeader(transcriptPath, sessionId);
@@ -176,7 +176,7 @@ async function createTranscriptFixture(prefix: string) {
 }
 
 async function createMissingEntryFixture(prefix: string) {
-  const dir = makeTempDir(_abortTempDirs, prefix);
+  const dir = makeTempDir(abortTempDirs, prefix);
   const transcriptPath = path.join(dir, "missing.jsonl");
   const sessionId = "client-supplied-session";
   setMockSessionEntry(transcriptPath, sessionId, false);
@@ -184,7 +184,7 @@ async function createMissingEntryFixture(prefix: string) {
 }
 
 afterAll(() => {
-  cleanupTempDirs(_abortTempDirs);
+  cleanupTempDirs(abortTempDirs);
 });
 
 afterEach(() => {

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -2,10 +2,10 @@
  * Tests persistence effects when chat abort requests complete.
  */
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import { onAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
 import {
   createActiveRun,
@@ -167,8 +167,7 @@ function setMockSessionEntry(transcriptPath: string, sessionId: string, hasEntry
 const _abortTempDirs: string[] = [];
 
 async function createTranscriptFixture(prefix: string) {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  _abortTempDirs.push(dir);
+  const dir = makeTempDir(_abortTempDirs, prefix);
   const sessionId = "sess-main";
   const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
   await writeTranscriptHeader(transcriptPath, sessionId);
@@ -177,16 +176,15 @@ async function createTranscriptFixture(prefix: string) {
 }
 
 async function createMissingEntryFixture(prefix: string) {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  _abortTempDirs.push(dir);
+  const dir = makeTempDir(_abortTempDirs, prefix);
   const transcriptPath = path.join(dir, "missing.jsonl");
   const sessionId = "client-supplied-session";
   setMockSessionEntry(transcriptPath, sessionId, false);
   return { sessionId };
 }
 
-afterAll(async () => {
-  await Promise.all(_abortTempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+afterAll(() => {
+  cleanupTempDirs(_abortTempDirs);
 });
 
 afterEach(() => {

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { onAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
 import {
   createActiveRun,
@@ -164,8 +164,11 @@ function setMockSessionEntry(transcriptPath: string, sessionId: string, hasEntry
   sessionEntryState.loadCalls = [];
 }
 
+const _abortTempDirs: string[] = [];
+
 async function createTranscriptFixture(prefix: string) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  _abortTempDirs.push(dir);
   const sessionId = "sess-main";
   const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
   await writeTranscriptHeader(transcriptPath, sessionId);
@@ -175,11 +178,16 @@ async function createTranscriptFixture(prefix: string) {
 
 async function createMissingEntryFixture(prefix: string) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  _abortTempDirs.push(dir);
   const transcriptPath = path.join(dir, "missing.jsonl");
   const sessionId = "client-supplied-session";
   setMockSessionEntry(transcriptPath, sessionId, false);
   return { sessionId };
 }
+
+afterAll(async () => {
+  await Promise.all(_abortTempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -183,7 +183,11 @@ async function useTempSessionStorePath() {
 }
 
 afterAll(async () => {
-  await Promise.all(_gwSessionTempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  await Promise.all(
+    _gwSessionTempDirs.map((dir) =>
+      fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }),
+    ),
+  );
 });
 
 describe("gateway server agent", () => {

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -1,10 +1,10 @@
 // Gateway agent integration tests cover channel routing, session context,
 // WebSocket requests, agent event delivery, and provider/runtime error handling.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { AcpRuntimeError } from "../acp/runtime/errors.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { emitAgentEvent, registerAgentRunContext } from "../infra/agent-events.js";
@@ -177,17 +177,12 @@ async function sendAgentWsRequestAndWaitFinal(
 const _gwSessionTempDirs: string[] = [];
 
 async function useTempSessionStorePath() {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
-  _gwSessionTempDirs.push(dir);
+  const dir = makeTempDir(_gwSessionTempDirs, "openclaw-gw-");
   testState.sessionStorePath = path.join(dir, "sessions.json");
 }
 
-afterAll(async () => {
-  await Promise.all(
-    _gwSessionTempDirs.map((dir) =>
-      fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }),
-    ),
-  );
+afterAll(() => {
+  cleanupTempDirs(_gwSessionTempDirs);
 });
 
 describe("gateway server agent", () => {

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -174,15 +174,15 @@ async function sendAgentWsRequestAndWaitFinal(
   return await finalP;
 }
 
-const _gwSessionTempDirs: string[] = [];
+const gwSessionTempDirs: string[] = [];
 
 async function useTempSessionStorePath() {
-  const dir = makeTempDir(_gwSessionTempDirs, "openclaw-gw-");
+  const dir = makeTempDir(gwSessionTempDirs, "openclaw-gw-");
   testState.sessionStorePath = path.join(dir, "sessions.json");
 }
 
 afterAll(() => {
-  cleanupTempDirs(_gwSessionTempDirs);
+  cleanupTempDirs(gwSessionTempDirs);
 });
 
 describe("gateway server agent", () => {

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -174,10 +174,17 @@ async function sendAgentWsRequestAndWaitFinal(
   return await finalP;
 }
 
+const _gwSessionTempDirs: string[] = [];
+
 async function useTempSessionStorePath() {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+  _gwSessionTempDirs.push(dir);
   testState.sessionStorePath = path.join(dir, "sessions.json");
 }
+
+afterAll(async () => {
+  await Promise.all(_gwSessionTempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
 
 describe("gateway server agent", () => {
   beforeEach(() => {

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -2,6 +2,7 @@
  * Gateway session compaction RPC tests.
  */
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
 import type { SessionCompactionCheckpoint } from "../config/sessions.js";

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -2,10 +2,10 @@
  * Gateway session compaction RPC tests.
  */
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
 import type { SessionCompactionCheckpoint } from "../config/sessions.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   embeddedRunMock,
@@ -793,75 +793,76 @@ test("sessions.compact maxLines aborts without truncating when an active run can
 });
 
 test("sessions.patch preserves nested model ids under provider overrides", async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-sessions-nested-"));
-  const storePath = path.join(dir, "sessions.json");
-  await fs.writeFile(
-    storePath,
-    JSON.stringify({
-      "agent:main:main": sessionStoreEntry("sess-main"),
-    }),
-    "utf-8",
-  );
+  await withTempDir({ prefix: "openclaw-gw-sessions-nested-" }, async (dir) => {
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": sessionStoreEntry("sess-main"),
+      }),
+      "utf-8",
+    );
 
-  await withEnvAsync({ OPENCLAW_CONFIG_PATH: undefined }, async () => {
-    const { clearConfigCache, clearRuntimeConfigSnapshot } = await getGatewayConfigModule();
-    clearConfigCache();
-    clearRuntimeConfigSnapshot();
-    const cfg = {
-      session: { store: storePath, mainKey: "main" },
-      agents: {
-        defaults: {
-          model: { primary: "openai/gpt-test-a" },
+    await withEnvAsync({ OPENCLAW_CONFIG_PATH: undefined }, async () => {
+      const { clearConfigCache, clearRuntimeConfigSnapshot } = await getGatewayConfigModule();
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+      const cfg = {
+        session: { store: storePath, mainKey: "main" },
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-test-a" },
+          },
+          list: [{ id: "main", default: true, workspace: dir }],
         },
-        list: [{ id: "main", default: true, workspace: dir }],
-      },
-    };
-    const configPath = path.join(dir, "openclaw.json");
-    await fs.writeFile(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+      };
+      const configPath = path.join(dir, "openclaw.json");
+      await fs.writeFile(configPath, JSON.stringify(cfg, null, 2), "utf-8");
 
-    await withEnvAsync({ OPENCLAW_CONFIG_PATH: configPath }, async () => {
-      const started = await startConnectedServerWithClient();
-      const { server, ws } = started;
-      try {
-        agentDiscoveryMock.enabled = true;
-        agentDiscoveryMock.models = [
-          { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5 (NVIDIA)", provider: "nvidia" },
-        ];
+      await withEnvAsync({ OPENCLAW_CONFIG_PATH: configPath }, async () => {
+        const started = await startConnectedServerWithClient();
+        const { server, ws } = started;
+        try {
+          agentDiscoveryMock.enabled = true;
+          agentDiscoveryMock.models = [
+            { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5 (NVIDIA)", provider: "nvidia" },
+          ];
 
-        const patched = await rpcReq<{
-          ok: true;
-          entry: {
-            modelOverride?: string;
-            providerOverride?: string;
-            model?: string;
-            modelProvider?: string;
-          };
-          resolved?: { model?: string; modelProvider?: string };
-        }>(ws, "sessions.patch", {
-          key: "agent:main:main",
-          model: "nvidia/moonshotai/kimi-k2.5",
-        });
-        expect(patched.ok).toBe(true);
-        expect(patched.payload?.entry.modelOverride).toBe("moonshotai/kimi-k2.5");
-        expect(patched.payload?.entry.providerOverride).toBe("nvidia");
-        expect(patched.payload?.entry.model).toBeUndefined();
-        expect(patched.payload?.entry.modelProvider).toBeUndefined();
-        expect(patched.payload?.resolved?.modelProvider).toBe("nvidia");
-        expect(patched.payload?.resolved?.model).toBe("moonshotai/kimi-k2.5");
+          const patched = await rpcReq<{
+            ok: true;
+            entry: {
+              modelOverride?: string;
+              providerOverride?: string;
+              model?: string;
+              modelProvider?: string;
+            };
+            resolved?: { model?: string; modelProvider?: string };
+          }>(ws, "sessions.patch", {
+            key: "agent:main:main",
+            model: "nvidia/moonshotai/kimi-k2.5",
+          });
+          expect(patched.ok).toBe(true);
+          expect(patched.payload?.entry.modelOverride).toBe("moonshotai/kimi-k2.5");
+          expect(patched.payload?.entry.providerOverride).toBe("nvidia");
+          expect(patched.payload?.entry.model).toBeUndefined();
+          expect(patched.payload?.entry.modelProvider).toBeUndefined();
+          expect(patched.payload?.resolved?.modelProvider).toBe("nvidia");
+          expect(patched.payload?.resolved?.model).toBe("moonshotai/kimi-k2.5");
 
-        const listed = await rpcReq<{
-          sessions: Array<{ key: string; modelProvider?: string; model?: string }>;
-        }>(ws, "sessions.list", {});
-        expect(listed.ok).toBe(true);
-        const mainSession = listed.payload?.sessions.find(
-          (session) => session.key === "agent:main:main",
-        );
-        expect(mainSession?.modelProvider).toBe("nvidia");
-        expect(mainSession?.model).toBe("moonshotai/kimi-k2.5");
-      } finally {
-        ws.close();
-        await server.close();
-      }
+          const listed = await rpcReq<{
+            sessions: Array<{ key: string; modelProvider?: string; model?: string }>;
+          }>(ws, "sessions.list", {});
+          expect(listed.ok).toBe(true);
+          const mainSession = listed.payload?.sessions.find(
+            (session) => session.key === "agent:main:main",
+          );
+          expect(mainSession?.modelProvider).toBe("nvidia");
+          expect(mainSession?.model).toBe("moonshotai/kimi-k2.5");
+        } finally {
+          ws.close();
+          await server.close();
+        }
+      });
     });
   });
 });

--- a/src/gateway/server.sessions.permissions-hooks.test.ts
+++ b/src/gateway/server.sessions.permissions-hooks.test.ts
@@ -1,23 +1,14 @@
 // Session permissions and hooks tests protect gateway access control around
 // patch/delete/compact/restore APIs plus emitted internal hook payloads.
-import { rmSync } from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterAll, expect, test, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
 const _permHookTempDirs: string[] = [];
 
-async function _mktemp(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  _permHookTempDirs.push(dir);
-  return dir;
-}
-
 afterAll(() => {
-  for (const dir of _permHookTempDirs) {
-    rmSync(dir, { recursive: true, force: true });
-  }
+  cleanupTempDirs(_permHookTempDirs);
 });
 import {
   GATEWAY_CLIENT_IDS,
@@ -133,7 +124,7 @@ test("webchat clients cannot patch, delete, compact, or restore sessions", async
 });
 
 test("session:patch hook fires with correct context", async () => {
-  const dir = await _mktemp("openclaw-sessions-patch-hook-");
+  const dir = makeTempDir(_permHookTempDirs, "openclaw-sessions-patch-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -173,7 +164,7 @@ test("session:patch hook fires with correct context", async () => {
 });
 
 test("session:patch hook does not fire for webchat clients", async () => {
-  const dir = await _mktemp("openclaw-sessions-webchat-hook-");
+  const dir = makeTempDir(_permHookTempDirs, "openclaw-sessions-webchat-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -202,7 +193,7 @@ test("session:patch hook does not fire for webchat clients", async () => {
 });
 
 test("session:patch hook only fires after successful patch", async () => {
-  const dir = await _mktemp("openclaw-sessions-success-hook-");
+  const dir = makeTempDir(_permHookTempDirs, "openclaw-sessions-success-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -314,7 +305,7 @@ test("session:patch hook mutations cannot change the response path", async () =>
 });
 
 test("control-ui client can delete sessions even in webchat mode", async () => {
-  const dir = await _mktemp("openclaw-sessions-control-ui-delete-");
+  const dir = makeTempDir(_permHookTempDirs, "openclaw-sessions-control-ui-delete-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 

--- a/src/gateway/server.sessions.permissions-hooks.test.ts
+++ b/src/gateway/server.sessions.permissions-hooks.test.ts
@@ -5,10 +5,10 @@ import path from "node:path";
 import { afterAll, expect, test, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
-const _permHookTempDirs: string[] = [];
+const permHookTempDirs: string[] = [];
 
 afterAll(() => {
-  cleanupTempDirs(_permHookTempDirs);
+  cleanupTempDirs(permHookTempDirs);
 });
 import {
   GATEWAY_CLIENT_IDS,
@@ -124,7 +124,7 @@ test("webchat clients cannot patch, delete, compact, or restore sessions", async
 });
 
 test("session:patch hook fires with correct context", async () => {
-  const dir = makeTempDir(_permHookTempDirs, "openclaw-sessions-patch-hook-");
+  const dir = makeTempDir(permHookTempDirs, "openclaw-sessions-patch-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -164,7 +164,7 @@ test("session:patch hook fires with correct context", async () => {
 });
 
 test("session:patch hook does not fire for webchat clients", async () => {
-  const dir = makeTempDir(_permHookTempDirs, "openclaw-sessions-webchat-hook-");
+  const dir = makeTempDir(permHookTempDirs, "openclaw-sessions-webchat-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -193,7 +193,7 @@ test("session:patch hook does not fire for webchat clients", async () => {
 });
 
 test("session:patch hook only fires after successful patch", async () => {
-  const dir = makeTempDir(_permHookTempDirs, "openclaw-sessions-success-hook-");
+  const dir = makeTempDir(permHookTempDirs, "openclaw-sessions-success-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -305,7 +305,7 @@ test("session:patch hook mutations cannot change the response path", async () =>
 });
 
 test("control-ui client can delete sessions even in webchat mode", async () => {
-  const dir = makeTempDir(_permHookTempDirs, "openclaw-sessions-control-ui-delete-");
+  const dir = makeTempDir(permHookTempDirs, "openclaw-sessions-control-ui-delete-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 

--- a/src/gateway/server.sessions.permissions-hooks.test.ts
+++ b/src/gateway/server.sessions.permissions-hooks.test.ts
@@ -1,5 +1,6 @@
 // Session permissions and hooks tests protect gateway access control around
 // patch/delete/compact/restore APIs plus emitted internal hook payloads.
+import { rmSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -15,7 +16,7 @@ async function _mktemp(prefix: string): Promise<string> {
 
 afterAll(() => {
   for (const dir of _permHookTempDirs) {
-    fs.rmSync(dir, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 import {

--- a/src/gateway/server.sessions.permissions-hooks.test.ts
+++ b/src/gateway/server.sessions.permissions-hooks.test.ts
@@ -3,7 +3,21 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { expect, test, vi } from "vitest";
+import { afterAll, expect, test, vi } from "vitest";
+
+const _permHookTempDirs: string[] = [];
+
+async function _mktemp(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  _permHookTempDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of _permHookTempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 import {
   GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
@@ -118,7 +132,7 @@ test("webchat clients cannot patch, delete, compact, or restore sessions", async
 });
 
 test("session:patch hook fires with correct context", async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-patch-hook-"));
+  const dir = await _mktemp("openclaw-sessions-patch-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -158,7 +172,7 @@ test("session:patch hook fires with correct context", async () => {
 });
 
 test("session:patch hook does not fire for webchat clients", async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-webchat-hook-"));
+  const dir = await _mktemp("openclaw-sessions-webchat-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -187,7 +201,7 @@ test("session:patch hook does not fire for webchat clients", async () => {
 });
 
 test("session:patch hook only fires after successful patch", async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-success-hook-"));
+  const dir = await _mktemp("openclaw-sessions-success-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -299,7 +313,7 @@ test("session:patch hook mutations cannot change the response path", async () =>
 });
 
 test("control-ui client can delete sessions even in webchat mode", async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-control-ui-delete-"));
+  const dir = await _mktemp("openclaw-sessions-control-ui-delete-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -859,6 +859,7 @@ describe("test-projects args", () => {
         config: "test/vitest/vitest.unit-fast.config.ts",
         forwardedArgs: [],
         includePatterns: [
+          "src/crestodian/operations.test.ts",
           "src/install-sh-version.test.ts",
           "src/proxy-capture/store.sqlite.test.ts",
           "test/scripts/android-version.test.ts",
@@ -870,6 +871,16 @@ describe("test-projects args", () => {
         config: "test/vitest/vitest.unit-fast-fake-timers.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/entry.compile-cache.test.ts"],
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.unit.config.ts",
+        forwardedArgs: [
+          "src/state/openclaw-agent-db.test.ts",
+          "src/state/openclaw-state-db.test.ts",
+          "src/state/sqlite-query-plan.test.ts",
+        ],
+        includePatterns: null,
         watchMode: false,
       },
       {
@@ -920,6 +931,26 @@ describe("test-projects args", () => {
         config: "test/vitest/vitest.runtime-config.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/config/sessions/entry-freshness.test.ts"],
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.gateway.config.ts",
+        forwardedArgs: [],
+        includePatterns: [
+          "src/gateway/hooks-mapping.test.ts",
+          "src/gateway/server-methods/chat.abort-persistence.test.ts",
+          "src/gateway/server.agent.gateway-server-agent-b.test.ts",
+          "src/gateway/server.sessions.permissions-hooks.test.ts",
+        ],
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.cron.config.ts",
+        forwardedArgs: [],
+        includePatterns: [
+          "src/cron/isolated-agent/run-session-state.test.ts",
+          "src/cron/run-log.error-reason.test.ts",
+        ],
         watchMode: false,
       },
       {

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -928,12 +928,6 @@ describe("test-projects args", () => {
         watchMode: false,
       },
       {
-        config: "test/vitest/vitest.runtime-config.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/config/sessions/entry-freshness.test.ts"],
-        watchMode: false,
-      },
-      {
         config: "test/vitest/vitest.gateway.config.ts",
         forwardedArgs: [],
         includePatterns: [
@@ -942,6 +936,12 @@ describe("test-projects args", () => {
           "src/gateway/server.agent.gateway-server-agent-b.test.ts",
           "src/gateway/server.sessions.permissions-hooks.test.ts",
         ],
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.runtime-config.config.ts",
+        forwardedArgs: [],
+        includePatterns: ["src/config/sessions/entry-freshness.test.ts"],
         watchMode: false,
       },
       {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -33,10 +33,10 @@ type RegisteredAgentDatabaseRow = {
   size_bytes: number | null;
 };
 
-const _agentDbTempDirs: string[] = [];
+const agentDbTempDirs: string[] = [];
 
 function createTempStateDir(): string {
-  return makeTempDir(_agentDbTempDirs, "openclaw-agent-db-");
+  return makeTempDir(agentDbTempDirs, "openclaw-agent-db-");
 }
 
 function listRegisteredAgentDatabasesForTest(options: { env?: NodeJS.ProcessEnv } = {}) {
@@ -54,7 +54,7 @@ function listRegisteredAgentDatabasesForTest(options: { env?: NodeJS.ProcessEnv 
 }
 
 afterAll(() => {
-  cleanupTempDirs(_agentDbTempDirs);
+  cleanupTempDirs(agentDbTempDirs);
 });
 
 afterEach(() => {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { listOpenFileDescriptorsForPath } from "../infra/open-file-descriptors.test-support.js";
@@ -35,9 +36,7 @@ type RegisteredAgentDatabaseRow = {
 const _agentDbTempDirs: string[] = [];
 
 function createTempStateDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-db-"));
-  _agentDbTempDirs.push(dir);
-  return dir;
+  return makeTempDir(_agentDbTempDirs, "openclaw-agent-db-");
 }
 
 function listRegisteredAgentDatabasesForTest(options: { env?: NodeJS.ProcessEnv } = {}) {
@@ -55,9 +54,7 @@ function listRegisteredAgentDatabasesForTest(options: { env?: NodeJS.ProcessEnv 
 }
 
 afterAll(() => {
-  for (const dir of _agentDbTempDirs) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  cleanupTempDirs(_agentDbTempDirs);
 });
 
 afterEach(() => {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { listOpenFileDescriptorsForPath } from "../infra/open-file-descriptors.test-support.js";
@@ -32,8 +32,12 @@ type RegisteredAgentDatabaseRow = {
   size_bytes: number | null;
 };
 
+const _agentDbTempDirs: string[] = [];
+
 function createTempStateDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-db-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-db-"));
+  _agentDbTempDirs.push(dir);
+  return dir;
 }
 
 function listRegisteredAgentDatabasesForTest(options: { env?: NodeJS.ProcessEnv } = {}) {
@@ -49,6 +53,12 @@ function listRegisteredAgentDatabasesForTest(options: { env?: NodeJS.ProcessEnv 
     sizeBytes: row.size_bytes,
   }));
 }
+
+afterAll(() => {
+  for (const dir of _agentDbTempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { readCronRunLogEntriesSync } from "../cron/run-log.js";
 import {
   executeSqliteQuerySync,
@@ -30,9 +31,7 @@ type StateDbTestDatabase = Pick<OpenClawStateKyselyDatabase, "diagnostic_events"
 const _stateDbTempDirs: string[] = [];
 
 function createTempStateDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-state-db-"));
-  _stateDbTempDirs.push(dir);
-  return dir;
+  return makeTempDir(_stateDbTempDirs, "openclaw-state-db-");
 }
 
 function statfsFixture(type: number): ReturnType<typeof fs.statfsSync> {
@@ -48,9 +47,7 @@ function statfsFixture(type: number): ReturnType<typeof fs.statfsSync> {
 }
 
 afterAll(() => {
-  for (const dir of _stateDbTempDirs) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  cleanupTempDirs(_stateDbTempDirs);
 });
 
 afterEach(() => {

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -28,10 +28,10 @@ import {
 
 type StateDbTestDatabase = Pick<OpenClawStateKyselyDatabase, "diagnostic_events" | "schema_meta">;
 
-const _stateDbTempDirs: string[] = [];
+const stateDbTempDirs: string[] = [];
 
 function createTempStateDir(): string {
-  return makeTempDir(_stateDbTempDirs, "openclaw-state-db-");
+  return makeTempDir(stateDbTempDirs, "openclaw-state-db-");
 }
 
 function statfsFixture(type: number): ReturnType<typeof fs.statfsSync> {
@@ -47,7 +47,7 @@ function statfsFixture(type: number): ReturnType<typeof fs.statfsSync> {
 }
 
 afterAll(() => {
-  cleanupTempDirs(_stateDbTempDirs);
+  cleanupTempDirs(stateDbTempDirs);
 });
 
 afterEach(() => {

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { readCronRunLogEntriesSync } from "../cron/run-log.js";
 import {
   executeSqliteQuerySync,
@@ -27,8 +27,12 @@ import {
 
 type StateDbTestDatabase = Pick<OpenClawStateKyselyDatabase, "diagnostic_events" | "schema_meta">;
 
+const _stateDbTempDirs: string[] = [];
+
 function createTempStateDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-state-db-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-state-db-"));
+  _stateDbTempDirs.push(dir);
+  return dir;
 }
 
 function statfsFixture(type: number): ReturnType<typeof fs.statfsSync> {
@@ -42,6 +46,12 @@ function statfsFixture(type: number): ReturnType<typeof fs.statfsSync> {
     ffree: 0,
   };
 }
+
+afterAll(() => {
+  for (const dir of _stateDbTempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();

--- a/src/state/sqlite-query-plan.test.ts
+++ b/src/state/sqlite-query-plan.test.ts
@@ -1,6 +1,4 @@
 // SQLite query-plan tests pin hot OpenClaw state indexes used by perf proof.
-import fs from "node:fs";
-import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
@@ -13,10 +11,10 @@ import {
   openOpenClawStateDatabase,
 } from "./openclaw-state-db.js";
 
-const _planTempDirs: string[] = [];
+const planTempDirs: string[] = [];
 
 function createTempStateDir(): string {
-  return makeTempDir(_planTempDirs, "openclaw-sqlite-plan-");
+  return makeTempDir(planTempDirs, "openclaw-sqlite-plan-");
 }
 
 function explainQueryPlan(
@@ -51,7 +49,7 @@ function expectPlanIncludes(params: {
 }
 
 afterAll(() => {
-  cleanupTempDirs(_planTempDirs);
+  cleanupTempDirs(planTempDirs);
 });
 
 afterEach(() => {

--- a/src/state/sqlite-query-plan.test.ts
+++ b/src/state/sqlite-query-plan.test.ts
@@ -1,9 +1,9 @@
 // SQLite query-plan tests pin hot OpenClaw state indexes used by perf proof.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -16,9 +16,7 @@ import {
 const _planTempDirs: string[] = [];
 
 function createTempStateDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-plan-"));
-  _planTempDirs.push(dir);
-  return dir;
+  return makeTempDir(_planTempDirs, "openclaw-sqlite-plan-");
 }
 
 function explainQueryPlan(
@@ -53,9 +51,7 @@ function expectPlanIncludes(params: {
 }
 
 afterAll(() => {
-  for (const dir of _planTempDirs) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  cleanupTempDirs(_planTempDirs);
 });
 
 afterEach(() => {

--- a/src/state/sqlite-query-plan.test.ts
+++ b/src/state/sqlite-query-plan.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -13,8 +13,12 @@ import {
   openOpenClawStateDatabase,
 } from "./openclaw-state-db.js";
 
+const _planTempDirs: string[] = [];
+
 function createTempStateDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-plan-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-plan-"));
+  _planTempDirs.push(dir);
+  return dir;
 }
 
 function explainQueryPlan(
@@ -47,6 +51,12 @@ function expectPlanIncludes(params: {
 }): void {
   expect(explainQueryPlan(params.db, params.sql, params.params)).toContain(params.expected);
 }
+
+afterAll(() => {
+  for (const dir of _planTempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();


### PR DESCRIPTION
## Summary

- Migrate 14 test files from raw `fs.mkdtemp`/`fs.mkdtempSync` to tracked cleanup via `withTempDir`, `withTempDirSync`, or `afterAll` cleanup arrays
- Files: 14 across `src/config`, `src/crestodian`, `src/cron`, `src/gateway`, `src/state`
- No user-visible behavior change

## Background

Part of the ongoing temp-dir migration (#87298). Shared helpers (`createSuiteTempRootTracker()`, `withTempDir()`, `withTempDirSync()`) provide automatic cleanup for temp directories. These files use raw `mkdtemp`/`mkdtempSync` with no cleanup at all, causing disk leaks and inconsistent patterns.

## What Problem This Solves

Gap finding: tempdir-8h9i0j1k

~100+ test files still use raw `fs.mkdtemp`/`fs.mkdtempSync` instead of shared helpers, causing:
1. **Disk leaks** — temp dirs created but never cleaned up
2. **Parallel test conflicts** — concurrent tests may collide on `/tmp` paths
3. **Inconsistent patterns** — the project has standardized on shared helpers

## Why This Change Was Made

Migrates second batch of high-risk test files with zero cleanup:

- `hooks-mapping.test.ts`: 14 `mkdtempSync` calls, never cleaned
- `operations.test.ts`: 6 `mkdtemp` calls per test case, never cleaned
- `run-log.error-reason.test.ts`: 4 `mkdtemp` calls per test case, never cleaned
- `permissions-hooks.test.ts`: 4 `mkdtemp` calls per test case, never cleaned
- `logging.test.ts`: `mkdtempSync` per test case, never cleaned
- `audit.test.ts`, `rescue-channel.live.test.ts`: `mkdtemp` per test case, never cleaned
- `run-session-state.test.ts`: `mkdtemp` via `createTranscriptFile()`, never cleaned
- `chat.abort-persistence.test.ts`: 2 `mkdtemp` via fixture helpers, never cleaned
- `server.agent.gateway-server-agent-b.test.ts`: `mkdtemp` via `useTempSessionStorePath()`, never cleaned
- `server.sessions.compaction.test.ts`: `mkdtemp` in `sessions.patch` test, never cleaned
- `openclaw-agent-db.test.ts`, `openclaw-state-db.test.ts`, `sqlite-query-plan.test.ts`: `createTempStateDir()` helper, never cleaned

## User Impact

Test-only. Reduces `/tmp` pressure, cleaner CI.

## Real behavior proof

Behavior addressed: 内部重构，无用户可见行为变化
Real environment tested: 本地开发环境 (Linux x86_64, Node 24)
Exact steps or command run after this patch:

```bash
pnpm test src/config/logging.test.ts src/crestodian/audit.test.ts src/state/sqlite-query-plan.test.ts src/cron/run-log.error-reason.test.ts
pnpm test src/crestodian/operations.test.ts src/gateway/hooks-mapping.test.ts
pnpm test src/gateway/server.sessions.compaction.test.ts src/gateway/server.sessions.permissions-hooks.test.ts src/gateway/server.agent.gateway-server-agent-b.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts
```

Evidence after fix:

```console
$ pnpm test src/config/logging.test.ts src/crestodian/audit.test.ts src/state/sqlite-query-plan.test.ts src/cron/run-log.error-reason.test.ts
 Test Files  4 passed (4)
      Tests  11 passed (11)

$ pnpm test src/crestodian/operations.test.ts src/gateway/hooks-mapping.test.ts
 Test Files  5 passed (5)
      Tests  125 passed (125)

$ pnpm test src/gateway/server.sessions.compaction.test.ts src/gateway/server.sessions.permissions-hooks.test.ts src/gateway/server.agent.gateway-server-agent-b.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts
 Test Files  8 passed (8)
      Tests  116 passed (116)
```

Observed result after fix: 252 tests pass across all 14 migrated test files, matching baseline behavior
What was not tested: full CI suite (triggered on push to remote)

## Revision (2026-06-25)

ClawSweeper review and CI identified 3 classes of issues, now fixed:

1. **Lint: `no-underscore-dangle`** — 12 `_`-prefixed temp-dir tracker names renamed (e.g. `_opTempDirs` → `opTempDirs`) across 11 files
2. **Lint: `no-unused-vars`** — 3 unused imports removed (`vi` from `rescue-channel.live.test.ts`, `fs`/`path` from `sqlite-query-plan.test.ts`)
3. **Tooling: `test-projects.test.ts`** — updated `buildVitestRunPlans(["test/helpers/temp-dir.ts"])` expectation to include new importers from `src/crestodian`, `src/state`, `src/gateway`, and `src/cron`

### Revision proof

```bash
# Verify lint passes on all affected files
$ for f in src/crestodian/operations.test.ts src/crestodian/rescue-channel.live.test.ts src/state/sqlite-query-plan.test.ts src/cron/run-log.error-reason.test.ts src/cron/isolated-agent/run-session-state.test.ts src/gateway/hooks-mapping.test.ts src/gateway/server.agent.gateway-server-agent-b.test.ts src/gateway/server.sessions.permissions-hooks.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts src/state/openclaw-state-db.test.ts src/state/openclaw-agent-db.test.ts; do node_modules/oxlint/bin/oxlint -c .oxlintrc.json "$f"; done
# Exit code: 0 (no lint errors)

# Verify test-projects routing test passes
$ pnpm vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/test-projects.test.ts -t "routes top-level test helpers"
 Test Files  1 passed (1)
      Tests  1 passed | 82 skipped (83)
```

## Revision 2 (2026-06-25)

ClawSweeper re-review caught a remaining unused `path` import in `src/crestodian/audit.test.ts` that was missed in the previous revision. CI `check-lint` was failing on this.

**Fix** (commit `2557f1f71d`):
- Removed `import path from "node:path";` from `src/crestodian/audit.test.ts:3` — no longer used after migration to `withTempDir`

### Revision 2 proof

```bash
# Verify lint passes on the affected file
$ node scripts/run-oxlint.mjs --tsconfig tsconfig.json src/crestodian/audit.test.ts
# Exit code: 0 (no lint errors)
```

## Revision 3 (2026-06-30)

Rebased onto `upstream/main` (`6cb82eaab8`) after merge conflicts in `src/scripts/test-projects.test.ts`. The upstream `main` had added new routing entries that conflicted with the PR's routing additions.

**Conflict resolution** (commit `2fe0c65fbe`):
- Resolved `src/scripts/test-projects.test.ts` merge conflict by keeping both upstream's new entries and the PR's entries
- Fixed expected plan ordering in `buildVitestRunPlans(["test/helpers/temp-dir.ts"])` test: swapped `gateway` and `runtime-config` entries to match actual output order

### Revision 3 proof

```bash
# test-projects full suite passes (83 tests)
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts src/scripts/test-projects.test.ts
 Test Files  1 passed (1)
      Tests  83 passed (83)

# Gateway tests pass (81 tests)
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/hooks-mapping.test.ts
 Test Files  3 passed (3)
      Tests  81 passed (81)

# State tests pass (33 tests)
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/state/openclaw-agent-db.test.ts src/state/openclaw-state-db.test.ts src/state/sqlite-query-plan.test.ts
 Test Files  3 passed (3)
      Tests  33 passed (33)

# Lint and format clean on changed files
$ node_modules/.bin/oxlint --quiet src/scripts/test-projects.test.ts
# Exit: 0
$ pnpm format:check src/scripts/test-projects.test.ts
# Exit: 0
```

