### PR TITLE
fix(codex): honor workspace-only fs for native tools

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -15,6 +15,7 @@ import {
   filterCodexDynamicToolsForAllowlist,
   hasWildcardCodexToolsAllow,
   includeForcedCodexDynamicToolAllow,
+  isCodexWorkspaceOnlyFsPolicyActive,
   mapCodexAppServerRemoteWorkspacePath,
   resetOpenClawCodingToolsFactoryForTests,
   resolveCodexAppServerExecutionCwd,
@@ -1293,7 +1294,7 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldEnableCodexAppServerNativeToolSurface(runtimePolicyParams)).toBe(true);
   });
 
-  it("disables Codex native tool surfaces when workspace-only fs policy is active", () => {
+  it("keeps Codex native tool surfaces when workspace-only fs policy is active", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
@@ -1321,16 +1322,26 @@ describe("Codex app-server dynamic tool build", () => {
       shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
         agentId: "poly",
       }),
-    ).toBe(false);
+    ).toBe(true);
+    expect(
+      isCodexWorkspaceOnlyFsPolicyActive(params, {
+        agentId: "poly",
+      }),
+    ).toBe(true);
 
     expect(
       shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
         agentId: "coder",
       }),
     ).toBe(true);
+    expect(
+      isCodexWorkspaceOnlyFsPolicyActive(params, {
+        agentId: "coder",
+      }),
+    ).toBe(false);
   });
 
-  it("disables Codex native tool surfaces for global workspace-only fs policy", () => {
+  it("keeps Codex native tool surfaces for global workspace-only fs policy", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
@@ -1340,7 +1351,8 @@ describe("Codex app-server dynamic tool build", () => {
       },
     } as never;
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(isCodexWorkspaceOnlyFsPolicyActive(params)).toBe(true);
   });
 
   it("uses default agent workspace-only fs policy when no agent id matches", () => {
@@ -1365,7 +1377,12 @@ describe("Codex app-server dynamic tool build", () => {
       shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
         agentId: "missing",
       }),
-    ).toBe(false);
+    ).toBe(true);
+    expect(
+      isCodexWorkspaceOnlyFsPolicyActive(params, {
+        agentId: "missing",
+      }),
+    ).toBe(true);
   });
 
   it("resolves workspace-only fs policy from the runtime session key", () => {
@@ -1389,7 +1406,12 @@ describe("Codex app-server dynamic tool build", () => {
       shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
         runtimeSessionKey: "agent:runtime:session-1",
       }),
-    ).toBe(false);
+    ).toBe(true);
+    expect(
+      isCodexWorkspaceOnlyFsPolicyActive(params, {
+        runtimeSessionKey: "agent:runtime:session-1",
+      }),
+    ).toBe(true);
   });
 
   it("lets explicit agent workspace-only false override global workspace-only true", () => {
@@ -1417,6 +1439,11 @@ describe("Codex app-server dynamic tool build", () => {
         agentId: "poly",
       }),
     ).toBe(true);
+    expect(
+      isCodexWorkspaceOnlyFsPolicyActive(params, {
+        agentId: "poly",
+      }),
+    ).toBe(false);
   });
 
   it("handles malformed workspace-only policy config defensively", () => {
@@ -1440,7 +1467,8 @@ describe("Codex app-server dynamic tool build", () => {
       },
     } as never;
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(isCodexWorkspaceOnlyFsPolicyActive(params)).toBe(true);
 
     params.config = {
       agents: {
@@ -1449,6 +1477,7 @@ describe("Codex app-server dynamic tool build", () => {
     } as never;
 
     expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(isCodexWorkspaceOnlyFsPolicyActive(params)).toBe(false);
   });
 
   it("disables Codex native tool surfaces whenever an OpenClaw sandbox is active", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1294,7 +1294,7 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldEnableCodexAppServerNativeToolSurface(runtimePolicyParams)).toBe(true);
   });
 
-  it("keeps Codex native tool surfaces when workspace-only fs policy is active", () => {
+  it("disables Codex native tool surfaces when workspace-only fs policy is active", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
@@ -1322,7 +1322,7 @@ describe("Codex app-server dynamic tool build", () => {
       shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
         agentId: "poly",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isCodexWorkspaceOnlyFsPolicyActive(params, {
         agentId: "poly",
@@ -1341,7 +1341,7 @@ describe("Codex app-server dynamic tool build", () => {
     ).toBe(false);
   });
 
-  it("keeps Codex native tool surfaces for global workspace-only fs policy", () => {
+  it("disables Codex native tool surfaces for global workspace-only fs policy", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
@@ -1351,7 +1351,7 @@ describe("Codex app-server dynamic tool build", () => {
       },
     } as never;
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
     expect(isCodexWorkspaceOnlyFsPolicyActive(params)).toBe(true);
   });
 
@@ -1377,7 +1377,7 @@ describe("Codex app-server dynamic tool build", () => {
       shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
         agentId: "missing",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isCodexWorkspaceOnlyFsPolicyActive(params, {
         agentId: "missing",
@@ -1406,7 +1406,7 @@ describe("Codex app-server dynamic tool build", () => {
       shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
         runtimeSessionKey: "agent:runtime:session-1",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isCodexWorkspaceOnlyFsPolicyActive(params, {
         runtimeSessionKey: "agent:runtime:session-1",
@@ -1467,7 +1467,7 @@ describe("Codex app-server dynamic tool build", () => {
       },
     } as never;
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
     expect(isCodexWorkspaceOnlyFsPolicyActive(params)).toBe(true);
 
     params.config = {

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1293,6 +1293,43 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldEnableCodexAppServerNativeToolSurface(runtimePolicyParams)).toBe(true);
   });
 
+  it("disables Codex native tool surfaces when workspace-only fs policy is active", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.sessionKey = "agent:poly:discord:group:test";
+    params.config = {
+      agents: {
+        list: [
+          {
+            id: "poly",
+            tools: {
+              fs: { workspaceOnly: true },
+            },
+          },
+          {
+            id: "coder",
+            tools: {
+              fs: { workspaceOnly: false },
+            },
+          },
+        ],
+      },
+    } as never;
+
+    expect(
+      shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
+        agentId: "poly",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
+        agentId: "coder",
+      }),
+    ).toBe(true);
+  });
+
   it("disables Codex native tool surfaces whenever an OpenClaw sandbox is active", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1355,10 +1355,11 @@ describe("Codex app-server dynamic tool build", () => {
     expect(isCodexWorkspaceOnlyFsPolicyActive(params)).toBe(true);
   });
 
-  it("uses default agent workspace-only fs policy when no agent id matches", () => {
+  it("uses default agent workspace-only fs policy when no active agent id is resolved", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
+    params.sessionKey = undefined;
     params.config = {
       agents: {
         list: [
@@ -1373,16 +1374,92 @@ describe("Codex app-server dynamic tool build", () => {
       },
     } as never;
 
-    expect(
-      shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
-        agentId: "missing",
-      }),
-    ).toBe(false);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+    expect(isCodexWorkspaceOnlyFsPolicyActive(params)).toBe(true);
+  });
+
+  it("falls back to global workspace-only fs policy when explicit agent id is missing", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.config = {
+      tools: {
+        fs: { workspaceOnly: true },
+      },
+      agents: {
+        list: [
+          {
+            id: "fallback",
+            default: true,
+            tools: {
+              fs: { workspaceOnly: false },
+            },
+          },
+        ],
+      },
+    } as never;
+
     expect(
       isCodexWorkspaceOnlyFsPolicyActive(params, {
         agentId: "missing",
       }),
     ).toBe(true);
+  });
+
+  it("falls back to global workspace-only fs policy when runtime session agent is missing", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.config = {
+      tools: {
+        fs: { workspaceOnly: true },
+      },
+      agents: {
+        list: [
+          {
+            id: "fallback",
+            default: true,
+            tools: {
+              fs: { workspaceOnly: false },
+            },
+          },
+        ],
+      },
+    } as never;
+
+    expect(
+      isCodexWorkspaceOnlyFsPolicyActive(params, {
+        runtimeSessionKey: "agent:missing:session-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("disables Codex native surface for global workspace-only when explicit agent id is missing", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.config = {
+      tools: {
+        fs: { workspaceOnly: true },
+      },
+      agents: {
+        list: [
+          {
+            id: "fallback",
+            default: true,
+            tools: {
+              fs: { workspaceOnly: false },
+            },
+          },
+        ],
+      },
+    } as never;
+
+    expect(
+      shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
+        agentId: "missing",
+      }),
+    ).toBe(false);
   });
 
   it("resolves workspace-only fs policy from the runtime session key", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1330,6 +1330,127 @@ describe("Codex app-server dynamic tool build", () => {
     ).toBe(true);
   });
 
+  it("disables Codex native tool surfaces for global workspace-only fs policy", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.config = {
+      tools: {
+        fs: { workspaceOnly: true },
+      },
+    } as never;
+
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
+  it("uses default agent workspace-only fs policy when no agent id matches", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.config = {
+      agents: {
+        list: [
+          {
+            id: "fallback",
+            default: true,
+            tools: {
+              fs: { workspaceOnly: true },
+            },
+          },
+        ],
+      },
+    } as never;
+
+    expect(
+      shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
+        agentId: "missing",
+      }),
+    ).toBe(false);
+  });
+
+  it("resolves workspace-only fs policy from the runtime session key", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.config = {
+      agents: {
+        list: [
+          {
+            id: "runtime",
+            tools: {
+              fs: { workspaceOnly: true },
+            },
+          },
+        ],
+      },
+    } as never;
+
+    expect(
+      shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
+        runtimeSessionKey: "agent:runtime:session-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("lets explicit agent workspace-only false override global workspace-only true", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.config = {
+      tools: {
+        fs: { workspaceOnly: true },
+      },
+      agents: {
+        list: [
+          {
+            id: "poly",
+            tools: {
+              fs: { workspaceOnly: false },
+            },
+          },
+        ],
+      },
+    } as never;
+
+    expect(
+      shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
+        agentId: "poly",
+      }),
+    ).toBe(true);
+  });
+
+  it("handles malformed workspace-only policy config defensively", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.config = {
+      tools: {
+        fs: { workspaceOnly: true },
+      },
+      agents: {
+        list: [
+          {
+            id: 42,
+            default: "yes",
+            tools: {
+              fs: { workspaceOnly: true },
+            },
+          },
+        ],
+      },
+    } as never;
+
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+
+    params.config = {
+      agents: {
+        list: "not-an-array",
+      },
+    } as never;
+
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+  });
+
   it("disables Codex native tool surfaces whenever an OpenClaw sandbox is active", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -477,18 +477,10 @@ export function shouldEnableCodexAppServerNativeToolSurface(
     sandboxExecServerEnabled?: boolean;
   } = {},
 ): boolean {
-  // Policy priority: memory flush and workspace-only fs hard blocks come before
-  // sandbox/native allowlist checks because native Codex tools cannot enforce
-  // OpenClaw's workspace-only filesystem wrapper.
+  // Policy priority: memory flush comes before sandbox/native allowlist checks.
+  // Workspace-only fs is enforced by constraining the Codex app-server sandbox
+  // at thread/turn start, leaving non-filesystem native features available.
   if (isCodexMemoryFlushRun(params)) {
-    return false;
-  }
-  if (
-    isCodexNativeExecutionBlockedByWorkspaceOnlyFs(params, {
-      agentId: options.agentId,
-      runtimeSessionKey: options.runtimeSessionKey,
-    })
-  ) {
     return false;
   }
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
@@ -509,14 +501,15 @@ type WorkspaceOnlyPolicyAgent = NonNullable<
   NonNullable<WorkspaceOnlyPolicyConfig["agents"]>["list"]
 >[number];
 
-/** Returns true when workspace-only filesystem policy must disable native Codex tools.
+/** Returns true when workspace-only filesystem policy constrains native Codex filesystem access.
  *
- * Per-agent `workspaceOnly` is authoritative: `true` blocks native tools and
- * `false` explicitly opts that agent out even when global config is true.
+ * Per-agent `workspaceOnly` is authoritative: `true` enables the workspace
+ * sandbox and `false` explicitly opts that agent out even when global config is
+ * true.
  * When no matching agent policy exists, the default agent policy is consulted
  * before falling back to global `tools.fs.workspaceOnly`.
  */
-function isCodexNativeExecutionBlockedByWorkspaceOnlyFs(
+export function isCodexWorkspaceOnlyFsPolicyActive(
   params: EmbeddedRunAttemptParams,
   options: {
     agentId?: string;

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -511,8 +511,9 @@ type WorkspaceOnlyPolicyAgent = NonNullable<
  * Per-agent `workspaceOnly` is authoritative: `true` enables the workspace
  * sandbox and `false` explicitly opts that agent out even when global config is
  * true.
- * When no matching agent policy exists, the default agent policy is consulted
- * before falling back to global `tools.fs.workspaceOnly`.
+ * Default-agent policy only applies when there is no active agent identity.
+ * A stale or unknown active agent id must fall back to global policy, matching
+ * OpenClaw-owned fs tools and avoiding a split native-filesystem boundary.
  */
 export function isCodexWorkspaceOnlyFsPolicyActive(
   params: EmbeddedRunAttemptParams,
@@ -552,11 +553,8 @@ function resolveWorkspaceOnlyPolicyAgent(
   const agentId =
     normalizeWorkspaceOnlyAgentId(options.agentId) ??
     (candidateSessionKey ? resolveAgentIdFromSessionKey(candidateSessionKey) : undefined);
-  if (agentId) {
-    const match = agents.find((entry) => normalizeWorkspaceOnlyAgentId(entry?.id) === agentId);
-    if (match) {
-      return match;
-    }
+  if (agentId !== undefined) {
+    return agents.find((entry) => normalizeWorkspaceOnlyAgentId(entry?.id) === agentId);
   }
   return agents.find((entry) => entry?.default === true);
 }

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -18,6 +18,7 @@ import {
   type RuntimeToolSchemaDiagnostic,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/routing";
 import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
 import { readCodexPluginConfig, type CodexPluginConfig } from "./config.js";
@@ -503,16 +504,7 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   );
 }
 
-type WorkspaceOnlyPolicyConfig = {
-  tools?: { fs?: { workspaceOnly?: unknown } };
-  agents?: {
-    list?: Array<{
-      id?: unknown;
-      default?: unknown;
-      tools?: { fs?: { workspaceOnly?: unknown } };
-    }>;
-  };
-};
+type WorkspaceOnlyPolicyConfig = Pick<OpenClawConfig, "agents" | "tools">;
 type WorkspaceOnlyPolicyAgent = NonNullable<
   NonNullable<WorkspaceOnlyPolicyConfig["agents"]>["list"]
 >[number];
@@ -555,12 +547,13 @@ function resolveWorkspaceOnlyPolicyAgent(
   options: { agentId?: string; runtimeSessionKey?: string },
 ): WorkspaceOnlyPolicyAgent | undefined {
   const agents = Array.isArray(config?.agents?.list) ? config?.agents?.list : [];
-  const agentId = normalizeWorkspaceOnlyAgentId(
-    options.agentId ??
-      resolveWorkspaceOnlyAgentIdFromSessionKey(options.runtimeSessionKey) ??
-      resolveWorkspaceOnlyAgentIdFromSessionKey(params.sandboxSessionKey) ??
-      resolveWorkspaceOnlyAgentIdFromSessionKey(params.sessionKey),
-  );
+  const candidateSessionKey =
+    options.runtimeSessionKey?.trim() ||
+    params.sandboxSessionKey?.trim() ||
+    params.sessionKey?.trim();
+  const agentId =
+    normalizeWorkspaceOnlyAgentId(options.agentId) ??
+    (candidateSessionKey ? resolveAgentIdFromSessionKey(candidateSessionKey) : undefined);
   if (agentId) {
     const match = agents.find((entry) => normalizeWorkspaceOnlyAgentId(entry?.id) === agentId);
     if (match) {
@@ -568,13 +561,6 @@ function resolveWorkspaceOnlyPolicyAgent(
     }
   }
   return agents.find((entry) => entry?.default === true);
-}
-
-function resolveWorkspaceOnlyAgentIdFromSessionKey(
-  sessionKey: string | undefined,
-): string | undefined {
-  const trimmed = sessionKey?.trim();
-  return trimmed ? resolveAgentIdFromSessionKey(trimmed) : undefined;
 }
 
 function normalizeWorkspaceOnlyAgentId(value: unknown): string | undefined {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -478,9 +478,14 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   } = {},
 ): boolean {
   // Policy priority: memory flush comes before sandbox/native allowlist checks.
-  // Workspace-only fs is enforced by constraining the Codex app-server sandbox
-  // at thread/turn start, leaving non-filesystem native features available.
   if (isCodexMemoryFlushRun(params)) {
+    return false;
+  }
+  // Codex native code mode owns shell and filesystem access as one surface.
+  // Until Codex exposes a true workspace-only read/write profile, OpenClaw
+  // workspace-only policy must keep that native surface disabled and rely on
+  // OpenClaw-owned workspace-scoped dynamic tools instead.
+  if (isCodexWorkspaceOnlyFsPolicyActive(params, options)) {
     return false;
   }
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -478,6 +478,14 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   if (isCodexMemoryFlushRun(params)) {
     return false;
   }
+  if (
+    isCodexNativeExecutionBlockedByWorkspaceOnlyFs(params, {
+      agentId: options.agentId,
+      runtimeSessionKey: options.runtimeSessionKey,
+    })
+  ) {
+    return false;
+  }
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);
@@ -489,6 +497,85 @@ export function shouldEnableCodexAppServerNativeToolSurface(
     hasWildcardCodexToolsAllow(toolsAllow) &&
     canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options)
   );
+}
+
+function isCodexNativeExecutionBlockedByWorkspaceOnlyFs(
+  params: EmbeddedRunAttemptParams,
+  options: {
+    agentId?: string;
+    runtimeSessionKey?: string;
+  } = {},
+): boolean {
+  const config = params.config as
+    | {
+        tools?: { fs?: { workspaceOnly?: unknown } };
+        agents?: {
+          list?: Array<{
+            id?: unknown;
+            default?: unknown;
+            tools?: { fs?: { workspaceOnly?: unknown } };
+          }>;
+        };
+      }
+    | undefined;
+  const agent = resolveWorkspaceOnlyPolicyAgent(config, params, options);
+  const agentWorkspaceOnly = readWorkspaceOnlyFs(agent?.tools?.fs);
+  if (agentWorkspaceOnly !== undefined) {
+    return agentWorkspaceOnly;
+  }
+  return readWorkspaceOnlyFs(config?.tools?.fs) === true;
+}
+
+function readWorkspaceOnlyFs(
+  fsConfig: { workspaceOnly?: unknown } | undefined,
+): boolean | undefined {
+  if (!fsConfig || typeof fsConfig !== "object" || !("workspaceOnly" in fsConfig)) {
+    return undefined;
+  }
+  return fsConfig.workspaceOnly === true;
+}
+
+function resolveWorkspaceOnlyPolicyAgent(
+  config:
+    | {
+        agents?: {
+          list?: Array<{
+            id?: unknown;
+            default?: unknown;
+            tools?: { fs?: { workspaceOnly?: unknown } };
+          }>;
+        };
+      }
+    | undefined,
+  params: EmbeddedRunAttemptParams,
+  options: { agentId?: string; runtimeSessionKey?: string },
+): { id?: unknown; default?: unknown; tools?: { fs?: { workspaceOnly?: unknown } } } | undefined {
+  const agents = Array.isArray(config?.agents?.list) ? config?.agents?.list : [];
+  const agentId = normalizeWorkspaceOnlyAgentId(
+    options.agentId ??
+      parseWorkspaceOnlyAgentIdFromSessionKey(options.runtimeSessionKey) ??
+      parseWorkspaceOnlyAgentIdFromSessionKey(params.sandboxSessionKey) ??
+      parseWorkspaceOnlyAgentIdFromSessionKey(params.sessionKey),
+  );
+  if (agentId) {
+    const match = agents.find((entry) => normalizeWorkspaceOnlyAgentId(entry?.id) === agentId);
+    if (match) {
+      return match;
+    }
+  }
+  return agents.find((entry) => entry?.default === true);
+}
+
+function parseWorkspaceOnlyAgentIdFromSessionKey(
+  sessionKey: string | undefined,
+): string | undefined {
+  const parts = sessionKey?.trim().split(":") ?? [];
+  return parts.length >= 3 && parts[0] === "agent" ? parts[1] : undefined;
+}
+
+function normalizeWorkspaceOnlyAgentId(value: unknown): string | undefined {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return normalized || undefined;
 }
 
 /** Returns true when OpenClaw policy requires the Node-owned exec/process tools instead. */

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -18,6 +18,7 @@ import {
   type RuntimeToolSchemaDiagnostic,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import { normalizeAgentId, resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/routing";
 import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
 import { readCodexPluginConfig, type CodexPluginConfig } from "./config.js";
 import {
@@ -475,6 +476,9 @@ export function shouldEnableCodexAppServerNativeToolSurface(
     sandboxExecServerEnabled?: boolean;
   } = {},
 ): boolean {
+  // Policy priority: memory flush and workspace-only fs hard blocks come before
+  // sandbox/native allowlist checks because native Codex tools cannot enforce
+  // OpenClaw's workspace-only filesystem wrapper.
   if (isCodexMemoryFlushRun(params)) {
     return false;
   }
@@ -499,6 +503,27 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   );
 }
 
+type WorkspaceOnlyPolicyConfig = {
+  tools?: { fs?: { workspaceOnly?: unknown } };
+  agents?: {
+    list?: Array<{
+      id?: unknown;
+      default?: unknown;
+      tools?: { fs?: { workspaceOnly?: unknown } };
+    }>;
+  };
+};
+type WorkspaceOnlyPolicyAgent = NonNullable<
+  NonNullable<WorkspaceOnlyPolicyConfig["agents"]>["list"]
+>[number];
+
+/** Returns true when workspace-only filesystem policy must disable native Codex tools.
+ *
+ * Per-agent `workspaceOnly` is authoritative: `true` blocks native tools and
+ * `false` explicitly opts that agent out even when global config is true.
+ * When no matching agent policy exists, the default agent policy is consulted
+ * before falling back to global `tools.fs.workspaceOnly`.
+ */
 function isCodexNativeExecutionBlockedByWorkspaceOnlyFs(
   params: EmbeddedRunAttemptParams,
   options: {
@@ -506,18 +531,7 @@ function isCodexNativeExecutionBlockedByWorkspaceOnlyFs(
     runtimeSessionKey?: string;
   } = {},
 ): boolean {
-  const config = params.config as
-    | {
-        tools?: { fs?: { workspaceOnly?: unknown } };
-        agents?: {
-          list?: Array<{
-            id?: unknown;
-            default?: unknown;
-            tools?: { fs?: { workspaceOnly?: unknown } };
-          }>;
-        };
-      }
-    | undefined;
+  const config = params.config as WorkspaceOnlyPolicyConfig | undefined;
   const agent = resolveWorkspaceOnlyPolicyAgent(config, params, options);
   const agentWorkspaceOnly = readWorkspaceOnlyFs(agent?.tools?.fs);
   if (agentWorkspaceOnly !== undefined) {
@@ -536,26 +550,16 @@ function readWorkspaceOnlyFs(
 }
 
 function resolveWorkspaceOnlyPolicyAgent(
-  config:
-    | {
-        agents?: {
-          list?: Array<{
-            id?: unknown;
-            default?: unknown;
-            tools?: { fs?: { workspaceOnly?: unknown } };
-          }>;
-        };
-      }
-    | undefined,
+  config: WorkspaceOnlyPolicyConfig | undefined,
   params: EmbeddedRunAttemptParams,
   options: { agentId?: string; runtimeSessionKey?: string },
-): { id?: unknown; default?: unknown; tools?: { fs?: { workspaceOnly?: unknown } } } | undefined {
+): WorkspaceOnlyPolicyAgent | undefined {
   const agents = Array.isArray(config?.agents?.list) ? config?.agents?.list : [];
   const agentId = normalizeWorkspaceOnlyAgentId(
     options.agentId ??
-      parseWorkspaceOnlyAgentIdFromSessionKey(options.runtimeSessionKey) ??
-      parseWorkspaceOnlyAgentIdFromSessionKey(params.sandboxSessionKey) ??
-      parseWorkspaceOnlyAgentIdFromSessionKey(params.sessionKey),
+      resolveWorkspaceOnlyAgentIdFromSessionKey(options.runtimeSessionKey) ??
+      resolveWorkspaceOnlyAgentIdFromSessionKey(params.sandboxSessionKey) ??
+      resolveWorkspaceOnlyAgentIdFromSessionKey(params.sessionKey),
   );
   if (agentId) {
     const match = agents.find((entry) => normalizeWorkspaceOnlyAgentId(entry?.id) === agentId);
@@ -566,15 +570,15 @@ function resolveWorkspaceOnlyPolicyAgent(
   return agents.find((entry) => entry?.default === true);
 }
 
-function parseWorkspaceOnlyAgentIdFromSessionKey(
+function resolveWorkspaceOnlyAgentIdFromSessionKey(
   sessionKey: string | undefined,
 ): string | undefined {
-  const parts = sessionKey?.trim().split(":") ?? [];
-  return parts.length >= 3 && parts[0] === "agent" ? parts[1] : undefined;
+  const trimmed = sessionKey?.trim();
+  return trimmed ? resolveAgentIdFromSessionKey(trimmed) : undefined;
 }
 
 function normalizeWorkspaceOnlyAgentId(value: unknown): string | undefined {
-  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  const normalized = typeof value === "string" ? normalizeAgentId(value) : "";
   return normalized || undefined;
 }
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -488,7 +488,7 @@ describe("runCodexAppServerAttempt", () => {
     expect((await fs.stat(workspaceDir)).isDirectory()).toBe(true);
   });
 
-  it("keeps native Codex features while constraining workspace-only fs runs", async () => {
+  it("disables native Codex file/code mode for workspace-only fs runs", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
@@ -511,22 +511,18 @@ describe("runCodexAppServerAttempt", () => {
     const startRequest = requests.find((request) => request.method === "thread/start");
     const startParams = startRequest?.params as Record<string, unknown> | undefined;
     const startConfig = startParams?.config as Record<string, unknown> | undefined;
-    expect(startParams?.sandbox).toBe("workspace-write");
-    expect(startConfig?.["features.code_mode"]).toBe(true);
+    expect(startParams?.sandbox).toBe("danger-full-access");
+    expect(startConfig?.["features.code_mode"]).toBe(false);
     expect(startConfig?.["features.code_mode_only"]).toBe(false);
-    expect(
-      (startConfig?.apps as Record<string, unknown> | undefined)?.["_default"],
-    ).toBeUndefined();
+    expect((startConfig?.apps as Record<string, unknown> | undefined)?.["_default"]).toEqual({
+      enabled: false,
+      destructive_enabled: false,
+      open_world_enabled: false,
+    });
 
     const turnRequest = requests.find((request) => request.method === "turn/start");
     const turnParams = turnRequest?.params as Record<string, unknown> | undefined;
-    expect(turnParams?.sandboxPolicy).toEqual({
-      type: "workspaceWrite",
-      writableRoots: [workspaceDir],
-      networkAccess: false,
-      excludeTmpdirEnvVar: false,
-      excludeSlashTmp: false,
-    });
+    expect(turnParams?.sandboxPolicy).toEqual({ type: "dangerFullAccess" });
   });
 
   it("starts active OpenClaw sandbox threads with Codex native execution disabled", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -488,6 +488,47 @@ describe("runCodexAppServerAttempt", () => {
     expect((await fs.stat(workspaceDir)).isDirectory()).toBe(true);
   });
 
+  it("keeps native Codex features while constraining workspace-only fs runs", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
+    const params = {
+      ...createParams(sessionFile, workspaceDir),
+      config: {
+        tools: {
+          fs: { workspaceOnly: true },
+        },
+      },
+    } as EmbeddedRunAttemptParams;
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { mode: "yolo", sandbox: "danger-full-access" } },
+    });
+    await waitForMethod("turn/start");
+    await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startRequest = requests.find((request) => request.method === "thread/start");
+    const startParams = startRequest?.params as Record<string, unknown> | undefined;
+    const startConfig = startParams?.config as Record<string, unknown> | undefined;
+    expect(startParams?.sandbox).toBe("workspace-write");
+    expect(startConfig?.["features.code_mode"]).toBe(true);
+    expect(startConfig?.["features.code_mode_only"]).toBe(false);
+    expect(
+      (startConfig?.apps as Record<string, unknown> | undefined)?.["_default"],
+    ).toBeUndefined();
+
+    const turnRequest = requests.find((request) => request.method === "turn/start");
+    const turnParams = turnRequest?.params as Record<string, unknown> | undefined;
+    expect(turnParams?.sandboxPolicy).toEqual({
+      type: "workspaceWrite",
+      writableRoots: [workspaceDir],
+      networkAccess: false,
+      excludeTmpdirEnvVar: false,
+      excludeSlashTmp: false,
+    });
+  });
+
   it("starts active OpenClaw sandbox threads with Codex native execution disabled", async () => {
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("exec"),

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -163,7 +163,6 @@ import {
   resetOpenClawCodingToolsFactoryForTests,
   setOpenClawCodingToolsFactoryForTests,
   shouldEnableCodexAppServerNativeToolSurface,
-  isCodexWorkspaceOnlyFsPolicyActive,
   shouldForceMessageTool,
   shouldWarnCodexDynamicToolBuildStageSummary,
 } from "./dynamic-tool-build.js";
@@ -638,14 +637,6 @@ export async function runCodexAppServerAttempt(
     env: process.env,
     agentDir,
   });
-  if (
-    isCodexWorkspaceOnlyFsPolicyActive(params, {
-      agentId: sessionAgentId,
-      runtimeSessionKey: sandboxSessionKey,
-    })
-  ) {
-    appServer = constrainCodexAppServerToWorkspaceWrite(appServer);
-  }
   pluginAppServer = appServer;
   nativeHookRelayEvents = resolveCodexNativeHookRelayEvents({
     configuredEvents: options.nativeHookRelay?.events,
@@ -3473,18 +3464,6 @@ function resolveCodexDynamicToolDirectNames(params: EmbeddedRunAttemptParams): s
     return [];
   }
   return ["message"];
-}
-
-function constrainCodexAppServerToWorkspaceWrite(
-  appServer: CodexAppServerRuntimeOptions,
-): CodexAppServerRuntimeOptions {
-  if (appServer.sandbox !== "danger-full-access") {
-    return appServer;
-  }
-  return {
-    ...appServer,
-    sandbox: "workspace-write",
-  };
 }
 
 export const testing = {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -163,6 +163,7 @@ import {
   resetOpenClawCodingToolsFactoryForTests,
   setOpenClawCodingToolsFactoryForTests,
   shouldEnableCodexAppServerNativeToolSurface,
+  isCodexWorkspaceOnlyFsPolicyActive,
   shouldForceMessageTool,
   shouldWarnCodexDynamicToolBuildStageSummary,
 } from "./dynamic-tool-build.js";
@@ -637,6 +638,14 @@ export async function runCodexAppServerAttempt(
     env: process.env,
     agentDir,
   });
+  if (
+    isCodexWorkspaceOnlyFsPolicyActive(params, {
+      agentId: sessionAgentId,
+      runtimeSessionKey: sandboxSessionKey,
+    })
+  ) {
+    appServer = constrainCodexAppServerToWorkspaceWrite(appServer);
+  }
   pluginAppServer = appServer;
   nativeHookRelayEvents = resolveCodexNativeHookRelayEvents({
     configuredEvents: options.nativeHookRelay?.events,
@@ -3464,6 +3473,18 @@ function resolveCodexDynamicToolDirectNames(params: EmbeddedRunAttemptParams): s
     return [];
   }
   return ["message"];
+}
+
+function constrainCodexAppServerToWorkspaceWrite(
+  appServer: CodexAppServerRuntimeOptions,
+): CodexAppServerRuntimeOptions {
+  if (appServer.sandbox !== "danger-full-access") {
+    return appServer;
+  }
+  return {
+    ...appServer,
+    sandbox: "workspace-write",
+  };
 }
 
 export const testing = {


### PR DESCRIPTION
## What Problem This Solves
When an OpenClaw agent sets `tools.fs.workspaceOnly=true`, OpenClaw-owned file tools enforce a workspace boundary. Codex app-server code mode also has a native shell/filesystem surface. Current Codex `workspace-write` is not a true OpenClaw workspace-only read boundary, so OpenClaw must fail closed for that native surface instead of projecting an unsafe sandbox downgrade.

## Summary
- disable the Codex app-server native code/file surface when effective `tools.fs.workspaceOnly=true`
- preserve explicit per-agent `tools.fs.workspaceOnly=false` as an opt-out from global workspace-only policy
- resolve workspace-only policy from the active agent, runtime/session key, default agent, then global config
- stop downgrading `danger-full-access` to Codex `workspace-write`, because that implied a stronger read boundary than Codex exposes
- cover mixed-agent, global, default-agent, runtime-session, explicit per-agent opt-out, malformed-config, and app-server request behavior

## Evidence
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts -t "workspace-only"` passed locally
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "disables native Codex file/code mode"` passed locally
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/dynamic-tool-build.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts` passed locally
- `node scripts/run-oxlint.mjs extensions/codex/src/app-server/dynamic-tool-build.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts` passed locally
- `pnpm tsgo:core` passed locally
- `pnpm tsgo:core:test` passed locally
- `git diff --check` passed locally

## Real Behavior Proof
Fresh live proof collected 2026-06-26 with a temporary redacted runner that starts the real Codex app-server via:

`/opt/homebrew/bin/codex app-server --listen stdio://`

The runner uses the production `runCodexAppServerAttempt` startup path, wraps the real initialized app-server client, records `initialize`, `thread/start`, and `turn/start` RPC attempts, and intentionally stops before forwarding `turn/start` so no model turn is executed.

Redacted terminal output:
```json
{
  "proofKind": "live-codex-app-server-thread-start",
  "collectedAt": "2026-06-26T18:11:18.452Z",
  "codexCli": "codex-cli 0.141.0",
  "runtimeIdentity": {
    "serverVersion": "0.141.0",
    "userAgent": "openclaw/0.141.0 (Mac OS 26.3.1; arm64) dumb (openclaw; 2026.6.10)",
    "codexHome": "<proof-temp>/agent/codex-home",
    "platformFamily": "unix",
    "platformOs": "macos"
  },
  "workspaceOnlyPolicy": true,
  "requestedAppServerSandbox": "danger-full-access",
  "observedMethods": [
    "initialize",
    "thread/start",
    "turn/start"
  ],
  "threadStartObserved": true,
  "turnStartForwarded": false,
  "threadStart": {
    "sandbox": "danger-full-access",
    "approvalPolicy": "never",
    "featuresCodeMode": false,
    "featuresCodeModeOnly": false,
    "defaultAppDenialPatch": {
      "enabled": false,
      "destructive_enabled": false,
      "open_world_enabled": false
    }
  },
  "blockedTurnStartSandboxPolicy": {
    "type": "dangerFullAccess"
  },
  "stopReason": "proof stop before model turn after live thread/start capture"
}
```

Observed result: in a real Codex app-server process (`serverVersion=0.141.0`) with effective `tools.fs.workspaceOnly=true` and configured `appServer.sandbox="danger-full-access"`, OpenClaw sends `thread/start` with native code/file mode disabled (`features.code_mode=false`, `features.code_mode_only=false`) and an `apps._default` denial patch while preserving the requested sandbox. Workspace-scoped filesystem access remains on OpenClaw-owned dynamic tools.

## Dependency Check
Checked sibling Codex source before the fix:
- `codex-rs/sandboxing/src/seatbelt_tests.rs`
- `codex-rs/app-server/src/thread_state.rs`

Current Codex sandbox profiles do not expose the OpenClaw workspace-only read/write boundary ClawSweeper asked for, so this PR now fails closed by disabling the native surface when workspace-only fs policy is active.

## Notes
- Per-agent `tools.fs.workspaceOnly=false` is treated as an explicit opt-out from a global workspace-only policy; omit the per-agent key to fall through to the global policy.
