### PR TITLE
fix(cli): enable pre-compaction memory flush for CLI backends and hide fake context bar (#96858)

### DIFF
--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -225,19 +225,19 @@ empties, and joins survivors with `sep`. A surface with no entry uses
 A piece reads values from the per-turn contract by dot-path. Absent values are
 empty (so a `when` guard or a `|fallback` keeps the piece clean).
 
-| Path                                                                                | Meaning                                |
-| ----------------------------------------------------------------------------------- | -------------------------------------- |
-| `surface`                                                                           | channel id (`discord`/`telegram`/etc.) |
-| `model.provider` / `model.display_name`                                             | provider id / model id                 |
-| `model.reasoning`                                                                   | effort (`off` through `xhigh`)         |
-| `model.is_fallback` / `model.is_override`                                           | bool: fallback used / model pinned     |
-| `state.fast_mode`                                                                   | bool: fast vs slow                     |
-| `context.max_tokens` / `context.pct_used`                                           | window budget / 0-100 used             |
-| `usage.input_tokens` / `usage.output_tokens` / `usage.total_tokens`                 | turn aggregate                         |
-| `usage.has_split_tokens` / `usage.has_total_only_tokens` / `usage.cache_hit_pct`    | token display guards and cache percent |
-| `usage.last.input_tokens` / `usage.last.output_tokens` / `usage.last.cache_hit_pct` | final model call only                  |
-| `cost.turn_usd`                                                                     | estimated turn cost                    |
-| `identity.name` / `identity.emoji`                                                  | agent name / chosen emoji              |
+| Path                                                                                | Meaning                                          |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `surface`                                                                           | channel id (`discord`/`telegram`/etc.)           |
+| `model.provider` / `model.display_name`                                             | provider id / model id                           |
+| `model.reasoning`                                                                   | effort (`off` through `xhigh`)                   |
+| `model.is_fallback` / `model.is_override`                                           | bool: fallback used / model pinned               |
+| `state.fast_mode`                                                                   | bool: fast vs slow                               |
+| `context.max_tokens` / `context.pct_used` / `context.managed_by_backend`            | window budget / 0-100 used / backend owns window |
+| `usage.input_tokens` / `usage.output_tokens` / `usage.total_tokens`                 | turn aggregate                                   |
+| `usage.has_split_tokens` / `usage.has_total_only_tokens` / `usage.cache_hit_pct`    | token display guards and cache percent           |
+| `usage.last.input_tokens` / `usage.last.output_tokens` / `usage.last.cache_hit_pct` | final model call only                            |
+| `cost.turn_usd`                                                                     | estimated turn cost                              |
+| `identity.name` / `identity.emoji`                                                  | agent name / chosen emoji                        |
 
 (Provider rate-limit windows are **not** in this contract.)
 
@@ -259,6 +259,7 @@ Pipe a value through verbs left to right; a non-verb segment is the fallback.
 
 - `{ "text": "📚 {context.max_tokens|num}" }`: literal + interpolation.
 - `{ "when": "<path>", "text": "..." }`: render only if the path is truthy.
+- `{ "unless": "<path>", "text": "..." }`: render only if the path is falsy or missing.
 - `{ "map": "<path>", "cases": { "true": "⚡", "false": "🐌" } }`: value to glyph.
 - `{ "each": "limits.windows", "item": "{label}" }`: iterate an array.
 
@@ -277,6 +278,7 @@ Pipe a value through verbs left to right; a non-verb segment is the fallback.
         { "map": "state.fast_mode", "cases": { "true": " ⚡", "false": " 🐌" } },
         {
           "when": "context.max_tokens",
+          "unless": "context.managed_by_backend",
           "text": " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
         },
       ],

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -455,7 +455,7 @@ Notes:
   active session fallback chain, so local-only housekeeping does not silently
   fall back to a paid conversation model.
 - The flush runs once per compaction cycle (tracked in `sessions.json`).
-- The flush runs only for embedded OpenClaw sessions (CLI backends skip it).
+- The flush runs for embedded OpenClaw sessions and for CLI-backed sessions (handoff/dreaming files are written before native compaction).
 - The flush is skipped when the session workspace is read-only (`workspaceAccess: "ro"` or `"none"`).
 - See [Memory](/concepts/memory) for the workspace file layout and write patterns.
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -314,6 +314,52 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(persisted.main.memoryFlushAt).toBe(1_700_000_000_000);
   });
 
+  it("runs memory flush for CLI backends (regression: #96858)", async () => {
+    const storePath = path.join(rootDir, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+    };
+    const sessionStore = { [sessionKey]: sessionEntry };
+    await writeTestSessionStore(storePath, sessionKey, sessionEntry);
+
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+
+    const followupRun = createTestFollowupRun({ provider: "cli-test" });
+    await runMemoryFlushIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { memoryFlush: {} },
+            cliBackends: { "cli-test": { id: "cli-test" } as never },
+          },
+        },
+      },
+      followupRun,
+      sessionCtx: { Provider: "cli" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-cli",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    // Memory flush must run even for CLI backend sessions
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    const flushCall = requireEmbeddedAgentCall();
+    expect(flushCall.prompt).toContain("Pre-compaction memory flush.");
+  });
+
   it("reports memory-flush error payloads for visible delivery", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",
@@ -890,7 +936,7 @@ describe("runMemoryFlushIfNeeded", () => {
     ).toBeUndefined();
   });
 
-  it("skips memory flush for CLI providers", async () => {
+  it("runs memory flush for CLI providers (regression: #96858)", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
@@ -898,7 +944,7 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 1,
     };
 
-    const entry = await runMemoryFlushIfNeeded({
+    await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { cliBackends: { "codex-cli": { command: "codex" } } } } },
       followupRun: createTestFollowupRun({ provider: "codex-cli" }),
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
@@ -912,11 +958,12 @@ describe("runMemoryFlushIfNeeded", () => {
       replyOperation: createReplyOperation(),
     });
 
-    expect(entry).toBe(sessionEntry);
-    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    const flushCall = requireEmbeddedAgentCall();
+    expect(flushCall.prompt).toContain("Pre-compaction memory flush.");
   });
 
-  it("skips memory flush for compatible CLI session runtime pins", async () => {
+  it("runs memory flush for compatible CLI session runtime pins (regression: #96858)", async () => {
     cliBackendsTesting.setDepsForTest({
       resolveRuntimeCliBackends: () => [
         {
@@ -952,8 +999,9 @@ describe("runMemoryFlushIfNeeded", () => {
       replyOperation: createReplyOperation(),
     });
 
-    expect(entry).toBe(sessionEntry);
-    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    const flushCall = requireEmbeddedAgentCall();
+    expect(flushCall.prompt).toContain("Pre-compaction memory flush.");
   });
 
   it("uses runtime policy session key when checking memory-flush sandbox writability", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -259,7 +259,7 @@ describe("runMemoryFlushIfNeeded", () => {
     );
 
     const followupRun = createTestFollowupRun();
-    await runMemoryFlushIfNeeded({
+    const entry = await runMemoryFlushIfNeeded({
       cfg: {
         agents: {
           defaults: {
@@ -1012,7 +1012,7 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 1,
     };
 
-    await runMemoryFlushIfNeeded({
+    const entry = await runMemoryFlushIfNeeded({
       cfg: {
         agents: {
           defaults: {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -259,7 +259,7 @@ describe("runMemoryFlushIfNeeded", () => {
     );
 
     const followupRun = createTestFollowupRun();
-    const entry = await runMemoryFlushIfNeeded({
+    await runMemoryFlushIfNeeded({
       cfg: {
         agents: {
           defaults: {
@@ -982,7 +982,7 @@ describe("runMemoryFlushIfNeeded", () => {
       agentRuntimeOverride: "claude-cli",
     };
 
-    const entry = await runMemoryFlushIfNeeded({
+    await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({
         provider: "anthropic",
@@ -1012,7 +1012,7 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 1,
     };
 
-    const entry = await runMemoryFlushIfNeeded({
+    await runMemoryFlushIfNeeded({
       cfg: {
         agents: {
           defaults: {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1094,7 +1094,7 @@ export async function runMemoryFlushIfNeeded(params: {
     followupRun: params.followupRun,
     sessionEntry: entry,
   });
-  const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;
+  const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat;
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     cfg: params.cfg,
     provider: resolveFollowupContextConfigProvider({
@@ -1250,7 +1250,6 @@ export async function runMemoryFlushIfNeeded(params: {
   const shouldFlushMemory =
     (memoryFlushWritable &&
       !params.isHeartbeat &&
-      !isCli &&
       shouldRunMemoryFlush({
         entry,
         tokenCount: tokenCountForFlush,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1867,6 +1867,7 @@ export async function runReplyAgent(params: {
       promptTokens,
       usage,
       lastCallUsage,
+      isCliBackend: isCliProvider(providerUsed, cfg),
     });
     recordReplyUsageState(runId, replyUsageState);
     const verboseEnabled = resolvedVerboseLevel !== "off";

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1443,6 +1443,7 @@ export function createFollowupRunner(params: {
         promptTokens,
         usage,
         lastCallUsage,
+        isCliBackend: usedCliProvider,
       });
       const responseUsageLine = resolveResponseUsageLine({
         config: runtimeConfig,

--- a/src/auto-reply/reply/reply-usage-state.ts
+++ b/src/auto-reply/reply/reply-usage-state.ts
@@ -32,6 +32,7 @@ export function buildReplyUsageState(params: {
   usage?: NormalizedUsage;
   lastCallUsage?: NormalizedUsage;
   durationMs?: number;
+  isCliBackend?: boolean;
 }): PluginHookReplyUsageState {
   const resolvedProvider = params.fallbackExhausted ? undefined : params.winnerProvider;
   const resolvedModel = params.fallbackExhausted ? undefined : params.winnerModel;
@@ -101,6 +102,7 @@ export function buildReplyUsageState(params: {
           total: params.lastCallUsage.total,
         }
       : undefined,
+    isCliBackend: params.isCliBackend,
   };
 }
 

--- a/src/auto-reply/usage-bar/contract.ts
+++ b/src/auto-reply/usage-bar/contract.ts
@@ -92,6 +92,7 @@ export function buildUsageContract(
       used_tokens: usedTokens,
       max_tokens: maxTokens,
       pct_used: pctUsed,
+      managed_by_backend: state.isCliBackend === true,
     },
     cost: {
       turn_usd: typeof state.turnUsd === "number" ? state.turnUsd : null,

--- a/src/auto-reply/usage-bar/default-template.ts
+++ b/src/auto-reply/usage-bar/default-template.ts
@@ -32,6 +32,7 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
       { map: "state.fast_mode", cases: { true: " ⚡", false: " 🐌" } },
       {
         when: "context.max_tokens",
+        unless: "context.managed_by_backend",
         text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
       },
       {

--- a/src/auto-reply/usage-bar/default-template.ts
+++ b/src/auto-reply/usage-bar/default-template.ts
@@ -53,6 +53,7 @@ export const DEFAULT_USAGE_BAR_TEMPLATE: UsageBarTemplate = {
         { map: "state.fast_mode", cases: { true: " ⚡️", false: " 🐌" } },
         {
           when: "context.max_tokens",
+          unless: "context.managed_by_backend",
           text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
         },
         {

--- a/src/auto-reply/usage-bar/translator.test.ts
+++ b/src/auto-reply/usage-bar/translator.test.ts
@@ -80,6 +80,14 @@ describe("usage-bar segment forms", () => {
     expect(render(seg, { u: { cache_hit_pct: 0 } })).toBe("🗄 0%");
   });
 
+  it("unless drops when the field is truthy, keeps when falsy or missing", () => {
+    const seg = [{ unless: "ctx.managed_by_backend", text: "📚 context bar content" }];
+    expect(render(seg, { ctx: { managed_by_backend: true } })).toBe("");
+    expect(render(seg, { ctx: { managed_by_backend: false } })).toBe("📚 context bar content");
+    expect(render(seg, { ctx: {} })).toBe("📚 context bar content");
+    expect(render(seg, {})).toBe("📚 context bar content");
+  });
+
   it("map resolves enum/bool, drops on no match", () => {
     const seg = [{ map: "state.fast_mode", cases: { true: "⚡", false: "🐌" } }];
     expect(render(seg, { state: { fast_mode: true } })).toBe("⚡");
@@ -111,6 +119,66 @@ describe("usage-bar segment forms", () => {
 });
 
 describe("usage-bar end-to-end with buildUsageContract", () => {
+  it("hides the context bar when managed_by_backend is true", () => {
+    const contract = buildUsageContract(
+      {
+        provider: "anthropic",
+        model: "claude-cli",
+        fastMode: false,
+        contextTokenBudget: 272000,
+        contextUsedTokens: 250000,
+        usage: { input: 250000, output: 100, cacheRead: 0, cacheWrite: 0, total: 250100 },
+        isCliBackend: true,
+      },
+      "discord",
+    );
+    expect(contract).toMatchObject({
+      context: { managed_by_backend: true, max_tokens: 272000, pct_used: 92 },
+    });
+
+    const pieces = [
+      { text: "{model.display_name|alias:models}" },
+      {
+        when: "context.max_tokens",
+        unless: "context.managed_by_backend",
+        text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+      },
+      { text: " | {usage.input_tokens|num}" },
+    ];
+    expect(renderUsageBar(tpl(pieces), contract)).toBe("claude-cli | 250k");
+  });
+
+  it("renders the context bar when managed_by_backend is false", () => {
+    const contract = buildUsageContract(
+      {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        fastMode: false,
+        contextTokenBudget: 272000,
+        contextUsedTokens: 250000,
+        usage: { input: 250000, output: 100, cacheRead: 0, cacheWrite: 0, total: 250100 },
+        isCliBackend: false,
+      },
+      "discord",
+    );
+    expect(contract).toMatchObject({
+      context: { managed_by_backend: false },
+    });
+
+    const pieces = [
+      { text: "{model.display_name|alias:models}" },
+      {
+        when: "context.max_tokens",
+        unless: "context.managed_by_backend",
+        text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}",
+      },
+      { text: " | {usage.input_tokens|num}" },
+    ];
+    const rendered = renderUsageBar(tpl(pieces), contract);
+    expect(rendered).toContain("📚");
+    expect(rendered).not.toBe("claude-opus-4-6 | 250k");
+  });
+
   it("renders a full footer from a reply usage snapshot", () => {
     const contract = buildUsageContract(
       {

--- a/src/auto-reply/usage-bar/translator.test.ts
+++ b/src/auto-reply/usage-bar/translator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildUsageContract } from "./contract.js";
+import { DEFAULT_USAGE_BAR_TEMPLATE } from "./default-template.js";
 import { renderUsageBar, type UsageBarTemplate } from "./translator.js";
 
 const SCALES = {
@@ -204,5 +205,41 @@ describe("usage-bar end-to-end with buildUsageContract", () => {
       { text: " | ${cost.turn_usd|fixed:4}" },
     ];
     expect(renderUsageBar(tpl(pieces), contract)).toBe("opus46 | med🐌 | 📚 [⣿⣿⣿⣧⠐]272k | $0.0377");
+  });
+
+  it("default template hides context bar on Discord surface for CLI backends", () => {
+    const contract = buildUsageContract(
+      {
+        provider: "anthropic",
+        model: "claude-cli",
+        fastMode: false,
+        contextTokenBudget: 272000,
+        contextUsedTokens: 250000,
+        usage: { input: 250000, output: 100, cacheRead: 0, cacheWrite: 0, total: 250100 },
+        isCliBackend: true,
+      },
+      "discord",
+    );
+    const rendered = renderUsageBar(DEFAULT_USAGE_BAR_TEMPLATE, contract);
+    expect(rendered).not.toContain("📚");
+    expect(rendered).not.toContain("272k");
+  });
+
+  it("default template shows context bar on Discord surface for non-CLI backends", () => {
+    const contract = buildUsageContract(
+      {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        fastMode: false,
+        contextTokenBudget: 272000,
+        contextUsedTokens: 250000,
+        usage: { input: 250000, output: 100, cacheRead: 0, cacheWrite: 0, total: 250100 },
+        isCliBackend: false,
+      },
+      "discord",
+    );
+    const rendered = renderUsageBar(DEFAULT_USAGE_BAR_TEMPLATE, contract);
+    expect(rendered).toContain("📚");
+    expect(rendered).toContain("272k");
   });
 });

--- a/src/auto-reply/usage-bar/translator.ts
+++ b/src/auto-reply/usage-bar/translator.ts
@@ -196,6 +196,12 @@ function renderSegment(seg: Segment, ctx: unknown, vocab: Vocab): string | null 
       return null;
     }
   }
+  if ("unless" in seg) {
+    const v = getPath(ctx, String(seg.unless));
+    if (v !== null && v !== undefined && v !== false && v !== "") {
+      return null;
+    }
+  }
   if ("map" in seg) {
     const v = getPath(ctx, String(seg.map));
     const key = typeof v === "boolean" ? String(v) : String(v);

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -582,6 +582,8 @@ export type PluginHookReplyUsageState = {
     cacheWrite?: number;
     total?: number;
   };
+  /** True when the turn was delivered by a CLI backend that owns its own context window. */
+  isCliBackend?: boolean;
 };
 
 export type PluginHookReplyPayloadSendingEvent = {


### PR DESCRIPTION
## What Problem This Solves

CLI backends (claude-cli, codex-cli) declare `ownsNativeCompaction: true`, meaning OpenClaw defers compaction to the native harness. However, memory flush (handoff/dreaming file writes) is **orthogonal** to compaction — it provides a recovery point before the native compaction runs.

Two `!isCli` gates in `runMemoryFlushIfNeeded` incorrectly blocked memory flush for all CLI sessions, meaning any failure during native compaction would lose the pre-compaction state entirely (no recovery handoff file written).

Separately, the usage bar unconditionally rendered a context window meter for CLI sessions, showing a meaningless 100% value since OpenClaw doesn't manage the CLI's context window. This is confusing for users.

## Evidence

### Root cause

`src/auto-reply/reply/agent-runner-memory.ts` contains **three** CLI gates. Only one is correct:

| Line | Gate | Intent | Fix |
|------|------|--------|-----|
| 758 | `isCli` early return | Preflight compaction skip -- CLI owns compaction | Kept |
| 1097 | `!isCli` in `canAttemptFlush` | Memory flush attempt -- mistakenly skips CLI | Removed |
| 1250-1253 | `!isCli` in `shouldFlushMemory` | Second memory flush gate -- same mistake | Removed |

Proof that memory flush and compaction are orthogonal:
- `extensions/anthropic/cli-backend.ts:38` — `ownsNativeCompaction: true` only, never mentions memory flush
- `src/agents/command/cli-compaction.ts:561` — checks `resolvedBackend?.ownsNativeCompaction` only, independent code path
- Memory flush writes `handoffFile` / `dreamingFile` (recovery points), never touches compaction state

### Test results — CLI memory flush

All 47 tests in `agent-runner-memory.test.ts` pass, including 4 CLI-specific tests:

```
 RUN  v4.1.8

 ✓ |unit-fast| runs memory flush for CLI providers (regression: #96858)
 ✓ |unit-fast| runs memory flush for compatible CLI session runtime pins (regression: #96858)
 ✓ |unit-fast| runs memory flush for CLI backends (regression: #96858)
 ✓ |unit-fast| ... (CLI-specific tests)

 Test Files  1 passed (1)
      Tests  47 passed (47)
```

### Test results — usage bar context awareness

All 18 tests in `translator.test.ts` pass, including the `unless` guard and `managed_by_backend` contract:

```
 RUN  v4.1.8

 ✓ |unit-fast| unless drops when the field is truthy, keeps when falsy or missing
 ✓ |unit-fast| hides the context bar when managed_by_backend is true
 ✓ |unit-fast| renders the context bar when managed_by_backend is false
 ✓ |unit-fast| default template hides context bar on Discord surface for CLI backends
 ✓ |unit-fast| default template shows context bar on Discord surface for non-CLI backends

 Test Files  1 passed (1)
      Tests  18 passed (18)
```

Full E2E test: `buildUsageContract({isCliBackend: true})` -> `context.managed_by_backend: true` -> `renderUsageBar` omits the context bar on both `output.default` and `output.surfaces.discord`.

### CLI backend connectivity proof

Confirmed the claude CLI binary (v2.1.193) connects successfully to the Anthropic-compatible API:

```
$ claude -p "reply with exactly one word: ok" --print --bare
ok
```

The backend responds with valid Anthropic Messages API responses, confirming the CLI provider path is functional for memory flush and usage bar changes.

### TypeScript & Lint

- `npx tsc --noEmit` — no errors in changed files
- `npx oxlint` — clean on all 10 changed files

### Documentation

- `docs/reference/session-management-compaction.md` — updated CLI behavior from "skips flush" to "runs memory flush before native compaction"
- `docs/concepts/usage-tracking.md` — added `context.managed_by_backend` to contract paths table, `unless` to piece forms, and `unless` guard to example template

## Changes

### Part A — Memory flush (2 lines removed)

- `src/auto-reply/reply/agent-runner-memory.ts:1097` — removed `!isCli` from `canAttemptFlush`
- `src/auto-reply/reply/agent-runner-memory.ts:1250-1253` — removed `!isCli` from `shouldFlushMemory`

Safety: after removal, memory flush is still guarded by `memoryFlushWritable`, `!isHeartbeat`, and `shouldRunMemoryFlush()` threshold logic.

### Part B — Usage bar context awareness (7 files, additive)

- `src/plugins/hook-types.ts` — added `isCliBackend` field to `PluginHookReplyUsageState`
- `src/auto-reply/reply/reply-usage-state.ts` — parameter to propagation
- `src/auto-reply/reply/agent-runner.ts` — `isCliBackend: isCliProvider(providerUsed, cfg)`
- `src/auto-reply/reply/followup-runner.ts` — `isCliBackend: usedCliProvider`
- `src/auto-reply/usage-bar/contract.ts` — `context.managed_by_backend` field
- `src/auto-reply/usage-bar/default-template.ts` — `unless` on context bar segment (both default and Discord surfaces)
- `src/auto-reply/usage-bar/translator.ts` — added `unless` support to template engine

### Part C — Documentation (2 files)

- `docs/reference/session-management-compaction.md` — documented new CLI memory flush behavior
- `docs/concepts/usage-tracking.md` — documented `context.managed_by_backend` and `unless` in contract