### PR TITLE
Fix #96525: Engage model fallback chain on cron result-level failures

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -2,6 +2,10 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { wrapUntrustedPromptDataBlock } from "../../agents/sanitize-for-prompt.js";
@@ -295,6 +299,13 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      classifyResult: ({ provider, model, result }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider,
+          model,
+          result,
+        }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());


### PR DESCRIPTION
## What Problem This Solves

Isolated cron runs use `runWithModelFallback` for provider/model fallback, but the cron code path was missing the `classifyResult` and `mergeExhaustedResult` callbacks. Without these, the fallback chain could not detect result-level failures (reasoning-only, empty, or incomplete-turn results), causing cron runs to silently drop answers that a normal chat path would recover via fallback.

## Why This Change Was Made

Added `classifyEmbeddedAgentRunResultForModelFallback` as `classifyResult` and `mergeEmbeddedAgentRunResultForModelFallbackExhaustion` as `mergeExhaustedResult` to the cron `runWithModelFallback` call, matching the behavior already present in the normal chat path.

## Evidence

- The cron isolated-agent path now uses the same result-fallback classifier as the normal embedded agent runner
- TypeScript compilation verified clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)