### PR TITLE
Fix #96240: Allow bootstrapMaxChars config paths to be modified by agents

### DIFF
--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -57,12 +57,16 @@ const ALLOWED_GATEWAY_CONFIG_PATHS = [
   "agents.defaults.subagents.thinking",
   "agents.defaults.reasoningDefault",
   "agents.defaults.fastModeDefault",
+  "agents.defaults.bootstrapMaxChars",
+  "agents.defaults.bootstrapTotalMaxChars",
   "agents.list[].id",
   "agents.list[].model",
   "agents.list[].thinkingDefault",
   "agents.list[].subagents.thinking",
   "agents.list[].reasoningDefault",
   "agents.list[].fastModeDefault",
+  "agents.list[].bootstrapMaxChars",
+  "agents.list[].bootstrapTotalMaxChars",
   // Mention gating is an agent-facing scope knob across channel adapters.
   // Depths here must cover the deepest `requireMention` path the channel
   // adapters use today — Telegram topic overrides live at


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced in the fix for #95939 where `agents.defaults.bootstrapMaxChars` and `agents.defaults.bootstrapTotalMaxChars` (and their per-agent overrides) were incorrectly treated as protected config paths.

## The Problem

When users tried to configure these bootstrap character limit fields via `config.apply` or `config.patch`, the gateway tool would reject the change with:
```
gateway config.patch cannot change protected config paths: agents.defaults.bootstrapMaxChars, ...
```

This caused the fields to be completely deleted on every Gateway restart instead of being preserved.

## The Fix

Add the following paths to `ALLOWED_GATEWAY_CONFIG_PATHS` in `src/agents/tools/gateway-tool.ts`:
- `agents.defaults.bootstrapMaxChars`
- `agents.defaults.bootstrapTotalMaxChars`
- `agents.list[].bootstrapMaxChars`
- `agents.list[].bootstrapTotalMaxChars`

These are low-risk prompt injection budget controls that users should be able to configure. They control how many characters from workspace bootstrap files get injected into agent prompts - not security-sensitive settings.

## Testing

The existing test suite in `src/agents/openclaw-gateway-tool.test.ts` covers the config path allowlist behavior. This change simply adds four new allowed paths alongside other low-risk agent runtime tuning settings like `thinkingDefault`, `reasoningDefault`, etc.

## Related Issues

- Fixes #96240
- Regression from the #95939 fix