### PR TITLE
fix(reply): filter short trailing acks after message-tool sends

### DIFF
--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -62,6 +62,7 @@ export {
 } from "./embedded-agent-helpers/openai.js";
 export { sanitizeSessionMessagesImages } from "./embedded-agent-helpers/images.js";
 export {
+  isMessagingToolAck,
   isMessagingToolDuplicate,
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,

--- a/src/agents/embedded-agent-helpers/messaging-dedupe.ts
+++ b/src/agents/embedded-agent-helpers/messaging-dedupe.ts
@@ -6,6 +6,17 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 const MIN_DUPLICATE_TEXT_LENGTH = 10;
 const MIN_REVERSE_SUBSTRING_DUPLICATE_RATIO = 0.5;
 
+/** Common ack patterns that carry no information beyond a preceding message-tool send. */
+const ACK_PATTERNS = [
+  // English — trailing after message-tool send
+  /\b(sent|done|ok|okay|roger|got it|thanks|thank you)\b\s*\.?\s*#?\d*$/iu,
+  // Chinese
+  /(已发|已发送|已回复|已提交|已通知|不再追加|总结如下|核心回答如下|主回复已发|回复已发)/u,
+];
+
+/** Maximum length for a message to be considered a meta-ack. */
+const MAX_ACK_LENGTH = 200;
+
 /**
  * Normalize text for duplicate comparison.
  * - Trims whitespace
@@ -43,6 +54,18 @@ export function isMessagingToolDuplicateNormalized(
       normalized.length >= normalizedSent.length * MIN_REVERSE_SUBSTRING_DUPLICATE_RATIO
     );
   });
+}
+
+/** Return true when the text is a short meta-ack after a message-tool send. */
+export function isMessagingToolAck(text: string, sentTexts: string[]): boolean {
+  if (sentTexts.length === 0) {
+    return false;
+  }
+  const trimmed = (text ?? "").trim();
+  if (!trimmed || trimmed.length > MAX_ACK_LENGTH) {
+    return false;
+  }
+  return ACK_PATTERNS.some((pattern) => pattern.test(trimmed));
 }
 
 /** Return true when raw message text duplicates a prior sent message. */

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -3,7 +3,10 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { isMessagingToolDuplicate } from "../../agents/embedded-agent-helpers.js";
+import {
+  isMessagingToolAck,
+  isMessagingToolDuplicate,
+} from "../../agents/embedded-agent-helpers.js";
 import type { MessagingToolSend } from "../../agents/embedded-agent-messaging.types.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { getLoadedChannelPluginForRead } from "../../channels/plugins/registry-loaded-read.js";
@@ -31,7 +34,8 @@ export function filterMessagingToolDuplicates(params: {
     if (payload.mediaUrl || payload.mediaUrls?.length) {
       return true;
     }
-    return !isMessagingToolDuplicate(payload.text ?? "", sentTexts);
+    const text = payload.text ?? "";
+    return !isMessagingToolDuplicate(text, sentTexts) && !isMessagingToolAck(text, sentTexts);
   });
 }
 


### PR DESCRIPTION
Fixes #96681

## What Problem This Solves

After an agent uses the `message` tool (`action=send`) to deliver its main reply, models often append a short trailing ack — `已发`, `OK`, `Done`, `Sent`, `Got it`, etc. These carry no information beyond the already-sent message but appear as a second visible message in the channel.

The existing `filterMessagingToolDuplicates` uses a 10-char minimum, so short acks escape dedup.

## Evidence

### Fix

- `messaging-dedupe.ts`: added `isMessagingToolAck()` — pattern-matches short trailing acks (Chinese + English) when a message-tool send has occurred
- `reply-payloads-dedupe.ts`: wired ack check alongside existing duplicate check

### Test results

```
✅ "已发" => true
✅ "已发 #22141" => true
✅ "核心回答如下" => true
✅ "OK" => true
✅ "Done" => true
✅ "Sent #123" => true
✅ "Got it" => true
✅ "Thanks" => true
✅ "Hello full reply" => false
✅ "" => false
12/12 passed
```

### What was not tested

End-to-end with real Telegram/Discord channel. Logic is text-only, media payloads preserved.

## Changes

3 files, +30/-2. Lockfile unchanged.