### PR TITLE
fix(cron): expose isolated-agent setup watchdog timeout as configurab…

### DIFF
--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -59,6 +59,12 @@ export type CronConfig = {
     maxBytes?: number | string;
     keepLines?: number;
   };
+  /**
+   * Timeout in milliseconds for isolated-agent setup before the watchdog fires.
+   * Increasing this gives slower environments (memory pressure, model warmup)
+   * more time before the cron subsystem considers setup stalled. Default: 60_000.
+   */
+  isolatedAgentSetupTimeoutMs?: number;
   failureAlert?: CronFailureAlertConfig;
   /** Default destination for failure notifications across all cron jobs. */
   failureDestination?: CronFailureDestinationConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -851,6 +851,7 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         store: z.string().optional(),
         maxConcurrentRuns: z.number().int().positive().optional(),
+        isolatedAgentSetupTimeoutMs: z.number().int().positive().optional(),
         retry: z
           .object({
             maxAttempts: z.number().int().min(0).max(10).optional(),

--- a/src/cron/service/agent-watchdog.test.ts
+++ b/src/cron/service/agent-watchdog.test.ts
@@ -44,4 +44,39 @@ describe("cron agent setup watchdog", () => {
     expect(triggerTimeout).toHaveBeenCalledTimes(1);
     expect(watchdog.observedLaneWait()).toBe(true);
   });
+
+  it("fires setup timeout at the configured setupTimeoutMs instead of the default", async () => {
+    vi.useFakeTimers();
+    const triggerTimeout = vi.fn();
+    const customSetupMs = 120_000;
+    const watchdog = createCronAgentWatchdog({
+      deferUntilRunner: true,
+      jobTimeoutMs: customSetupMs * 2,
+      setupTimeoutMs: customSetupMs,
+      triggerTimeout,
+    });
+
+    watchdog.start();
+
+    await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS + 1);
+    expect(triggerTimeout).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(customSetupMs - CRON_AGENT_SETUP_WATCHDOG_MS);
+    expect(triggerTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults setup timeout to CRON_AGENT_SETUP_WATCHDOG_MS when setupTimeoutMs is not provided", async () => {
+    vi.useFakeTimers();
+    const triggerTimeout = vi.fn();
+    const watchdog = createCronAgentWatchdog({
+      deferUntilRunner: true,
+      jobTimeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS * 2,
+      triggerTimeout,
+    });
+
+    watchdog.start();
+
+    await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS + 1);
+    expect(triggerTimeout).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -61,8 +61,10 @@ export type CronAgentWatchdog = {
 export function createCronAgentWatchdog(params: {
   deferUntilRunner: boolean;
   jobTimeoutMs: number;
+  setupTimeoutMs?: number;
   triggerTimeout: (reason: string) => void;
 }): CronAgentWatchdog {
+  const setupTimeoutMs = params.setupTimeoutMs ?? CRON_AGENT_SETUP_WATCHDOG_MS;
   let state: CronAgentWatchdogState = params.deferUntilRunner ? "waiting_for_runner" : "executing";
   let timeoutId: NodeJS.Timeout | undefined;
   let setupTimeoutId: NodeJS.Timeout | undefined;
@@ -142,7 +144,7 @@ export function createCronAgentWatchdog(params: {
           if (state === "waiting_for_runner") {
             setTimedOut(setupTimeoutErrorMessage(activeExecution));
           }
-        }, CRON_AGENT_SETUP_WATCHDOG_MS);
+        }, setupTimeoutMs);
         return;
       }
       startTimeout();

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -233,9 +233,12 @@ export async function executeJobCoreWithTimeout(
       }
       resolveTimeout?.(timeoutMarker);
     };
+    const setupTimeoutMs =
+      state.deps.cronConfig?.isolatedAgentSetupTimeoutMs ?? CRON_AGENT_SETUP_WATCHDOG_MS;
     const watchdog = createCronAgentWatchdog({
       deferUntilRunner: deferTimeoutUntilExecutionStart,
       jobTimeoutMs,
+      setupTimeoutMs,
       triggerTimeout,
     });
     const noteLaneState = (info?: { waiting?: boolean }) => {
@@ -278,7 +281,7 @@ export async function executeJobCoreWithTimeout(
         job.sessionTarget === "isolated" && isSetupTimeoutErrorText(error) && !observedLaneWait
           ? {
               error,
-              timeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS,
+              timeoutMs: setupTimeoutMs,
               otherCronJobsActiveAtTimeout: false,
             }
           : undefined;


### PR DESCRIPTION
Fixes #97002

## What Problem This Solves

Fixes an issue where operators cannot tune the isolated-agent setup watchdog timeout, causing cascading gateway restarts when cron jobs with short intervals run under memory pressure or slow model warmup. The timeout is hardcoded at 60s with no config override.

## Why This Change Was Made

Added a single optional config field `cron.isolatedAgentSetupTimeoutMs` that feeds through the watchdog creation and timeout-signal reporting path. The default (60_000) is preserved via `??` fallback so existing deployments see zero behavior change.

## User Impact

Operators can set `cron.isolatedAgentSetupTimeoutMs` in `openclaw.json` to a higher value (e.g. 120000) when their environment needs more setup time. Without the config field, behavior is identical to the current release.

## Evidence

Environment: Linux, Node v22.23.1, pnpm v11.2.2, worktree SHA `ec737ee74d`

### Before fix (main — 2 tests, no configurability)

Old `createCronAgentWatchdog` has no `setupTimeoutMs` parameter. The watchdog always fires at the hardcoded 60s constant.

```bash
$ pnpm test src/cron/service/agent-watchdog.test.ts
 ✓ |cron| src/cron/service/agent-watchdog.test.ts (2 tests) 88ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

### After fix (fix branch — 4 tests, configurable timeout)

New `createCronAgentWatchdog` accepts optional `setupTimeoutMs`. Custom value is used; default falls back to 60s.

```bash
$ pnpm test src/cron/service/agent-watchdog.test.ts
 ✓ |cron| src/cron/service/agent-watchdog.test.ts (4 tests) 98ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Negative control (watchdog on old code cannot exceed 60s):
```bash
$ git checkout main && pnpm test src/cron/service/agent-watchdog.test.ts
 ✓ |cron| src/cron/service/agent-watchdog.test.ts (2 tests)
```

New regression tests:
- `fires setup timeout at the configured setupTimeoutMs instead of the default` — proves custom 120s timeout works and does not fire prematurely at 60s
- `defaults setup timeout to CRON_AGENT_SETUP_WATCHDOG_MS when setupTimeoutMs is not provided` — proves backward compatibility

### Full cron service suite — no regressions

```bash
$ pnpm test src/cron/service/
 Test Files  15 passed (15)
      Tests  152 passed (152)
```

### Lint/format clean

```bash
$ oxfmt --check src/config/types.cron.ts src/config/zod-schema.ts src/cron/service/agent-watchdog.ts src/cron/service/timer.ts src/cron/service/agent-watchdog.test.ts
All matched files use the correct format.

$ npx oxlint@latest src/config/types.cron.ts src/config/zod-schema.ts src/cron/service/agent-watchdog.ts src/cron/service/timer.ts src/cron/service/agent-watchdog.test.ts
Found 0 warnings and 0 errors.
```

## Summary

- What problem does this PR solve? Expose hardcoded cron agent setup timeout as a configurable `openclaw.json` field.
- Why does this matter now? Operators on memory-pressured machines hit cascading gateway restarts with no knob to tune.
- What is the intended outcome? Operators can set `cron.isolatedAgentSetupTimeoutMs` to match their environment's capacity.
- What is intentionally out of scope? Other hardcoded cron timeouts; only the setup watchdog is addressed here.
- What should reviewers focus on? Config plumbing correctness and default-preserving fallback.

Fix classification: Root-cause fix
Root cause: `CRON_AGENT_SETUP_WATCHDOG_MS` was a module-level constant in `agent-watchdog.ts` with no config injection path.
Why this is root-cause fix: The config wire goes from `zod-schema → types → deps.cronConfig → timer.ts → watchdog params`, removing the hardcoded constant as the only source of truth.

## Linked context

- Which issue does this close? Closes #97002
- Was this requested by a maintainer or owner? No direct maintainer request; follows user-reported requirement from @Blakeshannon.

## Tests and validation

- `pnpm test src/cron/service/agent-watchdog.test.ts` — 4 tests (2 new + 2 existing)
- `pnpm test src/cron/service/` — 152 tests across 15 files, all passing
- Negative control: old code on main had only 2 tests, no `setupTimeoutMs` parameter

## Risk checklist

- Did user-visible behavior change? No — default timeout is unchanged.
- Did config, environment, or migration behavior change? Yes — new optional config field added. Backward compatible (absent key → 60s default).
- Did security, auth, secrets, network, or tool execution behavior change? No.
- What is the highest-risk area? Config schema validation (`z.number().int().positive()`).
- How is that risk mitigated? Existing zod schema test suite passes; invalid values rejected at config parse time.

## Current review state

- Next action: Await ClawSweeper / maintainer review.
