### PR TITLE
docs(xurl): document X Article full-text retrieval via tweet.fields=article (AI-assisted)

### DIFF
--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xurl
-description: "xurl CLI for authenticated X posts, replies, reads/search, DMs, media upload, followers, auth status, or raw v2 API calls."
+description: "xurl CLI for authenticated X posts, replies, reading X Article full text via raw API, search, DMs, media upload, followers, auth status, or raw v2 API calls."
 metadata:
   {
     "openclaw":
@@ -71,7 +71,25 @@ xurl dm @handle "message"
 xurl dms -n 10
 ```
 
-`POST_ID` can be a full `https://x.com/<user>/status/<id>` URL.
+## Reading X posts and X Articles from a URL
+
+Pass a full `https://x.com/<user>/status/<id>` URL directly as `POST_ID`:
+
+```bash
+xurl read https://x.com/username/status/1234567890123456789
+```
+
+**X Articles require raw API mode.** `xurl read` returns only tweet metadata and
+the article title for Article-type posts — the body is not included. Use the
+`article` tweet field to retrieve full content:
+
+```bash
+xurl '/2/tweets/<TWEET_ID>?tweet.fields=article,text,entities'
+```
+
+Read `data.article.plain_text` from the response for the full article body.
+
+The `/2/articles/<id>` endpoint is not accessible with xurl's current auth scope.
 
 ## Media
 


### PR DESCRIPTION
## What Problem This Solves

When a tweet links to an X Article, \`xurl read <url>\` returns only tweet
metadata and \`article.title\` — the article body is absent. There is no
documentation telling agents or users how to retrieve full article text.
The common alternative (\`/2/articles/<id>\` endpoint) also fails due to
auth scope. Sessions repeatedly rediscover the correct parameters through
trial and error.

## Why This Change Was Made

The X v2 API returns article body when \`tweet.fields=article\` is included
in a \`/2/tweets/:id\` request; the content is in \`data.article.plain_text\`.
This PR documents that pattern as a dedicated section and updates the skill
description so agents can route correctly on the first attempt.

## User Impact

Agents and users with an X Article URL can now retrieve the full article
text on the first attempt using the documented raw API call. No behavior,
config, migration, or environment contract changes.

## Evidence

Docs-only change to \`skills/xurl/SKILL.md\`.

```
git diff --check   ✓ passed
```

Autoreview: clean (no accepted/actionable findings).