### PR TITLE
fix(memory): stop chunkMarkdown injecting newlines into single-line chunks

### DIFF
--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -235,6 +235,23 @@ describe("memory host SDK package internals", () => {
     }
   });
 
+  it("keeps overlapping chunks of one long line free of injected newlines", () => {
+    // A single line longer than maxChars with no newlines (minified JSON,
+    // base64, a long URL, a pasted log) is coarse-split into fragments that all
+    // share one lineNo. With overlap on (the production default), flush()
+    // previously re-joined those fragments with "\n", so chunk text was no
+    // longer a substring of the source — that corrupted text was then embedded
+    // and surfaced verbatim in search snippets.
+    const source = "The quick brown fox jumps over the lazy dog. ".repeat(89);
+    expect(source).not.toContain("\n");
+    const chunks = chunkMarkdown(source, { tokens: 400, overlap: 80 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text).not.toContain("\n");
+      expect(source).toContain(chunk.text);
+    }
+  });
+
   it("remaps chunk lines using JSONL source line maps", () => {
     const lineMap = [4, 6, 7, 10, 13];
     const chunks = chunkMarkdown(

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -408,7 +408,17 @@ export function chunkMarkdown(
     if (!firstEntry || !lastEntry) {
       return;
     }
-    const text = current.map((entry) => entry.line).join("\n");
+    // Coarse/fine splits of one physical line share lineNo; joining them with
+    // "\n" would inject a newline the source never had, so the chunk text stops
+    // being a substring of the file and corrupts embeddings + search snippets.
+    const text = current.reduce((acc, entry, index) => {
+      if (index === 0) {
+        return entry.line;
+      }
+      const prev = current[index - 1];
+      const separator = prev && prev.lineNo === entry.lineNo ? "" : "\n";
+      return acc + separator + entry.line;
+    }, "");
     const startLine = firstEntry.lineNo;
     const endLine = lastEntry.lineNo;
     chunks.push({


### PR DESCRIPTION
## What Problem This Solves

`chunkMarkdown` (the chunker behind memory/embedding indexing) corrupts chunk text for any source that contains a single physical line longer than the chunk budget — minified JSON, base64 blobs, a long URL, a pasted log line, or flattened session text.

A long line is coarse/fine-split into fragments that all carry the **same** `lineNo`. When overlap is enabled — and it is by default (`DEFAULT_CHUNK_TOKENS=400`, `DEFAULT_CHUNK_OVERLAP=80`, `src/agents/memory-search.ts:116-117`) — the overlap carry packs several of those fragments into one chunk. `flush()` then joined every entry in `current` with `"\n"`:

```ts
const text = current.map((entry) => entry.line).join("\n");
```

That re-inserts a newline the source never had. The chunk text is no longer a substring of the file, and that corrupted text is what gets hashed, embedded (`manager-embedding-ops.ts:284`), and surfaced verbatim in search snippets (`manager-embedding-ops.ts:777,795`).

## Why This Change Was Made

`lineNo` already distinguishes fragments of one physical line from genuinely separate lines. `flush()` now joins consecutive same-`lineNo` fragments with `""` (reconstructing the original contiguous text) and emits `"\n"` only across distinct source lines. Distinct-line chunks are unchanged.

## User Impact

Memory/embedding search no longer indexes or returns text with spurious newlines spliced into long single-line content; chunk text is once again a faithful substring of the source. No config or API change.

## Evidence

### Real behavior proof

**Behavior addressed:** `chunkMarkdown` injected `"\n"` (absent from the source) into chunk text when a single line exceeds the chunk budget and overlap is on (the production default), corrupting embedded text and search snippets.

**Real environment tested:** Local checkout, Node v22.22.1, the package's real `chunkMarkdown` export driven via `tsx`, plus the package Vitest suite.

**Exact steps or command run after this patch:**
- `npx tsx` probe calling `chunkMarkdown('The quick brown fox jumps over the lazy dog. '.repeat(89) /* 4005 chars, 0 newlines */, { tokens: 400, overlap: 80 })`, asserting every `chunk.text` is a substring of the source and contains no `"\n"`.
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/internal.test.ts`
- Fail-before: restored `internal.ts` from `origin/main`, kept the new test, re-ran the filtered test.

**Evidence after fix:**
```
source has newline: false | len: 4005
chunks: 3
chunk[0] len=1600 hasNewline=false isSubstringOfSource=true
chunk[1] len=3200 hasNewline=false isSubstringOfSource=true
chunk[2] len=2405 hasNewline=false isSubstringOfSource=true
```
Distinct-line content still keeps its separators (verified: a long line + a trailing distinct line keeps the `"\n"` only between the two real lines).

Full suite:
```
Test Files  1 passed (1)
     Tests  10 passed (10)
```

**Observed result after fix:** Every chunk is a substring of the source with no injected newline; all 10 `internal.test.ts` tests pass; oxfmt `--check` and oxlint clean.

**Fail-before (proves the test catches the regression):** with `origin/main`'s `flush()` and the new test, the test fails exactly at the injected-newline assertion:
```
 ❯ packages/memory-host-sdk/src/host/internal.test.ts:250:30
    250|       expect(chunk.text).not.toContain("\n");
 Test Files  1 failed (1)
```

**What was not tested:** No live end-to-end embedding/index run against a real provider (the corruption is in the pure chunker upstream of embedding, exercised directly above). This change does not address a separate, downstream-mitigated issue where the overlap carry can also make a chunk exceed the token budget (`enforceEmbeddingMaxInputTokens` hard-caps bytes downstream); that is out of scope here.
