### PR TITLE
fix(openrouter): bound video response reads

### DIFF
--- a/extensions/openrouter/video-generation-provider.test.ts
+++ b/extensions/openrouter/video-generation-provider.test.ts
@@ -546,6 +546,7 @@ describe("openrouter video generation provider", () => {
         provider: "openrouter",
         capability: "video",
         baseUrl: "https://custom.openrouter.test/api/v1",
+        allowPrivateNetwork: false,
         request: requestOverrides,
       },
     );
@@ -672,11 +673,10 @@ describe("openrouter video generation provider", () => {
 
   it("wraps non-JSON successful OpenRouter submit responses", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => {
-          throw new SyntaxError("Unexpected token < in JSON");
-        },
-      },
+      response: new Response("<html></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
       release: vi.fn(async () => {}),
     });
 
@@ -689,6 +689,22 @@ describe("openrouter video generation provider", () => {
         cfg: {} as never,
       }),
     ).rejects.toThrow("OpenRouter video generation response malformed");
+  });
+
+  it("bounds oversized successful OpenRouter submit responses", async () => {
+    const oversized = releasedOversizedJsonStream();
+    postJsonRequestMock.mockResolvedValue(oversized);
+
+    const provider = buildOpenRouterVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "openrouter",
+        model: "google/veo-3.1",
+        prompt: "oversized body",
+        cfg: {} as never,
+      }),
+    ).rejects.toThrow("OpenRouter video generation: JSON response exceeds 16777216 bytes");
+    expect(oversized.wasCanceled()).toBe(true);
   });
 
   it("rejects unknown OpenRouter poll statuses without waiting for timeout", async () => {

--- a/extensions/openrouter/video-generation-provider.ts
+++ b/extensions/openrouter/video-generation-provider.ts
@@ -6,6 +6,7 @@ import {
   assertOkOrThrowHttpError,
   createProviderOperationDeadline,
   postJsonRequest,
+  readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
   resolveProviderOperationTimeoutMs,
   sanitizeConfiguredModelProviderRequest,
@@ -68,9 +69,12 @@ type OpenRouterFrameImagePart = OpenRouterImagePart & {
 async function readOpenRouterVideoJson(response: Response): Promise<Record<string, unknown>> {
   let payload: unknown;
   try {
-    payload = await response.json();
-  } catch {
-    throw new Error(OPENROUTER_VIDEO_MALFORMED_RESPONSE);
+    payload = await readProviderJsonResponse<unknown>(response, "OpenRouter video generation");
+  } catch (error) {
+    if (error instanceof Error && error.message.endsWith(": malformed JSON response")) {
+      throw new Error(OPENROUTER_VIDEO_MALFORMED_RESPONSE, { cause: error });
+    }
+    throw error;
   }
   if (!isRecord(payload)) {
     throw new Error(OPENROUTER_VIDEO_MALFORMED_RESPONSE);


### PR DESCRIPTION
## What Problem This Solves

The OpenRouter video provider parsed successful submit and poll JSON with an unbounded `response.json()` read. Because that response comes from an external endpoint, a buggy or hostile server could stream a large body without `Content-Length` and force the process to buffer it before parsing, causing an OOM or hang.

## Changes

- Route `readOpenRouterVideoJson` through the shared `readProviderJsonResponse` helper, which applies the established 16 MiB provider JSON cap and cancels an overflowing stream.
- Preserve the existing `OpenRouter video generation response malformed` mapping for invalid JSON and non-object payloads.
- Add a focused streamed-response regression that verifies an oversized successful submit body is rejected and canceled.
- Keep the existing default private-network denial covered in the video provider tests.

## Real behavior proof

Behavior addressed
- OpenRouter video success-path JSON responses stop at the shared 16 MiB cap and abort the streaming response when exceeded.

Real environment tested
- Local Node.js v22.22.0 process using a `node:http` loopback TCP server, no `Content-Length`, real `fetch`, and the exported OpenRouter video provider builder.

Exact steps
- `node --import tsx scratchpad/openrouter-bound-proof.mjs`
- `node scripts/run-vitest.mjs run extensions/openrouter/video-generation-provider.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`

Observed result
- The bounded OpenRouter video success JSON read throws `OpenRouter video generation: JSON response exceeds 16777216 bytes`, aborts the server socket, and stops before the full oversized body is sent.
- A raw `response.json()` negative control buffers the complete oversized body.
- Small OpenRouter video JSON responses continue to parse normally.
- The current PR head passes all 18 focused video provider tests.

What was not tested
- Live OpenRouter API calls.
- The optional OpenRouter generation-cost lookup is not changed in this PR.

## Evidence

```text
$ node --import tsx scratchpad/openrouter-bound-proof.mjs
PASS openrouter video submit success JSON: threw "OpenRouter video generation: JSON response exceeds 16777216 bytes"; socket abort=true; bytesSent=16842764; full=17825792
PASS negative control: raw response.json() buffered 17825792 bytes; bytesSent=17825806; cap=16777216
PASS happy path: OpenRouter video small JSON parsed normally
PASS openrouter node:http bounded success-path proof complete

$ node scripts/run-vitest.mjs run extensions/openrouter/video-generation-provider.test.ts
Test Files  1 passed (1)
Tests  18 passed (18)
```

**Label**: security
_AI-assisted._
