### PR TITLE
fix(proxy): bound SSE parser buffer to prevent OOM

### DIFF
--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -216,4 +216,33 @@ describe("streamProxy", () => {
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("exceeded max buffer size");
   });
+
+  it("handles a large transport chunk containing many valid newline-delimited proxy SSE lines", async () => {
+    // Regression: one TCP read can deliver >64 KiB of already-delimited lines;
+    // the cap must apply only to the unterminated tail, not the full chunk.
+    const encoder = new TextEncoder();
+    const line = `data: ${JSON.stringify({ type: "done", reason: "stop", usage })}\n`;
+    const manyLines = line.repeat(2000);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode(manyLines));
+            controller.close();
+          },
+        }),
+      })),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+  });
 });

--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -189,4 +189,31 @@ describe("streamProxy", () => {
       errorMessage: "Proxy stream ended before terminal event",
     });
   });
+
+  it("rejects oversized SSE response without line boundary in proxy reader", async () => {
+    const oversized = "x".repeat(65 * 1024);
+    const encoder = new TextEncoder();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode(oversized));
+            controller.close();
+          },
+        }),
+      })),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("exceeded max buffer size");
+  });
 });

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -229,13 +229,13 @@ export function streamProxy(
         }
 
         buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
         if (buffer.length > PROXY_SSE_BUFFER_MAX_BYTES) {
           throw new Error(
             `Proxy SSE response exceeded max buffer size (${PROXY_SSE_BUFFER_MAX_BYTES} bytes) without line boundary`,
           );
         }
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
 
         for (const line of lines) {
           processSseLine(line);

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -124,6 +124,11 @@ function sanitizeProxyModel(model: Model): Model {
   return safeModel as Model;
 }
 
+/** Max bytes for the internal SSE line-buffer. A response that cannot find a
+ *  `\n` boundary within this many characters is almost certainly hostile or
+ *  broken — cap the buffer rather than letting it grow unbounded. */
+const PROXY_SSE_BUFFER_MAX_BYTES = 64 * 1024;
+
 export function streamProxy(
   model: Model,
   context: Context,
@@ -224,6 +229,11 @@ export function streamProxy(
         }
 
         buffer += decoder.decode(value, { stream: true });
+        if (buffer.length > PROXY_SSE_BUFFER_MAX_BYTES) {
+          throw new Error(
+            `Proxy SSE response exceeded max buffer size (${PROXY_SSE_BUFFER_MAX_BYTES} bytes) without line boundary`,
+          );
+        }
         const lines = buffer.split("\n");
         buffer = lines.pop() || "";
 


### PR DESCRIPTION
## What Problem This Solves

The `streamProxy` SSE reader in `src/agents/runtime/proxy.ts:231` accumulates decoded chunks into an internal `buffer` string that only shrinks when a `\n` line boundary is found. If a hostile or misconfigured proxy endpoint sends data without newline delimiters, the buffer grows unboundedly — the same OOM vector fixed for the OpenAI `parseSSE` in #96972.

This affects every LLM call routed through the OpenClaw runtime proxy gateway.

## Changes

- `src/agents/runtime/proxy.ts` (+10 LoC): Added `PROXY_SSE_BUFFER_MAX_BYTES = 64 KiB` constant. After each chunk decode, the buffer check throws an error if the accumulated buffer exceeds the cap — preventing unbounded memory growth. Mirrors the `parseSSE` fix in #96972 exactly.

- `src/agents/runtime/proxy.test.ts` (+27 LoC): Added inline test `"rejects oversized SSE response without line boundary in proxy reader"` — 65 KiB proxy SSE response without `\n` → buffer cap error.

## Real behavior proof

- **Behavior addressed**: Unbounded SSE buffer growth in runtime proxy reader when data arrives without \n delimiters — buffer capped at 64 KiB.
- **Real environment tested**: Linux x86_64, Node 22.19, OpenClaw main@ec737ee74d
- **Exact steps or command run after this patch**:
  ```bash
  node --import tsx _proof_proxy_cap.mts
  ```
- **Evidence after fix**:
  ```
  PASS  oversized body: buffer cap error (server sent 65.0 KiB, cap=64.0 KiB)
  PASS  valid SSE: data passes through (server sent 39 B, 1 line(s))
  PASS  negative control: unbounded read buffer = 65.0 KiB (server sent 65.0 KiB, cap=64.0 KiB)

  Results: 3/3 passed
  ```
  5/5 unit tests passed: `pnpm test src/agents/runtime/proxy.test.ts --run`
- **Observed result after fix**:
  - Real `node:http` server delivering 65 KiB SSE without `\n` → reader throws buffer cap error at 64 KiB. Server-side bytes-sent: 65.0 KiB.
  - Same server with valid SSE data (39 B, `data: {"type":"done","reason":"stop"}\n\n`) → passes through correctly.
  - Negative control: same 65 KiB body without the cap → full 65 KiB accumulated in-memory (OOM vector confirmed).
- **What was not tested**: The proxy WebSocket path (uses a different parser); non-streaming proxy calls.

## Out of scope

- This is the parser-buffer counterpart to the stream-level cap in #96768 (16 MiB via `createSseByteGuard`). That PR and this one are complementary — #96768 caps total bytes, this PR caps the per-frame accumulation.

## Risk

**Low.** The cap (64 KiB) is well above any reasonable proxy event payload. If triggered, the stream errors with a clear message rather than silently terminating. The change is additive — no existing behavior is modified, only a guard added.

AI-assisted; reviewed before submission.
