### PR TITLE
fix(cli): reject invalid cron output cap

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -661,23 +661,26 @@ describe("cron cli", () => {
   describe.each(["--no-output-timeout-seconds", "--output-max-bytes"])(
     "cron add %s validation",
     (flag) => {
-      it.each(["", "0", "-1", "1.5", "1000ms"])("rejects invalid value %j", async (value) => {
-        await expectCronCommandExit([
-          "cron",
-          "add",
-          "--name",
-          "Invalid command limit",
-          "--every",
-          "10m",
-          "--command",
-          "echo ok",
-          flag,
-          value,
-        ]);
+      it.each(["", "0", "-1", "1.5", "1000ms", "nope"])(
+        "rejects invalid value %j",
+        async (value) => {
+          await expectCronCommandExit([
+            "cron",
+            "add",
+            "--name",
+            "Invalid command limit",
+            "--every",
+            "10m",
+            "--command",
+            "echo ok",
+            flag,
+            value,
+          ]);
 
-        expectRuntimeErrorContaining(`Invalid ${flag} (must be a positive integer).`);
-        expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.add")).toBe(false);
-      });
+          expectRuntimeErrorContaining(`Invalid ${flag} (must be a positive integer).`);
+          expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.add")).toBe(false);
+        },
+      );
     },
   );
 


### PR DESCRIPTION
## Summary

- Fix classification: root-cause regression guardrail for CLI validation.
- Maintainer-ready confidence: high; the branch is rebased onto current `main`, the merge conflict is resolved, and the remaining diff is one focused cron CLI test update.
- Root cause: `cron add` command-limit parsing needs to reject explicit non-positive or non-integer values before any `cron.add` RPC is sent; after the main-branch validation refactor, this PR needed to keep the missing non-numeric regression case in the shared command-limit validation coverage.
- Why this is root-cause fix: the validation is exercised at the CLI argument boundary where the bad value enters the system, so invalid command-limit input fails before job creation instead of relying on gateway defaults or downstream cleanup.
- Patch quality notes: this is intentionally test-only after rebasing because current `main` already contains the strict parser and source-path validation; the patch keeps the regression scenario that would catch a future fallback to permissive parsing.

## Linked context

No linked issue was detected for this PR. The user-visible behavior is inferred from the PR title/body and existing cron CLI tests: explicitly invalid command output caps should not create a cron job.

## Real behavior proof

- Behavior or issue addressed: `openclaw cron add --command ... --output-max-bytes nope` should fail fast instead of creating a job without the requested output cap.
- Real environment tested: local OpenClaw source checkout on Linux, current PR branch after rebasing onto `origin/main`.
- Exact steps or command run after this patch:

  ```text
  pnpm exec vitest run src/cli/cron-cli.test.ts
  ```

- Evidence after fix:

  ```text
  RUN  v4.1.8

  Test Files  1 passed (1)
       Tests  108 passed (108)
  ```

- Observed result after fix: the focused cron CLI suite passes, including the `cron add --output-max-bytes nope` regression path and the existing command-limit validation cases.
- What was not tested: no live gateway job was created, because the bug path is CLI-side validation that should stop before any `cron.add` RPC or scheduler side effect.

## Tests and validation

- Target test file: `src/cli/cron-cli.test.ts`.
- Scenario locked in: invalid values `""`, `"0"`, `"-1"`, `"1.5"`, `"1000ms"`, and `"nope"` are rejected for command-limit flags before `cron.add` is called.
- Why this is the smallest reliable guardrail: the regression test drives the actual Commander cron CLI registration and verifies the RPC is not invoked, while avoiding a broader gateway or scheduler fixture for a pre-RPC parse failure.

## Risk checklist

- Risk labels considered: `merge-risk: compatibility` is relevant because scripts that pass invalid `--output-max-bytes` values now fail fast.
- Risk explanation: the compatibility change is intentional; accepting an explicitly invalid cap makes users believe a smaller output limit was configured while the job actually uses the default behavior.
- Why acceptable: valid positive integer values and omitted `--output-max-bytes` behavior remain unchanged, and invalid explicit values are rejected at the CLI boundary with a clear error.
- Why it matters / User impact: users get immediate feedback for invalid output cap input and avoid silently misconfigured cron command jobs.
- What did NOT change: no cron storage schema, scheduler behavior, gateway RPC contract, default output cap, or valid command-job payload behavior changed in this update.
- Architecture / source-of-truth check: command-limit validation remains in the shared CLI parsing path; this PR does not add downstream string matching, fallback defaults, or gateway-side special cases.
- Related open PR / same-contract scan: this is an existing PR repair for PR #96826, not a competing replacement PR.
- Out of scope: live scheduler execution, gateway persistence, and command-output truncation behavior are not changed.

## Current review state

Which bot or reviewer comments were addressed?

- RF-001 / ClawSweeper P1 compatibility note: addressed in the Risk checklist. The fail-fast behavior for explicitly invalid `--output-max-bytes` values is intentional, user-visible, and called out as the compatibility boundary.

Current branch state:

- Rebased onto current `origin/main` and resolved conflicts in the cron CLI validation test/source area.
- Remaining diff against `origin/main`: `src/cli/cron-cli.test.ts` only.
- Focused validation: `pnpm exec vitest run src/cli/cron-cli.test.ts` passed with 108 tests.
