### PR TITLE
perf(plugins): classify cached tool candidates once

### DIFF
--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -707,6 +707,17 @@ function createCachedDescriptorPluginTool(params: {
         throw new Error(`plugin tool runtime unavailable (${pluginId}): ${toolName}`);
       }
       const requestedToolName = normalizeToolName(toolName);
+      const matchingNamedCandidates: PluginToolRegistration[] = [];
+      const unnamedCandidates: PluginToolRegistration[] = [];
+      for (const candidate of candidates) {
+        if (candidate.names.length === 0) {
+          unnamedCandidates.push(candidate);
+          continue;
+        }
+        if (candidate.names.some((name) => normalizeToolName(name) === requestedToolName)) {
+          matchingNamedCandidates.push(candidate);
+        }
+      }
       const resolveCandidateTool = (
         candidate: PluginToolRegistration,
       ): AnyAgentTool | undefined => {
@@ -724,12 +735,6 @@ function createCachedDescriptorPluginTool(params: {
         }
         return undefined;
       };
-      const matchingNamedCandidates = candidates.filter(
-        (candidate) =>
-          candidate.names.length > 0 &&
-          candidate.names.some((name) => normalizeToolName(name) === requestedToolName),
-      );
-      const unnamedCandidates = candidates.filter((candidate) => candidate.names.length === 0);
       for (const candidate of [...matchingNamedCandidates, ...unnamedCandidates]) {
         let matchedTool: AnyAgentTool | undefined;
         try {


### PR DESCRIPTION
## What Problem This Solves

Cached plugin descriptor execution scans the selected plugin tool candidates more than once when deciding which runtime registration should execute a requested tool. That path runs when a cached manifest descriptor needs to resolve the actual runtime tool implementation.

## Why This Change Was Made

The code now classifies plugin tool candidates in one pass into matching named registrations and unnamed fallback registrations. It preserves the existing execution order: matching named candidates first, then unnamed candidates, with stable registry order inside each group.

## User Impact

Plugin tool execution does less repeated candidate-list work on cached descriptor calls, especially for plugins with multiple tool registrations. Runtime behavior and fallback semantics are intended to stay unchanged.

## Evidence

- node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts"
- autoreview clean: no accepted/actionable findings reported; tests exit 0
