### PR TITLE
Fix TaskFlow stale audit for ended blocked flows

### DIFF
--- a/src/tasks/task-flow-registry.audit.test.ts
+++ b/src/tasks/task-flow-registry.audit.test.ts
@@ -226,6 +226,49 @@ describe("task-flow-registry audit", () => {
     });
   });
 
+  it("does not flag ended blocked flows as stale", async () => {
+    await withTaskFlowAuditStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-audit",
+        goal: "Terminal blocked work",
+        status: "running",
+        createdAt: 1,
+        updatedAt: 1,
+      });
+
+      setFlowWaiting({
+        flowId: flow.flowId,
+        expectedRevision: flow.revision,
+        blockedTaskId: "task-missing",
+        blockedSummary: "Completion handoff did not produce a visible reply",
+        updatedAt: 1,
+      });
+
+      const blocked = listTaskFlowAuditFindings({ now: 31 * 60_000 });
+      expect(requireFinding(blocked, "stale_blocked", flow.flowId).flow?.flowId).toBe(flow.flowId);
+
+      const terminalFlow: TaskFlowRecord = {
+        ...flow,
+        status: "blocked" as const,
+        blockedTaskId: "task-missing",
+        blockedSummary: "Completion handoff did not produce a visible reply",
+        endedAt: 1,
+        updatedAt: 1,
+      };
+
+      const terminalFindings = listTaskFlowAuditFindings({
+        flows: [terminalFlow],
+        now: 31 * 60_000,
+      });
+      expect(
+        terminalFindings.some(
+          (finding) => finding.code === "stale_blocked" && finding.flow?.flowId === flow.flowId,
+        ),
+      ).toBe(false);
+    });
+  });
+
   it("reports cancel-stuck before maintenance finalizes the flow", async () => {
     await withTaskFlowAuditStateDir(async () => {
       const flow = createManagedTaskFlow({

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -192,7 +192,7 @@ export function listTaskFlowAuditFindings(
       );
     }
 
-    if (flow.status === "blocked" && ageMs >= staleBlockedMs) {
+    if (flow.status === "blocked" && flow.endedAt == null && ageMs >= staleBlockedMs) {
       findings.push(
         createFinding({
           severity: "warn",


### PR DESCRIPTION
## Summary
- Treat blocked TaskFlows with `endedAt` as terminal history for stale-blocked audit purposes
- Keep stale-blocked warnings for non-ended blocked flows
- Add a regression covering ended blocked flows

## Test
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tasks.config.ts`
