### PR TITLE
fix(google): default web_search model to rolling alias, not retired gemini-2.5-flash

### DIFF
--- a/extensions/google/src/gemini-web-search-provider.shared.ts
+++ b/extensions/google/src/gemini-web-search-provider.shared.ts
@@ -5,7 +5,12 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeGoogleApiBaseUrl } from "../provider-policy.js";
 
-const DEFAULT_GEMINI_WEB_SEARCH_MODEL = "gemini-2.5-flash";
+// Use a rolling alias rather than a dated model id. Concrete ids (e.g.
+// "gemini-2.5-flash") get retired by Google and then return HTTP 404 on every
+// web_search call for any user who has not overridden the model. The "*-latest"
+// alias always resolves to a current Flash model and keeps grounding working.
+// See https://github.com/openclaw/openclaw/issues/96974.
+const DEFAULT_GEMINI_WEB_SEARCH_MODEL = "gemini-flash-latest";
 
 export type GeminiConfig = {
   apiKey?: unknown;


### PR DESCRIPTION
### What Problem This Solves
The built-in `web_search` tool with the **gemini** provider is unusable out-of-the-box. Its default model is hardcoded to `gemini-2.5-flash`, which Google has **retired** — the model now returns HTTP 404 from the Generative Language API. So any user who enables `tools.web.search` with `provider: "gemini"` and doesn't manually set `plugins.entries.google.config.webSearch.model` gets a 404 on every search. Tracked in #96974.

### Why This Change Was Made
Hardcoding a concrete, dated model id as a default guarantees it rots: every time Google sunsets that id, the default 404s for everyone (same class as #87116). This switches the default to the rolling **`gemini-flash-latest`** alias, which Google keeps pointed at a current Flash model — so the default keeps working across model generations without further maintenance. Users who already pin a model via config are unaffected (the override path is unchanged).

This is the minimal, self-contained fix (one constant). Inheriting the configured provider model is a reasonable future enhancement but needs cross-file wiring (a `providerModel` field, populated in the merge layer); not required to stop the 404 and kept out of scope here.

### User Impact
`web_search` (gemini) works on a fresh config with no model override. No behavior change for users who set an explicit model. No API surface change.

### Evidence
Retired default 404s; the proposed alias grounds cleanly (live, same API key):
```
# OLD default — retired:
POST …/models/gemini-2.5-flash:generateContent
→ HTTP 404  "models/gemini-2.5-flash is not found for API version v1beta…"

# NEW default — resolves AND grounds:
POST …/models/gemini-flash-latest:generateContent  (tools:[{google_search:{}}])
→ HTTP 200, groundingMetadata present
  "It is currently mostly cloudy in Los Angeles, with a cool temperature of around 62°F (17°C)."
```
Change is limited to `extensions/google/src/gemini-web-search-provider.shared.ts` (the default constant + an explanatory comment); `resolveGeminiModel`'s override precedence is untouched.

I was unable to run the full `pnpm build && pnpm check && pnpm test` locally (no monorepo checkout on this machine), so I've kept the change to a single constant whose behavior is verified by the live calls above — happy to adjust if CI surfaces anything.
