### PR TITLE
fix(telegram): drain ingress with native queue claims

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -2180,10 +2180,11 @@ describe("TelegramPollingSession", () => {
       if (!claimed) {
         throw new Error("Expected claimed update");
       }
+      const liveOwnerPid = process.ppid > 0 ? process.ppid : 1;
       await adoptClaimOwner({
         spoolDir: tempDir,
         updateId: 42,
-        ownerId: `${process.pid}:other-process`,
+        ownerId: `${liveOwnerPid}:other-process`,
         claimedAt: Date.now(),
       });
 
@@ -2203,10 +2204,9 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("fails timed-out current-process claims before draining later same-lane updates", async () => {
+  it("releases pid-reused claims before draining later same-lane updates", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
-      const log = vi.fn();
       const events: string[] = [];
       await writeSpooledTestUpdates(tempDir, [
         topicUpdate(42, 10, "wedged topic 10 turn"),
@@ -2232,7 +2232,6 @@ describe("TelegramPollingSession", () => {
       const { runPromise, stopWorker } = startIsolatedIngressSession({
         abort,
         spoolDir: tempDir,
-        log,
         spooledUpdateHandlerTimeoutMs: 100,
         handleUpdate: async (update) => {
           events.push(`handled:${update.update_id}`);
@@ -2240,17 +2239,11 @@ describe("TelegramPollingSession", () => {
         },
       });
 
-      await vi.waitFor(() => expect(events).toEqual(["handled:43"]));
+      await vi.waitFor(() => expect(events).toEqual(["handled:42"]));
       await runPromise;
-      expect(await failedUpdateReasons(tempDir)).toEqual([
-        { id: 42, reason: "lane-released-on-stuck" },
-      ]);
-      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await failedUpdateReasons(tempDir)).toEqual([]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([43]);
       expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
-      expectLogIncludes(
-        log,
-        "spooled update 42 Telegram spooled update claim owned by this process",
-      );
       stopWorker();
     });
   });

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1067,13 +1067,13 @@ describe("TelegramPollingSession", () => {
           const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
           return {
             ...queue,
-            claim: async (...args: Parameters<typeof queue.claim>) => {
-              if (args[0] === "0000000000000001" && !blockedFirstClaim) {
+            claimNext: async (...args: Parameters<typeof queue.claimNext>) => {
+              if (!blockedFirstClaim) {
                 blockedFirstClaim = true;
                 firstClaimStarted?.();
                 await firstClaimGate;
               }
-              return queue.claim(...args);
+              return queue.claimNext(...args);
             },
           };
         },

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -738,58 +738,6 @@ export class TelegramPollingSession {
     return deferredSpooledUpdateClaimsByKey.has(buildDeferredSpooledUpdateClaimKey(update));
   }
 
-  async #failTimedOutCurrentProcessSpooledUpdateClaims(params: {
-    activeLaneKeys: Set<string>;
-    spoolDir: string;
-  }): Promise<void> {
-    const claims = await listTelegramSpooledUpdateClaims({ spoolDir: params.spoolDir });
-    const now = Date.now();
-    for (const claim of claims) {
-      const claimOwner = claim.claim;
-      if (!claimOwner) {
-        continue;
-      }
-      if (this.#isDeferredSpooledUpdateClaim(claim)) {
-        continue;
-      }
-      if (params.activeLaneKeys.has(this.#spooledUpdateLaneKey(claim))) {
-        continue;
-      }
-      if (now - claimOwner.claimedAt < this.#spooledUpdateHandlerTimeoutMs) {
-        continue;
-      }
-      if (!isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim)) {
-        continue;
-      }
-      // Same PID with a stale owner id means this process orphaned a previous
-      // local handler state; different live PIDs may still be processing.
-      if (claimOwner.processPid !== process.pid) {
-        continue;
-      }
-      const claimedForMs = now - claimOwner.claimedAt;
-      const message = `Telegram spooled update claim owned by this process for ${formatDurationPrecise(claimedForMs)} without active handler state; marking failed so the lane can continue.`;
-      try {
-        const failed = await failTelegramSpooledUpdateClaim({
-          update: claim,
-          reason: "lane-released-on-stuck",
-          message,
-        });
-        if (!failed) {
-          this.opts.log(
-            `[telegram][diag] spooled update ${claim.updateId} current-process claim no longer had a processing marker to fail.`,
-          );
-          continue;
-        }
-      } catch (err) {
-        this.opts.log(
-          `[telegram][diag] spooled update ${claim.updateId} current-process claim could not be marked failed: ${formatErrorMessage(err)}`,
-        );
-        continue;
-      }
-      this.opts.log(`[telegram][diag] spooled update ${claim.updateId} ${message}`);
-    }
-  }
-
   async #failTimedOutDeferredSpooledUpdate(state: DeferredSpooledUpdateClaimState): Promise<void> {
     const message =
       state.timedOutMessage ??
@@ -919,10 +867,6 @@ export class TelegramPollingSession {
     spoolDir: string;
   }): Promise<SpooledUpdateDrainResult> {
     const activeLaneKeys = this.#activeSpooledUpdateLaneKeysForSpool(params.spoolDir);
-    await this.#failTimedOutCurrentProcessSpooledUpdateClaims({
-      activeLaneKeys,
-      spoolDir: params.spoolDir,
-    });
     await recoverStaleTelegramSpooledUpdateClaims({
       spoolDir: params.spoolDir,
       staleMs: 0,

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -34,7 +34,7 @@ import { TelegramPollingTransportState } from "./polling-transport-state.js";
 import { TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS } from "./request-timeouts.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import {
-  claimTelegramSpooledUpdate,
+  claimNextTelegramSpooledUpdate,
   deleteTelegramSpooledUpdate,
   failTelegramSpooledUpdateClaim,
   isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
@@ -564,14 +564,20 @@ export class TelegramPollingSession {
     }
   }
 
-  async #claimSpooledUpdate(
-    update: TelegramSpooledUpdate,
-  ): Promise<ClaimedTelegramSpooledUpdate | null> {
+  async #claimNextSpooledUpdate(params: {
+    blockedLaneKeys: Set<string>;
+    spoolDir: string;
+  }): Promise<ClaimedTelegramSpooledUpdate | null> {
     try {
-      return await claimTelegramSpooledUpdate(update);
+      return await claimNextTelegramSpooledUpdate({
+        spoolDir: params.spoolDir,
+        blockedLaneKeys: params.blockedLaneKeys,
+        botInfo: this.opts.botInfo,
+        scanLimit: TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT,
+      });
     } catch (err) {
       this.opts.log(
-        `[telegram][diag] spooled update ${update.updateId} claim failed; keeping for retry: ${formatErrorMessage(err)}`,
+        `[telegram][diag] spooled update claim failed; keeping pending updates for retry: ${formatErrorMessage(err)}`,
       );
       return null;
     }
@@ -875,8 +881,12 @@ export class TelegramPollingSession {
   }
 
   #spooledUpdateLaneKey(update: TelegramSpooledUpdate): string {
+    return this.#rawSpooledUpdateLaneKey(update.update);
+  }
+
+  #rawSpooledUpdateLaneKey(update: unknown): string {
     return getTelegramSequentialKey({
-      update: update.update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
+      update: update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
       ...(this.opts.botInfo ? { me: this.opts.botInfo } : {}),
     });
   }
@@ -933,27 +943,42 @@ export class TelegramPollingSession {
       limit: TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT,
     });
     const blockedByLane = new Set<string>();
-    let started = 0;
+    const retryDelayedLaneKeys = new Set<string>();
     for (const update of updates) {
       const laneKey = this.#spooledUpdateLaneKey(update);
-      if (this.opts.abortSignal?.aborted) {
-        break;
-      }
-      if (resolveSpooledUpdateRetryDelayMs(update) > 0) {
-        claimedLaneKeys.add(laneKey);
-        continue;
-      }
       const handlerKey = buildSpooledUpdateHandlerKey({ spoolDir: params.spoolDir, laneKey });
       if (activeSpooledUpdateHandlersByLane.has(handlerKey)) {
         blockedByLane.add(handlerKey);
-        continue;
       }
-      if (claimedLaneKeys.has(laneKey)) {
-        continue;
+      if (resolveSpooledUpdateRetryDelayMs(update) > 0) {
+        retryDelayedLaneKeys.add(laneKey);
       }
-      const claimedUpdate = await this.#claimSpooledUpdate(update);
+    }
+    const blockedLaneKeys = new Set([
+      ...activeLaneKeys,
+      ...claimedLaneKeys,
+      ...retryDelayedLaneKeys,
+    ]);
+    let started = 0;
+    while (started < TELEGRAM_SPOOLED_DRAIN_START_LIMIT) {
+      if (this.opts.abortSignal?.aborted) {
+        break;
+      }
+      const claimedUpdate = await this.#claimNextSpooledUpdate({
+        blockedLaneKeys,
+        spoolDir: params.spoolDir,
+      });
       if (!claimedUpdate) {
-        claimedLaneKeys.add(laneKey);
+        break;
+      }
+      const laneKey = this.#spooledUpdateLaneKey(claimedUpdate);
+      const handlerKey = buildSpooledUpdateHandlerKey({ spoolDir: params.spoolDir, laneKey });
+      if (activeSpooledUpdateHandlersByLane.has(handlerKey)) {
+        blockedByLane.add(handlerKey);
+        await releaseTelegramSpooledUpdateClaim(claimedUpdate, {
+          lastError: "active Telegram spool handler already owns this lane",
+        });
+        blockedLaneKeys.add(laneKey);
         continue;
       }
       const stopClaimRefresh = this.#startSpooledUpdateClaimRefresh(claimedUpdate);
@@ -967,13 +992,13 @@ export class TelegramPollingSession {
         laneKey,
         task: handler,
         update: claimedUpdate,
-        updateId: update.updateId,
+        updateId: claimedUpdate.updateId,
         startedAt: Date.now(),
         stopClaimRefresh,
       };
       activeSpooledUpdateHandlersByLane.set(handlerKey, state);
       this.#spooledUpdateHandlerKeys.add(handlerKey);
-      claimedLaneKeys.add(laneKey);
+      blockedLaneKeys.add(laneKey);
       void handler.finally(() => {
         if (
           !deferredSpooledUpdateClaimsByKey.has(buildDeferredSpooledUpdateClaimKey(claimedUpdate))
@@ -986,9 +1011,6 @@ export class TelegramPollingSession {
         this.#spooledUpdateHandlerKeys.delete(handlerKey);
       });
       started += 1;
-      if (started >= TELEGRAM_SPOOLED_DRAIN_START_LIMIT) {
-        break;
-      }
     }
     return { blockedByLane, started };
   }
@@ -1216,6 +1238,7 @@ export class TelegramPollingSession {
         void writeTelegramSpooledUpdate({
           spoolDir,
           update: message.update,
+          laneKey: this.#rawSpooledUpdateLaneKey(message.update),
         }).then(
           (updateId) => {
             ackSpooledUpdate(message.requestId, { ok: true, updateId });

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -566,6 +566,7 @@ export class TelegramPollingSession {
 
   async #claimNextSpooledUpdate(params: {
     blockedLaneKeys: Set<string>;
+    candidateUpdateIds: readonly number[];
     spoolDir: string;
   }): Promise<ClaimedTelegramSpooledUpdate | null> {
     try {
@@ -573,6 +574,7 @@ export class TelegramPollingSession {
         spoolDir: params.spoolDir,
         blockedLaneKeys: params.blockedLaneKeys,
         botInfo: this.opts.botInfo,
+        candidateUpdateIds: params.candidateUpdateIds,
         scanLimit: TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT,
       });
     } catch (err) {
@@ -942,6 +944,7 @@ export class TelegramPollingSession {
       spoolDir: params.spoolDir,
       limit: TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT,
     });
+    const candidateUpdateIds = updates.map((update) => update.updateId);
     const blockedByLane = new Set<string>();
     const retryDelayedLaneKeys = new Set<string>();
     for (const update of updates) {
@@ -966,6 +969,7 @@ export class TelegramPollingSession {
       }
       const claimedUpdate = await this.#claimNextSpooledUpdate({
         blockedLaneKeys,
+        candidateUpdateIds,
         spoolDir: params.spoolDir,
       });
       if (!claimedUpdate) {

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -207,6 +207,32 @@ describe("Telegram ingress spool", () => {
     });
   });
 
+  it("does not claim outside the provided candidate update ids", async () => {
+    await withTempSpool(async (spoolDir) => {
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 200, message: { chat: { id: 1 }, message_id: 1, text: "first" } },
+        now: 1,
+      });
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 201, message: { chat: { id: 2 }, message_id: 1, text: "later" } },
+        now: 2,
+      });
+
+      const claimed = await claimNextTelegramSpooledUpdate({
+        spoolDir,
+        blockedLaneKeys: ["telegram:1"],
+        candidateUpdateIds: [200],
+      });
+
+      expect(claimed).toBeNull();
+      expect(
+        (await listTelegramSpooledUpdates({ spoolDir })).map((update) => update.updateId),
+      ).toEqual([200, 201]);
+    });
+  });
+
   it("releases failed claims back to the pending spool", async () => {
     await withTempSpool(async (spoolDir) => {
       await writeTelegramSpooledUpdate({

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
 import type { TelegramRuntime } from "./runtime.types.js";
 import {
+  claimNextTelegramSpooledUpdate,
   claimTelegramSpooledUpdate,
   deleteTelegramSpooledUpdate,
   failTelegramSpooledUpdateClaim,
@@ -115,6 +116,94 @@ describe("Telegram ingress spool", () => {
       }
       await deleteTelegramSpooledUpdate(claimed);
       expect(await listTelegramSpooledUpdateClaims({ spoolDir })).toEqual([]);
+    });
+  });
+
+  it("claims next update through the native ingress queue in update id order", async () => {
+    await withTempSpool(async (spoolDir) => {
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 101, message: { chat: { id: 1 }, message_id: 1, text: "second" } },
+        now: 1,
+      });
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 100, message: { chat: { id: 1 }, message_id: 2, text: "first" } },
+        now: 2,
+      });
+
+      const claimed = await claimNextTelegramSpooledUpdate({ spoolDir });
+
+      expect(claimed?.updateId).toBe(100);
+      expect(await listTelegramSpooledUpdates({ spoolDir })).toHaveLength(1);
+      expect(
+        (await listTelegramSpooledUpdateClaims({ spoolDir })).map((claim) => claim.updateId),
+      ).toEqual([100]);
+    });
+  });
+
+  it("derives lane keys while claiming legacy rows without stored lane keys", async () => {
+    await withTempSpool(async (spoolDir) => {
+      const stateDir = path.dirname(path.dirname(spoolDir));
+      const queue = createChannelIngressQueue<{
+        version: 1;
+        updateId: number;
+        receivedAt: number;
+        update: unknown;
+      }>({
+        channelId: "telegram",
+        accountId: "test",
+        stateDir,
+      });
+      await queue.enqueue(
+        "0000000000000042",
+        {
+          version: 1,
+          updateId: 42,
+          receivedAt: 1,
+          update: {
+            update_id: 42,
+            message: {
+              chat: { id: 100, type: "supergroup", is_forum: true },
+              is_topic_message: true,
+              message_id: 1,
+              message_thread_id: 10,
+              text: "blocked topic",
+            },
+          },
+        },
+        { receivedAt: 1 },
+      );
+      await queue.enqueue(
+        "0000000000000043",
+        {
+          version: 1,
+          updateId: 43,
+          receivedAt: 2,
+          update: {
+            update_id: 43,
+            message: {
+              chat: { id: 100, type: "supergroup", is_forum: true },
+              is_topic_message: true,
+              message_id: 2,
+              message_thread_id: 11,
+              text: "open topic",
+            },
+          },
+        },
+        { receivedAt: 2 },
+      );
+
+      const claimed = await claimNextTelegramSpooledUpdate({
+        spoolDir,
+        blockedLaneKeys: ["telegram:100:topic:10"],
+      });
+
+      expect(claimed?.updateId).toBe(43);
+      expect(claimed?.claim?.claimToken).toEqual(expect.any(String));
+      expect(
+        (await listTelegramSpooledUpdates({ spoolDir })).map((update) => update.updateId),
+      ).toEqual([42]);
     });
   });
 

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -418,7 +418,7 @@ describe("Telegram ingress spool", () => {
     ).toBe(false);
   });
 
-  it("treats fresh claims with reused pids and different owner ids as live-owned", () => {
+  it("does not treat fresh claims with reused current pids as live-owned", () => {
     const now = Date.now();
     expect(
       isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess({
@@ -430,6 +430,25 @@ describe("Telegram ingress spool", () => {
         claim: {
           processId: "other-process",
           processPid: process.pid,
+          claimedAt: now,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats fresh claims with other live pids as live-owned", () => {
+    const now = Date.now();
+    const liveOwnerPid = process.ppid > 0 ? process.ppid : 1;
+    expect(
+      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess({
+        updateId: 51,
+        path: path.join(os.tmpdir(), "51.json.processing"),
+        pendingPath: path.join(os.tmpdir(), "51.json"),
+        update: { update_id: 51 },
+        receivedAt: now,
+        claim: {
+          processId: "other-process",
+          processPid: liveOwnerPid,
           claimedAt: now,
         },
       }),

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -288,12 +288,16 @@ export async function claimNextTelegramSpooledUpdate(params: {
   spoolDir: string;
   blockedLaneKeys?: Iterable<string>;
   botInfo?: TelegramBotInfo;
+  candidateUpdateIds?: Iterable<number>;
   scanLimit?: number;
 }): Promise<ClaimedTelegramSpooledUpdate | null> {
   const queue = createTelegramIngressQueue(params.spoolDir);
   const claimed = await queue.claimNext({
     ownerId: TELEGRAM_SPOOLED_UPDATE_PROCESS_ID,
     blockedLaneKeys: params.blockedLaneKeys,
+    ...(params.candidateUpdateIds === undefined
+      ? {}
+      : { candidateIds: [...params.candidateUpdateIds].map(queueEventId) }),
     orderBy: "id",
     scanLimit: params.scanLimit,
     deriveLaneKey: (record) => spooledUpdateLaneKey(record.payload.update, params.botInfo),

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -9,7 +9,9 @@ import type {
   ChannelIngressQueueRecord,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+import type { TelegramBotInfo } from "./bot-info.js";
 import { getTelegramRuntime } from "./runtime.js";
+import { getTelegramSequentialKey } from "./sequential-key.js";
 import { normalizeTelegramStateAccountId } from "./state-account-id.js";
 
 const SPOOL_VERSION = 1;
@@ -196,6 +198,13 @@ function parseQueueClaim(
   };
 }
 
+function spooledUpdateLaneKey(update: unknown, botInfo?: TelegramBotInfo): string {
+  return getTelegramSequentialKey({
+    update: update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
+    ...(botInfo ? { me: botInfo } : {}),
+  });
+}
+
 function sortTelegramUpdates<T extends TelegramSpooledUpdate>(updates: T[]): T[] {
   return updates.toSorted((a, b) => a.updateId - b.updateId);
 }
@@ -219,6 +228,7 @@ export function isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
 export async function writeTelegramSpooledUpdate(params: {
   spoolDir: string;
   update: unknown;
+  laneKey?: string;
   now?: number;
 }): Promise<number> {
   const updateId = resolveTelegramUpdateId(params.update);
@@ -236,7 +246,10 @@ export async function writeTelegramSpooledUpdate(params: {
       receivedAt,
       update: params.update,
     },
-    { receivedAt },
+    {
+      receivedAt,
+      laneKey: params.laneKey ?? spooledUpdateLaneKey(params.update),
+    },
   );
   return updateId;
 }
@@ -269,6 +282,34 @@ export async function claimTelegramSpooledUpdate(
     ownerId: TELEGRAM_SPOOLED_UPDATE_PROCESS_ID,
   });
   return claimed ? parseQueueClaim(spoolDir, claimed) : null;
+}
+
+export async function claimNextTelegramSpooledUpdate(params: {
+  spoolDir: string;
+  blockedLaneKeys?: Iterable<string>;
+  botInfo?: TelegramBotInfo;
+  scanLimit?: number;
+}): Promise<ClaimedTelegramSpooledUpdate | null> {
+  const queue = createTelegramIngressQueue(params.spoolDir);
+  const claimed = await queue.claimNext({
+    ownerId: TELEGRAM_SPOOLED_UPDATE_PROCESS_ID,
+    blockedLaneKeys: params.blockedLaneKeys,
+    orderBy: "id",
+    scanLimit: params.scanLimit,
+    deriveLaneKey: (record) => spooledUpdateLaneKey(record.payload.update, params.botInfo),
+  });
+  if (!claimed) {
+    return null;
+  }
+  const update = parseQueueClaim(params.spoolDir, claimed);
+  if (update) {
+    return update;
+  }
+  await queue.fail(claimed, {
+    reason: "invalid-spooled-update",
+    message: "Telegram spooled update payload was invalid.",
+  });
+  return null;
 }
 
 export async function releaseTelegramSpooledUpdateClaim(

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -220,6 +220,7 @@ export function isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
   return Boolean(
     claim.claim &&
     claim.claim.processId !== TELEGRAM_SPOOLED_UPDATE_PROCESS_ID &&
+    claim.claim.processPid !== process.pid &&
     isFreshClaimOwner(claim.claim) &&
     processExists(claim.claim.processPid),
   );

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -273,6 +273,29 @@ describe("channel ingress queue", () => {
     });
   });
 
+  it("claims next only from candidate ids when provided", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1;
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => clock++,
+      });
+
+      await queue.enqueue("a", { text: "outside snapshot" }, { receivedAt: 1 });
+      await queue.enqueue("b", { text: "inside snapshot" }, { receivedAt: 2 });
+
+      expect(
+        await queue.claimNext({
+          ownerId: "worker",
+          candidateIds: ["b"],
+        }),
+      ).toMatchObject({ id: "b" });
+      expect(await queue.claimNext({ candidateIds: [] })).toBeNull();
+    });
+  });
+
   it("derives missing lane keys before claiming next", async () => {
     await withTempState(async (stateDir) => {
       let clock = 1;

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -251,6 +251,55 @@ describe("channel ingress queue", () => {
     });
   });
 
+  it("claims next pending row by id when requested", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1;
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => clock++,
+      });
+
+      await queue.enqueue("0002", { text: "second" }, { receivedAt: 1 });
+      await queue.enqueue("0001", { text: "first" }, { receivedAt: 2 });
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        orderBy: "id",
+      });
+
+      expect(claimed?.id).toBe("0001");
+    });
+  });
+
+  it("derives missing lane keys before claiming next", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1;
+      const queue = createChannelIngressQueue<{ lane: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => clock++,
+      });
+
+      await queue.enqueue("a", { lane: "blocked" }, { receivedAt: 1 });
+      await queue.enqueue("b", { lane: "open" }, { receivedAt: 2 });
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        blockedLaneKeys: ["blocked"],
+        deriveLaneKey: (record) => record.payload.lane,
+      });
+
+      expect(claimed?.id).toBe("b");
+      expect(claimed?.laneKey).toBe("open");
+      expect(
+        (await queue.listPending()).find((record) => record.id === "a")?.laneKey,
+      ).toBeUndefined();
+    });
+  });
+
   it("requires claim tokens before mutating claimed rows", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueue<{ text: string }>({

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -323,6 +323,35 @@ describe("channel ingress queue", () => {
     });
   });
 
+  it("blocks lanes claimed by candidate rows before claiming later candidates", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1;
+      const queue = createChannelIngressQueue<{ lane: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => clock++,
+      });
+
+      await queue.enqueue("a", { lane: "chat-1" }, { receivedAt: 1 });
+      await queue.enqueue("b", { lane: "chat-1" }, { receivedAt: 2 });
+      await queue.enqueue("c", { lane: "chat-2" }, { receivedAt: 3 });
+      await queue.claim("a", { ownerId: "sibling-worker" });
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        candidateIds: ["a", "b", "c"],
+        orderBy: "id",
+        deriveLaneKey: (record) => record.payload.lane,
+      });
+
+      expect(claimed?.id).toBe("c");
+      expect(claimed?.laneKey).toBe("chat-2");
+      const sameLanePending = (await queue.listPending()).find((record) => record.id === "b");
+      expect(sameLanePending?.laneKey).toBeUndefined();
+    });
+  });
+
   it("requires claim tokens before mutating claimed rows", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueue<{ text: string }>({

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -137,6 +137,9 @@ export type ChannelIngressQueue<TPayload, TMetadata = unknown, TCompletedMetadat
     ownerId?: string;
     blockedLaneKeys?: Iterable<string>;
     staleMs?: number;
+    orderBy?: "received" | "id";
+    scanLimit?: number;
+    deriveLaneKey?: (record: ChannelIngressQueueRecord<TPayload, TMetadata>) => string | undefined;
   }): Promise<ChannelIngressQueueClaim<TPayload, TMetadata> | null>;
   claim(
     id: string,
@@ -322,6 +325,10 @@ function normalizeLimit(limit: number | "all" | undefined): number {
   return limit === "all" ? Number.MAX_SAFE_INTEGER : Math.max(1, Math.floor(limit ?? 100));
 }
 
+function normalizeScanLimit(limit: number | undefined): number {
+  return Math.max(1, Math.floor(limit ?? 100));
+}
+
 function normalizeMaxEntries(value: number | undefined): number | null {
   return value === undefined ? null : Math.max(0, Math.floor(value));
 }
@@ -461,22 +468,33 @@ export function createChannelIngressQueue<
         const kysely = getChannelIngressKysely(tx.db);
         const baseSelect = kysely
           .selectFrom("channel_ingress_events")
-          .select(["event_id", "lane_key"])
+          .selectAll()
           .where("queue_name", "=", queueName)
           .where("status", "=", "pending");
-        const select =
-          blocked.size === 0
-            ? baseSelect
-            : baseSelect.where((eb) =>
-                eb.or([eb("lane_key", "is", null), eb("lane_key", "not in", [...blocked])]),
-              );
-        const selected = executeSqliteQueryTakeFirstSync(
-          tx.db,
-          select.orderBy("received_at", "asc").orderBy("event_id", "asc").limit(1),
-        );
+        let select = baseSelect;
+        if (blocked.size > 0 && !claimOptions?.deriveLaneKey) {
+          select = select.where((eb) =>
+            eb.or([eb("lane_key", "is", null), eb("lane_key", "not in", [...blocked])]),
+          );
+        }
+        let orderedSelect =
+          claimOptions?.orderBy === "id"
+            ? select.orderBy("event_id", "asc")
+            : select.orderBy("received_at", "asc").orderBy("event_id", "asc");
+        orderedSelect =
+          claimOptions?.deriveLaneKey === undefined
+            ? orderedSelect.limit(1)
+            : orderedSelect.limit(normalizeScanLimit(claimOptions.scanLimit));
+        const rows = executeSqliteQuerySync(tx.db, orderedSelect).rows;
+        const selected = rows.find((row) => {
+          const laneKey = row.lane_key ?? claimOptions?.deriveLaneKey?.(baseRecord(row));
+          return !laneKey || !blocked.has(laneKey);
+        });
         if (!selected) {
           return null;
         }
+        const derivedLaneKey =
+          selected.lane_key ?? claimOptions?.deriveLaneKey?.(baseRecord(selected));
         const token = randomUUID();
         const claimedAt = now();
         const ownerId = normalizePart(claimOptions?.ownerId, `${process.pid}`);
@@ -489,6 +507,7 @@ export function createChannelIngressQueue<
               claim_token: token,
               claim_owner: ownerId,
               claimed_at: claimedAt,
+              ...(derivedLaneKey ? { lane_key: derivedLaneKey } : {}),
               updated_at: claimedAt,
             })
             .where("queue_name", "=", queueName)

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -139,6 +139,7 @@ export type ChannelIngressQueue<TPayload, TMetadata = unknown, TCompletedMetadat
     staleMs?: number;
     orderBy?: "received" | "id";
     scanLimit?: number;
+    candidateIds?: Iterable<string>;
     deriveLaneKey?: (record: ChannelIngressQueueRecord<TPayload, TMetadata>) => string | undefined;
   }): Promise<ChannelIngressQueueClaim<TPayload, TMetadata> | null>;
   claim(
@@ -337,6 +338,10 @@ function normalizedProtectedIds(ids: Iterable<string> | undefined): string[] {
   return [...(ids ?? [])].map((id) => id.trim()).filter(Boolean);
 }
 
+function normalizedCandidateIds(ids: Iterable<string> | undefined): string[] | undefined {
+  return ids === undefined ? undefined : [...ids].map((id) => id.trim()).filter(Boolean);
+}
+
 function queueNameForParts(channelId: string, accountId: string): string {
   // JSON tuple encoding keeps channel/account scopes unambiguous even when ids contain separators.
   return JSON.stringify([channelId, accountId]);
@@ -462,6 +467,10 @@ export function createChannelIngressQueue<
     const blocked = new Set(
       [...(claimOptions?.blockedLaneKeys ?? [])].map((key) => key.trim()).filter(Boolean),
     );
+    const candidateIds = normalizedCandidateIds(claimOptions?.candidateIds);
+    if (candidateIds?.length === 0) {
+      return null;
+    }
     const database = openStateDatabase(options.stateDir);
     return runOpenClawStateWriteTransaction(
       (tx) => {
@@ -472,6 +481,9 @@ export function createChannelIngressQueue<
           .where("queue_name", "=", queueName)
           .where("status", "=", "pending");
         let select = baseSelect;
+        if (candidateIds) {
+          select = select.where("event_id", "in", candidateIds);
+        }
         if (blocked.size > 0 && !claimOptions?.deriveLaneKey) {
           select = select.where((eb) =>
             eb.or([eb("lane_key", "is", null), eb("lane_key", "not in", [...blocked])]),

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -475,6 +475,26 @@ export function createChannelIngressQueue<
     return runOpenClawStateWriteTransaction(
       (tx) => {
         const kysely = getChannelIngressKysely(tx.db);
+        let effectiveBlocked = blocked;
+        if (candidateIds && candidateIds.length > 0) {
+          // Candidate snapshots can race a sibling drainer. If an earlier
+          // candidate is now claimed, its lane must block later same-lane rows.
+          const claimedCandidateRows = executeSqliteQuerySync(
+            tx.db,
+            kysely
+              .selectFrom("channel_ingress_events")
+              .selectAll()
+              .where("queue_name", "=", queueName)
+              .where("status", "=", "claimed")
+              .where("event_id", "in", candidateIds),
+          ).rows;
+          const claimedCandidateLaneKeys = claimedCandidateRows
+            .map((row) => row.lane_key ?? claimOptions?.deriveLaneKey?.(baseRecord(row)))
+            .filter((laneKey): laneKey is string => Boolean(laneKey));
+          if (claimedCandidateLaneKeys.length > 0) {
+            effectiveBlocked = new Set([...blocked, ...claimedCandidateLaneKeys]);
+          }
+        }
         const baseSelect = kysely
           .selectFrom("channel_ingress_events")
           .selectAll()
@@ -484,9 +504,9 @@ export function createChannelIngressQueue<
         if (candidateIds) {
           select = select.where("event_id", "in", candidateIds);
         }
-        if (blocked.size > 0 && !claimOptions?.deriveLaneKey) {
+        if (effectiveBlocked.size > 0 && !claimOptions?.deriveLaneKey) {
           select = select.where((eb) =>
-            eb.or([eb("lane_key", "is", null), eb("lane_key", "not in", [...blocked])]),
+            eb.or([eb("lane_key", "is", null), eb("lane_key", "not in", [...effectiveBlocked])]),
           );
         }
         let orderedSelect =
@@ -500,7 +520,7 @@ export function createChannelIngressQueue<
         const rows = executeSqliteQuerySync(tx.db, orderedSelect).rows;
         const selected = rows.find((row) => {
           const laneKey = row.lane_key ?? claimOptions?.deriveLaneKey?.(baseRecord(row));
-          return !laneKey || !blocked.has(laneKey);
+          return !laneKey || !effectiveBlocked.has(laneKey);
         });
         if (!selected) {
           return null;


### PR DESCRIPTION
## What Problem This Solves

Fixes #90945.

Telegram isolated ingress stores Bot API updates in the shared SQLite `channel_ingress_events` queue. The deadlock had two parts: Telegram selected pending rows outside the queue's native claim flow, and stale `claimed` rows could survive a restart when the recorded owner PID was reused by the new process. In containers this commonly means PID 1, so a dead claim could look live forever and block later same-lane updates.

This branch is rebased on the merged #96962 claim-refresh fix. It keeps that liveness/lease behavior and adds the separate queue-selection/PID-reuse fix.

## Why This Change Was Made

Telegram now asks the shared ingress queue to atomically `claimNext` the next eligible update, using the queue's existing claim token for complete/release/fail operations. The queue selection skips blocked lanes while preserving Telegram update-id ordering.

The queue claim path also blocks lanes from claimed rows in the same candidate snapshot. That preserves the old per-update ordering invariant if a sibling drainer claims an earlier same-lane row between Telegram's pending snapshot and `claimNext`.

The stale claimed-row fix stays in Telegram's existing drain recovery path: a claim with this process's PID but a different Telegram process owner id is no longer treated as another live process. The normal stale-claim recovery releases that row back to pending, so the original inbound update is handled before later same-lane updates instead of being failed or skipped.

This keeps recovery local to Telegram's drain loop instead of adding a gateway startup sweep.

## User Impact

Telegram users should see stuck isolated-ingress updates drain again without manual SQLite edits. Restarted or recovered Telegram sessions can release PID-reused stale claims, reclaim the original update, skip genuinely live blocked lanes, preserve active claim refresh from #96962, and continue unrelated lanes.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/telegram-ingress-spool.test.ts extensions/telegram/src/polling-session.test.ts src/channels/message/ingress-queue.test.ts` (`81` Telegram tests, `16` queue tests passed)
- `node scripts/run-oxlint.mjs extensions/telegram/src/polling-session.ts extensions/telegram/src/telegram-ingress-spool.ts extensions/telegram/src/telegram-ingress-spool.test.ts extensions/telegram/src/polling-session.test.ts src/channels/message/ingress-queue.ts src/channels/message/ingress-queue.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/polling-session.ts extensions/telegram/src/telegram-ingress-spool.ts extensions/telegram/src/telegram-ingress-spool.test.ts extensions/telegram/src/polling-session.test.ts src/channels/message/ingress-queue.ts src/channels/message/ingress-queue.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean after fixing the concurrent same-lane claim race it found)
