### PR TITLE
fix(gateway): report omitted chat-history messages in truncation log

### DIFF
--- a/src/gateway/server-methods/chat-history-budget.test.ts
+++ b/src/gateway/server-methods/chat-history-budget.test.ts
@@ -21,21 +21,31 @@ describe("enforceChatHistoryFinalBudget", () => {
     ];
     const result = enforceChatHistoryFinalBudget({ messages, maxBytes: 1_000_000 });
     expect(result.messages).toEqual(messages);
-    expect(result.placeholderCount).toBe(0);
+    expect(result.omittedCount).toBe(0);
   });
 
   it("returns the empty array unchanged for empty input", () => {
     const result = enforceChatHistoryFinalBudget({ messages: [], maxBytes: 10 });
     expect(result.messages).toEqual([]);
-    expect(result.placeholderCount).toBe(0);
+    expect(result.omittedCount).toBe(0);
   });
 
-  it("keeps just the last message when the full set is over budget but the last fits", () => {
+  it("reports the dropped count when keeping only the last message", () => {
     const big = { role: "user", content: [{ type: "text", text: "x".repeat(4000) }] };
     const last = { role: "assistant", content: [{ type: "text", text: "ok" }] };
     const result = enforceChatHistoryFinalBudget({ messages: [big, last], maxBytes: 2_000 });
     expect(result.messages).toEqual([last]);
-    expect(result.placeholderCount).toBe(0);
+    // The earlier oversized message was dropped, so truncation must stay visible.
+    expect(result.omittedCount).toBe(1);
+  });
+
+  it("counts every dropped message when only the last survives", () => {
+    const big = { role: "user", content: [{ type: "text", text: "x".repeat(4000) }] };
+    const mid = { role: "assistant", content: [{ type: "text", text: "x".repeat(4000) }] };
+    const last = { role: "assistant", content: [{ type: "text", text: "ok" }] };
+    const result = enforceChatHistoryFinalBudget({ messages: [big, mid, last], maxBytes: 2_000 });
+    expect(result.messages).toEqual([last]);
+    expect(result.omittedCount).toBe(2);
   });
 
   it("falls back to a small placeholder when even the last message is too large", () => {
@@ -48,7 +58,22 @@ describe("enforceChatHistoryFinalBudget", () => {
     const result = enforceChatHistoryFinalBudget({ messages: [last], maxBytes: 2_000 });
     expect(result.messages).toHaveLength(1);
     expect(firstText(result.messages)).toContain("chat.history omitted: message too large");
-    expect(result.placeholderCount).toBe(1);
+    expect(result.omittedCount).toBe(1);
+  });
+
+  it("counts the whole list as omitted when the last message is replaced by a placeholder", () => {
+    const earlier = { role: "user", content: [{ type: "text", text: "hi" }] };
+    const last = {
+      role: "assistant",
+      timestamp: 1,
+      content: [{ type: "text", text: "y".repeat(4000) }],
+      __openclaw: { id: "abc", seq: 7 },
+    };
+    const result = enforceChatHistoryFinalBudget({ messages: [earlier, last], maxBytes: 2_000 });
+    expect(result.messages).toHaveLength(1);
+    expect(firstText(result.messages)).toContain("chat.history omitted: message too large");
+    // No input message survives verbatim, so both are counted as omitted.
+    expect(result.omittedCount).toBe(2);
   });
 
   it("returns a metadata-free sentinel (never an empty transcript) when even the placeholder is over budget", () => {
@@ -68,6 +93,6 @@ describe("enforceChatHistoryFinalBudget", () => {
     expect(firstText(result.messages)).toContain("chat.history unavailable");
     // The sentinel does not carry the oversized source metadata.
     expect((result.messages[0] as Record<string, unknown>)["__openclaw"]).toBeUndefined();
-    expect(result.placeholderCount).toBe(1);
+    expect(result.omittedCount).toBe(1);
   });
 });

--- a/src/gateway/server-methods/chat-history-budget.test.ts
+++ b/src/gateway/server-methods/chat-history-budget.test.ts
@@ -21,31 +21,21 @@ describe("enforceChatHistoryFinalBudget", () => {
     ];
     const result = enforceChatHistoryFinalBudget({ messages, maxBytes: 1_000_000 });
     expect(result.messages).toEqual(messages);
-    expect(result.omittedCount).toBe(0);
   });
 
   it("returns the empty array unchanged for empty input", () => {
     const result = enforceChatHistoryFinalBudget({ messages: [], maxBytes: 10 });
     expect(result.messages).toEqual([]);
-    expect(result.omittedCount).toBe(0);
   });
 
-  it("reports the dropped count when keeping only the last message", () => {
+  it("keeps just the last message when the full set is over budget but the last fits", () => {
     const big = { role: "user", content: [{ type: "text", text: "x".repeat(4000) }] };
     const last = { role: "assistant", content: [{ type: "text", text: "ok" }] };
     const result = enforceChatHistoryFinalBudget({ messages: [big, last], maxBytes: 2_000 });
+    // The same last-message reference survives so callers can detect which
+    // originals were omitted by identity.
     expect(result.messages).toEqual([last]);
-    // The earlier oversized message was dropped, so truncation must stay visible.
-    expect(result.omittedCount).toBe(1);
-  });
-
-  it("counts every dropped message when only the last survives", () => {
-    const big = { role: "user", content: [{ type: "text", text: "x".repeat(4000) }] };
-    const mid = { role: "assistant", content: [{ type: "text", text: "x".repeat(4000) }] };
-    const last = { role: "assistant", content: [{ type: "text", text: "ok" }] };
-    const result = enforceChatHistoryFinalBudget({ messages: [big, mid, last], maxBytes: 2_000 });
-    expect(result.messages).toEqual([last]);
-    expect(result.omittedCount).toBe(2);
+    expect(result.messages[0]).toBe(last);
   });
 
   it("falls back to a small placeholder when even the last message is too large", () => {
@@ -58,22 +48,8 @@ describe("enforceChatHistoryFinalBudget", () => {
     const result = enforceChatHistoryFinalBudget({ messages: [last], maxBytes: 2_000 });
     expect(result.messages).toHaveLength(1);
     expect(firstText(result.messages)).toContain("chat.history omitted: message too large");
-    expect(result.omittedCount).toBe(1);
-  });
-
-  it("counts the whole list as omitted when the last message is replaced by a placeholder", () => {
-    const earlier = { role: "user", content: [{ type: "text", text: "hi" }] };
-    const last = {
-      role: "assistant",
-      timestamp: 1,
-      content: [{ type: "text", text: "y".repeat(4000) }],
-      __openclaw: { id: "abc", seq: 7 },
-    };
-    const result = enforceChatHistoryFinalBudget({ messages: [earlier, last], maxBytes: 2_000 });
-    expect(result.messages).toHaveLength(1);
-    expect(firstText(result.messages)).toContain("chat.history omitted: message too large");
-    // No input message survives verbatim, so both are counted as omitted.
-    expect(result.omittedCount).toBe(2);
+    // The placeholder is a new object, not the oversized original.
+    expect(result.messages[0]).not.toBe(last);
   });
 
   it("returns a metadata-free sentinel (never an empty transcript) when even the placeholder is over budget", () => {
@@ -93,6 +69,5 @@ describe("enforceChatHistoryFinalBudget", () => {
     expect(firstText(result.messages)).toContain("chat.history unavailable");
     // The sentinel does not carry the oversized source metadata.
     expect((result.messages[0] as Record<string, unknown>)["__openclaw"]).toBeUndefined();
-    expect(result.omittedCount).toBe(1);
   });
 });

--- a/src/gateway/server-methods/chat-history-omission-logging.test.ts
+++ b/src/gateway/server-methods/chat-history-omission-logging.test.ts
@@ -1,0 +1,121 @@
+// Real-behavior proof that the chat.history budget pipeline emits the
+// `payload.large` / `truncated` diagnostic whenever older history is omitted,
+// and that the omitted count reflects unique source messages (a message that is
+// first replaced and then trimmed is not double-counted). These run the real
+// production helpers and capture the real diagnostic event bus output.
+import { describe, expect, it } from "vitest";
+import { onDiagnosticEvent } from "../../infra/diagnostic-events.js";
+import type { DiagnosticPayloadLargeEvent } from "../../infra/diagnostic-events.js";
+import { capArrayByJsonBytes } from "../session-utils.js";
+import {
+  enforceChatHistoryFinalBudget,
+  replaceOversizedChatHistoryMessages,
+  reportOmittedChatHistory,
+} from "./chat.js";
+
+type Captured = DiagnosticPayloadLargeEvent[];
+
+// Mirrors the production sequence in handleChatHistoryRequest: replace oversized
+// messages, cap the array by byte budget, enforce the final budget, then report
+// omissions. Captures any emitted `payload.large` diagnostic event.
+function runHistoryBudgetPipeline(params: {
+  messages: unknown[];
+  maxHistoryBytes: number;
+  perMessageHardCap: number;
+}): { emittedCount: number; events: Captured; replacedCount: number; frontCapDropped: number } {
+  const { messages, maxHistoryBytes, perMessageHardCap } = params;
+  const events: Captured = [];
+  const unsubscribe = onDiagnosticEvent((evt) => {
+    if (evt.type === "payload.large") {
+      events.push(evt);
+    }
+  });
+  try {
+    const replaced = replaceOversizedChatHistoryMessages({
+      messages,
+      maxSingleMessageBytes: perMessageHardCap,
+    });
+    const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
+    const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
+    const emittedCount = reportOmittedChatHistory({
+      originalMessages: messages,
+      finalMessages: bounded.messages,
+      normalizedBytes: Buffer.byteLength(JSON.stringify(messages), "utf8"),
+      maxHistoryBytes,
+      logDebug: () => {},
+    });
+    return {
+      emittedCount,
+      events,
+      replacedCount: replaced.replacedCount,
+      frontCapDropped: replaced.messages.length - capped.length,
+    };
+  } finally {
+    unsubscribe();
+  }
+}
+
+function textMessage(role: string, text: string): Record<string, unknown> {
+  return { role, content: [{ type: "text", text }] };
+}
+
+describe("chat.history truncation logging (real diagnostic bus)", () => {
+  it("emits a truncated diagnostic when history is trimmed to the last message", () => {
+    const big = textMessage("user", "x".repeat(8000));
+    const last = textMessage("assistant", "ok");
+    const result = runHistoryBudgetPipeline({
+      messages: [big, last],
+      maxHistoryBytes: 2_000,
+      perMessageHardCap: 2_000,
+    });
+
+    expect(result.events).toHaveLength(1);
+    const event = result.events[0];
+    expect(event.surface).toBe("gateway.chat.history");
+    expect(event.action).toBe("truncated");
+    expect(event.reason).toBe("chat_history_budget");
+    expect(event.count).toBe(1);
+    expect(result.emittedCount).toBe(1);
+  });
+
+  it("emits no diagnostic when nothing is omitted", () => {
+    const result = runHistoryBudgetPipeline({
+      messages: [textMessage("user", "hello"), textMessage("assistant", "hi")],
+      maxHistoryBytes: 1_000_000,
+      perMessageHardCap: 1_000_000,
+    });
+
+    expect(result.events).toHaveLength(0);
+    expect(result.emittedCount).toBe(0);
+  });
+
+  it("counts a replaced-then-trimmed message once, not twice", () => {
+    // `huge` is oversized so it is replaced with a small placeholder, then the
+    // placeholder sits at the front and is dropped by the byte cap. The naive
+    // sum of replacedCount + front-cap drops would count `huge` twice.
+    const huge = textMessage("user", "h".repeat(8000));
+    const big1 = textMessage("assistant", "a".repeat(2000));
+    const big2 = textMessage("user", "b".repeat(2000));
+    const last = textMessage("assistant", "ok");
+    const messages = [huge, big1, big2, last];
+
+    const result = runHistoryBudgetPipeline({
+      messages,
+      maxHistoryBytes: 4_000,
+      perMessageHardCap: 3_000,
+    });
+
+    // Scenario preconditions: a message was replaced AND front-capped, so the
+    // old additive count would have over-reported.
+    expect(result.replacedCount).toBeGreaterThan(0);
+    expect(result.frontCapDropped).toBeGreaterThan(0);
+    const naiveAdditive = result.replacedCount + result.frontCapDropped;
+
+    // The emitted count equals the number of original messages that lost their
+    // verbatim representation, and is strictly less than the double-counting sum.
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].count).toBe(result.emittedCount);
+    expect(result.emittedCount).toBe(2);
+    expect(naiveAdditive).toBeGreaterThan(result.emittedCount);
+  });
+});

--- a/src/gateway/server-methods/chat-history-omission-request.test.ts
+++ b/src/gateway/server-methods/chat-history-omission-request.test.ts
@@ -1,0 +1,98 @@
+// Real-behavior proof that a full `chat.history` Gateway request — issued over a
+// real WebSocket to a real booted Gateway server, reading a real on-disk
+// transcript — emits the `payload.large` / `truncated` diagnostic when older
+// history is omitted by the byte budget. This drives the actual server method
+// (`handleChatHistoryRequest`), not the budget helpers in isolation, so it
+// covers the caller gate that previously swallowed front-cap and drop-to-last
+// omissions. It imports only the WebSocket harness and the diagnostic bus (no
+// changed symbols), so the same test reproduces the missing diagnostic on
+// pre-fix `main`.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import type { WebSocket } from "ws";
+import {
+  onDiagnosticEvent,
+  type DiagnosticPayloadLargeEvent,
+} from "../../infra/diagnostic-events.js";
+import { setMaxChatHistoryMessagesBytesForTest } from "../server-constants.js";
+import { installGatewayTestHooks, rpcReq, testState, writeSessionStore } from "../test-helpers.js";
+import { installConnectedControlUiServerSuite } from "../test-with-server.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+let ws: WebSocket;
+installConnectedControlUiServerSuite((started) => {
+  ws = started.ws;
+});
+
+describe("chat.history request emits truncation diagnostic (real WS gateway)", () => {
+  test("a real chat.history request logs payload.large when older history is omitted", async () => {
+    const SESSION_ID = "sess-omission-proof";
+    const MESSAGE_COUNT = 12;
+    const TEXT_BYTES = 2_000;
+    // Budget far below the seeded transcript but well above one message, so the
+    // front byte cap drops older messages without per-message placeholdering.
+    const BUDGET_BYTES = 8_000;
+
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chat-history-omit-"));
+    const captured: DiagnosticPayloadLargeEvent[] = [];
+    const unsubscribe = onDiagnosticEvent((evt) => {
+      if (evt.type === "payload.large" && evt.surface === "gateway.chat.history") {
+        captured.push(evt);
+      }
+    });
+    setMaxChatHistoryMessagesBytesForTest(BUDGET_BYTES);
+    testState.sessionStorePath = path.join(dir, "sessions.json");
+    try {
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: SESSION_ID,
+            sessionFile: path.join(dir, `${SESSION_ID}.jsonl`),
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      const messages = Array.from({ length: MESSAGE_COUNT }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: [{ type: "text", text: `m${i} ${"x".repeat(TEXT_BYTES)}` }],
+        timestamp: i + 1,
+      }));
+      const lines = messages.map((message) => JSON.stringify({ message }));
+      await fs.writeFile(path.join(dir, `${SESSION_ID}.jsonl`), lines.join("\n"), "utf-8");
+
+      const res = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+        sessionKey: "main",
+        limit: 1000,
+      });
+
+      expect(res.ok).toBe(true);
+      const returned = res.payload?.messages ?? [];
+      // The response keeps only the survivors under budget (never empty), so the
+      // request genuinely omitted older history.
+      expect(returned.length).toBeGreaterThan(0);
+      expect(returned.length).toBeLessThan(MESSAGE_COUNT);
+
+      expect(captured).toHaveLength(1);
+      const event = captured[0];
+      expect(event.action).toBe("truncated");
+      expect(event.reason).toBe("chat_history_budget");
+      expect(event.count).toBeGreaterThan(0);
+      expect(event.count).toBe(MESSAGE_COUNT - returned.length);
+
+      // Print the real runtime diagnostic so a `run-vitest` run shows the
+      // captured Gateway event (used as the PR real-behavior proof).
+      console.log(
+        `chat.history real-request diagnostic: returned=${returned.length} ` +
+          `event=${JSON.stringify(event)}`,
+      );
+    } finally {
+      unsubscribe();
+      setMaxChatHistoryMessagesBytesForTest(undefined);
+      testState.sessionStorePath = undefined;
+      await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+});

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -577,7 +577,7 @@ function buildChatHistoryUnavailableSentinel(): Record<string, unknown> {
 }
 const CHAT_STARTUP_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 25;
 const MANAGED_OUTGOING_IMAGE_PATH_PREFIX = "/api/chat/media/outgoing/";
-let chatHistoryPlaceholderEmitCount = 0;
+let chatHistoryOmittedEmitCount = 0;
 const chatHistoryManagedImageCleanupState = new Map<string, Promise<void>>();
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
   "main",
@@ -1674,28 +1674,36 @@ export function replaceOversizedChatHistoryMessages(params: {
 
 export function enforceChatHistoryFinalBudget(params: { messages: unknown[]; maxBytes: number }): {
   messages: unknown[];
-  placeholderCount: number;
+  // Number of input messages that lost their verbatim representation to fit the
+  // byte budget (dropped outright or swapped for a placeholder). The caller logs
+  // truncation only when this is positive, so every omitting branch must report
+  // it — a zero here while history is silently discarded hides truncation from
+  // operators.
+  omittedCount: number;
 } {
   const { messages, maxBytes } = params;
   if (messages.length === 0) {
-    return { messages, placeholderCount: 0 };
+    return { messages, omittedCount: 0 };
   }
   if (jsonUtf8Bytes(messages) <= maxBytes) {
-    return { messages, placeholderCount: 0 };
+    return { messages, omittedCount: 0 };
   }
   const last = messages.at(-1);
   if (last && jsonUtf8Bytes([last]) <= maxBytes) {
-    return { messages: [last], placeholderCount: 0 };
+    // Keep only the final message; every earlier message is dropped.
+    return { messages: [last], omittedCount: messages.length - 1 };
   }
   const placeholder = buildOversizedHistoryPlaceholder(last);
   if (jsonUtf8Bytes([placeholder]) <= maxBytes) {
-    return { messages: [placeholder], placeholderCount: 1 };
+    // Even the final message is over budget, so it too is replaced — no input
+    // message survives verbatim.
+    return { messages: [placeholder], omittedCount: messages.length };
   }
   // The oversized placeholder still does not fit (e.g. the source message
   // carried very large metadata). Never return an empty history — that renders
   // as a blank transcript and reads as data loss even though the on-disk
   // transcript is intact. Fall back to a small metadata-free sentinel.
-  return { messages: [buildChatHistoryUnavailableSentinel()], placeholderCount: 1 };
+  return { messages: [buildChatHistoryUnavailableSentinel()], omittedCount: messages.length };
 }
 
 function resolveTranscriptPath(params: {
@@ -2759,20 +2767,23 @@ async function handleChatHistoryRequest({
     context,
   });
   const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
+  // Front byte cap drops the oldest messages without reporting a count, so derive
+  // it from the length delta to keep that omission visible in truncation logs.
+  const frontCapDropped = replaced.messages.length - capped.length;
   const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
-  const placeholderCount = replaced.replacedCount + bounded.placeholderCount;
-  if (placeholderCount > 0) {
-    chatHistoryPlaceholderEmitCount += placeholderCount;
+  const omittedCount = replaced.replacedCount + frontCapDropped + bounded.omittedCount;
+  if (omittedCount > 0) {
+    chatHistoryOmittedEmitCount += omittedCount;
     logLargePayload({
       surface: "gateway.chat.history",
       action: "truncated",
       bytes: jsonUtf8Bytes(normalized),
       limitBytes: maxHistoryBytes,
-      count: placeholderCount,
+      count: omittedCount,
       reason: "chat_history_budget",
     });
     context.logGateway.debug(
-      `chat.history omitted oversized payloads placeholders=${placeholderCount} total=${chatHistoryPlaceholderEmitCount}`,
+      `chat.history omitted oversized payloads count=${omittedCount} total=${chatHistoryOmittedEmitCount}`,
     );
   }
   const modelCatalog = await modelCatalogPromise;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1672,38 +1672,73 @@ export function replaceOversizedChatHistoryMessages(params: {
   return { messages: replacedCount > 0 ? next : messages, replacedCount };
 }
 
+// Enforces the final byte budget for chat.history. Returns only the surviving
+// messages; how many original messages were omitted is measured end-to-end by
+// reportOmittedChatHistory, which alone sees the full replace/cap/final pipeline
+// and so can count unique omitted originals without double-counting.
 export function enforceChatHistoryFinalBudget(params: { messages: unknown[]; maxBytes: number }): {
   messages: unknown[];
-  // Number of input messages that lost their verbatim representation to fit the
-  // byte budget (dropped outright or swapped for a placeholder). The caller logs
-  // truncation only when this is positive, so every omitting branch must report
-  // it — a zero here while history is silently discarded hides truncation from
-  // operators.
-  omittedCount: number;
 } {
   const { messages, maxBytes } = params;
   if (messages.length === 0) {
-    return { messages, omittedCount: 0 };
+    return { messages };
   }
   if (jsonUtf8Bytes(messages) <= maxBytes) {
-    return { messages, omittedCount: 0 };
+    return { messages };
   }
   const last = messages.at(-1);
   if (last && jsonUtf8Bytes([last]) <= maxBytes) {
-    // Keep only the final message; every earlier message is dropped.
-    return { messages: [last], omittedCount: messages.length - 1 };
+    return { messages: [last] };
   }
   const placeholder = buildOversizedHistoryPlaceholder(last);
   if (jsonUtf8Bytes([placeholder]) <= maxBytes) {
-    // Even the final message is over budget, so it too is replaced — no input
-    // message survives verbatim.
-    return { messages: [placeholder], omittedCount: messages.length };
+    return { messages: [placeholder] };
   }
   // The oversized placeholder still does not fit (e.g. the source message
   // carried very large metadata). Never return an empty history — that renders
   // as a blank transcript and reads as data loss even though the on-disk
   // transcript is intact. Fall back to a small metadata-free sentinel.
-  return { messages: [buildChatHistoryUnavailableSentinel()], omittedCount: messages.length };
+  return { messages: [buildChatHistoryUnavailableSentinel()] };
+}
+
+// Counts how many of the original chat.history messages lost their verbatim
+// representation by the time the budget pipeline finished — whether they were
+// replaced with a placeholder, dropped by the front byte cap, or collapsed by
+// the final budget. Identity membership counts each omitted original exactly
+// once (a message that is first replaced and then trimmed is not counted twice),
+// and emits the truncation diagnostic so operators see when history is omitted.
+// Returns the omitted count (0 when nothing was omitted, so no diagnostic fires).
+export function reportOmittedChatHistory(params: {
+  originalMessages: unknown[];
+  finalMessages: unknown[];
+  normalizedBytes: number;
+  maxHistoryBytes: number;
+  logDebug: (message: string) => void;
+}): number {
+  const { originalMessages, finalMessages, normalizedBytes, maxHistoryBytes, logDebug } = params;
+  const survivors = new Set(finalMessages);
+  let omittedCount = 0;
+  for (const message of originalMessages) {
+    if (!survivors.has(message)) {
+      omittedCount += 1;
+    }
+  }
+  if (omittedCount === 0) {
+    return 0;
+  }
+  chatHistoryOmittedEmitCount += omittedCount;
+  logLargePayload({
+    surface: "gateway.chat.history",
+    action: "truncated",
+    bytes: normalizedBytes,
+    limitBytes: maxHistoryBytes,
+    count: omittedCount,
+    reason: "chat_history_budget",
+  });
+  logDebug(
+    `chat.history omitted oversized payloads count=${omittedCount} total=${chatHistoryOmittedEmitCount}`,
+  );
+  return omittedCount;
 }
 
 function resolveTranscriptPath(params: {
@@ -2767,25 +2802,14 @@ async function handleChatHistoryRequest({
     context,
   });
   const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
-  // Front byte cap drops the oldest messages without reporting a count, so derive
-  // it from the length delta to keep that omission visible in truncation logs.
-  const frontCapDropped = replaced.messages.length - capped.length;
   const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
-  const omittedCount = replaced.replacedCount + frontCapDropped + bounded.omittedCount;
-  if (omittedCount > 0) {
-    chatHistoryOmittedEmitCount += omittedCount;
-    logLargePayload({
-      surface: "gateway.chat.history",
-      action: "truncated",
-      bytes: jsonUtf8Bytes(normalized),
-      limitBytes: maxHistoryBytes,
-      count: omittedCount,
-      reason: "chat_history_budget",
-    });
-    context.logGateway.debug(
-      `chat.history omitted oversized payloads count=${omittedCount} total=${chatHistoryOmittedEmitCount}`,
-    );
-  }
+  reportOmittedChatHistory({
+    originalMessages: normalized,
+    finalMessages: bounded.messages,
+    normalizedBytes: jsonUtf8Bytes(normalized),
+    maxHistoryBytes,
+    logDebug: (message) => context.logGateway.debug(message),
+  });
   const modelCatalog = await modelCatalogPromise;
   const defaultAgentId = resolveDefaultAgentId(cfg);
   const startupMetadata = includeMetadata


### PR DESCRIPTION
## What Problem This Solves

`enforceChatHistoryFinalBudget` (the final byte-budget step of the `chat.history` Gateway response) returned `placeholderCount: 0` in the branch that keeps **only the last message** while silently dropping every earlier one:

```ts
const last = messages.at(-1);
if (last && jsonUtf8Bytes([last]) <= maxBytes) {
  return { messages: [last], placeholderCount: 0 }; // dropped N-1 messages, reported 0
}
```

The caller logs truncation only when that count is positive:

```ts
if (placeholderCount > 0) {
  logLargePayload({ surface: "gateway.chat.history", action: "truncated", ... });
}
```

So whenever history was trimmed down to its last message, the count was `0`, the gate never fired, and the truncation was invisible to operators. The front byte cap (`capArrayByJsonBytes`) also drops the oldest messages without reporting a count, so that omission went unlogged too. Closes #96783.

## Why This Change Was Made

The count was being assembled from per-step partial counts that did not compose: a step's "placeholders inserted" is not the same as "history omitted", and summing `replacedCount + front-cap drops + final-budget count` double-counts a message that is first replaced with a placeholder and then trimmed by the byte cap.

The fix gives the omission count a single owner that sees the whole pipeline. `enforceChatHistoryFinalBudget` now returns only its surviving messages (its message behavior is unchanged). A new `reportOmittedChatHistory` helper counts, by message identity, how many of the original messages lost their verbatim representation anywhere in the replace → cap → final-budget pipeline, and emits the diagnostic. Identity membership counts each omitted original exactly once.

## User Impact

Operators now get the `payload.large` / `truncated` diagnostic (and the debug line) whenever `chat.history` discards older history for any reason — drop-to-last, placeholder replacement, or front byte-cap trimming — with an accurate, non-inflated count. No API/response shape change for clients; this is purely diagnostic accounting. The internal field rename touched only the helper, its single Gateway caller, and the focused test (the TUI / embedded-stub callers read only `messages`).

## Evidence

**Real Gateway request (after fix).** A full `chat.history` request issued over a **booted Gateway WebSocket server** against a **real on-disk transcript** now emits the truncation diagnostic. The new regression test `chat-history-omission-request.test.ts` boots the gateway via the standard server harness, seeds a session store + transcript on disk (12 messages, budget lowered to 8 KB through the existing `setMaxChatHistoryMessagesBytesForTest` seam), then drives `rpcReq(ws, "chat.history", …)` end-to-end through the real `handleChatHistoryRequest` (not the budget helpers in isolation) and captures the real diagnostic event bus output:

```
chat.history real-request diagnostic: returned=3 event={
  "type":"payload.large","surface":"gateway.chat.history","action":"truncated",
  "bytes":25167,"limitBytes":8000,"count":9,"reason":"chat_history_budget", ...
}
```

12 messages in, 3 survive the byte budget, 9 older messages omitted → `count: 9`.

**Before (negative control).** Checking out pre-fix `main`'s `chat.ts` and running the *same* real-WS test reproduces the bug: the request still omits 9 messages but emits **no** diagnostic, so the assertion fails. The test imports only the WebSocket harness and the diagnostic bus (no changed symbols), so it compiles and runs against both `main` and the PR head — the only difference is whether the diagnostic fires.

```
$ git checkout 2e6e17f7c5 -- src/gateway/server-methods/chat.ts   # pre-fix main
$ node scripts/run-vitest.mjs run \
    src/gateway/server-methods/chat-history-omission-request.test.ts
  AssertionError: expected [] to have a length of 1 but got +0
     78|       expect(captured).toHaveLength(1);
  Test Files  2 failed (2)
$ git checkout HEAD -- src/gateway/server-methods/chat.ts          # restore fix → passes
```

**Premise.** On `main` the caller computed `placeholderCount = replaced.replacedCount + bounded.placeholderCount`. The front byte cap (`capArrayByJsonBytes`) and the keep-last branch of `enforceChatHistoryFinalBudget` both omit messages without contributing to either term, so the `if (placeholderCount > 0)` gate never fired for those paths. The fix routes all omission accounting through `reportOmittedChatHistory`, which counts originals missing from the final survivor set by identity (each omitted original once).

**Focused tests** exercise the real exported functions and the real WS request path:

```
node scripts/run-vitest.mjs \
  src/gateway/server-methods/chat-history-omission-request.test.ts \
  src/gateway/server-methods/chat-history-omission-logging.test.ts \
  src/gateway/server-methods/chat-history-budget.test.ts
```

- `chat-history-omission-request.test.ts`: a real Gateway WS `chat.history` request emits `payload.large` / `truncated` with the unique omitted count (output above); reproduces the missing diagnostic on pre-fix `main`.
- `chat-history-omission-logging.test.ts`: the diagnostic fires when history is trimmed, does **not** fire when nothing is omitted, and a message that is replaced and then front-capped is counted **once** (strictly less than the old additive `replacedCount + frontCapDropped` sum).
- `chat-history-budget.test.ts`: `enforceChatHistoryFinalBudget` returns the right surviving messages (pass-through, keep-last preserving the original reference, oversized placeholder, never-empty sentinel).

Formatting verified with `oxfmt`.

AI-assisted.
