### PR TITLE
fix(feishu): keep top-level appSecret SecretRef active for the implicit default account (fixes #96929)

### DIFF
--- a/extensions/feishu/src/secret-contract.ts
+++ b/extensions/feishu/src/secret-contract.ts
@@ -1,9 +1,11 @@
 // Feishu plugin module implements secret contract behavior.
 import {
   collectConditionalChannelFieldAssignments,
-  collectSimpleChannelFieldAssignments,
+  collectSecretInputAssignment,
   getChannelSurface,
+  hasConfiguredSecretInputValue,
   hasOwnProperty,
+  isBaseFieldActiveForChannelSurface,
   normalizeSecretStringValue,
   type ResolverContext,
   type SecretDefaults,
@@ -89,16 +91,48 @@ export function collectRuntimeConfigAssignments(params: {
     return;
   }
   const { channel: feishu, surface } = resolved;
-  collectSimpleChannelFieldAssignments({
-    channelKey: "feishu",
-    field: "appSecret",
-    channel: feishu,
-    surface,
+  // Feishu account listing starts an implicit default account from top-level
+  // appId+appSecret even when every named account overrides appSecret.  The
+  // shared helper's isBaseFieldActiveForChannelSurface only checks whether any
+  // explicit account inherits the field, so top-level appSecret refs would be
+  // skipped when all accounts override.  Account for the implicit default here.
+  const hasImplicitDefaultAccount =
+    surface.channelEnabled &&
+    hasConfiguredSecretInputValue(feishu.appId, params.defaults) &&
+    hasConfiguredSecretInputValue(feishu.appSecret, params.defaults);
+  const topLevelAppSecretActive =
+    hasImplicitDefaultAccount || isBaseFieldActiveForChannelSurface(surface, "appSecret");
+  collectSecretInputAssignment({
+    value: feishu.appSecret,
+    path: "channels.feishu.appSecret",
+    expected: "string",
     defaults: params.defaults,
     context: params.context,
-    topInactiveReason: "no enabled account inherits this top-level Feishu appSecret.",
-    accountInactiveReason: "Feishu account is disabled.",
+    active: topLevelAppSecretActive,
+    inactiveReason: "no enabled account inherits this top-level Feishu appSecret.",
+    apply: (value) => {
+      feishu.appSecret = value;
+    },
   });
+  if (surface.hasExplicitAccounts) {
+    for (const { accountId, account, enabled } of surface.accounts) {
+      if (!hasOwnProperty(account, "appSecret")) {
+        continue;
+      }
+      collectSecretInputAssignment({
+        value: account.appSecret,
+        path: `channels.feishu.accounts.${accountId}.appSecret`,
+        expected: "string",
+        defaults: params.defaults,
+        context: params.context,
+        active: enabled,
+        inactiveReason: "Feishu account is disabled.",
+        apply: (value) => {
+          account.appSecret = value;
+        },
+      });
+    }
+  }
   const baseConnectionMode =
     normalizeSecretStringValue(feishu.connectionMode) === "webhook" ? "webhook" : "websocket";
   const resolveAccountMode = (account: Record<string, unknown>) =>

--- a/src/secrets/runtime-external-channel-audit.test.ts
+++ b/src/secrets/runtime-external-channel-audit.test.ts
@@ -416,7 +416,9 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
             enabled: true,
             tts: {
               providers: {
-                openai: { apiKey: inactiveExecRef("DISCORD_DISABLED_VOICE_TTS_API_KEY") },
+                openai: {
+                  apiKey: inactiveExecRef("DISCORD_DISABLED_VOICE_TTS_API_KEY"),
+                },
               },
             },
           },
@@ -540,5 +542,37 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
       "channels.zalo.accounts.disabled.webhookSecret",
     ]);
     expectMetadataBackedContractsWereUsed();
+  });
+
+  it("resolves Feishu top-level appSecret SecretRef for the implicit default account", async () => {
+    const records = configureExternalChannelRecords(["feishu"]);
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "cli_default",
+            appSecret: ref("FEISHU_APP_SECRET"),
+            accounts: {
+              "resource-shrimp": {
+                enabled: true,
+                appId: "cli_resource",
+                appSecret: "inline-secret-here", // pragma: allowlist secret
+              },
+            },
+          },
+        },
+      }),
+      env: { FEISHU_APP_SECRET: "default-secret" },
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: externalChannelOrigins(records),
+    });
+
+    expectResolvedPaths(snapshot.config, {
+      "channels.feishu.appSecret": "default-secret",
+      "channels.feishu.accounts.resource-shrimp.appSecret": "inline-secret-here",
+    });
+    expect(snapshot.warnings).toStrictEqual([]);
+    expectMetadataBackedContractsWereUsed(["feishu"]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes #96929.

When a Feishu channel has both a top-level `appSecret` using SecretRef format and sub-accounts (e.g. `accounts.resource-shrimp`) with their own inline `appSecret`, the secrets resolver skips resolving the top-level SecretRef. This causes the `[default]` channel to fail on startup with:

```
channels.feishu.appSecret: unresolved SecretRef "env:default:FEISHU_APP_SECRET".
Resolve this command against an active gateway runtime snapshot before reading it.
```

The resolver logs `SECRETS_REF_IGNORED_INACTIVE_SURFACE` because it only checks whether any explicit account inherits the field — but the implicit `[default]` channel itself always uses the top-level value.

## Why This Change Was Made

`isBaseFieldActiveForChannelSurface` returns `true` only when at least one enabled account does NOT override the field. When all accounts provide their own inline values, the top-level SecretRef was incorrectly marked as inactive.

Feishu account listing (`extensions/feishu/src/accounts.ts`) always creates an implicit default account from top-level `appId` + `appSecret`, even when named accounts exist. This fix detects that implicit default account and keeps the top-level `appSecret` active accordingly.

The change stays **Feishu-scoped** instead of modifying the shared `collectSimpleChannelFieldAssignments` helper, avoiding any risk of affecting sibling channel semantics (Discord, Slack, IRC, etc.).

## User Impact

Users with multi-account Feishu configurations where all accounts provide their own `appSecret` can now use SecretRef format for the top-level `appSecret` without the `[default]` channel failing to start. Previously, the only workaround was replacing the SecretRef with an inline secret string.

## Changes Made

- `extensions/feishu/src/secret-contract.ts`: Replaced `collectSimpleChannelFieldAssignments` with inline `collectSecretInputAssignment` logic that checks for the implicit default account via `hasConfiguredSecretInputValue(appId) && hasConfiguredSecretInputValue(appSecret)`.
- `src/secrets/runtime-external-channel-audit.test.ts`: Added regression test verifying top-level SecretRef is resolved when all accounts override the field.

## Evidence

- **Unit tests:** `node scripts/run-vitest.mjs run src/secrets/runtime-external-channel-audit.test.ts` — 8/8 passed
- **Regression (Discord):** `node scripts/run-vitest.mjs run src/secrets/runtime-discord-surface.test.ts` — 8/8 passed
- **Regression (Feishu accounts):** `node scripts/run-vitest.mjs run extensions/feishu/src/accounts.test.ts` — 23/23 passed

## Real behavior proof

**Config tested:** Top-level `appSecret` as `env:default:FEISHU_APP_SECRET` with one sub-account overriding `appSecret` inline.

**Environment:** OpenClaw 2026.6.10 (7e4a082 — this fix), Linux, Node 24.13.1

**`secrets audit` result:**
```json
{
  "resolution": {
    "refsChecked": 1,
    "skippedExecRefs": 0,
    "resolvabilityComplete": true
  },
  "summary": {
    "plaintextCount": 1,
    "unresolvedRefCount": 0,
    "shadowedRefCount": 0,
    "legacyResidueCount": 0
  }
}
```

- ✅ Top-level SecretRef resolved (refsChecked=1, unresolvedRefCount=0)
- ✅ No `SECRETS_REF_IGNORED_INACTIVE_SURFACE` warning emitted
- ✅ Gateway started cleanly — no errors, no crashes
- ✅ Sub-account inline secret handled correctly (plaintextCount=1 is expected for inline secrets)

**What was not tested:** Live Feishu platform message delivery (not required — fix is in config/secret resolution layer).

- [x] AI-assisted