### PR TITLE
fix(agents): hide runtime-only placeholder prompt from user-visible transcript

### DIFF
--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -634,6 +634,10 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("");
   });
 
+  it("strips the runtime-only user prompt placeholder when it appears standalone", () => {
+    expect(sanitizeUserFacingText("Continue the OpenClaw runtime event.")).toBe("");
+  });
+
   it("does not strip ordinary text that merely mentions internal marker strings", () => {
     const input = [
       "The literal header `OpenClaw runtime context (internal):` appears in this note.",

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -25,7 +25,10 @@ import {
 } from "../../shared/text/assistant-visible-text.js";
 import { stripFinalTags } from "../../shared/text/final-tags.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
-import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
+import {
+  OPENCLAW_RUNTIME_EVENT_USER_PROMPT,
+  stripInternalRuntimeContext,
+} from "../internal-runtime-context.js";
 import { stableStringify } from "../stable-stringify.js";
 import {
   isBillingErrorMessage,
@@ -446,6 +449,12 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   );
   const trimmed = withoutToolCallBlocks.trim();
   if (!trimmed) {
+    return "";
+  }
+  // Runtime-only maintenance turns use this placeholder to trigger the agent
+  // loop. It is internal scaffolding, not user input — strip it before delivery
+  // so it never leaks into user-visible surfaces.
+  if (trimmed === OPENCLAW_RUNTIME_EVENT_USER_PROMPT) {
     return "";
   }
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4236,9 +4236,7 @@ export async function runEmbeddedAttempt(
               setActiveSessionSystemPrompt(runtimeSystemPrompt);
             }
           }
-          const runtimeContextForHook = promptSubmission.runtimeOnly
-            ? undefined
-            : promptSubmission.runtimeContext?.trim();
+          const runtimeContextForHook = promptSubmission.runtimeContext?.trim();
           const runtimeContextMessageForCurrentTurn =
             buildRuntimeContextCustomMessage(runtimeContextForHook);
           const messagesForCurrentPrompt = runtimeContextMessageForCurrentTurn
@@ -4776,31 +4774,25 @@ export async function runEmbeddedAttempt(
             };
             const cleanupProviderPromptHistoryTransform = installProviderPromptHistoryTransform();
             try {
-              if (promptSubmission.runtimeOnly) {
-                await promptActiveSession(promptForSession, {
-                  preflightResult: armModelPromptTransform,
-                });
-              } else {
-                const cleanupRuntimeContextMessage = installRuntimeContextMessageForPrompt({
-                  session: activeSession,
-                  message: runtimeContextMessageForCurrentTurn,
-                });
-                try {
-                  // Only pass images option if there are actually images to pass
-                  // This avoids potential issues with models that don't expect the images parameter
-                  if (imageResult.images.length > 0) {
-                    await promptActiveSession(promptForSession, {
-                      images: imageResult.images,
-                      preflightResult: armModelPromptTransform,
-                    });
-                  } else {
-                    await promptActiveSession(promptForSession, {
-                      preflightResult: armModelPromptTransform,
-                    });
-                  }
-                } finally {
-                  cleanupRuntimeContextMessage();
+              const cleanupRuntimeContextMessage = installRuntimeContextMessageForPrompt({
+                session: activeSession,
+                message: runtimeContextMessageForCurrentTurn,
+              });
+              try {
+                // Only pass images option if there are actually images to pass
+                // This avoids potential issues with models that don't expect the images parameter
+                if (imageResult.images.length > 0) {
+                  await promptActiveSession(promptForSession, {
+                    images: imageResult.images,
+                    preflightResult: armModelPromptTransform,
+                  });
+                } else {
+                  await promptActiveSession(promptForSession, {
+                    preflightResult: armModelPromptTransform,
+                  });
                 }
+              } finally {
+                cleanupRuntimeContextMessage();
               }
               if (leasedSteering) {
                 ackPendingAgentSteeringItems({

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -9,10 +9,9 @@ import {
   OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
   OPENCLAW_RUNTIME_CONTEXT_NOTICE,
   OPENCLAW_RUNTIME_EVENT_HEADER,
+  OPENCLAW_RUNTIME_EVENT_USER_PROMPT,
 } from "../../internal-runtime-context.js";
 import type { CurrentInboundPromptContext } from "./params.js";
-
-const OPENCLAW_RUNTIME_EVENT_USER_PROMPT = "Continue the OpenClaw runtime event.";
 
 type RuntimeContextPromptParts = {
   prompt: string;

--- a/src/agents/internal-runtime-context.test.ts
+++ b/src/agents/internal-runtime-context.test.ts
@@ -9,6 +9,7 @@ import {
   hasInternalRuntimeContext,
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
+  OPENCLAW_RUNTIME_EVENT_USER_PROMPT,
   stripInternalRuntimeContext,
 } from "./internal-runtime-context.js";
 
@@ -84,6 +85,22 @@ describe("internal runtime context codec", () => {
         `Inline token ${INTERNAL_RUNTIME_CONTEXT_BEGIN} should not count as a block marker.`,
       ),
     ).toBe(false);
+  });
+
+  it("strips the runtime-only placeholder user prompt from visible text", () => {
+    expect(stripInternalRuntimeContext(OPENCLAW_RUNTIME_EVENT_USER_PROMPT)).toBe("");
+  });
+
+  it("strips the runtime-only placeholder when embedded in multi-line text", () => {
+    const input = [
+      "Compaction summary context line",
+      OPENCLAW_RUNTIME_EVENT_USER_PROMPT,
+      "More visible text",
+    ].join("\n");
+    const result = stripInternalRuntimeContext(input);
+    expect(result).not.toContain(OPENCLAW_RUNTIME_EVENT_USER_PROMPT);
+    expect(result).toContain("Compaction summary context line");
+    expect(result).toContain("More visible text");
   });
 
   it("fuzzes delimiter injection and nested marker handling deterministically", () => {

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -21,6 +21,8 @@ export const OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER =
 export const OPENCLAW_RUNTIME_EVENT_HEADER = "OpenClaw runtime event.";
 /** Custom message type used for structured runtime-context messages. */
 export const OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE = "openclaw.runtime-context";
+/** User prompt placeholder for runtime-only turns that carry no user-authored text. */
+export const OPENCLAW_RUNTIME_EVENT_USER_PROMPT = "Continue the OpenClaw runtime event.";
 
 const LEGACY_INTERNAL_CONTEXT_HEADER =
   ["OpenClaw runtime context (internal):", OPENCLAW_RUNTIME_CONTEXT_NOTICE, ""].join("\n") + "\n";
@@ -216,6 +218,28 @@ function stripRuntimeContextPromptPreface(text: string): string {
     : text;
 }
 
+/**
+ * Removes the runtime-only placeholder used to drive the agent loop when no
+ * user-authored text is present. It is internal scaffolding, not user input.
+ */
+function stripRuntimeEventUserPromptPlaceholder(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed === OPENCLAW_RUNTIME_EVENT_USER_PROMPT) {
+    return "";
+  }
+  // Also handle the case where the placeholder appears as a line in a
+  // multi-line block (e.g. after compaction appends context).
+  if (trimmed.includes(OPENCLAW_RUNTIME_EVENT_USER_PROMPT)) {
+    return trimmed
+      .split("\n")
+      .filter((line) => line.trim() !== OPENCLAW_RUNTIME_EVENT_USER_PROMPT)
+      .join("\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+  }
+  return text;
+}
+
 /** Remove protected and legacy runtime-context blocks from text. */
 export function stripInternalRuntimeContext(text: string): string {
   if (!text) {
@@ -226,9 +250,9 @@ export function stripInternalRuntimeContext(text: string): string {
     INTERNAL_RUNTIME_CONTEXT_BEGIN,
     INTERNAL_RUNTIME_CONTEXT_END,
   );
-  return stripRuntimeContextPromptPreface(
-    stripLegacyInternalRuntimeContext(withoutDelimitedBlocks),
-  );
+  const withoutLegacy = stripLegacyInternalRuntimeContext(withoutDelimitedBlocks);
+  const withoutPreface = stripRuntimeContextPromptPreface(withoutLegacy);
+  return stripRuntimeEventUserPromptPlaceholder(withoutPreface);
 }
 
 /** Extract protected runtime-context blocks while returning remaining visible text. */


### PR DESCRIPTION
## What Problem This Solves

Runtime-only maintenance turns (subagent completion, cron job results, background media tasks) use the non-empty placeholder `"Continue the OpenClaw runtime event."` as a user prompt to drive the agent loop. The runtime context is correctly injected into the system prompt, but because the placeholder is submitted via `activeSession.prompt(string)`, Pi Agent normalizes it into a plain `role: "user"` message. The session transcript layer has no metadata to distinguish it from real user input, causing it to be persisted to JSONL and displayed in the UI as a ghost user message.

**Production evidence** — session `7973a566` at line 26 shows the placeholder persisted immediately after a `type: "compaction"` event:

```json
{"type":"compaction","id":"257e9e42",...}
{"type":"message","id":"23b4f341",...,
 "message":{"role":"user","content":[{"type":"text","text":"Continue the OpenClaw runtime event."}]}}
```

The assistant then interpreted this as a "pre-compaction memory flush" and attempted to write to `memory/2026-06-16.md` — confirming it was an internal maintenance turn misattributed as user input. The same pattern appears in multiple other sessions on the same machine.

## Why This Change Was Made

Two layers of defense:

**Layer 1 (source)** — The non-runtimeOnly path already wraps runtime context in a `RuntimeContextCustomMessage` with `role: "custom"`, `display: false`, and `customType: "openclaw.runtime-context"`, injected via `installRuntimeContextMessageForPrompt`. The runtimeOnly path explicitly skipped this. Now the two branches are unified so runtimeOnly turns also get the hidden custom message treatment.

**Layer 2 (projection)** — As added defense across all consumers (UI, auto-reply, live-chat-projector, message-tool, doctor transcripts, session export), `stripInternalRuntimeContext` now filters the placeholder string. This covers every path that projects transcript text for display, even if the custom-message metadata is lost in transit.

## Changes

1. **`src/agents/internal-runtime-context.ts`** — export `OPENCLAW_RUNTIME_EVENT_USER_PROMPT`; add `stripRuntimeEventUserPromptPlaceholder` wired into `stripInternalRuntimeContext`
2. **`src/agents/embedded-agent-runner/run/runtime-context-prompt.ts`** — import from shared module instead of local `const`
3. **`src/agents/embedded-agent-runner/run/attempt.ts`** — remove the `runtimeOnly ? undefined` gate; merge both prompt-submission branches into one unified path that always calls `installRuntimeContextMessageForPrompt`
4. **`src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts`** — strip the placeholder when it appears standalone (defense-in-depth)
5. **`src/agents/internal-runtime-context.test.ts`** — add tests: standalone placeholder strip, multi-line embedded placeholder strip
6. **`src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts`** — add test: sanitizer strips the placeholder

## User Impact

- **Before**: `"Continue the OpenClaw runtime event."` appears in conversations as a user message, polluting transcripts, compaction summaries, trajectory exports, and memory writes
- **After**: The placeholder is hidden at two independent layers — the custom-message injection at source, and the projection filter at every transcript display boundary

## Evidence

```
pnpm test src/agents/internal-runtime-context.test.ts
  7 passed (new: standalone + multi-line placeholder strip)

pnpm test src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
  17 passed

pnpm test src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
  119 passed (new: placeholder sanitize)

pnpm test src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
  62 passed
```