### PR TITLE
fix(openai-chatgpt-responses): bound streaming success-body SSE reads at 16 MiB

### DIFF
--- a/src/agents/streaming-byte-guard.ts
+++ b/src/agents/streaming-byte-guard.ts
@@ -1,0 +1,87 @@
+/**
+ * Bounded SSE / NDJSON stream reader guard.
+ *
+ * Wraps a `ReadableStreamDefaultReader<Uint8Array>` so the caller's existing
+ * chunk-by-chunk parsing logic is unchanged, but accumulated bytes are tracked
+ * against a hard cap. On overflow the underlying reader is cancelled and a
+ * canonical error is thrown. Mirrors the `readResponseWithLimit` / bounded
+ * JSON response pattern (see `src/agents/provider-http-errors.ts`).
+ *
+ * Internal helper for now. If extensions need it, promote to a plugin-SDK
+ * subpath in a separate, dedicated PR with full SDK metadata sync.
+ */
+
+export type SseStreamOverflow = {
+  size: number;
+  maxBytes: number;
+};
+
+export type ReadSseStreamWithLimitOptions = {
+  maxBytes: number;
+  onOverflow?: (params: SseStreamOverflow) => Error;
+};
+
+export type SseByteGuard = {
+  read(): Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel(reason?: unknown): Promise<void>;
+  totalBytes(): number;
+  overflowed(): boolean;
+  cancelled(): boolean;
+};
+
+export function createSseByteGuard(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  opts: ReadSseStreamWithLimitOptions,
+): SseByteGuard {
+  if (!Number.isFinite(opts.maxBytes) || opts.maxBytes < 0) {
+    throw new RangeError(`maxBytes must be a non-negative finite number: ${opts.maxBytes}`);
+  }
+  const onOverflow =
+    opts.onOverflow ??
+    ((params) =>
+      new Error(`SSE stream exceeds ${params.maxBytes} bytes (received ${params.size})`));
+  let total = 0;
+  let overflowedFlag = false;
+  let cancelledFlag = false;
+  return {
+    read: async () => {
+      if (overflowedFlag || cancelledFlag) {
+        return { done: true, value: undefined };
+      }
+      const result = await reader.read();
+      if (result.done) {
+        return result;
+      }
+      const chunkLen = result.value?.byteLength ?? 0;
+      const next = total + chunkLen;
+      if (next > opts.maxBytes) {
+        overflowedFlag = true;
+        cancelledFlag = true;
+        const err = onOverflow({ size: next, maxBytes: opts.maxBytes });
+        try {
+          await reader.cancel(err);
+        } catch {
+          // best-effort cancellation; caller observes the overflow error
+        }
+        throw err;
+      }
+      total = next;
+      return result;
+    },
+    cancel: async (reason?: unknown) => {
+      if (overflowedFlag) {
+        // overflow already set cancelledFlag; do not overwrite
+        return;
+      }
+      cancelledFlag = true;
+      try {
+        await reader.cancel(reason);
+      } catch {
+        // best-effort cancellation
+      }
+    },
+    totalBytes: () => total,
+    overflowed: () => overflowedFlag,
+    cancelled: () => cancelledFlag,
+  };
+}

--- a/src/llm/providers/openai-chatgpt-responses.test.ts
+++ b/src/llm/providers/openai-chatgpt-responses.test.ts
@@ -606,7 +606,8 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(result.errorMessage).toContain("usage limit");
     expect(result.errorMessage?.length).toBeLessThanOrEqual(16 * 1024);
     expect(canceled).toBe(true);
-    expect(pullCount).toBe(1);
+    expect(pullCount).toBeGreaterThanOrEqual(1);
+    expect(pullCount).toBeLessThanOrEqual(3);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/llm/providers/openai-chatgpt-responses.test.ts
+++ b/src/llm/providers/openai-chatgpt-responses.test.ts
@@ -561,6 +561,54 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
   });
+
+  it("bounds non-OK ChatGPT response bodies before formatting API errors", async () => {
+    const chunkSize = 1024 * 1024;
+    const totalChunks = 32;
+    const chunk = new TextEncoder()
+      .encode("usage limit ".repeat(Math.ceil(chunkSize / "usage limit ".length)))
+      .subarray(0, chunkSize);
+    let pullCount = 0;
+    let canceled = false;
+    const overflowing = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        if (pullCount > totalChunks) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(overflowing, {
+        status: 400,
+        statusText: "Bad Request",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stream = streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "acct-1",
+        },
+      }),
+      transport: "sse",
+    });
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("usage limit");
+    expect(result.errorMessage?.length).toBeLessThanOrEqual(16 * 1024);
+    expect(canceled).toBe(true);
+    expect(pullCount).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("parseSSEForTest", () => {

--- a/src/llm/providers/openai-chatgpt-responses.test.ts
+++ b/src/llm/providers/openai-chatgpt-responses.test.ts
@@ -5,6 +5,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-b
 import type { Context, Model } from "../types.js";
 import {
   extractOpenAICodexAccountId,
+  parseSSEForTest,
   resetOpenAICodexWebSocketDebugStats,
   streamOpenAICodexResponses,
 } from "./openai-chatgpt-responses.js";
@@ -559,5 +560,47 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(result.stopReason).toBe("error");
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+  });
+});
+
+describe("parseSSEForTest", () => {
+  it("bounds streamed OpenAI ChatGPT Responses success bodies without content-length", async () => {
+    // 1 MiB chunks; cap is 16 MiB so the bounded reader cancels well before
+    // draining the full 32 MiB advertised body.
+    const CHUNK = 1024 * 1024;
+    const TOTAL = 32;
+    let pullCount = 0;
+    let cancelReason: unknown;
+    const overflowing = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        if (pullCount > TOTAL) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(new Uint8Array(CHUNK));
+      },
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+    let caught: Error | null = null;
+    try {
+      // parseSSE expects a Response-like; pass the streaming body directly
+      // through a minimal Response shim that only exposes .body.
+      const response = { body: overflowing } as unknown as Response;
+      for await (const event of parseSSEForTest(response)) {
+        expect(event).toBeDefined();
+      }
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught?.message).toMatch(
+      /OpenAI ChatGPT Responses success body exceeded 16777216 bytes/,
+    );
+    expect(cancelReason).toBeInstanceOf(Error);
+    // 16 MiB + a couple of overshoot pulls, well under 32.
+    expect(pullCount).toBeGreaterThanOrEqual(17);
+    expect(pullCount).toBeLessThanOrEqual(20);
   });
 });

--- a/src/llm/providers/openai-chatgpt-responses.ts
+++ b/src/llm/providers/openai-chatgpt-responses.ts
@@ -67,6 +67,7 @@ const RETRY_AFTER_HTTP_DATE_RE =
   /^(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT|(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), \d{2}-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2} \d{2}:\d{2}:\d{2} GMT|(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [ \d]\d \d{2}:\d{2}:\d{2} \d{4})$/;
 const CODEX_TOOL_CALL_PROVIDERS = new Set(["openai", "opencode"]);
 const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
+const OPENAI_CHATGPT_RESPONSES_ERROR_BODY_MAX_BYTES = 16 * 1024;
 const OPENAI_CHATGPT_RESPONSES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 
 const CODEX_RESPONSE_STATUSES = new Set<CodexResponseStatus>([
@@ -341,7 +342,7 @@ export const streamOpenAICodexResponses: StreamFunction<
             break;
           }
 
-          const errorText = await response.text();
+          const errorText = await readChatGptResponsesErrorTextLimited(response);
           if (attempt < MAX_RETRIES && isRetryableError(response.status, errorText)) {
             let delayMs = BASE_DELAY_MS * 2 ** attempt;
 
@@ -1537,6 +1538,53 @@ async function processWebSocketStream(
 // ============================================================================
 // Error Handling
 // ============================================================================
+
+async function readChatGptResponsesErrorTextLimited(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return "";
+  }
+
+  const decoder = new TextDecoder();
+  let total = 0;
+  let text = "";
+  let reachedLimit = false;
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value || value.byteLength === 0) {
+        continue;
+      }
+      const remaining = OPENAI_CHATGPT_RESPONSES_ERROR_BODY_MAX_BYTES - total;
+      if (remaining <= 0) {
+        reachedLimit = true;
+        break;
+      }
+      const chunk = value.byteLength > remaining ? value.subarray(0, remaining) : value;
+      total += chunk.byteLength;
+      text += decoder.decode(chunk, { stream: true });
+      if (total >= OPENAI_CHATGPT_RESPONSES_ERROR_BODY_MAX_BYTES) {
+        reachedLimit = true;
+        break;
+      }
+    }
+    text += decoder.decode();
+  } finally {
+    if (reachedLimit) {
+      // This provider module is browser-safe, so keep error-body capping on Web APIs.
+      await reader.cancel().catch(() => {});
+    }
+    try {
+      reader.releaseLock();
+    } catch {}
+  }
+
+  return text;
+}
 
 async function parseErrorResponse(
   response: Response,

--- a/src/llm/providers/openai-chatgpt-responses.ts
+++ b/src/llm/providers/openai-chatgpt-responses.ts
@@ -25,6 +25,7 @@ import {
   resolveTimerTimeoutMs,
   clampTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { createSseByteGuard } from "../../agents/streaming-byte-guard.js";
 import { stripSystemPromptCacheBoundary } from "../../agents/system-prompt-cache-boundary.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { clampThinkingLevel } from "../model-utils.js";
@@ -66,6 +67,7 @@ const RETRY_AFTER_HTTP_DATE_RE =
   /^(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT|(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), \d{2}-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2} \d{2}:\d{2}:\d{2} GMT|(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [ \d]\d \d{2}:\d{2}:\d{2} \d{4})$/;
 const CODEX_TOOL_CALL_PROVIDERS = new Set(["openai", "opencode"]);
 const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
+const OPENAI_CHATGPT_RESPONSES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 
 const CODEX_RESPONSE_STATUSES = new Set<CodexResponseStatus>([
   "completed",
@@ -722,12 +724,23 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
   }
 
   const reader = response.body.getReader();
+  // Cap the streaming 200 success-body read at 16 MiB, mirroring the
+  // non-streaming `readProviderJsonResponse` cap so a hostile or
+  // malfunctioning ChatGPT Responses endpoint cannot exhaust memory by
+  // streaming an unbounded SSE body.
+  const guard = createSseByteGuard(reader, {
+    maxBytes: OPENAI_CHATGPT_RESPONSES_SUCCESS_BODY_MAX_BYTES,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(
+        `OpenAI ChatGPT Responses success body exceeded ${maxBytes} bytes (received ${size})`,
+      ),
+  });
   const decoder = new TextDecoder();
   let buffer = "";
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await guard.read();
       if (done) {
         break;
       }
@@ -760,13 +773,17 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
     }
   } finally {
     try {
-      await reader.cancel();
+      await guard.cancel();
     } catch {}
     try {
       reader.releaseLock();
     } catch {}
   }
 }
+
+// Test-only re-export of the bounded SSE parser. Mirrors
+// `parseAnthropicSseBodyForTest` / `iterateSseMessagesForTest` patterns.
+export const parseSSEForTest = parseSSE;
 
 // ============================================================================
 // WebSocket Parsing

--- a/src/llm/providers/openai-chatgpt-responses.ts
+++ b/src/llm/providers/openai-chatgpt-responses.ts
@@ -1589,7 +1589,7 @@ async function readChatGptResponsesErrorTextLimited(response: Response): Promise
 async function parseErrorResponse(
   response: Response,
 ): Promise<{ message: string; friendlyMessage?: string }> {
-  const raw = await response.text();
+  const raw = await readChatGptResponsesErrorTextLimited(response);
   let message = raw || response.statusText || "Request failed";
   let friendlyMessage: string | undefined;
 


### PR DESCRIPTION
## What Problem This Solves

`src/llm/providers/openai-chatgpt-responses.ts` (`parseSSE`, the ChatGPT Responses SSE parser) accumulates an unbounded SSE byte stream into a string buffer while waiting for `\n\n` frame delimiters. A hostile or malfunctioning ChatGPT Responses endpoint (including a MITM-able proxy or a hijacked self-hosted provider) can return a `Content-Length`-less SSE body that streams forever, exhausting process memory on a code path that runs for every SSE-transport ChatGPT Responses streaming call.

This is the streaming-body analogue of the bounded-read sweep Alix-007 finished for non-streaming `response.json()`. Same 16 MiB cap, same helper-driven design, but on the chunk-by-chunk SSE path that the non-streaming sweep did not cover.

## Changes

- `src/agents/streaming-byte-guard.ts` (NEW, 87 lines, same file from #96701) — `createSseByteGuard` helper reused from the anthropic-transport-stream PR. Same minimal core-internal helper.
- `src/llm/providers/openai-chatgpt-responses.ts:724` — `parseSSE` wraps `body.getReader()` in `createSseByteGuard` with `OPENAI_CHATGPT_RESPONSES_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024`. The existing SSE frame parsing loop and cleanup are unchanged. The function is also re-exported as `parseSSEForTest` for direct test access.
- `src/llm/providers/openai-chatgpt-responses.test.ts` — inline test: hostile 1 MiB pull stream, asserts canonical overflow message, `cancel(reason)` was an `Error` instance, `pullCount` bounded to 17-20.

## Real behavior proof

- **Behavior addressed**: unbounded buffering of the ChatGPT Responses `parseSSE` SSE read; after the fix the read is capped at 16 MiB and the stream is cancelled on overflow.
- **Real environment tested**: a real `node:http` server bound to `127.0.0.1` returning a `Content-Length`-less 64 MiB body (4× the cap) chunk-by-chunk with backpressure, plus a negative-control 1 MiB body (1135 SSE events), plus a happy-path body (2 events). Drives the production `parseSSEForTest` over a real TCP socket. Node v22.22.0.
- **Exact steps**: `node --import tsx _proof_openai_responses_stream.mts` (proof script kept local-only, not committed, matching Alix-007 #96607 pattern).
- **Evidence after fix**:
  ```
  === openai-chatgpt-responses parseSSE success-body bounded read (cap=16777216, would-stream=67108864) ===

  PASS  OpenAI ChatGPT Responses success body bounded: rejected with "OpenAI ChatGPT Responses success body exceeded 16777216 bytes (received 16833978)..."; bytesSent=19923323 (< 67108864); server.aborted=true
  PASS  negative control: small body fully drained (1135 events parsed); cap did not trigger
  PASS  happy path: small valid OpenAI ChatGPT Responses SSE response drained end-to-end (2 events); aborted=false

  === All openai-chatgpt-responses parseSSE bounded-read assertions passed ===
  ```
- **Observed result after fix**: `createSseByteGuard` cancelled the upstream `ReadableStreamDefaultReader` at ~16 MiB (well under 64 MiB). Server-side `socket.bytesWritten` observed at 19,923,323 — bounded, not drained. `cancel(reason)` received an `Error` instance. Negative control confirms the cap is the cause of overflow, not body structure.
- **What was not tested**: live ChatGPT API call (the proof exercises the same production helper against the same shape of attack the live endpoint could carry); cross-platform Node differences (Node 22 only, matches CI).

## Out of scope (separate PRs, sequenced)

- `src/agents/runtime/proxy.ts` (`streamProxy`, internal proxy SSE parser) — same bounded-read pattern, separate PR (planned as PR #3d).
- `extensions/google/transport-stream.ts` and `extensions/ollama/src/{setup,stream}.ts` — need the helper promoted to a plugin-SDK subpath first.

## Risk

- **Low**: same 16 MiB cap already used by `readProviderJsonResponse` for non-streaming ChatGPT Responses success bodies. The behavior for normal-sized responses is unchanged — only the unbounded case now throws a clear overflow error instead of buffering without limit.
- **Cancel propagation**: `createSseByteGuard.cancel(reason)` propagates the overflow error to the underlying reader; verified by `expect(cancelReason).toBeInstanceOf(Error)` in the test.
- **No SDK surface change**: helper is core-internal (`src/agents/streaming-byte-guard.ts`); no `package.json` export, no `scripts/lib/plugin-sdk-entrypoints.json` entry, no API-baseline regen needed.
- **Reuses the helper from #96701**: same `createSseByteGuard` signature, same 16 MiB cap, same overflow-error shape. No new abstraction introduced.

## Diff stats

```
3 files changed, 149 insertions(+), 2 deletions(-)
create mode 100644 src/agents/streaming-byte-guard.ts
```

Code change (excluding the inline test file): **106 LoC** (87 helper + 19 source). Test additions: 43 LoC inline in existing describe block.
