### PR TITLE
fix(codex): wait for native tool completion

### DIFF
--- a/extensions/codex/src/app-server/attempt-notification-state.ts
+++ b/extensions/codex/src/app-server/attempt-notification-state.ts
@@ -21,6 +21,7 @@ import {
   readCodexNotificationItem,
   readNotificationItemId,
   shouldDisarmAssistantCompletionIdleWatch,
+  updateActiveCompletionBlockerItemIds,
   updateActiveTurnItemIds,
 } from "./attempt-notifications.js";
 import { CODEX_POST_REASONING_REPLY_IDLE_TIMEOUT_MS } from "./attempt-timeouts.js";
@@ -92,6 +93,7 @@ export function applyCodexTurnNotificationState(params: {
   currentPromptTexts: string[];
   turnWatches: CodexAttemptTurnWatchController;
   activeTurnItemIds: Set<string>;
+  activeCompletionBlockerItemIds: Set<string>;
   activeAppServerTurnRequests: number;
   pendingOpenClawDynamicToolCompletionIds: Set<string>;
   turnCrossedToolHandoff: boolean;
@@ -121,6 +123,7 @@ export function applyCodexTurnNotificationState(params: {
     });
     params.onReportExecutionNotification(notification);
     updateActiveTurnItemIds(notification, params.activeTurnItemIds);
+    updateActiveCompletionBlockerItemIds(notification, params.activeCompletionBlockerItemIds);
     if (notification.method === "item/completed" && params.activeTurnItemIds.size === 0) {
       params.onScheduleTerminalDynamicToolReleaseCheck();
     }

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -63,6 +63,27 @@ export function updateActiveTurnItemIds(
   activeItemIds.delete(itemId);
 }
 
+export function updateActiveCompletionBlockerItemIds(
+  notification: CodexServerNotification,
+  activeItemIds: Set<string>,
+): void {
+  if (notification.method !== "item/started" && notification.method !== "item/completed") {
+    return;
+  }
+  const itemId = readNotificationItemId(notification);
+  if (!itemId) {
+    return;
+  }
+  if (notification.method === "item/completed") {
+    activeItemIds.delete(itemId);
+    return;
+  }
+  const item = readCodexNotificationItem(notification.params);
+  if (item && codexExecutionToolName(item)) {
+    activeItemIds.add(itemId);
+  }
+}
+
 function isCompletedAssistantNotification(notification: CodexServerNotification): boolean {
   if (!isJsonObject(notification.params)) {
     return false;

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -79,8 +79,26 @@ export function updateActiveCompletionBlockerItemIds(
     return;
   }
   const item = readCodexNotificationItem(notification.params);
-  if (item && codexExecutionToolName(item)) {
+  if (item && isCompletionBlockingItem(item)) {
     activeItemIds.add(itemId);
+  }
+}
+
+function isCompletionBlockingItem(item: CodexThreadItem): boolean {
+  // Codex emits paired item/started and item/completed notifications for these
+  // execution items. Completion must not time out while any pair is still open.
+  switch (item.type) {
+    case "collabAgentToolCall":
+    case "commandExecution":
+    case "dynamicToolCall":
+    case "fileChange":
+    case "imageGeneration":
+    case "imageView":
+    case "mcpToolCall":
+    case "webSearch":
+      return true;
+    default:
+      return false;
   }
 }
 

--- a/extensions/codex/src/app-server/attempt-turn-watches.test.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.test.ts
@@ -23,6 +23,7 @@ describe("Codex app-server attempt turn watches", () => {
     let terminalQueued = false;
     let activeRequests = 0;
     let activeItems = 0;
+    let activeCompletionBlockers = 0;
     const interrupts: Array<Record<string, unknown>> = [];
     const timeouts: Array<Record<string, unknown>> = [];
     const events: Array<{ name: string; fields: Record<string, unknown> }> = [];
@@ -36,6 +37,7 @@ describe("Codex app-server attempt turn watches", () => {
       isTerminalTurnNotificationQueued: () => terminalQueued,
       getActiveAppServerTurnRequests: () => activeRequests,
       getActiveTurnItemCount: () => activeItems,
+      getActiveCompletionBlockerItemCount: () => activeCompletionBlockers,
       turnCompletionIdleTimeoutMs: 10,
       turnAssistantCompletionIdleTimeoutMs: 10,
       turnAttemptIdleTimeoutMs: 10,
@@ -68,6 +70,9 @@ describe("Codex app-server attempt turn watches", () => {
       },
       set activeItems(value: number) {
         activeItems = value;
+      },
+      set activeCompletionBlockers(value: number) {
+        activeCompletionBlockers = value;
       },
       interrupts,
       timeouts,
@@ -153,6 +158,32 @@ describe("Codex app-server attempt turn watches", () => {
 
     expect(harness.timeouts).toEqual([]);
     expect(harness.abortController.signal.aborted).toBe(false);
+  });
+
+  it("waits for active completion blocker items before firing completion idle timeout", () => {
+    const harness = createController();
+    harness.activeCompletionBlockers = 1;
+
+    harness.controller.touchActivity("request:mcpServer/elicitation/request:response", {
+      arm: true,
+    });
+    vi.advanceTimersByTime(10);
+
+    expect(harness.timeouts).toEqual([]);
+    expect(harness.abortController.signal.aborted).toBe(false);
+
+    harness.activeCompletionBlockers = 0;
+    harness.controller.touchActivity("notification:item/completed");
+    vi.advanceTimersByTime(10);
+
+    expect(harness.timeouts).toMatchObject([
+      {
+        kind: "completion",
+        idleMs: 10,
+        timeoutMs: 10,
+        lastActivityReason: "notification:item/completed",
+      },
+    ]);
   });
 
   it("releases a completed assistant item after the assistant idle guard expires", () => {

--- a/extensions/codex/src/app-server/attempt-turn-watches.test.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover attempt turn watches plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { updateActiveCompletionBlockerItemIds } from "./attempt-notifications.js";
 import { createCodexAttemptTurnWatchController } from "./attempt-turn-watches.js";
 
 describe("Codex app-server attempt turn watches", () => {
@@ -244,4 +245,42 @@ describe("Codex app-server attempt turn watches", () => {
     ]);
     expect(harness.abortController.signal.reason).toBe("turn_progress_idle_timeout");
   });
+});
+
+describe("Codex completion blocker item tracking", () => {
+  it.each([
+    "collabAgentToolCall",
+    "commandExecution",
+    "dynamicToolCall",
+    "fileChange",
+    "imageGeneration",
+    "imageView",
+    "mcpToolCall",
+    "webSearch",
+  ])("tracks the %s lifecycle", (type) => {
+    const activeItemIds = new Set<string>();
+    updateActiveCompletionBlockerItemIds(
+      { method: "item/started", params: { item: { id: "item-1", type } } },
+      activeItemIds,
+    );
+    expect(activeItemIds).toEqual(new Set(["item-1"]));
+
+    updateActiveCompletionBlockerItemIds(
+      { method: "item/completed", params: { item: { id: "item-1", type } } },
+      activeItemIds,
+    );
+    expect(activeItemIds).toEqual(new Set());
+  });
+
+  it.each(["agentMessage", "contextCompaction", "plan", "reasoning", "subAgentActivity"])(
+    "does not track the %s lifecycle",
+    (type) => {
+      const activeItemIds = new Set<string>();
+      updateActiveCompletionBlockerItemIds(
+        { method: "item/started", params: { item: { id: "item-1", type } } },
+        activeItemIds,
+      );
+      expect(activeItemIds).toEqual(new Set());
+    },
+  );
 });

--- a/extensions/codex/src/app-server/attempt-turn-watches.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.ts
@@ -36,6 +36,7 @@ export function createCodexAttemptTurnWatchController(params: {
   isTerminalTurnNotificationQueued: () => boolean;
   getActiveAppServerTurnRequests: () => number;
   getActiveTurnItemCount: () => number;
+  getActiveCompletionBlockerItemCount: () => number;
   turnCompletionIdleTimeoutMs: number;
   turnAssistantCompletionIdleTimeoutMs: number;
   turnAttemptIdleTimeoutMs: number;
@@ -121,7 +122,8 @@ export function createCodexAttemptTurnWatchController(params: {
       params.isCompleted() ||
       params.signal.aborted ||
       !completionIdleWatchArmed ||
-      params.getActiveAppServerTurnRequests() > 0
+      params.getActiveAppServerTurnRequests() > 0 ||
+      params.getActiveCompletionBlockerItemCount() > 0
     ) {
       return;
     }
@@ -183,7 +185,8 @@ export function createCodexAttemptTurnWatchController(params: {
       params.isTerminalTurnNotificationQueued() ||
       params.signal.aborted ||
       !completionIdleWatchArmed ||
-      params.getActiveAppServerTurnRequests() > 0
+      params.getActiveAppServerTurnRequests() > 0 ||
+      params.getActiveCompletionBlockerItemCount() > 0
     ) {
       return false;
     }
@@ -302,7 +305,8 @@ export function createCodexAttemptTurnWatchController(params: {
       params.isTerminalTurnNotificationQueued() ||
       params.signal.aborted ||
       !completionIdleWatchArmed ||
-      params.getActiveAppServerTurnRequests() > 0
+      params.getActiveAppServerTurnRequests() > 0 ||
+      params.getActiveCompletionBlockerItemCount() > 0
     ) {
       return;
     }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1578,6 +1578,7 @@ export async function runCodexAppServerAttempt(
   let activeAppServerTurnRequests = 0;
   const pendingOpenClawDynamicToolCompletionIds = new Set<string>();
   const activeTurnItemIds = new Set<string>();
+  const activeCompletionBlockerItemIds = new Set<string>();
   let turnCrossedToolHandoff = false;
   let pendingTerminalDynamicToolRelease:
     | {
@@ -1627,6 +1628,7 @@ export async function runCodexAppServerAttempt(
     isTerminalTurnNotificationQueued: () => terminalTurnNotificationQueued,
     getActiveAppServerTurnRequests: () => activeAppServerTurnRequests,
     getActiveTurnItemCount: () => activeTurnItemIds.size,
+    getActiveCompletionBlockerItemCount: () => activeCompletionBlockerItemIds.size,
     turnCompletionIdleTimeoutMs,
     turnAssistantCompletionIdleTimeoutMs,
     turnAttemptIdleTimeoutMs,
@@ -1899,6 +1901,7 @@ export async function runCodexAppServerAttempt(
       currentPromptTexts: [codexTurnPromptText],
       turnWatches,
       activeTurnItemIds,
+      activeCompletionBlockerItemIds,
       activeAppServerTurnRequests,
       pendingOpenClawDynamicToolCompletionIds,
       turnCrossedToolHandoff,

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -49,9 +49,7 @@ const DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
   web_search: "disabled",
 });
 
-function writeCodexAppServerBinding(
-  ...args: Parameters<typeof writeRawCodexAppServerBinding>
-) {
+function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppServerBinding>) {
   const [sessionFile, binding, lookup] = args;
   return writeRawCodexAppServerBinding(
     sessionFile,
@@ -78,6 +76,7 @@ describe("createCodexAttemptTurnWatchController", () => {
       isTerminalTurnNotificationQueued: () => false,
       getActiveAppServerTurnRequests: () => 0,
       getActiveTurnItemCount: () => 0,
+      getActiveCompletionBlockerItemCount: () => 0,
       turnCompletionIdleTimeoutMs: 500,
       turnAssistantCompletionIdleTimeoutMs: 500,
       turnAttemptIdleTimeoutMs: 200,

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -806,6 +806,93 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(result.promptError).toBeNull();
   });
 
+  it("keeps an eliciting MCP tool active past the completion timeout", async () => {
+    const harness = createStartedThreadHarness();
+    const bridgedResponse = {
+      action: "accept",
+      content: null,
+      _meta: null,
+    } as const;
+    vi.spyOn(elicitationBridge, "handleCodexAppServerElicitationRequest").mockResolvedValue(
+      bridgedResponse,
+    );
+    const params = createParams(
+      path.join(tempDir, "session-mcp-elicitation.jsonl"),
+      path.join(tempDir, "workspace-mcp-elicitation"),
+    );
+    params.timeoutMs = 500;
+
+    let settled = false;
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 15,
+      turnAssistantCompletionIdleTimeoutMs: 1_000,
+      turnTerminalIdleTimeoutMs: 1_000,
+    }).finally(() => {
+      settled = true;
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "mcp-1",
+          type: "mcpToolCall",
+          server: "computer-use",
+          tool: "computer",
+          status: "inProgress",
+          arguments: {},
+        },
+      },
+    });
+
+    await expect(
+      harness.handleServerRequest({
+        id: "request-mcp-elicitation",
+        method: "mcpServer/elicitation/request",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          mode: "form",
+          message: "Approve?",
+          requestedSchema: { type: "object", properties: {} },
+          serverName: "computer-use",
+          _meta: null,
+        },
+      }),
+    ).resolves.toEqual(bridgedResponse);
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 40);
+    });
+    expect(settled).toBe(false);
+    expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "mcp-1",
+          type: "mcpToolCall",
+          server: "computer-use",
+          tool: "computer",
+          status: "completed",
+          arguments: {},
+          result: { content: [] },
+        },
+      },
+    });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+  });
+
   it("counts pending user input requests as turn attempt progress", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(


### PR DESCRIPTION
## What Problem This Solves

Fixes #96452.

Codex Computer Use turns routed through Discord could start the native `computer-use.get_app_state` MCP tool and then be aborted by OpenClaw's completion-idle watchdog while the native tool item was still in progress. The run then synthesized a failed `tool.result` with `missing_tool_result` even though the tool was still active.

## Why This Change Was Made

The completion-idle watchdog only checked active app-server requests before firing. Native Codex execution/tool items are reported through `item/started` / `item/completed` notifications, so the watchdog could see no active request and abort during an active native MCP tool call.

This change tracks a narrow set of active completion blockers for Codex execution/tool items, using the existing `codexExecutionToolName(item)` classification. Completion idle timeouts now wait for those blockers to complete, while general active item tracking remains separate so reasoning progress does not broadly suppress post-tool timeouts.

## User Impact

Discord-routed Codex Computer Use turns can complete after approval instead of being interrupted by a false completion-idle timeout while the native tool is still running.

## Evidence

- Before-fix live proof: a Discord-shaped Codex Computer Use turn emitted `tool.call` for `computer-use.get_app_state`, then `turn.completion_idle_timeout` after about 60s with `activeTurnItemCount: 1` and `activeAppServerTurnRequests: 0`, followed by a synthetic failed `tool.result` with `missing_tool_result`.
- After-fix live proof: a fresh Discord-shaped Codex Computer Use turn emitted one `tool.call` for `computer-use.get_app_state`, a completed `tool.result`, `model.completed`, and `session.ended` with `status: success`; no completion-idle timeout was emitted.
- Regression RED: the new completion-blocker watchdog test failed before the production change because a completion timeout fired while a blocker item was active.
- `pnpm test extensions/codex/src/app-server/attempt-turn-watches.test.ts extensions/codex/src/app-server/run-attempt.turn-watches.test.ts` — 2 files passed, 73 tests passed.
- `pnpm test:extension codex` — 90 files passed, 1662 tests passed.
- Changed-file oxlint with `--deny=warn --ignore-path=.oxlintignore` passed.
- `git diff --check` passed.