### PR TITLE
test(infra): add unit tests for semantic version comparison helpers

### DIFF
--- a/src/infra/semver-compare.test.ts
+++ b/src/infra/semver-compare.test.ts
@@ -1,0 +1,165 @@
+// Tests for semantic version comparison helpers.
+import { describe, expect, it } from "vitest";
+import {
+  normalizeLegacyDotBetaVersion,
+  parseComparableSemver,
+  comparePrereleaseIdentifiers,
+  compareComparableSemver,
+} from "./semver-compare.js";
+
+describe("normalizeLegacyDotBetaVersion", () => {
+  it("converts legacy dot-beta format", () => {
+    expect(normalizeLegacyDotBetaVersion("1.2.3.beta.4")).toBe("1.2.3-beta.4");
+  });
+
+  it("converts legacy dot-beta without suffix", () => {
+    expect(normalizeLegacyDotBetaVersion("1.2.3.beta")).toBe("1.2.3-beta");
+  });
+
+  it("preserves standard semver", () => {
+    expect(normalizeLegacyDotBetaVersion("1.2.3-beta.4")).toBe("1.2.3-beta.4");
+  });
+
+  it("preserves version without prerelease", () => {
+    expect(normalizeLegacyDotBetaVersion("1.2.3")).toBe("1.2.3");
+  });
+
+  it("handles v prefix", () => {
+    expect(normalizeLegacyDotBetaVersion("v1.2.3.beta.4")).toBe("v1.2.3-beta.4");
+  });
+
+  it("handles whitespace", () => {
+    expect(normalizeLegacyDotBetaVersion("  1.2.3.beta.4  ")).toBe("1.2.3-beta.4");
+  });
+});
+
+describe("parseComparableSemver", () => {
+  it("parses standard semver", () => {
+    expect(parseComparableSemver("1.2.3")).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: null,
+    });
+  });
+
+  it("parses semver with prerelease", () => {
+    expect(parseComparableSemver("1.2.3-beta.4")).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: ["beta", "4"],
+    });
+  });
+
+  it("parses semver with v prefix", () => {
+    expect(parseComparableSemver("v1.2.3")).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: null,
+    });
+  });
+
+  it("returns null for invalid version", () => {
+    expect(parseComparableSemver("invalid")).toBeNull();
+  });
+
+  it("returns null for null input", () => {
+    expect(parseComparableSemver(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(parseComparableSemver(undefined)).toBeNull();
+  });
+
+  it("normalizes legacy dot-beta when option enabled", () => {
+    expect(parseComparableSemver("1.2.3.beta.4", { normalizeLegacyDotBeta: true })).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: ["beta", "4"],
+    });
+  });
+});
+
+describe("comparePrereleaseIdentifiers", () => {
+  it("returns 0 for both null", () => {
+    expect(comparePrereleaseIdentifiers(null, null)).toBe(0);
+  });
+
+  it("returns 0 for both empty", () => {
+    expect(comparePrereleaseIdentifiers([], [])).toBe(0);
+  });
+
+  it("stable release has higher precedence than prerelease", () => {
+    expect(comparePrereleaseIdentifiers(null, ["beta"])).toBe(1);
+    expect(comparePrereleaseIdentifiers(["beta"], null)).toBe(-1);
+  });
+
+  it("compares numeric identifiers numerically", () => {
+    expect(comparePrereleaseIdentifiers(["1"], ["2"])).toBe(-1);
+    expect(comparePrereleaseIdentifiers(["2"], ["1"])).toBe(1);
+    expect(comparePrereleaseIdentifiers(["1"], ["1"])).toBe(0);
+  });
+
+  it("numeric identifiers have lower precedence than string", () => {
+    expect(comparePrereleaseIdentifiers(["1"], ["beta"])).toBe(-1);
+    expect(comparePrereleaseIdentifiers(["beta"], ["1"])).toBe(1);
+  });
+
+  it("compares string identifiers lexically", () => {
+    expect(comparePrereleaseIdentifiers(["alpha"], ["beta"])).toBe(-1);
+    expect(comparePrereleaseIdentifiers(["beta"], ["alpha"])).toBe(1);
+  });
+});
+
+describe("compareComparableSemver", () => {
+  it("returns null for null a", () => {
+    expect(
+      compareComparableSemver(null, { major: 1, minor: 0, patch: 0, prerelease: null }),
+    ).toBeNull();
+  });
+
+  it("returns null for null b", () => {
+    expect(
+      compareComparableSemver({ major: 1, minor: 0, patch: 0, prerelease: null }, null),
+    ).toBeNull();
+  });
+
+  it("compares major versions", () => {
+    expect(
+      compareComparableSemver(
+        { major: 1, minor: 0, patch: 0, prerelease: null },
+        { major: 2, minor: 0, patch: 0, prerelease: null },
+      ),
+    ).toBe(-1);
+  });
+
+  it("compares minor versions", () => {
+    expect(
+      compareComparableSemver(
+        { major: 1, minor: 0, patch: 0, prerelease: null },
+        { major: 1, minor: 1, patch: 0, prerelease: null },
+      ),
+    ).toBe(-1);
+  });
+
+  it("compares patch versions", () => {
+    expect(
+      compareComparableSemver(
+        { major: 1, minor: 0, patch: 0, prerelease: null },
+        { major: 1, minor: 0, patch: 1, prerelease: null },
+      ),
+    ).toBe(-1);
+  });
+
+  it("compares prerelease versions", () => {
+    expect(
+      compareComparableSemver(
+        { major: 1, minor: 0, patch: 0, prerelease: ["alpha"] },
+        { major: 1, minor: 0, patch: 0, prerelease: ["beta"] },
+      ),
+    ).toBe(-1);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `semver-compare.ts` module provides semantic version comparison helpers for package and runtime compatibility checks. However, this module lacked unit tests to verify the version comparison logic, which could lead to regressions when the function is modified.

## Why This Change Was Made

Add unit tests for `normalizeLegacyDotBetaVersion`, `parseComparableSemver`, `comparePrereleaseIdentifiers`, and `compareComparableSemver` functions to verify version comparison behavior. This improves test coverage and prevents regressions.

Focused tests cover legacy dot-beta normalization, semver parsing, prerelease identifier comparison, and full semver comparison.

## User Impact

Semantic version comparison now has comprehensive test coverage, reducing the risk of regressions when the function is modified.

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing helper behavior rather than reporting a user-visible runtime bug. Source inspection confirms the helper behavior the tests target.

Direct behavior probe:

```text
$ node --import tsx -e "import('./src/infra/semver-compare.js').then(({ normalizeLegacyDotBetaVersion, parseComparableSemver, comparePrereleaseIdentifiers, compareComparableSemver }) => console.log(JSON.stringify([{ desc: 'normalizeLegacyDotBetaVersion converts legacy format', input: '1.2.3.beta.4', result: normalizeLegacyDotBetaVersion('1.2.3.beta.4'), expected: '1.2.3-beta.4' }, { desc: 'parseComparableSemver parses standard semver', input: '1.2.3', result: parseComparableSemver('1.2.3'), expected: { major: 1, minor: 2, patch: 3, prerelease: null } }, { desc: 'comparePrereleaseIdentifiers returns 0 for both null', input: [null, null], result: comparePrereleaseIdentifiers(null, null), expected: 0 }, { desc: 'compareComparableSemver compares major versions', input: [{ major: 1, minor: 0, patch: 0, prerelease: null }, { major: 2, minor: 0, patch: 0, prerelease: null }], result: compareComparableSemver({ major: 1, minor: 0, patch: 0, prerelease: null }, { major: 2, minor: 0, patch: 0, prerelease: null }), expected: -1 }], null, 2)))"
[
  {
    "desc": "normalizeLegacyDotBetaVersion converts legacy format",
    "input": "1.2.3.beta.4",
    "result": "1.2.3-beta.4",
    "expected": "1.2.3-beta.4"
  },
  {
    "desc": "parseComparableSemver parses standard semver",
    "input": "1.2.3",
    "result": {
      "major": 1,
      "minor": 2,
      "patch": 3,
      "prerelease": null
    },
    "expected": {
      "major": 1,
      "minor": 2,
      "patch": 3,
      "prerelease": null
    }
  },
  {
    "desc": "comparePrereleaseIdentifiers returns 0 for both null",
    "input": [
      null,
      null
    ],
    "result": 0,
    "expected": 0
  },
  {
    "desc": "compareComparableSemver compares major versions",
    "input": [
      {
        "major": 1,
        "minor": 0,
        "patch": 0,
        "prerelease": null
      },
      {
        "major": 2,
        "minor": 0,
        "patch": 0,
        "prerelease": null
      }
    ],
    "result": -1,
    "expected": -1
  }
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/infra/semver-compare.test.ts

 RUN  v4.1.8 /home/0668001110/ZTEProject/openclaw-worktrees/pr-94335

 Test Files  1 passed (1)
      Tests  25 passed (25)
   Start at  18:59:16
   Duration  322ms (transform 56ms, setup 0ms, import 77ms, tests 10ms)

[test] passed 1 Vitest shard in 9.59s
```

Formatting:

```text
$ npx oxfmt --check src/infra/semver-compare.ts src/infra/semver-compare.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 53ms on 2 files using 8 threads.
```

Whitespace:

```text
$ git diff --check
```

## AI-assisted

Prepared with Codex. I reviewed the change, understand the touched code path, and kept the PR focused on the bug described above.
