### PR TITLE
fix(moonshot): prevent reasoning_content leak when reasoning is disabled

### DIFF
--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -401,11 +401,13 @@ export const streamOpenAICompletions: StreamFunction<
           const deltaFields = choice.delta as Record<string, unknown>;
           const shouldEmitReasoning = Boolean(model.reasoning && options?.reasoningEffort);
           let foundReasoningField: string | null = null;
-          for (const field of reasoningFields) {
-            const value = deltaFields[field];
-            if (typeof value === "string" && value.length > 0) {
-              foundReasoningField = field;
-              break;
+          if (shouldEmitReasoning) {
+            for (const field of reasoningFields) {
+              const value = deltaFields[field];
+              if (typeof value === "string" && value.length > 0) {
+                foundReasoningField = field;
+                break;
+              }
             }
           }
           if (foundReasoningField) {


### PR DESCRIPTION
## Summary
- When a model like kimi-k2.6 returns `reasoning_content` in stream deltas even with reasoning disabled, the parser still detected the field and marked strict content partitioning, causing reasoning text to leak into visible chat output
- Fix: only scan for reasoning fields (`reasoning_content`, `reasoning`, `reasoning_text`) when `shouldEmitReasoning` is true, so disabled-reasoning models don't trigger content partitioning from unprocessed reasoning deltas

## Test plan
- [ ] Verify moonshot/kimi-k2.6 with reasoning OFF no longer shows internal reasoning text in chat output
- [ ] Verify moonshot/kimi-k2.6 with reasoning ON still correctly emits thinking blocks
- [ ] Verify other OpenAI-compatible providers (DeepSeek, llama.cpp) still work correctly

Closes #96732

🤖 Generated with [Claude Code](https://claude.com/claude-code)