### PR TITLE
fix(net-policy): redact Telegram bot tokens from timeout URLs

### DIFF
--- a/.agents/skills/openclaw-landable-bug-sweep/SKILL.md
+++ b/.agents/skills/openclaw-landable-bug-sweep/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: openclaw-landable-bug-sweep
-description: "Find or repair small high-confidence non-SDK-boundary OpenClaw bugfix PRs until five are landable."
+description: "Find or repair a requested batch of small high-confidence non-SDK-boundary OpenClaw bugfix PRs until they are landable."
 ---
 
 # OpenClaw Landable Bug Sweep
 
-Autonomous maintainer workflow for producing five landable OpenClaw bugfix PR URLs.
+Autonomous maintainer workflow for producing a requested batch of landable OpenClaw bugfix PR URLs.
 Use for broad issue/PR sweeps where the bar is high and the output is PRs, not notes.
 Do not use for plugin SDK/API boundary work; those need separate architecture review.
 
 ## Target
 
-Return exactly five PR URLs, each with:
+Use `batch_size` from the request, defaulting to `5` and capped at `20`.
+Return up to that many qualified PR URLs, each with:
 
 - bug summary
 - why the fix is low-risk
@@ -20,9 +21,18 @@ Return exactly five PR URLs, each with:
 - CI green on the exact pushed PR head
 - issue/duplicate cleanup done or still pending
 
-The five URLs may be existing PRs that were reviewed/fixed, or new PRs created from issues/clusters.
+The URLs may be existing PRs that were reviewed/fixed, or new PRs created from issues/clusters.
 Do not present a PR URL to the maintainer until it has been refreshed on current `main`, left-tested, autoreviewed clean, pushed, and verified green in live GitHub CI.
 If code, tests, changelog, PR body, or branch base changes after autoreview, rerun autoreview before showing the URL.
+Do not pad a batch when the bounded search yields fewer qualified PRs.
+
+## Inputs
+
+- `batch_size`: requested number of landable PRs; default `5`, maximum `20`.
+- `source_mode`: `discovery` or `provided-prs`; default `discovery`.
+- `provided_prs`: explicit PR refs when `source_mode=provided-prs`.
+
+In `provided-prs` mode, inspect only the supplied PRs plus directly linked duplicate/canonical refs unless broader discovery is required to prove the best fix.
 
 ## Companion Skills
 
@@ -103,7 +113,7 @@ Reject:
    - close duplicates and fixed-on-main issues/PRs with proof as soon as you notice them during the sweep
    - never mutate more than five associated items in one cluster without explicit confirmation
    - comments must be kind, concrete, and include proof/PR/commit links
-8. Repeat until five landable PR URLs are ready.
+8. Repeat until `batch_size` landable PR URLs are ready or the bounded qualified queue is exhausted.
 
 ## PR Body Proof
 
@@ -151,7 +161,7 @@ closed:
 
 Final answer:
 
-- exactly five accepted PR URLs
+- the requested number of accepted PR URLs, or the smaller qualified count with the exhausted-search reason
 - 2-4 sentence explainer per PR
 - proof/CI state per PR
 - closed duplicates/fixed-on-main refs

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -87,9 +89,19 @@ class MainActivity : ComponentActivity() {
   }
 
   private fun enterScreenshotMode(scene: AndroidScreenshotScene) {
+    hideScreenshotModeStatusBar()
     setContent {
       AndroidScreenshotModeScreen(scene = scene)
     }
+  }
+
+  private fun hideScreenshotModeStatusBar() {
+    WindowCompat
+      .getInsetsController(window, window.decorView)
+      .apply {
+        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        hide(WindowInsetsCompat.Type.statusBars())
+      }
   }
 
   override fun onStart() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -182,6 +182,36 @@ fun OnboardingFlow(
 
     val permissionState = rememberPermissionState(context = context, viewModel = viewModel)
 
+    fun connectToGatewayConfig(
+      config: GatewayConnectConfig,
+      resetSetupAuth: Boolean,
+    ) {
+      setupError = null
+      attemptedGatewayName = null
+      attemptedConnect = true
+      connectAttemptStartedAtMs = SystemClock.elapsedRealtime()
+      viewModel.saveGatewayConfigAndConnect(
+        host = config.host,
+        port = config.port,
+        tls = config.tls,
+        token = config.token,
+        bootstrapToken = config.bootstrapToken,
+        password = config.password,
+        resetSetupAuth = resetSetupAuth,
+      )
+      step = OnboardingStep.Recovery
+    }
+
+    fun resolveCurrentGatewayConfig(setupCodeValue: String = setupCode): GatewayConnectConfig? =
+      resolveOnboardingGatewayConnectConfig(
+        setupCode = setupCodeValue,
+        manualHost = manualHost,
+        manualPort = manualPort,
+        manualTls = manualTls,
+        token = token,
+        password = password,
+      )
+
     LaunchedEffect(startAtGatewaySetup) {
       if (startAtGatewaySetup) {
         step = OnboardingStep.Gateway
@@ -261,15 +291,26 @@ fun OnboardingFlow(
               .startScan()
               .addOnSuccessListener { barcode ->
                 val scanned = resolveScannedSetupCodeResult(barcode.rawValue.orEmpty())
-                if (scanned.setupCode == null) {
+                val scannedSetupCode = scanned.setupCode
+                if (scannedSetupCode == null) {
                   setupError =
                     gatewayEndpointValidationMessage(
                       scanned.error ?: GatewayEndpointValidationError.INVALID_URL,
                       GatewayEndpointInputSource.QR_SCAN,
+                  )
+                  return@addOnSuccessListener
+                }
+                val config = resolveCurrentGatewayConfig(setupCodeValue = scannedSetupCode)
+                if (config == null) {
+                  setupError =
+                    gatewayEndpointValidationMessage(
+                      GatewayEndpointValidationError.INVALID_URL,
+                      GatewayEndpointInputSource.QR_SCAN,
                     )
                   return@addOnSuccessListener
                 }
-                setupCode = scanned.setupCode
+                setupCode = scannedSetupCode
+                connectToGatewayConfig(config, resetSetupAuth = true)
               }.addOnFailureListener { setupError = "Could not open the scanner." }
           },
           onSetupCodeChange = {
@@ -296,34 +337,12 @@ fun OnboardingFlow(
             step = OnboardingStep.Recovery
           },
           onPair = {
-            val config =
-              resolveGatewayConfig(
-                setupCode = setupCode,
-                manualHost = manualHost,
-                manualPort = manualPort,
-                manualTls = manualTls,
-                token = token,
-                password = password,
-              )
+            val config = resolveCurrentGatewayConfig()
             if (config == null) {
               setupError = "Enter a setup code or a valid gateway URL."
               return@GatewaySetupScreen
             }
-
-            setupError = null
-            attemptedGatewayName = null
-            attemptedConnect = true
-            connectAttemptStartedAtMs = SystemClock.elapsedRealtime()
-            viewModel.saveGatewayConfigAndConnect(
-              host = config.host,
-              port = config.port,
-              tls = config.tls,
-              token = config.token,
-              bootstrapToken = config.bootstrapToken,
-              password = config.password,
-              resetSetupAuth = true,
-            )
-            step = OnboardingStep.Recovery
+            connectToGatewayConfig(config, resetSetupAuth = true)
           },
         )
       OnboardingStep.Recovery ->
@@ -339,26 +358,8 @@ fun OnboardingFlow(
           connectSettling = recoveryNowMs - connectAttemptStartedAtMs < GATEWAY_CONNECT_SETTLING_MS,
           onBack = { step = OnboardingStep.Gateway },
           onRetry = {
-            attemptedConnect = true
-            connectAttemptStartedAtMs = SystemClock.elapsedRealtime()
-            val config =
-              resolveGatewayConfig(
-                setupCode = setupCode,
-                manualHost = manualHost,
-                manualPort = manualPort,
-                manualTls = manualTls,
-                token = token,
-                password = password,
-              ) ?: return@GatewayRecoveryScreen
-            viewModel.saveGatewayConfigAndConnect(
-              host = config.host,
-              port = config.port,
-              tls = config.tls,
-              token = config.token,
-              bootstrapToken = config.bootstrapToken,
-              password = config.password,
-              resetSetupAuth = false,
-            )
+            val config = resolveCurrentGatewayConfig() ?: return@GatewayRecoveryScreen
+            connectToGatewayConfig(config, resetSetupAuth = false)
           },
           onEdit = { step = OnboardingStep.Gateway },
           onContinue = { step = OnboardingStep.Permissions },
@@ -1151,59 +1152,28 @@ internal fun recoveryGatewayName(
       ?.takeIf { it.isNotEmpty() }
     ?: "Home Gateway"
 
-private data class GatewayConfig(
-  val host: String,
-  val port: Int,
-  val tls: Boolean,
-  val bootstrapToken: String,
-  val token: String,
-  val password: String,
-)
-
-/** Resolves setup-code or manual fields into the gateway config used for first connect. */
-private fun resolveGatewayConfig(
+/** Resolves onboarding setup-code or manual fields into the gateway config used for connect. */
+internal fun resolveOnboardingGatewayConnectConfig(
   setupCode: String,
   manualHost: String,
   manualPort: String,
   manualTls: Boolean,
   token: String,
   password: String,
-): GatewayConfig? {
-  val setup = setupCode.takeIf { it.isNotBlank() }?.let(::decodeGatewaySetupCode)
-  if (setup != null) {
-    val endpoint = parseGatewayEndpointResult(setup.url).config ?: return null
-    val bootstrapToken = setup.bootstrapToken?.trim().orEmpty()
-    // Bootstrap setup codes own first-pairing auth; fall back to typed token or
-    // password only for non-bootstrap setup payloads.
-    return GatewayConfig(
-      host = endpoint.host,
-      port = endpoint.port,
-      tls = endpoint.tls,
-      bootstrapToken = bootstrapToken,
-      token =
-        setup.token
-          ?.trim()
-          .orEmpty()
-          .ifEmpty { if (bootstrapToken.isEmpty()) token.trim() else "" },
-      password =
-        setup.password
-          ?.trim()
-          .orEmpty()
-          .ifEmpty { if (bootstrapToken.isEmpty()) password.trim() else "" },
-    )
-  }
-
-  val manualUrl = composeGatewayManualUrl(manualHost, manualPort, manualTls) ?: return null
-  val endpoint = parseGatewayEndpointResult(manualUrl).config ?: return null
-  return GatewayConfig(
-    host = endpoint.host,
-    port = endpoint.port,
-    tls = endpoint.tls,
-    bootstrapToken = "",
-    token = token.trim(),
-    password = password.trim(),
+): GatewayConnectConfig? =
+  resolveGatewayConnectConfig(
+    useSetupCode = setupCode.isNotBlank(),
+    setupCode = setupCode,
+    savedManualHost = manualHost,
+    savedManualPort = manualPort,
+    savedManualTls = manualTls,
+    manualHostInput = manualHost,
+    manualPortInput = manualPort,
+    manualTlsInput = manualTls,
+    fallbackBootstrapToken = "",
+    fallbackToken = token,
+    fallbackPassword = password,
   )
-}
 
 /** Selects the recovery detail line from endpoint metadata and transient gateway status. */
 internal fun recoveryGatewayDetail(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -7,8 +7,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.Base64
 
 class OnboardingFlowLogicTest {
   @Test
@@ -432,4 +434,51 @@ class OnboardingFlowLogicTest {
       ),
     )
   }
+
+  @Test
+  fun resolvesOnboardingSetupCodeConnectConfigForScannedQr() {
+    val setupCode =
+      encodeSetupCode("""{"url":"ws://10.0.2.2:18789","bootstrapToken":"bootstrap-1"}""")
+    val scanned = resolveScannedSetupCodeResult(setupCode)
+
+    val resolved =
+      resolveOnboardingGatewayConnectConfig(
+        setupCode = requireNotNull(scanned.setupCode),
+        manualHost = "127.0.0.1",
+        manualPort = "18789",
+        manualTls = false,
+        token = "stale-shared-token",
+        password = "stale-shared-password",
+      )
+
+    assertEquals("10.0.2.2", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
+    assertEquals("bootstrap-1", resolved?.bootstrapToken)
+    assertEquals("", resolved?.token)
+    assertEquals("", resolved?.password)
+    assertNull(scanned.error)
+  }
+
+  @Test
+  fun resolvesOnboardingManualConnectConfigWhenSetupCodeIsBlank() {
+    val resolved =
+      resolveOnboardingGatewayConnectConfig(
+        setupCode = "",
+        manualHost = "127.0.0.1",
+        manualPort = "18789",
+        manualTls = false,
+        token = "shared-token",
+        password = "shared-password",
+      )
+
+    assertEquals("127.0.0.1", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
+    assertEquals("", resolved?.bootstrapToken)
+    assertEquals("shared-token", resolved?.token)
+    assertEquals("shared-password", resolved?.password)
+  }
+
+  private fun encodeSetupCode(payloadJson: String): String = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray(Charsets.UTF_8))
 }

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -2883,16 +2883,16 @@ describe("active-memory plugin", () => {
     );
 
     const prependContext = requirePrependContext(result);
-    expect(prependContext).toContain("alpha beta gamma delta epsilon zeta");
+    expect(prependContext).toContain("alpha beta gamma delta epsilon zeta eta…");
     expect(prependContext).toContain("<active_memory_plugin>");
     expect(prependContext).not.toContain("theta");
     expect(prependContext).not.toContain("ignore this user text");
     const lines = getActiveMemoryLines(sessionKey);
     expectLinesToContain(lines, "🧩 Active Memory: status=timeout_partial");
-    expectLinesToContain(lines, "summary=35 chars");
+    expectLinesToContain(lines, "summary=40 chars");
     expectLinesToContain(
       lines,
-      "🔎 Active Memory Debug: timeout_partial: 35 chars recovered (not persisted)",
+      "🔎 Active Memory Debug: timeout_partial: 40 chars recovered (not persisted)",
     );
     expect(lines.join("\n")).not.toContain("alpha beta gamma delta");
   });
@@ -5358,9 +5358,26 @@ describe("active-memory plugin", () => {
 
     const prependContext = requirePrependContext(result);
     expect(prependContext).toContain("alpha beta gamma");
-    expect(prependContext).toContain("alpha beta gamma delta epsilon");
+    expect(prependContext).toContain("alpha beta gamma delta epsilon…");
     expect(prependContext).not.toContain("zetalo");
     expect(prependContext).not.toContain("zetalongword");
+  });
+
+  it("asks recall subagents to mark mutable operational facts stale unless source status is current", async () => {
+    await hooks.before_prompt_build(
+      { prompt: "is autonomous pickup running?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    const prompt = lastEmbeddedPrompt();
+    expect(prompt).toContain("Mutable operational facts");
+    expect(prompt).toContain("source timestamp");
+    expect(prompt).toContain("verify live");
   });
 
   it("uses the configured maxSummaryChars value in the subagent prompt", async () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1090,6 +1090,8 @@ function buildRecallPrompt(params: {
     "Questions like 'what is my favorite food', 'do you remember my flight preferences', or 'what do i usually get' should normally return memory when relevant results exist.",
     "If the provided conversation context already contains recalled-memory summaries, debug output, or prior memory/tool traces, ignore that surfaced text unless the latest user message clearly requires re-checking it.",
     "Return memory only when it would materially help the other model answer the user's latest message.",
+    "Mutable operational facts (cron/job health, automation status, deployments, incidents, service availability) go stale quickly: include the source timestamp when available, say when the memory may be stale, and tell the answering model to verify live before relying on it.",
+    "Do not summarize mutable operational facts as simply current/running/healthy unless the memory result itself contains a current source timestamp and matching health state.",
     "If the connection is weak, broad, or only vaguely related, reply with NONE.",
     "If nothing clearly useful is found, reply with NONE.",
     "Return exactly one of these two forms:",
@@ -2563,18 +2565,23 @@ function truncateSummary(summary: string, maxSummaryChars: number): string {
     return trimmed;
   }
 
-  const bounded = trimmed.slice(0, maxSummaryChars).trimEnd();
-  const nextChar = trimmed.charAt(maxSummaryChars);
+  const ellipsis = "…";
+  if (maxSummaryChars <= ellipsis.length) {
+    return ellipsis.slice(0, Math.max(0, maxSummaryChars));
+  }
+  const contentMaxChars = maxSummaryChars - ellipsis.length;
+  const bounded = trimmed.slice(0, contentMaxChars).trimEnd();
+  const nextChar = trimmed.charAt(contentMaxChars);
   if (!nextChar || /\s/.test(nextChar)) {
-    return bounded;
+    return `${bounded}${ellipsis}`;
   }
 
   const lastBoundary = bounded.search(/\s\S*$/);
   if (lastBoundary > 0) {
-    return bounded.slice(0, lastBoundary).trimEnd();
+    return `${bounded.slice(0, lastBoundary).trimEnd()}${ellipsis}`;
   }
 
-  return bounded;
+  return `${bounded}${ellipsis}`;
 }
 
 function buildMetadata(summary: string | null): string | undefined {

--- a/packages/net-policy/src/redact-sensitive-url.test.ts
+++ b/packages/net-policy/src/redact-sensitive-url.test.ts
@@ -9,6 +9,8 @@ import {
   redactSensitiveUrlLikeString,
 } from "./redact-sensitive-url.js";
 
+const SYNTHETIC_TELEGRAM_BOT_TOKEN = "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd";
+
 describe("redactSensitiveUrl", () => {
   it("redacts userinfo and sensitive query params from valid URLs", () => {
     expect(redactSensitiveUrl("https://user:pass@example.com/mcp?token=secret&safe=value")).toBe(
@@ -45,6 +47,27 @@ describe("redactSensitiveUrl", () => {
       "https://example.com/mcp?safe=value",
     );
   });
+
+  it("redacts Telegram Bot API path tokens from valid URLs", () => {
+    expect(
+      redactSensitiveUrl(
+        `https://api.telegram.org/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=1`,
+      ),
+    ).toBe("https://api.telegram.org/bot***/sendMessage?chat_id=1");
+    expect(
+      redactSensitiveUrl(
+        `https://telegram.internal/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN.replace(":", "%3A")}/getMe`,
+      ),
+    ).toBe("https://telegram.internal/bot***/getMe");
+  });
+
+  it.each(["/bot/settings", "/bots/chat", "/robot/test", "/bot123:status", "/bot123456:short"])(
+    "keeps ordinary bot-like URL path %s unchanged",
+    (path) => {
+      const url = `https://example.com${path}`;
+      expect(redactSensitiveUrl(url)).toBe(url);
+    },
+  );
 });
 
 describe("redactSensitiveUrlLikeString", () => {
@@ -88,6 +111,14 @@ describe("redactSensitiveUrlLikeString", () => {
         "wss://fallback-user:fallback-pass@[bad-host/socket?token=fallback-secret&keep=visible)",
       ),
     ).toBe("wss://***:***@[bad-host/socket?token=***&keep=visible)");
+  });
+
+  it("redacts Telegram Bot API path tokens in fallback strings", () => {
+    expect(
+      redactSensitiveUrlLikeString(
+        `timeout /bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage and /bot/settings`,
+      ),
+    ).toBe("timeout /bot***/sendMessage and /bot/settings");
   });
 });
 

--- a/packages/net-policy/src/redact-sensitive-url.ts
+++ b/packages/net-policy/src/redact-sensitive-url.ts
@@ -40,6 +40,14 @@ const SENSITIVE_URL_QUERY_PARAM_NAMES = new Set([
 // Keep in sync with FORM_BODY_KEY_SEPARATOR_RE in src/logging/redact.ts: Hangul fillers are
 // category Lo, so \p{C}\p{Z} alone would let them splice sensitive key names.
 const URL_QUERY_NAME_SEPARATOR_RE = /[\p{C}\p{Z}\u115F\u1160\u3164\uFFA0+]/gu;
+// Bot API credentials are path segments on both Telegram's hosted API and custom API roots.
+// Keep the real token shape strict so ordinary `/bot` application paths remain visible.
+const TELEGRAM_BOT_TOKEN_PATH_RE = /\/bot\d{6,}(?::|%3A)[A-Za-z0-9_-]{20,}(?=\/|[?#\s]|$)/giu;
+const REDACTED_TELEGRAM_BOT_TOKEN_PATH = "/bot***";
+
+function redactTelegramBotTokenPaths(value: string): string {
+  return value.replace(TELEGRAM_BOT_TOKEN_PATH_RE, REDACTED_TELEGRAM_BOT_TOKEN_PATH);
+}
 
 function normalizeUrlQueryParamName(name: string): string {
   const stripped = name.replace(URL_QUERY_NAME_SEPARATOR_RE, "");
@@ -82,6 +90,11 @@ export function redactSensitiveUrl(value: string): string {
   try {
     const parsed = new URL(value);
     let mutated = false;
+    const pathname = redactTelegramBotTokenPaths(parsed.pathname);
+    if (pathname !== parsed.pathname) {
+      parsed.pathname = pathname;
+      mutated = true;
+    }
     if (parsed.username || parsed.password) {
       parsed.username = parsed.username ? "***" : "";
       parsed.password = parsed.password ? "***" : "";
@@ -105,7 +118,7 @@ export function redactSensitiveUrlLikeString(value: string): string {
   if (redactedUrl !== value) {
     return redactedUrl;
   }
-  return value
+  return redactTelegramBotTokenPaths(value)
     .replace(/\/\/([^@/?#\s]+)@/g, "//***:***@")
     .replace(/([?&])([^=&]+)=([^&]*)/g, (match, prefix: string, key: string) =>
       isSensitiveUrlQueryParamName(key) ? `${prefix}${key}=***` : match,

--- a/src/agents/agent-project-settings.test.ts
+++ b/src/agents/agent-project-settings.test.ts
@@ -186,4 +186,29 @@ describe("createPreparedEmbeddedAgentSettingsManager", () => {
       await fs.rm(baseDir, { recursive: true, force: true });
     }
   });
+
+  it("keeps compaction reserve overrides after disabling runtime retry", () => {
+    const settingsManager = createPreparedEmbeddedAgentSettingsManager({
+      cwd: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              reserveTokensFloor: 50_000,
+              keepRecentTokens: 16_000,
+            },
+          },
+        },
+      },
+      contextTokenBudget: 200_000,
+    });
+
+    expect(settingsManager.getRetryEnabled()).toBe(false);
+    expect(settingsManager.getCompactionSettings()).toEqual({
+      enabled: true,
+      reserveTokens: 50_000,
+      keepRecentTokens: 16_000,
+    });
+  });
 });

--- a/src/agents/agent-settings.test.ts
+++ b/src/agents/agent-settings.test.ts
@@ -8,6 +8,7 @@ import {
   isSilentOverflowProneModel,
   resolveEffectiveCompactionMode,
 } from "./agent-settings.js";
+import { SettingsManager } from "./sessions/settings-manager.js";
 
 describe("applyAgentCompactionSettingsFromConfig", () => {
   it("bumps reserveTokens when below floor", () => {
@@ -516,6 +517,29 @@ describe("applyAgentAutoCompactionGuard", () => {
 
     expect(result).toEqual({ supported: true, disabled: true });
     expect(setCompactionEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("preserves configured reserve tokens when disabling embedded auto-compaction", () => {
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { enabled: true, reserveTokens: 16_384 },
+    });
+
+    applyAgentCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: { agents: { defaults: { compaction: { reserveTokensFloor: 50_000 } } } },
+      contextTokenBudget: 200_000,
+    });
+    const result = applyAgentAutoCompactionGuard({
+      settingsManager,
+      compactionMode: "safeguard",
+    });
+
+    expect(result).toEqual({ supported: true, disabled: true });
+    expect(settingsManager.getCompactionSettings()).toEqual({
+      enabled: false,
+      reserveTokens: 50_000,
+      keepRecentTokens: 20_000,
+    });
   });
 
   // Default-mode runs against ordinary providers must keep OpenClaw runtime's auto-compaction

--- a/src/agents/bash-tools.process-send-keys.ts
+++ b/src/agents/bash-tools.process-send-keys.ts
@@ -30,7 +30,7 @@ function failText(text: string): AgentToolResult<unknown> {
   };
 }
 
-async function writeToStdin(stdin: WritableStdin, data: string) {
+export async function writeProcessStdin(stdin: WritableStdin, data: string) {
   await new Promise<void>((resolve, reject) => {
     stdin.write(data, (err) => {
       if (err) {
@@ -69,7 +69,7 @@ export async function handleProcessSendKeys(params: {
   if (!data) {
     return failText("No key data provided.");
   }
-  await writeToStdin(params.stdin, data);
+  await writeProcessStdin(params.stdin, data);
   return {
     content: [
       {

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -19,7 +19,11 @@ import {
   setJobTtlMs,
 } from "./bash-process-registry.js";
 import { describeProcessTool } from "./bash-tools.descriptions.js";
-import { handleProcessSendKeys, type WritableStdin } from "./bash-tools.process-send-keys.js";
+import {
+  handleProcessSendKeys,
+  type WritableStdin,
+  writeProcessStdin,
+} from "./bash-tools.process-send-keys.js";
 import { processSchema } from "./bash-tools.schemas.js";
 import {
   clampWithDefault,
@@ -364,18 +368,6 @@ export function createProcessTool(
         return { ok: true as const, session: scopedSession, stdin };
       };
 
-      const writeToStdin = async (stdin: WritableStdin, data: string) => {
-        await new Promise<void>((resolve, reject) => {
-          stdin.write(data, (err) => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-        });
-      };
-
       const runningSessionResult = (
         sessionLocal: ProcessSession,
         text: string,
@@ -596,7 +588,7 @@ export function createProcessTool(
           if (!resolved.ok) {
             return resolved.result;
           }
-          await writeToStdin(resolved.stdin, params.data ?? "");
+          await writeProcessStdin(resolved.stdin, params.data ?? "");
           if (params.eof) {
             resolved.stdin.end();
           }
@@ -628,7 +620,7 @@ export function createProcessTool(
           if (!resolved.ok) {
             return resolved.result;
           }
-          await writeToStdin(resolved.stdin, "\r");
+          await writeProcessStdin(resolved.stdin, "\r");
           return runningSessionResult(
             resolved.session,
             `Submitted session ${params.sessionId} (sent CR).`,
@@ -652,7 +644,7 @@ export function createProcessTool(
               details: { status: "failed" },
             };
           }
-          await writeToStdin(resolved.stdin, payload);
+          await writeProcessStdin(resolved.stdin, payload);
           return runningSessionResult(
             resolved.session,
             `Pasted ${params.text?.length ?? 0} chars to session ${params.sessionId}.`,

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -305,6 +305,57 @@ describe("cli credentials", () => {
     });
   });
 
+  it("does not read stale Codex tokens when auth.json resolves to API-key mode", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-api-key-mode-"));
+    process.env.CODEX_HOME = tempHome;
+    const expSeconds = Math.floor(Date.parse("2026-03-24T12:34:56Z") / 1000);
+    execSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+
+    const authPath = path.join(tempHome, "auth.json");
+    fs.mkdirSync(tempHome, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        auth_mode: "apikey",
+        OPENAI_API_KEY: "sk-codex-api-key",
+        tokens: {
+          access_token: createJwtWithExp(expSeconds),
+          refresh_token: "stale-file-refresh",
+        },
+      }),
+      "utf8",
+    );
+
+    expect(readCodexCliCredentials({ platform: "linux", execSync: execSyncMock })).toBeNull();
+  });
+
+  it("treats an empty Codex auth.json API-key field as API-key mode", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-empty-api-key-mode-"));
+    process.env.CODEX_HOME = tempHome;
+    const expSeconds = Math.floor(Date.parse("2026-03-24T12:34:56Z") / 1000);
+    execSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+
+    const authPath = path.join(tempHome, "auth.json");
+    fs.mkdirSync(tempHome, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        OPENAI_API_KEY: "",
+        tokens: {
+          access_token: createJwtWithExp(expSeconds),
+          refresh_token: "stale-file-refresh",
+        },
+      }),
+      "utf8",
+    );
+
+    expect(readCodexCliCredentials({ platform: "linux", execSync: execSyncMock })).toBeNull();
+  });
+
   it("rejects Codex auth.json fallback expiry when stat and process clock are invalid", () => {
     const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-invalid-clock-"));
     process.env.CODEX_HOME = tempHome;

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -140,6 +140,14 @@ function resolveCodexHomePath(codexHome?: string) {
   }
 }
 
+function codexAuthJsonUsesChatGptTokens(data: Record<string, unknown>): boolean {
+  const authMode = typeof data.auth_mode === "string" ? data.auth_mode.toLowerCase() : undefined;
+  if (authMode) {
+    return authMode === "chatgpt" || authMode === "chatgptauthtokens";
+  }
+  return typeof data.OPENAI_API_KEY !== "string";
+}
+
 function resolveMiniMaxCliCredentialsPath(homeDir?: string) {
   const baseDir = homeDir ?? resolveUserPath("~");
   return path.join(baseDir, MINIMAX_CLI_CREDENTIALS_RELATIVE_PATH);
@@ -514,6 +522,9 @@ export function readCodexCliCredentials(options?: {
   }
 
   const data = raw as Record<string, unknown>;
+  if (!codexAuthJsonUsesChatGptTokens(data)) {
+    return null;
+  }
   const tokens = data.tokens as Record<string, unknown> | undefined;
   if (!tokens || typeof tokens !== "object") {
     return null;

--- a/src/agents/command/session.provider-owned-reset.test.ts
+++ b/src/agents/command/session.provider-owned-reset.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+
+const hoisted = vi.hoisted(() => ({
+  store: {} as Record<string, SessionEntry>,
+}));
+
+vi.mock("../../config/sessions/store-load.js", () => ({
+  loadSessionStore: () => hoisted.store,
+}));
+
+vi.mock("../../config/sessions/paths.js", () => ({
+  resolveStorePath: () => "/stores/main.json",
+}));
+
+const { resolveSession } = await import("./session.js");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function seedProviderOwned(sessionKey: string): void {
+  const startedAt = Date.now() - DAY_MS;
+  hoisted.store = {
+    [sessionKey]: {
+      sessionId: "old-session-id",
+      updatedAt: startedAt,
+      sessionStartedAt: startedAt,
+      lastInteractionAt: startedAt,
+      model: "claude-opus-4-6",
+      modelProvider: "claude-cli",
+      cliSessionBindings: { "claude-cli": { sessionId: "cli-conversation-xyz" } },
+    },
+  };
+}
+
+describe("command resolveSession provider-owned daily reset", () => {
+  it("keeps a provider-owned CLI session across the default daily boundary", () => {
+    const sessionKey = "agent:main:cli";
+    seedProviderOwned(sessionKey);
+
+    const result = resolveSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe("old-session-id");
+  });
+
+  it("still rotates a non-provider-owned session across the daily boundary", () => {
+    const sessionKey = "agent:main:cli";
+    const startedAt = Date.now() - DAY_MS;
+    hoisted.store = {
+      [sessionKey]: {
+        sessionId: "old-session-id",
+        updatedAt: startedAt,
+        sessionStartedAt: startedAt,
+        lastInteractionAt: startedAt,
+      },
+    };
+
+    const result = resolveSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("old-session-id");
+  });
+});

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -9,6 +9,7 @@ import {
   type ThinkLevel,
   type VerboseLevel,
 } from "../../auto-reply/thinking.js";
+import { hasProviderOwnedSession } from "../../config/sessions/entry-freshness.js";
 import {
   hasTerminalMainSessionTranscriptNewerThanRegistrySync,
   resolveSessionLifecycleTimestamps,
@@ -386,18 +387,21 @@ export function resolveSession(opts: {
           storePath,
         })
       : false;
+  const skipImplicitExpiry =
+    resetPolicy.configured !== true && hasProviderOwnedSession(sessionEntry);
   const fresh = sessionEntry
     ? !terminalMainTranscriptNewerThanRegistry &&
-      evaluateSessionFreshness({
-        updatedAt: sessionEntry.updatedAt,
-        ...resolveSessionLifecycleTimestamps({
-          entry: sessionEntry,
-          agentId: sessionAgentId,
-          storePath,
-        }),
-        now,
-        policy: resetPolicy,
-      }).fresh
+      (skipImplicitExpiry ||
+        evaluateSessionFreshness({
+          updatedAt: sessionEntry.updatedAt,
+          ...resolveSessionLifecycleTimestamps({
+            entry: sessionEntry,
+            agentId: sessionAgentId,
+            storePath,
+          }),
+          now,
+          policy: resetPolicy,
+        }).fresh)
     : false;
   const sessionId =
     requestedSessionId || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -738,6 +738,18 @@ describe("wrapAnthropicStreamWithRecovery", () => {
         }),
     },
     {
+      name: "ProviderHttpError errorBody",
+      createError: () =>
+        Object.assign(new Error(genericizedProviderError), {
+          errorBody: JSON.stringify({
+            error: {
+              message: terminalThinkingSignatureError,
+              type: "invalid_request_error",
+            },
+          }),
+        }),
+    },
+    {
       name: "cyclic cause graph",
       createError: () => {
         const root = new Error(genericizedProviderError) as Error & { cause?: unknown };

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -545,6 +545,7 @@ function shouldRecoverAnthropicThinkingError(
     current.error,
     current.rawError,
     current.errorMessage,
+    current.errorBody,
     current.message,
   ]);
   for (const candidate of candidates) {

--- a/src/agents/model-auth-label.test.ts
+++ b/src/agents/model-auth-label.test.ts
@@ -192,6 +192,39 @@ describe("resolveModelAuthLabel", () => {
     });
   });
 
+  it("uses Codex CLI auth for Codex-backed OpenAI before env fallback", () => {
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+    } as never);
+    mocks.resolveAuthProfileOrder.mockReturnValue([]);
+    mocks.readCodexCliCredentialsCached.mockReturnValue({
+      type: "oauth",
+      provider: "openai",
+      access: "token",
+      refresh: "refresh",
+      expires: Date.now() + 60_000,
+    });
+    mocks.resolveEnvApiKey.mockReturnValue({
+      apiKey: "env-key-placeholder",
+      source: "env: OPENAI_API_KEY",
+    });
+
+    const label = resolveModelAuthLabel({
+      provider: "openai",
+      cfg: {},
+      codexCliCredentialsHome: "/tmp/openclaw-agent/codex-home",
+    });
+
+    expect(label).toBe("oauth (codex-cli)");
+    expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalledWith({
+      codexHome: "/tmp/openclaw-agent/codex-home",
+      ttlMs: 5_000,
+      allowKeychainPrompt: false,
+    });
+    expect(mocks.resolveEnvApiKey).not.toHaveBeenCalled();
+  });
+
   it("shows claude cli auth for claude-cli provider without auth profiles", () => {
     mocks.ensureAuthProfileStore.mockReturnValue({
       version: 1,

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -33,6 +33,7 @@ export function resolveModelAuthLabel(params: {
   sessionEntry?: Partial<Pick<SessionEntry, "authProfileOverride">>;
   agentDir?: string;
   workspaceDir?: string;
+  codexCliCredentialsHome?: string;
   includeExternalProfiles?: boolean;
   acceptedProviderIds?: readonly string[];
 }): string | undefined {
@@ -116,6 +117,18 @@ export function resolveModelAuthLabel(params: {
     // Preserve the fact that config pointed at a profile while avoiding a
     // misleading auth mode for an incompatible provider/profile pairing.
     return "unknown";
+  }
+
+  if (
+    params.codexCliCredentialsHome &&
+    (providerKey === "openai" || providerKey === "codex") &&
+    readCodexCliCredentialsCached({
+      codexHome: params.codexCliCredentialsHome,
+      ttlMs: 5_000,
+      allowKeychainPrompt: false,
+    })
+  ) {
+    return "oauth (codex-cli)";
   }
 
   const envKey = resolveEnvApiKey(providerKey, process.env, {

--- a/src/agents/sessions/exec.test.ts
+++ b/src/agents/sessions/exec.test.ts
@@ -3,7 +3,8 @@
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { spawnMock, waitForChildProcessMock } = vi.hoisted(() => ({
+const { killProcessTreeMock, spawnMock, waitForChildProcessMock } = vi.hoisted(() => ({
+  killProcessTreeMock: vi.fn(),
   spawnMock: vi.fn(),
   waitForChildProcessMock: vi.fn(),
 }));
@@ -16,14 +17,20 @@ vi.mock("../utils/child-process.js", () => ({
   waitForChildProcess: waitForChildProcessMock,
 }));
 
+vi.mock("../../process/kill-tree.js", () => ({
+  killProcessTree: killProcessTreeMock,
+}));
+
 type StubChild = EventEmitter & {
   kill: ReturnType<typeof vi.fn>;
+  pid?: number;
   stderr: EventEmitter;
   stdout: EventEmitter;
 };
 
 function createStubChild(): StubChild {
   const child = new EventEmitter() as StubChild;
+  child.pid = 1234;
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
   child.kill = vi.fn();
@@ -42,6 +49,7 @@ function createDeferred<T>() {
 
 describe("execCommand", () => {
   beforeEach(() => {
+    killProcessTreeMock.mockReset();
     spawnMock.mockReset();
     waitForChildProcessMock.mockReset();
     vi.useRealTimers();
@@ -76,6 +84,26 @@ describe("execCommand", () => {
     expect(result.stderrTruncatedChars).toBeGreaterThan(0);
   });
 
+  it("spawns commands with process-tree cleanup options", async () => {
+    const child = createStubChild();
+    const wait = createDeferred<number | null>();
+    spawnMock.mockReturnValue(child);
+    waitForChildProcessMock.mockReturnValue(wait.promise);
+    const { execCommand } = await import("./exec.js");
+
+    const resultPromise = execCommand("cmd", ["arg"], "/tmp");
+    wait.resolve(0);
+    await resultPromise;
+
+    expect(spawnMock).toHaveBeenCalledWith("cmd", ["arg"], {
+      cwd: "/tmp",
+      detached: process.platform !== "win32",
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+  });
+
   it("honors caller-supplied small output caps", async () => {
     const child = createStubChild();
     const wait = createDeferred<number | null>();
@@ -105,7 +133,11 @@ describe("execCommand", () => {
     wait.resolve(0);
 
     const result = await resultPromise;
-    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(killProcessTreeMock).toHaveBeenCalledWith(1234, {
+      detached: process.platform !== "win32",
+      graceMs: 5000,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
     expect(result.code).toBe(1);
     expect(result.killed).toBe(true);
     expect(result.outputLimitExceeded).toBe("stdout");
@@ -114,9 +146,9 @@ describe("execCommand", () => {
     expect(result.stderr).toContain("exec stdout exceeded output limit");
   });
 
-  it("escalates timed-out commands to SIGKILL after the grace period", async () => {
-    // SIGTERM gives child processes a chance to clean up; SIGKILL is the
-    // bounded fallback so an ignored signal cannot hang the session.
+  it("terminates timed-out commands through the process-tree killer", async () => {
+    // Extension exec uses the same tree-kill boundary as the built-in shell so
+    // timed-out wrappers do not leave descendant processes running.
     vi.useFakeTimers();
     const child = createStubChild();
     const wait = createDeferred<number | null>();
@@ -126,13 +158,11 @@ describe("execCommand", () => {
 
     const resultPromise = execCommand("cmd", [], "/tmp", { timeout: 10 });
     await vi.advanceTimersByTimeAsync(10);
-    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
-    expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
-
-    await vi.advanceTimersByTimeAsync(4_999);
-    expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
-    await vi.advanceTimersByTimeAsync(1);
-    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(killProcessTreeMock).toHaveBeenCalledWith(1234, {
+      detached: process.platform !== "win32",
+      graceMs: 5000,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
 
     wait.resolve(null);
     const result = await resultPromise;

--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -3,6 +3,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { killProcessTree } from "../../process/kill-tree.js";
 import { waitForChildProcess } from "../utils/child-process.js";
 
 const DEFAULT_OUTPUT_LIMIT_CHARS = 16 * 1024 * 1024;
@@ -81,8 +82,10 @@ export async function execCommand(
   return new Promise((resolve) => {
     const proc = spawn(command, args, {
       cwd,
+      detached: process.platform !== "win32",
       shell: false,
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let stdout: OutputCapture = { text: "", truncatedChars: 0 };
@@ -136,13 +139,20 @@ export async function execCommand(
     const killProcess = () => {
       if (!killed) {
         killed = true;
-        proc.kill("SIGTERM");
-        forceKillTimer = setTimeout(() => {
-          if (!settled) {
-            proc.kill("SIGKILL");
-          }
-        }, FORCE_KILL_GRACE_MS);
-        forceKillTimer.unref?.();
+        if (proc.pid) {
+          killProcessTree(proc.pid, {
+            detached: process.platform !== "win32",
+            graceMs: FORCE_KILL_GRACE_MS,
+          });
+        } else {
+          proc.kill("SIGTERM");
+          forceKillTimer = setTimeout(() => {
+            if (!settled) {
+              proc.kill("SIGKILL");
+            }
+          }, FORCE_KILL_GRACE_MS);
+          forceKillTimer.unref?.();
+        }
       }
     };
 

--- a/src/agents/sessions/session-file-parser.ts
+++ b/src/agents/sessions/session-file-parser.ts
@@ -1,0 +1,46 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { FileEntry } from "./session-manager.js";
+
+export type SessionFileParseWarning = {
+  code: "invalid-session-json" | "invalid-session-row";
+  row: number;
+};
+
+function isSessionFileEntry(value: unknown): value is FileEntry {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return false;
+  }
+  if (value.type !== "message") {
+    return true;
+  }
+  return isRecord(value.message) && typeof value.message.role === "string";
+}
+
+export function parseSessionFileEntriesWithWarnings(content: string): {
+  entries: FileEntry[];
+  warnings: SessionFileParseWarning[];
+  rowByEntry: Map<FileEntry, number>;
+} {
+  const entries: FileEntry[] = [];
+  const warnings: SessionFileParseWarning[] = [];
+  const rowByEntry = new Map<FileEntry, number>();
+  const rows = content.split(/\r?\n/u);
+  for (const [index, rawLine] of rows.entries()) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    try {
+      const entry = JSON.parse(line) as unknown;
+      if (!isSessionFileEntry(entry)) {
+        warnings.push({ code: "invalid-session-row", row: index + 1 });
+        continue;
+      }
+      entries.push(entry);
+      rowByEntry.set(entry, index + 1);
+    } catch {
+      warnings.push({ code: "invalid-session-json", row: index + 1 });
+    }
+  }
+  return { entries, warnings, rowByEntry };
+}

--- a/src/agents/sessions/settings-manager.test.ts
+++ b/src/agents/sessions/settings-manager.test.ts
@@ -1,0 +1,49 @@
+/** Tests session settings manager runtime overrides. */
+import { describe, expect, it } from "vitest";
+import { SettingsManager } from "./settings-manager.js";
+
+describe("SettingsManager runtime overrides", () => {
+  it("preserves compaction overrides after global setting writes", async () => {
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 },
+    });
+
+    settingsManager.applyOverrides({
+      compaction: { reserveTokens: 50_000, keepRecentTokens: 16_000 },
+    });
+    settingsManager.setCompactionEnabled(false);
+
+    expect(settingsManager.getCompactionSettings()).toEqual({
+      enabled: false,
+      reserveTokens: 50_000,
+      keepRecentTokens: 16_000,
+    });
+
+    await settingsManager.flush();
+    await settingsManager.reload();
+
+    expect(settingsManager.getCompactionSettings()).toEqual({
+      enabled: false,
+      reserveTokens: 50_000,
+      keepRecentTokens: 16_000,
+    });
+  });
+
+  it("preserves runtime overrides after project setting writes", async () => {
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { reserveTokens: 16_384 },
+    });
+
+    settingsManager.applyOverrides({ compaction: { reserveTokens: 50_000 } });
+    settingsManager.setProjectPackages(["npm:@openclaw/example"]);
+
+    expect(settingsManager.getPackages()).toEqual(["npm:@openclaw/example"]);
+    expect(settingsManager.getCompactionReserveTokens()).toBe(50_000);
+
+    await settingsManager.flush();
+    await settingsManager.reload();
+
+    expect(settingsManager.getPackages()).toEqual(["npm:@openclaw/example"]);
+    expect(settingsManager.getCompactionReserveTokens()).toBe(50_000);
+  });
+});

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -250,7 +250,9 @@ export class SettingsManager {
   private storage: SettingsStorage;
   private globalSettings: Settings;
   private projectSettings: Settings;
-  private settings: Settings;
+  private settings: Settings = {};
+  // Non-persisted overrides layered above global/project settings for this manager.
+  private runtimeOverrides: Settings = {};
   private modifiedFields = new Set<keyof Settings>(); // Track global fields modified during session
   private modifiedNestedFields = new Map<keyof Settings, Set<string>>(); // Track global nested field modifications
   private modifiedProjectFields = new Set<keyof Settings>(); // Track project fields modified during session
@@ -274,7 +276,7 @@ export class SettingsManager {
     this.globalSettingsLoadError = globalLoadError;
     this.projectSettingsLoadError = projectLoadError;
     this.errors = [...initialErrors];
-    this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+    this.recomputeSettings();
   }
 
   /** Create a SettingsManager that loads from files */
@@ -417,6 +419,13 @@ export class SettingsManager {
     return structuredClone(this.projectSettings);
   }
 
+  private recomputeSettings(): void {
+    this.settings = deepMergeSettings(
+      deepMergeSettings(this.globalSettings, this.projectSettings),
+      this.runtimeOverrides,
+    );
+  }
+
   async reload(): Promise<void> {
     await this.writeQueue;
     const globalLoad = SettingsManager.tryLoadFromStorage(this.storage, "global");
@@ -442,12 +451,13 @@ export class SettingsManager {
       this.recordError("project", projectLoad.error);
     }
 
-    this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+    this.recomputeSettings();
   }
 
-  /** Apply additional overrides on top of current settings */
+  /** Apply non-persisted overrides on top of global/project settings. */
   applyOverrides(overrides: Partial<Settings>): void {
-    this.settings = deepMergeSettings(this.settings, overrides);
+    this.runtimeOverrides = deepMergeSettings(this.runtimeOverrides, overrides);
+    this.recomputeSettings();
   }
 
   /** Mark a global field as modified during this session */
@@ -541,7 +551,7 @@ export class SettingsManager {
   }
 
   private save(): void {
-    this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+    this.recomputeSettings();
 
     if (this.globalSettingsLoadError) {
       return;
@@ -563,7 +573,7 @@ export class SettingsManager {
 
   private saveProjectSettings(settings: Settings): void {
     this.projectSettings = structuredClone(settings);
-    this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+    this.recomputeSettings();
 
     if (this.projectSettingsLoadError) {
       return;

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -331,6 +331,56 @@ describe("subagent announce seam flow", () => {
     });
   });
 
+  it("warns when ANNOUNCE_SKIP suppresses a cron job completion", async () => {
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:cron-worker",
+      childRunId: "run-cron-announce-skip",
+      requesterSessionKey: "agent:main:cron:daily-report",
+      requesterDisplayKey: "cron:daily-report",
+      task: "cron job",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "ANNOUNCE_SKIP",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("cron job completion for session=agent:main:cron:daily-report"),
+    );
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("suppressed by ANNOUNCE_SKIP"));
+    logSpy.mockRestore();
+  });
+
+  it("does not warn when fallback reply is delivered for a cron ANNOUNCE_SKIP", async () => {
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:cron-worker",
+      childRunId: "run-cron-announce-skip-fallback",
+      requesterSessionKey: "agent:main:cron:daily-report",
+      requesterDisplayKey: "cron:daily-report",
+      task: "cron job",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "ANNOUNCE_SKIP",
+      fallbackReply: "an actual fallback result",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(logSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
   it("keeps lifecycle hooks enabled when deleting a completed session-mode child session", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -11,6 +11,7 @@ import {
   stripLeadingSilentToken,
   stripSilentToken,
 } from "../auto-reply/tokens.js";
+import { logWarn } from "../logger.js";
 import { defaultRuntime } from "../runtime.js";
 import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
@@ -437,10 +438,24 @@ export async function runSubagentAnnounceFlow(params: {
         if (fallbackReply && !fallbackIsSilent) {
           const cleaned = stripAndClassifyReply(fallbackReply);
           if (cleaned === null) {
+            if (isAnnounceSkip(reply) && isCronSessionKey(targetRequesterSessionKey)) {
+              logWarn(
+                `cron job completion for session=${targetRequesterSessionKey} ` +
+                  `run=${params.childRunId} suppressed by ANNOUNCE_SKIP; ` +
+                  `the agent replied with the skip sentinel instead of delivering a result`,
+              );
+            }
             return true;
           }
           reply = cleaned;
         } else {
+          if (isAnnounceSkip(reply) && isCronSessionKey(targetRequesterSessionKey)) {
+            logWarn(
+              `cron job completion for session=${targetRequesterSessionKey} ` +
+                `run=${params.childRunId} suppressed by ANNOUNCE_SKIP; ` +
+                `the agent replied with the skip sentinel instead of delivering a result`,
+            );
+          }
           return true;
         }
       } else if (reply) {

--- a/src/agents/thinking-block.test.ts
+++ b/src/agents/thinking-block.test.ts
@@ -1,0 +1,37 @@
+// Tests for thinking block detection.
+import { describe, expect, it } from "vitest";
+import { isThinkingLikeBlock } from "./thinking-block.js";
+
+describe("isThinkingLikeBlock", () => {
+  it("returns true for thinking type", () => {
+    expect(isThinkingLikeBlock({ type: "thinking" })).toBe(true);
+  });
+
+  it("returns true for redacted_thinking type", () => {
+    expect(isThinkingLikeBlock({ type: "redacted_thinking" })).toBe(true);
+  });
+
+  it("returns false for non-thinking type", () => {
+    expect(isThinkingLikeBlock({ type: "text" })).toBe(false);
+  });
+
+  it("returns false for missing type field", () => {
+    expect(isThinkingLikeBlock({ content: "hello" })).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isThinkingLikeBlock(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isThinkingLikeBlock(undefined)).toBe(false);
+  });
+
+  it("returns false for string", () => {
+    expect(isThinkingLikeBlock("thinking")).toBe(false);
+  });
+
+  it("returns false for empty object", () => {
+    expect(isThinkingLikeBlock({})).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -2,10 +2,12 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  parseSessionFileEntriesWithWarnings,
+  type SessionFileParseWarning,
+} from "../../agents/sessions/session-file-parser.js";
 import {
   migrateSessionEntries,
-  type FileEntry as SessionFileEntry,
   type SessionEntry as AgentSessionEntry,
   type SessionHeader,
 } from "../../agents/sessions/session-manager.js";
@@ -32,13 +34,8 @@ interface SessionData {
   tools?: Array<{ name: string; description?: string; parameters?: unknown }>;
 }
 
-type SessionExportJsonlWarning = {
-  code: "invalid-session-json" | "invalid-session-row";
-  row: number;
-};
-
 type SessionExportWarningSummary = {
-  code: SessionExportJsonlWarning["code"];
+  code: SessionFileParseWarning["code"];
   count: number;
   rows: number[];
 };
@@ -160,47 +157,10 @@ async function writeNewDefaultExportFile(filePath: string, html: string): Promis
   throw new Error(`Could not find an unused export filename near ${filePath}`);
 }
 
-function isSessionFileEntry(value: unknown): value is SessionFileEntry {
-  if (!isRecord(value) || typeof value.type !== "string") {
-    return false;
-  }
-  if (value.type !== "message") {
-    return true;
-  }
-  const message = value.message;
-  return isRecord(message) && typeof message.role === "string";
-}
-
-function parseSessionEntriesWithWarnings(content: string): {
-  entries: SessionFileEntry[];
-  warnings: SessionExportJsonlWarning[];
-} {
-  const entries: SessionFileEntry[] = [];
-  const warnings: SessionExportJsonlWarning[] = [];
-  const rows = content.split(/\r?\n/u);
-  for (const [index, rawLine] of rows.entries()) {
-    const line = rawLine.trim();
-    if (!line) {
-      continue;
-    }
-    try {
-      const parsed = JSON.parse(line) as unknown;
-      if (!isSessionFileEntry(parsed)) {
-        warnings.push({ code: "invalid-session-row", row: index + 1 });
-        continue;
-      }
-      entries.push(parsed);
-    } catch {
-      warnings.push({ code: "invalid-session-json", row: index + 1 });
-    }
-  }
-  return { entries, warnings };
-}
-
 function summarizeSessionExportWarnings(
-  warnings: SessionExportJsonlWarning[],
+  warnings: SessionFileParseWarning[],
 ): SessionExportWarningSummary[] {
-  const summaries = new Map<SessionExportJsonlWarning["code"], SessionExportWarningSummary>();
+  const summaries = new Map<SessionFileParseWarning["code"], SessionExportWarningSummary>();
   for (const warning of warnings) {
     const summary = summaries.get(warning.code);
     if (summary) {
@@ -246,7 +206,7 @@ async function readSessionDataFromTranscript(sessionFile: string): Promise<{
   warnings: SessionExportWarningSummary[];
 }> {
   const raw = await fsp.readFile(sessionFile, "utf-8");
-  const { entries: fileEntries, warnings } = parseSessionEntriesWithWarnings(raw);
+  const { entries: fileEntries, warnings } = parseSessionFileEntriesWithWarnings(raw);
   migrateSessionEntries(fileEntries);
   const header =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -963,6 +963,69 @@ describe("buildStatusReply subagent summary", () => {
     );
   });
 
+  it("uses the Codex app-server account before OpenAI env labels on Codex harness status", async () => {
+    registerStatusCodexHarness();
+
+    await withTempHome(
+      async (dir) => {
+        const agentDir = path.join(dir, ".openclaw", "agents", "main", "agent");
+        const codexHome = path.join(agentDir, "codex-home");
+        fs.mkdirSync(codexHome, { recursive: true });
+        fs.writeFileSync(
+          path.join(codexHome, "auth.json"),
+          JSON.stringify({
+            auth_mode: "chatgpt",
+            tokens: {
+              access_token: "codex-access-token",
+              refresh_token: "codex-refresh-token",
+            },
+          }),
+          "utf-8",
+        );
+
+        const text = await buildStatusText({
+          cfg: {
+            ...baseCfg,
+            agents: {
+              defaults: {
+                agentRuntime: { id: "codex" },
+              },
+            },
+          },
+          sessionEntry: {
+            sessionId: "sess-status-codex-home-oauth",
+            updatedAt: 0,
+          },
+          sessionKey: "agent:main:main",
+          parentSessionKey: "agent:main:main",
+          sessionScope: "per-sender",
+          statusChannel: "mobilechat",
+          provider: "openai",
+          model: "gpt-5.5",
+          contextTokens: 32_000,
+          resolvedFastMode: false,
+          resolvedVerboseLevel: "off",
+          resolvedReasoningLevel: "off",
+          resolveDefaultThinkingLevel: async () => undefined,
+          isGroup: false,
+          defaultGroupActivation: () => "mention",
+        });
+
+        const normalized = normalizeTestText(text);
+        expect(normalized).toContain("Model: openai/gpt-5.5");
+        expect(normalized).toContain("Runtime: OpenAI Codex");
+        expect(normalized).toContain("oauth (codex-cli)");
+        expect(normalized).not.toContain("api-key (env: OPENAI_API_KEY)");
+      },
+      {
+        env: {
+          OPENAI_API_KEY: "status-env-key-placeholder",
+          OPENAI_OAUTH_TOKEN: undefined,
+        },
+      },
+    );
+  });
+
   it("uses Codex usage for bare codex models running on the Codex harness", async () => {
     registerStatusCodexHarness();
 

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -727,4 +727,65 @@ describe("printDaemonStatus", () => {
     expect(errors).not.toContain("systemd user services unavailable");
     expect(errors).not.toContain("run loginctl enable-linger");
   });
+
+  it("warns that systemd gave up restarting a crash-looped gateway", () => {
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    try {
+      printDaemonStatus(
+        {
+          service: {
+            label: "systemd",
+            loaded: true,
+            loadedText: "loaded",
+            notLoadedText: "not loaded",
+            runtime: {
+              status: "stopped",
+              state: "failed",
+              systemd: { result: "exit-code", nRestarts: 5, startLimitBurst: 5 },
+            },
+          },
+          extraServices: [],
+        },
+        { json: false },
+      );
+    } finally {
+      platform.mockRestore();
+    }
+
+    const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
+    expect(errors).toContain("systemd stopped restarting the gateway after repeated crashes");
+    expect(errors).not.toContain("likely exited immediately");
+  });
+
+  it("keeps the generic stopped message after a config exit (78) despite a stale restart count", () => {
+    // RestartPreventExitStatus=78 stopped systemd deliberately; a leftover
+    // NRestarts must not surface start-limit recovery guidance here.
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    try {
+      printDaemonStatus(
+        {
+          service: {
+            label: "systemd",
+            loaded: true,
+            loadedText: "loaded",
+            notLoadedText: "not loaded",
+            runtime: {
+              status: "stopped",
+              state: "failed",
+              lastExitStatus: 78,
+              systemd: { result: "exit-code", nRestarts: 5, startLimitBurst: 5 },
+            },
+          },
+          extraServices: [],
+        },
+        { json: false },
+      );
+    } finally {
+      platform.mockRestore();
+    }
+
+    const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
+    expect(errors).toContain("Service is loaded but not running (likely exited immediately).");
+    expect(errors).not.toContain("systemd stopped restarting the gateway");
+  });
 });

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -10,6 +10,7 @@ import {
   resolveGatewayRestartLogPath,
   resolveGatewaySupervisorLogPaths,
 } from "../../daemon/restart-logs.js";
+import { isSystemdStartLimitHit } from "../../daemon/service-runtime.js";
 import {
   isSystemdUnavailableDetail,
   renderSystemdUnavailableHints,
@@ -366,8 +367,17 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
       defaultRuntime.error(errorText(hint));
     }
   } else if (service.loaded && service.runtime?.status === "stopped") {
+    const startLimitHit = process.platform === "linux" && isSystemdStartLimitHit(service.runtime);
     defaultRuntime.error(
-      errorText("Service is loaded but not running (likely exited immediately)."),
+      errorText(
+        startLimitHit
+          ? // systemd gave up restarting after repeated crashes; sending the operator
+            // to restart (which now clears the failed latch) beats "exited immediately".
+            `systemd stopped restarting the gateway after repeated crashes; run ${formatCliCommand(
+              "openclaw gateway restart",
+            )} or inspect logs.`
+          : "Service is loaded but not running (likely exited immediately).",
+      ),
     );
     for (const hint of renderRuntimeHints(
       service.runtime,

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -148,7 +148,8 @@ export function parseLsofOutput(output: string): PortProcess[] {
       if (current.pid) {
         results.push(current as PortProcess);
       }
-      current = { pid: Number.parseInt(line.slice(1), 10) };
+      const rawPid = Number.parseInt(line.slice(1), 10);
+      current = Number.isFinite(rawPid) && rawPid > 0 ? { pid: rawPid } : {};
     } else if (line.startsWith("c")) {
       current.command = line.slice(1);
     }

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -53,6 +53,35 @@ describe("gateway --force helpers", () => {
     ]);
   });
 
+  it("skips malformed lsof 'p' lines (no digits after p)", () => {
+    const sample = ["p", "cnode", "p456", "cpython", ""].join("\n");
+    const parsed = parseLsofOutput(sample);
+    expect(parsed).toEqual<PortProcess[]>([{ pid: 456, command: "python" }]);
+  });
+
+  it("skips malformed lsof 'p' lines (non-numeric suffix)", () => {
+    const sample = ["pabc", "cnode", "p456", "cpython", ""].join("\n");
+    const parsed = parseLsofOutput(sample);
+    expect(parsed).toEqual<PortProcess[]>([{ pid: 456, command: "python" }]);
+  });
+
+  it("returns empty array when all lsof 'p' lines are malformed", () => {
+    const sample = ["p", "cnode", "pabc", "", ""].join("\n");
+    const parsed = parseLsofOutput(sample);
+    expect(parsed).toEqual<PortProcess[]>([]);
+  });
+
+  it("handles empty lsof output", () => {
+    expect(parseLsofOutput("")).toEqual<PortProcess[]>([]);
+  });
+
+  it("handles 'p' lines with negative-like tokens (zero)", () => {
+    const sample = ["p0", "cnode", "p456", "cpython", ""].join("\n");
+    const parsed = parseLsofOutput(sample);
+    // PID 0 is filtered out (> 0 check), only valid PIDs remain
+    expect(parsed).toEqual<PortProcess[]>([{ pid: 456, command: "python" }]);
+  });
+
   it("returns empty list when lsof finds nothing", () => {
     (execFileSync as unknown as Mock).mockImplementation(() => {
       const err = new Error("no matches") as NodeJS.ErrnoException & { status?: number };

--- a/src/commands/doctor-format.test.ts
+++ b/src/commands/doctor-format.test.ts
@@ -58,6 +58,64 @@ describe("buildGatewayRuntimeHints", () => {
     expect(hints.join("\n")).not.toContain("systemd user services are unavailable");
   });
 
+  it("guides recovery when systemd hit its restart start limit (crash loop)", () => {
+    // Real give-up shape: process kept failing (Result=exit-code) until NRestarts
+    // reached StartLimitBurst and systemd stopped restarting.
+    const text = buildGatewayRuntimeHints(
+      {
+        status: "stopped",
+        state: "failed",
+        systemd: { result: "exit-code", nRestarts: 5, startLimitBurst: 5 },
+      },
+      { platform: "linux", env: {} },
+    ).join("\n");
+
+    expect(text).toContain("systemd stopped restarting the gateway after repeated crashes");
+    expect(text).toContain("openclaw gateway restart");
+    expect(text).not.toContain("likely exited immediately");
+  });
+
+  it("keeps the generic stopped hint for a single failed exit below the start limit", () => {
+    const text = buildGatewayRuntimeHints(
+      {
+        status: "stopped",
+        state: "failed",
+        systemd: { result: "exit-code", nRestarts: 1, startLimitBurst: 5 },
+      },
+      { platform: "linux", env: {} },
+    ).join("\n");
+
+    expect(text).toContain("likely exited immediately");
+    expect(text).not.toContain("systemd stopped restarting the gateway");
+  });
+
+  it("keeps the generic stopped hint after a config exit (78) despite a stale restart count", () => {
+    // RestartPreventExitStatus=78 stopped systemd on purpose; the leftover
+    // NRestarts must not flip the hint to start-limit recovery guidance.
+    const text = buildGatewayRuntimeHints(
+      {
+        status: "stopped",
+        state: "failed",
+        lastExitStatus: 78,
+        systemd: { result: "exit-code", nRestarts: 5, startLimitBurst: 5 },
+      },
+      { platform: "linux", env: {} },
+    ).join("\n");
+
+    expect(text).toContain("likely exited immediately");
+    expect(text).not.toContain("systemd stopped restarting the gateway");
+  });
+
+  it("keeps the generic stopped hint for an ordinary cleanly-stopped service", () => {
+    const text = buildGatewayRuntimeHints(
+      { status: "stopped", state: "inactive" },
+      { platform: "linux", env: {} },
+    ).join("\n");
+
+    expect(text).toContain("likely exited immediately");
+    expect(text).not.toContain("systemd stopped restarting the gateway");
+  });
+
   it("does not warn for normal systemd cgroup metrics", () => {
     expect(
       buildGatewayRuntimeHints(

--- a/src/commands/doctor-format.ts
+++ b/src/commands/doctor-format.ts
@@ -11,6 +11,7 @@ import { buildPlatformRuntimeLogHints } from "../daemon/runtime-hints.js";
 import {
   getSystemdCgroupHygieneSummary,
   isSystemdCgroupHygieneRisk,
+  isSystemdStartLimitHit,
   type GatewayServiceRuntime,
 } from "../daemon/service-runtime.js";
 import {
@@ -104,7 +105,16 @@ export function buildGatewayRuntimeHints(
     return hints;
   }
   if (runtime.status === "stopped") {
-    hints.push("Service is loaded but not running (likely exited immediately).");
+    if (platform === "linux" && isSystemdStartLimitHit(runtime)) {
+      // start-limit-hit means systemd gave up restarting after repeated crashes;
+      // a plain "exited immediately" hint would hide that recovery needs a restart.
+      hints.push(
+        "systemd stopped restarting the gateway after repeated crashes.",
+        `Recover with: ${formatCliCommand("openclaw gateway restart", env)}, then inspect logs if it keeps crashing.`,
+      );
+    } else {
+      hints.push("Service is loaded but not running (likely exited immediately).");
+    }
     if (fileLog) {
       hints.push(`File logs: ${fileLog}`);
     }

--- a/src/commands/doctor/shared/exec-safe-bins.ts
+++ b/src/commands/doctor/shared/exec-safe-bins.ts
@@ -1,18 +1,17 @@
 // Doctor checks and repairs for exec safeBins profiles and trusted binary directories.
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveCommandResolutionFromArgv } from "../../../infra/exec-command-resolution.js";
+import {
+  normalizeConfiguredSafeBins,
+  normalizeConfiguredTrustedSafeBinDirs,
+} from "../../../infra/exec-safe-bin-config.js";
 import {
   listInterpreterLikeSafeBins,
   resolveMergedSafeBinProfileFixtures,
 } from "../../../infra/exec-safe-bin-runtime-policy.js";
 import { listRiskyConfiguredSafeBins } from "../../../infra/exec-safe-bin-semantics.js";
-import {
-  getTrustedSafeBinDirs,
-  isTrustedSafeBinPath,
-  normalizeTrustedSafeBinDirs,
-} from "../../../infra/exec-safe-bin-trust.js";
+import { getTrustedSafeBinDirs, isTrustedSafeBinPath } from "../../../infra/exec-safe-bin-trust.js";
 import { asObjectRecord } from "./object.js";
 
 export type ExecSafeBinCoverageHit = {
@@ -44,28 +43,6 @@ export type ExecSafeBinTrustedDirHintHit = {
   /** Resolved executable path outside trusted safe-bin directories. */
   resolvedPath: string;
 };
-
-function normalizeConfiguredSafeBins(entries: unknown): string[] {
-  if (!Array.isArray(entries)) {
-    return [];
-  }
-  return Array.from(
-    new Set(
-      entries
-        .map((entry) => normalizeOptionalLowercaseString(entry) ?? "")
-        .filter((entry) => entry.length > 0),
-    ),
-  ).toSorted();
-}
-
-function normalizeConfiguredTrustedSafeBinDirs(entries: unknown): string[] {
-  if (!Array.isArray(entries)) {
-    return [];
-  }
-  return normalizeTrustedSafeBinDirs(
-    entries.filter((entry): entry is string => typeof entry === "string"),
-  );
-}
 
 function collectExecSafeBinScopes(cfg: OpenClawConfig): ExecSafeBinScopeRef[] {
   const scopes: ExecSafeBinScopeRef[] = [];

--- a/src/config/logging.test.ts
+++ b/src/config/logging.test.ts
@@ -1,8 +1,8 @@
 // Verifies logging config parsing and file path handling.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempDirSync } from "../test-helpers/temp-dir.js";
 
 const mocks = vi.hoisted(() => ({
   createConfigIO: vi.fn().mockReturnValue({
@@ -39,15 +39,16 @@ describe("config logging", () => {
   });
 
   it("formats backup as an indented detail when present", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-log-"));
-    const configPath = path.join(dir, "openclaw.json");
-    const backupPath = `${configPath}.bak`;
-    fs.writeFileSync(backupPath, "{}", "utf8");
+    withTempDirSync({ prefix: "openclaw-config-log-" }, (dir) => {
+      const configPath = path.join(dir, "openclaw.json");
+      const backupPath = `${configPath}.bak`;
+      fs.writeFileSync(backupPath, "{}", "utf8");
 
-    expect(
-      formatConfigUpdatedMessage(configPath, {
-        backupPath,
-      }),
-    ).toBe(`Updated config: ${configPath}\n  Backup: ${backupPath}`);
+      expect(
+        formatConfigUpdatedMessage(configPath, {
+          backupPath,
+        }),
+      ).toBe(`Updated config: ${configPath}\n  Backup: ${backupPath}`);
+    });
   });
 });

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -19,7 +19,6 @@ import type {
   SessionTranscriptUpdate,
   SessionTranscriptUpdateTarget,
 } from "../../sessions/transcript-events.js";
-import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import { extractGeneratedTranscriptSessionId } from "./generated-transcript-session-id.js";
@@ -37,6 +36,7 @@ import {
   type PluginHostSessionCleanupStoreParams,
 } from "./plugin-host-cleanup.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
+import { resolveSessionStorePathForScope } from "./session-store-path.js";
 import type {
   ResolvedSessionMaintenanceConfig,
   SessionMaintenanceWarning,
@@ -909,7 +909,7 @@ export async function updateResolvedSessionEntry<T>(
 /** Returns the entry for a canonical or alias session key, if one exists. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false || scope.readConsistency === "latest") {
-    const store = loadSessionStore(resolveAccessStorePath(scope), {
+    const store = loadSessionStore(resolveSessionStorePathForScope(scope), {
       ...(scope.clone === false ? { clone: false } : {}),
       ...(scope.readConsistency === "latest" ? { skipCache: true } : {}),
       ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
@@ -923,7 +923,7 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
 export function listSessionEntries(scope: SessionEntryListScope = {}): SessionEntrySummary[] {
   if (scope.clone === false) {
     return Object.entries(
-      loadSessionStore(resolveAccessStorePath({ ...scope, sessionKey: "" }), {
+      loadSessionStore(resolveSessionStorePathForScope({ ...scope, sessionKey: "" }), {
         clone: false,
         ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
       }),
@@ -1114,7 +1114,7 @@ export async function createSessionEntryWithTranscript<TError = string>(
     | Promise<SessionEntryCreateWithTranscriptPrepareResult<TError>>
     | SessionEntryCreateWithTranscriptPrepareResult<TError>,
 ): Promise<SessionEntryCreateWithTranscriptResult<TError>> {
-  const storePath = resolveAccessStorePath(scope);
+  const storePath = resolveSessionStorePathForScope(scope);
   return await updateSessionStore(storePath, async (store) => {
     const resolved = resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey });
     const created = await createEntry({
@@ -1245,7 +1245,7 @@ export async function updateSessionEntry(
   options: SessionEntryUpdateOptions = {},
 ): Promise<SessionEntry | null> {
   return await updateFileSessionStoreEntry({
-    storePath: resolveAccessStorePath(scope),
+    storePath: resolveSessionStorePathForScope(scope),
     sessionKey: scope.sessionKey,
     skipMaintenance: options.skipMaintenance,
     takeCacheOwnership: options.takeCacheOwnership,
@@ -1258,7 +1258,7 @@ export async function updateSessionEntry(
 export function resolveSessionAbortTarget(
   scope: SessionAccessScope,
 ): SessionAbortTargetIdentity | null {
-  const store = loadSessionStore(resolveAccessStorePath(scope));
+  const store = loadSessionStore(resolveSessionStorePathForScope(scope));
   const resolved = resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey });
   if (!resolved.existing) {
     return null;
@@ -1279,7 +1279,7 @@ export async function markSessionAbortTarget(params: {
   scope: SessionAccessScope;
   now?: () => number;
 }): Promise<SessionAbortTargetResult | null> {
-  const storePath = resolveAccessStorePath(params.scope);
+  const storePath = resolveSessionStorePathForScope(params.scope);
   let canPersistSingleEntry = false;
   let resolvedTarget: SessionAbortTargetResult | null = null;
   try {
@@ -2683,7 +2683,7 @@ function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry 
 function snapshotTemporarySessionMapping(
   scope: SessionAccessScope,
 ): TemporarySessionMappingSnapshot {
-  const storePath = resolveAccessStorePath(scope);
+  const storePath = resolveSessionStorePathForScope(scope);
   try {
     const store = loadSessionStore(storePath, { skipCache: true });
     const entry = store[scope.sessionKey];
@@ -2752,17 +2752,6 @@ async function archivePreviousSessionTranscript(params: {
     sessionFile: params.previousEntry.sessionFile,
     agentId: params.agentId,
     archivedTranscripts,
-  });
-}
-
-function resolveAccessStorePath(scope: SessionAccessScope): string {
-  if (scope.storePath) {
-    return scope.storePath;
-  }
-  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
-  return resolveStorePath(getRuntimeConfig().session?.store, {
-    agentId,
-    env: scope.env,
   });
 }
 

--- a/src/config/sessions/session-store-path.ts
+++ b/src/config/sessions/session-store-path.ts
@@ -1,0 +1,21 @@
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { getRuntimeConfig } from "../io.js";
+import { resolveStorePath } from "./paths.js";
+
+type SessionStorePathScope = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  sessionKey?: string;
+  storePath?: string;
+};
+
+export function resolveSessionStorePathForScope(scope: SessionStorePathScope): string {
+  if (scope.storePath) {
+    return scope.storePath;
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  return resolveStorePath(getRuntimeConfig().session?.store, {
+    agentId,
+    env: scope.env,
+  });
+}

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -6,7 +6,6 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import { resolveStoredSessionOwnerAgentId } from "../../gateway/session-store-key.js";
 import { writeTextAtomic } from "../../infra/json-files.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
   deliveryContextFromChannelRoute,
@@ -17,7 +16,6 @@ import {
 } from "../../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
-import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import {
@@ -26,11 +24,8 @@ import {
 } from "./disk-budget.js";
 import { extractGeneratedTranscriptSessionId } from "./generated-transcript-session-id.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
-import {
-  resolveExplicitSessionFilePath,
-  resolveSessionFilePath,
-  resolveStorePath,
-} from "./paths.js";
+import { resolveExplicitSessionFilePath, resolveSessionFilePath } from "./paths.js";
+import { resolveSessionStorePathForScope } from "./session-store-path.js";
 import {
   ensureSessionStorePromptBlobsForPersistence,
   isSessionSkillPromptBlobReadable,
@@ -360,23 +355,10 @@ export function projectSessionEntryForPersistenceRevision(params: {
   return projected.store.entry ?? stripped;
 }
 
-function resolveSessionWorkflowStorePath(
-  options: SessionEntryWorkflowOptions & { sessionKey?: string },
-): string {
-  if (options.storePath) {
-    return options.storePath;
-  }
-  const agentId = options.agentId ?? resolveAgentIdFromSessionKey(options.sessionKey);
-  return resolveStorePath(getRuntimeConfig().session?.store, {
-    agentId,
-    env: options.env,
-  });
-}
-
 export function getSessionEntry(
   options: SessionEntryWorkflowOptions & { sessionKey: string },
 ): SessionEntry | undefined {
-  const entry = readSessionEntry(resolveSessionWorkflowStorePath(options), options.sessionKey, {
+  const entry = readSessionEntry(resolveSessionStorePathForScope(options), options.sessionKey, {
     hydrateSkillPromptRefs: options.hydrateSkillPromptRefs,
   }) as SessionEntry | undefined;
   return entry ? cloneSessionEntry(entry) : undefined;
@@ -385,7 +367,7 @@ export function getSessionEntry(
 export function listSessionEntries(
   options: SessionEntryWorkflowOptions = {},
 ): Array<{ sessionKey: string; entry: SessionEntry }> {
-  return readSessionEntries(resolveSessionWorkflowStorePath(options)).map(
+  return readSessionEntries(resolveSessionStorePathForScope(options)).map(
     ([sessionKey, entry]) => ({
       sessionKey,
       entry: cloneSessionEntry(entry as SessionEntry),
@@ -1826,7 +1808,7 @@ export async function patchSessionEntry(
 export async function patchSessionEntryWithKey(
   params: SessionEntryPatchParams,
 ): Promise<{ sessionKey: string; entry: SessionEntry } | null> {
-  const storePath = resolveSessionWorkflowStorePath(params);
+  const storePath = resolveSessionStorePathForScope(params);
   return await runExclusiveSessionStoreWrite(storePath, async () => {
     const store = loadMutableSessionStoreForWriter(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
@@ -1868,7 +1850,7 @@ export async function upsertSessionEntry(
     entry: SessionEntry;
   },
 ): Promise<void> {
-  const storePath = resolveSessionWorkflowStorePath(params);
+  const storePath = resolveSessionStorePathForScope(params);
   await runExclusiveSessionStoreWrite(storePath, async () => {
     const store = loadMutableSessionStoreForWriter(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });

--- a/src/crestodian/audit.test.ts
+++ b/src/crestodian/audit.test.ts
@@ -1,8 +1,7 @@
 // Crestodian audit tests cover filesystem-backed rescue audit scenarios.
 import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../test-helpers/temp-dir.js";
 import { appendCrestodianAuditEntry, resolveCrestodianAuditPath } from "./audit.js";
 
 describe("Crestodian audit log", () => {
@@ -17,23 +16,24 @@ describe("Crestodian audit log", () => {
   });
 
   it("writes jsonl records under the OpenClaw audit dir", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-audit-"));
-    vi.stubEnv("OPENCLAW_STATE_DIR", tempDir);
+    await withTempDir({ prefix: "crestodian-audit-" }, async (tempDir) => {
+      vi.stubEnv("OPENCLAW_STATE_DIR", tempDir);
 
-    const auditPath = await appendCrestodianAuditEntry({
-      operation: "config.setDefaultModel",
-      summary: "Set default model to openai/gpt-5.2",
-      configHashBefore: "before",
-      configHashAfter: "after",
+      const auditPath = await appendCrestodianAuditEntry({
+        operation: "config.setDefaultModel",
+        summary: "Set default model to openai/gpt-5.2",
+        configHashBefore: "before",
+        configHashAfter: "after",
+      });
+
+      expect(auditPath).toBe(resolveCrestodianAuditPath());
+      const lines = (await fs.readFile(auditPath, "utf8")).trim().split("\n");
+      expect(lines).toHaveLength(1);
+      const entry = JSON.parse(lines[0] ?? "{}") as Record<string, unknown>;
+      expect(entry.operation).toBe("config.setDefaultModel");
+      expect(entry.summary).toBe("Set default model to openai/gpt-5.2");
+      expect(entry.configHashBefore).toBe("before");
+      expect(entry.configHashAfter).toBe("after");
     });
-
-    expect(auditPath).toBe(resolveCrestodianAuditPath());
-    const lines = (await fs.readFile(auditPath, "utf8")).trim().split("\n");
-    expect(lines).toHaveLength(1);
-    const entry = JSON.parse(lines[0] ?? "{}") as Record<string, unknown>;
-    expect(entry.operation).toBe("config.setDefaultModel");
-    expect(entry.summary).toBe("Set default model to openai/gpt-5.2");
-    expect(entry.configHashBefore).toBe("before");
-    expect(entry.configHashAfter).toBe("after");
   });
 });

--- a/src/crestodian/operations.test.ts
+++ b/src/crestodian/operations.test.ts
@@ -1,8 +1,8 @@
 // Crestodian operation tests cover rescue operation planning and execution.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { createCrestodianTestRuntime } from "./crestodian.test-helpers.js";
@@ -192,6 +192,12 @@ vi.mock("../config/model-input.js", () => ({
     typeof model === "string" ? model : model?.primary,
 }));
 
+const opTempDirs: string[] = [];
+
+afterAll(() => {
+  cleanupTempDirs(opTempDirs);
+});
+
 describe("parseCrestodianOperation", () => {
   let stateDirSnapshot: ReturnType<typeof captureEnv> | undefined;
 
@@ -325,7 +331,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("applies config set through typed deps and writes an audit entry", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-config-set-"));
+    const tempDir = makeTempDir(opTempDirs, "crestodian-config-set-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runConfigSet = vi.fn(async () => {});
@@ -361,7 +367,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("applies SecretRef config set through typed deps and writes an audit entry", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-config-ref-"));
+    const tempDir = makeTempDir(opTempDirs, "crestodian-config-ref-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runConfigSet = vi.fn(async () => {});
@@ -439,7 +445,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("installs plugins only after approval and audits the write", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-plugin-install-"));
+    const tempDir = makeTempDir(opTempDirs, "crestodian-plugin-install-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runPluginInstall = vi.fn(async (spec: string, pluginRuntime: RuntimeEnv) => {
@@ -485,7 +491,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("uninstalls plugins only after approval and audits the write", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-plugin-uninstall-"));
+    const tempDir = makeTempDir(opTempDirs, "crestodian-plugin-uninstall-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runPluginUninstall = vi.fn(async (pluginId: string, pluginRuntime: RuntimeEnv) => {
@@ -531,7 +537,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("runs setup bootstrap only after approval and audits it", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-setup-"));
+    const tempDir = makeTempDir(opTempDirs, "crestodian-setup-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     vi.stubEnv("OPENAI_API_KEY", "test-key");
     const { runtime, lines } = createCrestodianTestRuntime();
@@ -580,7 +586,7 @@ describe("parseCrestodianOperation", () => {
   });
 
   it("runs doctor repairs only after approval and audits them", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-doctor-fix-"));
+    const tempDir = makeTempDir(opTempDirs, "crestodian-doctor-fix-");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
     const { runtime, lines } = createCrestodianTestRuntime();
     const runDoctor = vi.fn(async () => {});

--- a/src/crestodian/rescue-channel.live.test.ts
+++ b/src/crestodian/rescue-channel.live.test.ts
@@ -1,11 +1,11 @@
 // Crestodian live rescue channel tests cover live-channel rescue message delivery.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { CommandContext } from "../auto-reply/reply/commands-types.js";
 import { clearConfigCache } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { runCrestodianRescueMessage } from "./rescue-message.js";
 
@@ -67,48 +67,49 @@ describeLive("Crestodian live rescue channel smoke", () => {
   });
 
   it("handles /crestodian status and a persistent approval roundtrip", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crestodian-live-rescue-"));
-    const configPath = path.join(tempDir, "openclaw.json");
-    setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    await fs.writeFile(
-      configPath,
-      JSON.stringify(
-        {
-          meta: { lastTouchedVersion: "live-test", lastTouchedAt: new Date(0).toISOString() },
-          agents: { defaults: {} },
-          tools: { exec: { security: "full", ask: "off" } },
-        },
-        null,
-        2,
-      ),
-    );
+    await withTempDir({ prefix: "crestodian-live-rescue-" }, async (tempDir) => {
+      const configPath = path.join(tempDir, "openclaw.json");
+      setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            meta: { lastTouchedVersion: "live-test", lastTouchedAt: new Date(0).toISOString() },
+            agents: { defaults: {} },
+            tools: { exec: { security: "full", ask: "off" } },
+          },
+          null,
+          2,
+        ),
+      );
 
-    const cfg: OpenClawConfig = {
-      crestodian: { rescue: { enabled: true } },
-      tools: { exec: { security: "full", ask: "off" } },
-    };
+      const cfg: OpenClawConfig = {
+        crestodian: { rescue: { enabled: true } },
+        tools: { exec: { security: "full", ask: "off" } },
+      };
 
-    await expect(runRescue({ commandBody: "/crestodian status", cfg })).resolves.toContain(
-      "[crestodian] done: status.check",
-    );
-    await expect(
-      runRescue({ commandBody: "/crestodian set default model openai/gpt-5.5", cfg }),
-    ).resolves.toContain("Reply /crestodian yes to apply");
-    await expect(runRescue({ commandBody: "/crestodian yes", cfg })).resolves.toContain(
-      "Default model: openai/gpt-5.5",
-    );
+      await expect(runRescue({ commandBody: "/crestodian status", cfg })).resolves.toContain(
+        "[crestodian] done: status.check",
+      );
+      await expect(
+        runRescue({ commandBody: "/crestodian set default model openai/gpt-5.5", cfg }),
+      ).resolves.toContain("Reply /crestodian yes to apply");
+      await expect(runRescue({ commandBody: "/crestodian yes", cfg })).resolves.toContain(
+        "Default model: openai/gpt-5.5",
+      );
 
-    const config = JSON.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig;
-    const defaultModel = config.agents?.defaults?.model;
-    if (!defaultModel || typeof defaultModel !== "object") {
-      throw new Error("expected default model object");
-    }
-    expect(defaultModel.primary).toBe("openai/gpt-5.5");
-    const auditPath = path.join(tempDir, "audit", "crestodian.jsonl");
-    const auditLines = (await fs.readFile(auditPath, "utf8")).trim().split("\n");
-    expect(auditLines.some((line) => line.includes('"operation":"config.setDefaultModel"'))).toBe(
-      true,
-    );
+      const config = JSON.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig;
+      const defaultModel = config.agents?.defaults?.model;
+      if (!defaultModel || typeof defaultModel !== "object") {
+        throw new Error("expected default model object");
+      }
+      expect(defaultModel.primary).toBe("openai/gpt-5.5");
+      const auditPath = path.join(tempDir, "audit", "crestodian.jsonl");
+      const auditLines = (await fs.readFile(auditPath, "utf8")).trim().split("\n");
+      expect(auditLines.some((line) => line.includes('"operation":"config.setDefaultModel"'))).toBe(
+        true,
+      );
+    });
   });
 });

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -3,7 +3,8 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   adoptCronRunSessionMetadata,
@@ -216,9 +217,15 @@ describe("createPersistCronSessionEntry", () => {
   });
 });
 
+const cronSessionTempDirs: string[] = [];
+
 async function createTranscriptFile(): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-session-"));
+  const dir = makeTempDir(cronSessionTempDirs, "openclaw-cron-session-");
   const file = path.join(dir, "session.jsonl");
   await fs.writeFile(file, `${JSON.stringify({ type: "session", sessionId: "run-session-id" })}\n`);
   return file;
 }
+
+afterAll(() => {
+  cleanupTempDirs(cronSessionTempDirs);
+});

--- a/src/cron/isolated-agent/session.provider-owned-reset.test.ts
+++ b/src/cron/isolated-agent/session.provider-owned-reset.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { getCliSessionBinding } from "../../config/sessions/cli-session-binding.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveCronSession } from "./session.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW_MS = 1_737_600_000_000;
+
+function providerOwnedEntry(): SessionEntry {
+  const startedAt = NOW_MS - DAY_MS;
+  return {
+    sessionId: "old-session-id",
+    updatedAt: startedAt,
+    sessionStartedAt: startedAt,
+    lastInteractionAt: startedAt,
+    model: "claude-opus-4-6",
+    modelProvider: "claude-cli",
+    cliSessionBindings: { "claude-cli": { sessionId: "cli-conversation-xyz" } },
+  };
+}
+
+describe("resolveCronSession provider-owned daily reset", () => {
+  it("keeps a provider-owned CLI session across the default daily boundary", () => {
+    const sessionKey = "agent:main:cron:daily-job";
+    const entry = providerOwnedEntry();
+
+    const result = resolveCronSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+      nowMs: NOW_MS,
+      forceNew: false,
+      store: { [sessionKey]: entry },
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionEntry.sessionId).toBe("old-session-id");
+    expect(getCliSessionBinding(result.sessionEntry, "claude-cli")).toEqual({
+      sessionId: "cli-conversation-xyz",
+    });
+  });
+
+  it("still rotates a non-provider-owned session across the daily boundary", () => {
+    const sessionKey = "agent:main:cron:daily-job";
+    const startedAt = NOW_MS - DAY_MS;
+    const entry: SessionEntry = {
+      sessionId: "old-session-id",
+      updatedAt: startedAt,
+      sessionStartedAt: startedAt,
+      lastInteractionAt: startedAt,
+    };
+
+    const result = resolveCronSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+      nowMs: NOW_MS,
+      forceNew: false,
+      store: { [sessionKey]: entry },
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.sessionId).not.toBe("old-session-id");
+  });
+
+  it("still rotates a provider-owned session when reset is explicitly configured", () => {
+    const sessionKey = "agent:main:cron:daily-job";
+    const entry = providerOwnedEntry();
+
+    const result = resolveCronSession({
+      cfg: { session: { reset: { mode: "daily" } } } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+      nowMs: NOW_MS,
+      forceNew: false,
+      store: { [sessionKey]: entry },
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.sessionId).not.toBe("old-session-id");
+    expect(getCliSessionBinding(result.sessionEntry, "claude-cli")).toBeUndefined();
+  });
+});

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -1,12 +1,14 @@
 /** Resolves session rollover and carried state for isolated cron runs. */
 import crypto from "node:crypto";
 import { clearBootstrapSnapshotOnSessionRollover } from "../../agents/bootstrap-cache.js";
+import { hasProviderOwnedSession } from "../../config/sessions/entry-freshness.js";
 import { resolveSessionLifecycleTimestamps } from "../../config/sessions/lifecycle.js";
 import { hasSessionAutoModelFallbackProvenance } from "../../config/sessions/model-override-provenance.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
   evaluateSessionFreshness,
   resolveSessionResetPolicy,
+  type SessionFreshness,
 } from "../../config/sessions/reset-policy.js";
 import { loadSessionStore } from "../../config/sessions/store-load.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
@@ -131,16 +133,19 @@ export function resolveCronSession(params: {
       sessionCfg,
       resetType: "direct",
     });
-    const freshness = evaluateSessionFreshness({
-      updatedAt: entry.updatedAt,
-      ...resolveSessionLifecycleTimestamps({
-        entry,
-        agentId: params.agentId,
-        storePath,
-      }),
-      now: params.nowMs,
-      policy: resetPolicy,
-    });
+    const skipImplicitExpiry = resetPolicy.configured !== true && hasProviderOwnedSession(entry);
+    const freshness = skipImplicitExpiry
+      ? ({ fresh: true } satisfies SessionFreshness)
+      : evaluateSessionFreshness({
+          updatedAt: entry.updatedAt,
+          ...resolveSessionLifecycleTimestamps({
+            entry,
+            agentId: params.agentId,
+            storePath,
+          }),
+          now: params.nowMs,
+          policy: resetPolicy,
+        });
 
     if (freshness.fresh) {
       sessionId = entry.sessionId;

--- a/src/cron/run-log.error-reason.test.ts
+++ b/src/cron/run-log.error-reason.test.ts
@@ -1,15 +1,21 @@
 // Cron run log error tests cover persisted failure reasons and summaries.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { migrateLegacyCronRunLogsToSqlite } from "../commands/doctor/cron/legacy-run-log-migration.js";
 import { appendCronRunLog, readCronRunLogEntriesPage, type CronRunLogEntry } from "./run-log.js";
+
+const runLogTempDirs: string[] = [];
+
+afterAll(() => {
+  cleanupTempDirs(runLogTempDirs);
+});
 
 async function writeLegacyRunLogAndMigrate(
   entries: Array<Record<string, unknown>>,
 ): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cron-run-log-"));
+  const dir = makeTempDir(runLogTempDirs, "cron-run-log-");
   const storePath = path.join(dir, "cron", "jobs.json");
   const file = path.join(dir, "cron", "runs", "job-1.jsonl");
   await fs.mkdir(path.dirname(file), { recursive: true });
@@ -43,7 +49,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("validates persisted errorReason against the full failover reason set", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cron-run-log-"));
+    const dir = makeTempDir(runLogTempDirs, "cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     const reasons = [
       "auth",
@@ -104,7 +110,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("uses provider context when deriving persisted run-log reasons", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cron-run-log-"));
+    const dir = makeTempDir(runLogTempDirs, "cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     await appendCronRunLog({
       storePath,
@@ -123,7 +129,7 @@ describe("cron run log errorReason", () => {
   });
 
   it("includes derived errorReason values in run-log search", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cron-run-log-"));
+    const dir = makeTempDir(runLogTempDirs, "cron-run-log-");
     const storePath = path.join(dir, "jobs.json");
     await appendCronRunLog({
       storePath,

--- a/src/daemon/service-runtime.test.ts
+++ b/src/daemon/service-runtime.test.ts
@@ -1,0 +1,110 @@
+// Tests for systemd supervision-state classification helpers.
+import { describe, expect, it } from "vitest";
+import { isSystemdStartLimitHit } from "./service-runtime.js";
+
+describe("isSystemdStartLimitHit", () => {
+  it("detects a crash loop where the restart counter reached StartLimitBurst", () => {
+    // Real systemd 249 give-up: process kept exiting non-zero so Result stays
+    // exit-code; NRestarts hitting StartLimitBurst is the give-up signal.
+    expect(
+      isSystemdStartLimitHit({
+        status: "stopped",
+        state: "failed",
+        systemd: { result: "exit-code", nRestarts: 5, startLimitBurst: 5 },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects a crash loop when the last exit was a non-config code", () => {
+    // exit 1 is a normal crash, not the RestartPreventExitStatus=78 no-restart
+    // path, so a counter that reached StartLimitBurst is real start-limit exhaustion.
+    expect(
+      isSystemdStartLimitHit({
+        status: "stopped",
+        state: "failed",
+        lastExitStatus: 1,
+        systemd: { result: "exit-code", nRestarts: 3, startLimitBurst: 3 },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects Result=start-limit-hit even when restart counters are absent", () => {
+    expect(
+      isSystemdStartLimitHit({
+        status: "stopped",
+        state: "failed",
+        systemd: { result: "start-limit-hit" },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not counter-detect the deliberate EX_CONFIG (78) no-restart exit", () => {
+    // RestartPreventExitStatus=78 stops systemd on purpose; the NRestarts left
+    // over from earlier crashes is stale and must not read as start-limit exhaustion.
+    expect(
+      isSystemdStartLimitHit({
+        status: "stopped",
+        state: "failed",
+        lastExitStatus: 78,
+        systemd: { result: "exit-code", nRestarts: 5, startLimitBurst: 5 },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps Result=start-limit-hit authoritative even after a config (78) exit", () => {
+    // The explicit systemd give-up signal wins regardless of the last exit code.
+    expect(
+      isSystemdStartLimitHit({
+        status: "stopped",
+        state: "failed",
+        lastExitStatus: 78,
+        systemd: { result: "start-limit-hit", nRestarts: 5, startLimitBurst: 5 },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not flag a single failed exit below the start limit", () => {
+    expect(
+      isSystemdStartLimitHit({
+        status: "stopped",
+        state: "failed",
+        systemd: { result: "exit-code", nRestarts: 1, startLimitBurst: 5 },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag a running unit even if its lifetime restart count is high", () => {
+    expect(
+      isSystemdStartLimitHit({
+        status: "running",
+        state: "active",
+        systemd: { result: "success", nRestarts: 9, startLimitBurst: 5 },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag when rate limiting is disabled (StartLimitBurst=0)", () => {
+    expect(
+      isSystemdStartLimitHit({
+        status: "stopped",
+        state: "failed",
+        systemd: { result: "exit-code", nRestarts: 9, startLimitBurst: 0 },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not counter-detect when StartLimitBurst is missing from the probe", () => {
+    expect(
+      isSystemdStartLimitHit({
+        status: "stopped",
+        state: "failed",
+        systemd: { result: "exit-code", nRestarts: 9 },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false without systemd supervision data or runtime", () => {
+    expect(isSystemdStartLimitHit({ status: "stopped", state: "failed" })).toBe(false);
+    expect(isSystemdStartLimitHit(undefined)).toBe(false);
+  });
+});

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -1,12 +1,18 @@
 /** Shared daemon runtime status types and systemd cgroup hygiene helpers. */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
-/** systemd cgroup fields used to spot unhealthy gateway service supervision. */
+/** systemd supervision fields used to spot unhealthy or given-up gateway service state. */
 export type GatewayServiceSystemdRuntime = {
   unit?: string;
   killMode?: string;
   tasksCurrent?: number;
   memoryCurrent?: number;
+  // systemd `Result` (e.g. success, exit-code, start-limit-hit) plus the restart
+  // counter and configured StartLimitBurst. Together they detect a crash-loop
+  // give-up that the collapsed `status` string and `Result` alone cannot.
+  result?: string;
+  nRestarts?: number;
+  startLimitBurst?: number;
 };
 
 export type GatewayServiceRuntime = {
@@ -28,6 +34,14 @@ export type GatewayServiceRuntime = {
 
 export const SYSTEMD_TASKS_CURRENT_WARNING_THRESHOLD = 200;
 export const SYSTEMD_MEMORY_CURRENT_WARNING_BYTES = 2 * 1024 * 1024 * 1024;
+
+// EX_CONFIG (78) from sysexits.h. The generated systemd unit pins
+// RestartPreventExitStatus=78 (see systemd-unit.ts) so the gateway's
+// config-error / duplicate-lock exit (gateway-cli run) deliberately stops
+// without a restart. A last exit of 78 therefore means systemd gave up on
+// purpose, not that it exhausted StartLimitBurst, so any accumulated NRestarts
+// is stale from earlier crashes and must not drive start-limit detection.
+const SYSTEMD_NO_RESTART_EXIT_STATUS = 78;
 
 export function isRiskySystemdKillMode(value: string | undefined): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(value);
@@ -82,4 +96,46 @@ export function getSystemdCgroupHygieneSummary(
 
 export function isSystemdCgroupHygieneRisk(runtime?: GatewayServiceSystemdRuntime): boolean {
   return getSystemdCgroupHygieneSummary(runtime) !== null;
+}
+
+/**
+ * True when systemd has stopped auto-restarting the gateway because it crashed
+ * faster than StartLimitBurst/StartLimitIntervalSec allows. Unlike an ordinary
+ * stopped/exited unit, this terminal latch needs an explicit `reset-failed` +
+ * restart to recover, so status/doctor must surface it instead of the generic
+ * "exited immediately" message.
+ *
+ * Detection: the unit is `failed` and either systemd reported the give-up
+ * directly (Result=start-limit-hit, the start-was-refused-before-exec case) or
+ * the restart counter reached the configured burst. The counter path is the
+ * common one: once the gateway process has actually run and exited non-zero,
+ * systemd keeps Result=exit-code and never overwrites it with start-limit-hit
+ * (verified against systemd 249), so Result alone misses real crash loops.
+ *
+ * The counter path is guarded against the deliberate no-restart exit: a last
+ * exit of 78 (EX_CONFIG, held back by RestartPreventExitStatus=78) means
+ * systemd stopped on purpose, so a stale NRestarts left over from earlier
+ * crashes must not be mistaken for start-limit exhaustion. The explicit
+ * Result=start-limit-hit signal stays authoritative regardless of exit status.
+ */
+export function isSystemdStartLimitHit(runtime?: GatewayServiceRuntime): boolean {
+  if (!runtime || normalizeLowercaseStringOrEmpty(runtime.state) !== "failed") {
+    return false;
+  }
+  const systemd = runtime.systemd;
+  if (!systemd) {
+    return false;
+  }
+  if (normalizeLowercaseStringOrEmpty(systemd.result) === "start-limit-hit") {
+    return true;
+  }
+  if (runtime.lastExitStatus === SYSTEMD_NO_RESTART_EXIT_STATUS) {
+    return false;
+  }
+  return (
+    typeof systemd.startLimitBurst === "number" &&
+    systemd.startLimitBurst > 0 &&
+    typeof systemd.nRestarts === "number" &&
+    systemd.nRestarts >= systemd.startLimitBurst
+  );
 }

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -740,10 +740,15 @@ describe("system-scope gateway unit detection (openclaw#87577)", () => {
   it("restartSystemdService restarts the system unit directly when running as root", async () => {
     mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-gateway.service" });
     mockEffectiveUid(0);
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      expect(args).toEqual(["restart", GATEWAY_SERVICE]);
-      cb(null, "", "");
-    });
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["reset-failed", GATEWAY_SERVICE]);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["restart", GATEWAY_SERVICE]);
+        cb(null, "", "");
+      });
     const { stdout, write } = createWritableStreamMock();
     const result = await restartSystemdService({ stdout, env: { HOME: TEST_MANAGED_HOME } });
     expect(result).toEqual({ outcome: "completed" });
@@ -804,6 +809,31 @@ describe("systemd runtime parsing", () => {
     });
   });
 
+  it("parses Result and the restart counter for crash-loop give-up detection", () => {
+    // Real systemd 249 give-up shape: a crash-looped unit keeps Result=exit-code
+    // (start-limit-hit never overwrites an exec failure), so the counter reaching
+    // StartLimitBurst is what flags the give-up.
+    const output = [
+      "ActiveState=failed",
+      "SubState=failed",
+      "Result=exit-code",
+      "NRestarts=5",
+      "StartLimitBurst=5",
+      "MainPID=0",
+      "ExecMainStatus=1",
+      "ExecMainCode=exited",
+    ].join("\n");
+    expect(parseSystemdShow(output)).toEqual({
+      activeState: "failed",
+      subState: "failed",
+      result: "exit-code",
+      nRestarts: 5,
+      startLimitBurst: 5,
+      execMainStatus: 1,
+      execMainCode: "exited",
+    });
+  });
+
   it("rejects pid and exit status values with junk suffixes", () => {
     const output = [
       "ActiveState=inactive",
@@ -855,7 +885,7 @@ describe("readSystemdServiceRuntime", () => {
           GATEWAY_SERVICE,
           "--no-page",
           "--property",
-          "Id,ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent",
+          "Id,ActiveState,SubState,Result,NRestarts,StartLimitBurst,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent",
         );
         cb(
           null,
@@ -887,6 +917,41 @@ describe("readSystemdServiceRuntime", () => {
         tasksCurrent: 807,
         memoryCurrent: 11_918_534_246,
       },
+    });
+  });
+
+  it("carries the supervision counters through a crash-looped failed unit", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "status");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
+        cb(
+          null,
+          [
+            "Id=openclaw-gateway.service",
+            "ActiveState=failed",
+            "SubState=failed",
+            "Result=exit-code",
+            "NRestarts=5",
+            "StartLimitBurst=5",
+            "MainPID=0",
+            "ExecMainStatus=1",
+            "ExecMainCode=exited",
+          ].join("\n"),
+          "",
+        );
+      });
+    const runtime = await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME });
+    // ActiveState=failed collapses to the generic "stopped" status, so the raw
+    // state + restart counters are what let callers detect the crash-loop give-up.
+    expect(runtime.status).toBe("stopped");
+    expect(runtime.state).toBe("failed");
+    expect(runtime.systemd).toMatchObject({
+      result: "exit-code",
+      nRestarts: 5,
+      startLimitBurst: 5,
     });
   });
 });
@@ -2008,14 +2073,25 @@ describe("systemd service control", () => {
     });
   });
 
-  it("restarts a profile-specific user unit", async () => {
+  it("runs reset-failed before restarting a profile-specific user unit", async () => {
+    const restartSequence: string[] = [];
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "reset-failed", "openclaw-gateway-work.service");
+        // args[0] is the "--user" scope flag; the systemctl verb is args[1].
+        restartSequence.push(args[1] ?? "");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "restart", "openclaw-gateway-work.service");
+        restartSequence.push(args[1] ?? "");
         cb(null, "", "");
       });
     await assertRestartSuccess({ OPENCLAW_PROFILE: "work" });
+    // reset-failed must clear any start-limit-hit latch before the restart so a
+    // crash-looped unit can recover.
+    expect(restartSequence).toEqual(["reset-failed", "restart"]);
   });
 
   it("surfaces stop failures with systemctl detail", async () => {
@@ -2063,6 +2139,10 @@ describe("systemd service control", () => {
         cb(null, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertMachineUserSystemctlArgs(args, "debian", "reset-failed", GATEWAY_SERVICE);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertMachineRestartArgs(args);
         cb(null, "", "");
       });
@@ -2074,6 +2154,10 @@ describe("systemd service control", () => {
     execFileMock
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "status");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
         cb(null, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
@@ -2097,6 +2181,10 @@ describe("systemd service control", () => {
         cb(null, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "restart", GATEWAY_SERVICE);
         cb(null, "", "");
       });
@@ -2115,6 +2203,17 @@ describe("systemd service control", () => {
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertMachineUserSystemctlArgs(args, "debian", "status");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
+        const err = createExecFileError("Failed to connect to user scope bus", {
+          stderr: "Failed to connect to user scope bus",
+        });
+        cb(err, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertMachineUserSystemctlArgs(args, "debian", "reset-failed", GATEWAY_SERVICE);
         cb(null, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -480,6 +480,9 @@ type SystemdServiceInfo = {
   mainPid?: number;
   execMainStatus?: number;
   execMainCode?: string;
+  result?: string;
+  nRestarts?: number;
+  startLimitBurst?: number;
   unit?: string;
   killMode?: string;
   tasksCurrent?: number;
@@ -514,6 +517,24 @@ export function parseSystemdShow(output: string): SystemdServiceInfo {
   const execMainCode = entries.execmaincode;
   if (execMainCode) {
     info.execMainCode = execMainCode;
+  }
+  const result = entries.result;
+  if (result) {
+    info.result = result;
+  }
+  const nRestartsValue = entries.nrestarts;
+  if (nRestartsValue) {
+    const nRestarts = parseStrictInteger(nRestartsValue);
+    if (nRestarts !== undefined) {
+      info.nRestarts = nRestarts;
+    }
+  }
+  const startLimitBurstValue = entries.startlimitburst;
+  if (startLimitBurstValue) {
+    const startLimitBurst = parseStrictInteger(startLimitBurstValue);
+    if (startLimitBurst !== undefined) {
+      info.startLimitBurst = startLimitBurst;
+    }
   }
   const unit = entries.id;
   if (unit) {
@@ -1184,6 +1205,13 @@ async function runSystemdServiceAction(params: {
         `${unitName} is a system-scope unit (${installed.unitPath}); run \`sudo systemctl ${params.action} ${unitName}\` to ${params.action} it`,
       );
     }
+    if (params.action === "restart") {
+      // systemd latches a unit into failed/start-limit-hit after it crashes faster
+      // than StartLimitBurst allows and then stops auto-restarting it. Clear the
+      // latch first so an operator restart can recover a crash-looped gateway;
+      // reset-failed is idempotent and a no-op on a healthy unit.
+      await execSystemctl(["reset-failed", unitName], env);
+    }
     const res = await execSystemctl([params.action, unitName], env);
     if (res.code !== 0) {
       throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
@@ -1192,6 +1220,11 @@ async function runSystemdServiceAction(params: {
     return;
   }
   await assertSystemdAvailable(env);
+  if (params.action === "restart") {
+    // Clear any failed/start-limit-hit latch before restart so a crash-looped
+    // gateway recovers (see system-scope branch above). Idempotent on healthy units.
+    await execSystemctlUser(env, ["reset-failed", unitName]);
+  }
   const res = await execSystemctlUser(env, [params.action, unitName]);
   if (res.code !== 0) {
     throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
@@ -1264,7 +1297,7 @@ export async function readSystemdServiceRuntime(
     unitName,
     "--no-page",
     "--property",
-    "Id,ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent",
+    "Id,ActiveState,SubState,Result,NRestarts,StartLimitBurst,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent",
   ];
   const res =
     installed?.scope === "system"
@@ -1294,6 +1327,9 @@ export async function readSystemdServiceRuntime(
       killMode: parsed.killMode,
       tasksCurrent: parsed.tasksCurrent,
       memoryCurrent: parsed.memoryCurrent,
+      result: parsed.result,
+      nRestarts: parsed.nRestarts,
+      startLimitBurst: parsed.startLimitBurst,
     },
   };
 }

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -3,7 +3,14 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+
+const hooksTempDirs: string[] = [];
+
+afterAll(() => {
+  cleanupTempDirs(hooksTempDirs);
+});
 import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
 
 const baseUrl = new URL("http://127.0.0.1:18789/hooks/gmail");
@@ -118,7 +125,7 @@ describe("hooks mapping", () => {
     payload?: Record<string, unknown>;
     sessionKey?: string;
   }) {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), params.tempPrefix));
+    const configDir = makeTempDir(hooksTempDirs, params.tempPrefix);
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     fs.writeFileSync(path.join(transformsRoot, "transform.mjs"), params.transformLines.join("\n"));
@@ -230,7 +237,7 @@ describe("hooks mapping", () => {
   });
 
   it("runs transform module", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-"));
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "transform.mjs");
@@ -341,7 +348,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transform module traversal outside transformsDir", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-traversal-"));
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-traversal-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -361,7 +368,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects absolute transform module path outside transformsDir", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-abs-"));
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const outside = path.join(os.tmpdir(), "evil.mjs");
@@ -382,7 +389,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir traversal outside the transforms root", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-trav-"));
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-xformdir-trav-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -403,7 +410,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir absolute path outside the transforms root", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-abs-"));
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-xformdir-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -424,7 +431,7 @@ describe("hooks mapping", () => {
   });
 
   it("accepts transformsDir subdirectory within the transforms root", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-ok-"));
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-xformdir-ok-");
     const result = await applyNullTransformFromTempConfig({ configDir, transformsDir: "subdir" });
     expectSkippedTransformResult(result);
   });
@@ -432,10 +439,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transform module symlink escape outside transformsDir",
     () => {
-      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-module-"));
+      const configDir = makeTempDir(hooksTempDirs, "openclaw-config-symlink-module-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-module-"));
+      const outsideDir = makeTempDir(hooksTempDirs, "openclaw-outside-module-");
       const outsideModule = path.join(outsideDir, "evil.mjs");
       fs.writeFileSync(outsideModule, 'export default () => ({ kind: "wake", text: "owned" });');
       fs.symlinkSync(outsideModule, path.join(transformsRoot, "linked.mjs"));
@@ -459,10 +466,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transformsDir symlink escape outside transforms root",
     () => {
-      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-dir-"));
+      const configDir = makeTempDir(hooksTempDirs, "openclaw-config-symlink-dir-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-dir-"));
+      const outsideDir = makeTempDir(hooksTempDirs, "openclaw-outside-dir-");
       fs.writeFileSync(path.join(outsideDir, "transform.mjs"), "export default () => null;");
       fs.symlinkSync(outsideDir, path.join(transformsRoot, "escape"), "dir");
       expect(() =>
@@ -484,7 +491,7 @@ describe("hooks mapping", () => {
   );
 
   it.runIf(process.platform !== "win32")("accepts in-root transform module symlink", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-ok-"));
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-symlink-ok-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     const nestedDir = path.join(transformsRoot, "nested");
     fs.mkdirSync(nestedDir, { recursive: true });
@@ -515,7 +522,7 @@ describe("hooks mapping", () => {
   });
 
   it("treats null transform as a handled skip", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-skip-"));
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-config-skip-");
     const result = await applyNullTransformFromTempConfig({ configDir });
     expectSkippedTransformResult(result);
   });
@@ -565,7 +572,7 @@ describe("hooks mapping", () => {
   });
 
   it("caches transform functions by module path and export name", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-export-"));
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-hooks-export-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "multi-export.mjs");

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -2,10 +2,10 @@
  * Tests persistence effects when chat abort requests complete.
  */
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import { onAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
 import {
   createActiveRun,
@@ -164,8 +164,10 @@ function setMockSessionEntry(transcriptPath: string, sessionId: string, hasEntry
   sessionEntryState.loadCalls = [];
 }
 
+const abortTempDirs: string[] = [];
+
 async function createTranscriptFixture(prefix: string) {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const dir = makeTempDir(abortTempDirs, prefix);
   const sessionId = "sess-main";
   const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
   await writeTranscriptHeader(transcriptPath, sessionId);
@@ -174,12 +176,16 @@ async function createTranscriptFixture(prefix: string) {
 }
 
 async function createMissingEntryFixture(prefix: string) {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const dir = makeTempDir(abortTempDirs, prefix);
   const transcriptPath = path.join(dir, "missing.jsonl");
   const sessionId = "client-supplied-session";
   setMockSessionEntry(transcriptPath, sessionId, false);
   return { sessionId };
 }
+
+afterAll(() => {
+  cleanupTempDirs(abortTempDirs);
+});
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -7,10 +7,16 @@ import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
   listChannelPlugins: vi.fn(),
+  resolveMissingOfficialExternalChannelPluginRepairHint: vi.fn(),
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
   listChannelPlugins: mocks.listChannelPlugins,
+}));
+
+vi.mock("../../plugins/official-external-plugin-repair-hints.js", () => ({
+  resolveMissingOfficialExternalChannelPluginRepairHint:
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint,
 }));
 
 import { webHandlers } from "./web.js";
@@ -48,6 +54,7 @@ function createOptions(
       stopChannel: vi.fn(),
       startChannel: vi.fn(),
       getRuntimeSnapshot: vi.fn(createRunningWhatsappSnapshot),
+      getRuntimeConfig: vi.fn(() => ({ channels: { whatsapp: { enabled: true } } })),
     },
     ...overrides,
   } as unknown as GatewayRequestHandlerOptions;
@@ -63,6 +70,7 @@ function createRunningWhatsappContext() {
       stopChannel,
       startChannel,
       getRuntimeSnapshot: vi.fn(createRunningWhatsappSnapshot),
+      getRuntimeConfig: vi.fn(() => ({ channels: { whatsapp: { enabled: true } } })),
     } as unknown as GatewayRequestHandlerOptions["context"],
   };
 }
@@ -70,6 +78,105 @@ function createRunningWhatsappContext() {
 describe("webHandlers web.login.start", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue(null);
+  });
+
+  it("surfaces the missing official external plugin hint when no web-login provider is loaded", async () => {
+    mocks.listChannelPlugins.mockReturnValue([]);
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue({
+      pluginId: "whatsapp",
+      channelId: "whatsapp",
+      label: "WhatsApp",
+      installSpec: "clawhub:@openclaw/whatsapp",
+      installCommand: "openclaw plugins install clawhub:@openclaw/whatsapp",
+      doctorFixCommand: "openclaw doctor --fix",
+      repairHint:
+        "Install the official external plugin with: openclaw plugins install clawhub:@openclaw/whatsapp, or run: openclaw doctor --fix.",
+    });
+    const respond = vi.fn();
+
+    await webHandlers["web.login.start"](
+      createOptions(
+        { accountId: "default" },
+        {
+          respond,
+        },
+      ),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message:
+          "web login provider is not available. Install the official external plugin with: openclaw plugins install clawhub:@openclaw/whatsapp, or run: openclaw doctor --fix.",
+      }),
+    );
+    expect(mocks.resolveMissingOfficialExternalChannelPluginRepairHint).toHaveBeenCalledWith({
+      config: { channels: { whatsapp: { enabled: true } } },
+      channelId: "whatsapp",
+    });
+  });
+
+  it("joins multiple missing official external plugin hints when more than one configured channel is missing", async () => {
+    mocks.listChannelPlugins.mockReturnValue([]);
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockImplementation(({ channelId }) =>
+      channelId === "whatsapp"
+        ? {
+            pluginId: "whatsapp",
+            channelId: "whatsapp",
+            label: "WhatsApp",
+            installSpec: "clawhub:@openclaw/whatsapp",
+            installCommand: "openclaw plugins install clawhub:@openclaw/whatsapp",
+            doctorFixCommand: "openclaw doctor --fix",
+            repairHint:
+              "Install the official external plugin with: openclaw plugins install clawhub:@openclaw/whatsapp, or run: openclaw doctor --fix.",
+          }
+        : channelId === "signal"
+          ? {
+              pluginId: "signal",
+              channelId: "signal",
+              label: "Signal",
+              installSpec: "clawhub:@openclaw/signal",
+              installCommand: "openclaw plugins install clawhub:@openclaw/signal",
+              doctorFixCommand: "openclaw doctor --fix",
+              repairHint:
+                "Install the official external plugin with: openclaw plugins install clawhub:@openclaw/signal, or run: openclaw doctor --fix.",
+            }
+          : null,
+    );
+    const respond = vi.fn();
+
+    await webHandlers["web.login.start"](
+      createOptions(
+        { accountId: "default" },
+        {
+          respond,
+          context: {
+            stopChannel: vi.fn(),
+            startChannel: vi.fn(),
+            getRuntimeSnapshot: vi.fn(createRunningWhatsappSnapshot),
+            getRuntimeConfig: vi.fn(() => ({
+              channels: {
+                whatsapp: { enabled: true },
+                signal: { enabled: true },
+              },
+            })),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message:
+          "web login provider is not available. Configured official external channel plugins are missing for WhatsApp, Signal. Install them with: openclaw plugins install clawhub:@openclaw/whatsapp; openclaw plugins install clawhub:@openclaw/signal, or run: openclaw doctor --fix.",
+      }),
+    );
   });
 
   it.each([
@@ -178,6 +285,7 @@ describe("webHandlers web.login.start", () => {
 describe("webHandlers web.login.wait", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue(null);
   });
 
   it("passes refreshed QR payloads back to the client while login is still pending", async () => {

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -8,8 +8,9 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
+import { resolveMissingOfficialExternalChannelPluginRepairHint } from "../../plugins/official-external-plugin-repair-hints.js";
 import { formatForLog } from "../ws-log.js";
-import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 const WEB_LOGIN_METHODS = new Set(["web.login.start", "web.login.wait"]);
@@ -33,11 +34,44 @@ function resolveAccountId(params: unknown): string | undefined {
     : undefined;
 }
 
-function respondProviderUnavailable(respond: RespondFn) {
-  respond(
+function resolveMissingWebLoginPluginHint(context: GatewayRequestContext): string | null {
+  const cfg = context.getRuntimeConfig();
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object" || Array.isArray(channels)) {
+    return null;
+  }
+  const hints = Object.keys(channels)
+    .map((channelId) =>
+      resolveMissingOfficialExternalChannelPluginRepairHint({
+        config: cfg,
+        channelId,
+      }),
+    )
+    .filter((hint): hint is NonNullable<typeof hint> => Boolean(hint));
+  if (hints.length === 0) {
+    return null;
+  }
+  if (hints.length === 1) {
+    return hints[0].repairHint;
+  }
+  const labels = [...new Set(hints.map((hint) => hint.label))];
+  const installCommands = [...new Set(hints.map((hint) => hint.installCommand))];
+  const doctorFixCommand = hints[0].doctorFixCommand;
+  return `Configured official external channel plugins are missing for ${labels.join(", ")}. Install them with: ${installCommands.join("; ")}, or run: ${doctorFixCommand}.`;
+}
+
+function respondProviderUnavailable(params: {
+  respond: RespondFn;
+  context: GatewayRequestContext;
+}) {
+  const repairHint = resolveMissingWebLoginPluginHint(params.context);
+  const message = repairHint
+    ? `web login provider is not available. ${repairHint}`
+    : "web login provider is not available";
+  params.respond(
     false,
     undefined,
-    errorShape(ErrorCodes.INVALID_REQUEST, "web login provider is not available"),
+    errorShape(ErrorCodes.INVALID_REQUEST, message),
   );
 }
 
@@ -57,6 +91,7 @@ function respondWebLoginUnavailable(respond: RespondFn, err: unknown) {
 function resolveWebLoginRequest<TMethod extends WebLoginGatewayMethod>(params: {
   rawParams: unknown;
   respond: RespondFn;
+  context: GatewayRequestContext;
   gatewayMethod: TMethod;
 }): {
   accountId?: string;
@@ -66,7 +101,10 @@ function resolveWebLoginRequest<TMethod extends WebLoginGatewayMethod>(params: {
   const accountId = resolveAccountId(params.rawParams);
   const provider = resolveWebLoginProvider();
   if (!provider) {
-    respondProviderUnavailable(params.respond);
+    respondProviderUnavailable({
+      respond: params.respond,
+      context: params.context,
+    });
     return null;
   }
   const gateway = provider.gateway;
@@ -108,6 +146,7 @@ export const webHandlers: GatewayRequestHandlers = {
       const request = resolveWebLoginRequest({
         rawParams: params,
         respond,
+        context,
         gatewayMethod: "loginWithQrStart",
       });
       if (!request) {
@@ -155,6 +194,7 @@ export const webHandlers: GatewayRequestHandlers = {
       const request = resolveWebLoginRequest({
         rawParams: params,
         respond,
+        context,
         gatewayMethod: "loginWithQrWait",
       });
       if (!request) {

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -1,10 +1,10 @@
 // Gateway agent integration tests cover channel routing, session context,
 // WebSocket requests, agent event delivery, and provider/runtime error handling.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { AcpRuntimeError } from "../acp/runtime/errors.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { emitAgentEvent, registerAgentRunContext } from "../infra/agent-events.js";
@@ -174,10 +174,16 @@ async function sendAgentWsRequestAndWaitFinal(
   return await finalP;
 }
 
+const gwSessionTempDirs: string[] = [];
+
 async function useTempSessionStorePath() {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+  const dir = makeTempDir(gwSessionTempDirs, "openclaw-gw-");
   testState.sessionStorePath = path.join(dir, "sessions.json");
 }
+
+afterAll(() => {
+  cleanupTempDirs(gwSessionTempDirs);
+});
 
 describe("gateway server agent", () => {
   beforeEach(() => {

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
 import type { SessionCompactionCheckpoint } from "../config/sessions.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   embeddedRunMock,
@@ -793,75 +794,76 @@ test("sessions.compact maxLines aborts without truncating when an active run can
 });
 
 test("sessions.patch preserves nested model ids under provider overrides", async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-sessions-nested-"));
-  const storePath = path.join(dir, "sessions.json");
-  await fs.writeFile(
-    storePath,
-    JSON.stringify({
-      "agent:main:main": sessionStoreEntry("sess-main"),
-    }),
-    "utf-8",
-  );
+  await withTempDir({ prefix: "openclaw-gw-sessions-nested-" }, async (dir) => {
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": sessionStoreEntry("sess-main"),
+      }),
+      "utf-8",
+    );
 
-  await withEnvAsync({ OPENCLAW_CONFIG_PATH: undefined }, async () => {
-    const { clearConfigCache, clearRuntimeConfigSnapshot } = await getGatewayConfigModule();
-    clearConfigCache();
-    clearRuntimeConfigSnapshot();
-    const cfg = {
-      session: { store: storePath, mainKey: "main" },
-      agents: {
-        defaults: {
-          model: { primary: "openai/gpt-test-a" },
+    await withEnvAsync({ OPENCLAW_CONFIG_PATH: undefined }, async () => {
+      const { clearConfigCache, clearRuntimeConfigSnapshot } = await getGatewayConfigModule();
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+      const cfg = {
+        session: { store: storePath, mainKey: "main" },
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-test-a" },
+          },
+          list: [{ id: "main", default: true, workspace: dir }],
         },
-        list: [{ id: "main", default: true, workspace: dir }],
-      },
-    };
-    const configPath = path.join(dir, "openclaw.json");
-    await fs.writeFile(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+      };
+      const configPath = path.join(dir, "openclaw.json");
+      await fs.writeFile(configPath, JSON.stringify(cfg, null, 2), "utf-8");
 
-    await withEnvAsync({ OPENCLAW_CONFIG_PATH: configPath }, async () => {
-      const started = await startConnectedServerWithClient();
-      const { server, ws } = started;
-      try {
-        agentDiscoveryMock.enabled = true;
-        agentDiscoveryMock.models = [
-          { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5 (NVIDIA)", provider: "nvidia" },
-        ];
+      await withEnvAsync({ OPENCLAW_CONFIG_PATH: configPath }, async () => {
+        const started = await startConnectedServerWithClient();
+        const { server, ws } = started;
+        try {
+          agentDiscoveryMock.enabled = true;
+          agentDiscoveryMock.models = [
+            { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5 (NVIDIA)", provider: "nvidia" },
+          ];
 
-        const patched = await rpcReq<{
-          ok: true;
-          entry: {
-            modelOverride?: string;
-            providerOverride?: string;
-            model?: string;
-            modelProvider?: string;
-          };
-          resolved?: { model?: string; modelProvider?: string };
-        }>(ws, "sessions.patch", {
-          key: "agent:main:main",
-          model: "nvidia/moonshotai/kimi-k2.5",
-        });
-        expect(patched.ok).toBe(true);
-        expect(patched.payload?.entry.modelOverride).toBe("moonshotai/kimi-k2.5");
-        expect(patched.payload?.entry.providerOverride).toBe("nvidia");
-        expect(patched.payload?.entry.model).toBeUndefined();
-        expect(patched.payload?.entry.modelProvider).toBeUndefined();
-        expect(patched.payload?.resolved?.modelProvider).toBe("nvidia");
-        expect(patched.payload?.resolved?.model).toBe("moonshotai/kimi-k2.5");
+          const patched = await rpcReq<{
+            ok: true;
+            entry: {
+              modelOverride?: string;
+              providerOverride?: string;
+              model?: string;
+              modelProvider?: string;
+            };
+            resolved?: { model?: string; modelProvider?: string };
+          }>(ws, "sessions.patch", {
+            key: "agent:main:main",
+            model: "nvidia/moonshotai/kimi-k2.5",
+          });
+          expect(patched.ok).toBe(true);
+          expect(patched.payload?.entry.modelOverride).toBe("moonshotai/kimi-k2.5");
+          expect(patched.payload?.entry.providerOverride).toBe("nvidia");
+          expect(patched.payload?.entry.model).toBeUndefined();
+          expect(patched.payload?.entry.modelProvider).toBeUndefined();
+          expect(patched.payload?.resolved?.modelProvider).toBe("nvidia");
+          expect(patched.payload?.resolved?.model).toBe("moonshotai/kimi-k2.5");
 
-        const listed = await rpcReq<{
-          sessions: Array<{ key: string; modelProvider?: string; model?: string }>;
-        }>(ws, "sessions.list", {});
-        expect(listed.ok).toBe(true);
-        const mainSession = listed.payload?.sessions.find(
-          (session) => session.key === "agent:main:main",
-        );
-        expect(mainSession?.modelProvider).toBe("nvidia");
-        expect(mainSession?.model).toBe("moonshotai/kimi-k2.5");
-      } finally {
-        ws.close();
-        await server.close();
-      }
+          const listed = await rpcReq<{
+            sessions: Array<{ key: string; modelProvider?: string; model?: string }>;
+          }>(ws, "sessions.list", {});
+          expect(listed.ok).toBe(true);
+          const mainSession = listed.payload?.sessions.find(
+            (session) => session.key === "agent:main:main",
+          );
+          expect(mainSession?.modelProvider).toBe("nvidia");
+          expect(mainSession?.model).toBe("moonshotai/kimi-k2.5");
+        } finally {
+          ws.close();
+          await server.close();
+        }
+      });
     });
   });
 });

--- a/src/gateway/server.sessions.permissions-hooks.test.ts
+++ b/src/gateway/server.sessions.permissions-hooks.test.ts
@@ -1,9 +1,15 @@
 // Session permissions and hooks tests protect gateway access control around
 // patch/delete/compact/restore APIs plus emitted internal hook payloads.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { expect, test, vi } from "vitest";
+import { afterAll, expect, test, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+
+const permHookTempDirs: string[] = [];
+
+afterAll(() => {
+  cleanupTempDirs(permHookTempDirs);
+});
 import {
   GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
@@ -118,7 +124,7 @@ test("webchat clients cannot patch, delete, compact, or restore sessions", async
 });
 
 test("session:patch hook fires with correct context", async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-patch-hook-"));
+  const dir = makeTempDir(permHookTempDirs, "openclaw-sessions-patch-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -158,7 +164,7 @@ test("session:patch hook fires with correct context", async () => {
 });
 
 test("session:patch hook does not fire for webchat clients", async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-webchat-hook-"));
+  const dir = makeTempDir(permHookTempDirs, "openclaw-sessions-webchat-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -187,7 +193,7 @@ test("session:patch hook does not fire for webchat clients", async () => {
 });
 
 test("session:patch hook only fires after successful patch", async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-success-hook-"));
+  const dir = makeTempDir(permHookTempDirs, "openclaw-sessions-success-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 
@@ -299,7 +305,7 @@ test("session:patch hook mutations cannot change the response path", async () =>
 });
 
 test("control-ui client can delete sessions even in webchat mode", async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-control-ui-delete-"));
+  const dir = makeTempDir(permHookTempDirs, "openclaw-sessions-control-ui-delete-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
 

--- a/src/infra/delivery-queue-sqlite.test.ts
+++ b/src/infra/delivery-queue-sqlite.test.ts
@@ -1,0 +1,162 @@
+// Validates SQLite delivery queue inflate guards against corrupted entry_json.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import {
+  deleteDeliveryQueueEntry,
+  loadDeliveryQueueEntries,
+  loadDeliveryQueueEntry,
+  moveDeliveryQueueEntryToFailed,
+  updateDeliveryQueueEntry,
+  upsertDeliveryQueueEntry,
+} from "./delivery-queue-sqlite.js";
+import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
+
+describe("delivery-queue-sqlite corrupt JSON resilience", () => {
+  let stateDir: string;
+  let tmpDir: string;
+  const QUEUE = "test-q";
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-dq-case-"));
+    stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function insertCorruptRow(id: string, json: string) {
+    const { db } = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    db.prepare(
+      `INSERT INTO delivery_queue_entries
+         (queue_name, id, status, entry_kind, session_key, channel, target, account_id,
+          retry_count, last_attempt_at, last_error, platform_send_started_at, recovery_state,
+          entry_json, enqueued_at, updated_at, failed_at)
+       VALUES (?, ?, 'pending', NULL, NULL, NULL, NULL, NULL,
+               0, NULL, NULL, NULL, NULL, ?, ?, ?, NULL)`,
+    ).run(QUEUE, id, json, Date.now(), Date.now());
+    db.close();
+  }
+
+  function enqueueValid(id: string) {
+    upsertDeliveryQueueEntry({
+      queueName: QUEUE,
+      entry: { id, enqueuedAt: Date.now(), retryCount: 0 },
+      stateDir,
+    });
+  }
+
+  describe("loadDeliveryQueueEntry", () => {
+    it("returns null for a row with corrupted entry_json", () => {
+      insertCorruptRow("bad-1", "{corrupt: true, >>>NOT JSON<<<");
+      expect(loadDeliveryQueueEntry(QUEUE, "bad-1", stateDir)).toBeNull();
+    });
+
+    it("returns the entry for valid JSON", () => {
+      enqueueValid("good-1");
+      const result = loadDeliveryQueueEntry(QUEUE, "good-1", stateDir);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("good-1");
+    });
+
+    it("returns null for a nonexistent entry", () => {
+      expect(loadDeliveryQueueEntry(QUEUE, "nonexistent", stateDir)).toBeNull();
+    });
+  });
+
+  describe("loadDeliveryQueueEntries", () => {
+    it("skips corrupt rows, returns only valid entries", () => {
+      enqueueValid("valid-a");
+      insertCorruptRow("bad-x", "{{{broken");
+      enqueueValid("valid-b");
+
+      const entries = loadDeliveryQueueEntries(QUEUE, stateDir);
+      expect(entries).toHaveLength(2);
+      expect(entries.map((e) => e.id).toSorted()).toEqual(["valid-a", "valid-b"]);
+    });
+
+    it("returns empty array when all rows are corrupt", () => {
+      insertCorruptRow("bad-1", "not json");
+      insertCorruptRow("bad-2", "{also broken");
+
+      expect(loadDeliveryQueueEntries(QUEUE, stateDir)).toEqual([]);
+    });
+
+    it("returns all entries when all rows are valid", () => {
+      enqueueValid("v1");
+      enqueueValid("v2");
+      enqueueValid("v3");
+
+      expect(loadDeliveryQueueEntries(QUEUE, stateDir)).toHaveLength(3);
+    });
+  });
+
+  describe("updateDeliveryQueueEntry with corrupt row", () => {
+    it("throws ENOENT (unrecoverable corrupt JSON)", () => {
+      insertCorruptRow("bad-update", "{corrupt");
+
+      expect(() => updateDeliveryQueueEntry(QUEUE, "bad-update", stateDir, (e) => e)).toThrow(
+        /No pending test-q delivery queue entry bad-update/,
+      );
+    });
+  });
+
+  describe("moveDeliveryQueueEntryToFailed with corrupt row", () => {
+    it("throws ENOENT (unrecoverable corrupt JSON)", () => {
+      insertCorruptRow("bad-move", "{corrupt");
+
+      expect(() => moveDeliveryQueueEntryToFailed(QUEUE, "bad-move", stateDir)).toThrow(
+        /No pending test-q delivery queue entry bad-move/,
+      );
+    });
+  });
+
+  describe("valid entry round-trips", () => {
+    it("upsert then load is identity", () => {
+      upsertDeliveryQueueEntry({
+        queueName: QUEUE,
+        entry: { id: "rt-1", enqueuedAt: 1000, retryCount: 0 },
+        stateDir,
+      });
+
+      const loaded = loadDeliveryQueueEntry(QUEUE, "rt-1", stateDir);
+      expect(loaded).toMatchObject({ id: "rt-1", enqueuedAt: 1000, retryCount: 0 });
+    });
+
+    it("update increments retry count", () => {
+      upsertDeliveryQueueEntry({
+        queueName: QUEUE,
+        entry: { id: "rt-2", enqueuedAt: 1000, retryCount: 0 },
+        stateDir,
+      });
+
+      updateDeliveryQueueEntry(QUEUE, "rt-2", stateDir, (entry) => ({
+        ...entry,
+        retryCount: entry.retryCount + 1,
+        lastError: "timeout",
+      }));
+
+      expect(loadDeliveryQueueEntry(QUEUE, "rt-2", stateDir)).toMatchObject({
+        id: "rt-2",
+        retryCount: 1,
+        lastError: "timeout",
+      });
+    });
+
+    it("delete removes the entry", () => {
+      upsertDeliveryQueueEntry({
+        queueName: QUEUE,
+        entry: { id: "rt-3", enqueuedAt: 1000, retryCount: 0 },
+        stateDir,
+      });
+
+      deleteDeliveryQueueEntry(QUEUE, "rt-3", stateDir);
+      expect(loadDeliveryQueueEntry(QUEUE, "rt-3", stateDir)).toBeNull();
+    });
+  });
+});

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -57,9 +57,15 @@ function enoent(queueName: string, id: string): Error & { code: string } {
   return err;
 }
 
-function inflate(row: QueueRow): DeliveryQueueEntryState {
+function inflate(row: QueueRow): DeliveryQueueEntryState | null {
+  let parsed: DeliveryQueueEntryState;
+  try {
+    parsed = JSON.parse(row.entry_json) as DeliveryQueueEntryState;
+  } catch {
+    return null;
+  }
   return {
-    ...(JSON.parse(row.entry_json) as DeliveryQueueEntryState),
+    ...parsed,
     id: row.id,
     enqueuedAt: Number(row.enqueued_at),
     retryCount: Number(row.retry_count),
@@ -205,7 +211,7 @@ export function loadDeliveryQueueEntries(
       .orderBy("enqueued_at", "asc")
       .orderBy("id", "asc"),
   ).rows as QueueRow[];
-  return rows.map(inflate);
+  return rows.map(inflate).filter((entry): entry is DeliveryQueueEntryState => entry != null);
 }
 
 /** Delete a pending delivery queue entry after successful delivery. */

--- a/src/infra/exec-safe-bin-config.ts
+++ b/src/infra/exec-safe-bin-config.ts
@@ -1,0 +1,24 @@
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeTrustedSafeBinDirs } from "./exec-safe-bin-trust.js";
+
+export function normalizeConfiguredSafeBins(entries: unknown): string[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      entries
+        .map((entry) => normalizeOptionalLowercaseString(entry) ?? "")
+        .filter((entry) => entry.length > 0),
+    ),
+  ).toSorted();
+}
+
+export function normalizeConfiguredTrustedSafeBinDirs(entries: unknown): string[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return normalizeTrustedSafeBinDirs(
+    entries.filter((entry): entry is string => typeof entry === "string"),
+  );
+}

--- a/src/infra/sqlite-user-version.test.ts
+++ b/src/infra/sqlite-user-version.test.ts
@@ -1,0 +1,47 @@
+// Tests for SQLite user_version pragma helper.
+import { describe, expect, it } from "vitest";
+import { readSqliteUserVersion } from "./sqlite-user-version.js";
+
+describe("readSqliteUserVersion", () => {
+  it("returns 0 when row is undefined", () => {
+    const db = {
+      prepare: () => ({ get: () => undefined }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(0);
+  });
+
+  it("returns 0 when user_version is null", () => {
+    const db = {
+      prepare: () => ({ get: () => ({ user_version: null }) }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(0);
+  });
+
+  it("returns numeric user_version", () => {
+    const db = {
+      prepare: () => ({ get: () => ({ user_version: 5 }) }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(5);
+  });
+
+  it("returns 0 when user_version is 0", () => {
+    const db = {
+      prepare: () => ({ get: () => ({ user_version: 0 }) }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(0);
+  });
+
+  it("converts string user_version to number", () => {
+    const db = {
+      prepare: () => ({ get: () => ({ user_version: "3" }) }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(3);
+  });
+
+  it("returns 0 for empty object", () => {
+    const db = {
+      prepare: () => ({ get: () => ({}) }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(0);
+  });
+});

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -859,6 +859,7 @@ describe("test-projects args", () => {
         config: "test/vitest/vitest.unit-fast.config.ts",
         forwardedArgs: [],
         includePatterns: [
+          "src/crestodian/operations.test.ts",
           "src/install-sh-version.test.ts",
           "src/proxy-capture/store.sqlite.test.ts",
           "test/scripts/android-version.test.ts",
@@ -870,6 +871,16 @@ describe("test-projects args", () => {
         config: "test/vitest/vitest.unit-fast-fake-timers.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/entry.compile-cache.test.ts"],
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.unit.config.ts",
+        forwardedArgs: [
+          "src/state/openclaw-agent-db.test.ts",
+          "src/state/openclaw-state-db.test.ts",
+          "src/state/sqlite-query-plan.test.ts",
+        ],
+        includePatterns: null,
         watchMode: false,
       },
       {
@@ -917,9 +928,29 @@ describe("test-projects args", () => {
         watchMode: false,
       },
       {
+        config: "test/vitest/vitest.gateway.config.ts",
+        forwardedArgs: [],
+        includePatterns: [
+          "src/gateway/hooks-mapping.test.ts",
+          "src/gateway/server-methods/chat.abort-persistence.test.ts",
+          "src/gateway/server.agent.gateway-server-agent-b.test.ts",
+          "src/gateway/server.sessions.permissions-hooks.test.ts",
+        ],
+        watchMode: false,
+      },
+      {
         config: "test/vitest/vitest.runtime-config.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/config/sessions/entry-freshness.test.ts"],
+        watchMode: false,
+      },
+      {
+        config: "test/vitest/vitest.cron.config.ts",
+        forwardedArgs: [],
+        includePatterns: [
+          "src/cron/isolated-agent/run-session-state.test.ts",
+          "src/cron/run-log.error-reason.test.ts",
+        ],
         watchMode: false,
       },
       {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -31,11 +31,14 @@ import {
   resolveExecApprovalsFromFile,
 } from "../infra/exec-approvals.js";
 import {
+  normalizeConfiguredSafeBins,
+  normalizeConfiguredTrustedSafeBinDirs,
+} from "../infra/exec-safe-bin-config.js";
+import {
   listInterpreterLikeSafeBins,
   resolveMergedSafeBinProfileFixtures,
 } from "../infra/exec-safe-bin-runtime-policy.js";
 import { listRiskyConfiguredSafeBins } from "../infra/exec-safe-bin-semantics.js";
-import { normalizeTrustedSafeBinDirs } from "../infra/exec-safe-bin-trust.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { collectDeepCodeSafetyFindings } from "./audit-deep-code-safety.js";
 import { collectDeepProbeFindings } from "./audit-deep-probe-findings.js";
@@ -940,26 +943,6 @@ export function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFi
     });
   }
 
-  const normalizeConfiguredSafeBins = (entries: unknown): string[] => {
-    if (!Array.isArray(entries)) {
-      return [];
-    }
-    return Array.from(
-      new Set(
-        entries
-          .map((entry) => normalizeOptionalLowercaseString(entry) ?? "")
-          .filter((entry) => entry.length > 0),
-      ),
-    ).toSorted();
-  };
-  const normalizeConfiguredTrustedDirs = (entries: unknown): string[] => {
-    if (!Array.isArray(entries)) {
-      return [];
-    }
-    return normalizeTrustedSafeBinDirs(
-      entries.filter((entry): entry is string => typeof entry === "string"),
-    );
-  };
   const classifyRiskySafeBinTrustedDir = (entry: string): string | null => {
     const raw = entry.trim();
     if (!raw) {
@@ -1003,7 +986,7 @@ export function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFi
   const globalExec = cfg.tools?.exec;
   const riskyTrustedDirHits: string[] = [];
   const collectRiskyTrustedDirHits = (scopePath: string, entries: unknown): void => {
-    for (const entry of normalizeConfiguredTrustedDirs(entries)) {
+    for (const entry of normalizeConfiguredTrustedSafeBinDirs(entries)) {
       const reason = classifyRiskySafeBinTrustedDir(entry);
       if (!reason) {
         continue;

--- a/src/shared/account-enabled.test.ts
+++ b/src/shared/account-enabled.test.ts
@@ -1,0 +1,41 @@
+// Tests for account enabled guard.
+import { describe, expect, it } from "vitest";
+import { isAccountEnabled } from "./account-enabled.js";
+
+describe("isAccountEnabled", () => {
+  it("returns true when enabled is true", () => {
+    expect(isAccountEnabled({ enabled: true })).toBe(true);
+  });
+
+  it("returns false when enabled is false", () => {
+    expect(isAccountEnabled({ enabled: false })).toBe(false);
+  });
+
+  it("returns true when enabled is undefined", () => {
+    expect(isAccountEnabled({ enabled: undefined })).toBe(true);
+  });
+
+  it("returns true for object without enabled field", () => {
+    expect(isAccountEnabled({ name: "test" })).toBe(true);
+  });
+
+  it("returns true when enabled is null", () => {
+    expect(isAccountEnabled({ enabled: null })).toBe(true);
+  });
+
+  it("returns true for null account", () => {
+    expect(isAccountEnabled(null)).toBe(true);
+  });
+
+  it("returns true for undefined account", () => {
+    expect(isAccountEnabled(undefined)).toBe(true);
+  });
+
+  it("returns true for string account", () => {
+    expect(isAccountEnabled("account-name")).toBe(true);
+  });
+
+  it("returns true for empty object", () => {
+    expect(isAccountEnabled({})).toBe(true);
+  });
+});

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3,7 +3,8 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { listOpenFileDescriptorsForPath } from "../infra/open-file-descriptors.test-support.js";
@@ -32,8 +33,10 @@ type RegisteredAgentDatabaseRow = {
   size_bytes: number | null;
 };
 
+const agentDbTempDirs: string[] = [];
+
 function createTempStateDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-db-"));
+  return makeTempDir(agentDbTempDirs, "openclaw-agent-db-");
 }
 
 function listRegisteredAgentDatabasesForTest(options: { env?: NodeJS.ProcessEnv } = {}) {
@@ -49,6 +52,10 @@ function listRegisteredAgentDatabasesForTest(options: { env?: NodeJS.ProcessEnv 
     sizeBytes: row.size_bytes,
   }));
 }
+
+afterAll(() => {
+  cleanupTempDirs(agentDbTempDirs);
+});
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -3,7 +3,8 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { readCronRunLogEntriesSync } from "../cron/run-log.js";
 import {
   executeSqliteQuerySync,
@@ -27,8 +28,10 @@ import {
 
 type StateDbTestDatabase = Pick<OpenClawStateKyselyDatabase, "diagnostic_events" | "schema_meta">;
 
+const stateDbTempDirs: string[] = [];
+
 function createTempStateDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-state-db-"));
+  return makeTempDir(stateDbTempDirs, "openclaw-state-db-");
 }
 
 function statfsFixture(type: number): ReturnType<typeof fs.statfsSync> {
@@ -42,6 +45,10 @@ function statfsFixture(type: number): ReturnType<typeof fs.statfsSync> {
     ffree: 0,
   };
 }
+
+afterAll(() => {
+  cleanupTempDirs(stateDbTempDirs);
+});
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();

--- a/src/state/sqlite-query-plan.test.ts
+++ b/src/state/sqlite-query-plan.test.ts
@@ -1,9 +1,7 @@
 // SQLite query-plan tests pin hot OpenClaw state indexes used by perf proof.
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -13,8 +11,10 @@ import {
   openOpenClawStateDatabase,
 } from "./openclaw-state-db.js";
 
+const planTempDirs: string[] = [];
+
 function createTempStateDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-plan-"));
+  return makeTempDir(planTempDirs, "openclaw-sqlite-plan-");
 }
 
 function explainQueryPlan(
@@ -47,6 +47,10 @@ function expectPlanIncludes(params: {
 }): void {
   expect(explainQueryPlan(params.db, params.sql, params.params)).toContain(params.expected);
 }
+
+afterAll(() => {
+  cleanupTempDirs(planTempDirs);
+});
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -1,5 +1,6 @@
 // Status text helpers render runtime status summaries for CLI output.
 import os from "node:os";
+import path from "node:path";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import {
   resolveAgentConfig,
@@ -64,6 +65,7 @@ const USAGE_OAUTH_ONLY_PROVIDERS = new Set([
   "google-gemini-cli",
   "openai",
 ]);
+const CODEX_APP_SERVER_HOME_DIRNAME = "codex-home";
 
 function resolveStatusChannelFeatureLine(params: {
   cfg: OpenClawConfig;
@@ -289,6 +291,15 @@ function resolveStatusRuntimeProvider(params: {
   return params.provider;
 }
 
+function resolveStatusCodexCliCredentialsHome(params: {
+  agentDir: string;
+  effectiveHarness?: string;
+}): string | undefined {
+  return normalizeOptionalLowercaseString(params.effectiveHarness) === "codex"
+    ? path.join(params.agentDir, CODEX_APP_SERVER_HOME_DIRNAME)
+    : undefined;
+}
+
 function formatAgentTaskCountsLine(agentId: string): string | undefined {
   const snapshot = buildTaskStatusSnapshot(listTasksForAgentIdForStatus(agentId));
   if (snapshot.totalCount === 0) {
@@ -370,6 +381,10 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
       sessionKey,
       sessionEntry,
     }));
+  const codexCliCredentialsHome = resolveStatusCodexCliCredentialsHome({
+    agentDir: statusAgentDir,
+    effectiveHarness,
+  });
   const selectedStatusProvider = resolveStatusRuntimeProvider({
     provider: selectedLookupProvider,
     effectiveHarness,
@@ -398,6 +413,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
         sessionEntry,
         agentDir: statusAgentDir,
         workspaceDir: statusWorkspaceDir,
+        codexCliCredentialsHome,
         includeExternalProfiles: false,
       });
   const activeModelAuth = Object.hasOwn(params, "activeModelAuthOverride")
@@ -410,6 +426,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
           sessionEntry,
           agentDir: statusAgentDir,
           workspaceDir: statusWorkspaceDir,
+          codexCliCredentialsHome,
           includeExternalProfiles: false,
         })
       : selectedModelAuth;

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { sanitizeDiagnosticPayload } from "../agents/payload-redaction.js";
 import type { AgentMessage } from "../agents/runtime/index.js";
+import { parseSessionFileEntriesWithWarnings } from "../agents/sessions/session-file-parser.js";
 import type { FileEntry, SessionEntry, SessionHeader } from "../agents/sessions/session-manager.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
@@ -72,56 +73,6 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
-function isSessionFileEntry(value: unknown): value is FileEntry {
-  if (!isRecord(value) || typeof value.type !== "string") {
-    return false;
-  }
-  if (value.type !== "message") {
-    return true;
-  }
-  const message = value.message;
-  return isRecord(message) && typeof message.role === "string";
-}
-
-function parseSessionEntries(content: string): {
-  entries: FileEntry[];
-  warnings: JsonlParseWarning[];
-  rowByEntry: Map<FileEntry, number>;
-} {
-  const entries: FileEntry[] = [];
-  const warnings: JsonlParseWarning[] = [];
-  const rowByEntry = new Map<FileEntry, number>();
-  const rows = content.split(/\r?\n/u);
-  for (const [index, rawLine] of rows.entries()) {
-    const line = rawLine.trim();
-    if (!line) {
-      continue;
-    }
-    try {
-      const parsed = JSON.parse(line) as unknown;
-      if (!isSessionFileEntry(parsed)) {
-        warnings.push({
-          source: "session",
-          code: "invalid-session-row",
-          row: index + 1,
-          message: "Skipped a session JSONL row that is not a session entry object.",
-        });
-        continue;
-      }
-      entries.push(parsed);
-      rowByEntry.set(parsed, index + 1);
-    } catch {
-      warnings.push({
-        source: "session",
-        code: "invalid-session-json",
-        row: index + 1,
-        message: "Skipped a session JSONL row that is not valid JSON.",
-      });
-    }
-  }
-  return { entries, warnings, rowByEntry };
-}
-
 function migrateLegacySessionEntries(entries: FileEntry[]): void {
   const header = entries.find((entry): entry is SessionHeader => entry.type === "session");
   const version = header?.version ?? 1;
@@ -175,9 +126,18 @@ async function readSessionBranch(filePath: string): Promise<{
 }> {
   const {
     entries: fileEntries,
-    warnings,
+    warnings: parseWarnings,
     rowByEntry,
-  } = parseSessionEntries(await fsp.readFile(filePath, "utf8"));
+  } = parseSessionFileEntriesWithWarnings(await fsp.readFile(filePath, "utf8"));
+  const warnings: JsonlParseWarning[] = parseWarnings.map((warning) => ({
+    source: "session",
+    code: warning.code,
+    row: warning.row,
+    message:
+      warning.code === "invalid-session-json"
+        ? "Skipped a session JSONL row that is not valid JSON."
+        : "Skipped a session JSONL row that is not a session entry object.",
+  }));
   migrateLegacySessionEntries(fileEntries);
   const header =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;

--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -35,6 +35,16 @@ function requireWarnRecord(callIndex: number): Record<string, unknown> {
   return record;
 }
 
+async function captureTimeoutLogUrl(url: string): Promise<Record<string, unknown>> {
+  const { cleanup } = buildTimeoutAbortSignal({ timeoutMs: 25, operation: "unit-test", url });
+  await vi.advanceTimersByTimeAsync(25);
+  const record = requireWarnRecord(0);
+  cleanup();
+  return record;
+}
+
+const SYNTHETIC_TELEGRAM_BOT_TOKEN = "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd";
+
 describe("buildTimeoutAbortSignal", () => {
   beforeEach(() => {
     warn.mockClear();
@@ -142,6 +152,38 @@ describe("buildTimeoutAbortSignal", () => {
     expect(requireWarnRecord(0).url).toBe("/api/responses");
 
     cleanup();
+  });
+
+  it("redacts Telegram bot tokens from timeout URL logs", async () => {
+    const record = await captureTimeoutLogUrl(
+      `https://api.telegram.org/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=1`,
+    );
+
+    expect(requireWarnMessage(0)).toBe("fetch timeout reached; aborting operation");
+    expect(record.url).toBe("https://api.telegram.org/bot***/sendMessage");
+    expect(record.consoleMessage).toBe(
+      "fetch timeout after 25ms (elapsed 25ms) operation=unit-test url=https://api.telegram.org/bot***/sendMessage",
+    );
+    expect(JSON.stringify(record)).not.toContain(SYNTHETIC_TELEGRAM_BOT_TOKEN);
+  });
+
+  it("redacts Telegram bot tokens from fallback timeout URL strings", async () => {
+    const record = await captureTimeoutLogUrl(
+      `/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=1`,
+    );
+
+    expect(record.url).toBe("/bot***/sendMessage");
+    expect(JSON.stringify(record)).not.toContain(SYNTHETIC_TELEGRAM_BOT_TOKEN);
+  });
+
+  it.each([
+    ["https://example.com/bot/settings?safe=1", "https://example.com/bot/settings"],
+    ["https://example.com/bots/chat?safe=1", "https://example.com/bots/chat"],
+    ["https://example.com/robot/test?safe=1", "https://example.com/robot/test"],
+    ["/bot123:status?safe=1", "/bot123:status"],
+    ["/bot123456:short/status?safe=1", "/bot123456:short/status"],
+  ])("keeps ordinary bot-like timeout path %s visible", async (url, expected) => {
+    expect((await captureTimeoutLogUrl(url)).url).toBe(expected);
   });
 
   it("tags fetch timeout aborts so callers can distinguish them from parent aborts", async () => {

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -1,4 +1,5 @@
 // Fetch timeout helpers wrap fetch calls with timeout and abort behavior.
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveSafeTimeoutDelayMs } from "./timer-delay.js";
 
@@ -39,15 +40,17 @@ function sanitizeTimeoutLogUrl(rawUrl: string | undefined): string | undefined {
     parsed.password = "";
     parsed.search = "";
     parsed.hash = "";
-    const value = parsed.toString();
+    const value = redactSensitiveUrlLikeString(parsed.toString());
     return value.length > LOG_URL_MAX_CHARS ? `${value.slice(0, LOG_URL_MAX_CHARS)}...` : value;
   } catch {
     const withoutQueryOrHash = trimmed.split(URL_SECRET_SUFFIX_PATTERN, 1)[0] ?? "";
-    const cleaned = withoutQueryOrHash
-      .replace(/[\r\n\u2028\u2029]+/g, " ")
-      .replace(/\p{Cc}+/gu, " ")
-      .replace(/\s+/g, " ")
-      .trim();
+    const cleaned = redactSensitiveUrlLikeString(
+      withoutQueryOrHash
+        .replace(/[\r\n\u2028\u2029]+/g, " ")
+        .replace(/\p{Cc}+/gu, " ")
+        .replace(/\s+/g, " ")
+        .trim(),
+    );
     if (!cleaned) {
       return undefined;
     }

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -7,7 +7,7 @@ import type { MessageGroup } from "../types/chat-types.ts";
 import {
   formatChatTimestampForDisplay,
   renderMessageGroup,
-  renderStreamingGroup,
+  renderStreamGroup,
   resetAssistantAttachmentAvailabilityCacheForTest,
 } from "./grouped-render.ts";
 import { normalizeMessage } from "./message-normalizer.ts";
@@ -882,7 +882,18 @@ describe("grouped chat rendering", () => {
     expect(time?.textContent?.trim()).toBe(display.label);
     expect(time?.getAttribute("title")).toBe(display.title);
 
-    render(renderStreamingGroup("Working", timestamp), container);
+    render(
+      renderStreamGroup([
+        {
+          kind: "stream",
+          key: `stream:${timestamp}`,
+          text: "Working",
+          startedAt: timestamp,
+          isStreaming: true,
+        },
+      ]),
+      container,
+    );
 
     const streamingTime = container.querySelector<HTMLTimeElement>(".chat-group-timestamp");
     expect(streamingTime?.textContent?.trim()).toBe(display.label);
@@ -891,7 +902,18 @@ describe("grouped chat rendering", () => {
   it("omits streaming bubble class for completed stream segments", () => {
     const container = document.createElement("div");
 
-    render(renderStreamingGroup("Completed segment", 1, false), container);
+    render(
+      renderStreamGroup([
+        {
+          kind: "stream",
+          key: "stream:1",
+          text: "Completed segment",
+          startedAt: 1,
+          isStreaming: false,
+        },
+      ]),
+      container,
+    );
 
     const bubble = container.querySelector(".chat-bubble");
     expect(bubble?.classList.contains("streaming")).toBe(false);
@@ -903,13 +925,65 @@ describe("grouped chat rendering", () => {
     streamingMarkdownRenderMock.mockClear();
     streamingTextRenderMock.mockClear();
 
-    render(renderStreamingGroup("**live**\nreply", 1), container);
+    render(
+      renderStreamGroup([
+        {
+          kind: "stream",
+          key: "stream:1",
+          text: "**live**\nreply",
+          startedAt: 1,
+          isStreaming: true,
+        },
+      ]),
+      container,
+    );
 
     expect(markdownRenderMock).not.toHaveBeenCalled();
     expect(streamingTextRenderMock).not.toHaveBeenCalled();
     expect(streamingMarkdownRenderMock).toHaveBeenCalledWith("**live**\nreply", undefined);
     const text = container.querySelector(".streaming-markdown");
     expect(text?.textContent).toBe("**live**\nreply");
+  });
+
+  it("renders a multi-segment stream run as one group with one avatar/footer", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderStreamGroup([
+        { kind: "stream", key: "stream-seg:s:0", text: "first", startedAt: 20, isStreaming: false },
+        {
+          kind: "stream",
+          key: "stream-seg:s:1",
+          text: "second",
+          startedAt: 10,
+          isStreaming: false,
+        },
+        { kind: "stream", key: "stream:s:live", text: "third", startedAt: 30, isStreaming: true },
+      ]),
+      container,
+    );
+
+    expect(container.querySelectorAll(".chat-group.assistant")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-group-footer")).toHaveLength(1);
+    // One bubble per segment, all under the single group.
+    expect(container.querySelectorAll(".chat-bubble")).toHaveLength(3);
+    // Footer time anchors to the earliest segment start, not render order.
+    const display = formatChatTimestampForDisplay(10);
+    expect(container.querySelector(".chat-group-timestamp")?.textContent?.trim()).toBe(
+      display.label,
+    );
+  });
+
+  it("renders a reading-indicator-only run as one group with no footer", () => {
+    const container = document.createElement("div");
+
+    render(renderStreamGroup([{ kind: "reading-indicator", key: "reading" }]), container);
+
+    expect(container.querySelectorAll(".chat-group.assistant")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(1);
+    expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
+    expect(container.querySelector(".chat-group-footer")).toBeNull();
   });
 
   it("renders configured local user names", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -13,6 +13,7 @@ import type { SidebarContent } from "../sidebar-content.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import { resolveToolDisplay } from "../tool-display.ts";
 import type {
+  ChatItem,
   MessageContentItem,
   MessageGroup,
   NormalizedMessage,
@@ -364,54 +365,61 @@ function extractTranscriptAttachments(message: unknown): AttachmentItem[] {
   return attachments;
 }
 
-export function renderReadingIndicatorGroup(
-  assistant?: AssistantIdentity,
-  basePath?: string,
-  authToken?: string | null,
-) {
+/** A contiguous run of in-flight streaming items rendered under one assistant group. */
+export type StreamGroupPart = Extract<ChatItem, { kind: "stream" } | { kind: "reading-indicator" }>;
+
+type StreamGroupOptions = {
+  onOpenSidebar?: (content: SidebarContent) => void;
+  assistant?: AssistantIdentity;
+  basePath?: string;
+  authToken?: string | null;
+};
+
+function renderReadingIndicatorBubble() {
   return html`
-    <div class="chat-group assistant">
-      ${renderChatAvatar("assistant", assistant, undefined, basePath, authToken)}
-      <div class="chat-group-messages">
-        <div class="chat-bubble chat-reading-indicator" aria-hidden="true">
-          <span class="chat-reading-indicator__dots">
-            <span></span><span></span><span></span>
-          </span>
-        </div>
-      </div>
+    <div class="chat-bubble chat-reading-indicator" aria-hidden="true">
+      <span class="chat-reading-indicator__dots"> <span></span><span></span><span></span> </span>
     </div>
   `;
 }
 
-export function renderStreamingGroup(
-  text: string,
-  startedAt: number,
-  isStreaming = true,
-  onOpenSidebar?: (content: SidebarContent) => void,
-  assistant?: AssistantIdentity,
-  basePath?: string,
-  authToken?: string | null,
-) {
+// One assistant group per contiguous run of streaming items: a reply that
+// arrives as several stream segments renders under a single avatar/footer
+// instead of flashing a separate avatar+bubble per segment (#63956).
+export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOptions = {}) {
+  const { onOpenSidebar, assistant, basePath, authToken } = opts;
   const name = assistant?.name ?? "Assistant";
+  // Footer (sender + time) anchors to the earliest streamed segment; a run that
+  // is only the reading indicator has no timestamp and therefore no footer.
+  const streamStarts = parts.flatMap((part) => (part.kind === "stream" ? [part.startedAt] : []));
+  const footerStartedAt = streamStarts.length > 0 ? Math.min(...streamStarts) : null;
 
   return html`
     <div class="chat-group assistant">
       ${renderChatAvatar("assistant", assistant, undefined, basePath, authToken)}
       <div class="chat-group-messages">
-        ${renderGroupedMessage(
-          {
-            role: "assistant",
-            content: [{ type: "text", text }],
-            timestamp: startedAt,
-          },
-          `stream:${startedAt}`,
-          { isStreaming, showReasoning: false },
-          onOpenSidebar,
+        ${parts.map((part) =>
+          part.kind === "reading-indicator"
+            ? renderReadingIndicatorBubble()
+            : renderGroupedMessage(
+                {
+                  role: "assistant",
+                  content: [{ type: "text", text: part.text }],
+                  timestamp: part.startedAt,
+                },
+                part.key,
+                { isStreaming: part.isStreaming, showReasoning: false },
+                onOpenSidebar,
+              ),
         )}
-        <div class="chat-group-footer">
-          <span class="chat-sender-name">${name}</span>
-          ${renderChatTimestamp(startedAt)}
-        </div>
+        ${footerStartedAt !== null
+          ? html`
+              <div class="chat-group-footer">
+                <span class="chat-sender-name">${name}</span>
+                ${renderChatTimestamp(footerStartedAt)}
+              </div>
+            `
+          : nothing}
       </div>
     </div>
   `;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -24,6 +24,7 @@ import {
 import { renderChatSessionSelect } from "../chat/session-controls.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { GatewaySessionRow, ModelCatalogEntry, SessionsListResult } from "../types.ts";
+import type { ChatItem, MessageGroup } from "../types/chat-types.ts";
 import type { ChatAttachment, ChatQueueItem } from "../ui-types.ts";
 import { renderChat, resetChatViewState } from "./chat.ts";
 import { renderMarkdownSidebar } from "./markdown-sidebar.ts";
@@ -156,16 +157,20 @@ vi.mock("../chat/build-chat-items.ts", () => ({
 vi.mock("../chat/grouped-render.ts", () => ({
   getAssistantAttachmentAvailabilityRenderVersion: () => assistantAttachmentRenderVersionMock.value,
   renderMessageGroup: renderMessageGroupMock,
-  renderReadingIndicatorGroup: () => {
-    const element = document.createElement("div");
-    element.className = "chat-reading-indicator";
-    return element;
-  },
-  renderStreamingGroup: (text: string) => {
-    const element = document.createElement("div");
-    element.className = "chat-stream";
-    element.textContent = text;
-    return element;
+  renderStreamGroup: (parts: Array<{ kind: string; text?: string }>) => {
+    const group = document.createElement("div");
+    group.className = "chat-stream-run";
+    for (const part of parts) {
+      const bubble = document.createElement("div");
+      if (part.kind === "reading-indicator") {
+        bubble.className = "chat-reading-indicator";
+      } else {
+        bubble.className = "chat-stream";
+        bubble.textContent = part.text ?? "";
+      }
+      group.appendChild(bubble);
+    }
+    return group;
   },
 }));
 
@@ -1352,6 +1357,46 @@ describe("chat loading skeleton", () => {
 
     expect(container.querySelector(".chat-loading-skeleton")).toBeNull();
     expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
+  });
+
+  it("folds adjacent streaming items into one group and lets a message group break the run (#63956)", () => {
+    const items: Array<ChatItem | MessageGroup> = [
+      {
+        kind: "stream",
+        key: "stream-seg:main:0",
+        text: "alpha",
+        startedAt: 10,
+        isStreaming: false,
+      },
+      { kind: "stream", key: "stream-seg:main:1", text: "beta", startedAt: 20, isStreaming: false },
+      { kind: "reading-indicator", key: "reading:main" },
+      {
+        kind: "group",
+        key: "group:assistant:test",
+        role: "assistant",
+        messages: [{ key: "m0", message: { content: "tool break" } }],
+        timestamp: 25,
+        isStreaming: false,
+      },
+      { kind: "stream", key: "stream:main:live", text: "gamma", startedAt: 30, isStreaming: true },
+    ];
+    buildChatItemsMock.mockReturnValueOnce(
+      items as unknown as ReturnType<typeof buildChatItemsMock>,
+    );
+
+    const container = renderChatView({ stream: "gamma", streamStartedAt: 30 });
+
+    // Two contiguous streaming runs, split by the message group between them.
+    const runs = container.querySelectorAll(".chat-stream-run");
+    expect(runs).toHaveLength(2);
+    // First run folds both committed segments plus the trailing reading indicator.
+    expect(runs[0]?.querySelectorAll(".chat-stream")).toHaveLength(2);
+    expect(runs[0]?.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
+    // The message group stays its own group and breaks the run.
+    expect(container.querySelectorAll(".chat-group")).toHaveLength(1);
+    // The live segment after the group forms the second run.
+    expect(runs[1]?.querySelectorAll(".chat-stream")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-stream")).toHaveLength(3);
   });
 
   it("shows prompt-bar progress while the current session send is awaiting acknowledgement", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -27,8 +27,8 @@ import { exportChatMarkdown } from "../chat/export.ts";
 import {
   getAssistantAttachmentAvailabilityRenderVersion,
   renderMessageGroup,
-  renderReadingIndicatorGroup,
-  renderStreamingGroup,
+  renderStreamGroup,
+  type StreamGroupPart,
 } from "../chat/grouped-render.ts";
 import { CHAT_HISTORY_RENDER_LIMIT } from "../chat/history-limits.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "../chat/input-history.ts";
@@ -680,6 +680,37 @@ function buildCachedChatItems(input: BuildChatItemsProps): ReturnType<typeof bui
   cached.input = input;
   cached.items = items;
   return items;
+}
+
+type RenderChatItem = ReturnType<typeof buildChatItems>[number];
+type StreamRunRenderItem = { kind: "stream-run"; key: string; parts: StreamGroupPart[] };
+
+// Fold each contiguous run of in-flight stream/reading-indicator items into a
+// single group so segmented replies render under one assistant avatar instead
+// of one bubble per segment (#63956). Any message/group/divider breaks the run,
+// so interleaved tool calls keep their own groups.
+function coalesceStreamRuns(
+  items: ReturnType<typeof buildChatItems>,
+): Array<RenderChatItem | StreamRunRenderItem> {
+  const result: Array<RenderChatItem | StreamRunRenderItem> = [];
+  let run: StreamGroupPart[] = [];
+  const flush = () => {
+    const [first] = run;
+    if (first) {
+      result.push({ kind: "stream-run", key: `stream-run:${first.key}`, parts: run });
+      run = [];
+    }
+  };
+  for (const item of items) {
+    if (item.kind === "stream" || item.kind === "reading-indicator") {
+      run.push(item);
+      continue;
+    }
+    flush();
+    result.push(item);
+  }
+  flush();
+  return result;
 }
 
 function deletedChatItemsSignature(
@@ -2339,7 +2370,7 @@ export function renderChat(props: ChatProps) {
           ],
           () =>
             repeat(
-              chatItems,
+              coalesceStreamRuns(chatItems),
               (item) => item.key,
               (item) => {
                 if (item.kind === "divider") {
@@ -2376,23 +2407,13 @@ export function renderChat(props: ChatProps) {
                     </div>
                   `;
                 }
-                if (item.kind === "reading-indicator") {
-                  return renderReadingIndicatorGroup(
-                    assistantIdentity,
-                    props.basePath,
-                    props.assistantAttachmentAuthToken ?? null,
-                  );
-                }
-                if (item.kind === "stream") {
-                  return renderStreamingGroup(
-                    item.text,
-                    item.startedAt,
-                    item.isStreaming,
-                    props.onOpenSidebar,
-                    assistantIdentity,
-                    props.basePath,
-                    props.assistantAttachmentAuthToken ?? null,
-                  );
+                if (item.kind === "stream-run") {
+                  return renderStreamGroup(item.parts, {
+                    onOpenSidebar: props.onOpenSidebar,
+                    assistant: assistantIdentity,
+                    basePath: props.basePath,
+                    authToken: props.assistantAttachmentAuthToken ?? null,
+                  });
                 }
                 if (item.kind === "group") {
                   if (deleted.has(item.key)) {


### PR DESCRIPTION
Fixes #96982.

## What Problem This Solves

Telegram Bot API credentials are part of the request path (`/bot<TOKEN>/method`). Fetch timeout logs removed URL userinfo, query strings, and fragments, but kept the path unchanged, so a timed-out Telegram request could expose its bot token. The same path could also reach diagnostics that use the shared URL redaction helpers.

## Why This Change Was Made

The fix now has one owner boundary for this credential shape:

- `packages/net-policy/src/redact-sensitive-url.ts` redacts real Telegram Bot API path tokens in both parsed URLs and URL-like fallback strings.
- `src/utils/fetch-timeout.ts` reuses that shared helper after applying its stronger timeout-log policy (remove userinfo, query, and fragment).

The matcher requires a Telegram-shaped credential: at least six digits, a literal or percent-encoded colon, and at least 20 Bot API secret characters. This avoids hiding ordinary paths such as `/bot/settings`, `/bots/chat`, `/robot/test`, or short token-like examples.

The maintainer refactor preserves @maweibin as the commit author. The strict matcher contribution from #97013 is credited to @yipengz622-rgb as a co-author.

## User Impact

Fetch-timeout logs and shared URL diagnostics retain the endpoint and method for troubleshooting but replace the credential-bearing segment with `/bot***`. Ordinary `/bot` application routes remain visible.

## Evidence

Prepared PR head: `56d96270d904780b05057fe0c247fe1542a02f73` (four files, based on `0a9708ed0ffa52cddb2dcfd3a4b4b5830b8a0a28`).

- Focused exact-head proof: `node scripts/run-vitest.mjs packages/net-policy/src/redact-sensitive-url.test.ts src/utils/fetch-timeout.test.ts` — 2 files, 40/40 tests passed locally and on Testbox.
- Fresh delegated Testbox/Crabbox proof: provider `blacksmith-testbox`, lease `tbx_01kweasy3ym60wsvx0megd4wrr`, [run 28502452528](https://github.com/openclaw/openclaw/actions/runs/28502452528). The harness fetched `pull/97003/head`, asserted SHA `56d96270d904780b05057fe0c247fe1542a02f73`, and verified the four synced files matched that ref before testing.
- Node 24 live scenario: `probeTelegram` called a deliberately stalled loopback Bot API server with a real-shaped synthetic token while `logging.redactSensitive` was explicitly `off`. The timeout line contained `url=http://127.0.0.1:<port>/bot***/getMe`; the harness reported `tokenPresent:false` and `redactedPathPresent:true`.
- Hosted exact-head gates: [CI run 28502354166](https://github.com/openclaw/openclaw/actions/runs/28502354166), plus CodeQL, CodeQL Critical Quality, OpenGrep, dependency guard, and security-sensitive guard. Build artifacts, production types, QA Smoke, network CodeQL, dependency checks, and changed-boundary/guard jobs passed. The socket-close timeout shard passed on one same-SHA retry. The remaining failures are outside this four-file diff: current-main lint/test-type errors and an unrelated Mistral provider test.
- Pre-sync broad proof on the identical stable patch: full build passed; production types, Oxlint, import cycles, database-first/sidecar/media/webhook/pairing guards passed. The broad changed gate stopped only at the same four current-main test-type errors, independently reproduced on pristine main.
- Fresh autoreview on reviewed commit `a56d6b0370cfa99dca86365d66dab4da45e04a41` reported no findings. Rebasing to the prepared head was conflict-free and retained the identical stable patch ID.

## Regression Test Plan

- Parsed URL path token and percent-encoded-colon token are redacted.
- Fallback URL-like strings redact the same credential shape.
- Fetch-timeout logs reuse the canonical redactor while still removing userinfo, query, fragment, and control characters.
- `/bot/settings`, `/bots/chat`, `/robot/test`, short IDs, and short secrets remain unchanged.

## AI Assistance

- **AI-assisted**: Yes
- **Original model**: Claude Opus 4.8 (1M context)
- **Maintainer implementation/review**: Codex
- **Contributor credit**: Preserved in the prepared commit author/co-author metadata
