### PR TITLE
fix(telegram): label forum topic sessions

### DIFF
--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -263,6 +263,7 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
     });
 
     expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
+    expect(ctx?.ctxPayload?.ThreadLabel).toBe("Deployments");
   });
 
   it("handles forum messages without session runtime overrides", async () => {
@@ -285,6 +286,7 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
     });
 
     expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
+    expect(ctx?.ctxPayload?.ThreadLabel).toBe("Deployments");
   });
 
   it("reloads topic name from disk after cache reset", async () => {
@@ -326,6 +328,7 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
       });
 
       expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
+      expect(ctx?.ctxPayload?.ThreadLabel).toBe("Deployments");
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
       resetTopicNameCacheForTest();
@@ -373,6 +376,7 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
       });
 
       expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
+      expect(ctx?.ctxPayload?.ThreadLabel).toBe("Deployments");
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
       resetTopicNameCacheForTest();

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -591,6 +591,7 @@ export async function buildTelegramInboundContextPayload(params: {
       SkipStickerMediaUnderstanding: stickerCacheHit ? true : undefined,
       ...locationContext,
       IsForum: isForum,
+      ThreadLabel: isForum && topicName ? topicName : undefined,
       TopicName: isForum && topicName ? topicName : undefined,
     },
   } satisfies BuildChannelInboundEventContextAsyncParams);

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1420,6 +1420,7 @@ export const registerTelegramNativeCommands = ({
           CommandTargetSessionKey: commandTargetSessionKey,
           MessageThreadId: threadSpec.id,
           IsForum: isForum,
+          ThreadLabel: isForum && topicName ? topicName : undefined,
           TopicName: isForum && topicName ? topicName : undefined,
           // Originating context for sub-agent announce routing
           OriginatingChannel: "telegram" as const,

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
@@ -260,9 +260,10 @@ describe("tool_result_persist hook", () => {
   it("keeps sensitive parent keys when custom value patterns match the key probe", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-redact-config-"));
     tempDirs.push(tempDir);
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", path.join(tempDir, "openclaw.json"));
+    const configPath = path.join(tempDir, "openclaw.json");
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
     fs.writeFileSync(
-      process.env.OPENCLAW_CONFIG_PATH,
+      configPath,
       JSON.stringify({ logging: { redactPatterns: ["/[a-z0-9]{30,}/g"] } }),
       "utf-8",
     );

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -198,6 +198,7 @@ export function deriveGroupSessionPatch(params: {
     patch.space = space;
   }
 
+  const threadLabel = normalizeOptionalString(params.ctx.ThreadLabel);
   const displayName = buildGroupDisplayName({
     provider: channel,
     subject: nextSubject ?? params.existing?.subject,
@@ -206,8 +207,8 @@ export function deriveGroupSessionPatch(params: {
     id: resolution.id,
     key: params.sessionKey,
   });
-  if (displayName) {
-    patch.displayName = displayName;
+  if (threadLabel || displayName) {
+    patch.displayName = threadLabel ?? displayName;
   }
 
   return patch;

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -78,6 +78,30 @@ describe("session store key normalization", () => {
     expect(store[CANONICAL_KEY]?.origin?.provider).toBe("webchat");
   });
 
+  it("records a thread label as the display name for grouped inbound metadata", async () => {
+    const sessionKey = "agent:main:telegram:group:-1001234567890:topic:42";
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey,
+      ctx: {
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "group",
+        From: "telegram:group:-1001234567890:topic:42",
+        To: "telegram:-1001234567890:topic:42",
+        SessionKey: sessionKey,
+        OriginatingTo: "telegram:-1001234567890:topic:42",
+        GroupSubject: "Test Forum",
+        MessageThreadId: 42,
+        ThreadLabel: "Deployments",
+      },
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[sessionKey]?.displayName).toBe("Deployments");
+    expect(store[sessionKey]?.subject).toBe("Test Forum");
+  });
+
   it("does not create a duplicate mixed-case key when last route is updated", async () => {
     await recordSessionMetaFromInbound({
       storePath,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -791,6 +791,26 @@ describe("gateway session utils", () => {
     expect(row.displayName).not.toBe("openclaw-tui");
   });
 
+  test("buildGatewaySessionRow displayName prefers stored topic labels for group sessions", () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+    const key = "agent:main:telegram:group:-1001234567890:topic:42";
+    const entry = {
+      chatType: "group",
+      channel: "telegram",
+      subject: "Engineering",
+      displayName: "Deployments",
+      origin: { label: "telegram:-1001234567890:topic:42" },
+    } as SessionEntry;
+    const row = buildGatewaySessionRow({
+      cfg,
+      storePath: "",
+      store: { [key]: entry },
+      key,
+      entry,
+    });
+    expect(row.displayName).toBe("Deployments");
+  });
+
   test("buildGatewaySessionRow prefers entry.label over origin.label for direct sessions", () => {
     const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
     const entry = {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -398,6 +398,13 @@ describe("resolveSessionDisplayName", () => {
     ).toBe("My Chat");
   });
 
+  it("uses stored displayName for Telegram topic sessions", () => {
+    const key = "agent:main:telegram:group:-1001234567890:topic:42";
+    expect(resolveSessionDisplayName(key, row({ key, displayName: "Deployments" }))).toBe(
+      "Deployments",
+    );
+  });
+
   it("prefers label over displayName when both are present", () => {
     expect(
       resolveSessionDisplayName(


### PR DESCRIPTION
What Problem This Solves

Fixes #7406. Telegram forum-topic sessions already learn `TopicName`, but that value stopped at prompt metadata. Session metadata, gateway rows, and the Control UI selector could still fall back to raw topic keys or generic group labels.

Why This Change Was Made

- Populate the existing generic `ThreadLabel` field from Telegram forum-topic names in normal inbound context and native-command context.
- Let grouped inbound metadata use `ThreadLabel` as the stored session `displayName`, matching the existing reply-session path.
- Add regression coverage from Telegram context generation through session metadata, gateway rows, and Control UI display resolution.
- Include the current-main `check-test-types` unblock for `OPENCLAW_CONFIG_PATH` so CI is not red from an unrelated test type error.

User Impact

Telegram forum topics with known names now show a readable stored session label such as `Deployments` instead of exposing `agent:main:telegram:group:...:topic:42` or a generic Telegram group fallback in session lists.

Evidence

- `node scripts/run-vitest.mjs run extensions/telegram/src/bot-message-context.dm-threads.test.ts extensions/telegram/src/bot-native-commands.session-meta.test.ts src/auto-reply/reply/session.test.ts src/config/sessions/store.session-key-normalization.test.ts ui/src/ui/app-render.helpers.node.test.ts` passed.
- `node scripts/run-vitest.mjs run src/gateway/session-utils.test.ts -t "displayName prefers stored topic labels"` passed.
- `node scripts/run-vitest.mjs run src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts` passed.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test`, and `pnpm tsgo:test:ui` passed.
- `oxfmt --check --threads=1` on changed files passed.
- `git diff --check` passed.

Known local note: running the full `src/gateway/session-utils.test.ts` file on this Windows checkout still hits unrelated existing failures (`EBUSY` removing sqlite temp files and `/tmp` path normalization to `C:\tmp`). The new gateway regression was run and passed in isolation.