### PR TITLE
fix(telegram): log forum thread delivery context

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -45,6 +45,12 @@ function createTelegramDeliverySendRetry() {
   });
 }
 
+function formatTelegramThreadLogFields(thread?: TelegramThreadSpec | null): string {
+  const threadId = thread?.id == null ? "none" : String(thread.id);
+  const threadScope = thread?.scope ?? "none";
+  return `threadId=${threadId} threadScope=${threadScope}`;
+}
+
 export async function sendTelegramWithThreadFallback<T>(params: {
   operation: string;
   runtime: RuntimeEnv;
@@ -61,17 +67,20 @@ export async function sendTelegramWithThreadFallback<T>(params: {
     ? (err: unknown) => params.shouldLog!(err) && !shouldSuppressFirstErrorLog(err)
     : (err: unknown) => !shouldSuppressFirstErrorLog(err);
   const requestWithRetry = createTelegramDeliverySendRetry();
+  const threadLogFields = formatTelegramThreadLogFields(params.thread);
   const runLoggedSend = (
     operation: string,
     requestParams: Record<string, unknown>,
     shouldLog?: (err: unknown) => boolean,
-  ) =>
-    withTelegramApiErrorLogging({
-      operation,
+  ) => {
+    const loggedOperation = `${operation} ${threadLogFields}`;
+    return withTelegramApiErrorLogging({
+      operation: loggedOperation,
       runtime: params.runtime,
       ...(shouldLog ? { shouldLog } : {}),
-      fn: () => requestWithRetry(() => params.send(requestParams), operation),
+      fn: () => requestWithRetry(() => params.send(requestParams), loggedOperation),
     });
+  };
 
   try {
     return await runLoggedSend(params.operation, params.requestParams, mergedShouldLog);
@@ -142,7 +151,9 @@ export async function sendTelegramText(
           ...effectiveParams,
         }),
     });
-    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id} (plain)`);
+    runtime.log?.(
+      `telegram sendMessage ok chat=${chatId} message=${res.message_id} ${formatTelegramThreadLogFields(opts?.thread)} (plain)`,
+    );
     return res.message_id;
   };
 
@@ -166,7 +177,9 @@ export async function sendTelegramText(
             ...effectiveParams,
           }),
       });
-      runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
+      runtime.log?.(
+        `telegram sendRichMessage ok chat=${chatId} message=${res.message_id} ${formatTelegramThreadLogFields(opts.thread)}`,
+      );
       return res.message_id;
     } catch (err) {
       const errText = formatErrorMessage(err);
@@ -207,7 +220,9 @@ export async function sendTelegramText(
           ...effectiveParams,
         }),
     });
-    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id}`);
+    runtime.log?.(
+      `telegram sendMessage ok chat=${chatId} message=${res.message_id} ${formatTelegramThreadLogFields(opts?.thread)}`,
+    );
     return res.message_id;
   } catch (err) {
     const errText = formatErrorMessage(err);

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -979,7 +979,7 @@ describe("deliverReplies", () => {
     expectRecordFields(mockCallArg(sendMessage, 0, 2), { message_thread_id: 42 });
   });
 
-  it("does not retry DM topic sends without the topic id when the topic is missing", async () => {
+  it("logs DM topic context when the topic is missing", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockRejectedValueOnce(createThreadNotFoundError("sendMessage"));
     const bot = createBot({ sendMessage });
@@ -996,9 +996,12 @@ describe("deliverReplies", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expectRecordFields(mockCallArg(sendMessage, 0, 2), { message_thread_id: 42 });
     expect(runtime.error).toHaveBeenCalledTimes(1);
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("sendMessage threadId=42 threadScope=dm failed"),
+    );
   });
 
-  it("does not retry forum sends without message_thread_id", async () => {
+  it("logs forum topic context when the topic is missing", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockRejectedValue(createThreadNotFoundError("sendMessage"));
     const bot = createBot({ sendMessage });
@@ -1014,6 +1017,9 @@ describe("deliverReplies", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(runtime.error).toHaveBeenCalledTimes(1);
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("sendMessage threadId=42 threadScope=forum failed"),
+    );
   });
 
   it("retries final text sends for wrapped pre-connect grammY HttpError envelopes", async () => {

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -572,6 +572,31 @@ describe("deliverReplies", () => {
     expectRecordFields(mockCallArg(sendMessage, 0, 2), { disable_notification: true });
   });
 
+  it("logs and sends the Telegram forum thread for direct auto-reply delivery", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 6,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "hello forum" }],
+      runtime,
+      bot,
+      thread: { id: 42, scope: "forum" },
+    });
+
+    expect(firstMockCallArg(sendMessage, 0)).toBe("123");
+    firstSendText(sendMessage);
+    expectRecordFields(mockCallArg(sendMessage, 0, 2), { message_thread_id: 42 });
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "telegram sendMessage ok chat=123 message=6 threadId=42 threadScope=forum",
+      ),
+    );
+  });
+
   it("emits internal message:sent when session hook context is available", async () => {
     const runtime = createRuntime(false);
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 9, chat: { id: "123" } });


### PR DESCRIPTION
## What Problem This Solves

Telegram forum-topic delivery failures were too hard to diagnose because the send path did not include enough forum-thread context in failure logs. When a topic appeared silent, operators could see that Telegram delivery failed, but not reliably tell which forum thread/topic route was involved.

## Why This Change Was Made

The Telegram delivery path already has the thread routing context needed for diagnosis. This change threads that context into the diagnostic log shape so forum-topic delivery failures can be tied back to the relevant thread without guessing from surrounding messages.

## User Impact

- Operators get clearer diagnostics for Telegram topic delivery failures.
- This improves incident triage for forum topics without changing delivery behavior, command parsing, model routing, or session state.
- No user-facing Telegram message text changes.

## Evidence

AI-assisted: yes. Hermes ported this from the local OpenClaw rollout as a focused upstream PR.

Local validation on the PR branch:

- `node scripts/run-vitest.mjs extensions/telegram/src/bot/delivery.test.ts` — passed, 60 tests
- `node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/bot/delivery.send.ts extensions/telegram/src/bot/delivery.test.ts` — passed

Runtime context from the local rollout:

- The fix was used while diagnosing Telegram forum topics that appeared checked/accepted but were not progressing.
- Better topic/thread delivery logs helped separate Telegram send/delivery issues from session-lane and model-routing issues.
