### PR TITLE
perf(ui): use sets for usage selection filters

### DIFF
--- a/ui/src/ui/views/usage-render-details.ts
+++ b/ui/src/ui/views/usage-render-details.ts
@@ -396,14 +396,15 @@ function renderTimeSeriesCompact(
   if (startDate || endDate || (selectedDays && selectedDays.length > 0)) {
     const startTs = startDate ? new Date(startDate + "T00:00:00").getTime() : 0;
     const endTs = endDate ? new Date(endDate + "T23:59:59").getTime() : Infinity;
+    const selectedDaySet = selectedDays?.length ? new Set(selectedDays) : undefined;
     points = timeSeries.points.filter((p) => {
       if (p.timestamp < startTs || p.timestamp > endTs) {
         return false;
       }
-      if (selectedDays && selectedDays.length > 0) {
+      if (selectedDaySet) {
         const d = new Date(p.timestamp);
         const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-        return selectedDays.includes(dateStr);
+        return selectedDaySet.has(dateStr);
       }
       return true;
     });

--- a/ui/src/ui/views/usage-render-overview.ts
+++ b/ui/src/ui/views/usage-render-overview.ts
@@ -398,6 +398,7 @@ function renderDailyChartCompact(
   // Calculate bar width based on number of days
   const barMaxWidth = daily.length > 30 ? 12 : daily.length > 20 ? 18 : daily.length > 14 ? 24 : 32;
   const showTotals = daily.length <= 14;
+  const selectedDaySet = new Set(selectedDays);
 
   return html`
     <div class="daily-chart-compact">
@@ -424,7 +425,7 @@ function renderDailyChartCompact(
         <div class="daily-chart-bars" style="--bar-max-width: ${barMaxWidth}px">
           ${daily.map((d, idx) => {
             const heightPx = barHeights[idx];
-            const isSelected = selectedDays.includes(d.date);
+            const isSelected = selectedDaySet.has(d.date);
             const label = formatDayLabel(d.date);
             // Shorter label for many days (just day number)
             const shortLabel =

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -163,6 +163,8 @@ export function renderUsage(props: UsageProps) {
   const isTokenMode = display.chartMode === "tokens";
   const hasQuery = filters.query.trim().length > 0;
   const hasDraftQuery = filters.queryDraft.trim().length > 0;
+  const selectedDaySet = new Set(filters.selectedDays);
+  const selectedSessionSet = new Set(filters.selectedSessions);
 
   // Sort sessions by tokens or cost depending on mode
   const sortedSessions = [...data.sessions].toSorted((a, b) => {
@@ -179,17 +181,17 @@ export function renderUsage(props: UsageProps) {
 
   // Filter sessions by selected days
   const dayFilteredSessions =
-    filters.selectedDays.length > 0
+    selectedDaySet.size > 0
       ? agentScopedSessions.filter((s) => {
           if (s.usage?.activityDates?.length) {
-            return s.usage.activityDates.some((d) => filters.selectedDays.includes(d));
+            return s.usage.activityDates.some((d) => selectedDaySet.has(d));
           }
           if (!s.updatedAt) {
             return false;
           }
           const d = new Date(s.updatedAt);
           const sessionDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-          return filters.selectedDays.includes(sessionDate);
+          return selectedDaySet.has(sessionDate);
         })
       : agentScopedSessions;
 
@@ -261,8 +263,8 @@ export function renderUsage(props: UsageProps) {
   };
 
   // Compute totals from daily data for selected days (more accurate than session totals)
-  const computeDailyTotals = (days: string[]): UsageTotals => {
-    const matchingDays = data.costDaily.filter((d) => days.includes(d.date));
+  const computeDailyTotals = (days: ReadonlySet<string>): UsageTotals => {
+    const matchingDays = data.costDaily.filter((d) => days.has(d.date));
     return matchingDays.reduce((acc, day) => addUsageTotals(acc, day), createEmptyUsageTotals());
   };
 
@@ -273,14 +275,12 @@ export function renderUsage(props: UsageProps) {
 
   if (filters.selectedSessions.length > 0) {
     // Sessions selected - compute totals from selected sessions
-    const selectedSessionEntries = filteredSessions.filter((s) =>
-      filters.selectedSessions.includes(s.key),
-    );
+    const selectedSessionEntries = filteredSessions.filter((s) => selectedSessionSet.has(s.key));
     displayTotals = computeSessionTotals(selectedSessionEntries);
     displaySessionCount = selectedSessionEntries.length;
   } else if (filters.selectedDays.length > 0 && filters.selectedHours.length === 0) {
     // Days selected - use daily aggregates for accurate per-day totals
-    displayTotals = computeDailyTotals(filters.selectedDays);
+    displayTotals = computeDailyTotals(selectedDaySet);
     displaySessionCount = filteredSessions.length;
   } else if (filters.selectedHours.length > 0) {
     displayTotals = computeSessionTotals(filteredSessions);
@@ -299,7 +299,7 @@ export function renderUsage(props: UsageProps) {
 
   const aggregateSessions =
     filters.selectedSessions.length > 0
-      ? filteredSessions.filter((s) => filters.selectedSessions.includes(s.key))
+      ? filteredSessions.filter((s) => selectedSessionSet.has(s.key))
       : hasQuery || filters.selectedHours.length > 0
         ? filteredSessions
         : filters.selectedDays.length > 0
@@ -326,9 +326,7 @@ export function renderUsage(props: UsageProps) {
   const filteredDaily =
     filters.selectedSessions.length > 0
       ? (() => {
-          const selectedEntries = filteredSessions.filter((s) =>
-            filters.selectedSessions.includes(s.key),
-          );
+          const selectedEntries = filteredSessions.filter((s) => selectedSessionSet.has(s.key));
           const allActivityDates = new Set<string>();
           for (const entry of selectedEntries) {
             for (const date of entry.usage?.activityDates ?? []) {


### PR DESCRIPTION
## What Problem This Solves

The Control UI usage view repeatedly checked selected day and selected session arrays while filtering sessions, daily totals, chart bars, and detail timelines. Those checks scale with the number of selected filters each time the UI walks sessions or chart points.

## Why This Change Was Made

This converts the selected day/session filters into Set lookups at the render boundary, preserving the existing selection semantics while avoiding repeated linear membership scans across the same render pass.

## User Impact

Large usage dashboards with many selected days or sessions do less repeated client-side work while rendering totals, charts, and detail timelines. Behavior and UI output are intended to stay unchanged.

## Evidence

- node scripts/run-vitest.mjs ui/src/ui/views/usage.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs ui/src/ui/views/usage.test.ts"
- autoreview clean: no accepted/actionable findings reported; tests exit 0 on the rebased head
