### PR TITLE
fix(runtime): sweep orphaned session lanes

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -281,7 +281,11 @@ describe("stuck session recovery", () => {
       allowActiveAbort: true,
     });
 
-    expect(outcome).toMatchObject({ status: "aborted", aborted: true, released: 0 });
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      aborted: true,
+      released: 0,
+    });
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
@@ -313,7 +317,10 @@ describe("stuck session recovery", () => {
       fs.writeFileSync(
         path.join(tempDir, "agents", "clawblocker", "sessions", "run-456.jsonl"),
         JSON.stringify({
-          message: { role: "assistant", content: "There are 40 cached mentions." },
+          message: {
+            role: "assistant",
+            content: "There are 40 cached mentions.",
+          },
         }) + "\n",
       );
       mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("run-456");
@@ -544,6 +551,77 @@ describe("stuck session recovery", () => {
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
     expect(warnLogMessages()).toEqual([
       "stuck session recovery outcome: status=skipped action=keep_lane sessionId=unregistered-work-session sessionKey=agent:main:main lane=session:agent:main:main reason=active_lane_task laneActive=1 laneQueued=1",
+    ]);
+  });
+
+  it("sweeps an orphaned session lane that starves a queued turn past the stale threshold", async () => {
+    // Regression: a session lane holding an active slot with no backing embedded-run
+    // handle (e.g. wedged before the run registers) must be reset once the stall ages
+    // past the stale-progress threshold and a queued topic turn is waiting behind it,
+    // instead of repeatedly returning keep_lane and starving the next turn until it
+    // aborts on its own deadline (~29m lane wait + AbortError in production).
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    // Same active id seen before and after recovery proves no fresh turn pumped in.
+    mocks.getCommandLaneActiveTaskIds.mockReturnValue([42]);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:main:main",
+      queuedCount: 1,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+    mocks.resetCommandLane.mockReturnValue(1);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "orphaned-lane-session",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 1,
+    });
+
+    expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.forceClearEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
+    expect(outcome).toMatchObject({
+      status: "released",
+      action: "release_lane",
+      released: 1,
+      lane: "session:agent:main:main",
+    });
+  });
+
+  it("keeps an unbacked session lane while the stall is below the stale threshold", async () => {
+    // The conservative inverse of the sweep: a freshly active lane task whose handle
+    // may not be registered yet must not be reset before it ages past the threshold.
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getCommandLaneActiveTaskIds.mockReturnValue([42]);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:main:main",
+      queuedCount: 1,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+
+    await recoverStuckDiagnosticSession({
+      sessionId: "fresh-lane-session",
+      sessionKey: "agent:main:main",
+      ageMs: 30_000,
+      queueDepth: 1,
+      staleActiveProgressAbortMs: 300_000,
+    });
+
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+    expect(warnLogMessages()).toEqual([
+      "stuck session recovery outcome: status=skipped action=keep_lane sessionId=fresh-lane-session sessionKey=agent:main:main lane=session:agent:main:main reason=active_lane_task laneActive=1 laneQueued=1",
     ]);
   });
 

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -62,7 +62,12 @@ function isActiveRunProgressStale(params: {
 
 function formatRecoveryContext(
   params: StuckSessionRecoveryParams,
-  extra?: { activeSessionId?: string; lane?: string; activeCount?: number; queuedCount?: number },
+  extra?: {
+    activeSessionId?: string;
+    lane?: string;
+    activeCount?: number;
+    queuedCount?: number;
+  },
 ): string {
   const fields = [
     `sessionId=${params.sessionId ?? extra?.activeSessionId ?? "unknown"}`,
@@ -237,18 +242,40 @@ export async function recoverStuckDiagnosticSession(
     if (!activeSessionId && sessionLane) {
       const laneSnapshot = getCommandLaneSnapshot(sessionLane);
       if (laneSnapshot.activeCount > 0) {
-        const outcome: StuckSessionRecoveryOutcome = {
-          status: "skipped",
-          action: "keep_lane",
-          reason: "active_lane_task",
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          lane: sessionLane,
-          activeCount: laneSnapshot.activeCount,
-          queuedCount: laneSnapshot.queuedCount,
-        };
-        diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-        return outcome;
+        // A lane task with no backing embedded-run handle is unbacked bookkeeping:
+        // either a just-started turn that has not registered its handle yet, or an
+        // orphaned slot whose work is dead (e.g. wedged before the run registers).
+        // Keep waiting only while it could still be a fresh turn; once the stall has
+        // aged past the stale-progress threshold and a queued turn is starving behind
+        // it, fall through to resetCommandLane so the lane sweeps the dead slot instead
+        // of blocking the next topic turn until it aborts on its own deadline.
+        const laneStartedFreshTask = getCommandLaneActiveTaskIds(sessionLane).some(
+          (id) => !preAbortActiveTaskIds.has(id),
+        );
+        const hasQueuedWork = laneSnapshot.queuedCount > 0 || (params.queueDepth ?? 0) > 0;
+        const orphanLaneStale = params.ageMs >= staleActiveProgressAbortMs;
+        const sweepOrphanedLane = !laneStartedFreshTask && hasQueuedWork && orphanLaneStale;
+        if (!sweepOrphanedLane) {
+          const outcome: StuckSessionRecoveryOutcome = {
+            status: "skipped",
+            action: "keep_lane",
+            reason: "active_lane_task",
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            lane: sessionLane,
+            activeCount: laneSnapshot.activeCount,
+            queuedCount: laneSnapshot.queuedCount,
+          };
+          diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
+          return outcome;
+        }
+        diag.warn(
+          `stuck session recovery sweeping orphaned lane: ${formatRecoveryContext(params, {
+            lane: sessionLane,
+            activeCount: laneSnapshot.activeCount,
+            queuedCount: laneSnapshot.queuedCount,
+          })}`,
+        );
       }
     }
 
@@ -273,7 +300,10 @@ export async function recoverStuckDiagnosticSession(
     if (aborted || forceCleared || released > 0 || clearStaleQueuedSession) {
       const action = aborted || forceCleared ? "abort_embedded_run" : "release_lane";
       const stoppedFields = formatStoppedCronSessionDiagnosticFields(
-        resolveCronSessionDiagnosticContext({ sessionKey: params.sessionKey, activeSessionId }),
+        resolveCronSessionDiagnosticContext({
+          sessionKey: params.sessionKey,
+          activeSessionId,
+        }),
       );
       diag.warn(
         `stuck session recovery: sessionId=${params.sessionId ?? activeSessionId ?? "unknown"} sessionKey=${


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's diagnostic stuck-session recovery could miss orphaned session lane state. In topic/session incidents, that means a lane can remain blocked by stale bookkeeping even after there is no real active run or queued work behind it.

## Why This Change Was Made

The recovery path needs to distinguish genuinely active work from orphaned lane bookkeeping. This PR extends the diagnostic recovery sweep so orphaned session lanes are identified and cleared instead of being treated as active work that should keep blocking subsequent turns.

## User Impact

- Topics/sessions are less likely to stay wedged after a run disappears or a recovery path partially clears state.
- Diagnostic recovery can unblock orphaned lanes without requiring manual reset/restart intervention.
- The change is limited to stuck-session recovery logic and tests; it does not change normal session scheduling or command behavior.

## Evidence

AI-assisted: yes. Hermes ported this from the local OpenClaw rollout after a Telegram topic incident involving stale lane accounting.

Local validation on the PR branch:

- `node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts` — passed, 24 tests
- `node_modules/.bin/oxfmt --check --threads=1 src/logging/diagnostic-stuck-session-recovery.runtime.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts` — passed
- `pnpm tsgo:core` — passed
- `pnpm tsgo:core:test` — passed

Runtime context from the local rollout:

- The motivating incident had stale lane accounting where a topic appeared occupied even though no active run/queue existed.
- After the recovery sweep change, orphaned lane state can be cleared by diagnostic stuck-session recovery rather than leaving the topic blocked.
