### PR TITLE
fix(compaction): keep accepted sessions_spawn results out of tool-failure summaries

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -14,6 +14,7 @@ import {
 import * as compactionModule from "../compaction.js";
 import { buildEmbeddedExtensionFactories } from "../embedded-agent-runner/extensions.js";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
+import { jsonResult } from "../tools/common.js";
 import {
   consumeCompactionSafeguardCancelReason,
   getCompactionSafeguardRuntime,
@@ -263,6 +264,104 @@ describe("compaction-safeguard tool failures", () => {
     const section = formatToolFailuresSection(failures);
     expect(section).toContain("## Tool Failures");
     expect(section).toContain("exec (status=failed exitCode=1): ENOENT: missing file");
+  });
+
+  it("excludes accepted sessions_spawn results even when persisted with isError", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "call-spawn-accepted",
+        toolName: "sessions_spawn",
+        isError: true,
+        details: {
+          status: "accepted",
+          childSessionKey: "agent:watcher:subagent:abc",
+          runId: "run-123",
+          mode: "run",
+        },
+        content: [{ type: "text", text: "accepted" }],
+        timestamp: Date.now(),
+      },
+    ];
+
+    expect(collectToolFailures(messages)).toHaveLength(0);
+  });
+
+  it("still reports sessions_spawn results that genuinely failed", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "call-spawn-error",
+        toolName: "sessions_spawn",
+        isError: true,
+        details: { status: "error" },
+        content: [{ type: "text", text: "spawn rejected" }],
+        timestamp: Date.now(),
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call-spawn-forbidden",
+        toolName: "sessions_spawn",
+        isError: true,
+        details: { status: "forbidden" },
+        content: [{ type: "text", text: "not allowed" }],
+        timestamp: Date.now(),
+      },
+    ];
+
+    const failures = collectToolFailures(messages);
+    expect(failures.map((failure) => failure.toolCallId)).toEqual([
+      "call-spawn-error",
+      "call-spawn-forbidden",
+    ]);
+  });
+
+  it("only excludes the accepted spawn from a mixed batch and reports look-alike non-spawn tools", () => {
+    // Build the accepted-spawn details via the production helper so the skip is
+    // proven against the real sessions_spawn result shape, not a hand-authored stub.
+    const acceptedDetails = jsonResult({
+      status: "accepted",
+      childSessionKey: "agent:watcher:subagent:abc",
+      runId: "run-123",
+      mode: "run",
+    }).details;
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "call-spawn-accepted",
+        toolName: "sessions_spawn",
+        isError: true,
+        details: acceptedDetails,
+        content: [{ type: "text", text: "accepted" }],
+        timestamp: Date.now(),
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call-exec-failed",
+        toolName: "exec",
+        isError: true,
+        details: { status: "failed", exitCode: 1 },
+        content: [{ type: "text", text: "boom" }],
+        timestamp: Date.now(),
+      },
+      {
+        // Same accepted-shaped details on a non-spawn tool must still be reported:
+        // the skip is gated on toolName so look-alike payloads are not suppressed.
+        role: "toolResult",
+        toolCallId: "call-other-lookalike",
+        toolName: "some_other_tool",
+        isError: true,
+        details: acceptedDetails,
+        content: [{ type: "text", text: "real failure" }],
+        timestamp: Date.now(),
+      },
+    ];
+
+    const failures = collectToolFailures(messages);
+    expect(failures.map((failure) => failure.toolCallId)).toEqual([
+      "call-exec-failed",
+      "call-other-lookalike",
+    ]);
   });
 
   it("dedupes by toolCallId and handles empty output", () => {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -10,6 +10,7 @@ import {
   getCompactionProvider,
   type CompactionProvider,
 } from "../../plugins/compaction-provider.js";
+import { normalizeAcceptedSessionSpawnResult } from "../accepted-session-spawn.js";
 import {
   buildHistoryPrunePlanWithWorker,
   computeAdaptiveChunkRatioWithWorker,
@@ -445,6 +446,17 @@ function collectToolFailures(messages: AgentMessage[]): ToolFailure[] {
       isError?: unknown;
     };
     if (toolResult.isError !== true) {
+      continue;
+    }
+    // Accepted sessions_spawn launches are successes, not failures, even when a legacy
+    // transcript persisted them with isError:true. Mirror the observer's detection
+    // (toolName + accepted child-run identity, see embedded-agent-subscribe.handlers.tools)
+    // so only real failures stay in the summary and non-spawn tools are never matched by shape.
+    if (
+      typeof toolResult.toolName === "string" &&
+      toolResult.toolName.trim() === "sessions_spawn" &&
+      normalizeAcceptedSessionSpawnResult(toolResult)
+    ) {
       continue;
     }
     const toolCallId = typeof toolResult.toolCallId === "string" ? toolResult.toolCallId : "";


### PR DESCRIPTION
Related: #96833

## What Problem This Solves

Fixes an issue where operators reviewing an agent's compaction summaries would see normal, successful `sessions_spawn` subagent launches reported as repeated `## Tool Failures` (for example `sessions_spawn: failed`), even though each launch was accepted. An active agent that spawns subagents accumulates many of these false-positive failure lines, making the summary's failure list untrustworthy.

## Why This Change Was Made

An accepted `sessions_spawn` launch can be persisted on the transcript as a `toolResult` carrying `isError: true` while its payload is `details.status: "accepted"` (with `runId` and `childSessionKey`). The compaction safeguard's `collectToolFailures` collected every `toolResult` with `isError === true`, so accepted launches were swept into the failure summary.

The fix teaches the failure collector that an accepted child spawn is a successful launch, not a failure: after the existing `isError` guard, `collectToolFailures` now skips results that the existing `normalizeAcceptedSessionSpawnResult` helper recognizes as accepted spawns. This is applied at the read boundary so it also covers legacy transcripts already persisted with `isError: true`. Spawns that genuinely failed (`status: "error"` / `"forbidden"`) are unaffected and still reported.

Scope boundary: this is a read-side guard in the compaction summary only. It does not change how tool results are persisted or `sessions_spawn` execution. The same persisted `isError: true` on an accepted spawn also reaches other read paths (model replay maps `toolResult.isError` to `is_error`; the TUI renders the historical result with error styling); normalizing the accepted-spawn classification at its source is a separate follow-up and is intentionally not bundled here. The detection mirrors the existing observer check (`toolName === "sessions_spawn"` plus the accepted child-run identity), so non-spawn tools are never matched by payload shape alone. Because the linked issue's expected behavior also covers source-side `isError` normalization, this PR links it with `Related:` rather than a closing keyword, so merging does not automatically close the linked issue. Maintainers can decide whether the compaction-only fix should close it or whether the source-side normalization follow-up stays open.

## User Impact

Compaction summaries no longer list accepted subagent launches as tool failures. The `## Tool Failures` section now reflects only genuine tool failures, including spawns that were actually rejected or errored.

## Evidence

Tier: internal deterministic logic (`collectToolFailures` is a pure function over `AgentMessage[]`; no runtime/network boundary). Proof is a focused regression test that fails before and passes after the change, plus the existing suite, plus a rendered before/after of the real compaction section (below).

Added regression tests in `src/agents/agent-hooks/compaction-safeguard.test.ts`:
- accepted `sessions_spawn` result with `isError: true` + `details.status: "accepted"` is excluded from `collectToolFailures` (asserts length 0).
- genuinely failed `sessions_spawn` results (`status: "error"` and `status: "forbidden"`) are still reported (deny symmetry, guards against over-correction).
- a mixed batch where the accepted details are built via the production `jsonResult` helper: the accepted spawn is excluded, a failed `exec` is still reported, and a non-spawn tool carrying the same accepted-shaped details is still reported (proves the `toolName` gate and that the skip does not perturb ordering).

Before the fix, the accepted-exclusion test failed (`expected length 0, got 1`), reproducing the bug. After the fix:

```
node scripts/run-vitest.mjs src/agents/agent-hooks/compaction-safeguard.test.ts
 Test Files  1 passed (1)
      Tests  98 passed (98)
```

Touched-file gates (local): `oxfmt --check` clean; `oxlint` clean; `tsgo` core and core-test lanes exit 0.

### Real-behavior before/after (rendered compaction section)

Beyond the unit test, the actual exported `formatToolFailuresSection(collectToolFailures(messages))` was run over a realistic transcript: two accepted `sessions_spawn` launches (persisted `isError: true`, `details.status: "accepted"` with `runId` + `childSessionKey`), one genuine `exec` failure (`exit 127`), and one rejected (`forbidden`) spawn. The same harness was run against the pre-fix tree and this branch. The transcript is synthetic, so there is nothing private to redact.

Before (pre-fix tree, no guard) — accepted launches pollute the section (`collectToolFailures` count = 4):

```text
## Tool Failures
- sessions_spawn (status=accepted): Accepted: launching child session to scan logs.
- sessions_spawn (status=accepted): Accepted: launching child session to repro locally.
- exec (status=error exitCode=127): command not found: pnpm (exit 127)
- sessions_spawn (status=forbidden): Forbidden: spawn limit reached.
```

After (this branch) — accepted launches are gone; the real `exec` failure and the `forbidden` spawn are still reported (count = 2):

```text
## Tool Failures
- exec (status=error exitCode=127): command not found: pnpm (exit 127)
- sessions_spawn (status=forbidden): Forbidden: spawn limit reached.
```

Only the two accepted launches are removed. To reproduce, import the `testing` exports from `src/agents/agent-hooks/compaction-safeguard.ts` and render the section on any transcript carrying an accepted `sessions_spawn` result.

## Security / Compatibility

No auth, secret, dependency, permission, migration, config, or data-access surface changes. No persisted-state shape change: the read-side guard leaves stored transcripts untouched and resolves the symptom for both new and existing transcripts.

## Risks and Mitigations

The exclusion is keyed on the accepted-spawn contract (`status: "accepted"` plus `runId` and `childSessionKey`) via the shared `normalizeAcceptedSessionSpawnResult` helper, so only accepted child spawns are skipped; failed/forbidden spawns and all other tool failures continue to be reported, covered by the deny-symmetry test.

AI-assisted; the contributor manually reviewed the change and is responsible for it.
