### PR TITLE
fix(session): prevent daily-reset archive from renaming live transcript mid-run

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -72,6 +72,7 @@ import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
+import { replyRunRegistry } from "./reply-run-registry.js";
 import { isResetAuthorizedForContext } from "./reset-authorization.js";
 import {
   maybeRetireLegacyMainDeliveryRoute,
@@ -541,7 +542,11 @@ async function initSessionStateAttemptLocked(
     (isSystemEvent && canReuseExistingEntry) ||
     (((reconnectResumeRequested && canReuseExistingEntry) ||
       (entryFreshness?.fresh ?? false) ||
-      (softResetAllowed && canReuseExistingEntry)) &&
+      (softResetAllowed && canReuseExistingEntry) ||
+      // Don't allow a daily/idle stale session to be archived while a reply run
+      // is still active — the archive renames the live transcript out from under
+      // the running turn, splitting output across archived/orphan files (#96546).
+      (!resetTriggered && replyRunRegistry.isActive(sessionKey) && canReuseExistingEntry)) &&
       !terminalMainTranscriptNewerThanRegistry);
   // Capture the current session entry before any reset so its transcript can be
   // archived afterward.  We need to do this for both explicit resets (/new, /reset)


### PR DESCRIPTION
## Summary
- When a daily/idle reset boundary is crossed while a reply run is still active, `initSessionState` would archive the live transcript by renaming it (`archiveFileOnDisk` → `fs.renameSync`), splitting the running turn's output across an archived file and a recreated orphan
- Check `replyRunRegistry.isActive(sessionKey)` before treating a session as stale, deferring the archive until the active run completes
- Only affects implicit (daily/idle) staleness; explicit `/new`/`/reset` commands are unaffected

## Test plan
- [x] TypeScript compilation verified
- [ ] Verify daily reset does not rename transcript while a turn is running
- [ ] Verify explicit `/new` still archives and resets correctly
- [ ] Verify idle reset still archives when no active run

Fixes #96546

🤖 Generated with [Claude Code](https://claude.com/claude-code)