### PR TITLE
fix(googlechat): replace unbounded response.json() with readProviderJsonResponse

### DIFF
--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -2,7 +2,10 @@
 import crypto from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
-import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
@@ -54,7 +57,7 @@ async function withGoogleChatResponse<T>(params: {
   });
   try {
     if (!response.ok) {
-      const text = await response.text().catch(() => "");
+      const text = await readResponseTextLimited(response).catch(() => "");
       throw new Error(`${errorPrefix} ${response.status}: ${text || response.statusText}`);
     }
     return await handleResponse(response);

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
@@ -13,11 +14,7 @@ const CHAT_API_BASE = "https://chat.googleapis.com/v1";
 const CHAT_UPLOAD_BASE = "https://chat.googleapis.com/upload/v1";
 
 async function readGoogleChatJsonResponse<T>(response: Response, label: string): Promise<T> {
-  try {
-    return (await response.json()) as T;
-  } catch (cause) {
-    throw new Error(`${label}: malformed JSON response`, { cause });
-  }
+  return readProviderJsonResponse<T>(response, label);
 }
 
 const headersToObject = (headers?: HeadersInit): Record<string, string> =>

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -1,4 +1,5 @@
 // Googlechat plugin module implements auth behavior.
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { fetchWithSsrFGuard } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
@@ -17,11 +18,10 @@ const CHAT_CERTS_URL =
   "https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com";
 
 async function readGoogleChatCertsResponse(response: Response): Promise<Record<string, string>> {
-  try {
-    return (await response.json()) as Record<string, string>;
-  } catch (cause) {
-    throw new Error("Google Chat cert fetch failed: malformed JSON response", { cause });
-  }
+  return readProviderJsonResponse<Record<string, string>>(
+    response,
+    "Google Chat cert fetch failed",
+  );
 }
 
 // Size-capped to prevent unbounded growth in long-running deployments (#4948)

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -658,5 +658,47 @@ describe("verifyGoogleChatRequest", () => {
       expect(canceled).toBe(true);
       expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
     });
+
+    it("caps non-OK sendMessage error bodies before formatting the API error", async () => {
+      const ONE_MIB = 1024 * 1024;
+      const TOTAL_CHUNKS = 32;
+      const chunk = new TextEncoder().encode("x".repeat(ONE_MIB));
+
+      let bytesPulled = 0;
+      let canceled = false;
+      const oversizedError = new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (bytesPulled >= TOTAL_CHUNKS * ONE_MIB) {
+              controller.close();
+              return;
+            }
+            bytesPulled += chunk.length;
+            controller.enqueue(chunk);
+          },
+          cancel() {
+            canceled = true;
+          },
+        }),
+        { status: 500, statusText: "Internal Server Error" },
+      );
+      const release = vi.fn(async () => {});
+      mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: oversizedError,
+        release,
+      });
+
+      await expect(
+        sendGoogleChatMessage({
+          account,
+          space: "spaces/AAA",
+          text: "hello",
+        }),
+      ).rejects.toThrow(/^Google Chat API 500: x+/);
+
+      expect(canceled).toBe(true);
+      expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
+      expect(release).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -568,4 +568,96 @@ describe("verifyGoogleChatRequest", () => {
     });
     expect(release).toHaveBeenCalledOnce();
   });
+
+  describe("bounded JSON read (readProviderJsonResponse delegation)", () => {
+    afterEach(() => {
+      authTesting.resetGoogleChatAuthForTests();
+      mocks.fetchWithSsrFGuard.mockClear();
+      vi.unstubAllGlobals();
+    });
+
+    it("cancels oversized cert fetch JSON body via the 16 MiB provider cap", async () => {
+      const ONE_MIB = 1024 * 1024;
+      const TOTAL_CHUNKS = 32;
+      const chunk = new Uint8Array(ONE_MIB);
+
+      let bytesPulled = 0;
+      let canceled = false;
+      const oversizedJson = new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (bytesPulled >= TOTAL_CHUNKS * ONE_MIB) {
+              controller.close();
+              return;
+            }
+            bytesPulled += chunk.length;
+            controller.enqueue(chunk);
+          },
+          cancel() {
+            canceled = true;
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+      const release = vi.fn(async () => {});
+      const oversizedBodyFetch = vi.fn().mockResolvedValue({ response: oversizedJson, release });
+      mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: oversizedJson,
+        release,
+      });
+
+      const result = await verifyGoogleChatRequest({
+        bearer: "token",
+        audienceType: "project-number",
+        audience: "123456789",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toMatch(/JSON response exceeds 16777216 bytes/);
+      expect(canceled).toBe(true);
+      expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
+      expect(release).toHaveBeenCalledOnce();
+    });
+
+    it("rejects oversized sendMessage JSON body via the 16 MiB provider cap", async () => {
+      const ONE_MIB = 1024 * 1024;
+      const TOTAL_CHUNKS = 32;
+      const chunk = new Uint8Array(ONE_MIB);
+
+      let bytesPulled = 0;
+      let canceled = false;
+      const oversizedJson = new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (bytesPulled >= TOTAL_CHUNKS * ONE_MIB) {
+              controller.close();
+              return;
+            }
+            bytesPulled += chunk.length;
+            controller.enqueue(chunk);
+          },
+          cancel() {
+            canceled = true;
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+      const release = vi.fn(async () => {});
+      mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: oversizedJson,
+        release,
+      });
+
+      await expect(
+        sendGoogleChatMessage({
+          account,
+          space: "spaces/AAA",
+          text: "hello",
+        }),
+      ).rejects.toThrow(/Google Chat API request failed: JSON response exceeds 16777216 bytes/);
+
+      expect(canceled).toBe(true);
+      expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
+    });
+  });
 });

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -600,7 +600,6 @@ describe("verifyGoogleChatRequest", () => {
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
       const release = vi.fn(async () => {});
-      const oversizedBodyFetch = vi.fn().mockResolvedValue({ response: oversizedJson, release });
       mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
         response: oversizedJson,
         release,


### PR DESCRIPTION
## What Problem This Solves

`extensions/googlechat/src/api.ts` (`readGoogleChatJsonResponse`) and `extensions/googlechat/src/auth.ts` (`readGoogleChatCertsResponse`) both call `await response.json()` with no byte-level cap. A hostile or malfunctioning Google Chat API endpoint (or an intermediary) can return an oversized JSON body that exhausts process memory during JSON parsing.

This is the same bounded-read pattern Alix-007 applied to 15+ other extensions (`readProviderJsonResponse`, 16 MiB cap). Google Chat was one of the remaining unbounded `.json()` call sites.

## Changes

- `extensions/googlechat/src/api.ts:15-19` — `readGoogleChatJsonResponse` now delegates to `readProviderJsonResponse<T>(response, label)`. The local `try { return await response.json() } catch (cause) { throw new Error(..., { cause }) }` wrapper is replaced by the SDK helper which provides the same error shape (`${label}: malformed JSON response`) plus a 16 MiB byte cap.
- `extensions/googlechat/src/auth.ts:19-25` — `readGoogleChatCertsResponse` now delegates to `readProviderJsonResponse<Record<string, string>>(response, "Google Chat cert fetch failed")`. Error message preserved identically.

## Real behavior proof

- **Behavior addressed**: unbounded `response.json()` on Google Chat API and cert HTTP responses; after the fix reads are capped at 16 MiB.
- **Real environment tested**: real `node:http` server (127.0.0.1, chunked transfer, no Content-Length) driving production `readProviderJsonResponse`. Node v22.22.0, Linux x86_64.
- **Exact steps or command run after this patch**:
  ```bash
  node --import tsx _proof_googlechat_bounded.mts
  ```
- **Evidence after fix**:
  ```
  === Google Chat JSON bounded-read assertions ===

    PASS  hostile body: overflow error thrown — Google Chat JSON: JSON response exceeds 16777216 bytes
    PASS  hostile body: cap value in error — cap=16777216
    PASS  hostile body: bytes read ≈ cap — server sent ~16.0 MiB (cap=16 MiB)
    PASS  hostile body: not full body — server sent 16 MiB, would have been 32 MiB without cap
    PASS  hostile body: connection handled — reader stopped before full body
    PASS  negative control: small body parses — status=ok
    PASS  negative control: bytes < cap — 0 KiB
    PASS  happy path: valid JSON parses — text="hello"
    PASS  happy path: bytes < cap — 0 KiB

  Results: 9/9 passed
  ```
- **Observed result after fix**: `readProviderJsonResponse` threw canonical overflow at 16 MiB (JSON response exceeds 16777216 bytes). Server sent ~16.0 MiB of a 32 MiB hostile payload — capped before full body. Negative control (small JSON, status=ok) and happy path (valid JSON, text="hello") parsed correctly. Server-side bytes-sent confirmed cap activation at 16.0 MiB, not the full 32 MiB.
- **What was not tested**: live Google Chat API call (the proof exercises the same production SDK helper against the same attack shape the live endpoint could carry); cross-platform Node differences (Node 22 only, matches CI).

## Out of scope

- `extensions/googlechat/src/api.ts:117` (`fetchBuffer`) already uses `readResponseWithLimit` for media downloads — not affected.
- Other extensions (image-generation, etc.) — separate per-surface PRs.

## Risk

- **Very low**: swap from a local `(await response.json()) as T` to `readProviderJsonResponse<T>(response, label)`. Error messages are preserved (`${label}: malformed JSON response`). The helper is already used by 15+ extensions. The byte cap (16 MiB, default) is invisible to normal-sized responses.
- **No SDK promotion**: `readProviderJsonResponse` has been in `openclaw/plugin-sdk/provider-http` since the Alix-007 bounded-read sweep.

AI-assisted; reviewed before submission.
