### PR TITLE
fix(markdown): a fenced-code line with trailing text is content, not a closing fence

### DIFF
--- a/packages/markdown-core/src/fences.test.ts
+++ b/packages/markdown-core/src/fences.test.ts
@@ -1,0 +1,26 @@
+// Tests fenced-code-block span scanning used to keep chunk breaks out of code blocks.
+import { describe, expect, it } from "vitest";
+import { isSafeFenceBreak, parseFenceSpans } from "./fences.js";
+
+describe("parseFenceSpans closing-fence rules", () => {
+  it("treats a marker line with trailing text as code content, not a closing fence", () => {
+    // CommonMark: a closing fence may be followed only by whitespace, so "``` not a close" is code
+    // content and the block stays open until the real closing fence. Reporting an interior offset
+    // as a safe break would let a chunker split inside the code block.
+    const text = "```\ncode\n``` not a close\nmore code\n```\n";
+    const spans = parseFenceSpans(text);
+
+    expect(spans).toHaveLength(1);
+    expect(isSafeFenceBreak(spans, text.indexOf("more code") + 1)).toBe(false);
+  });
+
+  it("still closes on a bare fence, a longer same-marker fence, and keeps an opener info string", () => {
+    expect(parseFenceSpans("```\ncode\n```\nafter\n")).toHaveLength(1);
+    expect(parseFenceSpans("```\ncode\n`````  \nafter\n")).toHaveLength(1);
+    expect(parseFenceSpans("```python\nx = 1\n```\n")).toHaveLength(1);
+
+    const closed = "```\ncode\n```\nafter\n";
+    const spans = parseFenceSpans(closed);
+    expect(isSafeFenceBreak(spans, closed.indexOf("after") + 1)).toBe(true);
+  });
+});

--- a/packages/markdown-core/src/fences.ts
+++ b/packages/markdown-core/src/fences.ts
@@ -58,9 +58,14 @@ export function scanFenceSpans(
           marker,
           indent,
         };
-      } else if (open.markerChar === markerChar && markerLen >= open.markerLen) {
-        // CommonMark allows a closing fence to be longer than the opener, but
-        // it must use the same marker character to avoid crossing fence kinds.
+      } else if (
+        open.markerChar === markerChar &&
+        markerLen >= open.markerLen &&
+        match[3].trim() === ""
+      ) {
+        // CommonMark: a closing fence uses the same marker character, may be longer than the
+        // opener, and may be followed only by whitespace. A marker line carrying trailing text
+        // (e.g. "``` note") is code content, not a close, so it must not end the block.
         const end = lineEnd;
         spans.push({
           start: open.start,


### PR DESCRIPTION
## What Problem This Solves

Fenced-code-block span scanning (used to keep chunk breaks out of code blocks) treats a marker line that carries trailing text (e.g. `` ``` not a close ``) as a *closing* fence. Per CommonMark §4.5 that line is code content and the block stays open — so the scanner ends the block early and can report an interior code offset as a "safe break," letting a chunker split **inside** a still-open code block.

Salvages #96687 by @ly-wang19 onto current `main` — clean single-commit rebase, original authorship preserved. The original was auto-closed by `openclaw-barnacle` for the author's >20-active-PR cap, not on merits; the bug is still live on `main`.

## Root Cause

**Symptom** — For `` ```\ncode\n``` not a close\nmore code\n``` ``, `parseFenceSpans` returns the block closed at the `` ``` not a close `` line, and `isSafeFenceBreak` returns `true` for an offset inside the still-open block.

**Root cause** — In `packages/markdown-core/src/fences.ts`, `scanFenceSpans()` closes a span when `open.markerChar === markerChar && markerLen >= open.markerLen`, but does not check that the rest of the marker line is blank. CommonMark §4.5: a closing fence "may be followed only by spaces or tabs." A marker followed by non-whitespace is content, not a close.

**Fix + why this level** — Add `&& match[3].trim() === ""` to the close condition so only a bare/whitespace-trailed fence closes the block. This is the correct layer: the close-detection predicate is exactly where CommonMark's "trailing whitespace only" rule belongs; downstream consumers (`isSafeFenceBreak`) correctly derive from accurate spans once the span boundary is right.

**Scope / risk** — Touches only the closing-fence branch. Still closes on a bare fence, a longer same-marker fence, and preserves an opener info string (`` ```python ``) — all asserted in the test. Opener detection unchanged.

## Evidence

**Host:** macOS (Darwin 25.4.0, arm64), node v25.5.0, repo's own vitest 4.1.5 + tsx. Input is a fenced code block whose body contains a marker line carrying trailing text (`` ``` not a close ``).

Input (escaped): `"```\ncode\n``` not a close\nmore code\n```\n"`

### Before (current `upstream/main` `packages/markdown-core/src/fences.ts`)
```
OLD upstream/main: spans = 2 | isSafeFenceBreak(inside block) = true
```
Main treats `` ``` not a close `` as a closing fence → splits the single block into **2 spans** and reports an interior offset as a **safe** chunk break — a chunker would split *through* the still-open code block.

### After (this PR branch, sha `05317fbd73`)
```
fenced-code spans detected: 1 (expected 1 — one block, opened at line 1, closed at the bare ``` on line 5)
is splitting at 'more code' (inside the block) a SAFE break? false
RESULT: PASS — trailing-text marker line kept as content; block stays open.
```

### Added unit tests (new: `packages/markdown-core/src/fences.test.ts`)
```
✓ parseFenceSpans closing-fence rules > treats a marker line with trailing text as code content, not a closing fence  2ms
✓ parseFenceSpans closing-fence rules > still closes on a bare fence, a longer same-marker fence, and keeps an opener info string  0ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

WITHOUT fix (same test against current `main` source for `fences.ts`):
```
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

## Changes from original

- Rebased onto current `main` (clean single commit, no conflicts). No code changes from @ly-wang19's original.

Credit: **Salvage of #96687 by @ly-wang19** — rebased onto current main. Original closed by the >20-active-PR queue cap, not on merits.
