### PR TITLE
fix(mcp): strip null values from MCP tool call arguments

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -37,6 +37,16 @@ import { loadEmbeddedAgentMcpConfig } from "./embedded-agent-mcp.js";
 import { isMcpConfigRecord } from "./mcp-config-shared.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
 
+function stripNullValues(args: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (value !== null) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 type BundleMcpSession = {
   serverName: string;
   client: Client;
@@ -902,7 +912,7 @@ export function createSessionMcpRuntime(params: {
           (await session.client.callTool(
             {
               name: toolName,
-              arguments: isMcpConfigRecord(input) ? input : {},
+              arguments: isMcpConfigRecord(input) ? stripNullValues(input) : {},
             },
             undefined,
             { timeout: session.requestTimeoutMs },


### PR DESCRIPTION
## Summary
- Some MCP servers (e.g. awslabs eks-mcp-server) distinguish between `null` and absent for optional parameters, causing tool calls that pass `null` for optional fields to fail
- Fix: strip top-level null values from tool call arguments before sending to the MCP server, so `{ insight_id: null }` becomes `{}` — matching the "not provided" semantics of JSON Schema optional parameters

## Test plan
- [ ] Verify MCP tool calls with null optional arguments succeed (same as when the field is absent)
- [ ] Verify non-null arguments are unaffected
- [ ] Verify nested null values are preserved (only top-level stripping)

Closes #96716

🤖 Generated with [Claude Code](https://claude.com/claude-code)