### PR TITLE
fix(llm-core): coerce JSON-stringified array/object arguments in tool validation

### DIFF
--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -39,4 +39,80 @@ describe("validateToolArguments", () => {
       }),
     ).toThrow(/Validation failed for tool "decimal-tool"/);
   });
+
+  it("coerces JSON-stringified arrays when schema expects array type", () => {
+    const arrayTool = {
+      name: "array-tool",
+      description: "test tool with array param",
+      parameters: {
+        type: "object",
+        properties: {
+          tags: { type: "array", items: { type: "string" } },
+        },
+        required: ["tags"],
+        additionalProperties: false,
+      },
+    } as Tool;
+
+    expect(
+      validateToolArguments(arrayTool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "array-tool",
+        arguments: { tags: '["test","debug"]' },
+      }),
+    ).toEqual({ tags: ["test", "debug"] });
+  });
+
+  it("coerces JSON-stringified objects when schema expects object type", () => {
+    const objectTool = {
+      name: "object-tool",
+      description: "test tool with object param",
+      parameters: {
+        type: "object",
+        properties: {
+          config: {
+            type: "object",
+            properties: { key: { type: "string" } },
+            additionalProperties: false,
+          },
+        },
+        required: ["config"],
+        additionalProperties: false,
+      },
+    } as Tool;
+
+    expect(
+      validateToolArguments(objectTool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "object-tool",
+        arguments: { config: '{"key":"value"}' },
+      }),
+    ).toEqual({ config: { key: "value" } });
+  });
+
+  it("rejects invalid JSON strings for array/object schemas", () => {
+    const arrayTool = {
+      name: "array-tool",
+      description: "test tool with array param",
+      parameters: {
+        type: "object",
+        properties: {
+          tags: { type: "array", items: { type: "string" } },
+        },
+        required: ["tags"],
+        additionalProperties: false,
+      },
+    } as Tool;
+
+    expect(() =>
+      validateToolArguments(arrayTool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "array-tool",
+        arguments: { tags: "not-json" },
+      }),
+    ).toThrow(/Validation failed for tool "array-tool"/);
+  });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -247,6 +247,28 @@ function coerceWithJsonSchema(value: unknown, schema: JsonSchemaObject): unknown
     }
   }
 
+  // LLMs may serialize array/object parameters as JSON strings
+  // (e.g. "[\"a\",\"b\"]" instead of ["a","b"]). Try to parse the
+  // string before giving up — this makes MCP tools work across
+  // providers that differ in how they emit complex parameter types.
+  if (typeof nextValue === "string" && schemaTypes.length > 0) {
+    const wantsContainer =
+      schemaTypes.includes("array") || schemaTypes.includes("object");
+    if (wantsContainer) {
+      try {
+        const parsed = JSON.parse(nextValue);
+        if (
+          (schemaTypes.includes("array") && Array.isArray(parsed)) ||
+          (schemaTypes.includes("object") && isRecord(parsed) && !Array.isArray(parsed))
+        ) {
+          nextValue = parsed;
+        }
+      } catch {
+        // Not valid JSON — keep the original string
+      }
+    }
+  }
+
   if (schemaTypes.includes("object") && isRecord(nextValue) && !Array.isArray(nextValue)) {
     applySchemaObjectCoercion(nextValue, schema);
   }


### PR DESCRIPTION
## Summary

Fixes #96916: MCP tool calls fail with validation errors when LLMs serialize array/object parameters as JSON strings (e.g. `"[\"test\",\"debug\"]"` instead of `["test","debug"]`). Affected providers include MiMo, Ollama, and others.

## What Problem This Solves

When an LLM emits `tool_calls[].function.arguments` with stringified complex types (e.g. `tags: "[\"test\",\"debug\"]"`), OpenClaw's `validateToolArguments` cannot coerce them back to native arrays/objects. TypeBox `Value.Convert` only handles primitive coercion (string→number, string→boolean). The `coerceWithJsonSchema` helper handles `anyOf`/`oneOf` union schemas but has no `JSON.parse` fallback for string values when the schema expects `array` or `object`.

## Root cause

`coerceWithJsonSchema()` in `packages/llm-core/src/validation.ts` handles primitive coercion (number, integer, boolean, string, null) but has no path for deserializing a JSON-stringified array/object when the schema expects `array`/`object` types. The `default` branch of `coercePrimitiveByType` returns the value unchanged.

## Changes

**`packages/llm-core/src/validation.ts`** (+18 lines):

Add a JSON.parse fallback in `coerceWithJsonSchema` after the primitive coercion loop:

```typescript
// LLMs may serialize array/object parameters as JSON strings.
// Try to parse before giving up.
if (typeof nextValue === "string" && schemaTypes.length > 0) {
  const wantsContainer =
    schemaTypes.includes("array") || schemaTypes.includes("object");
  if (wantsContainer) {
    try {
      const parsed = JSON.parse(nextValue);
      if (
        (schemaTypes.includes("array") && Array.isArray(parsed)) ||
        (schemaTypes.includes("object") && isRecord(parsed) && !Array.isArray(parsed))
      ) {
        nextValue = parsed;
      }
    } catch {
      // Not valid JSON — keep the original string
    }
  }
}
```

The parsed value must match the expected type (array → Array, object → non-array Record). Invalid JSON is silently ignored (keeps original string, validation will produce a clear error).

## Evidence

### Proof 1: Production code lacks coercion (OpenClaw v2026.6.10)

```
$ grep -c "JSON.parse" node_modules/openclaw/dist/validation*.js
→ 0 instances in production validation code
```

### Proof 2: Real test output

```
$ npx vitest run packages/llm-core/src/validation.test.ts --reporter=verbose

 ✓ coerces strict decimal numeric strings for plain JSON schemas       174ms
 ✓ rejects non-decimal numeric strings for plain JSON schemas            3ms
 ✓ coerces JSON-stringified arrays when schema expects array type        2ms  ← NEW
 ✓ coerces JSON-stringified objects when schema expects object type      2ms  ← NEW
 ✓ rejects invalid JSON strings for array/object schemas                 1ms  ← NEW

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### Summary

| Evidence | Method | Result |
|---|---|---|
| Production dist lacks JSON.parse coercion | `grep` installed npm dist | ✅ Bug confirmed |
| PR source has wantsContainer + JSON.parse | Source verification | ✅ Fix applied |
| 5/5 tests pass (3 new regression) | `npx vitest` real run | ✅ All pass |
| Invalid JSON still rejected properly | Test case | ✅ Preserved |

**Tested on:** Windows 11, Node 24.13.0, OpenClaw 2026.6.10 installed, full repo checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>