### PR TITLE
fix(telegram): strip internal cache uuid suffix from outbound filenames

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -18,6 +18,7 @@ import type { ReplyPayloadDelivery } from "openclaw/plugin-sdk/interactive-runti
 import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   buildOutboundMediaLoadOptions,
+  extractOriginalFilename,
   isGifMedia,
   kindFromMime,
   probeVideoDimensions,
@@ -402,7 +403,11 @@ async function deliverMediaReply(params: {
       contentType: media.contentType,
       fileName: media.fileName,
     });
-    const fileName = media.fileName ?? (isGif ? "animation.gif" : "file");
+    const fileName = media.fileName
+      ? extractOriginalFilename(media.fileName)
+      : isGif
+        ? "animation.gif"
+        : "file";
     const file = new InputFile(media.buffer, fileName);
     const { caption, followUpText } = splitTelegramCaption(
       isFirstMedia ? (params.reply.text ?? undefined) : undefined,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -883,6 +883,26 @@ describe("deliverReplies", () => {
     });
   });
 
+  it("strips internal cache uuid suffix from outbound filenames", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 14,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendPhoto });
+
+    mockMediaLoad("photo---a1b2c3d4-e5f6-7890-abcd-ef1234567890.jpg", "image/jpeg", "image");
+
+    await deliverWith({
+      replies: [{ mediaUrl: "/tmp/workspace-work/photo.jpg" }],
+      runtime,
+      bot,
+    });
+
+    const sentFile = sendPhoto.mock.calls[0]?.[1] as { fileName?: string };
+    expect(sentFile.fileName).toBe("photo.jpg");
+  });
+
   it("passes the configured media byte cap to media loading", async () => {
     const runtime = createRuntime();
     const sendPhoto = vi.fn().mockResolvedValue({


### PR DESCRIPTION
## What Problem This Solves
Files sent outbound via Telegram arrive with an internal cache identifier appended to the filename (e.g. `photo.jpg` arrives as `photo---a1b2c3d4-e5f6-7890-abcd-ef1234567890.jpg`). This leaks internal implementation details to end users. Fixes #96538.

## Why This Change Was Made
`media.fileName` in `deliverMediaReply` was passed straight from the media loader, which derives it from the staged-file basename (carrying the `---<uuid>` suffix used for cache identity). The media store already has a helper, `extractOriginalFilename`, that strips this exact suffix pattern elsewhere in the codebase — this fix reuses it at the Telegram outbound send path instead of writing new logic.

## User Impact
Telegram recipients now see the original, clean filename instead of one with an internal UUID suffix appended.

## Evidence
- Added a regression test (`extensions/telegram/src/bot/delivery.test.ts`) asserting the suffix is stripped before the file reaches `InputFile`.
- Ran the full existing test suite for the file: 60/60 passed.
- Ran the full Telegram extension test suite: 125 files / 2217 tests, all passed.
- Ran `pnpm check` typecheck: passed clean. Lint (oxlint/tsgolint) could not complete locally due to OOM on a 4GB dev machine (tsgolint alone uses ~3.6GB RSS on this large monorepo) — unrelated to this change; happy to address any CI lint findings.

## AI-assisted
This PR was developed with AI assistance (Claude). I reviewed and understand the change: it is a 5-line diff that pipes an existing filename-sanitizing helper through one additional call site, plus a matching test.