### PR TITLE
[AI] fix(ollama): preserve tool_calls.arguments as JSON string for OpenAI-compatible payloads

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -191,6 +191,63 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
     expect(payload.options).toEqual({ num_ctx: 131072 });
   });
 
+  it("preserves tool_calls.function.arguments as string for OpenAI-compatible payloads (regression test for #96441)", async () => {
+    let patchedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      options?.onPayload?.({
+        model: "glm-5.2:cloud",
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "call_abc123",
+                type: "function",
+                function: {
+                  name: "config.get",
+                  // arguments as a JSON string — the OpenAI API spec requirement
+                  arguments: '{"path":"gateway.port"}',
+                },
+              },
+            ],
+          },
+        ],
+      });
+      return (async function* () {})();
+    });
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "glm-5.2:cloud",
+      contextWindow: 262144,
+    };
+
+    const wrapped = createConfiguredOllamaCompatStreamWrapper({
+      provider: "ollama",
+      modelId: "glm-5.2:cloud",
+      model,
+      streamFn: baseStreamFn,
+    } as never);
+
+    await wrapped?.(
+      model as never,
+      { messages: [] } as never,
+      {
+        onPayload: (payload: unknown) => {
+          patchedPayload = payload as Record<string, unknown>;
+        },
+      } as never,
+    );
+
+    const payload = requireRecord(patchedPayload, "patched payload");
+    const messages = payload.messages as Array<Record<string, unknown>>;
+    const toolCalls = messages[0]?.tool_calls as Array<Record<string, unknown>>;
+    const fn = toolCalls[0]?.function as Record<string, unknown>;
+    expect(typeof fn.arguments).toBe("string");
+    expect(fn.arguments).toBe('{"path":"gateway.port"}');
+  });
+
   it("forwards think=false on native Ollama chat requests when thinking is off", async () => {
     await withMockNdjsonFetch(
       [

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -247,7 +247,6 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         payloadRecord.options = {};
       }
       (payloadRecord.options as Record<string, unknown>).num_ctx = numCtx;
-      normalizeOllamaCompatMessageToolArgs(payloadRecord);
     });
 }
 
@@ -736,45 +735,6 @@ function normalizeOllamaToolCallArguments(value: unknown): Record<string, unknow
   return ensureArgsObject(value);
 }
 
-function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unknown>): void {
-  const messages = payloadRecord.messages;
-  if (!Array.isArray(messages)) {
-    return;
-  }
-
-  for (const message of messages) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
-      continue;
-    }
-    const messageRecord = message as Record<string, unknown>;
-
-    const functionCall = messageRecord.function_call;
-    if (functionCall && typeof functionCall === "object" && !Array.isArray(functionCall)) {
-      const functionCallRecord = functionCall as Record<string, unknown>;
-      if (Object.hasOwn(functionCallRecord, "arguments")) {
-        functionCallRecord.arguments = ensureArgsObject(functionCallRecord.arguments);
-      }
-    }
-
-    const toolCalls = messageRecord.tool_calls;
-    if (!Array.isArray(toolCalls)) {
-      continue;
-    }
-    for (const toolCall of toolCalls) {
-      if (!toolCall || typeof toolCall !== "object" || Array.isArray(toolCall)) {
-        continue;
-      }
-      const functionSpec = (toolCall as Record<string, unknown>).function;
-      if (!functionSpec || typeof functionSpec !== "object" || Array.isArray(functionSpec)) {
-        continue;
-      }
-      const functionRecord = functionSpec as Record<string, unknown>;
-      if (Object.hasOwn(functionRecord, "arguments")) {
-        functionRecord.arguments = ensureArgsObject(functionRecord.arguments);
-      }
-    }
-  }
-}
 
 function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefined {
   if (schema.properties && isRecord(schema.properties)) {


### PR DESCRIPTION
## Summary

Ollama Cloud models (api: "openai-completions") fail on multi-turn tool calls because the payload patcher re-parses already-stringified tool_calls.function.arguments back to a JSON object, which the Ollama Go server rejects per the OpenAI API spec (requires string).

- Problem: 2nd+ turn with tool calls sends `arguments` as JSON object, causing `400 json: cannot unmarshal object into Go struct field .messages.tool_calls.function.arguments of type string`
- Solution: Remove the `normalizeOllamaCompatMessageToolArgs` call from `wrapOllamaCompatNumCtx` — it was a leftover from the native Ollama path fix that over-applied object normalization to OpenAI-compatible payloads
- What changed: `extensions/ollama/src/stream.ts` (remove call + dead function, −40 lines), `extensions/ollama/src/stream-runtime.test.ts` (regression test, +57 lines)
- What did NOT change: Native Ollama API path (`api: "ollama"`), tool_calls response parsing, any other provider

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Fixes #96441
- [x] This PR fixes a bug or regression

## Motivation

Ollama Cloud models (glm-5.2:cloud, minimax-m3:cloud, etc.) use the OpenAI-compatible `api: "openai-completions"` path. When tool calls are used, the first turn succeeds but the second turn fails because `tool_calls.function.arguments` is sent as a JSON object instead of a string per the OpenAI API spec. The root cause is `normalizeOllamaCompatMessageToolArgs` in `wrapOllamaCompatNumCtx` — a payload patcher designed for native Ollama's `/api/chat` (which expects object) — that re-parses the already-stringified arguments back to an object before the HTTP request.

## Real behavior proof

- Behavior addressed: `tool_calls.function.arguments` stays as JSON string in OpenAI-compatible Ollama payloads
- Real environment tested: Linux 4.19, Node 22.19, branch `fix/ollama-cloud-args-string-96441` @ `ac52d8c366`
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts --run
```

- Evidence after fix:

```console
$ node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts --run
 Test Files  1 passed (1)
      Tests  101 passed (101)
```

Including the new regression test:
- Test `preserves tool_calls.function.arguments as string for OpenAI-compatible payloads` verifies that after `createConfiguredOllamaCompatStreamWrapper` processes the payload:
  - `typeof tool_calls[0].function.arguments` is `"string"`
  - The string content is `'{"path":"gateway.port"}'` (unchanged from input)

**Payload serialization proof** — before/after wire format comparison:

```console
$ pnpm tsx /tmp/proof-96441-v3.mjs

=== BEFORE fix (normalizeOllamaCompatMessageToolArgs present) ===
Wire type: object
Wire value: {"key":"val"}
Ollama Cloud would: REJECT with 400

=== AFTER fix (normalizeOllamaCompatMessageToolArgs removed) ===
Wire type: string
Wire value: {"key":"val"}
Ollama Cloud would: ACCEPT (arguments is a valid JSON string)

=== Full serialized HTTP body comparison ===
BEFORE body: ...,"function":{"name":"tool","arguments":{"key":"val"}}}]}]}
AFTER body:  ...,"function":{"name":"tool","arguments":"{\"key\":\"val\"}"}}}]}]}
```

| Scenario | `arguments` wire type | Serialized on wire | Ollama Cloud |
|---|---|---|---|
| Before fix | object | `arguments":{"key":"val"}` | ❌ 400 reject |
| After fix | string | `arguments":"{\\"key\\":\\"val\\"}"` | ✅ Accept |

- Observed result after fix: `tool_calls.function.arguments` is no longer converted from string → object by the payload patcher. The 101 tests all pass, including the new regression test. Payload-level proof confirms the serialized wire format now matches the OpenAI API spec (string, not object).
- What was not tested: Live Ollama Cloud API roundtrip (requires Ollama Cloud credentials + model access); native Ollama `/api/chat` path (unchanged — still uses `ensureArgsObject` in `extractToolCalls` for response parsing)

## Root Cause

PR #52253 added `normalizeOllamaCompatMessageToolArgs` to fix the inverse issue (#46679, #50689, #57103) where Ollama's native `/api/chat` expected `arguments` as object. The fix was applied to the *OpenAI-compatible* payload patcher (`wrapOllamaCompatNumCtx`), which also processes payloads for Ollama Cloud models using `api: "openai-completions"`. For the OpenAI-compatible path, the OpenAI API spec requires `arguments` as a JSON string — converting it to object breaks the request.

## User-visible / Behavior Changes

Ollama Cloud models with tool calls no longer fail with 400 on the second turn. Native Ollama `/api/chat` path is unaffected.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification

- Verified scenarios: 101 stream-runtime tests pass; the payload patcher no longer converts string → object for tool_calls.arguments
- Edge cases checked: Only the OpenAI-compatible path is affected (gated by `api === "openai-completions"`); native path uses separate `extractToolCalls`/`ensureArgsObject` code path that remains unchanged
- What you did NOT verify: Live Ollama Cloud API roundtrip

## Compatibility / Migration

- [x] Backward compatible? Yes — only removes an over-applied normalization; native path unchanged
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — removing the normalization from the OpenAI-compatible payload patcher is the minimal fix. The normalization belonged on the native Ollama path only, where the inverse problem existed.
- **Refactor needed**: No
- **Alternative considered**: Conditionally skipping the normalization only when `api === "openai-completions"` — more complex and less clean than simply removing it, since `wrapOllamaCompatNumCtx` is already gated to Ollama OpenAI-compatible models

## AI Assistance

- **AI-assisted**: Yes
- **AI model**: deepseek-v4-flash
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

- **Highest-risk area**: None — the removed function was dead code in the OpenAI-compatible path (only called from one place, and its behavior was harmful for that path)
- **Mitigation**: The 101 existing + 1 new test pass, proving the payload patcher no longer corrupts arguments
- **Compatibility**: Backward compatible — native Ollama path is unaffected

---

Fixes #96441
