### PR TITLE
docs(logging): document exact model.usage diagnostic event fields and clarify event bus dispatch

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -371,10 +371,44 @@ to them directly without OTLP export.
 
 **Model usage**
 
-- `model.usage` - tokens, cost, duration, context, provider/model/channel,
-  session ids. `usage` is provider/turn accounting for cost and telemetry;
-  `context.used` is the current prompt/context snapshot and can be lower than
-  provider `usage.total` when cached input or tool-loop calls are involved.
+- `model.usage` - emitted after an agent turn when diagnostics are enabled and
+  usage is nonzero. The event carries the following fields:
+
+  Shared diagnostic envelope (added by the dispatcher before listeners receive
+  the event):
+  - `ts`: Unix timestamp in milliseconds when the event was dispatched.
+  - `seq`: Monotonically increasing sequence number within the diagnostic
+    session.
+  - `trace`: Optional distributed-trace context (`traceparent`, etc.).
+
+  Model-usage payload:
+  - `type`: `"model.usage"`.
+  - `sessionKey`: Session identifier string.
+  - `sessionId`: Session identifier string.
+  - `channel`: Originating channel, e.g. `"telegram"`, `"discord"`, or `"web"`.
+  - `agentId`: Active agent id.
+  - `provider`: Model provider name, e.g. `"openai"` or `"anthropic"`.
+  - `model`: Model identifier, e.g. `"gpt-4o"` or `"claude-sonnet-4-20250514"`.
+  - `usage.input`: Input token count.
+  - `usage.output`: Output token count.
+  - `usage.cacheRead`: Cached input tokens read from the provider prompt cache.
+  - `usage.cacheWrite`: Cached input tokens written to the provider prompt cache.
+  - `usage.promptTokens`: Prompt tokens; may differ from `usage.input` when
+    caching is involved.
+  - `usage.total`: Total token count.
+  - `context.limit`: Context-window token limit for the model.
+  - `context.used`: Actual context tokens used; can be lower than
+    `usage.total` when cached input or tool-loop calls are involved.
+  - `costUsd`: Estimated cost in USD; omitted when cost configuration is
+    unavailable.
+  - `durationMs`: Total turn duration in milliseconds.
+  - `lastCallUsage`: Per-call usage breakdown from the last individual API call
+    (optional). When present it contains the same shape as `usage`:
+    `input`, `output`, `cacheRead`, `cacheWrite`, and `total`.
+
+  `usage` is provider/turn accounting for cost and telemetry; `context.used`
+  is the current prompt/context snapshot and can be lower than provider
+  `usage.total` when cached input or tool-loop calls are involved.
 
 **Message flow**
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -118,6 +118,13 @@ available:
 OpenClaw preserves the original structured log arguments alongside these fields
 so existing parsers that read numbered tslog argument keys keep working.
 
+Diagnostic events such as `model.usage`, `session.state`, and
+`message.delivery.*` are dispatched through the diagnostic event bus and
+consumed by the stability recorder, OTLP exporter, and other diagnostic
+listeners. They are **not** written to the JSONL file log. See the
+[Diagnostic event catalog](/gateway/opentelemetry#diagnostic-event-catalog)
+for the exact field names and structure of each event type.
+
 Talk, realtime voice, and managed-room activity emits bounded lifecycle log
 records through this same file-log pipeline. These records include event type,
 mode, transport, provider, and size/timing measurements when available, but omit


### PR DESCRIPTION
Closes #49046

## What Problem This Solves

Fixes an issue where users building log parsers or cost-tracking integrations for OpenClaw could not find the exact JSON field names of the `model.usage` diagnostic event in the public docs. The diagnostic catalog and logging docs described the event only at a high level, forcing parser authors to inspect source code to learn the precise payload structure.

## Why This Change Was Made

This change documents the complete `model.usage` diagnostic event payload in the diagnostic event catalog, including the shared diagnostic envelope (`ts`, `seq`, `trace`) and all model-usage fields (`sessionKey`, `sessionId`, `channel`, `agentId`, `provider`, `model`, `usage.*`, `context.*`, `costUsd`, `durationMs`, and optional `lastCallUsage.*`). It also adds a note in the logging docs clarifying that diagnostic events are dispatched through the diagnostic event bus and are not written to the JSONL file log.

## User Impact

Developers and operators building external tooling (for example, cost trackers that parse OpenClaw diagnostics) can now rely on the documented field names without reading source code. The distinction between file-log JSONL records and diagnostic-event-bus payloads is also clearer, reducing confusion about where `model.usage` data is available.

## Evidence

- `pnpm docs:check-links` passes with 0 broken links.
- `git diff --check` passes with no whitespace errors.
- The documented field names were verified against `DiagnosticUsageEvent` and `DiagnosticBaseEvent` in `src/infra/diagnostic-events.ts`.
