### PR TITLE
fix(secrets): avoid exec target gateway failures

### DIFF
--- a/src/secrets/runtime-command-secrets.test.ts
+++ b/src/secrets/runtime-command-secrets.test.ts
@@ -60,11 +60,12 @@ discoverConfigSecretTargetsByIds(forcedFallbackConfig, new Set([firecrawlPath]))
 
 function activateMinimalSecretsRuntimeSnapshot(params: {
   config: OpenClawConfig;
+  resolvedConfig?: OpenClawConfig;
   env: Record<string, string | undefined>;
 }) {
   const snapshot = {
     sourceConfig: structuredClone(params.config),
-    config: structuredClone(params.config),
+    config: structuredClone(params.resolvedConfig ?? params.config),
     authStores: [],
     warnings: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
@@ -152,6 +153,60 @@ describe("runtime command secrets", () => {
       {
         path: firecrawlPath,
         value: "gateway-selected-firecrawl-key",
+      },
+    ]);
+    expect(resolved.diagnostics).toEqual([]);
+    expect(resolved.inactiveRefPaths).toEqual([]);
+  });
+
+  it("returns resolved snapshot assignments when exec targets remain unresolved", async () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          google: {
+            enabled: true,
+            apiKey: { source: "exec", provider: "default", id: "models/google/api-key" },
+          },
+          openai: {
+            enabled: true,
+            apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      },
+      secrets: {
+        providers: {
+          default: { source: "env" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    activateMinimalSecretsRuntimeSnapshot({
+      config: sourceConfig,
+      resolvedConfig: {
+        ...sourceConfig,
+        models: {
+          providers: {
+            ...sourceConfig.models?.providers,
+            openai: {
+              ...sourceConfig.models?.providers?.openai,
+              apiKey: "gateway-openai-key",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      env: {
+        HOME: process.env.HOME,
+      },
+    });
+
+    const resolved = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+      commandName: "reply",
+      targetIds: new Set(["models.providers.*.apiKey"]),
+    });
+
+    expect(resolved.assignments).toMatchObject([
+      {
+        path: "models.providers.openai.apiKey",
+        value: "gateway-openai-key",
       },
     ]);
     expect(resolved.diagnostics).toEqual([]);

--- a/src/secrets/runtime-command-secrets.ts
+++ b/src/secrets/runtime-command-secrets.ts
@@ -344,6 +344,33 @@ function mirrorResolvedProviderCredentialToDirectPaths(params: {
   }
 }
 
+function collectUnresolvedExecSecretRefPaths(params: {
+  sourceConfig: OpenClawConfig;
+  targetIds: ReadonlySet<string>;
+  unresolvedPaths: ReadonlySet<string>;
+  allowedPaths?: ReadonlySet<string>;
+}): Set<string> {
+  const defaults = params.sourceConfig.secrets?.defaults;
+  const execPaths = new Set<string>();
+  for (const target of discoverConfigSecretTargetsByIds(params.sourceConfig, params.targetIds)) {
+    if (params.allowedPaths && !params.allowedPaths.has(target.path)) {
+      continue;
+    }
+    if (!params.unresolvedPaths.has(target.path)) {
+      continue;
+    }
+    const { ref } = resolveSecretInputRef({
+      value: target.value,
+      refValue: target.refValue,
+      defaults,
+    });
+    if (ref?.source === "exec") {
+      execPaths.add(target.path);
+    }
+  }
+  return execPaths;
+}
+
 async function resolveForcedActiveCommandSecretTargets(params: {
   sourceConfig: OpenClawConfig;
   resolvedConfig: OpenClawConfig;
@@ -569,6 +596,28 @@ async function resolveCommandSecretsFromSnapshot(params: {
     params.forcedActivePaths?.has(entry.path),
   );
   if (selectedProviderUnresolved.length > 0 || forcedActiveUnresolved.length > 0) {
+    return {
+      assignments: analyzed.assignments,
+      diagnostics: analyzed.diagnostics,
+      inactiveRefPaths,
+    };
+  }
+  const unresolvedPaths = new Set(analyzed.unresolved.map((entry) => entry.path));
+  const unresolvedExecPaths = collectUnresolvedExecSecretRefPaths({
+    sourceConfig,
+    targetIds: params.targetIds,
+    unresolvedPaths,
+    allowedPaths: params.allowedPaths,
+  });
+  if (unresolvedExecPaths.size > 0) {
+    const nonExecUnresolved = analyzed.unresolved.filter(
+      (entry) => !unresolvedExecPaths.has(entry.path),
+    );
+    if (nonExecUnresolved.length > 0) {
+      throw new Error(
+        `${params.commandName}: ${nonExecUnresolved[0]?.path ?? "target"} is unresolved in the active runtime snapshot.`,
+      );
+    }
     return {
       assignments: analyzed.assignments,
       diagnostics: analyzed.diagnostics,


### PR DESCRIPTION
## What Problem This Solves

Fixes #96653.

`secrets.resolve` could return a generic `UNAVAILABLE` for reply-path command secret resolution when a broad target set included model-provider exec SecretRefs that were not materialized in the active runtime snapshot. That made the gateway log a noisy per-turn failure even though the CLI command-secret path can still degrade to local fallback for the unresolved exec target.

## Why This Change Was Made

The gateway runtime resolver now returns the assignments it can prove from the active snapshot when the remaining unresolved command targets are exec-backed SecretRefs. Non-exec unresolved targets still fail as before, and the CLI-side fallback remains responsible for resolving or degrading the unresolved exec paths.

This keeps the owner boundary in the gateway runtime secret resolver instead of adding a CLI shortcut that would bypass already-materialized gateway snapshot values.

## User Impact

Users with exec-backed model-provider credentials should no longer see misleading reply-path `secrets.resolve failed` / `UNAVAILABLE` gateway log noise for otherwise recoverable command-secret resolution. Already-resolved gateway snapshot credentials continue to be returned normally.

## Evidence

- `node_modules/.bin/oxfmt --write --threads=1 src/secrets/runtime-command-secrets.ts src/secrets/runtime-command-secrets.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs src/secrets/runtime-command-secrets.test.ts src/cli/command-secret-gateway.test.ts -- --reporter=verbose` passed: 2 shards, 37 tests
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs src/secrets/runtime-command-secrets.test.ts src/cli/command-secret-gateway.test.ts -- --reporter=verbose"` passed with no accepted/actionable findings
