### PR TITLE
fix(cli-backend): warn+ignore toolsAllow instead of hard-throw

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -2343,7 +2343,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
-  it("fails closed when a runtime toolsAllow is requested for CLI backends", async () => {
+  it("warns and ignores toolsAllow for CLI backends (run proceeds with full backend tools)", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
       const getActiveMcpLoopbackRuntime = vi.fn(() => ({
@@ -2355,24 +2355,25 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         getActiveMcpLoopbackRuntime,
       });
 
-      await expect(
-        prepareCliRunContext({
-          sessionId: "session-test",
-          sessionFile,
-          workspaceDir: dir,
-          prompt: "latest ask",
-          provider: "test-cli",
-          model: "test-model",
-          timeoutMs: 1_000,
-          runId: "run-test-tools-allow",
-          config: createCliBackendConfig({ bundleMcp: true }),
-          toolsAllow: ["read", "web_search"],
-        }),
-      ).rejects.toThrow(
-        "CLI backend test-cli cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy",
-      );
+      // Pre-2026.6.10 behavior restored: CLI backends cannot enforce per-run tool
+      // restriction, so toolsAllow is silently dropped (with a warning log) and the
+      // run proceeds instead of hard-failing.
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-tools-allow",
+        config: createCliBackendConfig({ bundleMcp: true }),
+        toolsAllow: ["read", "web_search"],
+      });
 
-      expect(getActiveMcpLoopbackRuntime).not.toHaveBeenCalled();
+      // Run must succeed and toolsAllow must be cleared from the prepared params.
+      expect(context).toBeDefined();
+      expect(context.params.toolsAllow).toBeUndefined();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -265,9 +265,10 @@ export async function prepareCliRunContext(
     throw new Error(`Unknown CLI backend: ${params.provider}`);
   }
   if (params.toolsAllow !== undefined) {
-    throw new Error(
-      `CLI backend ${backendResolved.id} cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy`,
+    cliBackendLog.warn(
+      `CLI backend ${backendResolved.id} cannot enforce runtime toolsAllow; ignoring tool policy and running with full backend tools (session=${redactedSessionKey})`,
     );
+    params.toolsAllow = undefined;
   }
   const sideQuestionDisablesNativeTools =
     isSideQuestion && backendResolved.sideQuestionToolMode === "disabled";


### PR DESCRIPTION
## What

Replace the hard `throw` for `params.toolsAllow !== undefined` in `prepareCliRunContext` with a `cliBackendLog.warn` + `params.toolsAllow = undefined`, so CLI-backend runs that carry a `toolsAllow` array proceed instead of crashing.

## Why

A guard in `prepareCliRunContext` throws whenever a runtime `toolsAllow` reaches a CLI backend:

```
CLI backend <id> cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy
```

CLI backends cannot enforce per-run tool restriction. This change aimed to restore the earlier behavior in which an auto-injected `toolsAllow` was ignored for CLI backends and the run proceeded.

## Change

- `src/agents/cli-runner/prepare.ts`: replace `throw new Error(...)` with a warning + `params.toolsAllow = undefined`.
- `src/agents/cli-runner/prepare.test.ts`: update the corresponding test to expect resolution with `toolsAllow` cleared.

## Test plan

- Unit test asserts the call resolves and `context.params.toolsAllow` is `undefined`.
- `tsc --noEmit` on the affected files: no errors.

> Note: superseded by the `toolsAllowIsDefault` mechanism already on `main` (`9aea104cc8`, `17066f2d7c`) — see the closing comment. Retained for reference.
