### PR TITLE
fix(ui): align Talk settings Voice/Model/Sensitivity controls vertically

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1033,6 +1033,10 @@
   color: var(--muted);
 }
 
+.agent-chat__talk-field > :last-child {
+  margin-top: auto;
+}
+
 .agent-chat__talk-options input,
 .agent-chat__talk-options select {
   width: 100%;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who open the Talk settings panel in the Control UI webchat see the Voice, Model, and Sensitivity input fields vertically misaligned in the primary settings row. Model's `<input>` sits higher than Voice and Sensitivity's `<select>` elements, making the row look uneven.

## Why This Change Was Made

Voice and Sensitivity are rendered via `renderNativeTalkSelect()` which emits a `selectedLabel` line above the `<select>`, creating a 3-row flex layout. Model is a plain `<label>` with only a label `<span>` and an `<input>`, creating a 2-row layout. Since all three are in the same CSS grid row, the shorter Model column leaves its `<input>` at the top while the taller columns push their `<select>` down by the extra label height.

| Column | DOM structure | Rows |
|--------|--------------|------|
| Voice | `[label]` + `[selectedLabel]` + `[select]` | 3 |
| Model | `[label]` + `[input]` | 2 |
| Sensitivity | `[label]` + `[selectedLabel]` + `[select]` | 3 |

The fix adds `margin-top: auto` to the last child of `.agent-chat__talk-field`, which pushes every input/select to the bottom of its flex container. Because the grid row height is driven by the tallest column, all control elements end up at the same vertical position.

```css
.agent-chat__talk-field > :last-child {
  margin-top: auto;
}
```

This is preferred over adding a hidden spacer span because it is:
- **Generic** — handles any future fields with uneven structure
- **Consistent** — also fixes the same class of misalignment in the Advanced section (Exact VAD, Pause before send, Lead-in)
- **Minimal** — 4 lines added, 0 lines deleted

Non-goal: this does not change any Talk settings behavior, values, callbacks, or mobile layout. It only fixes the visual alignment in the primary row.

## User Impact

Users opening Talk settings will see Voice, Model, and Sensitivity controls aligned on the same horizontal row instead of the Model input sitting visibly higher. No functional changes — values, interactions, and accessibility labels are unaffected.

## Evidence

- **All 119 existing unit tests pass** (`pnpm test ui/src/ui/views/chat.test.ts`)
- CSS-only change: 4 lines added to `ui/src/styles/chat/layout.css`
- Uses `margin-top: auto` on flex last-child, a standard Flexbox alignment technique

### Before — Model's `<input>` sits ~21px higher

```
┌──────────────────────────────────────────────────────┐
│ ┌─ Voice ───────┐ ┌─ Model ───────┐ ┌─ Sensitivity ┐ │
│ │ Voice         │ │ Model         │ │ Sensitivity   │ │
│ │ marin         │ │               │ │ Custom        │ │
│ │ [select    ▼] │ │ [input     ]← │ │ [select   ▼]  │ │
│ │               │ │   ↑ misalign  │ │               │ │
│ └───────────────┘ └───────────────┘ └──────────────┘ │
└──────────────────────────────────────────────────────┘
```

### After — controls align at the same row

```
┌──────────────────────────────────────────────────────┐
│ ┌─ Voice ───────┐ ┌─ Model ───────┐ ┌─ Sensitivity ┐ │
│ │ Voice         │ │ Model         │ │ Sensitivity   │ │
│ │ marin         │ │               │ │ Custom        │ │
│ │ [select    ▼] │ │ [input     ]  │ │ [select   ▼]  │ │
│ └───────────────┘ └───────────────┘ └──────────────┘ │
└──────────────────────────────────────────────────────┘
```
<img width="1571" height="271" alt="image" src="https://github.com/user-attachments/assets/c55bd262-e8da-4254-a32b-5c94eeec4303" />

Closes #96915
