### PR TITLE
fix(message): route WebChat message tool sends to source sink

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -526,6 +526,37 @@ describe("message tool secret scoping", () => {
     expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
   });
 
+  it("defaults webchat message tools to the internal source-reply sink", async () => {
+    mockSendResult();
+
+    const input = await executeSend({
+      action: { message: "hi" },
+      toolOptions: {
+        currentChannelProvider: "webchat",
+        agentSessionKey: "agent:main:webchat:dm:dashboard",
+      },
+    });
+
+    expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
+  });
+
+  it("preserves explicit automatic source delivery for webchat message tools", async () => {
+    mockSendResult();
+
+    const input = await executeSend({
+      action: { message: "hi" },
+      toolOptions: {
+        currentChannelProvider: "webchat",
+        sourceReplyDeliveryMode: "automatic",
+        agentSessionKey: "agent:main:webchat:dm:dashboard",
+      },
+    });
+
+    expect(input?.sourceReplyDeliveryMode).toBe("automatic");
+    expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
+  });
+
   it("passes current inbound audio to the outbound runner", async () => {
     mockSendResult();
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -63,7 +63,10 @@ import {
   parseThreadSessionSuffix,
 } from "../../routing/session-key.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
-import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listAllChannelSupportedActions, listChannelSupportedActions } from "../channel-tools.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
@@ -1175,6 +1178,12 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
   const replyToMode = options?.replyToMode ?? (currentThreadTs ? "all" : undefined);
   const agentAccountId =
     resolveAgentAccountId(options?.agentAccountId) ?? effectiveCurrentChannel.accountId;
+  const currentChannelIsInternal =
+    normalizeMessageChannel(effectiveCurrentChannel.currentChannelProvider) ===
+    INTERNAL_MESSAGE_CHANNEL;
+  const sourceReplyDeliveryMode =
+    options?.sourceReplyDeliveryMode ??
+    (currentChannelIsInternal ? "message_tool_only" : undefined);
   const resolvedAgentId =
     options?.agentId ??
     (options?.agentSessionKey
@@ -1209,7 +1218,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
     sessionId: options?.sessionId,
     agentId: resolvedAgentId,
     requireExplicitTarget: options?.requireExplicitTarget,
-    sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
+    sourceReplyDeliveryMode,
     requesterSenderId: options?.requesterSenderId,
     senderIsOwner: options?.senderIsOwner,
   });
@@ -1415,7 +1424,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           sessionId: options?.sessionId,
           agentId: resolvedAgentId,
           sandboxRoot: options?.sandboxRoot,
-          sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
+          sourceReplyDeliveryMode,
           inboundEventKind: options?.inboundEventKind,
           inboundAudio: options?.currentInboundAudio,
           abortSignal: signal,


### PR DESCRIPTION
## What Problem This Solves

Fixes #96840.

Targetless `message.send` calls created for WebChat source turns were still using automatic source delivery, so the outbound runner required an explicit target even though WebChat should provide the internal source-reply sink for message-tool sends.

## Why This Change Was Made

The fix keeps ordinary WebChat room-event turns on automatic source delivery, but defaults WebChat-constructed (internal-channel) message tools to `message_tool_only` unless a caller explicitly supplies another source delivery mode. That keeps the existing gateway routing behavior intact while giving targetless WebChat message-tool sends the internal sink they need.

## User Impact

WebChat agents can call `message.send` without an explicit target when replying to the current source, matching the documented/source-backed behavior. Explicit automatic source delivery remains preserved for callers that request it.

## Real behavior proof

**Behavior addressed:** Targetless `message(action="send")` from an active WebChat run failed with `Action send requires a target` instead of being projected into the active chat via the internal source-reply sink (#96840, per `docs/web/webchat.md`). After this patch, internal-channel (WebChat) message tools default `sourceReplyDeliveryMode` to `message_tool_only`, so a targetless send routes through the internal sink.

**Real environment tested:** Local `openclaw` source checkout in isolated git worktrees — PR branch `oss/96840-webchat-message-tool-sink` (`6c80752285`) versus base `main` (`c68484acc4`) — Node + pnpm, `node scripts/run-vitest.mjs` with external boundaries mocked.

**Exact steps or command run after this patch:** Ran the focused regression test against base `main` (fix absent) and against the PR branch via the repo's vitest runner, then the sibling/contract suite on the branch:
```bash
# RED (PR test on main source) / GREEN (PR branch)
node scripts/run-vitest.mjs src/agents/tools/message-tool.test.ts \
  --testNamePattern 'internal source-reply sink|explicit automatic source delivery for webchat' \
  --reporter dot --maxWorkers 1
# Sibling + contract suite (PR branch)
node scripts/run-vitest.mjs \
  src/agents/tools/message-tool.test.ts \
  src/infra/outbound/message-action-runner.send-validation.test.ts \
  src/gateway/tool-resolution.test.ts --reporter dot --maxWorkers 2
```

**Evidence after fix:** Red-green plus a source/contract trace:
- RED on `main` (fix absent): `Tests 2 failed | 2 passed` — *"defaults webchat message tools to the internal source-reply sink"* fails with `AssertionError: expected undefined to be 'message_tool_only'`.
- GREEN on branch: `Test Files 2 passed (2) · Tests 4 passed`.
- Sibling + contract on branch: `Test Files 6 passed (6) · Tests 249 passed (249)` (full `message-tool` + `message-action-runner.send-validation` + `gateway/tool-resolution`).
- Contract: `applyImplicitSourceReplySendPolicy` (`src/infra/outbound/message-action-runner.ts:604`) sets `bestEffort=true` only when `action==="send" && sourceReplyDeliveryMode==="message_tool_only"` and no explicit foreign target — bypassing the `Action send requires a target` throw (`src/infra/outbound/message-action-normalization.ts:76`). This patch makes internal-channel message tools default to that mode.

**Observed result after fix:** Targetless WebChat `message.send` resolves with `sourceReplyDeliveryMode=message_tool_only` and is routed to the internal source-reply sink with no target required. Ordinary WebChat room-event turns remain on `automatic`, and explicit `sourceReplyDeliveryMode` overrides are preserved — both verified by the tests above.

**What was not tested:** A live WebChat send and Control-UI visual capture were out of scope; the repo's gate is focused red-green plus a source/contract trace. The full monorepo vitest suite was not run — coverage was scoped to the affected message-tool module plus the runner send-validation and gateway tool-resolution contracts (249 tests). Non-internal-channel providers are unchanged and exercised by their existing passing tests.

AI assistance disclosure: Codex helped identify the source-sink boundary and implement the patch; the red-green and source/contract proof above were produced with Claude.
