### PR TITLE
fix(web-fetch): decode astral HTML entities by code point, not fromCharCode

### DIFF
--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -1,0 +1,23 @@
+// web_fetch extraction tests cover HTML entity decoding into model-facing text.
+import { describe, expect, it } from "vitest";
+import { htmlToMarkdown } from "./web-fetch-utils.js";
+
+describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
+  it("decodes astral-plane numeric entities by code point, not fromCharCode", () => {
+    // fromCharCode truncates mod 2^16, turning 😀 (U+1F600) into a wrong PUA
+    // glyph (U+F600); a fetched page that writes the emoji as a numeric entity
+    // must decode to the real emoji in the text returned to the model.
+    expect(htmlToMarkdown("<p>grin &#128512;</p>").text).toBe("grin \u{1F600}");
+    expect(htmlToMarkdown("<p>grin &#x1F600;</p>").text).toBe("grin \u{1F600}");
+    expect(htmlToMarkdown("<p>grin &#128512;</p>").text).not.toContain("");
+  });
+
+  it("leaves BMP numeric entities intact", () => {
+    expect(htmlToMarkdown("<p>&#65; &#9731;</p>").text).toBe("A ☃");
+  });
+
+  it("preserves an out-of-range numeric entity instead of throwing", () => {
+    expect(() => htmlToMarkdown("<p>&#9999999;</p>")).not.toThrow();
+    expect(htmlToMarkdown("<p>&#9999999;</p>").text).toBe("&#9999999;");
+  });
+});

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -8,6 +8,16 @@ import { sanitizeHtml, stripInvisibleUnicode } from "./web-fetch-visibility.js";
 /** Output mode requested by web_fetch extraction. */
 export type ExtractMode = "markdown" | "text";
 
+function decodeNumericEntity(raw: string, radix: 10 | 16): string {
+  // A numeric character reference denotes a Unicode code point, so fromCodePoint
+  // (not fromCharCode, which truncates mod 2^16 and corrupts astral-plane chars
+  // like emoji) is required. Mirrors decodeHtmlEntity in ../utils/html.ts.
+  const codePoint = Number.parseInt(raw, radix);
+  return Number.isFinite(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+    ? String.fromCodePoint(codePoint)
+    : `&#${radix === 16 ? "x" : ""}${raw};`;
+}
+
 function decodeEntities(value: string): string {
   return value
     .replace(/&nbsp;/gi, " ")
@@ -16,8 +26,8 @@ function decodeEntities(value: string): string {
     .replace(/&#39;/gi, "'")
     .replace(/&lt;/gi, "<")
     .replace(/&gt;/gi, ">")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCharCode(Number.parseInt(hex, 16)))
-    .replace(/&#(\d+);/gi, (_, dec) => String.fromCharCode(Number.parseInt(dec, 10)));
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => decodeNumericEntity(hex, 16))
+    .replace(/&#(\d+);/gi, (_, dec) => decodeNumericEntity(dec, 10));
 }
 
 function stripTags(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

`decodeEntities` in `src/agents/tools/web-fetch-utils.ts` decoded numeric HTML character references with `String.fromCharCode(Number.parseInt(...))`, which interprets its argument modulo 2¹⁶. Any non-BMP (astral-plane, > U+FFFF) numeric entity is therefore corrupted:

```
&#128512;  →  fromCharCode(128512) = fromCharCode(128512 & 0xFFFF) = U+F600   (a Private Use Area glyph)
&#x1F600;  →  same
```

Both should decode to 😀 (U+1F600 GRINNING FACE). Per the HTML spec a numeric character reference denotes the Unicode code point given by the number, so `String.fromCodePoint` is required.

This is reachable in production: `decodeEntities` → `stripTags` → `htmlToMarkdown` / `extractBasicHtmlContent`, both exported and consumed by the `web_fetch` agent tool (`src/agents/tools/web-fetch.ts:193,628`) and re-exported through the public plugin SDK (`src/plugin-sdk/web-content-extractor.ts`). Any fetched page whose text writes an emoji (or other astral character) as a numeric entity — common on the web — reaches the model mis-decoded as a wrong glyph.

## Why This Change Was Made

The project already has the correct contract in two sibling decoders that handle the identical construct: `decodeHtmlEntity` (`src/agents/utils/html.ts`) and `decodeHtmlEntities` (`src/agents/embedded-agent-runner/tool-call-argument-decoding.ts`) both use **guarded `String.fromCodePoint`** (`0 ≤ cp ≤ 0x10FFFF`). This change brings `decodeEntities` in line: a small local `decodeNumericEntity` helper removes the hex/dec duplication and decodes through `fromCodePoint`. BMP entities are unchanged; an out-of-range value is preserved as its literal entity (matching the `decodeHtmlEntities` sibling) instead of being silently wrapped to a wrong BMP character as before.

A repo-wide sweep of `String.fromCharCode` confirmed this was the only instance of the astral-truncation bug — every other use is a byte/octal/control-char or BMP-bounded decode, including the `\uXXXX` (4-hex) JSON-escape decoder which is correct as-is (surrogate pairs arrive as paired `\u` escapes).

## User Impact

Fetched-page text containing emoji or other astral characters written as numeric HTML entities is now decoded faithfully in the markdown/text the model sees. BMP content is unchanged. No config/API change.

## Evidence

### Real behavior proof

**Behavior addressed:** `decodeEntities` truncated non-BMP numeric HTML entities (e.g. `&#128512;`, `&#x1F600;`) to a wrong Private-Use-Area glyph instead of the intended astral character, corrupting `web_fetch` output to the model.

**Real environment tested:** Local checkout, Node v22.22.1, the real exported `htmlToMarkdown` driven via `tsx`, plus the colocated Vitest suite.

**Exact steps or command run after this patch:**
- `tsx` repro through the real `htmlToMarkdown` for `<p>grin &#128512;</p>`, `<p>grin &#x1F600;</p>`, `<p>&#65; &#9731;</p>`, `<p>&#9999999;</p>`.
- `node scripts/run-vitest.mjs src/agents/tools/web-fetch-utils.test.ts`
- Fail-before: restored `web-fetch-utils.ts` from `origin/main`, kept the new test, re-ran it.
- Repo sweep: `grep -rn "fromCharCode" src/ packages/` to confirm no sibling instance of the same bug.

**Evidence after fix:**
```
<p>grin &#128512;</p>  -> "grin 😀"   hasEmoji=true  hasPUA=false
<p>grin &#x1F600;</p>  -> "grin 😀"   hasEmoji=true  hasPUA=false
<p>&#65; &#9731;</p>   -> "A ☃"       (BMP unchanged)
<p>&#9999999;</p>      -> "&#9999999;" (out-of-range preserved, no throw)

Test Files  1 passed (1) ; Tests  3 passed (3)
```

**Observed result after fix:** Astral numeric entities decode to the real character; BMP entities unchanged; out-of-range preserved without throwing; oxfmt `--check`, oxlint, `tsgo:core` all green.

**Fail-before (proves the test catches the regression):** with `origin/main`'s `fromCharCode` and the new test:
```
 ❯ src/agents/tools/web-fetch-utils.test.ts:10:58
    10|     expect(htmlToMarkdown("<p>grin &#128512;</p>").text).toBe("grin 😀");
 Test Files  1 failed (1)
```

**What was not tested:** No live network fetch of a real page (the corruption is in the pure entity decoder, exercised directly above through the exported `htmlToMarkdown`).
