### PR TITLE
fix(cron): wire result classifier into isolated cron model fallback chain

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -2,6 +2,10 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { wrapUntrustedPromptDataBlock } from "../../agents/sanitize-for-prompt.js";
@@ -295,6 +299,13 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      classifyResult: ({ provider: providerLocal, model: modelLocal, result: resultLocal }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider: providerLocal,
+          model: modelLocal,
+          result: resultLocal,
+        }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());


### PR DESCRIPTION
## What Problem This Solves

Isolated cron / scheduled `agentTurn` jobs on embedded (non-CLI) providers with a configured model fallback chain silently drop the answer when the primary model returns a result-level terminal failure (reasoning-only, empty-visible, or `incomplete_turn`). The configured fallback model is never called, the cron run is recorded as `status: "error"`, and the operator receives the generic "Agent could not generate a response." payload, even though a healthy fallback model was configured and would have produced the real answer.

This contradicts the documented contract (`docs/automation/cron-jobs.md:179, :486`) which states that configured fallback chains still apply when the job primary fails. Thrown `FailoverError`s (auth, rate-limit, overload) do engage the chain via the catch path; only the returned result-level failure class is missed.

## Why This Change Was Made

The embedded cron path calls `runWithModelFallback` in `src/cron/isolated-agent/run-executor.ts:280` without passing `classifyResult` or `mergeExhaustedResult`. Every other answer-bearing caller passes both:
- `src/agents/agent-command.ts:1873-1879` (interactive path)
- `src/auto-reply/reply/agent-runner-execution.ts:2163-2178` (auto-reply path)

Without `classifyResult`, the `runResult.ok` branch in `src/agents/model-fallback.ts:419-462` resolves `classification = undefined`, so `classifiedError = null`, and the first candidate is returned as a success. The fallback loop never advances to candidate 2+.

The fix passes the same embedded result classifier and merge helper that the interactive and auto-reply paths already use.

## Changes

- **`src/cron/isolated-agent/run-executor.ts`** — imported `classifyEmbeddedAgentRunResultForModelFallback` and `mergeEmbeddedAgentRunResultForModelFallbackExhaustion` from `../../agents/embedded-agent-runner/result-fallback-classifier.js`; wired both into the cron `runWithModelFallback` call on the embedded (non-CLI) branch

## Evidence

### Test command
```
npx vitest run src/agents/model-fallback.test.ts --reporter=verbose
```

### Test output
```
 ✓ |agents-core| src/agents/model-fallback.test.ts (82 tests | 82 passed)
 ✓ |agents-support| src/agents/model-fallback.test.ts (82 tests | 82 passed)

 Test Files  2 passed (2)
      Tests  164 passed (164)
   Duration  648.73s
```

### Behavior verification
- Before: cron result-level failures (reasoning-only / incomplete_turn) treated as fatal errors, fallback model never called
- After: same results are classified, fallback chain engages, healthy fallback model produces the real answer

## Related

Closes #96525