### PR TITLE
fix(sessions): defer daily rollover during active reply runs

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
+import { replyRunRegistry, testing as replyRunRegistryTesting } from "./reply-run-registry.js";
 import { drainFormattedSystemEvents } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 import { initSessionState } from "./session.js";
@@ -466,6 +467,7 @@ beforeEach(() => {
 });
 afterEach(async () => {
   resetSystemEventsForTest();
+  replyRunRegistryTesting.resetReplyRunRegistry();
   await sessionMcpTesting.resetSessionMcpRuntimeManager();
 });
 describe("initSessionState thread forking", () => {
@@ -3660,6 +3662,68 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         entry.startsWith(`${existingSessionId}.jsonl.reset.`),
       );
       expect(archived).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("defers implicit daily rollover while the existing session has an active reply run", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+      const storePath = await createStorePath("openclaw-stale-active-run-");
+      const sessionKey = "agent:main:telegram:dm:archive-active-user";
+      const existingSessionId = "active-stale-session";
+      const transcriptPath = path.join(path.dirname(storePath), `${existingSessionId}.jsonl`);
+      const sessionStartedAt = new Date(2026, 0, 18, 3, 58, 0).getTime();
+
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          sessionStartedAt,
+          updatedAt: sessionStartedAt,
+        },
+      });
+      await fs.writeFile(transcriptPath, '{"type":"message","part":1}\n', "utf8");
+      replyRunRegistry.begin({
+        sessionKey,
+        sessionId: existingSessionId,
+        resetTriggered: false,
+      });
+
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const result = await initSessionState({
+        ctx: {
+          Body: "hello while previous turn streams",
+          RawBody: "hello while previous turn streams",
+          CommandBody: "hello while previous turn streams",
+          From: "user-active-stale",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(false);
+      expect(result.resetTriggered).toBe(false);
+      expect(result.sessionId).toBe(existingSessionId);
+      await expect(fs.readFile(transcriptPath, "utf8")).resolves.toBe(
+        '{"type":"message","part":1}\n',
+      );
+      const archived = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
+        entry.startsWith(`${existingSessionId}.jsonl.reset.`),
+      );
+      expect(archived).toHaveLength(0);
+      const store = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<
+        string,
+        SessionEntry
+      >;
+      expect(store[sessionKey]?.sessionId).toBe(existingSessionId);
+      expect(store[sessionKey]?.sessionStartedAt).toBe(sessionStartedAt);
     } finally {
       vi.useRealTimers();
     }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -71,6 +71,10 @@ import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
+import {
+  isReplyRunActiveForSessionId,
+  resolveActiveReplyRunSessionId,
+} from "./reply-run-registry.js";
 import { isResetAuthorizedForContext } from "./reset-authorization.js";
 import {
   maybeRetireLegacyMainDeliveryRoute,
@@ -156,6 +160,20 @@ function resolveStaleSessionEndReason(params: {
 function hasProviderOwnedSession(entry: SessionEntry | undefined): boolean {
   const provider = normalizeOptionalString(entry?.providerOverride ?? entry?.modelProvider);
   return Boolean(provider && getCliSessionBinding(entry, provider));
+}
+
+function hasActiveReplyRunForSessionEntry(params: {
+  entry: SessionEntry | undefined;
+  sessionKey: string;
+}): boolean {
+  const sessionId = normalizeOptionalString(params.entry?.sessionId);
+  if (!sessionId) {
+    return false;
+  }
+  return (
+    resolveActiveReplyRunSessionId(params.sessionKey) === sessionId &&
+    isReplyRunActiveForSessionId(sessionId)
+  );
 }
 
 export type SessionInitResult = {
@@ -482,6 +500,11 @@ async function initSessionStateAttempt(
           policy: resetPolicy,
         })
     : undefined;
+  const deferImplicitRolloverForActiveRun =
+    !resetTriggered &&
+    canReuseExistingEntry &&
+    entryFreshness?.fresh === false &&
+    hasActiveReplyRunForSessionEntry({ entry, sessionKey });
   const softResetAllowed =
     softReset.matched &&
     resetAuthorized &&
@@ -509,6 +532,7 @@ async function initSessionStateAttempt(
     }));
   const freshEntry =
     (isSystemEvent && canReuseExistingEntry) ||
+    deferImplicitRolloverForActiveRun ||
     (((reconnectResumeRequested && canReuseExistingEntry) ||
       (entryFreshness?.fresh ?? false) ||
       (softResetAllowed && canReuseExistingEntry)) &&


### PR DESCRIPTION
Fixes #96546.
Related: #96552.

## What Problem This Solves

Daily or scheduled session rollover could rotate a session while an existing reply run for that same session was still active. That could archive the transcript and mint a new session in the middle of an in-flight response, leaving later writes attached to stale session state.

## Why This Change Was Made

The session initializer now checks the reply-run registry before applying an implicit stale/daily rollover. If the persisted entry belongs to the active run for that same session id, OpenClaw reuses the existing entry and defers the implicit rollover. Explicit resets and inactive stale sessions keep the existing behavior.

This is the corrected follow-up to the earlier archive-only shape in #96552. That approach avoided one transcript rename, but it could still mint a new canonical session while the active run kept writing the old transcript. This PR defers the whole implicit rollover while the active run owns the session, so the store entry and transcript path remain reachable and the next inactive/stale initialization can perform normal rollover.

## User Impact

Long-running replies that cross the daily reset boundary continue writing to the session they started in instead of being split across an archived transcript and a new session. Users still get normal daily rollover once the active run is no longer in progress.

## Real Behavior Proof

Exact head: `22f679d9210d0236b61549ab239d9c8a6f016c28`.

The transcript-file behavior was verified at the file/store boundary with a stale daily-reset session and a matching active reply-run registry entry. The proof uses the same persisted artifacts the runtime owns: the session JSON store plus the `<sessionId>.jsonl` transcript file.

Control case, stale session without an active run:

```text
seed: sessionStartedAt/updatedAt before the 04:00 daily reset boundary
seed: <proof-root>/inactive-control/inactive-control-stale-session.jsonl exists
result: isNewSession=true, resetTriggered=false
result: returned session id != inactive-control-stale-session
transcript: original inactive-control-stale-session.jsonl removed
archive: inactive-control-stale-session.jsonl.reset.<timestamp> created
```

After-fix case, same stale session with an active reply run for the same session id:

```text
seed: sessionStartedAt/updatedAt before the 04:00 daily reset boundary
seed: replyRunRegistry.begin({ sessionKey, sessionId: "active-run-stale-session", resetTriggered: false })
seed: <proof-root>/active-run/active-run-stale-session.jsonl exists
result: isNewSession=false, resetTriggered=false
result: returned session id == active-run-stale-session
transcript: original active-run-stale-session.jsonl remains in place with content preserved
archive: 0 files matching active-run-stale-session.jsonl.reset.*
store: sessionKey still maps to active-run-stale-session and keeps the original sessionStartedAt
```

GitHub exact-head proof/check evidence:

- `Real behavior proof` passed on this PR head: https://github.com/openclaw/openclaw/actions/runs/28174522096/job/83447134892
- Full CI passed on this PR head: https://github.com/openclaw/openclaw/actions/runs/28174523280
- The relevant exact-head CI checks include `check-test-types`, `check-prod-types`, `check-lint`, `check-guards`, `checks-node-compact-*`, `QA Smoke CI`, and `ci-timings-summary`, all passing.

## Evidence

Head: `22f679d9210d0236b61549ab239d9c8a6f016c28`

- `node scripts/run-vitest.mjs run src/auto-reply/reply/session.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-embedded-agent.config.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts --reporter=verbose`
- `pnpm oxfmt --check src/auto-reply/reply/session.ts src/auto-reply/reply/session.test.ts`
- `pnpm tsgo:core`
- `git diff --check origin/main...HEAD`

Focused regression coverage includes:

- inactive stale daily sessions still rotate and archive the old transcript;
- active-run stale daily sessions reuse the existing session id;
- active-run stale daily sessions keep the live transcript file in place;
- active-run stale daily sessions do not create a `.jsonl.reset.<timestamp>` archive;
- the session store preserves the original session id and `sessionStartedAt` while the active run owns that session.
