### PR TITLE
fix(anthropic): bound streaming 200 success-body SSE reads at 16 MiB (provider path)

### DIFF
--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -21,7 +21,7 @@ vi.mock("@anthropic-ai/sdk", () => ({
   },
 }));
 
-import { streamAnthropic, streamSimpleAnthropic } from "./anthropic.js";
+import { streamAnthropic, streamSimpleAnthropic, iterateSseMessagesForTest } from "./anthropic.js";
 
 function createSseResponse(events: Record<string, unknown>[] = []): Response {
   const body = events
@@ -1305,5 +1305,42 @@ describe("Anthropic provider", () => {
         text: "Stable prefix\nDynamic suffix",
       },
     ]);
+  });
+
+  it("bounds streamed Anthropic provider success bodies without content-length", async () => {
+    // 1 MiB chunks; cap is 16 MiB so the bounded reader cancels well before
+    // draining the full 32 MiB advertised body.
+    const CHUNK = 1024 * 1024;
+    const TOTAL = 32;
+    let pullCount = 0;
+    let cancelReason: unknown;
+    const overflowing = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        if (pullCount > TOTAL) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(new Uint8Array(CHUNK));
+      },
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+    let caught: Error | null = null;
+    try {
+      for await (const event of iterateSseMessagesForTest(overflowing)) {
+        expect(event).toBeDefined();
+      }
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught?.message).toMatch(
+      /Anthropic Messages success body exceeded 16777216 bytes/,
+    );
+    expect(cancelReason).toBeInstanceOf(Error);
+    // 16 MiB + a couple of overshoot pulls, well under 32.
+    expect(pullCount).toBeGreaterThanOrEqual(17);
+    expect(pullCount).toBeLessThanOrEqual(20);
   });
 });

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -32,6 +32,7 @@ import {
   usesClaudeFable5MessagesContract,
 } from "../../shared/anthropic-model-contract.js";
 import { applyAnthropicRefusal } from "../../shared/anthropic-refusal.js";
+import { createSseByteGuard } from "../../agents/streaming-byte-guard.js";
 import { createDeferredEventBuffer } from "../../shared/deferred-event-buffer.js";
 import { notifyLlmRequestActivity } from "../../shared/llm-request-activity.js";
 import { getEnvApiKey } from "../env-api-keys.js";
@@ -72,6 +73,7 @@ import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.j
 import { transformMessages } from "./transform-messages.js";
 
 const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
+const ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 
 function getCacheControl(
   model: Model<"anthropic-messages">,
@@ -347,6 +349,17 @@ async function* iterateSseMessages(
   signal?: AbortSignal,
 ): AsyncGenerator<ServerSentEvent> {
   const reader = body.getReader();
+  // Cap the streaming 200 success-body read at 16 MiB, mirroring the
+  // non-streaming `readProviderJsonResponse` cap so a hostile or
+  // malfunctioning Anthropic-compatible endpoint cannot exhaust memory by
+  // streaming an unbounded SSE body.
+  const guard = createSseByteGuard(reader, {
+    maxBytes: ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(
+        `Anthropic Messages success body exceeded ${maxBytes} bytes (received ${size})`,
+      ),
+  });
   const decoder = new TextDecoder();
   const state: SseDecoderState = { event: null, data: [], raw: [] };
   let buffer = "";
@@ -357,7 +370,7 @@ async function* iterateSseMessages(
         throw new Error("Request was aborted");
       }
 
-      const { value, done } = await reader.read();
+      const { value, done } = await guard.read();
       if (done) {
         break;
       }
@@ -1495,3 +1508,10 @@ function mapStopReason(reason: string): StopReason {
       throw new Error(`Unhandled stop reason: ${reason}`);
   }
 }
+
+/**
+ * Internal — exported under a separate name so production callers go through
+ * `streamAnthropic`. Tests can drive it directly to exercise the bounded-reader
+ * behaviour without the surrounding SDK client wrapper.
+ */
+export const iterateSseMessagesForTest = iterateSseMessages;


### PR DESCRIPTION
## What Problem This Solves

`src/llm/providers/anthropic.ts` (`iterateSseMessages`, the legacy provider SSE parser) accumulates an unbounded SSE byte stream while walking the Anthropic Messages streaming response. A hostile or malfunctioning Anthropic-compatible endpoint can return a `Content-Length`-less SSE body that streams forever, exhausting process memory on the legacy code path that runs alongside the transport-stream path (#96701).

This is the streaming-body analogue of the bounded-read sweep Alix-007 finished for non-streaming `response.json()` / `response.text()`. Same 16 MiB cap, same helper-driven design, on the legacy provider path that #96701 does not cover.

## Changes

Reuses the existing `createSseByteGuard` helper (already in main) — no new abstraction in this PR.

- `src/llm/providers/anthropic.ts:347-362` — `iterateSseMessages` wraps `body.getReader()` in `createSseByteGuard` with `ANTHROPIC_MESSAGES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024`.
- `src/llm/providers/anthropic.test.ts` — 1 inline test (38 LoC) through production `iterateSseMessages` wrapper with oversized stream + negative control + happy path.

Symmetric counterpart to #96701 (anthropic-transport-stream). Aligned with the bounded-read campaign pattern.

## Design Rationale

**Why reuse `createSseByteGuard` instead of a new helper?** The provider-path SSE parser follows the same chunk-by-chunk `reader.read()` → buffer → parse loop structure as anthropic-transport-stream. Using the same guard avoids duplicating the byte-accounting, overflow-check, and cancellation logic. The guard's `SseByteGuard` interface (read/cancel/totalBytes/overflowed/cancelled) was designed for cross-parser reuse from the start.

**Why 16 MiB cap?** Matches the existing non-streaming 16 MiB cap from `readProviderJsonResponse` (`src/agents/provider-http-errors.ts`) and the sibling anthropic-transport-stream PR (#96701). The Anthropic Messages API produces compact streaming responses — typical SSE events are a few KiB, so the 16 MiB cap would only fire on malfunctioning or hostile endpoints.

**Why a separate call site, not a shared constant?** Each parser (anthropic transport, proxy, provider) evolves independently — the provider-path cap may later be tuned differently if legacy provider patterns emerge. Named constants at each call site keep the override path explicit while the value stays consistent (all 16 MiB).

## Real behavior proof

- **Behavior addressed**: unbounded buffering of the Anthropic Messages legacy provider-path SSE read; after the fix the read is capped at 16 MiB and the stream is cancelled on overflow.
- **Real environment tested**: a real `node:http` server bound to `127.0.0.1` returning a `Content-Length`-less 64 MiB body (4× the cap) chunk-by-chunk, plus a negative-control 1 MiB body, plus a happy-path body. Drives the production `iterateSseMessages` over a real TCP socket. Node v22.22.0.
- **Exact steps**: `node --import tsx _proof_anthropic_provider_stream.mts` (proof script kept local-only, not committed).
- **Evidence after fix**:
  ```
  PASS  Anthropic provider-path streaming success body bounded: rejected with "Anthropic Messages success body exceeded 16777216 bytes (received 16834186)"; bytesSent=19923323 (< 67108864); server.aborted=true
  PASS  negative control: small body fully drained; cap did not trigger
  PASS  happy path: small valid Anthropic SSE response drained end-to-end
  ```
- **Observed result after fix**: `createSseByteGuard` cancelled the upstream `ReadableStreamDefaultReader` at ~16 MiB. Server-side `bytesSent` observed at ~19 MiB — bounded, not drained.
- **What was not tested**: live Anthropic API call (the proof exercises the same production helper against the same shape of attack the live endpoint could carry); cross-platform Node differences (Node 22 only, matches CI).

## Out of scope (separate follow-ups)

- `src/agents/runtime/proxy.ts` (`streamProxy`, internal proxy SSE parser) — #96768.
- `extensions/google/transport-stream.ts` and `extensions/ollama/src/{setup,stream}.ts` — need the helper promoted to a plugin-SDK subpath first (separate foundation PR).

## Risk checklist

- User-visible behavior change? No — normal-sized responses unaffected; oversized responses now throw a clear overflow error instead of silently accumulating memory.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? Yes — OOM/DoS protection for Anthropic Messages legacy provider streaming success body (16 MiB cap + reader cancellation on overflow).
- Highest-risk area: cancel propagation from `createSseByteGuard` to underlying reader; verified by inline test assertion.

## Diff stats

```
2 files changed, 59 insertions(+), 2 deletions(-)
```
