### PR TITLE
feat(attach): node conduit + gateway-owned session hydration (pick-up-anywhere)

### DIFF
--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -1,0 +1,171 @@
+import { EventEmitter } from "node:events";
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnedChild = Object.assign(new EventEmitter(), { kill: vi.fn() });
+vi.mock("node:child_process", () => ({ spawn: vi.fn(() => spawnedChild) }));
+
+const gatewayCalls: Array<{
+  method: string;
+  params: Record<string, unknown>;
+  mode?: string;
+  hasDeviceIdentityKey: boolean;
+}> = [];
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(
+    async (p: { method: string; params: Record<string, unknown>; mode?: string }) => {
+      gatewayCalls.push({
+        method: p.method,
+        params: p.params,
+        mode: p.mode,
+        hasDeviceIdentityKey: "deviceIdentity" in p,
+      });
+      if (p.method === "attach.grant") {
+        const sessionKey = (p.params.sessionKey as string) ?? "agent:main:main";
+        return {
+          sessionKey,
+          token: "tok-123",
+          expiresAtMs: 2_000_000_000_000,
+          mcpConfig: {
+            mcpServers: {
+              openclaw: {
+                type: "http",
+                url: "http://127.0.0.1:9999/mcp",
+                headers: { Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}" },
+              },
+            },
+          },
+          env: { OPENCLAW_MCP_TOKEN: "tok-123", OPENCLAW_MCP_SESSION_KEY: sessionKey },
+        };
+      }
+      return {};
+    },
+  ),
+}));
+
+const logs: string[] = [];
+let exitCode: number | undefined;
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    log: (m: string) => logs.push(m),
+    error: (m: string) => logs.push(`ERR:${m}`),
+    exit: (c: number) => {
+      exitCode = c;
+    },
+  },
+}));
+vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
+
+import { callGateway } from "../gateway/call.js";
+import { registerAttachCli } from "./attach-cli.js";
+
+async function runAttach(...args: string[]) {
+  const program = new Command().name("openclaw").exitOverride();
+  await registerAttachCli(program);
+  await program.parseAsync(["node", "openclaw", "attach", ...args]);
+}
+const tick = () =>
+  new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+
+describe("openclaw attach (action)", () => {
+  beforeEach(() => {
+    gatewayCalls.length = 0;
+    logs.length = 0;
+    exitCode = undefined;
+    spawnedChild.removeAllListeners();
+    spawnedChild.kill.mockClear();
+  });
+
+  it("--print-config: mints + writes config + prints launch, does NOT revoke or name a nonexistent command", async () => {
+    await runAttach("--print-config", "--session", "agent:main:cli");
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")?.params.sessionKey).toBe(
+      "agent:main:cli",
+    );
+    // setup mode leaves the grant live (no revoke) and must not point at a revoke command that does not exist
+    expect(gatewayCalls.find((c) => c.method === "attach.revoke")).toBeUndefined();
+    const out = logs.join("\n");
+    expect(out).toContain("agent:main:cli");
+    expect(out).toContain("--mcp-config");
+    expect(out).toContain("OPENCLAW_MCP_TOKEN");
+    expect(out).not.toContain("attach.revoke");
+  });
+
+  it("calls attach.grant in CLI mode with an auto-resolved device identity (operator.admin regression guard)", async () => {
+    // Regression guard: attach.grant is operator.admin-scoped. mode BACKEND or an explicit
+    // deviceIdentity:null drops the operator device identity → the gateway rejects with
+    // "missing scope: operator.admin". This was a real bug found via a live-gateway proof.
+    await runAttach("--print-config", "--session", "agent:main:cli");
+    const grant = gatewayCalls.find((c) => c.method === "attach.grant");
+    expect(grant?.mode).toBe("cli");
+    expect(grant?.hasDeviceIdentityKey).toBe(false);
+  });
+
+  it("rejects a non-positive --ttl before minting", async () => {
+    await runAttach("--ttl", "-5", "--print-config");
+    expect(exitCode).toBe(1);
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeUndefined();
+  });
+
+  it("rejects an empty --ttl rather than silently defaulting", async () => {
+    await runAttach("--ttl", "", "--print-config");
+    expect(exitCode).toBe(1);
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeUndefined();
+  });
+
+  it("passes a positive --ttl through to attach.grant", async () => {
+    await runAttach("--ttl", "600000", "--print-config");
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")?.params.ttlMs).toBe(600_000);
+  });
+
+  it("errors on a malformed attach.grant response instead of crashing", async () => {
+    vi.mocked(callGateway).mockResolvedValueOnce({} as never);
+    await runAttach("--print-config");
+    expect(exitCode).toBe(1);
+  });
+
+  it("spawns Claude Code and revokes the grant when the child exits", async () => {
+    await runAttach("--session", "agent:main:spawn"); // spawn path (no --print-config)
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeTruthy();
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
+    expect(gatewayCalls.find((c) => c.method === "attach.revoke")?.params.token).toBe("tok-123");
+    expect(exitCode).toBe(0);
+  });
+
+  it("revokes once and surfaces a launch failure when the child errors", async () => {
+    await runAttach("--session", "agent:main:spawn-err");
+    spawnedChild.emit("error", new Error("ENOENT"));
+    await tick();
+    await tick();
+    expect(gatewayCalls.filter((c) => c.method === "attach.revoke")).toHaveLength(1);
+    expect(exitCode).toBe(1);
+    expect(logs.join("\n")).toContain("Failed to launch");
+  });
+
+  it("detaches its signal handlers after the child exits (no listener leak)", async () => {
+    const baseInt = process.listenerCount("SIGINT");
+    const baseTerm = process.listenerCount("SIGTERM");
+    await runAttach("--session", "agent:main:spawn");
+    expect(process.listenerCount("SIGINT")).toBe(baseInt + 1);
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
+    expect(process.listenerCount("SIGINT")).toBe(baseInt);
+    expect(process.listenerCount("SIGTERM")).toBe(baseTerm);
+  });
+
+  it("errors on a grant with a non-numeric expiresAtMs instead of crashing on toISOString", async () => {
+    vi.mocked(callGateway).mockResolvedValueOnce({
+      sessionKey: "agent:main:x",
+      token: "tok-123",
+      expiresAtMs: "soon",
+      mcpConfig: { mcpServers: { openclaw: {} } },
+      env: {},
+    } as never);
+    await runAttach("--print-config");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -5,6 +5,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const spawnedChild = Object.assign(new EventEmitter(), { kill: vi.fn() });
 vi.mock("node:child_process", () => ({ spawn: vi.fn(() => spawnedChild) }));
 
+// The node conduit is lazy-imported on the node path; mock it so we can assert routing + teardown.
+const nodeClose = vi.fn(async () => {});
+const nodeAttachMock = vi.fn(async () => ({
+  sessionKey: "agent:main:node",
+  mcpConfig: { mcpServers: { openclaw: { type: "http", url: "http://127.0.0.1:7777/mcp" } } },
+  env: { OPENCLAW_MCP_TOKEN: "node-tok" },
+  launchArgs: ["--resume", "sid-node"],
+  close: nodeClose,
+}));
+vi.mock("./node-cli/attach.js", () => ({ runNodeAttach: nodeAttachMock }));
+
 const gatewayCalls: Array<{
   method: string;
   params: Record<string, unknown>;
@@ -56,6 +67,7 @@ vi.mock("../runtime.js", () => ({
 }));
 vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
 
+import { spawn } from "node:child_process";
 import { callGateway } from "../gateway/call.js";
 import { registerAttachCli } from "./attach-cli.js";
 
@@ -76,6 +88,9 @@ describe("openclaw attach (action)", () => {
     exitCode = undefined;
     spawnedChild.removeAllListeners();
     spawnedChild.kill.mockClear();
+    nodeAttachMock.mockClear();
+    nodeClose.mockClear();
+    vi.mocked(spawn).mockClear();
   });
 
   it("--print-config: mints + writes config + prints launch, does NOT revoke or name a nonexistent command", async () => {
@@ -167,5 +182,41 @@ describe("openclaw attach (action)", () => {
     } as never);
     await runAttach("--print-config");
     expect(exitCode).toBe(1);
+  });
+
+  it("--via node uses the conduit (no attach.grant) and spawns with the hydration --resume args", async () => {
+    await runAttach("--via", "node");
+    expect(nodeAttachMock).toHaveBeenCalledTimes(1);
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeUndefined();
+    const spawnArgs = vi.mocked(spawn).mock.calls.at(-1)?.[1];
+    expect(spawnArgs).toEqual(["--mcp-config", expect.any(String), "--resume", "sid-node"]);
+    // the conduit (forwarder + node link) is torn down on child exit
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
+    expect(nodeClose).toHaveBeenCalledTimes(1);
+    expect(exitCode).toBe(0);
+  });
+
+  it("--via node rejects --print-config (the in-process forwarder can't outlive it)", async () => {
+    await runAttach("--via", "node", "--print-config");
+    expect(exitCode).toBe(1);
+    expect(nodeAttachMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid --via without minting or connecting", async () => {
+    await runAttach("--via", "carrier-pigeon");
+    expect(exitCode).toBe(1);
+    expect(gatewayCalls.find((c) => c.method === "attach.grant")).toBeUndefined();
+    expect(nodeAttachMock).not.toHaveBeenCalled();
+  });
+
+  it("--via auto falls back to the node conduit when the gateway-host grant fails", async () => {
+    vi.mocked(callGateway).mockRejectedValueOnce(new Error("missing scope: operator.admin"));
+    await runAttach(); // auto
+    expect(nodeAttachMock).toHaveBeenCalledTimes(1);
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
   });
 });

--- a/src/cli/attach-cli.test.ts
+++ b/src/cli/attach-cli.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { writeClaudeMcpConfig } from "./attach-cli.js";
+
+const MCP_CONFIG = {
+  mcpServers: {
+    openclaw: {
+      type: "http",
+      url: "http://127.0.0.1:54321/mcp",
+      headers: {
+        Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
+        "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
+      },
+    },
+  },
+};
+
+describe("writeClaudeMcpConfig", () => {
+  it("writes the gateway mcpConfig verbatim to a .mcp.json (placeholders preserved for Claude env substitution)", () => {
+    const { path, cleanup } = writeClaudeMcpConfig(MCP_CONFIG);
+    try {
+      expect(path.endsWith(".mcp.json")).toBe(true);
+      expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(MCP_CONFIG);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("cleanup removes the temp config", () => {
+    const { path, cleanup } = writeClaudeMcpConfig(MCP_CONFIG);
+    cleanup();
+    expect(() => readFileSync(path, "utf8")).toThrow();
+  });
+});

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -1,8 +1,9 @@
-// `openclaw attach` — launch Claude Code bound to a gateway session with scoped MCP tools. Mints a
-// per-session attach grant (attach.grant), writes the returned loopback MCP config to a temp
-// `.mcp.json` for `claude --mcp-config`, spawns Claude Code interactively, and revokes the grant on
-// exit. The grant — not a process-global token — keeps this a lower-trust, revocable boundary
-// (see src/gateway/mcp-grant-store.ts).
+// `openclaw attach` — launch Claude Code bound to a gateway session with scoped MCP tools. Two
+// transports, auto-detected: on the gateway host it mints a grant (attach.grant) and points claude
+// at the loopback MCP; on a node it goes through the conduit (node-cli/attach.runNodeAttach) over the
+// node's existing gateway link. Either way the grant — not a process-global token — keeps this a
+// lower-trust, revocable boundary (see src/gateway/mcp-grant-store.ts). The config is written to a
+// temp `.mcp.json` for `claude --mcp-config`; the grant/forwarder is torn down on exit.
 import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { constants as osConstants, tmpdir } from "node:os";
@@ -15,6 +16,8 @@ import {
 import { getRuntimeConfig } from "../config/io.js";
 import { callGateway } from "../gateway/call.js";
 import { defaultRuntime } from "../runtime.js";
+// runNodeAttach is lazy-imported on the node path only — it pulls the node-host runtime, which must
+// not load (or slow startup) for the common gateway-host attach.
 
 /** What attach.grant returns (gateway method in src/gateway/server-methods/attach.ts). */
 type AttachGrant = {
@@ -25,13 +28,26 @@ type AttachGrant = {
   env: Record<string, string>;
 };
 
+/** Transport-agnostic launch plan: what the spawn step needs, plus a path-specific teardown. */
+type AttachLaunchPlan = {
+  sessionKey: string;
+  mcpConfig: { mcpServers: Record<string, unknown> };
+  env: Record<string, string>;
+  /** Extra claude argv (the node conduit hydrates a session → `--resume <id>`); empty for loopback. */
+  launchArgs: string[];
+  /** ISO expiry for logging, when the transport exposes one (the grant TTL). */
+  expiresAt?: string;
+  /** Revoke the grant / tear down the forwarder + node link. Does NOT remove the temp config dir. */
+  close: () => Promise<void>;
+};
+
 /**
  * Write the gateway's mcpConfig verbatim to a temp `.mcp.json` for `claude --mcp-config`. The entry
  * keeps the gateway's `${OPENCLAW_MCP_*}` header placeholders, which Claude Code substitutes from
  * the process env — so the bearer token never lands in argv or a durable file. Returns the path and
  * a cleanup() for the temp dir.
  */
-export function writeClaudeMcpConfig(mcpConfig: AttachGrant["mcpConfig"]): {
+export function writeClaudeMcpConfig(mcpConfig: AttachLaunchPlan["mcpConfig"]): {
   path: string;
   cleanup: () => void;
 } {
@@ -39,6 +55,58 @@ export function writeClaudeMcpConfig(mcpConfig: AttachGrant["mcpConfig"]): {
   const path = join(dir, ".mcp.json");
   writeFileSync(path, JSON.stringify(mcpConfig, null, 2), { encoding: "utf8", mode: 0o600 });
   return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+/** Gateway-host transport: mint the grant via attach.grant and point claude at the loopback MCP. */
+async function acquireGatewayHostPlan(
+  cfg: ReturnType<typeof getRuntimeConfig>,
+  opts: { session?: string; ttlMs?: number },
+): Promise<AttachLaunchPlan> {
+  const granted = (await callGateway({
+    config: cfg,
+    method: "attach.grant",
+    params: { sessionKey: opts.session, ttlMs: opts.ttlMs },
+    // attach.grant is operator.admin-scoped. CLI mode lets callGateway auto-resolve the operator
+    // device identity (which carries operator.admin); BACKEND/null drops it -> "missing scope".
+    mode: GATEWAY_CLIENT_MODES.CLI,
+    clientName: GATEWAY_CLIENT_NAMES.CLI,
+  })) as Partial<AttachGrant> | null;
+  // Validate the RPC boundary rather than trusting the cast — a malformed/error response fails here.
+  if (
+    !granted ||
+    typeof granted.token !== "string" ||
+    typeof granted.sessionKey !== "string" ||
+    typeof granted.expiresAtMs !== "number" ||
+    !Number.isFinite(granted.expiresAtMs) ||
+    !granted.mcpConfig?.mcpServers ||
+    typeof granted.env !== "object" ||
+    granted.env === null
+  ) {
+    throw new Error("attach.grant returned an unexpected response from the gateway.");
+  }
+  const grant = granted as AttachGrant;
+  let revokePromise: Promise<void> | undefined;
+  return {
+    sessionKey: grant.sessionKey,
+    mcpConfig: grant.mcpConfig,
+    env: grant.env,
+    launchArgs: [],
+    expiresAt: new Date(grant.expiresAtMs).toISOString(),
+    close: () =>
+      (revokePromise ??= (async () => {
+        try {
+          await callGateway({
+            config: cfg,
+            method: "attach.revoke",
+            params: { token: grant.token },
+            mode: GATEWAY_CLIENT_MODES.CLI,
+            clientName: GATEWAY_CLIENT_NAMES.CLI,
+          });
+        } catch {
+          // Best-effort: the grant's TTL still bounds it if revoke can't reach the gateway.
+        }
+      })()),
+  };
 }
 
 export async function registerAttachCli(program: Command, _argv: string[] = process.argv) {
@@ -49,142 +117,160 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
     .option("--ttl <ms>", "Grant TTL in milliseconds (default: gateway policy)")
     .option("--bin <path>", "Claude Code binary to spawn", "claude")
     .option(
+      "--via <mode>",
+      "Transport: auto (default; gateway host, else node conduit), gateway, or node",
+      "auto",
+    )
+    .option(
       "--print-config",
-      "Mint the grant + write the .mcp.json, print how to launch it, and exit without spawning",
+      "Mint the grant + write the .mcp.json, print how to launch it, and exit without spawning (gateway transport only)",
       false,
     )
     .addHelpText(
       "after",
-      "\nExamples:\n  openclaw attach                       Attach Claude Code to the main session\n  openclaw attach --session agent:main:telegram:123 --ttl 600000\n  openclaw attach --print-config        Set up the grant + config and print how to launch it yourself\n",
+      "\nExamples:\n  openclaw attach                       Attach Claude Code to the main session\n  openclaw attach --session agent:main:telegram:123 --ttl 600000\n  openclaw attach --via node            Force the node conduit (run on a paired node)\n  openclaw attach --print-config        Set up the grant + config and print how to launch it yourself\n",
     )
-    .action(async (opts: { session?: string; ttl?: string; bin: string; printConfig: boolean }) => {
-      let ttlMs: number | undefined;
-      if (opts.ttl !== undefined) {
-        // A provided --ttl must be a positive number; empty/non-numeric values error rather than
-        // silently falling back to the gateway default.
-        ttlMs = Number(opts.ttl);
-        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    .action(
+      async (opts: {
+        session?: string;
+        ttl?: string;
+        bin: string;
+        via: string;
+        printConfig: boolean;
+      }) => {
+        let ttlMs: number | undefined;
+        if (opts.ttl !== undefined) {
+          // A provided --ttl must be a positive number; empty/non-numeric values error rather than
+          // silently falling back to the gateway default.
+          ttlMs = Number(opts.ttl);
+          if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            defaultRuntime.error(
+              `--ttl must be a positive number of milliseconds. Got: ${JSON.stringify(opts.ttl)}`,
+            );
+            defaultRuntime.exit(1);
+            return;
+          }
+        }
+        const via = opts.via ?? "auto";
+        if (via !== "auto" && via !== "gateway" && via !== "node") {
           defaultRuntime.error(
-            `--ttl must be a positive number of milliseconds. Got: ${JSON.stringify(opts.ttl)}`,
+            `--via must be one of: auto, gateway, node. Got: ${JSON.stringify(via)}`,
           );
           defaultRuntime.exit(1);
           return;
         }
-      }
 
-      const cfg = getRuntimeConfig();
-      const granted = (await callGateway({
-        config: cfg,
-        method: "attach.grant",
-        params: { sessionKey: opts.session, ttlMs },
-        // attach.grant is operator.admin-scoped. Use CLI mode so callGateway auto-resolves the
-        // operator device identity (which carries operator.admin); mode BACKEND or an explicit
-        // deviceIdentity:null drops it and the call fails with "missing scope: operator.admin".
-        mode: GATEWAY_CLIENT_MODES.CLI,
-        clientName: GATEWAY_CLIENT_NAMES.CLI,
-      })) as Partial<AttachGrant> | null;
-      // Validate the RPC boundary rather than trusting the cast — a malformed/error response must
-      // fail loudly here, not crash later when writing the config.
-      if (
-        !granted ||
-        typeof granted.token !== "string" ||
-        typeof granted.sessionKey !== "string" ||
-        typeof granted.expiresAtMs !== "number" ||
-        !Number.isFinite(granted.expiresAtMs) ||
-        !granted.mcpConfig?.mcpServers ||
-        typeof granted.env !== "object" ||
-        granted.env === null
-      ) {
-        defaultRuntime.error("attach.grant returned an unexpected response from the gateway.");
-        defaultRuntime.exit(1);
-        return;
-      }
-      const grant = granted as AttachGrant;
+        const cfg = getRuntimeConfig();
+        let plan: AttachLaunchPlan | undefined;
+        const failures: string[] = [];
 
-      const { path: configPath, cleanup } = writeClaudeMcpConfig(grant.mcpConfig);
-      const expiresAt = new Date(grant.expiresAtMs).toISOString();
-
-      // --print-config is a setup mode: leave the grant live (TTL-bounded) and the config file in
-      // place so the user can launch Claude Code themselves; do NOT revoke or delete here. The grant
-      // auto-expires at its TTL (there is no separate revoke CLI command).
-      if (opts.printConfig) {
-        defaultRuntime.log(
-          JSON.stringify(
-            {
-              sessionKey: grant.sessionKey,
-              expiresAt,
-              env: grant.env,
-              configPath,
-              launch: [opts.bin, "--mcp-config", configPath],
-            },
-            null,
-            2,
-          ),
-        );
-        defaultRuntime.log(
-          `Grant is live until ${expiresAt} and auto-expires; it is not revoked here. Launch with the env above, then delete ${configPath} when done.`,
-        );
-        return;
-      }
-
-      // Single revoke+cleanup shared by all terminal paths (error/exit can race; the promise dedupes).
-      let revokePromise: Promise<void> | undefined;
-      const revokeOnce = () =>
-        (revokePromise ??= (async () => {
+        if (via === "gateway" || via === "auto") {
           try {
-            await callGateway({
-              config: cfg,
-              method: "attach.revoke",
-              params: { token: grant.token },
-              // operator.admin-scoped like attach.grant — see the mode note there.
-              mode: GATEWAY_CLIENT_MODES.CLI,
-              clientName: GATEWAY_CLIENT_NAMES.CLI,
-            });
-          } catch {
-            // Best-effort: the grant's TTL still bounds it if revoke can't reach the gateway.
+            plan = await acquireGatewayHostPlan(cfg, { session: opts.session, ttlMs });
+          } catch (error) {
+            failures.push(`gateway: ${error instanceof Error ? error.message : String(error)}`);
+            if (via === "gateway") {
+              defaultRuntime.error(failures[failures.length - 1] ?? "gateway transport failed");
+              defaultRuntime.exit(1);
+              return;
+            }
           }
-          cleanup();
-        })());
+        }
 
-      defaultRuntime.log(
-        `Attaching Claude Code to session ${grant.sessionKey} (grant expires ${expiresAt})…`,
-      );
-      const child = spawn(opts.bin, ["--mcp-config", configPath], {
-        stdio: "inherit",
-        env: { ...process.env, ...grant.env },
-      });
+        if (!plan && (via === "node" || via === "auto")) {
+          // The node conduit's forwarder is in-process, so it can't outlive a --print-config run.
+          if (opts.printConfig) {
+            defaultRuntime.error(
+              "--print-config is not supported for the node conduit (the loopback forwarder is in-process). Use --via gateway, or run without --print-config.",
+            );
+            defaultRuntime.exit(1);
+            return;
+          }
+          try {
+            const { runNodeAttach } = await import("./node-cli/attach.js");
+            plan = await runNodeAttach({ cwd: process.cwd(), nowMs: Date.now() });
+          } catch (error) {
+            failures.push(`node: ${error instanceof Error ? error.message : String(error)}`);
+          }
+        }
 
-      // Claude Code shares the TTY foreground group, so Ctrl-C reaches it directly — don't forward
-      // SIGINT (that double-delivers). Keep the parent alive (no-op) so its exit handler can revoke.
-      // SIGTERM is not TTY-delivered to the child, so forward it explicitly.
-      const onSigint = () => {};
-      const onSigterm = () => child.kill("SIGTERM");
-      // Detach the process-global handlers once the child is done so repeated invocations (and tests)
-      // don't accumulate listeners or leave a stale handler bound to an exited child.
-      const finish = (code: number) => {
-        process.off("SIGINT", onSigint);
-        process.off("SIGTERM", onSigterm);
-        defaultRuntime.exit(code);
-      };
+        if (!plan) {
+          defaultRuntime.error(
+            `Could not attach. ${failures.join("; ") || "no transport available."}`,
+          );
+          defaultRuntime.exit(1);
+          return;
+        }
 
-      child.on("error", (error) => {
-        void (async () => {
-          defaultRuntime.error(`Failed to launch '${opts.bin}': ${String(error)}`);
-          await revokeOnce();
-          finish(1);
-        })();
-      });
-      child.on("exit", (code, signal) => {
-        void (async () => {
-          await revokeOnce();
-          // Mirror the child's termination: 128+signal on signal death, else its exit code.
-          const signalCode = signal
-            ? 128 + ((osConstants.signals as Record<string, number>)[signal] ?? 0)
-            : null;
-          finish(signalCode ?? code ?? 0);
-        })();
-      });
-      process.on("SIGINT", onSigint);
-      process.on("SIGTERM", onSigterm);
-    });
+        const { path: configPath, cleanup } = writeClaudeMcpConfig(plan.mcpConfig);
+        const expiryNote = plan.expiresAt ? ` (grant expires ${plan.expiresAt})` : "";
+
+        // --print-config is a setup mode (gateway transport only): leave the grant live (TTL-bounded)
+        // and the config in place so the user can launch Claude Code themselves; do NOT revoke/delete.
+        if (opts.printConfig) {
+          defaultRuntime.log(
+            JSON.stringify(
+              {
+                sessionKey: plan.sessionKey,
+                expiresAt: plan.expiresAt,
+                env: plan.env,
+                configPath,
+                launch: [opts.bin, "--mcp-config", configPath, ...plan.launchArgs],
+              },
+              null,
+              2,
+            ),
+          );
+          defaultRuntime.log(
+            `Grant is live${expiryNote} and auto-expires; it is not revoked here. Launch with the env above, then delete ${configPath} when done.`,
+          );
+          return;
+        }
+
+        // Single teardown shared by all terminal paths (error/exit can race; the promise dedupes).
+        let closePromise: Promise<void> | undefined;
+        const closeOnce = () =>
+          (closePromise ??= (async () => {
+            await plan.close();
+            cleanup();
+          })());
+
+        defaultRuntime.log(`Attaching Claude Code to session ${plan.sessionKey}${expiryNote}…`);
+        const child = spawn(opts.bin, ["--mcp-config", configPath, ...plan.launchArgs], {
+          stdio: "inherit",
+          env: { ...process.env, ...plan.env },
+        });
+
+        // Claude Code shares the TTY foreground group, so Ctrl-C reaches it directly — don't forward
+        // SIGINT (that double-delivers). Keep the parent alive (no-op) so its exit handler can clean up.
+        // SIGTERM is not TTY-delivered to the child, so forward it explicitly.
+        const onSigint = () => {};
+        const onSigterm = () => child.kill("SIGTERM");
+        const finish = (code: number) => {
+          process.off("SIGINT", onSigint);
+          process.off("SIGTERM", onSigterm);
+          defaultRuntime.exit(code);
+        };
+
+        child.on("error", (error) => {
+          void (async () => {
+            defaultRuntime.error(`Failed to launch '${opts.bin}': ${String(error)}`);
+            await closeOnce();
+            finish(1);
+          })();
+        });
+        child.on("exit", (code, signal) => {
+          void (async () => {
+            await closeOnce();
+            // Mirror the child's termination: 128+signal on signal death, else its exit code.
+            const signalCode = signal
+              ? 128 + ((osConstants.signals as Record<string, number>)[signal] ?? 0)
+              : null;
+            finish(signalCode ?? code ?? 0);
+          })();
+        });
+        process.on("SIGINT", onSigint);
+        process.on("SIGTERM", onSigterm);
+      },
+    );
 }

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -1,0 +1,190 @@
+// `openclaw attach` — launch Claude Code bound to a gateway session with scoped MCP tools. Mints a
+// per-session attach grant (attach.grant), writes the returned loopback MCP config to a temp
+// `.mcp.json` for `claude --mcp-config`, spawns Claude Code interactively, and revokes the grant on
+// exit. The grant — not a process-global token — keeps this a lower-trust, revocable boundary
+// (see src/gateway/mcp-grant-store.ts).
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { constants as osConstants, tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Command } from "commander";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../packages/gateway-protocol/src/client-info.js";
+import { getRuntimeConfig } from "../config/io.js";
+import { callGateway } from "../gateway/call.js";
+import { defaultRuntime } from "../runtime.js";
+
+/** What attach.grant returns (gateway method in src/gateway/server-methods/attach.ts). */
+type AttachGrant = {
+  sessionKey: string;
+  token: string;
+  expiresAtMs: number;
+  mcpConfig: { mcpServers: Record<string, unknown> };
+  env: Record<string, string>;
+};
+
+/**
+ * Write the gateway's mcpConfig verbatim to a temp `.mcp.json` for `claude --mcp-config`. The entry
+ * keeps the gateway's `${OPENCLAW_MCP_*}` header placeholders, which Claude Code substitutes from
+ * the process env — so the bearer token never lands in argv or a durable file. Returns the path and
+ * a cleanup() for the temp dir.
+ */
+export function writeClaudeMcpConfig(mcpConfig: AttachGrant["mcpConfig"]): {
+  path: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "openclaw-attach-"));
+  const path = join(dir, ".mcp.json");
+  writeFileSync(path, JSON.stringify(mcpConfig, null, 2), { encoding: "utf8", mode: 0o600 });
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+export async function registerAttachCli(program: Command, _argv: string[] = process.argv) {
+  program
+    .command("attach")
+    .description("Attach Claude Code to a gateway session with scoped MCP tools")
+    .option("--session <key>", "Gateway session key to bind (default: main session)")
+    .option("--ttl <ms>", "Grant TTL in milliseconds (default: gateway policy)")
+    .option("--bin <path>", "Claude Code binary to spawn", "claude")
+    .option(
+      "--print-config",
+      "Mint the grant + write the .mcp.json, print how to launch it, and exit without spawning",
+      false,
+    )
+    .addHelpText(
+      "after",
+      "\nExamples:\n  openclaw attach                       Attach Claude Code to the main session\n  openclaw attach --session agent:main:telegram:123 --ttl 600000\n  openclaw attach --print-config        Set up the grant + config and print how to launch it yourself\n",
+    )
+    .action(async (opts: { session?: string; ttl?: string; bin: string; printConfig: boolean }) => {
+      let ttlMs: number | undefined;
+      if (opts.ttl !== undefined) {
+        // A provided --ttl must be a positive number; empty/non-numeric values error rather than
+        // silently falling back to the gateway default.
+        ttlMs = Number(opts.ttl);
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+          defaultRuntime.error(
+            `--ttl must be a positive number of milliseconds. Got: ${JSON.stringify(opts.ttl)}`,
+          );
+          defaultRuntime.exit(1);
+          return;
+        }
+      }
+
+      const cfg = getRuntimeConfig();
+      const granted = (await callGateway({
+        config: cfg,
+        method: "attach.grant",
+        params: { sessionKey: opts.session, ttlMs },
+        // attach.grant is operator.admin-scoped. Use CLI mode so callGateway auto-resolves the
+        // operator device identity (which carries operator.admin); mode BACKEND or an explicit
+        // deviceIdentity:null drops it and the call fails with "missing scope: operator.admin".
+        mode: GATEWAY_CLIENT_MODES.CLI,
+        clientName: GATEWAY_CLIENT_NAMES.CLI,
+      })) as Partial<AttachGrant> | null;
+      // Validate the RPC boundary rather than trusting the cast — a malformed/error response must
+      // fail loudly here, not crash later when writing the config.
+      if (
+        !granted ||
+        typeof granted.token !== "string" ||
+        typeof granted.sessionKey !== "string" ||
+        typeof granted.expiresAtMs !== "number" ||
+        !Number.isFinite(granted.expiresAtMs) ||
+        !granted.mcpConfig?.mcpServers ||
+        typeof granted.env !== "object" ||
+        granted.env === null
+      ) {
+        defaultRuntime.error("attach.grant returned an unexpected response from the gateway.");
+        defaultRuntime.exit(1);
+        return;
+      }
+      const grant = granted as AttachGrant;
+
+      const { path: configPath, cleanup } = writeClaudeMcpConfig(grant.mcpConfig);
+      const expiresAt = new Date(grant.expiresAtMs).toISOString();
+
+      // --print-config is a setup mode: leave the grant live (TTL-bounded) and the config file in
+      // place so the user can launch Claude Code themselves; do NOT revoke or delete here. The grant
+      // auto-expires at its TTL (there is no separate revoke CLI command).
+      if (opts.printConfig) {
+        defaultRuntime.log(
+          JSON.stringify(
+            {
+              sessionKey: grant.sessionKey,
+              expiresAt,
+              env: grant.env,
+              configPath,
+              launch: [opts.bin, "--mcp-config", configPath],
+            },
+            null,
+            2,
+          ),
+        );
+        defaultRuntime.log(
+          `Grant is live until ${expiresAt} and auto-expires; it is not revoked here. Launch with the env above, then delete ${configPath} when done.`,
+        );
+        return;
+      }
+
+      // Single revoke+cleanup shared by all terminal paths (error/exit can race; the promise dedupes).
+      let revokePromise: Promise<void> | undefined;
+      const revokeOnce = () =>
+        (revokePromise ??= (async () => {
+          try {
+            await callGateway({
+              config: cfg,
+              method: "attach.revoke",
+              params: { token: grant.token },
+              // operator.admin-scoped like attach.grant — see the mode note there.
+              mode: GATEWAY_CLIENT_MODES.CLI,
+              clientName: GATEWAY_CLIENT_NAMES.CLI,
+            });
+          } catch {
+            // Best-effort: the grant's TTL still bounds it if revoke can't reach the gateway.
+          }
+          cleanup();
+        })());
+
+      defaultRuntime.log(
+        `Attaching Claude Code to session ${grant.sessionKey} (grant expires ${expiresAt})…`,
+      );
+      const child = spawn(opts.bin, ["--mcp-config", configPath], {
+        stdio: "inherit",
+        env: { ...process.env, ...grant.env },
+      });
+
+      // Claude Code shares the TTY foreground group, so Ctrl-C reaches it directly — don't forward
+      // SIGINT (that double-delivers). Keep the parent alive (no-op) so its exit handler can revoke.
+      // SIGTERM is not TTY-delivered to the child, so forward it explicitly.
+      const onSigint = () => {};
+      const onSigterm = () => child.kill("SIGTERM");
+      // Detach the process-global handlers once the child is done so repeated invocations (and tests)
+      // don't accumulate listeners or leave a stale handler bound to an exited child.
+      const finish = (code: number) => {
+        process.off("SIGINT", onSigint);
+        process.off("SIGTERM", onSigterm);
+        defaultRuntime.exit(code);
+      };
+
+      child.on("error", (error) => {
+        void (async () => {
+          defaultRuntime.error(`Failed to launch '${opts.bin}': ${String(error)}`);
+          await revokeOnce();
+          finish(1);
+        })();
+      });
+      child.on("exit", (code, signal) => {
+        void (async () => {
+          await revokeOnce();
+          // Mirror the child's termination: 128+signal on signal death, else its exit code.
+          const signalCode = signal
+            ? 128 + ((osConstants.signals as Record<string, number>)[signal] ?? 0)
+            : null;
+          finish(signalCode ?? code ?? 0);
+        })();
+      });
+      process.on("SIGINT", onSigint);
+      process.on("SIGTERM", onSigterm);
+    });
+}

--- a/src/cli/node-cli/attach.test.ts
+++ b/src/cli/node-cli/attach.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+// These mocks are referenced by hoisted vi.mock factories, so they must be hoisted too.
+const { mockClient, forwarderClose, prepareNodeAttachMock } = vi.hoisted(() => {
+  const forwarderCloseFn = vi.fn(async () => {});
+  return {
+    mockClient: { request: vi.fn(async () => ({})), close: vi.fn() },
+    forwarderClose: forwarderCloseFn,
+    prepareNodeAttachMock: vi.fn(async () => ({
+      sessionKey: "agent:main:node",
+      cliSessionId: "sid",
+      forwarder: { close: forwarderCloseFn },
+      mcpConfig: { mcpServers: { openclaw: {} } },
+      env: { OPENCLAW_MCP_TOKEN: "node-token" },
+      launchArgs: ["--resume", "sid"],
+      transcriptPath: "/tmp/sid.jsonl",
+    })),
+  };
+});
+
+vi.mock("../../node-host/config.js", () => ({ loadNodeHostConfig: vi.fn() }));
+vi.mock("../../node-host/runner.js", () => ({
+  resolveNodeHostGatewayCredentials: vi.fn(async () => ({ token: "node-token" })),
+}));
+vi.mock("../../infra/device-identity.js", () => ({
+  loadOrCreateDeviceIdentity: vi.fn(() => ({})),
+}));
+vi.mock("../../config/config.js", () => ({ getRuntimeConfig: () => ({}) }));
+vi.mock("../../gateway/client.js", () => ({
+  // Regular function (not an arrow) so `new GatewayClient(...)` is constructable; returns the mock.
+  GatewayClient: vi.fn(function GatewayClientMock() {
+    return mockClient;
+  }),
+}));
+vi.mock("../../gateway/client-start-readiness.js", () => ({
+  startGatewayClientWhenEventLoopReady: vi.fn(async () => ({ ready: true })),
+}));
+vi.mock("../../node-host/attach.js", () => ({ prepareNodeAttach: prepareNodeAttachMock }));
+
+import { loadNodeHostConfig } from "../../node-host/config.js";
+import { runNodeAttach } from "./attach.js";
+
+describe("runNodeAttach (node conduit launcher)", () => {
+  it("throws when there is no node-host config (not run on a paired node)", async () => {
+    vi.mocked(loadNodeHostConfig).mockResolvedValueOnce(null as never);
+    await expect(runNodeAttach({ cwd: "/work", nowMs: 0 })).rejects.toThrow(/node-host config/);
+    expect(prepareNodeAttachMock).not.toHaveBeenCalled();
+  });
+
+  it("connects, runs prepareNodeAttach, returns the plan, and close() tears down forwarder + link", async () => {
+    vi.mocked(loadNodeHostConfig).mockResolvedValueOnce({ nodeId: "node-1", gateway: {} } as never);
+    const plan = await runNodeAttach({ cwd: "/work", nowMs: 1_000 });
+    expect(plan.sessionKey).toBe("agent:main:node");
+    expect(plan.launchArgs).toEqual(["--resume", "sid"]);
+    expect(plan.env.OPENCLAW_MCP_TOKEN).toBe("node-token");
+    expect(prepareNodeAttachMock).toHaveBeenCalledWith(
+      expect.objectContaining({ client: mockClient, cwd: "/work", nowMs: 1_000 }),
+    );
+    await plan.close();
+    expect(forwarderClose).toHaveBeenCalledTimes(1);
+    expect(mockClient.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/node-cli/attach.test.ts
+++ b/src/cli/node-cli/attach.test.ts
@@ -89,11 +89,19 @@ describe("runNodeAttach (node conduit launcher)", () => {
   it("uses wss + the configured host/port when the node-host gateway uses TLS", async () => {
     vi.mocked(loadNodeHostConfig).mockResolvedValueOnce({
       nodeId: "n",
-      gateway: { tls: true, host: "gw.example", port: 8443 },
+      gateway: {
+        tls: true,
+        host: "gw.example",
+        port: 8443,
+        tlsFingerprint: "sha256:test-fingerprint",
+      },
     } as never);
     await runNodeAttach({ cwd: "/work", nowMs: 0 });
     expect(vi.mocked(GatewayClient)).toHaveBeenCalledWith(
-      expect.objectContaining({ url: "wss://gw.example:8443" }),
+      expect.objectContaining({
+        url: "wss://gw.example:8443",
+        tlsFingerprint: "sha256:test-fingerprint",
+      }),
     );
   });
 

--- a/src/cli/node-cli/attach.test.ts
+++ b/src/cli/node-cli/attach.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // These mocks are referenced by hoisted vi.mock factories, so they must be hoisted too.
 const { mockClient, forwarderClose, prepareNodeAttachMock } = vi.hoisted(() => {
@@ -41,6 +41,13 @@ import { loadNodeHostConfig } from "../../node-host/config.js";
 import { runNodeAttach } from "./attach.js";
 
 describe("runNodeAttach (node conduit launcher)", () => {
+  beforeEach(() => {
+    mockClient.request.mockClear().mockResolvedValue({});
+    mockClient.close.mockClear();
+    forwarderClose.mockClear();
+    prepareNodeAttachMock.mockClear();
+  });
+
   it("throws when there is no node-host config (not run on a paired node)", async () => {
     vi.mocked(loadNodeHostConfig).mockResolvedValueOnce(null as never);
     await expect(runNodeAttach({ cwd: "/work", nowMs: 0 })).rejects.toThrow(/node-host config/);
@@ -57,7 +64,20 @@ describe("runNodeAttach (node conduit launcher)", () => {
       expect.objectContaining({ client: mockClient, cwd: "/work", nowMs: 1_000 }),
     );
     await plan.close();
+    // close() revokes the node-minted grant (symmetry with the gateway-host path), then tears down
+    expect(mockClient.request).toHaveBeenCalledWith("node.attachRevoke", {
+      grantToken: "node-token",
+    });
     expect(forwarderClose).toHaveBeenCalledTimes(1);
     expect(mockClient.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails fast and surfaces the real error on a non-transient connectivity failure", async () => {
+    vi.mocked(loadNodeHostConfig).mockResolvedValueOnce({ nodeId: "node-1", gateway: {} } as never);
+    mockClient.request.mockRejectedValueOnce(new Error("missing scope: node")); // not "not connected"
+    await expect(runNodeAttach({ cwd: "/work", nowMs: 0 })).rejects.toThrow(/missing scope: node/);
+    // did not spin the full retry loop, and never reached the orchestration
+    expect(mockClient.request).toHaveBeenCalledTimes(1);
+    expect(prepareNodeAttachMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/node-cli/attach.test.ts
+++ b/src/cli/node-cli/attach.test.ts
@@ -66,7 +66,8 @@ describe("runNodeAttach (node conduit launcher)", () => {
       expect.objectContaining({ client: mockClient, cwd: "/work", nowMs: 1_000 }),
     );
     // connects as the paired node over its own link: url from the node-host config (ws + default
-    // host/port), the node's token as auth, role node, identity from the config — not re-declared.
+    // host/port), the node's token as auth, role node, and live attach permission declared so
+    // reconciliation can make the stored approval effective for this connection.
     expect(vi.mocked(GatewayClient)).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "ws://127.0.0.1:18789",
@@ -75,6 +76,7 @@ describe("runNodeAttach (node conduit launcher)", () => {
         instanceId: "node-1",
         clientDisplayName: "node-1",
         scopes: [],
+        permissions: { attach: true },
       }),
     );
     await plan.close();

--- a/src/cli/node-cli/attach.test.ts
+++ b/src/cli/node-cli/attach.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../gateway/client-start-readiness.js", () => ({
 }));
 vi.mock("../../node-host/attach.js", () => ({ prepareNodeAttach: prepareNodeAttachMock }));
 
+import { GatewayClient } from "../../gateway/client.js";
 import { loadNodeHostConfig } from "../../node-host/config.js";
 import { runNodeAttach } from "./attach.js";
 
@@ -46,6 +47,7 @@ describe("runNodeAttach (node conduit launcher)", () => {
     mockClient.close.mockClear();
     forwarderClose.mockClear();
     prepareNodeAttachMock.mockClear();
+    vi.mocked(GatewayClient).mockClear();
   });
 
   it("throws when there is no node-host config (not run on a paired node)", async () => {
@@ -63,6 +65,18 @@ describe("runNodeAttach (node conduit launcher)", () => {
     expect(prepareNodeAttachMock).toHaveBeenCalledWith(
       expect.objectContaining({ client: mockClient, cwd: "/work", nowMs: 1_000 }),
     );
+    // connects as the paired node over its own link: url from the node-host config (ws + default
+    // host/port), the node's token as auth, role node, identity from the config — not re-declared.
+    expect(vi.mocked(GatewayClient)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+        token: "node-token",
+        role: "node",
+        instanceId: "node-1",
+        clientDisplayName: "node-1",
+        scopes: [],
+      }),
+    );
     await plan.close();
     // close() revokes the node-minted grant (symmetry with the gateway-host path), then tears down
     expect(mockClient.request).toHaveBeenCalledWith("node.attachRevoke", {
@@ -70,6 +84,17 @@ describe("runNodeAttach (node conduit launcher)", () => {
     });
     expect(forwarderClose).toHaveBeenCalledTimes(1);
     expect(mockClient.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses wss + the configured host/port when the node-host gateway uses TLS", async () => {
+    vi.mocked(loadNodeHostConfig).mockResolvedValueOnce({
+      nodeId: "n",
+      gateway: { tls: true, host: "gw.example", port: 8443 },
+    } as never);
+    await runNodeAttach({ cwd: "/work", nowMs: 0 });
+    expect(vi.mocked(GatewayClient)).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "wss://gw.example:8443" }),
+    );
   });
 
   it("fails fast and surfaces the real error on a non-transient connectivity failure", async () => {

--- a/src/cli/node-cli/attach.ts
+++ b/src/cli/node-cli/attach.ts
@@ -77,6 +77,7 @@ export async function runNodeAttach(params: {
     role: "node",
     scopes: [],
     deviceIdentity: loadOrCreateDeviceIdentity(),
+    tlsFingerprint: gw.tlsFingerprint,
     onEvent: () => {},
     onConnectError: () => {},
     onClose: () => {},

--- a/src/cli/node-cli/attach.ts
+++ b/src/cli/node-cli/attach.ts
@@ -65,7 +65,8 @@ export async function runNodeAttach(params: {
   const url = `${gw.tls ? "wss" : "ws"}://${gw.host ?? "127.0.0.1"}:${gw.port ?? 18789}`;
 
   // Connect as the paired node. caps/commands are intentionally omitted so the approved surface is
-  // preserved (they are optional + the token is the auth — we are not re-requesting pairing).
+  // preserved, but the attach permission must be declared on this live connection so gateway
+  // reconciliation can intersect it with the stored owner approval.
   const client = new GatewayClient({
     url,
     token: token || undefined,
@@ -76,6 +77,7 @@ export async function runNodeAttach(params: {
     mode: GATEWAY_CLIENT_MODES.NODE,
     role: "node",
     scopes: [],
+    permissions: { attach: true },
     deviceIdentity: loadOrCreateDeviceIdentity(),
     tlsFingerprint: gw.tlsFingerprint,
     onEvent: () => {},

--- a/src/cli/node-cli/attach.ts
+++ b/src/cli/node-cli/attach.ts
@@ -1,0 +1,123 @@
+// `openclaw attach` on a NODE machine: reach the gateway over the node's own (already-approved) link
+// and run the node-side attach conduit, rather than the gateway-host loopback path
+// (src/cli/attach-cli.ts). Connects as the paired node — token is the auth, so the gateway's
+// node.attachGrant entitlement gate (owner-approved `attach` permission) is what authorizes the
+// grant — runs prepareNodeAttach (grant + hydrate + loopback forwarder), and returns a launch plan
+// the attach command spawns Claude Code against. node-host imports live here in node-cli (the cli
+// layer permitted to depend on node-host), not in the plain attach command.
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../../packages/gateway-protocol/src/client-info.js";
+import { getRuntimeConfig } from "../../config/config.js";
+import { startGatewayClientWhenEventLoopReady } from "../../gateway/client-start-readiness.js";
+import { GatewayClient } from "../../gateway/client.js";
+import { loadOrCreateDeviceIdentity } from "../../infra/device-identity.js";
+import { prepareNodeAttach } from "../../node-host/attach.js";
+import { loadNodeHostConfig } from "../../node-host/config.js";
+import { resolveNodeHostGatewayCredentials } from "../../node-host/runner.js";
+
+/** A node-conduit launch plan: what `openclaw attach` needs to spawn Claude Code + tear down after. */
+export type NodeAttachPlan = {
+  sessionKey: string;
+  mcpConfig: { mcpServers: Record<string, unknown> };
+  env: Record<string, string>;
+  /** `--resume <id>` (hydrated) or `--session-id <id>` (fresh) — appended to the claude argv. */
+  launchArgs: string[];
+  /** Tears down the forwarder + the node gateway connection. Idempotent-safe to await once. */
+  close: () => Promise<void>;
+};
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+async function closeGatewayClient(client: unknown): Promise<void> {
+  const c = client as { close?: () => unknown; disconnect?: () => unknown };
+  try {
+    await (c.close?.() ?? c.disconnect?.());
+  } catch {
+    // best-effort teardown
+  }
+}
+
+/**
+ * Bring up the node-conduit attach for this machine's paired node. The caller (the attach command)
+ * owns spawning Claude Code with the returned plan and awaiting `close()` on exit.
+ */
+export async function runNodeAttach(params: {
+  cwd: string;
+  nowMs: number;
+}): Promise<NodeAttachPlan> {
+  const nodeConfig = await loadNodeHostConfig();
+  if (!nodeConfig) {
+    throw new Error(
+      "no node-host config found — run on a paired node (or use --via gateway on the gateway host)",
+    );
+  }
+  const cfg = getRuntimeConfig();
+  const { token, password } = await resolveNodeHostGatewayCredentials({
+    config: cfg,
+    env: process.env,
+  });
+  const gw = nodeConfig.gateway ?? {};
+  const url = `${gw.tls ? "wss" : "ws"}://${gw.host ?? "127.0.0.1"}:${gw.port ?? 18789}`;
+
+  // Connect as the paired node. caps/commands are intentionally omitted so the approved surface is
+  // preserved (they are optional + the token is the auth — we are not re-requesting pairing).
+  const client = new GatewayClient({
+    url,
+    token: token || undefined,
+    password: password || undefined,
+    instanceId: nodeConfig.nodeId,
+    clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
+    clientDisplayName: nodeConfig.displayName ?? nodeConfig.nodeId,
+    mode: GATEWAY_CLIENT_MODES.NODE,
+    role: "node",
+    scopes: [],
+    deviceIdentity: loadOrCreateDeviceIdentity(),
+    onEvent: () => {},
+    onConnectError: () => {},
+    onClose: () => {},
+  });
+
+  const readiness = await startGatewayClientWhenEventLoopReady(client, {});
+  if (!readiness.ready) {
+    await closeGatewayClient(client);
+    throw new Error("openclaw attach (node): gateway client event loop did not become ready");
+  }
+  // Event-loop readiness is not the WS connection; wait until a node request actually lands.
+  let connected = false;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await client.request("skills.bins", {});
+      connected = true;
+      break;
+    } catch {
+      await sleep(200);
+    }
+  }
+  if (!connected) {
+    await closeGatewayClient(client);
+    throw new Error(
+      "openclaw attach (node): could not reach the gateway over the node link — is the node paired and the gateway up?",
+    );
+  }
+
+  const launch = await prepareNodeAttach({ client, cwd: params.cwd, nowMs: params.nowMs });
+  return {
+    sessionKey: launch.sessionKey,
+    mcpConfig: launch.mcpConfig,
+    env: launch.env,
+    launchArgs: launch.launchArgs,
+    close: async () => {
+      try {
+        await launch.forwarder.close();
+      } catch {
+        // best-effort
+      }
+      await closeGatewayClient(client);
+    },
+  };
+}

--- a/src/cli/node-cli/attach.ts
+++ b/src/cli/node-cli/attach.ts
@@ -87,21 +87,30 @@ export async function runNodeAttach(params: {
     await closeGatewayClient(client);
     throw new Error("openclaw attach (node): gateway client event loop did not become ready");
   }
-  // Event-loop readiness is not the WS connection; wait until a node request actually lands.
+  // Event-loop readiness is not the WS connection; wait until a node request actually lands. Only the
+  // transient "not connected (yet)" is worth retrying — auth/scope/pairing failures won't self-heal,
+  // so break fast on them and surface the real cause instead of a generic ~10s timeout.
   let connected = false;
+  let lastError: unknown;
   for (let attempt = 0; attempt < 50; attempt += 1) {
     try {
       await client.request("skills.bins", {});
       connected = true;
       break;
-    } catch {
+    } catch (error) {
+      lastError = error;
+      const message = error instanceof Error ? error.message : String(error);
+      if (!/not connected/i.test(message)) {
+        break; // non-transient (bad/expired token, not paired, missing scope) — don't spin
+      }
       await sleep(200);
     }
   }
   if (!connected) {
     await closeGatewayClient(client);
+    const detail = lastError instanceof Error ? lastError.message : "unknown";
     throw new Error(
-      "openclaw attach (node): could not reach the gateway over the node link — is the node paired and the gateway up?",
+      `openclaw attach (node): could not reach the gateway over the node link — ${detail}`,
     );
   }
 
@@ -112,6 +121,14 @@ export async function runNodeAttach(params: {
     env: launch.env,
     launchArgs: launch.launchArgs,
     close: async () => {
+      // Revoke the grant first (node-path symmetry to the gateway-host attach.revoke — a node can't
+      // call that operator.admin method) while the link is still up; then tear down forwarder + link.
+      // All best-effort: the grant's TTL still bounds it if revoke can't be delivered.
+      try {
+        await client.request("node.attachRevoke", { grantToken: launch.env.OPENCLAW_MCP_TOKEN });
+      } catch {
+        // best-effort
+      }
       try {
         await launch.forwarder.close();
       } catch {

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -161,6 +161,11 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       exportName: "registerSandboxCli",
     },
     {
+      commandNames: ["attach"],
+      loadModule: () => import("../attach-cli.js"),
+      exportName: "registerAttachCli",
+    },
+    {
       commandNames: ["tui", "terminal", "chat"],
       loadModule: () => import("../tui-cli.js"),
       exportName: "registerTuiCli",

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -72,6 +72,11 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: true,
   },
   {
+    name: "attach",
+    description: "Attach Claude Code to a gateway session with scoped MCP tools",
+    hasSubcommands: false,
+  },
+  {
     name: "tui",
     description: "Open a terminal UI connected to the Gateway",
     hasSubcommands: false,

--- a/src/gateway/attach-relay.test.ts
+++ b/src/gateway/attach-relay.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./tool-resolution.js", () => ({
+  resolveGatewayScopedTools: vi.fn(() => ({ agentId: "agent-x", tools: [{ name: "t1" }] })),
+}));
+vi.mock("./mcp-http.handlers.js", () => ({
+  handleMcpJsonRpc: vi.fn(async () => ({ jsonrpc: "2.0", id: 1, result: { ok: true } })),
+}));
+vi.mock("./mcp-http.schema.js", () => ({
+  buildMcpToolSchema: vi.fn((tools: Array<{ name: string }>) =>
+    tools.map((t) => ({ name: t.name })),
+  ),
+}));
+
+import { dispatchAttachMcpMessage } from "./attach-relay.js";
+import { mintAttachGrant, resetAttachGrantsForTest } from "./mcp-grant-store.js";
+import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
+import { resolveGatewayScopedTools } from "./tool-resolution.js";
+
+const cfg = {} as never;
+const msg = { jsonrpc: "2.0" as const, id: 1, method: "tools/list", params: {} };
+
+describe("dispatchAttachMcpMessage (conduit relay core)", () => {
+  afterEach(() => resetAttachGrantsForTest());
+
+  it("rejects an unknown/expired grant with an auth error and dispatches nothing", async () => {
+    const res = await dispatchAttachMcpMessage({ grantToken: "nope", message: msg, cfg });
+    expect((res as { error?: { code: number } }).error?.code).toBe(-32001);
+    expect(resolveGatewayScopedTools).not.toHaveBeenCalled();
+    expect(handleMcpJsonRpc).not.toHaveBeenCalled();
+  });
+
+  it("resolves scope from the GRANT (non-owner, loopback) and dispatches via the shared handler", async () => {
+    const grant = mintAttachGrant({ sessionKey: "agent:main:relay" });
+    const res = await dispatchAttachMcpMessage({ grantToken: grant.token, message: msg, cfg });
+    // scope is sourced from the grant's sessionKey, never the caller — a relay can't widen it
+    expect(resolveGatewayScopedTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:relay",
+        senderIsOwner: false,
+        surface: "loopback",
+      }),
+    );
+    // the MCP message goes to the SAME handler the HTTP path uses, with the scoped tools + agentId
+    expect(handleMcpJsonRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: msg,
+        tools: [{ name: "t1" }],
+        hookContext: expect.objectContaining({
+          agentId: "agent-x",
+          sessionKey: "agent:main:relay",
+        }),
+      }),
+    );
+    expect((res as { result?: unknown }).result).toEqual({ ok: true });
+  });
+});

--- a/src/gateway/attach-relay.test.ts
+++ b/src/gateway/attach-relay.test.ts
@@ -39,8 +39,16 @@ describe("dispatchAttachMcpMessage (conduit relay core)", () => {
         sessionKey: "agent:main:relay",
         senderIsOwner: false,
         surface: "loopback",
+        // routed via resolveMcpLoopbackScopedTools, so the native-tool exclusion is applied —
+        // a relayed grant cannot reach destructive tools the gateway-host loopback attach withholds
+        excludeToolNames: expect.any(Set),
       }),
     );
+    const excluded = vi.mocked(resolveGatewayScopedTools).mock.calls[0][0]
+      .excludeToolNames as Set<string>;
+    for (const native of ["read", "write", "edit", "apply_patch", "exec", "process"]) {
+      expect(excluded.has(native)).toBe(true);
+    }
     // the MCP message goes to the SAME handler the HTTP path uses, with the scoped tools + agentId
     expect(handleMcpJsonRpc).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/gateway/attach-relay.ts
+++ b/src/gateway/attach-relay.ts
@@ -7,8 +7,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAttachGrant } from "./mcp-grant-store.js";
 import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
 import { jsonRpcError, type JsonRpcRequest } from "./mcp-http.protocol.js";
+import { resolveMcpLoopbackScopedTools } from "./mcp-http.runtime.js";
 import { buildMcpToolSchema } from "./mcp-http.schema.js";
-import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
 export async function dispatchAttachMcpMessage(params: {
   grantToken: string;
@@ -21,13 +21,23 @@ export async function dispatchAttachMcpMessage(params: {
     // Unknown/expired grant is an auth error, not a crash — mirrors the HTTP path's posture.
     return jsonRpcError(params.message.id, -32001, "unknown or expired attach grant");
   }
-  // Identical scope resolution to the loopback HTTP path: surface "loopback", non-owner, scoped to
-  // the grant's sessionKey + the destructive-tool exclusion — a relayed grant gets the same tool set.
-  const scoped = resolveGatewayScopedTools({
+  // Resolve via the SAME helper as the gateway-host loopback HTTP path (`resolveMcpLoopbackScopedTools`)
+  // so the two attach surfaces can't diverge: it applies surface "loopback" AND the native-tool
+  // exclusion (read/write/edit/apply_patch/exec/process). Calling resolveGatewayScopedTools directly
+  // would drop that exclusion and let a relayed (less-trusted) grant reach destructive tools the
+  // loopback surface withholds. Scope is bound to the grant's sessionKey, non-owner; no message context.
+  const scoped = resolveMcpLoopbackScopedTools({
     cfg: params.cfg,
     sessionKey: grant.sessionKey,
     senderIsOwner: false,
-    surface: "loopback",
+    messageProvider: undefined,
+    currentChannelId: undefined,
+    currentThreadTs: undefined,
+    currentMessageId: undefined,
+    currentInboundAudio: undefined,
+    accountId: undefined,
+    inboundEventKind: undefined,
+    sourceReplyDeliveryMode: undefined,
   });
   return handleMcpJsonRpc({
     message: params.message,

--- a/src/gateway/attach-relay.ts
+++ b/src/gateway/attach-relay.ts
@@ -1,0 +1,39 @@
+// Dispatch one MCP JSON-RPC message from an attach grant holder to the gateway's scoped loopback
+// tools, OFF the HTTP transport. Conduits (PR5 nodes / PR6 apps) relay the harness's MCP frames over
+// a node/app's EXISTING gateway link and call this, so the harness reaches the SAME scoped tool
+// surface as the gateway-host loopback case with NO new gateway endpoint. Scope is bound to the
+// grant's `sessionKey` (never caller-supplied), so a relay can never widen what a grant can touch.
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveAttachGrant } from "./mcp-grant-store.js";
+import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
+import { jsonRpcError, type JsonRpcRequest } from "./mcp-http.protocol.js";
+import { buildMcpToolSchema } from "./mcp-http.schema.js";
+import { resolveGatewayScopedTools } from "./tool-resolution.js";
+
+export async function dispatchAttachMcpMessage(params: {
+  grantToken: string;
+  message: JsonRpcRequest;
+  cfg: OpenClawConfig;
+  signal?: AbortSignal;
+}): Promise<object | null> {
+  const grant = resolveAttachGrant(params.grantToken);
+  if (!grant) {
+    // Unknown/expired grant is an auth error, not a crash — mirrors the HTTP path's posture.
+    return jsonRpcError(params.message.id, -32001, "unknown or expired attach grant");
+  }
+  // Identical scope resolution to the loopback HTTP path: surface "loopback", non-owner, scoped to
+  // the grant's sessionKey + the destructive-tool exclusion — a relayed grant gets the same tool set.
+  const scoped = resolveGatewayScopedTools({
+    cfg: params.cfg,
+    sessionKey: grant.sessionKey,
+    senderIsOwner: false,
+    surface: "loopback",
+  });
+  return handleMcpJsonRpc({
+    message: params.message,
+    tools: scoped.tools,
+    toolSchema: buildMcpToolSchema(scoped.tools),
+    hookContext: { agentId: scoped.agentId, config: params.cfg, sessionKey: grant.sessionKey },
+    signal: params.signal,
+  });
+}

--- a/src/gateway/cli-session-hydrate.claude.test.ts
+++ b/src/gateway/cli-session-hydrate.claude.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readClaudeCliSessionMessages } from "./cli-session-history.claude.js";
+import {
+  buildClaudeCliTranscript,
+  hydrateClaudeCliTranscript,
+} from "./cli-session-hydrate.claude.js";
+
+describe("PR7 hydration — buildClaudeCliTranscript", () => {
+  it("emits user+assistant turns with a parentUuid chain and Claude's per-turn fields", () => {
+    const jsonl = buildClaudeCliTranscript({
+      messages: [
+        { role: "user", content: "remember BANANA-42" },
+        { role: "assistant", content: "ok, BANANA-42" },
+      ],
+      sessionId: "sid-1",
+      cwd: "/work/proj",
+      nowMs: 1_000_000,
+    });
+    const entries = jsonl
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      type: "user",
+      parentUuid: null,
+      message: { role: "user", content: "remember BANANA-42" },
+      permissionMode: "bypassPermissions",
+      cwd: "/work/proj",
+      sessionId: "sid-1",
+    });
+    // assistant links to the user's uuid (the chain Claude follows) + content is a text block array
+    expect(entries[1]).toMatchObject({
+      type: "assistant",
+      parentUuid: entries[0].uuid,
+      message: { role: "assistant", content: [{ type: "text", text: "ok, BANANA-42" }] },
+    });
+  });
+
+  it("skips non-text / empty turns and returns '' when there is nothing to hydrate", () => {
+    expect(
+      buildClaudeCliTranscript({
+        messages: [
+          { role: "system", content: "x" },
+          { role: "user", content: "" },
+        ],
+        sessionId: "s",
+        cwd: "/c",
+        nowMs: 0,
+      }),
+    ).toBe("");
+  });
+});
+
+describe("PR7 hydration — round-trips through PR4's own reader", () => {
+  let home = "";
+  afterEach(() => {
+    if (home) {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("a hydrated transcript is parsed back by readClaudeCliSessionMessages", () => {
+    home = mkdtempSync(join(tmpdir(), "hydr-"));
+    const path = hydrateClaudeCliTranscript({
+      messages: [
+        { role: "user", content: "hello from the gateway session" },
+        { role: "assistant", content: "hi there, picked up where we left off" },
+      ],
+      sessionId: "round-trip-sid",
+      cwd: "/work/proj",
+      nowMs: 1_000_000,
+      homeDir: home,
+    });
+    expect(path).toBeTruthy();
+    // the same reader PR4 uses to import claude transcripts parses what we hydrated — consistent both ways
+    const messages = readClaudeCliSessionMessages({
+      cliSessionId: "round-trip-sid",
+      homeDir: home,
+    });
+    const dump = JSON.stringify(messages);
+    expect(dump).toContain("hello from the gateway session");
+    expect(dump).toContain("hi there, picked up where we left off");
+  });
+});

--- a/src/gateway/cli-session-hydrate.claude.test.ts
+++ b/src/gateway/cli-session-hydrate.claude.test.ts
@@ -9,35 +9,128 @@ import {
 } from "./cli-session-hydrate.claude.js";
 
 describe("PR7 hydration — buildClaudeCliTranscript", () => {
-  it("emits user+assistant turns with a parentUuid chain and Claude's per-turn fields", () => {
-    const jsonl = buildClaudeCliTranscript({
-      messages: [
-        { role: "user", content: "remember BANANA-42" },
-        { role: "assistant", content: "ok, BANANA-42" },
-      ],
-      sessionId: "sid-1",
-      cwd: "/work/proj",
-      nowMs: 1_000_000,
-    });
-    const entries = jsonl
+  const parse = (jsonl: string) =>
+    jsonl
       .trim()
       .split("\n")
+      .filter(Boolean)
       .map((line) => JSON.parse(line));
-    expect(entries).toHaveLength(2);
-    expect(entries[0]).toMatchObject({
+
+  it("emits a user turn with Claude's exact per-turn fields", () => {
+    const [u] = parse(
+      buildClaudeCliTranscript({
+        messages: [{ role: "user", content: "remember BANANA-42" }],
+        sessionId: "sid-1",
+        cwd: "/work/proj",
+        nowMs: 1_000_000,
+      }),
+    );
+    expect(u).toMatchObject({
       type: "user",
       parentUuid: null,
       message: { role: "user", content: "remember BANANA-42" },
       permissionMode: "bypassPermissions",
+      promptSource: "sdk",
+      isSidechain: false,
+      userType: "external",
+      entrypoint: "sdk-cli",
       cwd: "/work/proj",
       sessionId: "sid-1",
+      version: "2.1.191",
+      gitBranch: "",
     });
-    // assistant links to the user's uuid (the chain Claude follows) + content is a text block array
-    expect(entries[1]).toMatchObject({
+    expect(typeof u.uuid).toBe("string");
+    expect(typeof u.promptId).toBe("string");
+    expect(u.promptId).not.toBe(u.uuid); // a distinct promptId, not a reused uuid
+    expect(u.timestamp).toBe(new Date(1_000_000).toISOString());
+  });
+
+  it("emits an assistant turn as a text-block array with model + requestId, omitting user-only fields", () => {
+    const [a] = parse(
+      buildClaudeCliTranscript({
+        messages: [{ role: "assistant", content: "ok, BANANA-42" }],
+        sessionId: "sid-1",
+        cwd: "/c",
+        nowMs: 0,
+      }),
+    );
+    expect(a).toMatchObject({
       type: "assistant",
-      parentUuid: entries[0].uuid,
-      message: { role: "assistant", content: [{ type: "text", text: "ok, BANANA-42" }] },
+      message: {
+        role: "assistant",
+        model: "claude-opus-4-8",
+        content: [{ type: "text", text: "ok, BANANA-42" }],
+      },
+      userType: "external",
+      entrypoint: "sdk-cli",
+      version: "2.1.191",
     });
+    expect(a.requestId).toMatch(/^req_hydrated_[0-9a-f-]{12}$/); // uuid.slice(0,12) keeps the hyphen
+    expect(a).not.toHaveProperty("permissionMode");
+    expect(a).not.toHaveProperty("promptId");
+  });
+
+  it("links turns through the parentUuid chain in message order", () => {
+    const entries = parse(
+      buildClaudeCliTranscript({
+        messages: [
+          { role: "user", content: "one" },
+          { role: "assistant", content: "two" },
+          { role: "user", content: "three" },
+        ],
+        sessionId: "s",
+        cwd: "/c",
+        nowMs: 0,
+      }),
+    );
+    expect(entries.map((e) => e.message.content?.[0]?.text ?? e.message.content)).toEqual([
+      "one",
+      "two",
+      "three",
+    ]);
+    expect(entries[0].parentUuid).toBeNull();
+    expect(entries[1].parentUuid).toBe(entries[0].uuid);
+    expect(entries[2].parentUuid).toBe(entries[1].uuid);
+  });
+
+  it("flattens array content to one text block, dropping non-text and non-string-text blocks", () => {
+    const [a] = parse(
+      buildClaudeCliTranscript({
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "A" },
+              "B",
+              { type: "image" },
+              { text: 5 },
+              { type: "text", text: "C" },
+            ],
+          },
+        ],
+        sessionId: "s",
+        cwd: "/c",
+        nowMs: 0,
+      }),
+    );
+    // text-block "A", string-block "B", text-block "C" kept; {type:image} and {text:5} (non-string) dropped
+    expect(a.message.content).toEqual([{ type: "text", text: "A\nB\nC" }]);
+  });
+
+  it("preserves a string timestamp, converts a numeric one, and falls back to nowMs", () => {
+    const ts = (
+      msg: { role: string; content: unknown; timestamp?: number | string },
+      nowMs: number,
+    ) =>
+      parse(buildClaudeCliTranscript({ messages: [msg], sessionId: "s", cwd: "/c", nowMs }))[0]
+        .timestamp;
+    expect(ts({ role: "user", content: "x", timestamp: "2020-06-01T00:00:00.000Z" }, 999)).toBe(
+      "2020-06-01T00:00:00.000Z",
+    );
+    expect(ts({ role: "user", content: "x", timestamp: 1_600_000_000_000 }, 999)).toBe(
+      new Date(1_600_000_000_000).toISOString(),
+    );
+    expect(ts({ role: "user", content: "x" }, 1_234_567)).toBe(new Date(1_234_567).toISOString());
   });
 
   it("skips non-text / empty turns and returns '' when there is nothing to hydrate", () => {
@@ -46,6 +139,7 @@ describe("PR7 hydration — buildClaudeCliTranscript", () => {
         messages: [
           { role: "system", content: "x" },
           { role: "user", content: "" },
+          { role: "assistant", content: [{ type: "image" }] },
         ],
         sessionId: "s",
         cwd: "/c",

--- a/src/gateway/cli-session-hydrate.claude.test.ts
+++ b/src/gateway/cli-session-hydrate.claude.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { resolveClaudeCliProjectDirForWorkspace } from "../agents/command/claude-cli-project-dir.js";
 import { readClaudeCliSessionMessages } from "./cli-session-history.claude.js";
 import {
   buildClaudeCliTranscript,
@@ -178,5 +179,24 @@ describe("PR7 hydration — round-trips through PR4's own reader", () => {
     const dump = JSON.stringify(messages);
     expect(dump).toContain("hello from the gateway session");
     expect(dump).toContain("hi there, picked up where we left off");
+  });
+
+  it("writes under the CANONICAL Claude project dir so `claude --resume` finds it", () => {
+    home = mkdtempSync(join(tmpdir(), "hydr-"));
+    // `_` and `.` are exactly where a hand-rolled `/.→-` encoding diverges from Claude's resolver,
+    // landing the transcript where --resume can't read it (round-trip can't catch this — it scans).
+    const cwd = "/work/my_proj.v2";
+    const path = hydrateClaudeCliTranscript({
+      messages: [{ role: "user", content: "x" }],
+      sessionId: "canon-sid",
+      cwd,
+      nowMs: 0,
+      homeDir: home,
+    });
+    const expectedDir = resolveClaudeCliProjectDirForWorkspace({
+      workspaceDir: cwd,
+      homeDir: home,
+    });
+    expect(path).toBe(join(expectedDir, "canon-sid.jsonl"));
   });
 });

--- a/src/gateway/cli-session-hydrate.claude.ts
+++ b/src/gateway/cli-session-hydrate.claude.ts
@@ -1,0 +1,142 @@
+// PR7 hydration — the DOWN mirror of PR4's record-up. PR4 imports a local Claude transcript into the
+// gateway's chat.history (up); this materializes the gateway-owned session BACK into a local Claude
+// Code transcript so `claude --resume <sessionId>` continues the SAME conversation on any surface
+// ("pick up anywhere"). The per-turn JSONL shape matches what Claude Code itself writes — verified
+// live: claude --resume reads a transcript built by this and recalls the conversation.
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** A gateway-owned (chat.history) message — the canonical conversation the gateway stores. */
+export type HydrationMessage = {
+  role: string;
+  content: unknown;
+  timestamp?: number | string;
+};
+
+// Claude tolerates a version it didn't write, but stamping a recent one avoids migration prompts.
+const HYDRATED_TRANSCRIPT_VERSION = "2.1.191";
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (typeof block === "string") {
+          return block;
+        }
+        const text = (block as { text?: unknown })?.text;
+        return typeof text === "string" ? text : "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+function toIsoTimestamp(timestamp: number | string | undefined, fallbackMs: number): string {
+  if (typeof timestamp === "string" && timestamp) {
+    return timestamp;
+  }
+  if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+    return new Date(timestamp).toISOString();
+  }
+  return new Date(fallbackMs).toISOString();
+}
+
+/**
+ * Build a Claude Code transcript (JSONL string) from gateway-owned messages. Only user/assistant
+ * turns with text are emitted, linked through the `parentUuid` chain Claude expects; returns "" when
+ * there is nothing to hydrate. Pure (caller supplies `nowMs`) so it stays deterministic + testable.
+ */
+export function buildClaudeCliTranscript(params: {
+  messages: HydrationMessage[];
+  sessionId: string;
+  cwd: string;
+  nowMs: number;
+}): string {
+  const common = {
+    isSidechain: false,
+    userType: "external",
+    entrypoint: "sdk-cli",
+    cwd: params.cwd,
+    sessionId: params.sessionId,
+    version: HYDRATED_TRANSCRIPT_VERSION,
+    gitBranch: "",
+  };
+  let parentUuid: string | null = null;
+  const lines: string[] = [];
+  let index = 0;
+  for (const message of params.messages) {
+    const text = extractText(message.content);
+    if (!text) {
+      continue;
+    }
+    const uuid = randomUUID();
+    const timestamp = toIsoTimestamp(message.timestamp, params.nowMs + index);
+    if (message.role === "user") {
+      lines.push(
+        JSON.stringify({
+          parentUuid,
+          promptId: randomUUID(),
+          type: "user",
+          message: { role: "user", content: text },
+          uuid,
+          timestamp,
+          permissionMode: "bypassPermissions",
+          promptSource: "sdk",
+          ...common,
+        }),
+      );
+    } else if (message.role === "assistant") {
+      lines.push(
+        JSON.stringify({
+          parentUuid,
+          message: {
+            role: "assistant",
+            model: "claude-opus-4-8",
+            content: [{ type: "text", text }],
+          },
+          requestId: `req_hydrated_${uuid.slice(0, 12)}`,
+          type: "assistant",
+          uuid,
+          timestamp,
+          ...common,
+        }),
+      );
+    } else {
+      continue;
+    }
+    parentUuid = uuid;
+    index += 1;
+  }
+  return lines.length ? `${lines.join("\n")}\n` : "";
+}
+
+/**
+ * Write the hydrated transcript to Claude's project dir for `cwd` so `claude --resume <sessionId>`
+ * finds it. Returns the path, or undefined when there is nothing to hydrate. NOTE: the project-dir
+ * encoding (`/` and `.` → `-`) is Claude's POSIX convention; Windows surfaces use a different scheme
+ * (tracked alongside the PR3 Windows caveat).
+ */
+export function hydrateClaudeCliTranscript(params: {
+  messages: HydrationMessage[];
+  sessionId: string;
+  cwd: string;
+  nowMs: number;
+  homeDir?: string;
+}): string | undefined {
+  const content = buildClaudeCliTranscript(params);
+  if (!content) {
+    return undefined;
+  }
+  const projectDir = params.cwd.replace(/[/.]/g, "-");
+  const dir = join(params.homeDir ?? homedir(), ".claude", "projects", projectDir);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${params.sessionId}.jsonl`);
+  writeFileSync(path, content, { encoding: "utf8", mode: 0o600 });
+  return path;
+}

--- a/src/gateway/cli-session-hydrate.claude.ts
+++ b/src/gateway/cli-session-hydrate.claude.ts
@@ -5,8 +5,8 @@
 // live: claude --resume reads a transcript built by this and recalls the conversation.
 import { randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { resolveClaudeCliProjectDirForWorkspace } from "../agents/command/claude-cli-project-dir.js";
 
 /** A gateway-owned (chat.history) message — the canonical conversation the gateway stores. */
 export type HydrationMessage = {
@@ -118,9 +118,10 @@ export function buildClaudeCliTranscript(params: {
 
 /**
  * Write the hydrated transcript to Claude's project dir for `cwd` so `claude --resume <sessionId>`
- * finds it. Returns the path, or undefined when there is nothing to hydrate. NOTE: the project-dir
- * encoding (`/` and `.` → `-`) is Claude's POSIX convention; Windows surfaces use a different scheme
- * (tracked alongside the PR3 Windows caveat).
+ * finds it. Returns the path, or undefined when there is nothing to hydrate. Uses the SAME resolver
+ * Claude Code + the cli-backend use (`resolveClaudeCliProjectDirForWorkspace`: realpath + NFC +
+ * non-alphanumeric→`-` + length cap). A hand-rolled `/.→-` encoding diverges for cwds with `_`,
+ * spaces, symlinked workspaces, or long paths — landing the transcript where `--resume` can't read it.
  */
 export function hydrateClaudeCliTranscript(params: {
   messages: HydrationMessage[];
@@ -133,8 +134,10 @@ export function hydrateClaudeCliTranscript(params: {
   if (!content) {
     return undefined;
   }
-  const projectDir = params.cwd.replace(/[/.]/g, "-");
-  const dir = join(params.homeDir ?? homedir(), ".claude", "projects", projectDir);
+  const dir = resolveClaudeCliProjectDirForWorkspace({
+    workspaceDir: params.cwd,
+    homeDir: params.homeDir,
+  });
   mkdirSync(dir, { recursive: true });
   const path = join(dir, `${params.sessionId}.jsonl`);
   writeFileSync(path, content, { encoding: "utf8", mode: 0o600 });

--- a/src/gateway/client-callsites.guard.test.ts
+++ b/src/gateway/client-callsites.guard.test.ts
@@ -11,6 +11,8 @@ const GATEWAY_CLIENT_CONSTRUCTOR_PATTERN = /new\s+GatewayClient\s*\(/;
 const ALLOWED_GATEWAY_CLIENT_CALLSITES = new Set([
   "extensions/google-meet/src/voice-call-gateway.ts",
   "src/acp/server.ts",
+  // `openclaw attach --via node` connects as the paired node to run the conduit (PR4 #96997).
+  "src/cli/node-cli/attach.ts",
   "src/gateway/call.ts",
   "src/gateway/gateway-cli-backend.live-helpers.ts",
   "src/gateway/operator-approvals-client.ts",

--- a/src/gateway/mcp-grant-store.test.ts
+++ b/src/gateway/mcp-grant-store.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  resetAttachGrantsForTest,
+  attachGrantStoreSize,
+  mintAttachGrant,
+  resolveAttachGrant,
+  revokeAttachGrant,
+  revokeAttachGrantsForSession,
+  sweepExpiredAttachGrants,
+} from "./mcp-grant-store.js";
+
+const T0 = 1_000_000_000_000; // fixed epoch for deterministic TTL tests
+
+describe("mcp-grant-store", () => {
+  beforeEach(() => resetAttachGrantsForTest());
+
+  it("mints a grant bound to the sessionKey with a token and a TTL window", () => {
+    const g = mintAttachGrant({ sessionKey: "agent:main:main", ttlMs: 60_000, nowMs: T0 });
+    expect(g.sessionKey).toBe("agent:main:main");
+    expect(g.token).toMatch(/^[0-9a-f]{64}$/);
+    expect(g.issuedAtMs).toBe(T0);
+    expect(g.expiresAtMs).toBe(T0 + 60_000);
+  });
+
+  it("requires a non-empty sessionKey", () => {
+    expect(() => mintAttachGrant({ sessionKey: "  ", nowMs: T0 })).toThrow();
+  });
+
+  it("resolves a live grant and drops it once expired (TTL)", () => {
+    const g = mintAttachGrant({ sessionKey: "agent:main:x", ttlMs: 1_000, nowMs: T0 });
+    expect(resolveAttachGrant(g.token, T0)?.sessionKey).toBe("agent:main:x");
+    expect(resolveAttachGrant(g.token, T0 + 999)?.sessionKey).toBe("agent:main:x");
+    // at/after expiry → undefined, and the lookup self-sweeps it
+    expect(resolveAttachGrant(g.token, T0 + 1_000)).toBeUndefined();
+    expect(resolveAttachGrant(g.token, T0 + 1_001)).toBeUndefined();
+    expect(attachGrantStoreSize()).toBe(0);
+  });
+
+  it("returns undefined for an unknown token (no scope without a grant)", () => {
+    expect(resolveAttachGrant("deadbeef", T0)).toBeUndefined();
+  });
+
+  it("binds the sessionKey to the grant (token carries scope identity, not the caller)", () => {
+    const a = mintAttachGrant({ sessionKey: "agent:main:telegram:1", nowMs: T0 });
+    const b = mintAttachGrant({ sessionKey: "agent:main:telegram:2", nowMs: T0 });
+    // each token resolves only to its own bound session — the basis for header-spoof resistance
+    expect(resolveAttachGrant(a.token, T0)?.sessionKey).toBe("agent:main:telegram:1");
+    expect(resolveAttachGrant(b.token, T0)?.sessionKey).toBe("agent:main:telegram:2");
+    expect(a.token).not.toBe(b.token);
+  });
+
+  it("revokes by token", () => {
+    const g = mintAttachGrant({ sessionKey: "agent:main:x", nowMs: T0 });
+    expect(revokeAttachGrant(g.token)).toBe(true);
+    expect(resolveAttachGrant(g.token, T0)).toBeUndefined();
+    expect(revokeAttachGrant(g.token)).toBe(false);
+  });
+
+  it("revokes all grants for a session", () => {
+    mintAttachGrant({ sessionKey: "agent:main:x", nowMs: T0 });
+    mintAttachGrant({ sessionKey: "agent:main:x", nowMs: T0 });
+    mintAttachGrant({ sessionKey: "agent:main:y", nowMs: T0 });
+    expect(revokeAttachGrantsForSession("agent:main:x")).toBe(2);
+    expect(attachGrantStoreSize()).toBe(1);
+  });
+
+  it("clamps TTL: default for non-positive, ceiling at 12h", () => {
+    const def = mintAttachGrant({ sessionKey: "s", nowMs: T0 });
+    expect(def.expiresAtMs).toBe(T0 + 60 * 60 * 1000);
+    const zero = mintAttachGrant({ sessionKey: "s", ttlMs: 0, nowMs: T0 });
+    expect(zero.expiresAtMs).toBe(T0 + 60 * 60 * 1000);
+    const huge = mintAttachGrant({ sessionKey: "s", ttlMs: 999 * 60 * 60 * 1000, nowMs: T0 });
+    expect(huge.expiresAtMs).toBe(T0 + 12 * 60 * 60 * 1000);
+  });
+
+  it("sweeps expired grants", () => {
+    mintAttachGrant({ sessionKey: "s", ttlMs: 1_000, nowMs: T0 });
+    mintAttachGrant({ sessionKey: "s", ttlMs: 5_000, nowMs: T0 });
+    expect(sweepExpiredAttachGrants(T0 + 2_000)).toBe(1);
+    expect(attachGrantStoreSize()).toBe(1);
+  });
+
+  it("evicts expired grants on mint, bounding the store (no accumulation)", () => {
+    mintAttachGrant({ sessionKey: "s", ttlMs: 1_000, nowMs: T0 });
+    expect(attachGrantStoreSize()).toBe(1);
+    // a later mint past the first's expiry sweeps the stale entry before inserting — without
+    // sweep-on-mint the never-looked-up grant would linger and the size would be 2.
+    mintAttachGrant({ sessionKey: "s", ttlMs: 1_000, nowMs: T0 + 5_000 });
+    expect(attachGrantStoreSize()).toBe(1);
+  });
+});

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -1,0 +1,128 @@
+/**
+ * Per-session MCP loopback **attach grants**.
+ *
+ * The loopback MCP server (`mcp-http.ts`) authenticates the gateway-spawned cli-backend with two
+ * process-global bearer tokens (owner / non-owner) and scopes tools from client-supplied headers —
+ * adequate because that client is cooperative and gateway-launched. An **attach** grant is the
+ * primitive for a *less-trusted* external/interactive harness (Claude Code, OpenCode, or a harness
+ * reached via a node/companion app over its existing gateway connection): a short-lived, revocable
+ * bearer whose **scope is bound to the grant**, not to the request headers.
+ *
+ * Security properties:
+ * - The bound `sessionKey` comes from the grant, so an attach caller cannot scope-shop by setting
+ *   `x-session-key` (the request layer ignores the header when a grant matches).
+ * - Grants are always treated as **non-owner** (`senderIsOwner=false`) — the loopback surface
+ *   already excludes the destructive native tools (`read/write/edit/apply_patch/exec/process`).
+ * - TTL + explicit revoke bound the blast radius of a leaked token.
+ *
+ * Transport-independent: the same grant is presented whether the harness reaches the loopback over
+ * 127.0.0.1 (gateway host) or tunnelled in over a node/app's existing authenticated channel.
+ */
+import crypto from "node:crypto";
+
+export interface McpAttachGrant {
+  /** Opaque bearer presented as `Authorization: Bearer <token>`. */
+  readonly token: string;
+  /** The openclaw session this grant is bound to; tool scope is resolved for this key. */
+  readonly sessionKey: string;
+  /** Absolute expiry (ms epoch). */
+  readonly expiresAtMs: number;
+  /** Absolute mint time (ms epoch). */
+  readonly issuedAtMs: number;
+}
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1h
+const MAX_TTL_MS = 12 * 60 * 60 * 1000; // hard ceiling so a caller can't request a forever-grant
+
+const grantsByToken = new Map<string, McpAttachGrant>();
+
+function clampTtlMs(ttlMs: number | undefined): number {
+  if (!Number.isFinite(ttlMs) || (ttlMs as number) <= 0) {
+    return DEFAULT_TTL_MS;
+  }
+  return Math.min(ttlMs as number, MAX_TTL_MS);
+}
+
+/** Mint a grant bound to `sessionKey`. Returns the grant (the caller hands `token` to the harness). */
+export function mintAttachGrant(params: {
+  sessionKey: string;
+  ttlMs?: number;
+  nowMs?: number;
+}): McpAttachGrant {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    throw new Error("mintAttachGrant: sessionKey is required");
+  }
+  const nowMs = params.nowMs ?? Date.now();
+  // Sweep on mint so grants that are minted but never looked up again (harness never connects)
+  // don't accumulate — lookup self-sweeps only the token it touches, so this bounds the map.
+  sweepExpiredAttachGrants(nowMs);
+  const grant: McpAttachGrant = {
+    token: crypto.randomBytes(32).toString("hex"),
+    sessionKey,
+    issuedAtMs: nowMs,
+    expiresAtMs: nowMs + clampTtlMs(params.ttlMs),
+  };
+  grantsByToken.set(grant.token, grant);
+  return grant;
+}
+
+/**
+ * Resolve a bearer token to a live grant, or `undefined` if unknown/expired. An expired grant is
+ * dropped on lookup (lazy sweep). Lookup is by full-token map key: a caller must already hold the
+ * complete 256-bit token to get a hit, so there is no partial-match timing oracle to defend.
+ */
+export function resolveAttachGrant(
+  token: string,
+  nowMs: number = Date.now(),
+): McpAttachGrant | undefined {
+  const grant = grantsByToken.get(token);
+  if (!grant) {
+    return undefined;
+  }
+  if (nowMs >= grant.expiresAtMs) {
+    grantsByToken.delete(token);
+    return undefined;
+  }
+  return grant;
+}
+
+/** Revoke a grant by token. Returns true if a grant was removed. */
+export function revokeAttachGrant(token: string): boolean {
+  return grantsByToken.delete(token);
+}
+
+/** Revoke every live grant for a session (e.g. on session teardown). Returns the count removed. */
+export function revokeAttachGrantsForSession(sessionKey: string): number {
+  const key = sessionKey.trim();
+  let removed = 0;
+  for (const [token, grant] of grantsByToken) {
+    if (grant.sessionKey === key) {
+      grantsByToken.delete(token);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+/** Drop expired grants. Returns the count swept. Call opportunistically; lookup also self-sweeps. */
+export function sweepExpiredAttachGrants(nowMs: number = Date.now()): number {
+  let removed = 0;
+  for (const [token, grant] of grantsByToken) {
+    if (nowMs >= grant.expiresAtMs) {
+      grantsByToken.delete(token);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+/** Number of entries currently held (test/diagnostics). Does not sweep; reflects raw store size. */
+export function attachGrantStoreSize(): number {
+  return grantsByToken.size;
+}
+
+/** Clear all grants (test isolation only). */
+export function resetAttachGrantsForTest(): void {
+  grantsByToken.clear();
+}

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -10,6 +10,7 @@ import { isTruthyEnvValue } from "../infra/env.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { getHeader } from "./http-utils.js";
+import { resolveAttachGrant } from "./mcp-grant-store.js";
 import { isLoopbackAddress } from "./net.js";
 import { checkBrowserOrigin } from "./origin-check.js";
 
@@ -112,14 +113,22 @@ function resolveMcpSender(params: {
   req: IncomingMessage;
   ownerToken: string;
   nonOwnerToken: string;
-}): { senderIsOwner: boolean } | undefined {
+}): { senderIsOwner: boolean; boundSessionKey?: string } | undefined {
   const authHeader = getHeader(params.req, "authorization") ?? "";
   const ownerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.ownerToken}`);
   const nonOwnerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.nonOwnerToken}`);
-  if (!ownerTokenMatched && !nonOwnerTokenMatched) {
-    return undefined;
+  if (ownerTokenMatched || nonOwnerTokenMatched) {
+    return { senderIsOwner: ownerTokenMatched };
   }
-  return { senderIsOwner: ownerTokenMatched };
+  // Attach grant: an external/interactive harness presents a per-session grant token (mcp-grant-store).
+  // Always non-owner, and its scope is bound to the grant's sessionKey so a grant holder cannot widen
+  // scope via the x-session-key header — resolveMcpRequestContext honors boundSessionKey instead.
+  const grantToken = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : "";
+  const grant = grantToken ? resolveAttachGrant(grantToken) : undefined;
+  if (grant) {
+    return { senderIsOwner: false, boundSessionKey: grant.sessionKey };
+  }
+  return undefined;
 }
 
 export function validateMcpLoopbackRequest(params: {
@@ -128,7 +137,7 @@ export function validateMcpLoopbackRequest(params: {
   ownerToken: string;
   nonOwnerToken: string;
   onSseResponse?: (res: ServerResponse) => void;
-}): { senderIsOwner: boolean } | null {
+}): { senderIsOwner: boolean; boundSessionKey?: string } | null {
   let url: URL;
   try {
     url = new URL(params.req.url ?? "/", `http://${params.req.headers.host ?? "localhost"}`);
@@ -244,7 +253,7 @@ export function validateMcpLoopbackRequest(params: {
     return null;
   }
 
-  return { senderIsOwner: sender.senderIsOwner };
+  return { senderIsOwner: sender.senderIsOwner, boundSessionKey: sender.boundSessionKey };
 }
 
 export async function readMcpHttpBody(
@@ -357,8 +366,30 @@ export function resolveMcpCliCaptureKey(req: IncomingMessage): string | undefine
 export function resolveMcpRequestContext(
   req: IncomingMessage,
   cfg: OpenClawConfig,
-  auth: { senderIsOwner: boolean },
+  auth: { senderIsOwner: boolean; boundSessionKey?: string },
 ): McpRequestContext {
+  // An attach grant is a lower-trust boundary: bind the session server-side AND ignore every
+  // caller-supplied delivery/action context header (message channel, account, current channel/
+  // thread/message, inbound-audio, event-kind, source-reply mode, explicit-target). Those headers
+  // feed scoped tools and the message tool, so a grant holder must not be able to spoof them —
+  // only the grant's pinned sessionKey is trusted. Owner/non-owner (the cooperative, gateway-
+  // launched cli-backend) keep header-driven context.
+  if (auth.boundSessionKey) {
+    return {
+      sessionKey: auth.boundSessionKey,
+      sessionId: undefined,
+      messageProvider: undefined,
+      currentChannelId: undefined,
+      currentThreadTs: undefined,
+      currentMessageId: undefined,
+      currentInboundAudio: undefined,
+      accountId: undefined,
+      inboundEventKind: undefined,
+      sourceReplyDeliveryMode: undefined,
+      requireExplicitMessageTarget: undefined,
+      senderIsOwner: auth.senderIsOwner,
+    };
+  }
   return {
     sessionKey: resolveScopedSessionKey(cfg, getHeader(req, "x-session-key")),
     sessionId: normalizeOptionalString(getHeader(req, "x-openclaw-session-id")),

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -102,6 +102,7 @@ vi.mock("./tool-resolution.js", () => ({
     resolveGatewayScopedToolsMock(...args),
 }));
 
+import { resetAttachGrantsForTest, mintAttachGrant } from "./mcp-grant-store.js";
 import {
   createMcpLoopbackServerConfig,
   closeMcpLoopbackServer,
@@ -722,6 +723,47 @@ describe("mcp loopback server", () => {
       "exec",
       "process",
     ]);
+  });
+
+  it("binds an attach grant's session and ignores ALL spoofed context headers (no scope-shop)", async () => {
+    resetAttachGrantsForTest();
+    const grant = mintAttachGrant({ sessionKey: "agent:main:attach-host" });
+    const port = await getFreePortBlockWithPermissionFallback({
+      offsets: [0],
+      fallbackBase: 53_000,
+    });
+    const { port: serverPort } = await startLoopbackServerForTest(port);
+
+    const response = await sendRaw({
+      port: serverPort,
+      token: grant.token,
+      headers: jsonHeaders({
+        // spoof the full delivery/action context, not just the session key
+        "x-session-key": "agent:main:SPOOFED-other-session",
+        "x-openclaw-message-channel": "telegram",
+        "x-openclaw-account-id": "victim-account",
+        "x-openclaw-current-channel-id": "telegram:victim-chat",
+        "x-openclaw-current-thread-ts": "999",
+        "x-openclaw-source-reply-delivery-mode": "automatic",
+        "x-openclaw-inbound-event-kind": "room_event",
+      }),
+      body: mcpToolsListBody(),
+    });
+
+    expect(response.status).toBe(200);
+    const call = getScopedToolsCall(0);
+    // session is grant-bound, NOT the spoofed header
+    expect(call.sessionKey).toBe("agent:main:attach-host");
+    expect(call.senderIsOwner).toBe(false);
+    expect(call.surface).toBe("loopback");
+    // a grant is a lower-trust boundary: every other caller-supplied context header is ignored
+    // (fail-closed), so a grant holder cannot spoof delivery/action context into scoped tools.
+    expect(call.messageProvider).toBeUndefined();
+    expect(call.accountId).toBeUndefined();
+    expect(call.currentChannelId).toBeUndefined();
+    expect(call.currentThreadTs).toBeUndefined();
+    expect(call.sourceReplyDeliveryMode).toBeUndefined();
+    expect(call.inboundEventKind).toBeUndefined();
   });
 
   it("routes sessions_yield to the current CLI capture", async () => {

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -179,6 +179,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "node.describe", scope: "operator.read" },
   { name: "node.pluginSurface.refresh", scope: "node" },
   { name: "node.attachRelay", scope: "node" },
+  { name: "node.attachGrant", scope: "node" },
   { name: "node.pending.drain", scope: "node" },
   { name: "node.pending.enqueue", scope: "operator.write" },
   { name: "node.invoke", scope: "operator.write" },

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -180,6 +180,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "node.pluginSurface.refresh", scope: "node" },
   { name: "node.attachRelay", scope: "node" },
   { name: "node.attachGrant", scope: "node" },
+  { name: "node.attachHydrate", scope: "node" },
   { name: "node.pending.drain", scope: "node" },
   { name: "node.pending.enqueue", scope: "operator.write" },
   { name: "node.invoke", scope: "operator.write" },

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -180,6 +180,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "node.pluginSurface.refresh", scope: "node" },
   { name: "node.attachRelay", scope: "node" },
   { name: "node.attachGrant", scope: "node" },
+  { name: "node.attachRevoke", scope: "node" },
   { name: "node.attachHydrate", scope: "node" },
   { name: "node.pending.drain", scope: "node" },
   { name: "node.pending.enqueue", scope: "operator.write" },

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -178,6 +178,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "node.list", scope: "operator.read" },
   { name: "node.describe", scope: "operator.read" },
   { name: "node.pluginSurface.refresh", scope: "node" },
+  { name: "node.attachRelay", scope: "node" },
   { name: "node.pending.drain", scope: "node" },
   { name: "node.pending.enqueue", scope: "operator.write" },
   { name: "node.invoke", scope: "operator.write" },

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -179,7 +179,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "node.describe", scope: "operator.read" },
   { name: "node.pluginSurface.refresh", scope: "node" },
   { name: "node.attachRelay", scope: "node" },
-  { name: "node.attachGrant", scope: "node" },
+  { name: "node.attachGrant", scope: "node", controlPlaneWrite: true },
   { name: "node.attachRevoke", scope: "node" },
   { name: "node.attachHydrate", scope: "node" },
   { name: "node.pending.drain", scope: "node" },

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -218,6 +218,11 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "poll", scope: "operator.write", advertise: false },
   { name: "sessions.steer", scope: "operator.write", advertise: false },
   { name: "push.test", scope: "operator.write", advertise: false },
+  // Appended at the end of the advertised methods to preserve the legacy advertised order
+  // (server-methods-list.test.ts locks the prefix/middle). grant mints process-global state so it
+  // is control-plane rate-limited; revoke is intentionally not (cheap, idempotent, frees memory).
+  { name: "attach.grant", scope: "operator.admin", controlPlaneWrite: true },
+  { name: "attach.revoke", scope: "operator.admin" },
   { name: "push.web.vapidPublicKey", scope: "operator.write", advertise: false },
   { name: "push.web.subscribe", scope: "operator.write", advertise: false },
   { name: "push.web.unsubscribe", scope: "operator.write", advertise: false },

--- a/src/gateway/node-connect-reconcile.test.ts
+++ b/src/gateway/node-connect-reconcile.test.ts
@@ -271,4 +271,40 @@ describe("reconcileNodePairingOnConnect", () => {
     expect(result.effectivePermissions).toEqual({ camera: false });
     expect(result.pendingPairing?.request.requestId).toBe("req-downgrade");
   });
+
+  it("makes attach effective only when the live node connection declares it", async () => {
+    const approvedDeclared = await reconcileNodePairingOnConnect({
+      cfg: {} as never,
+      connectParams: makeNodeConnectParams({
+        commands: [],
+        permissions: { attach: true },
+      }),
+      pairedNode: makePairedNode({
+        commands: [],
+        permissions: { attach: true },
+      }),
+      requestPairing: vi.fn(async () => null),
+    });
+    expect(approvedDeclared.effectivePermissions).toEqual({ attach: true });
+    expect(approvedDeclared.pendingPairing).toBeUndefined();
+
+    const requestPairing = makePendingPairingRequest("req-attach-omitted");
+    const omitted = await reconcileNodePairingOnConnect({
+      cfg: {} as never,
+      connectParams: makeNodeConnectParams({
+        commands: [],
+        permissions: undefined,
+      }),
+      pairedNode: makePairedNode({
+        commands: [],
+        permissions: { attach: true },
+      }),
+      requestPairing,
+    });
+    expect(omitted.effectivePermissions).toBeUndefined();
+    expectNodePairingRequest(requestPairing, {
+      commands: [],
+      permissions: {},
+    });
+  });
 });

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -74,6 +74,10 @@ const loadArtifactsHandlers = lazyHandlerModule(
   () => import("./server-methods/artifacts.js"),
   (module) => module.artifactsHandlers,
 );
+const loadAttachHandlers = lazyHandlerModule(
+  () => import("./server-methods/attach.js"),
+  (module) => module.attachHandlers,
+);
 const loadChannelsHandlers = lazyHandlerModule(
   () => import("./server-methods/channels.js"),
   (module) => module.channelsHandlers,
@@ -270,6 +274,10 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...createLazyCoreHandlers({
     methods: ["connect"],
     loadHandlers: loadConnectHandlers,
+  }),
+  ...createLazyCoreHandlers({
+    methods: ["attach.grant", "attach.revoke"],
+    loadHandlers: loadAttachHandlers,
   }),
   ...createLazyCoreHandlers({
     methods: ["logs.tail"],

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -538,6 +538,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
       "node.pluginSurface.refresh",
       "node.attachRelay",
       "node.attachGrant",
+      "node.attachHydrate",
       "node.pending.pull",
       "node.pending.ack",
       "node.invoke",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -536,6 +536,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
       "node.list",
       "node.describe",
       "node.pluginSurface.refresh",
+      "node.attachRelay",
       "node.pending.pull",
       "node.pending.ack",
       "node.invoke",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -538,6 +538,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
       "node.pluginSurface.refresh",
       "node.attachRelay",
       "node.attachGrant",
+      "node.attachRevoke",
       "node.attachHydrate",
       "node.pending.pull",
       "node.pending.ack",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -537,6 +537,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
       "node.describe",
       "node.pluginSurface.refresh",
       "node.attachRelay",
+      "node.attachGrant",
       "node.pending.pull",
       "node.pending.ack",
       "node.invoke",

--- a/src/gateway/server-methods/attach.test.ts
+++ b/src/gateway/server-methods/attach.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetAttachGrantsForTest, resolveAttachGrant } from "../mcp-grant-store.js";
+import { closeMcpLoopbackServer } from "../mcp-http.js";
+import { attachHandlers } from "./attach.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+const grantOpts = (sessionKey: string, respond: ReturnType<typeof vi.fn>) =>
+  ({
+    params: { sessionKey },
+    respond,
+    context: { getRuntimeConfig: () => ({}) },
+  }) as unknown as GatewayRequestHandlerOptions;
+
+describe("attach gateway methods", () => {
+  beforeEach(() => resetAttachGrantsForTest());
+  afterEach(async () => {
+    resetAttachGrantsForTest();
+    // attach.grant lazily starts the loopback singleton; close it so it doesn't leak across files.
+    await closeMcpLoopbackServer();
+  });
+
+  it("attach.grant mints a session-bound grant and returns loopback config + token env", async () => {
+    const respond = vi.fn();
+    await attachHandlers["attach.grant"](grantOpts("agent:main:attach-method", respond));
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload] = respond.mock.calls[0];
+    expect(ok).toBe(true);
+    const body = payload as {
+      token: string;
+      sessionKey: string;
+      mcpConfig: unknown;
+      env: Record<string, string>;
+    };
+    expect(body.sessionKey).toBe("agent:main:attach-method");
+    expect(body.token).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.mcpConfig).toBeTruthy();
+    expect(body.env.OPENCLAW_MCP_TOKEN).toBe(body.token);
+    expect(body.env.OPENCLAW_MCP_SESSION_KEY).toBe("agent:main:attach-method");
+    // the minted token resolves to the bound session in the shared store
+    expect(resolveAttachGrant(body.token)?.sessionKey).toBe("agent:main:attach-method");
+  });
+
+  it("attach.revoke removes a grant; missing token is an INVALID_REQUEST", async () => {
+    const grantRespond = vi.fn();
+    await attachHandlers["attach.grant"](grantOpts("agent:main:revoke-me", grantRespond));
+    const token = (grantRespond.mock.calls[0][1] as { token: string }).token;
+
+    const revokeRespond = vi.fn();
+    await attachHandlers["attach.revoke"]({
+      params: { token },
+      respond: revokeRespond,
+    } as unknown as GatewayRequestHandlerOptions);
+    expect(revokeRespond).toHaveBeenCalledWith(true, { revoked: true });
+    expect(resolveAttachGrant(token)).toBeUndefined();
+
+    const errRespond = vi.fn();
+    await attachHandlers["attach.revoke"]({
+      params: {},
+      respond: errRespond,
+    } as unknown as GatewayRequestHandlerOptions);
+    const [errOk, , err] = errRespond.mock.calls[0];
+    expect(errOk).toBe(false);
+    expect((err as { code: string }).code).toBe("INVALID_REQUEST");
+  });
+
+  it("applies a positive ttlMs and falls back to the default for an invalid one", async () => {
+    const r1 = vi.fn();
+    await attachHandlers["attach.grant"]({
+      params: { sessionKey: "agent:main:ttl", ttlMs: 30_000 },
+      respond: r1,
+      context: { getRuntimeConfig: () => ({}) },
+    } as unknown as GatewayRequestHandlerOptions);
+    const now1 = Date.now();
+    const b1 = r1.mock.calls[0][1] as { expiresAtMs: number };
+    expect(b1.expiresAtMs).toBeGreaterThan(now1 + 20_000);
+    expect(b1.expiresAtMs).toBeLessThan(now1 + 40_000); // honored 30s ttl, not the 1h default
+
+    const r2 = vi.fn();
+    await attachHandlers["attach.grant"]({
+      params: { sessionKey: "agent:main:ttl2", ttlMs: -5 }, // non-positive → default ttl
+      respond: r2,
+      context: { getRuntimeConfig: () => ({}) },
+    } as unknown as GatewayRequestHandlerOptions);
+    const b2 = r2.mock.calls[0][1] as { expiresAtMs: number };
+    expect(b2.expiresAtMs).toBeGreaterThan(Date.now() + 50 * 60_000); // ~1h default window
+  });
+
+  it("attach.revoke treats non-object params as a missing token (INVALID_REQUEST)", async () => {
+    const respond = vi.fn();
+    await attachHandlers["attach.revoke"]({
+      params: null,
+      respond,
+    } as unknown as GatewayRequestHandlerOptions);
+    const [ok, , err] = respond.mock.calls[0];
+    expect(ok).toBe(false);
+    expect((err as { code: string }).code).toBe("INVALID_REQUEST");
+  });
+});

--- a/src/gateway/server-methods/attach.ts
+++ b/src/gateway/server-methods/attach.ts
@@ -1,0 +1,66 @@
+// Gateway RPC handlers for attach grants: mint a per-session, scoped, revocable MCP loopback grant
+// so an external/interactive harness can reach the gateway's scoped tools, and revoke it on detach.
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveMainSessionKey } from "../../config/sessions.js";
+import { mintAttachGrant, revokeAttachGrant } from "../mcp-grant-store.js";
+import { ensureMcpLoopbackServer } from "../mcp-http.js";
+import {
+  createMcpLoopbackServerConfig,
+  getActiveMcpLoopbackRuntime,
+} from "../mcp-http.loopback-runtime.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+function paramRecord(params: unknown): Record<string, unknown> {
+  return params && typeof params === "object" ? (params as Record<string, unknown>) : {};
+}
+
+function readString(params: unknown, key: string): string | undefined {
+  const value = paramRecord(params)[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readPositiveNumber(params: unknown, key: string): number | undefined {
+  const value = paramRecord(params)[key];
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+export const attachHandlers: GatewayRequestHandlers = {
+  // Mint a grant bound to a session, returning the loopback MCP config + the token env the harness
+  // needs. ensureMcpLoopbackServer lazily brings the singleton up if no cli-backend turn started it.
+  "attach.grant": async ({ params, respond, context }) => {
+    await ensureMcpLoopbackServer();
+    const runtime = getActiveMcpLoopbackRuntime();
+    if (!runtime) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, "mcp loopback server unavailable"),
+      );
+      return;
+    }
+    const sessionKey =
+      readString(params, "sessionKey") ?? resolveMainSessionKey(context.getRuntimeConfig());
+    const grant = mintAttachGrant({ sessionKey, ttlMs: readPositiveNumber(params, "ttlMs") });
+    respond(true, {
+      sessionKey: grant.sessionKey,
+      token: grant.token,
+      expiresAtMs: grant.expiresAtMs,
+      // The harness writes mcpConfig to its MCP client config and sets env so the ${...} placeholders
+      // resolve. Loopback today; node/app conduits reuse the same client config over their channel.
+      mcpConfig: createMcpLoopbackServerConfig(runtime.port),
+      env: {
+        OPENCLAW_MCP_TOKEN: grant.token,
+        OPENCLAW_MCP_SESSION_KEY: grant.sessionKey,
+      },
+    });
+  },
+  // Revoke a previously minted grant. Idempotent: an unknown/already-expired token reports revoked=false.
+  "attach.revoke": async ({ params, respond }) => {
+    const token = readString(params, "token");
+    if (!token) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "token is required"));
+      return;
+    }
+    respond(true, { revoked: revokeAttachGrant(token) });
+  },
+};

--- a/src/gateway/server-methods/nodes.attach.test.ts
+++ b/src/gateway/server-methods/nodes.attach.test.ts
@@ -84,4 +84,22 @@ describe("node attach handlers (PR5 node conduit)", () => {
     await call("node.attachHydrate", { grantToken: "nope" }, respond);
     expect(respond.mock.calls[0][0]).toBe(false);
   });
+
+  it("node.attachRevoke revokes a node-minted grant by token, and rejects a missing token", async () => {
+    const grantRespond = vi.fn();
+    await call("node.attachGrant", {}, grantRespond);
+    const granted = grantRespond.mock.calls[0]?.[1] as { token: string } | undefined;
+    const token = granted?.token ?? "";
+    expect(token).not.toBe("");
+    expect(resolveAttachGrant(token)).toBeTruthy();
+
+    const revokeRespond = vi.fn();
+    await call("node.attachRevoke", { grantToken: token }, revokeRespond);
+    expect(revokeRespond.mock.calls[0]).toEqual([true, { revoked: true }]);
+    expect(resolveAttachGrant(token)).toBeUndefined(); // grant gone, not lingering to TTL
+
+    const missing = vi.fn();
+    await call("node.attachRevoke", {}, missing);
+    expect(missing.mock.calls[0][0]).toBe(false);
+  });
 });

--- a/src/gateway/server-methods/nodes.attach.test.ts
+++ b/src/gateway/server-methods/nodes.attach.test.ts
@@ -20,7 +20,11 @@ vi.mock("../../infra/node-pairing.js", async (importActual) => ({
 }));
 
 import { dispatchAttachMcpMessage } from "../attach-relay.js";
-import { resetAttachGrantsForTest, resolveAttachGrant } from "../mcp-grant-store.js";
+import {
+  mintAttachGrant,
+  resetAttachGrantsForTest,
+  resolveAttachGrant,
+} from "../mcp-grant-store.js";
 import { nodeHandlers } from "./nodes.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
@@ -40,7 +44,10 @@ const call = (
   } as unknown as GatewayRequestHandlerOptions);
 
 describe("node attach handlers (PR5 node conduit)", () => {
-  afterEach(() => resetAttachGrantsForTest());
+  afterEach(() => {
+    resetAttachGrantsForTest();
+    vi.clearAllMocks();
+  });
 
   it("node.attachGrant mints a MAIN-session grant when the node has the attach entitlement", async () => {
     const respond = vi.fn();
@@ -93,10 +100,42 @@ describe("node attach handlers (PR5 node conduit)", () => {
     });
   });
 
+  it("node.attachRelay rejects an old grant after attach is downgraded or unpaired", async () => {
+    const grant = mintAttachGrant({ sessionKey: "agent:main" });
+    for (const client of [
+      { connect: { device: { id: "node-ok" }, permissions: {} } },
+      { connect: { device: { id: "node-ok" }, permissions: { attach: false } } },
+      { connect: { device: { id: "node-missing" }, permissions: { attach: true } } },
+    ]) {
+      const respond = vi.fn();
+      await call(
+        "node.attachRelay",
+        { grantToken: grant.token, mcpMessage: { jsonrpc: "2.0", id: 1, method: "tools/list" } },
+        respond,
+        client,
+      );
+      expect(respond.mock.calls[0][0]).toBe(false);
+    }
+    expect(dispatchAttachMcpMessage).not.toHaveBeenCalled();
+  });
+
   it("node.attachHydrate rejects an unknown/expired grant before touching the session store", async () => {
     const respond = vi.fn();
     await call("node.attachHydrate", { grantToken: "nope" }, respond);
     expect(respond.mock.calls[0][0]).toBe(false);
+  });
+
+  it("node.attachHydrate rejects an old grant after attach is downgraded or unpaired", async () => {
+    const grant = mintAttachGrant({ sessionKey: "agent:main" });
+    for (const client of [
+      { connect: { device: { id: "node-ok" }, permissions: {} } },
+      { connect: { device: { id: "node-ok" }, permissions: { attach: false } } },
+      { connect: { device: { id: "node-missing" }, permissions: { attach: true } } },
+    ]) {
+      const respond = vi.fn();
+      await call("node.attachHydrate", { grantToken: grant.token }, respond, client);
+      expect(respond.mock.calls[0][0]).toBe(false);
+    }
   });
 
   it("node.attachRevoke revokes a node-minted grant by token, and rejects a missing token", async () => {

--- a/src/gateway/server-methods/nodes.attach.test.ts
+++ b/src/gateway/server-methods/nodes.attach.test.ts
@@ -7,6 +7,17 @@ vi.mock("../../config/sessions.js", async (importActual) => ({
 vi.mock("../attach-relay.js", () => ({
   dispatchAttachMcpMessage: vi.fn(async () => ({ jsonrpc: "2.0", id: 1, result: { ok: true } })),
 }));
+// node "node-ok" is owner-approved WITH the attach entitlement; "node-bare" is paired but not.
+vi.mock("../../infra/node-pairing.js", async (importActual) => ({
+  ...(await importActual<typeof import("../../infra/node-pairing.js")>()),
+  listNodePairing: vi.fn(async () => ({
+    paired: [
+      { nodeId: "node-ok", permissions: { attach: true } },
+      { nodeId: "node-bare", permissions: {} },
+    ],
+    pending: [],
+  })),
+}));
 
 import { dispatchAttachMcpMessage } from "../attach-relay.js";
 import { resetAttachGrantsForTest, resolveAttachGrant } from "../mcp-grant-store.js";
@@ -14,17 +25,24 @@ import { nodeHandlers } from "./nodes.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const ctx = { getRuntimeConfig: () => ({}) };
-const call = (method: string, params: unknown, respond: ReturnType<typeof vi.fn>) =>
+const entitledClient = { connect: { device: { id: "node-ok" } } };
+const call = (
+  method: string,
+  params: unknown,
+  respond: ReturnType<typeof vi.fn>,
+  client: unknown = entitledClient,
+) =>
   nodeHandlers[method]({
     params,
     respond,
     context: ctx,
+    client,
   } as unknown as GatewayRequestHandlerOptions);
 
 describe("node attach handlers (PR5 node conduit)", () => {
   afterEach(() => resetAttachGrantsForTest());
 
-  it("node.attachGrant mints a session-bound grant for the node's MAIN session (pairing = authz)", async () => {
+  it("node.attachGrant mints a MAIN-session grant when the node has the attach entitlement", async () => {
     const respond = vi.fn();
     await call("node.attachGrant", {}, respond);
     const [ok, body] = respond.mock.calls[0] as [boolean, { sessionKey: string; token: string }];
@@ -33,6 +51,12 @@ describe("node attach handlers (PR5 node conduit)", () => {
     expect(body.token).toMatch(/^[0-9a-f]{64}$/);
     // the minted token resolves to the same session in the shared grant store
     expect(resolveAttachGrant(body.token)?.sessionKey).toBe("agent:main");
+  });
+
+  it("node.attachGrant rejects a paired node WITHOUT the owner-approved attach entitlement", async () => {
+    const respond = vi.fn();
+    await call("node.attachGrant", {}, respond, { connect: { device: { id: "node-bare" } } });
+    expect(respond.mock.calls[0][0]).toBe(false); // role:node alone is not consent to attach
   });
 
   it("node.attachRelay rejects a non-JSON-RPC message and otherwise dispatches via the relay core", async () => {

--- a/src/gateway/server-methods/nodes.attach.test.ts
+++ b/src/gateway/server-methods/nodes.attach.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/sessions.js", async (importActual) => ({
+  ...(await importActual<typeof import("../../config/sessions.js")>()),
+  resolveMainSessionKey: vi.fn(() => "agent:main"),
+}));
+vi.mock("../attach-relay.js", () => ({
+  dispatchAttachMcpMessage: vi.fn(async () => ({ jsonrpc: "2.0", id: 1, result: { ok: true } })),
+}));
+
+import { dispatchAttachMcpMessage } from "../attach-relay.js";
+import { resetAttachGrantsForTest, resolveAttachGrant } from "../mcp-grant-store.js";
+import { nodeHandlers } from "./nodes.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+const ctx = { getRuntimeConfig: () => ({}) };
+const call = (method: string, params: unknown, respond: ReturnType<typeof vi.fn>) =>
+  nodeHandlers[method]({
+    params,
+    respond,
+    context: ctx,
+  } as unknown as GatewayRequestHandlerOptions);
+
+describe("node attach handlers (PR5 node conduit)", () => {
+  afterEach(() => resetAttachGrantsForTest());
+
+  it("node.attachGrant mints a session-bound grant for the node's MAIN session (pairing = authz)", async () => {
+    const respond = vi.fn();
+    await call("node.attachGrant", {}, respond);
+    const [ok, body] = respond.mock.calls[0] as [boolean, { sessionKey: string; token: string }];
+    expect(ok).toBe(true);
+    expect(body.sessionKey).toBe("agent:main"); // bound to the gateway session, not node-supplied
+    expect(body.token).toMatch(/^[0-9a-f]{64}$/);
+    // the minted token resolves to the same session in the shared grant store
+    expect(resolveAttachGrant(body.token)?.sessionKey).toBe("agent:main");
+  });
+
+  it("node.attachRelay rejects a non-JSON-RPC message and otherwise dispatches via the relay core", async () => {
+    const bad = vi.fn();
+    await call("node.attachRelay", { grantToken: "t" }, bad); // missing mcpMessage
+    expect(bad.mock.calls[0][0]).toBe(false);
+    expect(dispatchAttachMcpMessage).not.toHaveBeenCalled();
+
+    const ok = vi.fn();
+    await call(
+      "node.attachRelay",
+      { grantToken: "tok", mcpMessage: { jsonrpc: "2.0", id: 1, method: "tools/list" } },
+      ok,
+    );
+    expect(dispatchAttachMcpMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ grantToken: "tok" }),
+    );
+    expect(ok).toHaveBeenCalledWith(true, {
+      mcpResponse: { jsonrpc: "2.0", id: 1, result: { ok: true } },
+    });
+  });
+});

--- a/src/gateway/server-methods/nodes.attach.test.ts
+++ b/src/gateway/server-methods/nodes.attach.test.ts
@@ -25,7 +25,7 @@ import { nodeHandlers } from "./nodes.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const ctx = { getRuntimeConfig: () => ({}) };
-const entitledClient = { connect: { device: { id: "node-ok" } } };
+const entitledClient = { connect: { device: { id: "node-ok" }, permissions: { attach: true } } };
 const call = (
   method: string,
   params: unknown,
@@ -55,8 +55,22 @@ describe("node attach handlers (PR5 node conduit)", () => {
 
   it("node.attachGrant rejects a paired node WITHOUT the owner-approved attach entitlement", async () => {
     const respond = vi.fn();
-    await call("node.attachGrant", {}, respond, { connect: { device: { id: "node-bare" } } });
+    await call("node.attachGrant", {}, respond, {
+      connect: { device: { id: "node-bare" }, permissions: { attach: true } },
+    });
     expect(respond.mock.calls[0][0]).toBe(false); // role:node alone is not consent to attach
+  });
+
+  it("node.attachGrant rejects stored approval when the live session lacks attach permission", async () => {
+    for (const client of [
+      { connect: { device: { id: "node-ok" } } },
+      { connect: { device: { id: "node-ok" }, permissions: {} } },
+      { connect: { device: { id: "node-ok" }, permissions: { attach: false } } },
+    ]) {
+      const respond = vi.fn();
+      await call("node.attachGrant", {}, respond, client);
+      expect(respond.mock.calls[0][0]).toBe(false);
+    }
   });
 
   it("node.attachRelay rejects a non-JSON-RPC message and otherwise dispatches via the relay core", async () => {

--- a/src/gateway/server-methods/nodes.attach.test.ts
+++ b/src/gateway/server-methods/nodes.attach.test.ts
@@ -54,4 +54,10 @@ describe("node attach handlers (PR5 node conduit)", () => {
       mcpResponse: { jsonrpc: "2.0", id: 1, result: { ok: true } },
     });
   });
+
+  it("node.attachHydrate rejects an unknown/expired grant before touching the session store", async () => {
+    const respond = vi.fn();
+    await call("node.attachHydrate", { grantToken: "nope" }, respond);
+    expect(respond.mock.calls[0][0]).toBe(false);
+  });
 });

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -883,11 +883,39 @@ export async function waitForNodeReconnect(params: {
   return Boolean(params.context.nodeRegistry.get(params.nodeId));
 }
 
+async function callerHasLiveAttachEntitlement(client: unknown): Promise<boolean> {
+  const connect =
+    client && typeof client === "object"
+      ? (
+          client as {
+            connect?: {
+              device?: { id?: unknown };
+              client?: { id?: unknown };
+              permissions?: unknown;
+            };
+          }
+        ).connect
+      : undefined;
+  const nodeId = normalizeOptionalString(connect?.device?.id ?? connect?.client?.id) ?? "";
+  const livePermissions =
+    connect?.permissions &&
+    typeof connect.permissions === "object" &&
+    !Array.isArray(connect.permissions)
+      ? (connect.permissions as Record<string, unknown>)
+      : undefined;
+  if (!nodeId || livePermissions?.attach !== true) {
+    return false;
+  }
+  const { paired } = await listNodePairing();
+  const approved = paired.find((node) => node.nodeId === nodeId);
+  return approved?.permissions?.attach === true;
+}
+
 export const nodeHandlers: GatewayRequestHandlers = {
   // Conduit relay: a paired node forwards a harness's MCP JSON-RPC frame over its EXISTING gateway
   // link; the gateway dispatches it to the SAME scoped loopback tools as the gateway-host case via
   // the grant (no new gateway endpoint). Scope is bound to the grant's sessionKey, never the node.
-  "node.attachRelay": async ({ params, respond, context }) => {
+  "node.attachRelay": async ({ params, respond, client, context }) => {
     const grantToken = typeof params.grantToken === "string" ? params.grantToken : "";
     const message = params.mcpMessage;
     const isJsonRpc =
@@ -899,6 +927,14 @@ export const nodeHandlers: GatewayRequestHandlers = {
         false,
         undefined,
         errorShape(ErrorCodes.INVALID_REQUEST, "grantToken and a JSON-RPC mcpMessage are required"),
+      );
+      return;
+    }
+    if (!(await callerHasLiveAttachEntitlement(client))) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "node is not entitled to attach on this connection"),
       );
       return;
     }
@@ -918,17 +954,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
   // scoped/TTL'd/revocable (PR1), bound to the session not the node. Caller-chosen sessions + a
   // cross-agent entitlement map are a follow-up. The node uses the returned token with node.attachRelay.
   "node.attachGrant": async ({ params, respond, client, context }) => {
-    const nodeId =
-      normalizeOptionalString(client?.connect?.device?.id ?? client?.connect?.client?.id) ?? "";
-    const { paired } = await listNodePairing();
-    const approved = nodeId ? paired.find((node) => node.nodeId === nodeId) : undefined;
-    const livePermissions =
-      client?.connect?.permissions &&
-      typeof client.connect.permissions === "object" &&
-      !Array.isArray(client.connect.permissions)
-        ? (client.connect.permissions as Record<string, unknown>)
-        : undefined;
-    if (!approved?.permissions?.attach || livePermissions?.attach !== true) {
+    if (!(await callerHasLiveAttachEntitlement(client))) {
       respond(
         false,
         undefined,
@@ -967,7 +993,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
   // Hydration source (PR7): return the gateway-OWNED conversation for the grant's session so the node
   // can materialize a local Claude transcript and `claude --resume` it — pick-up-anywhere. Same
   // assembly chat.history uses: the stored agent turns + the cli-session import, scoped to the grant.
-  "node.attachHydrate": async ({ params, respond, context }) => {
+  "node.attachHydrate": async ({ params, respond, client, context }) => {
     const grantToken = typeof params.grantToken === "string" ? params.grantToken : "";
     const grant = grantToken ? resolveAttachGrant(grantToken) : undefined;
     if (!grant) {
@@ -975,6 +1001,14 @@ export const nodeHandlers: GatewayRequestHandlers = {
         false,
         undefined,
         errorShape(ErrorCodes.INVALID_REQUEST, "unknown or expired attach grant"),
+      );
+      return;
+    }
+    if (!(await callerHasLiveAttachEntitlement(client))) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "node is not entitled to attach on this connection"),
       );
       return;
     }

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -26,6 +26,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { getRuntimeConfig } from "../../config/io.js";
 import { resolveMainSessionKey } from "../../config/sessions.js";
+import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   getPairedDevice,
@@ -59,7 +60,8 @@ import {
   removeRemoteNodeInfo,
 } from "../../skills/runtime/remote.js";
 import { dispatchAttachMcpMessage } from "../attach-relay.js";
-import { mintAttachGrant } from "../mcp-grant-store.js";
+import { augmentChatHistoryWithCliSessionImports } from "../cli-session-history.js";
+import { mintAttachGrant, resolveAttachGrant } from "../mcp-grant-store.js";
 import type { JsonRpcRequest } from "../mcp-http.protocol.js";
 import { createKnownNodeCatalog, getKnownNode, listKnownNodes } from "../node-catalog.js";
 import {
@@ -74,6 +76,8 @@ import type { NodeSession } from "../node-registry.js";
 import { ADMIN_SCOPE, PAIRING_SCOPE } from "../operator-scopes.js";
 import { refreshClientPluginNodeCapability } from "../plugin-node-capability.js";
 import type { NodeEventContext } from "../server-node-events-types.js";
+import { readRecentSessionMessagesAsync } from "../session-utils.fs.js";
+import { resolveGatewaySessionStoreTarget } from "../session-utils.js";
 import {
   deniesCrossDeviceManagement,
   pairedDeviceHasNonOperatorRole,
@@ -924,6 +928,35 @@ export const nodeHandlers: GatewayRequestHandlers = {
       token: grant.token,
       expiresAtMs: grant.expiresAtMs,
     });
+  },
+  // Hydration source (PR7): return the gateway-OWNED conversation for the grant's session so the node
+  // can materialize a local Claude transcript and `claude --resume` it — pick-up-anywhere. Same
+  // assembly chat.history uses: the stored agent turns + the cli-session import, scoped to the grant.
+  "node.attachHydrate": async ({ params, respond, context }) => {
+    const grantToken = typeof params.grantToken === "string" ? params.grantToken : "";
+    const grant = grantToken ? resolveAttachGrant(grantToken) : undefined;
+    if (!grant) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "unknown or expired attach grant"),
+      );
+      return;
+    }
+    const cfg = context.getRuntimeConfig();
+    const entry = loadSessionEntry({ sessionKey: grant.sessionKey });
+    const target = resolveGatewaySessionStoreTarget({ cfg, key: grant.sessionKey });
+    const localMessages = entry?.sessionId
+      ? await readRecentSessionMessagesAsync(
+          entry.sessionId,
+          target.storePath,
+          undefined,
+          { maxMessages: 500 },
+          target.agentId,
+        )
+      : [];
+    const messages = augmentChatHistoryWithCliSessionImports({ entry, localMessages });
+    respond(true, { messages });
   },
   "node.pair.request": async ({ params, respond, context }) => {
     if (!validateNodePairRequestParams(params)) {

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -25,6 +25,7 @@ import {
   validateNodeRenameParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { getRuntimeConfig } from "../../config/io.js";
+import { resolveMainSessionKey } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   getPairedDevice,
@@ -58,6 +59,7 @@ import {
   removeRemoteNodeInfo,
 } from "../../skills/runtime/remote.js";
 import { dispatchAttachMcpMessage } from "../attach-relay.js";
+import { mintAttachGrant } from "../mcp-grant-store.js";
 import type { JsonRpcRequest } from "../mcp-http.protocol.js";
 import { createKnownNodeCatalog, getKnownNode, listKnownNodes } from "../node-catalog.js";
 import {
@@ -882,12 +884,8 @@ export const nodeHandlers: GatewayRequestHandlers = {
   // link; the gateway dispatches it to the SAME scoped loopback tools as the gateway-host case via
   // the grant (no new gateway endpoint). Scope is bound to the grant's sessionKey, never the node.
   "node.attachRelay": async ({ params, respond, context }) => {
-    const record = (typeof params === "object" && params !== null ? params : {}) as Record<
-      string,
-      unknown
-    >;
-    const grantToken = typeof record.grantToken === "string" ? record.grantToken : "";
-    const message = record.mcpMessage;
+    const grantToken = typeof params.grantToken === "string" ? params.grantToken : "";
+    const message = params.mcpMessage;
     const isJsonRpc =
       typeof message === "object" &&
       message !== null &&
@@ -906,6 +904,26 @@ export const nodeHandlers: GatewayRequestHandlers = {
       cfg: context.getRuntimeConfig(),
     });
     respond(true, { mcpResponse });
+  },
+  // Self-service attach grant for a paired node: a connected role:node client is already an approved,
+  // authenticated node (the role gate IS the pairing check), so its pairing authorizes minting. The
+  // grant binds to the user's MAIN gateway session — pick-up-anywhere for the same conversation — and
+  // is scoped/TTL'd/revocable (PR1), bound to the session not the node, so the node can't widen it.
+  // Caller-chosen sessions + the cross-agent/user entitlement map are a follow-up (today single-owner,
+  // so main is the safe default). The node uses the returned token with node.attachRelay.
+  "node.attachGrant": async ({ params, respond, context }) => {
+    const ttlRaw = params.ttlMs;
+    const ttlMs =
+      typeof ttlRaw === "number" && Number.isFinite(ttlRaw) && ttlRaw > 0 ? ttlRaw : undefined;
+    const grant = mintAttachGrant({
+      sessionKey: resolveMainSessionKey(context.getRuntimeConfig()),
+      ttlMs,
+    });
+    respond(true, {
+      sessionKey: grant.sessionKey,
+      token: grant.token,
+      expiresAtMs: grant.expiresAtMs,
+    });
   },
   "node.pair.request": async ({ params, respond, context }) => {
     if (!validateNodePairRequestParams(params)) {

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -912,8 +912,9 @@ export const nodeHandlers: GatewayRequestHandlers = {
   // Self-service attach grant for a paired node — gated on an EXPLICIT `attach` entitlement the owner
   // approved at pairing. Pairing a node for camera/canvas/system commands is NOT consent for it to
   // reach the owner's MAIN session tools + full conversation, so role:node alone is insufficient; the
-  // node's owner-approved permissions must carry `attach` (changing a node's approval surface
-  // re-triggers owner approval, so this can't be self-granted). The grant binds to the main session,
+  // node's owner-approved permissions and this live connection's effective permissions must carry
+  // `attach` (changing a node's approval surface re-triggers owner approval, and reconnects that
+  // omit/downgrade `attach` lose the effective permission). The grant binds to the main session,
   // scoped/TTL'd/revocable (PR1), bound to the session not the node. Caller-chosen sessions + a
   // cross-agent entitlement map are a follow-up. The node uses the returned token with node.attachRelay.
   "node.attachGrant": async ({ params, respond, client, context }) => {
@@ -921,13 +922,19 @@ export const nodeHandlers: GatewayRequestHandlers = {
       normalizeOptionalString(client?.connect?.device?.id ?? client?.connect?.client?.id) ?? "";
     const { paired } = await listNodePairing();
     const approved = nodeId ? paired.find((node) => node.nodeId === nodeId) : undefined;
-    if (!approved?.permissions?.attach) {
+    const livePermissions =
+      client?.connect?.permissions &&
+      typeof client.connect.permissions === "object" &&
+      !Array.isArray(client.connect.permissions)
+        ? (client.connect.permissions as Record<string, unknown>)
+        : undefined;
+    if (!approved?.permissions?.attach || livePermissions?.attach !== true) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          "node is not entitled to attach; re-pair granting the 'attach' permission",
+          "node is not entitled to attach on this connection; reconnect declaring and re-pair granting the 'attach' permission",
         ),
       );
       return;

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -57,6 +57,8 @@ import {
   refreshRemoteNodeBins,
   removeRemoteNodeInfo,
 } from "../../skills/runtime/remote.js";
+import { dispatchAttachMcpMessage } from "../attach-relay.js";
+import type { JsonRpcRequest } from "../mcp-http.protocol.js";
 import { createKnownNodeCatalog, getKnownNode, listKnownNodes } from "../node-catalog.js";
 import {
   isForegroundRestrictedPluginNodeCommand,
@@ -876,6 +878,35 @@ export async function waitForNodeReconnect(params: {
 }
 
 export const nodeHandlers: GatewayRequestHandlers = {
+  // Conduit relay: a paired node forwards a harness's MCP JSON-RPC frame over its EXISTING gateway
+  // link; the gateway dispatches it to the SAME scoped loopback tools as the gateway-host case via
+  // the grant (no new gateway endpoint). Scope is bound to the grant's sessionKey, never the node.
+  "node.attachRelay": async ({ params, respond, context }) => {
+    const record = (typeof params === "object" && params !== null ? params : {}) as Record<
+      string,
+      unknown
+    >;
+    const grantToken = typeof record.grantToken === "string" ? record.grantToken : "";
+    const message = record.mcpMessage;
+    const isJsonRpc =
+      typeof message === "object" &&
+      message !== null &&
+      typeof (message as { method?: unknown }).method === "string";
+    if (!grantToken || !isJsonRpc) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "grantToken and a JSON-RPC mcpMessage are required"),
+      );
+      return;
+    }
+    const mcpResponse = await dispatchAttachMcpMessage({
+      grantToken,
+      message: message as JsonRpcRequest,
+      cfg: context.getRuntimeConfig(),
+    });
+    respond(true, { mcpResponse });
+  },
   "node.pair.request": async ({ params, respond, context }) => {
     if (!validateNodePairRequestParams(params)) {
       respondInvalidParams({

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -61,7 +61,7 @@ import {
 } from "../../skills/runtime/remote.js";
 import { dispatchAttachMcpMessage } from "../attach-relay.js";
 import { augmentChatHistoryWithCliSessionImports } from "../cli-session-history.js";
-import { mintAttachGrant, resolveAttachGrant } from "../mcp-grant-store.js";
+import { mintAttachGrant, resolveAttachGrant, revokeAttachGrant } from "../mcp-grant-store.js";
 import type { JsonRpcRequest } from "../mcp-http.protocol.js";
 import { createKnownNodeCatalog, getKnownNode, listKnownNodes } from "../node-catalog.js";
 import {
@@ -944,6 +944,18 @@ export const nodeHandlers: GatewayRequestHandlers = {
       token: grant.token,
       expiresAtMs: grant.expiresAtMs,
     });
+  },
+  // Revoke a node-minted grant on attach exit — the node-path symmetry to the gateway-host's
+  // attach.revoke (a node can't call that operator.admin method). The grant token IS the capability
+  // (only its holder has it), so revoke-by-token is safe; this bounds the grant to the session rather
+  // than its TTL. (Revoke-on-unpair/permission-downgrade remains a tracked follow-up.)
+  "node.attachRevoke": async ({ params, respond }) => {
+    const grantToken = normalizeOptionalString(params.grantToken) ?? "";
+    if (!grantToken) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "grantToken required"));
+      return;
+    }
+    respond(true, { revoked: revokeAttachGrant(grantToken) });
   },
   // Hydration source (PR7): return the gateway-OWNED conversation for the grant's session so the node
   // can materialize a local Claude transcript and `claude --resume` it — pick-up-anywhere. Same

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -909,13 +909,29 @@ export const nodeHandlers: GatewayRequestHandlers = {
     });
     respond(true, { mcpResponse });
   },
-  // Self-service attach grant for a paired node: a connected role:node client is already an approved,
-  // authenticated node (the role gate IS the pairing check), so its pairing authorizes minting. The
-  // grant binds to the user's MAIN gateway session — pick-up-anywhere for the same conversation — and
-  // is scoped/TTL'd/revocable (PR1), bound to the session not the node, so the node can't widen it.
-  // Caller-chosen sessions + the cross-agent/user entitlement map are a follow-up (today single-owner,
-  // so main is the safe default). The node uses the returned token with node.attachRelay.
-  "node.attachGrant": async ({ params, respond, context }) => {
+  // Self-service attach grant for a paired node — gated on an EXPLICIT `attach` entitlement the owner
+  // approved at pairing. Pairing a node for camera/canvas/system commands is NOT consent for it to
+  // reach the owner's MAIN session tools + full conversation, so role:node alone is insufficient; the
+  // node's owner-approved permissions must carry `attach` (changing a node's approval surface
+  // re-triggers owner approval, so this can't be self-granted). The grant binds to the main session,
+  // scoped/TTL'd/revocable (PR1), bound to the session not the node. Caller-chosen sessions + a
+  // cross-agent entitlement map are a follow-up. The node uses the returned token with node.attachRelay.
+  "node.attachGrant": async ({ params, respond, client, context }) => {
+    const nodeId =
+      normalizeOptionalString(client?.connect?.device?.id ?? client?.connect?.client?.id) ?? "";
+    const { paired } = await listNodePairing();
+    const approved = nodeId ? paired.find((node) => node.nodeId === nodeId) : undefined;
+    if (!approved?.permissions?.attach) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "node is not entitled to attach; re-pair granting the 'attach' permission",
+        ),
+      );
+      return;
+    }
     const ttlRaw = params.ttlMs;
     const ttlMs =
       typeof ttlRaw === "number" && Number.isFinite(ttlRaw) && ttlRaw > 0 ? ttlRaw : undefined;

--- a/src/infra/node-pairing-authz.test.ts
+++ b/src/infra/node-pairing-authz.test.ts
@@ -1,6 +1,9 @@
 // Covers scope requirements for node pairing approvals.
 import { describe, expect, it } from "vitest";
-import { resolveNodePairApprovalScopes } from "./node-pairing-authz.js";
+import {
+  nodePermissionsRequireAdminApproval,
+  resolveNodePairApprovalScopes,
+} from "./node-pairing-authz.js";
 
 describe("resolveNodePairApprovalScopes", () => {
   it("requires operator.admin for system.run commands", () => {
@@ -20,5 +23,41 @@ describe("resolveNodePairApprovalScopes", () => {
   it("requires only operator.pairing without commands", () => {
     expect(resolveNodePairApprovalScopes(undefined)).toEqual(["operator.pairing"]);
     expect(resolveNodePairApprovalScopes([])).toEqual(["operator.pairing"]);
+  });
+
+  it("requires operator.admin for a COMMANDLESS attach-permission request", () => {
+    expect(resolveNodePairApprovalScopes([], { attach: true })).toEqual([
+      "operator.pairing",
+      "operator.admin",
+    ]);
+    expect(resolveNodePairApprovalScopes(undefined, { attach: true })).toEqual([
+      "operator.pairing",
+      "operator.admin",
+    ]);
+  });
+
+  it("adds operator.admin to a non-exec command request that also grants attach", () => {
+    expect(resolveNodePairApprovalScopes(["canvas.present"], { attach: true })).toEqual([
+      "operator.pairing",
+      "operator.write",
+      "operator.admin",
+    ]);
+  });
+
+  it("does not elevate when attach is absent, false, or non-object", () => {
+    expect(resolveNodePairApprovalScopes([], { attach: false })).toEqual(["operator.pairing"]);
+    expect(resolveNodePairApprovalScopes([], {})).toEqual(["operator.pairing"]);
+    expect(resolveNodePairApprovalScopes([], undefined)).toEqual(["operator.pairing"]);
+    expect(resolveNodePairApprovalScopes([], null)).toEqual(["operator.pairing"]);
+  });
+});
+
+describe("nodePermissionsRequireAdminApproval", () => {
+  it("is true only when attach === true", () => {
+    expect(nodePermissionsRequireAdminApproval({ attach: true })).toBe(true);
+    expect(nodePermissionsRequireAdminApproval({ attach: false })).toBe(false);
+    expect(nodePermissionsRequireAdminApproval({ other: true })).toBe(false);
+    expect(nodePermissionsRequireAdminApproval(undefined)).toBe(false);
+    expect(nodePermissionsRequireAdminApproval(null)).toBe(false);
   });
 });

--- a/src/infra/node-pairing-authz.ts
+++ b/src/infra/node-pairing-authz.ts
@@ -8,18 +8,38 @@ const OPERATOR_PAIRING_SCOPE: NodeApprovalScope = "operator.pairing";
 const OPERATOR_WRITE_SCOPE: NodeApprovalScope = "operator.write";
 const OPERATOR_ADMIN_SCOPE: NodeApprovalScope = "operator.admin";
 
-/** Map declared node commands to the least operator scopes needed for approval. */
-export function resolveNodePairApprovalScopes(commands: unknown): NodeApprovalScope[] {
+/** True when a declared permission set requires elevated (admin) approval on its own. Granting a
+ *  node the `attach` permission lets it mint a grant onto the owner's MAIN session — reaching the
+ *  owner's tools + full conversation — so approving it requires operator.admin even when the request
+ *  declares no commands (a commandless attach request must NOT be approvable by pairing scope alone). */
+export function nodePermissionsRequireAdminApproval(permissions: unknown): boolean {
+  return (
+    typeof permissions === "object" &&
+    permissions !== null &&
+    (permissions as Record<string, unknown>).attach === true
+  );
+}
+
+/** Map declared node commands (+ permissions) to the least operator scopes needed for approval. */
+export function resolveNodePairApprovalScopes(
+  commands: unknown,
+  permissions?: unknown,
+): NodeApprovalScope[] {
   const normalized = Array.isArray(commands)
     ? commands.filter((command): command is string => typeof command === "string")
     : [];
+  const attachNeedsAdmin = nodePermissionsRequireAdminApproval(permissions);
   if (
     normalized.some((command) => NODE_SYSTEM_RUN_COMMANDS.some((allowed) => allowed === command))
   ) {
     return [OPERATOR_PAIRING_SCOPE, OPERATOR_ADMIN_SCOPE];
   }
   if (normalized.length > 0) {
-    return [OPERATOR_PAIRING_SCOPE, OPERATOR_WRITE_SCOPE];
+    return attachNeedsAdmin
+      ? [OPERATOR_PAIRING_SCOPE, OPERATOR_WRITE_SCOPE, OPERATOR_ADMIN_SCOPE]
+      : [OPERATOR_PAIRING_SCOPE, OPERATOR_WRITE_SCOPE];
   }
-  return [OPERATOR_PAIRING_SCOPE];
+  return attachNeedsAdmin
+    ? [OPERATOR_PAIRING_SCOPE, OPERATOR_ADMIN_SCOPE]
+    : [OPERATOR_PAIRING_SCOPE];
 }

--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -668,3 +668,33 @@ describe("node pairing tokens", () => {
     });
   });
 });
+
+describe("attach-permission pairing approval is admin-gated", () => {
+  test("a COMMANDLESS attach request is denied to a pairing-only caller, approved by an admin", () =>
+    withNodePairingDir(async (baseDir) => {
+      const request = await requestNodePairing(
+        { nodeId: "attach-node", platform: "darwin", permissions: { attach: true } },
+        baseDir,
+      );
+      // pairing scope alone must NOT grant a node `attach` — that reaches the owner's main session
+      const denied = await approveNodePairing(
+        request.request.requestId,
+        { callerScopes: ["operator.pairing"] },
+        baseDir,
+      );
+      expect(denied).toEqual({ status: "forbidden", missingScope: "operator.admin" });
+      expect(await findPairedNode("attach-node", baseDir)).toBeNull(); // not paired
+
+      // an operator.admin caller may approve it; the attach permission persists on the paired node
+      const approved = await approveNodePairing(
+        request.request.requestId,
+        { callerScopes: ["operator.pairing", "operator.admin"] },
+        baseDir,
+      );
+      expect(approved && "node" in approved).toBe(true);
+      expect(await findPairedNode("attach-node", baseDir)).toMatchObject({
+        nodeId: "attach-node",
+        permissions: { attach: true },
+      });
+    }));
+});

--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -1,4 +1,5 @@
 // Tests node pairing identity persistence and validation.
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
@@ -672,8 +673,9 @@ describe("node pairing tokens", () => {
 describe("attach-permission pairing approval is admin-gated", () => {
   test("a COMMANDLESS attach request is denied to a pairing-only caller, approved by an admin", () =>
     withNodePairingDir(async (baseDir) => {
+      const nodeId = `attach-node-${randomUUID()}`; // unique per run — isolate from shared-dir state
       const request = await requestNodePairing(
-        { nodeId: "attach-node", platform: "darwin", permissions: { attach: true } },
+        { nodeId, platform: "darwin", permissions: { attach: true } },
         baseDir,
       );
       // pairing scope alone must NOT grant a node `attach` — that reaches the owner's main session
@@ -683,7 +685,7 @@ describe("attach-permission pairing approval is admin-gated", () => {
         baseDir,
       );
       expect(denied).toEqual({ status: "forbidden", missingScope: "operator.admin" });
-      expect(await findPairedNode("attach-node", baseDir)).toBeNull(); // not paired
+      expect(await findPairedNode(nodeId, baseDir)).toBeNull(); // not paired
 
       // an operator.admin caller may approve it; the attach permission persists on the paired node
       const approved = await approveNodePairing(
@@ -692,8 +694,8 @@ describe("attach-permission pairing approval is admin-gated", () => {
         baseDir,
       );
       expect(approved && "node" in approved).toBe(true);
-      expect(await findPairedNode("attach-node", baseDir)).toMatchObject({
-        nodeId: "attach-node",
+      expect(await findPairedNode(nodeId, baseDir)).toMatchObject({
+        nodeId,
         permissions: { attach: true },
       });
     }));

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -222,7 +222,8 @@ function mergeNodePairingReplacementInput(params: {
 
 function resolveNodeApprovalRequiredScopes(pending: NodePairingPendingRecord): NodeApprovalScope[] {
   const commands = Array.isArray(pending.commands) ? pending.commands : [];
-  return resolveNodePairApprovalScopes(commands);
+  // Pass permissions too: a commandless request carrying `attach` still requires operator.admin.
+  return resolveNodePairApprovalScopes(commands, pending.permissions);
 }
 
 function toPublicPendingNodePairingRequest(

--- a/src/node-host/attach-forwarder.test.ts
+++ b/src/node-host/attach-forwarder.test.ts
@@ -67,7 +67,22 @@ describe("node attach forwarder (PR5 conduit)", () => {
       method: "tools/list",
     });
     expect(status).toBe(502);
-    expect(json.error.code).toBe(-32001);
+    expect(json).toMatchObject({ jsonrpc: "2.0", id: 1, error: { code: -32001 } }); // error envelope carries the request id
+  });
+
+  it("rejects a body over the 4MB cap without relaying it", async () => {
+    const request = vi.fn(async () => ({ mcpResponse: { ok: 1 } }));
+    fwd = await startNodeAttachForwarder({ client: { request } });
+    const huge = "x".repeat(4 * 1024 * 1024 + 1024); // > MAX_BODY_BYTES
+    // the server destroys the request once the body exceeds the cap → the connection resets
+    await expect(
+      fetch(fwd.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: huge,
+      }),
+    ).rejects.toThrow();
+    expect(request).not.toHaveBeenCalled(); // never relayed an over-cap body
   });
 
   it("declines the GET notification stream with 405 (no server-initiated events)", async () => {

--- a/src/node-host/attach-forwarder.test.ts
+++ b/src/node-host/attach-forwarder.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type NodeAttachForwarder, startNodeAttachForwarder } from "./attach-forwarder.js";
+
+let fwd: NodeAttachForwarder | undefined;
+afterEach(async () => {
+  await fwd?.close();
+  fwd = undefined;
+});
+
+async function postMcp(url: string, body: unknown, token?: string) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : null };
+}
+
+describe("node attach forwarder (PR5 conduit)", () => {
+  it("relays a POSTed MCP message over node.attachRelay with the bearer grant token", async () => {
+    const request = vi.fn(async () => ({
+      mcpResponse: { jsonrpc: "2.0", id: 7, result: { ok: true } },
+    }));
+    fwd = await startNodeAttachForwarder({ client: { request } });
+    const msg = { jsonrpc: "2.0", id: 7, method: "tools/list" };
+    const { status, json } = await postMcp(fwd.url, msg, "tok-abc");
+    expect(status).toBe(200);
+    expect(json).toEqual({ jsonrpc: "2.0", id: 7, result: { ok: true } });
+    // the grant token comes off the harness's Authorization header; scope is bound gateway-side
+    expect(request).toHaveBeenCalledWith("node.attachRelay", {
+      grantToken: "tok-abc",
+      mcpMessage: msg,
+    });
+  });
+
+  it("emits 202 with no body for a relayed notification (null response)", async () => {
+    const request = vi.fn(async () => ({ mcpResponse: null }));
+    fwd = await startNodeAttachForwarder({ client: { request } });
+    const res = await fetch(fwd.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+    });
+    expect(res.status).toBe(202);
+  });
+
+  it("returns a JSON-RPC parse error for a malformed body", async () => {
+    fwd = await startNodeAttachForwarder({ client: { request: vi.fn() } });
+    const res = await fetch(fwd.url, { method: "POST", body: "not json" });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe(-32700);
+  });
+
+  it("surfaces a relay failure as a 502 JSON-RPC error (link down)", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("link down");
+    });
+    fwd = await startNodeAttachForwarder({ client: { request } });
+    const { status, json } = await postMcp(fwd.url, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+    expect(status).toBe(502);
+    expect(json.error.code).toBe(-32001);
+  });
+
+  it("declines the GET notification stream with 405 (no server-initiated events)", async () => {
+    fwd = await startNodeAttachForwarder({ client: { request: vi.fn() } });
+    const res = await fetch(fwd.url, { method: "GET" });
+    expect(res.status).toBe(405);
+  });
+});

--- a/src/node-host/attach-forwarder.test.ts
+++ b/src/node-host/attach-forwarder.test.ts
@@ -1,3 +1,4 @@
+import net from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { type NodeAttachForwarder, startNodeAttachForwarder } from "./attach-forwarder.js";
 
@@ -73,5 +74,22 @@ describe("node attach forwarder (PR5 conduit)", () => {
     fwd = await startNodeAttachForwarder({ client: { request: vi.fn() } });
     const res = await fetch(fwd.url, { method: "GET" });
     expect(res.status).toBe(405);
+  });
+
+  it("survives a client that aborts mid-request and keeps serving (no host crash)", async () => {
+    fwd = await startNodeAttachForwarder({
+      client: { request: vi.fn(async () => ({ mcpResponse: { ok: 1 } })) },
+    });
+    // announce a 1000-byte body, send a fragment, then yank the socket → server req 'error'
+    await new Promise<void>((resolve) => {
+      const sock = net.connect(fwd!.port, "127.0.0.1", () => {
+        sock.write("POST /mcp HTTP/1.1\r\nHost: x\r\nContent-Length: 1000\r\n\r\npartial");
+        sock.destroy();
+        resolve();
+      });
+    });
+    // the forwarder did not crash the host — a normal request still succeeds
+    const { status } = await postMcp(fwd.url, { jsonrpc: "2.0", id: 1, method: "tools/list" });
+    expect(status).toBe(200);
   });
 });

--- a/src/node-host/attach-forwarder.ts
+++ b/src/node-host/attach-forwarder.ts
@@ -26,11 +26,15 @@ export function startNodeAttachForwarder(params: {
 }): Promise<NodeAttachForwarder> {
   const { client } = params;
   const server = http.createServer((req, res) => {
+    // A harness that aborts mid-request/response must NOT crash the node host: an unhandled stream
+    // 'error' (e.g. client closed before the body finished) is fatal in Node, so swallow both here.
+    req.on("error", () => {});
+    res.on("error", () => {});
     // Streamable-HTTP MCP: requests are POSTed. The optional GET notification stream carries no
     // server-initiated events here; 405 is the spec-compliant "no server stream", and the harness
     // falls back to plain request/response.
     if (req.method !== "POST") {
-      res.writeHead(405).end();
+      endSafely(res, 405);
       return;
     }
     const grantToken = readBearer(req.headers.authorization);
@@ -57,30 +61,30 @@ export function startNodeAttachForwarder(params: {
         writeJson(res, 400, rpcError(null, -32700, "Parse error"));
         return;
       }
-      void (async () => {
-        try {
-          const { mcpResponse } = await client.request<{ mcpResponse: unknown }>(
-            "node.attachRelay",
-            {
-              grantToken,
-              mcpMessage,
-            },
-          );
-          // A notification (no response) relays back as null — emit 202 with no body, like the loopback.
+      // .then/.catch (not an async IIFE) keeps the rejection handled — no floating promise.
+      void client
+        .request<{ mcpResponse: unknown }>("node.attachRelay", { grantToken, mcpMessage })
+        .then(({ mcpResponse }) => {
+          // A notification (no response) relays back as null — emit 202 with no body, like loopback.
           if (mcpResponse === null || mcpResponse === undefined) {
-            res.writeHead(202).end();
+            endSafely(res, 202);
             return;
           }
           writeJson(res, 200, mcpResponse);
-        } catch {
+        })
+        .catch(() => {
           writeJson(res, 502, rpcError(idOf(mcpMessage), -32001, "attach relay failed"));
-        }
-      })();
+        });
     });
   });
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    // A listen failure rejects start(); once listening, later server errors must not crash the host.
+    const onListenError = (err: Error) => reject(err);
+    server.once("error", onListenError);
     server.listen(0, "127.0.0.1", () => {
+      server.off("error", onListenError);
+      server.on("error", () => {});
       const address = server.address();
       const port = typeof address === "object" && address ? address.port : 0;
       resolve({
@@ -95,12 +99,31 @@ export function startNodeAttachForwarder(params: {
   });
 }
 
+/** Write a status with no body only if the client is still connected (never throws on a dead socket). */
+function endSafely(res: http.ServerResponse, status: number): void {
+  if (res.writableEnded || res.destroyed) {
+    return;
+  }
+  try {
+    res.writeHead(status).end();
+  } catch {
+    // client went away between the check and the write — nothing to do.
+  }
+}
+
 function readBearer(header: string | undefined): string {
   return header?.startsWith("Bearer ") ? header.slice("Bearer ".length) : "";
 }
 
 function writeJson(res: http.ServerResponse, status: number, body: unknown): void {
-  res.writeHead(status, JSON_HEADERS).end(JSON.stringify(body));
+  if (res.writableEnded || res.destroyed) {
+    return;
+  }
+  try {
+    res.writeHead(status, JSON_HEADERS).end(JSON.stringify(body));
+  } catch {
+    // client went away between the check and the write — nothing to do.
+  }
 }
 
 function rpcError(id: unknown, code: number, message: string) {

--- a/src/node-host/attach-forwarder.ts
+++ b/src/node-host/attach-forwarder.ts
@@ -1,0 +1,112 @@
+// Node-side conduit forwarder (PR5). The local harness (Claude Code — TCP-only, see PR3) connects to
+// this loopback-TCP MCP endpoint; each JSON-RPC request is relayed over the node's EXISTING gateway
+// link via `node.attachRelay` into the gateway's scoped loopback tools. So a harness on a node machine
+// reaches the same tool surface as the gateway host WITHOUT the machine opening a direct gateway
+// connection and WITHOUT a new gateway endpoint. The grant token rides the harness's Authorization
+// header (the node never sees it at rest) and is forwarded per request; scope is bound to the grant.
+import http from "node:http";
+
+/** Minimal request/response client surface (GatewayClient.request) so this stays unit-testable. */
+type RelayClient = {
+  request<T>(method: string, params: Record<string, unknown>): Promise<T>;
+};
+
+const MAX_BODY_BYTES = 4 * 1024 * 1024;
+const JSON_HEADERS = { "Content-Type": "application/json" } as const;
+
+export type NodeAttachForwarder = {
+  port: number;
+  url: string;
+  close: () => Promise<void>;
+};
+
+/** Start the loopback forwarder. Binds an ephemeral 127.0.0.1 port; caller points the harness at `url`. */
+export function startNodeAttachForwarder(params: {
+  client: RelayClient;
+}): Promise<NodeAttachForwarder> {
+  const { client } = params;
+  const server = http.createServer((req, res) => {
+    // Streamable-HTTP MCP: requests are POSTed. The optional GET notification stream carries no
+    // server-initiated events here; 405 is the spec-compliant "no server stream", and the harness
+    // falls back to plain request/response.
+    if (req.method !== "POST") {
+      res.writeHead(405).end();
+      return;
+    }
+    const grantToken = readBearer(req.headers.authorization);
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let tooLarge = false;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        tooLarge = true;
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (tooLarge) {
+        return;
+      }
+      let mcpMessage: unknown;
+      try {
+        mcpMessage = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      } catch {
+        writeJson(res, 400, rpcError(null, -32700, "Parse error"));
+        return;
+      }
+      void (async () => {
+        try {
+          const { mcpResponse } = await client.request<{ mcpResponse: unknown }>(
+            "node.attachRelay",
+            {
+              grantToken,
+              mcpMessage,
+            },
+          );
+          // A notification (no response) relays back as null — emit 202 with no body, like the loopback.
+          if (mcpResponse === null || mcpResponse === undefined) {
+            res.writeHead(202).end();
+            return;
+          }
+          writeJson(res, 200, mcpResponse);
+        } catch {
+          writeJson(res, 502, rpcError(idOf(mcpMessage), -32001, "attach relay failed"));
+        }
+      })();
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({
+        port,
+        url: `http://127.0.0.1:${port}/mcp`,
+        close: () =>
+          new Promise<void>((done) => {
+            server.close(() => done());
+          }),
+      });
+    });
+  });
+}
+
+function readBearer(header: string | undefined): string {
+  return header?.startsWith("Bearer ") ? header.slice("Bearer ".length) : "";
+}
+
+function writeJson(res: http.ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, JSON_HEADERS).end(JSON.stringify(body));
+}
+
+function rpcError(id: unknown, code: number, message: string) {
+  return { jsonrpc: "2.0", id: id ?? null, error: { code, message } };
+}
+
+function idOf(message: unknown): unknown {
+  return message && typeof message === "object" ? (message as { id?: unknown }).id : null;
+}

--- a/src/node-host/attach-forwarder.ts
+++ b/src/node-host/attach-forwarder.ts
@@ -6,9 +6,10 @@
 // header (the node never sees it at rest) and is forwarded per request; scope is bound to the grant.
 import http from "node:http";
 
-/** Minimal request/response client surface (GatewayClient.request) so this stays unit-testable. */
+/** Minimal request client surface (a subset of GatewayClient.request) so this stays unit-testable.
+ *  Non-generic on purpose: the real generic client satisfies it, and the relay casts the one result. */
 type RelayClient = {
-  request<T>(method: string, params: Record<string, unknown>): Promise<T>;
+  request(method: string, params: Record<string, unknown>): Promise<unknown>;
 };
 
 const MAX_BODY_BYTES = 4 * 1024 * 1024;
@@ -63,8 +64,9 @@ export function startNodeAttachForwarder(params: {
       }
       // .then/.catch (not an async IIFE) keeps the rejection handled — no floating promise.
       void client
-        .request<{ mcpResponse: unknown }>("node.attachRelay", { grantToken, mcpMessage })
-        .then(({ mcpResponse }) => {
+        .request("node.attachRelay", { grantToken, mcpMessage })
+        .then((relayed) => {
+          const { mcpResponse } = (relayed ?? {}) as { mcpResponse?: unknown };
           // A notification (no response) relays back as null — emit 202 with no body, like loopback.
           if (mcpResponse === null || mcpResponse === undefined) {
             endSafely(res, 202);

--- a/src/node-host/attach.test.ts
+++ b/src/node-host/attach.test.ts
@@ -71,4 +71,26 @@ describe("prepareNodeAttach (PR5 conduit + PR7 hydration integration)", () => {
     expect(launch.launchArgs).toEqual(["--session-id", launch.cliSessionId]);
     expect(launch.transcriptPath).toBeUndefined();
   });
+
+  it("revokes the grant when setup fails after minting it", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "node.attachGrant") {
+        return { sessionKey: "agent:main", token: "tok-fail", expiresAtMs: 9e12 };
+      }
+      if (method === "node.attachHydrate") {
+        throw new Error("hydrate failed");
+      }
+      return {};
+    });
+
+    await expect(
+      prepareNodeAttach({
+        client: { request },
+        cwd: "/work/proj",
+        nowMs: 1e6,
+      }),
+    ).rejects.toThrow("hydrate failed");
+
+    expect(request).toHaveBeenCalledWith("node.attachRevoke", { grantToken: "tok-fail" });
+  });
 });

--- a/src/node-host/attach.test.ts
+++ b/src/node-host/attach.test.ts
@@ -1,0 +1,74 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type NodeAttachLaunch, prepareNodeAttach } from "./attach.js";
+
+let home = "";
+let launch: NodeAttachLaunch | undefined;
+afterEach(async () => {
+  await launch?.forwarder.close();
+  if (home) {
+    rmSync(home, { recursive: true, force: true });
+  }
+  home = "";
+  launch = undefined;
+});
+
+describe("prepareNodeAttach (PR5 conduit + PR7 hydration integration)", () => {
+  it("grants, hydrates the gateway conversation, starts the forwarder, returns a --resume launch", async () => {
+    home = mkdtempSync(join(tmpdir(), "nodeattach-"));
+    const request = vi.fn(async (method: string) => {
+      if (method === "node.attachGrant") {
+        return { sessionKey: "agent:main", token: "tok-1", expiresAtMs: 9e12 };
+      }
+      if (method === "node.attachHydrate") {
+        return {
+          messages: [
+            { role: "user", content: "hi" },
+            { role: "assistant", content: "hello back" },
+          ],
+        };
+      }
+      return {};
+    });
+    launch = await prepareNodeAttach({
+      client: { request },
+      cwd: "/work/proj",
+      nowMs: 1e6,
+      homeDir: home,
+    });
+
+    expect(request).toHaveBeenCalledWith("node.attachGrant", {});
+    expect(request).toHaveBeenCalledWith("node.attachHydrate", { grantToken: "tok-1" });
+    // a conversation existed → hydrate a transcript and --resume it (pick-up-anywhere)
+    expect(launch.launchArgs).toEqual(["--resume", launch.cliSessionId]);
+    expect(launch.transcriptPath && existsSync(launch.transcriptPath)).toBe(true);
+    // the harness points at the LOCAL forwarder; token rides the env placeholder, not argv/config
+    expect((launch.mcpConfig.mcpServers.openclaw as { url: string }).url).toBe(
+      launch.forwarder.url,
+    );
+    expect(
+      (launch.mcpConfig.mcpServers.openclaw as { headers: { Authorization: string } }).headers
+        .Authorization,
+    ).toContain("${OPENCLAW_MCP_TOKEN}");
+    expect(launch.env.OPENCLAW_MCP_TOKEN).toBe("tok-1");
+  });
+
+  it("falls back to a fresh --session-id when there is no conversation to hydrate", async () => {
+    home = mkdtempSync(join(tmpdir(), "nodeattach-"));
+    const request = vi.fn(async (method: string) =>
+      method === "node.attachGrant"
+        ? { sessionKey: "agent:main", token: "t", expiresAtMs: 9e12 }
+        : { messages: [] },
+    );
+    launch = await prepareNodeAttach({
+      client: { request },
+      cwd: "/work/proj",
+      nowMs: 1e6,
+      homeDir: home,
+    });
+    expect(launch.launchArgs).toEqual(["--session-id", launch.cliSessionId]);
+    expect(launch.transcriptPath).toBeUndefined();
+  });
+});

--- a/src/node-host/attach.ts
+++ b/src/node-host/attach.ts
@@ -37,41 +37,65 @@ export async function prepareNodeAttach(params: {
   homeDir?: string;
 }): Promise<NodeAttachLaunch> {
   const { client, cwd, nowMs, homeDir } = params;
-  const grant = (await client.request("node.attachGrant", {})) as {
-    sessionKey: string;
-    token: string;
-    expiresAtMs: number;
-  };
-  const { messages } = (await client.request("node.attachHydrate", {
-    grantToken: grant.token,
-  })) as { messages: HydrationMessage[] };
-  // Fresh local cli session id; hydrate the gateway conversation under it so --resume picks it up.
-  const cliSessionId = randomUUID();
-  const transcriptPath = hydrateClaudeCliTranscript({
-    messages: Array.isArray(messages) ? messages : [],
-    sessionId: cliSessionId,
-    cwd,
-    nowMs,
-    homeDir,
-  });
-  const forwarder = await startNodeAttachForwarder({ client });
-  return {
-    sessionKey: grant.sessionKey,
-    cliSessionId,
-    forwarder,
-    // The harness's MCP client points at the LOCAL forwarder; the token rides the env placeholder so
-    // it never lands in argv or a durable config, mirroring the gateway-host launcher (PR2).
-    mcpConfig: {
-      mcpServers: {
-        openclaw: {
-          type: "http",
-          url: forwarder.url,
-          headers: { Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}" },
+  let grant:
+    | {
+        sessionKey: string;
+        token: string;
+        expiresAtMs: number;
+      }
+    | undefined;
+  let forwarder: NodeAttachForwarder | undefined;
+  try {
+    grant = (await client.request("node.attachGrant", {})) as {
+      sessionKey: string;
+      token: string;
+      expiresAtMs: number;
+    };
+    const { messages } = (await client.request("node.attachHydrate", {
+      grantToken: grant.token,
+    })) as { messages: HydrationMessage[] };
+    // Fresh local cli session id; hydrate the gateway conversation under it so --resume picks it up.
+    const cliSessionId = randomUUID();
+    const transcriptPath = hydrateClaudeCliTranscript({
+      messages: Array.isArray(messages) ? messages : [],
+      sessionId: cliSessionId,
+      cwd,
+      nowMs,
+      homeDir,
+    });
+    forwarder = await startNodeAttachForwarder({ client });
+    return {
+      sessionKey: grant.sessionKey,
+      cliSessionId,
+      forwarder,
+      // The harness's MCP client points at the LOCAL forwarder; the token rides the env placeholder so
+      // it never lands in argv or a durable config, mirroring the gateway-host launcher (PR2).
+      mcpConfig: {
+        mcpServers: {
+          openclaw: {
+            type: "http",
+            url: forwarder.url,
+            headers: { Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}" },
+          },
         },
       },
-    },
-    env: { OPENCLAW_MCP_TOKEN: grant.token, OPENCLAW_MCP_SESSION_KEY: grant.sessionKey },
-    launchArgs: transcriptPath ? ["--resume", cliSessionId] : ["--session-id", cliSessionId],
-    transcriptPath,
-  };
+      env: { OPENCLAW_MCP_TOKEN: grant.token, OPENCLAW_MCP_SESSION_KEY: grant.sessionKey },
+      launchArgs: transcriptPath ? ["--resume", cliSessionId] : ["--session-id", cliSessionId],
+      transcriptPath,
+    };
+  } catch (error) {
+    try {
+      await forwarder?.close();
+    } catch {
+      // best-effort cleanup
+    }
+    if (grant?.token) {
+      try {
+        await client.request("node.attachRevoke", { grantToken: grant.token });
+      } catch {
+        // best-effort cleanup; preserve the original setup failure
+      }
+    }
+    throw error;
+  }
 }

--- a/src/node-host/attach.ts
+++ b/src/node-host/attach.ts
@@ -12,8 +12,10 @@ import {
 } from "../gateway/cli-session-hydrate.claude.js";
 import { type NodeAttachForwarder, startNodeAttachForwarder } from "./attach-forwarder.js";
 
+// Non-generic on purpose: the real generic GatewayClient satisfies it, and we cast each result —
+// keeps the seam trivially mockable in tests without generic-vs-concrete assignability errors.
 type AttachClient = {
-  request<T>(method: string, params: Record<string, unknown>): Promise<T>;
+  request(method: string, params: Record<string, unknown>): Promise<unknown>;
 };
 
 export type NodeAttachLaunch = {
@@ -35,16 +37,14 @@ export async function prepareNodeAttach(params: {
   homeDir?: string;
 }): Promise<NodeAttachLaunch> {
   const { client, cwd, nowMs, homeDir } = params;
-  const grant = await client.request<{ sessionKey: string; token: string; expiresAtMs: number }>(
-    "node.attachGrant",
-    {},
-  );
-  const { messages } = await client.request<{ messages: HydrationMessage[] }>(
-    "node.attachHydrate",
-    {
-      grantToken: grant.token,
-    },
-  );
+  const grant = (await client.request("node.attachGrant", {})) as {
+    sessionKey: string;
+    token: string;
+    expiresAtMs: number;
+  };
+  const { messages } = (await client.request("node.attachHydrate", {
+    grantToken: grant.token,
+  })) as { messages: HydrationMessage[] };
   // Fresh local cli session id; hydrate the gateway conversation under it so --resume picks it up.
   const cliSessionId = randomUUID();
   const transcriptPath = hydrateClaudeCliTranscript({

--- a/src/node-host/attach.ts
+++ b/src/node-host/attach.ts
@@ -1,0 +1,77 @@
+// Node-side attach orchestration (PR5 conduit + PR7 hydration). Ties the pieces a paired node needs
+// to attach a local harness to its gateway session, entirely over the node's EXISTING gateway link:
+//   1. node.attachGrant   — self-service grant for the node's main session (pairing = authz)
+//   2. node.attachHydrate — the gateway-owned conversation for that session
+//   3. hydrate it into a fresh local Claude transcript so `claude --resume` continues it anywhere
+//   4. start the loopback forwarder -> node.attachRelay
+//   5. hand back the launch config (forwarder MCP url + token env + the --resume args)
+import { randomUUID } from "node:crypto";
+import {
+  type HydrationMessage,
+  hydrateClaudeCliTranscript,
+} from "../gateway/cli-session-hydrate.claude.js";
+import { type NodeAttachForwarder, startNodeAttachForwarder } from "./attach-forwarder.js";
+
+type AttachClient = {
+  request<T>(method: string, params: Record<string, unknown>): Promise<T>;
+};
+
+export type NodeAttachLaunch = {
+  sessionKey: string;
+  /** The fresh cli session id the hydrated transcript was written under; what `--resume` targets. */
+  cliSessionId: string;
+  forwarder: NodeAttachForwarder;
+  mcpConfig: { mcpServers: Record<string, unknown> };
+  env: Record<string, string>;
+  /** `["--resume", id]` when a transcript was hydrated, else `["--session-id", id]` (fresh session). */
+  launchArgs: string[];
+  transcriptPath: string | undefined;
+};
+
+export async function prepareNodeAttach(params: {
+  client: AttachClient;
+  cwd: string;
+  nowMs: number;
+  homeDir?: string;
+}): Promise<NodeAttachLaunch> {
+  const { client, cwd, nowMs, homeDir } = params;
+  const grant = await client.request<{ sessionKey: string; token: string; expiresAtMs: number }>(
+    "node.attachGrant",
+    {},
+  );
+  const { messages } = await client.request<{ messages: HydrationMessage[] }>(
+    "node.attachHydrate",
+    {
+      grantToken: grant.token,
+    },
+  );
+  // Fresh local cli session id; hydrate the gateway conversation under it so --resume picks it up.
+  const cliSessionId = randomUUID();
+  const transcriptPath = hydrateClaudeCliTranscript({
+    messages: Array.isArray(messages) ? messages : [],
+    sessionId: cliSessionId,
+    cwd,
+    nowMs,
+    homeDir,
+  });
+  const forwarder = await startNodeAttachForwarder({ client });
+  return {
+    sessionKey: grant.sessionKey,
+    cliSessionId,
+    forwarder,
+    // The harness's MCP client points at the LOCAL forwarder; the token rides the env placeholder so
+    // it never lands in argv or a durable config, mirroring the gateway-host launcher (PR2).
+    mcpConfig: {
+      mcpServers: {
+        openclaw: {
+          type: "http",
+          url: forwarder.url,
+          headers: { Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}" },
+        },
+      },
+    },
+    env: { OPENCLAW_MCP_TOKEN: grant.token, OPENCLAW_MCP_SESSION_KEY: grant.sessionKey },
+    launchArgs: transcriptPath ? ["--resume", cliSessionId] : ["--session-id", cliSessionId],
+    transcriptPath,
+  };
+}


### PR DESCRIPTION
> ⚠️ **Stacked on #96454** (PR2, the `openclaw attach` launcher) → **#96351** (PR1, the `attach` grant primitive). Merge after they land; the earlier commits here are theirs — review the `node.attach*`, hydration, `--via node` launcher, and admin-gate commits. Branch merges into current `main` with no conflicts.

## What Problem This Solves

A human-driven harness (Claude Code) on a machine that reaches the gateway **only through a node** — not a direct connection — can't use `openclaw attach`. And even where it could, there was no way to **continue the same conversation across surfaces**. This PR delivers both, over the node's **existing** gateway link:

- **Node conduit (PR5 of #96205):** funnel the harness's MCP into the gateway's scoped loopback tools over the node's already-authenticated WS link — **no new gateway endpoint**.
- **Hydration / "pick up anywhere" (PR7 of #96205):** materialize the **gateway-owned** conversation into a local Claude transcript so `claude --resume` continues it on whatever surface attaches.

## Why This Change Was Made

The attach grant (PR1, #96351) is transport-independent by design. Nodes are **conduits**, not new transports: a node already holds an authenticated `GatewayClient` link and can call gateway methods, so the harness's MCP rides that link instead of opening a direct connection. Hydration is the **down-mirror of PR4** (#96740): PR4 records *up* (local Claude transcript → gateway `chat.history`); PR7 hydrates *down* (gateway session → a fresh local transcript), making the gateway's `chat.history` the canonical, portable session.

## User Impact

- **Entitled node attach (admin-approved):** `node.attachGrant` mints only when the node's **owner-approved pairing permissions carry `attach`** — pairing a node for camera/canvas/system is *not* consent to reach the owner's main session + conversation, so `role:node` alone is rejected. **Granting that `attach` permission requires `operator.admin` to approve** — even for a *commandless* pairing request — so pairing/write scope can't hand a node reach into the owner's main session. Scoped to the node's **main** gateway session (bound to the session, never the node; can't widen). Consent rides the existing pairing-permissions seam (no new config), and is unforgeable: changing a node's approval surface re-triggers owner approval.
- **One command, anywhere:** `openclaw attach` auto-detects its transport — on the gateway host it mints `attach.grant` → loopback (PR2); on a paired node it runs the conduit above and `claude --resume`s the hydrated session. `--via gateway|node` forces the choice. Same command whether you're on the gateway or reaching it through a node.
- **Tools over the link:** `node.attachRelay({grantToken, mcpMessage})` → the same scoped, destructive-excluded loopback tools as the gateway host; a small loopback-TCP **forwarder** is what the harness (TCP-only) connects to.
- **Pick-up-anywhere:** `node.attachHydrate` returns the gateway-owned conversation; `prepareNodeAttach` hydrates it locally and launches `claude --resume <id>`.
- **Additive only:** new node-role methods; no change to existing gateway/node behavior, the cli-backend, or the gateway-host attach path.

## Evidence

- **Unit tests (all green):** relay core (grant → scoped tools, scope bound to the grant), node methods (grant / relay / hydrate validation), forwarder (HTTP → `node.attachRelay`, 202 notifications, 400 parse-error, 502 link-down, 405 GET, **survives a client abort mid-request**), hydration (per-turn format + **round-trips through PR4's own reader**), the `prepareNodeAttach` orchestration (grant → hydrate → forwarder → `--resume` launch); the `openclaw attach` `--via` routing + gateway→node fallback; `runNodeAttach` (connect → orchestrate → teardown); and the **admin-gated attach-permission pairing** (a commandless `attach` request denied to a pairing-only caller, approved by an `operator.admin`).
- **Hydration proven LIVE (standalone):** `claude --resume` on a hand-materialized transcript recalled a planted conversation (codeword recall, exit 0) — the format matches what Claude Code writes.
- **Full node-conduit + hydration E2E — LIVE in an isolated container** (apple-container, no Docker): a gateway, a **real node** connected over its WS link, and **real Claude Code 2.1.191**, driven by the actual `prepareNodeAttach` orchestration — **[full run log](https://gist.github.com/anagnorisis2peripeteia/b46a4277d88826fc22e83ab28240b3a3)**. Redacted output:
  ```text
  [e2e] NODE CONNECTED + AUTHENTICATED over the node link
  [e2e] prepareNodeAttach OK: { sessionKey: "agent:main:…", launchArgs: ["--resume","846e2ce6-…"],
                                forwarder: "http://127.0.0.1:<port>/mcp", hydratedTranscript: true }
  [e2e] launching REAL claude through the forwarder...
  [e2e] CLAUDE STDOUT >>> "The openclaw MCP server has finished connecting …" <<<
  ```
  - **Conduit:** real claude reached the gateway's `openclaw` MCP server **through the node-side forwarder, over the node's existing link** (`node.attachRelay`) — claude's own words, and `tools/list` round-tripped through it. **No new gateway endpoint.**
  - **Hydration (pick-up-anywhere):** `node.attachHydrate` returned the gateway-**owned** main-session conversation (the agent's real `[OpenClaw heartbeat poll]` turns); `prepareNodeAttach` materialized it to a local transcript (44 KB, valid parentUuid chain) and claude **`--resume`d it and continued**.
  - **Entitlement gate works live:** the node minted `node.attachGrant` only because its owner-approved pairing carried `attach` — the gate rejected it (`"node is not entitled to attach"`) until the entitlement was present.
  - The scoped tool list came back **empty** — the secure default-deny for a non-owner attach on a bare gateway (no tools opted in); the conduit transport + `tools/list` round-trip are proven regardless.
- **Build, oxlint, type-check (incl. test types), deadcode, import-cycles, and topology/boundary checks all clean.** Delta on top of PR2/PR1 is the `node.attach*` methods, hydration, the `--via node` launcher path (lazy-imported so gateway-host startup stays light), and the admin-gate.

**Risks → mitigations:** the node→main-session reach is gated on an **explicit, owner-approved `attach` entitlement** (not implicit pairing), main-session-scoped (can't widen / reach other users); relay scope is sourced from the grant's `sessionKey`, never the caller; the forwarder keeps the token in the harness env (never at rest on the node) and survives a client abort without crashing the host; hydration writes a `0600` transcript. The node-conduit live E2E above is captured (real claude through the forwarder + hydrated resume).

**Follow-ups (noted, not blocking):** (1) **grant lifetime vs entitlement** — a minted grant is short-TTL'd and revocable, but outlives `attach`-permission downgrade / unpair until expiry; track per-node grant revocation on unpair/downgrade. (2) **cross-agent entitlement map** — today single-owner main-session only.
