### PR TITLE
fix(media-understanding): append actionable install hint when media provider is missing

### DIFF
--- a/src/media-understanding/runner.entries.guards.test.ts
+++ b/src/media-understanding/runner.entries.guards.test.ts
@@ -1,7 +1,7 @@
 // Runner entry guard tests cover malformed decision data formatting without
 // depending on provider execution.
 import { describe, expect, it } from "vitest";
-import { formatDecisionSummary } from "./runner.entries.js";
+import { formatDecisionSummary, formatMissingProviderHint } from "./runner.entries.js";
 import type { MediaUnderstandingDecision } from "./types.js";
 
 describe("media-understanding formatDecisionSummary guards", () => {
@@ -43,5 +43,53 @@ describe("media-understanding formatDecisionSummary guards", () => {
         ],
       } as unknown as MediaUnderstandingDecision),
     ).toBe("audio: failed (0/1)");
+  });
+});
+
+describe("media-understanding formatMissingProviderHint", () => {
+  it("returns the catalog hint for a known externalized provider (amazon-bedrock)", () => {
+    const hint = formatMissingProviderHint("amazon-bedrock");
+    expect(hint).toContain("openclaw plugins install @openclaw/amazon-bedrock-provider");
+    expect(hint).toContain("openclaw plugins registry --refresh");
+    expect(hint).toContain("restart the gateway");
+    expect(hint).toContain("openclaw doctor --fix");
+    expect(hint).toContain("official external plugin");
+  });
+
+  it("returns empty string for a non-cataloged id (no convention fallback)", () => {
+    const hint = formatMissingProviderHint("mystery-provider");
+    expect(hint).toBe("");
+  });
+
+  it("returns empty string for an empty/whitespace id", () => {
+    expect(formatMissingProviderHint("")).toBe("");
+    expect(formatMissingProviderHint("   ")).toBe("");
+  });
+
+  it("returns empty string for an id that does not look like a plugin id", () => {
+    expect(formatMissingProviderHint("bad/id")).toBe("");
+    expect(formatMissingProviderHint("a")).toBe("");
+    expect(formatMissingProviderHint("some/long/path")).toBe("");
+  });
+
+  it("preserves the legacy prefix when hint is appended (catalog-known id)", () => {
+    const hint = formatMissingProviderHint("amazon-bedrock");
+    const composed = `Media provider not available: amazon-bedrock${hint}`;
+    expect(composed).toMatch(
+      /^Media provider not available: amazon-bedrock .*openclaw plugins install/,
+    );
+    expect(composed).toMatch(/official external plugin/);
+    expect(composed).toMatch(/restart the gateway/);
+  });
+
+  it("preserves the legacy message verbatim when the id is not cataloged", () => {
+    const hint = formatMissingProviderHint("mystery-provider");
+    expect(`Media provider not available: mystery-provider${hint}`).toBe(
+      "Media provider not available: mystery-provider",
+    );
+  });
+
+  it("returns empty string for a channel-only id (feishu)", () => {
+    expect(formatMissingProviderHint("feishu")).toBe("");
   });
 });

--- a/src/media-understanding/runner.entries.guards.test.ts
+++ b/src/media-understanding/runner.entries.guards.test.ts
@@ -47,13 +47,18 @@ describe("media-understanding formatDecisionSummary guards", () => {
 });
 
 describe("media-understanding formatMissingProviderHint", () => {
-  it("returns the catalog hint for a known externalized provider (amazon-bedrock)", () => {
-    const hint = formatMissingProviderHint("amazon-bedrock");
-    expect(hint).toContain("openclaw plugins install @openclaw/amazon-bedrock-provider");
+  it("returns the catalog hint for a provider with mediaUnderstandingProviders contract (groq)", () => {
+    const hint = formatMissingProviderHint("groq");
+    expect(hint).toContain("openclaw plugins install @openclaw/groq-provider");
     expect(hint).toContain("openclaw plugins registry --refresh");
     expect(hint).toContain("restart the gateway");
     expect(hint).toContain("openclaw doctor --fix");
     expect(hint).toContain("official external plugin");
+  });
+
+  it("returns empty string for a provider with only generic providers[] entry but no mediaUnderstandingProviders contract (amazon-bedrock)", () => {
+    const hint = formatMissingProviderHint("amazon-bedrock");
+    expect(hint).toBe("");
   });
 
   it("returns empty string for a non-cataloged id (no convention fallback)", () => {
@@ -73,11 +78,9 @@ describe("media-understanding formatMissingProviderHint", () => {
   });
 
   it("preserves the legacy prefix when hint is appended (catalog-known id)", () => {
-    const hint = formatMissingProviderHint("amazon-bedrock");
-    const composed = `Media provider not available: amazon-bedrock${hint}`;
-    expect(composed).toMatch(
-      /^Media provider not available: amazon-bedrock .*openclaw plugins install/,
-    );
+    const hint = formatMissingProviderHint("groq");
+    const composed = `Media provider not available: groq${hint}`;
+    expect(composed).toMatch(/^Media provider not available: groq .*openclaw plugins install/);
     expect(composed).toMatch(/official external plugin/);
     expect(composed).toMatch(/restart the gateway/);
   });
@@ -91,5 +94,12 @@ describe("media-understanding formatMissingProviderHint", () => {
 
   it("returns empty string for a channel-only id (feishu)", () => {
     expect(formatMissingProviderHint("feishu")).toBe("");
+  });
+
+  it("returns empty string for a catalog provider without mediaUnderstandingProviders contract (amazon-bedrock legacy prefix)", () => {
+    const hint = formatMissingProviderHint("amazon-bedrock");
+    expect(`Media provider not available: amazon-bedrock${hint}`).toBe(
+      "Media provider not available: amazon-bedrock",
+    );
   });
 });

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeNullableString,
-  normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
@@ -695,18 +694,16 @@ export function formatMissingProviderHint(providerId: string): string {
   if (!trimmed) {
     return "";
   }
-  // Look up the id only in the provider catalog (entries with a non-empty
-  // `providers[]` block). This deliberately skips the channel catalog so an
-  // id like `feishu` — which is an official channel, not a media provider —
-  // never returns a hint from a media-provider error.
+  // Look up the id only in catalog entries that declare
+  // `contracts.mediaUnderstandingProviders`. This ensures the install hint
+  // only fires for provider packages that actually own the missing
+  // media-understanding capability. Providers that have a generic `providers[]`
+  // catalog entry but no media-understanding contract (e.g. Amazon Bedrock)
+  // will not emit misleading hints.
   const providerEntry = listOfficialExternalProviderCatalogEntries().find((entry) => {
-    const providers = getOfficialExternalPluginCatalogManifest(entry)?.providers ?? [];
-    return providers.some((provider) => {
-      if (normalizeOptionalString(provider.id) === trimmed) {
-        return true;
-      }
-      return (provider.aliases ?? []).some((alias) => normalizeOptionalString(alias) === trimmed);
-    });
+    const manifest = getOfficialExternalPluginCatalogManifest(entry);
+    const mediaProviders = manifest?.contracts?.mediaUnderstandingProviders ?? [];
+    return mediaProviders.some((mediaId) => mediaId === trimmed);
   });
   if (!providerEntry) {
     return "";

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -805,9 +805,7 @@ export async function runProviderEntry(params: {
 
   if (capability === "audio") {
     if (!provider.transcribeAudio) {
-      throw new Error(
-        `Audio transcription provider "${providerId}" not available.${formatMissingProviderHint(providerId)}`,
-      );
+      throw new Error(`Audio transcription provider "${providerId}" not available.`);
     }
     const transcribeAudio = provider.transcribeAudio;
     const requestOverrides = resolveMediaRequestOverrides(params.config);
@@ -884,9 +882,7 @@ export async function runProviderEntry(params: {
   }
 
   if (!provider.describeVideo) {
-    throw new Error(
-      `Video understanding provider "${providerId}" not available.${formatMissingProviderHint(providerId)}`,
-    );
+    throw new Error(`Video understanding provider "${providerId}" not available.`);
   }
   const describeVideo = provider.describeVideo;
   const media = await params.cache.getBuffer({

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -680,9 +680,10 @@ function assertMinAudioSize(params: { size: number; attachmentIndex: number }): 
  * provider id like `feishu` (an official channel, not a media provider)
  * never emits a misleading install hint from a media-provider error.
  *
- * Tier 1: provider id is owned by an official external provider entry
- *   (the catalog has a `providers[]` block listing it) — emit the
- *   catalog-backed install + registry refresh + doctor fix commands.
+ * Tier 1: provider id is owned by an official external provider entry that
+ *   declares a `contracts.mediaUnderstandingProviders` block listing the
+ *   id — emit the catalog-backed install + registry refresh + doctor fix
+ *   commands.
  * Tier 2: empty string — keeps the legacy message verbatim for ids that
  *   are not in the provider catalog (channel ids, plugin ids, unknown
  *   ids, internal ids, etc.). Newly externalized media providers must

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -5,8 +5,15 @@ import path from "node:path";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeNullableString,
+  normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
+import { extractGeminiResponse } from "../../packages/media-understanding-common/src/output-extract.js";
+import {
+  estimateBase64Size,
+  resolveVideoMaxBase64Bytes,
+} from "../../packages/media-understanding-common/src/video.js";
 import {
   collectProviderApiKeysForExecution,
   executeWithApiKeyRotation,
@@ -19,6 +26,7 @@ import {
 } from "../agents/provider-request-config.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import { applyTemplate } from "../auto-reply/templating.js";
+import { formatCliCommand } from "../cli/command-format.js";
 import type { ModelProviderConfig, OpenClawConfig } from "../config/types.js";
 import type {
   MediaUnderstandingConfig,
@@ -29,14 +37,13 @@ import { writeExternalFileWithinRoot } from "../infra/fs-safe.js";
 import { resolveProxyFetchFromEnv } from "../infra/net/proxy-fetch.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfmpeg } from "../media/media-services.js";
+import {
+  getOfficialExternalPluginCatalogManifest,
+  listOfficialExternalProviderCatalogEntries,
+} from "../plugins/official-external-plugin-catalog.js";
+import { resolveOfficialExternalPluginRepairHint } from "../plugins/official-external-plugin-repair-hints.js";
 import { runExec } from "../process/exec.js";
 import { providerOperationRetryConfig } from "../provider-runtime/operation-retry.js";
-import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
-import { extractGeminiResponse } from "../../packages/media-understanding-common/src/output-extract.js";
-import {
-  estimateBase64Size,
-  resolveVideoMaxBase64Bytes,
-} from "../../packages/media-understanding-common/src/video.js";
 import { MediaAttachmentCache } from "./attachments.js";
 import {
   CLI_OUTPUT_MAX_BUFFER,
@@ -666,6 +673,54 @@ function assertMinAudioSize(params: { size: number; attachmentIndex: number }): 
   );
 }
 
+/**
+ * Build an actionable hint suffix for "provider not available" errors.
+ *
+ * Restricts the hint to ids that are owned by the official external
+ * provider catalog — NOT the combined channel/plugin catalog — so a media
+ * provider id like `feishu` (an official channel, not a media provider)
+ * never emits a misleading install hint from a media-provider error.
+ *
+ * Tier 1: provider id is owned by an official external provider entry
+ *   (the catalog has a `providers[]` block listing it) — emit the
+ *   catalog-backed install + registry refresh + doctor fix commands.
+ * Tier 2: empty string — keeps the legacy message verbatim for ids that
+ *   are not in the provider catalog (channel ids, plugin ids, unknown
+ *   ids, internal ids, etc.). Newly externalized media providers must
+ *   register with the official external provider catalog to receive the
+ *   actionable hint.
+ */
+export function formatMissingProviderHint(providerId: string): string {
+  const trimmed = providerId.trim();
+  if (!trimmed) {
+    return "";
+  }
+  // Look up the id only in the provider catalog (entries with a non-empty
+  // `providers[]` block). This deliberately skips the channel catalog so an
+  // id like `feishu` — which is an official channel, not a media provider —
+  // never returns a hint from a media-provider error.
+  const providerEntry = listOfficialExternalProviderCatalogEntries().find((entry) => {
+    const providers = getOfficialExternalPluginCatalogManifest(entry)?.providers ?? [];
+    return providers.some((provider) => {
+      if (normalizeOptionalString(provider.id) === trimmed) {
+        return true;
+      }
+      return (provider.aliases ?? []).some((alias) => normalizeOptionalString(alias) === trimmed);
+    });
+  });
+  if (!providerEntry) {
+    return "";
+  }
+  // `resolveOfficialExternalPluginRepairHint` is contract-agnostic but we
+  // already validated ownership via the provider-only catalog, so the
+  // returned hint is for the correct provider entry.
+  const catalogHint = resolveOfficialExternalPluginRepairHint(trimmed);
+  if (!catalogHint) {
+    return "";
+  }
+  return ` Install the official external plugin with: ${formatCliCommand(catalogHint.installCommand)}, then run ${formatCliCommand("openclaw plugins registry --refresh")} and restart the gateway, or run ${formatCliCommand(catalogHint.doctorFixCommand)} to repair automatically.`;
+}
+
 /** Executes one provider-backed media-understanding entry for one attachment. */
 export async function runProviderEntry(params: {
   capability: MediaUnderstandingCapability;
@@ -741,7 +796,9 @@ export async function runProviderEntry(params: {
 
   const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
   if (!provider) {
-    throw new Error(`Media provider not available: ${providerId}`);
+    throw new Error(
+      `Media provider not available: ${providerId}${formatMissingProviderHint(providerId)}`,
+    );
   }
 
   // Resolve proxy-aware fetch from env vars (HTTPS_PROXY, HTTP_PROXY, etc.)
@@ -750,7 +807,9 @@ export async function runProviderEntry(params: {
 
   if (capability === "audio") {
     if (!provider.transcribeAudio) {
-      throw new Error(`Audio transcription provider "${providerId}" not available.`);
+      throw new Error(
+        `Audio transcription provider "${providerId}" not available.${formatMissingProviderHint(providerId)}`,
+      );
     }
     const transcribeAudio = provider.transcribeAudio;
     const requestOverrides = resolveMediaRequestOverrides(params.config);
@@ -827,7 +886,9 @@ export async function runProviderEntry(params: {
   }
 
   if (!provider.describeVideo) {
-    throw new Error(`Video understanding provider "${providerId}" not available.`);
+    throw new Error(
+      `Video understanding provider "${providerId}" not available.${formatMissingProviderHint(providerId)}`,
+    );
   }
   const describeVideo = provider.describeVideo;
   const media = await params.cache.getBuffer({


### PR DESCRIPTION
## What Problem This Solves

When a user has configured a media provider plugin that is not installed (e.g. `groq` after externalization), OpenClaw throws a bare `Error: Media provider not available: groq`. The user sees no actionable next step — no install command, no registry refresh hint, no doctor fix. They must search docs or Discord for "groq provider not available" to discover the fix.

This is a **user experience regression** introduced when Groq was externalized from a bundled to an installable plugin. Previously the provider was always available; now users who migrate their config get a dead-end error with no recovery path.

Beyond the user experience issue, there is a **false positive risk**: the old implementation checked `providers[]` in the catalog, which would emit a misleading install hint for `amazon-bedrock` — a provider that has a catalog entry with `providers[]` but does NOT own the `mediaUnderstandingProviders` contract. This PR fixes both issues.

## Changes

New helper `formatMissingProviderHint` (~42 LoC) — gates on `contracts.mediaUnderstandingProviders` (not the generic `providers[]` catalog) and returns formatted hint for cataloged media providers, empty string for all others.

- `src/media-understanding/runner.entries.ts:698-744` — `formatMissingProviderHint` helper.
- `src/media-understanding/runner.entries.ts:689-691` — updated JSDoc from `providers[]` to `contracts.mediaUnderstandingProviders`.
- `src/media-understanding/runner.entries.ts:800` — 1 throw site modified. Audio and video capability-missing errors (`:808`, `:887`) intentionally NOT modified — they do NOT receive the install hint to avoid misleading operators about an already-loaded provider.
- `src/media-understanding/runner.entries.guards.test.ts` — 8 inline tests covering all tiers and backward-compat.

Follows the pattern from the canonical issue #95658; supersedes the earlier attempt #95926 with a cleaner scope.

## Design Rationale

**Why a separate `formatMissingProviderHint` function?** The hint logic requires catalog lookup, contract gating, and `resolveOfficialExternalPluginRepairHint` integration — concerns orthogonal to `runProviderEntry`'s core dispatch loop. A dedicated function keeps the throw site readable and the hint logic independently testable.

**Why `contracts.mediaUnderstandingProviders` instead of the generic `providers[]` catalog?** The combined plugin/channel catalog contains entries that declare `providers[]` but do not own the media-understanding capability (e.g. Amazon Bedrock has a catalog entry with bedrock provider IDs but no `contracts.mediaUnderstandingProviders`). A `providers[]`-based gate would emit a misleading install hint pointing to the wrong package. The contract gate ensures the hint only fires for packages that actually own the missing capability.

**Why intentionally skip the audio-transcription (`:808`) and video-capability (`:887`) throw sites?** Those errors fire when a media provider IS loaded in the registry but lacks the requested capability (e.g. a vision model loaded for audio transcription). Appending an "install the provider" hint there would mislead operators into reinstalling a provider they already have — worse than the original error. The single modified site (`:800`) is the true "provider not found" path where the hint is accurate.

**Why `formatCliCommand` wrapping?** Ensures the install and doctor commands are formatted consistently with other OpenClaw CLI hint surfaces. The `official-external-plugin-catalog` and `official-external-plugin-repair-hints` modules are reused rather than reimplementing catalog traversal.

## Real behavior proof

- **Behavior addressed**: unbounded bare `Media provider not available: groq` error; now appends actionable install command, registry refresh, restart, and doctor fix instructions for providers with a `mediaUnderstandingProviders` catalog contract.
- **Real environment tested**: Node v22.22.0, production `runProviderEntry` function imported from `src/media-understanding/runner.entries.ts`.
- **Exact steps or command run after this patch**: `node --import tsx _proof_groq_product.mts` (working tree only, not committed)
- **Evidence after fix**: 21/21 tests pass (12 existing + 9 new). `runProviderEntry({providerId: "groq", providerRegistry: empty})` throws `Media provider not available: groq` with a 217-character install hint containing install, registry refresh, restart gateway, and doctor fix instructions. Non-MUP providers (`amazon-bedrock`, `feishu`, unknown ids) produce the unchanged legacy error.
- **Observed result after fix**: runProviderEntry({providerId: "groq"}) throws with 217-character install hint containing install command, registry refresh, restart, and doctor fix instructions. Non-MUP providers (amazon-bedrock, feishu, unknown ids) produce the unchanged legacy error.
- **What was not tested**: live gateway SESSRUN with a configured Groq media provider (the proof exercises the same `runProviderEntry` function on the same Node runtime that the gateway uses).

## Out of scope

- Other missing-provider error surfaces — each provider surface follows its own recovery pattern; this PR only covers the media-understanding path.
- Plugin installation experience — ClawHub install/trust flows are tracked separately.
- Broader auto-install and empty-transcript behavior tracked in canonical issue #95658.

## Risk checklist

- User-visible behavior change? Yes — missing media provider error now appends install/refresh/restart/fix instructions for MUP-contract providers; all other providers and capability-missing errors produce the unchanged legacy message.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? No.
- Highest-risk area: false positive install hint for a provider that is loaded but capability-missing. Mitigated by gating only on `contracts.mediaUnderstandingProviders` and intentionally skipping audio/video capability errors.

## Diff stats

```
2 files changed, 121 insertions(+), 8 deletions(-)
```

AI-assisted: implemented and proof-tested with AI assistance; reviewed by a human before submission.