### PR TITLE
fix(llm): coerce stringified JSON arrays/objects in tool argument validation (fixes #96916) (AI-assisted)

### DIFF
--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -40,3 +40,103 @@ describe("validateToolArguments", () => {
     ).toThrow(/Validation failed for tool "decimal-tool"/);
   });
 });
+
+const arrayTool = {
+  name: "array-tool",
+  description: "test tool with array param",
+  parameters: {
+    type: "object",
+    properties: {
+      tags: { type: "array", items: { type: "string" } },
+    },
+    required: ["tags"],
+    additionalProperties: false,
+  },
+} as Tool;
+
+const objectTool = {
+  name: "object-tool",
+  description: "test tool with object param",
+  parameters: {
+    type: "object",
+    properties: {
+      config: {
+        type: "object",
+        properties: {
+          enabled: { type: "boolean" },
+          retries: { type: "number" },
+        },
+      },
+    },
+    required: ["config"],
+    additionalProperties: false,
+  },
+} as Tool;
+
+describe("validateToolArguments — stringified JSON coercion", () => {
+  it("coerces stringified JSON array to array for plain JSON schemas", () => {
+    expect(
+      validateToolArguments(arrayTool, {
+        type: "toolCall",
+        id: "call-2",
+        name: "array-tool",
+        arguments: { tags: '["test","debug"]' },
+      }),
+    ).toEqual({ tags: ["test", "debug"] });
+  });
+
+  it("coerces stringified JSON object to object for plain JSON schemas", () => {
+    expect(
+      validateToolArguments(objectTool, {
+        type: "toolCall",
+        id: "call-3",
+        name: "object-tool",
+        arguments: { config: '{"enabled":true,"retries":3}' },
+      }),
+    ).toEqual({ config: { enabled: true, retries: 3 } });
+  });
+
+  it("passes through valid arrays unchanged", () => {
+    expect(
+      validateToolArguments(arrayTool, {
+        type: "toolCall",
+        id: "call-4",
+        name: "array-tool",
+        arguments: { tags: ["already", "array"] },
+      }),
+    ).toEqual({ tags: ["already", "array"] });
+  });
+
+  it("passes through valid objects unchanged", () => {
+    expect(
+      validateToolArguments(objectTool, {
+        type: "toolCall",
+        id: "call-5",
+        name: "object-tool",
+        arguments: { config: { enabled: false, retries: 1 } },
+      }),
+    ).toEqual({ config: { enabled: false, retries: 1 } });
+  });
+
+  it("rejects invalid JSON string for array param", () => {
+    expect(() =>
+      validateToolArguments(arrayTool, {
+        type: "toolCall",
+        id: "call-6",
+        name: "array-tool",
+        arguments: { tags: "not-json" },
+      }),
+    ).toThrow(/Validation failed for tool "array-tool"/);
+  });
+
+  it("rejects JSON string that is wrong type for array param", () => {
+    expect(() =>
+      validateToolArguments(arrayTool, {
+        type: "toolCall",
+        id: "call-7",
+        name: "array-tool",
+        arguments: { tags: '{"not":"array"}' },
+      }),
+    ).toThrow(/Validation failed for tool "array-tool"/);
+  });
+});

--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -139,4 +139,30 @@ describe("validateToolArguments — stringified JSON coercion", () => {
       }),
     ).toThrow(/Validation failed for tool "array-tool"/);
   });
+
+  it("skips JSON coercion for oversized array string", () => {
+    const hugeArray = JSON.stringify(Array.from({ length: 100_000 }, (_, i) => i));
+    expect(hugeArray.length).toBeGreaterThan(64 * 1024);
+    expect(() =>
+      validateToolArguments(arrayTool, {
+        type: "toolCall",
+        id: "call-8",
+        name: "array-tool",
+        arguments: { tags: hugeArray },
+      }),
+    ).toThrow(/Validation failed for tool "array-tool"/);
+  });
+
+  it("skips JSON coercion for oversized object string", () => {
+    const hugeObj = JSON.stringify({ data: "x".repeat(70_000) });
+    expect(hugeObj.length).toBeGreaterThan(64 * 1024);
+    expect(() =>
+      validateToolArguments(objectTool, {
+        type: "toolCall",
+        id: "call-9",
+        name: "object-tool",
+        arguments: { config: hugeObj },
+      }),
+    ).toThrow(/Validation failed for tool "object-tool"/);
+  });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -7,6 +7,9 @@ import type { Tool, ToolCall } from "./types.js";
 const validatorCache = new WeakMap<object, ReturnType<typeof Compile>>();
 const TYPEBOX_KIND = Symbol.for("TypeBox.Kind");
 
+/** Maximum string length accepted for schema-gated JSON coercion. */
+const MAX_JSON_COERCE_LENGTH = 64 * 1024;
+
 interface JsonSchemaObject {
   type?: string | string[];
   properties?: Record<string, JsonSchemaObject>;
@@ -155,7 +158,11 @@ function coercePrimitiveByType(value: unknown, type: string): unknown {
       return value;
     }
     case "array": {
-      if (typeof value === "string" && value.trim() !== "") {
+      if (
+        typeof value === "string" &&
+        value.trim() !== "" &&
+        value.length <= MAX_JSON_COERCE_LENGTH
+      ) {
         try {
           const parsed: unknown = JSON.parse(value);
           if (Array.isArray(parsed)) {
@@ -168,7 +175,11 @@ function coercePrimitiveByType(value: unknown, type: string): unknown {
       return value;
     }
     case "object": {
-      if (typeof value === "string" && value.trim() !== "") {
+      if (
+        typeof value === "string" &&
+        value.trim() !== "" &&
+        value.length <= MAX_JSON_COERCE_LENGTH
+      ) {
         try {
           const parsed: unknown = JSON.parse(value);
           if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -154,6 +154,32 @@ function coercePrimitiveByType(value: unknown, type: string): unknown {
       }
       return value;
     }
+    case "array": {
+      if (typeof value === "string" && value.trim() !== "") {
+        try {
+          const parsed: unknown = JSON.parse(value);
+          if (Array.isArray(parsed)) {
+            return parsed;
+          }
+        } catch {
+          // Not valid JSON; leave as-is for the validator to reject.
+        }
+      }
+      return value;
+    }
+    case "object": {
+      if (typeof value === "string" && value.trim() !== "") {
+        try {
+          const parsed: unknown = JSON.parse(value);
+          if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+            return parsed;
+          }
+        } catch {
+          // Not valid JSON; leave as-is for the validator to reject.
+        }
+      }
+      return value;
+    }
     case "null": {
       if (value === "" || value === 0 || value === false) {
         return null;


### PR DESCRIPTION
## What Problem This Solves

MCP tool calls fail with validation errors when LLMs serialize array or object parameters as JSON strings (e.g. `"tags": "[\"test\",\"debug\"]"` instead of `"tags": ["test","debug"]`). This affects providers like Xiaomi MiMo, Ollama, and others that stringify complex parameters in `tool_calls[].function.arguments`. All MCP tools with `array` or `object` typed parameters are affected.

## Why This Change Was Made

`coercePrimitiveByType` in `packages/llm-core/src/validation.ts` handles string-to-number, string-to-boolean, and string-to-integer coercion, but had no cases for `array` or `object`. When an LLM sends a stringified JSON array or object, the validator rejects it outright. The fix adds `JSON.parse`-based coercion for these types, matching the existing pattern for numeric strings.

## User Impact

MCP tools with array/object parameters now work across all providers, regardless of how the LLM serializes complex arguments. No config changes required.

## Changes Made

- `packages/llm-core/src/validation.ts`: Added `case "array"` and `case "object"` to `coercePrimitiveByType` that attempt `JSON.parse` when the value is a string, returning the parsed result only if it matches the expected type.
- `packages/llm-core/src/validation.test.ts`: Added 6 tests covering stringified array coercion, stringified object coercion, passthrough of valid arrays/objects, and rejection of invalid JSON / wrong-type JSON strings.

- [x] AI-assisted (Hermes Agent)

## Evidence

- **Behavior addressed:** MCP tool calls with stringified JSON array/object parameters fail validation.
- **Environment tested:** macOS, Node 22.22.3, OpenClaw workdir at `packages/llm-core/` (upstream/main @ 448b7c75).
- **Steps run after the patch:** Built the project (`pnpm build`), then imported `validateToolArguments` from `packages/llm-core/dist/validation.mjs` and called it with a tool whose `tags` parameter is `{ type: "array", items: { type: "string" } }`, passing `tags: '["test","debug"]'` (stringified JSON array).
- **Evidence after fix:**
```
$ node --input-type=module -e "..."
=== After fix: ===
Input:  { content: "test memory", tags: stringified JSON array }
Output: {"content":"test memory","tags":["test","debug"]}
tags is array: true
tags value: ["test","debug"]
```
- **Observed result after fix:** The stringified JSON array `"[\"test\",\"debug\"]"` is coerced to `["test","debug"]` and passes validation. Object coercion also works: `'{"enabled":true,"retries":3}'` → `{ enabled: true, retries: 3 }`.
- **What was not tested:** End-to-end MCP server integration (no MCP server configured in this environment). The fix is validated at the `validateToolArguments` function level, which is the exact code path MCP tool calls traverse.

## Real behavior proof

- **Behavior addressed:** MCP tool calls with stringified JSON array/object parameters fail validation.
- **Environment tested:** macOS, Node 22.22.3, OpenClaw workdir (upstream/main @ 448b7c75).
- **Steps run after the patch:** Built the project (`pnpm build`), imported `validateToolArguments` from `packages/llm-core/dist/validation.mjs`, called with stringified JSON array parameter.
- **Evidence after fix:**
```
Input:  { content: "test memory", tags: stringified JSON array }
Output: {"content":"test memory","tags":["test","debug"]}
tags is array: true
```
- **Observed result after fix:** Stringified JSON arrays/objects are coerced to proper types and pass validation.
- **What was not tested:** End-to-end MCP server integration. Fix validated at the `validateToolArguments` level.
