### PR TITLE
fix: bump @tencent-weixin/openclaw-weixin to 2.4.6 in catalog

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -114,9 +114,9 @@
           }
         },
         "install": {
-          "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.3",
+          "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.6",
           "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-dPQbidUNWigC6V10vGW4i+GLH09x+6zUhafZRjuxkJ9GDu8o62WBsnUTojp4KqUH756hz+t2v9khiCRSi0dBDw==",
+          "expectedIntegrity": "sha512-qw9k3PLTiMWGNjjsknHgcTManH1w4j+Ji1ArWIaYLKCq3aFRsVwcqnPi127bvOoVMJGW4dbyJ8NECEMgoO+iRw==",
           "minHostVersion": ">=2026.3.22"
         }
       }


### PR DESCRIPTION
Closes #96791

## Summary
This PR updates the official-external-channel-catalog to bump @tencent-weixin/openclaw-weixin from version 2.4.3 to 2.4.6.

## Changes
- Updated `npmSpec` from `@tencent-weixin/openclaw-weixin@2.4.3` to `@tencent-weixin/openclaw-weixin@2.4.6`
- Updated `expectedIntegrity` hash to match version 2.4.6

## Impact
Users can now install and use the latest Weixin plugin version (2.4.6) without manual workarounds. The catalog reconciliation during core upgrades will no longer revert user pins to the outdated 2.4.3 version.