### PR TITLE
fix(tools): treat no-op writes and edits as terminal tool-loop failures (fixes #96983)

### DIFF
--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -37,7 +37,10 @@ describe("edit tool", () => {
     await expect(
       tool.execute(
         "call-1",
-        { path: filePath, edits: [{ oldText: "missing", newText: "replacement" }] },
+        {
+          path: filePath,
+          edits: [{ oldText: "missing", newText: "replacement" }],
+        },
         undefined,
       ),
     ).rejects.toThrow(/Current file contents:\nactual current content/);
@@ -173,5 +176,40 @@ describe("edit tool", () => {
     expect((component as { preview?: { diff?: string } } | undefined)?.preview?.diff).toContain(
       "remote changed",
     );
+  });
+
+  it("returns terminal no-op when edit produces identical content", async () => {
+    const filePath = await createTempFile("unchanged content\n");
+    const tool = createEditTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      {
+        path: filePath,
+        edits: [{ oldText: "unchanged", newText: "unchanged" }],
+      },
+      undefined,
+    );
+
+    expect(result.content[0].text).toContain("No changes made");
+    // File must not be rewritten
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("unchanged content\n");
+  });
+
+  it("applies real changes normally (no false positive for no-op)", async () => {
+    const filePath = await createTempFile("old content\n");
+    const tool = createEditTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      {
+        path: filePath,
+        edits: [{ oldText: "old", newText: "new" }],
+      },
+      undefined,
+    );
+
+    expect(result.content[0].text).toContain("Successfully replaced");
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new content\n");
   });
 });

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -191,7 +191,8 @@ describe("edit tool", () => {
       undefined,
     );
 
-    expect(result.content[0].text).toContain("No changes made");
+    const textContent = result.content[0];
+    expect("text" in textContent ? textContent.text : "").toContain("No changes made");
     // File must not be rewritten
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("unchanged content\n");
   });
@@ -209,7 +210,8 @@ describe("edit tool", () => {
       undefined,
     );
 
-    expect(result.content[0].text).toContain("Successfully replaced");
+    const textContent = result.content[0];
+    expect("text" in textContent ? textContent.text : "").toContain("Successfully replaced");
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new content\n");
   });
 });

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -487,6 +487,7 @@ export function createEditToolDefinition(
                   text: `No changes made to ${path}. The replacement produced identical content.`,
                 },
               ],
+              details: undefined,
             };
           }
           throw normalizedError;

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -45,14 +45,18 @@ const replaceEditSchema = Type.Object(
       description:
         "Exact text for one targeted replacement. It must be unique in the original file and must not overlap with any other edits[].oldText in the same call.",
     }),
-    newText: Type.String({ description: "Replacement text for this targeted edit." }),
+    newText: Type.String({
+      description: "Replacement text for this targeted edit.",
+    }),
   },
   { additionalProperties: false },
 );
 
 const editSchema = Type.Object(
   {
-    path: Type.String({ description: "Path to the file to edit (relative or absolute)" }),
+    path: Type.String({
+      description: "Path to the file to edit (relative or absolute)",
+    }),
     edits: Type.Array(replaceEditSchema, {
       description:
         "One or more targeted replacements. Each edit is matched against the original file, not incrementally. Do not include overlapping or nested edits. If two changes touch the same block or nearby lines, merge them into one edit instead.",
@@ -123,7 +127,10 @@ function prepareEditArguments(input: unknown): EditToolInput {
   return { ...rest, edits } as EditToolInput;
 }
 
-function validateEditInput(input: EditToolInput): { path: string; edits: Edit[] } {
+function validateEditInput(input: EditToolInput): {
+  path: string;
+  edits: Edit[];
+} {
   if (!Array.isArray(input.edits) || input.edits.length === 0) {
     throw new Error("Edit tool input is invalid. edits must contain at least one replacement.");
   }
@@ -183,7 +190,12 @@ type RenderableEditArgs = {
 };
 
 type EditToolResultLike = {
-  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+  content: Array<{
+    type: string;
+    text?: string;
+    data?: string;
+    mimeType?: string;
+  }>;
   details?: EditToolDetails;
 };
 
@@ -441,7 +453,13 @@ export function createEditToolDefinition(
             .readFile(absolutePath)
             .then((current) => current.toString("utf-8"))
             .catch(() => rawContent);
-          if (didEditLikelyApply({ originalContent: rawContent, currentContent, edits })) {
+          if (
+            didEditLikelyApply({
+              originalContent: rawContent,
+              currentContent,
+              edits,
+            })
+          ) {
             return {
               content: [
                 {
@@ -454,6 +472,22 @@ export function createEditToolDefinition(
           }
           if (normalizedError.message.includes(EDIT_MISMATCH_MESSAGE)) {
             throw appendMismatchHint(normalizedError, currentContent);
+          }
+          // Terminal no-op: the edit produced identical content.  Return a
+          // structured result instead of throwing so the tool-loop treats it
+          // as terminal rather than retrying the same edit.
+          if (
+            normalizedError.message.includes("No changes made to") &&
+            normalizedError.message.includes("identical content")
+          ) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `No changes made to ${path}. The replacement produced identical content.`,
+                },
+              ],
+            };
           }
           throw normalizedError;
         }
@@ -505,7 +539,10 @@ export function createEditToolDefinition(
           changed =
             setEditPreview(
               callComponent,
-              { diff: resultDiff, firstChangedLine: typedResult.details?.firstChangedLine },
+              {
+                diff: resultDiff,
+                firstChangedLine: typedResult.details?.firstChangedLine,
+              },
               argsKey,
             ) || changed;
         }

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -122,4 +122,36 @@ describe("write tool", () => {
 
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("finished\n");
   });
+
+  it("returns terminal no-op when writing identical content to existing file", async () => {
+    const filePath = await createTempPath("identical.txt");
+    await fs.writeFile(filePath, "hello\n", "utf-8");
+    const tool = createWriteTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      { path: "identical.txt", content: "hello\n" },
+      undefined,
+    );
+
+    expect(result.content[0].text).toContain("No changes made");
+    expect(result.content[0].text).toContain("identical");
+    // File content must not change
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("hello\n");
+  });
+
+  it("writes different content successfully (no false positive for no-op)", async () => {
+    const filePath = await createTempPath("different.txt");
+    await fs.writeFile(filePath, "old\n", "utf-8");
+    const tool = createWriteTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      { path: "different.txt", content: "new\n" },
+      undefined,
+    );
+
+    expect(result.content[0].text).toContain("Successfully wrote");
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new\n");
+  });
 });

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -134,8 +134,9 @@ describe("write tool", () => {
       undefined,
     );
 
-    expect(result.content[0].text).toContain("No changes made");
-    expect(result.content[0].text).toContain("identical");
+    const textContent = result.content[0];
+    expect("text" in textContent ? textContent.text : "").toContain("No changes made");
+    expect("text" in textContent ? textContent.text : "").toContain("identical");
     // File content must not change
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("hello\n");
   });
@@ -151,7 +152,8 @@ describe("write tool", () => {
       undefined,
     );
 
-    expect(result.content[0].text).toContain("Successfully wrote");
+    const textContent = result.content[0];
+    expect("text" in textContent ? textContent.text : "").toContain("Successfully wrote");
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new\n");
   });
 });

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -417,6 +417,7 @@ export function createWriteToolDefinition(
                   text: `No changes made to ${path}. File content is identical.`,
                 },
               ],
+              details: undefined,
             };
           }
           await ops.mkdir(dir);

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -28,7 +28,9 @@ import {
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 const writeSchema = Type.Object({
-  path: Type.String({ description: "Path to the file to write (relative or absolute)" }),
+  path: Type.String({
+    description: "Path to the file to write (relative or absolute)",
+  }),
   content: Type.String({ description: "Content to write to the file" }),
 });
 export type { WriteToolInput } from "./tool-contracts.js";
@@ -237,7 +239,12 @@ function formatWriteCall(
 
 function formatWriteResult(
   result: {
-    content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+    content: Array<{
+      type: string;
+      text?: string;
+      data?: string;
+      mimeType?: string;
+    }>;
     isError?: boolean;
   },
   theme: typeof import("../../modes/interactive/theme/theme.js").theme,
@@ -297,7 +304,10 @@ async function readOriginalWriteState(
     const originalText = Buffer.isBuffer(originalContent)
       ? originalContent.toString("utf8")
       : originalContent;
-    return { state: originalText === content ? "same" : "different", beforeStat: stat };
+    return {
+      state: originalText === content ? "same" : "different",
+      beforeStat: stat,
+    };
   } catch {
     return { state: "unknown", beforeStat: stat };
   }
@@ -396,6 +406,18 @@ export function createWriteToolDefinition(
         try {
           if (signal?.aborted) {
             throw new Error("Operation aborted");
+          }
+          // Terminal no-op: file already has identical content.  Return a
+          // structured result so the tool loop does not retry the same write.
+          if (precheck.state === "same") {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `No changes made to ${path}. File content is identical.`,
+                },
+              ],
+            };
           }
           await ops.mkdir(dir);
           if (signal?.aborted) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #96983.

When the `write` tool is called with content identical to the existing file, or the `edit` tool produces unchanged content, the agent loop treats these as progress or a recoverable failure and retries the same no-op mutation indefinitely. This wastes tokens and confuses users.

## Why This Change Was Made

- `write` tool: `readOriginalWriteState` already detects identical content via size + content comparison. Previously, the tool wrote the file anyway and returned success. Now it returns a structured `No changes made` result before writing, giving the tool-loop a clear terminal signal.
- `edit` tool: `applyEditsToNormalizedContent` (in `edit-diff.ts`) already throws an error when edits produce identical content. Throwing made the agent retry the same edit. Now the error is caught and converted to a no-op result.

## User Impact

Agents no longer get stuck in loops rewriting identical file content or retrying no-op edits. Real changes and new file creation continue to work normally.

## Changes Made

- `src/agents/sessions/tools/write.ts`: After precheck detects identical content, return `No changes made` result before attempting write.
- `src/agents/sessions/tools/edit.ts`: In the catch block, detect the `No changes made` error from `edit-diff.ts` and return a terminal no-op result instead of re-throwing.
- `src/agents/sessions/tools/write.test.ts`: Added 2 regression tests.
- `src/agents/sessions/tools/edit.test.ts`: Added 2 regression tests.

## Evidence

- **Unit tests:** `node scripts/run-vitest.mjs run src/agents/sessions/tools/write.test.ts src/agents/sessions/tools/edit.test.ts` — 13/13 passed
- **Broader regression:** `node scripts/run-vitest.mjs run src/agents/sessions/` — 382/389 passed (7 pre-existing flaky failures unrelated to this change)

## Real behavior proof

**Environment:** Linux, OpenClaw 2026.6.10, Node 24.13.1

**Write tool — identical content:**
```
WRITE SAME: No changes made to demo.txt. File content is identical.
  file unchanged: true
```

**Write tool — different content (no false positive):**
```
WRITE DIFFERENT: Successfully wrote 12 bytes to demo.txt
  file updated: true
```

**Edit tool — oldText === newText:**
```
EDIT NO-OP: No changes made to ... The replacement produced identical content.
  file unchanged: true
```

**Edit tool — real change (no false positive):**
```
EDIT REAL CHANGE: Successfully replaced 1 block(s) in ...
  file updated: true
```

- ✅ Write to existing file with identical content → no-op, file unchanged
- ✅ Write with different content → normal success
- ✅ Write to new file → normal success
- ✅ Edit with identical old/new text → no-op, file unchanged
- ✅ Edit with real changes → normal replace success

**What was not tested:** E2E agent loop with LLM calling write/edit (requires real model inference).

- [x] AI-assisted