### PR TITLE
fix(plugins): route SearXNG and Tavily installs through ClawHub

### DIFF
--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -275,7 +275,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[raft](/plugins/reference/raft)** (`@openclaw/raft`) - npm; ClawHub. OpenClaw Raft channel plugin for secure CLI wake bridges.
 
-- **[searxng](/plugins/reference/searxng)** (`@openclaw/searxng-plugin`) - npm; ClawHub: `clawhub:@openclaw/searxng-plugin`. Adds web search provider support.
+- **[searxng](/plugins/reference/searxng)** (`@openclaw/searxng-plugin`) - ClawHub: `clawhub:@openclaw/searxng-plugin`; npm. Adds web search provider support.
 
 - **[signal](/plugins/reference/signal)** (`@openclaw/signal`) - npm; ClawHub: `clawhub:@openclaw/signal`. Adds the Signal channel surface for sending and receiving OpenClaw messages.
 
@@ -287,7 +287,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[synology-chat](/plugins/reference/synology-chat)** (`@openclaw/synology-chat`) - npm; ClawHub. Synology Chat channel plugin for OpenClaw channels and direct messages.
 
-- **[tavily](/plugins/reference/tavily)** (`@openclaw/tavily-plugin`) - npm; ClawHub: `clawhub:@openclaw/tavily-plugin`. Adds agent-callable tools. Adds web search provider support.
+- **[tavily](/plugins/reference/tavily)** (`@openclaw/tavily-plugin`) - ClawHub: `clawhub:@openclaw/tavily-plugin`; npm. Adds agent-callable tools. Adds web search provider support.
 
 - **[tencent](/plugins/reference/tencent)** (`@openclaw/tencent-provider`) - npm; ClawHub: `clawhub:@openclaw/tencent-provider`. Adds Tencent TokenHub model provider support to OpenClaw.
 

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -275,7 +275,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[raft](/plugins/reference/raft)** (`@openclaw/raft`) - npm; ClawHub. OpenClaw Raft channel plugin for secure CLI wake bridges.
 
-- **[searxng](/plugins/reference/searxng)** (`@openclaw/searxng-plugin`) - ClawHub: `clawhub:@openclaw/searxng-plugin`; npm. Adds web search provider support.
+- **[searxng](/plugins/reference/searxng)** (`@openclaw/searxng-plugin`) - ClawHub: `clawhub:@openclaw/searxng-plugin@beta`; npm. Adds web search provider support.
 
 - **[signal](/plugins/reference/signal)** (`@openclaw/signal`) - npm; ClawHub: `clawhub:@openclaw/signal`. Adds the Signal channel surface for sending and receiving OpenClaw messages.
 
@@ -287,7 +287,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[synology-chat](/plugins/reference/synology-chat)** (`@openclaw/synology-chat`) - npm; ClawHub. Synology Chat channel plugin for OpenClaw channels and direct messages.
 
-- **[tavily](/plugins/reference/tavily)** (`@openclaw/tavily-plugin`) - ClawHub: `clawhub:@openclaw/tavily-plugin`; npm. Adds agent-callable tools. Adds web search provider support.
+- **[tavily](/plugins/reference/tavily)** (`@openclaw/tavily-plugin`) - ClawHub: `clawhub:@openclaw/tavily-plugin@beta`; npm. Adds agent-callable tools. Adds web search provider support.
 
 - **[tencent](/plugins/reference/tencent)** (`@openclaw/tencent-provider`) - npm; ClawHub: `clawhub:@openclaw/tencent-provider`. Adds Tencent TokenHub model provider support to OpenClaw.
 

--- a/docs/plugins/reference/searxng.md
+++ b/docs/plugins/reference/searxng.md
@@ -12,7 +12,7 @@ Adds web search provider support.
 ## Distribution
 
 - Package: `@openclaw/searxng-plugin`
-- Install route: ClawHub: `clawhub:@openclaw/searxng-plugin`; npm
+- Install route: ClawHub: `clawhub:@openclaw/searxng-plugin@beta`; npm
 
 ## Surface
 

--- a/docs/plugins/reference/searxng.md
+++ b/docs/plugins/reference/searxng.md
@@ -12,7 +12,7 @@ Adds web search provider support.
 ## Distribution
 
 - Package: `@openclaw/searxng-plugin`
-- Install route: npm; ClawHub: `clawhub:@openclaw/searxng-plugin`
+- Install route: ClawHub: `clawhub:@openclaw/searxng-plugin`; npm
 
 ## Surface
 

--- a/docs/plugins/reference/tavily.md
+++ b/docs/plugins/reference/tavily.md
@@ -12,7 +12,7 @@ Adds agent-callable tools. Adds web search provider support.
 ## Distribution
 
 - Package: `@openclaw/tavily-plugin`
-- Install route: npm; ClawHub: `clawhub:@openclaw/tavily-plugin`
+- Install route: ClawHub: `clawhub:@openclaw/tavily-plugin`; npm
 
 ## Surface
 

--- a/docs/plugins/reference/tavily.md
+++ b/docs/plugins/reference/tavily.md
@@ -12,7 +12,7 @@ Adds agent-callable tools. Adds web search provider support.
 ## Distribution
 
 - Package: `@openclaw/tavily-plugin`
-- Install route: ClawHub: `clawhub:@openclaw/tavily-plugin`; npm
+- Install route: ClawHub: `clawhub:@openclaw/tavily-plugin@beta`; npm
 
 ## Surface
 

--- a/docs/tools/searxng-search.md
+++ b/docs/tools/searxng-search.md
@@ -22,7 +22,7 @@ Advantages:
 <Steps>
   <Step title="Install the plugin">
     ```bash
-    openclaw plugins install @openclaw/searxng-plugin
+    openclaw plugins install clawhub:@openclaw/searxng-plugin
     ```
   </Step>
   <Step title="Run a SearXNG instance">

--- a/docs/tools/searxng-search.md
+++ b/docs/tools/searxng-search.md
@@ -22,7 +22,7 @@ Advantages:
 <Steps>
   <Step title="Install the plugin">
     ```bash
-    openclaw plugins install clawhub:@openclaw/searxng-plugin
+    openclaw plugins install clawhub:@openclaw/searxng-plugin@beta
     ```
   </Step>
   <Step title="Run a SearXNG instance">

--- a/docs/tools/tavily.md
+++ b/docs/tools/tavily.md
@@ -19,6 +19,7 @@ Tavily returns structured results optimized for LLM consumption with configurabl
 | --------- | ----------------------------------- |
 | Plugin id | `tavily`                            |
 | Package   | `@openclaw/tavily-plugin`           |
+| Install   | `clawhub:@openclaw/tavily-plugin`   |
 | Auth      | `TAVILY_API_KEY` or config `apiKey` |
 | Base URL  | `https://api.tavily.com` (default)  |
 | Tools     | `tavily_search`, `tavily_extract`   |
@@ -28,7 +29,7 @@ Tavily returns structured results optimized for LLM consumption with configurabl
 <Steps>
   <Step title="Install the plugin">
     ```bash
-    openclaw plugins install @openclaw/tavily-plugin
+    openclaw plugins install clawhub:@openclaw/tavily-plugin
     ```
   </Step>
   <Step title="Get an API key">

--- a/docs/tools/tavily.md
+++ b/docs/tools/tavily.md
@@ -15,21 +15,21 @@ title: "Tavily"
 
 Tavily returns structured results optimized for LLM consumption with configurable search depth, topic filtering, domain filters, AI-generated answer summaries, and content extraction from URLs (including JavaScript-rendered pages).
 
-| Property  | Value                               |
-| --------- | ----------------------------------- |
-| Plugin id | `tavily`                            |
-| Package   | `@openclaw/tavily-plugin`           |
-| Install   | `clawhub:@openclaw/tavily-plugin`   |
-| Auth      | `TAVILY_API_KEY` or config `apiKey` |
-| Base URL  | `https://api.tavily.com` (default)  |
-| Tools     | `tavily_search`, `tavily_extract`   |
+| Property  | Value                                  |
+| --------- | -------------------------------------- |
+| Plugin id | `tavily`                               |
+| Package   | `@openclaw/tavily-plugin`              |
+| Install   | `clawhub:@openclaw/tavily-plugin@beta` |
+| Auth      | `TAVILY_API_KEY` or config `apiKey`    |
+| Base URL  | `https://api.tavily.com` (default)     |
+| Tools     | `tavily_search`, `tavily_extract`      |
 
 ## Getting started
 
 <Steps>
   <Step title="Install the plugin">
     ```bash
-    openclaw plugins install clawhub:@openclaw/tavily-plugin
+    openclaw plugins install clawhub:@openclaw/tavily-plugin@beta
     ```
   </Step>
   <Step title="Get an API key">

--- a/extensions/searxng/README.md
+++ b/extensions/searxng/README.md
@@ -5,7 +5,7 @@ Official OpenClaw plugin for SearXNG.
 ## Install
 
 ```sh
-openclaw plugins install @openclaw/searxng-plugin
+openclaw plugins install clawhub:@openclaw/searxng-plugin
 ```
 
 ## Docs

--- a/extensions/searxng/README.md
+++ b/extensions/searxng/README.md
@@ -5,7 +5,7 @@ Official OpenClaw plugin for SearXNG.
 ## Install
 
 ```sh
-openclaw plugins install clawhub:@openclaw/searxng-plugin
+openclaw plugins install clawhub:@openclaw/searxng-plugin@beta
 ```
 
 ## Docs

--- a/extensions/searxng/package.json
+++ b/extensions/searxng/package.json
@@ -13,7 +13,7 @@
     "install": {
       "clawhubSpec": "clawhub:@openclaw/searxng-plugin",
       "npmSpec": "@openclaw/searxng-plugin",
-      "defaultChoice": "npm",
+      "defaultChoice": "clawhub",
       "minHostVersion": ">=2026.6.9",
       "allowInvalidConfigRecovery": true
     },

--- a/extensions/searxng/package.json
+++ b/extensions/searxng/package.json
@@ -11,7 +11,7 @@
       "./index.ts"
     ],
     "install": {
-      "clawhubSpec": "clawhub:@openclaw/searxng-plugin",
+      "clawhubSpec": "clawhub:@openclaw/searxng-plugin@beta",
       "npmSpec": "@openclaw/searxng-plugin",
       "defaultChoice": "clawhub",
       "minHostVersion": ">=2026.6.9",

--- a/extensions/tavily/README.md
+++ b/extensions/tavily/README.md
@@ -5,7 +5,7 @@ Official OpenClaw plugin for Tavily.
 ## Install
 
 ```sh
-openclaw plugins install clawhub:@openclaw/tavily-plugin
+openclaw plugins install clawhub:@openclaw/tavily-plugin@beta
 ```
 
 ## Docs

--- a/extensions/tavily/README.md
+++ b/extensions/tavily/README.md
@@ -5,7 +5,7 @@ Official OpenClaw plugin for Tavily.
 ## Install
 
 ```sh
-openclaw plugins install @openclaw/tavily-plugin
+openclaw plugins install clawhub:@openclaw/tavily-plugin
 ```
 
 ## Docs

--- a/extensions/tavily/package.json
+++ b/extensions/tavily/package.json
@@ -14,7 +14,7 @@
       "./index.ts"
     ],
     "install": {
-      "clawhubSpec": "clawhub:@openclaw/tavily-plugin",
+      "clawhubSpec": "clawhub:@openclaw/tavily-plugin@beta",
       "npmSpec": "@openclaw/tavily-plugin",
       "defaultChoice": "clawhub",
       "minHostVersion": ">=2026.6.9",

--- a/extensions/tavily/package.json
+++ b/extensions/tavily/package.json
@@ -16,7 +16,7 @@
     "install": {
       "clawhubSpec": "clawhub:@openclaw/tavily-plugin",
       "npmSpec": "@openclaw/tavily-plugin",
-      "defaultChoice": "npm",
+      "defaultChoice": "clawhub",
       "minHostVersion": ">=2026.6.9",
       "allowInvalidConfigRecovery": true
     },

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -518,7 +518,7 @@
           }
         ],
         "install": {
-          "clawhubSpec": "clawhub:@openclaw/searxng-plugin",
+          "clawhubSpec": "clawhub:@openclaw/searxng-plugin@beta",
           "npmSpec": "@openclaw/searxng-plugin",
           "defaultChoice": "clawhub",
           "minHostVersion": ">=2026.6.9",
@@ -565,7 +565,7 @@
           }
         ],
         "install": {
-          "clawhubSpec": "clawhub:@openclaw/tavily-plugin",
+          "clawhubSpec": "clawhub:@openclaw/tavily-plugin@beta",
           "npmSpec": "@openclaw/tavily-plugin",
           "defaultChoice": "clawhub",
           "minHostVersion": ">=2026.6.9",

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -520,7 +520,7 @@
         "install": {
           "clawhubSpec": "clawhub:@openclaw/searxng-plugin",
           "npmSpec": "@openclaw/searxng-plugin",
-          "defaultChoice": "npm",
+          "defaultChoice": "clawhub",
           "minHostVersion": ">=2026.6.9",
           "allowInvalidConfigRecovery": true
         }
@@ -567,7 +567,7 @@
         "install": {
           "clawhubSpec": "clawhub:@openclaw/tavily-plugin",
           "npmSpec": "@openclaw/tavily-plugin",
-          "defaultChoice": "npm",
+          "defaultChoice": "clawhub",
           "minHostVersion": ">=2026.6.9",
           "allowInvalidConfigRecovery": true
         }

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -66,11 +66,12 @@ describe("official external plugin catalog", () => {
         minHostVersion: ">=2026.6.8",
       });
     }
+    const clawHubFirstUntilNpmArtifactsPublish = new Set(["searxng", "tavily"]);
     for (const [id, npmSpec] of newlyExternalized) {
       expect(resolveOfficialExternalPluginInstall(expectCatalogEntry(id))).toMatchObject({
         clawhubSpec: `clawhub:${npmSpec}`,
         npmSpec,
-        defaultChoice: "npm",
+        defaultChoice: clawHubFirstUntilNpmArtifactsPublish.has(id) ? "clawhub" : "npm",
         minHostVersion: ">=2026.6.9",
       });
     }

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -67,9 +67,13 @@ describe("official external plugin catalog", () => {
       });
     }
     const clawHubFirstUntilNpmArtifactsPublish = new Set(["searxng", "tavily"]);
+    const betaTaggedClawHubSpecsUntilLatestTagsPublish = new Set(["searxng", "tavily"]);
     for (const [id, npmSpec] of newlyExternalized) {
+      const expectedClawHubSpec = betaTaggedClawHubSpecsUntilLatestTagsPublish.has(id)
+        ? `clawhub:${npmSpec}@beta`
+        : `clawhub:${npmSpec}`;
       expect(resolveOfficialExternalPluginInstall(expectCatalogEntry(id))).toMatchObject({
-        clawhubSpec: `clawhub:${npmSpec}`,
+        clawhubSpec: expectedClawHubSpec,
         npmSpec,
         defaultChoice: clawHubFirstUntilNpmArtifactsPublish.has(id) ? "clawhub" : "npm",
         minHostVersion: ">=2026.6.9",


### PR DESCRIPTION
Closes #96878
Related: #96981 covers a broader CLI fallback path; this PR is the narrower catalog-and-docs route for the same placeholder npm package state.

## Follow-up proof: installable ClawHub beta specs

The unversioned ClawHub specs were smoke-tested first and currently fail because ClawHub lists these official packages with a `beta` tag but no `latest` version. This follow-up updates the catalog, extension metadata, docs, and test expectation to the installable beta-tagged specs:

- `clawhub:@openclaw/searxng-plugin@beta`
- `clawhub:@openclaw/tavily-plugin@beta`

Redacted real behavior proof was run in a throwaway environment with `HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH` all under `<PROOF_ROOT>`:

```text
OpenClaw 2026.6.11-beta.1 (c862a64)
openclaw plugins install clawhub:@openclaw/searxng-plugin@beta
Resolving clawhub:@openclaw/searxng-plugin@beta…
ClawHub code-plugin @openclaw/searxng-plugin@2026.6.11-beta.1 channel=official verification=source-linked
Downloading plugin @openclaw/searxng-plugin@2026.6.11-beta.1 from ClawHub…
Installing to <PROOF_ROOT>/state/extensions/searxng…
Installed plugin: searxng

openclaw plugins install clawhub:@openclaw/tavily-plugin@beta
Resolving clawhub:@openclaw/tavily-plugin@beta…
ClawHub bundle-plugin @openclaw/tavily-plugin@2026.6.11-beta.1 channel=official verification=source-linked
Downloading bundle @openclaw/tavily-plugin@2026.6.11-beta.1 from ClawHub…
Installing to <PROOF_ROOT>/state/extensions/tavily…
Installing plugin dependencies…
Installed plugin: tavily

Installed manifests:
<PROOF_ROOT>/state/extensions/searxng/openclaw.plugin.json
<PROOF_ROOT>/state/extensions/searxng/package.json
<PROOF_ROOT>/state/extensions/tavily/openclaw.plugin.json
<PROOF_ROOT>/state/extensions/tavily/package.json
```

Additional checks after the follow-up patch:

- `git diff --check` passed.
- JSON parsing passed for `scripts/lib/official-external-plugin-catalog.json`, `extensions/searxng/package.json`, and `extensions/tavily/package.json`.
- `node scripts/generate-plugin-inventory-doc.mjs --check` passed.
- Grep confirmed no direct npm install commands and no unversioned `clawhub:@openclaw/{searxng,tavily}-plugin` specs remain in docs, extension metadata, catalog, or the targeted catalog test.
- Targeted Vitest was still not run locally because repo dependencies are not installed, and local dependency installation was intentionally skipped.

## What Problem This Solves

Fixes an issue where users recovering SearXNG or Tavily `web_search` providers were directed to install official npm package names that currently resolve to reservation packages. Those npm packages do not contain OpenClaw plugin metadata, so the documented install path can fail before the provider can be restored.

## Why This Change Was Made

The catalog already contains both ClawHub and npm package identities for SearXNG and Tavily. This change keeps the npm package names as package identity metadata, but makes ClawHub the default install route for these two plugins until the npm artifacts contain valid OpenClaw plugin metadata. Documentation and catalog tests now match that route.

## User Impact

Users following the SearXNG or Tavily setup docs, plugin reference pages, or provider recovery hints are pointed at the ClawHub specs that contain the official plugin metadata instead of the current npm reservation packages. Existing package identity metadata is preserved for future npm publication and registry references.

## Evidence

- Live npm metadata check: `npm view @openclaw/searxng-plugin version description openclaw --json` returned version `0.0.0`, description `Bootstrap reservation for the OpenClaw SearXNG plugin package.`, and no `openclaw` metadata field.
- Live npm metadata check: `npm view @openclaw/tavily-plugin version description openclaw --json` returned version `0.0.0`, description `Bootstrap reservation for the OpenClaw Tavily plugin package.`, and no `openclaw` metadata field.
- Local pre-check only: `git diff --check` passed.
- Local pre-check only: JSON validation passed for the touched catalog and package metadata files.
- Local pre-check only: `node scripts/generate-plugin-inventory-doc.mjs --check` passed.
- Local pre-check only: searched docs and extension READMEs for `openclaw plugins install @openclaw/searxng-plugin` and `openclaw plugins install @openclaw/tavily-plugin`; neither direct npm install command remains.

## Summary

- Switches SearXNG and Tavily official external plugin install defaults from `npm` to `clawhub` in the catalog and extension package metadata.
- Updates SearXNG/Tavily setup docs, plugin reference docs, extension READMEs, and generated plugin inventory text to show ClawHub-first installs.
- Updates the official external plugin catalog test expectation so these two entries are intentionally ClawHub-first while preserving npm specs.

## Breaking changes (if any)

None. The npm package names remain in metadata; only the preferred install route for these two official plugins changes.

## Why / Motivation & user impact

The issue report and live registry metadata show that the current npm route points at `0.0.0` reservation packages. Routing these two entries through ClawHub is the smallest source change that aligns recovery hints and documentation with an available official plugin spec without changing the generic installer behavior for other official external plugins.

## Implementation

- Changed `defaultChoice` to `clawhub` for `searxng` and `tavily` in the official external plugin catalog.
- Changed the same default in each plugin package metadata block while retaining `npmSpec`.
- Updated user-facing install commands to use `clawhub:@openclaw/searxng-plugin` and `clawhub:@openclaw/tavily-plugin`.
- Regenerated/checked plugin inventory output so generated docs reflect the ClawHub-first route.

## Review context addressed

- Issue #96878 reports SearXNG and Tavily recovery instructions pointing to npm package installs that fail because live npm packages are reservation packages.
- The latest issue review identified the same source/registry mismatch and suggested either publishing real npm artifacts or routing to real official artifacts. This PR takes the narrow routing option while preserving npm identity metadata.
- Related PR #96981 proposes a broader CLI fallback when npm install fails. This PR does not change installer fallback behavior; it changes the default catalog/docs route for the two affected plugins.

## Maintainer / ClawSweeper review addressed

No maintainer PR review comments exist on this branch yet. The issue review evidence about placeholder npm packages and SearXNG/Tavily catalog routing is addressed by making the two affected entries ClawHub-first and updating the matching docs/tests.

## Labels considered

- `bug` / `regression`: provider recovery path regressed for users after externalization.
- `P1` / `beta-blocker`: the issue is user-facing and affects beta recovery guidance.
- `docs`: docs and generated plugin inventory are updated with the install-route change.
- `cli`: considered because the issue presents through CLI install guidance, but this PR intentionally does not change generic CLI fallback behavior.

## Validation

- Local pre-check only: `git diff --check` passed.
- Local pre-check only: touched JSON files were parsed successfully.
- Local pre-check only: plugin inventory docs check passed.
- Local pre-check only: docs/extensions grep confirmed the two direct npm install commands are no longer advertised.
- Not run locally: targeted Vitest for `src/plugins/official-external-plugin-catalog.test.ts`; the local checkout did not have dependencies installed, and no local dependency install was performed.
- GitHub Actions: pending after PR creation.

## Evidence source map

- Live npm metadata: both package names return `0.0.0` Bootstrap reservation metadata with no OpenClaw metadata field in the `npm view ... version description openclaw --json` result.
- Source catalog metadata: `scripts/lib/official-external-plugin-catalog.json` now keeps `npmSpec` and sets `defaultChoice: "clawhub"` for SearXNG and Tavily.
- Extension package metadata: `extensions/searxng/package.json` and `extensions/tavily/package.json` now keep `npmSpec` and set `defaultChoice: "clawhub"`.
- Docs/examples: SearXNG and Tavily tool docs plus extension READMEs now use `openclaw plugins install clawhub:@openclaw/...` commands.
- Test expectation: `src/plugins/official-external-plugin-catalog.test.ts` now records SearXNG/Tavily as the temporary ClawHub-first exceptions.

## Risk

- Compatibility risk is limited because npm specs are retained and only the default/preferred route changes for the two affected plugins.
- Regression risk is mostly catalog/docs drift; the generated inventory check and targeted grep cover the touched text surfaces.
- Operational risk is that future valid npm publication for these package names will need a follow-up to move the default route back to npm if maintainers prefer npm-first installs.
- Performance and security risk are not expected to change because no runtime provider execution path or credential handling path is changed.

## Rollback

Revert this commit to restore npm-first defaults and direct npm install docs for SearXNG/Tavily. No data migration, config migration, or irreversible state change is involved.

## Docs updated

- `docs/tools/searxng-search.md`: install command now uses the ClawHub spec.
- `docs/tools/tavily.md`: install command and summary table now use the ClawHub spec.
- `docs/plugins/reference/searxng.md` and `docs/plugins/reference/tavily.md`: distribution route now reflects ClawHub-first.
- `docs/plugins/plugin-inventory.md`: generated inventory text now reflects ClawHub-first.
- `extensions/searxng/README.md` and `extensions/tavily/README.md`: install commands now use the ClawHub specs.

## Related issue / PR

Closes #96878.
Related: #95683, #96981.

## Not tested / Limitations

- Targeted Vitest was not run locally because dependencies were not installed and local dependency installation was intentionally skipped.
- No local build or package install smoke test was run.
- GitHub Actions results were not available at PR creation time.

