### PR TITLE
fix(fal): bound video generation JSON response reads

### DIFF
--- a/extensions/fal/video-generation-provider.test.ts
+++ b/extensions/fal/video-generation-provider.test.ts
@@ -37,9 +37,10 @@ describe("fal video generation provider", () => {
 
   function releasedJson(value: unknown) {
     return {
-      response: {
-        json: async () => value,
-      },
+      response: new Response(JSON.stringify(value), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
       release: vi.fn(async () => {}),
     };
   }
@@ -686,5 +687,51 @@ describe("fal video generation provider", () => {
     ).rejects.toThrow(
       "fal Seedance reference-to-video requires at least one image or video reference when audio references are provided.",
     );
+  });
+
+  it("bounds fal video generation JSON response reads", async () => {
+    mockFalProviderRuntime();
+
+    const ONE_MIB = 1024 * 1024;
+    const TOTAL_CHUNKS = 32;
+    const chunk = new Uint8Array(ONE_MIB);
+    let bytesPulled = 0;
+    let canceled = false;
+
+    fetchGuardMock.mockResolvedValueOnce({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (bytesPulled / ONE_MIB >= TOTAL_CHUNKS) {
+              controller.close();
+              return;
+            }
+            bytesPulled += chunk.length;
+            controller.enqueue(chunk);
+          },
+          cancel() {
+            canceled = true;
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildFalVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "fal",
+        model: "fal-ai/minimax/video-01-live",
+        prompt: "test",
+        cfg: {},
+      }),
+    ).rejects.toThrow(/fal video generation response malformed|JSON response exceeds/);
+
+    expect(canceled).toBe(true);
+    expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
   });
 });

--- a/extensions/fal/video-generation-provider.ts
+++ b/extensions/fal/video-generation-provider.ts
@@ -5,6 +5,7 @@ import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import {
   assertOkOrThrowHttpError,
   createProviderOperationDeadline,
+  readProviderJsonResponse,
   type ProviderOperationDeadline,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
@@ -479,11 +480,7 @@ async function fetchFalJson(params: {
   });
   try {
     await assertOkOrThrowHttpError(response, params.errorContext);
-    try {
-      return await response.json();
-    } catch {
-      throw new Error(FAL_VIDEO_MALFORMED_RESPONSE);
-    }
+    return await readProviderJsonResponse(response, params.errorContext);
   } finally {
     await release();
   }


### PR DESCRIPTION
## What Problem This Solves

`fetchFalJson` in `extensions/fal/video-generation-provider.ts` reads the video generation submit, poll, and completion responses with an unbounded `await response.json()`. The shared fetch layer enforces an abort timeout but does **not** bound body size, so a misbehaving or compromised fal endpoint can stream an arbitrarily large (or `Content-Length`-less, never-ending) JSON body that `res.json()` buffers whole into memory — an OOM vector on the video generation queue path.

## Changes

- Route all JSON reads in `fetchFalJson` through the shared bounded reader `readProviderJsonResponse` (16 MiB cap = `PROVIDER_JSON_RESPONSE_MAX_BYTES`, re-exported via `openclaw/plugin-sdk/provider-http`): it reads under the shared 16 MiB cap, **cancels the underlying stream on overflow**, and throws `fal video generation failed: JSON response exceeds <N> bytes`.
- Removes the manual `try { return await response.json() } catch` in favour of `readProviderJsonResponse` which already provides label-scoped error messages.
- No new abstraction — reuses the same bounded reader as the recently merged provider response-limit PRs.

## Real behavior proof

- **Behavior addressed**: An unbounded fal video generation response with no `Content-Length` and an oversized / never-ending body must not be buffered whole; the read must stop at the cap, cancel the stream, and throw a bounded error — while valid small responses still parse unchanged.
- **Real environment tested**: A `ReadableStream` Response delivering 32 MiB in 1 MiB chunks (double the 16 MiB cap) drives the real `provider.generateVideo`. The test asserts the bounded reader cancels the stream mid-flight and never pulls the full advertised payload.
- **Observed outcome**: The provider throws a bounded JSON error. The underlying stream is canceled. `bytesPulled < 32 MiB` confirms no full buffering.