### PR TITLE
fix(session-memory): honor configured slug model

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -238,7 +238,7 @@ openclaw hooks enable <hook-name>
 
 ### session-memory details
 
-Extracts the last user/assistant messages (default 15, configurable with `hooks.internal.entries.session-memory.messages`) and saves them to `<workspace>/memory/YYYY-MM-DD-HHMM.md` using the host local date. Memory capture runs in the background so `/new` and `/reset` acknowledgements are not delayed by transcript reads or optional slug generation. Set `hooks.internal.entries.session-memory.llmSlug: true` to generate descriptive filename slugs with the configured model (falls back to timestamp slugs when unavailable). Requires `workspace.dir` to be configured.
+Extracts the last user/assistant messages (default 15, configurable with `hooks.internal.entries.session-memory.messages`) and saves them to `<workspace>/memory/YYYY-MM-DD-HHMM.md` using the host local date. Memory capture runs in the background so `/new` and `/reset` acknowledgements are not delayed by transcript reads or optional slug generation. Set `hooks.internal.entries.session-memory.llmSlug: true` to generate descriptive filename slugs, and optionally set `hooks.internal.entries.session-memory.model` to a configured alias such as `sonnet`, a bare model ID on the agent's default provider, or a `provider/model` ref. Slug generation uses the agent's default model when `model` is omitted and falls back to timestamp slugs when unavailable. Requires `workspace.dir` to be configured.
 
 <a id="bootstrap-extra-files"></a>
 

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -61,10 +61,11 @@ When `llmSlug` is enabled, the hook uses your configured LLM provider to generat
 
 The hook supports optional configuration:
 
-| Option     | Type    | Default | Description                                                                                 |
-| ---------- | ------- | ------- | ------------------------------------------------------------------------------------------- |
-| `messages` | number  | 15      | Number of user/assistant messages to include in the memory file                             |
-| `llmSlug`  | boolean | false   | Use your configured model to generate descriptive filename slugs instead of timestamp slugs |
+| Option     | Type    | Default           | Description                                                                                 |
+| ---------- | ------- | ----------------- | ------------------------------------------------------------------------------------------- |
+| `messages` | number  | 15                | Number of user/assistant messages to include in the memory file                             |
+| `llmSlug`  | boolean | false             | Use your configured model to generate descriptive filename slugs instead of timestamp slugs |
+| `model`    | string  | (agent default)   | Model name or provider-qualified ref to use for LLM slug generation. Supports bare names (`gpt-5.5`), aliases (`claude-sonnet-4-6`), and provider-qualified refs (`anthropic/claude-sonnet-4-6`). When omitted, the agent's default model is used. |
 
 Example configuration:
 

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -61,11 +61,11 @@ When `llmSlug` is enabled, the hook uses your configured LLM provider to generat
 
 The hook supports optional configuration:
 
-| Option     | Type    | Default           | Description                                                                                 |
-| ---------- | ------- | ----------------- | ------------------------------------------------------------------------------------------- |
-| `messages` | number  | 15                | Number of user/assistant messages to include in the memory file                             |
-| `llmSlug`  | boolean | false             | Use your configured model to generate descriptive filename slugs instead of timestamp slugs |
-| `model`    | string  | (agent default)   | Model name or provider-qualified ref to use for LLM slug generation. Supports bare names (`gpt-5.5`), aliases (`claude-sonnet-4-6`), and provider-qualified refs (`anthropic/claude-sonnet-4-6`). When omitted, the agent's default model is used. |
+| Option     | Type    | Default       | Description                                                                                 |
+| ---------- | ------- | ------------- | ------------------------------------------------------------------------------------------- |
+| `messages` | number  | 15            | Number of user/assistant messages to include in the memory file                             |
+| `llmSlug`  | boolean | false         | Use your configured model to generate descriptive filename slugs instead of timestamp slugs |
+| `model`    | string  | agent default | Configured alias, bare model ID on the default provider, or `provider/model` override       |
 
 Example configuration:
 
@@ -77,7 +77,8 @@ Example configuration:
         "session-memory": {
           "enabled": true,
           "messages": 25,
-          "llmSlug": true
+          "llmSlug": true,
+          "model": "sonnet"
         }
       }
     }
@@ -91,6 +92,7 @@ The hook automatically:
 - Uses timestamp slugs by default so `/new` and `/reset` stay fast on message channels
 - Runs memory capture in the background so reset acknowledgements can return immediately
 - Uses your configured LLM for slug generation only when `llmSlug` is `true`
+- Resolves configured aliases such as `sonnet`; bare model IDs use the agent's default provider, while `provider/model` selects another provider
 - Falls back to timestamp slugs if LLM slug generation is unavailable
 
 ## Disabling

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -354,6 +354,7 @@ describe("session-memory hook", () => {
                     "session-memory": {
                       enabled: true,
                       llmSlug: true,
+                      model: "sonnet",
                     },
                   },
                 },
@@ -365,93 +366,7 @@ describe("session-memory hook", () => {
     );
 
     expect(generateSlug).toHaveBeenCalledTimes(1);
-  });
-
-  it("forwards hook config model override to the slug generator", async () => {
-    const sessionContent = createMockSessionContent([
-      { role: "user", content: "What is 2+2?" },
-      { role: "assistant", content: "2+2 equals 4" },
-    ]);
-
-    const generateSlug = vi.mocked(generateSlugViaLLM);
-    generateSlug.mockClear();
-    generateSlug.mockResolvedValueOnce("math-discussion");
-
-    await withEnvAsync(
-      {
-        NODE_ENV: "production",
-        OPENCLAW_TEST_FAST: undefined,
-        VITEST: undefined,
-      },
-      async () => {
-        await runNewWithPreviousSession({
-          sessionContent,
-          cfg: (tempDir) =>
-            ({
-              agents: { defaults: { workspace: tempDir } },
-              hooks: {
-                internal: {
-                  entries: {
-                    "session-memory": {
-                      enabled: true,
-                      llmSlug: true,
-                      model: "claude-sonnet-4-6",
-                    },
-                  },
-                },
-              },
-            }) satisfies OpenClawConfig,
-        });
-      },
-    );
-
-    expect(generateSlug).toHaveBeenCalledTimes(1);
-    expect(generateSlug).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "claude-sonnet-4-6" }),
-    );
-  });
-
-  it("does not forward model when hook config omits it", async () => {
-    const sessionContent = createMockSessionContent([
-      { role: "user", content: "Hello" },
-      { role: "assistant", content: "Hi there" },
-    ]);
-
-    const generateSlug = vi.mocked(generateSlugViaLLM);
-    generateSlug.mockClear();
-    generateSlug.mockResolvedValueOnce("greeting");
-
-    await withEnvAsync(
-      {
-        NODE_ENV: "production",
-        OPENCLAW_TEST_FAST: undefined,
-        VITEST: undefined,
-      },
-      async () => {
-        await runNewWithPreviousSession({
-          sessionContent,
-          cfg: (tempDir) =>
-            ({
-              agents: { defaults: { workspace: tempDir } },
-              hooks: {
-                internal: {
-                  entries: {
-                    "session-memory": {
-                      enabled: true,
-                      llmSlug: true,
-                    },
-                  },
-                },
-              },
-            }) satisfies OpenClawConfig,
-        });
-      },
-    );
-
-    expect(generateSlug).toHaveBeenCalledTimes(1);
-    expect(generateSlug).not.toHaveBeenCalledWith(
-      expect.objectContaining({ model: expect.anything() as unknown }),
-    );
+    expect(generateSlug).toHaveBeenCalledWith(expect.objectContaining({ model: "sonnet" }));
   });
 
   it("does not block reset command handling on opt-in model slug generation", async () => {

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -367,6 +367,93 @@ describe("session-memory hook", () => {
     expect(generateSlug).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards hook config model override to the slug generator", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "What is 2+2?" },
+      { role: "assistant", content: "2+2 equals 4" },
+    ]);
+
+    const generateSlug = vi.mocked(generateSlugViaLLM);
+    generateSlug.mockClear();
+    generateSlug.mockResolvedValueOnce("math-discussion");
+
+    await withEnvAsync(
+      {
+        NODE_ENV: "production",
+        OPENCLAW_TEST_FAST: undefined,
+        VITEST: undefined,
+      },
+      async () => {
+        await runNewWithPreviousSession({
+          sessionContent,
+          cfg: (tempDir) =>
+            ({
+              agents: { defaults: { workspace: tempDir } },
+              hooks: {
+                internal: {
+                  entries: {
+                    "session-memory": {
+                      enabled: true,
+                      llmSlug: true,
+                      model: "claude-sonnet-4-6",
+                    },
+                  },
+                },
+              },
+            }) satisfies OpenClawConfig,
+        });
+      },
+    );
+
+    expect(generateSlug).toHaveBeenCalledTimes(1);
+    expect(generateSlug).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "claude-sonnet-4-6" }),
+    );
+  });
+
+  it("does not forward model when hook config omits it", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]);
+
+    const generateSlug = vi.mocked(generateSlugViaLLM);
+    generateSlug.mockClear();
+    generateSlug.mockResolvedValueOnce("greeting");
+
+    await withEnvAsync(
+      {
+        NODE_ENV: "production",
+        OPENCLAW_TEST_FAST: undefined,
+        VITEST: undefined,
+      },
+      async () => {
+        await runNewWithPreviousSession({
+          sessionContent,
+          cfg: (tempDir) =>
+            ({
+              agents: { defaults: { workspace: tempDir } },
+              hooks: {
+                internal: {
+                  entries: {
+                    "session-memory": {
+                      enabled: true,
+                      llmSlug: true,
+                    },
+                  },
+                },
+              },
+            }) satisfies OpenClawConfig,
+        });
+      },
+    );
+
+    expect(generateSlug).toHaveBeenCalledTimes(1);
+    expect(generateSlug).not.toHaveBeenCalledWith(
+      expect.objectContaining({ model: expect.anything() as unknown }),
+    );
+  });
+
   it("does not block reset command handling on opt-in model slug generation", async () => {
     const tempDir = await createCaseWorkspace("workspace");
     const sessionsDir = path.join(tempDir, "sessions");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -234,7 +234,9 @@ async function saveSessionMemoryNow(event: Parameters<HookHandler>[0]): Promise<
       if (sessionContent && cfg && allowLlmSlug) {
         log.debug("Calling generateSlugViaLLM...");
         // Use LLM to generate a descriptive slug
-        slug = await generateSlugViaLLM({ sessionContent, cfg });
+        const slugModel =
+          typeof hookConfig?.model === "string" ? hookConfig.model : undefined;
+        slug = await generateSlugViaLLM({ sessionContent, cfg, model: slugModel });
         log.debug("Generated slug", { slug });
       }
     }

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -234,8 +234,7 @@ async function saveSessionMemoryNow(event: Parameters<HookHandler>[0]): Promise<
       if (sessionContent && cfg && allowLlmSlug) {
         log.debug("Calling generateSlugViaLLM...");
         // Use LLM to generate a descriptive slug
-        const slugModel =
-          typeof hookConfig?.model === "string" ? hookConfig.model : undefined;
+        const slugModel = typeof hookConfig?.model === "string" ? hookConfig.model : undefined;
         slug = await generateSlugViaLLM({ sessionContent, cfg, model: slugModel });
         log.debug("Generated slug", { slug });
       }

--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -117,6 +117,51 @@ describe("generateSlugViaLLM", () => {
     expect(options.model).toBe("gpt-5.5");
   });
 
+  it("passes hook-level bare model name without a provider so the runner resolves both through its alias chain", async () => {
+    await generateSlugViaLLM({
+      sessionContent: "hello",
+      cfg: {} as OpenClawConfig,
+      model: "gpt-5.5",
+    });
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    const options = requireFirstRunOptions();
+    expect(options.provider).toBeUndefined();
+    expect(options.model).toBe("gpt-5.5");
+  });
+
+  it("passes hook-level provider-qualified ref without a separate provider, letting the runner extract it", async () => {
+    await generateSlugViaLLM({
+      sessionContent: "hello",
+      cfg: {} as OpenClawConfig,
+      model: "anthropic/claude-sonnet-4-6",
+    });
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    const options = requireFirstRunOptions();
+    expect(options.provider).toBeUndefined();
+    expect(options.model).toBe("anthropic/claude-sonnet-4-6");
+  });
+
+  it("uses the agent default model when no hook model override is provided", async () => {
+    await generateSlugViaLLM({
+      sessionContent: "hello",
+      cfg: {
+        agents: {
+          defaults: {
+            model: { primary: "gemini-pro" },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    const options = requireFirstRunOptions();
+    // Default behavior: provider resolved from config
+    expect(options.provider).toBeDefined();
+    expect(options.model).toBe("gemini-pro");
+  });
+
   it("rejects error payloads before slugifying them into memory filenames", async () => {
     runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [

--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -8,13 +8,6 @@ vi.mock("../agents/agent-scope.js", () => ({
   resolveDefaultAgentId: vi.fn(() => "main"),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-agent"),
   resolveAgentDir: vi.fn(() => "/tmp/openclaw-agent/.openclaw-agent"),
-  resolveAgentEffectiveModelPrimary: vi.fn((cfg: OpenClawConfig) => {
-    const model = cfg.agents?.defaults?.model;
-    if (typeof model === "string") {
-      return model;
-    }
-    return model?.primary;
-  }),
 }));
 
 vi.mock("../agents/embedded-agent.js", () => ({
@@ -81,7 +74,7 @@ describe("generateSlugViaLLM", () => {
     expect(requireFirstRunOptions().timeoutMs).toBe(500_000);
   });
 
-  it("infers provider metadata for bare configured agent models", async () => {
+  it("delegates default model resolution to the embedded runner", async () => {
     await generateSlugViaLLM({
       sessionContent: "hello",
       cfg: {
@@ -90,77 +83,30 @@ describe("generateSlugViaLLM", () => {
             model: { primary: "gpt-5.5" },
           },
         },
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://chatgpt.com/backend-api/codex",
-              models: [
-                {
-                  id: "gpt-5.5",
-                  name: "GPT 5.5",
-                  reasoning: true,
-                  input: ["text"],
-                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                  contextWindow: 200_000,
-                  maxTokens: 128_000,
-                },
-              ],
-            },
-          },
-        },
       } as OpenClawConfig,
     });
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
     const options = requireFirstRunOptions();
-    expect(options.provider).toBe("openai");
-    expect(options.model).toBe("gpt-5.5");
-  });
-
-  it("passes hook-level bare model name without a provider so the runner resolves both through its alias chain", async () => {
-    await generateSlugViaLLM({
-      sessionContent: "hello",
-      cfg: {} as OpenClawConfig,
-      model: "gpt-5.5",
-    });
-
-    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
-    const options = requireFirstRunOptions();
     expect(options.provider).toBeUndefined();
-    expect(options.model).toBe("gpt-5.5");
+    expect(options.model).toBeUndefined();
   });
 
-  it("passes hook-level provider-qualified ref without a separate provider, letting the runner extract it", async () => {
-    await generateSlugViaLLM({
-      sessionContent: "hello",
-      cfg: {} as OpenClawConfig,
-      model: "anthropic/claude-sonnet-4-6",
-    });
+  it.each(["gpt-5.5", "anthropic/claude-sonnet-4-6"])(
+    "passes hook-level model %s to the embedded runner without a provider",
+    async (model) => {
+      await generateSlugViaLLM({
+        sessionContent: "hello",
+        cfg: {} as OpenClawConfig,
+        model,
+      });
 
-    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
-    const options = requireFirstRunOptions();
-    expect(options.provider).toBeUndefined();
-    expect(options.model).toBe("anthropic/claude-sonnet-4-6");
-  });
-
-  it("uses the agent default model when no hook model override is provided", async () => {
-    await generateSlugViaLLM({
-      sessionContent: "hello",
-      cfg: {
-        agents: {
-          defaults: {
-            model: { primary: "gemini-pro" },
-          },
-        },
-      } as OpenClawConfig,
-    });
-
-    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
-    const options = requireFirstRunOptions();
-    // Default behavior: provider resolved from config
-    expect(options.provider).toBeDefined();
-    expect(options.model).toBe("gemini-pro");
-  });
+      expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
+      const options = requireFirstRunOptions();
+      expect(options.provider).toBeUndefined();
+      expect(options.model).toBe(model);
+    },
+  );
 
   it("rejects error payloads before slugifying them into memory filenames", async () => {
     runEmbeddedAgentMock.mockResolvedValueOnce({

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -74,6 +74,10 @@ function isErrorSlugPayload(payload: { text?: string; isError?: boolean } | unde
 export async function generateSlugViaLLM(params: {
   sessionContent: string;
   cfg: OpenClawConfig;
+  /** Optional hook-level model override. When set, only the model is overridden;
+   *  provider resolution stays with the agent default so alias/ref resolution
+   *  flows through runEmbeddedAgent's built-in model-resolution chain. */
+  model?: string;
 }): Promise<string | null> {
   let tempSessionFile: string | null = null;
 
@@ -93,10 +97,17 @@ ${truncateUtf16Safe(params.sessionContent, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
-    const { provider, model } = resolveDefaultModelForAgent({
+    const configuredDefault = resolveDefaultModelForAgent({
       cfg: params.cfg,
       agentId,
     });
+    // When the hook provides an explicit model, only pass that model (omit
+    // provider) so runEmbeddedAgent's built-in resolveInitialEmbeddedRunModel
+    // chain handles alias, provider-qualified ref, and bare-name resolution
+    // through a single source of truth. Passing both provider + model would
+    // short-circuit that path and skip alias resolution.
+    const provider = params.model ? undefined : configuredDefault.provider;
+    const model = params.model ?? configuredDefault.model;
     const timeoutMs = resolveSlugGeneratorTimeoutMs(params.cfg);
 
     const result = await runEmbeddedAgent({

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -13,7 +13,6 @@ import {
   resolveAgentDir,
 } from "../agents/agent-scope.js";
 import { runEmbeddedAgent } from "../agents/embedded-agent.js";
-import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../agents/timeout.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -74,9 +73,7 @@ function isErrorSlugPayload(payload: { text?: string; isError?: boolean } | unde
 export async function generateSlugViaLLM(params: {
   sessionContent: string;
   cfg: OpenClawConfig;
-  /** Optional hook-level model override. When set, only the model is overridden;
-   *  provider resolution stays with the agent default so alias/ref resolution
-   *  flows through runEmbeddedAgent's built-in model-resolution chain. */
+  /** Optional hook-level override; the embedded runner owns model resolution. */
   model?: string;
 }): Promise<string | null> {
   let tempSessionFile: string | null = null;
@@ -97,17 +94,6 @@ ${truncateUtf16Safe(params.sessionContent, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
-    const configuredDefault = resolveDefaultModelForAgent({
-      cfg: params.cfg,
-      agentId,
-    });
-    // When the hook provides an explicit model, only pass that model (omit
-    // provider) so runEmbeddedAgent's built-in resolveInitialEmbeddedRunModel
-    // chain handles alias, provider-qualified ref, and bare-name resolution
-    // through a single source of truth. Passing both provider + model would
-    // short-circuit that path and skip alias resolution.
-    const provider = params.model ? undefined : configuredDefault.provider;
-    const model = params.model ?? configuredDefault.model;
     const timeoutMs = resolveSlugGeneratorTimeoutMs(params.cfg);
 
     const result = await runEmbeddedAgent({
@@ -119,8 +105,7 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       agentDir,
       config: params.cfg,
       prompt,
-      provider,
-      model,
+      model: params.model,
       timeoutMs,
       runId: `slug-gen-${Date.now()}`,
       cleanupBundleMcpOnRunEnd: true,


### PR DESCRIPTION
Fixes #89551

## What Problem This Solves

Fixes an issue where users enabling LLM-generated session-memory slugs could not select a dedicated slug model: `hooks.internal.entries.session-memory.model` was accepted but ignored, so `/new` and `/reset` always used the agent's primary model.

## Why This Change Was Made

The session-memory hook now forwards its optional model override to the embedded runner. The runner remains the single owner of configured aliases, bare model IDs, provider-qualified refs, and agent-default fallback; no duplicate model-selection path is kept in the hook.

The bundled hook guide and public hooks documentation describe the supported model forms. No config migration, provider behavior, session format, or timestamp fallback changes.

## User Impact

Users can set `hooks.internal.entries.session-memory.model` to a configured alias such as `sonnet`, a bare model ID on the agent's default provider, or a `provider/model` ref. When omitted, slug generation still uses the agent's default model; failures still fall back to timestamp filenames.

## Evidence

- Sanitized AWS Crabbox on original contributor head `9967f3e7603084782a47d28023912e51ce4a1991`: focused hook tests, 46/46 passed (`run_536260e8afbc`).
- Blacksmith Testbox on patch-identical pre-rebase head `95d6a56b554f12d327b59cc2fd915376f6072f7b`: focused hook tests, 44/44 passed (`tbx_01kx7r7y05qk69r36br5zd561n`; [run 29140268648](https://github.com/openclaw/openclaw/actions/runs/29140268648)).
- Fresh branch autoreview on final exact head `ed5b80b4ee06f5fccc84737c0bbfa072e2065343`: no accepted/actionable findings, confidence 0.96.
- Targeted `oxfmt --check` on all six changed files and `git diff --check`: passed.
- [Patch-identical pre-rebase hosted CI run 29140246624](https://github.com/openclaw/openclaw/actions/runs/29140246624): 46 successful jobs, zero failures, including both QA Smoke profiles, docs, lint, production/test types, build artifacts, contracts, and all selected test shards. The repository prepare wrapper accepted this as recent-rebase evidence for final head `ed5b80b4ee06f5fccc84737c0bbfa072e2065343`.

No authenticated live provider call was run; routing is covered at the handler-to-embedded-runner boundary, while the runner's existing model-selection contract owns the provider call.
