### PR TITLE
fix(memory-core): report pending close work errors

### DIFF
--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -19,15 +19,20 @@ export async function startAsyncSearchSync(params: {
 export async function awaitPendingManagerWork(params: {
   pendingSync?: Promise<void> | null;
   pendingProviderInit?: Promise<void> | null;
+  onError?: (err: unknown, source: "pending-sync" | "pending-provider-init") => void;
 }): Promise<void> {
   if (params.pendingSync) {
     try {
       await params.pendingSync;
-    } catch {}
+    } catch (err: unknown) {
+      params.onError?.(err, "pending-sync");
+    }
   }
   if (params.pendingProviderInit) {
     try {
       await params.pendingProviderInit;
-    } catch {}
+    } catch (err: unknown) {
+      params.onError?.(err, "pending-provider-init");
+    }
   }
 }

--- a/extensions/memory-core/src/memory/manager.async-search.test.ts
+++ b/extensions/memory-core/src/memory/manager.async-search.test.ts
@@ -72,6 +72,24 @@ describe("memory search async sync", () => {
     await closePromise;
   });
 
+  it("reports rejected pending close work without failing close", async () => {
+    const syncError = new Error("sync failed");
+    const providerError = new Error("provider failed");
+    const onError = vi.fn();
+
+    await expect(
+      awaitPendingManagerWork({
+        pendingSync: Promise.reject(syncError),
+        pendingProviderInit: Promise.reject(providerError),
+        onError,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenNthCalledWith(1, syncError, "pending-sync");
+    expect(onError).toHaveBeenNthCalledWith(2, providerError, "pending-provider-init");
+  });
+
   it("skips background search sync when search-triggered sync is disabled", async () => {
     const syncMock = vi.fn(async () => {});
     await startAsyncSearchSync({

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1351,14 +1351,22 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         }
       }
     };
+    const reportPendingWorkError = (
+      err: unknown,
+      source: "pending-sync" | "pending-provider-init",
+    ) => {
+      const reason =
+        source === "pending-sync" ? "memory sync failed" : "memory provider init failed";
+      log.warn(`${reason} during close: ${String(err)}`);
+    };
     const awaitCurrentSync = async () => {
       const pendingSync = this.syncing;
       if (!pendingSync) {
         return;
       }
-      await awaitPendingManagerWork({ pendingSync });
+      await awaitPendingManagerWork({ pendingSync, onError: reportPendingWorkError });
     };
-    await awaitPendingManagerWork({ pendingProviderInit });
+    await awaitPendingManagerWork({ pendingProviderInit, onError: reportPendingWorkError });
     rememberCurrentProvider();
     try {
       await awaitCurrentSync();


### PR DESCRIPTION
## Summary

- report rejected close-time pending memory sync/provider initialization promises instead of silently discarding them
- keep close behavior non-throwing so shutdown ordering and provider cleanup behavior stay unchanged
- add regression coverage for both rejected pending close-work paths

Fixes #96766

## What Problem This Solves

Memory-core close waits for pending sync and provider initialization work during shutdown. Before this patch, rejected pending sync or provider-init promises were caught with empty catches, so close stayed non-throwing but no diagnostic was emitted. That left shutdown-time memory sync/provider failures invisible.

This patch preserves best-effort close behavior while routing those already-thrown pending-work errors through the existing memory logger path.

## Evidence

Scripted close-path runtime proof added 2026-06-25 on PR commit `960a53788910`.

Environment: local OpenClaw source checkout on macOS, branch `ben/issue-96766-pending-work-errors`, engine-compatible Node v24.14.0. `OPENCLAW_STATE_DIR` was pointed at a disposable `/tmp/openclaw-pr-96787-proof/state` directory.

Method: a one-off script imported the PR branch `MemoryIndexManager` implementation from `extensions/memory-core/src/memory/manager.ts`, injected rejected `providerInitPromise` and `syncing` promises, then called the real `manager.close()` method. This exercises the manager close path itself, not only the `awaitPendingManagerWork` helper.

Redacted terminal transcript:

```text
$ OPENCLAW_STATE_DIR=/tmp/openclaw-pr-96787-proof/state node --import tsx <scripted-close-proof>
[memory] provider init failed during close: Error: scripted provider init rejection for PR 96787 proof
[memory] sync failed during close: Error: scripted pending sync rejection for PR 96787 proof
proof: database close reached after pending-work warnings
proof: manager.close resolved without throwing
```

Structured memory log records from the same run contained `WARN` entries for subsystem `memory` with these messages:

```text
memory provider init failed during close: Error: scripted provider init rejection for PR 96787 proof
memory sync failed during close: Error: scripted pending sync rejection for PR 96787 proof
```

Result: both close-time pending provider-init and pending sync rejections were reported through the memory logger, and `manager.close()` still completed best-effort/non-throwing after reaching database close.

Additional focused checks already run:

- `PATH=/Users/imprvhealth/.nvm/versions/node/v22.22.1/bin:$PATH node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts --configLoader runner extensions/memory-core/src/memory/manager.async-search.test.ts extensions/memory-core/src/memory/index.test.ts` completed with `Test Files 2 passed (2)` and `Tests 58 passed (58)`.
- `node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/memory/manager-async-state.ts extensions/memory-core/src/memory/manager.async-search.test.ts extensions/memory-core/src/memory/manager.ts` reported `All matched files use the correct format.`.
- `git diff --check` exited cleanly.

What was not tested: no live SQLite lock, disk-full, or provider outage shutdown was forced; the runtime proof covers a scripted manager close with rejected pending provider-init and sync work.

## Security note

No auth, secrets, trust-boundary, upload, payment, or external-network behavior changed. The patch only reports already-thrown internal close-time errors through the existing memory logger path.
