### PR TITLE
fix(tui): avoid duplicate assistant reply after history replay

### DIFF
--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -75,6 +75,39 @@ describe("ChatLog", () => {
     expect(chatLog.children.length).toBe(1);
   });
 
+  it("suppresses an adjacent history replay/live final duplicate", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.finalizeAssistant("done");
+    chatLog.finalizeAssistant("done", "run-live");
+
+    expect(chatLog.children.length).toBe(1);
+    expect(chatLog.render(120).join("\n")).toContain("done");
+  });
+
+  it("allows duplicate assistant text when a user row separates replay and live final", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.finalizeAssistant("done");
+    chatLog.addUser("next prompt");
+    chatLog.finalizeAssistant("done", "run-live");
+
+    const rendered = chatLog.render(120).join("\n");
+    expect(chatLog.children.length).toBe(3);
+    expect(rendered).toContain("next prompt");
+    expect(rendered.match(/done/g)?.length).toBe(2);
+  });
+
+  it("allows duplicate live finals that did not come from history replay", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.finalizeAssistant("done", "run-one");
+    chatLog.finalizeAssistant("done", "run-two");
+
+    expect(chatLog.children.length).toBe(2);
+    expect(chatLog.render(120).join("\n").match(/done/g)?.length).toBe(2);
+  });
+
   it("reserves assistant position without clearing existing streamed text", () => {
     const chatLog = new ChatLog(40);
     chatLog.startAssistant("partial", "run-active");

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -9,6 +9,9 @@ import { UserMessageComponent } from "./user-message.js";
 
 // Tolerates history timestamps slightly before locally pending messages.
 const PENDING_HISTORY_CLOCK_SKEW_TOLERANCE_MS = 60_000;
+// History replay does not carry run ids; suppress an immediately following
+// live final only when it exactly matches the adjacent replayed assistant row.
+const HISTORY_REPLAY_LIVE_FINAL_DEDUP_MS = 5_000;
 
 type RepeatableSystemMessage = {
   component: Container;
@@ -34,6 +37,11 @@ export class ChatLog extends Container {
   private btwMessage: BtwInlineMessage | null = null;
   private toolsExpanded = false;
   private repeatableSystemMessage: RepeatableSystemMessage | null = null;
+  private lastHistoryAssistant: {
+    component: AssistantMessageComponent;
+    text: string;
+    createdAt: number;
+  } | null = null;
 
   constructor(maxComponents = 180) {
     super();
@@ -68,6 +76,9 @@ export class ChatLog extends Container {
     if (this.repeatableSystemMessage?.component === component) {
       this.repeatableSystemMessage = null;
     }
+    if (this.lastHistoryAssistant?.component === component) {
+      this.lastHistoryAssistant = null;
+    }
   }
 
   private pruneOverflow() {
@@ -88,6 +99,7 @@ export class ChatLog extends Container {
 
   private appendNonSystem(component: Component) {
     this.repeatableSystemMessage = null;
+    this.lastHistoryAssistant = null;
     this.append(component);
   }
 
@@ -98,6 +110,7 @@ export class ChatLog extends Container {
     this.pendingSystemNotices.clear();
     this.btwMessage = null;
     this.repeatableSystemMessage = null;
+    this.lastHistoryAssistant = null;
     if (!opts?.preservePendingUsers) {
       this.pendingUsers.clear();
     }
@@ -156,6 +169,7 @@ export class ChatLog extends Container {
       return;
     }
     const message = this.createSystemMessage(text);
+    this.lastHistoryAssistant = null;
     this.append(message.component);
     this.repeatableSystemMessage = opts?.coalesceConsecutive ? message : null;
   }
@@ -167,6 +181,7 @@ export class ChatLog extends Container {
     }
     const message = this.createSystemMessage(text);
     this.pendingSystemNotices.set(runId, message.component);
+    this.lastHistoryAssistant = null;
     this.append(message.component);
   }
 
@@ -308,9 +323,23 @@ export class ChatLog extends Container {
     if (existing) {
       existing.setText(text);
       this.streamingRuns.delete(effectiveRunId);
+      this.lastHistoryAssistant = null;
       return;
     }
-    this.appendNonSystem(new AssistantMessageComponent(text));
+    const now = Date.now();
+    if (
+      runId &&
+      this.lastHistoryAssistant &&
+      this.children[this.children.length - 1] === this.lastHistoryAssistant.component &&
+      this.lastHistoryAssistant.text === text &&
+      now - this.lastHistoryAssistant.createdAt <= HISTORY_REPLAY_LIVE_FINAL_DEDUP_MS
+    ) {
+      this.lastHistoryAssistant = null;
+      return;
+    }
+    const component = new AssistantMessageComponent(text);
+    this.appendNonSystem(component);
+    this.lastHistoryAssistant = runId ? null : { component, text, createdAt: now };
   }
 
   dropAssistant(runId?: string) {


### PR DESCRIPTION
Closes #96967

## Summary

- Deduplicates the narrow TUI ordering where an assistant message replayed from history is immediately followed by the matching live final event for the same visible text.
- Keeps the existing `sessions.changed` `new`/`reset` reload behavior intact so external session refreshes still rebuild the current session.
- Adds focused `ChatLog` unit coverage for the replay/live duplicate case and the adjacent cases that must still render duplicate text.

## What Problem This Solves

Fixes an issue where users viewing the TUI could see the same assistant reply twice when a Telegram-originated turn caused history replay and the live final message to meet in the current chat log.

## Root Cause

History replay renders assistant messages without a run id, while live final events render with a run id. The existing run-id dedupe cannot relate those two paths, so a replayed assistant row and its matching live final can be appended as separate visible rows when the events arrive adjacent to each other.

## Why This Change Was Made

The fix is scoped to `ChatLog`: it records only the most recent no-run-id assistant row from history replay and suppresses a live final with a run id only when it immediately follows that replayed row, has identical text, and arrives within a short TTL. The marker is cleared when other content is appended, the log is cleared, or the tracked component is pruned, so intentional repeated messages remain visible.

This avoids a broader event-handler change and preserves the `sessions.changed` reload path needed for external session `new`/`reset` updates.

## User Impact

TUI users should no longer see a duplicated assistant reply for the reported replay/live-final interleaving. Legitimate repeated assistant output remains visible when separated by user content or when both messages are live finals.

## Validation / Pre-checks

- `git diff --check` — passed as a local pre-check.
- `git diff --cached --check` — passed before committing.
- Targeted Vitest command requested for this PR was not run locally because dependencies are not installed in this checkout (`node_modules` is absent), and no dependency install was performed for the local pre-check.
- GitHub Actions validation is expected to run on this PR after creation.

## Evidence

Focused tests added in `src/tui/components/chat-log.test.ts` cover:

- suppressing an adjacent no-run-id history replay followed by a matching live final with a run id;
- allowing the same text when a user row separates replay and live final;
- allowing two same-text live finals when neither came from history replay.

## Evidence source map

- Issue report: #96967 describes duplicate TUI assistant output after a Telegram-triggered turn.
- History replay source: `src/tui/tui-session-actions.ts` rebuilds assistant history via `chatLog.finalizeAssistant(text)` without a run id.
- Live final source: `src/tui/tui-event-handlers.ts` final chat events render via `chatLog.finalizeAssistant(finalText, evt.runId)`.
- Fix surface: `src/tui/components/chat-log.ts` now dedupes only the adjacent history-replay/live-final pair.
- Regression tests: `src/tui/components/chat-log.test.ts` covers the suppression and allowed-duplicate boundaries.

## Risk / Rollback / Docs

- Risk: low-to-medium. The change affects assistant row append behavior, but only for identical adjacent replay/live final text within the short TTL.
- Rollback: revert this commit to restore the previous append behavior.
- Docs: no user-facing docs changed; this is a TUI rendering fix.

## Follow-up proof added after ClawSweeper review

### Terminal behavior proof: sessions.changed replay + live final leaves one visible assistant row

A local, dependency-free Node 24 harness was run against this branch at `6acf71618376655a80a6f2f1104a256cd3e14c20`. The harness loads the PR's `src/tui/components/chat-log.ts` source into a temporary module with minimal rendering stubs only, then exercises the same TUI boundary ordering described in the issue:

1. history replay path (`tui-session-actions.ts`) calls `chatLog.finalizeAssistant(text)` with **no run id**;
2. live final path (`tui-event-handlers.ts`) calls `chatLog.finalizeAssistant(text, runId)` with a **run id**;
3. visible rendered assistant rows are counted after both events.

Output:

```text
source=src/tui/components/chat-log.ts sha=6acf71618376655a80a6f2f1104a256cd3e14c20
scenario=sessions.changed history replay (no run id) immediately followed by live final (run id)
visible assistant rows after history replay: 1
visible assistant rows after live final: 1
chatLog.children after replay+live final: 1
render="redacted assistant final from replay/live ordering"
control rows when user separates replay/live: 2
control rows for two live finals: 2
PASS exactly one visible assistant row for replay+live final, while intentional duplicates remain visible
```

This avoids external messaging and does not mutate any active user/Gateway/Telegram/TUI configuration. A true native Telegram/TUI visual capture would require maintainer-controlled Mantis/Telegram desktop infrastructure; the useful maintainer trigger remains:

```text
@openclaw-mantis visual task: verify openclaw-tui shows exactly one assistant reply after a Telegram-originated message triggers sessions.changed history replay.
```

### CI / check evidence

- Full GitHub Actions CI for this head SHA passed: run https://github.com/openclaw/openclaw/actions/runs/28225940515 (`6acf71618376655a80a6f2f1104a256cd3e14c20`).
- CI TUI PTY lane passed in job https://github.com/openclaw/openclaw/actions/runs/28225940515/job/83618175004: `test/vitest/vitest.tui-pty.config.ts` started at 08:19:17 UTC and passed `src/tui/tui-pty-harness.e2e.test.ts` plus `src/tui/tui-pty-local.e2e.test.ts`.
- The repository's `Real behavior proof` workflow check passed in run https://github.com/openclaw/openclaw/actions/runs/28226954824 with log line `External PR includes problem context and evidence.`
- No existing CI log found an explicit run of `src/tui/components/chat-log.test.ts`; the local targeted Vitest command below could not run because this checkout intentionally has no installed dependencies.

### Local targeted test attempt

```text
$ node scripts/run-vitest.mjs src/tui/components/chat-log.test.ts src/tui/tui-event-handlers.test.ts src/tui/tui-session-actions.test.ts
Error: [vitest] node_modules is missing; Vitest cannot be resolved.
Install dependencies before running scripts/run-vitest.mjs:
  pnpm install --frozen-lockfile
...
code: 'OPENCLAW_MISSING_VITEST'
```

No dependency install was performed.

### OpenGrep changed paths diagnosis

The failed OpenGrep PR-diff check did not reach repository scanning. It failed while installing OpenGrep, before the changed-path scan step:

```text
OPENGREP_VERSION: v1.22.0
OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
Warning: cosign is required for --verify-signatures but is not installed. Skipping signature validation.
Error: Failed to fetch available versions from GitHub.
Process completed with exit code 1.
No files were found with the provided path: .opengrep-out/precise.sarif. No artifacts will be uploaded.
```

That appears to be an OpenGrep install/network workflow failure, not an actionable finding in this PR's two changed TUI files.
