### PR TITLE
fix(utils): keep reply directive ids unicode-safe

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -12,7 +12,9 @@ function hasUnpairedSurrogate(value: string): boolean {
   for (let i = 0; i < value.length; i += 1) {
     const code = value.charCodeAt(i);
     if (code >= 0xd800 && code <= 0xdbff) {
-      const next = value.charCodeAt(i + 1);
+      // High surrogate must be followed by a low surrogate. charCodeAt past end
+      // returns NaN; NaN comparisons are always false, so guard bounds explicitly.
+      const next = i + 1 < value.length ? value.charCodeAt(i + 1) : -1;
       if (next < 0xdc00 || next > 0xdfff) {
         return true;
       }
@@ -247,6 +249,18 @@ describe("sanitizeReplyDirectiveId", () => {
 
     expect(result).toBe(`${prefix}😊`);
     expect(hasUnpairedSurrogate(result ?? "")).toBe(false);
+  });
+
+  test("hasUnpairedSurrogate catches a lone trailing high surrogate", () => {
+    // Proves the helper itself reports the failure mode the production fix prevents.
+    // Pre-fix helper: charCodeAt(out-of-bounds) returned NaN, NaN < 0xdc00 was false,
+    // so a trailing high surrogate was missed and the assertion above was vacuous.
+    expect(hasUnpairedSurrogate("a\ud83d")).toBe(true);
+    expect(hasUnpairedSurrogate(`${"a".repeat(255)}\ud83d`)).toBe(true);
+  });
+
+  test("hasUnpairedSurrogate accepts a properly paired emoji", () => {
+    expect(hasUnpairedSurrogate("a😊b")).toBe(false);
   });
 });
 

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -8,6 +8,22 @@ import {
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "./directive-tags.js";
 
+function hasUnpairedSurrogate(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      i += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("stripInlineDirectiveTagsForDisplay", () => {
   test("removes reply and audio directives", () => {
     const input = "hello [[reply_to_current]] world [[reply_to:abc-123]] [[audio_as_voice]]";
@@ -223,6 +239,14 @@ describe("parseInlineDirectives", () => {
 describe("sanitizeReplyDirectiveId", () => {
   test("strips bracket and control characters from explicit reply ids", () => {
     expect(sanitizeReplyDirectiveId(" [abc]\u0000\r\u0085def ")).toBe("abcdef");
+  });
+
+  test("truncates long ids without splitting surrogate pairs", () => {
+    const prefix = "a".repeat(255);
+    const result = sanitizeReplyDirectiveId(`${prefix}😊tail`);
+
+    expect(result).toBe(`${prefix}😊`);
+    expect(hasUnpairedSurrogate(result ?? "")).toBe(false);
   });
 });
 

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -121,8 +121,9 @@ export function sanitizeReplyDirectiveId(rawReplyToId?: string): string | undefi
   if (!sanitized) {
     return undefined;
   }
-  if (sanitized.length > MAX_REPLY_DIRECTIVE_ID_LENGTH) {
-    return sanitized.slice(0, MAX_REPLY_DIRECTIVE_ID_LENGTH);
+  const chars = Array.from(sanitized);
+  if (chars.length > MAX_REPLY_DIRECTIVE_ID_LENGTH) {
+    return chars.slice(0, MAX_REPLY_DIRECTIVE_ID_LENGTH).join("");
   }
   return sanitized;
 }


### PR DESCRIPTION
## What Problem This Solves

`sanitizeReplyDirectiveId` capped reply directive ids with a raw UTF-16 `slice`. If a long id crossed the cap on an astral Unicode character, the generated `[[reply_to:<id>]]` directive could contain an unpaired surrogate.

## Why This Change Was Made

The sanitizer now counts Unicode code points before truncating, matching the intent of preserving a bounded reply id without emitting malformed text.

## User Impact

Reply directive ids generated from UI/webchat metadata stay valid when they contain emoji or other non-BMP characters near the length limit.

## Evidence

- `PATH=/Users/ywwl/.nvm/versions/node/v24.13.0/bin:$PATH pnpm test src/utils/directive-tags.test.ts`
- `PATH=/Users/ywwl/.nvm/versions/node/v24.13.0/bin:$PATH pnpm test src/gateway/server-methods/chat.directive-tags.test.ts --testNamePattern sanitizes`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
