### PR TITLE
fix(signal): use Homebrew for macOS signal-cli install

### DIFF
--- a/extensions/signal/src/install-signal-cli.test.ts
+++ b/extensions/signal/src/install-signal-cli.test.ts
@@ -5,20 +5,36 @@ import path from "node:path";
 import JSZip from "jszip";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import * as tar from "tar";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReleaseAsset } from "./install-signal-cli.js";
 
-const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
-  fetchWithSsrFGuardMock: vi.fn(),
-}));
+const { fetchWithSsrFGuardMock, resolveBrewExecutableMock, runPluginCommandWithTimeoutMock } =
+  vi.hoisted(() => ({
+    fetchWithSsrFGuardMock: vi.fn(),
+    resolveBrewExecutableMock: vi.fn(),
+    runPluginCommandWithTimeoutMock: vi.fn(),
+  }));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
+vi.mock("openclaw/plugin-sdk/setup-tools", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/setup-tools")>();
+  return {
+    ...actual,
+    resolveBrewExecutable: resolveBrewExecutableMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/run-command", () => ({
+  runPluginCommandWithTimeout: runPluginCommandWithTimeoutMock,
+}));
+
 const {
   downloadToFile,
   extractSignalCliArchive,
+  installSignalCli,
   installSignalCliFromRelease,
   looksLikeArchive,
   pickAsset,
@@ -74,6 +90,8 @@ async function withTempFile(run: (filePath: string) => Promise<void>) {
 
 beforeEach(() => {
   fetchWithSsrFGuardMock.mockReset();
+  resolveBrewExecutableMock.mockReset();
+  runPluginCommandWithTimeoutMock.mockReset();
 });
 
 function requireAsset(asset: ReleaseAsset | undefined, label: string): ReleaseAsset {
@@ -142,6 +160,25 @@ describe("pickAsset", () => {
     it("selects the macOS-native asset on x64", () => {
       const result = requireAsset(pickAsset(SAMPLE_ASSETS, "darwin", "x64"), "darwin x64");
       expect(result.name).toContain("macOS-native");
+    });
+
+    it("does not fall back to Linux client archives when macOS assets are absent", () => {
+      const currentUpstreamAssets: ReleaseAsset[] = [
+        {
+          name: "signal-cli-0.14.5-Linux-client.tar.gz",
+          browser_download_url: "https://example.com/linux-client.tar.gz",
+        },
+        {
+          name: "signal-cli-0.14.5-Linux-native.tar.gz",
+          browser_download_url: "https://example.com/linux-native.tar.gz",
+        },
+        {
+          name: "signal-cli-0.14.5.tar.gz",
+          browser_download_url: "https://example.com/jvm.tar.gz",
+        },
+      ];
+
+      expect(pickAsset(currentUpstreamAssets, "darwin", "arm64")).toBeUndefined();
     });
   });
 
@@ -302,6 +339,46 @@ describe("installSignalCliFromRelease", () => {
       },
     });
     expect(fetchResult.release).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("installSignalCli", () => {
+  const originalPlatform = process.platform;
+  const originalArch = process.arch;
+
+  function setProcessPlatform(platform: NodeJS.Platform, arch: string) {
+    Object.defineProperty(process, "platform", { configurable: true, value: platform });
+    Object.defineProperty(process, "arch", { configurable: true, value: arch });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    Object.defineProperty(process, "arch", { configurable: true, value: originalArch });
+  });
+
+  it("uses Homebrew on macOS instead of downloading the first GitHub release archive", async () => {
+    setProcessPlatform("darwin", "arm64");
+    const brewPrefix = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-brew-"));
+    await fs.mkdir(path.join(brewPrefix, "bin"), { recursive: true });
+    await fs.writeFile(path.join(brewPrefix, "bin", "signal-cli"), "");
+    resolveBrewExecutableMock.mockReturnValue("/opt/homebrew/bin/brew");
+    runPluginCommandWithTimeoutMock
+      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ code: 0, stdout: `${brewPrefix}\n`, stderr: "" })
+      .mockResolvedValueOnce({ code: 0, stdout: "signal-cli 0.14.5\n", stderr: "" });
+
+    try {
+      const result = await installSignalCli({ log: vi.fn() } as unknown as RuntimeEnv);
+
+      expect(result).toEqual({
+        ok: true,
+        cliPath: path.join(brewPrefix, "bin", "signal-cli"),
+        version: "0.14.5",
+      });
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(brewPrefix, { recursive: true, force: true });
+    }
   });
 });
 

--- a/extensions/signal/src/install-signal-cli.ts
+++ b/extensions/signal/src/install-signal-cli.ts
@@ -105,7 +105,7 @@ export function pickAsset(
   }
 
   if (platform === "darwin") {
-    return byName(/macos|osx|darwin/) || archives[0];
+    return byName(/macos|osx|darwin/);
   }
 
   if (platform === "win32") {
@@ -228,7 +228,7 @@ async function installSignalCliViaBrew(runtime: RuntimeEnv): Promise<SignalInsta
     return {
       ok: false,
       error:
-        `No native signal-cli build is available for ${process.arch}. ` +
+        `No native signal-cli build is available for ${process.platform}/${process.arch}. ` +
         "Install Homebrew (https://brew.sh) and try again, or install signal-cli manually.",
     };
   }
@@ -372,9 +372,9 @@ export async function installSignalCli(runtime: RuntimeEnv): Promise<SignalInsta
   }
 
   // The official signal-cli GitHub releases only ship a native binary for
-  // x86-64 Linux.  On other architectures (arm64, armv7, etc.) we delegate
-  // to Homebrew which builds from source and bundles the JRE automatically.
-  const hasNativeRelease = process.platform !== "linux" || process.arch === "x64";
+  // x86-64 Linux.  Other platforms use Homebrew instead of guessing from
+  // unrelated release archives.
+  const hasNativeRelease = process.platform === "linux" && process.arch === "x64";
 
   if (hasNativeRelease) {
     return installSignalCliFromRelease(runtime);


### PR DESCRIPTION
## What Problem This Solves

Signal QuickStart onboarding on macOS can download the upstream `signal-cli-0.14.5-Linux-client.tar.gz` asset when upstream has no macOS release asset. That archive contains `signal-cli-client`, not the `signal-cli` executable OpenClaw configures, so onboarding reports `signal-cli binary not found after extracting ...` and falls through to a manual path prompt.

## Why This Change Was Made

The Signal installer already has a Homebrew install path for platforms without an official native release. This change routes only Linux x64 through the GitHub release download path and sends macOS through Homebrew instead of falling back to unrelated release archives. The asset picker also stops returning Linux archives for darwin when no macOS asset exists.

## User Impact

macOS users selecting Signal during onboarding no longer get a misleading Linux archive download followed by a missing-binary error. If Homebrew is unavailable, the installer now reports the unsupported `platform/arch` pair and asks the user to install Homebrew or signal-cli manually.

## Evidence

- `pnpm test extensions/signal/src/install-signal-cli.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 extensions/signal/src/install-signal-cli.ts extensions/signal/src/install-signal-cli.test.ts`
- `git diff --check`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/signal/src/install-signal-cli.ts extensions/signal/src/install-signal-cli.test.ts`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review this focused OpenClaw Signal installer fix. Scope: macOS signal-cli onboarding should not download the upstream Linux-client archive when upstream has no macOS asset; macOS should use the existing Homebrew path. Touched files: extensions/signal/src/install-signal-cli.ts and its colocated test. Focus on installer behavior, platform routing, and test reliability."`

`pnpm check:changed` was attempted but blocked before repo checks ran because the local Crabbox binary is too old for current Blacksmith Testbox delegation (`requires Crabbox >= 0.22.0`, local reported `0.16.0-114-ged8016f`).
