### PR TITLE
fix: streaming chat fails when gateway mislabels SSE as JSON [AI-assisted]

### DIFF
--- a/real-proof-96497.mjs
+++ b/real-proof-96497.mjs
@@ -1,0 +1,70 @@
+// Real-runtime proof for #96497: drives the REAL buildGuardedModelFetch transport
+// (src/agents/provider-transport-fetch.ts, including the sanitizeOpenAISdkSseResponse
+// fix) against a REAL local HTTP server that streams SSE mislabeled as JSON.
+// No vitest, no mocks of the transport — real network I/O + real OpenAI SDK parser.
+import http from "node:http";
+import { Stream } from "openai/streaming";
+import { buildGuardedModelFetch } from "./src/agents/provider-transport-fetch.ts";
+
+const HEAD = String(process.env.PROOF_HEAD || "").trim();
+console.log(`[proof] openclaw provider transport double-prefix repro (head=${HEAD || "n/a"})`);
+
+// 1. Real local OpenAI-compatible gateway: returns standard SSE frames but MISLABELS
+//    content-type as application/json (the vLLM/Ollama/custom-proxy regression trigger).
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+  res.write(
+    'data: {"id":"a","choices":[{"index":0,"delta":{"content":"Hi","role":"assistant"}}]}\n\n',
+  );
+  res.write('data: {"id":"a","choices":[{"index":0,"delta":{"content":" there"}}]}\n\n');
+  res.write("data: [DONE]\n\n");
+  res.end();
+});
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+const port = server.address().port;
+const base = `http://127.0.0.1:${port}`;
+console.log(
+  `[proof] local gateway listening at ${base} (content-type mislabeled as application/json)`,
+);
+
+// 2. Real transport. endpointClass resolves to "local" from the loopback baseUrl,
+//    so SSRF trusts the configured origin — real fetch hits the real server.
+const model = {
+  id: "MiniMax-M3",
+  provider: "hetu",
+  api: "openai-completions",
+  baseUrl: base,
+};
+const guardedFetch = buildGuardedModelFetch(model);
+
+const response = await guardedFetch(`${base}/v1/chat/completions`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ model: "MiniMax-M3", stream: true }),
+});
+console.log(
+  `[proof] response status=${response.status} content-type=${response.headers.get("content-type")}`,
+);
+
+// 3. Real OpenAI SDK SSE parser consumes the sanitized stream.
+const items = [];
+let parseError = null;
+try {
+  for await (const item of Stream.fromSSEResponse(response, new AbortController())) {
+    items.push(item);
+  }
+} catch (err) {
+  parseError = err;
+}
+
+if (parseError) {
+  console.log(`[proof] RESULT: SDK PARSE FAILED -> ${parseError.name}: ${parseError.message}`);
+} else {
+  console.log(`[proof] RESULT: SDK PARSED ${items.length} frames`);
+  for (const item of items) {
+    console.log(`[proof]   frame: ${JSON.stringify(item)}`);
+  }
+}
+
+server.close();
+process.exit(parseError ? 1 : 0);

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1162,6 +1162,60 @@ describe("buildGuardedModelFetch", () => {
     expect(items).toEqual([{ ok: true }]);
   });
 
+  it("does not double-prefix SSE bodies mislabeled as JSON by streaming gateways", async () => {
+    const encoder = new TextEncoder();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"id":"a","choices":[{"index":0,"delta":{"content":"Hi","role":"assistant"}}]}\n\n',
+              ),
+            );
+            controller.enqueue(
+              encoder.encode(
+                'data: {"id":"a","choices":[{"index":0,"delta":{"content":" there"}}]}\n\n',
+              ),
+            );
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        // Real SSE body, but mislabeled with a JSON content-type, as some
+        // OpenAI-compatible gateways (vLLM, Ollama, custom proxies) return.
+        { headers: { "content-type": "application/json; charset=utf-8" } },
+      ),
+      finalUrl: "https://gateway.example/v1/chat/completions",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "MiniMax-M3",
+      provider: "hetu",
+      api: "openai-completions",
+      baseUrl: "https://gateway.example/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://gateway.example/v1/chat/completions",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "MiniMax-M3", stream: true }),
+      },
+    );
+
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    const items = [];
+    for await (const item of Stream.fromSSEResponse(response, new AbortController())) {
+      items.push(item);
+    }
+    expect(items).toEqual([
+      { id: "a", choices: [{ index: 0, delta: { content: "Hi", role: "assistant" } }] },
+      { id: "a", choices: [{ index: 0, delta: { content: " there" } }] },
+    ]);
+  });
+
   it("does not clone Request bodies while checking for streaming JSON fallbacks", async () => {
     const cloneSpy = vi.spyOn(Request.prototype, "clone");
     fetchWithSsrFGuardMock.mockResolvedValue({

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -114,7 +114,19 @@ function sanitizeOpenAISdkSseResponse(
               buffer += decoder.decode();
               const data = buffer.trim();
               if (data) {
-                controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                if (classifyOpenAISdkStreamBodyPrefix(data) === "sse") {
+                  // Some OpenAI-compatible gateways stream real SSE
+                  // (`data: {...}`) but mislabel the response as JSON. Re-wrapping
+                  // the body as `data: ${data}` would double-prefix every frame to
+                  // `data: data: {...}` and break JSON.parse in the SDK. Pass the
+                  // already-SSE body through verbatim (tolerating both `{...}` and
+                  // `data: {...}` shapes) and normalize it to a single trailing
+                  // event terminator.
+                  const normalizedSse = data.replace(/(?:\r\n|\n|\r)+$/u, "");
+                  controller.enqueue(encoder.encode(`${normalizedSse}\n\n`));
+                } else {
+                  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                }
               }
               controller.enqueue(encoder.encode("data: [DONE]\n\n"));
               controller.close();

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -120,10 +120,9 @@ function sanitizeOpenAISdkSseResponse(
                   // the body as `data: ${data}` would double-prefix every frame to
                   // `data: data: {...}` and break JSON.parse in the SDK. Pass the
                   // already-SSE body through verbatim (tolerating both `{...}` and
-                  // `data: {...}` shapes) and normalize it to a single trailing
-                  // event terminator.
-                  const normalizedSse = data.replace(/(?:\r\n|\n|\r)+$/u, "");
-                  controller.enqueue(encoder.encode(`${normalizedSse}\n\n`));
+                  // `data: {...}` shapes). `data` is already trimmed, so appending a
+                  // single event terminator yields well-formed SSE.
+                  controller.enqueue(encoder.encode(`${data}\n\n`));
                 } else {
                   controller.enqueue(encoder.encode(`data: ${data}\n\n`));
                 }


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code. Closes #96497.

## What Problem This Solves

Fixes an issue where users of self-hosted OpenAI-compatible gateways (vLLM, Ollama, custom proxies) would see every streaming chat turn fail before producing a reply with `Could not parse message into JSON: data: {...}` / `Unexpected token 'd', "data: {"id"... is not valid JSON` on OpenClaw 2026.6.x. The gateway returns standard single-prefix SSE (`data: {...}`), but when it mislabels the response `content-type` as `application/json`, OpenClaw re-wraps the body as `data: ${data}`, producing `data: data: {...}` which the OpenAI SDK cannot JSON.parse. This is a regression from 2026.5.4.

## Why This Change Was Made

In `sanitizeOpenAISdkSseResponse` (`src/agents/provider-transport-fetch.ts`), the `synthesizeJsonAsSse` branch buffers a JSON-labeled streaming body and emits it as a single SSE event via `data: ${data}\n\n`. When the body is already valid SSE, that re-prefixes every frame to `data: data: {...}`.

The fix detects already-SSE bodies at the synthesis point using the existing `classifyOpenAISdkStreamBodyPrefix` classifier: if the buffered body classifies as `"sse"`, it is passed through verbatim (with a normalized single trailing event terminator) instead of being re-wrapped. Genuine JSON bodies (`{...}` / `[...]`) still take the original `data: ${data}` synthesis path, so non-SSE JSON streaming is unchanged. This directly implements the issue's requested tolerance for both `data: {...}` and `{...}` body shapes. Non-goal: it does not change content-type normalization for the `text/event-stream` path or the missing-content-type sniff path.

## User Impact

Streaming chat against OpenAI-compatible gateways that mislabel SSE as JSON now works again: the response streams normally instead of failing with a JSON parse error before the first token. Gateways that already send a correct `text/event-stream` content-type, and gateways that genuinely return JSON, are unaffected.

## Evidence

This PR ships a real-runtime reproduction script `real-proof-96497.mjs` at the repo root. It starts a real local OpenAI-compatible HTTP gateway on `127.0.0.1` that streams standard SSE frames (`data: {...}\n\n`) but mislabels the response `content-type` as `application/json`, then drives the real `buildGuardedModelFetch` provider transport against it and iterates the real OpenAI SDK `Stream.fromSSEResponse` parser. No transport mocking. (A focused regression case in `src/agents/provider-transport-fetch.test.ts` covers the same path in the suite.)

Before the fix (parent commit `a0b397748f`), the real transport emits the `data: data: {...}` double-prefix on the wire and the SDK fails with the exact error from the issue:

```
$ pnpm exec tsx real-proof-96497.mjs   (real local gateway + real transport + real SDK parser)
[proof] local gateway listening at http://127.0.0.1:50423 (content-type mislabeled as application/json)
[model-fetch] start provider=hetu api=openai-completions model=MiniMax-M3 url=http://127.0.0.1:50423/v1/chat/completions policy=custom
[model-fetch] response provider=hetu api=openai-completions model=MiniMax-M3 status=200 contentType=application/json; charset=utf-8
[proof] response status=200 content-type=text/event-stream; charset=utf-8
Could not parse message into JSON: data: {"id":"a","choices":[{"index":0,"delta":{"content":"Hi","role":"assistant"}}]}
From chunk: [
  'data: data: {"id":"a","choices":[{"index":0,"delta":{"content":"Hi","role":"assistant"}}]}'
]
[proof] RESULT: SDK PARSE FAILED -> SyntaxError: Unexpected token 'd', "data: {"id"... is not valid JSON
```

After the fix, the same real-transport run streams correctly with no `data: data:` double-prefix:

```
[model-fetch] response provider=hetu api=openai-completions model=MiniMax-M3 status=200 contentType=application/json; charset=utf-8
[proof] response status=200 content-type=text/event-stream; charset=utf-8
[proof] RESULT: SDK PARSED 2 frames
[proof]   frame: {"id":"a","choices":[{"index":0,"delta":{"content":"Hi","role":"assistant"}}]}
[proof]   frame: {"id":"a","choices":[{"index":0,"delta":{"content":" there"}}]}
```

Local verification on Windows, Node v22.22.3: `pnpm tsgo` clean; `oxlint` on changed files clean; changed files pass `format:check` (221 pre-existing repo-wide format findings on `main` are unrelated to this change). The `openai-responses`/non-`openai-completions` and genuine-JSON synthesis paths are covered by existing regression coverage and remain green.

## Real behavior proof

- Behavior or issue addressed: Streaming chat fails before reply when an OpenAI-compatible gateway returns real SSE mislabeled as JSON, because OpenClaw double-prefixes `data:` before JSON parsing.
- Environment used for testing: Windows 10, Node v22.22.3, real local OpenAI-compatible HTTP gateway on 127.0.0.1, real OpenClaw provider transport, real OpenAI SDK streaming parser.
- Steps to reproduce: Run `real-proof-96497.mjs` (added in this PR) — it starts a real local gateway that streams `data: {...}\n\n` frames with `content-type: application/json`, points the real `buildGuardedModelFetch` transport at it, and iterates the real SDK SSE stream. Run on parent commit `a0b397748f` then on this branch.
- Observed result before fix: Real transport emits `data: data: {...}` on the wire; SDK raises `SyntaxError: Unexpected token 'd', "data: {"id"... is not valid JSON`; zero frames parsed.
- Observed result after fix: Two SSE frames parse into the expected delta items; no double-prefix.
- Evidence after fix (terminal capture):
```
$ pnpm exec tsx real-proof-96497.mjs   (real local gateway + real transport + real SDK parser)
[proof] local gateway listening at http://127.0.0.1:49813 (content-type mislabeled as application/json)
[model-fetch] start provider=hetu api=openai-completions model=MiniMax-M3 url=http://127.0.0.1:49813/v1/chat/completions policy=custom
[model-fetch] response provider=hetu api=openai-completions model=MiniMax-M3 status=200 contentType=application/json; charset=utf-8
[proof] response status=200 content-type=text/event-stream; charset=utf-8
[proof] RESULT: SDK PARSED 2 frames
[proof]   frame: {"id":"a","choices":[{"index":0,"delta":{"content":"Hi","role":"assistant"}}]}
[proof]   frame: {"id":"a","choices":[{"index":0,"delta":{"content":" there"}}]}
```

## Compatibility / Migration

No config, schema, or public CLI surface changes. The new branch only activates for JSON-labeled bodies that are already SSE (previously broken); genuine JSON synthesis and `text/event-stream` sanitization are untouched. Revert by removing the `classifyOpenAISdkStreamBodyPrefix(data) === "sse"` branch in `sanitizeOpenAISdkSseResponse`.

## Risks and Mitigations

- A gateway that returns a body starting with an SSE field prefix (`data:`, `event:`, `:`, `id:`, `retry:`) but is not intended as SSE would now pass through verbatim instead of being wrapped. Such a body is already valid SSE by the SSE spec, so the SDK parses it the same way; genuine JSON (`{`/`[`) never matches the `"sse"` classification. Mitigated by reusing the existing classifier rather than introducing a new heuristic.

## What was not tested

- No live external gateway (vLLM/Ollama/cloud proxy) was available; the repro uses the real transport + real SDK parser against a local SSE response rather than a live provider call.
- macOS/iOS not tested; the fix is platform-agnostic transport-layer logic.
- `pnpm check:host-env-policy:swift` skipped on Windows (no Swift toolchain).
