### PR TITLE
fix(voice-call): add persisted store fallback to getCall/getCallByProviderCallId

### DIFF
--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -17,6 +17,8 @@ import {
   speakInitialMessage as speakInitialMessageWithContext,
 } from "./manager/outbound.js";
 import {
+  getCallByProviderCallIdFromStore,
+  getCallFromStore,
   getCallHistoryFromStore,
   loadActiveCallsFromStore,
   persistCallRecord,
@@ -424,21 +426,27 @@ export class CallManager {
   }
 
   /**
-   * Get an active call by ID.
+   * Get a call by ID, checking the in-memory active calls first and
+   * falling back to the persisted store when the call has been evicted
+   * after completion (#96586).
    */
   getCall(callId: CallId): CallRecord | undefined {
-    return this.activeCalls.get(callId);
+    return this.activeCalls.get(callId) ?? getCallFromStore(this.storePath, callId);
   }
 
   /**
-   * Get an active call by provider call ID (e.g., Twilio CallSid).
+   * Get a call by provider call ID (e.g., Twilio CallSid), checking the
+   * in-memory active calls first and falling back to the persisted store
+   * when the call has been evicted after completion (#96586).
    */
   getCallByProviderCallId(providerCallId: string): CallRecord | undefined {
-    return getCallByProviderCallIdFromMaps({
-      activeCalls: this.activeCalls,
-      providerCallIdMap: this.providerCallIdMap,
-      providerCallId,
-    });
+    return (
+      getCallByProviderCallIdFromMaps({
+        activeCalls: this.activeCalls,
+        providerCallIdMap: this.providerCallIdMap,
+        providerCallId,
+      }) ?? getCallByProviderCallIdFromStore(this.storePath, providerCallId)
+    );
   }
 
   /**

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -394,3 +394,30 @@ export async function getCallHistoryFromStore(
   }
   return [];
 }
+
+/** Look up a single call record by callId from the persisted store. */
+export function getCallFromStore(storePath: string, callId: CallId): CallRecord | undefined {
+  const stores = tryCreateCallRecordStateStores(storePath);
+  if (!stores) return undefined;
+  try {
+    return readCallRecordEvents(stores).find((call) => call.callId === callId);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Look up a single call record by provider call ID from the persisted store. */
+export function getCallByProviderCallIdFromStore(
+  storePath: string,
+  providerCallId: string,
+): CallRecord | undefined {
+  const stores = tryCreateCallRecordStateStores(storePath);
+  if (!stores) return undefined;
+  try {
+    return readCallRecordEvents(stores).find(
+      (call) => call.providerCallId === providerCallId,
+    );
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

- **Problem**: `voice_call` tool `get_status` returns `{ found: false }` for completed calls once the in-memory call record is evicted, even though the full call record (with transcript) is persisted in the plugin state store.
- **Root cause**: `CallManager.getCall()` and `getCallByProviderCallId()` only check the in-memory `activeCalls` / `providerCallIdMap` — there is no fallback to the persisted call store.
- **Fix**: Add `getCallFromStore` / `getCallByProviderCallIdFromStore` helpers in `store.ts` that look up individual call records from the persisted plugin state store, then wire them as fallback paths in `CallManager.getCall()` / `getCallByProviderCallId()`.
- **What did NOT change**: The fix is purely additive — if a call is found in the in-memory active map, the store is never consulted. All existing call sites (`get_status`, legacy `status` mode, `resolveCallMessageRequest`) benefit from the manager-level fallback without any caller-side changes.

Closes #96586

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (voice-call extension)

## Root Cause

In `CallManager.getCall()` and `getCallByProviderCallId()`, only the in-memory maps are checked. Calls in `completed`, `failed`, `no-answer`, or `busy` state are classified as terminal by `TerminalStates` and are not restored into `activeCalls` during `loadActiveCallsFromStore()`. Once the gateway restarts or the manager evicts the call, `getCall` / `getCallByProviderCallId` return `undefined` for those calls, causing `get_status` to report `{ found: false }`.

## Real behavior proof

**Behavior addressed:** `getCall` / `getCallByProviderCallId` now fall back to the persisted plugin state store when a call is not found in the in-memory active maps.

**Environment tested:** Node 24.13.1 on Linux, `node --import tsx` calling the real call manager and store helpers from the fix branch.

**Steps run after the patch:** Created a completed call record, persisted it to the plugin state store via `persistCallRecord()`, then verified that `getCall()` and `getCallByProviderCallId()` find it via store fallback.

**Evidence after fix:**

```text
=== BEFORE FIX (upstream/main behavior) ===
BEFORE: Looking up completed call in activeCalls (empty — call evicted):
  getCall("call-completed-proof-1") → undefined (BUG: call not found!)
BEFORE: Looking up by providerCallId (empty — call evicted):
  getCallByProviderCallId("CA-proof-provider-1") → undefined (BUG: call not found!)
Verification: call IS persisted in store → found (callId=call-completed-proof-1, state=completed)

=== AFTER FIX (PR branch) ===
AFTER: getCall with store fallback:
  getCall("call-completed-proof-1") → FOUND (callId=call-completed-proof-1, state=completed, endReason=completed)
AFTER: getCallByProviderCallId with store fallback:
  getCallByProviderCallId("CA-proof-provider-1") → FOUND (callId=call-completed-proof-1, providerCallId=CA-proof-provider-1, state=completed)
AFTER: Non-existent call still returns undefined:
  getCall("nonexistent-call") → undefined (correct)

=== VERDICT ===
RESULT: PASS — store fallback correctly falls back to persisted store
```

**Observed result after the fix:** Completed calls that have been evicted from the in-memory `activeCalls` map are now correctly retrieved from the persisted plugin state store. Non-existent calls still return `undefined` (no false positives).

**Not tested:** Live voice-call gateway session with real Twilio/Plivo provider webhook and natural call lifecycle. The store fallback path is verified via the real production functions `persistCallRecord` + `getCallFromStore` / `getCallByProviderCallIdFromStore` + `getCall` / `getCallByProviderCallId`.

## Security Impact

- New permissions? No
- Secrets handling changed? No
- New network calls? No
