### PR TITLE
fix(sandbox): scope agent sandboxes by workspace

### DIFF
--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -167,6 +167,7 @@ Use `backend: "ssh"` when you want OpenClaw to sandbox `exec`, file tools, and m
 
     - Host-local edits made outside OpenClaw after the seed step are not visible remotely until you recreate the sandbox.
     - `openclaw sandbox recreate` deletes the per-scope remote root and seeds again from local on next use.
+    - Non-shared sandbox identity is scoped by the local workspace root. After upgrading from older releases, existing session/agent runtimes may be created once under new names and old runtimes can be removed with `openclaw sandbox recreate` or existing prune settings.
     - Browser sandboxing is not supported on the SSH backend.
     - `sandbox.docker.*` settings do not apply to the SSH backend.
 
@@ -285,6 +286,7 @@ OpenShell sandboxes are still managed through the normal sandbox lifecycle:
 - `openclaw sandbox list` shows OpenShell runtimes as well as Docker runtimes
 - `openclaw sandbox recreate` deletes the current runtime and lets OpenClaw recreate it on next use
 - prune logic is backend-aware too
+- non-shared runtimes are keyed by both session/agent scope and workspace root, so co-hosted workspaces do not share a sandbox runtime by accident
 
 For `remote` mode, recreate is especially important:
 

--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { registerSandboxBackend } from "./sandbox/backend.js";
 import { ensureSandboxWorkspaceForSession, resolveSandboxContext } from "./sandbox/context.js";
+import { resolveSandboxScopeKey } from "./sandbox/shared.js";
 
 const updateRegistryMock = vi.hoisted(() => vi.fn());
 const syncSkillsToWorkspaceMock = vi.hoisted(() => vi.fn(async () => undefined));
@@ -62,6 +63,29 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await fs.rm(sandboxFixtureRoot, { recursive: true, force: true });
+});
+
+describe("resolveSandboxScopeKey", () => {
+  it("scopes session sandboxes by workspace", () => {
+    const first = resolveSandboxScopeKey("session", "agent:poly:msteams:channel-1", {
+      workspaceDir: "/tmp/openclaw-customers/atica/openclaw/agents/poly/workspace",
+    });
+    const second = resolveSandboxScopeKey("session", "agent:poly:msteams:channel-1", {
+      workspaceDir: "/tmp/openclaw-customers/polytopic/openclaw/agents/poly/workspace",
+    });
+
+    expect(first).toMatch(/^agent:poly:msteams:channel-1:workspace:[a-f0-9]{8}$/);
+    expect(second).toMatch(/^agent:poly:msteams:channel-1:workspace:[a-f0-9]{8}$/);
+    expect(first).not.toBe(second);
+  });
+
+  it("keeps shared sandbox scope independent of workspace", () => {
+    expect(
+      resolveSandboxScopeKey("shared", "agent:poly:msteams:channel-1", {
+        workspaceDir: "/tmp/openclaw-customers/atica/openclaw/agents/poly/workspace",
+      }),
+    ).toBe("shared");
+  });
 });
 
 describe("resolveSandboxContext", () => {

--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -257,6 +257,72 @@ describe("resolveSandboxContext", () => {
     }
   }, 15_000);
 
+  it("scopes agent sandboxes by workspace to avoid cross-customer reuse", async () => {
+    const backendCalls: Array<{
+      scopeKey: string;
+      workspaceDir: string;
+      agentWorkspaceDir: string;
+    }> = [];
+    const restore = registerSandboxBackend("test-tenant-backend", async (params) => {
+      backendCalls.push({
+        scopeKey: params.scopeKey,
+        workspaceDir: params.workspaceDir,
+        agentWorkspaceDir: params.agentWorkspaceDir,
+      });
+      return {
+        id: "test-tenant-backend",
+        runtimeId: `runtime-${backendCalls.length}`,
+        runtimeLabel: `Runtime ${backendCalls.length}`,
+        workdir: "/workspace",
+        buildExecSpec: async () => ({
+          argv: ["test-tenant-backend", "exec"],
+          env: process.env,
+          stdinMode: "pipe-closed",
+        }),
+        runShellCommand: async () => ({
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.alloc(0),
+          code: 0,
+        }),
+      };
+    });
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "all",
+              backend: "test-tenant-backend",
+              scope: "agent",
+              workspaceAccess: "rw",
+              prune: { idleHours: 0, maxAgeDays: 0 },
+            },
+          },
+        },
+      };
+
+      await resolveSandboxContext({
+        config: cfg,
+        sessionKey: "agent:poly:msteams:channel-1",
+        workspaceDir: "/tmp/openclaw-customers/atica/openclaw/agents/poly/workspace",
+      });
+      await resolveSandboxContext({
+        config: cfg,
+        sessionKey: "agent:poly:msteams:channel-1",
+        workspaceDir: "/tmp/openclaw-customers/polytopic/openclaw/agents/poly/workspace",
+      });
+
+      expect(backendCalls).toHaveLength(2);
+      expect(backendCalls[0]?.scopeKey).toMatch(/^agent:poly:workspace:/);
+      expect(backendCalls[1]?.scopeKey).toMatch(/^agent:poly:workspace:/);
+      expect(backendCalls[0]?.scopeKey).not.toBe(backendCalls[1]?.scopeKey);
+      expect(backendCalls[0]?.workspaceDir).toBe(backendCalls[0]?.agentWorkspaceDir);
+      expect(backendCalls[1]?.workspaceDir).toBe(backendCalls[1]?.agentWorkspaceDir);
+    } finally {
+      restore();
+    }
+  }, 15_000);
+
   it("passes the resolved browser SSRF policy to sandbox browser setup", async () => {
     ensureSandboxBrowserMock.mockClear();
     const restore = registerSandboxBackend("test-browser-backend", async () => ({
@@ -408,7 +474,7 @@ describe("resolveSandboxContext", () => {
       path.join(".openclaw", "sandbox", "skills-workspaces"),
     );
     expect(syncOptions?.targetWorkspaceDir).toMatch(
-      /[\\/]agent-main-main-[a-f0-9]{8}[\\/]\.openclaw[\\/]sandbox-skills$/,
+      /[\\/]agent-main-main-workspace-[a-f0-9]{6}-[a-f0-9]{8}[\\/]\.openclaw[\\/]sandbox-skills$/,
     );
     expect(syncOptions?.targetWorkspaceDir).not.toBe(
       path.join(workspaceDir, ".openclaw", "sandbox-skills"),
@@ -455,7 +521,7 @@ describe("resolveSandboxContext", () => {
 
     expect(result?.workspaceDir).toBe(workspaceDir);
     expect(result?.containerWorkdir).toMatch(
-      /^\/remote\/openclaw\/openclaw-ssh-agent-main-main-[a-f0-9]{8}\/workspace$/,
+      /^\/remote\/openclaw\/openclaw-ssh-agent-main-main-workspace-[a-f0-9]{6}-[a-f0-9]{8}\/workspace$/,
     );
     expect(result?.containerWorkdir).not.toBe("/workspace");
     expect(result?.skillsWorkspaceDir).toContain(

--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -6,7 +6,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { registerSandboxBackend } from "./sandbox/backend.js";
 import { ensureSandboxWorkspaceForSession, resolveSandboxContext } from "./sandbox/context.js";
-import { resolveSandboxScopeKey } from "./sandbox/shared.js";
+import { resolveSandboxScopeKey, slugifySessionKey } from "./sandbox/shared.js";
 
 const updateRegistryMock = vi.hoisted(() => vi.fn());
 const syncSkillsToWorkspaceMock = vi.hoisted(() => vi.fn(async () => undefined));
@@ -66,6 +66,12 @@ afterAll(async () => {
 });
 
 describe("resolveSandboxScopeKey", () => {
+  it("preserves workspace hash entropy outside slug prefix truncation", () => {
+    expect(slugifySessionKey("agent:poly:msteams:channel-1:workspace:1234abcd")).toMatch(
+      /^agent-poly-msteams-chann-workspace-1234abcd-[a-f0-9]{8}$/,
+    );
+  });
+
   it("scopes session sandboxes by workspace", () => {
     const first = resolveSandboxScopeKey("session", "agent:poly:msteams:channel-1", {
       workspaceDir: "/tmp/openclaw-customers/atica/openclaw/agents/poly/workspace",
@@ -498,7 +504,7 @@ describe("resolveSandboxContext", () => {
       path.join(".openclaw", "sandbox", "skills-workspaces"),
     );
     expect(syncOptions?.targetWorkspaceDir).toMatch(
-      /[\\/]agent-main-main-workspace-[a-f0-9]{6}-[a-f0-9]{8}[\\/]\.openclaw[\\/]sandbox-skills$/,
+      /[\\/]agent-main-main-workspace-[a-f0-9]{8}-[a-f0-9]{8}[\\/]\.openclaw[\\/]sandbox-skills$/,
     );
     expect(syncOptions?.targetWorkspaceDir).not.toBe(
       path.join(workspaceDir, ".openclaw", "sandbox-skills"),
@@ -545,7 +551,7 @@ describe("resolveSandboxContext", () => {
 
     expect(result?.workspaceDir).toBe(workspaceDir);
     expect(result?.containerWorkdir).toMatch(
-      /^\/remote\/openclaw\/openclaw-ssh-agent-main-main-workspace-[a-f0-9]{6}-[a-f0-9]{8}\/workspace$/,
+      /^\/remote\/openclaw\/openclaw-ssh-agent-main-main-workspace-[a-f0-9]{8}-[a-f0-9]{8}\/workspace$/,
     );
     expect(result?.containerWorkdir).not.toBe("/workspace");
     expect(result?.skillsWorkspaceDir).toContain(

--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -5,8 +5,16 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { registerSandboxBackend } from "./sandbox/backend.js";
+import {
+  DEFAULT_SANDBOX_BROWSER_PREFIX,
+  DEFAULT_SANDBOX_CONTAINER_PREFIX,
+} from "./sandbox/constants.js";
 import { ensureSandboxWorkspaceForSession, resolveSandboxContext } from "./sandbox/context.js";
-import { resolveSandboxScopeKey, slugifySessionKey } from "./sandbox/shared.js";
+import {
+  formatSandboxContainerName,
+  resolveSandboxScopeKey,
+  slugifySessionKey,
+} from "./sandbox/shared.js";
 
 const updateRegistryMock = vi.hoisted(() => vi.fn());
 const syncSkillsToWorkspaceMock = vi.hoisted(() => vi.fn(async () => undefined));
@@ -70,6 +78,23 @@ describe("resolveSandboxScopeKey", () => {
     expect(slugifySessionKey("agent:poly:msteams:channel-1:workspace:1234abcd")).toMatch(
       /^agent-poly-msteams-chann-workspace-1234abcd-[a-f0-9]{8}$/,
     );
+  });
+
+  it("keeps workspace uniqueness suffixes inside default container name limits", () => {
+    const first = "agent:poly:msteams:channel-with-shared-readable-prefix-alpha:workspace:1234abcd";
+    const second = "agent:poly:msteams:channel-with-shared-readable-prefix-beta:workspace:1234abcd";
+
+    const dockerFirst = formatSandboxContainerName(DEFAULT_SANDBOX_CONTAINER_PREFIX, first);
+    const dockerSecond = formatSandboxContainerName(DEFAULT_SANDBOX_CONTAINER_PREFIX, second);
+    const browserFirst = formatSandboxContainerName(DEFAULT_SANDBOX_BROWSER_PREFIX, first);
+    const browserSecond = formatSandboxContainerName(DEFAULT_SANDBOX_BROWSER_PREFIX, second);
+
+    for (const name of [dockerFirst, dockerSecond, browserFirst, browserSecond]) {
+      expect(name.length).toBeLessThanOrEqual(63);
+      expect(name).toMatch(/-workspace-1234abcd-[a-f0-9]{8}$/);
+    }
+    expect(dockerFirst).not.toBe(dockerSecond);
+    expect(browserFirst).not.toBe(browserSecond);
   });
 
   it("scopes session sandboxes by workspace", () => {

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -51,7 +51,7 @@ import {
   issueNoVncObserverToken,
 } from "./novnc-auth.js";
 import { readBrowserRegistry, updateBrowserRegistry } from "./registry.js";
-import { resolveSandboxAgentId, slugifySessionKey } from "./shared.js";
+import { formatSandboxContainerName, resolveSandboxAgentId } from "./shared.js";
 import { isToolAllowed } from "./tool-policy.js";
 import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
 import { validateNetworkMode } from "./validate-sandbox-security.js";
@@ -231,9 +231,10 @@ export async function ensureSandboxBrowser(params: {
     return null;
   }
 
-  const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(params.scopeKey);
-  const name = `${params.cfg.browser.containerPrefix}${slug}`;
-  const containerName = name.slice(0, 63);
+  const containerName = formatSandboxContainerName(
+    params.cfg.browser.containerPrefix,
+    params.scopeKey,
+  );
   const state = await dockerContainerState(containerName);
   const browserImage = params.cfg.browser.image ?? DEFAULT_SANDBOX_BROWSER_IMAGE;
   const cdpSourceRange = normalizeOptionalString(params.cfg.browser.cdpSourceRange);

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -88,7 +88,9 @@ async function ensureSandboxWorkspaceLayout(params: {
     params.workspaceDir?.trim() || DEFAULT_AGENT_WORKSPACE_DIR,
   );
   const workspaceRoot = resolveUserPath(cfg.workspaceRoot);
-  const scopeKey = resolveSandboxScopeKey(cfg.scope, rawSessionKey);
+  const scopeKey = resolveSandboxScopeKey(cfg.scope, rawSessionKey, {
+    workspaceDir: agentWorkspaceDir,
+  });
   const sandboxWorkspaceDir =
     cfg.scope === "shared" ? workspaceRoot : resolveSandboxWorkspaceDir(workspaceRoot, scopeKey);
   const workspaceDir = cfg.workspaceAccess === "rw" ? agentWorkspaceDir : sandboxWorkspaceDir;

--- a/src/agents/sandbox/docker-backend.test.ts
+++ b/src/agents/sandbox/docker-backend.test.ts
@@ -2,6 +2,7 @@
 // handling for sandbox and browser containers.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { SandboxConfig } from "./types.js";
 
 const dockerMocks = vi.hoisted(() => ({
   dockerContainerState: vi.fn(),
@@ -21,7 +22,8 @@ vi.mock("./docker.js", async () => {
   };
 });
 
-const { dockerSandboxBackendManager } = await import("./docker-backend.js");
+const { createDockerSandboxBackend, dockerSandboxBackendManager } =
+  await import("./docker-backend.js");
 
 function createConfig(): OpenClawConfig {
   return {
@@ -41,6 +43,55 @@ function createConfig(): OpenClawConfig {
         },
       },
       list: [],
+    },
+  };
+}
+
+function createSandboxConfig(): SandboxConfig {
+  return {
+    mode: "all",
+    backend: "docker",
+    scope: "agent",
+    workspaceAccess: "rw",
+    workspaceRoot: "~/.openclaw/sandboxes",
+    docker: {
+      image: "openclaw-sandbox:bookworm-slim",
+      containerPrefix: "oc-test-",
+      workdir: "/workspace",
+      readOnlyRoot: true,
+      tmpfs: ["/tmp", "/var/tmp", "/run"],
+      network: "none",
+      capDrop: ["ALL"],
+      env: {},
+      dns: [],
+      extraHosts: [],
+      binds: ["/tmp/customer/workspace:/workspace:rw"],
+      dangerouslyAllowReservedContainerTargets: true,
+    },
+    ssh: {
+      command: "ssh",
+      workspaceRoot: "/tmp/openclaw-sandboxes",
+      strictHostKeyChecking: true,
+      updateHostKeys: true,
+    },
+    browser: {
+      enabled: false,
+      image: "openclaw-sandbox-browser:bookworm-slim",
+      containerPrefix: "oc-browser-",
+      network: "openclaw-sandbox-browser",
+      cdpPort: 9222,
+      vncPort: 5900,
+      noVncPort: 6080,
+      headless: true,
+      enableNoVnc: false,
+      autoStart: false,
+      autoStartTimeoutMs: 5_000,
+      allowHostControl: false,
+    },
+    tools: {},
+    prune: {
+      idleHours: 0,
+      maxAgeDays: 0,
     },
   };
 }
@@ -86,6 +137,25 @@ describe("docker sandbox backend manager", () => {
       actualConfigLabel: "openclaw-sandbox:bookworm-slim",
       configLabelMatch: true,
     });
+  });
+
+  it("forwards the resolved scope key to Docker container creation", async () => {
+    dockerMocks.ensureSandboxContainer.mockResolvedValueOnce("sandbox-container");
+
+    await createDockerSandboxBackend({
+      sessionKey: "agent:poly:msteams:channel-1",
+      scopeKey: "agent:poly:workspace:tenant123",
+      workspaceDir: "/tmp/customer/workspace",
+      agentWorkspaceDir: "/tmp/customer/workspace",
+      cfg: createSandboxConfig(),
+    });
+
+    expect(dockerMocks.ensureSandboxContainer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:poly:msteams:channel-1",
+        scopeKey: "agent:poly:workspace:tenant123",
+      }),
+    );
   });
 
   it("matches browser runtimes against sandbox.browser.image", async () => {

--- a/src/agents/sandbox/docker-backend.ts
+++ b/src/agents/sandbox/docker-backend.ts
@@ -37,6 +37,7 @@ export async function createDockerSandboxBackend(
 ): Promise<SandboxBackendHandle> {
   const containerName = await ensureSandboxContainer({
     sessionKey: params.sessionKey,
+    scopeKey: params.scopeKey,
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
     skillsWorkspaceDir: params.skillsWorkspaceDir,

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -180,10 +180,12 @@ async function ensureSandboxCreateCallForTest(params: {
   cfg: SandboxConfig;
   workspaceDir?: string;
   sessionKey?: string;
+  scopeKey?: string;
 }): Promise<SpawnCall> {
   const workspaceDir = params.workspaceDir ?? "/tmp/workspace";
   await ensureSandboxContainer({
     sessionKey: params.sessionKey ?? "agent:main:session-1",
+    scopeKey: params.scopeKey,
     workspaceDir,
     agentWorkspaceDir: workspaceDir,
     cfg: params.cfg,
@@ -213,6 +215,30 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     registryMocks.updateRegistry.mockClear();
     registryMocks.updateRegistry.mockResolvedValue(undefined);
     await loadFreshDockerModuleForTest();
+  });
+
+  it("uses the resolved scope key for agent-scoped container names and labels", async () => {
+    const workspaceDir = makeTempDir();
+    const cfg = createSandboxConfig([], [`${workspaceDir}:/workspace:rw`]);
+    cfg.scope = "agent";
+    spawnState.inspectRunning = false;
+    registryMocks.readRegistryEntry.mockResolvedValue(null);
+
+    const createCall = await ensureSandboxCreateCallForTest({
+      cfg,
+      workspaceDir,
+      sessionKey: "agent:poly:msteams:channel-1",
+      scopeKey: "agent:poly:workspace:tenant123",
+    });
+
+    expect(createCall.args).toContain("--name");
+    expect(createCall.args[createCall.args.indexOf("--name") + 1]).toBe(
+      "oc-test-agent-poly-workspace-tenant123-f73c4135",
+    );
+    expect(createCall.args).toContain("openclaw.sessionKey=agent:poly:workspace:tenant123");
+    const registryUpdate = registryMocks.updateRegistry.mock.calls.at(-1)?.[0];
+    expect(registryUpdate?.containerName).toBe("oc-test-agent-poly-workspace-tenant123-f73c4135");
+    expect(registryUpdate?.sessionKey).toBe("agent:poly:workspace:tenant123");
   });
 
   it("recreates shared container when array-order change alters hash", async () => {

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -592,12 +592,17 @@ function formatSandboxRecreateHint(params: { scope: SandboxConfig["scope"]; sess
 
 export async function ensureSandboxContainer(params: {
   sessionKey: string;
+  scopeKey?: string;
   workspaceDir: string;
   agentWorkspaceDir: string;
   skillsWorkspaceDir?: string;
   cfg: SandboxConfig;
 }) {
-  const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.sessionKey);
+  const scopeKey =
+    params.scopeKey ??
+    resolveSandboxScopeKey(params.cfg.scope, params.sessionKey, {
+      workspaceDir: params.agentWorkspaceDir,
+    });
   const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(scopeKey);
   const name = `${params.cfg.docker.containerPrefix}${slug}`;
   const containerName = name.slice(0, 63);

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -179,7 +179,11 @@ import {
 } from "./config-hash.js";
 import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
 import { readRegistryEntry, updateRegistry } from "./registry.js";
-import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
+import {
+  formatSandboxContainerName,
+  resolveSandboxAgentId,
+  resolveSandboxScopeKey,
+} from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
 import { validateSandboxSecurity } from "./validate-sandbox-security.js";
 import {
@@ -603,9 +607,7 @@ export async function ensureSandboxContainer(params: {
     resolveSandboxScopeKey(params.cfg.scope, params.sessionKey, {
       workspaceDir: params.agentWorkspaceDir,
     });
-  const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(scopeKey);
-  const name = `${params.cfg.docker.containerPrefix}${slug}`;
-  const containerName = name.slice(0, 63);
+  const containerName = formatSandboxContainerName(params.cfg.docker.containerPrefix, scopeKey);
   const readOnlyWorkspaceSkillMounts = resolveReadOnlyWorkspaceSkillMounts({
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,

--- a/src/agents/sandbox/shared.ts
+++ b/src/agents/sandbox/shared.ts
@@ -17,6 +17,8 @@ export function slugifySessionKey(value: string) {
   const safe = normalizeLowercaseStringOrEmpty(trimmed)
     .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "");
+  // Keep the readable prefix bounded; uniqueness comes from the trailing hash of
+  // the full untruncated key, including any workspace scope suffix.
   const base = safe.slice(0, 32) || "session";
   return `${base}-${hash}`;
 }

--- a/src/agents/sandbox/shared.ts
+++ b/src/agents/sandbox/shared.ts
@@ -10,6 +10,8 @@ import { resolveUserPath } from "../../utils.js";
 import { resolveAgentIdFromSessionKey } from "../agent-scope.js";
 import { hashTextSha256 } from "./hash.js";
 
+const DOCKER_NAME_MAX_LENGTH = 63;
+
 /** Converts an arbitrary session key into a bounded filesystem/container-safe slug. */
 export function slugifySessionKey(value: string) {
   const trimmed = value.trim() || "session";
@@ -30,6 +32,30 @@ export function slugifySessionKey(value: string) {
     return `${base}-workspace-${workspaceScopeHash}-${hash}`;
   }
   return `${base}-${hash}`;
+}
+
+/** Formats a Docker/container runtime name while preserving the unique slug suffix. */
+export function formatSandboxContainerName(prefix: string, scopeKey: string) {
+  const slug = scopeKey.trim() === "shared" ? "shared" : slugifySessionKey(scopeKey);
+  const name = `${prefix}${slug}`;
+  if (name.length <= DOCKER_NAME_MAX_LENGTH) {
+    return name;
+  }
+
+  const suffix =
+    slug.match(/-workspace-[a-f0-9]{8}-[a-f0-9]{8}$/i)?.[0] ??
+    slug.match(/-[a-f0-9]{8}$/i)?.[0] ??
+    `-${hashTextSha256(slug).slice(0, 8)}`;
+  const slugBudget = DOCKER_NAME_MAX_LENGTH - prefix.length;
+  if (slugBudget > suffix.length) {
+    const baseBudget = slugBudget - suffix.length;
+    const base = slug.slice(0, baseBudget).replace(/-+$/g, "") || "session".slice(0, baseBudget);
+    return `${prefix}${base}${suffix}`;
+  }
+
+  const fallbackSuffix = `-${hashTextSha256(name).slice(0, 8)}`;
+  const prefixBudget = Math.max(0, DOCKER_NAME_MAX_LENGTH - fallbackSuffix.length);
+  return `${prefix.slice(0, prefixBudget).replace(/-+$/g, "")}${fallbackSuffix}`;
 }
 
 /** Resolves the per-session sandbox workspace directory under the configured sandbox root. */

--- a/src/agents/sandbox/shared.ts
+++ b/src/agents/sandbox/shared.ts
@@ -29,16 +29,24 @@ export function resolveSandboxWorkspaceDir(root: string, sessionKey: string) {
 }
 
 /** Resolves the registry scope key for session-, agent-, or shared-scope sandbox lifetimes. */
-export function resolveSandboxScopeKey(scope: "session" | "agent" | "shared", sessionKey: string) {
+export function resolveSandboxScopeKey(
+  scope: "session" | "agent" | "shared",
+  sessionKey: string,
+  options?: { workspaceDir?: string },
+) {
   const trimmed = sessionKey.trim() || "main";
   if (scope === "shared") {
     return "shared";
   }
+  const workspaceDir = options?.workspaceDir?.trim();
+  const workspaceScopeSuffix = workspaceDir
+    ? `:workspace:${hashTextSha256(resolveUserPath(workspaceDir)).slice(0, 8)}`
+    : "";
   if (scope === "session") {
-    return trimmed;
+    return `${trimmed}${workspaceScopeSuffix}`;
   }
   const agentId = resolveAgentIdFromSessionKey(trimmed);
-  return `agent:${agentId}`;
+  return `agent:${agentId}${workspaceScopeSuffix}`;
 }
 
 /** Extracts the agent id represented by a sandbox scope key, when one exists. */

--- a/src/agents/sandbox/shared.ts
+++ b/src/agents/sandbox/shared.ts
@@ -17,9 +17,18 @@ export function slugifySessionKey(value: string) {
   const safe = normalizeLowercaseStringOrEmpty(trimmed)
     .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "");
+  const workspaceScopeHash = trimmed.match(/:workspace:([a-f0-9]{8})$/i)?.[1]?.toLowerCase();
   // Keep the readable prefix bounded; uniqueness comes from the trailing hash of
-  // the full untruncated key, including any workspace scope suffix.
-  const base = safe.slice(0, 32) || "session";
+  // the full untruncated key. Workspace-scoped keys keep their workspace hash
+  // outside the readable-prefix truncation window so container names and
+  // workspace paths retain tenant entropy even for long agent/session keys.
+  const base =
+    (workspaceScopeHash
+      ? safe.replace(/-workspace-[a-f0-9]{8}$/i, "").slice(0, 24)
+      : safe.slice(0, 32)) || "session";
+  if (workspaceScopeHash) {
+    return `${base}-workspace-${workspaceScopeHash}-${hash}`;
+  }
   return `${base}-${hash}`;
 }
 

--- a/src/agents/sandbox/ssh-backend.test.ts
+++ b/src/agents/sandbox/ssh-backend.test.ts
@@ -213,6 +213,13 @@ describe("ssh sandbox backend", () => {
     expect(commandParams.remoteCommand).toContain("/remote/openclaw/openclaw-ssh-agent-worker");
   });
 
+  it("preserves the legacy shared SSH runtime id", () => {
+    const runtimePaths = resolveSshRuntimePaths("/remote/openclaw", "shared");
+
+    expect(runtimePaths.runtimeId).toBe("openclaw-ssh-shared-8198076c");
+    expect(runtimePaths.runtimeRootDir).toBe("/remote/openclaw/openclaw-ssh-shared-8198076c");
+  });
+
   it("removes runtimes by deleting the remote scope root", async () => {
     await sshSandboxBackendManager.removeRuntime({
       entry: {

--- a/src/agents/sandbox/ssh-backend.ts
+++ b/src/agents/sandbox/ssh-backend.ts
@@ -5,7 +5,6 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type {
   SandboxBackendCommandParams,
   SandboxBackendCommandResult,
@@ -21,6 +20,7 @@ import {
   type RemoteShellSandboxHandle,
 } from "./remote-fs-bridge.js";
 import { sanitizeEnvVars } from "./sanitize-env-vars.js";
+import { slugifySessionKey } from "./shared.js";
 import {
   buildRemoteCommand,
   buildRemoteWorkdirValidationCommand,
@@ -444,16 +444,5 @@ export function resolveSshRuntimePaths(
 }
 
 function buildSshSandboxRuntimeId(scopeKey: string): string {
-  const trimmed = scopeKey.trim() || "session";
-  // Keep the path human-readable while hashing the original scope to avoid
-  // collisions after normalization and truncation.
-  const safe = normalizeLowercaseStringOrEmpty(trimmed)
-    .replace(/[^a-z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 32);
-  const hash = Array.from(trimmed).reduce(
-    (acc, char) => ((acc * 33) ^ char.charCodeAt(0)) >>> 0,
-    5381,
-  );
-  return `openclaw-ssh-${safe || "session"}-${hash.toString(16).slice(0, 8)}`;
+  return `openclaw-ssh-${slugifySessionKey(scopeKey)}`;
 }

--- a/src/agents/sandbox/ssh-backend.ts
+++ b/src/agents/sandbox/ssh-backend.ts
@@ -444,5 +444,8 @@ export function resolveSshRuntimePaths(
 }
 
 function buildSshSandboxRuntimeId(scopeKey: string): string {
+  if ((scopeKey.trim() || "session") === "shared") {
+    return "openclaw-ssh-shared-8198076c";
+  }
   return `openclaw-ssh-${slugifySessionKey(scopeKey)}`;
 }

--- a/src/commands/sandbox.test.ts
+++ b/src/commands/sandbox.test.ts
@@ -234,7 +234,11 @@ describe("sandboxRecreateCommand", () => {
         containerName: "container-workspace-b",
         sessionKey: "target-session:workspace:not-a-hash",
       });
-      mocks.listSandboxContainers.mockResolvedValue([container, noMatch]);
+      const sameLengthNoMatch = createContainer({
+        containerName: "container-workspace-c",
+        sessionKey: "otherx-session:workspace:5678abcd",
+      });
+      mocks.listSandboxContainers.mockResolvedValue([container, noMatch, sameLengthNoMatch]);
 
       await sandboxRecreateCommand(
         { session: "target-session", all: false, browser: false, force: true },
@@ -255,7 +259,11 @@ describe("sandboxRecreateCommand", () => {
         containerName: "browser-workspace-b",
         sessionKey: "target-session:workspace:not-a-hash",
       });
-      mocks.listSandboxBrowsers.mockResolvedValue([browser, noMatch]);
+      const sameLengthNoMatch = createBrowser({
+        containerName: "browser-workspace-c",
+        sessionKey: "otherx-session:workspace:1234abcd",
+      });
+      mocks.listSandboxBrowsers.mockResolvedValue([browser, noMatch, sameLengthNoMatch]);
 
       await sandboxRecreateCommand(
         { session: "target-session", all: false, browser: true, force: true },

--- a/src/commands/sandbox.test.ts
+++ b/src/commands/sandbox.test.ts
@@ -225,6 +225,48 @@ describe("sandboxRecreateCommand", () => {
       expect(mocks.removeSandboxContainer).toHaveBeenCalledWith(match.containerName);
     });
 
+    it("should filter workspace-qualified session containers by raw session key", async () => {
+      const container = createContainer({
+        containerName: "container-workspace-a",
+        sessionKey: "target-session:workspace:1234abcd",
+      });
+      const noMatch = createContainer({
+        containerName: "container-workspace-b",
+        sessionKey: "target-session:workspace:not-a-hash",
+      });
+      mocks.listSandboxContainers.mockResolvedValue([container, noMatch]);
+
+      await sandboxRecreateCommand(
+        { session: "target-session", all: false, browser: false, force: true },
+        runtime as never,
+      );
+
+      expect(mocks.removeSandboxContainer).toHaveBeenCalledTimes(1);
+      expect(mocks.removeSandboxContainer).toHaveBeenCalledWith(container.containerName);
+      expect(mocks.removeSandboxBrowserContainer).not.toHaveBeenCalled();
+    });
+
+    it("should filter workspace-qualified session browsers by raw session key", async () => {
+      const browser = createBrowser({
+        containerName: "browser-workspace-a",
+        sessionKey: "target-session:workspace:5678abcd",
+      });
+      const noMatch = createBrowser({
+        containerName: "browser-workspace-b",
+        sessionKey: "target-session:workspace:not-a-hash",
+      });
+      mocks.listSandboxBrowsers.mockResolvedValue([browser, noMatch]);
+
+      await sandboxRecreateCommand(
+        { session: "target-session", all: false, browser: true, force: true },
+        runtime as never,
+      );
+
+      expect(mocks.removeSandboxContainer).not.toHaveBeenCalled();
+      expect(mocks.removeSandboxBrowserContainer).toHaveBeenCalledTimes(1);
+      expect(mocks.removeSandboxBrowserContainer).toHaveBeenCalledWith(browser.containerName);
+    });
+
     it("should filter by agent (exact + subkeys)", async () => {
       const agent = createContainer({ sessionKey: "agent:work" });
       const agentSub = createContainer({ sessionKey: "agent:work:subtask" });

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -128,8 +128,9 @@ async function fetchAndFilterContainers(opts: SandboxRecreateOptions): Promise<F
   let browsers = opts.browser ? allBrowsers : [];
 
   if (opts.session) {
-    containers = containers.filter((c) => c.sessionKey === opts.session);
-    browsers = browsers.filter((b) => b.sessionKey === opts.session);
+    const matchesSession = createSessionMatcher(opts.session);
+    containers = containers.filter(matchesSession);
+    browsers = browsers.filter(matchesSession);
   } else if (opts.agent) {
     // Agent-scoped cleanup removes both the agent root session and its child
     // session keys while leaving unrelated agent containers untouched.
@@ -139,6 +140,19 @@ async function fetchAndFilterContainers(opts: SandboxRecreateOptions): Promise<F
   }
 
   return { containers, browsers };
+}
+
+function createSessionMatcher(sessionKey: string) {
+  const rawSessionKey = sessionKey.trim();
+  return (item: ContainerItem) => {
+    if (item.sessionKey === rawSessionKey) {
+      return true;
+    }
+    const workspaceSuffix = item.sessionKey.slice(rawSessionKey.length);
+    // Non-shared session-scope runtimes append an internal workspace hash, but
+    // CLI users still recreate them by the raw documented session key.
+    return /^:workspace:[a-f0-9]{8}$/i.test(workspaceSuffix);
+  };
 }
 
 function createAgentMatcher(agentId: string) {

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -148,6 +148,9 @@ function createSessionMatcher(sessionKey: string) {
     if (item.sessionKey === rawSessionKey) {
       return true;
     }
+    if (!item.sessionKey.startsWith(`${rawSessionKey}:workspace:`)) {
+      return false;
+    }
     const workspaceSuffix = item.sessionKey.slice(rawSessionKey.length);
     // Non-shared session-scope runtimes append an internal workspace hash, but
     // CLI users still recreate them by the raw documented session key.


### PR DESCRIPTION
## What Problem This Solves
Agent-scoped sandboxes currently key reuse only by agent/session identity. In multi-tenant deployments, the same agent id can be used across separate customer workspaces, so a non-shared sandbox may be reused with the wrong workspace/container identity. This scopes non-shared sandbox lifetime keys by resolved workspace path while preserving shared sandbox behavior.

## Summary
- include the resolved workspace path hash in non-shared sandbox scope keys
- preserve the workspace hash outside the readable slug truncation window for Docker, SSH, and sandbox skills paths
- pass the resolved scope key through Docker sandbox creation so container names, labels, and registry entries stay workspace-specific
- teach `openclaw sandbox recreate --session <key>` to match the new internal `:workspace:<hash>` session suffix only when it belongs to the requested raw session key
- document the one-time upgrade behavior for old non-shared runtimes
- cover session, shared, agent, Docker backend, SSH backend, and recreate filtering behavior with regression tests

## Evidence
- `node scripts/run-vitest.mjs src/commands/sandbox.test.ts src/agents/sandbox.resolveSandboxContext.test.ts src/agents/sandbox/docker-backend.test.ts src/agents/sandbox/ssh-backend.test.ts` passed locally
- `pnpm exec oxfmt --check --threads=1 src/commands/sandbox.ts src/commands/sandbox.test.ts` passed locally
- `node scripts/run-oxlint.mjs src/commands/sandbox.ts src/commands/sandbox.test.ts` passed locally
- `pnpm tsgo:core` passed locally
- `pnpm tsgo:core:test` passed locally
- `git diff --check` passed locally

## Real Behavior Proof
Fresh proof collected 2026-06-26 by exercising the exported production Docker backend path: `ensureSandboxContainer(...)` plus `resolveSandboxScopeKey(...)`, using the same raw session key and two distinct workspace roots. The temporary proof script used the already-local Docker image `pgvector/pgvector:pg16` only to avoid a registry pull; the OpenClaw container naming, label, config-hash, registry, and cleanup code paths were unchanged.

Command used:
- `node_modules/.bin/tsx tmp/proof-96866.mts`

Redacted captured output:
```json
{
  "rawSession": "agent:proof:session",
  "workspaceA": "<workspace-a>",
  "workspaceB": "<workspace-b>",
  "scopeA": "agent:proof:session:workspace:a9d219c1",
  "scopeB": "agent:proof:session:workspace:ebaf544b",
  "slugA": "agent-proof-session-workspace-a9d219c1-6c6522e6",
  "slugB": "agent-proof-session-workspace-ebaf544b-bae62cf4",
  "containerA": "/oc-proof-96866-agent-proof-session-workspace-a9d219c1-6c6522e6",
  "containerB": "/oc-proof-96866-agent-proof-session-workspace-ebaf544b-bae62cf4",
  "labelA": "agent:proof:session:workspace:a9d219c1",
  "labelB": "agent:proof:session:workspace:ebaf544b",
  "sameRawSession": true,
  "distinctScopeKeys": true,
  "distinctContainers": true,
  "labelsMatchScopeKeys": true
}
```

Observed result: the same raw agent/session in two workspace roots produced two distinct non-shared scope keys, two distinct Docker container names retaining the workspace hash, and Docker `openclaw.sessionKey` labels matching the workspace-scoped keys. The temporary containers were removed at the end of the proof run.

## Notes
- Existing pre-PR non-shared sandbox containers use the old scope key. After this change, they will be recreated once under workspace-scoped names and the old containers can be removed with `openclaw sandbox recreate` or aged out through the existing sandbox prune path.