### PR TITLE
chore(catalog): bump Weixin plugin to 2.4.6

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -114,9 +114,9 @@
           }
         },
         "install": {
-          "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.3",
+          "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.6",
           "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-dPQbidUNWigC6V10vGW4i+GLH09x+6zUhafZRjuxkJ9GDu8o62WBsnUTojp4KqUH756hz+t2v9khiCRSi0dBDw==",
+          "expectedIntegrity": "sha512-qw9k3PLTiMWGNjjsknHgcTManH1w4j+Ji1ArWIaYLKCq3aFRsVwcqnPi127bvOoVMJGW4dbyJ8NECEMgoO+iRw==",
           "minHostVersion": ">=2026.3.22"
         }
       }

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -117,7 +117,7 @@
           "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.6",
           "defaultChoice": "npm",
           "expectedIntegrity": "sha512-qw9k3PLTiMWGNjjsknHgcTManH1w4j+Ji1ArWIaYLKCq3aFRsVwcqnPi127bvOoVMJGW4dbyJ8NECEMgoO+iRw==",
-          "minHostVersion": ">=2026.3.22"
+          "minHostVersion": ">=2026.5.12"
         }
       }
     },


### PR DESCRIPTION
## What Problem This Solves
Fixes #96791. The official external channel catalog still pinned `@tencent-weixin/openclaw-weixin` to `2.4.3`, so installs and upgrade reconciliation would keep users on the older Weixin plugin even though the package has published `2.4.6`.

## Why This Change Was Made
The catalog entry is the source used by OpenClaw's official external channel install flow. Updating `npmSpec`, `expectedIntegrity`, and the catalog `minHostVersion` keeps the install metadata aligned with the published npm package so host compatibility checks do not accept a package version that declares a newer floor.

## User Impact
Users installing or reconciling the official Weixin channel plugin get `@tencent-weixin/openclaw-weixin@2.4.6` with its matching integrity and host floor instead of being forced back to `2.4.3` or seeing catalog/package compatibility drift.

## Evidence
Head commit: `3f163c4666a0c13adefeebe85b9cfe371afc5b69`.

Verified npm metadata with `npm view @tencent-weixin/openclaw-weixin@2.4.6 version dist.integrity openclaw.install.minHostVersion peerDependencies.openclaw --json`:

```json
{
  "version": "2.4.6",
  "dist.integrity": "sha512-qw9k3PLTiMWGNjjsknHgcTManH1w4j+Ji1ArWIaYLKCq3aFRsVwcqnPi127bvOoVMJGW4dbyJ8NECEMgoO+iRw==",
  "openclaw.install.minHostVersion": ">=2026.5.12",
  "peerDependencies.openclaw": ">=2026.5.12"
}
```

Verified the repo's official catalog loader and install-plan trust path with `pnpm exec tsx -e '<listChannelPluginCatalogEntries + resolveOfficialExternalNpmPackageTrust proof>'`. The proof confirmed:

```json
{
  "proof": "official catalog install path resolves Weixin 2.4.6 with npm trust metadata",
  "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.6",
  "minHostVersion": ">=2026.5.12",
  "expectedIntegrity": "sha512-qw9k3PLTiMWGNjjsknHgcTManH1w4j+Ji1ArWIaYLKCq3aFRsVwcqnPi127bvOoVMJGW4dbyJ8NECEMgoO+iRw==",
  "trustedSourceLinkedOfficialInstall": true,
  "warnings": []
}
```

Verified the real isolated install path with `pnpm openclaw plugins install openclaw-weixin` against a clean proof root. The installer selected and installed the exact package:

```text
Installing @tencent-weixin/openclaw-weixin@2.4.6 into <proof-root>/state/npm/projects/tencent-weixin-openclaw-weixin-7783ac86ba...
Installed plugin: openclaw-weixin
```

The generated package lock in the isolated proof root confirmed the resolved tarball and integrity:

```json
{
  "version": "2.4.6",
  "resolved": "https://registry.npmjs.org/@tencent-weixin/openclaw-weixin/-/openclaw-weixin-2.4.6.tgz",
  "integrity": "sha512-qw9k3PLTiMWGNjjsknHgcTManH1w4j+Ji1ArWIaYLKCq3aFRsVwcqnPi127bvOoVMJGW4dbyJ8NECEMgoO+iRw=="
}
```

Validation:

- `node scripts/run-vitest.mjs run src/plugins/official-external-plugin-catalog.test.ts test/official-channel-catalog.test.ts test/release-check.test.ts` passed.
- `pnpm tsgo:core` passed.
- `git diff --check origin/main...HEAD` passed.
