### PR TITLE
fix: classify HTTP 429 'temporarily overloaded' as overloaded, not rate_limit

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -808,6 +808,14 @@ function classifyFailoverClassificationFromHttpStatus(
     if (message && isBilling429MessageForProvider(message, provider)) {
       return toReasonClassification("billing");
     }
+    // Some providers (e.g. Z.ai/GLM) return HTTP 429 with an "overloaded"
+    // message body when their model fleet is at capacity — this is a
+    // transient server-side overload, not a per-account rate limit.
+    // Classify it as "overloaded" so the runner retries with backoff
+    // instead of immediately falling over to the next model.
+    if (messageReason === "overloaded") {
+      return messageClassification;
+    }
     return toReasonClassification("rate_limit");
   }
   if (status === 401 || status === 403) {
@@ -1031,11 +1039,16 @@ function classifyFailoverClassificationFromMessage(
   if (isPeriodicUsageLimitErrorMessage(raw)) {
     return toReasonClassification(isBillingErrorMessage(raw) ? "billing" : "rate_limit");
   }
-  if (isRateLimitErrorMessage(raw)) {
-    return toReasonClassification("rate_limit");
-  }
+  // Check overloaded BEFORE rate limit: some providers (Z.ai/GLM, Anthropic)
+  // return HTTP 429 with an "overloaded" message body when their model fleet
+  // is at capacity. The rateLimit pattern /429/ would match these first,
+  // misclassifying a transient server-side overload as a per-account rate
+  // limit and triggering immediate model fallback instead of retry-with-backoff.
   if (isOverloadedErrorMessage(raw)) {
     return toReasonClassification("overloaded");
+  }
+  if (isRateLimitErrorMessage(raw)) {
+    return toReasonClassification("rate_limit");
   }
   if (
     isStructuredServerErrorMessage(raw) &&

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -179,6 +179,50 @@ describe("server error status classification", () => {
   });
 });
 
+describe("HTTP 429 with overloaded message body", () => {
+  // Some providers (Z.ai/GLM, Anthropic) return HTTP 429 with an
+  // "overloaded" message when their model fleet is at capacity.
+  // This is a transient server-side overload, not a per-account
+  // rate limit — it should be classified as "overloaded" so the
+  // runner retries with backoff instead of immediately falling
+  // over to the next model.
+  it("classifies 429 'temporarily overloaded' as overloaded, not rate_limit", () => {
+    const raw = "429 The service may be temporarily overloaded, please try again later";
+    expect(isOverloadedErrorMessage(raw)).toBe(true);
+    expect(classifyFailoverReason(raw)).toBe("overloaded");
+  });
+
+  it("classifies 429 'overloaded' (bare) as overloaded", () => {
+    const raw = "429 overloaded";
+    expect(isOverloadedErrorMessage(raw)).toBe(true);
+    expect(classifyFailoverReason(raw)).toBe("overloaded");
+  });
+
+  it("classifies 429 'model is at capacity' as overloaded", () => {
+    const raw = "429 The selected model is at capacity";
+    expect(isOverloadedErrorMessage(raw)).toBe(true);
+    expect(classifyFailoverReason(raw)).toBe("overloaded");
+  });
+
+  it("still classifies 429 'rate limit exceeded' as rate_limit", () => {
+    const raw = "429 Rate limit exceeded";
+    expect(isRateLimitErrorMessage(raw)).toBe(true);
+    expect(classifyFailoverReason(raw)).toBe("rate_limit");
+  });
+
+  it("still classifies 429 'too many requests' as rate_limit", () => {
+    const raw = "429 Too many requests";
+    expect(isRateLimitErrorMessage(raw)).toBe(true);
+    expect(classifyFailoverReason(raw)).toBe("rate_limit");
+  });
+
+  it("still classifies 429 billing messages as billing", () => {
+    const raw =
+      '429 {"code":1311,"message":"The model you requested is not available in your current plan"}';
+    expect(classifyFailoverReason(raw)).toBe("billing");
+  });
+});
+
 describe("generic assistant error text classification (#93931)", () => {
   it("classifies the generic 'LLM request failed.' as a timeout (transient)", () => {
     // The generic error text wraps provider availability failures (model not


### PR DESCRIPTION
## What Problem This Solves

Some providers (Z.ai/GLM, Anthropic) return HTTP 429 with an "overloaded" message body when their model fleet is at capacity. This is a **transient server-side overload**, not a per-account rate limit.

OpenClaw was misclassifying these as `rate_limit`, triggering **immediate model fallback** instead of retry-with-backoff. This caused unnecessary failovers and ~30-60s stalls on every turn when the provider was overloaded.

### Root Cause

Two issues in `src/agents/embedded-agent-helpers/errors.ts`:

**1. `classifyFailoverClassificationFromMessage` — ordering bug**

The `isRateLimitErrorMessage` pattern includes `/429/` as a match. So a message like `"429 The service may be temporarily overloaded"` matched `rate_limit` before `isOverloadedErrorMessage` was ever evaluated.

**2. `classifyFailoverClassificationFromHttpStatus` — missing overloaded check**

The HTTP 429 handler always returned `rate_limit` for non-billing 429s. The 503 and 499 handlers already check `messageReason === "overloaded"` — the 429 handler should do the same.

### Fix

1. Reorder `classifyFailoverClassificationFromMessage` to check `isOverloadedErrorMessage` **before** `isRateLimitErrorMessage`
2. Add `if (messageReason === "overloaded") return messageClassification;` to the 429 status handler

### Impact

- **Before:** 429 "temporarily overloaded" → `rate_limit` → immediate model fallback (~30-60s stall)
- **After:** 429 "temporarily overloaded" → `overloaded` → retry with backoff (same as 503 behavior)

## Evidence

### Screenshot (runtime classifier proof)

![Runtime Proof: 429 Overloaded Classification](https://gist.githubusercontent.com/ChunkyPanda29/0dd1e93d08e91135f2e85272953fef8d/raw/runtime-proof.png)

### Full test suite output (3 test files, 113 tests, all pass)

```
✓ src/agents/embedded-agent-helpers/failover-matches.test.ts > HTTP 429 with overloaded message body > classifies 429 'temporarily overloaded' as overloaded, not rate_limit
✓ src/agents/embedded-agent-helpers/failover-matches.test.ts > HTTP 429 with overloaded message body > classifies 429 'overloaded' (bare) as overloaded
✓ src/agents/embedded-agent-helpers/failover-matches.test.ts > HTTP 429 with overloaded message body > classifies 429 'model is at capacity' as overloaded
✓ src/agents/embedded-agent-helpers/failover-matches.test.ts > HTTP 429 with overloaded message body > still classifies 429 'rate limit exceeded' as rate_limit
✓ src/agents/embedded-agent-helpers/failover-matches.test.ts > HTTP 429 with overloaded message body > still classifies 429 'too many requests' as rate_limit
✓ src/agents/embedded-agent-helpers/failover-matches.test.ts > HTTP 429 with overloaded message body > still classifies 429 billing messages as billing

✓ src/agents/model-fallback.test.ts > runWithModelFallback > falls back on a Zhipu GLM 1305 overload body and classifies it as overloaded

✓ src/agents/embedded-agent-runner/run/assistant-failover.test.ts > handleAssistantFailover > rotate_profile branch > retries the same model before spending a rate-limit profile rotation
✓ src/agents/embedded-agent-runner/run/assistant-failover.test.ts > handleAssistantFailover > rotate_profile branch > does not spend same-model retry budget on quota-style rate limits

 Test Files  3 passed (3)
      Tests  113 passed (113)
   Duration  79.64s
```

### Runtime classifier proof (classifyFailoverSignal — the actual path OpenClaw uses)

```
PASS: Z.ai/GLM 429 overloaded (real-world, with status) -> overloaded
PASS: Z.ai/GLM 429 overloaded (message only, no explicit status) -> overloaded
PASS: Anthropic 429 overloaded -> overloaded
PASS: 503 overloaded (existing behavior, should be overloaded) -> overloaded
PASS: 429 rate limit (should stay rate_limit) -> rate_limit
PASS: 429 too many requests (should stay rate_limit) -> rate_limit
PASS: 429 billing (should stay billing) -> billing
```

Key observations:
- 429 "temporarily overloaded" now classifies as `overloaded` (not `rate_limit`)
- `classifyProviderRuntimeFailureKind` returns `timeout` (retryable) for overloaded, vs `rate_limit` for actual rate limits — this is the existing behavior that was being bypassed
- 429 rate-limit and billing classifications are unchanged (regression-safe)
- 503 overloaded behavior is unchanged (parity confirmed)

### Real OpenClaw runtime path evidence (trajectory logs)

Redacted `model.fallback_step` trajectory events extracted from real OpenClaw session `.trajectory.jsonl` logs — the actual runtime failover path, not isolated classifier output.

#### Before-fix: June 24, 2026 — Heartbeat session (4 unnecessary failovers)

Z.ai/GLM returned HTTP 429 "temporarily overloaded" 4 times across two runs. Each was misclassified as `rate_limit`, triggering unnecessary model fallback:

```
# 2026-06-24T12:35:19Z — model.fallback_step
provider: zai | model: glm-5.1
fallbackStepFromModel: zai/glm-5.1 → fallbackStepToModel: zai/glm-5
fallbackStepFromFailureReason: rate_limit          ← misclassified (should be overloaded)
fallbackStepFromFailureDetail: 429 The service may be temporarily overloaded, please try again later
fallbackStepChainPosition: 1 | fallbackStepFinalOutcome: next_fallback

# 2026-06-24T12:36:08Z
fallbackStepFromFailureReason: rate_limit          ← misclassified
fallbackStepFromFailureDetail: 429 The service may be temporarily overloaded, please try again later
fallbackStepChainPosition: 2 | fallbackStepFinalOutcome: succeeded

# 2026-06-24T12:50:43Z (second occurrence)
fallbackStepFromFailureReason: rate_limit          ← misclassified
fallbackStepFromFailureDetail: 429 The service may be temporarily overloaded, please try again later
fallbackStepChainPosition: 1 | fallbackStepFinalOutcome: next_fallback

# 2026-06-24T12:50:59Z
fallbackStepFromFailureReason: rate_limit          ← misclassified
fallbackStepFromFailureDetail: 429 The service may be temporarily overloaded, please try again later
fallbackStepChainPosition: 2 | fallbackStepFinalOutcome: succeeded
```

#### Before-fix: June 25, 2026 — Subagent runs (4 chain exhaustions in 3 min)

During a Z.ai fleet-wide overload, 4 subagent runs all hit 429 overloaded. All misclassified as `rate_limit`, all resulted in **chain_exhausted**:

```
# 2026-06-25T08:31:19Z — subagent
fallbackStepFromModel: zai/glm-5.1
fallbackStepFromFailureReason: rate_limit          ← misclassified
fallbackStepFromFailureDetail: 429 The service may be temporarily overloaded, please try again later
fallbackStepFinalOutcome: chain_exhausted

# 2026-06-25T08:31:53Z — subagent
fallbackStepFromFailureReason: rate_limit | fallbackStepFinalOutcome: chain_exhausted

# 2026-06-25T08:32:51Z — subagent
fallbackStepFromFailureReason: rate_limit | fallbackStepFinalOutcome: chain_exhausted

# 2026-06-25T08:33:56Z — subagent
fallbackStepFromFailureReason: rate_limit | fallbackStepFinalOutcome: chain_exhausted
```

With the fix, these classify as `overloaded` → retry-with-backoff on the same model, avoiding cascading chain exhaustion across fallback models (which were all on the same overloaded Z.ai fleet).

### Before-fix logs (real-world)

```
event=embedded_run_agent_end | zai/glm-5.1 | run=e600fd8a | isError=true
failoverReason=rate_limit
rawErrorPreview="429 The service may be temporarily overloaded, please try again later"
```

After fix, this same error classifies as `failoverReason=overloaded`, engaging retry-with-backoff instead of immediate fallback.

### New unit tests (6 in failover-matches.test.ts)

| Input | Expected | Status |
|-------|----------|--------|
| `"429 The service may be temporarily overloaded..."` | `overloaded` | New |
| `"429 overloaded"` | `overloaded` | New |
| `"429 The selected model is at capacity"` | `overloaded` | New |
| `"429 Rate limit exceeded"` | `rate_limit` | Regression |
| `"429 Too many requests"` | `rate_limit` | Regression |
| `'429 {"code":1311,...}'` (billing) | `billing` | Regression |

## Related Issues

- #93211 — Model fallback not triggered for Zhipu (GLM) error code 1305 (overloaded pattern mismatch) — closed, related Chinese-text overload pattern gap
- #85103 — Model fallback chain not triggered on provider-wide quota exhaustion — open, complementary fix for fallback chain escalation
- #51336 — Surface API provider name in error/overload messages — open, related UX improvement
