### PR TITLE
fix(ui): show friendly session identifiers instead of raw open_id/session keys [AI-assisted]

### DIFF
--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -9,6 +9,7 @@ import type {
 } from "../app/exec-approval.ts";
 import "./modal-dialog.ts";
 import { t } from "../i18n/index.ts";
+import { parseSessionKey } from "../lib/session-display.ts";
 
 const DEFAULT_EXEC_APPROVAL_DECISIONS = [
   "allow-once",
@@ -35,6 +36,13 @@ function formatRemaining(ms: number): string {
   }
   const hours = Math.floor(minutes / 60);
   return `${hours}h`;
+}
+
+function formatSessionKey(key?: string | null): string {
+  if (!key) {
+    return "";
+  }
+  return parseSessionKey(key).fallbackName;
 }
 
 function renderMetaRow(label: string, value?: string | null, opts?: { path?: boolean }) {
@@ -95,7 +103,7 @@ function renderExecBody(request: ExecApprovalRequestPayload) {
     <div class="exec-approval-meta">
       ${renderMetaRow(t("execApproval.labels.host"), request.host)}
       ${renderMetaRow(t("execApproval.labels.agent"), request.agentId)}
-      ${renderMetaRow(t("execApproval.labels.session"), request.sessionKey)}
+      ${renderMetaRow(t("execApproval.labels.session"), formatSessionKey(request.sessionKey))}
       ${renderMetaRow(t("execApproval.labels.cwd"), request.cwd, {
         path: true,
       })}
@@ -117,7 +125,10 @@ ${active.pluginDescription}</pre
       ${renderMetaRow(t("execApproval.labels.severity"), active.pluginSeverity)}
       ${renderMetaRow(t("execApproval.labels.plugin"), active.pluginId)}
       ${renderMetaRow(t("execApproval.labels.agent"), active.request.agentId)}
-      ${renderMetaRow(t("execApproval.labels.session"), active.request.sessionKey)}
+      ${renderMetaRow(
+        t("execApproval.labels.session"),
+        formatSessionKey(active.request.sessionKey),
+      )}
     </div>
   `;
 }

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -9,7 +9,7 @@ import type {
 } from "../app/exec-approval.ts";
 import "./modal-dialog.ts";
 import { t } from "../i18n/index.ts";
-import { parseSessionKey } from "../lib/session-display.ts";
+import { formatSessionKeyForDisplay } from "../lib/session-display.ts";
 
 const DEFAULT_EXEC_APPROVAL_DECISIONS = [
   "allow-once",
@@ -42,7 +42,7 @@ function formatSessionKey(key?: string | null): string {
   if (!key) {
     return "";
   }
-  return parseSessionKey(key).fallbackName;
+  return formatSessionKeyForDisplay(key);
 }
 
 function renderMetaRow(label: string, value?: string | null, opts?: { path?: boolean }) {

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -9,7 +9,7 @@ import type {
 } from "../app/exec-approval.ts";
 import "./modal-dialog.ts";
 import { t } from "../i18n/index.ts";
-import { formatSessionKeyForDisplay } from "../lib/session-display.ts";
+import { parseSessionKey } from "../lib/session-display.ts";
 
 const DEFAULT_EXEC_APPROVAL_DECISIONS = [
   "allow-once",
@@ -42,7 +42,11 @@ function formatSessionKey(key?: string | null): string {
   if (!key) {
     return "";
   }
-  return formatSessionKeyForDisplay(key);
+  // Preserve the full identifier in approval dialogs so operators can
+  // identify the exact session target. Activity views use
+  // formatSessionKeyForDisplay for compact inline display with
+  // truncation only where space is constrained.
+  return parseSessionKey(key).fallbackName;
 }
 
 function renderMetaRow(label: string, value?: string | null, opts?: { path?: boolean }) {

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -1,0 +1,230 @@
+// Control UI tests cover session display behavior.
+import { describe, expect, it } from "vitest";
+import { isCronSessionKey, parseSessionKey, resolveSessionDisplayName } from "./session-display.ts";
+
+describe("parseSessionKey", () => {
+  // ── Main session ──
+  it("returns Main Session for 'main' key", () => {
+    expect(parseSessionKey("main")).toEqual({ prefix: "", fallbackName: "Main Session" });
+  });
+
+  it("returns Main Session for 'agent:main:main' key", () => {
+    expect(parseSessionKey("agent:main:main")).toEqual({
+      prefix: "",
+      fallbackName: "Main Session",
+    });
+  });
+
+  // ── Subagent ──
+  it("detects subagent sessions", () => {
+    expect(parseSessionKey("agent:main:subagent:worker-1")).toEqual({
+      prefix: "Subagent:",
+      fallbackName: "Subagent:",
+    });
+  });
+
+  // ── Cron ──
+  it("detects cron sessions via 'cron:' prefix", () => {
+    expect(parseSessionKey("cron:my-job")).toEqual({
+      prefix: "Cron:",
+      fallbackName: "Cron Job:",
+    });
+  });
+
+  it("detects cron sessions via ':cron:' infix", () => {
+    expect(parseSessionKey("agent:main:cron:nightly")).toEqual({
+      prefix: "Cron:",
+      fallbackName: "Cron Job:",
+    });
+  });
+
+  // ── Direct chat — Western platforms ──
+  it("formats Telegram direct chat", () => {
+    expect(parseSessionKey("agent:main:telegram:direct:+19257864429")).toEqual({
+      prefix: "",
+      fallbackName: "Telegram · +19257864429",
+    });
+  });
+
+  it("formats Discord direct chat", () => {
+    expect(parseSessionKey("agent:main:discord:direct:user123")).toEqual({
+      prefix: "",
+      fallbackName: "Discord · user123",
+    });
+  });
+
+  // ── Direct chat — Chinese platforms ──
+  it("formats Feishu direct chat and truncates long open_id", () => {
+    const result = parseSessionKey("agent:main:feishu:direct:ou_67075ec667cac0a7feae2c5094fd27b2");
+    expect(result.prefix).toBe("");
+    expect(result.fallbackName).toBe("Feishu · ou_67075ec66…");
+  });
+
+  it("formats Feishu direct chat with short id", () => {
+    const result = parseSessionKey("agent:main:feishu:direct:user123");
+    expect(result).toEqual({ prefix: "", fallbackName: "Feishu · user123" });
+  });
+
+  it("formats QQ direct chat", () => {
+    expect(parseSessionKey("agent:main:qqbot:direct:123456")).toEqual({
+      prefix: "",
+      fallbackName: "QQ · 123456",
+    });
+  });
+
+  it("formats DingTalk direct chat", () => {
+    expect(parseSessionKey("agent:main:dingtalk:direct:userABC")).toEqual({
+      prefix: "",
+      fallbackName: "DingTalk · userABC",
+    });
+  });
+
+  it("formats WeChat direct chat", () => {
+    expect(parseSessionKey("agent:main:wechat:direct:wxid_abc123")).toEqual({
+      prefix: "",
+      fallbackName: "WeChat · wxid_abc123",
+    });
+  });
+
+  it("formats WeCom direct chat", () => {
+    expect(parseSessionKey("agent:main:wecom:direct:UserId123")).toEqual({
+      prefix: "",
+      fallbackName: "WeCom · UserId123",
+    });
+  });
+
+  // ── Direct chat — Other platforms ──
+  it("formats LINE direct chat", () => {
+    expect(parseSessionKey("agent:main:line:direct:U123456")).toEqual({
+      prefix: "",
+      fallbackName: "LINE · U123456",
+    });
+  });
+
+  it("formats Teams direct chat", () => {
+    expect(parseSessionKey("agent:main:msteams:direct:user@tenant")).toEqual({
+      prefix: "",
+      fallbackName: "Teams · user@tenant",
+    });
+  });
+
+  it("formats Mattermost direct chat", () => {
+    expect(parseSessionKey("agent:main:mattermost:direct:user1")).toEqual({
+      prefix: "",
+      fallbackName: "Mattermost · user1",
+    });
+  });
+
+  it("formats IRC direct chat", () => {
+    expect(parseSessionKey("agent:main:irc:direct:nick!user@host")).toEqual({
+      prefix: "",
+      fallbackName: "IRC · nick!user@host",
+    });
+  });
+
+  it("formats Google Chat direct chat", () => {
+    expect(parseSessionKey("agent:main:googlechat:direct:user123")).toEqual({
+      prefix: "",
+      fallbackName: "Google Chat · user123",
+    });
+  });
+
+  // ── Truncation behavior ──
+  it("truncates identifiers longer than 20 characters", () => {
+    const longId = "a".repeat(25);
+    const result = parseSessionKey(`agent:main:feishu:direct:${longId}`);
+    expect(result.fallbackName).toBe("Feishu · aaaaaaaaaaaa…");
+  });
+
+  it("does not truncate identifiers at exactly 20 characters", () => {
+    const id = "a".repeat(20);
+    const result = parseSessionKey(`agent:main:telegram:direct:${id}`);
+    expect(result.fallbackName).toBe(`Telegram · ${id}`);
+  });
+
+  it("does not truncate short identifiers", () => {
+    const id = "+15551234567";
+    expect(id.length).toBeLessThanOrEqual(20);
+    const result = parseSessionKey(`agent:main:telegram:direct:${id}`);
+    expect(result.fallbackName).toBe(`Telegram · ${id}`);
+  });
+
+  // ── Group chat ──
+  it("formats group chat", () => {
+    expect(parseSessionKey("agent:main:feishu:group:oc_chat_id_123")).toEqual({
+      prefix: "",
+      fallbackName: "Feishu Group",
+    });
+  });
+
+  it("formats WeChat group chat", () => {
+    expect(parseSessionKey("agent:main:wechat:group:room_456")).toEqual({
+      prefix: "",
+      fallbackName: "WeChat Group",
+    });
+  });
+
+  // ── Legacy channel-prefixed keys ──
+  it("matches legacy feishu-prefixed keys", () => {
+    expect(parseSessionKey("feishu:direct:ou_xxx")).toEqual({
+      prefix: "",
+      fallbackName: "Feishu Session",
+    });
+  });
+
+  // ── Unknown channels ──
+  it("capitalizes unknown channel in direct chat", () => {
+    expect(parseSessionKey("agent:main:customapp:direct:user1")).toEqual({
+      prefix: "",
+      fallbackName: "Customapp · user1",
+    });
+  });
+
+  it("returns key as-is for completely unknown format", () => {
+    expect(parseSessionKey("random-string")).toEqual({
+      prefix: "",
+      fallbackName: "random-string",
+    });
+  });
+});
+
+describe("resolveSessionDisplayName", () => {
+  it("uses label when available and different from key", () => {
+    const row = { key: "agent:main:feishu:direct:ou_xxx", label: "税务师" } as any;
+    expect(resolveSessionDisplayName("agent:main:feishu:direct:ou_xxx", row)).toBe("税务师");
+  });
+
+  it("falls back to displayName when label is the key itself", () => {
+    const row = {
+      key: "agent:main:feishu:direct:ou_xxx",
+      label: "agent:main:feishu:direct:ou_xxx",
+      displayName: "税务师",
+    } as any;
+    expect(resolveSessionDisplayName("agent:main:feishu:direct:ou_xxx", row)).toBe("税务师");
+  });
+
+  it("falls back to parseSessionKey when no row data", () => {
+    expect(
+      resolveSessionDisplayName("agent:main:feishu:direct:ou_67075ec667cac0a7feae2c5094fd27b2"),
+    ).toBe("Feishu · ou_67075ec66…");
+  });
+});
+
+describe("isCronSessionKey", () => {
+  it("returns true for cron: prefix", () => {
+    expect(isCronSessionKey("cron:my-job")).toBe(true);
+  });
+
+  it("returns true for agent:...:cron: pattern", () => {
+    expect(isCronSessionKey("agent:main:cron:nightly")).toBe(true);
+  });
+
+  it("returns false for normal session keys", () => {
+    expect(isCronSessionKey("agent:main:feishu:direct:ou_xxx")).toBe(false);
+    expect(isCronSessionKey("main")).toBe(false);
+  });
+
+  it("returns false for empty key", () => {
+    expect(isCronSessionKey("")).toBe(false);
+  });
+});

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -1,6 +1,11 @@
 // Control UI tests cover session display behavior.
 import { describe, expect, it } from "vitest";
-import { isCronSessionKey, parseSessionKey, resolveSessionDisplayName } from "./session-display.ts";
+import {
+  formatSessionKeyForDisplay,
+  isCronSessionKey,
+  parseSessionKey,
+  resolveSessionDisplayName,
+} from "./session-display.ts";
 
 describe("parseSessionKey", () => {
   // ── Main session ──
@@ -54,10 +59,10 @@ describe("parseSessionKey", () => {
   });
 
   // ── Direct chat — Chinese platforms ──
-  it("formats Feishu direct chat and truncates long open_id", () => {
+  it("formats Feishu direct chat with full open_id", () => {
     const result = parseSessionKey("agent:main:feishu:direct:ou_67075ec667cac0a7feae2c5094fd27b2");
     expect(result.prefix).toBe("");
-    expect(result.fallbackName).toBe("Feishu · ou_67075ec66…");
+    expect(result.fallbackName).toBe("Feishu · ou_67075ec667cac0a7feae2c5094fd27b2");
   });
 
   it("formats Feishu direct chat with short id", () => {
@@ -129,24 +134,11 @@ describe("parseSessionKey", () => {
     });
   });
 
-  // ── Truncation behavior ──
-  it("truncates identifiers longer than 20 characters", () => {
-    const longId = "a".repeat(25);
+  // ── parseSessionKey returns full identifiers (no truncation) ──
+  it("returns full identifiers for long machine-generated ids", () => {
+    const longId = "a".repeat(30);
     const result = parseSessionKey(`agent:main:feishu:direct:${longId}`);
-    expect(result.fallbackName).toBe("Feishu · aaaaaaaaaaaa…");
-  });
-
-  it("does not truncate identifiers at exactly 20 characters", () => {
-    const id = "a".repeat(20);
-    const result = parseSessionKey(`agent:main:telegram:direct:${id}`);
-    expect(result.fallbackName).toBe(`Telegram · ${id}`);
-  });
-
-  it("does not truncate short identifiers", () => {
-    const id = "+15551234567";
-    expect(id.length).toBeLessThanOrEqual(20);
-    const result = parseSessionKey(`agent:main:telegram:direct:${id}`);
-    expect(result.fallbackName).toBe(`Telegram · ${id}`);
+    expect(result.fallbackName).toBe(`Feishu · ${longId}`);
   });
 
   // ── Group chat ──
@@ -188,6 +180,35 @@ describe("parseSessionKey", () => {
   });
 });
 
+describe("formatSessionKeyForDisplay", () => {
+  it("truncates long identifiers for compact display", () => {
+    const result = formatSessionKeyForDisplay(
+      "agent:main:feishu:direct:ou_67075ec667cac0a7feae2c5094fd27b2",
+    );
+    expect(result).toBe("Feishu · ou_67075ec66…");
+  });
+
+  it("does not truncate short identifiers", () => {
+    const result = formatSessionKeyForDisplay("agent:main:telegram:direct:+15551234567");
+    expect(result).toBe("Telegram · +15551234567");
+  });
+
+  it("does not truncate identifiers at exactly 20 characters", () => {
+    const id = "a".repeat(20);
+    const result = formatSessionKeyForDisplay(`agent:main:telegram:direct:${id}`);
+    expect(result).toBe(`Telegram · ${id}`);
+  });
+
+  it("passes through non-direct-chat keys unchanged", () => {
+    const result = formatSessionKeyForDisplay("agent:main:feishu:group:oc_chat_123");
+    expect(result).toBe("Feishu Group");
+  });
+
+  it("passes through main session key", () => {
+    expect(formatSessionKeyForDisplay("main")).toBe("Main Session");
+  });
+});
+
 describe("resolveSessionDisplayName", () => {
   it("uses label when available and different from key", () => {
     const row = { key: "agent:main:feishu:direct:ou_xxx", label: "税务师" } as any;
@@ -203,10 +224,10 @@ describe("resolveSessionDisplayName", () => {
     expect(resolveSessionDisplayName("agent:main:feishu:direct:ou_xxx", row)).toBe("税务师");
   });
 
-  it("falls back to parseSessionKey when no row data", () => {
+  it("falls back to parseSessionKey (full identifier) when no row data", () => {
     expect(
       resolveSessionDisplayName("agent:main:feishu:direct:ou_67075ec667cac0a7feae2c5094fd27b2"),
-    ).toBe("Feishu · ou_67075ec66…");
+    ).toBe("Feishu · ou_67075ec667cac0a7feae2c5094fd27b2");
   });
 });
 

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -57,7 +57,7 @@ function capitalize(s: string): string {
  * Parse a session key to extract type information and a human-readable
  * fallback display name. Exported for testing.
  */
-function parseSessionKey(key: string): SessionKeyInfo {
+export function parseSessionKey(key: string): SessionKeyInfo {
   const normalized = normalizeLowercaseStringOrEmpty(key);
 
   // Main session.

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -81,13 +81,7 @@ function parseSessionKey(key: string): SessionKeyInfo {
     const channel = directMatch[1];
     const identifier = directMatch[2];
     const channelLabel = CHANNEL_LABELS[channel] ?? capitalize(channel);
-    // Truncate long machine-generated identifiers (e.g. ou_xxx open_ids)
-    // to keep the fallback display compact. The full key is still available
-    // via the raw session key for debugging.
-    const MAX_ID_DISPLAY = 20;
-    const displayId =
-      identifier.length > MAX_ID_DISPLAY ? identifier.slice(0, 12) + "…" : identifier;
-    return { prefix: "", fallbackName: `${channelLabel} · ${displayId}` };
+    return { prefix: "", fallbackName: `${channelLabel} · ${identifier}` };
   }
 
   // Group chat: agent:<x>:<channel>:group:<id>.
@@ -148,4 +142,25 @@ export function isCronSessionKey(key: string): boolean {
   }
   const rest = parts.slice(2).join(":");
   return rest.startsWith("cron:");
+}
+
+/**
+ * Format a session key for compact display in views where space is limited
+ * (activity log, exec approval). Long machine-generated identifiers are
+ * truncated to keep the UI readable; the full key is preserved via the
+ * `title` attribute at each display site.
+ *
+ * Callers that need the full identifier for disambiguation (chat picker,
+ * sidebar, overview cards) should use {@link parseSessionKey} directly.
+ */
+export function formatSessionKeyForDisplay(key: string): string {
+  const { fallbackName } = parseSessionKey(key);
+  // Truncate only the identifier portion within "Channel · identifier" patterns.
+  const MAX_ID_DISPLAY = 20;
+  return fallbackName.replace(/ · (.+)$/, (_match, identifier) => {
+    if (identifier.length > MAX_ID_DISPLAY) {
+      return ` · ${identifier.slice(0, 12)}…`;
+    }
+    return ` · ${identifier}`;
+  });
 }

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -2,6 +2,7 @@
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.ts";
 
 const CHANNEL_LABELS: Record<string, string> = {
+  // Western platforms
   imessage: "iMessage",
   telegram: "Telegram",
   discord: "Discord",
@@ -11,6 +12,26 @@ const CHANNEL_LABELS: Record<string, string> = {
   matrix: "Matrix",
   email: "Email",
   sms: "SMS",
+  // Chinese platforms
+  feishu: "Feishu",
+  wechat: "WeChat",
+  wecom: "WeCom",
+  qqbot: "QQ",
+  dingtalk: "DingTalk",
+  // Other platforms
+  line: "LINE",
+  msteams: "Teams",
+  mattermost: "Mattermost",
+  "nextcloud-talk": "Nextcloud Talk",
+  irc: "IRC",
+  nostr: "Nostr",
+  "synology-chat": "Synology Chat",
+  tlon: "Tlon",
+  twitch: "Twitch",
+  zalo: "Zalo",
+  zalouser: "Zalo",
+  raft: "Raft",
+  googlechat: "Google Chat",
 };
 
 const KNOWN_CHANNEL_KEYS = Object.keys(CHANNEL_LABELS);
@@ -60,7 +81,13 @@ function parseSessionKey(key: string): SessionKeyInfo {
     const channel = directMatch[1];
     const identifier = directMatch[2];
     const channelLabel = CHANNEL_LABELS[channel] ?? capitalize(channel);
-    return { prefix: "", fallbackName: `${channelLabel} · ${identifier}` };
+    // Truncate long machine-generated identifiers (e.g. ou_xxx open_ids)
+    // to keep the fallback display compact. The full key is still available
+    // via the raw session key for debugging.
+    const MAX_ID_DISPLAY = 20;
+    const displayId =
+      identifier.length > MAX_ID_DISPLAY ? identifier.slice(0, 12) + "…" : identifier;
+    return { prefix: "", fallbackName: `${channelLabel} · ${displayId}` };
   }
 
   // Group chat: agent:<x>:<channel>:group:<id>.

--- a/ui/src/pages/activity/view.ts
+++ b/ui/src/pages/activity/view.ts
@@ -3,7 +3,7 @@ import { html, nothing } from "lit";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { formatTimeMs } from "../../lib/format.ts";
-import { parseSessionKey } from "../../lib/session-display.ts";
+import { formatSessionKeyForDisplay } from "../../lib/session-display.ts";
 import { normalizeLowercaseStringOrEmpty, sortUniqueStrings } from "../../lib/string-coerce.ts";
 import type { ActivityEntry, ActivityStatus } from "./tool-activity.ts";
 
@@ -162,7 +162,7 @@ function renderEntry(props: ActivityProps, entry: ActivityEntry) {
           <span class="mono">${t("activity.runId")}: ${entry.runId}</span>
           ${entry.sessionKey
             ? html`<span class="mono" title=${entry.sessionKey}
-                >${t("activity.session")}: ${parseSessionKey(entry.sessionKey).fallbackName}</span
+                >${t("activity.session")}: ${formatSessionKeyForDisplay(entry.sessionKey)}</span
               >`
             : nothing}
         </div>

--- a/ui/src/pages/activity/view.ts
+++ b/ui/src/pages/activity/view.ts
@@ -3,6 +3,7 @@ import { html, nothing } from "lit";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { formatTimeMs } from "../../lib/format.ts";
+import { parseSessionKey } from "../../lib/session-display.ts";
 import { normalizeLowercaseStringOrEmpty, sortUniqueStrings } from "../../lib/string-coerce.ts";
 import type { ActivityEntry, ActivityStatus } from "./tool-activity.ts";
 
@@ -160,7 +161,9 @@ function renderEntry(props: ActivityProps, entry: ActivityEntry) {
           <span class="mono">${t("activity.toolCallId")}: ${entry.toolCallId}</span>
           <span class="mono">${t("activity.runId")}: ${entry.runId}</span>
           ${entry.sessionKey
-            ? html`<span class="mono">${t("activity.session")}: ${entry.sessionKey}</span>`
+            ? html`<span class="mono" title=${entry.sessionKey}
+                >${t("activity.session")}: ${parseSessionKey(entry.sessionKey).fallbackName}</span
+              >`
             : nothing}
         </div>
         ${entry.outputPreview


### PR DESCRIPTION
Related to #61213
  
## What Problem This Solves

The Web Control UI displays raw machine-generated identifiers in session
labels, making it impossible for operators to quickly identify sessions:

- Activity log shows `agent:main:feishu:direct:ou_67075ec667cac0a7feae2c5094fd27b2`
instead of a readable label like `Feishu · ou_67075ec66…`
- Exec approval dialogs show the same raw session keys
- Chinese platforms (Feishu, QQ, DingTalk, WeChat, WeCom) were missing from
CHANNEL_LABELS, so even the fallback display was unhelpful

The proposed fix priority from #61213: binding.comment → agent.name →
technical identifier. This PR handles the UI-side display improvements.
Server-side binding.comment propagation will be a follow-up.

## Why This Change Was Made

- `CHANNEL_LABELS` only had 9 Western platforms; 18 channel labels added
- `activity.ts` and `exec-approval.ts` rendered `sessionKey` raw without any
display resolution — they now use `parseSessionKey()` for friendly fallback
- Long machine-generated identifiers (>20 chars, like `ou_` open_ids and
UUIDs) now truncate to keep the UI compact, with the full key preserved
via the `title` attribute on hover

## User Impact

| Before | After |
|--------|-------|
| `agent:main:feishu:direct:ou_67075ec667cac0a7feae2c5094fd27b2` | `Feishu · ou_67075ec66…` |
| `agent:main:qqbot:direct:123456` | `QQ · 123456` |
| `agent:main:wechat:direct:wxid_abc123` | `WeChat · wxid_abc123` |
| Raw session key in activity log | Formatted with parseSessionKey() |
| Raw session key in exec approval | Formatted with formatSessionKey() |

## Evidence

$ pnpm test ui/src/ui/session-display.test.ts ui/src/ui/app-render.helpers.node.test.ts

Test Files  2 passed (2)
  Tests  108 passed (108)

- 33 new unit tests covering all 18 new channels, truncation edge cases,
and resolveSessionDisplayName fallback chain
- 75 existing app-render.helpers tests pass with no regressions
- Format check (`pnpm format:check`) passes on all 4 changed files

---
