### PR TITLE
fix(opencode-go): disable thinking for minimax-m3 anthropic-messages path

### DIFF
--- a/extensions/opencode-go/stream.ts
+++ b/extensions/opencode-go/stream.ts
@@ -47,6 +47,42 @@ export function createOpencodeGoKimiNoReasoningWrapper(
   };
 }
 
+// Minimax models using the Anthropic Messages path through opencode-go return
+// thinking content as regular text blocks rather than proper type:"thinking"
+// Anthropic blocks. Disable thinking at the request level for these models
+// to prevent internal reasoning from leaking to channel output.
+function isOpencodeGoMinimaxAnthropicModelId(modelId: unknown): boolean {
+  return (
+    typeof modelId === "string" &&
+    modelId.trim().toLowerCase() === "minimax-m3"
+  );
+}
+
+function injectMinimaxThinkingDisabled(payloadObj: Record<string, unknown>): void {
+  payloadObj.thinking = { type: "disabled" };
+}
+
+export function createOpencodeGoMinimaxNoThinkingWrapper(
+  baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
+): ProviderWrapStreamFnContext["streamFn"] {
+  if (!baseStreamFn) {
+    return undefined;
+  }
+  const underlying = baseStreamFn;
+  return (model, context, options) => {
+    if (model.provider !== "opencode-go" || !isOpencodeGoMinimaxAnthropicModelId(model.id)) {
+      return underlying(model, context, options);
+    }
+    return streamWithPayloadPatch(
+      underlying,
+      model,
+      context,
+      options,
+      injectMinimaxThinkingDisabled,
+    );
+  };
+}
+
 export function createOpencodeGoWrapper(
   baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
   thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
@@ -54,7 +90,10 @@ export function createOpencodeGoWrapper(
   if (!baseStreamFn) {
     return undefined;
   }
-  const kimiWrapped = createOpencodeGoKimiNoReasoningWrapper(baseStreamFn) ?? baseStreamFn;
+  const minimaxWrapped =
+    createOpencodeGoMinimaxNoThinkingWrapper(baseStreamFn) ?? baseStreamFn;
+  const kimiWrapped =
+    createOpencodeGoKimiNoReasoningWrapper(minimaxWrapped) ?? minimaxWrapped;
   const deepSeekWrapped =
     createOpencodeGoDeepSeekV4Wrapper(kimiWrapped, thinkingLevel) ?? kimiWrapped;
   // Outermost layer: provider-owned stalled SSE termination so the underlying


### PR DESCRIPTION
## What Problem This Solves

Minimax models on the Anthropic Messages path return thinking as regular text blocks. This adds a stream wrapper injecting thinking: { type: disabled } for minimax-m3, preventing reasoning leakage.

## Evidence

Vitest:

```
pnpm exec vitest run extensions/opencode-go/
  Test Files  5 passed (5)
       Tests  28 passed (28)
```

**Label**: bug
_AI-assisted._