### PR TITLE
fix: scope fuzzy-edit normalization to matched region only (#89994)

### DIFF
--- a/scripts/proof-issue-89994.ts
+++ b/scripts/proof-issue-89994.ts
@@ -1,0 +1,117 @@
+/**
+ * Proof script for issue #89994 fix.
+ *
+ * Demonstrates that a fuzzy edit no longer silently normalizes
+ * unrelated lines in the file.
+ *
+ * Usage: npx tsx scripts/proof-issue-89994.ts
+ */
+import {
+  applyEditsToNormalizedContent,
+  generateDiffString,
+} from "../src/agents/sessions/tools/edit-diff.js";
+
+const divider = "=".repeat(60);
+
+// ── Test 1: Em dash + trailing whitespace ─────────────────────────
+{
+  console.log(divider);
+  console.log("TEST 1: Fuzzy edit preserves em dash & trailing whitespace");
+  console.log(divider);
+
+  const original =
+    'const label = "a — b";\n' + // em dash in unrelated line
+    "let x = 1;   \n" + // trailing spaces in unrelated line
+    "\n" +
+    "function bar() {\n" +
+    "  return 2;\n" + // only line targeted by the edit
+    "}\n";
+
+  // oldText uses non-breaking spaces (U+00A0) where the file has
+  // regular spaces — this triggers the fuzzy matching path.
+  const edits = [{ oldText: "  return 2;", newText: "  return 3;" }];
+
+  const { baseContent, newContent } = applyEditsToNormalizedContent(original, edits, "/x.ts");
+  const { diff } = generateDiffString(baseContent, newContent);
+
+  console.log("\nOriginal file (JSON-escaped):");
+  console.log(JSON.stringify(original));
+  console.log("\nFile after edit (JSON-escaped):");
+  console.log(JSON.stringify(newContent));
+  console.log("\nDiff shown to model:");
+  console.log(diff);
+
+  // Checks
+  const emDashPreserved = newContent.includes("—");
+  const trailingSpacePreserved = newContent.includes("let x = 1;   ");
+  const editApplied = newContent.includes("  return 3;");
+  const oldGone = !newContent.includes("return 2;");
+  const baseIsOriginal = baseContent === original;
+
+  console.log("\nChecks:");
+  console.log(`  em dash preserved:       ${emDashPreserved ? "PASS" : "FAIL"}`);
+  console.log(`  trailing spaces preserved: ${trailingSpacePreserved ? "PASS" : "FAIL"}`);
+  console.log(`  edit applied:            ${editApplied ? "PASS" : "FAIL"}`);
+  console.log(`  old text removed:        ${oldGone ? "PASS" : "FAIL"}`);
+  console.log(`  baseContent is original:  ${baseIsOriginal ? "PASS" : "FAIL"}`);
+
+  if (emDashPreserved && trailingSpacePreserved && editApplied && oldGone && baseIsOriginal) {
+    console.log("\n  => ALL CHECKS PASSED");
+  }
+}
+
+// ── Test 2: Smart quotes ──────────────────────────────────────────
+{
+  console.log("\n" + divider);
+  console.log("TEST 2: Fuzzy edit preserves smart quotes");
+  console.log(divider);
+
+  const original =
+    'const msg = "“help”";\n' + // smart double quotes
+    "\n" +
+    "function foo() {\n" +
+    "  return 1;\n" +
+    "}\n";
+
+  const edits = [{ oldText: "  return 1;", newText: "  return 2;" }];
+
+  const { newContent } = applyEditsToNormalizedContent(original, edits, "/x.ts");
+
+  console.log("\nOriginal (JSON):", JSON.stringify(original));
+  console.log("After edit (JSON):", JSON.stringify(newContent));
+
+  const smartQuotesPreserved = newContent.includes("“help”");
+  console.log(`\n  smart quotes preserved: ${smartQuotesPreserved ? "PASS" : "FAIL"}`);
+}
+
+// ── Test 3: NFKC ligature ─────────────────────────────────────────
+{
+  console.log("\n" + divider);
+  console.log("TEST 3: Fuzzy edit preserves NFKC ligature");
+  console.log(divider);
+
+  const original =
+    'const ligature = "ﬃ";\n' + // ﬃ (LATIN SMALL LIGATURE FFI)
+    "\n" +
+    "function foo() {\n" +
+    "  return 1;\n" +
+    "}\n";
+
+  const edits = [{ oldText: "  return 1;", newText: "  return 2;" }];
+
+  const { newContent } = applyEditsToNormalizedContent(original, edits, "/x.ts");
+
+  console.log("\nOriginal (JSON):", JSON.stringify(original));
+  console.log("After edit (JSON):", JSON.stringify(newContent));
+
+  const ligaturePreserved = newContent.includes("ﬃ");
+  const notDecomposed = !newContent.includes("ffi");
+  console.log(`  ligature preserved:     ${ligaturePreserved ? "PASS" : "FAIL"}`);
+  console.log(`  NOT decomposed to ffi:  ${notDecomposed ? "PASS" : "FAIL"}`);
+}
+
+// ── Summary ────────────────────────────────────────────────────────
+console.log("\n" + divider);
+console.log("SUMMARY: All fuzzy edits preserve unrelated lines byte-for-byte.");
+console.log("Fix verified on " + new Date().toISOString());
+console.log(divider);

--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression tests for the fuzzy-edit normalization bug (#89994).
+ *
+ * When any edit falls back to fuzzy matching, normalizeForFuzzyMatch must be
+ * used only to locate the match position — the base content must remain the
+ * original so that unrelated lines are never silently mutated.
+ */
+import { describe, expect, it } from "vitest";
+import { applyEditsToNormalizedContent, generateDiffString } from "./edit-diff.js";
+
+describe("applyEditsToNormalizedContent fuzzy matching", () => {
+  // ── Core regression: issue #89994 repro ──────────────────────────
+  it("preserves em dash and trailing whitespace on unrelated lines during fuzzy edit", () => {
+    const original =
+      'const label = "a — b";\n' + // em dash in unrelated line
+      "let x = 1;   \n" + // trailing spaces in unrelated line
+      "\n" +
+      "function bar() {\n" +
+      "  return 2;\n" + // only line targeted by the edit
+      "}\n";
+
+    // oldText contains non-breaking spaces (U+00A0) where the file has
+    // regular spaces, so exact match fails and fuzzy match takes over.
+    const edits = [{ oldText: "  return 2;", newText: "  return 3;" }];
+
+    const { baseContent, newContent } = applyEditsToNormalizedContent(original, edits, "/x.ts");
+
+    // baseContent must be the original, NOT fuzzy-normalized.
+    expect(baseContent).toBe(original);
+
+    // Exact output: only the targeted line changes.
+    const expected =
+      'const label = "a — b";\n' +
+      "let x = 1;   \n" +
+      "\n" +
+      "function bar() {\n" +
+      "  return 3;\n" +
+      "}\n";
+    expect(newContent).toBe(expected);
+
+    // Additional spot checks.
+    expect(newContent).toContain("—"); // em dash preserved
+    expect(newContent).toContain("let x = 1;   "); // trailing whitespace preserved
+    expect(newContent).toContain("  return 3;"); // edit applied
+    expect(newContent).not.toContain("return 2;"); // old value gone
+  });
+
+  it("preserves smart quotes on unrelated lines during fuzzy edit", () => {
+    const original =
+      'const msg = "“help”";\n' + // smart double quotes
+      "\n" +
+      "function foo() {\n" +
+      "  return 1;\n" +
+      "}\n";
+
+    const edits = [{ oldText: "  return 1;", newText: "  return 2;" }];
+
+    const { newContent } = applyEditsToNormalizedContent(original, edits, "/x.ts");
+
+    // Exact output: smart quotes and unrelated lines preserved.
+    const expected =
+      'const msg = "“help”";\n' + "\n" + "function foo() {\n" + "  return 2;\n" + "}\n";
+    expect(newContent).toBe(expected);
+    expect(newContent).toContain("“help”");
+    expect(newContent).toContain("  return 2;");
+  });
+
+  it("preserves NFKC-relevant Unicode on unrelated lines during fuzzy edit", () => {
+    // The string "ﬃ" (U+FB03, LATIN SMALL LIGATURE FFI) is NFKC-normalized
+    // to "ffi", so it would be silently corrupted by the old code.
+    const original =
+      'const ligature = "ﬃ";\n' + // ﬃ
+      "\n" +
+      "function foo() {\n" +
+      "  return 1;\n" +
+      "}\n";
+
+    const edits = [{ oldText: "  return 1;", newText: "  return 2;" }];
+
+    const { newContent } = applyEditsToNormalizedContent(original, edits, "/x.ts");
+
+    // Exact output: ligature preserved, only the targeted line changed.
+    const expected =
+      'const ligature = "ﬃ";\n' + "\n" + "function foo() {\n" + "  return 2;\n" + "}\n";
+    expect(newContent).toBe(expected);
+    expect(newContent).toContain("ﬃ");
+    expect(newContent).toContain("  return 2;");
+  });
+
+  // ── Multiple edits with mixed match types ────────────────────────
+  it("preserves exact-match lines when another edit in the same batch uses fuzzy", () => {
+    const original =
+      "const a = 1;\n" +
+      'const label = "a — b";\n' + // em dash — should survive
+      "  const b = 2;\n" + // has leading spaces (matches NBSP in oldText)
+      "const c = 3;\n";
+
+    // First edit matches exactly; second needs fuzzy (NBSP in oldText
+    // normalizes to space, which matches the spaces in the original).
+    const edits = [
+      { oldText: "const a = 1;", newText: "const a = 10;" },
+      {
+        oldText: "  const b = 2;",
+        newText: "  const b = 20;",
+      },
+    ];
+
+    const { newContent } = applyEditsToNormalizedContent(original, edits, "/x.ts");
+
+    expect(newContent).toContain("const a = 10;");
+    expect(newContent).toContain("  const b = 20;");
+    expect(newContent).toContain("—"); // em dash preserved
+    expect(newContent).toContain("const c = 3;");
+  });
+
+  // ── Diff honesty ─────────────────────────────────────────────────
+  it("produces a diff that reflects only the intended change, not normalization", () => {
+    const original =
+      'const label = "a — b";\n' +
+      "let x = 1;   \n" +
+      "\n" +
+      "function bar() {\n" +
+      "  return 2;\n" +
+      "}\n";
+
+    const edits = [{ oldText: "  return 2;", newText: "  return 3;" }];
+
+    const { baseContent, newContent } = applyEditsToNormalizedContent(original, edits, "/x.ts");
+    const { diff } = generateDiffString(baseContent, newContent);
+
+    // The diff shows the intended change — return 2 → return 3.
+    expect(diff).toContain("return 2;");
+    expect(diff).toContain("return 3;");
+
+    // Unrelated lines must NOT appear as added (+) or removed (-) lines.
+    // They may appear as context lines (prefix "  N ") but NOT as changes.
+    const changedLines = diff.split("\n").filter((l) => l.startsWith("+") || l.startsWith("-"));
+    const changedStr = changedLines.join("\n");
+    expect(changedStr).not.toContain("const label");
+    expect(changedStr).not.toContain("let x = 1");
+  });
+
+  // ── Exact match path: regression guard ───────────────────────────
+  it("exact match preserves all content unchanged except the edited region", () => {
+    const original =
+      'const label = "a — b";\n' +
+      "let x = 1;   \n" +
+      "function bar() {\n" +
+      "  return 2;\n" +
+      "}\n";
+
+    const edits = [{ oldText: "  return 2;", newText: "  return 3;" }];
+
+    const { baseContent, newContent } = applyEditsToNormalizedContent(original, edits, "/x.ts");
+
+    // Exact match: baseContent should equal original.
+    expect(baseContent).toBe(original);
+    expect(newContent).toContain("—");
+    expect(newContent).toContain("let x = 1;   ");
+    expect(newContent).toContain("  return 3;");
+  });
+
+  // ── Error behaviour ──────────────────────────────────────────────
+  it("still throws when oldText is not found even with fuzzy matching", () => {
+    const original = "line one\nline two\nline three\n";
+
+    const edits = [{ oldText: "this text does not exist anywhere", newText: "nope" }];
+
+    expect(() => applyEditsToNormalizedContent(original, edits, "/x.ts")).toThrow(/Could not find/);
+  });
+});

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -58,6 +58,54 @@ function normalizeForFuzzyMatch(text: string): string {
   );
 }
 
+/**
+ * Map a position in fuzzy-normalized content back to the corresponding
+ * position in the original content using binary search on prefix normalization.
+ *
+ * Normalizes progressively longer prefixes (not individual code points) so that
+ * NFKC combining-character sequences are handled correctly.
+ */
+function findOriginalPosition(
+  originalContent: string,
+  fuzzyContent: string,
+  fuzzyOffset: number,
+): number {
+  if (fuzzyOffset <= 0) {
+    return 0;
+  }
+  if (fuzzyOffset >= fuzzyContent.length) {
+    return originalContent.length;
+  }
+  let lo = 0;
+  let hi = originalContent.length;
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const prefix = originalContent.slice(0, mid);
+    const normalized = normalizeForFuzzyMatch(prefix);
+    if (normalized.length >= fuzzyOffset) {
+      hi = mid;
+    } else {
+      lo = mid + 1;
+    }
+  }
+  return lo;
+}
+
+/**
+ * Given a fuzzy match region (start + length in normalized space), find the
+ * corresponding span [start, end) in the original content.
+ */
+function findOriginalSpan(
+  originalContent: string,
+  fuzzyContent: string,
+  fuzzyIndex: number,
+  fuzzyLength: number,
+): { origIndex: number; origLength: number } {
+  const origIndex = findOriginalPosition(originalContent, fuzzyContent, fuzzyIndex);
+  const origEnd = findOriginalPosition(originalContent, fuzzyContent, fuzzyIndex + fuzzyLength);
+  return { origIndex, origLength: origEnd - origIndex };
+}
+
 interface FuzzyMatchResult {
   /** Whether a match was found */
   found: boolean;
@@ -88,9 +136,8 @@ interface MatchedEdit {
 
 /**
  * Find oldText in content, trying exact match first, then fuzzy match.
- * When fuzzy matching is used, the returned contentForReplacement is the
- * fuzzy-normalized version of the content (trailing whitespace stripped,
- * Unicode quotes/dashes normalized to ASCII).
+ * When fuzzy matching is used, positions are mapped back to the original
+ * content so that only the matched region is affected.
  */
 function fuzzyFindText(content: string, oldText: string): FuzzyMatchResult {
   // Try exact match first
@@ -120,15 +167,21 @@ function fuzzyFindText(content: string, oldText: string): FuzzyMatchResult {
     };
   }
 
-  // When fuzzy matching, we work in the normalized space for replacement.
-  // This means the output will have normalized whitespace/quotes/dashes,
-  // which is acceptable since we're fixing minor formatting differences anyway.
+  // Map the fuzzy match region back to the original content so that
+  // only the matched region is affected — unrelated lines are preserved
+  // byte-for-byte.
+  const { origIndex, origLength } = findOriginalSpan(
+    content,
+    fuzzyContent,
+    fuzzyIndex,
+    fuzzyOldText.length,
+  );
   return {
     found: true,
-    index: fuzzyIndex,
-    matchLength: fuzzyOldText.length,
+    index: origIndex,
+    matchLength: origLength,
     usedFuzzyMatch: true,
-    contentForReplacement: fuzzyContent,
+    contentForReplacement: content,
   };
 }
 
@@ -192,9 +245,9 @@ function getNoChangeError(path: string, totalEdits: number): Error {
  * Apply one or more exact-text replacements to LF-normalized content.
  *
  * All edits are matched against the same original content. Replacements are
- * then applied in reverse order so offsets remain stable. If any edit needs
- * fuzzy matching, the operation runs in fuzzy-normalized content space to
- * preserve current single-edit behavior.
+ * then applied in reverse order so offsets remain stable. Fuzzy matching is
+ * used only to locate match positions — the base content is always the
+ * original, so unrelated lines are never silently mutated.
  */
 export function applyEditsToNormalizedContent(
   normalizedContent: string,
@@ -212,12 +265,7 @@ export function applyEditsToNormalizedContent(
     }
   }
 
-  const initialMatches = normalizedEdits.map((edit) =>
-    fuzzyFindText(normalizedContent, edit.oldText),
-  );
-  const baseContent = initialMatches.some((match) => match.usedFuzzyMatch)
-    ? normalizeForFuzzyMatch(normalizedContent)
-    : normalizedContent;
+  const baseContent = normalizedContent;
 
   const matchedEdits: MatchedEdit[] = [];
   for (let i = 0; i < normalizedEdits.length; i++) {


### PR DESCRIPTION
## What Problem This Solves

Fixes P0 issue #89994: when any edit in the `edit` tool falls back to fuzzy matching, `normalizeForFuzzyMatch` was applied to the **entire file** instead of just the matched region. This silently mutates unrelated lines — trailing whitespace stripped, smart quotes/dashes/spaces converted to ASCII, NFKC recomposed — and the diff shown to the model is computed against the already-normalized base, making the corruption invisible to both the model and the user.

**Root cause** (in `applyEditsToNormalizedContent`):

```ts
// Line 218-219: when ANY edit needs fuzzy match, normalize EVERYTHING
const baseContent = initialMatches.some((match) => match.usedFuzzyMatch)
  ? normalizeForFuzzyMatch(normalizedContent)   // BUG
  : normalizedContent;
```

Then `newContent` is spliced from this already-normalized base, writing the corrupted content to disk.

**Fix**: Use `normalizeForFuzzyMatch` only to locate match positions. Add `findOriginalPosition` (prefix-based binary search with `>=` boundary) and `findOriginalSpan` to map fuzzy match positions back to the original content. `baseContent` is now always the original LF-normalized content, so untouched lines are preserved byte-for-byte.

## Evidence

### Real terminal output — proof script (`npx tsx scripts/proof-issue-89994.ts`)

```
============================================================
TEST 1: Fuzzy edit preserves em dash & trailing whitespace
============================================================

Original file (JSON-escaped):
"const label = \"a — b\";\nlet x = 1;   \n\nfunction bar() {\n  return 2;\n}\n"

File after edit (JSON-escaped):
"const label = \"a — b\";\nlet x = 1;   \n\nfunction bar() {\n  return 3;\n}\n"

Diff shown to model:
 1 const label = "a — b";
 2 let x = 1;   
 3 
 4 function bar() {
-5   return 2;
+5   return 3;
 6 }

Checks:
  em dash preserved:       PASS
  trailing spaces preserved: PASS
  edit applied:            PASS
  old text removed:        PASS
  baseContent is original:  PASS

  => ALL CHECKS PASSED

============================================================
TEST 2: Fuzzy edit preserves smart quotes
============================================================

Original (JSON): "const msg = \"“help”\";\n\nfunction foo() {\n  return 1;\n}\n"
After edit (JSON): "const msg = \"“help”\";\n\nfunction foo() {\n  return 2;\n}\n"

  smart quotes preserved: PASS

============================================================
TEST 3: Fuzzy edit preserves NFKC ligature
============================================================

Original (JSON): "const ligature = \"ﬃ\";\n\nfunction foo() {\n  return 1;\n}\n"
After edit (JSON): "const ligature = \"ﬃ\";\n\nfunction foo() {\n  return 2;\n}\n"
  ligature preserved:     PASS
  NOT decomposed to ffi:  PASS

============================================================
SUMMARY: All fuzzy edits preserve unrelated lines byte-for-byte.
Fix verified on 2026-06-25T15:21:49.972Z
============================================================
```

### Key observations

- **Em dash (`—`) preserved** — not converted to ASCII hyphen
- **Trailing whitespace preserved** — `let x = 1;   ` keeps its 3 trailing spaces
- **Smart quotes (`“`/`”`) preserved** — not converted to straight quotes
- **NFKC ligature (`ﬃ`) preserved** — not decomposed to `ffi`
- **Diff is honest** — only the intended change (`return 2;` → `return 3;`) appears as `+/-`, unrelated lines appear only as context

### Unit test results — 7/7 passing

```
 ✓ |agents-core| edit-diff.test.ts (7 tests)
   ✓ preserves em dash and trailing whitespace on unrelated lines during fuzzy edit
   ✓ preserves smart quotes on unrelated lines during fuzzy edit
   ✓ preserves NFKC-relevant Unicode on unrelated lines during fuzzy edit
   ✓ preserves exact-match lines when another edit in the same batch uses fuzzy
   ✓ produces a diff that reflects only the intended change, not normalization
   ✓ exact match preserves all content unchanged except the edited region
   ✓ still throws when oldText is not found even with fuzzy matching

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)