### PR TITLE
fix(agents): allow per-call host=node override from auto when sandbox…

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -191,16 +191,20 @@ describe("resolveExecTarget", () => {
     );
   });
 
-  it("rejects per-call host=node override from auto when sandbox is available", () => {
-    expect(() =>
+  it("allows per-call host=node override from auto when sandbox is available", () => {
+    expectExecTarget(
       resolveExecTarget({
         configuredTarget: "auto",
         requestedTarget: "node",
         elevatedRequested: false,
         sandboxAvailable: true,
       }),
-    ).toThrow(
-      "exec host not allowed (requested node; configured host is auto; set tools.exec.host=node to allow this override).",
+      {
+        configuredTarget: "auto",
+        requestedTarget: "node",
+        selectedTarget: "node",
+        effectiveHost: "node",
+      },
     );
   });
 
@@ -358,6 +362,36 @@ describe("resolveExecTarget", () => {
       }),
     ).toThrow(
       "exec host not allowed (requested gateway; configured host is node; set tools.exec.host=gateway or auto to allow this override).",
+    );
+  });
+
+  it("rejects per-call host=gateway override from auto when sandbox is available (negative control)", () => {
+    expect(() =>
+      resolveExecTarget({
+        configuredTarget: "auto",
+        requestedTarget: "gateway",
+        elevatedRequested: false,
+        sandboxAvailable: true,
+      }),
+    ).toThrow(
+      "exec host not allowed (requested gateway; configured host is auto; set tools.exec.host=gateway to allow this override).",
+    );
+  });
+
+  it("allows per-call host=node override from auto when sandbox is available (regression: #61009)", () => {
+    expectExecTarget(
+      resolveExecTarget({
+        configuredTarget: "auto",
+        requestedTarget: "node",
+        elevatedRequested: false,
+        sandboxAvailable: true,
+      }),
+      {
+        configuredTarget: "auto",
+        requestedTarget: "node",
+        selectedTarget: "node",
+        effectiveHost: "node",
+      },
     );
   });
 });

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -213,10 +213,7 @@ export function isRequestedExecTargetAllowed(params: {
     return true;
   }
   if (params.configuredTarget === "auto") {
-    if (
-      params.sandboxAvailable &&
-      (params.requestedTarget === "gateway" || params.requestedTarget === "node")
-    ) {
+    if (params.sandboxAvailable && params.requestedTarget === "gateway") {
       return false;
     }
     return true;

--- a/src/agents/exec-defaults.test.ts
+++ b/src/agents/exec-defaults.test.ts
@@ -28,7 +28,7 @@ describe("resolveExecDefaults", () => {
     ).toBe(false);
   });
 
-  it("does not advertise node routing when exec host is auto and sandbox is available", () => {
+  it("advertises node routing when exec host is auto and sandbox is available", () => {
     const defaults = resolveExecDefaults({
       cfg: {
         tools: {
@@ -42,7 +42,7 @@ describe("resolveExecDefaults", () => {
 
     expect(defaults.host).toBe("auto");
     expect(defaults.effectiveHost).toBe("sandbox");
-    expect(defaults.canRequestNode).toBe(false);
+    expect(defaults.canRequestNode).toBe(true);
   });
 
   it("keeps node routing available when exec host is auto without sandbox", () => {
@@ -294,7 +294,7 @@ describe("resolveExecDefaults", () => {
     });
   });
 
-  it("blocks node advertising in helper calls when sandbox is available", () => {
+  it("allows node advertising in helper calls when sandbox is available", () => {
     expect(
       canExecRequestNode({
         cfg: {
@@ -306,6 +306,6 @@ describe("resolveExecDefaults", () => {
         },
         sandboxAvailable: true,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #61009

## What Problem This Solves

Fixes #61009 — `isRequestedExecTargetAllowed` incorrectly rejects per-call `host=node` from `tools.exec.host=auto` when a sandbox runtime is active. The docs explicitly state "Per-call host=node is allowed from auto" (retained through #70543's normalized auto mode refactor), but the runtime sympathetically blocks both `gateway` and `node`.

## Why This Change Was Made

Two prior docs-only PRs (#73757, #89439) attempted to align the docs with the wrong runtime behavior and were both closed. This PR takes the correct approach: fixing the runtime to match documented product intent. Only `host=gateway` should be blocked from `auto` with an active sandbox (prevents sandbox bypass); `host=node` is a safe per-call override.

## User Impact

Users who set `tools.exec.host=auto` with a sandbox runtime active can now use per-call `host=node` (e.g. `/exec host=node`) to execute commands on the local machine without changing their global config. The security boundary is preserved: per-call `host=gateway` remains blocked from `auto` when sandbox is active.

## Evidence

**Root cause**: `src/agents/bash-tools.exec-runtime.ts:218` — `isRequestedExecTargetAllowed` incorrectly grouped `requestedTarget === "node"` with `requestedTarget === "gateway"` in the rejection condition.

**Fix**: Remove `params.requestedTarget === "node"` from the rejection condition (net -3 prod lines).

**Tests** (114 total, all passing):
- `bash-tools.exec-runtime.test.ts` — 38 tests (2 updated)
- `exec-defaults.test.ts` — 13 tests (2 updated)
- `bash-tools.exec.security-floor.test.ts` — 15 tests
- `bash-tools.exec-host-node.test.ts` — 48 tests

**Negative control**: per-call `host=gateway` from `auto` + sandbox → still rejected

**Regression (#61009)**: per-call `host=node` from `auto` + sandbox → now allowed

**Format/lint**: oxfmt check + oxlint check both clean.
