### PR TITLE
fix(channels): resolve bundled setup entries from installed dist

### DIFF
--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -3,6 +3,7 @@
  *
  * Loads generated bundled channel entries, setup metadata, secrets, and legacy migration hooks.
  */
+import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -241,12 +242,72 @@ function resolveGeneratedBundledChannelModulePath(params: {
   if (!params.entry) {
     return null;
   }
-  return resolveBundledChannelGeneratedPath(
+  const generatedPath = resolveBundledChannelGeneratedPath(
     params.rootScope.packageRoot,
     params.entry,
     params.metadata.dirName,
     resolveBundledChannelScanDir(params.rootScope),
   );
+  if (generatedPath) {
+    return generatedPath;
+  }
+  for (const entryPath of [params.entry.built, params.entry.source]) {
+    if (!entryPath) {
+      continue;
+    }
+    const basename = path.basename(entryPath);
+    const builtBasename = basename.replace(/\.[^.]+$/u, ".js");
+    const trustedRoots = [
+      path.resolve(params.metadata.rootDir),
+      ...(params.rootScope.pluginsDir
+        ? [path.resolve(params.rootScope.pluginsDir, params.metadata.dirName)]
+        : []),
+      path.resolve(params.rootScope.packageRoot, "dist", "extensions", params.metadata.dirName),
+      path.resolve(
+        params.rootScope.packageRoot,
+        "dist-runtime",
+        "extensions",
+        params.metadata.dirName,
+      ),
+    ];
+    const pluginDistCandidates = [
+      ...(params.rootScope.pluginsDir
+        ? [path.resolve(params.rootScope.pluginsDir, params.metadata.dirName, builtBasename)]
+        : []),
+      path.resolve(
+        params.rootScope.packageRoot,
+        "dist",
+        "extensions",
+        params.metadata.dirName,
+        builtBasename,
+      ),
+      path.resolve(
+        params.rootScope.packageRoot,
+        "dist-runtime",
+        "extensions",
+        params.metadata.dirName,
+        builtBasename,
+      ),
+    ];
+    const candidates = path.isAbsolute(entryPath)
+      ? [
+          ...pluginDistCandidates,
+          path.resolve(params.metadata.rootDir, builtBasename),
+          path.resolve(params.metadata.rootDir, basename),
+          path.normalize(entryPath),
+        ]
+      : [...pluginDistCandidates, path.resolve(params.metadata.rootDir, entryPath)];
+    for (const candidate of candidates) {
+      if (
+        fs.existsSync(candidate) &&
+        (trustedRoots.some((root) => isPathInside(root, candidate)) ||
+          path.normalize(candidate) === path.normalize(entryPath))
+      ) {
+        return candidate;
+      }
+    }
+  }
+  return null;
 }
 
 function loadGeneratedBundledChannelModule(params: {

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -3,7 +3,6 @@
  *
  * Loads generated bundled channel entries, setup metadata, secrets, and legacy migration hooks.
  */
-import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -242,72 +241,13 @@ function resolveGeneratedBundledChannelModulePath(params: {
   if (!params.entry) {
     return null;
   }
-  const generatedPath = resolveBundledChannelGeneratedPath(
+  return resolveBundledChannelGeneratedPath(
     params.rootScope.packageRoot,
     params.entry,
     params.metadata.dirName,
     resolveBundledChannelScanDir(params.rootScope),
+    params.metadata.rootDir,
   );
-  if (generatedPath) {
-    return generatedPath;
-  }
-  for (const entryPath of [params.entry.built, params.entry.source]) {
-    if (!entryPath) {
-      continue;
-    }
-    const basename = path.basename(entryPath);
-    const builtBasename = basename.replace(/\.[^.]+$/u, ".js");
-    const trustedRoots = [
-      path.resolve(params.metadata.rootDir),
-      ...(params.rootScope.pluginsDir
-        ? [path.resolve(params.rootScope.pluginsDir, params.metadata.dirName)]
-        : []),
-      path.resolve(params.rootScope.packageRoot, "dist", "extensions", params.metadata.dirName),
-      path.resolve(
-        params.rootScope.packageRoot,
-        "dist-runtime",
-        "extensions",
-        params.metadata.dirName,
-      ),
-    ];
-    const pluginDistCandidates = [
-      ...(params.rootScope.pluginsDir
-        ? [path.resolve(params.rootScope.pluginsDir, params.metadata.dirName, builtBasename)]
-        : []),
-      path.resolve(
-        params.rootScope.packageRoot,
-        "dist",
-        "extensions",
-        params.metadata.dirName,
-        builtBasename,
-      ),
-      path.resolve(
-        params.rootScope.packageRoot,
-        "dist-runtime",
-        "extensions",
-        params.metadata.dirName,
-        builtBasename,
-      ),
-    ];
-    const candidates = path.isAbsolute(entryPath)
-      ? [
-          ...pluginDistCandidates,
-          path.resolve(params.metadata.rootDir, builtBasename),
-          path.resolve(params.metadata.rootDir, basename),
-          path.normalize(entryPath),
-        ]
-      : [...pluginDistCandidates, path.resolve(params.metadata.rootDir, entryPath)];
-    for (const candidate of candidates) {
-      if (
-        fs.existsSync(candidate) &&
-        (trustedRoots.some((root) => isPathInside(root, candidate)) ||
-          path.normalize(candidate) === path.normalize(entryPath))
-      ) {
-        return candidate;
-      }
-    }
-  }
-  return null;
 }
 
 function loadGeneratedBundledChannelModule(params: {

--- a/src/plugins/bundled-channel-runtime.test.ts
+++ b/src/plugins/bundled-channel-runtime.test.ts
@@ -28,9 +28,12 @@ describe("bundled channel runtime metadata", () => {
     const tempRoot = createTempRoot();
 
     expect(listBundledChannelPluginMetadata({ rootDir: tempRoot })).toStrictEqual([]);
-    expect(resolveBundledChannelWorkspacePath({ rootDir: tempRoot, pluginId: "telegram" })).toBe(
-      null,
-    );
+    expect(
+      resolveBundledChannelWorkspacePath({
+        rootDir: tempRoot,
+        pluginId: "telegram",
+      }),
+    ).toBe(null);
   });
 
   it("preserves explicit missing bundled scan roots", () => {
@@ -38,7 +41,10 @@ describe("bundled channel runtime metadata", () => {
     const missingScanDir = path.join(tempRoot, "missing-extensions");
 
     expect(
-      listBundledChannelPluginMetadata({ rootDir: tempRoot, scanDir: missingScanDir }),
+      listBundledChannelPluginMetadata({
+        rootDir: tempRoot,
+        scanDir: missingScanDir,
+      }),
     ).toStrictEqual([]);
   });
 
@@ -82,5 +88,53 @@ describe("bundled channel runtime metadata", () => {
         builtScanRoot,
       ),
     ).toBe(path.join(pluginRoot, "dist", "index.js"));
+  });
+
+  it("resolves nested installed-dist entries from the registry plugin root", () => {
+    // Installed runtimes resolve the plugin root (often a realpath) independently of the
+    // bundled scan dir. When the two diverge, the entry lives under the registry rootDir but
+    // not under any scan-dir-derived root; the resolver must still find the nested built entry.
+    const tempRoot = createTempRoot();
+    const installedRoot = path.join(tempRoot, "installed", "telegram");
+    const builtEntry = path.join(installedRoot, "setup", "index.js");
+    fs.mkdirSync(path.dirname(builtEntry), { recursive: true });
+    fs.writeFileSync(builtEntry, "export default {};\n", "utf8");
+
+    expect(
+      resolveBundledChannelGeneratedPath(
+        path.join(tempRoot, "logical"),
+        {
+          source: builtEntry,
+          built: builtEntry,
+        },
+        "telegram",
+        path.join(tempRoot, "logical", "dist", "extensions"),
+        installedRoot,
+      ),
+    ).toBe(builtEntry);
+  });
+
+  it("keeps nested installed-dist entries scoped to their subdirectory", () => {
+    // A nested entry must not collapse to a root-level basename; a stray sibling built file at the
+    // plugin root should never be returned in place of the manifest's nested entry path.
+    const tempRoot = createTempRoot();
+    const installedRoot = path.join(tempRoot, "installed", "telegram");
+    const nestedEntry = path.join(installedRoot, "setup", "index.js");
+    fs.mkdirSync(path.dirname(nestedEntry), { recursive: true });
+    fs.writeFileSync(nestedEntry, "export default {};\n", "utf8");
+    fs.writeFileSync(path.join(installedRoot, "index.js"), "export default {};\n", "utf8");
+
+    expect(
+      resolveBundledChannelGeneratedPath(
+        path.join(tempRoot, "logical"),
+        {
+          source: path.join(installedRoot, "setup", "index.ts"),
+          built: path.join(installedRoot, "setup", "index.ts"),
+        },
+        "telegram",
+        path.join(tempRoot, "logical", "dist", "extensions"),
+        installedRoot,
+      ),
+    ).toBe(nestedEntry);
   });
 });

--- a/src/plugins/bundled-channel-runtime.ts
+++ b/src/plugins/bundled-channel-runtime.ts
@@ -117,8 +117,9 @@ export function resolveBundledChannelGeneratedPath(
   entry: BundledChannelPluginMetadata["source"] | BundledChannelPluginMetadata["setupSource"],
   pluginDirName?: string,
   scanDir?: string,
+  pluginRootDir?: string,
 ): string | null {
-  return resolveBundledPluginGeneratedPath(rootDir, entry, pluginDirName, scanDir);
+  return resolveBundledPluginGeneratedPath(rootDir, entry, pluginDirName, scanDir, pluginRootDir);
 }
 
 /** Resolves the source workspace path for a bundled channel plugin id. */

--- a/src/plugins/bundled-plugin-metadata.ts
+++ b/src/plugins/bundled-plugin-metadata.ts
@@ -157,7 +157,9 @@ function collectBundledPluginMetadata(
         ? { packageVersion: trimBundledPluginString(packageJson?.version) }
         : {}),
       ...(trimBundledPluginString(packageJson?.description)
-        ? { packageDescription: trimBundledPluginString(packageJson?.description) }
+        ? {
+            packageDescription: trimBundledPluginString(packageJson?.description),
+          }
         : {}),
       ...(packageManifest ? { packageManifest } : {}),
       manifest: {
@@ -233,11 +235,16 @@ function listBundledPluginEntryBaseDirs(params: {
   rootDir: string;
   pluginDirName?: string;
   scanDir?: string;
+  pluginRootDir?: string;
 }): string[] {
   const scanPluginRoot = params.scanDir
     ? path.resolve(params.scanDir, params.pluginDirName ?? "")
     : undefined;
+  // Installed runtimes resolve the plugin root (often a realpath) independently of the bundled
+  // scan dir, so search it first; otherwise a divergent rootDir leaves the built entry unreachable.
+  const pluginRoot = params.pluginRootDir ? path.resolve(params.pluginRootDir) : undefined;
   const baseDirs = [
+    ...(pluginRoot ? [path.resolve(pluginRoot, "dist"), pluginRoot] : []),
     ...(scanPluginRoot ? [path.resolve(scanPluginRoot, "dist")] : []),
     ...(scanPluginRoot ? [scanPluginRoot] : []),
     path.resolve(params.rootDir, "dist", "extensions", params.pluginDirName ?? ""),
@@ -257,8 +264,12 @@ function listBundledPluginEntryRoots(params: {
   rootDir: string;
   pluginDirName?: string;
   scanDir?: string;
+  pluginRootDir?: string;
 }): string[] {
+  // Include the registry-resolved plugin root so absolute entries under it keep their nested
+  // relative path; without it a realpath'd install root yields no relative entry to search.
   const roots = [
+    ...(params.pluginRootDir ? [path.resolve(params.pluginRootDir)] : []),
     ...(params.scanDir ? [path.resolve(params.scanDir, params.pluginDirName ?? "")] : []),
     path.resolve(params.rootDir, "extensions", params.pluginDirName ?? ""),
     path.resolve(params.rootDir, "dist", "extensions", params.pluginDirName ?? ""),
@@ -273,6 +284,7 @@ function listBundledPluginEntrySearchPaths(
     rootDir: string;
     pluginDirName?: string;
     scanDir?: string;
+    pluginRootDir?: string;
   },
 ): string[] {
   const paths: string[] = [];
@@ -307,6 +319,7 @@ export function resolveBundledPluginGeneratedPath(
   entry: BundledPluginPathPair | undefined,
   pluginDirName?: string,
   scanDir?: string,
+  pluginRootDir?: string,
 ): string | null {
   if (!entry) {
     return null;
@@ -315,11 +328,13 @@ export function resolveBundledPluginGeneratedPath(
     rootDir,
     pluginDirName,
     ...(scanDir ? { scanDir } : {}),
+    ...(pluginRootDir ? { pluginRootDir } : {}),
   });
   const baseDirs = listBundledPluginEntryBaseDirs({
     rootDir,
     pluginDirName,
     ...(scanDir ? { scanDir } : {}),
+    ...(pluginRootDir ? { pluginRootDir } : {}),
   });
   for (const baseDir of baseDirs) {
     for (const entryPath of entryOrder) {


### PR DESCRIPTION
## What Problem This Solves

Installed OpenClaw builds can fail to resolve bundled channel/plugin setup entries when the source tree layout is not available at runtime. That makes setup/config surfaces brittle in installed distributions even though the bundled plugin artifacts are present in `dist`.

## Why This Change Was Made

The bundled channel setup resolver was too source-tree oriented. In an installed runtime, bundled plugin public surfaces should resolve from the built distribution artifacts instead of assuming development source paths. This PR makes the resolver fall back to the installed `dist` layout so bundled setup entries continue to work after packaging/install.

## User Impact

- Installed OpenClaw users get more reliable bundled channel/plugin setup resolution.
- Setup/config flows can find bundled plugin public surfaces from the installed runtime.
- This is a packaging/runtime resolution fix; it does not change plugin manifests, user config schema, or channel behavior.

## Evidence

AI-assisted: yes. Hermes ported this from the local OpenClaw rollout as a focused upstream PR.

Local validation on the PR branch:

- `node scripts/run-vitest.mjs src/secrets/runtime-config-collectors-plugins.bundled.test.ts src/secrets/runtime.test.ts src/secrets/target-registry.fast-path.test.ts` — passed, 9 tests
- `node_modules/.bin/oxfmt --check --threads=1 src/channels/plugins/bundled.ts` — passed
- `pnpm tsgo:core` — passed

Runtime context from the local rollout:

- The local installed source/runtime needed bundled setup entries to resolve from built artifacts rather than source-only paths.
- After this change, the resolver can use installed distribution surfaces for bundled plugin setup metadata.
