### PR TITLE
fix(moonshot): kimi search 401 with china-region api keys

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -4680,6 +4680,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Provider-only (SenseAudio)
   - H3: Echo transcript to chat (opt-in)
   - H2: Notes and limits
+  - H3: Resident local STT
   - H3: Proxy environment support
   - H2: Mention detection in groups
   - H2: Gotchas
@@ -9413,6 +9414,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Config
   - H2: Grounding requirement
   - H2: Tool parameters
+  - H2: Base URL overrides
   - H2: Related
 
 ## tools/llm-task.md

--- a/docs/tools/kimi-search.md
+++ b/docs/tools/kimi-search.md
@@ -43,7 +43,7 @@ also prompts for:
         config: {
           webSearch: {
             apiKey: "sk-...", // optional if KIMI_API_KEY or MOONSHOT_API_KEY is set
-            baseUrl: "https://api.moonshot.ai/v1",
+            baseUrl: "https://api.moonshot.ai/v1", // set to https://api.moonshot.cn/v1 for CN keys
             model: "kimi-k2.6",
           },
         },
@@ -62,6 +62,20 @@ also prompts for:
 
 `tools.web.search.provider` is auto-detected from available API keys when omitted;
 set it to `kimi` explicitly if multiple search credentials are configured.
+
+<Note>
+  Kimi API keys are region-specific: keys from
+  <a href="https://platform.moonshot.cn">platform.moonshot.cn</a> (China) must use
+  `https://api.moonshot.cn/v1` as the base URL, while international keys default to
+  `https://api.moonshot.ai/v1`. Using a CN key without setting the base URL to `.cn`
+  returns HTTP 401.
+</Note>
+
+If you use a native Moonshot endpoint for chat (`models.providers.moonshot.baseUrl`
+set to `api.moonshot.ai` or `api.moonshot.cn`), OpenClaw automatically reuses that
+same host for Kimi web search when no explicit search base URL is configured.
+
+You can also set the base URL via `plugins.entries.moonshot.config.webSearch.baseUrl`.
 
 Equivalent scoped form under `tools.web.search.kimi` (`apiKey`, `baseUrl`, `model`)
 also works; both shapes merge into the same resolved config.
@@ -92,6 +106,16 @@ result. Retry the query, switch to a structured provider such as Brave, or use
 | `query`                                                         | Yes                                                                                                                      |
 | `count`                                                         | Accepted for cross-provider compatibility, but ignored: Kimi always returns one synthesized answer, not an N-result list |
 | `country`, `language`, `freshness`, `date_after`, `date_before` | No                                                                                                                       |
+
+## Base URL overrides
+
+Set `plugins.entries.moonshot.config.webSearch.baseUrl` when Kimi web search
+must route through a custom Moonshot-compatible proxy or private deployment.
+
+Kimi web search only inherits `models.providers.moonshot.baseUrl` when it points
+to a native Moonshot endpoint (`api.moonshot.ai` or `api.moonshot.cn`). Custom
+proxy addresses are not inherited and must be configured explicitly for web
+search.
 
 ## Related
 

--- a/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
@@ -248,7 +248,14 @@ async function runKimiSearch(params: {
         res,
       ): Promise<{ done: true; content: string; citations: string[] } | { done: false }> => {
         if (!res.ok) {
-          throw await createProviderHttpError(res, "Kimi API error");
+          const err = await createProviderHttpError(res, "Kimi API error");
+          if (res.status === 401) {
+            err.message +=
+              " Verify that the base URL region matches your API key " +
+              "(api.moonshot.ai for international keys, api.moonshot.cn for China keys). " +
+              "Set plugins.entries.moonshot.config.webSearch.baseUrl explicitly for custom proxies.";
+          }
+          throw err;
         }
 
         const data = (await readProviderJsonObjectResponse(


### PR DESCRIPTION

Closes #94979

## What Problem This Solves

Fixes an issue where users with China-region Moonshot API keys receive 401 Invalid Authentication from Kimi web search when no explicit search base URL is configured. The same API key works correctly for Moonshot chat completions, but fails for web search because the default search endpoint (`api.moonshot.ai`) does not accept China-region keys. Users with custom chat proxy endpoints also encounter the same problem when no separate search base URL is set.

## Why This Change Was Made

The root cause is a documentation and discoverability gap, not a code logic defect. The existing `isNativeMoonshotBaseUrl` guard is an intentional security boundary to avoid routing search credentials to unvetted custom endpoints that may not support Moonshot's `$web_search` API. This PR closes the information gap with three targeted, non-breaking improvements, without changing any core routing or inheritance behavior:

- Documentation updates to highlight region-specific base URL requirements and explicit proxy configuration rules
- Enhanced 401 error messages with actionable troubleshooting guidance
- Full preservation of the existing guard, fallback order, and onboarding flow

## User Impact

- Users with China-region Moonshot API keys can find the correct base URL configuration directly from the Config example and note, without needing to file an issue.
- Users with custom Moonshot-compatible proxies have clear documented guidance via the new Base URL overrides section, and receive actionable next steps in 401 error messages.
- Existing users using official native endpoints (`.ai` or `.cn`) experience no change in behavior.

## Evidence

### real behavior proof

<details>
<summary>Reproduce the issue before modification using proxy-api https://api.genai.gd.edu.kg/moonshot/v1</summary>

base config

```
{
  "models": {
    "providers": {
      "moonshot": {
        "apiKey": "my-apikey",
        "baseUrl": "https://api.genai.gd.edu.kg/moonshot/v1"
      }
    }
  },
  plugins: {
    entries: {
      moonshot: {
        config: {
          webSearch: {
            apiKey: "my-apikey"
          },
        },
      },
    },
  },
  tools: {
    web: {
      search: {
        provider: "kimi"
      },
    },
  },
}
```

(1) chat success
OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer model run --model moonshot/kimi-k2.6 --prompt "Hello" --json

[openclaw]$ OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer model run --model moonshot/kimi-k2.6 --prompt "Hello" --json
08:25:51 [provider-transport-fetch] [model-fetch] start provider=moonshot api=openai-completions model=kimi-k2.6 method=POST url=https://api.genai.gd.edu.kg/moonshot/v1/chat/completions timeoutMs=undefined proxy=env policy=custom                                           
08:25:53 [provider-transport-fetch] [model-fetch] response provider=moonshot api=openai-completions model=kimi-k2.6 status=200 elapsedMs=2267 contentType=text/event-stream                                                                                                     
{
  "ok": true,
  "capability": "model.run",
  "transport": "local",
  "provider": "moonshot",
  "model": "kimi-k2.6",
  "attempts": [],
  "outputs": [
    {
      "text": "Hello! How can I help you today?",
      "mediaUrl": null
    }
  ]
}

(2) web_search fail. Same as the current user's issue: only the error message "Invalid Authentication" is displayed, with no additional useful information.
OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer web search --query "What's the UTC time now?" --provider kimi --json

[openclaw]$ OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer web search --query "What's the UTC time now?" --provider kimi --json
08:28:21 [plugins] qa-lab failed to load from /media/vdb/outcoco/do0704-main-web/openclaw/extensions/qa-lab/index.ts: Error: Cannot find module '/media/vdb/outcoco/do0704-main-web/openclaw/dist/plugin-sdk/root-alias.cjs/qa-channel'                                         
Require stack:
- /media/vdb/outcoco/do0704-main-web/openclaw/extensions/qa-lab/src/runtime-api.ts
ProviderHttpError: Kimi API error (401): Invalid Authentication [type=invalid_authentication_error]

(3) After adding the configuration item plugins.entries.moonshot.config.webSearch.baseUrl=https://api.genai.gd.edu.kg/moonshot/v1, chat success
OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer model run --model moonshot/kimi-k2.6 --prompt "Hello" --json

[openclaw]$ OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer model run --model moonshot/kimi-k2.6 --prompt "Hello" --json
08:30:11 [provider-transport-fetch] [model-fetch] start provider=moonshot api=openai-completions model=kimi-k2.6 method=POST url=https://api.genai.gd.edu.kg/moonshot/v1/chat/completions timeoutMs=undefined proxy=env policy=custom                                           
08:30:14 [provider-transport-fetch] [model-fetch] response provider=moonshot api=openai-completions model=kimi-k2.6 status=200 elapsedMs=2610 contentType=text/event-stream                                                                                                     
{
  "ok": true,
  "capability": "model.run",
  "transport": "local",
  "provider": "moonshot",
  "model": "kimi-k2.6",
  "attempts": [],
  "outputs": [
    {
      "text": "Hello! How can I help you today?",
      "mediaUrl": null
    }
  ]
}

(4) After adding the configuration item plugins.entries.moonshot.config.webSearch.baseUrl=https://api.genai.gd.edu.kg/moonshot/v1, web_search success. Confirmed that the user's issue can be resolved by adding the plugins.entries.moonshot.config.webSearch.baseUrl configuration item.
OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer web search --query "What's the UTC time now?" --provider kimi --json

[openclaw]$ OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer web search --query "What's the UTC time now?" --provider kimi --json
08:31:03 [plugins] qa-lab failed to load from /media/vdb/outcoco/do0704-main-web/openclaw/extensions/qa-lab/index.ts: Error: Cannot find module '/media/vdb/outcoco/do0704-main-web/openclaw/dist/plugin-sdk/root-alias.cjs/qa-channel'                                         
Require stack:
- /media/vdb/outcoco/do0704-main-web/openclaw/extensions/qa-lab/src/runtime-api.ts
{
  "ok": true,
  "capability": "web.search",
  "transport": "local",
  "provider": "kimi",
  "attempts": [],
  "outputs": [
    {
      "result": {
        "query": "What's the UTC time now?",
        "provider": "kimi",
        "model": "kimi-k2.6",
        "tookMs": 11903,
        "externalContent": {
          "untrusted": true,
          "source": "web_search",
          "provider": "kimi",
          "wrapped": true
        },
        "content": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"a6b4ca3d9c4dae84\">>>\nSource: Web Search\n---\nBased on the search results, the current UTC time is **23:13:01** on **Saturday, July 4, 2026**.\n\nHowever, I should note that there are some inconsistencies in the search results (different websites show different times ranging from 16:26 to 23:13), which is likely due to caching or the time when those pages were generated. \n\nIf you need the precise real-time UTC, I recommend checking a reliable source like [time.is/UTC](https://time.is/UTC) or [timeanddate.com](https://www.timeanddate.com/worldclock/) directly, as my search results may not reflect the exact current moment.\n\nAs a general reference, you can also calculate UTC from your local time:\n- **Beijing/China**: UTC = Local time - 8 hours\n- **New York (EDT)**: UTC = Local time + 4 hours\n- **London (BST)**: UTC = Local time - 1 hour\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"a6b4ca3d9c4dae84\">>>",
        "citations": []
      }
    }
  ]
}

</details>

<details>
<summary>Tested again using proxy-api https://api.genai.gd.edu.kg/moonshot/v1 after the modification</summary>

base config

```
{
  "models": {
    "providers": {
      "moonshot": {
        "apiKey": "my-apikey",
        "baseUrl": "https://api.genai.gd.edu.kg/moonshot/v1"
      }
    }
  },
  plugins: {
    entries: {
      moonshot: {
        config: {
          webSearch: {
            apiKey: "my-apikey"
          },
        },
      },
    },
  },
  tools: {
    web: {
      search: {
        provider: "kimi"
      },
    },
  },
}
```

(1) chat success
OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer model run --model moonshot/kimi-k2.6 --prompt "Hello" --json

[openclaw-lang]$ OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer model run --model moonshot/kimi-k2.6 --prompt "Hello" --json
08:36:58 [provider-transport-fetch] [model-fetch] start provider=moonshot api=openai-completions model=kimi-k2.6 method=POST url=https://api.genai.gd.edu.kg/moonshot/v1/chat/completions timeoutMs=undefined proxy=env policy=custom                                           
08:37:00 [provider-transport-fetch] [model-fetch] response provider=moonshot api=openai-completions model=kimi-k2.6 status=200 elapsedMs=1681 contentType=text/event-stream                                                                                                     
{
  "ok": true,
  "capability": "model.run",
  "transport": "local",
  "provider": "moonshot",
  "model": "kimi-k2.6",
  "attempts": [],
  "outputs": [
    {
      "text": "Hello! How can I help you today?",
      "mediaUrl": null
    }
  ]
}

(2) web_search fail. Same as the current user's issue: but in addition to the "Invalid Authentication" error, it provides more information to guide users in troubleshooting.
OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer web search --query "What's the UTC time now?" --provider kimi --json

[openclaw-lang]$ OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer web search --query "What's the UTC time now?" --provider kimi --json
16:35:16 [plugins] qa-lab failed to load from /media/vdb/outcoco/checklang/openclaw-lang/extensions/qa-lab/index.ts: Error: Cannot find module '/media/vdb/outcoco/checklang/openclaw-lang/dist/plugin-sdk/root-alias.cjs/qa-channel'
Require stack:
- /media/vdb/outcoco/checklang/openclaw-lang/extensions/qa-lab/src/runtime-api.ts
ProviderHttpError: Kimi API error (401): Invalid Authentication [type=invalid_authentication_error] Verify that the base URL region matches your API key (api.moonshot.ai for international keys, api.moonshot.cn for China keys). Set plugins.entries.moonshot.config.webSearch.baseUrl explicitly for custom proxies.

(3) After adding the configuration item plugins.entries.moonshot.config.webSearch.baseUrl=https://api.genai.gd.edu.kg/moonshot/v1, chat success
OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer model run --model moonshot/kimi-k2.6 --prompt "Hello" --json

[openclaw-lang]$ OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer model run --model moonshot/kimi-k2.6 --prompt "Hello" --json
08:39:48 [provider-transport-fetch] [model-fetch] start provider=moonshot api=openai-completions model=kimi-k2.6 method=POST url=https://api.genai.gd.edu.kg/moonshot/v1/chat/completions timeoutMs=undefined proxy=env policy=custom                                           
08:39:50 [provider-transport-fetch] [model-fetch] response provider=moonshot api=openai-completions model=kimi-k2.6 status=200 elapsedMs=2754 contentType=text/event-stream                                                                                                     
{
  "ok": true,
  "capability": "model.run",
  "transport": "local",
  "provider": "moonshot",
  "model": "kimi-k2.6",
  "attempts": [],
  "outputs": [
    {
      "text": "Hello! How can I help you today?",
      "mediaUrl": null
    }
  ]
}

(4) After adding the configuration item plugins.entries.moonshot.config.webSearch.baseUrl=https://api.genai.gd.edu.kg/moonshot/v1, web_search success. Confirmed that the user's issue can be resolved by adding the plugins.entries.moonshot.config.webSearch.baseUrl configuration item.
OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer web search --query "What's the UTC time now?" --provider kimi --json

[openclaw-lang]$ OPENCLAW_CONFIG_PATH=../openclaw.json node openclaw.mjs infer web search --query "What's the UTC time now?" --provider kimi --json
08:40:53 [plugins] qa-lab failed to load from /media/vdb/outcoco/checklang/openclaw-lang/extensions/qa-lab/index.ts: Error: Cannot find module '/media/vdb/outcoco/checklang/openclaw-lang/dist/plugin-sdk/root-alias.cjs/qa-channel'                                           
Require stack:
- /media/vdb/outcoco/checklang/openclaw-lang/extensions/qa-lab/src/runtime-api.ts
{
  "ok": true,
  "capability": "web.search",
  "transport": "local",
  "provider": "kimi",
  "attempts": [],
  "outputs": [
    {
      "result": {
        "query": "What's the UTC time now?",
        "provider": "kimi",
        "model": "kimi-k2.6",
        "tookMs": 10313,
        "externalContent": {
          "untrusted": true,
          "source": "web_search",
          "provider": "kimi",
          "wrapped": true
        },
        "content": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"b888abbb015cd468\">>>\nSource: Web Search\n---\nBased on the search results, the current UTC time is:\n\n**Saturday, July 4, 2026, 16:26:46 UTC** (or 4:26:46 PM UTC)\n\nThis is based on the most recent timestamp from timeanddate.com, which showed **16:26:46 UTC on Saturday, July 4, 2026**.\n\nNote: Different sources in the search results show slightly different times due to when they were cached, but the timeanddate.com result (16:26:46 UTC) appears to be the most current reliable reference. UTC does not observe daylight saving time and maintains a constant offset of +00:00 year-round.\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"b888abbb015cd468\">>>",
        "citations": []
      }
    }
  ]
}

</details>

### other poof

- **15/15 tests pass with zero modifications** — no regressions; the existing test asserting "custom proxy base URLs are not inherited" remains valid and unchanged.
- **Consistent with all 12 bundled search provider docs** — all use `plugins.entries.*.config.webSearch.*` as the canonical configuration path.
- **Base URL overrides section aligns with Gemini** (`docs/tools/gemini-search.md:102-109`) and **Grok** (`docs/tools/grok-search.md:117-123`) in structure and wording.
- **401 error enhancement follows Ollama's established pattern** (`extensions/ollama/src/web-search-provider.ts:202`) of including actionable diagnostics in error messages.
- **Test output:** `pnpm test extensions/moonshot/src/kimi-web-search-provider.test.ts` → all 15 tests passed.
- **Diff:** 2 files, ~+21 lines. No changes to core routing, `isNativeMoonshotBaseUrl`, config schema, or onboarding.


---

This PR is AI-assisted. Analysis, implementation, and testing were performed using opencode with human review by the author.