### PR TITLE
fix(speech): bound TTS response reads

### DIFF
--- a/extensions/volcengine/tts.test.ts
+++ b/extensions/volcengine/tts.test.ts
@@ -7,6 +7,8 @@ const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
 }));
 
+const PROVIDER_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
@@ -43,6 +45,18 @@ function clearTtsEnv() {
   delete process.env.VOLCENGINE_TTS_API_KEY;
   delete process.env.VOLCENGINE_TTS_APPID;
   delete process.env.VOLCENGINE_TTS_TOKEN;
+}
+
+function makeOversizedStreamResponse(): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(PROVIDER_RESPONSE_MAX_BYTES));
+        controller.enqueue(new Uint8Array(1));
+        controller.close();
+      },
+    }),
+  );
 }
 
 function restoreOptionalEnv(key: string, value: string | undefined) {
@@ -301,6 +315,23 @@ describe("volcengineTTS", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("bounds Seed Speech success response reads", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: makeOversizedStreamResponse(),
+      release,
+    });
+
+    await expect(
+      volcengineTTS({
+        text: "hello",
+        apiKey: "secret-api-key",
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow("BytePlus Seed Speech TTS response exceeds 16777216 bytes");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("reports provider errors without exposing credentials", async () => {
     const release = vi.fn();
     fetchWithSsrFGuardMock.mockResolvedValue({
@@ -325,6 +356,24 @@ describe("volcengineTTS", () => {
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toBe("Volcengine TTS error 3001: load grant failed");
     expect((error as Error).message).not.toContain("secret-token");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds legacy Volcengine success response reads", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: makeOversizedStreamResponse(),
+      release,
+    });
+
+    await expect(
+      volcengineTTS({
+        text: "hello",
+        appId: "app-id",
+        token: "secret-token",
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow("Volcengine TTS response exceeds 16777216 bytes");
     expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/volcengine/tts.ts
+++ b/extensions/volcengine/tts.ts
@@ -1,5 +1,6 @@
 // Volcengine plugin module implements tts behavior.
 import * as crypto from "node:crypto";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
 export type VolcengineTtsEncoding = "ogg_opus" | "mp3" | "pcm" | "wav";
@@ -27,6 +28,7 @@ const DEFAULT_LEGACY_VOICE = "zh_female_xiaohe_uranus_bigtts";
 const DEFAULT_CLUSTER = "volcano_tts";
 const DEFAULT_SEED_TTS_RESOURCE_ID = "seed-tts-1.0";
 const DEFAULT_SEED_TTS_APP_KEY = "aGjiRDfUWi";
+const VOLCENGINE_TTS_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const BYTEPLUS_SEED_TTS_URL =
   "https://voice.ap-southeast-1.bytepluses.com/api/v3/tts/unidirectional";
 const VOLCENGINE_LEGACY_TTS_URL = "https://openspeech.bytedance.com/api/v1/tts";
@@ -158,7 +160,13 @@ async function seedSpeechTTS(params: VolcengineTTSParams & { apiKey: string }): 
   });
 
   try {
-    const frames = parseSeedTtsFrames(await response.text());
+    const responseText = new TextDecoder().decode(
+      await readResponseWithLimit(response, VOLCENGINE_TTS_RESPONSE_MAX_BYTES, {
+        onOverflow: ({ maxBytes }) =>
+          new Error(`BytePlus Seed Speech TTS response exceeds ${maxBytes} bytes`),
+      }),
+    );
+    const frames = parseSeedTtsFrames(responseText);
     const chunks: Buffer[] = [];
     for (const frame of frames) {
       if (frame.code === 0) {
@@ -240,7 +248,13 @@ async function legacyVolcengineTTS(
   });
 
   try {
-    const body = parseLegacyTtsResponse(await response.text());
+    const responseText = new TextDecoder().decode(
+      await readResponseWithLimit(response, VOLCENGINE_TTS_RESPONSE_MAX_BYTES, {
+        onOverflow: ({ maxBytes }) =>
+          new Error(`Volcengine TTS response exceeds ${maxBytes} bytes`),
+      }),
+    );
+    const body = parseLegacyTtsResponse(responseText);
     if (!response.ok || body.code !== 3000 || !body.data) {
       throw new Error(
         `Volcengine TTS error ${body.code ?? response.status}: ${body.message ?? "unknown"}`,

--- a/extensions/xiaomi/speech-provider.test.ts
+++ b/extensions/xiaomi/speech-provider.test.ts
@@ -4,11 +4,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const transcodeAudioBufferToOpusMock = vi.hoisted(() => vi.fn());
 
+const PROVIDER_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+
 vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
   transcodeAudioBufferToOpus: transcodeAudioBufferToOpusMock,
 }));
 
 import { buildXiaomiSpeechProvider } from "./speech-provider.js";
+
+function makeOversizedStreamResponse(): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(PROVIDER_RESPONSE_MAX_BYTES));
+        controller.enqueue(new Uint8Array(1));
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
 
 describe("buildXiaomiSpeechProvider", () => {
   const provider = buildXiaomiSpeechProvider();
@@ -409,6 +427,20 @@ describe("buildXiaomiSpeechProvider", () => {
           timeoutMs: 30000,
         }),
       ).rejects.toThrow("Xiaomi TTS API returned no audio data");
+    });
+
+    it("bounds oversized Xiaomi TTS success response reads", async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeOversizedStreamResponse());
+
+      await expect(
+        provider.synthesize({
+          text: "Test",
+          cfg: {} as never,
+          providerConfig: { apiKey: "sk-test" },
+          target: "audio-file",
+          timeoutMs: 30000,
+        }),
+      ).rejects.toThrow("Xiaomi TTS API: JSON response exceeds 16777216 bytes");
     });
   });
 });

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -1,7 +1,10 @@
 // Xiaomi provider module implements model/runtime integration.
 import { transcodeAudioBufferToOpus } from "openclaw/plugin-sdk/media-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
-import { assertOkOrThrowProviderError } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowProviderError,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type {
   SpeechDirectiveTokenParseContext,
@@ -269,7 +272,8 @@ async function xiaomiTTS(params: {
     });
     try {
       await assertOkOrThrowProviderError(response, "Xiaomi TTS API error");
-      return decodeXiaomiAudioData(await response.json());
+      const body = await readProviderJsonResponse<unknown>(response, "Xiaomi TTS API");
+      return decodeXiaomiAudioData(body);
     } finally {
       await release();
     }


### PR DESCRIPTION
## What Problem This Solves

speech/TTS success-path 之前会对不可信响应体执行无界 `await response.text()` / `await response.json()`，音频生成 JSON/base64 或 Seed frame 随音频长度膨胀时可能导致 OOM/hang。

## Changes

- 将 Volcengine Seed Speech success response 从无界 `response.text()` 改为共享 `readResponseWithLimit`，16MiB cap，overflow 时 cancel stream。
- 将 Volcengine legacy TTS success response 从无界 `response.text()` 改为共享 `readResponseWithLimit`，16MiB cap，overflow 时 cancel stream。
- 将 Xiaomi TTS success response 从无界 `response.json()` 改为共享 `readProviderJsonResponse`，复用 provider JSON 16MiB cap。
- 增加 Volcengine Seed/legacy 与 Xiaomi TTS oversized success body 单测。

## Real behavior proof

Behavior addressed:
- Volcengine Seed Speech success body、Volcengine legacy TTS success body、Xiaomi TTS success JSON 都不再无界读取。
- overflow 时真实 fetch 响应流被 cancel，node:http loopback proxy 看到 socket abort。
- 小 JSON happy-path 仍正常解析。
- 负向 control 证明旧式无界 `.text()` 会完整 buffer 超过 cap 的 body。

Real environment tested:
- 本地 worktree `fix/bound-speech-tts`，基于最新 `upstream/main` rebase 后执行。
- 真实 `node:http` loopback proxy + production `fetchWithSsrFGuard` 路径；目标 URL 使用 `http://example.com`，代理把响应转成本机无 Content-Length 流式 body。

Exact steps:
- `PNPM_CONFIG_MODULES_DIR=/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules node --import tsx scratchpad/proof-speech-tts-bound.ts 2>&1 | tee scratchpad/proof-speech-tts-bound.out`
- `PNPM_CONFIG_MODULES_DIR=/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules node scripts/run-vitest.mjs extensions/volcengine/tts.test.ts extensions/xiaomi/speech-provider.test.ts`
- `PNPM_CONFIG_MODULES_DIR=/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `PNPM_CONFIG_MODULES_DIR=/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

Observed result:
- node:http proof: `[proof] 5 PASS, 0 FAIL` / `[proof] ALL PASS`
- focused Vitest: 2 shards passed, 32 tests passed.
- extensions prod tsgo: exit 0, no diagnostics.
- extensions test tsgo: exit 0, no diagnostics.
- autoreview: `autoreview clean: no accepted/actionable findings reported`

What was not tested:
- No live Volcengine or Xiaomi API call; proof uses real local TCP/fetch behavior with deterministic oversized streaming bodies.

## Evidence

```text
[proof] node:http loopback proxy=http://127.0.0.1:38051 target=http://example.com cap=16777216 full=67108864
PASS happy-path small JSON parsed for Seed, legacy Volcengine, and Xiaomi: ok
PASS BytePlus Seed Speech bounded overflow: error="BytePlus Seed Speech TTS response exceeds 16777216 bytes" abort=true bytesSent=17825792/67108864 chunks=17
PASS Volcengine legacy bounded overflow: error="Volcengine TTS response exceeds 16777216 bytes" abort=true bytesSent=17825792/67108864 chunks=17
PASS Xiaomi TTS bounded overflow: error="Xiaomi TTS API: JSON response exceeds 16777216 bytes" abort=true bytesSent=17825792/67108864 chunks=17
PASS legacy unbounded negative control buffered: 67108864 bytes (> 16777216)
[proof] 5 PASS, 0 FAIL
[proof] ALL PASS
```

**Label**: security
_AI-assisted._
