### PR TITLE
fix: OpenAI bridge rejects Anthropic custom tools

### DIFF
--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
@@ -259,14 +259,20 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
     });
   });
 
-  it("preserves custom tools and named custom choices", () => {
+  it("converts custom tools and named custom choices to OpenAI functions", () => {
     const payload = runWrapper({
       tools: [
         {
           type: "custom",
+          cache_control: { type: "ephemeral" },
           custom: {
             name: "shell",
             description: "Run a shell command.",
+            input_schema: {
+              type: "object",
+              properties: { command: { type: "string" } },
+              required: ["command"],
+            },
           },
         },
       ],
@@ -279,21 +285,92 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
     expect(payload).toEqual({
       tools: [
         {
-          type: "custom",
-          custom: {
+          type: "function",
+          cache_control: { type: "ephemeral" },
+          function: {
             name: "shell",
             description: "Run a shell command.",
+            parameters: {
+              type: "object",
+              properties: { command: { type: "string" } },
+              required: ["command"],
+            },
           },
         },
       ],
       tool_choice: {
-        type: "custom",
-        custom: { name: "shell" },
+        type: "function",
+        function: { name: "shell" },
       },
     });
   });
 
-  it("filters allowed tool choices against surviving function and custom tools", () => {
+  it("defaults custom tool parameters when no input schema is provided", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          type: "custom",
+          custom: {
+            name: "shell",
+          },
+        },
+      ],
+    });
+
+    expect(payload?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "shell",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ]);
+  });
+
+  it("quarantines custom tools that cannot be projected", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          type: "custom",
+          custom: { description: "Missing tool name." },
+        },
+        {
+          type: "custom",
+          custom: {
+            name: "bad_schema",
+            input_schema: { type: "string" },
+          },
+        },
+      ],
+      tool_choice: { type: "auto" },
+    });
+
+    expect(payload).not.toHaveProperty("tools");
+    expect(payload).not.toHaveProperty("tool_choice");
+  });
+
+  it("rejects named custom choices when the custom tool is quarantined", () => {
+    expect(() =>
+      runWrapper({
+        tools: [
+          {
+            type: "custom",
+            custom: {
+              name: "bad_schema",
+              input_schema: { type: "string" },
+            },
+          },
+        ],
+        tool_choice: {
+          type: "custom",
+          custom: { name: "bad_schema" },
+        },
+      }),
+    ).toThrow('requested unavailable tool "bad_schema"');
+  });
+
+  it("converts allowed custom tool choices against surviving function tools", () => {
     const payload = runWrapper({
       tools: [
         {
@@ -325,7 +402,7 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
       type: "allowed_tools",
       allowed_tools: {
         mode: "required",
-        tools: [{ type: "custom", custom: { name: "shell" } }],
+        tools: [{ type: "function", function: { name: "shell" } }],
       },
     });
   });

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
@@ -14,13 +14,12 @@ type AnthropicToolPayloadCompatibilityOptions = {
 type PayloadFieldRead = { ok: true; value: unknown } | { ok: false };
 
 type OpenAiToolProjection = {
-  readonly kind?: "custom" | "function";
+  readonly kind?: "function";
   readonly name?: string;
   readonly tool: Record<string, unknown>;
 };
 
 type OpenAiFunctionToolsProjection = {
-  readonly customNames: ReadonlySet<string>;
   readonly functionNames: ReadonlySet<string>;
   readonly tools: readonly Record<string, unknown>[];
 };
@@ -111,6 +110,49 @@ function snapshotToolMetadata(tool: Record<string, unknown>): Record<string, unk
     }
   }
   return metadata;
+}
+
+function projectCustomToolSnapshot(
+  snapshot: Record<string, unknown>,
+): OpenAiToolProjection | undefined {
+  if (snapshot.type !== "custom" || !isRecord(snapshot.custom)) {
+    return undefined;
+  }
+  const name = normalizeOptionalString(snapshot.custom.name) ?? undefined;
+  if (!name) {
+    return undefined;
+  }
+  let parameters: Record<string, unknown> = { type: "object", properties: {} };
+  if (snapshot.custom.input_schema !== undefined) {
+    const projectedParameters = projectJsonObjectSchema(
+      snapshot.custom.input_schema,
+      `${name}.input_schema`,
+    );
+    if (!projectedParameters) {
+      return undefined;
+    }
+    parameters = projectedParameters;
+  }
+  const functionSpec: Record<string, unknown> = {
+    name,
+    parameters,
+  };
+  const description = normalizeOptionalString(snapshot.custom.description) ?? undefined;
+  if (description) {
+    functionSpec.description = description;
+  }
+  const metadata = { ...snapshot };
+  delete metadata.type;
+  delete metadata.custom;
+  return {
+    kind: "function",
+    name,
+    tool: {
+      ...metadata,
+      type: "function",
+      function: functionSpec,
+    },
+  };
 }
 
 function hasOpenAiAnthropicToolPayloadCompatFlag(model: { compat?: unknown }): boolean {
@@ -235,9 +277,12 @@ function normalizeOpenAiFunctionAnthropicToolDefinition(
     if (!snapshot) {
       return undefined;
     }
-    if (snapshot.type === "custom" && isRecord(snapshot.custom)) {
-      const name = normalizeOptionalString(snapshot.custom.name) ?? undefined;
-      return name ? { kind: "custom", name, tool: snapshot } : undefined;
+    const customProjection = projectCustomToolSnapshot(snapshot);
+    if (customProjection) {
+      return customProjection;
+    }
+    if (snapshot.type === "custom") {
+      return undefined;
     }
     return { tool: snapshot };
   }
@@ -298,7 +343,6 @@ function projectOpenAiFunctionAnthropicTools(
   tools: readonly unknown[],
 ): OpenAiFunctionToolsProjection {
   const projectedTools: Record<string, unknown>[] = [];
-  const customNames = new Set<string>();
   const functionNames = new Set<string>();
   for (const tool of tools) {
     const projection = normalizeOpenAiFunctionAnthropicToolDefinition(tool);
@@ -306,14 +350,11 @@ function projectOpenAiFunctionAnthropicTools(
       continue;
     }
     projectedTools.push(projection.tool);
-    if (projection.kind === "custom" && projection.name) {
-      customNames.add(projection.name);
-    } else if (projection.kind === "function" && projection.name) {
+    if (projection.kind === "function" && projection.name) {
       functionNames.add(projection.name);
     }
   }
   return {
-    customNames,
     functionNames,
     tools: projectedTools,
   };
@@ -321,12 +362,9 @@ function projectOpenAiFunctionAnthropicTools(
 
 function isProjectedToolAvailable(
   projection: OpenAiFunctionToolsProjection | undefined,
-  kind: "custom" | "function",
   name: string,
 ): boolean {
-  return (
-    !projection || (kind === "custom" ? projection.customNames : projection.functionNames).has(name)
-  );
+  return !projection || projection.functionNames.has(name);
 }
 
 function normalizeAllowedToolChoice(
@@ -349,7 +387,9 @@ function normalizeAllowedToolChoice(
       snapshot.type === "custom" ? "custom" : snapshot.type === "function" ? "function" : undefined;
     const definition = kind && isRecord(snapshot[kind]) ? snapshot[kind] : undefined;
     const name = definition ? (normalizeOptionalString(definition.name) ?? "") : "";
-    return kind && name && isProjectedToolAvailable(toolProjection, kind, name) ? [snapshot] : [];
+    return kind && name && isProjectedToolAvailable(toolProjection, name)
+      ? [{ type: "function", function: { name } }]
+      : [];
   });
   if (tools.length === 0) {
     if (mode === "auto") {
@@ -404,7 +444,7 @@ function normalizeOpenAiStringModeAnthropicToolChoice(
   }
   if (choice.type === "tool" && typeof choice.name === "string" && choice.name.trim()) {
     const name = choice.name.trim();
-    if (!isProjectedToolAvailable(toolProjection, "function", name)) {
+    if (!isProjectedToolAvailable(toolProjection, name)) {
       throw new Error(
         `OpenAI-compatible Anthropic tool_choice requested unavailable tool "${name}" after payload conversion`,
       );
@@ -416,7 +456,7 @@ function normalizeOpenAiStringModeAnthropicToolChoice(
   }
   if (choice.type === "function" && isRecord(choice.function)) {
     const name = normalizeOptionalString(choice.function.name) ?? "";
-    if (name && !isProjectedToolAvailable(toolProjection, "function", name)) {
+    if (name && !isProjectedToolAvailable(toolProjection, name)) {
       throw new Error(
         `OpenAI-compatible Anthropic tool_choice requested unavailable tool "${name}" after payload conversion`,
       );
@@ -430,15 +470,15 @@ function normalizeOpenAiStringModeAnthropicToolChoice(
   }
   if (choice.type === "custom" && isRecord(choice.custom)) {
     const name = normalizeOptionalString(choice.custom.name) ?? "";
-    if (name && !isProjectedToolAvailable(toolProjection, "custom", name)) {
+    if (name && !isProjectedToolAvailable(toolProjection, name)) {
       throw new Error(
         `OpenAI-compatible Anthropic tool_choice requested unavailable tool "${name}" after payload conversion`,
       );
     }
     if (name) {
       return {
-        type: "custom",
-        custom: { name },
+        type: "function",
+        function: { name },
       };
     }
   }


### PR DESCRIPTION
Closes #97020

## What Problem This Solves

Fixes an issue where users routing Anthropic-family tool payloads through an OpenAI-compatible model would hit an OpenAI 400 response when the payload included an Anthropic custom tool.

## Why This Change Was Made

The OpenAI-compatible Anthropic bridge now projects Anthropic custom tool definitions into OpenAI function tools, including pinned custom choices and allowed custom choices. The projection preserves provider metadata such as cache controls, copies `custom.input_schema` into function `parameters`, falls back to an empty object schema only when a custom tool has no input schema, and quarantines custom tools that cannot be projected instead of passing raw `type: "custom"` payloads through to OpenAI.

## User Impact

Tool-bearing failover/provider-bridge turns can reach OpenAI-compatible chat-completions models without leaking `type: "custom"` payloads that those models reject. Malformed custom tool definitions are now dropped before they can become OpenAI-invalid or silently callable with the wrong schema.

## Evidence

Real behavior proof: a redacted terminal harness imported the production wrapper and ran representative OpenAI-compatible Anthropic payloads through it. The after-fix output shows custom tool definitions, named custom choices, and allowed custom choices all projected to `type: "function"`, while invalid custom definitions are quarantined before payload delivery.

```text
OpenClaw #97023 after-fix wrapper proof (redacted; no provider secrets)
namedCustomChoice.tools[0].type = "function"
namedCustomChoice.tool_choice.type = "function"
allowedCustomChoice.tools[0].type = "function"
allowedCustomChoice.tool_choice.allowed_tools.tools[0].type = "function"
invalidCustomAuto = {}
invalidCustomPinned.threw = true
invalidCustomPinned.message = "OpenAI-compatible Anthropic tool_choice requested unavailable tool \"bad_schema\" after payload conversion"
```

Validation passed on the pushed head:

- `node scripts/run-vitest.mjs src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts` - 19 tests passed
- `node scripts/run-vitest.mjs src/agents/openai-tool-projection.test.ts` - 14 tests passed
- `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts`
- `git diff --check origin/main...HEAD`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`

Live OpenAI proof was attempted with `OPENAI_LIVE_TEST=1 node scripts/test-live.mjs -- src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts`, but the live runner produced only its running heartbeat through 140 seconds and was stopped without using it as evidence.

AI-assisted: Yes. I used Codex to prepare and review this patch; I understand the changed provider bridge behavior and validated the focused tests above.