### PR TITLE
fix(signal): avoid duplicate signal-cli missing note

### DIFF
--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -23,6 +23,7 @@ import {
 import { probeSignal } from "./probe.js";
 import { clearSignalRuntime } from "./runtime.js";
 import {
+  createSignalCliPathTextInput,
   normalizeSignalAccountInput,
   parseSignalAllowFromEntries,
   signalDmPolicy,
@@ -213,6 +214,13 @@ describe("probeSignal", () => {
     });
 
     expect(status.configured).toBe(true);
+  });
+
+  it("does not show a second missing-binary note before the cliPath prompt", () => {
+    const input = createSignalCliPathTextInput(async () => true);
+
+    expect(input.helpLines).toBeUndefined();
+    expect(input.helpTitle).toBeUndefined();
   });
 });
 

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -193,10 +193,6 @@ export function createSignalCliPathTextInput(
     resolvePath: ({ cfg, accountId, credentialValues }) =>
       resolveSignalCliPath({ cfg, accountId, credentialValues }),
     shouldPrompt,
-    helpTitle: "Signal",
-    helpLines: [
-      "signal-cli not found. Install it, then rerun this step or set channels.signal.cliPath.",
-    ],
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Signal QuickStart could show two consecutive missing-binary notes after `signal-cli` installation failed: first the installer failure from the Signal prepare step, then the generic cliPath help note before asking for `signal-cli path`.

## Why This Change Was Made

The path prompt itself is already the recovery action, and the installer failure already explains the failure. Removing the Signal-specific cliPath help note keeps the setup flow to one error note plus the path prompt without adding wizard state or changing shared setup behavior.

## User Impact

Users see one Signal install failure message instead of two similar Signal missing-binary messages, then can still enter a custom `signal-cli` path.

## Evidence

- `pnpm test extensions/signal/src/core.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 extensions/signal/src/setup-core.ts extensions/signal/src/core.test.ts`
- `git diff --check`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/signal/src/setup-core.ts extensions/signal/src/core.test.ts`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- `pnpm check:changed -- extensions/signal/src/setup-core.ts extensions/signal/src/core.test.ts` via Blacksmith Testbox `tbx_01kw12d6xprcv4gw3c8hb6pwg6`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review this focused OpenClaw Signal setup copy fix. Scope: avoid duplicate Signal missing-binary notes by removing the generic Signal cliPath help note; installer failure remains and the path prompt still appears. Touched files: extensions/signal/src/setup-core.ts and extensions/signal/src/core.test.ts. Focus on setup UX, wizard behavior, and test value."`
