### PR TITLE
fix: prioritize chatAvatarUrl over assistant agent route to avoid 401

### DIFF
--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -326,6 +326,34 @@ describe("renderApp assistant avatar routing", () => {
     });
   });
 
+  it("prioritizes chatAvatarUrl over the assistant agent route for configAssistantAvatarUrl", () => {
+    renderApp(
+      createState({
+        chatAvatarUrl: "https://example.com/identity-avatar.png",
+        chatAvatarStatus: "url",
+        assistantAgentId: "main",
+        assistantAvatar: "/avatar/main",
+      }),
+    );
+
+    expect(quickSettingsProps.current?.assistantAvatarUrl).toBe(
+      "https://example.com/identity-avatar.png",
+    );
+  });
+
+  it("falls back to the assistant agent route when chatAvatarUrl is null and avatar status is local", () => {
+    renderApp(
+      createState({
+        chatAvatarUrl: null,
+        assistantAvatarStatus: "local",
+        assistantAgentId: "main",
+        basePath: "",
+      }),
+    );
+
+    expect(quickSettingsProps.current?.assistantAvatarUrl).toBe("/avatar/main");
+  });
+
   it("applies the configured chat message width as a shell CSS variable", () => {
     const container = document.createElement("div");
 

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -341,7 +341,7 @@ describe("renderApp assistant avatar routing", () => {
     );
   });
 
-  it("falls back to the assistant agent route when chatAvatarUrl is null and avatar status is local", () => {
+  it("returns null for configAssistantAvatarUrl when chatAvatarUrl is null and avatar status is local (protected route)", () => {
     renderApp(
       createState({
         chatAvatarUrl: null,
@@ -351,7 +351,7 @@ describe("renderApp assistant avatar routing", () => {
       }),
     );
 
-    expect(quickSettingsProps.current?.assistantAvatarUrl).toBe("/avatar/main");
+    expect(quickSettingsProps.current?.assistantAvatarUrl).toBeNull();
   });
 
   it("applies the configured chat message width as a shell CSS variable", () => {

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -330,7 +330,8 @@ describe("renderApp assistant avatar routing", () => {
     renderApp(
       createState({
         chatAvatarUrl: "https://example.com/identity-avatar.png",
-        chatAvatarStatus: "url",
+        chatAvatarStatus: "remote",
+        assistantAvatarStatus: "local",
         assistantAgentId: "main",
         assistantAvatar: "/avatar/main",
       }),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1442,10 +1442,12 @@ export function renderApp(state: AppViewState) {
       : state.assistantAvatar);
   const configAssistantAvatarUrl =
     localAssistantAvatarOverride ??
+    state.chatAvatarUrl ??
     (configAssistantAvatarStatus === "local" && state.assistantAgentId
       ? buildAssistantAvatarRoute(state.basePath, state.assistantAgentId)
-      : (state.chatAvatarUrl ??
-        (configAssistantAvatarMissing ? null : (assistantAvatarUrl ?? null))));
+      : configAssistantAvatarMissing
+        ? null
+        : (assistantAvatarUrl ?? null));
   const configValue =
     state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null);
   const configuredDreaming = resolveConfiguredDreaming(configValue);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1443,8 +1443,8 @@ export function renderApp(state: AppViewState) {
   const configAssistantAvatarUrl =
     localAssistantAvatarOverride ??
     state.chatAvatarUrl ??
-    (configAssistantAvatarStatus === "local" && state.assistantAgentId
-      ? buildAssistantAvatarRoute(state.basePath, state.assistantAgentId)
+    (configAssistantAvatarStatus === "local"
+      ? null
       : configAssistantAvatarMissing
         ? null
         : (assistantAvatarUrl ?? null));

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1078,12 +1078,6 @@ function resolveAssistantAvatarOverride(config: unknown): string | null {
   return normalizeOptionalString((assistant as { avatar?: unknown }).avatar) ?? null;
 }
 
-function buildAssistantAvatarRoute(basePathValue: string | null | undefined, agentId: string) {
-  const basePath = normalizeBasePath(basePathValue ?? "");
-  const encoded = encodeURIComponent(agentId);
-  return basePath ? `${basePath}/avatar/${encoded}` : `/avatar/${encoded}`;
-}
-
 // ── Quick Settings data extraction helpers ──
 
 const KNOWN_CHANNEL_IDS = [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who set an `Avatar` in their `IDENTITY.md` document would see a broken avatar image (401 response) in Settings → Personal → Assistant on the control-ui page. The avatar route built from the assistant agent ID (`/avatar/<agentId>`) was being preferred over the `chatAvatarUrl` provided by the profile document.

## Why This Change Was Made

Two issues in the `configAssistantAvatarUrl` fallback chain:

1. **Priority order**: `buildAssistantAvatarRoute` was checked before `state.chatAvatarUrl`, so the agent-based route always took precedence over the IDENTITY.md avatar.

2. **Protected route fallback**: Even after reordering, when `chatAvatarUrl` was null and the avatar status was "local", the code fell back to `buildAssistantAvatarRoute`, which emits `/avatar/<agentId>` — a route protected by bearer auth. Browser `<img>` tags cannot attach bearer headers, so this path always returns 401.

The proper fix is both: prioritize `chatAvatarUrl` first, and remove the protected route fallback entirely. When the avatar is local and no `chatAvatarUrl` is set, return `null` instead of a route that requires authentication.

## User Impact

Users who have configured an avatar in `IDENTITY.md` will now see it correctly rendered in Settings → Personal → Assistant instead of a broken image. Users without a profile avatar and a local assistant avatar will see no avatar (null) instead of a broken 401 image.

## Changes

### `ui/src/ui/app-render.ts`
- Prioritize `state.chatAvatarUrl` before the agent route check
- Remove `buildAssistantAvatarRoute()` fallback — return `null` when `configAssistantAvatarStatus === "local"` instead of building a protected `/avatar/<agentId>` URL

### `ui/src/ui/app-render.assistant-avatar.test.ts`
- Update the "falls back to assistant agent route" test to expect `null` for local status without `chatAvatarUrl`
- Rename test to reflect the new behavior: "returns null for configAssistantAvatarUrl when chatAvatarUrl is null and avatar status is local (protected route)"

## Evidence

Tests:
- `app-render.assistant-avatar.test.ts`: 22 passed
- `config-quick.test.ts`: 15 passed

## Real behavior proof 

F12 Network screenshot, there is no longer a 401 error interface:
<img width="709" height="438" alt="image" src="https://github.com/user-attachments/assets/e8c788ae-baaa-4b8f-96d7-498aad511f13" />

Control UI Setting page screenshot, the avatar is displayed normally:
<img width="861" height="281" alt="image" src="https://github.com/user-attachments/assets/a1f258fb-cc1c-4f7c-b93a-7aec7c07361f" />


Closes #85750