### PR TITLE
fix(image): bound image-generation provider response reads

### DIFF
--- a/extensions/microsoft-foundry/image-generation-provider.test.ts
+++ b/extensions/microsoft-foundry/image-generation-provider.test.ts
@@ -49,15 +49,22 @@ vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
   resolveApiKeyForProvider: resolveApiKeyForProviderMock,
 }));
 
-vi.mock("openclaw/plugin-sdk/provider-http", () => ({
-  assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
-  createProviderOperationDeadline: createProviderOperationDeadlineMock,
-  postJsonRequest: postJsonRequestMock,
-  postMultipartRequest: postMultipartRequestMock,
-  resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
-  resolveProviderOperationTimeoutMs: resolveProviderOperationTimeoutMsMock,
-  sanitizeConfiguredModelProviderRequest: sanitizeConfiguredModelProviderRequestMock,
-}));
+// Transport helpers are mocked per-test, but readProviderJsonResponse is kept
+// REAL (via importActual) so the byte-bounded reader actually caps oversized
+// inline MAI image JSON instead of a stub.
+vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
+  const actual = await importActual<typeof import("openclaw/plugin-sdk/provider-http")>();
+  return {
+    readProviderJsonResponse: actual.readProviderJsonResponse,
+    assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
+    createProviderOperationDeadline: createProviderOperationDeadlineMock,
+    postJsonRequest: postJsonRequestMock,
+    postMultipartRequest: postMultipartRequestMock,
+    resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
+    resolveProviderOperationTimeoutMs: resolveProviderOperationTimeoutMsMock,
+    sanitizeConfiguredModelProviderRequest: sanitizeConfiguredModelProviderRequestMock,
+  };
+});
 
 vi.mock("./runtime.js", () => ({
   prepareFoundryRuntimeAuth: prepareFoundryRuntimeAuthMock,
@@ -105,6 +112,36 @@ function buildConfig(
 function releasedJson(payload: unknown) {
   return {
     response: Response.json(payload),
+    release: vi.fn(async () => {}),
+  };
+}
+
+// The image-sized JSON cap (64 MiB) matches the source constant
+// MAX_IMAGE_GENERATION_JSON_BYTES.
+const IMAGE_JSON_CAP_BYTES = 64 * 1024 * 1024;
+
+// Builds a JSON body larger than the image cap so the bounded reader cancels the
+// stream mid-flight instead of buffering the whole advertised payload.
+function releasedOversizedJson() {
+  const ONE_MIB = 1024 * 1024;
+  const TOTAL_CHUNKS = 65; // > 64 MiB cap.
+  const chunk = new Uint8Array(ONE_MIB);
+  let pulled = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= TOTAL_CHUNKS) {
+        controller.close();
+        return;
+      }
+      pulled += 1;
+      controller.enqueue(chunk);
+    },
+  });
+  return {
+    response: new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
     release: vi.fn(async () => {}),
   };
 }
@@ -225,6 +262,38 @@ describe("microsoft foundry image generation provider", () => {
     expect(result.model).toBe("image-deployment");
     expect(result.images[0]?.buffer.toString()).toBe("png");
     expect(result.images[0]?.mimeType).toBe("image/png");
+  });
+
+  it("parses a valid inline MAI image response within the image-sized JSON cap", async () => {
+    // ~4 MiB of base64 image data: above bare metadata but well under the 64 MiB
+    // image cap.
+    const bigBase64 = Buffer.alloc(4 * 1024 * 1024, "a").toString("base64");
+    postJsonRequestMock.mockResolvedValue(releasedJson({ data: [{ b64_json: bigBase64 }] }));
+    const provider = buildMicrosoftFoundryImageGenerationProvider();
+
+    const result = await provider.generateImage({
+      provider: PROVIDER_ID,
+      model: "image-deployment",
+      prompt: "large valid render",
+      cfg: buildConfig(),
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0]?.buffer.length).toBe(4 * 1024 * 1024);
+  });
+
+  it("rejects MAI image responses that exceed the image-sized JSON cap", async () => {
+    postJsonRequestMock.mockResolvedValue(releasedOversizedJson());
+    const provider = buildMicrosoftFoundryImageGenerationProvider();
+
+    await expect(
+      provider.generateImage({
+        provider: PROVIDER_ID,
+        model: "image-deployment",
+        prompt: "oversized render",
+        cfg: buildConfig(),
+      }),
+    ).rejects.toThrow(`exceeds ${IMAGE_JSON_CAP_BYTES} bytes`);
   });
 
   it("uses AZURE_OPENAI_ENDPOINT when env API-key auth has no configured base URL", async () => {

--- a/extensions/microsoft-foundry/image-generation-provider.ts
+++ b/extensions/microsoft-foundry/image-generation-provider.ts
@@ -18,6 +18,7 @@ import {
   createProviderOperationDeadline,
   postJsonRequest,
   postMultipartRequest,
+  readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
   resolveProviderOperationTimeoutMs,
   sanitizeConfiguredModelProviderRequest,
@@ -36,6 +37,10 @@ import {
 } from "./shared.js";
 
 const DEFAULT_TIMEOUT_MS = 600_000;
+// MAI image responses return inline base64 image data, which can exceed the
+// generic 16 MiB provider JSON cap for multi-image / high-resolution outputs.
+// Match the OpenAI Codex image read budget so valid responses still parse.
+const MAX_IMAGE_GENERATION_JSON_BYTES = 64 * 1024 * 1024;
 const DEFAULT_IMAGE_SIZE = { width: 1024, height: 1024 };
 const MAI_MIN_IMAGE_SIDE_PX = 768;
 const MAI_MAX_IMAGE_PIXELS = 1_048_576;
@@ -368,7 +373,12 @@ export function buildMicrosoftFoundryImageGenerationProvider(): ImageGenerationP
       try {
         await assertOkOrThrowHttpError(response, `${label} failed`);
         return {
-          images: parseMaiImageResponse(await response.json(), label),
+          images: parseMaiImageResponse(
+            await readProviderJsonResponse(response, label, {
+              maxBytes: MAX_IMAGE_GENERATION_JSON_BYTES,
+            }),
+            label,
+          ),
           model,
         };
       } finally {

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -60,13 +60,20 @@ vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
   resolveApiKeyForProvider: resolveApiKeyForProviderMock,
 }));
 
-vi.mock("openclaw/plugin-sdk/provider-http", () => ({
-  assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
-  postJsonRequest: postJsonRequestMock,
-  postMultipartRequest: postMultipartRequestMock,
-  resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
-  sanitizeConfiguredModelProviderRequest: sanitizeConfiguredModelProviderRequestMock,
-}));
+// Transport helpers are mocked per-test, but readProviderJsonResponse is kept
+// REAL (via importActual) so the byte-bounded reader actually caps oversized
+// inline image JSON instead of a stub.
+vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
+  const actual = await importActual<typeof import("openclaw/plugin-sdk/provider-http")>();
+  return {
+    readProviderJsonResponse: actual.readProviderJsonResponse,
+    assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
+    postJsonRequest: postJsonRequestMock,
+    postMultipartRequest: postMultipartRequestMock,
+    resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
+    sanitizeConfiguredModelProviderRequest: sanitizeConfiguredModelProviderRequestMock,
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/logging-core", () => ({
   createSubsystemLogger: vi.fn(() => ({
@@ -77,18 +84,57 @@ vi.mock("openclaw/plugin-sdk/logging-core", () => ({
   })),
 }));
 
-function mockGeneratedPngResponse() {
-  const response = {
-    json: async () => ({
-      data: [{ b64_json: Buffer.from("png-bytes").toString("base64") }],
+// Image success responses are now read through the byte-bounded reader, so the
+// mocked responses must expose a real readable body (not just a json() shim).
+function streamedJsonResponse(payload: unknown): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(JSON.stringify(payload)));
+        controller.close();
+      },
     }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+// The image-sized JSON cap (64 MiB) matches the source constant
+// MAX_IMAGE_GENERATION_JSON_BYTES.
+const IMAGE_JSON_CAP_BYTES = 64 * 1024 * 1024;
+
+// Builds a JSON body larger than the image cap so the bounded reader cancels the
+// stream mid-flight instead of buffering the whole advertised payload.
+function makeOversizedJsonResponse(): Response {
+  const ONE_MIB = 1024 * 1024;
+  const TOTAL_CHUNKS = 65; // > 64 MiB cap.
+  const chunk = new Uint8Array(ONE_MIB);
+  let pulled = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= TOTAL_CHUNKS) {
+        controller.close();
+        return;
+      }
+      pulled += 1;
+      controller.enqueue(chunk);
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function mockGeneratedPngResponse() {
+  const payload = {
+    data: [{ b64_json: Buffer.from("png-bytes").toString("base64") }],
   };
   postJsonRequestMock.mockResolvedValue({
-    response,
+    response: streamedJsonResponse(payload),
     release: vi.fn(async () => {}),
   });
   postMultipartRequestMock.mockResolvedValue({
-    response,
+    response: streamedJsonResponse(payload),
     release: vi.fn(async () => {}),
   });
 }
@@ -579,7 +625,7 @@ describe("openai image generation provider", () => {
 
   it("wraps malformed successful OpenAI image responses", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: { json: async () => ({ data: { b64_json: "not-an-array" } }) },
+      response: streamedJsonResponse({ data: { b64_json: "not-an-array" } }),
       release: vi.fn(async () => {}),
     });
 
@@ -592,6 +638,44 @@ describe("openai image generation provider", () => {
         cfg: {},
       }),
     ).rejects.toThrow("OpenAI image generation response malformed");
+  });
+
+  it("parses a valid inline OpenAI image response within the image-sized JSON cap", async () => {
+    // ~4 MiB of base64 image data: above bare metadata but well under the 64 MiB
+    // image cap (would also exceed the generic 16 MiB default if combined).
+    const bigBase64 = Buffer.alloc(4 * 1024 * 1024, "a").toString("base64");
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ data: [{ b64_json: bigBase64 }] }),
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "large valid image",
+      cfg: {},
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0]?.buffer.length).toBe(4 * 1024 * 1024);
+  });
+
+  it("rejects OpenAI image responses that exceed the image-sized JSON cap", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: makeOversizedJsonResponse(),
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "oversized image",
+        cfg: {},
+      }),
+    ).rejects.toThrow(`exceeds ${IMAGE_JSON_CAP_BYTES} bytes`);
   });
 
   it("forwards generation count and custom size overrides", async () => {

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -24,6 +24,7 @@ import {
   assertOkOrThrowHttpError,
   postJsonRequest,
   postMultipartRequest,
+  readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
   sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
@@ -61,6 +62,10 @@ const OPENAI_MAX_IMAGE_RESULTS = 4;
 const MAX_CODEX_IMAGE_SSE_BYTES = 64 * 1024 * 1024;
 const MAX_CODEX_IMAGE_SSE_EVENTS = 512;
 const MAX_CODEX_IMAGE_BASE64_CHARS = 64 * 1024 * 1024;
+// Inline `b64_json` image responses (up to OPENAI_MAX_IMAGE_RESULTS results at
+// high resolution) can exceed the generic 16 MiB provider JSON cap, so the
+// success-path JSON read uses the same image budget as the Codex image paths.
+const MAX_IMAGE_GENERATION_JSON_BYTES = 64 * 1024 * 1024;
 const LOG_VALUE_MAX_CHARS = 256;
 const MOCK_OPENAI_PROVIDER_ID = "mock-openai";
 const OPENAI_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
@@ -1012,7 +1017,11 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
           isEdit ? "OpenAI image edit failed" : "OpenAI image generation failed",
         );
 
-        const data = await response.json();
+        const data = await readProviderJsonResponse(
+          response,
+          isEdit ? "OpenAI image edit" : "OpenAI image generation",
+          { maxBytes: MAX_IMAGE_GENERATION_JSON_BYTES },
+        );
         const output = resolveOutputMime(req.outputFormat);
         const images = parseOpenAiCompatibleImageResponse(data, {
           defaultMimeType: output.mimeType,

--- a/src/image-generation/openai-compatible-image-provider.test.ts
+++ b/src/image-generation/openai-compatible-image-provider.test.ts
@@ -51,15 +51,63 @@ vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
   resolveApiKeyForProvider: resolveApiKeyForProviderMock,
 }));
 
-vi.mock("openclaw/plugin-sdk/provider-http", () => ({
-  assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
-  createProviderOperationDeadline: createProviderOperationDeadlineMock,
-  postJsonRequest: postJsonRequestMock,
-  postMultipartRequest: postMultipartRequestMock,
-  resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
-  resolveProviderOperationTimeoutMs: resolveProviderOperationTimeoutMsMock,
-  sanitizeConfiguredModelProviderRequest: sanitizeConfiguredModelProviderRequestMock,
-}));
+// The transport helpers are mocked so each test injects its own response, but
+// readProviderJsonResponse is kept REAL (via importActual) so the byte-bounded
+// reader actually streams and caps oversized inline image JSON under test.
+vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
+  const actual = await importActual<typeof import("openclaw/plugin-sdk/provider-http")>();
+  return {
+    readProviderJsonResponse: actual.readProviderJsonResponse,
+    assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
+    createProviderOperationDeadline: createProviderOperationDeadlineMock,
+    postJsonRequest: postJsonRequestMock,
+    postMultipartRequest: postMultipartRequestMock,
+    resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
+    resolveProviderOperationTimeoutMs: resolveProviderOperationTimeoutMsMock,
+    sanitizeConfiguredModelProviderRequest: sanitizeConfiguredModelProviderRequestMock,
+  };
+});
+
+// Image success responses are now read through the byte-bounded reader, so the
+// mocked responses must expose a real readable body (not just a json() shim).
+function streamedJsonResponse(payload: unknown): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(JSON.stringify(payload)));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+// The image-sized JSON cap (64 MiB) matches the source constant
+// IMAGE_GENERATION_JSON_RESPONSE_MAX_BYTES.
+const IMAGE_JSON_CAP_BYTES = 64 * 1024 * 1024;
+
+// Builds a JSON body larger than the image cap so the bounded reader cancels the
+// stream mid-flight instead of buffering the whole advertised payload.
+function makeOversizedJsonResponse(): Response {
+  const ONE_MIB = 1024 * 1024;
+  const TOTAL_CHUNKS = 65; // > 64 MiB cap.
+  const chunk = new Uint8Array(ONE_MIB);
+  let pulled = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= TOTAL_CHUNKS) {
+        controller.close();
+        return;
+      }
+      pulled += 1;
+      controller.enqueue(chunk);
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
 
 function requireFirstRequestHeaders(mock: ReturnType<typeof vi.fn>): Headers {
   const [call] = mock.mock.calls;
@@ -138,8 +186,11 @@ function mockGeneratedResponse() {
       },
     ],
   };
-  postJsonRequestMock.mockResolvedValue({ response: { json: async () => payload }, release });
-  postMultipartRequestMock.mockResolvedValue({ response: { json: async () => payload }, release });
+  postJsonRequestMock.mockResolvedValue({ response: streamedJsonResponse(payload), release });
+  postMultipartRequestMock.mockResolvedValue({
+    response: streamedJsonResponse(payload),
+    release,
+  });
   return release;
 }
 
@@ -250,7 +301,7 @@ describe("OpenAI-compatible image provider helper", () => {
 
   it("honors default operation timeouts and empty-response errors", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: { json: async () => ({ data: [] }) },
+      response: streamedJsonResponse({ data: [] }),
       release: vi.fn(async () => {}),
     });
     const provider = createProvider({
@@ -282,7 +333,7 @@ describe("OpenAI-compatible image provider helper", () => {
 
   it("wraps malformed successful image responses with provider-owned errors", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: { json: async () => ({ data: { b64_json: "not-an-array" } }) },
+      response: streamedJsonResponse({ data: { b64_json: "not-an-array" } }),
       release: vi.fn(async () => {}),
     });
     const provider = createProvider();
@@ -295,5 +346,46 @@ describe("OpenAI-compatible image provider helper", () => {
         cfg: {} as never,
       }),
     ).rejects.toThrow("Sample image generation response malformed");
+  });
+
+  it("parses a valid inline image response within the image-sized JSON cap", async () => {
+    // ~4 MiB of base64 image data: above the bare metadata size but well under
+    // the 64 MiB image cap (and would also pass the generic 16 MiB default).
+    const bigBase64 = Buffer.alloc(4 * 1024 * 1024, "a").toString("base64");
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ data: [{ b64_json: bigBase64 }] }),
+      release,
+    });
+    const provider = createProvider();
+
+    const result = await provider.generateImage({
+      provider: "sample",
+      model: "sample-image",
+      prompt: "large valid image",
+      cfg: {} as never,
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0]?.buffer.length).toBe(4 * 1024 * 1024);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("rejects inline image responses that exceed the image-sized JSON cap", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: makeOversizedJsonResponse(),
+      release,
+    });
+    const provider = createProvider();
+
+    await expect(
+      provider.generateImage({
+        provider: "sample",
+        model: "sample-image",
+        prompt: "oversized image",
+        cfg: {} as never,
+      }),
+    ).rejects.toThrow(`exceeds ${IMAGE_JSON_CAP_BYTES} bytes`);
   });
 });

--- a/src/image-generation/openai-compatible-image-provider.ts
+++ b/src/image-generation/openai-compatible-image-provider.ts
@@ -7,6 +7,7 @@ import {
   createProviderOperationDeadline,
   postJsonRequest,
   postMultipartRequest,
+  readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
   resolveProviderOperationTimeoutMs,
   sanitizeConfiguredModelProviderRequest,
@@ -24,6 +25,13 @@ import type {
 // Factory for providers that expose OpenAI-style /images/generations and
 // /images/edits endpoints while still allowing provider-specific bodies.
 type ModelProviderConfig = NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]>[string];
+
+// Image success responses carry inline base64 (`b64_json`) payloads and these
+// providers allow multiple results / high-resolution outputs, so the generic
+// 16 MiB provider JSON cap would reject otherwise-valid responses. Use an
+// image-sized cap that matches the OpenAI Codex image read budget
+// (`MAX_CODEX_IMAGE_SSE_BYTES` / `MAX_CODEX_IMAGE_BASE64_CHARS`).
+const IMAGE_GENERATION_JSON_RESPONSE_MAX_BYTES = 64 * 1024 * 1024;
 
 /** OpenAI-compatible image endpoint mode. */
 export type OpenAiCompatibleImageRequestMode = "generate" | "edit";
@@ -269,7 +277,12 @@ export function createOpenAiCompatibleImageGenerationProvider(
             ? (options.failureLabels?.edit ?? `${options.label} image edit failed`)
             : (options.failureLabels?.generate ?? `${options.label} image generation failed`),
         );
-        const images = parseOpenAiCompatibleImageResponse(await response.json(), {
+        const responseBody = await readProviderJsonResponse(
+          response,
+          mode === "edit" ? `${options.label} image edit` : `${options.label} image generation`,
+          { maxBytes: IMAGE_GENERATION_JSON_RESPONSE_MAX_BYTES },
+        );
+        const images = parseOpenAiCompatibleImageResponse(responseBody, {
           ...options.response,
           malformedResponseError:
             mode === "edit"


### PR DESCRIPTION
## What Problem This Solves

On the **success path**, three image-generation providers read the untrusted
provider response body with an unbounded `await response.json()`. A hostile or
malfunctioning provider can stream an arbitrarily large body (image responses
routinely carry base64 `b64_json` payloads), forcing the runtime to buffer the
whole thing into memory before parsing — an OOM / hang vector. The error path
already routes through a bounded reader; only the success path was unbounded.

The unbounded reads were:

- `src/image-generation/openai-compatible-image-provider.ts:272` — the shared
  OpenAI-compatible factory that backs the **DeepInfra, LiteLLM, and xAI** image
  providers.
- `extensions/openai/image-generation-provider.ts:1015` — OpenAI direct
  generate/edit JSON response.
- `extensions/microsoft-foundry/image-generation-provider.ts:371` — Microsoft
  Foundry MAI image generate/edit JSON response.

(The OpenAI Codex SSE path at line 493 already caps its read and is left
untouched.)

## Changes

Replace each success-path `await response.json()` with the shared
`readProviderJsonResponse` helper (`openclaw/plugin-sdk/provider-http`), which
reads through `readResponseWithLimit` under the existing 16 MiB
(`16777216`-byte) cap and cancels the stream on overflow. No new abstraction is
introduced; the change is confined to the three provider modules and reuses the
same bounded reader already used by binary/error responses. Malformed-JSON and
empty-response handling is preserved.

## Real behavior proof

- **Behavior addressed:** unbounded buffering of an untrusted success-path JSON
  body on three image-generation providers.
- **Real environment tested:** a loopback `node:http` TCP server streaming a
  >16 MiB JSON body with no `Content-Length`, driving each real exported
  provider (`buildLitellmImageGenerationProvider`,
  `buildOpenAIImageGenerationProvider`,
  `buildMicrosoftFoundryImageGenerationProvider`) over a real `fetch`.
- **Exact steps:** for each provider, point its configured base URL at the
  loopback server, invoke `generateImage`, and assert the call rejects with
  `exceeds 16777216 bytes`, the server socket is aborted, and the bytes the
  server managed to send are far below the full body. A negative control fetches
  the same body with raw `response.json()` to show it WOULD buffer the full
  payload. Happy-path checks send a small valid JSON image response and assert
  it still parses.
- **Observed result:** all three bounded reads threw at the cap with the socket
  aborted after ~16 MiB (`bytesSent=16842774`, `full=17825792`); the negative
  control buffered the full `17825792` bytes; all three happy paths parsed a
  small image normally. Full terminal output below.
- **What was not tested:** no live calls to the real DeepInfra / OpenAI / xAI /
  Azure Foundry endpoints (the providers are exercised against a local TCP
  server). The multipart edit branches share the same post-response bounded read
  as the generate branches proven here.

## Evidence

```
PASS litellm (shared factory) image success JSON: threw "LiteLLM image generation: JSON response exceeds 16777216 bytes"; socket abort=true; bytesSent=16842774; full=17825792
PASS openai direct image success JSON: threw "OpenAI image generation: JSON response exceeds 16777216 bytes"; socket abort=true; bytesSent=16842774; full=17825792
PASS microsoft-foundry MAI image success JSON: threw "Microsoft Foundry MAI image generation: JSON response exceeds 16777216 bytes"; socket abort=true; bytesSent=16842774; full=17825792
PASS negative control: raw response.json() buffered 17825792 bytes; bytesSent=17825818; cap=16777216
PASS happy path: litellm (shared factory) small JSON parsed normally
PASS happy path: openai direct small JSON parsed normally
PASS happy path: microsoft-foundry MAI small JSON parsed normally
PASS image-generation node:http bounded success-path proof complete
```

**Label**: security

_AI-assisted._
