### PR TITLE
fix(telegram): expose sender bot status in context

### DIFF
--- a/extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
@@ -92,6 +92,7 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
           text: "parent",
           from: { id: 99, first_name: "Bob" },
         },
+        from: { id: 42, first_name: "Alice", username: "alice_bot", is_bot: true },
       },
       sessionRuntime: {
         buildChannelInboundEventContext:
@@ -100,10 +101,12 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
     });
 
     expect(ctx?.ctxPayload.ReplyToBody).toBe("parent");
+    expect(ctx?.ctxPayload.SenderIsBot).toBe(true);
     expect(buildChannelInboundEventContextMock).toHaveBeenCalledOnce();
     const [turnOptions] = buildChannelInboundEventContextMock.mock.calls.at(0) ?? [];
     expect(turnOptions?.channel).toBe("telegram");
     expect(turnOptions?.from).toBe("telegram:1234");
+    expect(turnOptions?.sender?.isBot).toBe(true);
     expect(turnOptions?.message.rawBody).toBe("hello");
     expect(turnOptions?.message.bodyForAgent).toBe("hello");
     expect(turnOptions?.reply?.to).toBe("telegram:1234");

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -488,6 +488,7 @@ export async function buildTelegramInboundContextPayload(params: {
       ...(senderId ? { id: senderId } : {}),
       name: senderName,
       username: senderUsername || undefined,
+      isBot: msg.from?.is_bot,
     },
     conversation: {
       kind: conversationKind,

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -442,11 +442,13 @@ describe("buildInboundUserContextPrefix", () => {
       ChatType: "direct",
       SenderName: "Tyler",
       SenderId: "+15551234567",
+      SenderIsBot: true,
     } as TemplateContext);
 
     const senderInfo = parseSenderInfoPayload(text);
     expect(senderInfo["label"]).toBe("Tyler (+15551234567)");
     expect(senderInfo["id"]).toBe("+15551234567");
+    expect(senderInfo["is_bot"]).toBe(true);
   });
 
   it("includes formatted timestamp in conversation info when provided", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -648,6 +648,7 @@ export function buildInboundUserContextPrefix(
     username: normalizePromptMetadataString(ctx.SenderUsername),
     tag: normalizePromptMetadataString(ctx.SenderTag),
     e164: normalizePromptMetadataString(ctx.SenderE164),
+    is_bot: typeof ctx.SenderIsBot === "boolean" ? ctx.SenderIsBot : undefined,
   };
   if (senderInfo?.label) {
     blocks.push(formatUntrustedJsonBlock("Sender (untrusted metadata):", senderInfo));

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -251,6 +251,7 @@ export type MsgContext = {
   SenderUsername?: string;
   SenderTag?: string;
   SenderE164?: string;
+  SenderIsBot?: boolean;
   Timestamp?: number;
   LocationLat?: number;
   LocationLon?: number;

--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -50,6 +50,7 @@ describe("buildChannelInboundEventContext", () => {
         name: "User One",
         username: "userone",
         tag: "User#0001",
+        isBot: true,
         roles: ["admin"],
       },
       conversation: {
@@ -162,6 +163,7 @@ describe("buildChannelInboundEventContext", () => {
       SenderId: "u1",
       SenderUsername: "userone",
       SenderTag: "User#0001",
+      SenderIsBot: true,
       MemberRoleIds: ["admin"],
       Timestamp: 123,
       Provider: "test-provider",

--- a/src/channels/inbound-event/context.ts
+++ b/src/channels/inbound-event/context.ts
@@ -503,6 +503,7 @@ export function buildChannelInboundEventContext(
     SenderId: params.sender.id,
     SenderUsername: params.sender.username,
     SenderTag: params.sender.tag,
+    SenderIsBot: params.sender.isBot,
     MemberRoleIds: params.sender.roles,
     Timestamp: params.timestamp,
     Provider: params.provider ?? params.channel,


### PR DESCRIPTION
## What Problem This Solves

Fixes #40838. Telegram inbound messages already carry `msg.from.is_bot`, and the shared channel sender model already has `SenderFacts.isBot`, but the value was not projected into the finalized OpenClaw message context or the sender metadata shown to the agent.

## Why This Change Was Made

Telegram users need agent-visible sender bot status to distinguish human senders from bot-authored messages without relying on fragile name or username heuristics. This keeps the fix narrow by reusing the existing sender facts path instead of adding raw Telegram payloads to prompts.

## User Impact

Agents handling Telegram turns can now see `SenderIsBot` in the runtime message context, and the untrusted sender metadata block includes `is_bot` when Telegram provides that boolean. Existing sender id/name/username behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs run src/channels/inbound-event/context.test.ts src/auto-reply/reply/inbound-meta.test.ts extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts`
- `pnpm oxfmt --check src/auto-reply/templating.ts src/channels/inbound-event/context.ts extensions/telegram/src/bot-message-context.session.ts src/auto-reply/reply/inbound-meta.ts src/channels/inbound-event/context.test.ts src/auto-reply/reply/inbound-meta.test.ts extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts`
- `pnpm tsgo:extensions`
- `pnpm tsgo:core`
- `git diff --check origin/main...HEAD`