### PR TITLE
fix(vydra): bound control response reads

### DIFF
--- a/extensions/vydra/image-generation-provider.test.ts
+++ b/extensions/vydra/image-generation-provider.test.ts
@@ -17,6 +17,13 @@ function fetchCall(fetchMock: ReturnType<typeof vi.fn>, index = 0): [string, Req
   return call as [string, RequestInit];
 }
 
+function oversizedJsonResponse(): Response {
+  return new Response(Buffer.alloc(16 * 1024 * 1024 + 1, 0x20), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 describe("vydra image-generation provider", () => {
   installPinnedHostnameTestHooks();
 
@@ -94,6 +101,21 @@ describe("vydra image-generation provider", () => {
     ).rejects.toThrow("Vydra image download exceeds 1 bytes");
   });
 
+  it("rejects image creation JSON responses that exceed the provider cap", async () => {
+    stubVydraApiKey();
+    stubFetch(oversizedJsonResponse());
+
+    const provider = buildVydraImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "vydra",
+        model: "grok-imagine",
+        prompt: "draw a cat",
+        cfg: {},
+      }),
+    ).rejects.toThrow("vydra.image-generation: JSON response exceeds 16777216 bytes");
+  });
+
   it("passes request SSRF policy to the image creation request", async () => {
     stubVydraApiKey();
     const fetchMock = stubFetch(
@@ -150,5 +172,20 @@ describe("vydra image-generation provider", () => {
     const pollCall = fetchCall(fetchMock, 1);
     expect(pollCall[0]).toBe("https://www.vydra.ai/api/v1/jobs/job-456");
     expect(pollCall[1].method).toBe("GET");
+  });
+
+  it("rejects job poll JSON responses that exceed the provider cap", async () => {
+    stubVydraApiKey();
+    stubFetch(jsonResponse({ jobId: "job-456", status: "queued" }), oversizedJsonResponse());
+
+    const provider = buildVydraImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "vydra",
+        model: "grok-imagine",
+        prompt: "draw a cat",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Vydra job status: JSON response exceeds 16777216 bytes");
   });
 });

--- a/extensions/vydra/shared.ts
+++ b/extensions/vydra/shared.ts
@@ -6,6 +6,7 @@ import {
   assertOkOrThrowHttpError,
   createProviderOperationDeadline,
   fetchWithTimeout,
+  readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
   waitProviderOperationPollInterval,
@@ -287,7 +288,7 @@ async function waitForVydraJob(params: {
       params.fetchFn,
     );
     await assertOkOrThrowHttpError(response, "Vydra job status request failed");
-    const payload = await response.json();
+    const payload = await readProviderJsonResponse<unknown>(response, "Vydra job status");
     const status = resolveVydraResponseStatus(payload);
     if (status === "completed" || extractVydraResultUrls(payload, params.kind).length > 0) {
       return payload;

--- a/extensions/vydra/speech-provider.test.ts
+++ b/extensions/vydra/speech-provider.test.ts
@@ -8,6 +8,12 @@ describe("vydra speech provider", () => {
 
   const provider = buildVydraSpeechProvider();
 
+  const oversizedJsonResponse = () =>
+    new Response(Buffer.alloc(16 * 1024 * 1024 + 1, 0x20), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
@@ -102,5 +108,19 @@ describe("vydra speech provider", () => {
         timeoutMs: 30_000,
       }),
     ).rejects.toThrow("Vydra audio download exceeds 1 bytes");
+  });
+
+  it("rejects speech synthesis JSON responses that exceed the provider cap", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(oversizedJsonResponse()));
+
+    await expect(
+      provider.synthesize({
+        text: "OpenClaw test",
+        cfg: {} as never,
+        providerConfig: { apiKey: "vydra-test-key" },
+        target: "audio-file",
+        timeoutMs: 30_000,
+      }),
+    ).rejects.toThrow("Vydra speech synthesis: JSON response exceeds 16777216 bytes");
   });
 });

--- a/extensions/vydra/speech-provider.ts
+++ b/extensions/vydra/speech-provider.ts
@@ -2,6 +2,7 @@
 import {
   assertOkOrThrowHttpError,
   postJsonRequest,
+  readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
@@ -129,7 +130,7 @@ export function buildVydraSpeechProvider(): SpeechProviderPlugin {
 
       try {
         await assertOkOrThrowHttpError(response, "Vydra speech synthesis failed");
-        const payload = await response.json();
+        const payload = await readProviderJsonResponse<unknown>(response, "Vydra speech synthesis");
         const audioUrl = extractVydraResultUrls(payload, "audio")[0];
         if (!audioUrl) {
           throw new Error("Vydra speech synthesis response missing audio URL");

--- a/extensions/vydra/video-generation-provider.test.ts
+++ b/extensions/vydra/video-generation-provider.test.ts
@@ -18,6 +18,13 @@ function fetchCall(fetchMock: ReturnType<typeof vi.fn>, index: number) {
   return call;
 }
 
+function oversizedJsonResponse(): Response {
+  return new Response(Buffer.alloc(16 * 1024 * 1024 + 1, 0x20), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 describe("vydra video-generation provider", () => {
   installPinnedHostnameTestHooks();
 
@@ -94,6 +101,21 @@ describe("vydra video-generation provider", () => {
         cfg: { agents: { defaults: { mediaMaxMb: 0.000001 } } },
       }),
     ).rejects.toThrow("Vydra video download exceeds 1 bytes");
+  });
+
+  it("rejects video creation JSON responses that exceed the provider cap", async () => {
+    stubVydraApiKey();
+    stubFetch(oversizedJsonResponse());
+
+    const provider = buildVydraVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "vydra",
+        model: "veo3",
+        prompt: "tiny city at sunrise",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Vydra video generation: JSON response exceeds 16777216 bytes");
   });
 
   it("requires a remote image url for kling", async () => {

--- a/extensions/vydra/video-generation-provider.ts
+++ b/extensions/vydra/video-generation-provider.ts
@@ -5,6 +5,7 @@ import {
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
   postJsonRequest,
+  readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
 } from "openclaw/plugin-sdk/provider-http";
 import type { VideoGenerationProvider } from "openclaw/plugin-sdk/video-generation";
@@ -111,7 +112,10 @@ export function buildVydraVideoGenerationProvider(): VideoGenerationProvider {
 
       try {
         await assertOkOrThrowHttpError(response, "Vydra video generation failed");
-        const submitted = await response.json();
+        const submitted = await readProviderJsonResponse<unknown>(
+          response,
+          "Vydra video generation",
+        );
         const completedPayload = await resolveCompletedVydraPayload({
           submitted,
           baseUrl,


### PR DESCRIPTION
## What Problem This Solves

Vydra success-path untrusted body handling read submit and job-poll control JSON with unbounded `await response.json()`, so a hostile, misconfigured, or SSRF-reachable endpoint could stream a no-`Content-Length` body indefinitely and force OpenClaw to buffer it before parsing, causing OOM pressure or a hang on image, video, and speech generation paths.

The affected reads were:

- `extensions/vydra/image-generation-provider.ts` image submit JSON
- `extensions/vydra/speech-provider.ts` speech submit JSON
- `extensions/vydra/video-generation-provider.ts` video submit JSON
- `extensions/vydra/shared.ts` shared job poll JSON used by image/video async jobs

## Changes

- Replace those four success-path `response.json()` calls with the shared `readProviderJsonResponse` helper from `openclaw/plugin-sdk/provider-http`.
- Keep the fix plugin-scoped and reuse the existing 16 MiB provider JSON cap; no new abstraction.
- Preserve the existing `assertOkOrThrowHttpError` behavior, job id/status extraction, asset download path, and `release()` cleanup.
- Add focused Vydra regression tests for oversized image submit, speech submit, video submit, and shared poll JSON responses.

## Real behavior proof

- **Behavior addressed**: Vydra submit and job-poll control JSON from an untrusted external endpoint must not be buffered whole on the success path. Oversized no-`Content-Length` bodies must stop at the 16 MiB cap, cancel the stream, and throw a bounded `...exceeds 16777216 bytes` error. Small valid JSON must continue to parse normally.
- **Real environment tested**: A real `node:http` server (`createServer`) bound to `127.0.0.1`, streaming JSON in 64 KiB chunks with no `Content-Length` header and a would-stream size of about 64 MiB. The script drove the real exported `buildVydraImageGenerationProvider().generateImage()` over a real loopback socket through the real `postJsonRequest`, guarded fetch path, and `readProviderJsonResponse`. The shared poll helper was exercised by returning a queued submit payload and then streaming the oversized poll response from `/jobs/<id>`. Node v22.22.0.
- **Exact steps**: `node --import tsx scratchpad/vydra-bound-proof.mts` — start the streaming server → call real Vydra image submit and assert bounded throw + server-side socket abort near the cap → call real Vydra image job poll path and assert bounded throw + socket abort near the cap → run a negative control using old unbounded `fetch().arrayBuffer()` against the same streaming body → call the real provider against a small valid JSON response and asset response.
- **Observed result**: submit JSON threw `Vydra image generation: JSON response exceeds 16777216 bytes` and aborted after 20,119,564 bytes; shared poll JSON threw `Vydra job status: JSON response exceeds 16777216 bytes` and aborted after 18,022,412 bytes. The negative control buffered the full 67,108,866 bytes, proving the cap is load-bearing. The small happy path returned the generated image payload and metadata.
- **What was not tested**: I did not hit the live Vydra service; live endpoints would not reproduce a hostile oversized body. The real socket proof covers the transport and cancellation behavior. The TCP proof uses the image provider to exercise submit and shared poll because Vydra image requests expose the request-level SSRF policy needed for local loopback proof; speech/video submit bounding is covered by the focused in-repo Vitest regressions using the same shared reader and error text. The proof script is not committed.

## Evidence

Real `node:http` terminal proof (real loopback socket, real exported Vydra provider, real bounded reader):

```
[proof] real node:http server on http://127.0.0.1:39391/api/v1, cap=16777216 bytes, would-stream≈67108864 bytes per overflow route

PASS  image submit JSON: overflow throws bounded error :: threw=true msg="Vydra image generation: JSON response exceeds 16777216 bytes"
PASS  image submit JSON: stream cancelled near 16MiB :: aborted=true bytesSent=20119564 (<33554432)
PASS  shared poll JSON: overflow throws bounded error :: threw=true msg="Vydra job status: JSON response exceeds 16777216 bytes"
PASS  shared poll JSON: stream cancelled near 16MiB :: aborted=true bytesSent=18022412 (<33554432)
PASS  negative control: OLD unbounded read buffers PAST the 16MiB cap :: buffered=67108866 bytes (> 16777216)
PASS  negative control consumed far more than bounded reads :: unbounded buffered=67108866 vs image submit sent≈20119564
PASS  happy path: small submit JSON still parses and asset download still works :: jobId=job-happy bytes=8 status=completed

[proof] 7 PASS / 0 FAIL
[proof] ALL PASS
```

Focused Vitest after rebase:

```
node scripts/run-vitest.mjs extensions/vydra/image-generation-provider.test.ts extensions/vydra/video-generation-provider.test.ts extensions/vydra/speech-provider.test.ts

Test Files  3 passed (3)
Tests  16 passed (16)
[proof] focused Vydra Vitest exit=0
```

Type and format checks after rebase:

```
pnpm tsgo:extensions
[proof] post-rebase tsgo:extensions exit=0

pnpm tsgo:test:extensions
[proof] post-rebase tsgo:test:extensions exit=0

pnpm format:check -- extensions/vydra/image-generation-provider.ts extensions/vydra/image-generation-provider.test.ts extensions/vydra/shared.ts extensions/vydra/speech-provider.ts extensions/vydra/speech-provider.test.ts extensions/vydra/video-generation-provider.ts extensions/vydra/video-generation-provider.test.ts
All matched files use the correct format.

git diff --check
# clean
```

Autoreview after rebase:

```
.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
autoreview clean: no accepted/actionable findings reported
```

**Label**: security

_AI-assisted._

---

**Post-rebase scope update:** `main` has since landed the Vydra **image submit** bound, so this PR no longer changes `image-generation-provider.ts` (only a focused image regression test remains). This PR now bounds the remaining success-path reads: `shared.ts` (shared job-poll JSON used by image/video async jobs), `speech-provider.ts` (speech submit), and `video-generation-provider.ts` (video submit) — all routed through the shared `readProviderJsonResponse` (16 MiB cap). The `image-generation-provider.ts` source line in the bullet list above can be disregarded.
