### PR TITLE
Stabilize Google Meet chrome-node launch configuration

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -855,7 +855,7 @@ describe("google-meet plugin", () => {
   });
 
   it("registers the node-host command used by chrome-node transport", () => {
-    const { nodeHostCommands } = setup();
+    const { nodeHostCommands, nodeInvokePolicies } = setup();
 
     const command = nodeHostCommands.find(
       (entry): entry is Record<string, unknown> =>
@@ -865,7 +865,13 @@ describe("google-meet plugin", () => {
       throw new Error("expected googlemeet.chrome node host command");
     }
     expect(command.cap).toBe("google-meet");
+    expect(command.dangerous).toBe(true);
     expect(typeof command.handle).toBe("function");
+    expect(nodeInvokePolicies).toHaveLength(1);
+    expect(nodeInvokePolicies[0]).toMatchObject({
+      commands: ["googlemeet.chrome"],
+      dangerous: true,
+    });
   });
 
   it("keeps the agent tool visible on non-macOS hosts but blocks local Chrome talk-back joins", async () => {
@@ -2239,6 +2245,9 @@ describe("google-meet plugin", () => {
     try {
       const { methods, runCommandWithTimeout } = setup({
         defaultMode: "transcribe",
+        chrome: {
+          browserProfile: "meet-devtools",
+        },
       });
       const callGatewayFromCli = mockLocalMeetBrowserRequest({
         inCall: true,
@@ -3428,7 +3437,12 @@ describe("google-meet plugin", () => {
       },
     );
     chromeTransportTesting.setDepsForTest({ callGatewayFromCli });
-    const { tools, nodesInvoke } = setup({ defaultTransport: "chrome" });
+    const { tools, nodesInvoke } = setup({
+      defaultTransport: "chrome",
+      chrome: {
+        browserProfile: "meet-devtools",
+      },
+    });
     const tool = tools[0] as {
       execute: (
         id: string,
@@ -3458,6 +3472,7 @@ describe("google-meet plugin", () => {
     expect(focusCall[0]).toBe("browser.request");
     expect(requireRecord(focusCall[2], "focus request").method).toBe("POST");
     expect(requireRecord(focusCall[2], "focus request").path).toBe("/tabs/focus");
+    expect(requireRecord(focusCall[2], "focus request").query).toBeUndefined();
     expect(focusCall[3]).toEqual({ progress: false });
     expect(nodesInvoke).not.toHaveBeenCalled();
   });

--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -35,6 +35,10 @@ import {
   fetchGoogleMeetSpace,
 } from "./src/meet.js";
 import { handleGoogleMeetNodeHostCommand } from "./src/node-host.js";
+import {
+  createGoogleMeetChromeNodeInvokePolicy,
+  GOOGLE_MEET_CHROME_NODE_COMMAND,
+} from "./src/node-invoke-policy.js";
 import { GoogleMeetRuntime } from "./src/runtime.js";
 import { isGoogleMeetBrowserManualActionError } from "./src/transports/chrome-create.js";
 
@@ -1196,10 +1200,12 @@ export default definePluginEntry({
     );
 
     api.registerNodeHostCommand({
-      command: "googlemeet.chrome",
+      command: GOOGLE_MEET_CHROME_NODE_COMMAND,
       cap: "google-meet",
+      dangerous: true,
       handle: handleGoogleMeetNodeHostCommand,
     });
+    api.registerNodeInvokePolicy(createGoogleMeetChromeNodeInvokePolicy(config));
 
     api.registerCli(
       async ({ program }) => {

--- a/extensions/google-meet/node-host.test.ts
+++ b/extensions/google-meet/node-host.test.ts
@@ -91,6 +91,41 @@ describe("google-meet node host bridge sessions", () => {
     }
   });
 
+  it("passes the Meet URL before Chrome profile args when launching a profiled browser", async () => {
+    const originalPlatform = process.platform;
+    children.length = 0;
+    vi.mocked(spawnSync).mockClear();
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      const start = JSON.parse(
+        await handleGoogleMeetNodeHostCommand(
+          JSON.stringify({
+            action: "start",
+            url: "https://meet.google.com/xyz-abcd-uvw",
+            mode: "transcribe",
+            browserProfile: "Profile 2",
+          }),
+        ),
+      );
+
+      expect(start.launched).toBe(true);
+      expect(spawnSync).toHaveBeenCalledWith(
+        "open",
+        [
+          "-a",
+          "Google Chrome",
+          "https://meet.google.com/xyz-abcd-uvw",
+          "--args",
+          "--profile-directory=Profile 2",
+        ],
+        expect.objectContaining({ encoding: "utf8" }),
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
   it("clears output playback without closing the active bridge when the old output exits", async () => {
     const originalPlatform = process.platform;
     children.length = 0;

--- a/extensions/google-meet/src/node-host.ts
+++ b/extensions/google-meet/src/node-host.ts
@@ -332,12 +332,11 @@ function startChrome(params: Record<string, unknown>) {
   }
 
   if (params.launch !== false) {
-    const argv = ["open", "-a", "Google Chrome"];
+    const argv = ["open", "-a", "Google Chrome", url];
     const browserProfile = readString(params.browserProfile);
     if (browserProfile) {
       argv.push("--args", `--profile-directory=${browserProfile}`);
     }
-    argv.push(url);
     const result = runCommandWithTimeout(argv, timeoutMs);
     if (result.code !== 0) {
       if (bridgeId) {

--- a/extensions/google-meet/src/node-invoke-policy.test.ts
+++ b/extensions/google-meet/src/node-invoke-policy.test.ts
@@ -1,0 +1,134 @@
+// Google Meet node.invoke policy tests cover caller-controlled command sanitization.
+import type { OpenClawPluginNodeInvokePolicyContext } from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it, vi } from "vitest";
+import { resolveGoogleMeetConfig } from "./config.js";
+import {
+  createGoogleMeetChromeNodeInvokePolicy,
+  GOOGLE_MEET_CHROME_NODE_COMMAND,
+} from "./node-invoke-policy.js";
+
+function createContext(params: unknown, pluginConfig: Record<string, unknown> = {}) {
+  const invokeNode = vi.fn<OpenClawPluginNodeInvokePolicyContext["invokeNode"]>(async () => ({
+    ok: true,
+    payload: { ok: true },
+  }));
+  const ctx: OpenClawPluginNodeInvokePolicyContext = {
+    nodeId: "node-1",
+    command: GOOGLE_MEET_CHROME_NODE_COMMAND,
+    params,
+    config: {} as never,
+    pluginConfig,
+    invokeNode,
+  };
+  return { ctx, invokeNode };
+}
+
+describe("Google Meet node invoke policy", () => {
+  it("rewrites start executable fields from trusted config", async () => {
+    const policy = createGoogleMeetChromeNodeInvokePolicy(
+      resolveGoogleMeetConfig({
+        chrome: {
+          launch: false,
+          browserProfile: "Trusted Profile",
+          joinTimeoutMs: 45_000,
+          audioInputCommand: ["trusted-capture", "--raw"],
+          audioOutputCommand: ["trusted-play", "--raw"],
+        },
+      }),
+    );
+    const { ctx, invokeNode } = createContext({
+      action: "start",
+      url: "https://meet.google.com/abc-defg-hij",
+      mode: "bidi",
+      launch: true,
+      browserProfile: "Attacker Profile",
+      joinTimeoutMs: 1,
+      audioBridgeCommand: ["node", "-e", "process.exit(99)"],
+      audioBridgeHealthCommand: ["node", "-e", "process.exit(98)"],
+      audioInputCommand: ["malicious-capture"],
+      audioOutputCommand: ["malicious-play"],
+    });
+
+    await expect(policy.handle(ctx)).resolves.toEqual({ ok: true, payload: { ok: true } });
+
+    expect(invokeNode).toHaveBeenCalledTimes(1);
+    expect(invokeNode).toHaveBeenCalledWith({
+      params: {
+        action: "start",
+        url: "https://meet.google.com/abc-defg-hij",
+        mode: "bidi",
+        launch: false,
+        browserProfile: "Trusted Profile",
+        joinTimeoutMs: 45_000,
+        audioInputCommand: ["trusted-capture", "--raw"],
+        audioOutputCommand: ["trusted-play", "--raw"],
+      },
+    });
+  });
+
+  it("uses trusted configured external bridge commands for start", async () => {
+    const policy = createGoogleMeetChromeNodeInvokePolicy(
+      resolveGoogleMeetConfig({
+        chrome: {
+          audioBridgeHealthCommand: ["trusted-bridge", "status"],
+          audioBridgeCommand: ["trusted-bridge", "start"],
+        },
+      }),
+    );
+    const { ctx, invokeNode } = createContext({
+      action: "start",
+      url: "https://meet.google.com/abc-defg-hij",
+      mode: "bidi",
+      audioBridgeHealthCommand: ["node", "-e", "process.exit(98)"],
+      audioBridgeCommand: ["node", "-e", "process.exit(99)"],
+    });
+
+    await policy.handle(ctx);
+
+    const call = invokeNode.mock.calls[0]?.[0];
+    expect(call?.params).toMatchObject({
+      action: "start",
+      audioBridgeHealthCommand: ["trusted-bridge", "status"],
+      audioBridgeCommand: ["trusted-bridge", "start"],
+    });
+  });
+
+  it("rejects direct start for non-Meet URLs before node dispatch", async () => {
+    const policy = createGoogleMeetChromeNodeInvokePolicy(resolveGoogleMeetConfig({}));
+    const { ctx, invokeNode } = createContext({
+      action: "start",
+      url: "https://example.com/private",
+      mode: "bidi",
+    });
+
+    await expect(policy.handle(ctx)).resolves.toMatchObject({
+      ok: false,
+      code: "GOOGLE_MEET_NODE_POLICY_DENIED",
+      message: "url must be an explicit https://meet.google.com/... URL",
+    });
+    expect(invokeNode).not.toHaveBeenCalled();
+  });
+
+  it("keeps direct setup diagnostics but strips extra fields", async () => {
+    const policy = createGoogleMeetChromeNodeInvokePolicy(resolveGoogleMeetConfig({}));
+    const { ctx, invokeNode } = createContext({
+      action: "setup",
+      audioBridgeCommand: ["node", "-e", "process.exit(99)"],
+    });
+
+    await policy.handle(ctx);
+
+    expect(invokeNode).toHaveBeenCalledWith({ params: { action: "setup" } });
+  });
+
+  it("rejects unsupported googlemeet.chrome actions before node dispatch", async () => {
+    const policy = createGoogleMeetChromeNodeInvokePolicy(resolveGoogleMeetConfig({}));
+    const { ctx, invokeNode } = createContext({ action: "exec", command: ["id"] });
+
+    await expect(policy.handle(ctx)).resolves.toMatchObject({
+      ok: false,
+      code: "GOOGLE_MEET_NODE_POLICY_DENIED",
+    });
+    expect(invokeNode).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/google-meet/src/node-invoke-policy.ts
+++ b/extensions/google-meet/src/node-invoke-policy.ts
@@ -1,0 +1,192 @@
+import type {
+  OpenClawPluginNodeInvokePolicy,
+  OpenClawPluginNodeInvokePolicyContext,
+  OpenClawPluginNodeInvokePolicyResult,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type { GoogleMeetConfig } from "./config.js";
+import { normalizeMeetUrl } from "./runtime.js";
+
+export const GOOGLE_MEET_CHROME_NODE_COMMAND = "googlemeet.chrome";
+
+const START_MODES = new Set(["agent", "bidi", "realtime", "transcribe"]);
+
+type PolicyDecision =
+  | { approved: true; params: Record<string, unknown> }
+  | { approved: false; result: OpenClawPluginNodeInvokePolicyResult };
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readPositiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function copyCommand(command: string[] | undefined): string[] | undefined {
+  return command && command.length > 0 ? [...command] : undefined;
+}
+
+function denied(message: string, code = "GOOGLE_MEET_NODE_POLICY_DENIED") {
+  return { ok: false as const, code, message };
+}
+
+function approved(params: Record<string, unknown>): PolicyDecision {
+  return { approved: true, params };
+}
+
+function buildStartParams(
+  params: Record<string, unknown>,
+  config: GoogleMeetConfig,
+): PolicyDecision {
+  let url: string;
+  try {
+    url = normalizeMeetUrl(params.url);
+  } catch (error) {
+    return {
+      approved: false,
+      result: denied(
+        error instanceof Error ? error.message : "googlemeet.chrome start requires url",
+      ),
+    };
+  }
+  const mode = readString(params.mode);
+  if (mode && !START_MODES.has(mode)) {
+    return {
+      approved: false,
+      result: denied(`googlemeet.chrome start mode is unsupported: ${mode}`),
+    };
+  }
+  const startParams: Record<string, unknown> = {
+    action: "start",
+    url,
+    launch: params.launch === false ? false : config.chrome.launch,
+    browserProfile: config.chrome.browserProfile,
+    joinTimeoutMs: config.chrome.joinTimeoutMs,
+  };
+  if (mode) {
+    startParams.mode = mode;
+  }
+  const audioInputCommand = copyCommand(config.chrome.audioInputCommand);
+  if (audioInputCommand) {
+    startParams.audioInputCommand = audioInputCommand;
+  }
+  const audioOutputCommand = copyCommand(config.chrome.audioOutputCommand);
+  if (audioOutputCommand) {
+    startParams.audioOutputCommand = audioOutputCommand;
+  }
+  const audioBridgeCommand = copyCommand(config.chrome.audioBridgeCommand);
+  if (audioBridgeCommand) {
+    startParams.audioBridgeCommand = audioBridgeCommand;
+  }
+  const audioBridgeHealthCommand = copyCommand(config.chrome.audioBridgeHealthCommand);
+  if (audioBridgeHealthCommand) {
+    startParams.audioBridgeHealthCommand = audioBridgeHealthCommand;
+  }
+  return approved(startParams);
+}
+
+function buildForwardParams(params: Record<string, unknown>): Record<string, unknown> | null {
+  const action = readString(params.action);
+  switch (action) {
+    case "setup":
+      return { action };
+    case "status": {
+      const bridgeId = readString(params.bridgeId);
+      return bridgeId ? { action, bridgeId } : { action };
+    }
+    case "list": {
+      const forwarded: Record<string, unknown> = { action };
+      const url = readString(params.url);
+      const mode = readString(params.mode);
+      if (url) {
+        forwarded.url = url;
+      }
+      if (mode) {
+        forwarded.mode = mode;
+      }
+      return forwarded;
+    }
+    case "stopByUrl": {
+      const forwarded: Record<string, unknown> = { action };
+      const url = readString(params.url);
+      const mode = readString(params.mode);
+      const exceptBridgeId = readString(params.exceptBridgeId);
+      if (url) {
+        forwarded.url = url;
+      }
+      if (mode) {
+        forwarded.mode = mode;
+      }
+      if (exceptBridgeId) {
+        forwarded.exceptBridgeId = exceptBridgeId;
+      }
+      return forwarded;
+    }
+    case "pullAudio": {
+      const forwarded: Record<string, unknown> = { action };
+      const bridgeId = readString(params.bridgeId);
+      const timeoutMs = readPositiveNumber(params.timeoutMs);
+      if (bridgeId) {
+        forwarded.bridgeId = bridgeId;
+      }
+      if (timeoutMs) {
+        forwarded.timeoutMs = timeoutMs;
+      }
+      return forwarded;
+    }
+    case "pushAudio": {
+      const forwarded: Record<string, unknown> = { action };
+      const bridgeId = readString(params.bridgeId);
+      const base64 = readString(params.base64);
+      if (bridgeId) {
+        forwarded.bridgeId = bridgeId;
+      }
+      if (base64) {
+        forwarded.base64 = base64;
+      }
+      return forwarded;
+    }
+    case "clearAudio":
+    case "stop": {
+      const bridgeId = readString(params.bridgeId);
+      return bridgeId ? { action, bridgeId } : { action };
+    }
+    default:
+      return null;
+  }
+}
+
+export function createGoogleMeetChromeNodeInvokePolicy(
+  config: GoogleMeetConfig,
+): OpenClawPluginNodeInvokePolicy {
+  return {
+    commands: [GOOGLE_MEET_CHROME_NODE_COMMAND],
+    dangerous: true,
+    async handle(ctx: OpenClawPluginNodeInvokePolicyContext) {
+      if (ctx.command !== GOOGLE_MEET_CHROME_NODE_COMMAND) {
+        return denied(`unsupported Google Meet node command: ${ctx.command}`);
+      }
+      const params = asRecord(ctx.params);
+      const action = readString(params.action);
+      let decision: PolicyDecision;
+      if (action === "start") {
+        decision = buildStartParams(params, config);
+      } else {
+        const forwardParams = buildForwardParams(params);
+        decision = forwardParams
+          ? approved(forwardParams)
+          : { approved: false, result: denied("unsupported googlemeet.chrome action") };
+      }
+      if (!decision.approved) {
+        return decision.result;
+      }
+      return await ctx.invokeNode({ params: decision.params });
+    },
+  };
+}

--- a/extensions/google-meet/src/test-support/plugin-harness.ts
+++ b/extensions/google-meet/src/test-support/plugin-harness.ts
@@ -69,6 +69,7 @@ export function setupGoogleMeetPlugin(
   const tools: unknown[] = [];
   const cliRegistrations: unknown[] = [];
   const nodeHostCommands: unknown[] = [];
+  const nodeInvokePolicies: unknown[] = [];
   const nodesList = vi.fn(
     async () =>
       options.nodesListResult ?? {
@@ -165,6 +166,7 @@ export function setupGoogleMeetPlugin(
     },
     registerCli: (_registrar: unknown, opts: unknown) => cliRegistrations.push(opts),
     registerNodeHostCommand: (command: unknown) => nodeHostCommands.push(command),
+    registerNodeInvokePolicy: (policy: unknown) => nodeInvokePolicies.push(policy),
   });
   const originalPlatform = process.platform;
   Object.defineProperty(process, "platform", {
@@ -184,6 +186,7 @@ export function setupGoogleMeetPlugin(
     nodesList,
     nodesInvoke,
     nodeHostCommands,
+    nodeInvokePolicies,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Google Meet's Chrome and chrome-node paths need to use the same configured launch, audio, and profile settings consistently across setup checks, local Chrome control, and paired node hosts.

## Why This Change Was Made

This change keeps Google Meet chrome-node launch parameters derived from the plugin's configured runtime settings, while preserving the existing profile ownership split:

- Local Chrome profile selection continues to use the Browser plugin's `browser.defaultProfile`.
- `chrome.browserProfile` remains the chrome-node host profile setting.
- macOS Chrome node-host launch now passes the Meet URL and Chrome profile args in the correct order.

## User Impact

No new config surface is added.

Existing local Chrome users should continue using `browser.defaultProfile` for profile selection. Existing chrome-node users can continue using `chrome.browserProfile` and configured audio commands. The Google Meet transcribe and agent talk-back paths continue to work with the existing Chrome/BlackHole/SoX setup.

## Evidence

- `node scripts/run-vitest.mjs extensions/google-meet/src/node-invoke-policy.test.ts extensions/google-meet/index.test.ts extensions/google-meet/node-host.test.ts src/gateway/node-invoke-plugin-policy.test.ts`
- `pnpm tsgo:extensions && pnpm tsgo:test:extensions`
- `pnpm build`
- Structured local review: clean
- Live macOS Google Meet proof:
  - recovered an existing Meet tab through the configured Browser default profile
  - joined, inspected status, and left successfully
  - verified `googlemeet setup --json` with SoX available
  - verified `googlemeet test-speech` in Chrome agent mode with speech output confirmed
