### PR TITLE
fix(cli): sync official plugins during update --all

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -399,13 +399,17 @@ Updates apply to tracked plugin installs in the managed plugin index and tracked
   <Accordion title="Resolving plugin id vs npm spec">
     When you pass a plugin id, OpenClaw reuses the recorded install spec for that plugin. That means previously stored dist-tags such as `@beta` and exact pinned versions continue to be used on later `update <id>` runs.
 
+    That targeted-update rule is different from the bulk `openclaw plugins update --all` maintenance path. Bulk updates still respect ordinary tracked install specs, but trusted official OpenClaw plugin records can sync to the current official catalog target instead of staying on a stale exact official package. Use targeted `update <id>` when you intentionally want to keep an exact or tagged official spec untouched.
+
     For npm installs, you can also pass an explicit npm package spec with a dist-tag or exact version. OpenClaw resolves that package name back to the tracked plugin record, updates that installed plugin, and records the new npm spec for future id-based updates.
 
     Passing the npm package name without a version or tag also resolves back to the tracked plugin record. Use this when a plugin was pinned to an exact version and you want to move it back to the registry's default release line.
 
   </Accordion>
   <Accordion title="Beta channel updates">
-    `openclaw plugins update` reuses the tracked plugin spec unless you pass a new spec. `openclaw update` additionally knows the active OpenClaw update channel: on the beta channel, default-line npm and ClawHub plugin records try `@beta` first. They fall back to the recorded default/latest spec if no plugin beta release exists; npm plugins also fall back when the beta package exists but fails install validation. That fallback is reported as a warning and does not fail the core update. Exact versions and explicit tags stay pinned to that selector.
+    Targeted `openclaw plugins update <id-or-npm-spec>` reuses the tracked plugin spec unless you pass a new spec. Bulk `openclaw plugins update --all` uses the configured `update.channel` when it syncs trusted official plugin records to the official catalog target, so beta-channel installs can stay on the beta release line instead of being silently normalized to stable/latest.
+
+    `openclaw update` also knows the active OpenClaw update channel: on the beta channel, default-line npm and ClawHub plugin records try `@beta` first. They fall back to the recorded default/latest spec if no plugin beta release exists; npm plugins also fall back when the beta package exists but fails install validation. That fallback is reported as a warning and does not fail the core update. Exact versions and explicit tags stay pinned to that selector for targeted updates.
 
   </Accordion>
   <Accordion title="Version checks and integrity drift">

--- a/docs/plugins/manage-plugins.md
+++ b/docs/plugins/manage-plugins.md
@@ -110,6 +110,13 @@ When you pass a plugin id, OpenClaw reuses the tracked install spec. Stored
 dist-tags such as `@beta` and exact pinned versions continue to be used on
 later `update <plugin-id>` runs.
 
+`openclaw plugins update --all` is the bulk maintenance path. It still respects
+ordinary tracked install specs, but trusted official OpenClaw plugin records can
+sync to the current official catalog target instead of staying on a stale exact
+official package. If `update.channel` is set to `beta`, that bulk official sync
+uses the beta-channel context. Use a targeted `update <plugin-id>` when you
+intentionally want to keep an exact or tagged official spec untouched.
+
 For npm installs, you can pass an explicit package spec to switch the tracked
 record:
 

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -978,6 +978,32 @@ describe("plugins cli update", () => {
     const updateParams = expectSingleCallParams(updateNpmInstalledPlugins);
     expect(updateParams.pluginIds).toEqual(["codex"]);
     expect(updateParams.syncOfficialPluginInstalls).toBeUndefined();
+    expect(updateParams.updateChannel).toBeUndefined();
+    expect(updateParams.officialPluginUpdateChannel).toBeUndefined();
+  });
+
+  it("syncs official catalog specs with beta channel context for update --all", async () => {
+    const config = createTrackedPluginConfig({
+      pluginId: "codex",
+      spec: "@openclaw/codex@2026.6.8-beta.1",
+      resolvedName: "@openclaw/codex",
+    });
+    config.update = { channel: "beta" };
+    loadConfig.mockReturnValue(config);
+    setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
+    updateNpmInstalledPlugins.mockResolvedValue({
+      config,
+      changed: false,
+      outcomes: [],
+    });
+
+    await runPluginsCommand(["plugins", "update", "--all"]);
+
+    const updateParams = expectSingleCallParams(updateNpmInstalledPlugins);
+    expect(updateParams.pluginIds).toEqual(["codex"]);
+    expect(updateParams.syncOfficialPluginInstalls).toBe(true);
+    expect(updateParams.officialPluginUpdateChannel).toBe("beta");
+    expect(updateParams.updateChannel).toBeUndefined();
   });
 
   it("writes updated config when updater reports changes", async () => {

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -12,6 +12,7 @@ import { extractShippedPluginInstallConfigRecords } from "../config/plugin-insta
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { updateNpmInstalledHookPacks } from "../hooks/update.js";
+import { normalizeUpdateChannel } from "../infra/update-channels.js";
 import {
   loadInstalledPluginIndexInstallRecords,
   withoutPluginInstallRecords,
@@ -260,6 +261,10 @@ export async function runPluginUpdateCommand(params: {
           pluginIds: pluginSelection.pluginIds,
           specOverrides: pluginSelection.specOverrides,
           dryRun: params.opts.dryRun,
+          officialPluginUpdateChannel: params.opts.all
+            ? (normalizeUpdateChannel(cfg.update?.channel) ?? undefined)
+            : undefined,
+          syncOfficialPluginInstalls: params.opts.all ? true : undefined,
           dangerouslyForceUnsafeInstall: params.opts.dangerouslyForceUnsafeInstall,
           logger,
           onIntegrityDrift: async (drift) => {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -42,8 +42,10 @@ const tempDirs: string[] = [];
 
 vi.mock("./install.js", () => ({
   installPluginFromNpmSpec: (...args: unknown[]) => installPluginFromNpmSpecMock(...args),
-  resolvePluginInstallDir: (pluginId: string, extensionsDir = "/tmp") =>
-    `${extensionsDir}/${pluginId}`,
+  resolvePluginInstallDir: (pluginId: string, extensionsDir = "/tmp") => {
+    const separator = process.platform === "win32" ? "\\" : "/";
+    return `${extensionsDir.replace(/[\\/]+$/, "")}${separator}${pluginId}`;
+  },
   PLUGIN_INSTALL_ERROR_CODE: {
     NPM_PACKAGE_NOT_FOUND: "npm_package_not_found",
   },
@@ -1077,6 +1079,45 @@ describe("updateNpmInstalledPlugins", () => {
     expect(result.config.plugins?.installs?.["lossless-claw"]?.resolvedSpec).toBe(
       "@martian-engineering/lossless-claw@0.9.1",
     );
+  });
+
+  it("does not apply official beta-channel sync to third-party npm specs", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@martian-engineering/lossless-claw",
+      version: "0.9.0",
+    });
+    mockNpmViewMetadata({
+      name: "@martian-engineering/lossless-claw",
+      version: "0.9.1",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "lossless-claw",
+        targetDir: installPath,
+        version: "0.9.1",
+        npmResolution: {
+          name: "@martian-engineering/lossless-claw",
+          version: "0.9.1",
+          resolvedSpec: "@martian-engineering/lossless-claw@0.9.1",
+        },
+      }),
+    );
+
+    await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "lossless-claw",
+        spec: "@martian-engineering/lossless-claw",
+        installPath,
+        resolvedName: "@martian-engineering/lossless-claw",
+        resolvedSpec: "@martian-engineering/lossless-claw@0.9.0",
+        resolvedVersion: "0.9.0",
+      }),
+      pluginIds: ["lossless-claw"],
+      syncOfficialPluginInstalls: true,
+      officialPluginUpdateChannel: "beta",
+    });
+
+    expect(npmInstallCall()?.spec).toBe("@martian-engineering/lossless-claw");
   });
 
   it("does not skip trusted official default updates when latest resolves to the installed prerelease", async () => {
@@ -3906,10 +3947,11 @@ describe("updateNpmInstalledPlugins", () => {
       pluginIds: ["demo"],
     });
 
-    expect(npmInstallCall()?.extensionsDir).toBe(extensionsDir);
-    expect(clawHubInstallCall()?.extensionsDir).toBe(extensionsDir);
-    expect(marketplaceInstallCall()?.extensionsDir).toBe(extensionsDir);
-    expect(gitInstallCall()?.extensionsDir).toBe(extensionsDir);
+    const expectedExtensionsDir = path.resolve(extensionsDir);
+    expect(npmInstallCall()?.extensionsDir).toBe(expectedExtensionsDir);
+    expect(clawHubInstallCall()?.extensionsDir).toBe(expectedExtensionsDir);
+    expect(marketplaceInstallCall()?.extensionsDir).toBe(expectedExtensionsDir);
+    expect(gitInstallCall()?.extensionsDir).toBe(expectedExtensionsDir);
   });
 });
 

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1238,6 +1238,7 @@ export async function updateNpmInstalledPlugins(params: {
   timeoutMs?: number;
   dryRun?: boolean;
   updateChannel?: UpdateChannel;
+  officialPluginUpdateChannel?: UpdateChannel;
   dangerouslyForceUnsafeInstall?: boolean;
   specOverrides?: Record<string, string>;
   onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
@@ -1314,6 +1315,7 @@ export async function updateNpmInstalledPlugins(params: {
     const officialClawHubSpec = params.syncOfficialPluginInstalls
       ? resolveTrustedSourceLinkedOfficialClawHubSpec({ pluginId, record })
       : undefined;
+    const officialSyncUpdateChannel = params.officialPluginUpdateChannel ?? params.updateChannel;
 
     if (normalizedPluginConfig) {
       const enableState = resolveEffectiveEnableState({
@@ -1347,7 +1349,7 @@ export async function updateNpmInstalledPlugins(params: {
             record,
             specOverride: params.specOverrides?.[pluginId],
             officialSpecOverride: officialNpmSpec,
-            updateChannel: params.updateChannel,
+            updateChannel: officialNpmSpec ? officialSyncUpdateChannel : params.updateChannel,
           })
         : undefined;
     const clawhubSpecs =
@@ -1355,7 +1357,7 @@ export async function updateNpmInstalledPlugins(params: {
         ? resolveClawHubUpdateSpecs({
             record,
             officialSpecOverride: officialClawHubSpec,
-            updateChannel: params.updateChannel,
+            updateChannel: officialClawHubSpec ? officialSyncUpdateChannel : params.updateChannel,
           })
         : undefined;
     const effectiveSpec =
@@ -1377,7 +1379,9 @@ export async function updateNpmInstalledPlugins(params: {
             record,
             effectiveClawHubSpec: effectiveSpec,
             recordClawHubSpec: recordSpec,
-            updateChannel: params.updateChannel,
+            updateChannel: params.syncOfficialPluginInstalls
+              ? officialSyncUpdateChannel
+              : params.updateChannel,
           })
         : null;
     let officialNpmFallbackInstallSpec = officialNpmFallbackSpecs?.installSpec;


### PR DESCRIPTION
Closes #94083
Supersedes #94084
Related: #94225, #95541, #84256, #83337

## What Problem This Solves

This is a maintainer landing copy of #94084 by @ooiuuii, applied cleanly on current `origin/main` so the diff stays small and reviewable. The commit author is preserved as `ooiuuii <169449607+ooiuuii@users.noreply.github.com>`.

Operators using `openclaw plugins update --all` after a core upgrade could leave trusted official OpenClaw plugins pinned to stale exact beta install records. The gateway/doctor drift checks could still report official plugin version drift, so the bulk maintenance command did not reliably converge the official plugin set.

## Why This Change Was Made

`plugins update --all` now opts into the existing official catalog sync path, matching the post-core update recovery behavior users expect from a bulk maintenance command. The implementation passes the configured update channel through a new official-only channel parameter, so beta-channel context is available when a trusted official catalog override is selected without rewriting ordinary third-party tracked npm or ClawHub specs.

Targeted `openclaw plugins update <id>` remains unchanged: recorded exact versions and explicit tags stay pinned unless the operator passes a new package spec.

Cluster handling:

- #94084 is the original canonical contributor PR; this PR is the clean maintainer landing copy of that code.
- #94225 was the narrower duplicate already closed in favor of #94084; this keeps the channel-aware version from #94084.
- #95541 is the already-merged companion that fixes targeted repair-command guidance.
- #84256 and #83337 are broader plugin drift/pin-policy issues and should remain separate follow-up work.

## User Impact

Operators can use `openclaw plugins update --all` after core upgrades to reconcile trusted official OpenClaw plugins with the current official catalog target. Users who intentionally pin a specific plugin through targeted updates keep that behavior, and third-party plugins are not silently moved to beta-channel selectors just because `update.channel` is `beta`.

## Evidence

Original PR-head CLI proof from #94084 covered:

```text
Scenario: bulk official sync for a trusted official exact beta record
command: node openclaw.mjs plugins update --all
result: Updated acpx: 2026.6.10-beta.2 -> 2026.6.10.

Scenario: targeted update keeps the exact beta pin
command: node openclaw.mjs plugins update acpx
result: acpx already at 2026.6.10-beta.2.

Scenario: third-party npm spec is not rewritten by beta channel context
command: node openclaw.mjs plugins update --all
result: lossless-claw is up to date (0.9.0).
```

Maintainer-copy validation on this branch:

```sh
pnpm docs:list
node scripts/run-vitest.mjs src/plugins/update.test.ts src/cli/plugins-cli.update.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/plugins-update-command.ts src/cli/plugins-cli.update.test.ts src/plugins/update.ts src/plugins/update.test.ts
git diff --check
```

Results: docs listing completed, focused Vitest passed (`28` CLI tests and `98` plugin tests), oxlint passed, and `git diff --check` passed.
