### PR TITLE
fix(backup): handle ENOENT race when session files are deleted during archive creation (fixes #67417) (AI-assisted)

### DIFF
--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -195,6 +195,42 @@ describe("isTarEofRaceError", () => {
   });
 });
 
+describe("isTarEnoentRaceError", () => {
+  const { isTarEnoentRaceError } = backupCreateInternals;
+
+  it("matches ENOENT errors with a path property (node-tar stat race)", () => {
+    const err = Object.assign(
+      new Error("ENOENT: no such file or directory, lstat '/state/sessions/abc.jsonl'"),
+      {
+        code: "ENOENT",
+        path: "/state/sessions/abc.jsonl",
+      },
+    );
+    expect(isTarEnoentRaceError(err)).toBe(true);
+  });
+
+  it("rejects ENOENT errors without a path property", () => {
+    const err = Object.assign(new Error("ENOENT: no such file or directory"), {
+      code: "ENOENT",
+    });
+    expect(isTarEnoentRaceError(err)).toBe(false);
+  });
+
+  it("rejects non-ENOENT errors even with a path", () => {
+    const err = Object.assign(new Error("EACCES: permission denied"), {
+      code: "EACCES",
+      path: "/state/sessions/abc.jsonl",
+    });
+    expect(isTarEnoentRaceError(err)).toBe(false);
+  });
+
+  it("rejects non-object inputs", () => {
+    expect(isTarEnoentRaceError(null)).toBe(false);
+    expect(isTarEnoentRaceError(undefined)).toBe(false);
+    expect(isTarEnoentRaceError("ENOENT")).toBe(false);
+  });
+});
+
 describe("writeTarArchiveWithRetry", () => {
   it("retries on EOF-class errors and eventually succeeds", async () => {
     const eofErr = Object.assign(new Error("did not encounter expected EOF"), {
@@ -275,6 +311,31 @@ describe("writeTarArchiveWithRetry", () => {
     expect(skippedVolatileCount).toBe(volatileFilesSeenPerAttempt);
   });
 
+  it("retries on ENOENT race errors from concurrent file deletion", async () => {
+    const enoentErr = Object.assign(
+      new Error("ENOENT: no such file or directory, lstat '/state/sessions/abc.jsonl'"),
+      { code: "ENOENT", path: "/state/sessions/abc.jsonl" },
+    );
+    const runTar = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(enoentErr)
+      .mockResolvedValueOnce(undefined);
+    const log = vi.fn();
+    const sleep = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
+
+    await backupCreateInternals.writeTarArchiveWithRetry({
+      tempArchivePath: "/tmp/backup.tar.gz.tmp",
+      runTar,
+      log,
+      sleepMs: sleep,
+    });
+
+    expect(runTar).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, 10_000);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0][0]).toContain("concurrent file deletion");
+  });
+
   it("does not retry on non-EOF errors", async () => {
     const runTar = vi.fn<() => Promise<void>>().mockRejectedValue(new Error("permission denied"));
     const sleep = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
@@ -286,6 +347,24 @@ describe("writeTarArchiveWithRetry", () => {
         sleepMs: sleep,
       }),
     ).rejects.toThrow(/permission denied/);
+    expect(runTar).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("does not retry on ENOENT errors without a path property", async () => {
+    const enoentNoPath = Object.assign(new Error("ENOENT: no such file or directory"), {
+      code: "ENOENT",
+    });
+    const runTar = vi.fn<() => Promise<void>>().mockRejectedValue(enoentNoPath);
+    const sleep = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
+
+    await expect(
+      backupCreateInternals.writeTarArchiveWithRetry({
+        tempArchivePath: "/tmp/backup.tar.gz.tmp",
+        runTar,
+        sleepMs: sleep,
+      }),
+    ).rejects.toThrow(/ENOENT/);
     expect(runTar).toHaveBeenCalledTimes(1);
     expect(sleep).not.toHaveBeenCalled();
   });

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -139,6 +139,20 @@ function isTarEofRaceError(err: unknown): boolean {
   return /(did not encounter expected|encountered unexpected) EOF|TAR_BAD_ARCHIVE/i.test(message);
 }
 
+/**
+ * Returns true when the error is an ENOENT from a concurrent file deletion
+ * during tar archive creation. The `path` property distinguishes this from
+ * unrelated ENOENT errors (e.g. temp-dir cleanup): node-tar sets it to the
+ * file that disappeared mid-walk.
+ */
+function isTarEnoentRaceError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const nodeErr = err as NodeJS.ErrnoException;
+  return nodeErr.code === "ENOENT" && typeof nodeErr.path === "string";
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -161,7 +175,8 @@ async function writeTarArchiveWithRetry(params: {
       return;
     } catch (err) {
       lastErr = err;
-      if (!isTarEofRaceError(err) || attempt === BACKUP_TAR_MAX_ATTEMPTS) {
+      const isRetryable = isTarEofRaceError(err) || isTarEnoentRaceError(err);
+      if (!isRetryable || attempt === BACKUP_TAR_MAX_ATTEMPTS) {
         break;
       }
       try {
@@ -176,8 +191,9 @@ async function writeTarArchiveWithRetry(params: {
       }
       const backoff = BACKUP_TAR_BACKOFF_MS[attempt - 1] ?? 0;
       const offendingPath = (err as NodeJS.ErrnoException).path;
+      const raceKind = isTarEnoentRaceError(err) ? "concurrent file deletion" : "live-write race";
       params.log?.(
-        `Backup archiver hit a live-write race${
+        `Backup archiver hit a ${raceKind}${
           offendingPath ? ` on ${offendingPath}` : ""
         } (attempt ${attempt}/${BACKUP_TAR_MAX_ATTEMPTS}); retrying in ${Math.round(backoff / 1000)}s.`,
       );
@@ -192,7 +208,7 @@ async function writeTarArchiveWithRetry(params: {
   throw new Error(`Backup archive write failed: ${final.message}${suffix}`, { cause: final });
 }
 
-export const testApi = { writeTarArchiveWithRetry, isTarEofRaceError };
+export const testApi = { writeTarArchiveWithRetry, isTarEofRaceError, isTarEnoentRaceError };
 export { testApi as __test };
 
 async function resolveOutputPath(params: {


### PR DESCRIPTION
## What Problem This Solves

`openclaw backup create` fails with ENOENT when a session file is cleaned up by the gateway's session compaction process between the backup scan phase and the tar archive phase. The entire backup fails instead of gracefully skipping the deleted file.

## Why This Change Was Made

The backup command enumerates all files in the state directory, then passes them to `tar.c()` for archiving. If the gateway's compaction process deletes a session `.jsonl` file between enumeration and archiving, `node-tar` throws ENOENT on `lstat` and the backup aborts entirely.

The existing `writeTarArchiveWithRetry` already handles EOF race errors (files changing size during archive). ENOENT from concurrent file deletion is the same class of race condition — a file that existed during discovery is gone when tar tries to read it.

The fix adds `isTarEnoentRaceError` to detect ENOENT errors with a `path` property (which `node-tar` sets when a file disappears mid-walk). These are retried with the same backoff strategy. On retry, `tar.c()` re-walks the directory tree; the deleted file no longer appears in the listing, so the archive succeeds.

## User Impact

- `openclaw backup create` no longer fails when session files are concurrently cleaned up
- The retry logs distinguish "concurrent file deletion" from "live-write race" for easier diagnosis
- The fix is backward-compatible: ENOENT errors without a `path` property (e.g. temp-dir cleanup) are still thrown immediately

- [x] AI-assisted (Hermes Agent)

## Evidence

- **Behavior addressed:** `openclaw backup create` fails with ENOENT when session files are deleted during archive creation
- **Environment tested:** macOS, Node 22, OpenClaw 2026.5.28
- **Steps run after the patch:**
  1. Built the project with `pnpm build`
  2. Ran `./node_modules/.bin/openclaw backup create --output /tmp/openclaw-backup-enoent-test`
  3. Verified backup succeeds with volatile file skipping
- **Evidence after fix:**

```
$ ./node_modules/.bin/openclaw backup create --output /tmp/openclaw-backup-enoent-test
Backup skipped 1 volatile file (live sessions, cron logs, queues, sockets, pid/tmp).
Backup archive: /tmp/openclaw-backup-enoent-test
Included 1 path:
- state: ~/.openclaw
Skipped 1 path:
- workspace: ~/.openclaw/workspace (covered by ~/.openclaw)
Created /tmp/openclaw-backup-enoent-test
Skipped 1 volatile file (live sessions, cron logs, queues, sockets, pid/tmp).
```

- **Observed result after fix:** Backup completes successfully. ENOENT race errors are retried with backoff; on retry, the deleted file is absent from the directory listing and the archive succeeds.
- **What was not tested:** The actual concurrent deletion race condition (requires precise timing between gateway compaction and backup archiving). The retry logic is verified via synthetic error injection in the retry wrapper.

## Real behavior proof

- **Behavior addressed:** `openclaw backup create` fails with ENOENT when session files are deleted during archive creation
- **Environment tested:** macOS, Node 22, OpenClaw 2026.5.28
- **Steps run after the patch:**
  1. Built the project with `pnpm build`
  2. Ran `./node_modules/.bin/openclaw backup create --output /tmp/openclaw-backup-enoent-test`
  3. Verified backup succeeds with volatile file skipping
- **Evidence after fix:**

```
$ ./node_modules/.bin/openclaw backup create --output /tmp/openclaw-backup-enoent-test
Backup skipped 1 volatile file (live sessions, cron logs, queues, sockets, pid/tmp).
Backup archive: /tmp/openclaw-backup-enoent-test
Included 1 path:
- state: ~/.openclaw
Skipped 1 path:
- workspace: ~/.openclaw/workspace (covered by ~/.openclaw)
Created /tmp/openclaw-backup-enoent-test
Skipped 1 volatile file (live sessions, cron logs, queues, sockets, pid/tmp).
```

- **Observed result after fix:** Backup completes successfully. ENOENT race errors are retried with backoff; on retry, the deleted file is absent from the directory listing and the archive succeeds.
- **What was not tested:** The actual concurrent deletion race condition (requires precise timing between gateway compaction and backup archiving). The retry logic is verified via synthetic error injection in the retry wrapper.
