### PR TITLE
fix(telegram): project album sibling media as usable paths in conversation context

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -950,8 +950,9 @@ export const registerTelegramHandlers = ({
       }
 
       const allMedia: TelegramMediaRef[] = [];
+      const currentTurnMediaByMessageId = new Map<string, TelegramMediaRef>();
       let skippedCount = 0;
-      for (const { ctx } of entry.messages) {
+      for (const { ctx, msg } of entry.messages) {
         let media;
         try {
           media = await resolveMedia({
@@ -970,11 +971,13 @@ export const registerTelegramHandlers = ({
           continue;
         }
         if (media) {
-          allMedia.push({
+          const mediaRef: TelegramMediaRef = {
             path: media.path,
-            contentType: media.contentType,
-            stickerMetadata: media.stickerMetadata,
-          });
+            ...(media.contentType ? { contentType: media.contentType } : {}),
+            ...(media.stickerMetadata ? { stickerMetadata: media.stickerMetadata } : {}),
+          };
+          allMedia.push(mediaRef);
+          currentTurnMediaByMessageId.set(String(msg.message_id), mediaRef);
         } else {
           skippedCount++;
         }
@@ -1004,6 +1007,7 @@ export const registerTelegramHandlers = ({
         ctx: primaryEntry.ctx,
         msg: primaryEntry.msg,
         allMedia,
+        currentTurnMediaByMessageId,
         storeAllowFrom: entry.storeAllowFrom,
         options: {
           ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
@@ -1373,6 +1377,7 @@ export const registerTelegramHandlers = ({
     ctx: TelegramContext;
     msg: Message;
     allMedia: TelegramMediaRef[];
+    currentTurnMediaByMessageId?: ReadonlyMap<string, TelegramMediaRef>;
     storeAllowFrom: string[];
     options?: TelegramMessageContextOptions;
     dispatchDedupeKeys?: string[];
@@ -1448,17 +1453,28 @@ export const registerTelegramHandlers = ({
         shouldHydrateReplyMedia,
       );
       const promptContextMediaByMessageId = new Map<string, TelegramMediaRef>();
+      const addPromptContextMedia = (messageId: string | undefined, media: TelegramMediaRef) => {
+        const promptMediaPath = resolveTelegramPromptMediaPath(media.path);
+        if (!messageId || !promptMediaPath) {
+          return;
+        }
+        promptContextMediaByMessageId.set(messageId, {
+          ...media,
+          path: promptMediaPath,
+        });
+      };
+      for (const [messageId, media] of params.currentTurnMediaByMessageId ?? []) {
+        addPromptContextMedia(messageId, media);
+      }
       const currentMessageId =
         typeof params.msg.message_id === "number" ? String(params.msg.message_id) : undefined;
       const currentMedia = params.allMedia[0];
-      const currentPromptMediaPath = currentMedia?.path
-        ? resolveTelegramPromptMediaPath(currentMedia.path)
-        : undefined;
-      if (currentMessageId && currentMedia && currentPromptMediaPath) {
-        promptContextMediaByMessageId.set(currentMessageId, {
-          ...currentMedia,
-          path: currentPromptMediaPath,
-        });
+      if (
+        currentMessageId &&
+        currentMedia &&
+        !promptContextMediaByMessageId.has(currentMessageId)
+      ) {
+        addPromptContextMedia(currentMessageId, currentMedia);
       }
       for (const entry of replyChain) {
         const promptMediaPath = entry.mediaPath

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -31,6 +31,32 @@ function replyPayload(replySpy: ReturnType<typeof vi.fn>, index = 0): ReplyPaylo
   return payload as ReplyPayload;
 }
 
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`expected ${label} to be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`expected ${label} to be an array`);
+  }
+  return value;
+}
+
+function structuredContextMessages(payload: ReplyPayload): Record<string, unknown>[] {
+  const [conversationContext] = requireArray(
+    payload.UntrustedStructuredContext,
+    "structured context",
+  );
+  const contextRecord = requireRecord(conversationContext, "conversation context");
+  const contextPayload = requireRecord(contextRecord.payload, "conversation context payload");
+  return requireArray(contextPayload.messages, "conversation context messages").map(
+    (message, index) => requireRecord(message, `conversation context message ${index + 1}`),
+  );
+}
+
 function downloadRequest(
   fetchSpy: ReturnType<typeof vi.spyOn>,
   index: number,
@@ -489,6 +515,85 @@ describe("telegram media groups", () => {
           expect(runtimeError).not.toHaveBeenCalled();
           scenario.assert(replySpy);
         }
+      } finally {
+        setTimeoutSpy.mockRestore();
+        clearTimeoutSpy.mockRestore();
+        fetchSpy.mockRestore();
+      }
+    },
+    MEDIA_GROUP_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "hydrates every media-group message in prompt context",
+    async () => {
+      const runtimeError = vi.fn();
+      const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
+      const fetchSpy = mockTelegramPngDownload();
+      let nextTimerHandle = 1;
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
+        const handle = nextTimerHandle;
+        nextTimerHandle += 1;
+        return handle as unknown as ReturnType<typeof setTimeout>;
+      });
+      const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+      const firstPath = "/tmp/openclaw/media/inbound/album-photo-501.png";
+      const secondPath = "/tmp/openclaw/media/inbound/album-photo-502.png";
+
+      try {
+        setNextSavedMediaPath({ path: firstPath, contentType: "image/png" });
+        setNextSavedMediaPath({ path: secondPath, contentType: "image/png" });
+
+        await Promise.all([
+          handler({
+            message: {
+              chat: { id: 42, type: "private" as const },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 501,
+              date: 1736380800,
+              media_group_id: "album-context",
+              photo: [{ file_id: "photo501" }],
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({ file_path: "photos/photo501.png" }),
+          }),
+          handler({
+            message: {
+              chat: { id: 42, type: "private" as const },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 502,
+              caption: "Here are my photos",
+              date: 1736380801,
+              media_group_id: "album-context",
+              photo: [{ file_id: "photo502" }],
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({ file_path: "photos/photo502.png" }),
+          }),
+        ]);
+
+        await flushActiveScheduledTimersForDelay({
+          setTimeoutSpy,
+          clearTimeoutSpy,
+          delayMs: TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs,
+          expectedCount: 1,
+        });
+        await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
+
+        expect(runtimeError).not.toHaveBeenCalled();
+        const payload = replyPayload(replySpy);
+        expect(payload.MediaPaths).toEqual(expect.arrayContaining([firstPath, secondPath]));
+        const messages = structuredContextMessages(payload);
+        const messagesById = new Map(
+          messages.map((message) => [String(message.message_id), message]),
+        );
+        expect(messagesById.get("501")).toMatchObject({
+          media_path: "media://inbound/album-photo-501.png",
+        });
+        expect(messagesById.get("501")?.media_ref).toBeUndefined();
+        expect(messages.some((message) => message.media_ref === "telegram:file/photo501")).toBe(
+          false,
+        );
       } finally {
         setTimeoutSpy.mockRestore();
         clearTimeoutSpy.mockRestore();


### PR DESCRIPTION
Refs #96846

## What Problem This Solves

In a Telegram photo album (media group), every photo is downloaded and the
current turn's media array already carries all of them — so the model receives
each album photo as a native image block. However, the **conversation-context
projection** (`UntrustedStructuredContext` chat window) only associated resolved
media with the *primary* album message. Sibling album messages were therefore
listed in that context with their raw cache reference, e.g.
`[image/png telegram:file/AgAC...]`, instead of a usable `media://inbound/...`
path.

This is the same raw-reference class that reply-chain hydration already fixed
for replied media (#93575); albums were the remaining gap for sibling messages.

## Why This Change Was Made

The media-group flush resolves every album photo but keyed prompt-context
hydration only to `params.allMedia[0]` / the primary message id, leaving sibling
album message ids with no resolved mapping. This change carries the resolved
per-message media (by source Telegram message id) into prompt-context hydration
so sibling album messages project to `media://inbound/...` paths — matching the
existing current-turn and reply-chain projection — without changing the
current-turn media array, reply-chain handling, or channel policy.

## Scope (what this does and does not change)

- **Does:** normalize sibling album messages in the untrusted conversation
  context from raw `telegram:file/...` refs to `media://inbound/...` paths, so
  the context text is consistent with how current and replied media is already
  shown.
- **Does not:** change which images the model can visually decode. The model
  sees album images via the current-turn `MediaPaths` array
  (`bot-message-context.body.ts` → `current-turn-images.ts`), which already
  includes every downloaded album photo on `main`. Context-window entries are
  rendered to the model as **text** (`inbound-meta.ts` `formatChatWindowMessage`),
  so this change improves the textual reference, not native image rendering.

## User Impact

Multi-photo Telegram album sends no longer leave unreadable `telegram:file/...`
references in the model-facing conversation context; sibling album messages are
shown with the same `media://inbound/...` paths as primary and replied media.
No change to current-turn image rendering or any channel/policy behavior.

## Evidence

Local source-level red-green (mocked Telegram boundary).

New regression test, on this branch — **passes** (sibling message `501` projects
`media_path: media://inbound/album-photo-501.png`, no `media_ref`, no
`telegram:file/...`):

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts \
  extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts \
  --testNamePattern 'hydrates every media-group message' --reporter verbose \
  --maxWorkers 1 --testTimeout 30000
```

Same test against base `main` runtime (PR test + base
`bot-handlers.runtime.ts`) — **fails** as expected:
`expected { message_id: '501', … } to match object { media_path }`, received
`media_path: undefined`.

The pre-existing `MediaPaths` assertion in the same test
(`arrayContaining([firstPath, secondPath])`) passes on both base and branch,
confirming current-turn image rendering of all album photos is unchanged by this
PR.

**What was not tested:** a live Telegram album send through the real Bot API to a
real model. This PR is scoped to the deterministic context-projection seam and
does not alter the native image path, so live visible proof is not required to
validate this change's stated effect. The broader end-to-end album-render path
is tracked separately on #96846.

AI-assisted. I reviewed and own the diff.
