### PR TITLE
fix(agents): hide runtime-only placeholder prompt from user-visible transcript

### DIFF
--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -634,6 +634,10 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("");
   });
 
+  it("strips the runtime-only user prompt placeholder when it appears standalone", () => {
+    expect(sanitizeUserFacingText("Continue the OpenClaw runtime event.")).toBe("");
+  });
+
   it("does not strip ordinary text that merely mentions internal marker strings", () => {
     const input = [
       "The literal header `OpenClaw runtime context (internal):` appears in this note.",

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -25,7 +25,10 @@ import {
 } from "../../shared/text/assistant-visible-text.js";
 import { stripFinalTags } from "../../shared/text/final-tags.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
-import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
+import {
+  OPENCLAW_RUNTIME_EVENT_USER_PROMPT,
+  stripInternalRuntimeContext,
+} from "../internal-runtime-context.js";
 import { stableStringify } from "../stable-stringify.js";
 import {
   isBillingErrorMessage,
@@ -446,6 +449,12 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   );
   const trimmed = withoutToolCallBlocks.trim();
   if (!trimmed) {
+    return "";
+  }
+  // Runtime-only maintenance turns use this placeholder to trigger the agent
+  // loop. It is internal scaffolding, not user input — strip it before delivery
+  // so it never leaks into user-visible surfaces.
+  if (trimmed === OPENCLAW_RUNTIME_EVENT_USER_PROMPT) {
     return "";
   }
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4236,9 +4236,7 @@ export async function runEmbeddedAttempt(
               setActiveSessionSystemPrompt(runtimeSystemPrompt);
             }
           }
-          const runtimeContextForHook = promptSubmission.runtimeOnly
-            ? undefined
-            : promptSubmission.runtimeContext?.trim();
+          const runtimeContextForHook = promptSubmission.runtimeContext?.trim();
           const runtimeContextMessageForCurrentTurn =
             buildRuntimeContextCustomMessage(runtimeContextForHook);
           const messagesForCurrentPrompt = runtimeContextMessageForCurrentTurn
@@ -4776,31 +4774,25 @@ export async function runEmbeddedAttempt(
             };
             const cleanupProviderPromptHistoryTransform = installProviderPromptHistoryTransform();
             try {
-              if (promptSubmission.runtimeOnly) {
-                await promptActiveSession(promptForSession, {
-                  preflightResult: armModelPromptTransform,
-                });
-              } else {
-                const cleanupRuntimeContextMessage = installRuntimeContextMessageForPrompt({
-                  session: activeSession,
-                  message: runtimeContextMessageForCurrentTurn,
-                });
-                try {
-                  // Only pass images option if there are actually images to pass
-                  // This avoids potential issues with models that don't expect the images parameter
-                  if (imageResult.images.length > 0) {
-                    await promptActiveSession(promptForSession, {
-                      images: imageResult.images,
-                      preflightResult: armModelPromptTransform,
-                    });
-                  } else {
-                    await promptActiveSession(promptForSession, {
-                      preflightResult: armModelPromptTransform,
-                    });
-                  }
-                } finally {
-                  cleanupRuntimeContextMessage();
+              const cleanupRuntimeContextMessage = installRuntimeContextMessageForPrompt({
+                session: activeSession,
+                message: runtimeContextMessageForCurrentTurn,
+              });
+              try {
+                // Only pass images option if there are actually images to pass
+                // This avoids potential issues with models that don't expect the images parameter
+                if (imageResult.images.length > 0) {
+                  await promptActiveSession(promptForSession, {
+                    images: imageResult.images,
+                    preflightResult: armModelPromptTransform,
+                  });
+                } else {
+                  await promptActiveSession(promptForSession, {
+                    preflightResult: armModelPromptTransform,
+                  });
                 }
+              } finally {
+                cleanupRuntimeContextMessage();
               }
               if (leasedSteering) {
                 ackPendingAgentSteeringItems({

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -9,10 +9,9 @@ import {
   OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
   OPENCLAW_RUNTIME_CONTEXT_NOTICE,
   OPENCLAW_RUNTIME_EVENT_HEADER,
+  OPENCLAW_RUNTIME_EVENT_USER_PROMPT,
 } from "../../internal-runtime-context.js";
 import type { CurrentInboundPromptContext } from "./params.js";
-
-const OPENCLAW_RUNTIME_EVENT_USER_PROMPT = "Continue the OpenClaw runtime event.";
 
 type RuntimeContextPromptParts = {
   prompt: string;

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -21,6 +21,8 @@ export const OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER =
 export const OPENCLAW_RUNTIME_EVENT_HEADER = "OpenClaw runtime event.";
 /** Custom message type used for structured runtime-context messages. */
 export const OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE = "openclaw.runtime-context";
+/** User prompt placeholder for runtime-only turns that carry no user-authored text. */
+export const OPENCLAW_RUNTIME_EVENT_USER_PROMPT = "Continue the OpenClaw runtime event.";
 
 const LEGACY_INTERNAL_CONTEXT_HEADER =
   ["OpenClaw runtime context (internal):", OPENCLAW_RUNTIME_CONTEXT_NOTICE, ""].join("\n") + "\n";


### PR DESCRIPTION
What Problem This Solves
Runtime-only maintenance turns (subagent completion, cron job, background media task results) use the non-empty placeholder "Continue the OpenClaw runtime event." as a user prompt to trigger the agent loop. The runtime context is correctly injected into the system prompt, but the placeholder is submitted via activeSession.prompt(string), so the upstream Pi Agent normalizes it into a plain role: "user" message. The session transcript layer has no metadata to distinguish it from real user input, causing it to be persisted to JSONL and displayed in the UI as a user message.

Users see a ghost message they never sent, and the placeholder pollutes compaction summaries, trajectory exports, and conversation history.

Why This Change Was Made
The non-runtimeOnly path already has a correct mechanism: it wraps runtime context in a RuntimeContextCustomMessage with role: "custom", display: false, and customType: "openclaw.runtime-context", injected via installRuntimeContextMessageForPrompt. The runtimeOnly path explicitly skipped this — its runtimeContextForHook was gated to undefined, and it called activeSession.prompt(promptForSession) without the custom message injection.

This change unifies the two paths so runtimeOnly turns also get the hidden custom message treatment, and adds a safety-net filter in sanitizeUserFacingText in case the custom-message metadata is ever lost in transit.

Changes
src/agents/internal-runtime-context.ts — export OPENCLAW_RUNTIME_EVENT_USER_PROMPT alongside the other runtime-context constants
src/agents/embedded-agent-runner/run/runtime-context-prompt.ts — import from the shared module instead of a local const
src/agents/embedded-agent-runner/run/attempt.ts —
Remove the runtimeOnly ? undefined : ... gate so runtimeContextForHook is always populated
Merge the two if/else prompt-submission branches into a unified path that always calls installRuntimeContextMessageForPrompt
src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts — strip the placeholder when it appears standalone as a defense-in-depth safety net
src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts — add test covering the new sanitize rule
User Impact
Before: "Continue the OpenClaw runtime event." appears in conversations as a user message
After: The placeholder is hidden from all user-visible surfaces (UI transcript, compaction summaries, trajectory exports)
Evidence

pnpm test src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
  119 passed (new: "strips the runtime-only user prompt placeholder when it appears standalone")

pnpm test src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
  17 passed

pnpm test src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
  62 passed

pnpm test src/agents/internal-runtime-context.test.ts
  5 passed