### PR TITLE
fix(plugin-sdk): follow paginated live model catalogs

### DIFF
--- a/src/plugin-sdk/provider-catalog-live-runtime.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.test.ts
@@ -144,6 +144,143 @@ describe("provider-catalog-live-runtime", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("follows next_cursor pagination before projecting model ids", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi
+      .fn()
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            data: [{ id: "model-a", object: "model" }],
+            has_more: true,
+            next_cursor: "cursor-2",
+          }),
+        ),
+        finalUrl: "https://provider.example.test/v1/models",
+        release,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({ data: [{ id: "model-b", object: "model" }], has_more: false }),
+        ),
+        finalUrl: "https://provider.example.test/v1/models?after=cursor-2",
+        release,
+      });
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).resolves.toEqual(["model-a", "model-b"]);
+
+    expect(fetchGuardMock).toHaveBeenCalledTimes(2);
+    expect(fetchGuardMock.mock.calls[1]?.[0].url).toBe(
+      "https://provider.example.test/v1/models?after=cursor-2",
+    );
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it("follows absolute next links when providers return them", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi
+      .fn()
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            data: [{ id: "model-a", object: "model" }],
+            next: "https://provider.example.test/v1/models?page=2",
+          }),
+        ),
+        finalUrl: "https://provider.example.test/v1/models",
+        release,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ data: [{ id: "model-b", object: "model" }] })),
+        finalUrl: "https://provider.example.test/v1/models?page=2",
+        release,
+      });
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).resolves.toEqual(["model-a", "model-b"]);
+
+    expect(fetchGuardMock.mock.calls[1]?.[0].url).toBe(
+      "https://provider.example.test/v1/models?page=2",
+    );
+  });
+
+  it("follows nested links.next pagination when providers return it", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi
+      .fn()
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            data: [{ id: "model-a", object: "model" }],
+            links: { next: "/v1/models?page=2" },
+          }),
+        ),
+        finalUrl: "https://provider.example.test/v1/models",
+        release,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ data: [{ id: "model-b", object: "model" }] })),
+        finalUrl: "https://provider.example.test/v1/models?page=2",
+        release,
+      });
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).resolves.toEqual(["model-a", "model-b"]);
+
+    expect(fetchGuardMock.mock.calls[1]?.[0].url).toBe(
+      "https://provider.example.test/v1/models?page=2",
+    );
+  });
+
+  it("follows nextPageToken pagination before projecting model ids", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi
+      .fn()
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            data: [{ id: "model-a", object: "model" }],
+            nextPageToken: "page-2",
+          }),
+        ),
+        finalUrl: "https://provider.example.test/v1/models",
+        release,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ data: [{ id: "model-b", object: "model" }] })),
+        finalUrl: "https://provider.example.test/v1/models?pageToken=page-2",
+        release,
+      });
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).resolves.toEqual(["model-a", "model-b"]);
+
+    expect(fetchGuardMock.mock.calls[1]?.[0].url).toBe(
+      "https://provider.example.test/v1/models?pageToken=page-2",
+    );
+  });
+
   it("caches raw live model rows for provider-specific projection", async () => {
     const { fetchGuard, fetchGuardMock } = buildFetchGuard({
       models: [{ slug: "custom-a" }, { slug: "custom-b" }],

--- a/src/plugin-sdk/provider-catalog-live-runtime.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.test.ts
@@ -310,6 +310,33 @@ describe("provider-catalog-live-runtime", () => {
     expect(release).toHaveBeenCalledTimes(50);
   });
 
+  it("fails explicit incomplete live catalog pagination without a supported next page", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
+      response: new Response(
+        JSON.stringify({
+          data: [{ id: "model-a", object: "model" }],
+          has_more: true,
+        }),
+      ),
+      finalUrl: "https://provider.example.test/v1/models",
+      release,
+    }));
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).rejects.toThrow(
+      "provider model discovery did not include a supported next page before the catalog completed",
+    );
+
+    expect(fetchGuardMock).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("uses one timeout budget across paginated live catalog discovery", async () => {
     vi.useFakeTimers();
     try {

--- a/src/plugin-sdk/provider-catalog-live-runtime.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.test.ts
@@ -281,6 +281,79 @@ describe("provider-catalog-live-runtime", () => {
     );
   });
 
+  it("fails truncated live catalog pagination instead of returning partial rows", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async ({ url }) => {
+      const page = Number(new URL(url).searchParams.get("after") ?? "0");
+      return {
+        response: new Response(
+          JSON.stringify({
+            data: [{ id: `model-${page}`, object: "model" }],
+            has_more: true,
+            next_cursor: String(page + 1),
+          }),
+        ),
+        finalUrl: url,
+        release,
+      };
+    });
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).rejects.toThrow("provider model discovery exceeded 50 pages before the catalog completed");
+
+    expect(fetchGuardMock).toHaveBeenCalledTimes(50);
+    expect(release).toHaveBeenCalledTimes(50);
+  });
+
+  it("uses one timeout budget across paginated live catalog discovery", async () => {
+    vi.useFakeTimers();
+    try {
+      const release = vi.fn(async () => undefined);
+      const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          await vi.advanceTimersByTimeAsync(800);
+          return {
+            response: new Response(
+              JSON.stringify({
+                data: [{ id: "model-a", object: "model" }],
+                has_more: true,
+                next_cursor: "cursor-2",
+              }),
+            ),
+            finalUrl: "https://provider.example.test/v1/models",
+            release,
+          };
+        })
+        .mockImplementationOnce(async () => ({
+          response: new Response(JSON.stringify({ data: [{ id: "model-b", object: "model" }] })),
+          finalUrl: "https://provider.example.test/v1/models?after=cursor-2",
+          release,
+        }));
+
+      await expect(
+        fetchLiveProviderModelIds({
+          providerId: "provider",
+          endpoint: "https://provider.example.test/v1/models",
+          fetchGuard: fetchGuardMock,
+          timeoutMs: 1_000,
+        }),
+      ).resolves.toEqual(["model-a", "model-b"]);
+
+      expect(fetchGuardMock).toHaveBeenCalledTimes(2);
+      expect(fetchGuardMock.mock.calls[0]?.[0].timeoutMs).toBe(1_000);
+      expect(fetchGuardMock.mock.calls[1]?.[0].timeoutMs).toBe(200);
+      expect(release).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("caches raw live model rows for provider-specific projection", async () => {
     const { fetchGuard, fetchGuardMock } = buildFetchGuard({
       models: [{ slug: "custom-a" }, { slug: "custom-b" }],

--- a/src/plugin-sdk/provider-catalog-live-runtime.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.test.ts
@@ -281,6 +281,54 @@ describe("provider-catalog-live-runtime", () => {
     );
   });
 
+  it("does not re-add credentials to redirected-origin pagination requests", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi
+      .fn()
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            data: [{ id: "model-a", object: "model" }],
+            links: { next: "?page=2" },
+          }),
+        ),
+        finalUrl: "https://redirected.example.test/v1/models/",
+        release,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ data: [{ id: "model-b", object: "model" }] })),
+        finalUrl: "https://redirected.example.test/v1/models/?page=2",
+        release,
+      });
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        discoveryApiKey: "provider-token",
+        fetchGuard: fetchGuardMock,
+        buildRequestHeaders: ({ discoveryApiKey }) => ({
+          Accept: "application/json",
+          ...(discoveryApiKey ? { Authorization: `Bearer ${discoveryApiKey}` } : {}),
+          "ChatGPT-Account-ID": "acct-1",
+        }),
+      }),
+    ).resolves.toEqual(["model-a", "model-b"]);
+
+    const firstHeaders = fetchGuardMock.mock.calls[0]?.[0].init?.headers;
+    const secondHeaders = fetchGuardMock.mock.calls[1]?.[0].init?.headers;
+    expect(firstHeaders).toBeInstanceOf(Headers);
+    expect(secondHeaders).toBeInstanceOf(Headers);
+    expect((firstHeaders as Headers).get("authorization")).toBe("Bearer provider-token");
+    expect((firstHeaders as Headers).get("chatgpt-account-id")).toBe("acct-1");
+    expect(fetchGuardMock.mock.calls[1]?.[0].url).toBe(
+      "https://redirected.example.test/v1/models/?page=2",
+    );
+    expect((secondHeaders as Headers).get("authorization")).toBeNull();
+    expect((secondHeaders as Headers).get("chatgpt-account-id")).toBeNull();
+    expect((secondHeaders as Headers).get("accept")).toBe("application/json");
+  });
+
   it("follows nextPageToken pagination before projecting model ids", async () => {
     const release = vi.fn(async () => undefined);
     const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi

--- a/src/plugin-sdk/provider-catalog-live-runtime.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.test.ts
@@ -248,6 +248,39 @@ describe("provider-catalog-live-runtime", () => {
     );
   });
 
+  it("resolves relative pagination links against the guarded fetch final URL", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi
+      .fn()
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            data: [{ id: "model-a", object: "model" }],
+            links: { next: "?page=2" },
+          }),
+        ),
+        finalUrl: "https://provider.example.test/v1/models/",
+        release,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ data: [{ id: "model-b", object: "model" }] })),
+        finalUrl: "https://provider.example.test/v1/models/?page=2",
+        release,
+      });
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).resolves.toEqual(["model-a", "model-b"]);
+
+    expect(fetchGuardMock.mock.calls[1]?.[0].url).toBe(
+      "https://provider.example.test/v1/models/?page=2",
+    );
+  });
+
   it("follows nextPageToken pagination before projecting model ids", async () => {
     const release = vi.fn(async () => undefined);
     const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -54,6 +54,7 @@ export type CachedLiveProviderModelRowsParams = FetchLiveProviderModelRowsParams
 // and grows) while still bounding memory, matching the existing bounded reads
 // for provider error bodies.
 const LIVE_MODEL_CATALOG_BODY_MAX_BYTES = 4 * 1024 * 1024;
+const LIVE_MODEL_CATALOG_MAX_PAGES = 50;
 
 export class LiveModelCatalogHttpError extends Error {
   readonly status: number;
@@ -154,18 +155,71 @@ async function readLiveModelCatalogJson(response: Response, timeoutMs: number): 
   return JSON.parse(new TextDecoder().decode(buffer));
 }
 
-export async function fetchLiveProviderModelRows(
-  params: FetchLiveProviderModelRowsParams,
-): Promise<readonly unknown[]> {
-  const fetchGuard = params.fetchGuard ?? fetchWithSsrFGuard;
-  const timeoutMs = params.timeoutMs ?? 5_000;
-  const { response, release } = await fetchGuard({
-    url: params.endpoint,
+function readLiveModelCatalogString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readLiveModelCatalogRecord(body: unknown): Record<string, unknown> | undefined {
+  return body && typeof body === "object" && !Array.isArray(body)
+    ? (body as Record<string, unknown>)
+    : undefined;
+}
+
+function readLiveModelCatalogNextUrl(body: unknown): string | undefined {
+  const record = readLiveModelCatalogRecord(body);
+  if (!record) {
+    return undefined;
+  }
+  const links = readLiveModelCatalogRecord(record.links);
+  return readLiveModelCatalogString(record.next) ?? readLiveModelCatalogString(links?.next);
+}
+
+function readLiveModelCatalogCursor(
+  body: unknown,
+): { name: "after" | "pageToken"; value: string } | undefined {
+  const record = readLiveModelCatalogRecord(body);
+  if (!record || record.has_more === false) {
+    return undefined;
+  }
+  const nextCursor = readLiveModelCatalogString(record.next_cursor);
+  if (nextCursor) {
+    return { name: "after", value: nextCursor };
+  }
+  const nextPageToken = readLiveModelCatalogString(record.nextPageToken);
+  return nextPageToken ? { name: "pageToken", value: nextPageToken } : undefined;
+}
+
+function buildLiveModelCatalogNextPageUrl(currentUrl: string, body: unknown): string | undefined {
+  const rawNextUrl = readLiveModelCatalogNextUrl(body);
+  if (rawNextUrl) {
+    const nextUrl = new URL(rawNextUrl, currentUrl);
+    if (nextUrl.origin === new URL(currentUrl).origin) {
+      return nextUrl.toString();
+    }
+  }
+  const cursor = readLiveModelCatalogCursor(body);
+  if (!cursor) {
+    return undefined;
+  }
+  const nextUrl = new URL(currentUrl);
+  nextUrl.searchParams.set(cursor.name, cursor.value);
+  return nextUrl.toString();
+}
+
+async function fetchLiveProviderModelCatalogPage(
+  params: FetchLiveProviderModelRowsParams & {
+    fetchGuard: LiveModelCatalogFetchGuard;
+    url: string;
+    timeoutMs: number;
+  },
+): Promise<{ body: unknown; rows: readonly unknown[] }> {
+  const { response, release } = await params.fetchGuard({
+    url: params.url,
     init: {
       headers: buildHeaders(params),
     },
     signal: params.signal,
-    timeoutMs,
+    timeoutMs: params.timeoutMs,
     policy: params.policy ?? ssrfPolicyFromHttpBaseUrlAllowedHostname(params.endpoint),
     ...(params.lookupFn ? { lookupFn: params.lookupFn } : {}),
     ...(params.requireHttps !== undefined ? { requireHttps: params.requireHttps } : {}),
@@ -176,12 +230,36 @@ export async function fetchLiveProviderModelRows(
       await cancelUnreadResponseBody(response);
       throw new LiveModelCatalogHttpError(params.providerId, response.status);
     }
-    return (params.readRows ?? readDefaultLiveModelCatalogRows)(
-      await readLiveModelCatalogJson(response, timeoutMs),
-    );
+    const body = await readLiveModelCatalogJson(response, params.timeoutMs);
+    return { body, rows: (params.readRows ?? readDefaultLiveModelCatalogRows)(body) };
   } finally {
     await release();
   }
+}
+
+export async function fetchLiveProviderModelRows(
+  params: FetchLiveProviderModelRowsParams,
+): Promise<readonly unknown[]> {
+  const fetchGuard = params.fetchGuard ?? fetchWithSsrFGuard;
+  const timeoutMs = params.timeoutMs ?? 5_000;
+  const rows: unknown[] = [];
+  const seenPageUrls = new Set<string>();
+  let pageUrl: string | undefined = params.endpoint;
+  for (let page = 0; page < LIVE_MODEL_CATALOG_MAX_PAGES && pageUrl; page += 1) {
+    if (seenPageUrls.has(pageUrl)) {
+      break;
+    }
+    seenPageUrls.add(pageUrl);
+    const result = await fetchLiveProviderModelCatalogPage({
+      ...params,
+      fetchGuard,
+      url: pageUrl,
+      timeoutMs,
+    });
+    rows.push(...result.rows);
+    pageUrl = buildLiveModelCatalogNextPageUrl(pageUrl, result.body);
+  }
+  return rows;
 }
 
 function liveModelCatalogAuthCacheKey(params: LiveModelCatalogHeaderContext): string | undefined {

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -1,5 +1,6 @@
 import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { isNonSecretApiKeyMarker } from "../agents/model-auth-markers.js";
+import { retainSafeHeadersForCrossOriginRedirect } from "../infra/net/redirect-headers.js";
 import {
   clearLiveCatalogCacheForTests,
   getCachedLiveCatalogValue,
@@ -124,14 +125,18 @@ function buildDefaultLiveModelCatalogHeaders(ctx: LiveModelCatalogHeaderContext)
   };
 }
 
-function buildHeaders(params: FetchLiveProviderModelIdsParams): Headers {
-  const requestApiKey = selectLiveModelCatalogRequestApiKey(params);
-  const headers = new Headers(
-    (params.buildRequestHeaders ?? buildDefaultLiveModelCatalogHeaders)({
-      apiKey: normalizeLiveModelCatalogRequestApiKey(params.apiKey),
-      discoveryApiKey: requestApiKey,
-    }),
-  );
+function buildHeaders(
+  params: FetchLiveProviderModelIdsParams,
+  safeReplayHeaders?: Headers,
+): Headers {
+  const headers = safeReplayHeaders
+    ? new Headers(safeReplayHeaders)
+    : new Headers(
+        (params.buildRequestHeaders ?? buildDefaultLiveModelCatalogHeaders)({
+          apiKey: normalizeLiveModelCatalogRequestApiKey(params.apiKey),
+          discoveryApiKey: selectLiveModelCatalogRequestApiKey(params),
+        }),
+      );
   if (!headers.has("accept")) {
     headers.set("accept", "application/json");
   }
@@ -234,12 +239,14 @@ async function fetchLiveProviderModelCatalogPage(
     fetchGuard: LiveModelCatalogFetchGuard;
     url: string;
     timeoutMs: number;
+    safeReplayHeaders?: Headers;
   },
-): Promise<{ body: unknown; finalUrl: string; rows: readonly unknown[] }> {
+): Promise<{ body: unknown; finalUrl: string; requestHeaders: Headers; rows: readonly unknown[] }> {
+  const requestHeaders = buildHeaders(params, params.safeReplayHeaders);
   const { response, finalUrl, release } = await params.fetchGuard({
     url: params.url,
     init: {
-      headers: buildHeaders(params),
+      headers: requestHeaders,
     },
     signal: params.signal,
     timeoutMs: params.timeoutMs,
@@ -254,7 +261,12 @@ async function fetchLiveProviderModelCatalogPage(
       throw new LiveModelCatalogHttpError(params.providerId, response.status);
     }
     const body = await readLiveModelCatalogJson(response, params.timeoutMs);
-    return { body, finalUrl, rows: (params.readRows ?? readDefaultLiveModelCatalogRows)(body) };
+    return {
+      body,
+      finalUrl,
+      requestHeaders,
+      rows: (params.readRows ?? readDefaultLiveModelCatalogRows)(body),
+    };
   } finally {
     await release();
   }
@@ -269,6 +281,7 @@ export async function fetchLiveProviderModelRows(
   const rows: unknown[] = [];
   const seenPageUrls = new Set<string>();
   let pageUrl: string | undefined = params.endpoint;
+  let safeReplayHeaders: Headers | undefined;
   for (let page = 0; page < LIVE_MODEL_CATALOG_MAX_PAGES && pageUrl; page += 1) {
     if (seenPageUrls.has(pageUrl)) {
       break;
@@ -280,13 +293,20 @@ export async function fetchLiveProviderModelRows(
       );
     }
     seenPageUrls.add(pageUrl);
+    const requestedPageUrl = pageUrl;
     const result = await fetchLiveProviderModelCatalogPage({
       ...params,
       fetchGuard,
-      url: pageUrl,
+      url: requestedPageUrl,
       timeoutMs: remainingTimeoutMs,
+      safeReplayHeaders,
     });
     rows.push(...result.rows);
+    if (safeReplayHeaders || new URL(result.finalUrl).origin !== new URL(requestedPageUrl).origin) {
+      safeReplayHeaders = new Headers(
+        retainSafeHeadersForCrossOriginRedirect(result.requestHeaders),
+      );
+    }
     const nextPage = resolveLiveModelCatalogNextPage(result.finalUrl, result.body);
     if (nextPage.status === "incomplete") {
       throw new Error(

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -242,6 +242,7 @@ export async function fetchLiveProviderModelRows(
 ): Promise<readonly unknown[]> {
   const fetchGuard = params.fetchGuard ?? fetchWithSsrFGuard;
   const timeoutMs = params.timeoutMs ?? 5_000;
+  const startedAt = Date.now();
   const rows: unknown[] = [];
   const seenPageUrls = new Set<string>();
   let pageUrl: string | undefined = params.endpoint;
@@ -249,15 +250,26 @@ export async function fetchLiveProviderModelRows(
     if (seenPageUrls.has(pageUrl)) {
       break;
     }
+    const remainingTimeoutMs = timeoutMs - (Date.now() - startedAt);
+    if (remainingTimeoutMs <= 0) {
+      throw new Error(
+        `${params.providerId} model discovery exceeded ${timeoutMs}ms before the catalog completed`,
+      );
+    }
     seenPageUrls.add(pageUrl);
     const result = await fetchLiveProviderModelCatalogPage({
       ...params,
       fetchGuard,
       url: pageUrl,
-      timeoutMs,
+      timeoutMs: remainingTimeoutMs,
     });
     rows.push(...result.rows);
     pageUrl = buildLiveModelCatalogNextPageUrl(pageUrl, result.body);
+  }
+  if (pageUrl) {
+    throw new Error(
+      `${params.providerId} model discovery exceeded ${LIVE_MODEL_CATALOG_MAX_PAGES} pages before the catalog completed`,
+    );
   }
   return rows;
 }

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -189,21 +189,44 @@ function readLiveModelCatalogCursor(
   return nextPageToken ? { name: "pageToken", value: nextPageToken } : undefined;
 }
 
-function buildLiveModelCatalogNextPageUrl(currentUrl: string, body: unknown): string | undefined {
+type LiveModelCatalogNextPageResolution =
+  | { status: "complete" }
+  | { status: "incomplete" }
+  | { status: "next"; url: string };
+
+function bodyAdvertisesMoreLiveModelCatalogPages(body: unknown): boolean {
+  const record = readLiveModelCatalogRecord(body);
+  if (!record || record.has_more === false) {
+    return false;
+  }
+  return Boolean(
+    record.has_more === true ||
+    readLiveModelCatalogNextUrl(body) ||
+    readLiveModelCatalogString(record.next_cursor) ||
+    readLiveModelCatalogString(record.nextPageToken),
+  );
+}
+
+function resolveLiveModelCatalogNextPage(
+  currentUrl: string,
+  body: unknown,
+): LiveModelCatalogNextPageResolution {
   const rawNextUrl = readLiveModelCatalogNextUrl(body);
   if (rawNextUrl) {
     const nextUrl = new URL(rawNextUrl, currentUrl);
     if (nextUrl.origin === new URL(currentUrl).origin) {
-      return nextUrl.toString();
+      return { status: "next", url: nextUrl.toString() };
     }
   }
   const cursor = readLiveModelCatalogCursor(body);
-  if (!cursor) {
-    return undefined;
+  if (cursor) {
+    const nextUrl = new URL(currentUrl);
+    nextUrl.searchParams.set(cursor.name, cursor.value);
+    return { status: "next", url: nextUrl.toString() };
   }
-  const nextUrl = new URL(currentUrl);
-  nextUrl.searchParams.set(cursor.name, cursor.value);
-  return nextUrl.toString();
+  return bodyAdvertisesMoreLiveModelCatalogPages(body)
+    ? { status: "incomplete" }
+    : { status: "complete" };
 }
 
 async function fetchLiveProviderModelCatalogPage(
@@ -264,7 +287,13 @@ export async function fetchLiveProviderModelRows(
       timeoutMs: remainingTimeoutMs,
     });
     rows.push(...result.rows);
-    pageUrl = buildLiveModelCatalogNextPageUrl(pageUrl, result.body);
+    const nextPage = resolveLiveModelCatalogNextPage(pageUrl, result.body);
+    if (nextPage.status === "incomplete") {
+      throw new Error(
+        `${params.providerId} model discovery did not include a supported next page before the catalog completed`,
+      );
+    }
+    pageUrl = nextPage.status === "next" ? nextPage.url : undefined;
   }
   if (pageUrl) {
     throw new Error(

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -235,8 +235,8 @@ async function fetchLiveProviderModelCatalogPage(
     url: string;
     timeoutMs: number;
   },
-): Promise<{ body: unknown; rows: readonly unknown[] }> {
-  const { response, release } = await params.fetchGuard({
+): Promise<{ body: unknown; finalUrl: string; rows: readonly unknown[] }> {
+  const { response, finalUrl, release } = await params.fetchGuard({
     url: params.url,
     init: {
       headers: buildHeaders(params),
@@ -254,7 +254,7 @@ async function fetchLiveProviderModelCatalogPage(
       throw new LiveModelCatalogHttpError(params.providerId, response.status);
     }
     const body = await readLiveModelCatalogJson(response, params.timeoutMs);
-    return { body, rows: (params.readRows ?? readDefaultLiveModelCatalogRows)(body) };
+    return { body, finalUrl, rows: (params.readRows ?? readDefaultLiveModelCatalogRows)(body) };
   } finally {
     await release();
   }
@@ -287,7 +287,7 @@ export async function fetchLiveProviderModelRows(
       timeoutMs: remainingTimeoutMs,
     });
     rows.push(...result.rows);
-    const nextPage = resolveLiveModelCatalogNextPage(pageUrl, result.body);
+    const nextPage = resolveLiveModelCatalogNextPage(result.finalUrl, result.body);
     if (nextPage.status === "incomplete") {
       throw new Error(
         `${params.providerId} model discovery did not include a supported next page before the catalog completed`,


### PR DESCRIPTION
## Summary

What problem does this PR solve?
Fixes a root-cause live provider discovery issue where `/models` pagination metadata was parsed but the discovery result could still be incomplete or cross a redirect auth boundary incorrectly: first-page-only catalogs hid later models, page-cap exhaustion could return a truncated catalog as success, explicit `has_more: true` without a supported next page could be cached as complete, redirected relative `links.next` values could resolve against the pre-redirect request URL, and redirected-origin follow-up pages could rebuild provider credentials after the guarded fetch had stripped them.

Why does this matter now?
Users whose providers paginate model catalogs can miss valid models even when the provider advertises them. The failure mode is especially confusing because a truncated live catalog can look successful and then hide models until the cache expires or static fallback is used.

What is the intended outcome?
Root-cause fix: live model discovery now treats the provider catalog as incomplete until the pagination contract reaches a real terminal page. It follows same-origin `next_cursor`, `nextPageToken`, `next`, and `links.next`, resolves relative next links against the guarded fetch final URL, preserves the guarded fetch redirect-auth stripping boundary for redirected-origin follow-up pages, shares one timeout budget across the whole discovery refresh, and fails unfinished catalogs instead of returning partial rows.

What is intentionally out of scope?
Out of scope: no provider auth changes, no config/schema/default/migration changes, no static model definition changes, no provider routing changes, and no non-model request behavior changes. This keeps the public contract surface limited to runtime interpretation of existing provider pagination metadata.

What does success look like?
A paginated provider catalog returns models from later pages; malformed or unbounded pagination does not cache a truncated live catalog; redirected relative next links fetch the canonical redirected path; static provider rows remain the fallback when live discovery is unavailable.

What should reviewers focus on?
Review the pagination resolver invariants and the source-of-truth boundary: the guarded fetch final URL is the canonical base for relative pagination links, same-origin checks still gate absolute next links, cross-origin redirect auth stripping is preserved for follow-up page requests, and incomplete provider pagination is treated as unavailable instead of being mirrored into cache as a complete catalog.

- Fix classification: Root-cause fix for live model catalog pagination completion and URL resolution.
- Maintainer-ready confidence: High; focused regression tests cover each reviewer finding, a local paginated stub exercises the live runtime fetch path, and ClawSweeper commit review passed on the current head.
- Root cause: The live catalog discovery resolver did not enforce the provider pagination completion and redirect-auth invariants. It could consume only the first page, accept partial rows after a page cap or unsupported continuation, resolve relative next links from the original request URL instead of the guarded fetch final URL returned after redirects, and rebuild provider credentials for redirected-origin follow-up pages after guarded fetch had stripped them.
- Why this is root-cause fix: The patch fixes the resolver at the source boundary that decides whether a provider catalog is complete and which headers are safe to replay. It follows supported same-origin continuation signals until completion, fails explicit incomplete catalogs before caching, applies one discovery timeout budget, uses the guarded response final URL as the canonical pagination base, and replays only cross-origin-safe headers after a redirected final origin rather than masking symptoms downstream.

## Linked context

Which issue does this close?
None. This updates existing PR #97012 and leaves any issue closure decision to maintainers.

Closes #
None.

Which issues, PRs, or discussions are related?
Related: existing PR #97012 reviewer discussion requesting real behavior proof and fixes for pagination budget/truncation behavior.

Related #
PR #97012.

Was this requested by a maintainer or owner?
The follow-up work addresses ClawSweeper reviewer findings on PR #97012, including the real behavior proof request, page-budget/truncated-catalog findings, and the redirected relative-next finding.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Live provider model discovery follows a paginated `/v1/models` catalog through multiple pages and returns models from later pages instead of stopping at the first page.
- Real environment tested: Local HTTP stub server on loopback exercised through the live runtime fetch path with the SSRF guard policy adjusted only to permit loopback HTTP for this proof. No API keys, public endpoints, or non-public provider hosts were used.
- Exact steps or command run after this patch: Ran the local paginated catalog proof script against the current PR head, then ran the focused live catalog regression suite.
- Evidence after fix:

  ```text
  local paginated catalog proof
  endpoint: http://127.0.0.1:<redacted-port>/v1/models
  requests: GET /v1/models | GET /v1/models?after=cursor-2 | GET /v1/models?after=cursor-3
  model ids: model-page-1, model-page-2, model-page-3
  pages followed: 3
  elapsed ms: 221
  ```

  ```text
  RUN  v4.1.8

  Test Files  1 passed (1)
       Tests  19 passed (19)
    Duration  6.09s
  ```

- Observed result after fix: The runtime fetch path made three sequential catalog requests, followed `next_cursor` through two continuations, and returned `model-page-1`, `model-page-2`, and `model-page-3`. The focused regression suite also passed all 19 live catalog tests on the current patch.
- What was not tested: No external provider account or public provider endpoint was called, and no UI flow was exercised. This PR is scoped to the plugin SDK live model catalog runtime helper, so the proof uses the runtime function directly with a controlled paginated provider stub.
- Proof limitations or environment constraints: The proof is near-real rather than vendor-live: the HTTP server is local and redacted, but the production runtime fetch path, guarded fetch behavior, pagination parsing, same-origin continuation, and model-id projection are exercised.

## Tests and validation

Which commands did you run?
- Focused regression suite for the live catalog runtime: `pnpm exec vitest run src/plugin-sdk/provider-catalog-live-runtime.test.ts`.
- Targeted red/green checks for page-cap exhaustion, total timeout budget, explicit incomplete pagination, and redirected relative next-link resolution.
- Local paginated catalog proof through the live runtime fetch path using a redacted loopback stub server.
- ClawSweeper commit review on the current head; result passed.

What regression coverage was added or updated?
- Added coverage for `next_cursor` pagination returning later-page models.
- Added coverage for absolute `next`, nested `links.next`, and `nextPageToken` pagination.
- Added coverage that page-cap exhaustion rejects instead of returning partial rows.
- Added coverage that one timeout budget is shared across paginated discovery.
- Added coverage that explicit `has_more: true` without a supported continuation rejects before rows can be cached.
- Added coverage that relative `links.next` after a redirect resolves against the guarded fetch final URL.
- Added coverage that redirected-origin pagination follow-up requests do not re-add `Authorization` or account metadata after guarded fetch has stripped cross-origin credentials.

What failed before this fix, if known?
- Page-cap red test failed because discovery resolved a partial list `model-0` through `model-49` instead of rejecting.
- Total-timeout red test failed because the second page still received the full `1000ms` timeout instead of the remaining `200ms` after an `800ms` first page.
- Incomplete-pagination red test failed because `has_more: true` without a supported next page resolved `model-a` instead of rejecting.
- Redirected relative-next red test failed because `links.next: "?page=2"` after a guarded fetch final URL ending in `/v1/models/` resolved to `/v1/models?page=2` instead of `/v1/models/?page=2`.
- Redirected auth-boundary red test failed because the second page re-added `Authorization: Bearer provider-token` after the first page had a different guarded fetch final origin.

If no test was added, why not?
Not applicable; focused regression tests were added for the new pagination completion, timeout, truncation, and redirected relative-link behavior.

- Target test file: `src/plugin-sdk/provider-catalog-live-runtime.test.ts`.
- Scenario locked in: paginated provider catalogs must keep fetching supported same-origin continuations until completion and must reject unfinished catalogs before caching partial rows.
- Why this is the smallest reliable guardrail: The tests exercise the public runtime helper with mocked guarded fetch responses for precise red/green assertions, while the local stub proof verifies the same runtime path against real HTTP pagination.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes. Users can see models from later live catalog pages, and malformed incomplete live catalogs now fall back to static provider rows instead of being treated as a successful truncated live catalog.

Did config, environment, or migration behavior change? (`Yes/No`)
No. No config keys, environment variables, migrations, defaults, or schema behavior changed.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
Yes, the patch explicitly preserves an existing security boundary for redirected pagination. Network behavior remains constrained to guarded same-origin catalog pagination; relative pagination uses the guarded fetch final URL, absolute next links still require the same origin, and follow-up pagination after a cross-origin redirect replays only headers that the existing redirect boundary marks safe.

What is the highest-risk area?
Merge risk: auth-provider / security-boundary / live provider discovery. The risk is extra provider catalog requests when a provider advertises pagination, plus public contract risk around existing provider pagination fields such as `links.next`, and the redirected-origin credential boundary called out by ClawSweeper.

How is that risk mitigated?
Risk mitigated by keeping the contract surface canonical and narrow: only existing pagination hints are interpreted, no provider schema/config/default/migration behavior changes, absolute links must stay same-origin, duplicate page URLs are bounded, discovery has a 50-page cap, all pages share one timeout budget, incomplete catalogs fail closed to the existing static rows fallback, and redirected-origin follow-up pages reuse the existing `retainSafeHeadersForCrossOriginRedirect` contract instead of rebuilding provider credentials. Related open PR / same-contract scan found this is an existing PR update, not a new competing canonical PR. Patch quality warnings for guards/default returns are intentional parser boundary handling for untrusted provider JSON, not symptom masking.

What is the next action?
Update PR #97012 with this body and current commits, then let the normal remote PR checks and ClawSweeper review run.

- Risk labels considered: merge-risk auth-provider, security-boundary, and live provider discovery risk.
- Risk explanation: A provider can now cause multiple guarded catalog requests when it advertises pagination, and redirected final origins must not receive provider credentials that guarded fetch already stripped.
- Why acceptable: The behavior only follows provider-declared same-origin catalog pagination, rejects unfinished catalogs before caching, preserves static model fallback if live discovery cannot complete, and replays only cross-origin-safe headers after redirected final origins.
- Patch quality notes: Added guard/default returns are parser-boundary checks for untrusted provider response shapes; timeout changes reduce maximum total discovery latency rather than expanding it per page; redirect header replay delegates to the existing network boundary helper; public contract compatibility is backward-compatible because existing single-page catalogs and static fallback behavior remain unchanged.

## Current review state

What is still waiting on author, maintainer, CI, or external proof?
Nothing known locally after the current update: focused tests pass, local runtime proof is included, ClawSweeper commit review passed, and the remaining checks are remote PR settle/re-review signals after submission.

Which bot or reviewer comments were addressed?
- RF-001 fixed: added redacted real behavior proof from a local paginated provider stub showing three pages followed through the live runtime fetch path.
- RF-002 fixed: PR body now includes terminal proof output, observed model IDs, request sequence, and proof limitations instead of listing tests only.
- RF-003 fixed: paginated discovery now uses one timeout budget across the full refresh, with a red/green regression showing the second page receives the remaining budget.
- RF-004 fixed: page-cap exhaustion now rejects instead of returning collected partial rows as success.
- RF-005 fixed: the contributor proof gate, page-budget behavior, and PR body mapping are all addressed before submit.
- RF-006 fixed: truncated or explicitly incomplete catalogs fail before rows can be returned or cached.
- ClawSweeper follow-up fixed: redirected relative `links.next` values now resolve against the guarded fetch final URL, covered by a red/green regression.
- ClawSweeper P1 redirected auth-boundary finding fixed: when the first catalog request has a different guarded fetch final origin, follow-up pagination requests now replay only cross-origin-safe headers and do not re-add provider `Authorization` or account metadata, covered by a red/green regression.
