### PR TITLE
fix(opencode-go): treat block-boundary SSE events as liveness for idle timer

### DIFF
--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -55,7 +55,11 @@ function isProviderProgressEvent(event: AssistantMessageEvent): boolean {
   return (
     event.type === "text_delta" ||
     event.type === "thinking_delta" ||
-    event.type === "toolcall_delta"
+    event.type === "toolcall_delta" ||
+    event.type === "text_end" ||
+    event.type === "thinking_end" ||
+    event.type === "toolcall_start" ||
+    event.type === "toolcall_end"
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Treat block-boundary SSE events as liveness for idle timer, preventing
premature stream abort at block boundaries.

## Changes

`extensions/opencode-go/stream-termination.ts`: Add `text_end`, `thinking_end`,
`toolcall_start`, `toolcall_end` to `isProviderProgressEvent`.

## Evidence

### Unit tests: stalled stream wrapper

```
pnpm exec vitest run extensions/opencode-go/stream-termination.test.ts

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

_AI-assisted._