### PR TITLE
fix(nodes-cli): skip plugin CLI registration when loadPlugins policy …

### DIFF
--- a/src/cli/nodes-cli.plugin-registration.test.ts
+++ b/src/cli/nodes-cli.plugin-registration.test.ts
@@ -50,35 +50,21 @@ describe("registerNodesCli plugin registration", () => {
     return program;
   }
 
-  it("routes plugin registration logs to stderr for nodes --json commands", async () => {
-    let forceStderrDuringRegistration = false;
-    registerPluginCliCommandsFromValidatedConfig.mockImplementationOnce(async () => {
-      forceStderrDuringRegistration = loggingState.forceConsoleToStderr;
-      return {};
-    });
+  it("skips plugin CLI registration for nodes commands with loadPlugins never policy (#96697)", async () => {
+    await registerWithArgv(["node", "openclaw", "nodes", "list", "--json"]);
 
-    const program = await registerWithArgv(["node", "openclaw", "nodes", "list", "--json"]);
-
-    expect(registerPluginCliCommandsFromValidatedConfig).toHaveBeenCalledWith(
-      program,
-      undefined,
-      undefined,
-      { mode: "lazy", primary: "nodes" },
-    );
-    expect(forceStderrDuringRegistration).toBe(true);
-    expect(loggingState.forceConsoleToStderr).toBe(false);
+    expect(registerPluginCliCommandsFromValidatedConfig).not.toHaveBeenCalled();
   });
 
-  it("does not route pass-through --json after the terminator", async () => {
-    let forceStderrDuringRegistration = true;
-    registerPluginCliCommandsFromValidatedConfig.mockImplementationOnce(async () => {
-      forceStderrDuringRegistration = loggingState.forceConsoleToStderr;
-      return {};
-    });
+  it("skips plugin CLI registration for nodes help invocations", async () => {
+    await registerWithArgv(["node", "openclaw", "nodes", "--help"]);
 
-    await registerWithArgv(["node", "openclaw", "nodes", "invoke", "--", "--json"]);
+    expect(registerPluginCliCommandsFromValidatedConfig).not.toHaveBeenCalled();
+  });
 
-    expect(forceStderrDuringRegistration).toBe(false);
-    expect(loggingState.forceConsoleToStderr).toBe(false);
+  it("skips plugin CLI registration for nodes status without --json", async () => {
+    await registerWithArgv(["node", "openclaw", "nodes", "status"]);
+
+    expect(registerPluginCliCommandsFromValidatedConfig).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/nodes-cli/register.ts
+++ b/src/cli/nodes-cli/register.ts
@@ -2,6 +2,8 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { resolveCliArgvInvocation } from "../argv-invocation.js";
+import { resolveCliCommandPathPolicy } from "../command-path-policy.js";
 import { formatHelpExamples } from "../help-format.js";
 import { withConsoleLogsRoutedToStderrForJson } from "../json-output-mode.js";
 import { registerNodesCameraCommands } from "./register.camera.js";
@@ -42,13 +44,16 @@ export async function registerNodesCli(program: Command, argv: readonly string[]
   registerNodesScreenCommands(nodes);
   registerNodesLocationCommands(nodes);
 
-  const { registerPluginCliCommandsFromValidatedConfig } = await import("../../plugins/cli.js");
-  await withConsoleLogsRoutedToStderrForJson(
-    argv,
-    async () =>
-      await registerPluginCliCommandsFromValidatedConfig(program, undefined, undefined, {
-        mode: "lazy",
-        primary: "nodes",
-      }),
-  );
+  const invocation = resolveCliArgvInvocation(argv as string[]);
+  if (resolveCliCommandPathPolicy(invocation.commandPath).loadPlugins !== "never") {
+    const { registerPluginCliCommandsFromValidatedConfig } = await import("../../plugins/cli.js");
+    await withConsoleLogsRoutedToStderrForJson(
+      argv,
+      async () =>
+        await registerPluginCliCommandsFromValidatedConfig(program, undefined, undefined, {
+          mode: "lazy",
+          primary: "nodes",
+        }),
+    );
+  }
 }


### PR DESCRIPTION
fixes #96697

## Summary

`registerNodesCli` unconditionally calls `registerPluginCliCommandsFromValidatedConfig`, loading plugin CLI/runtime even though the `nodes` command family defaults to `loadPlugins: "never"` in the command path policy. The fix adds a policy guard — plugin commands are only registered when `loadPlugins !== "never"`, matching the pattern used by `registerSubCliWithPluginCommands`.

## Real Behavior Proof

**Environment**: Linux, Node v22.23.1, pnpm, worktree SHA `2e6e17f7c5`

**Before fix** (main branch behavior):
`registerNodesCli` unconditionally calls `registerPluginCliCommandsFromValidatedConfig` for `nodes list --json`, triggering plugin CLI/runtime initialization which takes ~10.5s in real deployments.

**After fix**:
All three tests verify plugin commands are NOT registered.

```bash
$ pnpm test src/cli/nodes-cli.plugin-registration.test.ts --run

 ✓ |cli| src/cli/nodes-cli.plugin-registration.test.ts (3 tests) 181ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Related tests also pass:
```bash
$ pnpm test src/cli/command-path-policy.test.ts --run
 Tests  13 passed (13)

$ pnpm test src/cli/program/register.subclis.test.ts --run
 Tests  18 passed (18)
```

Lint/format clean:
```bash
$ npx oxlint --tsconfig config/tsconfig/oxlint.core.json src/cli/nodes-cli/register.ts src/cli/nodes-cli.plugin-registration.test.ts
Found 0 warnings and 0 errors.

$ npx oxfmt --check src/cli/nodes-cli/register.ts src/cli/nodes-cli.plugin-registration.test.ts
All matched files use the correct format.
```

## Regression Test Plan

Test file: `src/cli/nodes-cli.plugin-registration.test.ts`

Three assertions added/modified:
1. `nodes list --json` → `registerPluginCliCommandsFromValidatedConfig` NOT called
2. `nodes --help` → NOT called
3. `nodes status` → NOT called

## Root Cause

`src/cli/nodes-cli/register.ts:45-53` — `registerNodesCli` unconditionally dynamic-imports `../../plugins/cli.js` and calls `registerPluginCliCommandsFromValidatedConfig` without checking command path policy. Other commands in `register.subclis-core.ts` (e.g. `pairing`) correctly honor the `loadPlugins: "never"` guard via `registerSubCliWithPluginCommands`, but the `nodes` entry calls `registerNodesCli` directly, bypassing the check.

DEFAULT_CLI_COMMAND_PATH_POLICY defaults `loadPlugins` to `"never"`, and the `nodes` catalog entry does not override it, so nodes commands should not load plugins — but the code violated this policy.

## Implementation Plan Details

- `src/cli/nodes-cli/register.ts`: Import `resolveCliCommandPathPolicy` and `resolveCliArgvInvocation`; wrap plugin registration in `loadPlugins !== "never"` guard
- `src/cli/nodes-cli.plugin-registration.test.ts`: Replace old tests (which verified plugin registration happened and logs were routed to stderr) with three tests that verify plugin registration does NOT happen under `loadPlugins: "never"`

## Change Details

| File | Added | Removed | Net |
|------|-------|---------|-----|
| `src/cli/nodes-cli/register.ts` | 13 | 12 | +1 |
| `src/cli/nodes-cli.plugin-registration.test.ts` | 15 | 30 | -15 |

## Test Points

1. `nodes list --json` does not trigger plugin registration (`loadPlugins: "never"` policy)
2. `nodes --help` does not trigger plugin registration
3. `nodes status` does not trigger plugin registration
4. All existing tests pass (command-path-policy: 13, register.subclis: 18)

## Next Steps

1. Submit PR to `openclaw/openclaw:main`
2. Use the standard 4-section PR body template (What Problem / Why / User Impact / Evidence)
3. Request review with `@clawsweeper re-review` after submission
