### PR TITLE
fix(feishu): allow number/boolean/array types in bitable fields parameter

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -530,7 +530,13 @@ const CreateRecordSchema = Type.Object({
     description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
+  fields: Type.Record(Type.String(), Type.Union([
+    Type.String(),
+    Type.Number(),
+    Type.Boolean(),
+    Type.Array(Type.Any()),
+    Type.Record(Type.String(), Type.Any()),
+  ]), {
     description:
       "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}",
   }),
@@ -572,7 +578,13 @@ const UpdateRecordSchema = Type.Object({
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
   record_id: Type.String({ description: "Record ID to update" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
+  fields: Type.Record(Type.String(), Type.Union([
+    Type.String(),
+    Type.Number(),
+    Type.Boolean(),
+    Type.Array(Type.Any()),
+    Type.Record(Type.String(), Type.Any()),
+  ]), {
     description: "Field values to update (same format as create_record)",
   }),
 });


### PR DESCRIPTION
## Problem

The `fields` parameter in `CreateRecordSchema` and `UpdateRecordSchema` uses `Type.Any()` which serializes to an empty JSON Schema `{}`. This makes the LLM default to passing all values as **strings**, even for numeric fields where `number` type is expected.

For example, the LLM passes `{"Price": "99"}` instead of `{"Price": 99}`, causing type mismatches in the Bitable API.

## Fix

Change `Type.Any()` to `Type.Union([Type.String(), Type.Number(), Type.Boolean(), Type.Array(Type.Any()), Type.Record(Type.String(), Type.Any())])` so the JSON Schema explicitly advertises `"type": ["string", "number", "boolean", "array", "object"]`.

### Changes
- **`CreateRecordSchema.fields`** (line 533): `Type.Any()` → explicit union type
- **`UpdateRecordSchema.fields`** (line 575): same change

Both `property` in `CreateFieldSchema` keeps `Type.Any()` as-is, since field creation properties have field-type-specific structures that are too varied to constrain.