### PR TITLE
fix(chutes-oauth): bound core helper JSON response reads at 16 MiB

### DIFF
--- a/src/agents/chutes-oauth.ts
+++ b/src/agents/chutes-oauth.ts
@@ -6,6 +6,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveExpiresAtMsFromDurationSeconds } from "../infra/parse-finite-number.js";
 import type { OAuthCredentials } from "../llm/oauth.js";
+import { readProviderJsonResponse } from "./provider-http-errors.js";
 
 const CHUTES_OAUTH_ISSUER = "https://api.chutes.ai";
 export const CHUTES_AUTHORIZE_ENDPOINT = `${CHUTES_OAUTH_ISSUER}/idp/authorize`;
@@ -115,7 +116,7 @@ async function fetchChutesUserInfo(params: {
     await cancelUnreadResponseBody(response);
     return null;
   }
-  const data = (await response.json()) as unknown;
+  const data = await readProviderJsonResponse<unknown>(response, "Chutes userinfo");
   if (!data || typeof data !== "object") {
     return null;
   }
@@ -155,11 +156,11 @@ export async function exchangeChutesCodeForTokens(params: {
     throw new Error(`Chutes token exchange failed: ${text}`);
   }
 
-  const data = (await response.json()) as {
+  const data = await readProviderJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: number;
-  };
+  }>(response, "Chutes token exchange");
 
   const access = data.access_token?.trim();
   const refresh = data.refresh_token?.trim();
@@ -226,11 +227,11 @@ export async function refreshChutesTokens(params: {
     throw new Error(`Chutes token refresh failed: ${text}`);
   }
 
-  const data = (await response.json()) as {
+  const data = await readProviderJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: number;
-  };
+  }>(response, "Chutes token refresh");
   const access = data.access_token?.trim();
   const newRefresh = data.refresh_token?.trim();
   const expires = resolveChutesExpiresAt(data.expires_in, now);


### PR DESCRIPTION
## What Problem This Solves

`src/agents/chutes-oauth.ts` had 3 unbounded `await response.json()` calls (userinfo fetch, token exchange, token refresh). A hostile Chutes endpoint, proxy, or CDN can return an oversized HTTP 200 JSON body with no `Content-Length` and stream an arbitrarily large payload — `response.json()` buffers everything into memory before parsing, making this an **OOM vector** on a path that runs with user-attached OAuth credentials.

This is the JSON bounded-read analogue for the deprecated core Chutes helper (the active plugin path at `extensions/chutes/oauth.ts` is covered by sibling PR #96779).

## Changes

No new abstraction — reuses the existing `readProviderJsonResponse` helper from `openclaw/plugin-sdk/provider-http` (16 MiB default cap, same helper used by 15+ provider plugin bounded-read PRs).

- `src/agents/chutes-oauth.ts:119,159,230` — replace 3 `(await response.json()) as Type` calls with `readProviderJsonResponse<Type>(response, "<label>")`. Labels: `"Chutes userinfo"`, `"Chutes token exchange"`, `"Chutes token refresh"`. (+6/-5)

## Design Rationale

**Why `readProviderJsonResponse` instead of `response.json()`?** `response.json()` buffers the entire HTTP body in memory before parsing — no byte-level cap. `readProviderJsonResponse` reads the body as a bounded stream, cancelling the underlying reader at 16 MiB (the SDK default) and throwing a canonical overflow error. This is the same pattern used by 15+ bounded-read PRs across the codebase.

**Why the same 16 MiB cap for all three calls (userinfo, token exchange, token refresh)?** All three endpoints serve JSON OAuth payloads of comparable size (typically < 1 KiB). Using the same threshold avoids introducing per-endpoint cap distinctions with no operational benefit. The deprecated helper is being replaced by the plugin path (#96779); keeping the cap consistent simplifies eventual removal.

**Why no inline test additions?** The deprecated helper (`src/agents/chutes-oauth.ts`) has 6 existing tests covering all three endpoints. The proof exercises the exact production helper with a real HTTP server, verifying overflow behavior. Adding inline tests would duplicate the helper's existing test coverage.

## Real behavior proof

- **Behavior addressed**: 3 unbounded `response.json()` calls → capped at 16 MiB via shared SDK helper.
- **Real environment tested**: real `node:http` server (127.0.0.1, chunked transfer, no Content-Length) driving production `readProviderJsonResponse`. Node v22.22.0.
- **Exact steps or command run after this patch**:
  ```bash
  node --import tsx _proof_chutes_oauth_core.mts
  ```
- **Evidence after fix**: 4/4 assertions pass. AFTER: hostile 32 MiB body triggers bounded overflow error, valid token/userinfo responses parse correctly. BEFORE: unbounded read consumes 32.0 MiB (OOM vector confirmed).
- **Observed result after fix**: 4/4 assertions pass. Hostile 32 MiB body triggers bounded overflow error at 16 MiB. Valid token exchange and userinfo responses parse correctly. Negative control: unbounded read consumed 32.0 MiB — cap is load-bearing.
- **Negative control**: unbounded read consumed 32.0 MiB — proves the cap is load-bearing.
- **What was not tested**: live Chutes API call (the proof exercises the same production SDK helper against the same attack shape); cross-platform Node differences.

## Out of scope

- `extensions/chutes/oauth.ts` (active plugin path) — covered by sibling PR #96779.
- Other unbounded `response.json()` call sites in core — covered by bounded-read campaign PRs (#96776, #96772, #96782, etc.).

## Risk checklist

- User-visible behavior change? No — normal-sized responses unaffected; oversized responses now throw a clear overflow error instead of silently accumulating memory.
- Config/env/migration change? No — 16 MiB is the SDK helper default; no new config options.
- Security/auth/secrets/network/tool-execution change? Yes — OOM/DoS protection for Chutes OAuth core helper userinfo, token exchange, and token refresh paths.
- Highest-risk area: accidentally rejecting a legitimate response larger than 16 MiB; covered by the happy path assertion and the 6 existing tests.

## Diff stats

```
1 file changed, 6 insertions(+), 5 deletions(-)
```

AI-assisted: implemented and proof-tested with AI assistance; reviewed by a human before submission.