### PR TITLE
fix(secrets): resolve top-level SecretRef when all channel accounts override the field (fixes #96929) (AI-assisted)

### DIFF
--- a/src/secrets/channel-secret-basic-runtime.ts
+++ b/src/secrets/channel-secret-basic-runtime.ts
@@ -132,7 +132,13 @@ export function collectSimpleChannelFieldAssignments(params: {
     expected: "string",
     defaults: params.defaults,
     context: params.context,
-    active: isBaseFieldActiveForChannelSurface(params.surface, params.field),
+    // Simple channel fields (e.g. appSecret, token) are always used by the
+    // implicit [default] channel when the channel is enabled, even when every
+    // explicit account overrides the field.  The previous gate
+    // (isBaseFieldActiveForChannelSurface) only checked whether any explicit
+    // account inherits the field, which caused top-level SecretRefs to be
+    // skipped when all accounts provided their own inline values.
+    active: params.surface.channelEnabled,
     inactiveReason: params.topInactiveReason,
     apply: (value) => {
       params.channel[params.field] = value;

--- a/src/secrets/runtime-external-channel-audit.test.ts
+++ b/src/secrets/runtime-external-channel-audit.test.ts
@@ -541,4 +541,41 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
     ]);
     expectMetadataBackedContractsWereUsed();
   });
+
+  it("resolves top-level Feishu appSecret SecretRef when all accounts override the field", async () => {
+    const records = configureExternalChannelRecords(["feishu"]);
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          feishu: {
+            enabled: true,
+            appSecret: ref("FEISHU_APP_SECRET"),
+            accounts: {
+              work: {
+                enabled: true,
+                appSecret: "inline-work-secret",
+              },
+            },
+          },
+        },
+      }),
+      env: { FEISHU_APP_SECRET: "resolved-feishu-secret" },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: externalChannelOrigins(records),
+    });
+
+    // The top-level appSecret must be resolved even though the only account
+    // overrides it — the implicit [default] channel still uses the top-level value.
+    expect(getPath(snapshot.config, ["channels", "feishu", "appSecret"])).toBe(
+      "resolved-feishu-secret",
+    );
+    expect(
+      snapshot.warnings.some(
+        (w) =>
+          w.code === "SECRETS_REF_IGNORED_INACTIVE_SURFACE" &&
+          w.path === "channels.feishu.appSecret",
+      ),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

When a Feishu channel has both a top-level `appSecret` using SecretRef format and sub-accounts with their own inline `appSecret`, the secrets resolver skips resolving the top-level SecretRef. This causes the `[default]` channel to fail on startup with:

```
channels.feishu.appSecret: unresolved SecretRef "env:default:FEISHU_APP_SECRET".
```

The resolver logs `SECRETS_REF_IGNORED_INACTIVE_SURFACE` because it only checks whether any explicit account inherits the field — but the implicit `[default]` channel itself always uses the top-level value.

## Why This Change Was Made

`collectSimpleChannelFieldAssignments` used `isBaseFieldActiveForChannelSurface` to determine whether a top-level field is active. That function returns `true` only when at least one enabled account does NOT override the field. When all accounts provide their own inline values, the top-level SecretRef was incorrectly marked as inactive.

The fix: for simple channel fields, use `channelEnabled` directly. The implicit `[default]` channel always uses the top-level value when the channel is enabled, regardless of whether explicit accounts override it.

## User Impact

Users with multi-account Feishu configurations where all accounts provide their own `appSecret` can now use SecretRef format for the top-level `appSecret` without the `[default]` channel failing to start. Previously, the only workaround was replacing the SecretRef with an inline secret string.

## Changes Made

- `src/secrets/channel-secret-basic-runtime.ts`: Changed `collectSimpleChannelFieldAssignments` to use `surface.channelEnabled` instead of `isBaseFieldActiveForChannelSurface(surface, field)` for the top-level field active gate.
- `src/secrets/runtime-external-channel-audit.test.ts`: Added regression test verifying top-level SecretRef is resolved when all accounts override the field.

## Evidence

- **Behavior addressed:** Top-level channel SecretRef skipped when all explicit accounts override the same field
- **Environment tested:** macOS, OpenClaw 2026.5.28, Node 22.19+
- **Steps run after the patch:** Ran `node scripts/run-vitest.mjs run src/secrets/runtime-external-channel-audit.test.ts` — the new test creates a Feishu config with top-level SecretRef and an account that overrides `appSecret`, then verifies the SecretRef is resolved
- **Evidence after fix:**

```
 RUN  v4.1.8
 ✓  secrets  src/secrets/runtime-external-channel-audit.test.ts (8 tests) 339ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

- **Observed result after fix:** Top-level `appSecret` SecretRef resolves to the env var value; no `SECRETS_REF_IGNORED_INACTIVE_SURFACE` warning emitted for `channels.feishu.appSecret`
- **What was not tested:** Live Feishu platform message delivery (not required — fix is in config/secret resolution layer)

## Real behavior proof

- **Behavior addressed:** Top-level channel SecretRef skipped when all explicit accounts override the same field
- **Environment tested:** macOS, OpenClaw 2026.5.28, Node 22.19+
- **Steps run after the patch:** Ran `node scripts/run-vitest.mjs run src/secrets/runtime-external-channel-audit.test.ts` — the new test creates a Feishu config with top-level SecretRef and an account that overrides `appSecret`, then verifies the SecretRef is resolved
- **Evidence after fix:**

```
 RUN  v4.1.8
 ✓  secrets  src/secrets/runtime-external-channel-audit.test.ts (8 tests) 339ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

- **Observed result after fix:** Top-level `appSecret` SecretRef resolves to the env var value; no `SECRETS_REF_IGNORED_INACTIVE_SURFACE` warning emitted for `channels.feishu.appSecret`
- **What was not tested:** Live Feishu platform message delivery (not required — fix is in config/secret resolution layer)

- [x] AI-assisted (Hermes Agent)
