### PR TITLE
fix(trajectory): preserve token usage when truncating oversized trajectory events

### DIFF
--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -240,7 +240,10 @@ describe("Codex trajectory recorder", () => {
     });
 
     const trajectoryRecorder = expectTrajectoryRecorder(recorder);
-    trajectoryRecorder.recordEvent("context.compiled", {
+    const usage = { input: 5000, output: 200, total: 5200 };
+    trajectoryRecorder.recordEvent("model.completed", {
+      finishReason: "stop",
+      usage,
       fields: Object.fromEntries(
         Array.from({ length: 100 }, (_, index) => [`field-${index}`, "x".repeat(3_000)]),
       ),
@@ -249,8 +252,13 @@ describe("Codex trajectory recorder", () => {
 
     const parsed = JSON.parse(
       fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
-    ) as { data?: { truncated?: boolean; reason?: string } };
+    ) as { data?: { truncated?: boolean; reason?: string; usage?: { input: number; output: number; total: number } } };
     expect(parsed.data?.truncated).toBe(true);
     expect(parsed.data?.reason).toBe("trajectory-event-size-limit");
+    // usage must survive event-level truncation (#96804)
+    expect(parsed.data?.usage).toBeDefined();
+    expect(parsed.data?.usage?.input).toBe(5000);
+    expect(parsed.data?.usage?.output).toBe(200);
+    expect(parsed.data?.usage?.total).toBe(5200);
   });
 });

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -82,7 +82,30 @@ function boundedTrajectoryLine(event: Record<string, unknown>): string | undefin
   if (bytes <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
     return `${line}\n`;
   }
+  // Preserve token usage from the original data when truncating (#96804).
+  // usage is ~96 bytes but is lost when the entire data block is replaced.
+  // Preserve it so downstream accounting can still read per-turn token counts.
+  const originalData = event.data as Record<string, unknown> | undefined;
+  const preservedUsage = originalData?.usage;
+  const stubData: Record<string, unknown> = {
+    truncated: true,
+    originalBytes: bytes,
+    limitBytes: TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
+    reason: "trajectory-event-size-limit",
+  };
+  if (preservedUsage) {
+    stubData.usage = preservedUsage;
+  }
   const truncated = JSON.stringify({
+    ...event,
+    data: stubData,
+  });
+  if (Buffer.byteLength(truncated, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
+    return `${truncated}\n`;
+  }
+  // Fallback: full truncation without usage preservation if the size
+  // limit is still exceeded (extremely unlikely for a ~96-byte usage blob).
+  const fallback = JSON.stringify({
     ...event,
     data: {
       truncated: true,
@@ -91,8 +114,8 @@ function boundedTrajectoryLine(event: Record<string, unknown>): string | undefin
       reason: "trajectory-event-size-limit",
     },
   });
-  if (Buffer.byteLength(truncated, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
-    return `${truncated}\n`;
+  if (Buffer.byteLength(fallback, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
+    return `${fallback}\n`;
   }
   return undefined;
 }

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -136,6 +136,47 @@ describe("trajectory runtime", () => {
     );
   });
 
+  it("preserves usage when truncating oversized model.completed events (#96804)", () => {
+    const writes: string[] = [];
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      writer: {
+        filePath: "/tmp/session.trajectory.jsonl",
+        write: (line) => {
+          writes.push(line);
+        },
+        flush: async () => undefined,
+      },
+    });
+
+    const usage = { input: 5000, output: 200, total: 5200 };
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    runtimeRecorder.recordEvent("model.completed", {
+      finishReason: "stop",
+      usage,
+      // Fill enough fields to force event-level truncation
+      fields: Object.fromEntries(
+        Array.from({ length: 20 }, (_, index) => [`field-${index}`, "y".repeat(20 * 1024)]),
+      ),
+    });
+
+    expect(writes).toHaveLength(1);
+    const parsed = JSON.parse(writes[0]);
+    // Event-level truncation should have fired
+    expect(parsed.data.truncated).toBe(true);
+    expect(parsed.data.reason).toBe("trajectory-event-size-limit");
+    // Usage must be preserved
+    expect(parsed.data.usage).toBeDefined();
+    expect(parsed.data.usage.input).toBe(5000);
+    expect(parsed.data.usage.output).toBe(200);
+    expect(parsed.data.usage.total).toBe(5200);
+    // Truncated line must still be within the byte limit
+    expect(Buffer.byteLength(writes[0], "utf8")).toBeLessThanOrEqual(
+      TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
+    );
+  });
+
   it("rotates runtime capture at the file budget and keeps newer events", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -128,7 +128,30 @@ function truncateOversizedTrajectoryEvent(
   if (bytes <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
     return line;
   }
+  // Preserve token usage from the original data when truncating (#96804).
+  // usage is ~96 bytes but is lost when the entire data block is replaced.
+  // Preserve it so downstream accounting can still read per-turn token counts.
+  const originalData = event.data as Record<string, unknown> | undefined;
+  const preservedUsage = originalData?.usage;
+  const stubData: Record<string, unknown> = {
+    truncated: true,
+    originalBytes: bytes,
+    limitBytes: TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
+    reason: "trajectory-event-size-limit",
+  };
+  if (preservedUsage) {
+    stubData.usage = preservedUsage;
+  }
   const truncated = safeJsonStringify({
+    ...event,
+    data: stubData,
+  });
+  if (truncated && Buffer.byteLength(truncated, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
+    return truncated;
+  }
+  // Fallback: full truncation without usage preservation if the size
+  // limit is still exceeded (extremely unlikely for a 96-byte usage blob).
+  const fallback = safeJsonStringify({
     ...event,
     data: {
       truncated: true,
@@ -137,8 +160,8 @@ function truncateOversizedTrajectoryEvent(
       reason: "trajectory-event-size-limit",
     },
   });
-  if (truncated && Buffer.byteLength(truncated, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
-    return truncated;
+  if (fallback && Buffer.byteLength(fallback, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
+    return fallback;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

- **Problem**: When a `model.completed` trajectory event exceeds the 256 KB per-event size limit, both the core `truncateOversizedTrajectoryEvent` and Codex `boundedTrajectoryLine` replace the entire `data` block with a bare truncation stub — including the `usage` object (~96 bytes). This silently zeros out token/cost accounting for exactly the heaviest turns, where spend is largest.
- **Root cause**: Both event-level truncation helpers treat `data` as an indivisible blob and do not extract small structured fields.
- **Fix**: Extract `usage` from the original event data and carry it forward into the truncation stub in both `src/trajectory/runtime.ts` and `extensions/codex/src/app-server/trajectory.ts`. A fallback to the original full-truncation behavior is kept for edge cases.
- **What did NOT change**: Field-level truncation is untouched. Events that don't exceed the limit are unchanged. The truncation rationale fields are unchanged.

Closes #96804

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway (trajectory runtime — core + Codex app-server recorder)

## Real behavior proof

**Behavior addressed:** Both the core `truncateOversizedTrajectoryEvent` and Codex `boundedTrajectoryLine` now preserve `usage` from the original `data` when replacing oversized event payloads with a truncation stub.

**Environment tested:** Node 24.13.1 on Linux, `node --import tsx` calling the real production functions.

**Steps run after the patch:** 
1. Core: created a trajectory runtime recorder, recorded a `model.completed` event with `usage` plus 20 extra 20 KB fields to force event-level truncation, flushed to disk, inspected the written trajectory line.
2. Codex: created a Codex trajectory recorder via `createCodexTrajectoryRecorder`, recorded a `model.completed` event with `usage` plus 100 extra 3 KB fields, flushed to disk, inspected the written trajectory line.

**Evidence after fix:**

Core recorder (`createTrajectoryRuntimeRecorder`):
```text
line bytes: 399 (well within the 256 KB limit after truncation)
truncated: YES
usage present: true
usage: {"input":384954,"output":5624,"cacheRead":333824,"reasoningTokens":2038,"total":724402}
```

Codex recorder (`createCodexTrajectoryRecorder`):
```text
line bytes: 461 (limit: 262144)
truncated: YES
usage present: true
usage.input: 384954
usage.output: 5624
usage.cacheRead: 333824
usage.total: 724402
RESULT: PASS - usage preserved after Codex truncation
```

**Observed result after the fix:** In both the core and Codex trajectory recorders, token usage is preserved in the truncation stub when an event exceeds 256 KB. The truncated event stays within the limit (truncation stub + usage = ~400-460 bytes).

**Not tested:** Live gateway session with real model interaction producing a `model.completed` event that exceeds 256 KB. The event-level truncation path is verified via the real production functions `createTrajectoryRuntimeRecorder` / `createCodexTrajectoryRecorder` + `recordEvent` + `flush`.

## Security Impact

- New permissions? No
- Secrets handling changed? No
- New network calls? No
