### PR TITLE
fix(signal): strip media-store UUID suffix from outbound attachment filenames

### DIFF
--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -512,6 +512,41 @@ describe("containerSendMessage", () => {
     // Cleanup
     await fs.rm(tmpDir, { recursive: true });
   });
+
+  it("strips the internal media-store UUID suffix from outbound attachment filenames", async () => {
+    const fs = await import("node:fs/promises");
+    const os = await import("node:os");
+    const path = await import("node:path");
+
+    // Mirror the media-store staging shape (`<original-name>---<uuid>.<ext>`)
+    // produced by saveMediaBuffer for every outbound attachment.
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "signal-test-"));
+    const stagedFile = path.join(tmpDir, "report---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg");
+    await fs.writeFile(stagedFile, Buffer.from([0xff, 0xd8, 0xff, 0xe0])); // JPEG magic bytes
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({}),
+    });
+
+    await containerSendMessage({
+      baseUrl: "http://localhost:8080",
+      account: "+14259798283",
+      recipients: ["+15550001111"],
+      message: "Photo",
+      attachments: [stagedFile],
+    });
+
+    const body = parseFetchBody();
+    if (!Array.isArray(body.base64_attachments)) {
+      throw new Error("expected base64 attachments array");
+    }
+    // Recipient must see "report.jpg", not "report---<uuid>.jpg".
+    expect(body.base64_attachments[0]).toMatch(/^data:image\/jpeg;filename=report\.jpg;base64,/);
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
 });
 
 describe("containerSendTyping", () => {

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -7,9 +7,12 @@
  */
 
 import fs from "node:fs/promises";
-import nodePath from "node:path";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
-import { detectMime, parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
+import {
+  detectMime,
+  extractOriginalFilename,
+  parseMediaContentLength,
+} from "openclaw/plugin-sdk/media-runtime";
 import {
   parseStrictNonNegativeInteger,
   resolveTimerTimeoutMs,
@@ -381,7 +384,11 @@ async function filesToBase64DataUris(filePaths: string[]): Promise<string[]> {
   for (const filePath of filePaths) {
     const buffer = await fs.readFile(filePath);
     const mime = (await detectMime({ buffer, filePath })) ?? "application/octet-stream";
-    const filename = nodePath.basename(filePath);
+    // Outbound media is staged in the media store as `<name>---<uuid>.<ext>`.
+    // Recover the caller-facing name so recipients don't see the internal UUID
+    // suffix; extractOriginalFilename strips only that staging shape and otherwise
+    // returns the plain basename (same helper the msteams channel uses).
+    const filename = extractOriginalFilename(filePath);
     const b64 = buffer.toString("base64");
     results.push(`data:${mime};filename=${filename};base64,${b64}`);
   }


### PR DESCRIPTION
## What Problem This Solves

When OpenClaw sends an outbound attachment through the Signal (bbernhard container) channel, the recipient sees the file named with an internal media-store UUID suffix — e.g. `report---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg` instead of `report.jpg`.

Every outbound attachment is staged into the media store as `<original-name>---<uuid>.<ext>` (`saveMediaBuffer` in `src/media/store.ts`, reached via `resolveOutboundAttachmentFromUrl` in `src/media/outbound-attachment.ts`). Channels are expected to recover the caller-facing name with `extractOriginalFilename` before presenting it: the msteams channel does this (`extensions/msteams/src/media-helpers.ts`), and the core `loadWebMedia` path was fixed to do it in #96565. The Signal container client missed it — `filesToBase64DataUris` built the data-URI `filename=` straight from `path.basename(stagedPath)`, leaking the UUID suffix into the `base64_attachments` payload sent to the container.

## Why This Change Was Made

`extractOriginalFilename` is the canonical helper for exactly this shape: it strips only the `---<uuid>` staging suffix and otherwise returns the plain basename, so non-staged names pass through unchanged. Reusing it keeps Signal consistent with the msteams channel and the #96565 core fix rather than inventing a new path. Signal's `filesToBase64DataUris` only ever receives store-staged attachment paths (from `resolveOutboundAttachmentFromUrl`), so no media-dir guard is needed here — that guard lives in `web-media` only because it also loads user-supplied paths.

Risk note: this changes only the *displayed* attachment filename for outbound Signal media; bytes, MIME detection, and delivery are untouched.

## User Impact

Signal recipients now see the original attachment filename (`report.jpg`) instead of the internal `report---<uuid>.jpg`. No config or other behavior change.

## Evidence

AI-assisted (Claude). Commands run locally on a normal checkout. All numbers below are synthetic test values (no real phone numbers/accounts/endpoints).

**Premise — outbound staging really mints the suffix (real core function, no mocks).** Drove `saveMediaBuffer(buffer, "image/png", "outbound", …, "report.png")` — the function `src/infra/outbound/message-action-params.ts` uses to hand channels their path:
- staged basename = `report---e46cdea3-a285-48f6-958d-ad31352855d6.png`
- `extractOriginalFilename(stagedPath)` = `report.png`

**Real local container round-trip (real HTTP `fetch`, no mock).** Stood up a real `node:http` server emulating the bbernhard `/v2/send` endpoint, pointed `containerSendMessage` at it, and let the real Signal transport (`resolveFetch` → real `fetch` → real POST) deliver the payload. The server decoded the received `base64_attachments[0]` and logged the on-the-wire `filename=`:

| source | `filename=` the container actually received |
| --- | --- |
| pre-fix (`basename`) | `report---a1b2c3d4-5678-90ab-cdef-1234567890ab.jpg`  ← leak |
| this PR (`extractOriginalFilename`) | `report.jpg` |

So the corrected value is what actually crosses the wire to the container; the container forwards that filename to the recipient unchanged.

**Unit regression + negative control.** `node scripts/run-vitest.mjs run extensions/signal/src/client-container.test.ts` → `Test Files 1 passed (1) · Tests 50 passed (50)` (49 existing + 1 new). The new test drives `containerSendMessage` end-to-end and asserts `filename=report.jpg`; reverting the one-line fix flips it to the leaked `report---<uuid>.jpg` (fails), and the existing `filename=test-image.jpg` test (a plain, non-staged name) still passes, confirming non-staged names are untouched.

Also clean: `oxfmt --check`, `oxlint`, `tsgo:extensions` (all exit 0).

**On the "stored data model" review flag:** the flagged `extensions/signal/src/client-container.test.ts` change is a base64 data-URI string inside a unit-test assertion, not a persisted data model or serialized state — no migration/upgrade path is involved.

**Not tested:** no round-trip against a live, account-registered Signal/bbernhard deployment. Because the `filename=` value is fully determined by OpenClaw before the REST call and the container forwards it verbatim, the real-HTTP round-trip above captures the determinative behavior; a fully live send would only re-confirm the same string reaches the recipient.
