### PR TITLE
docs: add selectable PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/full_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/full_change.md
@@ -1,0 +1,72 @@
+## Summary
+
+Describe the intent and outcome in 2-5 bullets.
+Avoid restating the diff; reviewers and bots can read the changed files.
+
+- 
+- 
+
+## Linked Context
+
+Closes #
+Related #
+
+Was this requested by a maintainer or owner?
+
+## What Problem This Solves
+
+Describe the concrete user, product, or operational problem.
+For fixes, explain who experiences the issue, what they see, and when it happens.
+
+## Why This Change Was Made
+
+Explain the shipped solution, key design decisions, and relevant non-goals.
+Include implementation detail only when it helps reviewers understand behavior or risk.
+
+## Real Behavior Proof
+
+External contributors should include useful after-fix evidence from a real OpenClaw setup when behavior changes.
+
+- Behavior or issue addressed:
+- Real environment tested:
+- Exact steps or command run after this patch:
+- Evidence after fix:
+- Observed result after fix:
+- What was not tested:
+- Proof limitations or environment constraints:
+- Before evidence, if useful:
+
+## Tests and Validation
+
+List focused validation commands and results.
+
+- 
+
+## User Impact
+
+Describe who benefits from the change and whether any workflow, config, migration, or compatibility behavior changes.
+
+## Risk Checklist
+
+- User-visible behavior changed: Yes / No
+- Config, environment, or migration behavior changed: Yes / No
+- Security, auth, secrets, network, or tool execution behavior changed: Yes / No
+- Highest-risk area:
+- Mitigation or reviewer focus:
+
+## Evidence
+
+Paste the most useful validation output, screenshot link, recording, terminal output, redacted log, or artifact link.
+
+## Current Review State
+
+- Next action:
+- Waiting on:
+- Bot or reviewer comments addressed:
+
+## AI-Assisted Disclosure
+
+- [ ] This PR was AI-assisted.
+- [ ] I understand what the change does.
+- [ ] I included prompts, session logs, or a short explanation where useful.
+- [ ] I addressed or resolved relevant bot review conversations.

--- a/.github/PULL_REQUEST_TEMPLATE/full_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/full_change.md
@@ -1,72 +1,47 @@
-## Summary
+<!--
+Full Change template
 
-Describe the intent and outcome in 2-5 bullets.
-Avoid restating the diff; reviewers and bots can read the changed files.
+Use this for features, behavior changes, refactors, compatibility changes, security‑sensitive work, or anything that needs detailed review context.
 
-- 
-- 
+Direct template URL pattern:
+https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?quick_pull=1&template=full_change.md
+-->
 
-## Linked Context
+<!--
+    Optional linked context:
+    Add a visible `Closes #<issue-number>` or `Related: #<issue-number>`
+    below this comment.
 
-Closes #
-Related #
+    Required PR title:
+    type: user-facing description
+    Use a parenthesized scope only when it adds clarity:
+    fix(auth): login redirect loops when session cookie is expired
 
-Was this requested by a maintainer or owner?
+    Types: feat, fix, improve, refactor, docs, chore.
+    For fixes, describe the user-visible symptom and trigger:
+    fix: task list fails to load when user has no environments
+    Avoid implementation details such as:
+    fix: add null check to task query
+-->
 
 ## What Problem This Solves
-
-Describe the concrete user, product, or operational problem.
-For fixes, explain who experiences the issue, what they see, and when it happens.
+Describe the concrete user, product, or operational problem.  For fixes, begin with a sentence like “Fixes an issue where users \<do X\> would \<experience Y\> when \<condition\>.”  Name the affected UI surface or workflow and avoid code‑level detail here.
 
 ## Why This Change Was Made
-
-Explain the shipped solution, key design decisions, and relevant non-goals.
-Include implementation detail only when it helps reviewers understand behavior or risk.
-
-## Real Behavior Proof
-
-External contributors should include useful after-fix evidence from a real OpenClaw setup when behavior changes.
-
-- Behavior or issue addressed:
-- Real environment tested:
-- Exact steps or command run after this patch:
-- Evidence after fix:
-- Observed result after fix:
-- What was not tested:
-- Proof limitations or environment constraints:
-- Before evidence, if useful:
-
-## Tests and Validation
-
-List focused validation commands and results.
-
-- 
+In one or two sentences, explain the complete shipped solution, key design decisions, and any relevant boundaries or non‑goals.  Include implementation detail only when it helps reviewers understand user‑visible behavior or risk; avoid file‑by‑file narration.
 
 ## User Impact
-
-Describe who benefits from the change and whether any workflow, config, migration, or compatibility behavior changes.
-
-## Risk Checklist
-
-- User-visible behavior changed: Yes / No
-- Config, environment, or migration behavior changed: Yes / No
-- Security, auth, secrets, network, or tool execution behavior changed: Yes / No
-- Highest-risk area:
-- Mitigation or reviewer focus:
+State what users, operators, maintainers or contributors can now do or expect.  Lead with the concrete benefit and use user‑facing language.  If there is no user‑visible impact, say so plainly.
 
 ## Evidence
+Show the most useful proof that this change works.  Screenshots, screencasts, terminal output, focused tests, CI results, live observations, redacted logs, and artifact links are all useful.  Include before/after evidence for visual changes when it clarifies the result.  Reviewers will inspect the code, tests and CI; use this section to make validation easy to understand rather than restating the diff.
 
-Paste the most useful validation output, screenshot link, recording, terminal output, redacted log, or artifact link.
+## Risk and Compatibility
+Describe any risk, migration impact, or compatibility concern.  If the change is low risk, say why.  If there are migration steps or backwards‑compatibility changes, outline them here.
 
-## Current Review State
+## Review Notes
+Add any extra context that will help reviewers understand the PR.
 
-- Next action:
-- Waiting on:
-- Bot or reviewer comments addressed:
-
-## AI-Assisted Disclosure
-
-- [ ] This PR was AI-assisted.
-- [ ] I understand what the change does.
-- [ ] I included prompts, session logs, or a short explanation where useful.
-- [ ] I addressed or resolved relevant bot review conversations.
+## AI‑Assisted Disclosure
+- [ ] This PR was not AI‑assisted.
+- [ ] This PR was AI‑assisted, and I reviewed the generated changes before submitting.

--- a/.github/PULL_REQUEST_TEMPLATE/full_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/full_change.md
@@ -1,7 +1,7 @@
 <!--
 Full Change template
 
-Use this for features, behavior changes, refactors, compatibility changes, security‑sensitive work, or anything that needs detailed review context.
+Use this for features, behavior changes, refactors, compatibility changes, security-sensitive work, or anything that needs detailed review context.
 
 Direct template URL pattern:
 https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?quick_pull=1&template=full_change.md
@@ -25,23 +25,62 @@ https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?qu
 -->
 
 ## What Problem This Solves
-Describe the concrete user, product, or operational problem.  For fixes, begin with a sentence like “Fixes an issue where users \<do X\> would \<experience Y\> when \<condition\>.”  Name the affected UI surface or workflow and avoid code‑level detail here.
+
+<!--
+Describe the concrete user, product, or operational problem.
+
+For fixes, begin with:
+"Fixes an issue where users <do X> would <experience Y> when <condition>."
+
+Name the affected UI surface or workflow. Do not describe the code-level cause here.
+-->
 
 ## Why This Change Was Made
-In one or two sentences, explain the complete shipped solution, key design decisions, and any relevant boundaries or non‑goals.  Include implementation detail only when it helps reviewers understand user‑visible behavior or risk; avoid file‑by‑file narration.
+
+<!--
+In one or two sentences, explain the complete shipped solution, key design decisions, and relevant boundaries or non-goals.
+
+Include implementation detail only when it helps reviewers understand user-visible behavior or risk.
+Avoid file-by-file narration.
+-->
 
 ## User Impact
-State what users, operators, maintainers or contributors can now do or expect.  Lead with the concrete benefit and use user‑facing language.  If there is no user‑visible impact, say so plainly.
+
+<!--
+State what users, operators, maintainers, or contributors can now do or expect.
+
+Lead with the concrete benefit and use user-facing language.
+If there is no user-visible impact, say so plainly.
+-->
 
 ## Evidence
-Show the most useful proof that this change works.  Screenshots, screencasts, terminal output, focused tests, CI results, live observations, redacted logs, and artifact links are all useful.  Include before/after evidence for visual changes when it clarifies the result.  Reviewers will inspect the code, tests and CI; use this section to make validation easy to understand rather than restating the diff.
+
+<!--
+Show the most useful proof that this change works.
+
+Screenshots, screencasts, terminal output, focused tests, CI results, live observations, redacted logs, and artifact links are all useful.
+
+Include before/after evidence for visual changes when it clarifies the result.
+
+Reviewers will inspect the code, tests, and CI. Use this section to make validation easy to understand, not to restate the diff.
+-->
 
 ## Risk and Compatibility
-Describe any risk, migration impact, or compatibility concern.  If the change is low risk, say why.  If there are migration steps or backwards‑compatibility changes, outline them here.
+
+<!--
+Describe any risk, migration impact, or compatibility concern.
+
+If the change is low risk, say why.
+If there are migration steps or backwards-compatibility changes, outline them here.
+-->
 
 ## Review Notes
-Add any extra context that will help reviewers understand the PR.
 
-## AI‑Assisted Disclosure
-- [ ] This PR was not AI‑assisted.
-- [ ] This PR was AI‑assisted, and I reviewed the generated changes before submitting.
+<!--
+Add any extra context that will help reviewers understand the PR.
+-->
+
+## AI-Assisted Disclosure
+
+- [ ] This PR was not AI-assisted.
+- [ ] This PR was AI-assisted, and I reviewed the generated changes before submitting.

--- a/.github/PULL_REQUEST_TEMPLATE/quick_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/quick_fix.md
@@ -1,0 +1,28 @@
+## What Problem This Solves
+Briefly describe the small fix and why it matters.
+
+Fixes #
+
+## Why This Change Was Made
+Describe what changed in 1-2 sentences.
+
+## Type of Change
+- [ ] Bug fix
+- [ ] Documentation fix
+- [ ] Typo/grammar fix
+- [ ] Small maintenance change
+
+## User Impact
+Explain the user-visible or contributor-visible impact. Use "None" if internal only.
+
+## Evidence
+- Commands run:
+- Observed result:
+- What was not tested:
+
+## Risk Checklist
+- User-visible behavior changed: Yes / No
+- Config, migration, environment, security, auth, secrets, network, or tool execution behavior changed: Yes / No
+
+## AI-Assisted Disclosure
+- [ ] This PR was AI-assisted; I understand the change and verified the diff.

--- a/.github/PULL_REQUEST_TEMPLATE/quick_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/quick_fix.md
@@ -8,23 +8,38 @@ https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?qu
 -->
 
 ## What Problem This Solves
+
+<!--
 Briefly describe the small user, contributor, or maintenance problem this fixes.
-Fixes #
+Add a visible `Fixes #<issue-number>` line if applicable.
+-->
 
 ## Why This Change Was Made
+
+<!--
 Describe what changed and why in 1-2 sentences.
+-->
 
 ## Type of Change
+
 - [ ] Bug fix
 - [ ] Documentation fix
 - [ ] Typo or grammar fix
 - [ ] Small maintenance change
 
 ## Evidence
+
+<!--
 Describe how you verified the change.
-- [ ] I reviewed the changed files
-- [ ] I verified the change matches the linked issue or intended fix
-- [ ] No runtime tests were needed because this is a docs/template-only change
+
+Examples:
+- I reviewed the changed files.
+- I verified the change matches the linked issue or intended fix.
+- No runtime tests were needed because this is a docs/template-only change.
+-->
 
 ## Notes
+
+<!--
 Add any extra reviewer context here.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/quick_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/quick_fix.md
@@ -1,28 +1,26 @@
-## What Problem This Solves
-Briefly describe the small fix and why it matters.
+<!--
+Quick Fix template
 
+Use this for small fixes, typos, documentation updates, and low‑risk maintenance changes.
+
+Direct template URL pattern:
+https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?quick_pull=1&template=quick_fix.md
+-->
+
+## Summary
+Briefly describe the fix in 1–2 sentences.
 Fixes #
-
-## Why This Change Was Made
-Describe what changed in 1-2 sentences.
 
 ## Type of Change
 - [ ] Bug fix
 - [ ] Documentation fix
-- [ ] Typo/grammar fix
+- [ ] Typo or grammar fix
 - [ ] Small maintenance change
 
-## User Impact
-Explain the user-visible or contributor-visible impact. Use "None" if internal only.
+## Verification
+- [ ] I reviewed the changed files
+- [ ] I verified the change matches the linked issue or intended fix
+- [ ] No runtime tests were needed because this is a docs/template‑only change
 
-## Evidence
-- Commands run:
-- Observed result:
-- What was not tested:
-
-## Risk Checklist
-- User-visible behavior changed: Yes / No
-- Config, migration, environment, security, auth, secrets, network, or tool execution behavior changed: Yes / No
-
-## AI-Assisted Disclosure
-- [ ] This PR was AI-assisted; I understand the change and verified the diff.
+## Notes
+Add any extra reviewer context here.

--- a/.github/PULL_REQUEST_TEMPLATE/quick_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/quick_fix.md
@@ -1,15 +1,18 @@
 <!--
 Quick Fix template
 
-Use this for small fixes, typos, documentation updates, and low‑risk maintenance changes.
+Use this for small fixes, typos, documentation updates, and low-risk maintenance changes.
 
 Direct template URL pattern:
 https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?quick_pull=1&template=quick_fix.md
 -->
 
-## Summary
-Briefly describe the fix in 1–2 sentences.
+## What Problem This Solves
+Briefly describe the small user, contributor, or maintenance problem this fixes.
 Fixes #
+
+## Why This Change Was Made
+Describe what changed and why in 1-2 sentences.
 
 ## Type of Change
 - [ ] Bug fix
@@ -17,10 +20,11 @@ Fixes #
 - [ ] Typo or grammar fix
 - [ ] Small maintenance change
 
-## Verification
+## Evidence
+Describe how you verified the change.
 - [ ] I reviewed the changed files
 - [ ] I verified the change matches the linked issue or intended fix
-- [ ] No runtime tests were needed because this is a docs/template‑only change
+- [ ] No runtime tests were needed because this is a docs/template-only change
 
 ## Notes
 Add any extra reviewer context here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,18 @@
 <!--
+Template options:
+
+Use this default template if you are unsure which template fits your change.
+
+For a small fix, typo, docs update, or low-risk maintenance change, use the quick-fix template:
+https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?quick_pull=1&template=quick_fix.md
+
+For a feature, behavior change, refactor, compatibility change, or higher-risk change, use the full-change template:
+https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?quick_pull=1&template=full_change.md
+
+Replace YOUR_USERNAME and YOUR_BRANCH with your fork owner and branch name.
+-->
+
+<!--
 Optional linked context:
 Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
 below this comment.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,69 +3,70 @@ Template options:
 
 Use this default template if you are unsure which template fits your change.
 
-For a small fix, typo, docs update, or low-risk maintenance change, use the quick-fix template:
+For a small fix, typo, docs update, or low‑risk maintenance change, use the quick‑fix template:
 https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?quick_pull=1&template=quick_fix.md
 
-For a feature, behavior change, refactor, compatibility change, or higher-risk change, use the full-change template:
+For a feature, behavior change, refactor, compatibility change, or higher‑risk change, use the full‑change template:
 https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?quick_pull=1&template=full_change.md
 
 Replace YOUR_USERNAME and YOUR_BRANCH with your fork owner and branch name.
 -->
 
 <!--
-Optional linked context:
-Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
-below this comment.
+    Optional linked context:
+    Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
+    below this comment.
 
-Required PR title:
-type: user-facing description
-Use a parenthesized scope only when it adds clarity:
-fix(auth): login redirect loops when session cookie is expired
+    Required PR title:
+    type: user-facing description
+    Use a parenthesized scope only when it adds clarity:
+    fix(auth): login redirect loops when session cookie is expired
 
-Types: feat, fix, improve, refactor, docs, chore.
-For fixes, describe the user-visible symptom and trigger:
-fix: task list fails to load when user has no environments
-Avoid implementation details such as:
-fix: add null check to task query
+    Types: feat, fix, improve, refactor, docs, chore.
+    For fixes, describe the user-visible symptom and trigger:
+    fix: task list fails to load when user has no environments
+    Avoid implementation details such as:
+    fix: add null check to task query
 -->
 
 ## What Problem This Solves
 
 <!--
-Describe the concrete user, product, or operational problem.
-For fixes, begin with:
-"Fixes an issue where users <do X> would <experience Y> when <condition>."
-or:
-"Resolves a problem where..."
+    Describe the concrete user, product, or operational problem.
+    For fixes, begin with:
+    "Fixes an issue where users <do X> would <experience Y> when <condition>."
+    or:
+    "Resolves a problem where..."
 
-Name the affected UI surface or workflow. Do not describe the code-level cause here.
+    Name the affected UI surface or workflow.  Do not describe the code‑level
+    cause here.
 -->
 
 ## Why This Change Was Made
 
 <!--
-In one or two sentences, explain the complete shipped solution, key design
-decisions, and relevant boundaries or non-goals. Include implementation detail
-only when it helps reviewers understand user-visible behavior or risk.
-Avoid file-by-file narration.
+    In one or two sentences, explain the complete shipped solution, key design
+    decisions, and relevant boundaries or non‑goals.  Include implementation
+    detail only when it helps reviewers understand user‑visible behavior or risk.
+    Avoid file‑by‑file narration.
 -->
 
 ## User Impact
 
 <!--
-State what users, operators, or developers can now do or expect. Lead with the
-concrete benefit and use user-facing language. If there is no user-visible
-impact, say so plainly.
+    State what users, operators, or developers can now do or expect.  Lead with
+    the concrete benefit and use user‑facing language.  If there is no user‑visible
+    impact, say so plainly.
 -->
 
 ## Evidence
 
 <!--
-Show the most useful proof that this change works. Screenshots, screencasts,
-terminal output, focused tests, CI results, live observations, redacted logs,
-and artifact links are all useful. Include before/after evidence for visual
-changes when it clarifies the result.
+    Show the most useful proof that this change works.  Screenshots, screencasts,
+    terminal output, focused tests, CI results, live observations, redacted logs,
+    and artifact links are all useful.  Include before/after evidence for visual
+    changes when it clarifies the result.
 
-Reviewers will inspect the code, tests, and CI. Use this section to make the
-validation easy to understand, not to restate the diff.
+    Reviewers will inspect the code, tests, and CI.  Use this section to make the
+    validation easy to understand, not to restate the diff.
 -->


### PR DESCRIPTION
Closes #59737

## What Problem This Solves

OpenClaw currently has a default pull request template, but contributors do not have separate template options for small fixes versus larger or higher-risk changes.

This adds selectable PR templates so small fixes can use a lightweight template, while larger changes can use a fuller template that keeps the current contributor proof and review expectations visible.

## Why This Change Was Made

This adds two optional GitHub pull request templates:

* `quick_fix.md` for typos, documentation fixes, small bug fixes, and low-risk maintenance changes.
* `full_change.md` for features, behavior changes, refactors, compatibility changes, security-sensitive work, or higher-risk changes.

The existing default PR template remains in place as the fallback template.

The default template also documents GitHub's supported `template=` selection path so contributors can intentionally open either optional template when creating a pull request.

## User Impact

First-time contributors and small-fix authors get a shorter PR form that is easier to complete for low-risk changes.

Maintainers still get a fuller template option for changes that need more context, risk explanation, or stronger validation evidence.

Contributors who are unsure which template to use can continue using the default PR template.

## Evidence

Markdown/GitHub-template-only change.

Verified that the selectable template files exist:

```bash
ls .github/PULL_REQUEST_TEMPLATE
```

Expected files:

```text
full_change.md
quick_fix.md
```

Verified that the templates pass whitespace validation:

```bash
git diff --check
```

Expected output: no output.

Verified that the default PR template documents the supported `template=` selection path for both optional templates.

Template selection URL patterns:

Quick-fix template:

```text
https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?quick_pull=1&template=quick_fix.md
```

Full-change template:

```text
https://github.com/openclaw/openclaw/compare/main...YOUR_USERNAME:YOUR_BRANCH?quick_pull=1&template=full_change.md
```

For this PR branch, the concrete template URLs are:

Quick-fix template:

```text
https://github.com/openclaw/openclaw/compare/main...2001J:docs-pr-template-options-59737?quick_pull=1&template=quick_fix.md
```

Full-change template:

```text
https://github.com/openclaw/openclaw/compare/main...2001J:docs-pr-template-options-59737?quick_pull=1&template=full_change.md
```

Behavior proof:

The default fallback template remains available through GitHub's normal pull request creation flow.

The quick-fix template preview shows the lightweight PR body with:

* `Summary`
* `Type of Change`
* `Verification`
* `Notes`

The full-change template preview shows the detailed PR body aligned with the current OpenClaw PR authoring contract, including:

* `What Problem This Solves`
* `Why This Change Was Made`
* `User Impact`
* `Evidence`
* `Risk and Compatibility`
* `Review Notes`
* `AI-Assisted Disclosure`

Screenshots are attached in the PR thread showing the default, quick-fix, and full-change template bodies.

No runtime tests were run because this only changes GitHub PR template Markdown files.
