### PR TITLE
fix(feishu): keep default appSecret refs active

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -80,6 +80,23 @@ describe("resolveDefaultFeishuAccountId", () => {
     expect(resolveDefaultFeishuAccountId(cfg as never)).toBe("default");
   });
 
+  it("preserves top-level default account when appSecret is a SecretRef", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          appId: "cli_default",
+          appSecret: { source: "env", provider: "default", id: "FEISHU_APP_SECRET" },
+          accounts: {
+            work: { appId: "cli_work", appSecret: "secret_work" }, // pragma: allowlist secret
+          },
+        },
+      },
+    };
+
+    expect(listFeishuAccountIds(cfg as never)).toEqual(["default", "work"]);
+    expect(resolveDefaultFeishuAccountId(cfg as never)).toBe("default");
+  });
+
   it("prefers channels.feishu.defaultAccount when configured", () => {
     const cfg = {
       channels: {

--- a/extensions/feishu/src/secret-contract.ts
+++ b/extensions/feishu/src/secret-contract.ts
@@ -1,4 +1,5 @@
 // Feishu plugin module implements secret contract behavior.
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import {
   collectConditionalChannelFieldAssignments,
   collectSecretInputAssignment,
@@ -92,9 +93,13 @@ export function collectRuntimeConfigAssignments(params: {
   }
   const { channel: feishu, surface } = resolved;
   // Feishu account listing starts an implicit default account from top-level credentials
-  // even when every named account overrides appSecret.
+  // only when an explicit default account does not already own that account id.
+  const hasExplicitDefaultAccount =
+    surface.hasExplicitAccounts &&
+    surface.accounts.some(({ accountId }) => normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID);
   const hasImplicitDefaultAccount =
     surface.channelEnabled &&
+    !hasExplicitDefaultAccount &&
     hasConfiguredSecretInputValue(feishu.appId, params.defaults) &&
     hasConfiguredSecretInputValue(feishu.appSecret, params.defaults);
   const topLevelAppSecretActive =

--- a/extensions/feishu/src/secret-contract.ts
+++ b/extensions/feishu/src/secret-contract.ts
@@ -1,9 +1,11 @@
 // Feishu plugin module implements secret contract behavior.
 import {
   collectConditionalChannelFieldAssignments,
-  collectSimpleChannelFieldAssignments,
+  collectSecretInputAssignment,
   getChannelSurface,
   hasOwnProperty,
+  hasConfiguredSecretInputValue,
+  isBaseFieldActiveForChannelSurface,
   normalizeSecretStringValue,
   type ResolverContext,
   type SecretDefaults,
@@ -89,16 +91,45 @@ export function collectRuntimeConfigAssignments(params: {
     return;
   }
   const { channel: feishu, surface } = resolved;
-  collectSimpleChannelFieldAssignments({
-    channelKey: "feishu",
-    field: "appSecret",
-    channel: feishu,
-    surface,
+  // Feishu account listing starts an implicit default account from top-level credentials
+  // even when every named account overrides appSecret.
+  const hasImplicitDefaultAccount =
+    surface.channelEnabled &&
+    hasConfiguredSecretInputValue(feishu.appId, params.defaults) &&
+    hasConfiguredSecretInputValue(feishu.appSecret, params.defaults);
+  const topLevelAppSecretActive =
+    hasImplicitDefaultAccount || isBaseFieldActiveForChannelSurface(surface, "appSecret");
+  collectSecretInputAssignment({
+    value: feishu.appSecret,
+    path: "channels.feishu.appSecret",
+    expected: "string",
     defaults: params.defaults,
     context: params.context,
-    topInactiveReason: "no enabled account inherits this top-level Feishu appSecret.",
-    accountInactiveReason: "Feishu account is disabled.",
+    active: topLevelAppSecretActive,
+    inactiveReason: "no enabled account inherits this top-level Feishu appSecret.",
+    apply: (value) => {
+      feishu.appSecret = value;
+    },
   });
+  if (surface.hasExplicitAccounts) {
+    for (const { accountId, account, enabled } of surface.accounts) {
+      if (!hasOwnProperty(account, "appSecret")) {
+        continue;
+      }
+      collectSecretInputAssignment({
+        value: account.appSecret,
+        path: `channels.feishu.accounts.${accountId}.appSecret`,
+        expected: "string",
+        defaults: params.defaults,
+        context: params.context,
+        active: enabled,
+        inactiveReason: "Feishu account is disabled.",
+        apply: (value) => {
+          account.appSecret = value;
+        },
+      });
+    }
+  }
   const baseConnectionMode =
     normalizeSecretStringValue(feishu.connectionMode) === "webhook" ? "webhook" : "websocket";
   const resolveAccountMode = (account: Record<string, unknown>) =>

--- a/src/secrets/runtime-external-channel-audit.test.ts
+++ b/src/secrets/runtime-external-channel-audit.test.ts
@@ -401,6 +401,40 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
     },
   );
 
+  it("resolves Feishu top-level appSecret refs for the implicit default account", async () => {
+    const records = configureExternalChannelRecords(["feishu"]);
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "cli_default",
+            appSecret: ref("FEISHU_APP_SECRET"),
+            accounts: {
+              resource: {
+                enabled: true,
+                appId: "cli_resource",
+                appSecret: "resource-secret", // pragma: allowlist secret
+              },
+            },
+          },
+        },
+      }),
+      env: {
+        FEISHU_APP_SECRET: "default-secret",
+      },
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: externalChannelOrigins(records),
+    });
+
+    expectResolvedPaths(snapshot.config, {
+      "channels.feishu.appSecret": "default-secret",
+      "channels.feishu.accounts.resource.appSecret": "resource-secret",
+    });
+    expect(snapshot.warnings).toStrictEqual([]);
+    expectMetadataBackedContractsWereUsed(["feishu"]);
+  });
+
   it("skips inactive exec-backed SecretRefs for every externalized channel contract", async () => {
     const records = configureExternalChannelRecords();
     const config = asConfig({

--- a/src/secrets/runtime-external-channel-audit.test.ts
+++ b/src/secrets/runtime-external-channel-audit.test.ts
@@ -435,6 +435,85 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
     expectMetadataBackedContractsWereUsed(["feishu"]);
   });
 
+  it("skips stale Feishu top-level appSecret refs when explicit default overrides them", async () => {
+    const records = configureExternalChannelRecords(["feishu"]);
+    const staleTopLevelRef = ref("FEISHU_STALE_TOP_LEVEL_APP_SECRET");
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "cli_top_level",
+            appSecret: staleTopLevelRef,
+            accounts: {
+              default: {
+                enabled: true,
+                appId: "cli_default",
+                appSecret: "default-secret", // pragma: allowlist secret
+              },
+              resource: {
+                enabled: true,
+                appId: "cli_resource",
+                appSecret: "resource-secret", // pragma: allowlist secret
+              },
+            },
+          },
+        },
+      }),
+      env: {},
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: externalChannelOrigins(records),
+    });
+
+    expect(getPath(snapshot.config, ["channels", "feishu", "appSecret"])).toEqual(staleTopLevelRef);
+    expectResolvedPaths(snapshot.config, {
+      "channels.feishu.accounts.default.appSecret": "default-secret",
+      "channels.feishu.accounts.resource.appSecret": "resource-secret",
+    });
+    expect(snapshot.warnings.map((warning) => warning.path)).toStrictEqual([
+      "channels.feishu.appSecret",
+    ]);
+    expectMetadataBackedContractsWereUsed(["feishu"]);
+  });
+
+  it("skips stale Feishu top-level appSecret refs when explicit default is disabled", async () => {
+    const records = configureExternalChannelRecords(["feishu"]);
+    const staleTopLevelRef = ref("FEISHU_DISABLED_DEFAULT_TOP_LEVEL_APP_SECRET");
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "cli_top_level",
+            appSecret: staleTopLevelRef,
+            accounts: {
+              default: {
+                enabled: false,
+              },
+              resource: {
+                enabled: true,
+                appId: "cli_resource",
+                appSecret: "resource-secret", // pragma: allowlist secret
+              },
+            },
+          },
+        },
+      }),
+      env: {},
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: externalChannelOrigins(records),
+    });
+
+    expect(getPath(snapshot.config, ["channels", "feishu", "appSecret"])).toEqual(staleTopLevelRef);
+    expectResolvedPaths(snapshot.config, {
+      "channels.feishu.accounts.resource.appSecret": "resource-secret",
+    });
+    expect(snapshot.warnings.map((warning) => warning.path)).toStrictEqual([
+      "channels.feishu.appSecret",
+    ]);
+    expectMetadataBackedContractsWereUsed(["feishu"]);
+  });
+
   it("skips inactive exec-backed SecretRefs for every externalized channel contract", async () => {
     const records = configureExternalChannelRecords();
     const config = asConfig({


### PR DESCRIPTION
## What Problem This Solves

Fixes #96929.

When Feishu has top-level `appId`/`appSecret` credentials and named accounts that each override `appSecret`, the secrets runtime can incorrectly mark `channels.feishu.appSecret` inactive. That leaves the implicit default Feishu account with an unresolved top-level SecretRef at startup.

## Why This Change Was Made

Feishu account resolution treats top-level credentials as an implicit `default` account even when named accounts exist. The Feishu secret contract now mirrors that account-listing behavior for `appSecret`: top-level `appSecret` refs remain active when top-level credentials define the implicit default account, while named account appSecret refs still use their existing enabled-account rules.

The change stays Feishu-scoped instead of changing the shared channel secret helper semantics for Discord, Slack, IRC, or other account-scoped channels. It also keeps stale top-level `appSecret` refs inactive when an explicit `accounts.default` entry overrides or disables the default account, because no enabled Feishu account inherits that top-level value in those configs.

## User Impact

Users can keep a top-level Feishu `appSecret` SecretRef for the default account while adding named Feishu accounts with their own inline or referenced app secrets. The default account no longer fails startup because its top-level SecretRef was skipped as inactive.

Configs with an explicit `accounts.default.appSecret` override or disabled `accounts.default` do not start resolving stale top-level `channels.feishu.appSecret` SecretRefs that no enabled runtime account reads.

## Evidence

Runtime proof from local terminal on `867bc4ba48a74c28b041dde3e34ef1a830f4c45c` using only synthetic/redacted secrets. `OPENCLAW_BUNDLED_PLUGINS_DIR=<repo>/extensions` points the production bundled-plugin public-surface loader at this checkout's Feishu `secret-contract-api.ts`, so the command exercises the PR head source instead of the previously built dist artifact.

- `OPENCLAW_BUNDLED_PLUGINS_DIR=<repo>/extensions node --import tsx --input-type=module <runtime-proof-script>`
  - Output:
    ```text
    [runtime-proof] Feishu implicit default account SecretRef resolved
    [runtime-proof] channels.feishu.appSecret=default-secret-redacted
    [runtime-proof] channels.feishu.accounts.resource.appSecret=resource-secret-redacted
    [runtime-proof] warningCount=0
    ```
- `OPENCLAW_BUNDLED_PLUGINS_DIR=<repo>/extensions node --import tsx --input-type=module <explicit-default-stale-ref-proof-script>`
  - Output:
    ```text
    [runtime-proof] explicit default overrides top-level appSecret
    [runtime-proof] topLevelAppSecretStillSecretRef=true
    [runtime-proof] resourceAccountAppSecret=resource-secret-redacted
    [runtime-proof] warnings=channels.feishu.appSecret
    [runtime-proof] explicit default disabled
    [runtime-proof] topLevelAppSecretStillSecretRef=true
    [runtime-proof] resourceAccountAppSecret=resource-secret-redacted
    [runtime-proof] warnings=channels.feishu.appSecret
    ```
- `node scripts/run-vitest.mjs src/secrets/runtime-external-channel-audit.test.ts extensions/feishu/src/accounts.test.ts src/secrets/runtime-discord-surface.test.ts -- --reporter=verbose`
  - Passed: `resolves Feishu top-level appSecret refs for the implicit default account`.
  - Passed: `skips stale Feishu top-level appSecret refs when explicit default overrides them`.
  - Passed: `skips stale Feishu top-level appSecret refs when explicit default is disabled`.
  - Result: secrets shard `Test Files 2 passed (2)`, `Tests 18 passed (18)`; Feishu extension shard `Test Files 1 passed (1)`, `Tests 24 passed (24)`.
- `corepack pnpm format:check -- extensions/feishu/src/secret-contract.ts src/secrets/runtime-external-channel-audit.test.ts extensions/feishu/src/accounts.test.ts`
  - Result: `All matched files use the correct format.`
- `git diff --check`
  - Result: no whitespace errors.

CI note: GitHub `Real behavior proof` is green on this head. The remaining red CI job is `checks-node-compact-small-7`, which timed out in `src/gateway/server-startup-session-migration.test.ts` on the PR merge ref. That file/test comes from current `main` on the merge ref, not from this Feishu secret-contract diff; rerun was attempted with `gh run rerun --failed` but GitHub rejected it because this account does not have repository admin rights.
