### PR TITLE
fix(tools): classify no-op file mutations

### DIFF
--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -11,7 +11,7 @@ import {
   createRebindableDirectoryAlias,
   withRealpathSymlinkRebindRace,
 } from "../test-utils/symlink-rebind-race.js";
-import { applyPatch } from "./apply-patch.js";
+import { applyPatch, createApplyPatchTool } from "./apply-patch.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
@@ -134,6 +134,38 @@ describe("applyPatch", () => {
     expect(memory.files.get("/sandbox/dest.txt")).toBe("foo\nbaz\n");
     expect(memory.files.has("/sandbox/source.txt")).toBe(false);
     expect(result.summary.modified).toEqual(["dest.txt"]);
+  });
+
+  it("reports no-op update hunks as terminal failures", async () => {
+    const memory = createMemoryPatchSandbox({
+      "source.txt": "foo\nbar\n",
+    });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+ foo
+-bar
++bar
+*** End Patch`;
+
+    const result = await createApplyPatchTool(memory.options).execute(
+      "call-1",
+      { input: patch },
+      undefined,
+    );
+
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "No changes made to source.txt. The patch produced identical content.",
+    });
+    expect(result.details).toEqual({
+      ok: false,
+      status: "blocked",
+      reason: "no-op-patch",
+      summary: { added: [], modified: [], deleted: [] },
+    });
+    expect(result.terminate).toBe(true);
+    expect(memory.files.get("/sandbox/source.txt")).toBe("foo\nbar\n");
   });
 
   it("updates in place when move target resolves to the source file", async () => {

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -62,11 +62,23 @@ export type ApplyPatchSummary = {
 type ApplyPatchResult = {
   summary: ApplyPatchSummary;
   text: string;
+  noOpReason?: "no-op-patch";
 };
 
 type ApplyPatchToolDetails = {
   summary: ApplyPatchSummary;
-};
+} & (
+  | {
+      ok: false;
+      status: "blocked";
+      reason: "no-op-patch";
+    }
+  | {
+      ok?: true;
+      status?: "ok";
+      reason?: undefined;
+    }
+);
 
 type SandboxApplyPatchConfig = {
   root: string;
@@ -122,7 +134,15 @@ export function createApplyPatchTool(
 
       return {
         content: [{ type: "text", text: result.text }],
-        details: { summary: result.summary },
+        details: result.noOpReason
+          ? {
+              ok: false,
+              status: "blocked",
+              reason: result.noOpReason,
+              summary: result.summary,
+            }
+          : { summary: result.summary },
+        ...(result.noOpReason ? { terminate: true } : {}),
       };
     },
   };
@@ -149,6 +169,7 @@ export async function applyPatch(
     deleted: new Set<string>(),
   };
   const fileOps = resolvePatchFileOps(options);
+  let firstNoOpDisplay: string | undefined;
 
   for (const hunk of parsed.hunks) {
     if (options.signal?.aborted) {
@@ -174,8 +195,12 @@ export async function applyPatch(
     }
 
     const target = await resolvePatchPath(hunk.path, options);
+    let originalContents = "";
     const applied = await applyUpdateHunk(target.resolved, hunk.chunks, {
-      readFile: (pathLocal) => fileOps.readFile(pathLocal),
+      readFile: async (pathLocal) => {
+        originalContents = await fileOps.readFile(pathLocal);
+        return originalContents;
+      },
     });
 
     if (hunk.movePath) {
@@ -184,6 +209,10 @@ export async function applyPatch(
       await ensureDir(moveTarget.resolved, fileOps);
       const moveResolvesToSource =
         path.resolve(moveTarget.resolved) === path.resolve(target.resolved);
+      if (moveResolvesToSource && originalContents === applied) {
+        firstNoOpDisplay ??= target.display;
+        continue;
+      }
       await fileOps.writeFile(
         moveResolvesToSource ? target.resolved : moveTarget.resolved,
         applied,
@@ -198,15 +227,33 @@ export async function applyPatch(
         moveResolvesToSource ? target.display : moveTarget.display,
       );
     } else {
+      if (originalContents === applied) {
+        firstNoOpDisplay ??= target.display;
+        continue;
+      }
       await fileOps.writeFile(target.resolved, applied);
       recordSummary(summary, seen, "modified", target.display);
     }
+  }
+
+  if (isEmptySummary(summary) && firstNoOpDisplay) {
+    return {
+      summary,
+      text: `No changes made to ${firstNoOpDisplay}. The patch produced identical content.`,
+      noOpReason: "no-op-patch",
+    };
   }
 
   return {
     summary,
     text: formatSummary(summary),
   };
+}
+
+function isEmptySummary(summary: ApplyPatchSummary): boolean {
+  return (
+    summary.added.length === 0 && summary.modified.length === 0 && summary.deleted.length === 0
+  );
 }
 
 function recordSummary(

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -179,13 +179,19 @@ function getEmptyOldTextError(path: string, editIndex: number, totalEdits: numbe
   return new Error(`edits[${editIndex}].oldText must not be empty in ${path}.`);
 }
 
+export class NoChangeEditError extends Error {
+  override name = "NoChangeEditError";
+}
+
 function getNoChangeError(path: string, totalEdits: number): Error {
   if (totalEdits === 1) {
-    return new Error(
+    return new NoChangeEditError(
       `No changes made to ${path}. The replacement produced identical content. This might indicate an issue with special characters or the text not existing as expected.`,
     );
   }
-  return new Error(`No changes made to ${path}. The replacements produced identical content.`);
+  return new NoChangeEditError(
+    `No changes made to ${path}. The replacements produced identical content.`,
+  );
 }
 
 /**

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -30,6 +30,42 @@ describe("edit tool", () => {
     return filePath;
   }
 
+  it("reports identical replacements as terminal no-op failures", async () => {
+    const filePath = await createTempFile("const value = 1;\n");
+    const writeFile = vi.fn(async (absolutePath: string, content: string) => {
+      await fs.writeFile(absolutePath, content, "utf-8");
+    });
+    const operations: EditOperations = {
+      access: async (absolutePath) => {
+        await fs.access(absolutePath);
+      },
+      readFile: (absolutePath) => fs.readFile(absolutePath),
+      writeFile,
+    };
+    const tool = createEditTool(tmpDir, { operations });
+
+    const result = await tool.execute(
+      "call-1",
+      {
+        path: filePath,
+        edits: [{ oldText: "const value = 1;", newText: "const value = 1;" }],
+      },
+      undefined,
+    );
+
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: `No changes made to ${filePath}. The replacement produced identical content.`,
+    });
+    expect(result.details).toEqual({
+      ok: false,
+      status: "blocked",
+      reason: "no-op-edit",
+    });
+    expect(result.terminate).toBe(true);
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
   it("adds current file contents to exact-match mismatch errors", async () => {
     const filePath = await createTempFile("actual current content");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -23,6 +23,7 @@ import {
   type EditDiffResult,
   generateDiffString,
   generateUnifiedPatch,
+  NoChangeEditError,
   normalizeToLF,
   restoreLineEndings,
   stripBom,
@@ -30,7 +31,12 @@ import {
 import { withFileMutationQueue } from "./file-mutation-queue.js";
 import { resolveToCwd } from "./path-utils.js";
 import { invalidArgText, shortenPath, str } from "./render-utils.js";
-import type { EditToolDetails, EditToolInput } from "./tool-contracts.js";
+import type {
+  EditToolDetails,
+  EditToolInput,
+  EditToolSuccessDetails,
+  FileMutationNoOpDetails,
+} from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 type EditPreview = EditDiffResult | EditDiffError;
@@ -174,6 +180,28 @@ function appendMismatchHint(error: Error, currentContent: string): Error {
   return enhanced;
 }
 
+function createNoOpEditResult(message: string) {
+  const terminalMessage = message.replace(
+    " This might indicate an issue with special characters or the text not existing as expected.",
+    "",
+  );
+  return {
+    content: [{ type: "text" as const, text: terminalMessage }],
+    details: {
+      ok: false,
+      status: "blocked",
+      reason: "no-op-edit",
+    } satisfies FileMutationNoOpDetails,
+    terminate: true,
+  };
+}
+
+function isEditToolSuccessDetails(
+  details: EditToolDetails | undefined,
+): details is EditToolSuccessDetails {
+  return Boolean(details && "diff" in details && "patch" in details);
+}
+
 type RenderableEditArgs = {
   path?: string;
   file_path?: string;
@@ -287,7 +315,8 @@ function formatEditResult(
     return theme.fg("error", errorText);
   }
 
-  const resultDiff = result.details?.diff;
+  const successDetails = isEditToolSuccessDetails(result.details) ? result.details : undefined;
+  const resultDiff = successDetails?.diff;
   if (resultDiff && resultDiff !== previewDiff) {
     return renderDiff(resultDiff, { filePath: rawPath ?? undefined });
   }
@@ -455,6 +484,9 @@ export function createEditToolDefinition(
           if (normalizedError.message.includes(EDIT_MISMATCH_MESSAGE)) {
             throw appendMismatchHint(normalizedError, currentContent);
           }
+          if (normalizedError instanceof NoChangeEditError) {
+            return createNoOpEditResult(normalizedError.message);
+          }
           throw normalizedError;
         }
       });
@@ -498,14 +530,18 @@ export function createEditToolDefinition(
         ? JSON.stringify({ path: previewInput.path, edits: previewInput.edits })
         : undefined;
       const typedResult = result as EditToolResultLike;
-      const resultDiff = !context.isError ? typedResult.details?.diff : undefined;
+      const successDetails =
+        !context.isError && isEditToolSuccessDetails(typedResult.details)
+          ? typedResult.details
+          : undefined;
+      const resultDiff = successDetails?.diff;
       let changed = false;
       if (callComponent) {
         if (typeof resultDiff === "string") {
           changed =
             setEditPreview(
               callComponent,
-              { diff: resultDiff, firstChangedLine: typedResult.details?.firstChangedLine },
+              { diff: resultDiff, firstChangedLine: successDetails?.firstChangedLine },
               argsKey,
             ) || changed;
         }

--- a/src/agents/sessions/tools/tool-contracts.ts
+++ b/src/agents/sessions/tools/tool-contracts.ts
@@ -21,7 +21,15 @@ export interface EditToolInput {
   edits: Edit[];
 }
 
-export interface EditToolDetails {
+export type FileMutationNoOpReason = "no-op-write" | "no-op-edit" | "no-op-patch";
+
+export interface FileMutationNoOpDetails {
+  ok: false;
+  status: "blocked";
+  reason: FileMutationNoOpReason;
+}
+
+export interface EditToolSuccessDetails {
   /** Display-oriented diff of the changes made */
   diff: string;
   /** Standard unified patch of the changes made */
@@ -29,6 +37,8 @@ export interface EditToolDetails {
   /** Line number of the first change in the new file (for editor navigation) */
   firstChangedLine?: number;
 }
+
+export type EditToolDetails = EditToolSuccessDetails | FileMutationNoOpDetails;
 
 export interface FindToolInput {
   pattern: string;
@@ -81,3 +91,5 @@ export interface WriteToolInput {
   path: string;
   content: string;
 }
+
+export type WriteToolDetails = FileMutationNoOpDetails;

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createWriteTool, type WriteOperations } from "./write.js";
 
 describe("write tool", () => {
@@ -49,6 +49,35 @@ describe("write tool", () => {
       },
     };
   }
+
+  it("reports same-content writes as terminal no-op failures", async () => {
+    const filePath = await createTempPath();
+    await fs.writeFile(filePath, "finished\n", "utf-8");
+    const writeFile = vi.fn(async (absolutePath: string, content: string) => {
+      await fs.writeFile(absolutePath, content, "utf-8");
+    });
+    const tool = createWriteTool(tmpDir, {
+      operations: createRecoverableOperations(writeFile),
+    });
+
+    const result = await tool.execute(
+      "call-1",
+      { path: filePath, content: "finished\n" },
+      undefined,
+    );
+
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: `No changes made to ${filePath}. The file already has identical content.`,
+    });
+    expect(result.details).toEqual({
+      ok: false,
+      status: "blocked",
+      reason: "no-op-write",
+    });
+    expect(result.terminate).toBe(true);
+    expect(writeFile).not.toHaveBeenCalled();
+  });
 
   it("recovers success after a post-write abort when readback matches requested content", async () => {
     // Remote transports can report cancellation after the write landed; verify

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -25,6 +25,7 @@ import {
   shortenPath,
   str,
 } from "./render-utils.js";
+import type { WriteToolDetails } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 const writeSchema = Type.Object({
@@ -366,10 +367,27 @@ async function recoverSuccessfulWrite(params: {
   };
 }
 
+function createNoOpWriteResult(path: string) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `No changes made to ${path}. The file already has identical content.`,
+      },
+    ],
+    details: {
+      ok: false,
+      status: "blocked",
+      reason: "no-op-write",
+    } satisfies WriteToolDetails,
+    terminate: true,
+  };
+}
+
 export function createWriteToolDefinition(
   cwd: string,
   options?: WriteToolOptions,
-): ToolDefinition<typeof writeSchema, undefined> {
+): ToolDefinition<typeof writeSchema, WriteToolDetails | undefined> {
   const ops = options?.operations ?? defaultWriteOperations;
   return {
     name: "write",
@@ -393,10 +411,13 @@ export function createWriteToolDefinition(
       const dir = dirname(absolutePath);
       return withFileMutationQueue(absolutePath, async () => {
         const precheck = await readOriginalWriteState(absolutePath, content, ops);
+        if (signal?.aborted) {
+          throw new Error("Operation aborted");
+        }
+        if (precheck.state === "same") {
+          return createNoOpWriteResult(path);
+        }
         try {
-          if (signal?.aborted) {
-            throw new Error("Operation aborted");
-          }
           await ops.mkdir(dir);
           if (signal?.aborted) {
             throw new Error("Operation aborted");
@@ -475,6 +496,6 @@ export function createWriteToolDefinition(
 export function createWriteTool(
   cwd: string,
   options?: WriteToolOptions,
-): AgentTool<typeof writeSchema> {
+): AgentTool<typeof writeSchema, WriteToolDetails | undefined> {
   return wrapToolDefinition(createWriteToolDefinition(cwd, options));
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #96983.

No-op file mutations in agent-controlled tools could previously look like successful progress or ordinary retryable failures. In particular, identical `write` calls rewrote the file and returned success, identical `edit` calls threw only an unstructured no-change error, and `apply_patch` update hunks could report a modified file even when the patch produced identical content.

## Why This Change Was Made

This change classifies no-op file mutations at the built-in file-tool boundary instead of adding broader loop policy:

- `write` now returns a terminal `blocked` result with `reason: "no-op-write"` when precheck proves the target already has identical content, without calling the write operation.
- `edit` now converts its no-change edit condition into a terminal `blocked` result with `reason: "no-op-edit"`, without writing the file.
- `apply_patch` now skips no-op update hunks and returns a terminal `blocked` result with `reason: "no-op-patch"` when the entire patch changes nothing.

Real write, edit, add, delete, move, and patch mutation paths remain unchanged.

## User Impact

Agents get a machine-readable terminal result for no-op file mutations instead of false progress or a generic retryable error. This should reduce repeated identical write/edit/patch loops while preserving normal file mutation behavior.

## Evidence

Behavior addressed: no-op file mutations should be terminal blocked tool results, not successful writes or unstructured retryable failures.

Real environment tested: local OpenClaw source checkout on branch `codex/no-op-file-mutations`, commit `c74a317888f201ea73797002b222dbf0ac7d7c4a`.

Exact steps or command run after this patch:

```shell
node scripts/run-vitest.mjs src/agents/sessions/tools/write.test.ts src/agents/sessions/tools/edit.test.ts src/agents/apply-patch.test.ts
node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts
git diff --check
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-oxlint-shards.mjs --only=core --split-core
.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
```

Evidence after fix:

- Focused file-tool tests: 3 files passed, 33 tests passed.
- Adjacent terminal-result plumbing tests: 3 files passed, 179 tests passed across 2 Vitest shards.
- `git diff --check`: passed.
- `tsgo` core production: passed.
- `tsgo` core tests: passed.
- Core oxlint split shard: passed.
- Autoreview: clean, no accepted/actionable findings.

Observed result after fix:

- Same-content `write` returns `details: { ok: false, status: "blocked", reason: "no-op-write" }`, sets `terminate: true`, and does not call the write operation.
- Identical `edit` returns `details: { ok: false, status: "blocked", reason: "no-op-edit" }`, sets `terminate: true`, and does not call the write operation.
- No-op `apply_patch` returns `details: { ok: false, status: "blocked", reason: "no-op-patch" }`, sets `terminate: true`, and leaves file content unchanged.

What was not tested:

- `node scripts/check-changed.mjs` could not start remote Testbox proof because the local `crabbox` binary failed its sanity check before provisioning. The touched core surface was covered with focused Vitest, core `tsgo`, core oxlint, `git diff --check`, and autoreview instead.
- No live agent-loop replay was run; the repair is covered at the built-in tool-result boundary that feeds existing terminal-result plumbing.

AI-assisted: This PR was authored with AI assistance. The behavior and verification above were checked in the local repository.
