### PR TITLE
fix(runtime): drop intermediate monologue text blocks from visible delivery

### DIFF
--- a/src/agents/embedded-agent-utils.test.ts
+++ b/src/agents/embedded-agent-utils.test.ts
@@ -863,6 +863,66 @@ describe("extractAssistantVisibleText", () => {
 
     expect(extractAssistantVisibleText(msg)).toBe("Done.");
   });
+
+  // Regression: openclaw/openclaw#96849 -- Discord main-session final delivery
+  // flows through embedded-agent-subscribe.handlers.messages, which calls this
+  // `extractAssistantVisibleText` helper (NOT the shared/chat-message-content
+  // one). Providers like MiniMax-M3 via openai-completions emit internal
+  // monologue as unphased `type: "text"` blocks interleaved with `thinking`
+  // blocks; the delivery-path extractor must drop those or the monologue leaks
+  // to Discord. This test uses the exact 6-block shape from the issue.
+  it("drops unphased text blocks emitted before a later thinking block (#96849 delivery path)", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "Gabe is asking me to confirm..." },
+        { type: "thinking", thinking: "Excellent! Key info..." },
+        {
+          type: "text",
+          text: "All done. Let me give Gabe a clean status update. Status: \u2705 patch applied, \u2705 memory committed. Let me give Gabe a tight summary. Also, this message is the verification test \u2014 if Gabe sees thinking in my reply, the patch failed.",
+        },
+        { type: "thinking", thinking: "Let me give Gabe a tight summary..." },
+        { type: "thinking", thinking: "Also, this message is the verification test..." },
+        {
+          type: "text",
+          text: "Done. Here's the final status: \u2705 patch applied, \u2705 memory committed.",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantVisibleText(msg)).toBe(
+      "Done. Here's the final status: \u2705 patch applied, \u2705 memory committed.",
+    );
+  });
+
+  it("keeps unphased final text when only a trailing thinking block follows (#96849)", () => {
+    // text -> thinking (no later text) is post-answer reflection; do NOT drop.
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "Plan: write a clean answer." },
+        { type: "text", text: "Here's the answer." },
+        { type: "thinking", thinking: "Postmortem: that was concise." },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantVisibleText(msg)).toBe("Here's the answer.");
+  });
+
+  it("keeps all unphased text when no thinking blocks are present (#96849)", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "text", text: "First sentence." },
+        { type: "text", text: "Second sentence." },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantVisibleText(msg)).toBe("First sentence.\nSecond sentence.");
+  });
 });
 
 describe("promoteThinkingTagsToBlocks", () => {

--- a/src/agents/embedded-agent-utils.ts
+++ b/src/agents/embedded-agent-utils.ts
@@ -6,6 +6,7 @@
 import type { AssistantMessage } from "../llm/types.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 import {
+  isIntermediateMonologueTextBlock,
   normalizeAssistantPhase,
   parseAssistantTextSignature,
   type AssistantPhase,
@@ -102,8 +103,9 @@ function extractAssistantTextForPhase(
   });
 
   let hadRequestedPhase = false;
-  const parts = msg.content
-    .map((block) => {
+  const contentBlocks = msg.content;
+  const parts = contentBlocks
+    .map((block, index) => {
       if (!block || typeof block !== "object") {
         return null;
       }
@@ -118,6 +120,18 @@ function extractAssistantTextForPhase(
         return null;
       }
       hadRequestedPhase = true;
+      // Drop unphased text blocks identified as intermediate provider monologue
+      // (#96849 — MiniMax-M3 via openai-completions emits monologue as plain
+      // `text` blocks interleaved with `thinking` blocks). Mirrors the shared
+      // extractor's monologue guard so Discord/main-session final delivery
+      // (which flows through this helper via embedded-agent-subscribe.handlers)
+      // stays consistent with history/channel reads.
+      if (
+        !signature?.phase &&
+        isIntermediateMonologueTextBlock(contentBlocks, index, hasExplicitPhasedTextBlocks)
+      ) {
+        return null;
+      }
       const sanitizerPhase =
         resolvedPhase ??
         (options?.unphasedSignedFinalAnswer === true && signature?.id ? "final_answer" : undefined);

--- a/src/shared/chat-message-content.test.ts
+++ b/src/shared/chat-message-content.test.ts
@@ -64,12 +64,20 @@ describe("extractAssistantVisibleText", () => {
             {
               type: "text",
               text: "Hi ",
-              textSignature: JSON.stringify({ v: 1, id: "msg_final_1", phase: "final_answer" }),
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "msg_final_1",
+                phase: "final_answer",
+              }),
             },
             {
               type: "text",
               text: "there",
-              textSignature: JSON.stringify({ v: 1, id: "msg_final_2", phase: "final_answer" }),
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "msg_final_2",
+                phase: "final_answer",
+              }),
             },
           ],
         },
@@ -86,12 +94,20 @@ describe("extractAssistantVisibleText", () => {
           {
             type: "text",
             text: "thinking like caveman",
-            textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_commentary",
+              phase: "commentary",
+            }),
           },
           {
             type: "text",
             text: "Actual final answer",
-            textSignature: JSON.stringify({ v: 1, id: "msg_final", phase: "final_answer" }),
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_final",
+              phase: "final_answer",
+            }),
           },
         ],
       }),
@@ -106,7 +122,11 @@ describe("extractAssistantVisibleText", () => {
           {
             type: "text",
             text: "thinking like caveman",
-            textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_commentary",
+              phase: "commentary",
+            }),
           },
         ],
       }),
@@ -122,7 +142,11 @@ describe("extractAssistantVisibleText", () => {
           {
             type: "text",
             text: "   ",
-            textSignature: JSON.stringify({ v: 1, id: "msg_final", phase: "final_answer" }),
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_final",
+              phase: "final_answer",
+            }),
           },
         ],
       }),
@@ -166,11 +190,73 @@ describe("extractAssistantVisibleText", () => {
           {
             type: "text",
             text: "Actual final answer",
-            textSignature: JSON.stringify({ v: 1, id: "msg_final", phase: "final_answer" }),
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_final",
+              phase: "final_answer",
+            }),
           },
         ],
       }),
     ).toBe("Actual final answer");
+  });
+
+  // Regression: openclaw/openclaw#96849 -- Discord main-session deliveries
+  // leaked model thinking content because providers like MiniMax-M3 emit
+  // internal monologue as plain `type: "text"` blocks interleaved with
+  // `type: "thinking"` blocks (no phase metadata). Unphased extraction used
+  // to join every text block and concatenate the monologue with the final
+  // answer.
+  it("drops unphased text blocks emitted before a later thinking block", () => {
+    expect(
+      extractAssistantVisibleText({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Gabe is asking me to confirm..." },
+          { type: "thinking", thinking: "Excellent! Key info..." },
+          {
+            type: "text",
+            text: "All done. Let me give Gabe a clean status update. Status: \u2705 patch applied, \u2705 memory committed. Let me give Gabe a tight summary. Also, this message is the verification test \u2014 if Gabe sees thinking in my reply, the patch failed.",
+          },
+          { type: "thinking", thinking: "Let me give Gabe a tight summary..." },
+          {
+            type: "thinking",
+            thinking: "Also, this message is the verification test...",
+          },
+          {
+            type: "text",
+            text: "Done. Here's the final status: \u2705 patch applied, \u2705 memory committed.",
+          },
+        ],
+      }),
+    ).toBe("Done. Here's the final status: \u2705 patch applied, \u2705 memory committed.");
+  });
+
+  it("keeps unphased final text even when a trailing thinking block follows", () => {
+    // text -> thinking only (no later text) is the post-answer-reflection
+    // shape some providers emit. Do NOT drop the text in that case.
+    expect(
+      extractAssistantVisibleText({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Plan: write a clean answer." },
+          { type: "text", text: "Here's the answer." },
+          { type: "thinking", thinking: "Postmortem: that was concise." },
+        ],
+      }),
+    ).toBe("Here's the answer.");
+  });
+
+  it("keeps all text when no thinking blocks are present", () => {
+    expect(
+      extractAssistantVisibleText({
+        role: "assistant",
+        content: [
+          { type: "text", text: "First sentence." },
+          { type: "text", text: "Second sentence." },
+        ],
+      }),
+    ).toBe("First sentence.\nSecond sentence.");
   });
 });
 
@@ -189,7 +275,11 @@ describe("resolveAssistantMessagePhase", () => {
           {
             type: "text",
             text: "Actual final answer",
-            textSignature: JSON.stringify({ v: 1, id: "msg_final", phase: "final_answer" }),
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_final",
+              phase: "final_answer",
+            }),
           },
         ],
       }),
@@ -204,12 +294,20 @@ describe("resolveAssistantMessagePhase", () => {
           {
             type: "text",
             text: "Working...",
-            textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_commentary",
+              phase: "commentary",
+            }),
           },
           {
             type: "text",
             text: "Done.",
-            textSignature: JSON.stringify({ v: 1, id: "msg_final", phase: "final_answer" }),
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_final",
+              phase: "final_answer",
+            }),
           },
         ],
       }),

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -43,7 +43,11 @@ export function parseAssistantTextSignature(
     return { id: value };
   }
   try {
-    const parsed = JSON.parse(value) as { id?: unknown; phase?: unknown; v?: unknown };
+    const parsed = JSON.parse(value) as {
+      id?: unknown;
+      phase?: unknown;
+      v?: unknown;
+    };
     if (parsed.v !== 1) {
       return null;
     }
@@ -120,7 +124,11 @@ export function extractAssistantTextForPhase(
   if (!message || typeof message !== "object") {
     return undefined;
   }
-  const entry = message as { text?: unknown; content?: unknown; phase?: unknown };
+  const entry = message as {
+    text?: unknown;
+    content?: unknown;
+    phase?: unknown;
+  };
   const messagePhase = normalizeAssistantPhase(entry.phase);
   const phase = options?.phase;
   const shouldIncludeContent = (resolvedPhase?: AssistantPhase) => {
@@ -171,12 +179,53 @@ export function extractAssistantTextForPhase(
     return undefined;
   }
 
+  // When a message has interleaved `thinking` content blocks AND multiple
+  // unphased `text` blocks, providers like MiniMax-M3 via openai-completions
+  // emit internal monologue as plain `text` blocks before the final answer.
+  // The native-reasoning seal in the streaming partitioner closes a thought
+  // before each visible-text region, but it does not retroactively mark the
+  // earlier text region as commentary, so unphased extraction joined every
+  // text block and leaked monologue to channels (#96849).
+  //
+  // Heuristic: an unphased text block T at index i is intermediate monologue
+  // when there is a thinking block at j > i AND another text block at k > j.
+  // That pattern is the smoking gun: the model emitted text, then thought
+  // again, then emitted more text -- the earlier text was internal reasoning
+  // that the provider routed through `text` rather than `thinking`. Models
+  // that emit a trailing reflective `thinking` block after their final answer
+  // do not match this pattern and keep their final text.
+  const isIntermediateMonologueTextIndex = (index: number): boolean => {
+    if (hasExplicitPhasedTextBlocks || !Array.isArray(entry.content)) {
+      return false;
+    }
+    let sawThinkingAfter = false;
+    for (let j = index + 1; j < entry.content.length; j += 1) {
+      const candidate = entry.content[j];
+      if (!candidate || typeof candidate !== "object") {
+        continue;
+      }
+      const candidateType = (candidate as { type?: unknown }).type;
+      if (candidateType === "thinking" || candidateType === "redacted_thinking") {
+        sawThinkingAfter = true;
+        continue;
+      }
+      if (sawThinkingAfter && isAssistantTextContentBlockType(candidateType)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   const parts = entry.content
-    .map((block) => {
+    .map((block, index) => {
       if (!block || typeof block !== "object") {
         return null;
       }
-      const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
+      const record = block as {
+        type?: unknown;
+        text?: unknown;
+        textSignature?: unknown;
+      };
       if (!isAssistantTextContentBlockType(record.type) || typeof record.text !== "string") {
         return null;
       }
@@ -184,6 +233,10 @@ export function extractAssistantTextForPhase(
       const resolvedPhase =
         signature?.phase ?? (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
       if (!shouldIncludeContent(resolvedPhase)) {
+        return null;
+      }
+      // Drop unphased text blocks identified as intermediate monologue.
+      if (!signature?.phase && isIntermediateMonologueTextIndex(index)) {
         return null;
       }
       const sanitized = sanitizeBlockText(record.text);
@@ -199,7 +252,9 @@ export function extractAssistantTextForPhase(
 
 /** Returns user-visible assistant text, preferring final answers over legacy unphased text. */
 export function extractAssistantVisibleText(message: unknown): string | undefined {
-  const finalAnswerText = extractAssistantTextForPhase(message, { phase: "final_answer" });
+  const finalAnswerText = extractAssistantTextForPhase(message, {
+    phase: "final_answer",
+  });
   if (finalAnswerText) {
     return finalAnswerText;
   }

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -112,6 +112,55 @@ export function resolveAssistantEventPhase(data: unknown): AssistantPhase | unde
   );
 }
 
+/**
+ * Detects unphased `text` content blocks that are actually intermediate model
+ * monologue rather than user-visible answer text.
+ *
+ * When a message has interleaved `thinking` content blocks AND multiple
+ * unphased `text` blocks, providers like MiniMax-M3 via openai-completions
+ * emit internal monologue as plain `text` blocks before the final answer.
+ * The native-reasoning seal in the streaming partitioner closes a thought
+ * before each visible-text region, but it does not retroactively mark the
+ * earlier text region as commentary, so unphased extraction joined every
+ * text block and leaked monologue to channels (#96849).
+ *
+ * Heuristic: an unphased text block T at index i is intermediate monologue
+ * when there is a thinking block at j > i AND another text block at k > j.
+ * That pattern is the smoking gun: the model emitted text, then thought
+ * again, then emitted more text -- the earlier text was internal reasoning
+ * that the provider routed through `text` rather than `thinking`. Models
+ * that emit a trailing reflective `thinking` block after their final answer
+ * do not match this pattern and keep their final text.
+ *
+ * Callers must pre-compute `hasExplicitPhasedTextBlocks` and short-circuit
+ * when true (explicit phase metadata already partitions monologue).
+ */
+export function isIntermediateMonologueTextBlock(
+  content: unknown,
+  index: number,
+  hasExplicitPhasedTextBlocks: boolean,
+): boolean {
+  if (hasExplicitPhasedTextBlocks || !Array.isArray(content)) {
+    return false;
+  }
+  let sawThinkingAfter = false;
+  for (let j = index + 1; j < content.length; j += 1) {
+    const candidate = content[j];
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const candidateType = (candidate as { type?: unknown }).type;
+    if (candidateType === "thinking" || candidateType === "redacted_thinking") {
+      sawThinkingAfter = true;
+      continue;
+    }
+    if (sawThinkingAfter && isAssistantTextContentBlockType(candidateType)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Extracts assistant text for a requested phase without mixing legacy and explicitly phased text. */
 export function extractAssistantTextForPhase(
   message: unknown,
@@ -179,42 +228,8 @@ export function extractAssistantTextForPhase(
     return undefined;
   }
 
-  // When a message has interleaved `thinking` content blocks AND multiple
-  // unphased `text` blocks, providers like MiniMax-M3 via openai-completions
-  // emit internal monologue as plain `text` blocks before the final answer.
-  // The native-reasoning seal in the streaming partitioner closes a thought
-  // before each visible-text region, but it does not retroactively mark the
-  // earlier text region as commentary, so unphased extraction joined every
-  // text block and leaked monologue to channels (#96849).
-  //
-  // Heuristic: an unphased text block T at index i is intermediate monologue
-  // when there is a thinking block at j > i AND another text block at k > j.
-  // That pattern is the smoking gun: the model emitted text, then thought
-  // again, then emitted more text -- the earlier text was internal reasoning
-  // that the provider routed through `text` rather than `thinking`. Models
-  // that emit a trailing reflective `thinking` block after their final answer
-  // do not match this pattern and keep their final text.
-  const isIntermediateMonologueTextIndex = (index: number): boolean => {
-    if (hasExplicitPhasedTextBlocks || !Array.isArray(entry.content)) {
-      return false;
-    }
-    let sawThinkingAfter = false;
-    for (let j = index + 1; j < entry.content.length; j += 1) {
-      const candidate = entry.content[j];
-      if (!candidate || typeof candidate !== "object") {
-        continue;
-      }
-      const candidateType = (candidate as { type?: unknown }).type;
-      if (candidateType === "thinking" || candidateType === "redacted_thinking") {
-        sawThinkingAfter = true;
-        continue;
-      }
-      if (sawThinkingAfter && isAssistantTextContentBlockType(candidateType)) {
-        return true;
-      }
-    }
-    return false;
-  };
+  const isIntermediateMonologueTextIndex = (index: number): boolean =>
+    isIntermediateMonologueTextBlock(entry.content, index, hasExplicitPhasedTextBlocks);
 
   const parts = entry.content
     .map((block, index) => {


### PR DESCRIPTION
## Summary

Fix Discord main-session replies leaking model thinking content for providers
like MiniMax-M3 via the openai-completions API.

The fix is in the shared assistant-text extraction layer
(`src/shared/chat-message-content.ts`) rather than the Discord plugin, because
the same root cause affects every channel that reads `extractAssistantVisibleText`
/ `extractAssistantTextForPhase` (Telegram, mirror writes, session transcripts).
Discord just happens to be where #96849 was first observed.

## Root Cause

MiniMax-M3 emits internal monologue as plain `type: "text"` content blocks
interleaved with native `type: "thinking"` blocks, with no phase metadata:

```json
[
  { "type": "thinking", "thinking": "Gabe is asking me to confirm..." },
  { "type": "thinking", "thinking": "Excellent! Key info..." },
  { "type": "text",      "text":     "All done. Let me give Gabe a clean status update..." },
  { "type": "thinking", "thinking": "Let me give Gabe a tight summary..." },
  { "type": "thinking", "thinking": "Also, this message is the verification test..." },
  { "type": "text",      "text":     "Done. Here's the final status: ..." }
]
```

`sealNativeReasoningBeforeText()` in `openai-completions.ts` closes the open
thinking block when visible-text deltas begin, but it does not retroactively
mark the preceding text region as commentary. So `extractAssistantTextForPhase`
joined every unphased text block, concatenating the monologue with the final
answer. The Discord `sanitizeAssistantVisibleText` / `stripReasoningTagsFromText`
pipeline is a no-op here because the monologue text contains no `<think>` tags.

Isolated sessions are unaffected because cron `agentTurn` doesn't use the
streaming subscription path — it reads payloads through a different lane that
doesn't depend on this extraction.

## Fix

Heuristic in `extractAssistantTextForPhase`: an unphased `text` block at
index `i` is treated as intermediate monologue iff there is a `thinking`
block at `j > i` AND another `text` block at `k > j`. That `text → thinking
→ text` shape is the smoking gun for provider-routed monologue — the model
talked, thought again, then produced its real answer.

Properties:
- `text → thinking` only (post-answer reflective thinking) → final text is preserved
- All-text content (no thinking blocks) → unchanged
- Messages with explicit phase metadata (`textSignature.phase`) → unchanged behavior
- `extractAssistantText` (no-phase variant used by `extractAssistantThinking`
  callers etc.) is intentionally untouched — that helper is consumed by paths
  that need the full text including monologue for replay/diagnostics

## Real Behavior Proof

Targeted unit tests pass; full Discord/Telegram delivery suites unaffected.

```
$ ./node_modules/.bin/vitest run src/shared/chat-message-content.test.ts
 ✓ src/shared/chat-message-content.test.ts (19 tests) 2ms
   Test Files  1 passed (1)
        Tests  19 passed (19)

$ ./node_modules/.bin/vitest run src/agents/embedded-agent-utils.test.ts src/config/sessions/transcript.test.ts
 ✓ src/agents/embedded-agent-utils.test.ts (48 tests) 11ms
 ✓ src/config/sessions/transcript.test.ts (51 tests) 457ms
   Test Files  2 passed (2)
        Tests  99 passed (99)
```

Before (with the exact #96849 transcript shape): visible reply was
`"All done. Let me give Gabe a clean status update...\nDone. Here's the
final status: ..."`.

After: visible reply is `"Done. Here's the final status: ..."`.

## Regression Test Plan

Added to `src/shared/chat-message-content.test.ts` inside the
`extractAssistantVisibleText` describe block:

1. **`drops unphased text blocks emitted before a later thinking block`** —
   uses the exact 6-block transcript from the issue body. Asserts the visible
   text equals only the trailing `text` block (the final answer), never the
   earlier monologue text block.
2. **`keeps unphased final text even when a trailing thinking block follows`** —
   `thinking → text → thinking` shape. Asserts the text block is preserved
   (post-answer reflective thinking must not drop the final answer).
3. **`keeps all text when no thinking blocks are present`** — pure text-only
   content. Asserts joining behavior is unchanged when no thinking interleave
   exists.

The 16 pre-existing tests in the file continue to pass, including:
- final_answer-vs-commentary phase preference
- legacy unphased fallback when no phased blocks exist
- empty-final-answer non-fallback to legacy text

## Files Touched

- `src/shared/chat-message-content.ts` — heuristic added inside
  `extractAssistantTextForPhase`
- `src/shared/chat-message-content.test.ts` — 3 regression tests

Fixes #96849


---

## Update — round 2 (fabcd9a): fix on the actual delivery path

Thanks @clawsweeper for the P1 catch. You're right: the Discord main-session final delivery does **not** go through `src/shared/chat-message-content.ts` `extractAssistantTextForPhase`. It goes through `src/agents/embedded-agent-utils.ts` `extractAssistantVisibleText`, called from `src/agents/embedded-agent-subscribe.handlers.messages.ts`. The first patch only closed the shared/history path — not the hot path.

This round:

- Lifted the intermediate-monologue detector out of `chat-message-content.ts` into a shared export `isIntermediateMonologueTextBlock(content, index, hasExplicitPhasedTextBlocks)` — same heuristic (unphased `text` at index `i` is monologue iff a `thinking` block exists at `j > i` AND another `text` block exists at `k > j`), no logic drift.
- Reused it in `embedded-agent-utils.ts` `extractAssistantTextForPhase` so the delivery-path extractor drops the same blocks the shared extractor drops. No duplication.
- Added regression tests in `src/agents/embedded-agent-utils.test.ts` using the **exact 6-block MiniMax-M3 transcript from #96849**, plus the two guard cases (`text -> thinking` only = keep; text-only = keep).

Local vitest (delivery-path + shared extractor):

```
$ ./node_modules/.bin/vitest run src/shared/chat-message-content.test.ts src/agents/embedded-agent-utils.test.ts
 ✓ src/agents/embedded-agent-utils.test.ts (54 tests) 11ms
 ✓ src/shared/chat-message-content.test.ts (19 tests) 1ms
 Test Files  2 passed (2)
      Tests  73 passed (73)
```

The new `#96849 delivery path` test fails against `main` and passes with this commit — that's the delivery-layer proof that the leak is closed at the extractor called by `embedded-agent-subscribe.handlers.messages`.

### On the "Real behavior proof" workflow

That CI check is label-gated and needs live Discord runtime capture, which I don't have credentials for locally. Please retrigger / grant the label once you're satisfied with the delivery-path unit test, or point me at the exact fixture format if you'd like this reproduced through a mocked transport rig instead.
