### PR TITLE
fix(fal): bound music/video generation response reads

### DIFF
--- a/extensions/fal/music-generation-provider.test.ts
+++ b/extensions/fal/music-generation-provider.test.ts
@@ -58,6 +58,13 @@ function streamedAudioResponse(bytes: string): Response {
   );
 }
 
+function falMusicJsonResponse(value: unknown) {
+  return {
+    response: Response.json(value),
+    release: vi.fn(async () => {}),
+  };
+}
+
 describe("fal music generation provider", () => {
   afterEach(() => {
     assertOkOrThrowHttpErrorMock.mockClear();
@@ -72,18 +79,15 @@ describe("fal music generation provider", () => {
   });
 
   it("submits MiniMax music through fal and downloads the generated track", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          audio: {
-            url: "https://v3b.fal.media/files/b/kangaroo/out.mp3",
-            content_type: "audio/mpeg",
-            file_name: "out.mp3",
-          },
-        }),
-      },
-      release: vi.fn(async () => {}),
-    });
+    postJsonRequestMock.mockResolvedValue(
+      falMusicJsonResponse({
+        audio: {
+          url: "https://v3b.fal.media/files/b/kangaroo/out.mp3",
+          content_type: "audio/mpeg",
+          file_name: "out.mp3",
+        },
+      }),
+    );
     const fetchMock = vi.fn(
       async () =>
         new Response(Buffer.from("mp3-bytes"), {
@@ -125,17 +129,14 @@ describe("fal music generation provider", () => {
   });
 
   it("rejects generated music downloads that exceed the configured media cap", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          audio: {
-            url: "https://v3b.fal.media/files/b/out.mp3",
-            content_type: "audio/mpeg",
-          },
-        }),
-      },
-      release: vi.fn(async () => {}),
-    });
+    postJsonRequestMock.mockResolvedValue(
+      falMusicJsonResponse({
+        audio: {
+          url: "https://v3b.fal.media/files/b/out.mp3",
+          content_type: "audio/mpeg",
+        },
+      }),
+    );
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => streamedAudioResponse("too-large")),
@@ -167,16 +168,13 @@ describe("fal music generation provider", () => {
   });
 
   it("maps ACE-Step duration and instrumental controls", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          audio: { url: "https://example.com/out.wav", content_type: "audio/wav" },
-          seed: 42,
-          tags: "lofi, chill",
-        }),
-      },
-      release: vi.fn(async () => {}),
-    });
+    postJsonRequestMock.mockResolvedValue(
+      falMusicJsonResponse({
+        audio: { url: "https://example.com/out.wav", content_type: "audio/wav" },
+        seed: 42,
+        tags: "lofi, chill",
+      }),
+    );
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -205,14 +203,11 @@ describe("fal music generation provider", () => {
   });
 
   it("maps Stable Audio duration controls", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          audio: "https://example.com/stable.wav",
-        }),
-      },
-      release: vi.fn(async () => {}),
-    });
+    postJsonRequestMock.mockResolvedValue(
+      falMusicJsonResponse({
+        audio: "https://example.com/stable.wav",
+      }),
+    );
     vi.stubGlobal(
       "fetch",
       vi.fn(

--- a/extensions/fal/music-generation-provider.ts
+++ b/extensions/fal/music-generation-provider.ts
@@ -6,7 +6,11 @@ import {
   type MusicGenerationRequest,
 } from "openclaw/plugin-sdk/music-generation";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
-import { assertOkOrThrowHttpError, postJsonRequest } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowHttpError,
+  postJsonRequest,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveFalHttpRequestConfig } from "./http-config.js";
 
@@ -161,7 +165,7 @@ export function buildFalMusicGenerationProvider(): MusicGenerationProvider {
 
       try {
         await assertOkOrThrowHttpError(response, "fal music generation failed");
-        const payload = await response.json();
+        const payload = await readProviderJsonResponse<unknown>(response, "fal music generation");
         const [candidate] = extractGeneratedMusicFileCandidates(payload);
         if (!candidate) {
           throw new Error("fal music generation response missing audio output");

--- a/extensions/fal/video-generation-provider.test.ts
+++ b/extensions/fal/video-generation-provider.test.ts
@@ -37,9 +37,7 @@ describe("fal video generation provider", () => {
 
   function releasedJson(value: unknown) {
     return {
-      response: {
-        json: async () => value,
-      },
+      response: Response.json(value),
       release: vi.fn(async () => {}),
     };
   }
@@ -254,11 +252,10 @@ describe("fal video generation provider", () => {
   it("wraps non-JSON successful fal submit responses", async () => {
     mockFalProviderRuntime();
     fetchGuardMock.mockResolvedValueOnce({
-      response: {
-        json: async () => {
-          throw new SyntaxError("Unexpected token < in JSON");
-        },
-      },
+      response: new Response("<html><body>Bad Gateway</body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
       release: vi.fn(async () => {}),
     });
 

--- a/extensions/fal/video-generation-provider.ts
+++ b/extensions/fal/video-generation-provider.ts
@@ -5,6 +5,7 @@ import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import {
   assertOkOrThrowHttpError,
   createProviderOperationDeadline,
+  readProviderJsonResponse,
   type ProviderOperationDeadline,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
@@ -480,9 +481,12 @@ async function fetchFalJson(params: {
   try {
     await assertOkOrThrowHttpError(response, params.errorContext);
     try {
-      return await response.json();
-    } catch {
-      throw new Error(FAL_VIDEO_MALFORMED_RESPONSE);
+      return await readProviderJsonResponse<unknown>(response, params.errorContext);
+    } catch (error) {
+      if (error instanceof Error && error.message.endsWith(": malformed JSON response")) {
+        throw new Error(FAL_VIDEO_MALFORMED_RESPONSE, { cause: error });
+      }
+      throw error;
     }
   } finally {
     await release();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the fal image, music, and video generation providers read a **successful** fal API JSON response through an unbounded `await response.json()` after the HTTP status check. A hostile, compromised, or buggy fal endpoint can stream an arbitrarily large success body with no `Content-Length`, forcing the runtime to buffer the entire payload in memory before parsing. This risks out-of-memory crashes or hangs on the media-generation path — affecting any agent or workflow that generates images, music, or video through the fal provider.

This is the success path: the existing `assertOkOrThrowHttpError` / bounded error-body reader only guards non-2xx responses, so the oversized-body risk is on 2xx replies that reach `response.json()`.

## Why This Change Was Made

All three success-path reads are routed through the shared `readProviderJsonResponse` helper (already used by other media providers, e.g. byteplus). It reads the body through the same 16 MiB bounded reader used for binary responses and cancels the upstream stream on overflow, then parses JSON. No new abstraction is introduced — this reuses existing plugin-SDK infrastructure.

- `extensions/fal/image-generation-provider.ts` (success read at the generation call)
- `extensions/fal/music-generation-provider.ts` (success read after `postJsonRequest`)
- `extensions/fal/video-generation-provider.ts` (`fetchFalJson`, the shared submit/status/result read)

Boundary preserved: the video path keeps its existing `FAL_VIDEO_MALFORMED_RESPONSE` mapping for malformed JSON while letting the new overflow error propagate unchanged, so existing behavior for malformed payloads is unaffected.

## User Impact

No change to normal behavior: well-formed fal responses parse exactly as before. When a fal endpoint returns an oversized success body, the provider now fails fast with a clear bounded error and tears down the connection instead of buffering unbounded memory. Operators running fal-backed media generation are protected from an OOM/hang failure mode.

## Evidence

**Behavior addressed:** success-path untrusted JSON body is now bounded to 16 MiB; overflow throws and the TCP stream is cancelled.

**Real environment tested:** a real `node:http` loopback server streams a 20 MiB JSON success body with **no `Content-Length`**; the real exported provider functions (`generateImage`, `generateMusic`, `generateVideo`) are driven against it over real TCP. Only the credential/config resolution and the fetch-guard transport are stubbed to point at loopback — the bounded read under test (`readProviderJsonResponse`) runs for real.

**Exact steps:** drive each provider against the oversize server; assert it throws `... JSON response exceeds 16777216 bytes`, that fewer than the full 20 MiB hit the wire (`bytesSent < 20971520`), and that the socket is torn down. Plus a negative control (the pre-fix `response.json()` buffers the whole body) and a happy-path control (small JSON still parses).

**Observed result (real terminal output):**

```
[image] bounded throw OK; bytesSent=19464238 (<20971520=full); socketTornDown=true
 ✓ image generation bounds an oversize success body and tears down the socket 362ms
[video] bounded throw OK; bytesSent=17825838 (<20971520=full); socketTornDown=true
 ✓ video submit bounds an oversize success body and tears down the socket 139ms
[music] bounded throw OK; bytesSent=18546734 (<20971520=full); socketTornDown=true
 ✓ music generation bounds an oversize success body and tears down the socket 436ms
[negative] unbounded json() buffered fullBytes=20971566 (>=20971520); junkLen=20971520 (>cap=16777216)
 ✓ NEGATIVE CONTROL: the old unbounded response.json() buffers the whole oversize body past the cap 237ms
[happy] small JSON parsed OK through bounded reader; bytesSent=38
 ✓ HAPPY PATH: a small JSON success body still parses through the bounded reader 9ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

The three numbers above show only ~17–19 MiB reached the wire before the bounded reader cancelled the stream, versus the full 20 MiB the unbounded path buffered in the negative control.

**Existing suite:** the fal provider tests pass after updating the test doubles to stream real `Response` bodies (the old doubles only implemented `.json()`):

```
 Test Files  3 passed (3)
      Tests  49 passed (49)
```

Typecheck: `tsgo` over the extensions + test projects reports 0 errors.

**What was not tested:** no live call against the real fal API (requires credentials); the proof exercises the bounded read over a real TCP loopback socket instead.

**Label**: security

_AI-assisted._

---

**Post-rebase scope update:** `main` has since landed the fal **image** response bound, so the image hunk has been dropped from this branch. This PR is now narrowed to the fal **music** and **video** success-path reads only — `music-generation-provider.ts` and `video-generation-provider.ts` (via `fetchFalJson`), both routed through the shared `readProviderJsonResponse` (16 MiB cap), with the video path preserving its existing `FAL_VIDEO_MALFORMED_RESPONSE` mapping. The `image-generation-provider.ts` change and the `[image] …` line in the Evidence block above no longer correspond to this PR's diff and can be disregarded.
