### PR TITLE
[codex] Add rainbow Sessions background

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1304,17 +1304,18 @@
 }
 
 .content--sessions {
-  --sessions-bg: color-mix(in srgb, var(--danger) 72%, black);
+  --sessions-bg: #58a63c;
+  --sessions-foreground: #081108;
   --bg-content: var(--sessions-bg);
   background: var(--sessions-bg);
 }
 
 .content--sessions .page-title {
-  color: var(--destructive-foreground);
+  color: var(--sessions-foreground);
 }
 
 .content--sessions .page-sub {
-  color: var(--destructive-foreground);
+  color: var(--sessions-foreground);
 }
 
 .content--chat {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1303,21 +1303,6 @@
   background: var(--bg-content);
 }
 
-.content--sessions {
-  --sessions-bg: #58a63c;
-  --sessions-foreground: #081108;
-  --bg-content: var(--sessions-bg);
-  background: var(--sessions-bg);
-}
-
-.content--sessions .page-title {
-  color: var(--sessions-foreground);
-}
-
-.content--sessions .page-sub {
-  color: var(--sessions-foreground);
-}
-
 .content--chat {
   display: flex;
   flex-direction: column;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1303,6 +1303,80 @@
   background: var(--bg-content);
 }
 
+.content--sessions {
+  position: relative;
+  isolation: isolate;
+  background:
+    radial-gradient(circle at 8% 12%, rgba(255, 0, 128, 0.6), transparent 24%),
+    radial-gradient(circle at 90% 10%, rgba(0, 180, 255, 0.58), transparent 25%),
+    radial-gradient(circle at 82% 88%, rgba(132, 255, 0, 0.48), transparent 26%),
+    linear-gradient(
+      135deg,
+      #ff004c 0%,
+      #ff8a00 15%,
+      #ffe600 30%,
+      #00d084 45%,
+      #00a3ff 60%,
+      #6d4cff 75%,
+      #ff4fd8 90%,
+      #ff004c 100%
+    );
+  background-attachment: local;
+}
+
+.content--sessions::before {
+  content: "";
+  position: fixed;
+  inset: var(--shell-topbar-height) 0 0 var(--shell-nav-width);
+  z-index: -2;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(115deg, rgba(255, 255, 255, 0.24) 0 18px, transparent 18px 36px),
+    conic-gradient(
+      from 0.1turn at 52% 48%,
+      rgba(255, 0, 76, 0.42),
+      rgba(255, 138, 0, 0.38),
+      rgba(255, 230, 0, 0.36),
+      rgba(0, 208, 132, 0.38),
+      rgba(0, 163, 255, 0.42),
+      rgba(109, 76, 255, 0.42),
+      rgba(255, 79, 216, 0.44),
+      rgba(255, 0, 76, 0.42)
+    );
+  filter: saturate(1.45);
+  mix-blend-mode: screen;
+}
+
+.shell--nav-collapsed .content--sessions::before {
+  left: var(--shell-nav-rail-width);
+}
+
+.content--sessions::after {
+  content: "";
+  position: fixed;
+  inset: var(--shell-topbar-height) 0 0 var(--shell-nav-width);
+  z-index: -1;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg, rgba(8, 8, 16, 0.34), rgba(8, 8, 16, 0.66)),
+    radial-gradient(circle at 50% 18%, rgba(255, 255, 255, 0.36), transparent 22%);
+}
+
+.shell--nav-collapsed .content--sessions::after {
+  left: var(--shell-nav-rail-width);
+}
+
+.content--sessions .content-header,
+.content--sessions .panel,
+.content--sessions .card,
+.content--sessions .settings-workspace {
+  backdrop-filter: blur(14px) saturate(1.35);
+  -webkit-backdrop-filter: blur(14px) saturate(1.35);
+  box-shadow:
+    0 16px 44px rgba(0, 0, 0, 0.26),
+    0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
 .content--chat {
   display: flex;
   flex-direction: column;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1303,6 +1303,20 @@
   background: var(--bg-content);
 }
 
+.content--sessions {
+  --sessions-bg: color-mix(in srgb, var(--danger) 72%, black);
+  --bg-content: var(--sessions-bg);
+  background: var(--sessions-bg);
+}
+
+.content--sessions .page-title {
+  color: var(--destructive-foreground);
+}
+
+.content--sessions .page-sub {
+  color: var(--destructive-foreground);
+}
+
 .content--chat {
   display: flex;
   flex-direction: column;

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -348,15 +348,6 @@ describe("renderApp assistant avatar routing", () => {
     expect(content?.classList.contains("content--chat")).toBe(false);
   });
 
-  it("marks the sessions route for its page background", () => {
-    const container = document.createElement("div");
-
-    render(renderApp(createState({ tab: "sessions" })), container);
-
-    const content = container.querySelector<HTMLElement>("main.content");
-    expect(content?.classList.contains("content--sessions")).toBe(true);
-  });
-
   it("does not render chat errors in non-chat page headers", () => {
     const container = document.createElement("div");
 

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -348,6 +348,16 @@ describe("renderApp assistant avatar routing", () => {
     expect(content?.classList.contains("content--chat")).toBe(false);
   });
 
+  it("marks the sessions route so it can carry the rainbow background treatment", () => {
+    const container = document.createElement("div");
+
+    render(renderApp(createState({ tab: "sessions" })), container);
+
+    const content = container.querySelector<HTMLElement>("main.content");
+    expect(content?.classList.contains("content--sessions")).toBe(true);
+    expect(content?.classList.contains("content--chat")).toBe(false);
+  });
+
   it("does not render chat errors in non-chat page headers", () => {
     const container = document.createElement("div");
 

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -348,6 +348,15 @@ describe("renderApp assistant avatar routing", () => {
     expect(content?.classList.contains("content--chat")).toBe(false);
   });
 
+  it("marks the sessions route for its page background", () => {
+    const container = document.createElement("div");
+
+    render(renderApp(createState({ tab: "sessions" })), container);
+
+    const content = container.querySelector<HTMLElement>("main.content");
+    expect(content?.classList.contains("content--sessions")).toBe(true);
+  });
+
   it("does not render chat errors in non-chat page headers", () => {
     const container = document.createElement("div");
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2649,11 +2649,10 @@ export function renderApp(state: AppViewState) {
         </aside>
       </div>
       <main
-        class="content ${isChat ? "content--chat" : ""} ${state.tab === "sessions"
-          ? "content--sessions"
-          : ""} ${state.tab === "logs" ? "content--logs" : ""} ${state.tab === "workboard"
-          ? "content--workboard"
-          : ""} ${state.tab === "skillWorkshop"
+        class="content ${isChat ? "content--chat" : ""} ${state.tab === "logs"
+          ? "content--logs"
+          : ""} ${state.tab === "workboard" ? "content--workboard" : ""} ${state.tab ===
+        "skillWorkshop"
           ? `content--skill-workshop ${
               state.skillWorkshopMode === "today" ? "content--skill-workshop-today" : ""
             }`

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2651,8 +2651,9 @@ export function renderApp(state: AppViewState) {
       <main
         class="content ${isChat ? "content--chat" : ""} ${state.tab === "logs"
           ? "content--logs"
-          : ""} ${state.tab === "workboard" ? "content--workboard" : ""} ${state.tab ===
-        "skillWorkshop"
+          : ""} ${state.tab === "sessions" ? "content--sessions" : ""} ${state.tab === "workboard"
+          ? "content--workboard"
+          : ""} ${state.tab === "skillWorkshop"
           ? `content--skill-workshop ${
               state.skillWorkshopMode === "today" ? "content--skill-workshop-today" : ""
             }`

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2649,10 +2649,11 @@ export function renderApp(state: AppViewState) {
         </aside>
       </div>
       <main
-        class="content ${isChat ? "content--chat" : ""} ${state.tab === "logs"
-          ? "content--logs"
-          : ""} ${state.tab === "workboard" ? "content--workboard" : ""} ${state.tab ===
-        "skillWorkshop"
+        class="content ${isChat ? "content--chat" : ""} ${state.tab === "sessions"
+          ? "content--sessions"
+          : ""} ${state.tab === "logs" ? "content--logs" : ""} ${state.tab === "workboard"
+          ? "content--workboard"
+          : ""} ${state.tab === "skillWorkshop"
           ? `content--skill-workshop ${
               state.skillWorkshopMode === "today" ? "content--skill-workshop-today" : ""
             }`


### PR DESCRIPTION
## What Problem This Solves

Makes the Sessions route visually unmistakable for this iteration by giving it a loud rainbow treatment.

## Why This Change Was Made

The PR is being used to iterate on the Sessions page background. This version scopes the rainbow effect to the Sessions content route instead of changing the whole Control UI shell.

## User Impact

Users opening `/sessions` see a celebratory rainbow mesh and diagonal stripe background behind the Sessions page, while the table and controls remain readable on their dark panels. Other routes keep their existing backgrounds.

## Evidence

- `node scripts/run-vitest.mjs ui/src/ui/app-render.assistant-avatar.test.ts` - 21 tests passed
- `pnpm -s exec oxfmt --check --threads=1 --config .oxfmtrc.jsonc ui/src/ui/app-render.ts ui/src/ui/app-render.assistant-avatar.test.ts ui/src/styles/layout.css` - passed
- `git diff --check` - passed
- Crabbox AWS visual proof on `cbx_fc2dc9150f68` / `pearl-lobster`: synced the branch, refreshed Chrome at `http://127.0.0.1:5187/sessions`, and captured `.artifacts/control-ui-e2e/rainbow-sessions-crabbox-20260626-2255/screenshot.png`.

Not run: autoreview, per session instruction.
