### PR TITLE
fix(embedding): bound OpenAI-compatible embedding response reads

### DIFF
--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -219,7 +219,8 @@ async function startOversizedSuccessEmbeddingServer(): Promise<OversizedStreamSe
       if (!(await writeChunk(prefix))) {
         return;
       }
-      while (bodyBytesSent < plannedBodyBytes) {
+      const chunksToSend = Math.ceil((plannedBodyBytes - bodyBytesSent) / chunk.byteLength);
+      for (let i = 0; i < chunksToSend; i++) {
         if (!(await writeChunk(chunk))) {
           return;
         }

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -31,6 +31,13 @@ type FixtureResponse = {
   };
 };
 
+type OversizedStreamServer = {
+  baseUrl: string;
+  closed: Promise<void>;
+  getBodyBytesSent: () => number;
+  getPlannedBodyBytes: () => number;
+};
+
 const servers: Array<{ close: () => Promise<void> }> = [];
 
 function createOptions(
@@ -160,6 +167,95 @@ async function startHangingErrorEmbeddingServer(): Promise<{
   return {
     baseUrl: `http://127.0.0.1:${address.port}/v1`,
     closed,
+  };
+}
+
+async function startOversizedSuccessEmbeddingServer(): Promise<OversizedStreamServer> {
+  const chunk = Buffer.alloc(64 * 1024, 0x20);
+  const prefix = Buffer.from('{"data":[');
+  const plannedBodyBytes = 64 * 1024 * 1024;
+  const sockets = new Set<Socket>();
+  let bodyBytesSent = 0;
+  let resolveClosed: () => void = () => undefined;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    void (async () => {
+      await readJsonBody(req);
+      let closedAlready = false;
+      res.on("close", () => {
+        closedAlready = true;
+        resolveClosed();
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      const writeChunk = async (buffer: Buffer): Promise<boolean> => {
+        if (closedAlready) {
+          return false;
+        }
+        const accepted = res.write(buffer);
+        bodyBytesSent += buffer.byteLength;
+        if (accepted) {
+          return true;
+        }
+        return await new Promise<boolean>((resolve) => {
+          const cleanup = () => {
+            res.off("drain", onDrain);
+            res.off("close", onClose);
+          };
+          const onDrain = () => {
+            cleanup();
+            resolve(!closedAlready);
+          };
+          const onClose = () => {
+            cleanup();
+            resolve(false);
+          };
+          res.once("drain", onDrain);
+          res.once("close", onClose);
+        });
+      };
+
+      if (!(await writeChunk(prefix))) {
+        return;
+      }
+      while (bodyBytesSent < plannedBodyBytes) {
+        if (!(await writeChunk(chunk))) {
+          return;
+        }
+      }
+      res.end("]}");
+    })();
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  servers.push({
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        for (const socket of sockets) {
+          socket.destroy();
+        }
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    closed,
+    getBodyBytesSent: () => bodyBytesSent,
+    getPlannedBodyBytes: () => plannedBodyBytes,
   };
 }
 
@@ -331,6 +427,29 @@ describe("openai-compatible generic embedding provider", () => {
         }),
       ]),
     ).resolves.toBe("closed");
+  });
+
+  it("bounds and cancels oversized successful embedding JSON bodies", async () => {
+    const server = await startOversizedSuccessEmbeddingServer();
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        model: "text-embedding-bge-m3",
+        remote: { baseUrl: server.baseUrl },
+      }),
+    );
+
+    await expect(provider.embed("hello")).rejects.toThrow(
+      "openai-compatible embeddings failed: JSON response exceeds 16777216 bytes",
+    );
+    await expect(
+      Promise.race([
+        server.closed.then(() => "closed" as const),
+        new Promise<"open">((resolve) => {
+          setTimeout(() => resolve("open"), 1_000);
+        }),
+      ]),
+    ).resolves.toBe("closed");
+    expect(server.getBodyBytesSent()).toBeLessThan(server.getPlannedBodyBytes() / 2);
   });
 
   it("resolves env SecretRef API keys on the memory search secret surface", async () => {

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -1,5 +1,6 @@
 // Builds OpenAI-compatible embedding provider entries for plugins.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import { normalizeSecretInputString } from "../config/types.secrets.js";
 import { resolveConfiguredSecretInputString } from "../gateway/resolve-configured-secret-input-string.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
@@ -285,11 +286,7 @@ function readEmbeddingVectors(
 }
 
 async function readJsonResponse(response: Response): Promise<unknown> {
-  try {
-    return await response.json();
-  } catch (cause) {
-    throw new Error("openai-compatible embeddings failed: malformed JSON response", { cause });
-  }
+  return await readProviderJsonResponse(response, "openai-compatible embeddings failed");
 }
 
 function concatBytes(chunks: Uint8Array[], totalLength: number): Uint8Array {


### PR DESCRIPTION
## What Problem This Solves

Success-path untrusted body reads in the OpenAI-compatible embedding provider used unbounded `response.json()`, so a user-configured OpenAI-compatible embedding endpoint could stream an oversized JSON body and force OpenClaw to buffer until OOM or hang before parsing.

## Changes

- Replace the OpenAI-compatible embedding success-path `response.json()` call with shared `readProviderJsonResponse`, which applies the existing 16 MiB provider JSON cap and cancels the stream on overflow.
- Add a focused real `node:http` regression test for an oversized chunked success JSON response that verifies the provider throws the shared cap error and the server sees the socket close before the full body is sent.

## Real behavior proof

Behavior addressed: OpenAI-compatible embedding success responses now use the shared bounded JSON reader instead of unbounded `response.json()`.

Real environment tested: local Linux checkout, Node runtime, real loopback `node:http` server, production `createOpenAICompatibleEmbeddingProvider` export, production fetch path, no mocked response object for the proof script.

Exact steps:

```bash
node scripts/run-vitest.mjs src/plugins/openai-compatible-embedding-provider.test.ts
pnpm tsgo:core
pnpm tsgo:core:test
node --import tsx scratchpad/embedding-bound-proof.mts
.agents/skills/autoreview/scripts/autoreview --mode local
```

Observed result: focused Vitest passed, both tsgo lanes exited 0, the scratchpad proof produced PASS lines for bounded throw, socket abort, small JSON happy path, and an old unbounded `response.json()` negative control.

What was not tested: full repository Vitest/CI matrix was not run; this patch only changes the OpenAI-compatible embedding success JSON read path and its focused provider tests.

## Evidence

```text
$ node scripts/run-vitest.mjs src/plugins/openai-compatible-embedding-provider.test.ts
[test] starting test/vitest/vitest.unit-fast.config.ts

 RUN  v4.1.8 /media/vdc/0668001470/workSpace/claw-campaign/campaign-wt/embedding

 Test Files  1 passed (1)
      Tests  26 passed (26)
   Start at  07:33:58
   Duration  2.00s (transform 560ms, setup 0ms, import 1.24s, tests 550ms, environment 0ms)

[test] passed 1 Vitest shard in 12.98s

$ pnpm tsgo:core
$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
# exited 0

$ pnpm tsgo:core:test
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
# exited 0

$ node --import tsx scratchpad/embedding-bound-proof.mts
[proof] node:http loopback server=http://127.0.0.1:41541, cap=16777216 bytes, oversizedBody=67108864 bytes
PASS  bounded throw :: openai-compatible embeddings failed: JSON response exceeds 16777216 bytes
PASS  bounded stream cancelled :: abort=true bytesSent=19988489 (<67108864)
PASS  happy path small JSON parses :: embedding=[0.25,0.5]
PASS  negative control: old unbounded response.json buffers past cap :: bytesSent=67108873 (> 16777216)
PASS  bounded read consumes far less than negative control :: boundedBytesSent=19988489 negativeBytesSent=67108873

$ .agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.82)
```

**Label**: security
_AI-assisted._
