### PR TITLE
fix(qqbot): bound STT transcription JSON response

### DIFF
--- a/extensions/qqbot/src/engine/utils/stt.test.ts
+++ b/extensions/qqbot/src/engine/utils/stt.test.ts
@@ -1,8 +1,8 @@
 // Qqbot tests cover stt plugin behavior.
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ssrfRuntimeMocks = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn(),
@@ -38,6 +38,36 @@ function cancelTrackedResponse(
   return {
     response: new Response(stream, init),
     wasCanceled: () => canceled,
+  };
+}
+
+function largeTranscriptionJsonResponse(params: { chunkCount: number; chunkSize: number }): {
+  response: Response;
+  getReadCount: () => number;
+} {
+  let chunkIndex = 0;
+  const encoder = new TextEncoder();
+  const chunks = [
+    '{"text":"',
+    ...Array.from({ length: params.chunkCount }, () => "a".repeat(params.chunkSize)),
+    '"}',
+  ];
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (chunkIndex >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(encoder.encode(chunks[chunkIndex]));
+      chunkIndex += 1;
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    getReadCount: () => chunkIndex,
   };
 }
 
@@ -173,6 +203,44 @@ describe("engine/utils/stt", () => {
       expect(new Uint8Array(await (file as File).arrayBuffer())).toEqual(
         new Uint8Array([1, 2, 3, 4]),
       );
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("bounds successful STT JSON responses before parsing", async () => {
+    await withTempDir("openclaw-qqbot-stt-success-limit-", async (tmpDir) => {
+      const audioPath = path.join(tmpDir, "voice.wav");
+      fs.writeFileSync(audioPath, Buffer.from([1, 2, 3, 4]));
+
+      const release = vi.fn(async () => {});
+      const streamed = largeTranscriptionJsonResponse({
+        chunkCount: 18,
+        chunkSize: 1024 * 1024,
+      });
+      ssrfRuntimeMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: streamed.response,
+        release,
+      });
+
+      let error: unknown;
+      try {
+        await transcribeAudio(audioPath, {
+          channels: {
+            qqbot: {
+              stt: {
+                baseUrl: "https://api.example.test/v1/",
+                apiKey: "secret",
+                model: "whisper-1",
+              },
+            },
+          },
+        });
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(String(error)).toContain("qqbot.stt: JSON response exceeds 16777216 bytes");
+      expect(streamed.getReadCount()).toBeLessThan(20);
       expect(release).toHaveBeenCalledTimes(1);
     });
   });

--- a/extensions/qqbot/src/engine/utils/stt.ts
+++ b/extensions/qqbot/src/engine/utils/stt.ts
@@ -8,7 +8,10 @@
 import * as fs from "node:fs";
 import path from "node:path";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeOptionalString,
@@ -100,7 +103,7 @@ export async function transcribeAudio(
       throw new Error(`STT failed (HTTP ${resp.status}): ${detail.slice(0, 300)}`);
     }
 
-    const result = (await resp.json()) as { text?: string };
+    const result = await readProviderJsonResponse<{ text?: string }>(resp, "qqbot.stt");
     return normalizeOptionalString(result.text) ?? null;
   } finally {
     await release();


### PR DESCRIPTION
## Summary

- Bound QQBot STT successful JSON response parsing by routing it through the shared provider JSON reader.
- Add a regression that streams an oversized successful transcription JSON body and verifies the read stops before the whole body is consumed.

## What Problem This Solves

QQBot STT already bounded non-OK provider error bodies, but successful transcription responses still used direct `resp.json()`. A configured or self-hosted OpenAI-compatible STT endpoint could therefore force OpenClaw to buffer a very large successful JSON body before parsing it.

## User Impact

Users who configure QQBot STT against a buggy, hostile, or misconfigured provider get the same bounded successful JSON behavior used by other provider paths instead of an unbounded success-body read.

- **Why it matters / User impact:** This keeps the QQBot STT provider boundary consistent with #96496 and prevents a provider success response from consuming unbounded memory before transcript extraction.

## Origin / follow-up

Follow-up to #96496.

- **Follows/completes:** #96496 bounded successful JSON reads for speech/media provider response paths.
- **Gap this fills:** QQBot's OpenAI-compatible STT utility still handled non-OK error bodies with `readResponseTextLimited(...)`, but successful responses used direct `resp.json()`.
- **Consistency:** This patch applies the same shared `readProviderJsonResponse(...)` pattern already used by the bounded speech/media provider paths.

## Competition / linked PR analysis

- **Related open PR scan:** No open PR was found for the same QQBot STT bounded-success-response gap in searches for `qqbot stt`, `qqbot bounded`, `bound response json`, and bounded speech-provider response reads.
- **Canonical PR check:** This is not a replacement for #96496; it is a narrow sibling follow-up for the QQBot STT path that remained on direct `resp.json()`.

## Real behavior proof

- **Behavior or issue addressed:** QQBot STT successful provider JSON responses are now read through the bounded provider JSON helper instead of direct `resp.json()`, so oversized success bodies are rejected under the shared cap before the whole response is consumed.
- **Real environment tested:** Linux worktree `/media/vdb/code/ai/aispace/openclaw-worktrees/pr-96968`, Node runtime in the OpenClaw repo, current branch `repair/pr-96968` at `a862db9bc4aae01c485b9e0cded6cf1792129bde`.
- **Exact steps or command run after this patch:**

```bash
source "/media/vdb/code/ai/aispace/openclaw-pr-96968-evidence/context.env" && (cd "$TASK_WORKTREE" && node --import tsx --input-type=module --eval 'import { writeFile, rm } from "node:fs/promises"; import { tmpdir } from "node:os"; import path from "node:path"; import { transcribeAudio } from "./extensions/qqbot/src/engine/utils/stt.ts"; const originalFetch = globalThis.fetch; let chunkIndex = 0; const chunkCount = 18; const chunkSize = 1024 * 1024; let canceled = false; const proofFetch = async (input, init) => { console.log(`fetch called ${init?.method ?? "GET"} ${input}`); const encoder = new TextEncoder(); const stream = new ReadableStream({ pull(controller) { if (chunkIndex === 0) { controller.enqueue(encoder.encode("{\"text\":\"")); chunkIndex += 1; return; } if (chunkIndex <= chunkCount) { controller.enqueue(encoder.encode("a".repeat(chunkSize))); chunkIndex += 1; return; } controller.enqueue(encoder.encode("\"}")); chunkIndex += 1; controller.close(); }, cancel() { canceled = true; } }); return new Response(stream, { status: 200, headers: { "content-type": "application/json" } }); }; proofFetch.mock = {}; globalThis.fetch = proofFetch; const audioPath = path.join(tmpdir(), `qqbot-transcribe-proof-${process.pid}.wav`); await writeFile(audioPath, Buffer.from([1, 2, 3, 4])); try { await transcribeAudio(audioPath, { channels: { qqbot: { stt: { baseUrl: "https://api.example.test/v1/", apiKey: "redacted-proof-key", model: "whisper-1" } } } }); console.log("unexpected success"); } catch (error) { console.log(String(error)); } finally { console.log(`chunks served ${chunkIndex} of ${chunkCount + 2}`); console.log(`stream canceled ${canceled}`); globalThis.fetch = originalFetch; await rm(audioPath, { force: true }); }')
```

```bash
source "/media/vdb/code/ai/aispace/openclaw-pr-96968-evidence/context.env" && (cd "$TASK_WORKTREE" && node scripts/run-vitest.mjs extensions/qqbot/src/engine/utils/stt.test.ts)
```

```bash
source "/media/vdb/code/ai/aispace/openclaw-pr-96968-evidence/context.env" && (cd "$TASK_WORKTREE" && "$DAILY_FIX_SCRIPT" guard-workspace)
source "/media/vdb/code/ai/aispace/openclaw-pr-96968-evidence/context.env" && (cd "$TASK_WORKTREE" && git diff --check HEAD~1..HEAD)
```

- **Evidence after fix:**

```text
fetch called POST https://api.example.test/v1/audio/transcriptions
Error: qqbot.stt: JSON response exceeds 16777216 bytes
chunks served 18 of 20
stream canceled true
```

```text
Test Files  1 passed (1)
Tests  6 passed (6)
[test] passed 1 Vitest shard in 24.04s
```

```text
daily-fix: workspace ok
git diff --check HEAD~1..HEAD: passed with no output
```

- **Observed result after fix:** The QQBot `transcribeAudio` path posts to `/audio/transcriptions`, receives an oversized successful JSON stream, throws `qqbot.stt: JSON response exceeds 16777216 bytes`, and cancels the response stream after 18 of 20 chunks instead of reading the complete body.
- **What was not tested:** Live QQBot bot delivery and a real third-party STT account were not tested. The proof invokes the changed QQBot STT runtime function with a redacted in-process STT responder so the provider response boundary is exercised without external credentials; QQBot transport delivery is unchanged.
- **Fix classification:** Root cause fix.

## Review findings addressed

- **RF-001:** Addressed by the QQBot `transcribeAudio` runtime proof above. The command invokes the changed QQBot path against an oversized successful JSON response and records the labeled cap error plus early stream stop.
- **RF-002:** Addressed by replacing the earlier shared-helper-only proof with redacted terminal output from the changed QQBot `transcribeAudio` path after the patch.
- **RF-003:** Addressed by supplementing the mocked regression test with direct QQBot-path runtime proof showing `qqbot.stt: JSON response exceeds 16777216 bytes`, `chunks served 18 of 20`, and `stream canceled true`.
- **RF-004:** Addressed for the proof gate with QQBot-path runtime proof and explicit disclosure that live QQBot bot delivery and a real third-party STT account were not tested; the code change remains the same narrow parser-boundary fix.

## Regression Test Plan

- **Target test file:** `extensions/qqbot/src/engine/utils/stt.test.ts`
- **Scenario locked in:** A successful OpenAI-compatible transcription response streams a valid JSON body larger than the shared provider JSON cap; QQBot STT must reject it with the `qqbot.stt` bounded-reader error before reading all chunks.
- **Why this is the smallest reliable guardrail:** The regression exercises the QQBot STT response boundary that owned the direct `resp.json()` call while leaving request construction and existing error-body coverage unchanged.
- Added `bounds successful STT JSON responses before parsing`, which streams a valid oversized transcription JSON success body and asserts the bounded-reader error plus early stream stop.
- The same targeted test file was run after the patch and passed.

Before the production change, the new regression failed because the direct `resp.json()` path returned successfully instead of producing the bounded-reader error:

```text
× bounds successful STT JSON responses before parsing
AssertionError: expected 'undefined' to contain 'qqbot.stt: JSON response exceeds 1677…'

Expected: "qqbot.stt: JSON response exceeds 16777216 bytes"
Received: "undefined"

Test Files  1 failed (1)
Tests  1 failed | 5 passed (6)
```

## Merge risk

- **Risk labels considered:** Provider/availability risk from changing STT response parsing on a channel extension.
- **Risk explanation:** Existing successful JSON responses under 16 MiB still parse through the shared provider JSON reader. Oversized or malformed JSON now fails with a labeled provider parsing error instead of being fully buffered by `resp.json()`.
- **Why acceptable:** The patch only changes the success-body parser and reuses the shared provider HTTP cap that #96496 already established for similar provider paths.

## Risk / Compatibility

Low compatibility risk. This does not change QQBot STT credentials, endpoint selection, multipart form fields, non-OK error response formatting, release behavior, or transcript normalization.

## What was not changed

- **What did NOT change:** QQBot STT config resolution, SSRF-guarded request URL, audit context, headers, multipart form fields, non-OK response handling, and transcript normalization are unchanged; only successful provider JSON parsing changes.
- **Architecture / source-of-truth check:** The shared provider HTTP helper is the canonical source-of-truth for provider JSON response size limits. This PR moves QQBot STT to that source-of-truth instead of defining a new cap, config default, schema field, protocol behavior, or migration path.
- QQBot STT config resolution.
- The SSRF-guarded request URL, audit context, headers, and multipart form fields.
- Non-OK response handling with `readResponseTextLimited(...)`.
- Transcript trimming/normalization behavior.

## Root Cause

- **Root cause:** The root cause was a parser boundary mismatch in `extensions/qqbot/src/engine/utils/stt.ts`: the non-OK provider response path used a bounded reader, but the successful provider response parser still called direct `resp.json()`, which caused oversized success JSON bodies to bypass the shared provider JSON size invariant.
- **Why this is root-cause fix:** This fixes the source parser invariant at the QQBot STT provider boundary because the direct success-body parser is removed and replaced with `readProviderJsonResponse<{ text?: string }>(resp, "qqbot.stt")`, the canonical bounded JSON reader used by other provider paths.
- **Maintainer-ready confidence:** High for the scoped provider-boundary fix because the diff is limited to the parser call plus a regression that failed before the production change and passed after it.
- **Patch quality notes:** Two files changed, no CHANGELOG or dependency changes, no request-shape changes, and verification is recorded in `$EVIDENCE_DIR`.
