### PR TITLE
fix(cli): fall back to ClawHub when npm install fails for official external plugins

### DIFF
--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -89,6 +89,25 @@ describe("plugin install plan helpers", () => {
     });
   });
 
+  it("includes clawhubSpec in official external plan when present", () => {
+    const findOfficialExternalPlugin = vi.fn().mockReturnValue({
+      pluginId: "searxng",
+      npmSpec: "@openclaw/searxng-plugin",
+      clawhubSpec: "clawhub:@openclaw/searxng-plugin",
+    });
+
+    const result = resolveOfficialExternalInstallPlanBeforeNpm({
+      rawSpec: "searxng",
+      findOfficialExternalPlugin,
+    });
+
+    expect(result).toEqual({
+      pluginId: "searxng",
+      npmSpec: "@openclaw/searxng-plugin",
+      clawhubSpec: "clawhub:@openclaw/searxng-plugin",
+    });
+  });
+
   it("skips official external plan for explicit npm selectors", () => {
     const findOfficialExternalPlugin = vi.fn();
 

--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -155,6 +155,43 @@ describe("plugin install plan helpers", () => {
     });
   });
 
+  it("includes clawhubSpec in npm package trust when present", () => {
+    const findOfficialExternalPackage = vi.fn().mockReturnValue({
+      pluginId: "searxng",
+      npmSpec: "@openclaw/searxng-plugin",
+      clawhubSpec: "clawhub:@openclaw/searxng-plugin",
+    });
+
+    const result = resolveOfficialExternalNpmPackageTrust({
+      npmSpec: "@openclaw/searxng-plugin",
+      findOfficialExternalPackage,
+    });
+
+    expect(result).toEqual({
+      pluginId: "searxng",
+      clawhubSpec: "clawhub:@openclaw/searxng-plugin",
+      trustedSourceLinkedOfficialInstall: true,
+    });
+  });
+
+  it("omits clawhubSpec from npm package trust when not in catalog entry", () => {
+    const findOfficialExternalPackage = vi.fn().mockReturnValue({
+      pluginId: "discord",
+      npmSpec: "@openclaw/discord",
+    });
+
+    const result = resolveOfficialExternalNpmPackageTrust({
+      npmSpec: "@openclaw/discord",
+      findOfficialExternalPackage,
+    });
+
+    expect(result).toEqual({
+      pluginId: "discord",
+      trustedSourceLinkedOfficialInstall: true,
+    });
+    expect(result).not.toHaveProperty("clawhubSpec");
+  });
+
   it("does not trust npm package names outside the official external catalog", () => {
     const findOfficialExternalPackage = vi.fn();
 

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -13,6 +13,7 @@ type OfficialExternalPluginLookup = (pluginId: string) =>
   | {
       pluginId: string;
       npmSpec?: string;
+      clawhubSpec?: string;
       expectedIntegrity?: string;
     }
   | undefined;
@@ -111,7 +112,7 @@ export function resolveBundledInstallPlanBeforeNpm(params: {
 export function resolveOfficialExternalInstallPlanBeforeNpm(params: {
   rawSpec: string;
   findOfficialExternalPlugin: OfficialExternalPluginLookup;
-}): { pluginId: string; npmSpec: string; expectedIntegrity?: string } | null {
+}): { pluginId: string; npmSpec: string; clawhubSpec?: string; expectedIntegrity?: string } | null {
   if (!isBareNpmPackageName(params.rawSpec)) {
     return null;
   }
@@ -123,6 +124,7 @@ export function resolveOfficialExternalInstallPlanBeforeNpm(params: {
   return {
     pluginId: entry.pluginId,
     npmSpec,
+    ...(entry.clawhubSpec ? { clawhubSpec: entry.clawhubSpec } : {}),
     ...(entry.expectedIntegrity ? { expectedIntegrity: entry.expectedIntegrity } : {}),
   };
 }

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -22,6 +22,7 @@ type OfficialExternalPackageLookup = (packageName: string) =>
   | {
       pluginId: string;
       npmSpec?: string;
+      clawhubSpec?: string;
       expectedIntegrity?: string;
     }
   | undefined;
@@ -134,6 +135,7 @@ export function resolveOfficialExternalNpmPackageTrust(params: {
   findOfficialExternalPackage: OfficialExternalPackageLookup;
 }): {
   pluginId: string;
+  clawhubSpec?: string;
   expectedIntegrity?: string;
   trustedSourceLinkedOfficialInstall: true;
 } | null {
@@ -152,6 +154,7 @@ export function resolveOfficialExternalNpmPackageTrust(params: {
   }
   return {
     pluginId: entry.pluginId,
+    ...(entry.clawhubSpec ? { clawhubSpec: entry.clawhubSpec } : {}),
     ...(entry.expectedIntegrity && catalogSpec === params.npmSpec.trim()
       ? { expectedIntegrity: entry.expectedIntegrity }
       : {}),

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -119,6 +119,7 @@ function findTrustedCatalogPackageInstall(packageName: string):
   | {
       pluginId: string;
       npmSpec?: string;
+      clawhubSpec?: string;
       expectedIntegrity?: string;
     }
   | undefined {
@@ -137,6 +138,7 @@ function findTrustedCatalogPackageInstall(packageName: string):
   return {
     pluginId,
     ...(install?.npmSpec ? { npmSpec: install.npmSpec } : {}),
+    ...(install?.clawhubSpec ? { clawhubSpec: install.clawhubSpec } : {}),
     ...(install?.expectedIntegrity ? { expectedIntegrity: install.expectedIntegrity } : {}),
   };
 }
@@ -1303,6 +1305,7 @@ export async function runPluginInstallCommand(params: {
           mode: installMode,
           spec: officialExternalPlan.clawhubSpec,
           extensionsDir,
+          expectedPluginId: officialExternalPlan.pluginId,
           logger: createPluginInstallLogger(runtime),
         });
         if (clawhubResult.ok) {
@@ -1378,6 +1381,34 @@ export async function runPluginInstallCommand(params: {
     runtime,
   });
   if (!npmResult.ok) {
+    if (officialNpmTrust?.clawhubSpec) {
+      runtime.log(
+        `npm install failed for ${raw}; trying ClawHub fallback…`,
+      );
+      const clawhubResult = await installPluginFromClawHub({
+        ...safetyOverrides,
+        mode: installMode,
+        spec: officialNpmTrust.clawhubSpec,
+        extensionsDir,
+        expectedPluginId: officialNpmTrust.pluginId,
+        logger: createPluginInstallLogger(runtime),
+      });
+      if (clawhubResult.ok) {
+        await persistPluginInstall({
+          snapshot,
+          pluginId: clawhubResult.pluginId,
+          install: {
+            ...buildClawHubPluginInstallRecordFields(clawhubResult.clawhub),
+            spec: officialNpmTrust.clawhubSpec,
+            installPath: clawhubResult.targetDir,
+          },
+          invalidateRuntimeCache,
+          runtime,
+        });
+        return;
+      }
+      runtime.error(clawhubResult.error);
+    }
     return runtime.exit(1);
   }
 }

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -962,6 +962,7 @@ export async function runPluginInstallCommand(params: {
             ? {
                 pluginId: resolvedPluginId,
                 npmSpec,
+                ...(install.clawhubSpec ? { clawhubSpec: install.clawhubSpec } : {}),
                 ...(install.expectedIntegrity
                   ? { expectedIntegrity: install.expectedIntegrity }
                   : {}),
@@ -1293,6 +1294,33 @@ export async function runPluginInstallCommand(params: {
       runtime,
     });
     if (!npmResult.ok) {
+      if (officialExternalPlan.clawhubSpec) {
+        runtime.log(
+          `npm install failed for ${officialExternalPlan.npmSpec}; trying ClawHub fallback…`,
+        );
+        const clawhubResult = await installPluginFromClawHub({
+          ...safetyOverrides,
+          mode: installMode,
+          spec: officialExternalPlan.clawhubSpec,
+          extensionsDir,
+          logger: createPluginInstallLogger(runtime),
+        });
+        if (clawhubResult.ok) {
+          await persistPluginInstall({
+            snapshot,
+            pluginId: clawhubResult.pluginId,
+            install: {
+              ...buildClawHubPluginInstallRecordFields(clawhubResult.clawhub),
+              spec: officialExternalPlan.clawhubSpec,
+              installPath: clawhubResult.targetDir,
+            },
+            invalidateRuntimeCache,
+            runtime,
+          });
+          return;
+        }
+        runtime.error(clawhubResult.error);
+      }
       return runtime.exit(1);
     }
     return;


### PR DESCRIPTION
## What Problem This Solves

After PR #95683 externalized searxng/tavily from bundled to official npm packages, installing these plugins fails because the live npm packages (`@openclaw/searxng-plugin@0.0.0`, `@openclaw/tavily-plugin@0.0.0`) are reservation stubs without OpenClaw plugin metadata. The installer expects plugin ID `searxng` but the stub package resolves to `@openclaw/searxng-plugin`, causing an ID mismatch.

The catalog already declares both `npmSpec` and `clawhubSpec` for these plugins, but the official external install path only tries npm with no ClawHub fallback.

## Changes

- **`src/cli/plugin-install-plan.ts`**: Include `clawhubSpec` in `OfficialExternalPluginLookup` type and `resolveOfficialExternalInstallPlanBeforeNpm` return value
- **`src/cli/plugins-install-command.ts`**: Pass `clawhubSpec` through the official external plugin callback; after npm install failure for an official external plan, try ClawHub fallback when `clawhubSpec` is available; log informational message about the fallback
- **`src/cli/plugin-install-plan.test.ts`**: Added test for `clawhubSpec` passthrough in the plan resolver

## Evidence

**Behavior matrix:**

| Scenario | Before | After |
|----------|--------|-------|
| npm succeeds | ✅ Works | ✅ No change |
| npm fails, no clawhubSpec | ❌ Exit 1 | ❌ Exit 1 (no change) |
| npm fails, clawhubSpec succeeds | ❌ Exit 1 | ✅ Installs from ClawHub |
| npm fails, clawhubSpec also fails | ❌ Exit 1 (npm error only) | ❌ Exit 1 (both errors shown) |

**Code path validation:**

The fallback follows the same pattern as the existing standalone `clawhubSpec` install path (line ~1301 in `plugins-install-command.ts`), reusing `installPluginFromClawHub`, `persistPluginInstall`, and `buildClawHubPluginInstallRecordFields` — all of which are already tested in CI.

**Catalog verification:**
```json
// scripts/lib/official-external-plugin-catalog.json — searxng entry
{
  "clawhubSpec": "clawhub:@openclaw/searxng-plugin",
  "npmSpec": "@openclaw/searxng-plugin"
}
```

Both install sources are declared but only `npmSpec` was previously used in the official external plan path. This fix connects the `clawhubSpec` as a fallback.

**Lint/format:** `oxlint` 0 warnings, 0 errors. `oxfmt --check` passes.

Fixes #96878