### PR TITLE
feat(local-realtime-voice): route voice turns through main OpenClaw agent loop

### DIFF
--- a/extensions/local-realtime-voice/LICENSE
+++ b/extensions/local-realtime-voice/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenClaw contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/local-realtime-voice/README.md
+++ b/extensions/local-realtime-voice/README.md
@@ -38,19 +38,11 @@ docker run -d --name kokoro \
 
 ### 2. Install the plugin
 
-**Stock extension (if merged):**
-
-```bash
-openclaw plugins install @openclaw/local-realtime-voice
-```
-
-**From npm (Option B):**
-
 ```bash
 openclaw plugins install openclaw-local-realtime-voice
 ```
 
-**From a local path:**
+Or install from a local path:
 
 ```bash
 openclaw plugins install --link /path/to/openclaw-local-realtime-voice
@@ -61,6 +53,12 @@ openclaw plugins install --link /path/to/openclaw-local-realtime-voice
 ```bash
 openclaw config set talk.realtime.provider local
 openclaw config set plugins.entries.voice-call.config.streaming.provider local
+
+# Optional: route voice turns through the main OpenClaw agent loop
+# (so voice can use tools, sub-agents, file writes, etc.)
+openclaw config set talk.realtime.providers.local.useMainAgent true
+openclaw config set talk.realtime.providers.local.mainAgentSessionKey main
+openclaw config set talk.realtime.providers.local.voiceInstructions "The user is speaking via realtime voice. Keep replies short. You can use tools. Briefly summarize results."
 ```
 
 ### 4. Use it
@@ -78,8 +76,13 @@ All values are optional and default to local endpoints.
 | `whisperModel` | `""` | Specific Whisper model; empty uses the server default |
 | `kokoroBaseUrl` | `http://127.0.0.1:8880` | Kokoro TTS endpoint |
 | `kokoroVoice` | `af` | Kokoro voice |
-| `ollamaBaseUrl` | `http://127.0.0.1:11434` | Ollama API endpoint |
-| `chatModel` | primary Ollama model | Model used for assistant replies |
+| `ollamaBaseUrl` | `http://127.0.0.1:11434` | Ollama API endpoint (fallback mode only) |
+| `chatModel` | primary Ollama model | Model used for local fallback replies |
+| `useMainAgent` | `false` | Route voice turns to the main OpenClaw chat/agent loop |
+| `mainAgentSessionKey` | `main` | Session used for main-agent chat when `useMainAgent=true` |
+| `gatewayUrl` | `ws://127.0.0.1:18789` | Gateway WebSocket URL for main-agent mode |
+| `gatewayToken` | read from `~/.openclaw/openclaw.json` | Static auth token for main-agent mode |
+| `voiceInstructions` | see source | Prefix instruction sent with every voice turn in main-agent mode |
 | `vadThreshold` | `100` | Voice activity detection energy threshold |
 | `silenceMs` | `1200` | Silence before a voice turn ends |
 | `maxTurnMs` | `15000` | Maximum voice turn length |

--- a/extensions/local-realtime-voice/README.md
+++ b/extensions/local-realtime-voice/README.md
@@ -1,0 +1,97 @@
+# OpenClaw Local Realtime Voice
+
+A free, self-hosted realtime voice provider for OpenClaw.
+
+- **Realtime voice assistant** — talk to your agent; it replies with synthesized speech.
+- **Realtime dictation** — speak and your words appear as text.
+- **No paid APIs** — runs entirely on your own hardware using Whisper, Kokoro, and Ollama.
+
+## Requirements
+
+- OpenClaw gateway ≥ `2026.3.24-beta.2`
+- Docker (or native installs of Whisper, Kokoro, and Ollama)
+- ffmpeg
+- A running Ollama server with at least one chat model
+
+## Quick start
+
+### 1. Start the backend services
+
+```bash
+# Whisper STT (CPU; runs on http://127.0.0.1:8000)
+docker run -d --name whisper \
+  -p 127.0.0.1:8000:8000 \
+  -e WHISPER__MODEL=Systran/faster-whisper-tiny.en \
+  -e WHISPER__PRELOAD_MODELS='["Systran/faster-whisper-tiny.en"]' \
+  -e WHISPER__MODEL__LOAD_ON_STARTUP=true \
+  --restart unless-stopped \
+  fedirz/faster-whisper-server:latest-cpu
+
+# Kokoro TTS (CPU; runs on http://127.0.0.1:8880)
+docker run -d --name kokoro \
+  -p 127.0.0.1:8880:8880 \
+  --restart unless-stopped \
+  ghcr.io/remsky/kokoro-fastapi-cpu:v0.1.4
+
+# Ollama must already be running on http://127.0.0.1:11434
+```
+
+### 2. Install the plugin
+
+**Stock extension (if merged):**
+
+```bash
+openclaw plugins install @openclaw/local-realtime-voice
+```
+
+**From npm (Option B):**
+
+```bash
+openclaw plugins install openclaw-local-realtime-voice
+```
+
+**From a local path:**
+
+```bash
+openclaw plugins install --link /path/to/openclaw-local-realtime-voice
+```
+
+### 3. Configure OpenClaw
+
+```bash
+openclaw config set talk.realtime.provider local
+openclaw config set plugins.entries.voice-call.config.streaming.provider local
+```
+
+### 4. Use it
+
+- **Realtime Talk**: hold/press the talk button in the OpenClaw Companion app and speak.
+- **Dictation**: tap the mic button in the text input and speak.
+
+## Configuration
+
+All values are optional and default to local endpoints.
+
+| Key | Default | Description |
+|---|---|---|
+| `whisperBaseUrl` | `http://127.0.0.1:8000` | faster-whisper-server endpoint |
+| `whisperModel` | `""` | Specific Whisper model; empty uses the server default |
+| `kokoroBaseUrl` | `http://127.0.0.1:8880` | Kokoro TTS endpoint |
+| `kokoroVoice` | `af` | Kokoro voice |
+| `ollamaBaseUrl` | `http://127.0.0.1:11434` | Ollama API endpoint |
+| `chatModel` | primary Ollama model | Model used for assistant replies |
+| `vadThreshold` | `100` | Voice activity detection energy threshold |
+| `silenceMs` | `1200` | Silence before a voice turn ends |
+| `maxTurnMs` | `15000` | Maximum voice turn length |
+| `partialIntervalMs` | `2000` | Rolling dictation partial interval |
+| `audioChunkMs` | `50` | Assistant audio chunk size |
+
+## Performance notes
+
+- Use the `tiny.en` Whisper model for the lowest latency on CPU.
+- For better accuracy at the cost of latency, use `base` or `small`.
+- GPU containers (`latest` instead of `latest-cpu`, `kokoro-fastapi-cuda` etc.) significantly reduce latency if you have a compatible GPU.
+
+## License
+
+MIT

--- a/extensions/local-realtime-voice/index.js
+++ b/extensions/local-realtime-voice/index.js
@@ -2,8 +2,10 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import WebSocket from "ws";
 
 const PREFIX = "[local-realtime]";
 const log = (...args) => console.error(PREFIX, ...args);
@@ -24,6 +26,11 @@ function resolveConfig(rawConfig) {
     vadThreshold: rawConfig?.vadThreshold ?? 100,
     partialIntervalMs: rawConfig?.partialIntervalMs ?? 2000,
     audioChunkMs: rawConfig?.audioChunkMs ?? 50,
+    useMainAgent: rawConfig?.useMainAgent === true,
+    mainAgentSessionKey: rawConfig?.mainAgentSessionKey ?? "main",
+    gatewayUrl: rawConfig?.gatewayUrl ?? "ws://127.0.0.1:18789",
+    gatewayToken: rawConfig?.gatewayToken,
+    voiceInstructions: rawConfig?.voiceInstructions ?? "The user is speaking via a realtime voice session. Keep your reply concise and natural. Avoid long outputs unless asked; prefer summaries.",
   };
 }
 
@@ -37,6 +44,33 @@ function resolveOllamaModel(cfg, config) {
 function resolveOllamaBaseUrl(cfg, config) {
   if (config.ollamaBaseUrl) return config.ollamaBaseUrl;
   return cfg?.models?.providers?.ollama?.baseUrl ?? "http://127.0.0.1:11434";
+}
+
+function resolveGatewayToken(config) {
+  if (config.gatewayToken) return config.gatewayToken;
+  try {
+    const home = os.homedir();
+    const cfgPath = path.join(home, ".openclaw", "openclaw.json");
+    const raw = JSON.parse(readFileSync(cfgPath, "utf8"));
+    return raw?.gateway?.auth?.token ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function extractCompleteSentences(text) {
+  const sentences = [];
+  const re = /([.!?])(\s+|$)/g;
+  let lastEnd = 0;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const end = match.index + match[0].length;
+    const sentence = text.slice(lastEnd, end).trim();
+    if (sentence) sentences.push(sentence);
+    lastEnd = end;
+  }
+  const remainder = text.slice(lastEnd);
+  return { sentences, remainder };
 }
 
 async function runFfmpeg(inputArgs, outputArgs, inputBuffer) {
@@ -190,6 +224,104 @@ function stripWavHeader(buf) {
   return buf;
 }
 
+// --- Gateway chat client (turn voice into normal chat I/O) ---
+
+class GatewayChatClient {
+  constructor({ url, token, sessionKey }) {
+    this.url = url;
+    this.token = token;
+    this.sessionKey = sessionKey;
+    this.ws = null;
+    this.connectPromise = null;
+    this.runId = null;
+    this.onDelta = null;
+    this.onFinal = null;
+    this.onError = null;
+  }
+
+  async ensureConnected() {
+    if (this.ws?.readyState === WebSocket.OPEN) return;
+    if (this.connectPromise) return this.connectPromise;
+    this.connectPromise = new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.url);
+      this.ws = ws;
+      let resolved = false;
+      const finish = (fn, arg) => {
+        if (resolved) return;
+        resolved = true;
+        this.connectPromise = null;
+        fn(arg);
+      };
+      ws.on("open", () => {
+        const frame = {
+          type: "req",
+          id: randomUUID(),
+          method: "connect",
+          params: {
+            minProtocol: 4,
+            maxProtocol: 4,
+            client: { id: "gateway-client", version: "2026.6.6", platform: "linux", mode: "backend" },
+            role: "operator",
+            scopes: ["operator.write"],
+            auth: { token: this.token }
+          }
+        };
+        ws.send(JSON.stringify(frame));
+      });
+      ws.on("message", (data) => {
+        try {
+          const frame = JSON.parse(data.toString());
+          if (frame.type === "res" && frame.ok && frame.payload?.type === "hello-ok") {
+            return finish(resolve);
+          }
+          if (frame.type === "res" && !frame.ok) {
+            return finish(reject, new Error(frame.error?.message || "gateway connect failed"));
+          }
+          if (frame.type === "event" && frame.event === "chat") {
+            const p = frame.payload;
+            if (p.runId !== this.runId) return;
+            if (p.state === "delta" && p.deltaText) {
+              this.onDelta?.(p.deltaText, false);
+            } else if (p.state === "final") {
+              this.onFinal?.();
+            } else if (p.state === "error") {
+              this.onError?.(new Error(p.errorMessage || "chat error"));
+            }
+          }
+        } catch (err) {
+          this.onError?.(err);
+        }
+      });
+      ws.on("error", (err) => finish(reject, err));
+      ws.on("close", () => { this.ws = null; });
+    });
+    return this.connectPromise;
+  }
+
+  async sendMessage(message, instruction) {
+    await this.ensureConnected();
+    const runId = randomUUID();
+    this.runId = runId;
+    const fullMessage = instruction ? `${instruction}\n\nUser said: ${message}` : message;
+    this.ws.send(JSON.stringify({
+      type: "req",
+      id: randomUUID(),
+      method: "chat.send",
+      params: {
+        sessionKey: this.sessionKey,
+        message: fullMessage,
+        idempotencyKey: runId,
+        deliver: true
+      }
+    }));
+  }
+
+  close() {
+    this.ws?.close();
+    this.ws = null;
+  }
+}
+
 // --- Realtime transcription session (dictation) ---
 
 class LocalRealtimeTranscriptionSession {
@@ -283,18 +415,30 @@ class LocalRealtimeVoiceBridge {
     this.silenceTimer = null;
     this.turnTimer = null;
     this.isSpeaking = false;
+    this.responseIsSpeaking = false;
     this.speakingCooldownTimer = null;
     this.inCooldown = false;
     this.totalAudioBytesSent = 0;
     this.messages = [{ role: "system", content: config.instructions ?? "You are a helpful voice assistant. Keep replies short and natural. Answer directly; do not say you will check, search, or look something up unless you actually have a tool to do so." }];
     this.chatModel = resolveOllamaModel(config.cfg, this.providerConfig);
     this.ollamaBaseUrl = resolveOllamaBaseUrl(config.cfg, this.providerConfig);
-    log("voice bridge created", this.audioFormat, "model", this.chatModel);
+    this.useMainAgent = this.providerConfig.useMainAgent;
+    this.mainAgentSessionKey = this.providerConfig.mainAgentSessionKey;
+    this.voiceInstructions = this.providerConfig.voiceInstructions;
+    this.gatewayClient = this.useMainAgent
+      ? new GatewayChatClient({
+          url: this.providerConfig.gatewayUrl,
+          token: resolveGatewayToken(this.providerConfig),
+          sessionKey: this.providerConfig.mainAgentSessionKey,
+        })
+      : null;
+    log("voice bridge created", this.audioFormat, "model", this.chatModel, "useMainAgent", this.useMainAgent);
   }
 
   async connect() {
     this.connected = true;
     this.isSpeaking = false;
+    this.responseIsSpeaking = false;
     this.inCooldown = false;
     this.totalAudioBytesSent = 0;
     this.clearTimers();
@@ -305,9 +449,11 @@ class LocalRealtimeVoiceBridge {
   close() {
     this.connected = false;
     this.isSpeaking = false;
+    this.responseIsSpeaking = false;
     this.inCooldown = false;
     this.totalAudioBytesSent = 0;
     this.clearTimers();
+    this.gatewayClient?.close();
     log("voice close");
     this.config.onClose?.("completed");
   }
@@ -328,7 +474,7 @@ class LocalRealtimeVoiceBridge {
     log("voice sendUserMessage", text);
     if (this.responsePending) return;
     this.messages.push({ role: "user", content: text });
-    this.runResponse();
+    this.runResponse(text);
   }
 
   clearTimers() {
@@ -345,6 +491,8 @@ class LocalRealtimeVoiceBridge {
   }
 
   beginCooldown(extraMs = 200) {
+    this.isSpeaking = false;
+    this.responseIsSpeaking = false;
     this.inCooldown = true;
     if (this.speakingCooldownTimer) { clearTimeout(this.speakingCooldownTimer); this.speakingCooldownTimer = null; }
     const bytesPerChannel = this.audioFormat.encoding === "g711_ulaw" ? 1 : 2;
@@ -356,6 +504,111 @@ class LocalRealtimeVoiceBridge {
       this.inCooldown = false;
       this.speakingCooldownTimer = null;
     }, cooldownMs);
+  }
+
+  async speakSentence(text, { markEvent = true } = {}) {
+    if (!text.trim()) return;
+    try {
+      log("voice speak chunk", text);
+      const wav = await kokoroSpeak(text, this.providerConfig);
+      let audio = stripWavHeader(wav);
+      if (this.audioFormat.encoding === "g711_ulaw") {
+        const pcm8k = await runFfmpeg(["-f", "s16le", "-ar", "24000", "-ac", "1"], ["-f", "s16le", "-ar", "8000", "-ac", "1"], audio);
+        audio = encodeMuLaw(pcm8k);
+      }
+      log("voice audio out bytes", audio.length);
+      const bytesPerChannel = this.audioFormat.encoding === "g711_ulaw" ? 1 : 2;
+      const bytesPerMs = (this.audioFormat.sampleRateHz || 24000) * bytesPerChannel / 1000;
+      const chunkBytes = Math.max(2400, Math.round((this.providerConfig.audioChunkMs ?? 50) * bytesPerMs));
+      this.totalAudioBytesSent += audio.length;
+      for (let offset = 0; offset < audio.length; offset += chunkBytes) {
+        this.config.onAudio(audio.slice(offset, offset + chunkBytes));
+      }
+      if (markEvent) {
+        this.config.onEvent?.({ type: "response.audio.delta", direction: "server" });
+      }
+    } catch (e) {
+      log("voice speak chunk error", e);
+      this.config.onError?.(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  async streamResponseFromOllama() {
+    const stream = ollamaChat(this.chatModel, this.messages, this.ollamaBaseUrl);
+    let sentenceBuffer = "";
+    let fullText = "";
+    for await (const chunk of stream) {
+      fullText += chunk.text;
+      sentenceBuffer += chunk.text;
+      this.config.onTranscript?.("assistant", chunk.text, false);
+      const { sentences, remainder } = extractCompleteSentences(sentenceBuffer);
+      sentenceBuffer = remainder;
+      for (const s of sentences) {
+        await this.speakSentence(s);
+      }
+    }
+    if (sentenceBuffer.trim()) {
+      fullText += sentenceBuffer;
+      await this.speakSentence(sentenceBuffer);
+    }
+    return fullText;
+  }
+
+  async streamResponseFromMainAgent(transcript) {
+    let sentenceBuffer = "";
+    let fullText = "";
+    let processing = false;
+    let finalPending = false;
+    let finalResolver;
+    const finalPromise = new Promise((resolve) => { finalResolver = resolve; });
+
+    const flush = async (force) => {
+      const { sentences, remainder } = extractCompleteSentences(sentenceBuffer);
+      sentenceBuffer = remainder;
+      for (const s of sentences) {
+        fullText += s;
+        await this.speakSentence(s);
+      }
+      if (force && remainder.trim()) {
+        fullText += remainder;
+        await this.speakSentence(remainder);
+        sentenceBuffer = "";
+      }
+    };
+
+    const processBuffer = async () => {
+      if (processing) return;
+      processing = true;
+      try {
+        await flush(false);
+      } finally {
+        processing = false;
+        if (finalPending) await flush(true).then(() => finalResolver());
+      }
+    };
+
+    this.gatewayClient.onDelta = (text) => {
+      sentenceBuffer += text;
+      this.config.onTranscript?.("assistant", text, false);
+      processBuffer();
+    };
+    this.gatewayClient.onFinal = () => {
+      finalPending = true;
+      processBuffer();
+    };
+    this.gatewayClient.onError = (err) => {
+      log("gateway chat error", err);
+      finalResolver();
+    };
+
+    await this.gatewayClient.sendMessage(transcript, this.voiceInstructions);
+    await finalPromise;
+    if (sentenceBuffer.trim()) {
+      fullText += sentenceBuffer;
+      await this.speakSentence(sentenceBuffer);
+      sentenceBuffer = "";
+    }
+    return fullText;
   }
 
   sendAudio(audio) {
@@ -440,8 +693,8 @@ class LocalRealtimeVoiceBridge {
         return;
       }
       this.config.onTranscript?.("user", transcript, true);
-      this.messages.push({ role: "user", content: transcript });
-      await this.runResponse();
+      if (!this.useMainAgent) this.messages.push({ role: "user", content: transcript });
+      await this.runResponse(transcript);
     } catch (error) {
       log("voice finishTurn error", error);
       this.responsePending = false;
@@ -449,68 +702,21 @@ class LocalRealtimeVoiceBridge {
     }
   }
 
-  async runResponse() {
+  async runResponse(userTranscript) {
     this.responsePending = true;
+    this.responseIsSpeaking = true;
     try {
       log("voice response start");
       this.config.onEvent?.({ type: "response.created", direction: "server" });
-      let fullText = "";
-      let sentenceBuffer = "";
-      const stream = ollamaChat(this.chatModel, this.messages, this.ollamaBaseUrl);
-
-      const flushSentence = async () => {
-        const text = sentenceBuffer.trim();
-        sentenceBuffer = "";
-        if (!text) return;
-        try {
-          log("voice speak chunk", text);
-          const wav = await kokoroSpeak(text, this.providerConfig);
-          let audio = stripWavHeader(wav);
-          if (this.audioFormat.encoding === "g711_ulaw") {
-            const pcm8k = await runFfmpeg(["-f", "s16le", "-ar", "24000", "-ac", "1"], ["-f", "s16le", "-ar", "8000", "-ac", "1"], audio);
-            audio = encodeMuLaw(pcm8k);
-          }
-          log("voice audio out bytes", audio.length);
-          const bytesPerMs = (this.audioFormat.sampleRateHz || 24000) * 2 / 1000;
-          const chunkBytes = Math.max(2400, Math.round((this.providerConfig.audioChunkMs ?? 50) * bytesPerMs));
-          this.isSpeaking = true;
-          this.totalAudioBytesSent += audio.length;
-          for (let offset = 0; offset < audio.length; offset += chunkBytes) {
-            this.config.onAudio(audio.slice(offset, offset + chunkBytes));
-          }
-          this.isSpeaking = false;
-          this.config.onEvent?.({ type: "response.audio.delta", direction: "server" });
-        } catch (e) {
-          this.isSpeaking = false;
-          log("voice speak chunk error", e);
-          this.config.onError?.(e instanceof Error ? e : new Error(String(e)));
-        }
-      };
-
-      for await (const chunk of stream) {
-        fullText += chunk.text;
-        sentenceBuffer += chunk.text;
-        this.config.onTranscript?.("assistant", chunk.text, false);
-
-        const sentenceRe = /([.!?]+\s+)/g;
-        let match;
-        while ((match = sentenceRe.exec(sentenceBuffer)) !== null) {
-          const splitAt = match.index + match[0].length;
-          const flushText = sentenceBuffer.slice(0, splitAt);
-          const remainder = sentenceBuffer.slice(splitAt);
-          sentenceRe.lastIndex = 0;
-          if (flushText.trim() && remainder.trim().length > 0) {
-            sentenceBuffer = flushText.trim();
-            await flushSentence();
-            sentenceBuffer = remainder;
-          }
-        }
+      let fullText;
+      if (this.useMainAgent && this.gatewayClient) {
+        fullText = await this.streamResponseFromMainAgent(userTranscript);
+      } else {
+        if (userTranscript) this.messages.push({ role: "user", content: userTranscript });
+        fullText = await this.streamResponseFromOllama();
       }
-
-      await flushSentence();
       this.beginCooldown();
-
-      this.messages.push({ role: "assistant", content: fullText });
+      if (!this.useMainAgent) this.messages.push({ role: "assistant", content: fullText });
       this.config.onTranscript?.("assistant", fullText, true);
       this.config.onEvent?.({ type: "response.done", direction: "server" });
       log("voice response done", fullText.slice(0, 80));
@@ -520,6 +726,7 @@ class LocalRealtimeVoiceBridge {
     } finally {
       this.responsePending = false;
       this.totalAudioBytesSent = 0;
+      this.responseIsSpeaking = false;
     }
   }
 

--- a/extensions/local-realtime-voice/index.js
+++ b/extensions/local-realtime-voice/index.js
@@ -282,7 +282,11 @@ class LocalRealtimeVoiceBridge {
     this.responsePending = false;
     this.silenceTimer = null;
     this.turnTimer = null;
-    this.messages = [{ role: "system", content: config.instructions ?? "You are a helpful voice assistant. Keep replies short and natural." }];
+    this.isSpeaking = false;
+    this.speakingCooldownTimer = null;
+    this.inCooldown = false;
+    this.totalAudioBytesSent = 0;
+    this.messages = [{ role: "system", content: config.instructions ?? "You are a helpful voice assistant. Keep replies short and natural. Answer directly; do not say you will check, search, or look something up unless you actually have a tool to do so." }];
     this.chatModel = resolveOllamaModel(config.cfg, this.providerConfig);
     this.ollamaBaseUrl = resolveOllamaBaseUrl(config.cfg, this.providerConfig);
     log("voice bridge created", this.audioFormat, "model", this.chatModel);
@@ -290,12 +294,19 @@ class LocalRealtimeVoiceBridge {
 
   async connect() {
     this.connected = true;
+    this.isSpeaking = false;
+    this.inCooldown = false;
+    this.totalAudioBytesSent = 0;
+    this.clearTimers();
     log("voice connect");
     this.config.onReady?.();
   }
 
   close() {
     this.connected = false;
+    this.isSpeaking = false;
+    this.inCooldown = false;
+    this.totalAudioBytesSent = 0;
     this.clearTimers();
     log("voice close");
     this.config.onClose?.("completed");
@@ -323,6 +334,7 @@ class LocalRealtimeVoiceBridge {
   clearTimers() {
     if (this.silenceTimer) { clearTimeout(this.silenceTimer); this.silenceTimer = null; }
     if (this.turnTimer) { clearTimeout(this.turnTimer); this.turnTimer = null; }
+    if (this.speakingCooldownTimer) { clearTimeout(this.speakingCooldownTimer); this.speakingCooldownTimer = null; }
   }
 
   resetTurn() {
@@ -332,8 +344,22 @@ class LocalRealtimeVoiceBridge {
     this.turnStartAt = 0;
   }
 
+  beginCooldown(extraMs = 200) {
+    this.inCooldown = true;
+    if (this.speakingCooldownTimer) { clearTimeout(this.speakingCooldownTimer); this.speakingCooldownTimer = null; }
+    const bytesPerChannel = this.audioFormat.encoding === "g711_ulaw" ? 1 : 2;
+    const bytesPerMs = ((this.audioFormat.sampleRateHz || 24000) * bytesPerChannel) / 1000;
+    const playbackMs = this.totalAudioBytesSent / bytesPerMs;
+    const cooldownMs = Math.max(600, Math.round(playbackMs + extraMs));
+    log("voice cooldown", cooldownMs, "ms");
+    this.speakingCooldownTimer = setTimeout(() => {
+      this.inCooldown = false;
+      this.speakingCooldownTimer = null;
+    }, cooldownMs);
+  }
+
   sendAudio(audio) {
-    if (!this.connected) return;
+    if (!this.connected || this.isSpeaking || this.inCooldown) return;
     const buf = Buffer.from(audio);
     let pcm;
     if (this.audioFormat.encoding === "g711_ulaw") {
@@ -447,11 +473,15 @@ class LocalRealtimeVoiceBridge {
           log("voice audio out bytes", audio.length);
           const bytesPerMs = (this.audioFormat.sampleRateHz || 24000) * 2 / 1000;
           const chunkBytes = Math.max(2400, Math.round((this.providerConfig.audioChunkMs ?? 50) * bytesPerMs));
+          this.isSpeaking = true;
+          this.totalAudioBytesSent += audio.length;
           for (let offset = 0; offset < audio.length; offset += chunkBytes) {
             this.config.onAudio(audio.slice(offset, offset + chunkBytes));
           }
+          this.isSpeaking = false;
           this.config.onEvent?.({ type: "response.audio.delta", direction: "server" });
         } catch (e) {
+          this.isSpeaking = false;
           log("voice speak chunk error", e);
           this.config.onError?.(e instanceof Error ? e : new Error(String(e)));
         }
@@ -478,6 +508,7 @@ class LocalRealtimeVoiceBridge {
       }
 
       await flushSentence();
+      this.beginCooldown();
 
       this.messages.push({ role: "assistant", content: fullText });
       this.config.onTranscript?.("assistant", fullText, true);
@@ -488,6 +519,7 @@ class LocalRealtimeVoiceBridge {
       this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
     } finally {
       this.responsePending = false;
+      this.totalAudioBytesSent = 0;
     }
   }
 

--- a/extensions/local-realtime-voice/index.js
+++ b/extensions/local-realtime-voice/index.js
@@ -1,0 +1,539 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+const PREFIX = "[local-realtime]";
+const log = (...args) => console.error(PREFIX, ...args);
+
+const G711_ULAW_8KHZ = { encoding: "g711_ulaw", sampleRateHz: 8000, channels: 1 };
+const PCM16_24KHZ = { encoding: "pcm16", sampleRateHz: 24000, channels: 1 };
+
+function resolveConfig(rawConfig) {
+  return {
+    whisperBaseUrl: rawConfig?.whisperBaseUrl ?? "http://127.0.0.1:8000",
+    whisperModel: rawConfig?.whisperModel ?? "",
+    kokoroBaseUrl: rawConfig?.kokoroBaseUrl ?? "http://127.0.0.1:8880",
+    kokoroVoice: rawConfig?.kokoroVoice ?? "af",
+    ollamaBaseUrl: rawConfig?.ollamaBaseUrl ?? "http://127.0.0.1:11434",
+    chatModel: rawConfig?.chatModel,
+    silenceMs: rawConfig?.silenceMs ?? 1200,
+    maxTurnMs: rawConfig?.maxTurnMs ?? 15000,
+    vadThreshold: rawConfig?.vadThreshold ?? 100,
+    partialIntervalMs: rawConfig?.partialIntervalMs ?? 2000,
+    audioChunkMs: rawConfig?.audioChunkMs ?? 50,
+  };
+}
+
+function resolveOllamaModel(cfg, config) {
+  if (config.chatModel) return config.chatModel;
+  const primary = cfg?.agents?.defaults?.model?.primary;
+  if (primary && primary.startsWith("ollama/")) return primary.slice("ollama/".length);
+  return "kimi-k2.7-code:cloud";
+}
+
+function resolveOllamaBaseUrl(cfg, config) {
+  if (config.ollamaBaseUrl) return config.ollamaBaseUrl;
+  return cfg?.models?.providers?.ollama?.baseUrl ?? "http://127.0.0.1:11434";
+}
+
+async function runFfmpeg(inputArgs, outputArgs, inputBuffer) {
+  return new Promise((resolve, reject) => {
+    const args = ["-hide_banner", "-loglevel", "error", ...inputArgs, "-i", "pipe:0", ...outputArgs, "pipe:1"];
+    log("ffmpeg", args.join(" "));
+    const child = spawn("ffmpeg", args, { stdio: ["pipe", "pipe", "pipe"] });
+    const chunks = [];
+    let stderr = "";
+    child.stdout.on("data", (c) => chunks.push(c));
+    child.stderr.on("data", (c) => { stderr += c.toString(); });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        log("ffmpeg failed", code, stderr);
+        return reject(new Error(`ffmpeg exited ${code}: ${stderr}`));
+      }
+      resolve(Buffer.concat(chunks));
+    });
+    child.stdin.write(inputBuffer);
+    child.stdin.end();
+  });
+}
+
+function decodeMuLaw(buffer) {
+  const exp_lut = [0, 132, 396, 924, 1980, 4092, 8316, 16764];
+  const out = new Int16Array(buffer.length);
+  for (let i = 0; i < buffer.length; i++) {
+    let b = ~buffer[i] & 0xFF;
+    const sign = (b & 0x80) ? -1 : 1;
+    const exponent = (b >> 4) & 0x07;
+    const mantissa = b & 0x0F;
+    let sample = exp_lut[exponent] + (mantissa << (exponent + 3));
+    if (exponent === 0) sample = (mantissa << 4) + 8;
+    out[i] = sign * sample;
+  }
+  return Buffer.from(out.buffer);
+}
+
+function encodeMuLaw(pcm16) {
+  const BIAS = 0x84;
+  const out = Buffer.alloc(pcm16.length / 2);
+  for (let i = 0; i < pcm16.length / 2; i++) {
+    let sample = pcm16.readInt16LE(i * 2);
+    const sign = (sample < 0) ? 0x80 : 0;
+    if (sample < 0) sample = -sample;
+    sample = Math.min(sample, 32767);
+    sample += BIAS;
+    let seg;
+    for (seg = 0; seg < 8; seg++) {
+      if (sample <= (0x80 << seg)) break;
+    }
+    if (seg >= 8) seg = 7;
+    const uval = sign | (seg << 4) | (((sample >> (seg + 3)) & 0x0F));
+    out[i] = ~uval & 0xFF;
+  }
+  return out;
+}
+
+function buildWav(pcm16, sampleRate) {
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0);
+  header.writeUInt32LE(36 + pcm16.length, 4);
+  header.write("WAVE", 8);
+  header.write("fmt ", 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(1, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(sampleRate * 2, 28);
+  header.writeUInt16LE(2, 32);
+  header.writeUInt16LE(16, 34);
+  header.write("data", 36);
+  header.writeUInt32LE(pcm16.length, 40);
+  return Buffer.concat([header, pcm16]);
+}
+
+async function whisperTranscribe(pcm16_16k, config) {
+  const wav = buildWav(pcm16_16k, 16000);
+  const tmp = path.join(os.tmpdir(), `local-whisper-${randomUUID()}.wav`);
+  await fs.writeFile(tmp, wav);
+  try {
+    const fileData = await fs.readFile(tmp);
+    const blob = new Blob([fileData], { type: "audio/wav" });
+    const body = new FormData();
+    body.append("file", blob, "audio.wav");
+    body.append("language", "en");
+    body.append("response_format", "json");
+    if (config.whisperModel) body.append("model", config.whisperModel);
+    log("whisper request", tmp, pcm16_16k.length);
+    const res = await fetch(`${config.whisperBaseUrl}/v1/audio/transcriptions`, { method: "POST", body });
+    if (!res.ok) throw new Error(`Whisper STT ${res.status}: ${await res.text()}`);
+    const json = await res.json();
+    log("whisper result", JSON.stringify(json));
+    return json.text ?? "";
+  } finally {
+    await fs.unlink(tmp).catch(() => {});
+  }
+}
+
+async function* ollamaChat(model, messages, baseUrl) {
+  log("ollama request", model, messages.length);
+  const res = await fetch(`${baseUrl}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, messages, stream: true }),
+  });
+  if (!res.ok) throw new Error(`Ollama chat ${res.status}: ${await res.text()}`);
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop();
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const obj = JSON.parse(line);
+        const text = obj.message?.content ?? "";
+        if (text) yield { text, done: obj.done ?? false };
+      } catch {}
+    }
+  }
+}
+
+async function kokoroSpeak(text, config) {
+  log("kokoro request", text.slice(0, 80));
+  const res = await fetch(`${config.kokoroBaseUrl}/v1/audio/speech`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: "kokoro",
+      input: text,
+      voice: config.kokoroVoice,
+      response_format: "wav",
+    }),
+  });
+  if (!res.ok) throw new Error(`Kokoro TTS ${res.status}: ${await res.text()}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  log("kokoro response bytes", buf.length);
+  return buf;
+}
+
+function stripWavHeader(buf) {
+  if (buf.length > 44 && buf.toString("ascii", 0, 4) === "RIFF" && buf.toString("ascii", 8, 12) === "WAVE") {
+    return buf.slice(44);
+  }
+  return buf;
+}
+
+// --- Realtime transcription session (dictation) ---
+
+class LocalRealtimeTranscriptionSession {
+  constructor(config) {
+    this.config = resolveConfig(config.providerConfig);
+    this.callbacks = config;
+    this.ulawBuffer = Buffer.alloc(0);
+    this.pcm8kProcessedBytes = 0;
+    this.lastPartial = "";
+    this.closed = false;
+    this.partialTimer = null;
+    this.partialIntervalMs = Math.max(1500, this.config.partialIntervalMs ?? 2000);
+  }
+
+  async connect() {
+    log("transcription connect");
+    this.schedulePartial();
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.partialTimer) { clearTimeout(this.partialTimer); this.partialTimer = null; }
+    log("transcription close, bytes", this.ulawBuffer.length);
+    this.finalize().catch((err) => this.callbacks.onError?.(err));
+  }
+
+  sendAudio(audio) {
+    this.ulawBuffer = Buffer.concat([this.ulawBuffer, Buffer.from(audio)]);
+    log("transcription audio", audio.length, "total", this.ulawBuffer.length);
+  }
+
+  schedulePartial() {
+    if (this.closed) return;
+    this.partialTimer = setTimeout(() => this.runPartial(), this.partialIntervalMs);
+  }
+
+  async runPartial() {
+    if (this.closed) return;
+    try {
+      const totalBytes = this.ulawBuffer.length;
+      if (totalBytes - this.pcm8kProcessedBytes >= 8000) {
+        const chunk = this.ulawBuffer.slice(this.pcm8kProcessedBytes);
+        const pcm8k = decodeMuLaw(chunk);
+        const pcm16k = await runFfmpeg(["-f", "s16le", "-ar", "8000", "-ac", "1"], ["-f", "s16le", "-ar", "16000", "-ac", "1"], pcm8k);
+        const text = await whisperTranscribe(pcm16k, this.config);
+        log("transcription partial", text);
+        if (text && text !== this.lastPartial) {
+          this.callbacks.onPartial?.(text);
+          this.lastPartial = text;
+        }
+        this.pcm8kProcessedBytes = totalBytes;
+      }
+    } catch (err) {
+      log("transcription partial error", err);
+    } finally {
+      this.schedulePartial();
+    }
+  }
+
+  async finalize() {
+    if (this.ulawBuffer.length === 0) {
+      this.callbacks.onTranscript?.("");
+      return;
+    }
+    try {
+      const pcm8k = decodeMuLaw(this.ulawBuffer);
+      const pcm16k = await runFfmpeg(["-f", "s16le", "-ar", "8000", "-ac", "1"], ["-f", "s16le", "-ar", "16000", "-ac", "1"], pcm8k);
+      const text = await whisperTranscribe(pcm16k, this.config);
+      log("transcription final", text);
+      this.callbacks.onTranscript?.(text || this.lastPartial);
+    } catch (err) {
+      this.callbacks.onError?.(err);
+    }
+  }
+}
+
+// --- Realtime voice session ---
+
+class LocalRealtimeVoiceBridge {
+  constructor(config) {
+    this.config = config;
+    this.connected = false;
+    this.audioFormat = config.audioFormat ?? PCM16_24KHZ;
+    this.providerConfig = resolveConfig(config.providerConfig);
+    this.pcmBuffer = Buffer.alloc(0);
+    this.speechStarted = false;
+    this.lastSpeechAt = 0;
+    this.turnStartAt = 0;
+    this.responsePending = false;
+    this.silenceTimer = null;
+    this.turnTimer = null;
+    this.messages = [{ role: "system", content: config.instructions ?? "You are a helpful voice assistant. Keep replies short and natural." }];
+    this.chatModel = resolveOllamaModel(config.cfg, this.providerConfig);
+    this.ollamaBaseUrl = resolveOllamaBaseUrl(config.cfg, this.providerConfig);
+    log("voice bridge created", this.audioFormat, "model", this.chatModel);
+  }
+
+  async connect() {
+    this.connected = true;
+    log("voice connect");
+    this.config.onReady?.();
+  }
+
+  close() {
+    this.connected = false;
+    this.clearTimers();
+    log("voice close");
+    this.config.onClose?.("completed");
+  }
+
+  isConnected() {
+    return this.connected;
+  }
+
+  setMediaTimestamp() {}
+  acknowledgeMark() {}
+
+  triggerGreeting(instructions) {
+    log("voice greeting", instructions);
+    this.sendUserMessage(instructions ?? "Greet the user briefly.");
+  }
+
+  sendUserMessage(text) {
+    log("voice sendUserMessage", text);
+    if (this.responsePending) return;
+    this.messages.push({ role: "user", content: text });
+    this.runResponse();
+  }
+
+  clearTimers() {
+    if (this.silenceTimer) { clearTimeout(this.silenceTimer); this.silenceTimer = null; }
+    if (this.turnTimer) { clearTimeout(this.turnTimer); this.turnTimer = null; }
+  }
+
+  resetTurn() {
+    this.pcmBuffer = Buffer.alloc(0);
+    this.speechStarted = false;
+    this.lastSpeechAt = 0;
+    this.turnStartAt = 0;
+  }
+
+  sendAudio(audio) {
+    if (!this.connected) return;
+    const buf = Buffer.from(audio);
+    let pcm;
+    if (this.audioFormat.encoding === "g711_ulaw") {
+      pcm = decodeMuLaw(buf);
+    } else if (this.audioFormat.encoding === "pcm16") {
+      pcm = buf;
+    } else {
+      this.config.onError?.(new Error(`Unsupported audio format ${this.audioFormat.encoding}`));
+      return;
+    }
+
+    const energy = this.computeEnergy(pcm);
+    const now = Date.now();
+
+    if (this.pcmBuffer.length === 0) this.turnStartAt = now;
+    this.pcmBuffer = Buffer.concat([this.pcmBuffer, pcm]);
+
+    const wasSpeaking = this.speechStarted;
+    if (energy > this.providerConfig.vadThreshold) {
+      this.speechStarted = true;
+      this.lastSpeechAt = now;
+      if (!wasSpeaking) {
+        log("voice speech started, energy", Math.round(energy));
+        this.config.onEvent?.({ type: "input_audio_buffer.speech_started", direction: "server" });
+      }
+    }
+
+    this.clearTimers();
+
+    if (this.speechStarted && now - this.lastSpeechAt > this.providerConfig.silenceMs) {
+      log("voice silence immediate", now - this.lastSpeechAt);
+      this.finishTurn();
+      return;
+    }
+    if (now - this.turnStartAt > this.providerConfig.maxTurnMs) {
+      log("voice max turn");
+      this.finishTurn();
+      return;
+    }
+
+    this.silenceTimer = setTimeout(() => this.finishTurn(), this.providerConfig.silenceMs);
+    this.turnTimer = setTimeout(() => this.finishTurn(), this.providerConfig.maxTurnMs - (now - this.turnStartAt));
+  }
+
+  computeEnergy(pcm16) {
+    let sum = 0;
+    const count = pcm16.length / 2;
+    for (let i = 0; i < count; i++) {
+      const s = pcm16.readInt16LE(i * 2);
+      sum += s * s;
+    }
+    return Math.sqrt(sum / count);
+  }
+
+  async finishTurn() {
+    this.clearTimers();
+    if (this.responsePending || this.pcmBuffer.length === 0) {
+      log("voice finishTurn skipped", { pending: this.responsePending, len: this.pcmBuffer.length });
+      return;
+    }
+    const pcm = this.pcmBuffer;
+    this.resetTurn();
+
+    log("voice finishTurn", pcm.length);
+    try {
+      this.responsePending = true;
+      let pcm16;
+      if (this.audioFormat.encoding === "g711_ulaw") {
+        pcm16 = await runFfmpeg(["-f", "s16le", "-ar", "8000", "-ac", "1"], ["-f", "s16le", "-ar", "16000", "-ac", "1"], pcm);
+      } else {
+        pcm16 = await runFfmpeg(["-f", "s16le", "-ar", "24000", "-ac", "1"], ["-f", "s16le", "-ar", "16000", "-ac", "1"], pcm);
+      }
+
+      const transcript = await whisperTranscribe(pcm16, this.providerConfig);
+      log("voice user transcript", transcript);
+      if (!transcript.trim()) {
+        this.responsePending = false;
+        return;
+      }
+      this.config.onTranscript?.("user", transcript, true);
+      this.messages.push({ role: "user", content: transcript });
+      await this.runResponse();
+    } catch (error) {
+      log("voice finishTurn error", error);
+      this.responsePending = false;
+      this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  async runResponse() {
+    this.responsePending = true;
+    try {
+      log("voice response start");
+      this.config.onEvent?.({ type: "response.created", direction: "server" });
+      let fullText = "";
+      let sentenceBuffer = "";
+      const stream = ollamaChat(this.chatModel, this.messages, this.ollamaBaseUrl);
+
+      const flushSentence = async () => {
+        const text = sentenceBuffer.trim();
+        sentenceBuffer = "";
+        if (!text) return;
+        try {
+          log("voice speak chunk", text);
+          const wav = await kokoroSpeak(text, this.providerConfig);
+          let audio = stripWavHeader(wav);
+          if (this.audioFormat.encoding === "g711_ulaw") {
+            const pcm8k = await runFfmpeg(["-f", "s16le", "-ar", "24000", "-ac", "1"], ["-f", "s16le", "-ar", "8000", "-ac", "1"], audio);
+            audio = encodeMuLaw(pcm8k);
+          }
+          log("voice audio out bytes", audio.length);
+          const bytesPerMs = (this.audioFormat.sampleRateHz || 24000) * 2 / 1000;
+          const chunkBytes = Math.max(2400, Math.round((this.providerConfig.audioChunkMs ?? 50) * bytesPerMs));
+          for (let offset = 0; offset < audio.length; offset += chunkBytes) {
+            this.config.onAudio(audio.slice(offset, offset + chunkBytes));
+          }
+          this.config.onEvent?.({ type: "response.audio.delta", direction: "server" });
+        } catch (e) {
+          log("voice speak chunk error", e);
+          this.config.onError?.(e instanceof Error ? e : new Error(String(e)));
+        }
+      };
+
+      for await (const chunk of stream) {
+        fullText += chunk.text;
+        sentenceBuffer += chunk.text;
+        this.config.onTranscript?.("assistant", chunk.text, false);
+
+        const sentenceRe = /([.!?]+\s+)/g;
+        let match;
+        while ((match = sentenceRe.exec(sentenceBuffer)) !== null) {
+          const splitAt = match.index + match[0].length;
+          const flushText = sentenceBuffer.slice(0, splitAt);
+          const remainder = sentenceBuffer.slice(splitAt);
+          sentenceRe.lastIndex = 0;
+          if (flushText.trim() && remainder.trim().length > 0) {
+            sentenceBuffer = flushText.trim();
+            await flushSentence();
+            sentenceBuffer = remainder;
+          }
+        }
+      }
+
+      await flushSentence();
+
+      this.messages.push({ role: "assistant", content: fullText });
+      this.config.onTranscript?.("assistant", fullText, true);
+      this.config.onEvent?.({ type: "response.done", direction: "server" });
+      log("voice response done", fullText.slice(0, 80));
+    } catch (error) {
+      log("voice response error", error);
+      this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      this.responsePending = false;
+    }
+  }
+
+  submitToolResult() {
+    // not supported in prototype
+  }
+}
+
+function buildLocalRealtimeVoiceProvider() {
+  return {
+    id: "local",
+    label: "Local Whisper + Kokoro",
+    defaultModel: "local-realtime",
+    autoSelectOrder: 1,
+    capabilities: {
+      transports: ["gateway-relay"],
+      inputAudioFormats: [G711_ULAW_8KHZ, PCM16_24KHZ],
+      outputAudioFormats: [G711_ULAW_8KHZ, PCM16_24KHZ],
+      supportsBrowserSession: false,
+      supportsBargeIn: true,
+      supportsToolCalls: false,
+    },
+    resolveConfig: ({ rawConfig }) => resolveConfig(rawConfig),
+    isConfigured: () => true,
+    createBridge: (req) => new LocalRealtimeVoiceBridge(req),
+  };
+}
+
+function buildLocalRealtimeTranscriptionProvider() {
+  return {
+    id: "local",
+    label: "Local Whisper Dictation",
+    defaultModel: "local-whisper",
+    autoSelectOrder: 1,
+    resolveConfig: ({ rawConfig }) => resolveConfig(rawConfig),
+    isConfigured: () => true,
+    createSession: (req) => new LocalRealtimeTranscriptionSession(req),
+  };
+}
+
+export default definePluginEntry({
+  id: "local-realtime-voice",
+  name: "Local Realtime Voice",
+  description: "Local realtime voice and dictation using Whisper + Kokoro",
+  register(api) {
+    api.registerRealtimeVoiceProvider(buildLocalRealtimeVoiceProvider());
+    api.registerRealtimeTranscriptionProvider(buildLocalRealtimeTranscriptionProvider());
+  },
+});

--- a/extensions/local-realtime-voice/openclaw.plugin.json
+++ b/extensions/local-realtime-voice/openclaw.plugin.json
@@ -1,15 +1,15 @@
 {
   "id": "local-realtime-voice",
   "name": "Local Realtime Voice",
-  "description": "Local realtime voice assistant and dictation using Whisper STT, Kokoro TTS, and Ollama chat",
-  "activation": {
-    "onStartup": true
-  },
-  "enabledByDefault": false,
+  "description": "Local realtime voice (Whisper STT + Kokoro TTS) and dictation transcription",
   "contracts": {
     "realtimeVoiceProviders": ["local"],
     "realtimeTranscriptionProviders": ["local"]
   },
+  "activation": {
+    "onStartup": true
+  },
+  "enabledByDefault": false,
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -17,10 +17,6 @@
       "whisperBaseUrl": {
         "type": "string",
         "default": "http://127.0.0.1:8000"
-      },
-      "whisperModel": {
-        "type": "string",
-        "default": ""
       },
       "kokoroBaseUrl": {
         "type": "string",
@@ -37,9 +33,17 @@
       "chatModel": {
         "type": "string"
       },
-      "vadThreshold": {
+      "whisperModel": {
+        "type": "string",
+        "default": ""
+      },
+      "partialIntervalMs": {
         "type": "number",
-        "default": 100
+        "default": 2000
+      },
+      "audioChunkMs": {
+        "type": "number",
+        "default": 50
       },
       "silenceMs": {
         "type": "number",
@@ -49,13 +53,30 @@
         "type": "number",
         "default": 15000
       },
-      "partialIntervalMs": {
+      "vadThreshold": {
         "type": "number",
-        "default": 2000
+        "default": 100
       },
-      "audioChunkMs": {
-        "type": "number",
-        "default": 50
+      "useMainAgent": {
+        "type": "boolean",
+        "default": false,
+        "description": "Route voice turns through the main OpenClaw chat/agent loop instead of local Ollama"
+      },
+      "mainAgentSessionKey": {
+        "type": "string",
+        "default": "main"
+      },
+      "gatewayUrl": {
+        "type": "string",
+        "default": "ws://127.0.0.1:18789"
+      },
+      "voiceInstructions": {
+        "type": "string",
+        "default": "The user is speaking via a realtime voice session. Keep your reply concise and natural. Avoid long outputs unless asked; prefer summaries."
+      },
+      "gatewayToken": {
+        "type": "string",
+        "description": "Static gateway auth token (defaults to value in ~/.openclaw/openclaw.json if omitted)"
       }
     }
   }

--- a/extensions/local-realtime-voice/openclaw.plugin.json
+++ b/extensions/local-realtime-voice/openclaw.plugin.json
@@ -1,0 +1,62 @@
+{
+  "id": "local-realtime-voice",
+  "name": "Local Realtime Voice",
+  "description": "Local realtime voice assistant and dictation using Whisper STT, Kokoro TTS, and Ollama chat",
+  "activation": {
+    "onStartup": true
+  },
+  "enabledByDefault": false,
+  "contracts": {
+    "realtimeVoiceProviders": ["local"],
+    "realtimeTranscriptionProviders": ["local"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "whisperBaseUrl": {
+        "type": "string",
+        "default": "http://127.0.0.1:8000"
+      },
+      "whisperModel": {
+        "type": "string",
+        "default": ""
+      },
+      "kokoroBaseUrl": {
+        "type": "string",
+        "default": "http://127.0.0.1:8880"
+      },
+      "kokoroVoice": {
+        "type": "string",
+        "default": "af"
+      },
+      "ollamaBaseUrl": {
+        "type": "string",
+        "default": "http://127.0.0.1:11434"
+      },
+      "chatModel": {
+        "type": "string"
+      },
+      "vadThreshold": {
+        "type": "number",
+        "default": 100
+      },
+      "silenceMs": {
+        "type": "number",
+        "default": 1200
+      },
+      "maxTurnMs": {
+        "type": "number",
+        "default": 15000
+      },
+      "partialIntervalMs": {
+        "type": "number",
+        "default": 2000
+      },
+      "audioChunkMs": {
+        "type": "number",
+        "default": 50
+      }
+    }
+  }
+}

--- a/extensions/local-realtime-voice/package.json
+++ b/extensions/local-realtime-voice/package.json
@@ -5,6 +5,9 @@
   "description": "OpenClaw local realtime voice and dictation provider",
   "type": "module",
   "main": "./index.js",
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
   },

--- a/extensions/local-realtime-voice/package.json
+++ b/extensions/local-realtime-voice/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/local-realtime-voice",
+  "version": "2026.6.9",
+  "private": true,
+  "description": "OpenClaw local realtime voice and dictation provider",
+  "type": "module",
+  "main": "./index.js",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": ["./index.js"]
+  }
+}


### PR DESCRIPTION
This PR adds an optional main-agent routing mode to the local realtime voice provider so voice sessions can use the same tools, sub-agents, and file writes as typed chat.

**Depends on:** #96173 (Add local-realtime-voice extension). The diff will shrink to only the routing commit once that PR is merged.

**What it does**
- Adds `GatewayChatClient` that connects to the gateway as an `operator`/`backend` client and sends `chat.send` to a configured session.
- New provider config options: `useMainAgent`, `mainAgentSessionKey`, `gatewayUrl`, `gatewayToken`, `voiceInstructions`.
- Refactors TTS flushing into `speakSentence()` and a robust `extractCompleteSentences()` helper for streaming spoken replies.
- Keeps the existing local Ollama path as fallback when `useMainAgent` is false.

**Why**
Realtime voice should not be limited to a local chatbot while the rest of the UI can run tools. With this mode, the provider becomes audio I/O only: STT → main agent → TTS.

**Files changed**
- `extensions/local-realtime-voice/README.md`
- `extensions/local-realtime-voice/index.js`
- `extensions/local-realtime-voice/openclaw.plugin.json`
- `extensions/local-realtime-voice/package.json`