### PR TITLE
fix(copilot-oauth): bound OAuth and API endpoint response reads

### DIFF
--- a/src/llm/utils/oauth/github-copilot.test.ts
+++ b/src/llm/utils/oauth/github-copilot.test.ts
@@ -149,6 +149,28 @@ describe("GitHub Copilot OAuth model policy", () => {
     );
   });
 
+  it("rejects an oversized Copilot token refresh response", async () => {
+    let pullCount = 0;
+    const cancel = vi.fn(async () => undefined);
+    const oversizedStream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        controller.enqueue(new Uint8Array(pullCount === 1 ? 16 * 1024 * 1024 + 1 : 1));
+      },
+      cancel,
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(oversizedStream, { status: 200 })),
+    );
+
+    await expect(refreshGitHubCopilotToken("old-refresh-token")).rejects.toThrow("too large");
+
+    expect(pullCount).toBeLessThanOrEqual(2);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it("treats timed out model listing as optional policy setup", async () => {
     stubHangingFetch(5);
 

--- a/src/llm/utils/oauth/github-copilot.ts
+++ b/src/llm/utils/oauth/github-copilot.ts
@@ -2,6 +2,7 @@
  * GitHub Copilot OAuth flow
  */
 
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import {
   nonNegativeSecondsToSafeMilliseconds,
@@ -28,6 +29,7 @@ const COPILOT_HEADERS = {
 
 const INITIAL_POLL_INTERVAL_MULTIPLIER = 1.2;
 const SLOW_DOWN_POLL_INTERVAL_MULTIPLIER = 1.4;
+const COPILOT_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const COPILOT_ROUTER_ID_PREFIX = "accounts/";
 const COPILOT_REQUEST_TIMEOUT_MS = 30_000;
 
@@ -182,11 +184,22 @@ async function fetchJson(
   options: CopilotRequestOptions = {},
 ): Promise<unknown> {
   const response = await fetchResponse(url, init, operation, options);
+
+  const buffer = await readResponseWithLimit(response, COPILOT_RESPONSE_MAX_BYTES, {
+    onOverflow: ({ size }) =>
+      new Error(`GitHub Copilot ${operation} response too large: ${size} bytes`),
+  });
+  const text = new TextDecoder().decode(buffer);
+
   if (!response.ok) {
-    const text = await response.text();
     throw new Error(`${response.status} ${response.statusText}: ${text}`);
   }
-  return response.json();
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${response.status} ${response.statusText}: invalid JSON`);
+  }
 }
 
 async function startDeviceFlow(


### PR DESCRIPTION
## What Problem This Solves

`fetchJson` in `src/llm/utils/oauth/github-copilot.ts` reads the GitHub Copilot
OAuth and API endpoint response bodies with unbounded `await response.text()`
and `await response.json()`. A compromised or hijacked endpoint can stream an
arbitrarily large body and force the runtime to buffer the entire payload — an
OOM/DoS vector.

This is the same vulnerability class already hardened in the Anthropic OAuth
sibling (`src/llm/utils/oauth/anthropic.ts`, PR #96644).

## Changes

- `src/llm/utils/oauth/github-copilot.ts` — import `readResponseWithLimit`
  from `@openclaw/media-core/read-response-with-limit`; replace both
  `await response.text()` and `await response.json()` with
  `readResponseWithLimit` at 16 MiB cap + `new TextDecoder().decode(buffer)` +
  `JSON.parse`. Uses `TextDecoder` to preserve UTF-8 BOM stripping semantics
  that `response.text()` provides.

## Evidence

### Real behavior proof

A real `node:http` server was started on `127.0.0.1`, and the real exported
`refreshGitHubCopilotToken` was driven against it over a real TCP socket
(global `fetch` stubbed only to rewrite the hostname to the loopback server).
Node v22.22.0.

```text
$ node --import tsx _proof_copilot_overflow.mts
[proof] cap=16777216 (16 MiB)

[test 1/3] oversized body — real refreshGitHubCopilotToken
[server] ← GET /copilot_internal/v2/token
  PASS  throws bounded cap error :: GitHub Copilot token refresh request response too large: 16794740 bytes
  PASS  client read 16794740 bytes (< cap + 1 MiB) :: clientRead=16794740, cap=16777216
[server] write ECANCELED after client stopped reading

[test 2/3] negative control — raw response.text() against oversized endpoint
[server] ← GET /copilot_internal/v2/token
  PASS  unbounded read: 24.0 MiB > 16 MiB cap :: buffered=25165824 bytes

[test 3/3] happy path — small valid JSON response
  PASS  happy path: parsed successfully :: access=pro-copilot-token
  PASS  happy path: access token is non-empty string :: access=pro-copilot-token
  PASS  happy path: expires is finite number :: expires=1799999700000

[proof] ALL PASS (pass=6 fail=0)
```

- **Oversized case**: `refreshGitHubCopilotToken` threw
  `GitHub Copilot token refresh request response too large: 16794740 bytes`;
  the server write was cancelled (`ECANCELED`) after the client stopped reading,
  confirming the stream was **cancelled**, not drained.
- **Negative control**: the OLD unbounded `response.text()` buffered the full
  **24 MiB** (≫ the 16 MiB cap), proving the cap is load-bearing.
- **Happy path**: small valid `{token, expires_at}` JSON parsed intact
  (`access=pro-copilot-token`).

### Tests

- **New Vitest case `rejects an oversized Copilot token refresh response`**
  creates a ReadableStream whose first chunk exceeds the 16 MiB cap and proves
  the bounded read cancels the body (`cancel` called once, `pull` count ≤ 2)
  and throws an error containing `"too large"`.
- **Existing 10 Vitest cases unchanged** — device flow, token refresh, model
  listing, timeout, and unsafe lifetime rejection all pass.
- `pnpm test src/llm/utils/oauth/github-copilot.test.ts` → **11 passed (11)**
