### PR TITLE
fix(chunk): keep surrogate pairs whole when hard-splitting an over-long line

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -513,6 +513,19 @@ describe("chunkByNewline", () => {
   it.each(["", "   \n\n   "] as const)("returns empty array for input %j", (text) => {
     expect(chunkByNewline(text, 100)).toStrictEqual([]);
   });
+
+  it("does not split surrogate pairs when hard-splitting an over-long line", () => {
+    // An emoji-dense line with no break point forces the raw head cut at an odd code-unit offset;
+    // it must back off to a code-point boundary so no chunk ends in a high (or starts with a low)
+    // surrogate — the same contract the recursive chunkText path already honors.
+    const text = "😀".repeat(30);
+    const chunks = chunkByNewline(text, 11);
+
+    expect(chunks.join("")).toBe(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => !/[\uD800-\uDBFF]$/u.test(chunk))).toBe(true);
+    expect(chunks.every((chunk) => !/^[\uDC00-\uDFFF]/u.test(chunk))).toBe(true);
+  });
 });
 
 describe("chunkTextWithMode", () => {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -163,7 +163,10 @@ export function chunkByNewline(
       continue;
     }
 
-    const firstLimit = Math.max(1, maxLineLength - prefix.length);
+    // Back the head cut off to a code-point boundary so an over-long line never splits a surrogate
+    // pair; the recursive chunkText below is already surrogate-safe, only this first cut was raw.
+    const rawLimit = Math.max(1, maxLineLength - prefix.length);
+    const firstLimit = avoidTrailingHighSurrogateBreak(lineValue, 0, rawLimit);
     const first = lineValue.slice(0, firstLimit);
     chunks.push(prefix + first);
     const remaining = lineValue.slice(firstLimit);


### PR DESCRIPTION
## What Problem This Solves

`chunkByNewline` splits a surrogate pair when it hard-cuts an over-long line that has no break point, so an emoji-dense message can produce a chunk ending in a lone high surrogate (and the next starting with a lone low surrogate) — corrupting the emoji at every chunk boundary.

Salvages #96671 by @ly-wang19 onto current `main` — clean single-commit rebase, original authorship preserved. The original was auto-closed by `openclaw-barnacle` for the author's >20-active-PR cap, not on merits; the bug is still live on `main`.

## Root Cause

**Symptom** — A long unbroken line of emoji (e.g. `"😀".repeat(30)`) chunked at a small limit yields chunks that end in `\uD800–\uDBFF` (lone high surrogate) / start with `\uDC00–\uDFFF` (lone low surrogate). The emoji at the cut is mojibake.

**Root cause** — In `src/auto-reply/chunk.ts`, `chunkByNewline()` computes the head cut as `firstLimit = Math.max(1, maxLineLength - prefix.length)` and slices the line at that raw UTF-16 code-*unit* offset. If that offset lands between the two code units of a surrogate pair, the pair is severed. The recursive `chunkText` path below already routes through `avoidTrailingHighSurrogateBreak`; only this first cut was raw.

**Fix + why this level** — Run the existing, already-imported `avoidTrailingHighSurrogateBreak(lineValue, 0, rawLimit)` on the first cut, mirroring the contract the recursive path already honors. Fixing at the cut site is correct: it's the only place that produces a non-code-point-aligned boundary, and reusing the existing helper keeps both cut paths consistent.

**Scope / risk** — Touches only the first-cut offset in `chunkByNewline`. Lines with a natural break point and BMP-only content are unaffected (back-off is a no-op when the boundary is already aligned). `chunks.join("")` still reconstructs the input exactly.

## Evidence

- **Regression test (new):** `src/auto-reply/chunk.test.ts` → "does not split surrogate pairs when hard-splitting an over-long line" — **fails without the fix**.
- **Captured run on this branch:**

WITH fix:
```
 Test Files  1 passed (1)
      Tests  66 passed (66)
```

WITHOUT fix (test against current `main` source for `chunk.ts`):
```
      Tests  1 failed | 65 passed (66)
```

## Changes from original

- Rebased onto current `main` (clean single commit, no conflicts).
- No code changes from @ly-wang19's original.

Note: #96415 addressed the same `firstLimit` cut; this salvage (#96671) is the cleaner of the two and supersedes it.

Credit: **Salvage of #96671 by @ly-wang19** — rebased onto current main. Original closed by the >20-active-PR queue cap, not on merits.
