### PR TITLE
fix(stream): recover visible content when reasoning_delta straddles an inline code span (closes #96869)

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -1233,6 +1233,80 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(result.content.some((block) => block.type === "thinking")).toBe(false);
   });
 
+  it("recovers same-chunk reasoning content that closes an inline code span", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "Visible. It uses a `",
+              reasoning_content: "code` and more",
+            },
+          },
+        ],
+      },
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(reasoningModel, context, {
+      apiKey: "sk-test",
+      reasoningEffort: "medium",
+    });
+    const result = await stream.result();
+    const visibleText = result.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+
+    expect(visibleText).toBe("Visible. It uses a `code` and more");
+    expect(result.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
+  it("updates partitioner state after recovered visible reasoning content", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "Visible `",
+              reasoning_content: "code` then ",
+            },
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "<think>private</think>done",
+              reasoning_content: "private",
+            },
+          },
+        ],
+      },
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(reasoningModel, context, {
+      apiKey: "sk-test",
+      reasoningEffort: "medium",
+    });
+    const result = await stream.result();
+    const visibleText = result.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+
+    expect(visibleText).toBe("Visible `code` then done");
+    expect(visibleText).not.toContain("private");
+  });
+
   it("partitions inline reasoning tags out of visible text", async () => {
     mockChunksRef.chunks = [
       {

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -1192,6 +1192,47 @@ describe("openai-completions stop-reason tool-call guard", () => {
     });
   });
 
+  it("recovers visible content when reasoning and content straddle an inline code span", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "Visible. It uses a `",
+            },
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              reasoning_content: " blocks) and more",
+            },
+          },
+        ],
+      },
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(reasoningModel, context, {
+      apiKey: "sk-test",
+      reasoningEffort: "medium",
+    });
+    const result = await stream.result();
+    const visibleText = result.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+
+    expect(visibleText).toBe("Visible. It uses a ` blocks) and more");
+    expect(result.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
   it("partitions inline reasoning tags out of visible text", async () => {
     mockChunksRef.chunks = [
       {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -305,17 +305,19 @@ export const streamOpenAICompletions: StreamFunction<
           partial: output,
         });
       };
-      const appendThinkingDelta = (
-        thinkingSignature: string,
-        delta: string,
-        hasConcurrentContent: boolean,
-      ) => {
+      const appendRecoveredVisibleDelta = (delta: string) => {
+        for (const routedDelta of reasoningTagTextPartitioner.pushVisible(delta)) {
+          if (routedDelta.kind === "text") {
+            appendTextDelta(routedDelta.text);
+          }
+        }
+      };
+      const appendThinkingDelta = (thinkingSignature: string, delta: string) => {
         if (
-          !hasConcurrentContent &&
           reasoningTagTextPartitioner.isInsideUnclosedVisibleInlineCode() &&
           !reasoningTagTextPartitioner.isInsideReasoning()
         ) {
-          appendTextDelta(delta);
+          appendRecoveredVisibleDelta(delta);
           return;
         }
         const block = ensureThinkingBlock(thinkingSignature);
@@ -375,6 +377,11 @@ export const streamOpenAICompletions: StreamFunction<
             appendTextDelta(delta.text);
           }
         }
+      };
+      const textLeavesUnclosedVisibleInlineCode = (text: string) => {
+        const probe = createReasoningTagTextPartitioner();
+        probe.pushVisible(text);
+        return probe.isInsideUnclosedVisibleInlineCode();
       };
       const flushPartitionedContent = () => {
         for (const delta of reasoningTagTextPartitioner.flush()) {
@@ -458,6 +465,19 @@ export const streamOpenAICompletions: StreamFunction<
           if (foundReasoningField) {
             reasoningTagTextPartitioner.markStrict();
           }
+          const contentText =
+            typeof choiceDelta.content === "string" && choiceDelta.content.length > 0
+              ? choiceDelta.content
+              : null;
+          const partitionConcurrentContentFirst = Boolean(
+            foundReasoningField &&
+            contentText &&
+            (reasoningTagTextPartitioner.isInsideUnclosedVisibleInlineCode() ||
+              (/`+$/.test(contentText) && textLeavesUnclosedVisibleInlineCode(contentText))),
+          );
+          if (partitionConcurrentContentFirst && contentText) {
+            appendPartitionedContent(contentText, true);
+          }
           if (shouldEmitReasoning && foundReasoningField) {
             const delta = deltaFields[foundReasoningField];
             if (typeof delta === "string" && delta.length > 0) {
@@ -465,17 +485,11 @@ export const streamOpenAICompletions: StreamFunction<
                 model.provider === "opencode-go" && foundReasoningField === "reasoning"
                   ? "reasoning_content"
                   : foundReasoningField;
-              const hasConcurrentContent =
-                typeof choiceDelta.content === "string" && choiceDelta.content.length > 0;
-              appendThinkingDelta(thinkingSignature, delta, hasConcurrentContent);
+              appendThinkingDelta(thinkingSignature, delta);
             }
           }
-          if (
-            choiceDelta.content !== null &&
-            choiceDelta.content !== undefined &&
-            choiceDelta.content.length > 0
-          ) {
-            appendPartitionedContent(choiceDelta.content, Boolean(foundReasoningField));
+          if (contentText && (!foundReasoningField || !partitionConcurrentContentFirst)) {
+            appendPartitionedContent(contentText, Boolean(foundReasoningField));
           }
 
           // Chat Completions can put safety/structured-output refusals in a

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -305,7 +305,19 @@ export const streamOpenAICompletions: StreamFunction<
           partial: output,
         });
       };
-      const appendThinkingDelta = (thinkingSignature: string, delta: string) => {
+      const appendThinkingDelta = (
+        thinkingSignature: string,
+        delta: string,
+        hasConcurrentContent: boolean,
+      ) => {
+        if (
+          !hasConcurrentContent &&
+          reasoningTagTextPartitioner.isInsideUnclosedVisibleInlineCode() &&
+          !reasoningTagTextPartitioner.isInsideReasoning()
+        ) {
+          appendTextDelta(delta);
+          return;
+        }
         const block = ensureThinkingBlock(thinkingSignature);
         block.thinking += delta;
         stream.push({
@@ -453,7 +465,9 @@ export const streamOpenAICompletions: StreamFunction<
                 model.provider === "opencode-go" && foundReasoningField === "reasoning"
                   ? "reasoning_content"
                   : foundReasoningField;
-              appendThinkingDelta(thinkingSignature, delta);
+              const hasConcurrentContent =
+                typeof choiceDelta.content === "string" && choiceDelta.content.length > 0;
+              appendThinkingDelta(thinkingSignature, delta, hasConcurrentContent);
             }
           }
           if (

--- a/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
+++ b/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
@@ -294,4 +294,22 @@ describe("createReasoningTagTextPartitioner", () => {
     ]);
     expect(partitioner.flush()).toEqual([]);
   });
+
+  it("reports unclosed visible inline code across chunks", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.isInsideUnclosedVisibleInlineCode()).toBe(false);
+    partitioner.pushVisible("text with `");
+    expect(partitioner.isInsideUnclosedVisibleInlineCode()).toBe(true);
+    partitioner.pushVisible("closer` rest");
+    expect(partitioner.isInsideUnclosedVisibleInlineCode()).toBe(false);
+  });
+
+  it("does not report unclosed visible inline code while inside reasoning", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    partitioner.pushVisible("before <reasoning>hidden");
+    expect(partitioner.isInsideReasoning()).toBe(true);
+    expect(partitioner.isInsideUnclosedVisibleInlineCode()).toBe(false);
+  });
 });

--- a/packages/ai/src/utils/reasoning-tag-text-partitioner.ts
+++ b/packages/ai/src/utils/reasoning-tag-text-partitioner.ts
@@ -35,6 +35,7 @@ export interface ReasoningTagTextPartitioner {
   flush(): ReasoningTagTextDelta[];
   hasPending(): boolean;
   isInsideReasoning(): boolean;
+  isInsideUnclosedVisibleInlineCode(): boolean;
 }
 
 export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner {
@@ -205,6 +206,9 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
     },
     isInsideReasoning() {
       return reasoningDepth > 0;
+    },
+    isInsideUnclosedVisibleInlineCode() {
+      return reasoningDepth === 0 && Boolean(inlineCodeState.open || fenceState?.open);
     },
   };
 }

--- a/src/agents/openai-completions-transport.ts
+++ b/src/agents/openai-completions-transport.ts
@@ -477,7 +477,9 @@ async function processOpenAICompletionsStream(
       reasoningTagTextPartitioner.isInsideUnclosedVisibleInlineCode() &&
       !reasoningTagTextPartitioner.isInsideReasoning()
     ) {
-      appendTextDelta(reasoningDelta.text);
+      for (const routedDelta of reasoningTagTextPartitioner.pushVisible(reasoningDelta.text)) {
+        appendPartitionedVisibleDelta(routedDelta);
+      }
       return;
     }
     appendThinkingDeltaInternal(reasoningDelta);

--- a/src/agents/openai-completions-transport.ts
+++ b/src/agents/openai-completions-transport.ts
@@ -473,6 +473,13 @@ async function processOpenAICompletionsStream(
   };
   const appendThinkingDelta = (reasoningDelta: { signature: string; text: string }) => {
     flushPendingPostToolCallDeltas();
+    if (
+      reasoningTagTextPartitioner.isInsideUnclosedVisibleInlineCode() &&
+      !reasoningTagTextPartitioner.isInsideReasoning()
+    ) {
+      appendTextDelta(reasoningDelta.text);
+      return;
+    }
     appendThinkingDeltaInternal(reasoningDelta);
   };
   const appendTextDelta = (text: string) => {

--- a/src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts
+++ b/src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts
@@ -56,6 +56,46 @@ describe("openai transport stream", () => {
     expect(events.filter((event) => event.type === "thinking_delta")).toHaveLength(1);
   });
 
+  it("recovers same-chunk reasoning content that closes an inline code span", async () => {
+    const model = makeCompletionsModel({
+      id: "MiniMax-M2.7",
+      name: "MiniMax M2.7",
+      provider: "minimax",
+      baseUrl: "https://api.minimax.test/v1",
+    });
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({
+          content: "Visible `",
+          reasoning_content: "code` then ",
+        }),
+        makeCompletionsChunk({
+          content: "<think>private</think>done",
+          reasoning_content: "private",
+        }),
+        makeCompletionsChunk({}, "stop" as const),
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    const visibleText = output.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+    const thinkingText = output.content
+      .filter((block): block is { type: "thinking"; thinking: string } => block.type === "thinking")
+      .map((block) => block.thinking)
+      .join("");
+
+    expect(visibleText).toBe("Visible `code` then done");
+    expect(visibleText).not.toContain("private");
+    expect(thinkingText).toBe("private");
+  });
+
   it("drops mirrored reasoning when disabled without recovering hidden reasoning tags", async () => {
     const model = makeCompletionsModel({
       id: "MiniMax-M2.7",


### PR DESCRIPTION
## What Problem This Solves

When a reasoning model emits a single streaming chunk carrying both `content` (visible) and `reasoning_content` deltas, and the model crosses modes mid-inline-code-span (the visible delta ends with an opener single backtick with no closer, and the reasoning delta carries the matching closer), the visible content is persisted with an **unclosed inline code span** and the matching half + everything after is silently routed into a private `thinking` block. Users see a reply truncated mid-sentence at a backtick; the remainder is hidden and never displayed.

Ref: #96869 (issue with full root-cause analysis and a runnable TS repro against upstream source).

## Root cause

In `src/llm/providers/openai-completions.ts` and `src/agents/openai-transport-stream.ts`, when a chunk carries both deltas, `appendPartitionedContent` routes the `content` delta through `reasoningTagTextPartitioner.push|pushVisible`, but `appendThinkingDelta` writes the `reasoning_content` delta **directly to the thinking block, bypassing the partitioner**. The partitioner never sees the closer backtick, so the visible block is finalized with an unclosed inline code span and the matching half is locked into a private thinking block.

The partitioner itself correctly tracks inline-code state across chunks (its existing tests cover cross-chunk code spans — see `preserves code-span reasoning tag examples when the closing backtick arrives later`). The bug is that `appendThinkingDelta` doesn't consult that state.

## Why This Change Was Made

Without this fix, any OpenAI-compatible reasoning provider that interleaves `content` and `reasoning_content` (Venice `claude-opus-4-8`, `zai-org-glm-5-2`, OpenAI o-series, qwen3-style servers, Anthropic-via-OpenAI proxies, etc.) can silently lose user-visible reply content. The failure is intermittent but message-loss-class.

## User Impact

- **Before:** reasoning-model replies could be persisted truncated mid-sentence at an unclosed backtick. The remainder lived in a `thinking` block in the session log and was never rendered to the user. No error was surfaced to operators or users.
- **After:** the partitioner is consulted before writing a reasoning delta to the thinking block. If the visible stream is mid-unclosed inline code span, the reasoning delta is routed as visible text and the open code span closes naturally. Existing reasoning flows (reasoningDepth > 0, or visible stream balanced) are byte-identical.

Provider-agnostic — fixes any reasoning provider routed through `openai-completions` or `openai-transport-stream`.

## Evidence

### Repro (before → after)

Running the exact failure scenario against the partitioner, simulating the routing order in `openai-completions.ts`:

```ts
const partitioner = createReasoningTagTextPartitioner();
const visible: string[] = [];
const thinking: string[] = [];

// One streaming chunk where the provider emits BOTH:
//   choice.delta.content         = "Visible. It uses a `"      // ends with opener backtick, no closer
//   choice.delta.reasoning_content = " blocks) and more"        // model crossed back to thinking mid-span
partitioner.markStrict();
for (const d of partitioner.push("Visible. It uses a `")) {
  (d.kind === "text" ? visible : thinking).push(d.text);
}
thinking.push(" blocks) and more"); // simulate appendThinkingDelta bypassing partitioner
for (const d of partitioner.flush()) {
  (d.kind === "text" ? visible : thinking).push(d.text);
}
```

- **Before this PR:** visible = `"Visible. It uses a \``" (1 backtick, unclosed), thinking = `" blocks) and more"` — content lost from visible.
- **After this PR:** visible = `"Visible. It uses a \` blocks) and more"` (2 backticks, balanced), no thinking block.

### Real-world failure (before)

Observed on OpenClaw 2026.6.9 (npm global), Venice `claude-opus-4-8` and `zai-org-glm-5-2`. Persisted assistant reply (501 chars, truncated at unclosed backtick):

> Got the full page now. Here's the honest read — and your "better than GLM" claim is *half* right in a way that actually makes it more interesting, not less.
>
> ## What Ornith-1.0-397B actually is
>
> - **397B MoE**, post-trained on Gemma 4 + Qwen 3.5
> - **MIT licensed** — fully open, no regional restrictions
> - **Built for agentic coding** — tool calling, terminal agents, SWE-bench. It's a reasoning model (`

The matching half was stored in a `thinking` block in the OpenClaw session, never displayed:

> ` blocks).
> - Notably: it explicitly lists **OpenClaw** and **OpenCode** as supported harnesses. This model is *built* for the exact kind of work we do.

### Tests added

- `src/shared/text/reasoning-tag-text-partitioner.test.ts` — 2 tests for the new `isInsideUnclosedVisibleInlineCode()` (unclosed across chunks, false while inside reasoning).
- `src/llm/providers/openai-completions.test.ts` — regression test for the exact chunk shape in the repro: content ending in opener backtick + reasoning-only chunk with the continuation. Asserts visible text `"Visible. It uses a \` blocks) and more"` with balanced backticks and **no** `thinking` block.

### Test results (local lane, on `origin/main` @ 95b97e5b0b)

- `pnpm test src/shared/text/reasoning-tag-text-partitioner.test.ts` → 28 / 28 pass (26 existing + 2 new)
- `pnpm test src/llm/providers/openai-completions.test.ts` → 32 / 32 pass (31 existing + 1 new regression)
- `pnpm test src/agents/openai-transport-stream.test.ts` → 266 pass / 10 fail — **the 10 failures are pre-existing on clean `main`** (verified by stashing this change: same 266 pass / 10 fail). All unrelated DeepSeek DSML / ModelStudio / Qwen / DashScope streaming-usage tests.
- `node scripts/run-tsgo.mjs` → clean exit, no type errors.
- `pnpm build` (tsdown) → success; dist bundles contain the new `isInsideUnclosedVisibleInlineCode` symbol.

## AI-assisted

Yes — this PR was authored with AI assistance. The diagnosis, repro, fix, and tests were produced with an AI coding agent (Eva / OpenClaw). I (the human author) reviewed the diff and the test results.

## Checklist

- [x] Marked AI-assisted above
- [x] Evidence included (repro + real-world failure + test results)
- [x] Focused PR (one bug, one fix lane: 3 source files + 2 test files)
- [x] Existing partitioner + provider tests still pass
- [x] No CHANGELOG edits (per CONTRIBUTING)
- [x] No refactor-only or unrelated changes
- [x] Branch is on a fork; "Allow edits by maintainers" left enabled (default for fork PRs)
- [x] American English spelling in code/comments

Happy to revise per maintainer review. The two valid fix directions discussed in the issue were (a) route the `reasoning_content` delta through the partitioner as well, or (b) guard `appendThinkingDelta`. This PR implements (b) — the more surgical fix that preserves the partitioner's current behavior for genuine reasoning flows. If (a) is preferred, I can revise.