### PR TITLE
fix(telegram): suppress system notices

### DIFF
--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -98,6 +98,24 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-2", chatId: "12345" });
   });
 
+  it("suppresses system-marked payloads before Telegram delivery", () => {
+    const payload = { text: "⚙️ available commands updated" };
+
+    expect(telegramOutbound.normalizePayload?.({ payload })).toBeNull();
+  });
+
+  it("suppresses compaction notices before Telegram delivery", () => {
+    const payload = { text: "Auto-compaction complete", isCompactionNotice: true };
+
+    expect(telegramOutbound.normalizePayload?.({ payload })).toBeNull();
+  });
+
+  it("keeps regular payloads deliverable", () => {
+    const payload = { text: "visible reply" };
+
+    expect(telegramOutbound.normalizePayload?.({ payload })).toBe(payload);
+  });
+
   it("passes delivery pin notify requests to Telegram pinning", async () => {
     pinMessageTelegramMock.mockResolvedValueOnce({ ok: true, messageId: "tg-1", chatId: "12345" });
 

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -25,6 +25,7 @@ import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound
 import { pinMessageTelegram } from "./send.js";
 
 export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
+const TELEGRAM_SYSTEM_MESSAGE_PREFIX = "⚙️";
 
 type TelegramSendFn = typeof import("./send.js").sendMessageTelegram;
 type TelegramSendOpts = Parameters<TelegramSendFn>[2];
@@ -123,6 +124,16 @@ export const telegramOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   extractMarkdownImages: true,
   textChunkLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
+  normalizePayload: ({ payload }) => {
+    if (payload.isCompactionNotice === true) {
+      return null;
+    }
+    const text = payload.text?.trimStart();
+    if (text?.startsWith(TELEGRAM_SYSTEM_MESSAGE_PREFIX)) {
+      return null;
+    }
+    return payload;
+  },
   sanitizeText: ({ text }) => sanitizeForPlainText(text),
   shouldSkipPlainTextSanitization: ({ payload }) => Boolean(payload.channelData),
   presentationCapabilities: {


### PR DESCRIPTION
## Summary
- suppress Telegram outbound payloads marked with the system prefix
- suppress Telegram compaction notices before delivery
- keep regular Telegram payloads deliverable

## Tests
- pnpm test extensions/telegram/src/outbound-adapter.test.ts
- pnpm build