### PR TITLE
Fix #96588: Use numeric collation for model alias version sorting

### DIFF
--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -116,11 +116,11 @@ function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | 
 
   if (aliases.length > 0) {
     // Prefer alias - if multiple aliases, pick the one that sorts highest
-    aliases.sort((a, b) => b.id.localeCompare(a.id));
+    aliases.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
     return aliases[0];
   }
   // No alias found, pick latest dated version
-  datedVersions.sort((a, b) => b.id.localeCompare(a.id));
+  datedVersions.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
   return datedVersions[0];
 }
 


### PR DESCRIPTION
## What Problem This Solves

Model alias resolution uses `localeCompare` without `{ numeric: true }`, which uses lexicographic ordering. When a model family reaches double-digit minor versions (e.g., `claude-sonnet-4-10` vs `claude-sonnet-4-9`), lexicographic sort picks `4-9` over `4-10` because `"9" > "1"`, causing the resolver to select an older version.

## Why This Change Was Made

Adding `{ numeric: true }` to `localeCompare` calls in the alias and dated-versions sorting makes version comparison numerically correct, so `4-10` > `4-9`.

## Evidence

- All existing model-resolver tests pass
- TypeScript compilation verified clean
- Before: `["claude-sonnet-4-10", "claude-sonnet-4-9"].sort((a,b) => b.localeCompare(a))` → `["claude-sonnet-4-9", "claude-sonnet-4-10"]` (wrong)
- After: `["claude-sonnet-4-10", "claude-sonnet-4-9"].sort((a,b) => b.localeCompare(a, undefined, { numeric: true }))` → `["claude-sonnet-4-10", "claude-sonnet-4-9"]` (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)