### PR TITLE
fix(codex): successful sessions_spawn and goal tool results recorded as failures

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -308,6 +308,100 @@ describe("createCodexDynamicToolBridge", () => {
     });
   });
 
+  it("treats an accepted child session spawn result as a successful dynamic tool call", async () => {
+    // An accepted sessions_spawn launch carries details.status "accepted" with a
+    // runId + childSessionKey. The launch succeeded (the child session was
+    // accepted), so Codex must see a successful tool call, not an error.
+    // Regression for #96833: "accepted" was missing from the non-error status
+    // allowlist, so the launch was classified as an error and persisted with
+    // isError: true (and reported to Codex as success: false).
+    const onAgentToolResult = vi.fn();
+    const bridge = createBridgeWithToolResult(
+      "sessions_spawn",
+      textToolResult("Accepted: launching child session to scan logs.", {
+        status: "accepted",
+        runId: "run_5f3a9c",
+        childSessionKey: "child-7b21",
+        mode: "run",
+      }),
+    );
+
+    const result = await bridge.handleToolCall(
+      {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-accepted",
+        namespace: null,
+        tool: "sessions_spawn",
+        arguments: { task: "scan logs" },
+      },
+      { onAgentToolResult },
+    );
+
+    // success: true proves the accepted launch is not classified as an error;
+    // the content assertion proves the tool actually executed (not a denial path).
+    expect(result.success).toBe(true);
+    expect(result.contentItems).toEqual([
+      { type: "inputText", text: "Accepted: launching child session to scan logs." },
+    ]);
+    expect(onAgentToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "sessions_spawn", isError: false }),
+    );
+  });
+
+  it("still reports a forbidden sessions_spawn result as a failed dynamic tool call", async () => {
+    // Deny symmetry: a genuinely rejected spawn (status "forbidden") must stay an
+    // error so the accepted-status allowlist entry does not over-correct.
+    const bridge = createBridgeWithToolResult(
+      "sessions_spawn",
+      textToolResult("Forbidden: spawn limit reached.", { status: "forbidden" }),
+    );
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-forbidden",
+      namespace: null,
+      tool: "sessions_spawn",
+      arguments: { task: "deploy" },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("treats accepted goal tool statuses (created / updated) as successful dynamic tool calls", async () => {
+    // Same classifier-completeness class as the accepted spawn fix: create_goal /
+    // update_goal return details.status "created" / "updated", reach codex agents
+    // through the dynamic-tool bridge, and must not be classified as errors (#96833).
+    const createdBridge = createBridgeWithToolResult(
+      "create_goal",
+      textToolResult("Goal created.", { status: "created" }),
+    );
+    const createdResult = await createdBridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-created",
+      namespace: null,
+      tool: "create_goal",
+      arguments: { text: "ship the fix" },
+    });
+    expect(createdResult.success).toBe(true);
+
+    const updatedBridge = createBridgeWithToolResult(
+      "update_goal",
+      textToolResult("Goal updated.", { status: "updated" }),
+    );
+    const updatedResult = await updatedBridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-updated",
+      namespace: null,
+      tool: "update_goal",
+      arguments: { status: "completed" },
+    });
+    expect(updatedResult.success).toBe(true);
+  });
+
   it("keeps available and registered schemas paired with their tools", () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -902,6 +902,9 @@ function isCodexToolResultError(result: AgentToolResult<unknown>): boolean {
     status !== "success" &&
     status !== "completed" &&
     status !== "recorded" &&
+    status !== "created" &&
+    status !== "updated" &&
+    status !== "accepted" &&
     status !== "pending" &&
     status !== "started" &&
     status !== "running" &&


### PR DESCRIPTION
Related: #96833

## What Problem This Solves

Fixes an issue where a Codex-runtime agent's *successful* dynamic tool calls are recorded as tool failures. When an agent launches a subagent, the accepted launch (`sessions_spawn`) is persisted on the session transcript as a failed tool result; the same happens for successful `create_goal` / `update_goal` calls. The model then sees its own successful actions as failures in the live transcript, and the compaction "Tool Failures" summary lists them as failures, making an agent's failure list untrustworthy.

This is the source-side counterpart to #96842 (which guards the compaction summary on the read side). This PR fixes the classification at its origin so the wrong terminal state is never produced for these results.

## Why This Change Was Made

In the Codex app-server runtime, `isCodexToolResultError` (`extensions/codex/src/app-server/dynamic-tools.ts`) classifies a dynamic tool result by a non-error status allowlist and fail-closes any status not in the list. A result classified as an error becomes `success: false` in the response sent to Codex, which Codex maps to a `Failed` dynamic-tool item status, and which OpenClaw persists on the transcript as `toolResult.isError: true`.

Several success statuses emitted by OpenClaw tools that are exposed to Codex agents were missing from the allowlist:

- `sessions_spawn` accepted launches → `details.status: "accepted"`
- `create_goal` / `update_goal` results → `details.status: "created"` / `"updated"`

The fix adds these statuses to the allowlist alongside their sibling success statuses (`completed`, `recorded`, `started`, `running`, …). Genuinely failed or rejected results (`status: "error"` / `"forbidden"`) remain fail-closed and continue to be reported as failures.

Scope boundary: this changes only the Codex dynamic-tool result classifier. The Pi agent-loop runtime is unaffected — it uses an inverse failure-status allowlist (`src/agents/tool-result-error.ts`) under which `accepted` / `created` / `updated` are already non-errors. The message tool's `suppressed` status is intentionally left out, since a suppressed outbound send may be intended as a model-facing failure (a product decision, not a clear bug).

## User Impact

Codex-runtime agents no longer have their successful subagent launches and successful goal create/update calls recorded as tool failures. The live transcript and the compaction summary reflect only genuinely failed tool calls. As a side benefit, post-tool-use hooks now fire correctly for accepted launches (the Codex runtime gates those hooks on the same success flag).

## Evidence

Tier: internal deterministic classifier (`isCodexToolResultError` is pure logic over a tool result), but its effect is observable end-to-end through the real persistence path, so a real-runtime before/after is included below in addition to focused tests.

### Focused regression tests

`extensions/codex/src/app-server/dynamic-tools.test.ts`, exercised through the real `createCodexDynamicToolBridge` executor:
- an accepted `sessions_spawn` result is reported as a successful dynamic tool call (fails before the change, passes after);
- `create_goal` (`"created"`) and `update_goal` (`"updated"`) results are reported as successful;
- a `forbidden` `sessions_spawn` result is still reported as a failure (deny symmetry, guards against over-correction);
- the existing "unrecognized non-success statuses stay fail-closed" contract test is unchanged and still passes.

```
node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts
 Test Files  1 passed (1)
      Tests  59 passed (59)
```

Touched-file gates (local): `oxfmt --check` clean; `oxlint` clean.

### Real behavior proof

- **Behavior or issue addressed:** an accepted `sessions_spawn` result is persisted on the session transcript with `toolResult.isError: true` (and reported to Codex as `success: false`) instead of as a success.
- **Real environment tested:** the real `runCodexAppServerAttempt` orchestration driving the real dynamic-tool bridge → `isCodexToolResultError` → event projector → session-JSONL transcript writer. The tools that return the accepted/created/updated payloads are supplied via the test tool registry; the classification and persistence path are the production code paths. (The classifier, not the Codex binary, computes `isError`: the Rust app-server only relays `success` and maps it to the item status — verified against the upstream Codex source.)
- **Exact steps run after this patch:** drive one attempt with a `sessions_spawn` (`accepted`), a `create_goal` (`created`), and an `update_goal` (`updated`) dynamic-tool result, then read the persisted `session.jsonl` and inspect each `toolResult` entry. Run the identical scenario on the base branch (no change) and on this branch.
- **Evidence after fix:** persisted `session.jsonl` entry for the accepted launch (copied from the run; the `created`/`updated` entries are identical with their own tool/status):

```json
{"role":"toolResult","toolCallId":"call-accepted","toolName":"sessions_spawn","isError":false,
 "content":[{"type":"toolResult","name":"sessions_spawn","content":"Accepted: launching child session to scan logs."}]}
```

- **Observed result after fix:** for all three (`accepted` / `created` / `updated`), protocol `success = true` and persisted `toolResult.isError = false`. On the base branch (without the change), the identical run persists `toolResult.isError = true` and reports `success = false` for all three.
- **What was not tested:** no live model or external network path is involved in this classifier, so none was exercised; the proof is the real in-process orchestration + persistence path described above.

## Security / Compatibility

No auth, secret, dependency, permission, migration, config, or data-access surface changes. No persisted-state shape change. The change only widens which statuses are classified as non-errors; failure statuses are unaffected.

## Risks and Mitigations

The allowlist is tool-name-agnostic, so any dynamic tool result carrying `status: "accepted"` / `"created"` / `"updated"` is now treated as a success. A survey of producers found these statuses are only emitted by successful operations (failures use `error` / `forbidden`), and the deny-symmetry test guards the failure path. The allowlist remains hand-maintained and could diverge from producers again as new tools are added; a follow-up to derive it from a shared typed status contract would make this class of divergence statically impossible.

AI-assisted; the contributor manually reviewed the change and is responsible for it.
