### PR TITLE
fix(agents): stop recording accepted sessions_spawn launches as tool failures

### DIFF
--- a/src/agents/embedded-agent-runner.extensions.test.ts
+++ b/src/agents/embedded-agent-runner.extensions.test.ts
@@ -15,6 +15,7 @@ import {
 import { buildEmbeddedExtensionFactories } from "./embedded-agent-runner/extensions.js";
 import { consumeEmbeddedToolSendReceipt } from "./embedded-agent-runner/tool-send-receipts.js";
 import { cleanupTempPluginTestEnvironment } from "./test-helpers/temp-plugin-extension-fixtures.js";
+import { jsonResult } from "./tools/common.js";
 
 const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
 const tempDirs: string[] = [];
@@ -515,26 +516,25 @@ describe("buildEmbeddedExtensionFactories", () => {
       },
     } as never);
     const handler = handlers.get("tool_result");
-    const content = [{ type: "text", text: "spawned watcher" }];
-    const details = {
+    const acceptedResult = jsonResult({
       status: "accepted",
       childSessionKey: "agent:watcher:subagent:abc",
       runId: "run-123",
       mode: "run",
-    };
+    });
 
     const result = await handler?.(
       {
         toolName: "sessions_spawn",
         toolCallId: "call-spawn",
-        content,
-        details,
+        content: acceptedResult.content,
+        details: acceptedResult.details,
         isError: true,
       },
       { cwd: "/tmp" },
     );
 
-    expect(result).toEqual({ content, details });
+    expect(result).toEqual(acceptedResult);
   });
 
   it("still marks a forbidden sessions_spawn as a model-visible failure", async () => {
@@ -628,11 +628,11 @@ describe("buildEmbeddedExtensionFactories", () => {
     } as never);
     const handler = handlers.get("tool_result");
     const content = [{ type: "text", text: "boom" }];
-    const details = {
+    const details = jsonResult({
       status: "accepted",
       childSessionKey: "agent:watcher:subagent:abc",
       runId: "run-123",
-    };
+    }).details;
 
     const result = await handler?.(
       {

--- a/src/agents/embedded-agent-runner.extensions.test.ts
+++ b/src/agents/embedded-agent-runner.extensions.test.ts
@@ -497,6 +497,157 @@ describe("buildEmbeddedExtensionFactories", () => {
     });
   });
 
+  it("keeps an accepted sessions_spawn launch successful even when the event is flagged as an error", async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+    });
+
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+    const handler = handlers.get("tool_result");
+    const content = [{ type: "text", text: "spawned watcher" }];
+    const details = {
+      status: "accepted",
+      childSessionKey: "agent:watcher:subagent:abc",
+      runId: "run-123",
+      mode: "run",
+    };
+
+    const result = await handler?.(
+      {
+        toolName: "sessions_spawn",
+        toolCallId: "call-spawn",
+        content,
+        details,
+        isError: true,
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toEqual({ content, details });
+  });
+
+  it("still marks a forbidden sessions_spawn as a model-visible failure", async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+    });
+
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+    const handler = handlers.get("tool_result");
+    const content = [{ type: "text", text: "spawn denied" }];
+    const details = { status: "forbidden", reason: "subagents disabled" };
+
+    const result = await handler?.(
+      {
+        toolName: "sessions_spawn",
+        toolCallId: "call-spawn-forbidden",
+        content,
+        details,
+        isError: true,
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toEqual({ content, details, isError: true });
+  });
+
+  it("still flags an accepted-status sessions_spawn that is missing spawn identity", async () => {
+    // Only the full accepted contract (runId + childSessionKey) is a launch; an
+    // accepted status alone must not clear an error flag.
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+    });
+
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+    const handler = handlers.get("tool_result");
+    const content = [{ type: "text", text: "partial" }];
+    const details = { status: "accepted" };
+
+    const result = await handler?.(
+      {
+        toolName: "sessions_spawn",
+        toolCallId: "call-spawn-partial",
+        content,
+        details,
+        isError: true,
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toEqual({ content, details, isError: true });
+  });
+
+  it("does not clear the error flag for a non-spawn tool with accepted-shaped details", async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+    });
+
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+    const handler = handlers.get("tool_result");
+    const content = [{ type: "text", text: "boom" }];
+    const details = {
+      status: "accepted",
+      childSessionKey: "agent:watcher:subagent:abc",
+      runId: "run-123",
+    };
+
+    const result = await handler?.(
+      {
+        toolName: "exec",
+        toolCallId: "call-exec-accepted-shape",
+        content,
+        details,
+        isError: true,
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toEqual({ content, details, isError: true });
+  });
+
   it("does not mark results as errors when status is absent or non-error", async () => {
     setActivePluginRegistry(createEmptyPluginRegistry());
 

--- a/src/agents/embedded-agent-runner.extensions.test.ts
+++ b/src/agents/embedded-agent-runner.extensions.test.ts
@@ -4,7 +4,15 @@ import {
   textToolResult,
 } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 // Covers embedded runner extension factories and tool-result middleware bridge.
-import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import {
+  AuthStorage,
+  createEventBus,
+  createExtensionRuntime,
+  ExtensionRunner,
+  loadExtensionFromFactory,
+  ModelRegistry,
+  SessionManager,
+} from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
@@ -509,13 +517,26 @@ describe("buildEmbeddedExtensionFactories", () => {
       model: undefined,
     });
 
-    const handlers = new Map<string, Function>();
-    await factories[0]?.({
-      on(event: string, handler: Function) {
-        handlers.set(event, handler);
-      },
-    } as never);
-    const handler = handlers.get("tool_result");
+    const factory = factories[0];
+    expect(factory).toBeDefined();
+    if (!factory) {
+      throw new Error("Expected embedded tool-result extension factory");
+    }
+    const runtime = createExtensionRuntime();
+    const extension = await loadExtensionFromFactory(
+      factory,
+      "/tmp",
+      createEventBus(),
+      runtime,
+      "<embedded-test>",
+    );
+    const runner = new ExtensionRunner(
+      [extension],
+      runtime,
+      "/tmp",
+      SessionManager.inMemory(),
+      ModelRegistry.inMemory(AuthStorage.inMemory()),
+    );
     const acceptedResult = jsonResult({
       status: "accepted",
       childSessionKey: "agent:watcher:subagent:abc",
@@ -523,18 +544,17 @@ describe("buildEmbeddedExtensionFactories", () => {
       mode: "run",
     });
 
-    const result = await handler?.(
-      {
-        toolName: "sessions_spawn",
-        toolCallId: "call-spawn",
-        content: acceptedResult.content,
-        details: acceptedResult.details,
-        isError: true,
-      },
-      { cwd: "/tmp" },
-    );
+    const result = await runner.emitToolResult({
+      type: "tool_result",
+      toolName: "sessions_spawn",
+      toolCallId: "call-spawn",
+      input: {},
+      content: acceptedResult.content,
+      details: acceptedResult.details,
+      isError: true,
+    });
 
-    expect(result).toEqual(acceptedResult);
+    expect(result).toEqual({ ...acceptedResult, isError: false });
   });
 
   it("still marks a forbidden sessions_spawn as a model-visible failure", async () => {

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -4,6 +4,7 @@
 import { randomUUID } from "node:crypto";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { normalizeAcceptedSessionSpawnResult } from "../accepted-session-spawn.js";
 import { setCompactionSafeguardRuntime } from "../agent-hooks/compaction-safeguard-runtime.js";
 import compactionSafeguardExtension from "../agent-hooks/compaction-safeguard.js";
 import contextPruningExtension from "../agent-hooks/context-pruning.js";
@@ -89,7 +90,11 @@ function buildAgentToolResultMiddlewareFactory(
         isError: event.isError,
         result: current,
       });
-      const isError = event.isError === true || inputHadErrorStatus || isToolResultError(result);
+      const isAcceptedSessionSpawn =
+        event.toolName === "sessions_spawn" && normalizeAcceptedSessionSpawnResult(result) !== null;
+      const isError =
+        !isAcceptedSessionSpawn &&
+        (event.isError === true || inputHadErrorStatus || isToolResultError(result));
       if (eventToolCallId) {
         finalizeToolTerminalPresentation({
           toolCallId: eventToolCallId,

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -95,6 +95,9 @@ function buildAgentToolResultMiddlewareFactory(
       const isError =
         !isAcceptedSessionSpawn &&
         (event.isError === true || inputHadErrorStatus || isToolResultError(result));
+      const clearsAcceptedSessionSpawnError =
+        isAcceptedSessionSpawn &&
+        (event.isError === true || inputHadErrorStatus || isToolResultError(result));
       if (eventToolCallId) {
         finalizeToolTerminalPresentation({
           toolCallId: eventToolCallId,
@@ -107,6 +110,7 @@ function buildAgentToolResultMiddlewareFactory(
         content: result.content,
         details: result.details,
         ...(isError ? { isError: true } : {}),
+        ...(clearsAcceptedSessionSpawnError ? { isError: false } : {}),
       };
     });
   };


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->
Closes #96833

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where an operator reviewing an agent's compaction summaries sees normal, *accepted* `sessions_spawn` subagent launches reported under `## Tool Failures` (for example `sessions_spawn (status=accepted): ...`), even though each launch succeeded. An agent that spawns several subagents accumulates a list of phantom failures, so the summary's failure list - and any operator triage based on it - becomes untrustworthy.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

An accepted `sessions_spawn` result can reach the transcript carrying `isError: true` while its payload is `details.status: "accepted"` (with `runId` and `childSessionKey`). Two layers then treat that successful launch as a failure:

- the embedded runner's tool-result classification (`embedded-agent-runner/extensions.ts`) computes the persisted/forwarded error flag from `event.isError === true || ...`, so new transcripts keep storing accepted launches as errors; and
- the compaction safeguard's `collectToolFailures` collects every `toolResult` with `isError === true`, so both new and legacy transcripts surface accepted launches in `## Tool Failures`.

This change teaches both layers that an accepted child spawn is a successful launch, reusing the existing `normalizeAcceptedSessionSpawnResult` helper - which already encodes the accepted contract (`status: "accepted"` plus a non-empty `runId` and `childSessionKey`):

- `extensions.ts` no longer classifies an accepted spawn as an error, so going forward accepted launches are persisted/forwarded with `isError: false` (the issue's first expected-behavior bullet).
- `collectToolFailures` skips accepted spawns at the read boundary, so legacy transcripts already persisted with `isError: true` also stop showing the phantom failure (the issue's third bullet).

Spawns that genuinely failed (`status: "error"` / `"forbidden"`) do not match the accepted contract and remain classified and reported as failures, as do all other tool errors. Both checks are gated on `toolName === "sessions_spawn"`, so no other tool is affected by payload shape alone. This is the smallest change that satisfies the issue's expected behavior at both the source (classification) and the read boundary (compaction); it does not alter how spawns execute or any persisted-state shape.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Compaction summaries now list only genuine tool failures. Accepted subagent launches no longer appear as `sessions_spawn: failed`; rejected or errored spawns are still reported. The fix covers both new transcripts (classified correctly at the source) and existing transcripts (filtered at read time).

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
I ran the production compaction-summary logic (`collectToolFailures` + `formatToolFailuresSection`) and the `extensions.ts` `isError` classification under Node (Docker `node:24-bookworm`), over a transcript that reproduces the issue: an accepted `sessions_spawn` persisted with `isError: true`, alongside a genuinely failed `exec` and a `forbidden` spawn. The functions are taken byte-for-byte from `main`. Captured the operator-facing `## Tool Failures` section before vs after the fix:

```
node v24.16.0

================ SURFACE 1: compaction-safeguard summary ================

--- BEFORE fix (current main) - operator sees: ---


## Tool Failures
- sessions_spawn (status=accepted): Spawned background watcher subagent.
- exec (status=failed exitCode=1): build failed: TS2304
- sessions_spawn (status=forbidden): Spawn rejected: subagents disabled.

--- AFTER fix - operator sees: ---


## Tool Failures
- exec (status=failed exitCode=1): build failed: TS2304
- sessions_spawn (status=forbidden): Spawn rejected: subagents disabled.

================ SURFACE 2: extensions.ts persisted isError ================
  accepted spawn (isError flagged on event): isError before=true  after=false
  forbidden spawn: isError before=true  after=true

================ assertions ================
  PASS  BEFORE: accepted spawn IS wrongly listed as a failure
  PASS  BEFORE: 3 failures listed (the bug)
  PASS  AFTER: accepted spawn is NOT listed
  PASS  AFTER: exec failure still listed
  PASS  AFTER: forbidden spawn still listed
  PASS  AFTER: exactly 2 genuine failures remain
  PASS  extensions: accepted spawn isError flips true->false
  PASS  extensions: forbidden spawn stays isError=true

ALL PASS ✅
```

Before the fix, the operator-facing summary lists the accepted launch as a failure; after the fix it is gone while the real `exec` and `forbidden` failures remain. At the source, the accepted spawn's persisted `isError` flips `true → false`, and the forbidden spawn stays `true`.

Regression tests added in this PR (run in Docker `node:24-bookworm` with the repo's `node scripts/run-vitest.mjs`):

- `src/agents/agent-hooks/compaction-safeguard.test.ts` - 5 new cases: accepted spawn excluded; forbidden + errored spawns still reported; accepted status without spawn identity still reported; non-spawn tool carrying accepted-shaped details still reported; mixed batch keeps genuine failures.
- `src/agents/embedded-agent-runner.extensions.test.ts` - 4 new cases: accepted spawn forwarded with no error flag even when the event arrives flagged; forbidden spawn stays a failure; accepted status without identity stays a failure; non-spawn tool with accepted-shaped details stays a failure.

With the fix applied, both files are green:

```
 ✓  agents  src/agents/agent-hooks/compaction-safeguard.test.ts (100 tests)
 ✓  agents  src/agents/embedded-agent-runner.extensions.test.ts (13 tests)
 Test Files  2 passed (2)
      Tests  113 passed (113)
```

Reverting only the two source changes (keeping the new tests) fails exactly the three positive-behavior assertions, confirming the tests pin the fix:

```
 FAIL  src/agents/embedded-agent-runner.extensions.test.ts > keeps an accepted sessions_spawn launch successful even when the event is flagged as an error
 FAIL  src/agents/agent-hooks/compaction-safeguard.test.ts > excludes accepted sessions_spawn results even when persisted with isError true
 FAIL  src/agents/agent-hooks/compaction-safeguard.test.ts > keeps genuine failures while dropping accepted spawns in a mixed batch
 Test Files  2 failed (2)
      Tests  3 failed | 110 passed (113)
```

(The deny-symmetry cases - forbidden/errored spawns and accepted-shaped non-spawn tools still reported - pass with or without the fix by design, guarding against over-correction.)

Touched-file gates (Docker `node:24-bookworm`, all on the four changed files):

- `oxfmt --check` - *All matched files use the correct format.*
- `oxlint` - *Found 0 warnings and 0 errors.*
- `pnpm tsgo:core` and `pnpm tsgo:core:test` - both exit 0 (no type errors).