### PR TITLE
fix(trajectory): preserve usage in truncated events

### DIFF
--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -313,4 +313,178 @@ describe("Codex trajectory recorder", () => {
     expect(parsed.data.droppedFields).toContain("messagesSnapshot");
     expect(Buffer.byteLength(JSON.stringify(parsed), "utf8")).toBeLessThanOrEqual(256 * 1024);
   });
+
+  it("drops oversized preserved fields when needed to keep completion events bounded", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const attempt = {
+      sessionFile,
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      provider: "codex",
+      modelId: "gpt-5.4",
+      model: { api: "responses" },
+    } as never;
+    const oversizedUsage = Object.fromEntries(
+      Array.from({ length: 100 }, (_value, index) => [`field-${index}`, "x".repeat(5_000)]),
+    );
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt,
+      env: {},
+    });
+
+    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
+    recordCodexTrajectoryCompletion(trajectoryRecorder, {
+      attempt,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      timedOut: false,
+      result: {
+        aborted: false,
+        attemptUsage: oversizedUsage,
+        assistantTexts: ["x".repeat(32_000)],
+        messagesSnapshot: [{ role: "assistant", content: "x".repeat(32_000) }],
+      } as never,
+    });
+    await trajectoryRecorder.flush();
+
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
+    );
+    expect(parsed.data).toMatchObject({
+      truncated: true,
+      reason: "trajectory-event-size-limit",
+    });
+    expect(parsed.data.usage).toBeUndefined();
+    expect(parsed.data.droppedFields).toEqual(
+      expect.arrayContaining(["usage", "assistantTexts", "messagesSnapshot"]),
+    );
+    expect(Buffer.byteLength(JSON.stringify(parsed), "utf8")).toBeLessThanOrEqual(256 * 1024);
+  });
+
+  it("preserves usage on non-final oversized model completion events", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const attempt = {
+      sessionFile,
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      provider: "codex",
+      modelId: "gpt-5.4",
+      model: { api: "responses" },
+    } as never;
+    const firstUsage = {
+      input: 384_954,
+      output: 5_624,
+      cacheRead: 333_824,
+      reasoningTokens: 2_038,
+      total: 724_402,
+    };
+    const secondUsage = { input: 12, output: 3, total: 15 };
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt,
+      env: {},
+    });
+
+    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
+    recordCodexTrajectoryCompletion(trajectoryRecorder, {
+      attempt,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      timedOut: false,
+      result: {
+        aborted: false,
+        attemptUsage: firstUsage,
+        assistantTexts: ["first"],
+        messagesSnapshot: Array.from({ length: 20 }, (_value, index) => ({
+          role: index % 2 === 0 ? "user" : "assistant",
+          content: `message-${index} ${"x".repeat(32_000)}`,
+        })),
+      } as never,
+    });
+    recordCodexTrajectoryCompletion(trajectoryRecorder, {
+      attempt,
+      threadId: "thread-1",
+      turnId: "turn-2",
+      timedOut: false,
+      result: {
+        aborted: false,
+        attemptUsage: secondUsage,
+        assistantTexts: ["final answer"],
+        messagesSnapshot: [{ role: "assistant", content: "final answer" }],
+      } as never,
+    });
+    await trajectoryRecorder.flush();
+
+    const events = fs
+      .readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8")
+      .trim()
+      .split(/\r?\n/u)
+      .map((line) => JSON.parse(line));
+    expect(events).toHaveLength(2);
+    expect(events[0].data).toMatchObject({
+      truncated: true,
+      usage: firstUsage,
+    });
+    expect(events[1].data).toMatchObject({
+      turnId: "turn-2",
+      usage: secondUsage,
+      assistantTexts: ["final answer"],
+    });
+    expect(events[1].data.truncated).toBeUndefined();
+  });
+
+  it("redacts secrets before preserving usage in truncated completion events", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const attempt = {
+      sessionFile,
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      provider: "codex",
+      modelId: "gpt-5.4",
+      model: { api: "responses" },
+    } as never;
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt,
+      env: {},
+    });
+
+    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
+    recordCodexTrajectoryCompletion(trajectoryRecorder, {
+      attempt,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      timedOut: false,
+      result: {
+        aborted: false,
+        attemptUsage: {
+          total: 1,
+          apiKey: "sk-test-secret-token",
+          authorization: "Bearer sk-other-secret-token",
+        },
+        assistantTexts: ["done"],
+        messagesSnapshot: Array.from({ length: 20 }, (_value, index) => ({
+          role: index % 2 === 0 ? "user" : "assistant",
+          content: `message-${index} ${"x".repeat(32_000)}`,
+        })),
+      } as never,
+    });
+    await trajectoryRecorder.flush();
+
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
+    );
+    const preservedUsage = JSON.stringify(parsed.data.usage);
+    expect(parsed.data.truncated).toBe(true);
+    expect(preservedUsage).toContain("redacted");
+    expect(preservedUsage).not.toContain("sk-test-secret-token");
+    expect(preservedUsage).not.toContain("sk-other-secret-token");
+  });
 });

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   createCodexTrajectoryRecorder,
+  recordCodexTrajectoryCompletion,
   recordCodexTrajectoryContext,
   resolveCodexTrajectoryAppendFlags,
   resolveCodexTrajectoryPointerFlags,
@@ -80,7 +81,9 @@ describe("Codex trajectory recorder", () => {
     expect(content).not.toContain("secret");
     expect(content).not.toContain("sk-test-secret-token");
     expect(content).not.toContain("sk-other-secret-token");
-    expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+    }
     expect(fs.existsSync(path.join(tmpDir, "session.trajectory-path.json"))).toBe(true);
   });
 
@@ -252,5 +255,62 @@ describe("Codex trajectory recorder", () => {
     ) as { data?: { truncated?: boolean; reason?: string } };
     expect(parsed.data?.truncated).toBe(true);
     expect(parsed.data?.reason).toBe("trajectory-event-size-limit");
+  });
+
+  it("preserves usage when truncating oversized model completion events", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const attempt = {
+      sessionFile,
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      provider: "codex",
+      modelId: "gpt-5.4",
+      model: { api: "responses" },
+    } as never;
+    const usage = {
+      input: 384_954,
+      output: 5_624,
+      cacheRead: 333_824,
+      reasoningTokens: 2_038,
+      total: 724_402,
+    };
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt,
+      env: {},
+    });
+
+    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
+    recordCodexTrajectoryCompletion(trajectoryRecorder, {
+      attempt,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      timedOut: false,
+      result: {
+        aborted: false,
+        attemptUsage: usage,
+        assistantTexts: ["done"],
+        messagesSnapshot: Array.from({ length: 20 }, (_value, index) => ({
+          role: index % 2 === 0 ? "user" : "assistant",
+          content: `message-${index} ${"x".repeat(32_000)}`,
+        })),
+      } as never,
+    });
+    await trajectoryRecorder.flush();
+
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
+    );
+    expect(parsed.type).toBe("model.completed");
+    expect(parsed.data).toMatchObject({
+      truncated: true,
+      reason: "trajectory-event-size-limit",
+      usage,
+    });
+    expect(parsed.data.messagesSnapshot).toBeUndefined();
+    expect(parsed.data.droppedFields).toContain("messagesSnapshot");
+    expect(Buffer.byteLength(JSON.stringify(parsed), "utf8")).toBeLessThanOrEqual(256 * 1024);
   });
 });

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -40,6 +40,7 @@ const JWT_VALUE_RE = /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]
 const COOKIE_PAIR_RE = /\b([A-Za-z][A-Za-z0-9_.-]{1,64})=([A-Za-z0-9+/._~%=-]{16,})(?=;|\s|$)/gu;
 const TRAJECTORY_RUNTIME_FILE_MAX_BYTES = 50 * 1024 * 1024;
 const TRAJECTORY_RUNTIME_EVENT_MAX_BYTES = 256 * 1024;
+const TRAJECTORY_RUNTIME_OVERSIZE_PRESERVED_DATA_KEYS = ["usage", "promptCache"] as const;
 
 type CodexTrajectoryOpenFlagConstants = Pick<
   typeof nodeFs.constants,
@@ -82,19 +83,57 @@ function boundedTrajectoryLine(event: Record<string, unknown>): string | undefin
   if (bytes <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
     return `${line}\n`;
   }
-  const truncated = JSON.stringify({
-    ...event,
-    data: {
-      truncated: true,
-      originalBytes: bytes,
-      limitBytes: TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
-      reason: "trajectory-event-size-limit",
-    },
-  });
-  if (Buffer.byteLength(truncated, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
-    return `${truncated}\n`;
+
+  const originalData =
+    event.data && typeof event.data === "object" && !Array.isArray(event.data)
+      ? (event.data as Record<string, unknown>)
+      : {};
+  const originalDataKeys = Object.keys(originalData);
+  const preservedDataKeys = new Set<string>();
+  const baseData = {
+    truncated: true,
+    originalBytes: bytes,
+    limitBytes: TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
+    reason: "trajectory-event-size-limit",
+  };
+  const buildTruncatedLine = (includeDroppedFields: boolean): string | undefined => {
+    const data: Record<string, unknown> = { ...baseData };
+    for (const key of TRAJECTORY_RUNTIME_OVERSIZE_PRESERVED_DATA_KEYS) {
+      if (preservedDataKeys.has(key)) {
+        data[key] = originalData[key];
+      }
+    }
+    if (includeDroppedFields) {
+      const droppedFields = originalDataKeys.filter((key) => !preservedDataKeys.has(key));
+      if (droppedFields.length > 0) {
+        data.droppedFields = droppedFields;
+      }
+    }
+    const truncated = JSON.stringify({ ...event, data });
+    if (Buffer.byteLength(truncated, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
+      return `${truncated}\n`;
+    }
+    return undefined;
+  };
+
+  let best = buildTruncatedLine(true) ?? buildTruncatedLine(false);
+  if (!best) {
+    return undefined;
   }
-  return undefined;
+
+  for (const key of TRAJECTORY_RUNTIME_OVERSIZE_PRESERVED_DATA_KEYS) {
+    if (!Object.hasOwn(originalData, key)) {
+      continue;
+    }
+    preservedDataKeys.add(key);
+    const next = buildTruncatedLine(true) ?? buildTruncatedLine(false);
+    if (next) {
+      best = next;
+      continue;
+    }
+    preservedDataKeys.delete(key);
+  }
+  return best;
 }
 
 function resolveTrajectoryPointerFilePath(sessionFile: string): string {

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -248,6 +248,57 @@ describe("exportTrajectoryBundle", () => {
     expect(fs.existsSync(path.join(outputDir, "tools.json"))).toBe(false);
   });
 
+  it("exports usage from truncated model completion runtime events", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const runtimeFile = path.join(tmpDir, "session.trajectory.jsonl");
+    const outputDir = path.join(tmpDir, "bundle");
+    const usage = {
+      input: 384_954,
+      output: 5_624,
+      cacheRead: 333_824,
+      reasoningTokens: 2_038,
+      total: 724_402,
+    };
+    const promptCache = { readTokens: 333_824, writeTokens: 51_130 };
+    writeSimpleSessionFile(sessionFile);
+    const runtimeEvent: TrajectoryEvent = {
+      traceSchema: "openclaw-trajectory",
+      schemaVersion: 1,
+      traceId: "session-1",
+      source: "runtime",
+      type: "model.completed",
+      ts: "2026-04-22T08:00:02.000Z",
+      seq: 1,
+      sourceSeq: 1,
+      sessionId: "session-1",
+      data: {
+        truncated: true,
+        originalBytes: 300_000,
+        limitBytes: 256 * 1024,
+        reason: "trajectory-event-size-limit",
+        usage,
+        promptCache,
+        droppedFields: ["messagesSnapshot"],
+      },
+    };
+    fs.writeFileSync(runtimeFile, `${JSON.stringify(runtimeEvent)}\n`, "utf8");
+
+    await exportTrajectoryBundle({
+      outputDir,
+      sessionFile,
+      sessionId: "session-1",
+      workspaceDir: tmpDir,
+      runtimeFile,
+    });
+
+    const artifacts = JSON.parse(
+      fs.readFileSync(path.join(outputDir, "artifacts.json"), "utf8"),
+    ) as { usage?: unknown; promptCache?: unknown };
+    expect(artifacts.usage).toEqual(usage);
+    expect(artifacts.promptCache).toEqual(promptCache);
+  });
+
   it("preserves numeric transcript timestamps", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -181,6 +181,136 @@ describe("trajectory runtime", () => {
     );
   });
 
+  it("drops oversized preserved fields when needed to keep runtime events bounded", () => {
+    const writes: string[] = [];
+    const oversizedUsage = Object.fromEntries(
+      Array.from({ length: 64 }, (_value, index) => [`field-${index}`, "x".repeat(5_000)]),
+    );
+    const promptCache = { readTokens: 333_824, writeTokens: 51_130 };
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      writer: {
+        filePath: "/tmp/session.trajectory.jsonl",
+        write: (line) => {
+          writes.push(line);
+        },
+        flush: async () => undefined,
+      },
+    });
+
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    runtimeRecorder.recordEvent("model.completed", {
+      usage: oversizedUsage,
+      promptCache,
+      messagesSnapshot: [{ role: "user", content: "x".repeat(32_000) }],
+    });
+
+    expect(writes).toHaveLength(1);
+    const parsed = JSON.parse(writes[0]);
+    expect(parsed.data).toMatchObject({
+      truncated: true,
+      reason: "trajectory-event-size-limit",
+      promptCache,
+    });
+    expect(parsed.data.usage).toBeUndefined();
+    expect(parsed.data.droppedFields).toEqual(
+      expect.arrayContaining(["usage", "messagesSnapshot"]),
+    );
+    expect(Buffer.byteLength(writes[0], "utf8")).toBeLessThanOrEqual(
+      TRAJECTORY_RUNTIME_EVENT_MAX_BYTES + 1,
+    );
+  });
+
+  it("preserves usage on non-final oversized runtime completions", () => {
+    const writes: string[] = [];
+    const firstUsage = {
+      input: 384_954,
+      output: 5_624,
+      cacheRead: 333_824,
+      reasoningTokens: 2_038,
+      total: 724_402,
+    };
+    const secondUsage = { input: 12, output: 3, total: 15 };
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      writer: {
+        filePath: "/tmp/session.trajectory.jsonl",
+        write: (line) => {
+          writes.push(line);
+        },
+        flush: async () => undefined,
+      },
+    });
+
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    runtimeRecorder.recordEvent("model.completed", {
+      usage: firstUsage,
+      promptCache: { readTokens: 333_824 },
+      messagesSnapshot: Array.from({ length: 12 }, (_value, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `message-${index} ${"x".repeat(32_000)}`,
+      })),
+    });
+    runtimeRecorder.recordEvent("model.completed", {
+      usage: secondUsage,
+      assistantTexts: ["final answer"],
+    });
+
+    expect(writes).toHaveLength(2);
+    const first = JSON.parse(writes[0]);
+    const second = JSON.parse(writes[1]);
+    expect(first.data).toMatchObject({
+      truncated: true,
+      usage: firstUsage,
+      promptCache: { readTokens: 333_824 },
+    });
+    expect(second.data).toMatchObject({
+      usage: secondUsage,
+      assistantTexts: ["final answer"],
+    });
+    expect(second.data.truncated).toBeUndefined();
+  });
+
+  it("redacts secrets before preserving usage in truncated runtime events", () => {
+    const writes: string[] = [];
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      writer: {
+        filePath: "/tmp/session.trajectory.jsonl",
+        write: (line) => {
+          writes.push(line);
+        },
+        flush: async () => undefined,
+      },
+    });
+
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    runtimeRecorder.recordEvent("model.completed", {
+      usage: {
+        total: 1,
+        note: "Authorization: Bearer sk-inline-secret-token",
+        apiKey: "sk-test-secret-token",
+        authorization: "Bearer sk-other-secret-token",
+      },
+      messagesSnapshot: Array.from({ length: 12 }, (_value, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `message-${index} ${"x".repeat(32_000)}`,
+      })),
+    });
+
+    expect(writes).toHaveLength(1);
+    const parsed = JSON.parse(writes[0]);
+    const preservedUsage = JSON.stringify(parsed.data.usage);
+    expect(parsed.data.truncated).toBe(true);
+    expect(preservedUsage).toContain("redacted");
+    expect(preservedUsage).not.toContain("sk-inline-secret-token");
+    expect(preservedUsage).not.toContain("sk-test-secret-token");
+    expect(preservedUsage).not.toContain("sk-other-secret-token");
+  });
+
   it("rotates runtime capture at the file budget and keeps newer events", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -9,10 +9,7 @@ import {
   resolveTrajectoryPointerFilePath,
   resolveTrajectoryPointerOpenFlags,
 } from "./paths.js";
-import {
-  createTrajectoryRuntimeRecorder,
-  toTrajectoryToolDefinitions,
-} from "./runtime.js";
+import { createTrajectoryRuntimeRecorder, toTrajectoryToolDefinitions } from "./runtime.js";
 
 type TrajectoryRuntimeRecorder = NonNullable<ReturnType<typeof createTrajectoryRuntimeRecorder>>;
 
@@ -57,7 +54,7 @@ describe("trajectory runtime", () => {
         env: { OPENCLAW_TRAJECTORY_DIR: "/tmp/traces" },
         sessionId: "../evil/session",
       }),
-    ).toBe("/tmp/traces/___evil_session.jsonl");
+    ).toBe(path.join(path.resolve("/tmp/traces"), "___evil_session.jsonl"));
   });
 
   it("records sanitized runtime events by default", () => {
@@ -131,6 +128,54 @@ describe("trajectory runtime", () => {
     const parsed = JSON.parse(writes[0]);
     expect(parsed.data.prompt.truncated).toBe(true);
     expect(parsed.data.prompt.reason).toBe("trajectory-field-size-limit");
+    expect(Buffer.byteLength(writes[0], "utf8")).toBeLessThanOrEqual(
+      TRAJECTORY_RUNTIME_EVENT_MAX_BYTES + 1,
+    );
+  });
+
+  it("preserves usage when truncating oversized runtime events", () => {
+    const writes: string[] = [];
+    const usage = {
+      input: 384_954,
+      output: 5_624,
+      cacheRead: 333_824,
+      reasoningTokens: 2_038,
+      total: 724_402,
+    };
+    const promptCache = { readTokens: 333_824, writeTokens: 51_130 };
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      writer: {
+        filePath: "/tmp/session.trajectory.jsonl",
+        write: (line) => {
+          writes.push(line);
+        },
+        flush: async () => undefined,
+      },
+    });
+
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    runtimeRecorder.recordEvent("model.completed", {
+      usage,
+      promptCache,
+      messagesSnapshot: Array.from({ length: 12 }, (_value, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `message-${index} ${"x".repeat(32_000)}`,
+      })),
+    });
+
+    expect(writes).toHaveLength(1);
+    const parsed = JSON.parse(writes[0]);
+    expect(parsed.type).toBe("model.completed");
+    expect(parsed.data).toMatchObject({
+      truncated: true,
+      reason: "trajectory-event-size-limit",
+      usage,
+      promptCache,
+    });
+    expect(parsed.data.messagesSnapshot).toBeUndefined();
+    expect(parsed.data.droppedFields).toContain("messagesSnapshot");
     expect(Buffer.byteLength(writes[0], "utf8")).toBeLessThanOrEqual(
       TRAJECTORY_RUNTIME_EVENT_MAX_BYTES + 1,
     );

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -52,6 +52,7 @@ const TRAJECTORY_RUNTIME_DATA_STRING_MAX_CHARS = 32_768;
 const TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS = 64;
 const TRAJECTORY_RUNTIME_DATA_OBJECT_MAX_KEYS = 64;
 const TRAJECTORY_RUNTIME_DATA_MAX_DEPTH = 6;
+const TRAJECTORY_RUNTIME_OVERSIZE_PRESERVED_DATA_KEYS = ["usage", "promptCache"] as const;
 
 type TrajectoryRuntimeWriterDiagnostics = Omit<QueuedFileWriterDiagnostics, "activeOperation"> & {
   activeOperation: QueuedFileWriterDiagnostics["activeOperation"] | "file-replace";
@@ -128,19 +129,54 @@ function truncateOversizedTrajectoryEvent(
   if (bytes <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
     return line;
   }
-  const truncated = safeJsonStringify({
-    ...event,
-    data: {
-      truncated: true,
-      originalBytes: bytes,
-      limitBytes: TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
-      reason: "trajectory-event-size-limit",
-    },
-  });
-  if (truncated && Buffer.byteLength(truncated, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
-    return truncated;
+
+  const originalData = event.data ?? {};
+  const originalDataKeys = Object.keys(originalData);
+  const preservedDataKeys = new Set<string>();
+  const baseData = {
+    truncated: true,
+    originalBytes: bytes,
+    limitBytes: TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
+    reason: "trajectory-event-size-limit",
+  };
+  const buildTruncatedEventLine = (includeDroppedFields: boolean): string | undefined => {
+    const data: Record<string, unknown> = { ...baseData };
+    for (const key of TRAJECTORY_RUNTIME_OVERSIZE_PRESERVED_DATA_KEYS) {
+      if (preservedDataKeys.has(key)) {
+        data[key] = originalData[key];
+      }
+    }
+    if (includeDroppedFields) {
+      const droppedFields = originalDataKeys.filter((key) => !preservedDataKeys.has(key));
+      if (droppedFields.length > 0) {
+        data.droppedFields = droppedFields;
+      }
+    }
+    const truncated = safeJsonStringify({ ...event, data });
+    if (truncated && Buffer.byteLength(truncated, "utf8") <= TRAJECTORY_RUNTIME_EVENT_MAX_BYTES) {
+      return truncated;
+    }
+    return undefined;
+  };
+
+  let best = buildTruncatedEventLine(true) ?? buildTruncatedEventLine(false);
+  if (!best) {
+    return undefined;
   }
-  return undefined;
+
+  for (const key of TRAJECTORY_RUNTIME_OVERSIZE_PRESERVED_DATA_KEYS) {
+    if (!Object.hasOwn(originalData, key)) {
+      continue;
+    }
+    preservedDataKeys.add(key);
+    const next = buildTruncatedEventLine(true) ?? buildTruncatedEventLine(false);
+    if (next) {
+      best = next;
+      continue;
+    }
+    preservedDataKeys.delete(key);
+  }
+  return best;
 }
 
 function truncatedTrajectoryValue(reason: string, details: Record<string, unknown> = {}): unknown {


### PR DESCRIPTION
Fixes #96804.

## What Problem This Solves
Oversized `model.completed` trajectory rows currently replace the entire `data` block with a truncation stub. When the size pressure comes from `messagesSnapshot`, that also discards small accounting fields such as `data.usage`, so heavy turns can appear to have zero token usage downstream.

## Why This Change Was Made
The event limit should still protect trajectory files from very large payloads, but truncation should not throw away tiny structured fields that are important for accounting. This change keeps the existing per-event byte cap, emits `droppedFields` for omitted data, and opportunistically preserves `usage` and `promptCache` when they fit inside the bounded row.

ClawSweeper pointed out the Codex app-server recorder has the same event-level truncation shape. This update applies the same bounded preserved-field behavior there and adds a regression test through `recordCodexTrajectoryCompletion`, so both trajectory recorders preserve accounting-critical usage fields.

## User Impact
Usage and cost consumers can continue reading `model.completed.data.usage` for heavy turns even when the runtime has to omit large snapshot payloads. Large fields such as `messagesSnapshot` remain dropped, so the trajectory size budget is still enforced.

## Real Behavior Proof
I ran a real recorder proof against the patched code using both runtime recorder paths. The script created temporary trajectory JSONL files through `createTrajectoryRuntimeRecorder` and `createCodexTrajectoryRecorder`, recorded oversized `model.completed` events with large `messagesSnapshot` arrays, flushed them to disk, then parsed the persisted events.

```json
{
  "proof": "trajectory oversized model.completed preserves usage",
  "core": {
    "type": "model.completed",
    "truncated": true,
    "reason": "trajectory-event-size-limit",
    "hasUsage": true,
    "usageTotal": 724402,
    "hasPromptCache": true,
    "hasMessagesSnapshot": false,
    "droppedFields": ["messagesSnapshot"],
    "bytes": 667
  },
  "codex": {
    "type": "model.completed",
    "truncated": true,
    "reason": "trajectory-event-size-limit",
    "hasUsage": true,
    "usageTotal": 724402,
    "hasPromptCache": false,
    "hasMessagesSnapshot": false,
    "droppedFields": [
      "threadId",
      "turnId",
      "timedOut",
      "yieldDetected",
      "aborted",
      "promptError",
      "assistantTexts",
      "messagesSnapshot"
    ],
    "bytes": 753
  }
}
```

## Evidence
- `node scripts/run-vitest.mjs run src/trajectory/runtime.test.ts extensions/codex/src/app-server/trajectory.test.ts`
- `pnpm oxfmt --check src/trajectory/runtime.ts src/trajectory/runtime.test.ts extensions/codex/src/app-server/trajectory.ts extensions/codex/src/app-server/trajectory.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:extensions`
- `git diff --check origin/main...HEAD`