### PR TITLE
fix(launchd): detect profile-scoped updater jobs

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -470,6 +470,7 @@ describe("launchctl list detection", () => {
         "- 127 ai.openclaw.update.2026.5.12",
         "- 0 ai.openclaw.manual-update.1717168800",
         "- 0 ai.openclaw.tayoun.update.20260625T201026-0400",
+        "- 0 ai.openclaw.dev.team.update.20260625T201026-0400",
         "8142 0 ai.openclaw.update.2026.5.13-beta.1",
         "- 0 ai.openclaw.manual-updater.1717168800",
         "- 0 com.example.other",
@@ -477,6 +478,10 @@ describe("launchctl list detection", () => {
     );
 
     expect(jobs).toEqual([
+      {
+        label: "ai.openclaw.dev.team.update.20260625T201026-0400",
+        lastExitStatus: 0,
+      },
       {
         label: "ai.openclaw.manual-update.1717168800",
         lastExitStatus: 0,
@@ -503,11 +508,16 @@ describe("launchctl list detection", () => {
       state.listOutput = [
         "- 127 ai.openclaw.update.2026.5.12",
         "- 0 ai.openclaw.tayoun.update.20260625T201026-0400",
+        "- 0 ai.openclaw.dev.team.update.20260625T201026-0400",
       ].join("\n");
 
       const jobs = await findStaleOpenClawUpdateLaunchdJobs();
 
       expect(jobs).toEqual([
+        {
+          label: "ai.openclaw.dev.team.update.20260625T201026-0400",
+          lastExitStatus: 0,
+        },
         {
           label: "ai.openclaw.tayoun.update.20260625T201026-0400",
           lastExitStatus: 0,
@@ -586,14 +596,14 @@ describe("launchctl list detection", () => {
     async () => {
       await expect(
         disableCurrentOpenClawUpdateLaunchdJob({
-          LAUNCH_JOB_LABEL: "ai.openclaw.tayoun.update.20260625T201026-0400",
+          LAUNCH_JOB_LABEL: "ai.openclaw.dev.team.update.20260625T201026-0400",
         }),
       ).resolves.toBe(true);
 
       const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
       expect(state.launchctlCalls).toContainEqual([
         "disable",
-        `${domain}/ai.openclaw.tayoun.update.20260625T201026-0400`,
+        `${domain}/ai.openclaw.dev.team.update.20260625T201026-0400`,
       ]);
       expect(launchctlCommandNames()).not.toContain("remove");
     },
@@ -734,13 +744,13 @@ describe("launchctl list detection", () => {
     "disables explicit profile-scoped updater jobs",
     async () => {
       await expect(
-        disableOpenClawUpdateLaunchdJob("ai.openclaw.tayoun.update.20260625T201026-0400"),
+        disableOpenClawUpdateLaunchdJob("ai.openclaw.dev.team.update.20260625T201026-0400"),
       ).resolves.toBe(true);
 
       const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
       expect(state.launchctlCalls).toContainEqual([
         "disable",
-        `${domain}/ai.openclaw.tayoun.update.20260625T201026-0400`,
+        `${domain}/ai.openclaw.dev.team.update.20260625T201026-0400`,
       ]);
     },
   );

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -469,6 +469,7 @@ describe("launchctl list detection", () => {
         "123 0 ai.openclaw.gateway",
         "- 127 ai.openclaw.update.2026.5.12",
         "- 0 ai.openclaw.manual-update.1717168800",
+        "- 0 ai.openclaw.tayoun.update.20260625T201026-0400",
         "8142 0 ai.openclaw.update.2026.5.13-beta.1",
         "- 0 ai.openclaw.manual-updater.1717168800",
         "- 0 com.example.other",
@@ -478,6 +479,10 @@ describe("launchctl list detection", () => {
     expect(jobs).toEqual([
       {
         label: "ai.openclaw.manual-update.1717168800",
+        lastExitStatus: 0,
+      },
+      {
+        label: "ai.openclaw.tayoun.update.20260625T201026-0400",
         lastExitStatus: 0,
       },
       {
@@ -495,11 +500,18 @@ describe("launchctl list detection", () => {
   it.runIf(process.platform === "darwin")(
     "finds stale OpenClaw updater jobs via launchctl list",
     async () => {
-      state.listOutput = "- 127 ai.openclaw.update.2026.5.12\n";
+      state.listOutput = [
+        "- 127 ai.openclaw.update.2026.5.12",
+        "- 0 ai.openclaw.tayoun.update.20260625T201026-0400",
+      ].join("\n");
 
       const jobs = await findStaleOpenClawUpdateLaunchdJobs();
 
       expect(jobs).toEqual([
+        {
+          label: "ai.openclaw.tayoun.update.20260625T201026-0400",
+          lastExitStatus: 0,
+        },
         {
           label: "ai.openclaw.update.2026.5.12",
           lastExitStatus: 127,
@@ -564,6 +576,24 @@ describe("launchctl list detection", () => {
       expect(state.launchctlCalls).toContainEqual([
         "disable",
         `${domain}/ai.openclaw.manual-update.1717168800`,
+      ]);
+      expect(launchctlCommandNames()).not.toContain("remove");
+    },
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "disables the current profile-scoped updater launchd job",
+    async () => {
+      await expect(
+        disableCurrentOpenClawUpdateLaunchdJob({
+          LAUNCH_JOB_LABEL: "ai.openclaw.tayoun.update.20260625T201026-0400",
+        }),
+      ).resolves.toBe(true);
+
+      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+      expect(state.launchctlCalls).toContainEqual([
+        "disable",
+        `${domain}/ai.openclaw.tayoun.update.20260625T201026-0400`,
       ]);
       expect(launchctlCommandNames()).not.toContain("remove");
     },
@@ -674,6 +704,20 @@ describe("launchctl list detection", () => {
     },
   );
 
+  it.runIf(process.platform === "darwin")(
+    "does not disable profile-specific gateway jobs that match profile update label shape",
+    async () => {
+      await expect(
+        disableCurrentOpenClawUpdateLaunchdJob({
+          LAUNCH_JOB_LABEL: "ai.openclaw.tayoun.update.20260625T201026-0400",
+          OPENCLAW_PROFILE: "tayoun.update.20260625T201026-0400",
+        }),
+      ).resolves.toBe(false);
+
+      expect(state.launchctlCalls).toEqual([]);
+    },
+  );
+
   it.runIf(process.platform === "darwin")("disables explicit legacy updater jobs", async () => {
     await expect(disableOpenClawUpdateLaunchdJob("ai.openclaw.update.2026.5.12")).resolves.toBe(
       true,
@@ -685,6 +729,21 @@ describe("launchctl list detection", () => {
       `${domain}/ai.openclaw.update.2026.5.12`,
     ]);
   });
+
+  it.runIf(process.platform === "darwin")(
+    "disables explicit profile-scoped updater jobs",
+    async () => {
+      await expect(
+        disableOpenClawUpdateLaunchdJob("ai.openclaw.tayoun.update.20260625T201026-0400"),
+      ).resolves.toBe(true);
+
+      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+      expect(state.launchctlCalls).toContainEqual([
+        "disable",
+        `${domain}/ai.openclaw.tayoun.update.20260625T201026-0400`,
+      ]);
+    },
+  );
 
   it.runIf(process.platform === "darwin")("disables explicit manual updater jobs", async () => {
     await expect(

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -51,6 +51,8 @@ const LAUNCH_AGENT_ENV_DIR_NAME = "service-env";
 const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 const OPENCLAW_UPDATE_LAUNCHD_LABEL_PREFIX = "ai.openclaw.update.";
 const OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN = /^ai\.openclaw\.manual-update\.\d+$/;
+const OPENCLAW_PROFILE_UPDATE_LAUNCHD_LABEL_PATTERN =
+  /^ai\.openclaw\.[A-Za-z0-9_-]+\.update\.[A-Za-z0-9._-]+$/;
 const LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS = LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000;
 const LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS = 100;
 
@@ -70,7 +72,13 @@ function normalizeOpenClawUpdateLaunchdLabel(label: unknown): string | null {
   }
   // Manual update jobs include a timestamp-like suffix and should be cleaned up
   // without matching arbitrary ai.openclaw labels.
-  return OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN.test(trimmed) ? trimmed : null;
+  if (OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+  // Profile-scoped update jobs are submitted as
+  // `ai.openclaw.<profile>.update.<timestamp>`. Recognize only the full shape
+  // so normal profile gateway labels remain protected by isCurrentGatewayLaunchdLabel.
+  return OPENCLAW_PROFILE_UPDATE_LAUNCHD_LABEL_PATTERN.test(trimmed) ? trimmed : null;
 }
 
 function isCurrentGatewayLaunchdLabel(label: string, env: NodeJS.ProcessEnv): boolean {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -52,7 +52,7 @@ const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 const OPENCLAW_UPDATE_LAUNCHD_LABEL_PREFIX = "ai.openclaw.update.";
 const OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN = /^ai\.openclaw\.manual-update\.\d+$/;
 const OPENCLAW_PROFILE_UPDATE_LAUNCHD_LABEL_PATTERN =
-  /^ai\.openclaw\.[A-Za-z0-9_-]+\.update\.[A-Za-z0-9._-]+$/;
+  /^ai\.openclaw\.[A-Za-z0-9._-]+\.update\.[A-Za-z0-9._-]+$/;
 const LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS = LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000;
 const LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS = 100;
 


### PR DESCRIPTION
## What Problem This Solves

A macOS profile-scoped updater launchd job can get stuck repeatedly rerunning `openclaw update --yes`.

Observed locally with profile `tayoun`: launchd job `ai.openclaw.tayoun.update.20260625T201026-0400` ran the updater 300 times. The first run upgraded OpenClaw from `2026.6.1` to `2026.6.10`; the next 299 runs were no-op updates from `2026.6.10` to `2026.6.10`, repeatedly stopping/killing the gateway. The stuck job used the profile-scoped label shape `ai.openclaw.<profile>.update.<timestamp>`.

The existing launchd updater cleanup/detection parser recognized legacy `ai.openclaw.update.*` and `ai.openclaw.manual-update.<digits>` labels, but not profile-scoped updater labels. That meant the update CLI startup cleanup did not disable the current updater job, and status/doctor could not reliably surface the stale profile-scoped update job.

## Summary

- Recognize profile-scoped launchd updater labels such as `ai.openclaw.tayoun.update.20260625T201026-0400`.
- Match dotted profile labels that are valid under the existing launchd label contract, such as `ai.openclaw.dev.team.update.20260625T201026-0400`.
- Include those jobs in stale updater detection so `status`/doctor can surface stuck update jobs.
- Let the update CLI's startup cleanup disable the current profile-scoped updater job instead of leaving `KeepAlive` free to rerun `openclaw update --yes`.
- Preserve the existing guard that avoids disabling a gateway LaunchAgent when the active profile name itself matches the update-label shape.

## Evidence

Local incident evidence:

- `update-20260625T201026-0400.log` contained 300 `Updating OpenClaw` entries.
- The same log contained 300 `Update Result: OK` entries.
- The first run showed `Before: 2026.6.1` and `After: 2026.6.10`.
- Subsequent runs showed `Before: 2026.6.10` and `After: 2026.6.10`.
- `update-20260625T201026-0400.err.log` contained 300 gateway restart/kill entries.
- The stuck label was `ai.openclaw.tayoun.update.20260625T201026-0400`.

Live macOS launchd proof after this patch:

```text
LABEL=ai.openclaw.dev.team.update.20260626T012120-0400
-- launchctl list before patched cleanup --
39117	0	ai.openclaw.dev.team.update.20260626T012120-0400
-- patched parser sees stale updater job --
{"label":"ai.openclaw.dev.team.update.20260626T012120-0400","pid":39117,"lastExitStatus":0}
-- patched cleanup disables dotted profile updater job --
{"label":"ai.openclaw.dev.team.update.20260626T012120-0400","disabled":true}
-- launchctl print-disabled after patched cleanup --
		"ai.openclaw.dev.team.update.20260626T012120-0400" => disabled
```

The proof job was a temporary benign user LaunchAgent using `/bin/sleep 600` with `KeepAlive=true`; it was booted out and removed after the proof capture.

Regression coverage added in this PR:

- Parses `ai.openclaw.tayoun.update.20260625T201026-0400` from `launchctl list`.
- Parses and disables dotted profile labels such as `ai.openclaw.dev.team.update.20260625T201026-0400`.
- Reports profile-scoped updater labels from `findStaleOpenClawUpdateLaunchdJobs()`.
- Disables a current profile-scoped updater label via `disableCurrentOpenClawUpdateLaunchdJob()`.
- Keeps the existing safety guard for gateway jobs whose profile-derived label happens to match the profile update-label shape.

Verification run locally:

- `node scripts/run-vitest.mjs src/daemon/launchd.test.ts` — 92 passed.
- `pnpm exec oxfmt --check src/daemon/launchd.ts src/daemon/launchd.test.ts`.
- `node scripts/run-oxlint.mjs src/daemon/launchd.ts src/daemon/launchd.test.ts`.
- `pnpm tsgo:core`.
- `git diff --check`.
