### PR TITLE
fix: log pending sync and provider init errors on manager close

### DIFF
--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -19,15 +19,20 @@ export async function startAsyncSearchSync(params: {
 export async function awaitPendingManagerWork(params: {
   pendingSync?: Promise<void> | null;
   pendingProviderInit?: Promise<void> | null;
+  onError?: (err: unknown) => void;
 }): Promise<void> {
   if (params.pendingSync) {
     try {
       await params.pendingSync;
-    } catch {}
+    } catch (err: unknown) {
+      params.onError?.(err);
+    }
   }
   if (params.pendingProviderInit) {
     try {
       await params.pendingProviderInit;
-    } catch {}
+    } catch (err: unknown) {
+      params.onError?.(err);
+    }
   }
 }

--- a/extensions/memory-core/src/memory/manager.async-search.test.ts
+++ b/extensions/memory-core/src/memory/manager.async-search.test.ts
@@ -72,6 +72,50 @@ describe("memory search async sync", () => {
     await closePromise;
   });
 
+  it("reports pending sync rejection during close", async () => {
+    const onError = vi.fn();
+    const err = new Error("sync failed");
+    await awaitPendingManagerWork({
+      pendingSync: Promise.reject(err),
+      onError,
+    });
+    expect(onError).toHaveBeenCalledWith(err);
+  });
+
+  it("reports pending provider init rejection during close", async () => {
+    const onError = vi.fn();
+    const err = new Error("provider init failed");
+    await awaitPendingManagerWork({
+      pendingProviderInit: Promise.reject(err),
+      onError,
+    });
+    expect(onError).toHaveBeenCalledWith(err);
+  });
+
+  it("reports both pending work rejections during close", async () => {
+    const onError = vi.fn();
+    const syncErr = new Error("sync failed");
+    const providerErr = new Error("provider init failed");
+    await awaitPendingManagerWork({
+      pendingSync: Promise.reject(syncErr),
+      pendingProviderInit: Promise.reject(providerErr),
+      onError,
+    });
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledWith(syncErr);
+    expect(onError).toHaveBeenCalledWith(providerErr);
+  });
+
+  it("does not invoke onError when pending work resolves", async () => {
+    const onError = vi.fn();
+    await awaitPendingManagerWork({
+      pendingSync: Promise.resolve(),
+      pendingProviderInit: Promise.resolve(),
+      onError,
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("skips background search sync when search-triggered sync is disabled", async () => {
     const syncMock = vi.fn(async () => {});
     await startAsyncSearchSync({

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1356,9 +1356,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       if (!pendingSync) {
         return;
       }
-      await awaitPendingManagerWork({ pendingSync });
+      await awaitPendingManagerWork({
+        pendingSync,
+        onError: (err) => {
+          log.warn(`memory sync failed (close): ${String(err)}`);
+        },
+      });
     };
-    await awaitPendingManagerWork({ pendingProviderInit });
+    await awaitPendingManagerWork({
+      pendingProviderInit,
+      onError: (err) => {
+        log.warn(`memory provider init failed (close): ${String(err)}`);
+      },
+    });
     rememberCurrentProvider();
     try {
       await awaitCurrentSync();


### PR DESCRIPTION
Closes #96766

## What Problem This Solves

Fixes an issue where close-time failures of pending memory sync or provider initialization were silently swallowed, making it impossible to diagnose shutdown-time data-loss or indexing problems.

## Why This Change Was Made

`awaitPendingManagerWork` previously used empty `catch {}` blocks for both `pendingSync` and `pendingProviderInit`, discarding all rejections. The change threads an optional `onError` callback through the helper and wires `MemoryIndexManager.close()` to log those failures via the existing memory subsystem logger, matching the error-reporting pattern already used elsewhere in the memory manager.

## User Impact

Operators and developers will now see warning logs when a memory sync or provider initialization fails during manager close, making shutdown-time data-loss or indexing issues diagnosable instead of silent.

## Evidence

```
$ git diff --check
(no output)

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts --configLoader runner extensions/memory-core/src/memory/manager.async-search.test.ts extensions/memory-core/src/memory/index.test.ts

 RUN  v4.1.8 ...

 Test Files  2 passed (2)
      Tests  61 passed (61)
   Duration  81.43s (transform 14.38s, setup 1.65s, import 26.37s, tests 52.11s, environment 0ms)
```
