### PR TITLE
ci: park timing summary collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2419,7 +2419,8 @@ jobs:
       - macos-swift
       - ios-build
       - android
-    if: ${{ !cancelled() && always() && github.event_name != 'push' && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
+    # Re-enable this job when we want to collect CI timing data for timing optimization.
+    if: ${{ false && !cancelled() && always() && github.event_name != 'push' && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -573,7 +573,11 @@ describe("ci workflow guards", () => {
     expect(runStep.run).toContain("childEnv[key] = value");
   });
 
-  it("uploads a CI timing summary after the run lanes finish", () => {
+  it("keeps the CI timing summary parked for timing optimization work", () => {
+    expect(readFileSync(".github/workflows/ci.yml", "utf8")).toContain(
+      "Re-enable this job when we want to collect CI timing data for timing optimization.",
+    );
+
     const workflow = readCiWorkflow();
     const timingJob = workflow.jobs["ci-timings-summary"];
 
@@ -598,6 +602,7 @@ describe("ci workflow guards", () => {
       "ios-build",
       "android",
     ]);
+    expect(timingJob.if).toContain("false");
     expect(timingJob.if).toContain("always()");
     expect(timingJob.if).toContain("!cancelled()");
 


### PR DESCRIPTION
I had enabled this to optimize CI but now it affects wall time quite a bit and not using. Disabling for now.

## What Problem This Solves

The CI timing summary job is currently wired into the main CI workflow, which starts collecting and uploading timing data before maintainers have decided to use it for timing optimization work.

## Why This Change Was Made

This keeps the existing `ci-timings-summary` job definition in place but disables it at the job condition with an explanatory comment. Re-enabling timing collection is a one-line workflow change when we want to start using the data.

## User Impact

Normal CI no longer invokes the timing summary collection job. No product behavior changes.

## Evidence

- `git diff --check`
- `actionlint .github/workflows/ci.yml`
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review this narrow CI workflow change: ci-timings-summary should remain defined but not run until maintainers want CI timing data for optimization; the guard test should verify the disabled state and explanatory comment."` returned clean with no accepted/actionable findings.
