### PR TITLE
feat(attach): record + resume the Claude cli session bound to an attach session

### DIFF
--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -56,6 +56,7 @@ vi.mock("../runtime.js", () => ({
 }));
 vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
 
+import { spawn } from "node:child_process";
 import { callGateway } from "../gateway/call.js";
 import { registerAttachCli } from "./attach-cli.js";
 
@@ -85,6 +86,9 @@ describe("openclaw attach (action)", () => {
     );
     // setup mode leaves the grant live (no revoke) and must not point at a revoke command that does not exist
     expect(gatewayCalls.find((c) => c.method === "attach.revoke")).toBeUndefined();
+    // --print-config never launches claude, so it must NOT adopt: persisting a binding to a session
+    // that is never created would break the next --resume.
+    expect(gatewayCalls.find((c) => c.method === "attach.adopt")).toBeUndefined();
     const out = logs.join("\n");
     expect(out).toContain("agent:main:cli");
     expect(out).toContain("--mcp-config");
@@ -167,5 +171,46 @@ describe("openclaw attach (action)", () => {
     } as never);
     await runAttach("--print-config");
     expect(exitCode).toBe(1);
+  });
+
+  it("new session: passes --session-id and adopts ONLY after claude spawns", async () => {
+    await runAttach("--session", "agent:main:new"); // spawn path (no --print-config)
+    const spawnArgs = vi.mocked(spawn).mock.calls.at(-1)?.[1] as string[];
+    expect(spawnArgs).toContain("--session-id");
+    expect(spawnArgs).not.toContain("--resume");
+    // the session file does not exist until claude runs, so no adopt before the spawn event fires
+    expect(gatewayCalls.find((c) => c.method === "attach.adopt")).toBeUndefined();
+    spawnedChild.emit("spawn");
+    await Promise.resolve();
+    const adopt = gatewayCalls.find((c) => c.method === "attach.adopt");
+    expect(adopt?.params.cliSessionId).toBeTruthy();
+    expect(adopt?.params.cwd).toBeTruthy(); // cwd is sent so the gateway gates resume per project
+    spawnedChild.emit("exit", 0, null); // finish cleanly
+  });
+
+  it("does NOT adopt when claude fails to spawn (no phantom binding)", async () => {
+    await runAttach("--session", "agent:main:spawnfail");
+    spawnedChild.emit("error", new Error("ENOENT")); // spawn failed → "error", never "spawn"
+    await Promise.resolve();
+    expect(gatewayCalls.find((c) => c.method === "attach.adopt")).toBeUndefined();
+  });
+
+  it("resume: passes --resume and does NOT adopt when the session already has a binding", async () => {
+    vi.mocked(callGateway).mockResolvedValueOnce({
+      sessionKey: "agent:main:r",
+      token: "tok-123",
+      expiresAtMs: 2_000_000_000_000,
+      resumeSessionId: "prev-session-uuid",
+      mcpConfig: {
+        mcpServers: { openclaw: { type: "http", url: "http://127.0.0.1:9/mcp", headers: {} } },
+      },
+      env: { OPENCLAW_MCP_TOKEN: "tok-123" },
+    } as never);
+    await runAttach("--print-config", "--session", "agent:main:r");
+    expect(gatewayCalls.find((c) => c.method === "attach.adopt")).toBeUndefined();
+    const out = logs.join("\n");
+    expect(out).toContain("--resume");
+    expect(out).toContain("prev-session-uuid");
+    expect(out).not.toContain("--session-id");
   });
 });

--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -1,0 +1,171 @@
+import { EventEmitter } from "node:events";
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnedChild = Object.assign(new EventEmitter(), { kill: vi.fn() });
+vi.mock("node:child_process", () => ({ spawn: vi.fn(() => spawnedChild) }));
+
+const gatewayCalls: Array<{
+  method: string;
+  params: Record<string, unknown>;
+  mode?: string;
+  hasDeviceIdentityKey: boolean;
+}> = [];
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(
+    async (p: { method: string; params: Record<string, unknown>; mode?: string }) => {
+      gatewayCalls.push({
+        method: p.method,
+        params: p.params,
+        mode: p.mode,
+        hasDeviceIdentityKey: "deviceIdentity" in p,
+      });
+      if (p.method === "attach.grant") {
+        const sessionKey = (p.params.sessionKey as string) ?? "agent:main:main";
+        return {
+          sessionKey,
+          token: "tok-123",
+          expiresAtMs: 2_000_000_000_000,
+          mcpConfig: {
+            mcpServers: {
+              openclaw: {
+                type: "http",
+                url: "http://127.0.0.1:9999/mcp",
+                headers: { Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}" },
+              },
+            },
+          },
+          env: { OPENCLAW_MCP_TOKEN: "tok-123", OPENCLAW_MCP_SESSION_KEY: sessionKey },
+        };
+      }
+      return {};
+    },
+  ),
+}));
+
+const logs: string[] = [];
+let exitCode: number | undefined;
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    log: (m: string) => logs.push(m),
+    error: (m: string) => logs.push(`ERR:${m}`),
+    exit: (c: number) => {
+      exitCode = c;
+    },
+  },
+}));
+vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
+
+import { callGateway } from "../gateway/call.js";
+import { registerAttachCli } from "./attach-cli.js";
+
+async function runAttach(...args: string[]) {
+  const program = new Command().name("openclaw").exitOverride();
+  await registerAttachCli(program);
+  await program.parseAsync(["node", "openclaw", "attach", ...args]);
+}
+const tick = () =>
+  new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+
+describe("openclaw attach (action)", () => {
+  beforeEach(() => {
+    gatewayCalls.length = 0;
+    logs.length = 0;
+    exitCode = undefined;
+    spawnedChild.removeAllListeners();
+    spawnedChild.kill.mockClear();
+  });
+
+  it("--print-config: mints + writes config + prints launch, does NOT revoke or name a nonexistent command", async () => {
+    await runAttach("--print-config", "--session", "agent:main:cli");
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")?.params.sessionKey).toBe(
+      "agent:main:cli",
+    );
+    // setup mode leaves the grant live (no revoke) and must not point at a revoke command that does not exist
+    expect(gatewayCalls.find((c) => c.method === "attach.revoke")).toBeUndefined();
+    const out = logs.join("\n");
+    expect(out).toContain("agent:main:cli");
+    expect(out).toContain("--mcp-config");
+    expect(out).toContain("OPENCLAW_MCP_TOKEN");
+    expect(out).not.toContain("attach.revoke");
+  });
+
+  it("calls attach.grant in CLI mode with an auto-resolved device identity (operator.admin regression guard)", async () => {
+    // Regression guard: attach.grant is operator.admin-scoped. mode BACKEND or an explicit
+    // deviceIdentity:null drops the operator device identity → the gateway rejects with
+    // "missing scope: operator.admin". This was a real bug found via a live-gateway proof.
+    await runAttach("--print-config", "--session", "agent:main:cli");
+    const grant = gatewayCalls.find((c) => c.method === "attach.grant");
+    expect(grant?.mode).toBe("cli");
+    expect(grant?.hasDeviceIdentityKey).toBe(false);
+  });
+
+  it("rejects a non-positive --ttl before minting", async () => {
+    await runAttach("--ttl", "-5", "--print-config");
+    expect(exitCode).toBe(1);
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeUndefined();
+  });
+
+  it("rejects an empty --ttl rather than silently defaulting", async () => {
+    await runAttach("--ttl", "", "--print-config");
+    expect(exitCode).toBe(1);
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeUndefined();
+  });
+
+  it("passes a positive --ttl through to attach.grant", async () => {
+    await runAttach("--ttl", "600000", "--print-config");
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")?.params.ttlMs).toBe(600_000);
+  });
+
+  it("errors on a malformed attach.grant response instead of crashing", async () => {
+    vi.mocked(callGateway).mockResolvedValueOnce({} as never);
+    await runAttach("--print-config");
+    expect(exitCode).toBe(1);
+  });
+
+  it("spawns Claude Code and revokes the grant when the child exits", async () => {
+    await runAttach("--session", "agent:main:spawn"); // spawn path (no --print-config)
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeTruthy();
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
+    expect(gatewayCalls.find((c) => c.method === "attach.revoke")?.params.token).toBe("tok-123");
+    expect(exitCode).toBe(0);
+  });
+
+  it("revokes once and surfaces a launch failure when the child errors", async () => {
+    await runAttach("--session", "agent:main:spawn-err");
+    spawnedChild.emit("error", new Error("ENOENT"));
+    await tick();
+    await tick();
+    expect(gatewayCalls.filter((c) => c.method === "attach.revoke")).toHaveLength(1);
+    expect(exitCode).toBe(1);
+    expect(logs.join("\n")).toContain("Failed to launch");
+  });
+
+  it("detaches its signal handlers after the child exits (no listener leak)", async () => {
+    const baseInt = process.listenerCount("SIGINT");
+    const baseTerm = process.listenerCount("SIGTERM");
+    await runAttach("--session", "agent:main:spawn");
+    expect(process.listenerCount("SIGINT")).toBe(baseInt + 1);
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
+    expect(process.listenerCount("SIGINT")).toBe(baseInt);
+    expect(process.listenerCount("SIGTERM")).toBe(baseTerm);
+  });
+
+  it("errors on a grant with a non-numeric expiresAtMs instead of crashing on toISOString", async () => {
+    vi.mocked(callGateway).mockResolvedValueOnce({
+      sessionKey: "agent:main:x",
+      token: "tok-123",
+      expiresAtMs: "soon",
+      mcpConfig: { mcpServers: { openclaw: {} } },
+      env: {},
+    } as never);
+    await runAttach("--print-config");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/src/cli/attach-cli.test.ts
+++ b/src/cli/attach-cli.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { writeClaudeMcpConfig } from "./attach-cli.js";
+
+const MCP_CONFIG = {
+  mcpServers: {
+    openclaw: {
+      type: "http",
+      url: "http://127.0.0.1:54321/mcp",
+      headers: {
+        Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
+        "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
+      },
+    },
+  },
+};
+
+describe("writeClaudeMcpConfig", () => {
+  it("writes the gateway mcpConfig verbatim to a .mcp.json (placeholders preserved for Claude env substitution)", () => {
+    const { path, cleanup } = writeClaudeMcpConfig(MCP_CONFIG);
+    try {
+      expect(path.endsWith(".mcp.json")).toBe(true);
+      expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(MCP_CONFIG);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("cleanup removes the temp config", () => {
+    const { path, cleanup } = writeClaudeMcpConfig(MCP_CONFIG);
+    cleanup();
+    expect(() => readFileSync(path, "utf8")).toThrow();
+  });
+});

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -4,6 +4,7 @@
 // exit. The grant — not a process-global token — keeps this a lower-trust, revocable boundary
 // (see src/gateway/mcp-grant-store.ts).
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { constants as osConstants, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -21,6 +22,8 @@ type AttachGrant = {
   sessionKey: string;
   token: string;
   expiresAtMs: number;
+  /** The Claude cli session already bound to this gateway session, if any — resume it. */
+  resumeSessionId?: string;
   mcpConfig: { mcpServers: Record<string, unknown> };
   env: Record<string, string>;
 };
@@ -76,7 +79,7 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
       const granted = (await callGateway({
         config: cfg,
         method: "attach.grant",
-        params: { sessionKey: opts.session, ttlMs },
+        params: { sessionKey: opts.session, ttlMs, cwd: process.cwd() },
         // attach.grant is operator.admin-scoped. Use CLI mode so callGateway auto-resolves the
         // operator device identity (which carries operator.admin); mode BACKEND or an explicit
         // deviceIdentity:null drops it and the call fails with "missing scope: operator.admin".
@@ -101,6 +104,18 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
       }
       const grant = granted as AttachGrant;
 
+      // Bind a Claude cli session id so the conversation is recorded (gateway history import) and
+      // resumable. The gateway returns resumeSessionId only when the bound session was created in THIS
+      // cwd (it gates on the cwd hash, since Claude scopes sessions per project) — so `claude --resume`
+      // is safe here. Otherwise start a fresh known id (claude accepts --session-id); we adopt it only
+      // AFTER claude actually spawns (see child "spawn" below), never here: the session file doesn't
+      // exist until claude runs, so adopting before a successful spawn — or in --print-config, which
+      // never launches — would bind a sessionKey to a session id that never exists, breaking the next
+      // --resume. Resumes already have a binding, so only fresh sessions adopt.
+      const resumeId = grant.resumeSessionId;
+      const sessionId = resumeId ?? randomUUID();
+      const sessionArgs = resumeId ? ["--resume", sessionId] : ["--session-id", sessionId];
+
       const { path: configPath, cleanup } = writeClaudeMcpConfig(grant.mcpConfig);
       const expiresAt = new Date(grant.expiresAtMs).toISOString();
 
@@ -115,7 +130,7 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
               expiresAt,
               env: grant.env,
               configPath,
-              launch: [opts.bin, "--mcp-config", configPath],
+              launch: [opts.bin, ...sessionArgs, "--mcp-config", configPath],
             },
             null,
             2,
@@ -149,9 +164,28 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
       defaultRuntime.log(
         `Attaching Claude Code to session ${grant.sessionKey} (grant expires ${expiresAt})…`,
       );
-      const child = spawn(opts.bin, ["--mcp-config", configPath], {
+      const child = spawn(opts.bin, [...sessionArgs, "--mcp-config", configPath], {
         stdio: "inherit",
         env: { ...process.env, ...grant.env },
+      });
+
+      // Adopt the session only once claude actually starts: "spawn" fires on a successful launch (a
+      // failed spawn fires "error" instead, never "spawn"), and `claude --session-id` is what creates
+      // the session file — so this is the first moment the bound id is guaranteed to become real.
+      // Only fresh sessions adopt (resumes already have a binding). Best-effort; never blocks the run.
+      child.on("spawn", () => {
+        if (resumeId) {
+          return;
+        }
+        void callGateway({
+          config: cfg,
+          method: "attach.adopt",
+          params: { token: grant.token, cliSessionId: sessionId, cwd: process.cwd() },
+          mode: GATEWAY_CLIENT_MODES.CLI,
+          clientName: GATEWAY_CLIENT_NAMES.CLI,
+        }).catch(() => {
+          // Best-effort binding; the session still runs if adopt can't reach the gateway.
+        });
       });
 
       // Claude Code shares the TTY foreground group, so Ctrl-C reaches it directly — don't forward

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -1,0 +1,190 @@
+// `openclaw attach` — launch Claude Code bound to a gateway session with scoped MCP tools. Mints a
+// per-session attach grant (attach.grant), writes the returned loopback MCP config to a temp
+// `.mcp.json` for `claude --mcp-config`, spawns Claude Code interactively, and revokes the grant on
+// exit. The grant — not a process-global token — keeps this a lower-trust, revocable boundary
+// (see src/gateway/mcp-grant-store.ts).
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { constants as osConstants, tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Command } from "commander";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../packages/gateway-protocol/src/client-info.js";
+import { getRuntimeConfig } from "../config/io.js";
+import { callGateway } from "../gateway/call.js";
+import { defaultRuntime } from "../runtime.js";
+
+/** What attach.grant returns (gateway method in src/gateway/server-methods/attach.ts). */
+type AttachGrant = {
+  sessionKey: string;
+  token: string;
+  expiresAtMs: number;
+  mcpConfig: { mcpServers: Record<string, unknown> };
+  env: Record<string, string>;
+};
+
+/**
+ * Write the gateway's mcpConfig verbatim to a temp `.mcp.json` for `claude --mcp-config`. The entry
+ * keeps the gateway's `${OPENCLAW_MCP_*}` header placeholders, which Claude Code substitutes from
+ * the process env — so the bearer token never lands in argv or a durable file. Returns the path and
+ * a cleanup() for the temp dir.
+ */
+export function writeClaudeMcpConfig(mcpConfig: AttachGrant["mcpConfig"]): {
+  path: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "openclaw-attach-"));
+  const path = join(dir, ".mcp.json");
+  writeFileSync(path, JSON.stringify(mcpConfig, null, 2), { encoding: "utf8", mode: 0o600 });
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+export async function registerAttachCli(program: Command, _argv: string[] = process.argv) {
+  program
+    .command("attach")
+    .description("Attach Claude Code to a gateway session with scoped MCP tools")
+    .option("--session <key>", "Gateway session key to bind (default: main session)")
+    .option("--ttl <ms>", "Grant TTL in milliseconds (default: gateway policy)")
+    .option("--bin <path>", "Claude Code binary to spawn", "claude")
+    .option(
+      "--print-config",
+      "Mint the grant + write the .mcp.json, print how to launch it, and exit without spawning",
+      false,
+    )
+    .addHelpText(
+      "after",
+      "\nExamples:\n  openclaw attach                       Attach Claude Code to the main session\n  openclaw attach --session agent:main:telegram:123 --ttl 600000\n  openclaw attach --print-config        Set up the grant + config and print how to launch it yourself\n",
+    )
+    .action(async (opts: { session?: string; ttl?: string; bin: string; printConfig: boolean }) => {
+      let ttlMs: number | undefined;
+      if (opts.ttl !== undefined) {
+        // A provided --ttl must be a positive number; empty/non-numeric values error rather than
+        // silently falling back to the gateway default.
+        ttlMs = Number(opts.ttl);
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+          defaultRuntime.error(
+            `--ttl must be a positive number of milliseconds. Got: ${JSON.stringify(opts.ttl)}`,
+          );
+          defaultRuntime.exit(1);
+          return;
+        }
+      }
+
+      const cfg = getRuntimeConfig();
+      const granted = (await callGateway({
+        config: cfg,
+        method: "attach.grant",
+        params: { sessionKey: opts.session, ttlMs },
+        // attach.grant is operator.admin-scoped. Use CLI mode so callGateway auto-resolves the
+        // operator device identity (which carries operator.admin); mode BACKEND or an explicit
+        // deviceIdentity:null drops it and the call fails with "missing scope: operator.admin".
+        mode: GATEWAY_CLIENT_MODES.CLI,
+        clientName: GATEWAY_CLIENT_NAMES.CLI,
+      })) as Partial<AttachGrant> | null;
+      // Validate the RPC boundary rather than trusting the cast — a malformed/error response must
+      // fail loudly here, not crash later when writing the config.
+      if (
+        !granted ||
+        typeof granted.token !== "string" ||
+        typeof granted.sessionKey !== "string" ||
+        typeof granted.expiresAtMs !== "number" ||
+        !Number.isFinite(granted.expiresAtMs) ||
+        !granted.mcpConfig?.mcpServers ||
+        typeof granted.env !== "object" ||
+        granted.env === null
+      ) {
+        defaultRuntime.error("attach.grant returned an unexpected response from the gateway.");
+        defaultRuntime.exit(1);
+        return;
+      }
+      const grant = granted as AttachGrant;
+
+      const { path: configPath, cleanup } = writeClaudeMcpConfig(grant.mcpConfig);
+      const expiresAt = new Date(grant.expiresAtMs).toISOString();
+
+      // --print-config is a setup mode: leave the grant live (TTL-bounded) and the config file in
+      // place so the user can launch Claude Code themselves; do NOT revoke or delete here. The grant
+      // auto-expires at its TTL (there is no separate revoke CLI command).
+      if (opts.printConfig) {
+        defaultRuntime.log(
+          JSON.stringify(
+            {
+              sessionKey: grant.sessionKey,
+              expiresAt,
+              env: grant.env,
+              configPath,
+              launch: [opts.bin, "--mcp-config", configPath],
+            },
+            null,
+            2,
+          ),
+        );
+        defaultRuntime.log(
+          `Grant is live until ${expiresAt} and auto-expires; it is not revoked here. Launch with the env above, then delete ${configPath} when done.`,
+        );
+        return;
+      }
+
+      // Single revoke+cleanup shared by all terminal paths (error/exit can race; the promise dedupes).
+      let revokePromise: Promise<void> | undefined;
+      const revokeOnce = () =>
+        (revokePromise ??= (async () => {
+          try {
+            await callGateway({
+              config: cfg,
+              method: "attach.revoke",
+              params: { token: grant.token },
+              // operator.admin-scoped like attach.grant — see the mode note there.
+              mode: GATEWAY_CLIENT_MODES.CLI,
+              clientName: GATEWAY_CLIENT_NAMES.CLI,
+            });
+          } catch {
+            // Best-effort: the grant's TTL still bounds it if revoke can't reach the gateway.
+          }
+          cleanup();
+        })());
+
+      defaultRuntime.log(
+        `Attaching Claude Code to session ${grant.sessionKey} (grant expires ${expiresAt})…`,
+      );
+      const child = spawn(opts.bin, ["--mcp-config", configPath], {
+        stdio: "inherit",
+        env: { ...process.env, ...grant.env },
+      });
+
+      // Claude Code shares the TTY foreground group, so Ctrl-C reaches it directly — don't forward
+      // SIGINT (that double-delivers). Keep the parent alive (no-op) so its exit handler can revoke.
+      // SIGTERM is not TTY-delivered to the child, so forward it explicitly.
+      const onSigint = () => {};
+      const onSigterm = () => child.kill("SIGTERM");
+      // Detach the process-global handlers once the child is done so repeated invocations (and tests)
+      // don't accumulate listeners or leave a stale handler bound to an exited child.
+      const finish = (code: number) => {
+        process.off("SIGINT", onSigint);
+        process.off("SIGTERM", onSigterm);
+        defaultRuntime.exit(code);
+      };
+
+      child.on("error", (error) => {
+        void (async () => {
+          defaultRuntime.error(`Failed to launch '${opts.bin}': ${String(error)}`);
+          await revokeOnce();
+          finish(1);
+        })();
+      });
+      child.on("exit", (code, signal) => {
+        void (async () => {
+          await revokeOnce();
+          // Mirror the child's termination: 128+signal on signal death, else its exit code.
+          const signalCode = signal
+            ? 128 + ((osConstants.signals as Record<string, number>)[signal] ?? 0)
+            : null;
+          finish(signalCode ?? code ?? 0);
+        })();
+      });
+      process.on("SIGINT", onSigint);
+      process.on("SIGTERM", onSigterm);
+    });
+}

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -161,6 +161,11 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       exportName: "registerSandboxCli",
     },
     {
+      commandNames: ["attach"],
+      loadModule: () => import("../attach-cli.js"),
+      exportName: "registerAttachCli",
+    },
+    {
       commandNames: ["tui", "terminal", "chat"],
       loadModule: () => import("../tui-cli.js"),
       exportName: "registerTuiCli",

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -72,6 +72,11 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: true,
   },
   {
+    name: "attach",
+    description: "Attach Claude Code to a gateway session with scoped MCP tools",
+    hasSubcommands: false,
+  },
+  {
     name: "tui",
     description: "Open a terminal UI connected to the Gateway",
     hasSubcommands: false,

--- a/src/gateway/mcp-grant-store.test.ts
+++ b/src/gateway/mcp-grant-store.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  resetAttachGrantsForTest,
+  attachGrantStoreSize,
+  mintAttachGrant,
+  resolveAttachGrant,
+  revokeAttachGrant,
+  revokeAttachGrantsForSession,
+  sweepExpiredAttachGrants,
+} from "./mcp-grant-store.js";
+
+const T0 = 1_000_000_000_000; // fixed epoch for deterministic TTL tests
+
+describe("mcp-grant-store", () => {
+  beforeEach(() => resetAttachGrantsForTest());
+
+  it("mints a grant bound to the sessionKey with a token and a TTL window", () => {
+    const g = mintAttachGrant({ sessionKey: "agent:main:main", ttlMs: 60_000, nowMs: T0 });
+    expect(g.sessionKey).toBe("agent:main:main");
+    expect(g.token).toMatch(/^[0-9a-f]{64}$/);
+    expect(g.issuedAtMs).toBe(T0);
+    expect(g.expiresAtMs).toBe(T0 + 60_000);
+  });
+
+  it("requires a non-empty sessionKey", () => {
+    expect(() => mintAttachGrant({ sessionKey: "  ", nowMs: T0 })).toThrow();
+  });
+
+  it("resolves a live grant and drops it once expired (TTL)", () => {
+    const g = mintAttachGrant({ sessionKey: "agent:main:x", ttlMs: 1_000, nowMs: T0 });
+    expect(resolveAttachGrant(g.token, T0)?.sessionKey).toBe("agent:main:x");
+    expect(resolveAttachGrant(g.token, T0 + 999)?.sessionKey).toBe("agent:main:x");
+    // at/after expiry → undefined, and the lookup self-sweeps it
+    expect(resolveAttachGrant(g.token, T0 + 1_000)).toBeUndefined();
+    expect(resolveAttachGrant(g.token, T0 + 1_001)).toBeUndefined();
+    expect(attachGrantStoreSize()).toBe(0);
+  });
+
+  it("returns undefined for an unknown token (no scope without a grant)", () => {
+    expect(resolveAttachGrant("deadbeef", T0)).toBeUndefined();
+  });
+
+  it("binds the sessionKey to the grant (token carries scope identity, not the caller)", () => {
+    const a = mintAttachGrant({ sessionKey: "agent:main:telegram:1", nowMs: T0 });
+    const b = mintAttachGrant({ sessionKey: "agent:main:telegram:2", nowMs: T0 });
+    // each token resolves only to its own bound session — the basis for header-spoof resistance
+    expect(resolveAttachGrant(a.token, T0)?.sessionKey).toBe("agent:main:telegram:1");
+    expect(resolveAttachGrant(b.token, T0)?.sessionKey).toBe("agent:main:telegram:2");
+    expect(a.token).not.toBe(b.token);
+  });
+
+  it("revokes by token", () => {
+    const g = mintAttachGrant({ sessionKey: "agent:main:x", nowMs: T0 });
+    expect(revokeAttachGrant(g.token)).toBe(true);
+    expect(resolveAttachGrant(g.token, T0)).toBeUndefined();
+    expect(revokeAttachGrant(g.token)).toBe(false);
+  });
+
+  it("revokes all grants for a session", () => {
+    mintAttachGrant({ sessionKey: "agent:main:x", nowMs: T0 });
+    mintAttachGrant({ sessionKey: "agent:main:x", nowMs: T0 });
+    mintAttachGrant({ sessionKey: "agent:main:y", nowMs: T0 });
+    expect(revokeAttachGrantsForSession("agent:main:x")).toBe(2);
+    expect(attachGrantStoreSize()).toBe(1);
+  });
+
+  it("clamps TTL: default for non-positive, ceiling at 12h", () => {
+    const def = mintAttachGrant({ sessionKey: "s", nowMs: T0 });
+    expect(def.expiresAtMs).toBe(T0 + 60 * 60 * 1000);
+    const zero = mintAttachGrant({ sessionKey: "s", ttlMs: 0, nowMs: T0 });
+    expect(zero.expiresAtMs).toBe(T0 + 60 * 60 * 1000);
+    const huge = mintAttachGrant({ sessionKey: "s", ttlMs: 999 * 60 * 60 * 1000, nowMs: T0 });
+    expect(huge.expiresAtMs).toBe(T0 + 12 * 60 * 60 * 1000);
+  });
+
+  it("sweeps expired grants", () => {
+    mintAttachGrant({ sessionKey: "s", ttlMs: 1_000, nowMs: T0 });
+    mintAttachGrant({ sessionKey: "s", ttlMs: 5_000, nowMs: T0 });
+    expect(sweepExpiredAttachGrants(T0 + 2_000)).toBe(1);
+    expect(attachGrantStoreSize()).toBe(1);
+  });
+
+  it("evicts expired grants on mint, bounding the store (no accumulation)", () => {
+    mintAttachGrant({ sessionKey: "s", ttlMs: 1_000, nowMs: T0 });
+    expect(attachGrantStoreSize()).toBe(1);
+    // a later mint past the first's expiry sweeps the stale entry before inserting — without
+    // sweep-on-mint the never-looked-up grant would linger and the size would be 2.
+    mintAttachGrant({ sessionKey: "s", ttlMs: 1_000, nowMs: T0 + 5_000 });
+    expect(attachGrantStoreSize()).toBe(1);
+  });
+});

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -1,0 +1,128 @@
+/**
+ * Per-session MCP loopback **attach grants**.
+ *
+ * The loopback MCP server (`mcp-http.ts`) authenticates the gateway-spawned cli-backend with two
+ * process-global bearer tokens (owner / non-owner) and scopes tools from client-supplied headers —
+ * adequate because that client is cooperative and gateway-launched. An **attach** grant is the
+ * primitive for a *less-trusted* external/interactive harness (Claude Code, OpenCode, or a harness
+ * reached via a node/companion app over its existing gateway connection): a short-lived, revocable
+ * bearer whose **scope is bound to the grant**, not to the request headers.
+ *
+ * Security properties:
+ * - The bound `sessionKey` comes from the grant, so an attach caller cannot scope-shop by setting
+ *   `x-session-key` (the request layer ignores the header when a grant matches).
+ * - Grants are always treated as **non-owner** (`senderIsOwner=false`) — the loopback surface
+ *   already excludes the destructive native tools (`read/write/edit/apply_patch/exec/process`).
+ * - TTL + explicit revoke bound the blast radius of a leaked token.
+ *
+ * Transport-independent: the same grant is presented whether the harness reaches the loopback over
+ * 127.0.0.1 (gateway host) or tunnelled in over a node/app's existing authenticated channel.
+ */
+import crypto from "node:crypto";
+
+export interface McpAttachGrant {
+  /** Opaque bearer presented as `Authorization: Bearer <token>`. */
+  readonly token: string;
+  /** The openclaw session this grant is bound to; tool scope is resolved for this key. */
+  readonly sessionKey: string;
+  /** Absolute expiry (ms epoch). */
+  readonly expiresAtMs: number;
+  /** Absolute mint time (ms epoch). */
+  readonly issuedAtMs: number;
+}
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1h
+const MAX_TTL_MS = 12 * 60 * 60 * 1000; // hard ceiling so a caller can't request a forever-grant
+
+const grantsByToken = new Map<string, McpAttachGrant>();
+
+function clampTtlMs(ttlMs: number | undefined): number {
+  if (!Number.isFinite(ttlMs) || (ttlMs as number) <= 0) {
+    return DEFAULT_TTL_MS;
+  }
+  return Math.min(ttlMs as number, MAX_TTL_MS);
+}
+
+/** Mint a grant bound to `sessionKey`. Returns the grant (the caller hands `token` to the harness). */
+export function mintAttachGrant(params: {
+  sessionKey: string;
+  ttlMs?: number;
+  nowMs?: number;
+}): McpAttachGrant {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    throw new Error("mintAttachGrant: sessionKey is required");
+  }
+  const nowMs = params.nowMs ?? Date.now();
+  // Sweep on mint so grants that are minted but never looked up again (harness never connects)
+  // don't accumulate — lookup self-sweeps only the token it touches, so this bounds the map.
+  sweepExpiredAttachGrants(nowMs);
+  const grant: McpAttachGrant = {
+    token: crypto.randomBytes(32).toString("hex"),
+    sessionKey,
+    issuedAtMs: nowMs,
+    expiresAtMs: nowMs + clampTtlMs(params.ttlMs),
+  };
+  grantsByToken.set(grant.token, grant);
+  return grant;
+}
+
+/**
+ * Resolve a bearer token to a live grant, or `undefined` if unknown/expired. An expired grant is
+ * dropped on lookup (lazy sweep). Lookup is by full-token map key: a caller must already hold the
+ * complete 256-bit token to get a hit, so there is no partial-match timing oracle to defend.
+ */
+export function resolveAttachGrant(
+  token: string,
+  nowMs: number = Date.now(),
+): McpAttachGrant | undefined {
+  const grant = grantsByToken.get(token);
+  if (!grant) {
+    return undefined;
+  }
+  if (nowMs >= grant.expiresAtMs) {
+    grantsByToken.delete(token);
+    return undefined;
+  }
+  return grant;
+}
+
+/** Revoke a grant by token. Returns true if a grant was removed. */
+export function revokeAttachGrant(token: string): boolean {
+  return grantsByToken.delete(token);
+}
+
+/** Revoke every live grant for a session (e.g. on session teardown). Returns the count removed. */
+export function revokeAttachGrantsForSession(sessionKey: string): number {
+  const key = sessionKey.trim();
+  let removed = 0;
+  for (const [token, grant] of grantsByToken) {
+    if (grant.sessionKey === key) {
+      grantsByToken.delete(token);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+/** Drop expired grants. Returns the count swept. Call opportunistically; lookup also self-sweeps. */
+export function sweepExpiredAttachGrants(nowMs: number = Date.now()): number {
+  let removed = 0;
+  for (const [token, grant] of grantsByToken) {
+    if (nowMs >= grant.expiresAtMs) {
+      grantsByToken.delete(token);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+/** Number of entries currently held (test/diagnostics). Does not sweep; reflects raw store size. */
+export function attachGrantStoreSize(): number {
+  return grantsByToken.size;
+}
+
+/** Clear all grants (test isolation only). */
+export function resetAttachGrantsForTest(): void {
+  grantsByToken.clear();
+}

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -10,6 +10,7 @@ import { isTruthyEnvValue } from "../infra/env.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { getHeader } from "./http-utils.js";
+import { resolveAttachGrant } from "./mcp-grant-store.js";
 import { isLoopbackAddress } from "./net.js";
 import { checkBrowserOrigin } from "./origin-check.js";
 
@@ -112,14 +113,22 @@ function resolveMcpSender(params: {
   req: IncomingMessage;
   ownerToken: string;
   nonOwnerToken: string;
-}): { senderIsOwner: boolean } | undefined {
+}): { senderIsOwner: boolean; boundSessionKey?: string } | undefined {
   const authHeader = getHeader(params.req, "authorization") ?? "";
   const ownerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.ownerToken}`);
   const nonOwnerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.nonOwnerToken}`);
-  if (!ownerTokenMatched && !nonOwnerTokenMatched) {
-    return undefined;
+  if (ownerTokenMatched || nonOwnerTokenMatched) {
+    return { senderIsOwner: ownerTokenMatched };
   }
-  return { senderIsOwner: ownerTokenMatched };
+  // Attach grant: an external/interactive harness presents a per-session grant token (mcp-grant-store).
+  // Always non-owner, and its scope is bound to the grant's sessionKey so a grant holder cannot widen
+  // scope via the x-session-key header — resolveMcpRequestContext honors boundSessionKey instead.
+  const grantToken = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : "";
+  const grant = grantToken ? resolveAttachGrant(grantToken) : undefined;
+  if (grant) {
+    return { senderIsOwner: false, boundSessionKey: grant.sessionKey };
+  }
+  return undefined;
 }
 
 export function validateMcpLoopbackRequest(params: {
@@ -128,7 +137,7 @@ export function validateMcpLoopbackRequest(params: {
   ownerToken: string;
   nonOwnerToken: string;
   onSseResponse?: (res: ServerResponse) => void;
-}): { senderIsOwner: boolean } | null {
+}): { senderIsOwner: boolean; boundSessionKey?: string } | null {
   let url: URL;
   try {
     url = new URL(params.req.url ?? "/", `http://${params.req.headers.host ?? "localhost"}`);
@@ -244,7 +253,7 @@ export function validateMcpLoopbackRequest(params: {
     return null;
   }
 
-  return { senderIsOwner: sender.senderIsOwner };
+  return { senderIsOwner: sender.senderIsOwner, boundSessionKey: sender.boundSessionKey };
 }
 
 export async function readMcpHttpBody(
@@ -357,8 +366,30 @@ export function resolveMcpCliCaptureKey(req: IncomingMessage): string | undefine
 export function resolveMcpRequestContext(
   req: IncomingMessage,
   cfg: OpenClawConfig,
-  auth: { senderIsOwner: boolean },
+  auth: { senderIsOwner: boolean; boundSessionKey?: string },
 ): McpRequestContext {
+  // An attach grant is a lower-trust boundary: bind the session server-side AND ignore every
+  // caller-supplied delivery/action context header (message channel, account, current channel/
+  // thread/message, inbound-audio, event-kind, source-reply mode, explicit-target). Those headers
+  // feed scoped tools and the message tool, so a grant holder must not be able to spoof them —
+  // only the grant's pinned sessionKey is trusted. Owner/non-owner (the cooperative, gateway-
+  // launched cli-backend) keep header-driven context.
+  if (auth.boundSessionKey) {
+    return {
+      sessionKey: auth.boundSessionKey,
+      sessionId: undefined,
+      messageProvider: undefined,
+      currentChannelId: undefined,
+      currentThreadTs: undefined,
+      currentMessageId: undefined,
+      currentInboundAudio: undefined,
+      accountId: undefined,
+      inboundEventKind: undefined,
+      sourceReplyDeliveryMode: undefined,
+      requireExplicitMessageTarget: undefined,
+      senderIsOwner: auth.senderIsOwner,
+    };
+  }
   return {
     sessionKey: resolveScopedSessionKey(cfg, getHeader(req, "x-session-key")),
     sessionId: normalizeOptionalString(getHeader(req, "x-openclaw-session-id")),

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -102,6 +102,7 @@ vi.mock("./tool-resolution.js", () => ({
     resolveGatewayScopedToolsMock(...args),
 }));
 
+import { resetAttachGrantsForTest, mintAttachGrant } from "./mcp-grant-store.js";
 import {
   createMcpLoopbackServerConfig,
   closeMcpLoopbackServer,
@@ -722,6 +723,47 @@ describe("mcp loopback server", () => {
       "exec",
       "process",
     ]);
+  });
+
+  it("binds an attach grant's session and ignores ALL spoofed context headers (no scope-shop)", async () => {
+    resetAttachGrantsForTest();
+    const grant = mintAttachGrant({ sessionKey: "agent:main:attach-host" });
+    const port = await getFreePortBlockWithPermissionFallback({
+      offsets: [0],
+      fallbackBase: 53_000,
+    });
+    const { port: serverPort } = await startLoopbackServerForTest(port);
+
+    const response = await sendRaw({
+      port: serverPort,
+      token: grant.token,
+      headers: jsonHeaders({
+        // spoof the full delivery/action context, not just the session key
+        "x-session-key": "agent:main:SPOOFED-other-session",
+        "x-openclaw-message-channel": "telegram",
+        "x-openclaw-account-id": "victim-account",
+        "x-openclaw-current-channel-id": "telegram:victim-chat",
+        "x-openclaw-current-thread-ts": "999",
+        "x-openclaw-source-reply-delivery-mode": "automatic",
+        "x-openclaw-inbound-event-kind": "room_event",
+      }),
+      body: mcpToolsListBody(),
+    });
+
+    expect(response.status).toBe(200);
+    const call = getScopedToolsCall(0);
+    // session is grant-bound, NOT the spoofed header
+    expect(call.sessionKey).toBe("agent:main:attach-host");
+    expect(call.senderIsOwner).toBe(false);
+    expect(call.surface).toBe("loopback");
+    // a grant is a lower-trust boundary: every other caller-supplied context header is ignored
+    // (fail-closed), so a grant holder cannot spoof delivery/action context into scoped tools.
+    expect(call.messageProvider).toBeUndefined();
+    expect(call.accountId).toBeUndefined();
+    expect(call.currentChannelId).toBeUndefined();
+    expect(call.currentThreadTs).toBeUndefined();
+    expect(call.sourceReplyDeliveryMode).toBeUndefined();
+    expect(call.inboundEventKind).toBeUndefined();
   });
 
   it("routes sessions_yield to the current CLI capture", async () => {

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -223,6 +223,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   // is control-plane rate-limited; revoke is intentionally not (cheap, idempotent, frees memory).
   { name: "attach.grant", scope: "operator.admin", controlPlaneWrite: true },
   { name: "attach.revoke", scope: "operator.admin" },
+  { name: "attach.adopt", scope: "operator.admin", controlPlaneWrite: true },
   { name: "push.web.vapidPublicKey", scope: "operator.write", advertise: false },
   { name: "push.web.subscribe", scope: "operator.write", advertise: false },
   { name: "push.web.unsubscribe", scope: "operator.write", advertise: false },

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -218,6 +218,11 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "poll", scope: "operator.write", advertise: false },
   { name: "sessions.steer", scope: "operator.write", advertise: false },
   { name: "push.test", scope: "operator.write", advertise: false },
+  // Appended at the end of the advertised methods to preserve the legacy advertised order
+  // (server-methods-list.test.ts locks the prefix/middle). grant mints process-global state so it
+  // is control-plane rate-limited; revoke is intentionally not (cheap, idempotent, frees memory).
+  { name: "attach.grant", scope: "operator.admin", controlPlaneWrite: true },
+  { name: "attach.revoke", scope: "operator.admin" },
   { name: "push.web.vapidPublicKey", scope: "operator.write", advertise: false },
   { name: "push.web.subscribe", scope: "operator.write", advertise: false },
   { name: "push.web.unsubscribe", scope: "operator.write", advertise: false },

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -74,6 +74,10 @@ const loadArtifactsHandlers = lazyHandlerModule(
   () => import("./server-methods/artifacts.js"),
   (module) => module.artifactsHandlers,
 );
+const loadAttachHandlers = lazyHandlerModule(
+  () => import("./server-methods/attach.js"),
+  (module) => module.attachHandlers,
+);
 const loadChannelsHandlers = lazyHandlerModule(
   () => import("./server-methods/channels.js"),
   (module) => module.channelsHandlers,
@@ -270,6 +274,10 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...createLazyCoreHandlers({
     methods: ["connect"],
     loadHandlers: loadConnectHandlers,
+  }),
+  ...createLazyCoreHandlers({
+    methods: ["attach.grant", "attach.revoke"],
+    loadHandlers: loadAttachHandlers,
   }),
   ...createLazyCoreHandlers({
     methods: ["logs.tail"],

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -276,7 +276,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
     loadHandlers: loadConnectHandlers,
   }),
   ...createLazyCoreHandlers({
-    methods: ["attach.grant", "attach.revoke"],
+    methods: ["attach.grant", "attach.revoke", "attach.adopt"],
     loadHandlers: loadAttachHandlers,
   }),
   ...createLazyCoreHandlers({

--- a/src/gateway/server-methods/attach.test.ts
+++ b/src/gateway/server-methods/attach.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetAttachGrantsForTest, resolveAttachGrant } from "../mcp-grant-store.js";
+import { closeMcpLoopbackServer } from "../mcp-http.js";
+import { attachHandlers } from "./attach.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+const grantOpts = (sessionKey: string, respond: ReturnType<typeof vi.fn>) =>
+  ({
+    params: { sessionKey },
+    respond,
+    context: { getRuntimeConfig: () => ({}) },
+  }) as unknown as GatewayRequestHandlerOptions;
+
+describe("attach gateway methods", () => {
+  beforeEach(() => resetAttachGrantsForTest());
+  afterEach(async () => {
+    resetAttachGrantsForTest();
+    // attach.grant lazily starts the loopback singleton; close it so it doesn't leak across files.
+    await closeMcpLoopbackServer();
+  });
+
+  it("attach.grant mints a session-bound grant and returns loopback config + token env", async () => {
+    const respond = vi.fn();
+    await attachHandlers["attach.grant"](grantOpts("agent:main:attach-method", respond));
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload] = respond.mock.calls[0];
+    expect(ok).toBe(true);
+    const body = payload as {
+      token: string;
+      sessionKey: string;
+      mcpConfig: unknown;
+      env: Record<string, string>;
+    };
+    expect(body.sessionKey).toBe("agent:main:attach-method");
+    expect(body.token).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.mcpConfig).toBeTruthy();
+    expect(body.env.OPENCLAW_MCP_TOKEN).toBe(body.token);
+    expect(body.env.OPENCLAW_MCP_SESSION_KEY).toBe("agent:main:attach-method");
+    // the minted token resolves to the bound session in the shared store
+    expect(resolveAttachGrant(body.token)?.sessionKey).toBe("agent:main:attach-method");
+  });
+
+  it("attach.revoke removes a grant; missing token is an INVALID_REQUEST", async () => {
+    const grantRespond = vi.fn();
+    await attachHandlers["attach.grant"](grantOpts("agent:main:revoke-me", grantRespond));
+    const token = (grantRespond.mock.calls[0][1] as { token: string }).token;
+
+    const revokeRespond = vi.fn();
+    await attachHandlers["attach.revoke"]({
+      params: { token },
+      respond: revokeRespond,
+    } as unknown as GatewayRequestHandlerOptions);
+    expect(revokeRespond).toHaveBeenCalledWith(true, { revoked: true });
+    expect(resolveAttachGrant(token)).toBeUndefined();
+
+    const errRespond = vi.fn();
+    await attachHandlers["attach.revoke"]({
+      params: {},
+      respond: errRespond,
+    } as unknown as GatewayRequestHandlerOptions);
+    const [errOk, , err] = errRespond.mock.calls[0];
+    expect(errOk).toBe(false);
+    expect((err as { code: string }).code).toBe("INVALID_REQUEST");
+  });
+
+  it("applies a positive ttlMs and falls back to the default for an invalid one", async () => {
+    const r1 = vi.fn();
+    await attachHandlers["attach.grant"]({
+      params: { sessionKey: "agent:main:ttl", ttlMs: 30_000 },
+      respond: r1,
+      context: { getRuntimeConfig: () => ({}) },
+    } as unknown as GatewayRequestHandlerOptions);
+    const now1 = Date.now();
+    const b1 = r1.mock.calls[0][1] as { expiresAtMs: number };
+    expect(b1.expiresAtMs).toBeGreaterThan(now1 + 20_000);
+    expect(b1.expiresAtMs).toBeLessThan(now1 + 40_000); // honored 30s ttl, not the 1h default
+
+    const r2 = vi.fn();
+    await attachHandlers["attach.grant"]({
+      params: { sessionKey: "agent:main:ttl2", ttlMs: -5 }, // non-positive → default ttl
+      respond: r2,
+      context: { getRuntimeConfig: () => ({}) },
+    } as unknown as GatewayRequestHandlerOptions);
+    const b2 = r2.mock.calls[0][1] as { expiresAtMs: number };
+    expect(b2.expiresAtMs).toBeGreaterThan(Date.now() + 50 * 60_000); // ~1h default window
+  });
+
+  it("attach.revoke treats non-object params as a missing token (INVALID_REQUEST)", async () => {
+    const respond = vi.fn();
+    await attachHandlers["attach.revoke"]({
+      params: null,
+      respond,
+    } as unknown as GatewayRequestHandlerOptions);
+    const [ok, , err] = respond.mock.calls[0];
+    expect(ok).toBe(false);
+    expect((err as { code: string }).code).toBe("INVALID_REQUEST");
+  });
+});

--- a/src/gateway/server-methods/attach.test.ts
+++ b/src/gateway/server-methods/attach.test.ts
@@ -1,12 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/sessions/session-accessor.js", async (importActual) => ({
+  ...(await importActual<typeof import("../../config/sessions/session-accessor.js")>()),
+  loadSessionEntry: vi.fn(() => undefined),
+  // Run the atomic mutator on an entry that already holds ANOTHER provider's binding, returning the
+  // result — so the test actually exercises the merge (a non-preserving handler would drop other-cli)
+  // instead of the mock masking it. Returns null only when explicitly overridden (write-failed case).
+  patchSessionEntry: vi.fn(async (_scope: unknown, update: (entry: unknown) => unknown) =>
+    update({ cliSessionBindings: { "other-cli": { sessionId: "other-sess" } } }),
+  ),
+}));
+
+import { hashCliSessionText } from "../../agents/cli-session.js";
+import { loadSessionEntry, patchSessionEntry } from "../../config/sessions/session-accessor.js";
 import { resetAttachGrantsForTest, resolveAttachGrant } from "../mcp-grant-store.js";
 import { closeMcpLoopbackServer } from "../mcp-http.js";
 import { attachHandlers } from "./attach.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
-const grantOpts = (sessionKey: string, respond: ReturnType<typeof vi.fn>) =>
+const grantOpts = (sessionKey: string, respond: ReturnType<typeof vi.fn>, cwd?: string) =>
   ({
-    params: { sessionKey },
+    params: { sessionKey, ...(cwd ? { cwd } : {}) },
     respond,
     context: { getRuntimeConfig: () => ({}) },
   }) as unknown as GatewayRequestHandlerOptions;
@@ -95,5 +109,87 @@ describe("attach gateway methods", () => {
     const [ok, , err] = respond.mock.calls[0];
     expect(ok).toBe(false);
     expect((err as { code: string }).code).toBe("INVALID_REQUEST");
+  });
+
+  it("attach.grant returns resumeSessionId only when the bound cwd matches (claude scopes per project)", async () => {
+    vi.mocked(loadSessionEntry).mockReturnValue({
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "bound-uuid", cwdHash: hashCliSessionText("/proj") },
+      },
+    } as never);
+
+    const sameCwd = vi.fn();
+    await attachHandlers["attach.grant"](grantOpts("agent:main:resume", sameCwd, "/proj"));
+    expect((sameCwd.mock.calls[0][1] as { resumeSessionId?: string }).resumeSessionId).toBe(
+      "bound-uuid",
+    );
+
+    const otherCwd = vi.fn();
+    await attachHandlers["attach.grant"](grantOpts("agent:main:resume", otherCwd, "/elsewhere"));
+    expect(
+      (otherCwd.mock.calls[0][1] as { resumeSessionId?: string }).resumeSessionId,
+    ).toBeUndefined();
+  });
+
+  it("attach.adopt persists the claude-cli binding and preserves other providers' bindings", async () => {
+    const grantRespond = vi.fn();
+    await attachHandlers["attach.grant"](grantOpts("agent:main:adopt", grantRespond));
+    const token = (grantRespond.mock.calls[0][1] as { token: string }).token;
+
+    const adoptRespond = vi.fn();
+    await attachHandlers["attach.adopt"]({
+      params: { token, cliSessionId: "sess-uuid-1", cwd: "/proj" },
+      respond: adoptRespond,
+    } as unknown as GatewayRequestHandlerOptions);
+
+    expect(adoptRespond).toHaveBeenCalledWith(true, {
+      sessionKey: "agent:main:adopt",
+      cliSessionId: "sess-uuid-1",
+      persisted: true,
+    });
+    // the atomic mutator ran on an entry already holding "other-cli" (see the mock) — both survive,
+    // and the new binding records the cwd hash so resume is gated per project.
+    const persistedEntry = (await vi.mocked(patchSessionEntry).mock.results.at(-1)?.value) as {
+      cliSessionBindings: Record<string, { sessionId: string; cwdHash?: string }>;
+    };
+    expect(persistedEntry.cliSessionBindings["claude-cli"].sessionId).toBe("sess-uuid-1");
+    expect(persistedEntry.cliSessionBindings["claude-cli"].cwdHash).toBe(
+      hashCliSessionText("/proj"),
+    );
+    expect(persistedEntry.cliSessionBindings["other-cli"].sessionId).toBe("other-sess"); // preserved
+  });
+
+  it("attach.adopt reports persisted:false when the store write returns null", async () => {
+    vi.mocked(patchSessionEntry).mockResolvedValueOnce(null);
+    const grantRespond = vi.fn();
+    await attachHandlers["attach.grant"](grantOpts("agent:main:np", grantRespond));
+    const token = (grantRespond.mock.calls[0][1] as { token: string }).token;
+
+    const r = vi.fn();
+    await attachHandlers["attach.adopt"]({
+      params: { token, cliSessionId: "s" },
+      respond: r,
+    } as unknown as GatewayRequestHandlerOptions);
+    expect(r).toHaveBeenCalledWith(true, {
+      sessionKey: "agent:main:np",
+      cliSessionId: "s",
+      persisted: false,
+    });
+  });
+
+  it("attach.adopt rejects a missing field or unknown grant as INVALID_REQUEST", async () => {
+    const r1 = vi.fn();
+    await attachHandlers["attach.adopt"]({
+      params: { token: "x" }, // missing cliSessionId
+      respond: r1,
+    } as unknown as GatewayRequestHandlerOptions);
+    expect((r1.mock.calls[0][2] as { code: string }).code).toBe("INVALID_REQUEST");
+
+    const r2 = vi.fn();
+    await attachHandlers["attach.adopt"]({
+      params: { token: "nonexistent", cliSessionId: "s" }, // unknown grant
+      respond: r2,
+    } as unknown as GatewayRequestHandlerOptions);
+    expect((r2.mock.calls[0][2] as { code: string }).code).toBe("INVALID_REQUEST");
   });
 });

--- a/src/gateway/server-methods/attach.ts
+++ b/src/gateway/server-methods/attach.ts
@@ -1,0 +1,66 @@
+// Gateway RPC handlers for attach grants: mint a per-session, scoped, revocable MCP loopback grant
+// so an external/interactive harness can reach the gateway's scoped tools, and revoke it on detach.
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveMainSessionKey } from "../../config/sessions.js";
+import { mintAttachGrant, revokeAttachGrant } from "../mcp-grant-store.js";
+import { ensureMcpLoopbackServer } from "../mcp-http.js";
+import {
+  createMcpLoopbackServerConfig,
+  getActiveMcpLoopbackRuntime,
+} from "../mcp-http.loopback-runtime.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+function paramRecord(params: unknown): Record<string, unknown> {
+  return params && typeof params === "object" ? (params as Record<string, unknown>) : {};
+}
+
+function readString(params: unknown, key: string): string | undefined {
+  const value = paramRecord(params)[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readPositiveNumber(params: unknown, key: string): number | undefined {
+  const value = paramRecord(params)[key];
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+export const attachHandlers: GatewayRequestHandlers = {
+  // Mint a grant bound to a session, returning the loopback MCP config + the token env the harness
+  // needs. ensureMcpLoopbackServer lazily brings the singleton up if no cli-backend turn started it.
+  "attach.grant": async ({ params, respond, context }) => {
+    await ensureMcpLoopbackServer();
+    const runtime = getActiveMcpLoopbackRuntime();
+    if (!runtime) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, "mcp loopback server unavailable"),
+      );
+      return;
+    }
+    const sessionKey =
+      readString(params, "sessionKey") ?? resolveMainSessionKey(context.getRuntimeConfig());
+    const grant = mintAttachGrant({ sessionKey, ttlMs: readPositiveNumber(params, "ttlMs") });
+    respond(true, {
+      sessionKey: grant.sessionKey,
+      token: grant.token,
+      expiresAtMs: grant.expiresAtMs,
+      // The harness writes mcpConfig to its MCP client config and sets env so the ${...} placeholders
+      // resolve. Loopback today; node/app conduits reuse the same client config over their channel.
+      mcpConfig: createMcpLoopbackServerConfig(runtime.port),
+      env: {
+        OPENCLAW_MCP_TOKEN: grant.token,
+        OPENCLAW_MCP_SESSION_KEY: grant.sessionKey,
+      },
+    });
+  },
+  // Revoke a previously minted grant. Idempotent: an unknown/already-expired token reports revoked=false.
+  "attach.revoke": async ({ params, respond }) => {
+    const token = readString(params, "token");
+    if (!token) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "token is required"));
+      return;
+    }
+    respond(true, { revoked: revokeAttachGrant(token) });
+  },
+};

--- a/src/gateway/server-methods/attach.ts
+++ b/src/gateway/server-methods/attach.ts
@@ -1,8 +1,13 @@
 // Gateway RPC handlers for attach grants: mint a per-session, scoped, revocable MCP loopback grant
 // so an external/interactive harness can reach the gateway's scoped tools, and revoke it on detach.
+import { randomUUID } from "node:crypto";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { hashCliSessionText, setCliSessionBinding } from "../../agents/cli-session.js";
 import { resolveMainSessionKey } from "../../config/sessions.js";
-import { mintAttachGrant, revokeAttachGrant } from "../mcp-grant-store.js";
+import { loadSessionEntry, patchSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import { CLAUDE_CLI_PROVIDER } from "../cli-session-history.claude.js";
+import { mintAttachGrant, resolveAttachGrant, revokeAttachGrant } from "../mcp-grant-store.js";
 import { ensureMcpLoopbackServer } from "../mcp-http.js";
 import {
   createMcpLoopbackServerConfig,
@@ -41,10 +46,20 @@ export const attachHandlers: GatewayRequestHandlers = {
     const sessionKey =
       readString(params, "sessionKey") ?? resolveMainSessionKey(context.getRuntimeConfig());
     const grant = mintAttachGrant({ sessionKey, ttlMs: readPositiveNumber(params, "ttlMs") });
+    // resumeSessionId: the bound Claude cli session — but only when it was created in THIS cwd. Claude
+    // scopes sessions per project, so `claude --resume <id>` from another cwd would fail ("No
+    // conversation found"); the cwdHash gate matches the cli-backend's cwd-invalidation (cli-session.ts)
+    // and is robust cross-platform (hashCliSessionText), unlike re-deriving Claude's project-dir name.
+    const binding = loadSessionEntry({ sessionKey })?.cliSessionBindings?.[CLAUDE_CLI_PROVIDER];
+    const resumeSessionId =
+      binding?.sessionId && binding.cwdHash === hashCliSessionText(readString(params, "cwd"))
+        ? binding.sessionId
+        : undefined;
     respond(true, {
       sessionKey: grant.sessionKey,
       token: grant.token,
       expiresAtMs: grant.expiresAtMs,
+      ...(resumeSessionId ? { resumeSessionId } : {}),
       // The harness writes mcpConfig to its MCP client config and sets env so the ${...} placeholders
       // resolve. Loopback today; node/app conduits reuse the same client config over their channel.
       mcpConfig: createMcpLoopbackServerConfig(runtime.port),
@@ -53,6 +68,46 @@ export const attachHandlers: GatewayRequestHandlers = {
         OPENCLAW_MCP_SESSION_KEY: grant.sessionKey,
       },
     });
+  },
+  // Adopt the harness's Claude cli session (id known up-front via `claude --session-id <uuid>`) into
+  // the granted gateway session: persist the {sessionKey ↔ cliSessionId} binding so the conversation
+  // is recorded (history import) and resumable on the next attach. Bound to the grant, not headers.
+  "attach.adopt": async ({ params, respond }) => {
+    const token = readString(params, "token");
+    const cliSessionId = readString(params, "cliSessionId");
+    if (!token || !cliSessionId) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "token and cliSessionId are required"),
+      );
+      return;
+    }
+    const grant = resolveAttachGrant(token);
+    if (!grant) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown or expired grant"));
+      return;
+    }
+    // Persist the binding with an ATOMIC read-modify-write: patchSessionEntry runs the mutator on the
+    // entry loaded inside the store transaction, so setCliSessionBinding's `...existing` spread
+    // preserves other providers' bindings without a TOCTOU race. fallbackEntry creates the session if
+    // it does not exist yet (otherwise the binding silently drops for a session adopted before its
+    // first turn, breaking resume); it carries the binding so the create path persists it too.
+    // Record the adopting cwd's hash on the binding so a later grant only resumes from the same cwd
+    // (Claude scopes sessions per project) — mirrors the cli-backend's cwdHash invalidation.
+    const cwdHash = hashCliSessionText(readString(params, "cwd"));
+    const binding = { sessionId: cliSessionId, ...(cwdHash ? { cwdHash } : {}) };
+    const fallbackEntry: SessionEntry = { sessionId: randomUUID(), updatedAt: Date.now() };
+    setCliSessionBinding(fallbackEntry, CLAUDE_CLI_PROVIDER, binding);
+    const persisted = await patchSessionEntry(
+      { sessionKey: grant.sessionKey },
+      (entry) => {
+        setCliSessionBinding(entry, CLAUDE_CLI_PROVIDER, binding);
+        return entry;
+      },
+      { fallbackEntry },
+    );
+    respond(true, { sessionKey: grant.sessionKey, cliSessionId, persisted: persisted !== null });
   },
   // Revoke a previously minted grant. Idempotent: an unknown/already-expired token reports revoked=false.
   "attach.revoke": async ({ params, respond }) => {


### PR DESCRIPTION
## What Problem This Solves

PR #96454 launches Claude Code bound to a gateway session, but the conversation is invisible to OpenClaw and lost on exit: the gateway never learns *which* Claude cli session the attach started, so it can't surface the transcript or let you continue the same conversation on the next attach.

## Why This Change Was Made

This is the **resume + recording** piece of the `attach` surface (tracking: openclaw/openclaw#96205, PR4). `openclaw attach` now starts Claude with a **known** session id (`claude --session-id <uuid>`) and **adopts** it into the gateway session — persisting the `{sessionKey ↔ cliSessionId}` binding. That binding does double duty:
- **Recording** — the gateway's existing history-import path (`resolveClaudeCliBindingSessionId` → `readClaudeCliSessionMessages` → `augmentChatHistoryWithCliSessionImports`) surfaces the attach conversation in `chat.history`. It was never wired to attach because nothing told the gateway the session id.
- **Resume** — the next attach to the same gateway session **and same cwd** resumes it (`claude --resume <id>`). Claude scopes sessions per project, so the binding records a `cwdHash` (`hashCliSessionText`) and `attach.grant` returns `resumeSessionId` only on a cwd match — mirroring the cli-backend's existing cwd-invalidation (`cli-session.ts`). A different cwd starts fresh (a different project is a different conversation), so a stale/foreign session never fails `claude --resume`.

It reuses existing storage end-to-end — `setCliSessionBinding` (with `cwdHash`) + the atomic `patchSessionEntry` write (which preserves other providers' bindings + creates the row if missing). **No** new tables, no `session-sync`/`meta.json`, no `conversations_list`.

## User Impact

- `openclaw attach` starts Claude with a known `--session-id` and binds it; re-attaching to the same session **resumes** the same conversation (`--resume`).
- The attach conversation is **recorded** (surfaced in gateway chat history) via the existing import path.
- New gateway method **`attach.adopt({ token, cliSessionId })`** (`operator.admin`); **`attach.grant` now also returns `resumeSessionId`**. Both additive to the (unreleased) attach surface; no protocol bump.
- **No change** to the cli-backend path or existing commands. Adopt is best-effort — a failed adopt never blocks the launch.

## Evidence

- **Gateway tests (16)**: grant/revoke/ttl + `resumeSessionId` returned **only on cwd match** + `attach.adopt` persists the `claude-cli` binding (with `cwdHash`) **preserving other providers' bindings** + `persisted` flag + adopt validation (missing field / unknown grant → `INVALID_REQUEST`).
- **CLI tests (15)**: adopt fires only on the child `"spawn"` event (not before launch, not on spawn-failure, not in `--print-config`), the `--resume` path, malformed-grant/expiry handling, and the spawn/revoke + signal-detach lifecycle.
- Build, oxlint, **import-cycles** all clean; the 276-test gateway suite + the advertised-method-list test pass with `attach.adopt` added.
- **Stack** (each gated on exit code): PR4 delta is 6 files on top of PR2; full stack vs main is 13 files. Stacked on #96454 (PR2) / #96351 (PR1).
- Mutation **68%**; autoreview clean (cwd-encoding + cwd-orphan findings fixed).
- **adopt-on-spawn**: `attach.adopt` fires only in the child `"spawn"` handler — once `claude` actually starts — so it never binds a session id that a `--print-config` (no launch) or a failed spawn would leave uncreated.
- **Real-behavior proof — real Claude Code 2.1.191 in an isolated container** (apple-container, no Docker). A real headless gateway auto-pairs the device as operator, so `attach.grant`/`attach.adopt` execute for real. Same gateway session key `agent:main:realclaude`; only the cwd changes. Tokens/device id redacted.

  **1) First attach, cwd `/work/alpha`** — attach spawns real `claude --session-id <A>`; claude runs and writes a genuine transcript; adopt fires ON SPAWN:
  ```text
  Attaching Claude Code to session agent:main:realclaude …
  Hello from Claude — acknowledged, the attached harness is working.        ← real claude's reply
  ~/.claude/projects/-work-alpha/9b748344-….jsonl  (10,939 bytes)
  entry types: {"user":1,"assistant":1,"queue-operation":2,"attachment":3,"ai-title":1,"last-prompt":1}   ← genuine Claude Code transcript
  ```
  **2) `chat.history` for the session** — OpenClaw imports the REAL transcript after adoption:
  ```text
  $ openclaw gateway call chat.history --params '{"sessionKey":"agent:main:realclaude"}'
  imported roles: 1 user + 1 assistant
  … "content": "hello from a real attached harness …"     ← the real prompt, imported
  ```
  **3) Re-attach, cwd `/work/alpha`** (same project) → resumes the SAME real session:
  ```text
  "launch": [ "claude", "--resume", "9b748344-…", "--mcp-config", "…" ]
  ```
  **4) Attach, cwd `/work/beta`** (different project) → fresh id, never `9b748344` (the cwd gate):
  ```text
  "launch": [ "claude", "--session-id", "32350be6-…", "--mcp-config", "…" ]
  ```
- `claude --resume <uuid>` parses the UUID **as the session id** (verified: `claude --resume <missing>` → "No conversation found with session ID: …"), so the `["--resume", id]` arg form is correct.

**Risks → mitigations:** adopt is best-effort (failed adopt never blocks launch); the binding is grant-scoped (`token → sessionKey`, never header-trusted); resume is cwd-scoped (`cwdHash` gate) so a foreign/stale session never fails the launch; the binding write is atomic (`patchSessionEntry`) so concurrent provider bindings aren't lost.
