### PR TITLE
perf(status): select recent sessions without full sort

### DIFF
--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -510,6 +510,40 @@ describe("getStatusSummary", () => {
     expect(hydratedKeys).not.toContain("agent:main:session-2");
   });
 
+  it("preserves store order for tied recent session timestamps", async () => {
+    const store = Object.fromEntries(
+      Array.from({ length: 11 }, (_, index) => {
+        const number = index + 1;
+        return [
+          `agent:main:session-${number}`,
+          {
+            sessionId: `session-${number}`,
+            updatedAt: 1,
+          },
+        ];
+      }),
+    );
+    statusSummaryMocks.listSessionEntries.mockReturnValue(toSessionEntrySummaries(store));
+
+    const summary = await getStatusSummary();
+
+    expect(summary.sessions.recent.map((session) => session.key)).toEqual([
+      "agent:main:session-1",
+      "agent:main:session-2",
+      "agent:main:session-3",
+      "agent:main:session-4",
+      "agent:main:session-5",
+      "agent:main:session-6",
+      "agent:main:session-7",
+      "agent:main:session-8",
+      "agent:main:session-9",
+      "agent:main:session-10",
+    ]);
+    expect(summary.sessions.byAgent[0]?.recent.map((session) => session.key)).toEqual(
+      summary.sessions.recent.map((session) => session.key),
+    );
+  });
+
   it("passes agent scope when listing configured agent session stores", async () => {
     vi.mocked(listGatewayAgentsBasic).mockReturnValue({
       defaultId: "main",

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -180,6 +180,27 @@ function compareSessionCandidatesByUpdatedAt(left: SessionCandidate, right: Sess
   return (right.updatedAt ?? 0) - (left.updatedAt ?? 0);
 }
 
+function selectRecentSessionCandidates(
+  candidates: SessionCandidate[],
+  limit: number,
+): SessionCandidate[] {
+  const selected: SessionCandidate[] = [];
+  for (const candidate of candidates) {
+    const insertAt = selected.findIndex(
+      (selectedCandidate) => compareSessionCandidatesByUpdatedAt(candidate, selectedCandidate) < 0,
+    );
+    if (insertAt >= 0) {
+      selected.splice(insertAt, 0, candidate);
+      if (selected.length > limit) {
+        selected.pop();
+      }
+    } else if (selected.length < limit) {
+      selected.push(candidate);
+    }
+  }
+  return selected;
+}
+
 function listSessionCandidates(storePath: string, agentId?: string) {
   return (
     listSessionEntries({
@@ -193,7 +214,6 @@ function listSessionCandidates(storePath: string, agentId?: string) {
         entry,
         updatedAt: entry?.updatedAt ?? null,
       }))
-      .toSorted(compareSessionCandidatesByUpdatedAt)
   );
 }
 
@@ -471,9 +491,10 @@ export async function getStatusSummary(
     agentList.agents.map(async (agent) => {
       const storePath = resolveStorePath(cfg.session?.store, { agentId: agent.id });
       const candidates = loadSessionCandidates(storePath, agent.id);
-      const sessions = await buildSessionRows(candidates.slice(0, RECENT_SESSION_LIMIT), {
-        agentIdOverride: agent.id,
-      });
+      const sessions = await buildSessionRows(
+        selectRecentSessionCandidates(candidates, RECENT_SESSION_LIMIT),
+        { agentIdOverride: agent.id },
+      );
       return {
         agentId: agent.id,
         path: storePath,
@@ -492,9 +513,10 @@ export async function getStatusSummary(
         source.storePath,
         pathCounts.get(source.storePath) === 1 ? source.agentId : undefined,
       ),
-    )
-    .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
-  const recent = await buildSessionRows(allSessions.slice(0, RECENT_SESSION_LIMIT));
+    );
+  const recent = await buildSessionRows(
+    selectRecentSessionCandidates(allSessions, RECENT_SESSION_LIMIT),
+  );
   const totalSessions = allSessions.length;
 
   const summary: StatusSummary = {


### PR DESCRIPTION
## What Problem This Solves

`openclaw status` only displays and hydrates the most recent 10 session rows, but the summary path sorted every session candidate before slicing that small window. Large long-lived session stores paid O(n log n) work even though the command only needs a bounded recent subset plus the total count.

## Why This Change Was Made

This changes status session selection to keep a stable bounded top-N list while scanning candidates. Counts still use the full candidate list, but per-agent and aggregate recent-session hydration now sort only the displayed window. Timestamp ties keep store order to match stable `toSorted(...).slice(0, 10)` behavior.

## User Impact

Users with large session stores should see less status-summary CPU work before the command renders recent sessions. Output order, counts, and model/runtime hydration semantics are preserved.

## Evidence

- `node scripts/run-vitest.mjs src/commands/status.summary.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs src/commands/status.summary.test.ts"`
- `git diff --check`
