### PR TITLE
fix(stream-wrapper): convert Anthropic custom tools to OpenAI function format in bridge

### DIFF
--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
@@ -276,19 +276,21 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
       },
     });
 
+    // Custom tools are projected to OpenAI function format (#97020).
     expect(payload).toEqual({
       tools: [
         {
-          type: "custom",
-          custom: {
+          type: "function",
+          function: {
             name: "shell",
             description: "Run a shell command.",
+            parameters: { type: "object", properties: {} },
           },
         },
       ],
       tool_choice: {
-        type: "custom",
-        custom: { name: "shell" },
+        type: "function",
+        function: { name: "shell" },
       },
     });
   });

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
@@ -327,7 +327,7 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
       type: "allowed_tools",
       allowed_tools: {
         mode: "required",
-        tools: [{ type: "custom", custom: { name: "shell" } }],
+        tools: [{ type: "function", function: { name: "shell" } }],
       },
     });
   });

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
@@ -372,7 +372,16 @@ function normalizeAllowedToolChoice(
     const definitionKey = isCustom ? "custom" : kind;
     const definition = definitionKey && isRecord(snapshot[definitionKey]) ? snapshot[definitionKey] : undefined;
     const name = definition ? (normalizeOptionalString(definition.name) ?? "") : "";
-    return kind && name && isProjectedToolAvailable(toolProjection, kind, name) ? [snapshot] : [];
+    if (!kind || !name || !isProjectedToolAvailable(toolProjection, kind, name)) return [];
+    // Project custom allowed_tools entries to function format (#97020).
+    if (isCustom) {
+      const desc = normalizeOptionalString(snapshot.custom.description) ?? undefined;
+      return [{
+        type: "function",
+        function: { name, ...(desc ? { description: desc } : {}) },
+      }];
+    }
+    return [snapshot];
   });
   if (tools.length === 0) {
     if (mode === "auto") {

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
@@ -243,8 +243,12 @@ function normalizeOpenAiFunctionAnthropicToolDefinition(
       const description = normalizeOptionalString(snapshot.custom.description) ?? undefined;
       let parameters: unknown = { type: "object", properties: {} };
       if (isRecord(snapshot.custom.input_schema)) {
-        const projected = projectJsonObjectSchema(snapshot.custom.input_schema, `${name}.input_schema`);
-        if (projected) parameters = projected;
+        const projected = projectJsonObjectSchema(
+          snapshot.custom.input_schema,
+          `${name}.input_schema`,
+        );
+        if (!projected) return undefined;
+        parameters = projected;
       }
       return {
         kind: "function",
@@ -366,20 +370,22 @@ function normalizeAllowedToolChoice(
       return [];
     }
     const isCustom = snapshot.type === "custom";
-    const kind =
-      isCustom || snapshot.type === "function" ? "function" : undefined;
+    const kind = isCustom || snapshot.type === "function" ? "function" : undefined;
     // Custom tools store their definition under "custom", not "function" (#97020).
     const definitionKey = isCustom ? "custom" : kind;
-    const definition = definitionKey && isRecord(snapshot[definitionKey]) ? snapshot[definitionKey] : undefined;
+    const definition =
+      definitionKey && isRecord(snapshot[definitionKey]) ? snapshot[definitionKey] : undefined;
     const name = definition ? (normalizeOptionalString(definition.name) ?? "") : "";
     if (!kind || !name || !isProjectedToolAvailable(toolProjection, kind, name)) return [];
     // Project custom allowed_tools entries to function format (#97020).
     if (isCustom) {
-      const desc = normalizeOptionalString(snapshot.custom.description) ?? undefined;
-      return [{
-        type: "function",
-        function: { name, ...(desc ? { description: desc } : {}) },
-      }];
+      const desc = normalizeOptionalString(definition?.description) ?? undefined;
+      return [
+        {
+          type: "function",
+          function: { name, ...(desc ? { description: desc } : {}) },
+        },
+      ];
     }
     return [snapshot];
   });

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
@@ -237,7 +237,27 @@ function normalizeOpenAiFunctionAnthropicToolDefinition(
     }
     if (snapshot.type === "custom" && isRecord(snapshot.custom)) {
       const name = normalizeOptionalString(snapshot.custom.name) ?? undefined;
-      return name ? { kind: "custom", name, tool: snapshot } : undefined;
+      if (!name) return undefined;
+      // Convert Anthropic custom tool to OpenAI function format (#97020).
+      // type:"custom" is rejected by OpenAI Chat Completions (400).
+      const description = normalizeOptionalString(snapshot.custom.description) ?? undefined;
+      let parameters: unknown = { type: "object", properties: {} };
+      if (isRecord(snapshot.custom.input_schema)) {
+        const projected = projectJsonObjectSchema(snapshot.custom.input_schema, `${name}.input_schema`);
+        if (projected) parameters = projected;
+      }
+      return {
+        kind: "function",
+        name,
+        tool: {
+          type: "function",
+          function: {
+            name,
+            ...(description ? { description } : {}),
+            parameters,
+          },
+        },
+      };
     }
     return { tool: snapshot };
   }
@@ -345,9 +365,12 @@ function normalizeAllowedToolChoice(
     if (!snapshot) {
       return [];
     }
+    const isCustom = snapshot.type === "custom";
     const kind =
-      snapshot.type === "custom" ? "custom" : snapshot.type === "function" ? "function" : undefined;
-    const definition = kind && isRecord(snapshot[kind]) ? snapshot[kind] : undefined;
+      isCustom || snapshot.type === "function" ? "function" : undefined;
+    // Custom tools store their definition under "custom", not "function" (#97020).
+    const definitionKey = isCustom ? "custom" : kind;
+    const definition = definitionKey && isRecord(snapshot[definitionKey]) ? snapshot[definitionKey] : undefined;
     const name = definition ? (normalizeOptionalString(definition.name) ?? "") : "";
     return kind && name && isProjectedToolAvailable(toolProjection, kind, name) ? [snapshot] : [];
   });
@@ -430,15 +453,16 @@ function normalizeOpenAiStringModeAnthropicToolChoice(
   }
   if (choice.type === "custom" && isRecord(choice.custom)) {
     const name = normalizeOptionalString(choice.custom.name) ?? "";
-    if (name && !isProjectedToolAvailable(toolProjection, "custom", name)) {
+    // Custom tools are projected to function format (#97020).
+    if (name && !isProjectedToolAvailable(toolProjection, "function", name)) {
       throw new Error(
         `OpenAI-compatible Anthropic tool_choice requested unavailable tool "${name}" after payload conversion`,
       );
     }
     if (name) {
       return {
-        type: "custom",
-        custom: { name },
+        type: "function",
+        function: { name },
       };
     }
   }


### PR DESCRIPTION
## Summary

- **Problem**: The OpenAI↔Anthropic stream-wrapper bridge preserves custom tools as `type:"custom"` — OpenAI rejects this with HTTP 400. Cross-provider failover from Anthropic-family to OpenAI breaks for any tool-using request.
- **Root cause**: Three emission points in the bridge don't convert to `type:"function"`: tool definitions, `allowed_tools` entries, and `tool_choice`.
- **Fix**: Convert custom tools to `{ type:"function", function: { name, description, parameters } }` (projecting `custom.input_schema`). Convert `tool_choice` and `allowed_tools` entries to function format. All three paths now consistent with canonical `projectOpenAITools`.
- **What did NOT change**: Function-tool projection path unchanged. Non-custom tools unaffected.

Closes #97020

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway (Anthropic→OpenAI stream-wrapper bridge)

## Real behavior proof

**Behavior addressed:** `createOpenAIAnthropicToolPayloadCompatibilityWrapper` now emits custom tools, `allowed_tools` entries, and `tool_choice` as `type:"function"`.

**Environment tested:** Node 24.13.1 on Linux, `node --import tsx` calling real production wrapper.

**Steps run after the patch:** Custom tool payload with custom definitions, `allowed_tools`, and `tool_choice` through the compat wrapper, inspected all three emission points.

**Evidence after fix:**

Tools and tool_choice:
```text
tools[0].type: function
tools[0].function.name: shell
tools[0].function.description: Run a shell command.
tools[0].function.parameters: {"type":"object","properties":{}}
tool_choice.type: function
tool_choice.function.name: shell
```

Allowed_tools (custom entry projected to function):
```text
allowed_tools.tools[0].type: function
allowed_tools.tools[0].function.name: shell
allowed_tools.tools[1].type: function
allowed_tools.tools[1].function.name: grep
RESULT: PASS - allowed_tools custom entry converted to function
```

**Observed result after the fix:** All three emission points convert custom tools to OpenAI-compatible function format. Existing tests: 16/16 passed.

**Not tested:** Live OpenAI API with cross-provider failover. Verified via real production wrapper with compat-flagged model.

## Security Impact

- New permissions? No
- Secrets handling changed? No
- New network calls? No
