### PR TITLE
fix(gateway): report dropped message count in enforceChatHistoryFinalBudget (fixes #96783) (AI-assisted)

### DIFF
--- a/src/gateway/server-methods/chat-history-budget.test.ts
+++ b/src/gateway/server-methods/chat-history-budget.test.ts
@@ -35,7 +35,20 @@ describe("enforceChatHistoryFinalBudget", () => {
     const last = { role: "assistant", content: [{ type: "text", text: "ok" }] };
     const result = enforceChatHistoryFinalBudget({ messages: [big, last], maxBytes: 2_000 });
     expect(result.messages).toEqual([last]);
-    expect(result.placeholderCount).toBe(0);
+    expect(result.placeholderCount).toBe(1);
+  });
+
+  it("reports correct drop count when multiple messages are discarded", () => {
+    const big1 = { role: "user", content: [{ type: "text", text: "a".repeat(3000) }] };
+    const big2 = { role: "assistant", content: [{ type: "text", text: "b".repeat(3000) }] };
+    const big3 = { role: "user", content: [{ type: "text", text: "c".repeat(3000) }] };
+    const last = { role: "assistant", content: [{ type: "text", text: "ok" }] };
+    const result = enforceChatHistoryFinalBudget({
+      messages: [big1, big2, big3, last],
+      maxBytes: 2_000,
+    });
+    expect(result.messages).toEqual([last]);
+    expect(result.placeholderCount).toBe(3);
   });
 
   it("falls back to a small placeholder when even the last message is too large", () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1685,7 +1685,7 @@ export function enforceChatHistoryFinalBudget(params: { messages: unknown[]; max
   }
   const last = messages.at(-1);
   if (last && jsonUtf8Bytes([last]) <= maxBytes) {
-    return { messages: [last], placeholderCount: 0 };
+    return { messages: [last], placeholderCount: messages.length - 1 };
   }
   const placeholder = buildOversizedHistoryPlaceholder(last);
   if (jsonUtf8Bytes([placeholder]) <= maxBytes) {


### PR DESCRIPTION
## What Problem This Solves

`enforceChatHistoryFinalBudget` returns `placeholderCount: 0` when it drops all prior messages but keeps the last one that fits the byte budget. The caller at `src/gateway/server-methods/chat.ts:2764` uses `placeholderCount > 0` to gate truncation logging — so this silent drop goes completely unlogged. Operators have no visibility into when chat history is truncated to a single message.

## Why This Change Was Made

The early-return path at line 1688 (`messages.length - 1` messages discarded) returned a hardcoded `placeholderCount: 0`, while every other truncation path in the same function correctly returns a non-zero count. This was a one-line oversight — the fix replaces `0` with `messages.length - 1`.

## User Impact

Operators and debugging workflows will now correctly see truncation log entries when chat history is reduced to the last message due to byte budget constraints. No behavioral change for end users — the same messages are kept/dropped; only the reporting changes.

## Evidence

## Real behavior proof

- **Behavior addressed:** `enforceChatHistoryFinalBudget` misreports `placeholderCount: 0` when dropping prior messages that exceed the byte budget while keeping the last message.
- **Environment tested:** macOS, Node 22.22.3, OpenClaw 2026.5.28, local build from `upstream/main` at 2e6e17f7.
- **Steps run after the patch:**
  1. Built the project with `pnpm build`.
  2. Imported the compiled `enforceChatHistoryFinalBudget` from `dist/chat-Mx6RzAL8.js`.
  3. Called the function with 2 messages (1 oversized + 1 small) and `maxBytes: 2000`.
  4. Called the function with 4 messages (3 oversized + 1 small) and `maxBytes: 2000`.
  5. Ran the test suite: `node scripts/run-vitest.mjs run src/gateway/server-methods/chat-history-budget.test.ts`.
- **Evidence after fix:**
```
Test 1 (2 msgs, drop 1): messages= 1 placeholderCount= 1
Test 2 (4 msgs, drop 3): messages= 1 placeholderCount= 3
Test 3 (within budget): messages= 1 placeholderCount= 0
ALL CORRECT: true
```
Test suite: 12 passed (6 tests × 2 configs), 0 failures.
- **Observed result after fix:** `placeholderCount` correctly reports the number of dropped messages (1 for 2-message input, 3 for 4-message input). The caller's `if (placeholderCount > 0)` guard now fires, enabling truncation logging.
- **What was not tested:** Live gateway session with full chat history (requires multi-turn session setup); only the isolated function and its test suite were exercised.

- [x] AI-assisted (Hermes Agent)
