### PR TITLE
fix(logging): redact Telegram bot tokens from fetch timeout URLs

### DIFF
--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -144,6 +144,81 @@ describe("buildTimeoutAbortSignal", () => {
     cleanup();
   });
 
+  it("redacts Telegram bot token embedded in an absolute URL path", async () => {
+    const { cleanup } = buildTimeoutAbortSignal({
+      timeoutMs: 25,
+      operation: "unit-test",
+      url: "https://api.telegram.org/bot123456:ABCdefGHIjklMNOpqrST/sendMessage?chat_id=1",
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    const record = requireWarnRecord(0);
+    expect(record.url).toBe("https://api.telegram.org/botredacted/sendMessage");
+    expect(String(record.consoleMessage)).toContain(
+      "url=https://api.telegram.org/botredacted/sendMessage",
+    );
+    expect(String(record.consoleMessage)).not.toContain("123456:ABCdefGHIjklMNOpqrST");
+    expect(String(record.url)).not.toContain("123456:ABCdefGHIjklMNOpqrST");
+
+    cleanup();
+  });
+
+  it("redacts Telegram bot token embedded in a relative URL path", async () => {
+    const { cleanup } = buildTimeoutAbortSignal({
+      timeoutMs: 25,
+      operation: "unit-test",
+      url: "/bot123456:ABCdefGHIjklMNOpqrST/sendMessage",
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    const record = requireWarnRecord(0);
+    expect(record.url).toBe("/botredacted/sendMessage");
+    expect(String(record.url)).not.toContain("123456:ABCdefGHIjklMNOpqrST");
+
+    cleanup();
+  });
+
+  it("leaves non-Telegram paths containing 'bot' as a subsegment unchanged", async () => {
+    const { cleanup } = buildTimeoutAbortSignal({
+      timeoutMs: 25,
+      operation: "unit-test",
+      url: "https://api.example.com/v1/bots/chat?x=1",
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    const record = requireWarnRecord(0);
+    expect(record.url).toBe("https://api.example.com/v1/bots/chat");
+    expect(String(record.url)).not.toContain("redacted");
+
+    cleanup();
+  });
+
+  it("redacts Telegram bot token before truncating to LOG_URL_MAX_CHARS", async () => {
+    const longToken = "A".repeat(20);
+    const url =
+      "https://api.telegram.org/bot123456:" + longToken + "/" + "f".repeat(500) + "/sendMessage";
+
+    const { cleanup } = buildTimeoutAbortSignal({
+      timeoutMs: 25,
+      operation: "unit-test",
+      url,
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    const record = requireWarnRecord(0);
+    const logged = String(record.url);
+    expect(logged.endsWith("...")).toBe(true);
+    expect(logged.includes("/botredacted/")).toBe(true);
+    expect(logged.includes("123456:")).toBe(false);
+    expect(logged.includes(longToken)).toBe(false);
+
+    cleanup();
+  });
+
   it("tags fetch timeout aborts so callers can distinguish them from parent aborts", async () => {
     const fetchFn = vi.fn<typeof fetch>(
       async (_input, init) =>

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -5,6 +5,23 @@ import { resolveSafeTimeoutDelayMs } from "./timer-delay.js";
 const log = createSubsystemLogger("fetch-timeout");
 const LOG_URL_MAX_CHARS = 500;
 const URL_SECRET_SUFFIX_PATTERN = /[?#]/;
+// Matches `/bot<TOKEN>` as a single path segment, where the Telegram token
+// shape is `<bot_id>:<secret>` (bot_id: 6+ digits, secret: 20+ base64url
+// chars). The leading `/` and trailing `/` (or EOS) enforce segment
+// boundaries so substrings like `bots`, `/v1/bots/chat`, `/botcat` never
+// match.
+const TELEGRAM_BOT_TOKEN_PATH_PATTERN = /\/bot(\d{6,}:[A-Za-z0-9_-]{20,})(?=\/|$)/g;
+
+/**
+ * Redacts Telegram Bot API tokens embedded as `/bot<TOKEN>` path segments
+ * so the full token never reaches a log line. Downstream `redactSensitiveText`
+ * would only emit a hinted mask (prefix+suffix retained) and is gated by
+ * config; this path-aware step guarantees full replacement even when
+ * downstream redaction is disabled.
+ */
+function redactTelegramBotTokenInPath(url: string): string {
+  return url.replace(TELEGRAM_BOT_TOKEN_PATH_PATTERN, "/botredacted");
+}
 
 type TimeoutAbortSignalParams = {
   timeoutMs?: number;
@@ -39,15 +56,17 @@ function sanitizeTimeoutLogUrl(rawUrl: string | undefined): string | undefined {
     parsed.password = "";
     parsed.search = "";
     parsed.hash = "";
-    const value = parsed.toString();
+    const value = redactTelegramBotTokenInPath(parsed.toString());
     return value.length > LOG_URL_MAX_CHARS ? `${value.slice(0, LOG_URL_MAX_CHARS)}...` : value;
   } catch {
     const withoutQueryOrHash = trimmed.split(URL_SECRET_SUFFIX_PATTERN, 1)[0] ?? "";
-    const cleaned = withoutQueryOrHash
-      .replace(/[\r\n\u2028\u2029]+/g, " ")
-      .replace(/\p{Cc}+/gu, " ")
-      .replace(/\s+/g, " ")
-      .trim();
+    const cleaned = redactTelegramBotTokenInPath(
+      withoutQueryOrHash
+        .replace(/[\r\n\u2028\u2029]+/g, " ")
+        .replace(/\p{Cc}+/gu, " ")
+        .replace(/\s+/g, " ")
+        .trim(),
+    );
     if (!cleaned) {
       return undefined;
     }


### PR DESCRIPTION
## What Problem This Solves

`src/utils/fetch-timeout.ts` contains `sanitizeTimeoutLogUrl`, which
strips URL username, password, query, and fragment before logging.
Telegram Bot API URLs embed the bot token in the path segment, so the
existing sanitization still leaks the full token into fetch timeout
logs and console diagnostics whenever a Telegram channel HTTP request
times out.

Closes #96982.

## Why This Change Was Made

Downstream `redactSensitiveText` in `src/logging/redact.ts` already has
a Telegram pattern wired through the logger pipeline, but it is
insufficient for two reasons. First, it emits a hinted mask with a
6-character prefix and a 4-character suffix retained, which is still a
partial token leak. Second, it is gated by a configuration flag, so a
misconfigured or disabled redactor ships the full token in cleartext.

A path-aware redaction inside `sanitizeTimeoutLogUrl` itself removes
the dependency on downstream redaction and guarantees full replacement
even when downstream redaction is disabled.

The new regex is a strict token-shape path-segment match that requires
both the path-segment boundary and the real Telegram token shape, so
unrelated paths containing the substring `bot` are not redacted. The
placeholder is the literal string `redacted`, matching the existing
house style for substituted secrets.

## User Impact

Behavior is unchanged. The fix is logging only. Telegram bot tokens no
longer appear in fetch timeout log lines or user-facing console
messages, even when downstream redaction is disabled. Performance is
unchanged: the regex is local, has no nested quantifiers, and runs
once per timeout log emission.

## Evidence

I ran the affected vitest file locally and all 14 tests pass (10
pre-existing plus 4 new). The 4 new tests are:

- `redacts Telegram bot token embedded in an absolute URL path`
  covers the URL parser branch and asserts the recorded URL becomes
  the redacted form.
- `redacts Telegram bot token embedded in a relative URL path` covers
  the fallback string-cleaning branch.
- `leaves non-Telegram paths containing bot as a subsegment unchanged`
  is the false-positive guard for unrelated paths.
- `redacts Telegram bot token before truncating to LOG_URL_MAX_CHARS`
  asserts the redaction runs before the 500-character truncation so
  long tokens are fully replaced rather than sliced.

I also ran the repository's `oxfmt` and `oxlint` wrappers on the two
changed files. Formatting is clean and there are zero lint warnings.

No new exports, no new imports, no signature changes. The change is
internal to `src/utils/fetch-timeout.ts`.

### Files changed

- `src/utils/fetch-timeout.ts`: +25 lines, -6 lines.
- `src/utils/fetch-timeout.test.ts`: +75 lines, -0 lines.
