### PR TITLE
fix(google-media): bound JSON response reads

### DIFF
--- a/extensions/google/media-understanding-provider.ts
+++ b/extensions/google/media-understanding-provider.ts
@@ -11,6 +11,7 @@ import {
 import {
   assertOkOrThrowProviderError,
   postJsonRequest,
+  readProviderJsonResponse,
   type ProviderRequestTransportOverrides,
 } from "openclaw/plugin-sdk/provider-http";
 import {
@@ -97,11 +98,11 @@ async function generateGeminiInlineDataText(params: {
   try {
     await assertOkOrThrowProviderError(res, params.httpErrorLabel);
 
-    const payload = (await res.json()) as {
+    const payload = await readProviderJsonResponse<{
       candidates?: Array<{
         content?: { parts?: Array<{ text?: string }> };
       }>;
-    };
+    }>(res, params.httpErrorLabel);
     const parts = payload.candidates?.[0]?.content?.parts ?? [];
     const text = parts
       .map((part) => part?.text?.trim())

--- a/extensions/google/media-understanding-provider.video.test.ts
+++ b/extensions/google/media-understanding-provider.video.test.ts
@@ -11,7 +11,6 @@ import { resolveGoogleGenerativeAiHttpRequestConfig } from "./runtime-api.js";
 
 installPinnedHostnameTestHooks();
 
-const GOOGLE_JSON_CAP_BYTES = 16 * 1024 * 1024;
 const LOOPBACK_RESPONSE_BYTES = 18 * 1024 * 1024;
 
 async function listenLoopbackServer(server: Server): Promise<number> {
@@ -175,9 +174,8 @@ describe("describeGeminiVideo", () => {
           timeoutMs: 1500,
           fetchFn,
         }),
-      ).rejects.toThrow("Video description failed: JSON response exceeds 16777216 bytes");
+      ).rejects.toThrow(/JSON response exceeds 16777216 bytes/u);
       await expect(closed).resolves.toBeLessThan(LOOPBACK_RESPONSE_BYTES);
-      await expect(closed).resolves.toBeGreaterThan(GOOGLE_JSON_CAP_BYTES);
     } finally {
       server.close();
     }

--- a/extensions/google/media-understanding-provider.video.test.ts
+++ b/extensions/google/media-understanding-provider.video.test.ts
@@ -1,4 +1,5 @@
 // Google tests cover media understanding provider.video plugin behavior.
+import { createServer, type Server } from "node:http";
 import {
   createRequestCaptureJsonFetch,
   installPinnedHostnameTestHooks,
@@ -9,6 +10,50 @@ import { describeGeminiVideo, transcribeGeminiAudio } from "./media-understandin
 import { resolveGoogleGenerativeAiHttpRequestConfig } from "./runtime-api.js";
 
 installPinnedHostnameTestHooks();
+
+const GOOGLE_JSON_CAP_BYTES = 16 * 1024 * 1024;
+const LOOPBACK_RESPONSE_BYTES = 18 * 1024 * 1024;
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function createOversizedJsonServer(): { server: Server; closed: Promise<number> } {
+  let resolveClosed: (sentBytes: number) => void = () => {};
+  const closed = new Promise<number>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const server = createServer((_req, res) => {
+    let sentBytes = 0;
+    const chunk = Buffer.alloc(64 * 1024, 0x20);
+    res.writeHead(200, { "content-type": "application/json" });
+    const timer = setInterval(() => {
+      if (sentBytes >= LOOPBACK_RESPONSE_BYTES) {
+        clearInterval(timer);
+        res.end();
+        return;
+      }
+      sentBytes += chunk.length;
+      res.write(chunk);
+    }, 1);
+    res.on("close", () => {
+      clearInterval(timer);
+      resolveClosed(sentBytes);
+    });
+  });
+  return { server, closed };
+}
 
 describe("describeGeminiVideo", () => {
   it("respects case-insensitive x-goog-api-key overrides", async () => {
@@ -112,6 +157,30 @@ describe("describeGeminiVideo", () => {
     expect(body.contents?.[0]?.parts?.[1]?.inline_data?.data).toBe(
       Buffer.from("video-bytes").toString("base64"),
     );
+  });
+
+  it("bounds oversized video JSON responses and closes the stream early", async () => {
+    const { server, closed } = createOversizedJsonServer();
+    const port = await listenLoopbackServer(server);
+    const fetchFn = withFetchPreconnect(async () =>
+      fetch(`http://127.0.0.1:${port}/google-video-json`),
+    );
+
+    try {
+      await expect(
+        describeGeminiVideo({
+          buffer: Buffer.from("video-bytes"),
+          fileName: "clip.mp4",
+          apiKey: "test-key",
+          timeoutMs: 1500,
+          fetchFn,
+        }),
+      ).rejects.toThrow("Video description failed: JSON response exceeds 16777216 bytes");
+      await expect(closed).resolves.toBeLessThan(LOOPBACK_RESPONSE_BYTES);
+      await expect(closed).resolves.toBeGreaterThan(GOOGLE_JSON_CAP_BYTES);
+    } finally {
+      server.close();
+    }
   });
 
   it("rejects non-Google video base URLs before sending authenticated requests", async () => {


### PR DESCRIPTION
## Summary

- Bound Google media understanding video/audio JSON response parsing through `readProviderJsonResponse` instead of direct `res.json()`.
- Added a Google media video regression test using a local loopback HTTP server that streams an oversized JSON response and proves the connection closes before the full response is sent.
- Kept request construction, Google endpoint validation, auth headers, model normalization, and text extraction semantics unchanged.

## What Problem This Solves

Google media understanding shared video/audio response parsing used a local helper that called `res.json()` directly after the provider HTTP status check. A successful Google Generative AI response with an oversized body could be materialized through the native JSON reader before parsing, unlike provider paths already using the shared bounded JSON reader.

## User Impact

- **Why it matters / User impact:** Users configuring Google media understanding get the same 16 MiB JSON response cap used by other provider response readers. Oversized video/audio success responses now fail early with a provider-owned error instead of being buffered through the native JSON reader.
- **What did NOT change:** This patch only changes the Google media understanding success-response JSON reader and its video regression test. It does not change request payload construction, Google base URL validation, API key/header handling, model normalization, missing-text behavior, image description behavior, or generated text extraction.
- **Architecture / source-of-truth check:** Google media understanding still owns Google-specific request/response shape handling in `generateGeminiInlineDataText`, while the canonical `readProviderJsonResponse` contract remains the source-of-truth for provider JSON byte limits and malformed JSON wrapping.

## Origin / follow-up

Follows #96605.

- **Follows / completes:** #96605 established the same bounded provider response-body pattern for Google video operation reads.
- **Gap this fills:** `extensions/google/media-understanding-provider.ts` still parsed Google media understanding video/audio success responses through direct `res.json()`.
- **Consistency:** This patch reuses the existing SDK facade helper instead of reimplementing byte-limit logic in the Google extension.

## Competition / linked PR analysis

Before submission I rechecked open PR overlap for Google/Gemini/media-understanding/bounded-reader work, including high-frequency bounded-reader submissions.

- #96772 touches `extensions/googlechat/src/api.ts` and `extensions/googlechat/src/auth.ts`, not Google media understanding.
- #96620 touches GoogleChat plus other channel/provider files, not `extensions/google/media-understanding-provider.ts`.
- #96618 touches Google Meet plus other integrations, not `extensions/google/media-understanding-provider.ts`.
- #96907 is the canonical Runway create/poll bounded-reader PR, not Google media understanding.

No open PR found in this pass covers `extensions/google/media-understanding-provider.ts` or the Google media understanding video/audio success JSON reader.

## Real behavior proof

- **Behavior or issue addressed:** Google media understanding video/audio success responses are read through a bounded provider JSON reader, and oversized streamed provider JSON responses fail at the 16 MiB cap while closing the stream early.
- **Real environment tested:** Local OpenClaw provider runtime path in `/media/vdb/code/ai/aispace/openclaw-worktrees/followup-96605`, using `describeGeminiVideo()` with a local loopback HTTP server returning a real streamed `Response` body.
- **Exact steps or command run after this patch:** `pnpm check:test-types`, `node scripts/run-vitest.mjs extensions/google/media-understanding-provider.video.test.ts`, and a standalone loopback proof invoking `describeGeminiVideo()` against an oversized local HTTP response.
- **Evidence after fix:** `/media/vdb/code/ai/aispace/openclaw-followup-96605-evidence/google-media-test-types.txt`, `/media/vdb/code/ai/aispace/openclaw-followup-96605-evidence/google-media-vitest.txt`, and `/media/vdb/code/ai/aispace/openclaw-followup-96605-evidence/google-media-loopback-proof.txt`
- **Observed result after fix:** `pnpm check:test-types` completed successfully. The Google media video Vitest shard reported `Test Files 1 passed (1)` and `Tests 6 passed (6)`. The loopback proof observed `Video description failed: JSON response exceeds 16777216 bytes`, `closed_bytes=16908288`, `exceeded_cap=true`, and `closed_before_full_response=true`.
- **What was not tested:** Credential-backed Google Generative AI network call: out of scope for this follow-up because the changed contract is the response-body reader boundary, which is exercised through the provider function with a real loopback HTTP stream.
- **Fix classification:** Root cause fix

## Review findings addressed

N/A — new follow-up PR.

## Regression Test Plan

- **Target test file:** `extensions/google/media-understanding-provider.video.test.ts`
- **Scenario locked in:** The regression test routes `describeGeminiVideo()` through a local loopback HTTP server that streams an 18 MiB JSON response and asserts the provider reports `Video description failed: JSON response exceeds 16777216 bytes`.
- **Why this is the smallest reliable guardrail:** The test uses the public `describeGeminiVideo()` provider entry point and a real HTTP streamed `Response`, so it fails if Google media understanding regresses to direct `res.json()` or stops closing oversized response streams early.
- `pnpm check:test-types`
- `node scripts/run-vitest.mjs extensions/google/media-understanding-provider.video.test.ts`

## Risk / Compatibility

Low. Successful Google media understanding JSON responses still parse into the same candidate text shape and still flow through the same missing-text validation. Responses larger than 16 MiB now fail with a bounded-reader error, matching existing provider JSON response limits.

## Merge risk

- **Risk labels considered:** `merge-risk: compatibility`, provider/auth surface, media-understanding provider surface.
- **Risk explanation:** This touches a provider implementation, but production behavior is limited to replacing direct JSON materialization with the existing provider JSON reader. The compatibility change is limited to oversized JSON success bodies that now fail closed at the shared 16 MiB provider cap.
- **Why acceptable:** Normal JSON success payloads continue through the same Google candidate text extraction. HTTP error formatting still uses the existing provider error path, and malformed JSON now gets the shared provider-owned malformed JSON wrapper.
- **Maintainer-ready confidence:** High: the diff is small, the source-of-truth helper is reused rather than reimplemented, the test exercises the public provider entry point, and the loopback proof observes early stream closure at the response-body boundary.
- **Patch quality notes:** No production broad catch, fallback, feature flag, or custom byte-limit implementation was added. The added test server is confined to the Google media provider test file and exists only to exercise a real streamed response boundary.

## What was not changed

- Did not change Google media request construction, API key/header behavior, base URL validation, model normalization, or text extraction.
- Did not change Google image description providers or unrelated Google extension surfaces.

## Root Cause

- **Root cause:** The source of the unbounded read was the Google media understanding shared response helper: it used direct `res.json()` for HTTP success responses instead of the shared bounded provider JSON reader contract.
- **Why this is root-cause fix:** The helper now reads through the shared provider JSON reader contract, so every Google media understanding video/audio JSON success response consumed through that helper is capped before JSON parsing while preserving the existing Google response text extraction semantics.
