### PR TITLE
docs(opentelemetry): add Latitude as an OTLP export backend

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -3,7 +3,7 @@ summary: "Export OpenClaw diagnostics to OpenTelemetry collectors or stdout JSON
 title: "OpenTelemetry export"
 read_when:
   - You want to send OpenClaw model usage, message flow, or session metrics to an OpenTelemetry collector
-  - You are wiring traces, metrics, or logs into Grafana, Datadog, Honeycomb, New Relic, Tempo, or another OTLP backend
+  - You are wiring traces, metrics, or logs into Grafana, Datadog, Honeycomb, New Relic, Tempo, Latitude, or another OTLP backend
   - You need the exact metric names, span names, or attribute shapes to build dashboards or alerts
 ---
 
@@ -69,6 +69,48 @@ openclaw plugins enable diagnostics-otel
 <Note>
 `protocol` currently supports `http/protobuf` only. `grpc` is ignored.
 </Note>
+
+### Example: export to Latitude
+
+[Latitude](https://latitude.so) is an open-source LLM observability and
+evaluation platform that ingests OTLP traces. Because OpenClaw already exports
+OTLP/HTTP protobuf, you point `diagnostics.otel` at Latitude's ingestion
+endpoint and authenticate with two headers:
+
+```json5
+{
+  plugins: {
+    allow: ["diagnostics-otel"],
+    entries: {
+      "diagnostics-otel": { enabled: true },
+    },
+  },
+  diagnostics: {
+    enabled: true,
+    otel: {
+      enabled: true,
+      endpoint: "https://ingest.latitude.so",
+      protocol: "http/protobuf",
+      serviceName: "openclaw-gateway",
+      headers: {
+        Authorization: "Bearer ${LATITUDE_API_KEY}",
+        "X-Latitude-Project": "${LATITUDE_PROJECT}",
+      },
+      traces: true,
+      metrics: false,
+      logs: false,
+    },
+  },
+}
+```
+
+`LATITUDE_API_KEY` and `LATITUDE_PROJECT` come from your Latitude project
+settings. Sign up at [console.latitude.so](https://console.latitude.so/login),
+or self-host and point `endpoint` at your own ingestion host. OpenClaw appends
+`/v1/traces` to the base `endpoint`, so model-call, run, tool, and message spans
+arrive in Latitude with token usage, cost, and latency aggregated per trace.
+Latitude ingests OTLP traces, so this example leaves `metrics` and `logs` off.
+Route those signals to a metrics or logs backend if you need them.
 
 ## Signals exported
 


### PR DESCRIPTION
## What Problem This Solves

The OpenTelemetry export page tells users any OTLP/HTTP backend works and names several (Grafana, Datadog, Honeycomb, New Relic, Tempo), but it has no worked example for a hosted backend. Users who want to send OpenClaw traces to Latitude (an open-source, self-hostable LLM observability platform) have to work out the endpoint and the auth headers themselves.

## Why This Change Was Made

OpenClaw already exports OTLP/HTTP protobuf, and Latitude ingests OTLP traces at `https://ingest.latitude.so`, authenticating with an `Authorization: Bearer` header plus an `X-Latitude-Project` header. That maps directly onto the existing `diagnostics.otel.endpoint` and `diagnostics.otel.headers` config, so no code change is needed. This is a docs-only addition: a short worked example under Quick start, plus Latitude added to the `read_when` backend list.

## User Impact

Users get a copy-pasteable config to route model-call, run, tool, and message spans into Latitude, with token usage, cost, and latency aggregated per trace. The example sets `metrics` and `logs` to `false` because Latitude ingests traces, which avoids failed exports to endpoints it does not serve.

## Evidence

- Endpoint and header shape match Latitude's documented OTLP ingestion (`https://ingest.latitude.so`, `Authorization: Bearer <key>`, `X-Latitude-Project: <slug>`), the same contract Latitude documents for its other OTLP integrations.
- Docs-only change to `docs/gateway/opentelemetry.md`. No runtime code touched.
- Config keys used (`endpoint`, `protocol`, `serviceName`, `headers`, `traces`, `metrics`, `logs`) all already exist in the page's Configuration reference.

AI-assisted: drafted with Claude. I understand the change and verified the config keys and Latitude ingestion contract.