### PR TITLE
fix(pixverse): bound video-generation success JSON response reads at 16 MiB

### DIFF
--- a/extensions/pixverse/video-generation-provider.test.ts
+++ b/extensions/pixverse/video-generation-provider.test.ts
@@ -11,7 +11,6 @@ const {
   postMultipartRequestMock,
   fetchWithTimeoutMock,
   pollProviderOperationJsonMock,
-  readProviderJsonResponseMock,
   resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequestMock,
 } = getProviderHttpMocks();

--- a/extensions/pixverse/video-generation-provider.test.ts
+++ b/extensions/pixverse/video-generation-provider.test.ts
@@ -11,6 +11,7 @@ const {
   postMultipartRequestMock,
   fetchWithTimeoutMock,
   pollProviderOperationJsonMock,
+  readProviderJsonResponseMock,
   resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequestMock,
 } = getProviderHttpMocks();

--- a/extensions/pixverse/video-generation-provider.ts
+++ b/extensions/pixverse/video-generation-provider.ts
@@ -9,6 +9,7 @@ import {
   pollProviderOperationJson,
   postJsonRequest,
   postMultipartRequest,
+  readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
   sanitizeConfiguredModelProviderRequest,
@@ -183,13 +184,8 @@ function readPixVerseSuccess<T>(payload: PixVerseEnvelope<T>, label: string): T 
   return payload.Resp;
 }
 
-async function readPixVerseJson<T>(response: Pick<Response, "json">, label: string): Promise<T> {
-  let payload: unknown;
-  try {
-    payload = await response.json();
-  } catch (cause) {
-    throw new Error(`${label}: malformed JSON response`, { cause });
-  }
+async function readPixVerseJson<T>(response: Response, label: string): Promise<T> {
+  const payload = await readProviderJsonResponse(response, label);
   return readPixVerseSuccess(payload as PixVerseEnvelope<T>, label);
 }
 

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -36,6 +36,7 @@ type AnyMock = Mock<(...args: unknown[]) => unknown>;
 interface ProviderHttpMocks {
   resolveApiKeyForProviderMock: Mock<() => Promise<{ apiKey: string }>>;
   executeProviderOperationWithRetryMock: AnyMock;
+  readProviderJsonResponseMock: AnyMock;
   postJsonRequestMock: AnyMock;
   postMultipartRequestMock: AnyMock;
   fetchWithTimeoutMock: AnyMock;
@@ -56,6 +57,10 @@ interface ProviderHttpMocks {
 const providerHttpMocks = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
   executeProviderOperationWithRetryMock: vi.fn(),
+  readProviderJsonResponseMock: vi.fn(async (...args: unknown[]) => {
+    const response = args[0] as { json: () => Promise<unknown> };
+    return response.json();
+  }),
   postJsonRequestMock: vi.fn(),
   postMultipartRequestMock: vi.fn(),
   fetchWithTimeoutMock: vi.fn(),
@@ -210,6 +215,7 @@ vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
 
 vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   assertOkOrThrowHttpError: providerHttpMocks.assertOkOrThrowHttpErrorMock,
+  readProviderJsonResponse: providerHttpMocks.readProviderJsonResponseMock,
   assertOkOrThrowProviderError: providerHttpMocks.assertOkOrThrowProviderErrorMock,
   createProviderOperationDeadline: ({
     label,

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -267,5 +267,6 @@ export function installProviderHttpMockCleanup(): void {
     providerHttpMocks.assertOkOrThrowProviderErrorMock.mockClear();
     providerHttpMocks.sanitizeConfiguredModelProviderRequestMock.mockClear();
     providerHttpMocks.resolveProviderHttpRequestConfigMock.mockClear();
+    providerHttpMocks.readProviderJsonResponseMock.mockClear();
   });
 }


### PR DESCRIPTION
## What Problem This Solves

`extensions/pixverse/video-generation-provider.ts:189` calls `await response.json()` with no byte-level cap. A hostile, compromised, or misconfigured PixVerse endpoint can return a success status with no `Content-Length` and stream an arbitrarily large JSON payload, causing OOM.

The fix routes through `readProviderJsonResponse` (openclaw/plugin-sdk/provider-http, 16 MiB default cap), which reads the body as a bounded stream and cancels on overflow. The existing `readPixVerseSuccess` layer is preserved for PixVerse-specific envelope validation.

## Changes

- `extensions/pixverse/video-generation-provider.ts:186-190` — replace `payload = await response.json()` in `readPixVerseJson` with `readProviderJsonResponse(response, label)`. Removes the manual try/catch (malformed JSON handling is built into the SDK helper). Type changed from `Pick<Response, "json">` to `Response`.
- `extensions/pixverse/video-generation-provider.test.ts` — add `readProviderJsonResponseMock` to destructured mock imports (shared mock handles the delegation).
- `src/plugin-sdk/test-helpers/provider-http-mocks.ts` — add `readProviderJsonResponseMock` to shared mock interface and the `vi.mock("openclaw/plugin-sdk/provider-http")` block, so extension tests can mock it alongside other provider-http exports.

## Real behavior proof

Drives `readProviderJsonResponse` over a real `node:http` server (chunked transfer, no Content-Length). Node v22.22.0.

```
=== PixVerse bounded-read proof ===

  PASS  happy path: status ok
  PASS  happy path: returns object with Resp — video_id=123
  PASS  oversized: throws bounded error with label — err=PixVerse test: JSON response exceeds 16777216 bytes
  PASS  oversized: bytes on wire stayed near cap (< 20 MiB) — bytesSent=18.4 MiB, cap=16 MiB

=== PixVerse bounded-read: 4/4 passed ===
```

- **Behavior addressed**: unbounded `response.json()` on PixVerse video generation success responses; now capped at 16 MiB (SDK default) with cancellation on overflow.
- **Real environment tested**: real `node:http` server (127.0.0.1, chunked transfer, no Content-Length). Node v22.22.0.
- **Exact steps**: `node --import tsx _proof_pixverse.mts` (working tree only, not committed)
- **Evidence after fix**: 4/4 assertions pass. Happy path: valid PixVerse envelope parsed correctly. Oversized (endless chunked stream): throws "JSON response exceeds 16777216 bytes" at ~18.4 MiB.
- **What was not tested**: live PixVerse API call (the proof exercises the same `readProviderJsonResponse` helper used in production).

## Out of scope

- Other unbounded `response.json()` call sites in `extensions/pixverse/` — covered in separate bounded-read sibling PRs.
- Default cap policy — 16 MiB is the SDK helper default, matching all other non-image provider JSON reads.

## Risk

- **Low**: swap from `response.json()` to `readProviderJsonResponse`. Error behavior preserves the same upstream catch path. Byte cap is 16 MiB — invisible to normal PixVerse JSON responses (typically < 1 MiB).
- **Tested**: 15/15 existing unit tests pass.

## Diff stats

```
3 files changed, 10 insertions(+), 7 deletions(-)
```

AI-assisted: implemented and proof-tested with AI assistance; reviewed by a human before submission.