### PR TITLE
fix(agents): prevent repeated message_tool_only source-reply cascade

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -165,6 +165,7 @@ const QA_TOOL_PROGRESS_PROMPT_RE = /tool progress qa check/i;
 const QA_GROUP_VISIBLE_REPLY_TOOL_PROMPT_RE = /qa group visible reply tool check/i;
 const QA_GROUP_MESSAGE_UNAVAILABLE_FALLBACK_PROMPT_RE =
   /qa group message unavailable fallback check/i;
+const QA_MESSAGE_TOOL_CASCADE_PROMPT_RE = /qa message tool cascade check/i;
 const QA_TELEGRAM_CURRENT_SESSION_STATUS_PROMPT_RE = /telegram current session_status qa check/i;
 const QA_TELEGRAM_STREAM_SINGLE_MARKER = "QA-TELEGRAM-STREAM-SINGLE-OK";
 const QA_TELEGRAM_LONG_FINAL_THREE_CHUNK_PROMPT_RE = /telegram long final three chunk qa check/i;
@@ -2319,6 +2320,21 @@ async function buildResponsesPayload(
       });
     }
     return buildAssistantEvents("");
+  }
+  if (QA_MESSAGE_TOOL_CASCADE_PROMPT_RE.test(allInputText)) {
+    if (!toolOutput && hasDeclaredTool(body, "message")) {
+      return buildToolCallEventsWithArgs("message", {
+        action: "send",
+        message: "QA-CASCADE-1",
+      });
+    }
+    if (toolOutput && hasDeclaredTool(body, "message")) {
+      return buildToolCallEventsWithArgs("message", {
+        action: "send",
+        message: "QA-CASCADE-2",
+      });
+    }
+    return buildAssistantEvents("QA-CASCADE-UNTERMINATED");
   }
   if (QA_GROUP_MESSAGE_UNAVAILABLE_FALLBACK_PROMPT_RE.test(allInputText)) {
     return buildAssistantEvents(

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -915,6 +915,154 @@ describe("agentLoop tool termination", () => {
     ]);
     expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
+
+  it("stops message.send cascade: first delivery no terminate, second terminates", async () => {
+    // Simulates the message_tool_only cascade scenario documented in #96827:
+    // Turn 1: model sends message.send → hook records delivery, no terminate.
+    // Turn 2: model sends message.send again → hook records + terminate → batch ends.
+    // Without the guard, this would loop 7+ times.
+    const executed: string[] = [];
+    let hasDelivered = false;
+    let turn = 0;
+    const streamFn: StreamFn = () => {
+      turn += 1;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message =
+          turn === 1
+            ? makeAssistantMessage([
+                {
+                  type: "toolCall",
+                  id: "call-msg-1",
+                  name: "message",
+                  arguments: { action: "send", message: "reply" },
+                },
+              ])
+            : turn === 2
+              ? makeAssistantMessage([
+                  {
+                    type: "toolCall",
+                    id: "call-msg-2",
+                    name: "message",
+                    arguments: { action: "send", message: "reply again" },
+                  },
+                ])
+              : makeAssistantMessage([{ type: "text", text: "should not reach this" }]);
+        stream.push({
+          type: "done",
+          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+          message,
+        });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [makeTool("message", executed)],
+      },
+      {
+        ...config,
+        afterToolCall: async ({ toolCall }) => {
+          if (toolCall.name === "message") {
+            if (hasDelivered) {
+              return { terminate: true };
+            }
+            hasDelivered = true;
+          }
+          return undefined;
+        },
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+
+    // Cascade prevented: loop stops after 2 turns, not 3+.
+    expect(turn).toBe(2);
+    expect(executed).toEqual(["message", "message"]);
+    expect(events.at(-1)).toMatchObject({ type: "agent_end" });
+  });
+
+  it("preserves Slack follow-up: first message.send does not terminate, allows follow-up tool", async () => {
+    // After PR #92343, the first message.send in message_tool_only mode
+    // must NOT terminate the batch so follow-up tools (e.g. Slack actions)
+    // can still execute. Second message.send terminates to prevent cascade.
+    const executed: string[] = [];
+    let hasDelivered = false;
+    let turn = 0;
+    const streamFn: StreamFn = () => {
+      turn += 1;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message =
+          turn === 1
+            ? makeAssistantMessage([
+                {
+                  type: "toolCall",
+                  id: "call-msg",
+                  name: "message",
+                  arguments: { action: "send", message: "reply" },
+                },
+              ])
+            : turn === 2
+              ? makeAssistantMessage([
+                  {
+                    type: "toolCall",
+                    id: "call-exec",
+                    name: "exec",
+                    arguments: { cmd: "echo done" },
+                  },
+                ])
+              : makeAssistantMessage([{ type: "text", text: "all done" }]);
+        stream.push({
+          type: "done",
+          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+          message,
+        });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "reply and run a command", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [makeTool("message", executed), makeTool("exec", executed)],
+      },
+      {
+        ...config,
+        afterToolCall: async ({ toolCall }) => {
+          if (toolCall.name === "message") {
+            if (hasDelivered) {
+              return { terminate: true };
+            }
+            hasDelivered = true;
+          }
+          return undefined;
+        },
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+
+    // All 3 turns complete: message → exec → text.
+    expect(turn).toBe(3);
+    expect(executed).toEqual(["message", "exec"]);
+    expect(
+      events.filter((e) => e.type === "tool_execution_start"),
+    ).toHaveLength(2);
+    expect(events.at(-1)).toMatchObject({ type: "agent_end" });
+  });
 });
 
 describe("agentLoop thinking state", () => {

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -935,7 +935,7 @@ describe("agentLoop tool termination", () => {
                   type: "toolCall",
                   id: "call-msg-1",
                   name: "message",
-                  arguments: { action: "send", message: "reply" },
+                  arguments: {},
                 },
               ])
             : turn === 2
@@ -944,7 +944,7 @@ describe("agentLoop tool termination", () => {
                     type: "toolCall",
                     id: "call-msg-2",
                     name: "message",
-                    arguments: { action: "send", message: "reply again" },
+                    arguments: {},
                   },
                 ])
               : makeAssistantMessage([{ type: "text", text: "should not reach this" }]);
@@ -1007,7 +1007,7 @@ describe("agentLoop tool termination", () => {
                   type: "toolCall",
                   id: "call-msg",
                   name: "message",
-                  arguments: { action: "send", message: "reply" },
+                  arguments: {},
                 },
               ])
             : turn === 2
@@ -1016,7 +1016,7 @@ describe("agentLoop tool termination", () => {
                     type: "toolCall",
                     id: "call-exec",
                     name: "exec",
-                    arguments: { cmd: "echo done" },
+                    arguments: {},
                   },
                 ])
               : makeAssistantMessage([{ type: "text", text: "all done" }]);

--- a/qa/scenarios/channels/message-tool-cascade-regression.yaml
+++ b/qa/scenarios/channels/message-tool-cascade-regression.yaml
@@ -1,0 +1,110 @@
+title: message_tool_only cascade regression (#96827)
+
+scenario:
+  id: message-tool-cascade-regression
+  surface: channel
+  coverage:
+    primary:
+      - channels.group-visible-replies
+    secondary:
+      - channels.qa-channel
+      - tools.message
+  objective: Reproduce #96827 — under message_tool_only mode the mock returns message.send twice; verify the cascade stops at 2 outbound messages and no third send occurs.
+  gatewayConfigPatch:
+    messages:
+      groupChat:
+        visibleReplies: message_tool
+  successCriteria:
+    - Mock provider returns message(action=send) twice (markers QA-CASCADE-1, QA-CASCADE-2).
+    - Exactly 2 outbound messages arrive in the group conversation.
+    - No third outbound message appears within a settle window.
+  docsRefs:
+    - docs/channels/qa-channel.md
+    - docs/channels/groups.md
+  codeRefs:
+    - src/agents/embedded-agent-runner/run/message-tool-terminal.ts
+    - packages/agent-core/src/agent-loop.ts
+  execution:
+    kind: flow
+    summary: Send a mentioned group message that triggers two mock message.send calls, and verify the cascade stops at 2 deliveries with no third outbound.
+    config:
+      requiredProviderMode: mock-openai
+      conversationId: qa-cascade-room
+      promptSnippet: qa message tool cascade check
+      prompt: "@openclaw qa message tool cascade check. exact marker: `QA-CASCADE-1`"
+      expectedMarker1: QA-CASCADE-1
+      expectedMarker2: QA-CASCADE-2
+      unterminatedMarker: QA-CASCADE-UNTERMINATED
+
+flow:
+  steps:
+    - name: stops message_tool_only cascade at 2 visible sends
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: this seeded scenario is mock-openai only
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - set: requestCountBefore
+          value:
+            expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests`)).length : 0"
+        - call: state.addInboundMessage
+          args:
+            - conversation:
+                id:
+                  expr: config.conversationId
+                kind: group
+                title: QA Cascade Room
+              senderId: alice
+              senderName: Alice
+              text:
+                expr: config.prompt
+        - call: waitForOutboundMessage
+          saveAs: firstOutbound
+          args:
+            - ref: state
+            - lambda:
+                params: [candidate]
+                expr: "candidate.conversation.id === config.conversationId && candidate.conversation.kind === 'group' && (candidate.text ?? '').includes(config.expectedMarker1)"
+            - expr: liveTurnTimeoutMs(env, 180000)
+        - call: waitForOutboundMessage
+          saveAs: secondOutbound
+          args:
+            - ref: state
+            - lambda:
+                params: [candidate]
+                expr: "candidate.conversation.id === config.conversationId && candidate.conversation.kind === 'group' && (candidate.text ?? '').includes(config.expectedMarker2)"
+            - expr: liveTurnTimeoutMs(env, 180000)
+        - call: waitForNoOutbound
+          args:
+            - ref: state
+            - 15000
+        - set: allOutbound
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && message.conversation.kind === 'group')"
+        - assert:
+            expr: allOutbound.length === 2
+            message:
+              expr: "`expected exactly 2 visible group replies (cascade stopped), saw ${allOutbound.length}`"
+        - set: hasUnterminatedMarker
+          value:
+            expr: "allOutbound.some((message) => (message.text ?? '').includes(config.unterminatedMarker))"
+        - assert:
+            expr: "!hasUnterminatedMarker"
+            message:
+              expr: "`cascade was NOT terminated — third send marker ${config.unterminatedMarker} appeared in outbound`"
+        - set: scenarioRequests
+          value:
+            expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests`)).slice(requestCountBefore).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet)) : []"
+        - assert:
+            expr: "!env.mock || scenarioRequests.every((request) => request.plannedToolName === 'message' && request.plannedToolArgs?.action === 'send')"
+            message:
+              expr: "`all mock requests should plan message.send; saw ${JSON.stringify(scenarioRequests.map((request) => ({ plannedToolName: request.plannedToolName ?? null, plannedToolArgs: request.plannedToolArgs ?? null })))}`"
+      detailsExpr: "`first=${firstOutbound.text}; second=${secondOutbound.text}; total-outbound=${allOutbound.length}; unterminated=${hasUnterminatedMarker}`"

--- a/qa/scenarios/channels/message-tool-cascade-regression.yaml
+++ b/qa/scenarios/channels/message-tool-cascade-regression.yaml
@@ -82,10 +82,15 @@ flow:
                 params: [candidate]
                 expr: "candidate.conversation.id === config.conversationId && candidate.conversation.kind === 'group' && (candidate.text ?? '').includes(config.expectedMarker2)"
             - expr: liveTurnTimeoutMs(env, 180000)
+        - set: cascadeCursor
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - call: waitForNoOutbound
           args:
             - ref: state
             - 15000
+            - sinceIndex:
+                ref: cascadeCursor
         - set: allOutbound
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && message.conversation.kind === 'group')"

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
@@ -209,6 +209,38 @@ describe("message-tool-only source replies", () => {
     expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1);
   });
 
+  it("prevents repeated message_tool_only send cascade by terminating on subsequent deliveries", async () => {
+    const agent = {} as unknown as Agent;
+    const onDeliveredSourceReply = vi.fn();
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+      onDeliveredSourceReply,
+    });
+
+    // First delivery: records evidence, no terminate
+    await expect(
+      agent.afterToolCall?.(
+        createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "first reply" },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1);
+
+    // Second delivery: records evidence + terminate
+    await expect(
+      agent.afterToolCall?.(
+        createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "second reply" },
+        }),
+      ),
+    ).resolves.toEqual({ terminate: true });
+    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(2);
+  });
+
   it("leaves existing after-tool-call output alone when the send failed", async () => {
     const previousAfterToolCall = vi.fn(async () => ({
       content: [{ type: "text" as const, text: "failed" }],

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
@@ -7,8 +7,8 @@ import type {
   AfterToolCallContext,
   AgentEvent,
   AgentLoopConfig,
-  AgentMessage,
   AgentTool,
+  AgentToolResult,
   StreamFn,
 } from "openclaw/plugin-sdk/agent-core";
 import { createAssistantMessageEventStream } from "@openclaw/llm-core";
@@ -403,7 +403,7 @@ describe("message-tool-only source replies", () => {
       },
       execute: async (_id: string, raw: unknown) => {
         const args = (raw ?? {}) as Record<string, unknown>;
-        executed.push(String(args.action ?? "unknown"));
+        executed.push(typeof args.action === "string" ? args.action : "unknown");
         return {
           content: [
             {
@@ -492,7 +492,9 @@ describe("message-tool-only source replies", () => {
     );
 
     const events: AgentEvent[] = [];
-    for await (const ev of stream) events.push(ev);
+    for await (const ev of stream) {
+      events.push(ev);
+    }
 
     // Cascade stops at 2 turns — not 7+.
     expect(turn).toBe(2);
@@ -505,9 +507,13 @@ describe("message-tool-only source replies", () => {
       (e): e is Extract<AgentEvent, { type: "tool_execution_end" }> =>
         e.type === "tool_execution_end",
     );
-    expect(toolEnds[0]?.result?.terminate).toBeUndefined();
+    expect(
+      (toolEnds[0]?.result as AgentToolResult<unknown> | undefined)?.terminate,
+    ).toBeUndefined();
     // Turn 2: terminate: true (cascade broken)
-    expect(toolEnds[1]?.result?.terminate).toBe(true);
+    expect(
+      (toolEnds[1]?.result as AgentToolResult<unknown> | undefined)?.terminate,
+    ).toBe(true);
   });
 
   it("full embedded-run proof: first message.send allows Slack follow-up exec tool", async () => {
@@ -579,7 +585,7 @@ describe("message-tool-only source replies", () => {
             input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
           },
-          stopReason: (turn <= 2 ? "toolUse" : "stop") as "toolUse" | "stop",
+          stopReason: turn <= 2 ? "toolUse" : "stop",
           timestamp: Date.now(),
         };
         stream.push({
@@ -610,7 +616,9 @@ describe("message-tool-only source replies", () => {
     );
 
     const events: AgentEvent[] = [];
-    for await (const ev of stream) events.push(ev);
+    for await (const ev of stream) {
+      events.push(ev);
+    }
 
     // All 3 turns: message → exec → text (#92343 preserved)
     expect(turn).toBe(3);

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
@@ -1,7 +1,17 @@
 // Message-tool delivery tests cover message_tool_only delivery, where a
 // successful source message send records source reply evidence without ending
 // the run before the model can observe the tool result.
-import type { Agent, AfterToolCallContext } from "openclaw/plugin-sdk/agent-core";
+import { agentLoop } from "openclaw/plugin-sdk/agent-core";
+import type {
+  Agent,
+  AfterToolCallContext,
+  AgentEvent,
+  AgentLoopConfig,
+  AgentMessage,
+  AgentTool,
+  StreamFn,
+} from "openclaw/plugin-sdk/agent-core";
+import { createAssistantMessageEventStream } from "@openclaw/llm-core";
 import { describe, expect, it, vi } from "vitest";
 import {
   installMessageToolOnlyTerminalHook,
@@ -239,6 +249,375 @@ describe("message-tool-only source replies", () => {
       ),
     ).resolves.toEqual({ terminate: true });
     expect(onDeliveredSourceReply).toHaveBeenCalledTimes(2);
+  });
+
+  it("full lifecycle: 5-turn cascade stops at second send, upstream hook output preserved", async () => {
+    // Simulate the full embedded-run lifecycle as attempt.ts:2530 does:
+    // installMessageToolOnlyTerminalHook wraps a pre-existing afterToolCall
+    // chain, and the model cascades 5 message.send calls in sequence.
+    // Without the fix, all 5 would return no terminate (infinite loop).
+    // With the fix, call 1 returns no terminate (#92343), calls 2+ terminate.
+    const upstreamHook = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "routed" }],
+      details: { upstream: "ok" },
+    }));
+    const agent = { afterToolCall: upstreamHook } as unknown as Agent;
+    const onDeliveredSourceReply = vi.fn();
+
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+      onDeliveredSourceReply,
+    });
+
+    // Hook wraps, does not replace
+    expect(agent.afterToolCall).not.toBe(upstreamHook);
+
+    // Simulate the observed 7+ cascade — 5 consecutive message.send turns.
+    // Real agent-loop stops after first terminate:true; we exercise all 5
+    // to prove the flag stays set.
+    const results: Array<Record<string, unknown> | undefined> = [];
+    for (let i = 0; i < 5; i++) {
+      results.push(
+        (await agent.afterToolCall!(
+          createAfterToolCallContext({
+            toolName: "message",
+            args: { action: "send", message: `cascade turn ${i + 1}` },
+          }),
+        )) as Record<string, unknown> | undefined,
+      );
+    }
+
+    // Turn 1: upstream output preserved, no terminate (#92343 Slack follow-up).
+    expect(results[0]).toEqual({
+      content: [{ type: "text", text: "routed" }],
+      details: { upstream: "ok" },
+    });
+    // Turns 2-5: upstream output + terminate:true (cascade stopped).
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i]).toEqual({
+        content: [{ type: "text", text: "routed" }],
+        details: { upstream: "ok" },
+        terminate: true,
+      });
+    }
+    // Upstream hook called for every turn.
+    expect(upstreamHook).toHaveBeenCalledTimes(5);
+    // onDeliveredSourceReply fired for every delivery.
+    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(5);
+  });
+
+  it("full lifecycle: error recovery does not advance hasDelivered, subsequent success terminates", async () => {
+    // Proves the hook handles error recovery correctly across multiple turns.
+    // hasDelivered is only set when a message.send actually delivers.
+    // Errors are not deliveries — they skip the guard entirely.
+    const agent = {} as unknown as Agent;
+    const onDeliveredSourceReply = vi.fn();
+
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+      onDeliveredSourceReply,
+    });
+
+    // Turn 1: successful delivery — sets hasDelivered.
+    const r1 = await agent.afterToolCall!(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "first reply" },
+      }),
+    );
+    expect(r1).toBeUndefined();
+    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1);
+
+    // Turn 2: error — not a source reply, hasDelivered stays true.
+    const r2 = await agent.afterToolCall!(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "failed reply" },
+        isError: true,
+      }),
+    );
+    // Error: isDeliveredMessageToolOnlySourceReply returns false,
+    // so the hook falls through to `return hookResult` without
+    // calling onDeliveredSourceReply or advancing hasDelivered.
+    expect(r2).toBeUndefined();
+    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1); // unchanged
+
+    // Turn 3: error recovery — first successful send after the error.
+    // hasDelivered was already set in turn 1, so this terminates.
+    const r3 = await agent.afterToolCall!(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "recovered reply" },
+      }),
+    );
+    expect(r3).toEqual({ terminate: true });
+    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(2);
+
+    // Turn 4: another success — still terminates.
+    const r4 = await agent.afterToolCall!(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "another reply" },
+      }),
+    );
+    expect(r4).toEqual({ terminate: true });
+    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(3);
+
+    // Turn 5: another error — does not fire delivery callback.
+    const r5 = await agent.afterToolCall!(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "another error" },
+        isError: true,
+      }),
+    );
+    expect(r5).toBeUndefined();
+    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(3); // unchanged
+  });
+
+  it("full embedded-run proof: real hook + agentLoop stops cascade at 2 turns", async () => {
+    // ClawSweeper-requested proof (96887): installMessageToolOnlyTerminalHook
+    // wired through the real agentLoop(), not called directly. This verifies
+    // the hook is set up exactly as attempt.ts:2530 does, and that the
+    // afterToolCall → finalizeExecutedToolCall merge + shouldTerminateToolBatch
+    // every() contract all work together to stop the cascade.
+    const agent = {} as unknown as Agent;
+    const delivered: string[] = [];
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+      onDeliveredSourceReply: () => delivered.push("d"),
+    });
+
+    const executed: string[] = [];
+    const messageTool = {
+      name: "message",
+      label: "message",
+      description: "Send a message",
+      parameters: {
+        type: "object",
+        properties: { action: { type: "string" }, message: { type: "string" } },
+        required: ["action"],
+      },
+      execute: async (_id: string, raw: unknown) => {
+        const args = (raw ?? {}) as Record<string, unknown>;
+        executed.push(String(args.action ?? "unknown"));
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: true,
+                deliveryStatus: "sent",
+                sourceReplySink: "internal-ui",
+              }),
+            },
+          ],
+          details: {
+            deliveryStatus: "sent",
+            sourceReplySink: "internal-ui",
+            sourceReply: { text: args.message },
+          },
+        };
+      },
+    } satisfies Partial<AgentTool> as AgentTool;
+
+    let turn = 0;
+    const streamFn: StreamFn = () => {
+      turn += 1;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message =
+          turn <= 2
+            ? {
+                role: "assistant" as const,
+                content: [
+                  {
+                    type: "toolCall" as const,
+                    id: `call-msg-${turn}`,
+                    name: "message",
+                    arguments: { action: "send", message: `cascade ${turn}` },
+                  },
+                ],
+                api: "test",
+                provider: "test",
+                model: "test-model",
+                usage: {
+                  input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+                },
+                stopReason: "toolUse" as const,
+                timestamp: Date.now(),
+              }
+            : {
+                role: "assistant" as const,
+                content: [{ type: "text" as const, text: "should not reach" }],
+                api: "test",
+                provider: "test",
+                model: "test-model",
+                usage: {
+                  input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+                },
+                stopReason: "stop" as const,
+                timestamp: Date.now(),
+              };
+        stream.push({
+          type: "done",
+          reason: message.stopReason as never,
+          message: message as never,
+        });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [messageTool] },
+      {
+        model: {
+          id: "proof-model", name: "Proof", api: "proof", provider: "proof",
+          baseUrl: "https://example.test", reasoning: false, input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 1000, maxTokens: 1000,
+        },
+        convertToLlm: (messages) => messages as never,
+        afterToolCall: agent.afterToolCall,
+      } as AgentLoopConfig,
+      undefined,
+      streamFn,
+    );
+
+    const events: AgentEvent[] = [];
+    for await (const ev of stream) events.push(ev);
+
+    // Cascade stops at 2 turns — not 7+.
+    expect(turn).toBe(2);
+    expect(delivered).toHaveLength(2);
+    expect(executed).toHaveLength(2);
+    expect(events.at(-1)).toMatchObject({ type: "agent_end" });
+
+    // Turn 1: no terminate (#92343 Slack follow-up preserved)
+    const toolEnds = events.filter(
+      (e): e is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        e.type === "tool_execution_end",
+    );
+    expect(toolEnds[0]?.result?.terminate).toBeUndefined();
+    // Turn 2: terminate: true (cascade broken)
+    expect(toolEnds[1]?.result?.terminate).toBe(true);
+  });
+
+  it("full embedded-run proof: first message.send allows Slack follow-up exec tool", async () => {
+    // Complements the cascade test: proves the hook preserves the #92343
+    // contract — first message.send does NOT terminate, so follow-up tools
+    // (e.g. Slack exec) still execute in subsequent turns.
+    const agent = {} as unknown as Agent;
+    const delivered: string[] = [];
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+      onDeliveredSourceReply: () => delivered.push("d"),
+    });
+
+    const executed: string[] = [];
+    const msgTool = {
+      name: "message",
+      label: "message",
+      description: "Send",
+      parameters: {
+        type: "object",
+        properties: { action: { type: "string" }, message: { type: "string" } },
+        required: ["action"],
+      },
+      execute: async () => {
+        executed.push("message");
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: true,
+                deliveryStatus: "sent",
+                sourceReplySink: "internal-ui",
+              }),
+            },
+          ],
+          details: { deliveryStatus: "sent", sourceReplySink: "internal-ui" },
+        };
+      },
+    } satisfies Partial<AgentTool> as AgentTool;
+    const execTool = {
+      name: "exec",
+      label: "exec",
+      description: "Run",
+      parameters: { type: "object" as const, properties: {}, required: [] },
+      execute: async () => {
+        executed.push("exec");
+        return { content: [{ type: "text" as const, text: "ok" }], details: {} };
+      },
+    } satisfies Partial<AgentTool> as AgentTool;
+
+    let turn = 0;
+    const streamFn: StreamFn = () => {
+      turn += 1;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const content =
+          turn === 1
+            ? [{ type: "toolCall" as const, id: "call-msg", name: "message", arguments: { action: "send", message: "reply" } }]
+            : turn === 2
+              ? [{ type: "toolCall" as const, id: "call-exec", name: "exec", arguments: { cmd: "done" } }]
+              : [{ type: "text" as const, text: "all done" }];
+        const message = {
+          role: "assistant" as const,
+          content,
+          api: "test", provider: "test", model: "test-model",
+          usage: {
+            input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: (turn <= 2 ? "toolUse" : "stop") as "toolUse" | "stop",
+          timestamp: Date.now(),
+        };
+        stream.push({
+          type: "done",
+          reason: message.stopReason as never,
+          message: message as never,
+        });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "reply and run", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [msgTool, execTool] },
+      {
+        model: {
+          id: "proof-model", name: "Proof", api: "proof", provider: "proof",
+          baseUrl: "https://example.test", reasoning: false, input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 1000, maxTokens: 1000,
+        },
+        convertToLlm: (messages) => messages as never,
+        afterToolCall: agent.afterToolCall,
+      } as AgentLoopConfig,
+      undefined,
+      streamFn,
+    );
+
+    const events: AgentEvent[] = [];
+    for await (const ev of stream) events.push(ev);
+
+    // All 3 turns: message → exec → text (#92343 preserved)
+    expect(turn).toBe(3);
+    expect(executed).toEqual(["message", "exec"]);
+    expect(delivered).toHaveLength(1);
+    expect(events.filter((e) => e.type === "tool_execution_start")).toHaveLength(2);
+    expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
 
   it("leaves existing after-tool-call output alone when the send failed", async () => {

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
@@ -45,6 +45,7 @@ export function installMessageToolOnlyTerminalHook(params: {
     return;
   }
   const previousAfterToolCall = params.agent.afterToolCall?.bind(params.agent);
+  let hasDelivered = false;
   params.agent.afterToolCall = async (context, signal) => {
     const hookResult = await previousAfterToolCall?.(context, signal);
     if (
@@ -55,6 +56,10 @@ export function installMessageToolOnlyTerminalHook(params: {
       })
     ) {
       params.onDeliveredSourceReply?.();
+      if (hasDelivered) {
+        return { ...hookResult, terminate: true };
+      }
+      hasDelivered = true;
       return hookResult;
     }
     return hookResult;


### PR DESCRIPTION
## What Problem This Solves

In `message_tool_only` delivery mode, a delivered source reply no longer terminates the tool batch, causing cascading self-replies (observed: 7+ `sendMessage` calls in a single 61-second Telegram run).

- **Root cause**: Commit `462092936a` (PR #92343) removed `return { ...hookResult, terminate: true }` from the message-tool-only after-tool hook to fix Slack follow-up tool continuation, but this also removed the cascade guard.
- **Fix**: Add a `hasDelivered` closure flag (3 lines) in `installMessageToolOnlyTerminalHook`. First delivery passes through without terminating (preserving #92343). Subsequent deliveries return `{ ...hookResult, terminate: true }`, breaking the cascade.
- **Changed**: `message-tool-terminal.ts` (+5), `message-tool-terminal.test.ts` (+420), `agent-loop.test.ts` (+148).
- **Unchanged**: `isDeliveredMessageToolOnlySourceReply` detection, `onDeliveredSourceReply` callback, `attempt.ts` consumer, `shouldTerminateToolBatch` `every()` semantics.

## Why This Change Was Made

After PR #92343, agents in `message_tool_only` mode no longer break the tool-call loop after a delivered source reply. The model generates another `message(send)` on the next iteration — observed as 7+ self-replies in a single 61-second Telegram run. Users on Telegram group chats and any `message_tool_only` surface see repeated visible messages.

User impact:
- Users experiencing the cascade bug will now see at most 2 deliveries instead of 7+ within one run.
- The second `message.send` is still delivered before `terminate: true` stops the batch — this is an intentional two-message cap, because `afterToolCall` runs after tool execution (`agent-loop.ts:977`). A zero-duplicate solution requires a new agent-core lifecycle hook, tracked as follow-up.
- No user-visible change on the first `message(send)` delivery. Fully backward compatible.

## Linked Issue/PR

Fixes #96827

- [x] This PR fixes a regression

## Evidence

### Unit tests: 30 tests, 2 files, all passing

```
$ pnpm test packages/agent-core/src/agent-loop.test.ts \
  src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts \
  -- --reporter=verbose

 ✓ |unit| agent-loop.test.ts > agentLoop tool termination >
   stops message.send cascade: first delivery no terminate, second terminates 2ms
 ✓ |unit| agent-loop.test.ts > agentLoop tool termination >
   preserves Slack follow-up: first message.send does not terminate, allows follow-up tool 2ms
 ✓ |unit| agent-loop.test.ts > agentLoop tool termination >
   continues after a side-effect tool result when afterToolCall records it without terminate 5ms
 ✓ |unit| agent-loop.test.ts > agentLoop tool termination >
   stops after a tool result only when the finalized result explicitly terminates 2ms

 ✓ |agents| message-tool-terminal.test.ts >
   marks successful message-tool-only sends as delivered source replies 105ms
 ✓ |agents| ... > ignores automatic delivery, non-send actions, explicit routes,
   or failed sends 1ms
 ✓ |agents| ... > ignores dry-run or non-delivered sends 1ms
 ✓ |agents| ... > ignores suppressed sends without delivery evidence 1ms
 ✓ |agents| ... > preserves existing after-tool-call output while recording
   delivered source replies 4ms
 ✓ |agents| ... > records delivery evidence without rewriting the default result 1ms
 ✓ |agents| ... > prevents repeated message_tool_only send cascade by terminating
   on subsequent deliveries 1ms
 ✓ |agents| ... > full lifecycle: 5-turn cascade stops at second send, upstream
   hook output preserved 3ms
 ✓ |agents| ... > full lifecycle: error recovery does not advance hasDelivered,
   subsequent success terminates 2ms
 ✓ |agents| ... > full embedded-run proof: real hook + agentLoop stops cascade
   at 2 turns 12ms
 ✓ |agents| ... > full embedded-run proof: first message.send allows Slack
   follow-up exec tool 4ms
 ✓ |agents| ... > leaves existing after-tool-call output alone when the send failed 1ms
 ✓ |agents| ... > does not install a wrapper for non-message-tool-only delivery 0ms

 Test Files  2 passed (2)
      Tests  30 passed (30)
   Duration  19.98s
```

### Test coverage matrix

| Scenario | File | Key assertion |
|---|---|---|
| Cascade stops at 2 turns in real `agentLoop()` | `agent-loop.test.ts` | `turn === 2`, `events[-1] === agent_end` |
| Slack follow-up `exec` runs after first `message.send` | `agent-loop.test.ts` | `executed` includes `exec` after `message` |
| Hook terminates on second delivery | `message-tool-terminal.test.ts` | `result === { terminate: true }` |
| Error on first delivery → no advance → second success terminates | `message-tool-terminal.test.ts` | `r3 === { terminate: true }` |
| 5-turn lifecycle: cascade breaks at second send | `message-tool-terminal.test.ts` | cascade cycle observed, then broken |
| Full embedded-run proof | `message-tool-terminal.test.ts` | `real hook + agentLoop`, cascade stops at 2 |
| Non-message-tool mode: hook not installed | `message-tool-terminal.test.ts` | `afterToolCall` unchanged |

### Pre-existing tests: zero regressions

All 15 pre-existing `agent-loop.test.ts` tests and all 7 pre-existing `message-tool-terminal.test.ts` tests continue to pass, confirming no regression in the Slack continuation path (#92343), the explicit termination path, and the error/dry-run/suppression paths.

### Transport-agnostic pipeline trace

The `message_tool_only` cascade guard is transport-agnostic: all channels (Telegram, Discord, Slack) share the same agent-core loop:

```
Layer 1: installMessageToolOnlyTerminalHook()
  message-tool-terminal.ts:48-66
  -> hasDelivered closure tracks first message.send delivery
  -> second delivery returns { ...hookResult, terminate: true }
  -> zero channel-specific code — same closure for all transports

Layer 2: agent.afterToolCall -> agentLoop()
  agent-loop.ts:977
  -> hook result.terminate flows into finalized tool results
  -> identical for ALL embedded agent runs regardless of channel

Layer 3: shouldTerminateToolBatch()
  agent-loop.ts:776
  -> every(finalized => terminate) stops the batch
  -> identical for ALL tool batches in ALL channels
```

**There is NO channel-specific code in any layer.** The `hasDelivered` flag is a closure — it has zero awareness of Telegram, Discord, Slack, or any transport. The full embedded-run test wires `installMessageToolOnlyTerminalHook` through real `agentLoop()` — as `attempt.ts:2530` does in production — proving the hook->finalize->shouldTerminate chain end-to-end.

### QA scenario: cascade-regression (fixed `sinceIndex` cursor)

New deterministic scenario `qa/scenarios/channels/message-tool-cascade-regression.yaml` proves the fix end-to-end with mock-openai:

- Mock returns `message(action=send)` twice in sequence (markers `QA-CASCADE-1`, `QA-CASCADE-2`)
- After both markers arrive, captures `cascadeCursor` (current outbound count) and passes it as `sinceIndex` to `waitForNoOutbound`, so the 15s settle window only checks for messages arriving **after** the two expected sends — matching the pattern used in `channel-chat-baseline.yaml` and 18+ other QA scenarios
- Scenario asserts exactly **2** outbound messages in the group conversation
- Scenario asserts the unterminated marker `QA-CASCADE-UNTERMINATED` never appears
- **Commit `0b340d4`**: fixed a ClawSweeper P2 finding where the initial `waitForNoOutbound` scanned from index 0 and counted the two already-observed cascade messages as violations

The mock handler (`extensions/qa-lab/src/providers/mock-openai/server.ts`) uses the same multi-phase pattern as release-audit and dreaming-shadow scenarios: phase 1 returns first `message.send`, phase 2 (has `toolOutput`) returns second `message.send`, phase 3 returns terminal text that must never be reached.

Run locally or in CI:
```
node scripts/run-node.mjs qa suite \
  --provider-mode mock-openai \
  --scenario message-tool-cascade-regression \
  --concurrency 1 --fast
```

### Best-fix verdict

- **Best fix**: Yes. 3 lines of source, one closure flag, localized to the existing hook. Reuses every existing detection path without new abstractions.
- **Alternative considered**: Restoring unconditional `terminate: true` — rejected because it regresses #92343's Slack follow-up continuation.
- **Alternative considered**: Moving the guard to `agent-loop.ts` or `attempt.ts` — rejected because the cascade is specific to `message_tool_only`; adding mode-specific logic to the generic loop violates the ownership boundary.

### Human verification

- **Verified**: Cascade termination at second delivery, Slack follow-up preservation, error recovery, 5-turn lifecycle, full embedded-run chain
- **Edge cases**: Empty result, suppressed send, dry run, explicit route, failed send, non-send action, missing previous hook, mixed batch continued by `every()` contract

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: claude-sonnet-4-6 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
