### PR TITLE
fix(opencode-go): treat block-boundary SSE events as liveness for idle timer

### DIFF
--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -638,6 +638,40 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     }
   });
 
+  it("treats block-boundary SSE events as liveness that resets the idle timer", async () => {
+    const { stream: baseStream, controller } = createFakeBaseStream();
+    let abortCalled = false;
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) options.signal.addEventListener("abort", () => { abortCalled = true; });
+      return baseStream;
+    });
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, { provider: "opencode-go", idleTimeoutMs: 5_000 });
+    const downstream = await Promise.resolve(wrapper({ provider: "opencode-go", id: "deepseek-v4-flash" } as any, {} as any, {} as any));
+    expect(downstream).toBeDefined();
+    if (!downstream) return;
+    const consumer = (async () => { for await (const e of downstream) void e; })();
+    const partial = { role: "assistant", content: [{ type: "text", text: "hi" }], stopReason: undefined };
+    controller.emit({ type: "start", partial } as any);
+    controller.emit({ type: "text_delta", contentIndex: 0, delta: "hi", partial } as any);
+    const boundaryEvents = [
+      { type: "text_end", contentIndex: 0, partial } as any,
+      { type: "thinking_end", contentIndex: 0, partial } as any,
+      { type: "toolcall_start", contentIndex: 0, partial } as any,
+      { type: "toolcall_end", contentIndex: 0, partial } as any,
+    ];
+    for (const ev of boundaryEvents) {
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(abortCalled).toBe(false);
+      controller.emit(ev);
+    }
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(abortCalled).toBe(false);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(abortCalled).toBe(true);
+    controller.end();
+    await consumer;
+  }, 15_000);
+
   it("preserves normal delayed usage-only completion without aborting", async () => {
     // Arrange: a fake base stream that streams a normal completion, including
     // a long quiet gap before the final usage-only delta — but well within the

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -55,7 +55,11 @@ function isProviderProgressEvent(event: AssistantMessageEvent): boolean {
   return (
     event.type === "text_delta" ||
     event.type === "thinking_delta" ||
-    event.type === "toolcall_delta"
+    event.type === "toolcall_delta" ||
+    event.type === "text_end" ||
+    event.type === "thinking_end" ||
+    event.type === "toolcall_start" ||
+    event.type === "toolcall_end"
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

OpenCode Go sends block-boundary SSE events between content blocks. The stalled-stream liveness wrapper only recognized text_delta/thinking_delta/toolcall_delta as progress, causing premature timeouts. Adding text_end, thinking_end, toolcall_start, toolcall_end treats them as liveness.

## Evidence

Vitest (includes new regression test for all 4 event types):

```
pnpm exec vitest run extensions/opencode-go/
  Test Files  5 passed (5)
       Tests  28 passed (28)
```

**Label**: bug
_AI-assisted._