### PR TITLE
fix(llm): trust control escapes in JSON strings that escape backslashes

### DIFF
--- a/src/llm/utils/json-parse.test.ts
+++ b/src/llm/utils/json-parse.test.ts
@@ -31,6 +31,20 @@ describe("json-parse repairJson invalid \\u escapes", () => {
     });
   });
 
+  it("preserves a real control escape after an escaped Windows path", () => {
+    // Valid JSON whose path uses escaped \\ separators and whose \n is a genuine
+    // newline. The Windows-path repair heuristic must not fire here — doing so
+    // turned the real newline into a literal backslash-n, corrupting tool-call
+    // arguments (e.g. a multi-line shell command containing a Windows path).
+    const wire = JSON.stringify({ text: "Saved to C:\\Users\\me\nDone." });
+    expect(parseJsonWithRepair(wire)).toEqual(JSON.parse(wire));
+    expect((parseJsonWithRepair(wire) as { text: string }).text).toContain("\n");
+    expect((parseStreamingJson(wire) as { text: string }).text).toContain("\n");
+    // A real tab after an escaped path is likewise a genuine control escape.
+    const tabbed = JSON.stringify({ p: "D:\\a\\b\tEND" });
+    expect(parseJsonWithRepair(tabbed)).toEqual(JSON.parse(tabbed));
+  });
+
   it("recovers streaming tool-call arguments instead of dropping them to {}", () => {
     // LaTeX-style \u (\underline) is a valid string value the model may emit in args.
     const args = '{"cmd":"\\underline{x}"}';

--- a/src/llm/utils/json-parse.ts
+++ b/src/llm/utils/json-parse.ts
@@ -35,6 +35,11 @@ export function repairJson(json: string): string {
   let repaired = "";
   let inString = false;
   let stringValuePrefix = "";
+  // Once a string contains a properly escaped backslash, the model demonstrably
+  // escapes correctly, so later \n/\t/etc. are genuine control escapes — not
+  // unescaped Windows path separators. Tracking this stops the path heuristic
+  // below from corrupting a real newline that follows an escaped path.
+  let sawEscapedBackslash = false;
 
   for (let index = 0; index < json.length; index++) {
     const char = json[index];
@@ -44,6 +49,7 @@ export function repairJson(json: string): string {
       if (char === '"') {
         inString = true;
         stringValuePrefix = "";
+        sawEscapedBackslash = false;
       }
       continue;
     }
@@ -52,6 +58,7 @@ export function repairJson(json: string): string {
       repaired += char;
       inString = false;
       stringValuePrefix = "";
+      sawEscapedBackslash = false;
       continue;
     }
 
@@ -79,7 +86,11 @@ export function repairJson(json: string): string {
         continue;
       }
 
-      if (JSON_CONTROL_ESCAPES.has(nextChar) && looksLikeWindowsPathPrefix(stringValuePrefix)) {
+      if (
+        JSON_CONTROL_ESCAPES.has(nextChar) &&
+        !sawEscapedBackslash &&
+        looksLikeWindowsPathPrefix(stringValuePrefix)
+      ) {
         repaired += "\\\\";
         stringValuePrefix += "\\";
         continue;
@@ -87,7 +98,12 @@ export function repairJson(json: string): string {
 
       if (VALID_JSON_ESCAPES.has(nextChar)) {
         repaired += `\\${nextChar}`;
-        stringValuePrefix += nextChar === "\\" ? "\\" : `\\${nextChar}`;
+        if (nextChar === "\\") {
+          stringValuePrefix += "\\";
+          sawEscapedBackslash = true;
+        } else {
+          stringValuePrefix += `\\${nextChar}`;
+        }
         index += 1;
         continue;
       }


### PR DESCRIPTION
## What Problem This Solves

Salvages #96737 by @ly-wang19 onto current `main` — clean single-commit rebase, original authorship preserved. The original was auto-closed by `openclaw-barnacle` for the author's >20-active-PR cap, not on merits; the bug is still live on `main`.

`repairJson` — the tolerant parser behind `parseStreamingJson`/`parseJsonWithRepair` used for model tool-call arguments — **corrupts genuine control escapes** (`\n`, `\t`, …) that legitimately follow an escaped Windows path inside a JSON string. A real newline in a multi-line tool-call argument becomes a literal backslash-n.

## Root Cause

**Symptom** — A tool-call argument like `{"text":"Saved to C:\\Users\\me\nDone."}` (valid JSON: `\\` are escaped separators, `\n` is a real newline) comes back with the `\n` rewritten to a literal `\\n`, breaking multi-line shell commands and any value that mixes a Windows path with a real control char.

**Root cause** — In `src/llm/utils/json-parse.ts`, `repairJson()` has a heuristic that, when it sees a control-escape char after text that `looksLikeWindowsPathPrefix`, assumes the model forgot to escape a backslash and rewrites `\` → `\\`. But once a string has already contained a *properly escaped* backslash (`\\`), the model has demonstrated it escapes correctly, so subsequent `\n`/`\t` are genuine control escapes — the heuristic fires anyway and corrupts them.

**Evidence** — On current `main`, line 82 guards only on `looksLikeWindowsPathPrefix(stringValuePrefix)`, with no "already saw a correct escape" condition. The new regression test fails against this `main` source (see Real behavior proof).

**Fix + why this level** — Track `sawEscapedBackslash` per string; once a correctly escaped `\\` is seen, suppress the Windows-path rewrite for the remainder of that string. Reset on string open/close. This is the right level because the false positive is intrinsic to the repair heuristic's assumption — downstream consumers can't distinguish a real newline from a corrupted one after the fact.

**Scope / risk** — Touches only the Windows-path repair branch in `repairJson`. Strings that never contain a correct `\\` still get the original repair behavior (the genuinely-malformed case it was designed for). Reset on string boundaries prevents cross-string leakage.

## Evidence

- **Regression test (new):** `src/llm/utils/json-parse.test.ts` → "preserves a real control escape after an escaped Windows path" — **fails without the fix**.
- **Captured run on this branch:**

WITH fix:
```
 ✓ src/llm/utils/json-parse.test.ts (15 tests) 82ms
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

WITHOUT fix (test against current `main` source for `json-parse.ts`):
```
 Test Files  1 failed (1)
      Tests  1 failed | 14 passed (15)
```

## Changes from original

- Rebased onto current `main` (clean single commit, no conflicts).
- No code changes from @ly-wang19's original.

Credit: **Salvage of #96737 by @ly-wang19** — rebased onto current main. Original closed by the >20-active-PR queue cap, not on merits.

