### PR TITLE
fix(thinking): strip non-replayable thinking signatures from the latest assistant turn

### DIFF
--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -287,7 +287,7 @@ describe("stripInvalidThinkingSignatures", () => {
     expect(result).toBe(messages);
   });
 
-  it("preserves invalid thinking signatures on the latest assistant message", () => {
+  it("strips invalid thinking signatures from the latest assistant message by default", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({ role: "user", content: "hello" }),
       castAgentMessage({
@@ -305,14 +305,35 @@ describe("stripInvalidThinkingSignatures", () => {
     const result = stripInvalidThinkingSignatures(messages);
     const assistant = result[1] as Extract<AgentMessage, { role: "assistant" }>;
 
-    expect(result).toBe(messages);
+    // The non-replayable thinking blocks (missing / empty / blank signature) on
+    // the latest assistant turn are now dropped so providers do not reject the
+    // outbound request; the validly-signed thinking block and text survive.
+    expect(result).not.toBe(messages);
     expect(assistant.content).toEqual([
-      { type: "thinking", thinking: "missing" },
-      { type: "thinking", thinking: "empty", thinkingSignature: "" },
-      { type: "thinking", thinking: "blank", thinkingSignature: "   " },
       { type: "thinking", thinking: "signed", thinkingSignature: "sig" },
       { type: "text", text: "answer" },
     ]);
+  });
+
+  it("returns the latest assistant message byte-identical when its thinking is validly signed", () => {
+    const signedAssistant = castAgentMessage({
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "internal", thinkingSignature: "sig" },
+        { type: "text", text: "answer" },
+      ],
+    });
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "hello" }),
+      signedAssistant,
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+
+    // A healthy signed latest turn must never be rewritten: the same array and
+    // the same message object reference are returned unchanged.
+    expect(result).toBe(messages);
+    expect(result[1]).toBe(signedAssistant);
   });
 
   it("can strip invalid thinking signatures from the latest assistant message", () => {

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -247,11 +247,18 @@ function hasReplayableThinkingSignature(block: AssistantContentBlock): boolean {
  * absent, empty, or blank. They are also the authority for opaque signature
  * validity, so this intentionally avoids local length or shape heuristics.
  *
- * By default, the latest assistant turn is exempt: providers reject modified
- * latest thinking blocks, so corrupted latest turns must flow through recovery
- * rather than being rewritten before the request. Callers that append a new
- * user turn before provider replay can disable that exemption because the
- * stored assistant turn is no longer latest in the outbound request.
+ * Non-replayable thinking blocks are dropped from every assistant turn,
+ * including the latest one: shipping an unsigned/blank latest thinking block
+ * makes providers reject the request ("signature headers are missing" /
+ * "cannot be modified") and wedges the session in a retry loop. Validly-signed
+ * thinking blocks are preserved byte-identical (the original message reference
+ * is reused when nothing in that turn changed), so healthy signed turns are
+ * never rewritten.
+ *
+ * The preserveLatestAssistant option is retained for callers that distinguish
+ * the latest assistant turn (e.g. when a new user turn is appended before
+ * replay so the stored assistant turn is no longer latest); it no longer
+ * exempts that turn from stripping.
  */
 export function stripInvalidThinkingSignatures(
   messages: AgentMessage[],
@@ -278,7 +285,30 @@ export function stripInvalidThinkingSignatures(
       continue;
     }
     if (i === latestAssistantIndex) {
-      out.push(message);
+      // The latest assistant turn must not ship thinking blocks that lack a
+      // replayable signature: providers reject an unsigned/invalid latest
+      // thinking block ("signature headers are missing" / "cannot be
+      // modified"), which wedges the session in a retry loop. Drop only the
+      // non-replayable thinking blocks here; validly-signed blocks are kept
+      // byte-identical (original message reference is reused when unchanged).
+      const latestContent: AssistantContentBlock[] = [];
+      let latestChanged = false;
+      for (const block of message.content) {
+        if (!isThinkingBlock(block) || hasReplayableThinkingSignature(block)) {
+          latestContent.push(block);
+          continue;
+        }
+        latestChanged = true;
+        touched = true;
+      }
+      if (!latestChanged) {
+        out.push(message);
+        continue;
+      }
+      out.push({
+        ...message,
+        content: latestContent.length > 0 ? latestContent : buildOmittedAssistantReasoningContent(),
+      });
       continue;
     }
 


### PR DESCRIPTION
Summary

stripInvalidThinkingSignatures preserves the latest assistant turn verbatim — including thinking blocks that have no replayable signature. On native signed-thinking providers (Anthropic Claude 4.x with extended thinking), an unsigned/blank-signature thinking block in the latest assistant slot is sent to the API, which rejects the request with errors such as "signature headers are missing" or "thinking block ... cannot be modified".
The agent runner then retries with the same (still-invalid) payload, fails again, and the session wedges — every subsequent turn produces "assistant turn failed before producing content" until a /reset.
This is reproducible with thinking: max on claude-opus-4-*: an unsigned thinking block reliably lands in the latest slot after a replay/compaction pass (signatures can be lost when the prefix changes), and the latest-slot exemption ships it straight to Anthropic.
Root cause

Two places encode "preserve the latest assistant turn", but the decision is positional, never signature-aware:
shouldPreserveLatestAssistantThinking() returns true based on position / current-tool-turn reasoning — it never checks whether the latest thinking block is actually replayable (signed).
stripInvalidThinkingSignatures() honors that preserve flag with an unconditional early continue for the latest slot — so a non-replayable thinking block in that slot bypasses the very signature check the function exists to perform.
Result: an unsigned latest thinking block — which the provider will reject regardless — is preserved instead of stripped.
Fix (this PR)

Make the latest-slot branch of stripInvalidThinkingSignatures run the same strip pass as non-latest turns, but only for thinking blocks without a replayable signature:
Non-replayable thinking blocks in the latest slot are dropped (this is what unwedges the session — an unsigned block is rejected anyway, so dropping it is strictly safer than shipping it).
Validly-signed thinking blocks are preserved byte-identical — when nothing changes, the original message reference is reused (no rewrite), so the provider's "preserved thinking blocks must be returned unmodified" contract is upheld.
dropThinkingBlocks and the preserveLatestAssistant option are untouched; callers that explicitly opt out (compact.ts) keep their behavior.
Tests

Updated the existing test that encoded the old behavior (latest unsigned blocks surviving) to assert the fixed behavior.
Added a regression test proving a validly-signed latest thinking block is returned by reference identity (never rewritten).
Full thinking.test.ts suite passes (47/47).
Alternative considered (discussion)

A cleaner-but-larger fix would make the preserve decision itself signature-aware: have shouldPreserveLatestAssistantThinking() (or the replay caller in replay-history.ts) return false when the latest assistant thinking block lacks a replayable signature, rather than fixing it at the strip step. That keeps the strip function's latest-slot exemption intact and pushes the correctness up to where the intent is decided.
We went with the strip-step fix here because it's minimal, local, and guarantees no unsigned latest block can reach the provider regardless of which call-site or preserve heuristic is in play — but maintainers may prefer the signature-aware preserve decision as the "true" fix, or both. Happy to reshape.
Verification

Beyond unit tests, the fix was applied to a live build and validated with a fresh opus + thinking: max session running 6 sequential tool turns (the exact replay pattern that previously wedged): completed 6/6 with zero signature/replay errors.
