### PR TITLE
fix(tui): suppress duplicate assistant message after sessions.changed event

### DIFF
--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -323,6 +323,10 @@ export class ChatLog extends Container {
     this.streamingRuns.delete(effectiveRunId);
   }
 
+  hasStreamingRun(runId?: string) {
+    return this.streamingRuns.has(this.resolveRunId(runId));
+  }
+
   showBtw(params: { question: string; text: string; isError?: boolean }) {
     if (this.btwMessage) {
       this.btwMessage.setResult(params);

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -20,6 +20,7 @@ type HandlerChatLog = {
   updateAssistant: (...args: unknown[]) => void;
   finalizeAssistant: (...args: unknown[]) => void;
   dropAssistant: (...args: unknown[]) => void;
+  hasStreamingRun: (...args: unknown[]) => boolean;
 };
 type HandlerBtwPresenter = {
   showResult: (...args: unknown[]) => void;
@@ -35,6 +36,7 @@ type MockChatLog = {
   updateAssistant: MockFn;
   finalizeAssistant: MockFn;
   dropAssistant: MockFn;
+  hasStreamingRun: MockFn;
 };
 type MockBtwPresenter = {
   showResult: MockFn;
@@ -52,6 +54,7 @@ function createMockChatLog(): MockChatLog & HandlerChatLog {
     updateAssistant: vi.fn(),
     finalizeAssistant: vi.fn(),
     dropAssistant: vi.fn(),
+    hasStreamingRun: vi.fn().mockReturnValue(false),
   } as unknown as MockChatLog & HandlerChatLog;
 }
 

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -26,6 +26,7 @@ type EventHandlerChatLog = {
   updateAssistant: (text: string, runId: string) => void;
   finalizeAssistant: (text: string, runId: string) => void;
   dropAssistant: (runId: string) => void;
+  hasStreamingRun: (runId: string) => boolean;
 };
 
 type EventHandlerTui = {
@@ -89,6 +90,16 @@ export function createEventHandlers(context: EventHandlerContext) {
   let lastSessionKey = state.currentSessionKey;
   let pendingHistoryRefresh = false;
   let reconnectPendingRunId: string | null = null;
+  // RunIds surrendered to a pending loadHistory() call from
+  // handleSessionsChangedEvent. When the sessions.changed "new" event fires
+  // after a chat run starts streaming, loadHistory() clears the chat log and
+  // replays the message as a static entry. If the final chat event arrives
+  // AFTER that replay, finalizeAssistant creates a duplicate because the
+  // streaming component was already removed. Tracking surrendered runIds lets
+  // us skip the late final event and avoid the duplicate.
+  const surrenderedToHistoryRunIds = new Set<string>();
+  let surrenderedToHistoryCleanupTimer: ReturnType<typeof setTimeout> | null = null;
+  const SURRENDERED_TO_HISTORY_CLEANUP_MS = 15_000;
   const pendingTerminalLifecycleErrors = new Map<
     string,
     { errorMessage: string; timer: ReturnType<typeof setTimeout> }
@@ -138,6 +149,17 @@ export function createEventHandlers(context: EventHandlerContext) {
       clearTimeout(pending.timer);
     }
     pendingTerminalLifecycleErrors.clear();
+  };
+
+  const scheduleSurrenderedRunIdsCleanup = () => {
+    if (surrenderedToHistoryCleanupTimer) {
+      clearTimeout(surrenderedToHistoryCleanupTimer);
+    }
+    surrenderedToHistoryCleanupTimer = setTimeout(() => {
+      surrenderedToHistoryRunIds.clear();
+      surrenderedToHistoryCleanupTimer = null;
+    }, SURRENDERED_TO_HISTORY_CLEANUP_MS);
+    surrenderedToHistoryCleanupTimer.unref?.();
   };
 
   const pauseStreamingWatchdog = () => {
@@ -611,6 +633,66 @@ export function createEventHandlers(context: EventHandlerContext) {
         }
       }
     }
+    // When a sessions.changed "new" event surrendered this runId to a
+    // pending loadHistory() call, the history replay may have already
+    // rendered the message as a static entry. If loadHistory() restored
+    // the run as in-flight (via inFlightRun), the runId will have an
+    // active streaming component — do NOT suppress it, because the
+    // in-flight streaming component needs live delta/final events to
+    // reach its final state. Only suppress when there is no active
+    // streaming component, meaning the message was replayed as a static
+    // entry and a late final event would append a duplicate.
+    if (surrenderedToHistoryRunIds.has(evt.runId)) {
+      // loadHistory() restored this run as in-flight — keep processing
+      // normally so the streaming component stays live.
+      if (chatLog.hasStreamingRun(evt.runId)) {
+        surrenderedToHistoryRunIds.delete(evt.runId);
+        // Fall through to normal event handling below.
+      } else {
+        if (evt.state === "delta") {
+          return;
+        }
+        if (evt.state === "final") {
+          surrenderedToHistoryRunIds.delete(evt.runId);
+          // Still finalize the run's tracking state so the activity
+          // indicator and pending-run cleanup stay consistent, but do
+          // not re-render the message text — history replay already
+          // displayed it as a static entry.
+          noteFinalizedRun(evt.runId);
+          const wasActiveRun = state.activeChatRunId === evt.runId;
+          clearActiveRunIfMatch(evt.runId);
+          const promotedRemainingRun = promoteMostRecentSessionRun();
+          flushPendingHistoryRefreshIfIdle();
+          if (!promotedRemainingRun) {
+            if (wasActiveRun) {
+              setActivityStatus("idle");
+              clearStreamingWatchdog();
+            } else {
+              if (streamingWatchdogRunId === evt.runId) {
+                clearStreamingWatchdog();
+              }
+              clearStaleStreamingIfNoTrackedRunRemains();
+            }
+          }
+          void refreshSessionInfo?.();
+          tui.requestRender();
+          return;
+        }
+        // For aborted / error states after surrender, clean up but
+        // don't render duplicate history entries.
+        if (evt.state === "aborted" || evt.state === "error") {
+          surrenderedToHistoryRunIds.delete(evt.runId);
+          completedRuns.set(evt.runId, Date.now());
+          pruneRunMap(completedRuns);
+          streamAssembler.drop(evt.runId);
+          clearActiveRunIfMatch(evt.runId);
+          promoteMostRecentSessionRun();
+          flushPendingHistoryRefreshIfIdle();
+          tui.requestRender();
+          return;
+        }
+      }
+    }
     if (reconnectPendingRunId === evt.runId) {
       reconnectPendingRunId = null;
     }
@@ -745,6 +827,32 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     if (evt.reason !== "new" && evt.reason !== "reset") {
       return;
+    }
+
+    // When a sessions.changed "new" event fires while a chat run is still
+    // streaming, the subsequent loadHistory() will clear the chat log and
+    // replay the message as a static entry. If the final chat event arrives
+    // after that replay, finalizeAssistant would append a duplicate because
+    // the streaming component is already gone. Save every tracked runId so
+    // handleChatEvent can skip late-arriving deltas/finals that history
+    // replay already covered.
+    if (evt.reason === "new") {
+      if (state.activeChatRunId) {
+        surrenderedToHistoryRunIds.add(state.activeChatRunId);
+      }
+      if (state.pendingChatRunId) {
+        surrenderedToHistoryRunIds.add(state.pendingChatRunId);
+      }
+      for (const runId of sessionRuns.keys()) {
+        surrenderedToHistoryRunIds.add(runId);
+      }
+      // finalizedRuns entries are already resolved; include them so a
+      // duplicate final event (rare, but possible during reconnect storms)
+      // is also suppressed.
+      for (const runId of finalizedRuns.keys()) {
+        surrenderedToHistoryRunIds.add(runId);
+      }
+      scheduleSurrenderedRunIdsCleanup();
     }
 
     clearTrackedRunState();
@@ -953,6 +1061,11 @@ export function createEventHandlers(context: EventHandlerContext) {
   const dispose = () => {
     clearStreamingWatchdog();
     clearPendingTerminalLifecycleErrors();
+    if (surrenderedToHistoryCleanupTimer) {
+      clearTimeout(surrenderedToHistoryCleanupTimer);
+      surrenderedToHistoryCleanupTimer = null;
+    }
+    surrenderedToHistoryRunIds.clear();
   };
 
   const consumeCompletedRunForPendingSend = (runId: string) => {


### PR DESCRIPTION
## What Problem This Solves
handleSessionsChangedEvent in src/tui/tui-event-handlers.ts triggers loadHistory() when a sessions.changed event with reason: "new" fires. loadHistory() clears the chat log and replays all messages as static history entries. However, if a chat run was actively streaming at the time the event fired, the streaming final event can arrive after the history replay has already rendered the same message as a static entry. handleChatEvent unconditionally calls finalizeAssistant, which appends the message a second time — producing a duplicate in the chat log.

The race is:

User sends a message; the agent starts streaming (activeChatRunId / sessionRuns populated)
A sessions.changed "new" event fires (e.g. session file created/recreated on disk)
handleSessionsChangedEvent calls clearTrackedRunState() and queues loadHistory()
loadHistory() clears the chat log, replays the in-flight message as a static entry, removing the streaming component
The original streaming run's final event arrives → finalizeAssistant appends a second copy of the message
The same duplicate pattern could also affect delta and aborted/error states arriving late.

## Why This Change Was Made
The fix introduces a surrenderedToHistoryRunIds set that tracks run IDs handed off to a pending loadHistory() call. When handleSessionsChangedEvent receives a "new" event, it captures every tracked run ID (activeChatRunId, pendingChatRunId, sessionRuns, finalizedRuns) into this set. handleChatEvent then checks this set before processing chat events:

delta: suppressed entirely — the history replay already rendered the message as static
final: tracking state is finalized (activity indicator, watchdog, pending-run cleanup), but finalizeAssistant is not called — avoiding the duplicate render
aborted/error: cleaned up without appending duplicate history entries
A critical edge case is when loadHistory() restores a run as an in-flight streaming component (via inFlightRun). In that case, chatLog.hasStreamingRun() returns true, and the handler falls through to normal processing — the streaming component needs live delta/final events to reach its final state. The hasStreamingRun method was added to ChatLog as a clean query for this check.

A 15-second cleanup timer (unref'd so it doesn't keep the process alive) prevents the set from leaking run IDs indefinitely.

## User Impact
TUI users no longer see duplicate messages when a sessions.changed event fires mid-streaming. Normal chat flows are unaffected.

## Evidence
No new test file was added for this fix. The existing test suite in src/tui/tui-event-handlers.test.ts was extended to stub hasStreamingRun on the mock chat log.

What was not tested: live TUI sessions with real sessions.changed events during streaming.