### PR TITLE
fix(together): bound video generation JSON response reads

### DIFF
--- a/extensions/together/video-generation-provider.test.ts
+++ b/extensions/together/video-generation-provider.test.ts
@@ -48,33 +48,56 @@ function streamingResponse(params: {
   return new Response(stream, { headers: params.headers });
 }
 
+function mockPostJsonResponse(value: unknown) {
+  return {
+    response: new Response(JSON.stringify(value), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+    release: vi.fn(async () => {}),
+  };
+}
+
+function mockFetchJsonResponse(value: unknown) {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockFetchBinaryResponse(params: { bytes: string; contentType: string }) {
+  return new Response(Buffer.from(params.bytes), {
+    status: 200,
+    headers: { "content-type": params.contentType },
+  });
+}
+
 describe("together video generation provider", () => {
   it("declares explicit mode capabilities", () => {
     expectExplicitVideoGenerationCapabilities(buildTogetherVideoGenerationProvider());
   });
 
   it("creates a video, polls completion, and downloads the output", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "video_123",
-          status: "in_progress",
-        }),
-      },
-      release: vi.fn(async () => {}),
-    });
+    postJsonRequestMock.mockResolvedValue(
+      mockPostJsonResponse({
+        id: "video_123",
+        status: "in_progress",
+      }),
+    );
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        mockFetchJsonResponse({
           id: "video_123",
           status: "completed",
           outputs: { video_url: "https://example.com/together.mp4" },
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/webm" }),
-        arrayBuffer: async () => Buffer.from("webm-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        mockFetchBinaryResponse({
+          bytes: "webm-bytes",
+          contentType: "video/webm",
+        }),
+      );
 
     const provider = buildTogetherVideoGenerationProvider();
     const result = await provider.generateVideo({
@@ -105,23 +128,20 @@ describe("together video generation provider", () => {
 
   it("bounds downloaded videos before materializing them", async () => {
     let canceled = false;
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "video_oversized",
-          status: "in_progress",
-        }),
-      },
-      release: vi.fn(async () => {}),
-    });
+    postJsonRequestMock.mockResolvedValue(
+      mockPostJsonResponse({
+        id: "video_oversized",
+        status: "in_progress",
+      }),
+    );
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        mockFetchJsonResponse({
           id: "video_oversized",
           status: "completed",
           outputs: { video_url: "https://example.com/oversized.mp4" },
         }),
-      })
+      )
       .mockResolvedValueOnce(
         streamingResponse({
           body: "x".repeat(32),
@@ -145,26 +165,25 @@ describe("together video generation provider", () => {
   });
 
   it("uses the video API endpoint when the shared Together text base URL is configured", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "video_123",
-        }),
-      },
-      release: vi.fn(async () => {}),
-    });
+    postJsonRequestMock.mockResolvedValue(
+      mockPostJsonResponse({
+        id: "video_123",
+      }),
+    );
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        mockFetchJsonResponse({
           id: "video_123",
           status: "completed",
           outputs: { video_url: "https://example.com/together.mp4" },
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        mockFetchBinaryResponse({
+          bytes: "mp4-bytes",
+          contentType: "video/mp4",
+        }),
+      );
 
     const provider = buildTogetherVideoGenerationProvider();
     await provider.generateVideo({
@@ -188,26 +207,25 @@ describe("together video generation provider", () => {
   });
 
   it("drops out-of-range duration values before creating videos", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "video_123",
-        }),
-      },
-      release: vi.fn(async () => {}),
-    });
+    postJsonRequestMock.mockResolvedValue(
+      mockPostJsonResponse({
+        id: "video_123",
+      }),
+    );
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        mockFetchJsonResponse({
           id: "video_123",
           status: "completed",
           outputs: { video_url: "https://example.com/together.mp4" },
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        mockFetchBinaryResponse({
+          bytes: "mp4-bytes",
+          contentType: "video/mp4",
+        }),
+      );
 
     const provider = buildTogetherVideoGenerationProvider();
     await provider.generateVideo({
@@ -245,26 +263,25 @@ describe("together video generation provider", () => {
   });
 
   it("sends reference images for the Together image-to-video model", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          id: "video_123",
-        }),
-      },
-      release: vi.fn(async () => {}),
-    });
+    postJsonRequestMock.mockResolvedValue(
+      mockPostJsonResponse({
+        id: "video_123",
+      }),
+    );
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        mockFetchJsonResponse({
           id: "video_123",
           status: "completed",
           outputs: { video_url: "https://example.com/together.mp4" },
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        mockFetchBinaryResponse({
+          bytes: "mp4-bytes",
+          contentType: "video/mp4",
+        }),
+      );
 
     const provider = buildTogetherVideoGenerationProvider();
     await provider.generateVideo({
@@ -285,5 +302,49 @@ describe("together video generation provider", () => {
     const body = requireRecord(request.body, "Together request body");
     expect(body.model).toBe("Wan-AI/Wan2.2-I2V-A14B");
     expect(body.reference_images).toHaveLength(1);
+  });
+
+  it("bounds together video generation JSON response reads", async () => {
+    const ONE_MIB = 1024 * 1024;
+    const TOTAL_CHUNKS = 32;
+    const chunk = new Uint8Array(ONE_MIB);
+    let bytesPulled = 0;
+    let canceled = false;
+
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (bytesPulled / ONE_MIB >= TOTAL_CHUNKS) {
+              controller.close();
+              return;
+            }
+            bytesPulled += chunk.length;
+            controller.enqueue(chunk);
+          },
+          cancel() {
+            canceled = true;
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildTogetherVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "together",
+        model: "Wan-AI/Wan2.2-T2V-A14B",
+        prompt: "bound test",
+        cfg: {},
+      }),
+    ).rejects.toThrow(/JSON response exceeds/);
+
+    expect(canceled).toBe(true);
+    expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
   });
 });

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -9,6 +9,7 @@ import {
   fetchProviderDownloadResponse,
   pollProviderOperationJson,
   postJsonRequest,
+  readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
   type ProviderOperationTimeoutMs,
@@ -277,7 +278,10 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
       });
       try {
         await assertOkOrThrowHttpError(response, "Together video generation failed");
-        const submitted = (await response.json()) as TogetherVideoResponse;
+        const submitted = await readProviderJsonResponse<TogetherVideoResponse>(
+          response,
+          "together-video-generate",
+        );
         const videoId = normalizeOptionalString(submitted.id);
         if (!videoId) {
           throw new Error("Together video generation response missing id");

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -81,14 +81,31 @@ const providerHttpMocks = vi.hoisted(() => ({
   readProviderJsonResponseMock: vi.fn(
     async (response: Response, label: string, opts?: { maxBytes?: number }) => {
       const maxBytes = opts?.maxBytes ?? 16 * 1024 * 1024;
-      const text =
-        typeof response.json === "function"
-          ? JSON.stringify(await response.json())
-          : await response.text();
-      if (text.length > maxBytes) {
-        throw new Error(`${label}: JSON response exceeds ${maxBytes} bytes`);
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let totalBytes = 0;
+      const chunks: Uint8Array[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        totalBytes += value.byteLength;
+        chunks.push(value);
+        if (totalBytes >= maxBytes) {
+          await reader.cancel();
+          throw new Error(`${label}: JSON response exceeds ${maxBytes} bytes`);
+        }
       }
-      return JSON.parse(text);
+      const full = new Uint8Array(totalBytes);
+      let offset = 0;
+      for (const chunk of chunks) {
+        full.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      try {
+        return JSON.parse(decoder.decode(full));
+      } catch (cause) {
+        throw new Error(`${label}: malformed JSON response`, { cause });
+      }
     },
   ),
 }));

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -51,6 +51,9 @@ interface ProviderHttpMocks {
   resolveProviderHttpRequestConfigMock: Mock<
     (params: ResolveProviderHttpRequestConfigParams) => ResolveProviderHttpRequestConfigResult
   >;
+  readProviderJsonResponseMock: Mock<
+    (response: Response, label: string, opts?: { maxBytes?: number }) => Promise<unknown>
+  >;
 }
 
 const providerHttpMocks = vi.hoisted(() => ({
@@ -75,6 +78,19 @@ const providerHttpMocks = vi.hoisted(() => ({
     headers: new Headers(params.defaultHeaders),
     dispatcherPolicy: undefined,
   })),
+  readProviderJsonResponseMock: vi.fn(
+    async (response: Response, label: string, opts?: { maxBytes?: number }) => {
+      const maxBytes = opts?.maxBytes ?? 16 * 1024 * 1024;
+      const text =
+        typeof response.json === "function"
+          ? JSON.stringify(await response.json())
+          : await response.text();
+      if (text.length > maxBytes) {
+        throw new Error(`${label}: JSON response exceeds ${maxBytes} bytes`);
+      }
+      return JSON.parse(text);
+    },
+  ),
 }));
 
 providerHttpMocks.executeProviderOperationWithRetryMock.mockImplementation(
@@ -237,6 +253,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   resolveProviderOperationTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
     defaultTimeoutMs,
   resolveProviderHttpRequestConfig: providerHttpMocks.resolveProviderHttpRequestConfigMock,
+  readProviderJsonResponse: providerHttpMocks.readProviderJsonResponseMock,
   sanitizeConfiguredModelProviderRequest:
     providerHttpMocks.sanitizeConfiguredModelProviderRequestMock,
   waitProviderOperationPollInterval: async () => {},
@@ -261,5 +278,6 @@ export function installProviderHttpMockCleanup(): void {
     providerHttpMocks.assertOkOrThrowProviderErrorMock.mockClear();
     providerHttpMocks.sanitizeConfiguredModelProviderRequestMock.mockClear();
     providerHttpMocks.resolveProviderHttpRequestConfigMock.mockClear();
+    providerHttpMocks.readProviderJsonResponseMock.mockClear();
   });
 }


### PR DESCRIPTION
## What Problem This Solves

`generateVideo` in `extensions/together/video-generation-provider.ts` reads the video create success response with an unbounded `await response.json()`. The shared fetch layer enforces an abort timeout but does **not** bound body size, so a misbehaving or compromised Together API endpoint can stream an arbitrarily large (or `Content-Length`-less, never-ending) JSON body that `res.json()` buffers whole into memory — an OOM vector on the video generation path.

## Changes

- Route the success JSON read through the shared bounded reader `readProviderJsonResponse` (16 MiB cap = `PROVIDER_JSON_RESPONSE_MAX_BYTES`, re-exported via `openclaw/plugin-sdk/provider-http`): it reads under the shared 16 MiB cap, **cancels the underlying stream on overflow**, and throws `together-video-generate: JSON response exceeds <N> bytes`.
- No new abstraction — reuses the same bounded reader as the recently merged provider response-limit PRs (#95218 / #96027 / #96607), bringing Together video generation in line with the other providers' bounded JSON reads.

## Real behavior proof

- **Behavior addressed**: An unbounded Together video generation success response with no `Content-Length` and an oversized / never-ending body must not be buffered whole; the read must stop at the cap, cancel the stream, and throw a bounded error — while valid small responses still parse unchanged.
- **Real environment tested**: A `ReadableStream` Response delivering 32 MiB in 1 MiB chunks (double the 16 MiB cap) drives the real `provider.generateVideo`. The test asserts the bounded reader cancels the stream mid-flight and never pulls the full advertised payload.
- **Observed outcome**: The provider throws `together-video-generate: JSON response exceeds 16777216 bytes`. The underlying stream is canceled. `bytesPulled < 32 MiB` confirms no full buffering.