### PR TITLE
feat(codex): scope user MCP server attachment by the tool allowlist

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -26,8 +26,36 @@ When no OpenClaw sandbox is active, OpenClaw starts Codex app-server threads
 with Codex native code mode enabled while leaving code-mode-only off by default.
 That keeps Codex native workspace and code capabilities available while
 OpenClaw dynamic tools continue through the app-server `item/tool/call` bridge.
-Active OpenClaw sandboxing and restricted tool policies disable native code mode
-entirely unless you opt into the experimental sandbox exec-server path.
+Active OpenClaw sandboxing disables native code mode entirely unless you opt into
+the experimental sandbox exec-server path.
+
+A restricted tool policy (`tools.allow` / `tools.alsoAllow` without a `*`) keeps
+native code mode off, but it no longer blocks user MCP servers wholesale. MCP
+server attachment is now driven by the same allowlist: a server is attached to
+the Codex thread only when the allowlist references at least one of its tools,
+using OpenClaw's `<server>__<tool>` tool-naming convention:
+
+- `*`, `bundle-mcp`, or `group:plugins` — attach every configured MCP server with
+  all of its tools (`*` also enables native code mode).
+- `<server>__*` — attach that server (e.g. `opik__*`) with all of its tools,
+  without enabling the native shell/file surface.
+- `<server>__<tool>` — attach the server scoped to the named tool(s) (e.g.
+  `opik__list`). The scoped tools are projected into Codex's per-server
+  `enabled_tools` filter, so other tools from that same server are **not**
+  registered.
+- no MCP-referencing entry — no user MCP servers are attached (unchanged).
+
+Server names and tool fragments are matched against the provider-safe model-facing
+tool ids OpenClaw exposes (sanitized via the bundle-MCP naming rules), not the raw
+`mcp.servers` config key — so a server keyed `Outlook Graph` is referenced as
+`outlook-graph__*`.
+
+This lets a least-privilege Codex agent reach a specific MCP server, or specific
+tools within it, without being forced to grant the full native code-mode surface.
+Per-tool scoping via `enabled_tools` is exact for provider-safe tool names; for
+tool names that require sanitization it fails closed (the tool is simply not
+enabled). You can further constrain an attached server with an approval mode
+(`codex.defaultToolsApprovalMode`).
 
 This Codex-native feature is separate from
 [OpenClaw code mode](/reference/code-mode), which is an opt-in QuickJS-WASI

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -107,6 +107,7 @@ export async function startCodexAttemptThread(params: {
   nativeHookRelayGeneration?: string;
   bundleMcpThreadConfig: CodexBundleMcpThreadConfig;
   nativeToolSurfaceEnabled: boolean;
+  userMcpServersEnabled?: boolean;
   nativeProviderWebSearchSupport: CodexNativeWebSearchSupport;
   sandboxExecServerEnabled: boolean;
   sandbox: CodexSandboxContext;
@@ -326,7 +327,8 @@ export async function startCodexAttemptThread(params: {
                 nativeCodeModeEnabled: params.nativeToolSurfaceEnabled,
                 nativeProviderWebSearchSupport: params.nativeProviderWebSearchSupport,
                 nativeCodeModeOnlyEnabled: params.appServer.codeModeOnly,
-                userMcpServersEnabled: params.nativeToolSurfaceEnabled,
+                userMcpServersEnabled:
+                  params.userMcpServersEnabled ?? params.nativeToolSurfaceEnabled,
                 mcpServersFingerprint: params.bundleMcpThreadConfig.fingerprint,
                 mcpServersFingerprintEvaluated: params.bundleMcpThreadConfig.evaluated,
                 environmentSelection: startupEnvironmentSelection,

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -22,6 +22,7 @@ import {
   resolveCodexMessageToolProvider,
   setOpenClawCodingToolsFactoryForTests,
   shouldEnableCodexAppServerNativeToolSurface,
+  shouldEnableUserMcpServersForCodexAppServer,
   shouldForceMessageTool,
 } from "./dynamic-tool-build.js";
 import {
@@ -1209,6 +1210,40 @@ describe("Codex app-server dynamic tool build", () => {
 
     expect(filterCodexDynamicToolsForAllowlist(tools, [" * "])).toEqual(tools);
     expect(hasWildcardCodexToolsAllow([" * "])).toBe(true);
+  });
+
+  it("decouples user MCP server attachment from the native code-mode surface", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+
+    // The native shell/file surface stays fail-closed on a literal "*"; MCP server
+    // attachment is gated only on memory-flush + sandbox, leaving the actual
+    // per-server decision to the allowlist-aware projection (covered separately).
+    for (const toolsAllow of [["*"], ["opik__*"], ["opik__list"], ["message"], []] as string[][]) {
+      params.toolsAllow = toolsAllow;
+      expect(shouldEnableUserMcpServersForCodexAppServer(params)).toBe(true);
+    }
+    // Native surface remains wildcard-only regardless of MCP gate.
+    params.toolsAllow = ["opik__*"];
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+    params.toolsAllow = ["*"];
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    // Undefined (no restriction) keeps both available.
+    params.toolsAllow = undefined;
+    expect(shouldEnableUserMcpServersForCodexAppServer(params)).toBe(true);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+  });
+
+  it("does not attach user MCP servers on memory-flush runs", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.trigger = "memory";
+    params.memoryFlushWritePath = path.join(tempDir, "flush.md");
+    params.toolsAllow = ["opik__*"];
+    expect(shouldEnableUserMcpServersForCodexAppServer(params)).toBe(false);
   });
 
   it("disables Codex native tool surfaces for restricted runtime allowlists", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -942,6 +942,35 @@ export function hasWildcardCodexToolsAllow(toolsAllow: string[]): boolean {
   return toolsAllow.some((name) => normalizeCodexDynamicToolName(name) === "*");
 }
 
+/**
+ * Returns true when user-configured MCP servers may be attached to the Codex
+ * app-server thread for this turn.
+ *
+ * This is deliberately decoupled from `shouldEnableCodexAppServerNativeToolSurface`.
+ * Native code mode (Codex's built-in shell/filesystem/apply_patch surface) is a
+ * dangerous, sandbox-sensitive capability that must stay fail-closed on a literal
+ * `*` allowlist. Attaching user MCP servers is a separate, narrower capability:
+ * which servers (and tools) actually become reachable is decided downstream by the
+ * allowlist-aware projection (`buildCodexUserMcpServersThreadConfigPatch`), so this
+ * gate only answers the orthogonal question "is it safe to attach external MCP
+ * servers at all this turn?" — i.e. not a memory-flush run, and OpenClaw sandboxing
+ * (if active) can be honored. The allowlist itself never widens the native surface.
+ */
+export function shouldEnableUserMcpServersForCodexAppServer(
+  params: EmbeddedRunAttemptParams,
+  sandbox?: OpenClawSandboxContext,
+  options: {
+    agentId?: string;
+    runtimeSessionKey?: string;
+    sandboxExecServerEnabled?: boolean;
+  } = {},
+): boolean {
+  if (isCodexMemoryFlushRun(params)) {
+    return false;
+  }
+  return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);
+}
+
 /** Forces message delivery through the message tool when the source channel requires it. */
 export function shouldForceMessageTool(params: EmbeddedRunAttemptParams): boolean {
   return (

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -163,6 +163,7 @@ import {
   resetOpenClawCodingToolsFactoryForTests,
   setOpenClawCodingToolsFactoryForTests,
   shouldEnableCodexAppServerNativeToolSurface,
+  shouldEnableUserMcpServersForCodexAppServer,
   shouldForceMessageTool,
   shouldWarnCodexDynamicToolBuildStageSummary,
 } from "./dynamic-tool-build.js";
@@ -676,6 +677,11 @@ export async function runCodexAppServerAttempt(
   preDynamicStartupStages.mark("bundle-mcp");
   const sandboxExecServerEnabled = isCodexSandboxExecServerEnabled(pluginConfig);
   const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params, sandbox, {
+    agentId: sessionAgentId,
+    runtimeSessionKey: sandboxSessionKey,
+    sandboxExecServerEnabled,
+  });
+  const userMcpServersEnabled = shouldEnableUserMcpServersForCodexAppServer(params, sandbox, {
     agentId: sessionAgentId,
     runtimeSessionKey: sandboxSessionKey,
     sandboxExecServerEnabled,
@@ -1490,6 +1496,7 @@ export async function runCodexAppServerAttempt(
       buildFinalConfigPatch: buildNativeHookRelayFinalConfigPatch,
       bundleMcpThreadConfig,
       nativeToolSurfaceEnabled,
+      userMcpServersEnabled,
       nativeProviderWebSearchSupport,
       sandboxExecServerEnabled,
       sandbox,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -344,6 +344,11 @@ export async function startOrResumeThread(params: {
       ? undefined
       : buildCodexUserMcpServersThreadConfigPatch(params.params.config, {
           agentId: params.agentId ?? params.params.agentId,
+          // Allowlist-aware projection: only servers the effective allowlist
+          // references are attached. The patch (and therefore its fingerprint)
+          // changes when the allowlist changes which servers are in scope, so an
+          // existing thread rebinds correctly.
+          toolsAllow: params.params.toolsAllow,
         });
   const userMcpServersFingerprint = fingerprintUserMcpServersConfigPatch(userMcpServersConfigPatch);
   const environmentSelectionFingerprint = fingerprintEnvironmentSelection(

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -1,11 +1,13 @@
-/**
- * Codex CLI and app-server bundle MCP projection helpers.
- */
 import { normalizeConfiguredMcpServers } from "../../config/mcp-config-normalize.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { BundleMcpConfig, BundleMcpServerConfig } from "../../plugins/bundle-mcp.js";
 import { isValidAgentId, normalizeAgentId } from "../../routing/session-key.js";
+/**
+ * Codex CLI and app-server bundle MCP projection helpers.
+ */
+import { sanitizeServerName, TOOL_NAME_SEPARATOR } from "../agent-bundle-mcp-names.js";
 import { buildCodexMcpServersConfig, normalizeCodexMcpServerConfig } from "../codex-mcp-config.js";
+import { normalizeToolName } from "../tool-policy-shared.js";
 import { isRecord } from "./bundle-mcp-adapter-shared.js";
 import { serializeTomlInlineValue } from "./toml-inline.js";
 
@@ -25,7 +27,72 @@ type CodexThreadConfigObject = { [key: string]: CodexThreadConfigValue };
 
 type CodexUserMcpServersProjectionOptions = {
   agentId?: string;
+  /**
+   * Effective OpenClaw tool allowlist for the turn (`tools.allow` / `tools.alsoAllow`,
+   * already merged). When provided, only MCP servers with at least one permitted tool
+   * are projected. When `undefined`, the allowlist imposes no restriction and every
+   * enabled server is projected (legacy unrestricted behavior).
+   */
+  toolsAllow?: string[];
 };
+
+/** Allowlist tokens that grant every MCP server (and all of its tools). */
+function isGlobalMcpAllowToken(token: string): boolean {
+  // Mirrors the bundle-MCP allowlist contract in tool-policy.ts: a literal
+  // wildcard, the `bundle-mcp` plugin entry, and the `group:plugins` group all
+  // mean "every user MCP server".
+  return token === "*" || token === "bundle-mcp" || token === "group:plugins";
+}
+
+/**
+ * Resolves whether a configured MCP server is permitted by the effective tool
+ * allowlist, and which of its tools are in scope.
+ *
+ * Matching uses the **provider-safe** model-facing tool ids OpenClaw actually
+ * exposes — `<sanitizedServer>__<sanitizedTool>` (see `agent-bundle-mcp-names`),
+ * not the raw `mcp.servers` config key. `safeServerName` must therefore be the
+ * output of `sanitizeServerName` for the server. Rules over normalized tokens:
+ *   - allowlist `undefined`               -> include, all tools (no restriction)
+ *   - `*` / `bundle-mcp` / `group:plugins`-> include, all tools
+ *   - `<safeServer>__*`                   -> include, all tools of that server
+ *   - `<safeServer>__<tool>`              -> include, scoped to the named tool(s)
+ *   - no matching token                   -> exclude the server
+ *
+ * `toolNames` (the tool fragment after the `<server>__` prefix) is returned for
+ * the scoped case so the projection can emit Codex `enabled_tools`. It is
+ * `undefined` when all of the server's tools are in scope.
+ */
+export function resolveCodexMcpServerAllow(
+  safeServerName: string,
+  toolsAllow: string[] | undefined,
+): { include: boolean; toolNames?: string[] } {
+  if (toolsAllow === undefined) {
+    return { include: true };
+  }
+  const prefix = normalizeToolName(`${safeServerName}${TOOL_NAME_SEPARATOR}`);
+  const scopedTools: string[] = [];
+  for (const raw of toolsAllow) {
+    const token = normalizeToolName(raw);
+    if (!token) {
+      continue;
+    }
+    if (isGlobalMcpAllowToken(token)) {
+      return { include: true };
+    }
+    if (token.length <= prefix.length || !token.startsWith(prefix)) {
+      continue;
+    }
+    const toolPart = token.slice(prefix.length);
+    if (toolPart === "*") {
+      return { include: true };
+    }
+    scopedTools.push(toolPart);
+  }
+  if (scopedTools.length === 0) {
+    return { include: false };
+  }
+  return { include: true, toolNames: [...new Set(scopedTools)] };
+}
 
 function normalizeAgentIds(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -88,6 +155,12 @@ export function buildCodexUserMcpServersThreadConfigPatch(
     return undefined;
   }
   const mcp_servers: CodexThreadConfigObject = {};
+  // Reserve sanitized names only for servers that are actually exposed, in config
+  // order — disabled and agent-scoped-out servers must NOT reserve a name, or a
+  // dropped server could shift a later server's collision suffix and break an
+  // otherwise-valid `<server>__*` allowlist match. Mirrors how the live tool-id
+  // generation (and tool-policy's prefix contract) only names exposed servers.
+  const usedNames = new Set<string>();
   for (const [name, server] of entries) {
     if (server.enabled === false) {
       continue;
@@ -95,10 +168,28 @@ export function buildCodexUserMcpServersThreadConfigPatch(
     if (!isCodexMcpServerAllowedForAgent(server as BundleMcpServerConfig, options)) {
       continue;
     }
-    mcp_servers[name] = normalizeCodexMcpServerConfig(
+    const safeServerName = sanitizeServerName(name, usedNames);
+    // Only project servers the effective tool allowlist actually references, so a
+    // scoped allowlist (e.g. ["opik__*"]) attaches opik but not other configured
+    // servers. Without this, every enabled server was attached regardless of the
+    // allowlist, over-exposing tools the operator never granted.
+    const allow = resolveCodexMcpServerAllow(safeServerName, options?.toolsAllow);
+    if (!allow.include) {
+      continue;
+    }
+    const projected = normalizeCodexMcpServerConfig(
       name,
       server as BundleMcpServerConfig,
     ) as CodexThreadConfigObject;
+    if (allow.toolNames && allow.toolNames.length > 0) {
+      // Exact `<server>__<tool>` allowlist entries scope the attached server to
+      // those tools via Codex's per-server `enabled_tools` filter, so other tools
+      // from the same server stay unreachable. The tool fragment comes from the
+      // (sanitized, lowercased) allowlist token; this is exact for provider-safe
+      // tool names and fails closed (tool simply not enabled) otherwise.
+      projected.enabled_tools = [...allow.toolNames];
+    }
+    mcp_servers[name] = projected;
   }
   if (Object.keys(mcp_servers).length === 0) {
     return undefined;

--- a/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
@@ -1,7 +1,10 @@
 /** Tests projecting OpenClaw user MCP servers into Codex app-server config. */
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { buildCodexUserMcpServersThreadConfigPatch } from "./bundle-mcp-codex.js";
+import {
+  buildCodexUserMcpServersThreadConfigPatch,
+  resolveCodexMcpServerAllow,
+} from "./bundle-mcp-codex.js";
 
 describe("buildCodexUserMcpServersThreadConfigPatch", () => {
   it("returns undefined when cfg has no mcp.servers (regression: #80814)", () => {
@@ -280,5 +283,133 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
     expect(Object.keys(patch!.mcp_servers).toSorted()).toEqual(["one", "two"]);
     expect(patch!.mcp_servers.one).toMatchObject({ command: "one" });
     expect(patch!.mcp_servers.two).toMatchObject({ command: "two" });
+  });
+
+  describe("allowlist-aware server projection", () => {
+    const twoServerCfg = {
+      mcp: {
+        servers: {
+          opik: { transport: "stdio", command: "opik" },
+          notion: { transport: "stdio", command: "notion" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    it("attaches every enabled server when toolsAllow is undefined (no restriction)", () => {
+      const patch = buildCodexUserMcpServersThreadConfigPatch(twoServerCfg, {
+        toolsAllow: undefined,
+      });
+      expect(Object.keys(patch!.mcp_servers).toSorted()).toEqual(["notion", "opik"]);
+    });
+
+    it("attaches every server for a wildcard allowlist", () => {
+      const patch = buildCodexUserMcpServersThreadConfigPatch(twoServerCfg, {
+        toolsAllow: ["*"],
+      });
+      expect(Object.keys(patch!.mcp_servers).toSorted()).toEqual(["notion", "opik"]);
+    });
+
+    it("attaches only the server referenced by a server-scoped glob", () => {
+      const patch = buildCodexUserMcpServersThreadConfigPatch(twoServerCfg, {
+        toolsAllow: ["opik__*"],
+      });
+      expect(Object.keys(patch!.mcp_servers)).toEqual(["opik"]);
+      // A server glob grants every tool, so no enabled_tools filter is emitted.
+      expect(patch!.mcp_servers.opik).not.toHaveProperty("enabled_tools");
+    });
+
+    it("scopes an attached server to exact tools via enabled_tools", () => {
+      const patch = buildCodexUserMcpServersThreadConfigPatch(twoServerCfg, {
+        toolsAllow: ["opik__list", "opik__read", "notion__api-post-search"],
+      });
+      expect(Object.keys(patch!.mcp_servers).toSorted()).toEqual(["notion", "opik"]);
+      expect(patch!.mcp_servers.opik).toMatchObject({ enabled_tools: ["list", "read"] });
+      expect(patch!.mcp_servers.notion).toMatchObject({ enabled_tools: ["api-post-search"] });
+    });
+
+    it("does not set enabled_tools for a wildcard allowlist", () => {
+      const patch = buildCodexUserMcpServersThreadConfigPatch(twoServerCfg, { toolsAllow: ["*"] });
+      expect(patch!.mcp_servers.opik).not.toHaveProperty("enabled_tools");
+      expect(patch!.mcp_servers.notion).not.toHaveProperty("enabled_tools");
+    });
+
+    it("matches the provider-safe (sanitized) server name, not the raw config key", () => {
+      const cfg = {
+        mcp: {
+          servers: {
+            "Outlook Graph": { transport: "stdio", command: "outlook" },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      // The model-facing prefix is `outlook-graph__`, so that is what the operator
+      // writes in the allowlist — the raw "Outlook Graph" key must still resolve.
+      const patch = buildCodexUserMcpServersThreadConfigPatch(cfg, {
+        toolsAllow: ["outlook-graph__*"],
+      });
+      expect(Object.keys(patch!.mcp_servers)).toEqual(["Outlook Graph"]);
+    });
+
+    it("does not let a disabled server's name collision shift an enabled server's prefix", () => {
+      // "atlas" (disabled) and "Atlas" (enabled) both reserve the lowercase name
+      // "atlas". If the disabled one reserves first, the enabled one is pushed to
+      // "Atlas-2" and the operator's `atlas__*` allowlist no longer matches it. The
+      // disabled server must be skipped before any name is reserved.
+      const cfg = {
+        mcp: {
+          servers: {
+            atlas: { enabled: false, transport: "stdio", command: "old" },
+            Atlas: { transport: "stdio", command: "new" },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const patch = buildCodexUserMcpServersThreadConfigPatch(cfg, { toolsAllow: ["atlas__*"] });
+      expect(Object.keys(patch!.mcp_servers)).toEqual(["Atlas"]);
+    });
+
+    it("honors bundle-mcp and group:plugins as attach-all entries", () => {
+      for (const token of ["bundle-mcp", "group:plugins"]) {
+        const patch = buildCodexUserMcpServersThreadConfigPatch(twoServerCfg, {
+          toolsAllow: [token],
+        });
+        expect(Object.keys(patch!.mcp_servers).toSorted()).toEqual(["notion", "opik"]);
+      }
+    });
+
+    it("returns undefined when the allowlist references no configured server", () => {
+      expect(
+        buildCodexUserMcpServersThreadConfigPatch(twoServerCfg, { toolsAllow: ["message"] }),
+      ).toBeUndefined();
+      expect(
+        buildCodexUserMcpServersThreadConfigPatch(twoServerCfg, { toolsAllow: [] }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("resolveCodexMcpServerAllow", () => {
+    it("includes all tools when the allowlist is undefined", () => {
+      expect(resolveCodexMcpServerAllow("opik", undefined)).toEqual({ include: true });
+    });
+
+    it("includes all tools for wildcard, bundle-mcp, group:plugins, or a server glob", () => {
+      expect(resolveCodexMcpServerAllow("opik", ["*"])).toEqual({ include: true });
+      expect(resolveCodexMcpServerAllow("opik", ["bundle-mcp"])).toEqual({ include: true });
+      expect(resolveCodexMcpServerAllow("opik", ["group:plugins"])).toEqual({ include: true });
+      expect(resolveCodexMcpServerAllow("opik", ["opik__*"])).toEqual({ include: true });
+      expect(resolveCodexMcpServerAllow("opik", [" Opik__* "])).toEqual({ include: true }); // trims/lowercases
+    });
+
+    it("scopes to named tools for exact tool tokens", () => {
+      expect(resolveCodexMcpServerAllow("opik", ["opik__list", "opik__read"])).toEqual({
+        include: true,
+        toolNames: ["list", "read"],
+      });
+    });
+
+    it("excludes a server with no matching token", () => {
+      expect(resolveCodexMcpServerAllow("opik", ["notion__*"])).toEqual({ include: false });
+      expect(resolveCodexMcpServerAllow("opik", ["message"])).toEqual({ include: false });
+      expect(resolveCodexMcpServerAllow("opik", ["opik__"])).toEqual({ include: false }); // bare prefix, no tool
+      expect(resolveCodexMcpServerAllow("opik", [])).toEqual({ include: false });
+    });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

An OpenClaw operator running a **Codex-runtime agent** cannot give that agent access to a configured MCP server without also granting Codex's full native code-mode shell/filesystem surface — the two are conflated behind one gate.

`shouldEnableCodexAppServerNativeToolSurface` returns true only for a literal `*` allowlist, and that boolean is reused as `userMcpServersEnabled`, deciding whether `buildCodexUserMcpServersThreadConfigPatch` projects `cfg.mcp.servers` into the Codex thread at all. So:

1. **All-or-nothing.** Any scoped allowlist (`tools.allow`/`tools.alsoAllow` without `*`) silently disables **every** user MCP server, even ones it names — the process spawns but tools never register.
2. **Over-exposure when servers do attach.** The projection attached **every** enabled server, filtered only by `codex.agents`, never consulting the allowlist.

General gap for any scoped Codex agent with any MCP server.

## What Changed

Decouple the two capabilities and route MCP attachment through the **same allowlist contract OpenClaw already uses** (`tool-policy.ts`):

- **Native code mode unchanged** — still fail-closed, wildcard-only.
- **`shouldEnableUserMcpServersForCodexAppServer`** answers only *"is it safe to attach external MCP servers this turn?"* (not memory-flush; sandbox honored). The per-server decision moves to the projection.
- **`resolveCodexMcpServerAllow`** matches the **provider-safe model-facing ids** (`sanitizeServerName` + `normalizeToolName`), not the raw `mcp.servers` key, honoring the bundle-MCP contract: `*`/`bundle-mcp`/`group:plugins` → all; `<server>__*` → that server, all tools; `<server>__<tool>` → scoped; else excluded.
- **`buildCodexUserMcpServersThreadConfigPatch`** projects only referenced servers and emits Codex per-server **`enabled_tools`** for exact-tool entries, so other tools from an attached server stay unreachable.

### Addresses ClawSweeper review
- **Provider-safe matching** (was raw-key): `Outlook Graph` resolves as `outlook-graph__*`; `bundle-mcp`/`group:plugins` honored.
- **Per-tool scope** (was discarded): exact entries emit `enabled_tools` (sanitized fragment; exact for provider-safe names, fail-closed otherwise).
- **Reservation ordering** (2nd-pass review): sanitized names are now reserved **only for projected servers**, after the disabled/agent skips — a disabled server can no longer shift an enabled server's collision suffix. Regression test added.
- **Docs** updated to describe `enabled_tools` scoping + provider-safe matching.

## Files
`extensions/codex/src/app-server/{dynamic-tool-build,run-attempt,attempt-startup,thread-lifecycle}.ts`, `src/agents/cli-runner/bundle-mcp-codex.ts`, `docs/plugins/codex-harness.md`, tests.

## Evidence

### Unit tests (`vitest run`)
- `bundle-mcp-codex.user-config.test.ts` — **25 passed** (attach-all for `*`/`bundle-mcp`/`group:plugins`; `opik__*` only opik no filter; exact `opik__list,opik__read` → `enabled_tools`; provider-safe `Outlook Graph`↔`outlook-graph__*`; disabled-server collision regression; `["message"]`/`[]` → none).
- `dynamic-tool-build.test.ts` — **51 passed**, incl. `shouldEnableCodexAppServerNativeToolSurface(["opik__*"]) === false` (native code mode stays disabled under a scoped MCP allowlist).

### Integrated runtime proof — OpenClaw → real Codex app-server, one run
Single flow driving the **real** OpenClaw gates + projection, feeding the projection's actual output to the **real `codex app-server`** (codex-cli) via JSON-RPC `mcpServerStatus/list`. Leaf MCP servers are local stubs (each exposing `list,read,write,schema`); every OpenClaw decision and the Codex binary are real. Isolated `CODEX_HOME` so no personal config merges in. Allowlist under test: `["opik__list"]` (config has both `opik` and `notion`).
```
== OpenClaw gate decisions (real code) ==
  toolsAllow              = ["opik__list"]
  native code mode        = false   (expected false: no "*")
  attach user MCP servers = true

== OpenClaw projection output (real code) ==
{ "mcp_servers": { "opik": { "command": "node", "args": [...stub..., "opik", "list,read,write,schema"],
                             "enabled_tools": ["list"] } } }    <- notion EXCLUDED by the allowlist

== Tools the REAL codex app-server registered (codex-cli) ==
  opik   = ["list"]            <- enabled_tools honored end-to-end
  notion = "(not attached)"    <- excluded server never reaches Codex
```
One `opik__list` entry → OpenClaw attaches only opik scoped to `list`, drops notion, and keeps native code mode off; the real Codex binary registers exactly that.

### Types
Full-CI `check-prod-types` / `check-lint` / `check-docs` pass; standalone extension `tsc` shows only pre-existing plugin-sdk `dist`-sync noise, none referencing this PR's symbols.

## Security posture
- Native code-mode shell/file access still requires a literal `*` — unchanged (proven above).
- Default-open for unrestricted (`undefined`) agents preserved; sandbox-without-exec-server attaches no user MCP servers.
- Net effect is *tighter*: scoped allowlists attach only referenced servers; exact-tool entries attach only named tools via `enabled_tools`.

> This changes how existing `tools.allow`/`tools.alsoAllow` entries decide which MCP servers/tools/credentials reach Codex — a deliberate compatibility + security-boundary change for maintainer sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)