### PR TITLE
fix(discord): preserve tool updates when progress preview is empty

### DIFF
--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -106,12 +106,15 @@ export function createDiscordDraftPreviewController(params: {
   const narrationHideCommandText =
     narrationProgressEnabled &&
     resolveChannelStreamingPreviewCommandText(params.discordConfig) === "status";
-  const suppressDefaultToolProgressMessages =
+  const canSuppressDefaultToolProgressMessages =
     Boolean(draftStream) &&
     resolveChannelStreamingSuppressDefaultToolProgressMessages(params.discordConfig, {
       draftStreamActive: true,
       previewToolProgressEnabled,
     });
+  const suppressDefaultToolProgressImmediately =
+    canSuppressDefaultToolProgressMessages &&
+    (discordStreamMode !== "progress" || !previewToolProgressEnabled);
   const progressSeed = `${params.accountId}:${params.deliverChannelId}`;
   const progressDraft = createChannelProgressDraftCompositor({
     entry: params.discordConfig,
@@ -171,7 +174,13 @@ export function createDiscordDraftPreviewController(params: {
     narrationProgressEnabled,
     narrationHideCommandText,
     commentaryProgressEnabled: progressDraft.commentaryProgressEnabled,
-    suppressDefaultToolProgressMessages,
+    get suppressDefaultToolProgressMessages() {
+      return (
+        suppressDefaultToolProgressImmediately ||
+        hasStreamedMessage ||
+        progressDraft.suppressDefaultToolProgressMessages
+      );
+    },
     get isProgressMode() {
       return discordStreamMode === "progress";
     },
@@ -189,6 +198,12 @@ export function createDiscordDraftPreviewController(params: {
     markProgressDraftCollapsed() {
       progressDraftCollapsed = true;
       progressDraftStartedBeforeFinal = false;
+    },
+    get shouldSuppressBlockReplies() {
+      return hasStreamedMessage;
+    },
+    get shouldDeferProgressBlockReplies() {
+      return canSuppressDefaultToolProgressMessages && discordStreamMode === "progress";
     },
     get finalizedViaPreviewMessage() {
       return finalizedViaPreviewMessage;

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -3247,6 +3247,99 @@ describe("processDiscordMessage draft streaming", () => {
     ).toBe(true);
   });
 
+  it("restores Discord tool replies when progress preview stays empty", async () => {
+    createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      expect(params?.replyOptions?.suppressDefaultToolProgressMessages).toBeUndefined();
+      await params?.dispatcher.sendBlockReply({ text: "fast command finished" });
+      await params?.dispatcher.waitForIdle();
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 1 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+          progress: {
+            label: false,
+            toolProgress: false,
+          },
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      replies: [{ text: "fast command finished" }],
+      kind: "block",
+    });
+  });
+
+  it("keeps default progress-mode fast block replies when no Discord draft is visible", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      expect(params?.replyOptions?.suppressDefaultToolProgressMessages).toBeUndefined();
+      await params?.dispatcher.sendBlockReply({ text: "fast command finished" });
+      await params?.dispatcher.waitForIdle();
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 1 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      replies: [{ text: "fast command finished" }],
+      kind: "block",
+    });
+  });
+
+  it("flushes deferred Discord progress blocks before a final reply when no draft is visible", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      expect(params?.replyOptions?.suppressDefaultToolProgressMessages).toBeUndefined();
+      await params?.dispatcher.sendBlockReply({ text: "fast command finished" });
+      await params?.dispatcher.waitForIdle();
+      await params?.dispatcher.sendFinalReply({ text: "done" });
+      await params?.dispatcher.waitForIdle();
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 1 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(2);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      replies: [{ text: "fast command finished" }],
+      kind: "block",
+    });
+    expect(deliverDiscordReply.mock.calls[1]?.[0]).toMatchObject({
+      replies: [{ text: "done" }],
+      kind: "final",
+    });
+  });
+
   it("renders a preamble headline without enabling commentary progress", async () => {
     const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
     const draftStream = createMockDraftStreamForTest();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -531,10 +531,15 @@ async function processDiscordMessageInner(
   let pendingToolWarningFinal:
     | { payload: ReplyPayload; info: { kind: ReplyDispatchKind } }
     | undefined;
+  let pendingProgressBlockReplies: Array<{
+    payload: ReplyPayload;
+    info: { kind: ReplyDispatchKind };
+  }> = [];
   const markUserFacingFinalDelivered = () => {
     userFacingFinalDelivered = true;
     userFacingFinalDeliveryFailed = false;
     pendingToolWarningFinal = undefined;
+    pendingProgressBlockReplies = [];
     draftPreview.markFinalReplyDelivered();
     observer?.onFinalReplyDelivered?.();
   };
@@ -663,6 +668,21 @@ async function processDiscordMessageInner(
     await replyPipeline.typingCallbacks?.onReplyStart();
     await statusReactions.setThinking();
   };
+  const isDeferrableProgressBlockReply = (
+    payload: ReplyPayload,
+    info: { kind: ReplyDispatchKind },
+  ) => {
+    if (
+      !draftPreview.draftStream ||
+      !draftPreview.isProgressMode ||
+      !draftPreview.shouldDeferProgressBlockReplies ||
+      info.kind !== "block"
+    ) {
+      return false;
+    }
+    const reply = resolveSendableOutboundReplyParts(payload);
+    return !reply.hasMedia && !payload.isError;
+  };
   const beforeDiscordPayloadDelivery = (
     payload: ReplyPayload,
     info: { kind: ReplyDispatchKind },
@@ -681,7 +701,12 @@ async function processDiscordMessageInner(
     if (payload.isReasoning || payload.isCommentary) {
       return payload;
     }
-    if (draftPreview.draftStream && draftPreview.isProgressMode && info.kind === "block") {
+    if (
+      draftPreview.draftStream &&
+      draftPreview.isProgressMode &&
+      draftPreview.shouldSuppressBlockReplies &&
+      info.kind === "block"
+    ) {
       const reply = resolveSendableOutboundReplyParts(payload);
       if (!reply.hasMedia && !payload.isError) {
         return null;
@@ -696,7 +721,10 @@ async function processDiscordMessageInner(
   const deliverDiscordPayload = async (
     payload: ReplyPayload,
     info: { kind: ReplyDispatchKind },
-    options?: { allowFallbackOnlyToolWarning?: boolean },
+    options?: {
+      allowDeferredProgressBlockFallback?: boolean;
+      allowFallbackOnlyToolWarning?: boolean;
+    },
   ) => {
     if (isProcessAborted(abortSignal)) {
       // Surface so operators don't chase missing replies when an abort
@@ -797,11 +825,17 @@ async function processDiscordMessageInner(
       await onDiscordReplyStart();
     }
     const draftStream = draftPreview.draftStream;
-    if (draftStream && draftPreview.isProgressMode && info.kind === "block") {
-      const reply = resolveSendableOutboundReplyParts(deliverablePayload);
-      if (!reply.hasMedia && !deliverablePayload.isError) {
+    if (draftStream && isDeferrableProgressBlockReply(deliverablePayload, info)) {
+      if (draftPreview.shouldSuppressBlockReplies) {
         return { visibleReplySent: false };
       }
+      if (!options?.allowDeferredProgressBlockFallback) {
+        pendingProgressBlockReplies.push({ payload: deliverablePayload, info });
+        return { visibleReplySent: false };
+      }
+    }
+    if (isFinal && pendingProgressBlockReplies.length && !userFacingFinalDelivered) {
+      await deliverPendingProgressBlockRepliesIfNeeded();
     }
     const shouldCollapseProgressDraft =
       draftStream &&
@@ -1015,6 +1049,38 @@ async function processDiscordMessageInner(
       return { visibleReplySent: false };
     }
   };
+  const deliverPendingProgressBlockRepliesIfNeeded = async () => {
+    if (!pendingProgressBlockReplies.length) {
+      return undefined;
+    }
+    const pending = pendingProgressBlockReplies;
+    pendingProgressBlockReplies = [];
+    if (
+      userFacingFinalDelivered ||
+      isProcessAborted(abortSignal) ||
+      draftPreview.shouldSuppressBlockReplies ||
+      draftPreview.hasProgressDraftStarted
+    ) {
+      return undefined;
+    }
+    let lastResult: { visibleReplySent: boolean } | undefined;
+    for (const pendingReply of pending) {
+      try {
+        lastResult = await deliverDiscordPayload(pendingReply.payload, pendingReply.info, {
+          allowDeferredProgressBlockFallback: true,
+        });
+      } catch (err) {
+        dispatchError = true;
+        onDiscordDeliveryError(err, pendingReply.info);
+        lastResult = { visibleReplySent: false };
+      }
+    }
+    return lastResult;
+  };
+  const deliverPendingFreshDiscordDeliveries = async () => {
+    await deliverPendingProgressBlockRepliesIfNeeded();
+    return await deliverPendingToolWarningFinalIfNeeded();
+  };
   try {
     if (isProcessAborted(abortSignal)) {
       dispatchAborted = true;
@@ -1037,7 +1103,7 @@ async function processDiscordMessageInner(
         humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
         beforeDeliver: beforeDiscordPayloadDelivery,
         onReplyStart: onDiscordReplyStart,
-        onFreshSettledDelivery: deliverPendingToolWarningFinalIfNeeded,
+        onFreshSettledDelivery: deliverPendingFreshDiscordDeliveries,
       },
       delivery: {
         deliver: deliverDiscordPayload,
@@ -1084,11 +1150,12 @@ async function processDiscordMessageInner(
             }
           : undefined,
         onModelSelected,
-        suppressDefaultToolProgressMessages:
-          (sourceRepliesAreToolOnly && statusReactionsExplicitlyEnabled) ||
-          draftPreview.suppressDefaultToolProgressMessages
+        get suppressDefaultToolProgressMessages() {
+          return (sourceRepliesAreToolOnly && statusReactionsExplicitlyEnabled) ||
+            draftPreview.suppressDefaultToolProgressMessages
             ? true
-            : undefined,
+            : undefined;
+        },
         allowToolLifecycleWhenProgressHidden: statusReactionsEnabled ? true : undefined,
         commentaryProgressEnabled: draftPreview.isProgressMode
           ? draftPreview.commentaryProgressEnabled

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -127,9 +127,143 @@ describe("createChannelProgressDraftCompositor", () => {
       update,
     });
 
+    expect(progress.suppressDefaultToolProgressMessages).toBe(false);
+
     await progress.pushToolProgress("🛠️ Exec", { startImmediately: true });
 
     expect(update).toHaveBeenCalledWith("Shelling", { flush: true, lines: [] });
+    expect(progress.suppressDefaultToolProgressMessages).toBe(true);
+  });
+
+  it("suppresses default tool messages only after progress drafts become visible", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress" } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    expect(progress.suppressDefaultToolProgressMessages).toBe(false);
+
+    await progress.pushToolProgress("Exec started");
+
+    expect(update).not.toHaveBeenCalled();
+    expect(progress.hasStarted).toBe(false);
+    expect(progress.suppressDefaultToolProgressMessages).toBe(false);
+
+    await progress.pushToolProgress("Exec finished");
+
+    expect(update).toHaveBeenCalled();
+    expect(progress.hasStarted).toBe(true);
+    expect(progress.suppressDefaultToolProgressMessages).toBe(true);
+  });
+
+  it("does not suppress default tool messages when progress drafts stay empty", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: {
+        streaming: { mode: "progress", progress: { label: false, toolProgress: false } },
+      },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.pushToolProgress("🛠️ Exec", { startImmediately: true });
+
+    expect(update).not.toHaveBeenCalled();
+    expect(progress.suppressDefaultToolProgressMessages).toBe(false);
+  });
+
+  it("materializes a label-only progress draft after upstream answer activity", async () => {
+    vi.useFakeTimers();
+    try {
+      const update = vi.fn();
+      const progress = createChannelProgressDraftCompositor({
+        entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+        mode: "progress",
+        active: true,
+        seed: "test",
+        update,
+      });
+
+      await progress.noteActivity();
+      expect(update).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS);
+
+      expect(update).toHaveBeenCalledWith("Shelling", { flush: true, lines: [] });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not materialize delayed answer activity after final delivery starts or lands", async () => {
+    vi.useFakeTimers();
+    try {
+      for (const markFinal of ["markFinalReplyStarted", "markFinalReplyDelivered"] as const) {
+        const update = vi.fn();
+        const progress = createChannelProgressDraftCompositor({
+          entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+          mode: "progress",
+          active: true,
+          seed: "test",
+          update,
+        });
+
+        await progress.noteActivity();
+        progress[markFinal]();
+        await vi.advanceTimersByTimeAsync(DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS);
+
+        expect(update).not.toHaveBeenCalled();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("starts a label-only progress draft on repeated upstream answer activity", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.noteActivity();
+    await progress.noteActivity();
+
+    expect(update).toHaveBeenCalledWith("Shelling", { flush: true, lines: [] });
+  });
+
+  it("passes structured progress lines to draft updates", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+    const line = {
+      kind: "tool" as const,
+      text: "🛠️ Exec: git status",
+      label: "Exec",
+      icon: "🛠️",
+      detail: "git status",
+    };
+
+    await progress.pushToolProgress(line, { startImmediately: true });
+
+    expect(update).toHaveBeenCalledWith("Shelling\n\n🛠️ Exec: git status", {
+      flush: true,
+      lines: [line],
+    });
   });
 
   it("gates window thinking on its own flag, independent of tool progress", async () => {

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -136,28 +136,33 @@ describe("createChannelProgressDraftCompositor", () => {
   });
 
   it("suppresses default tool messages only after progress drafts become visible", async () => {
-    const update = vi.fn();
-    const progress = createChannelProgressDraftCompositor({
-      entry: { streaming: { mode: "progress" } },
-      mode: "progress",
-      active: true,
-      seed: "test",
-      update,
-    });
+    vi.useFakeTimers();
+    try {
+      const update = vi.fn();
+      const progress = createChannelProgressDraftCompositor({
+        entry: { streaming: { mode: "progress" } },
+        mode: "progress",
+        active: true,
+        seed: "test",
+        update,
+      });
 
-    expect(progress.suppressDefaultToolProgressMessages).toBe(false);
+      expect(progress.suppressDefaultToolProgressMessages).toBe(false);
 
-    await progress.pushToolProgress("Exec started");
+      await progress.pushToolProgress("Exec started");
 
-    expect(update).not.toHaveBeenCalled();
-    expect(progress.hasStarted).toBe(false);
-    expect(progress.suppressDefaultToolProgressMessages).toBe(false);
+      expect(update).not.toHaveBeenCalled();
+      expect(progress.hasStarted).toBe(false);
+      expect(progress.suppressDefaultToolProgressMessages).toBe(false);
 
-    await progress.pushToolProgress("Exec finished");
+      await vi.advanceTimersByTimeAsync(DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS);
 
-    expect(update).toHaveBeenCalled();
-    expect(progress.hasStarted).toBe(true);
-    expect(progress.suppressDefaultToolProgressMessages).toBe(true);
+      expect(update).toHaveBeenCalled();
+      expect(progress.hasStarted).toBe(true);
+      expect(progress.suppressDefaultToolProgressMessages).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not suppress default tool messages when progress drafts stay empty", async () => {
@@ -223,22 +228,6 @@ describe("createChannelProgressDraftCompositor", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  it("starts a label-only progress draft on repeated upstream answer activity", async () => {
-    const update = vi.fn();
-    const progress = createChannelProgressDraftCompositor({
-      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-      mode: "progress",
-      active: true,
-      seed: "test",
-      update,
-    });
-
-    await progress.noteActivity();
-    await progress.noteActivity();
-
-    expect(update).toHaveBeenCalledWith("Shelling", { flush: true, lines: [] });
   });
 
   it("passes structured progress lines to draft updates", async () => {

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -160,7 +160,7 @@ export function createChannelProgressDraftCompositor(params: {
     params.active && resolveChannelStreamingProgressCommentary(params.entry);
   const thinkingProgressEnabled =
     params.active && (params.reasoningGate ?? previewToolProgressEnabled);
-  const suppressDefaultToolProgressMessages =
+  const canSuppressDefaultToolProgressMessages =
     params.active &&
     resolveChannelStreamingSuppressDefaultToolProgressMessages(params.entry, {
       draftStreamActive: true,
@@ -398,7 +398,9 @@ export function createChannelProgressDraftCompositor(params: {
       return commentaryProgressEnabled;
     },
     get suppressDefaultToolProgressMessages() {
-      return suppressDefaultToolProgressMessages;
+      return (
+        canSuppressDefaultToolProgressMessages && (params.mode !== "progress" || gate.hasStarted)
+      );
     },
     get hasStarted() {
       return gate.hasStarted;
@@ -600,6 +602,7 @@ export function createChannelProgressDraftCompositor(params: {
         params.mode !== "progress" ||
         !text ||
         progressSuppressed ||
+        finalReplyStarted ||
         finalReplyDelivered ||
         !thinkingProgressEnabled
       ) {

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -844,6 +844,13 @@ export function resolveChannelStreamingSuppressDefaultToolProgressMessages(
     return false;
   }
   if (mode === "progress") {
+    const progress = resolveChannelProgressDraftConfig(entry);
+    const toolProgressEnabled =
+      options?.previewToolProgressEnabled ?? resolveChannelStreamingPreviewToolProgress(entry);
+    const commentaryEnabled = resolveChannelStreamingProgressCommentary(entry);
+    if (progress.label === false && !toolProgressEnabled && !commentaryEnabled) {
+      return false;
+    }
     return true;
   }
   if (options?.draftStreamActive === true) {


### PR DESCRIPTION
## What Problem This Solves
Fixes #87704. In Discord `streaming.mode=progress`, OpenClaw could suppress standalone tool/block progress messages even when the progress preview lane never produced a visible draft. That left operators without visible tool updates during default progress-mode fast-tool turns.

A follow-up gap remained when an empty progress preview later produced a final response: the deferred progress block could be dropped before the final message, so users still missed the only visible tool update for that turn.

## Why This Change Was Made

- Expose default tool-progress suppression only after the progress compositor has actually started a visible progress draft in `progress` mode.
- Keep immediate suppression for configurations that can render a label-only progress draft, so existing visible-preview behavior is preserved.
- Defer Discord text-only block replies that may be replaced by a progress draft; if the draft stays empty, flush the deferred block before the final reply.
- Drop deferred interim blocks once a progress draft becomes visible, preventing the existing duplicate `on it` plus draft behavior.

## User Impact
Discord operators keep seeing meaningful fast-tool/block updates when progress preview mode is enabled but has no visible content yet. If a final reply arrives after an empty preview lane, the deferred progress block is delivered before that final message instead of being lost.

Existing visible progress drafts still own the progress lane, so users do not get duplicated interim block messages after real progress appears.

## Evidence
Head commit: `f2aa368ec554a0ce2dedfa2357f9fd3b85a9b56e`.

Real behavior proof from the Discord and channel compositor harnesses:

- Default Discord progress mode with no visible draft: `replyOptions.suppressDefaultToolProgressMessages` is `undefined`, `draftStream.update` is not called, and one fallback block reply is delivered with text `fast command finished`.
- Empty Discord progress preview followed by a final reply: the deferred block is flushed before the final reply so both the tool update and final answer are visible in order.
- Discord progress mode after work expands: the draft updates to `Shelling` with the exec progress lines, the earlier text-only interim block is not delivered, and the final reply edits the preview to `done`.
- Channel compositor: `suppressDefaultToolProgressMessages` is `false` before the progress draft starts, stays `false` after the first delayed work event, and becomes `true` after the second work event starts the visible draft.

Validation:

- `node scripts/run-vitest.mjs run extensions/discord/src/monitor/message-handler.process.test.ts` passed: 111 tests.
- `node scripts/run-vitest.mjs run src/channels/progress-draft-compositor.test.ts` passed: 18 tests.
- `pnpm tsgo:extensions:test` passed.
- `pnpm oxfmt --check src/channels/progress-draft-compositor.ts src/channels/progress-draft-compositor.test.ts extensions/discord/src/monitor/message-handler.draft-preview.ts extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.process.test.ts` passed.
- `git diff --check` passed.
