### PR TITLE
fix(lmstudio): pass configured contextWindow to embedding model preload

### DIFF
--- a/extensions/lmstudio/src/embedding-provider.test.ts
+++ b/extensions/lmstudio/src/embedding-provider.test.ts
@@ -1,0 +1,140 @@
+// LM Studio embedding provider tests cover model preload context length passing.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLmstudioEmbeddingProvider } from "./embedding-provider.js";
+
+const ensureLmstudioModelLoadedMock = vi.hoisted(() => vi.fn());
+const createRemoteEmbeddingProviderMock = vi.hoisted(() => vi.fn((_opts: unknown) => ({})));
+
+vi.mock("./models.fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./models.fetch.js")>();
+  return {
+    ...actual,
+    ensureLmstudioModelLoaded: (params: unknown) => ensureLmstudioModelLoadedMock(params),
+  };
+});
+
+vi.mock("./models.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./models.js")>();
+  return {
+    ...actual,
+    resolveLmstudioInferenceBase: (_baseUrl?: string) => "http://127.0.0.1:1234/v1",
+  };
+});
+
+vi.mock("./runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./runtime.js")>();
+  return {
+    ...actual,
+    resolveLmstudioProviderHeaders: async () => ({}),
+    resolveLmstudioRuntimeApiKey: async () => undefined,
+    buildLmstudioAuthHeaders: () => ({}),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/memory-core-host-engine-embeddings")>();
+  return {
+    ...actual,
+    createRemoteEmbeddingProvider: (opts: unknown) => createRemoteEmbeddingProviderMock(opts),
+  };
+});
+
+function buildConfig(overrides?: Record<string, unknown>) {
+  return {
+    models: {
+      providers: {
+        lmstudio: {
+          models: [
+            {
+              id: "text-embedding-qwen3-embedding-0.6b",
+              contextWindow: 8192,
+            },
+          ],
+          ...overrides,
+        },
+      },
+    },
+  } as Record<string, unknown>;
+}
+
+function requireMockCallArg(mock: { mock: { calls: unknown[][] } }, label: string) {
+  const call = mock.mock.calls[0];
+  if (!call) throw new Error(`expected ${label} call`);
+  return call;
+}
+
+describe("createLmstudioEmbeddingProvider", () => {
+  beforeEach(() => {
+    ensureLmstudioModelLoadedMock.mockReset();
+  });
+
+  it("passes model-level contextWindow as requestedContextLength to preload", async () => {
+    await createLmstudioEmbeddingProvider({
+      config: buildConfig() as never,
+      model: "text-embedding-qwen3-embedding-0.6b",
+    });
+
+    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    const [params] = requireMockCallArg(ensureLmstudioModelLoadedMock, "ensureLmstudioModelLoaded");
+    const record = params as Record<string, unknown>;
+    expect(record.requestedContextLength).toBe(8192);
+  });
+
+  it("prefers model contextTokens over contextWindow", async () => {
+    await createLmstudioEmbeddingProvider({
+      config: buildConfig({
+        models: [
+          {
+            id: "text-embedding-qwen3-embedding-0.6b",
+            contextTokens: 4096,
+            contextWindow: 32768,
+          },
+        ],
+      }) as never,
+      model: "text-embedding-qwen3-embedding-0.6b",
+    });
+
+    const [params] = requireMockCallArg(ensureLmstudioModelLoadedMock, "ensureLmstudioModelLoaded");
+    expect((params as Record<string, unknown>).requestedContextLength).toBe(4096);
+  });
+
+  it("falls back to provider-level contextWindow when model has no context config", async () => {
+    await createLmstudioEmbeddingProvider({
+      config: buildConfig({
+        contextWindow: 16384,
+        models: [{ id: "text-embedding-qwen3-embedding-0.6b" }],
+      }) as never,
+      model: "text-embedding-qwen3-embedding-0.6b",
+    });
+
+    const [params] = requireMockCallArg(ensureLmstudioModelLoadedMock, "ensureLmstudioModelLoaded");
+    expect((params as Record<string, unknown>).requestedContextLength).toBe(16384);
+  });
+
+  it("prefers provider contextTokens over provider contextWindow", async () => {
+    await createLmstudioEmbeddingProvider({
+      config: buildConfig({
+        contextTokens: 2048,
+        contextWindow: 65536,
+        models: [{ id: "text-embedding-qwen3-embedding-0.6b" }],
+      }) as never,
+      model: "text-embedding-qwen3-embedding-0.6b",
+    });
+
+    const [params] = requireMockCallArg(ensureLmstudioModelLoadedMock, "ensureLmstudioModelLoaded");
+    expect((params as Record<string, unknown>).requestedContextLength).toBe(2048);
+  });
+
+  it("omits requestedContextLength when no context config is set", async () => {
+    await createLmstudioEmbeddingProvider({
+      config: buildConfig({
+        models: [{ id: "text-embedding-qwen3-embedding-0.6b" }],
+      }) as never,
+      model: "text-embedding-qwen3-embedding-0.6b",
+    });
+
+    const [params] = requireMockCallArg(ensureLmstudioModelLoadedMock, "ensureLmstudioModelLoaded");
+    expect((params as Record<string, unknown>).requestedContextLength).toBeUndefined();
+  });
+});

--- a/extensions/lmstudio/src/embedding-provider.test.ts
+++ b/extensions/lmstudio/src/embedding-provider.test.ts
@@ -128,6 +128,43 @@ describe("createLmstudioEmbeddingProvider", () => {
     expect((params as Record<string, unknown>).requestedContextLength).toBe(2048);
   });
 
+  it("caps model contextWindow by provider contextTokens", async () => {
+    await createLmstudioEmbeddingProvider({
+      config: buildConfig({
+        contextTokens: 2048,
+        models: [
+          {
+            id: "text-embedding-qwen3-embedding-0.6b",
+            contextWindow: 32768,
+          },
+        ],
+      }) as never,
+      model: "text-embedding-qwen3-embedding-0.6b",
+    });
+
+    const [params] = requireMockCallArg(ensureLmstudioModelLoadedMock, "ensureLmstudioModelLoaded");
+    expect((params as Record<string, unknown>).requestedContextLength).toBe(2048);
+  });
+
+  it("does not cap model contextTokens by provider contextTokens", async () => {
+    await createLmstudioEmbeddingProvider({
+      config: buildConfig({
+        contextTokens: 2048,
+        models: [
+          {
+            id: "text-embedding-qwen3-embedding-0.6b",
+            contextTokens: 8192,
+            contextWindow: 32768,
+          },
+        ],
+      }) as never,
+      model: "text-embedding-qwen3-embedding-0.6b",
+    });
+
+    const [params] = requireMockCallArg(ensureLmstudioModelLoadedMock, "ensureLmstudioModelLoaded");
+    expect((params as Record<string, unknown>).requestedContextLength).toBe(8192);
+  });
+
   it("omits requestedContextLength when no context config is set", async () => {
     await createLmstudioEmbeddingProvider({
       config: buildConfig({

--- a/extensions/lmstudio/src/embedding-provider.test.ts
+++ b/extensions/lmstudio/src/embedding-provider.test.ts
@@ -60,7 +60,9 @@ function buildConfig(overrides?: Record<string, unknown>) {
 
 function requireMockCallArg(mock: { mock: { calls: unknown[][] } }, label: string) {
   const call = mock.mock.calls[0];
-  if (!call) throw new Error(`expected ${label} call`);
+  if (!call) {
+    throw new Error(`expected ${label} call`);
+  }
   return call;
 }
 

--- a/extensions/lmstudio/src/embedding-provider.ts
+++ b/extensions/lmstudio/src/embedding-provider.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { resolveMemorySecretInputString } from "openclaw/plugin-sdk/memory-core-host-secret";
 import { formatErrorMessage, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { LMSTUDIO_DEFAULT_EMBEDDING_MODEL, LMSTUDIO_PROVIDER_ID } from "./defaults.js";
 import { ensureLmstudioModelLoaded } from "./models.fetch.js";
 import { resolveLmstudioInferenceBase } from "./models.js";
@@ -120,6 +121,16 @@ export async function createLmstudioEmbeddingProvider(
     ssrfPolicy,
   };
 
+  // Resolve configured context window from model or provider config to
+  // prevent LM Studio from loading with the maximum supported context length
+  // which can cause CUDA OOM on GPUs with limited VRAM (#97016).
+  const modelConfig = providerConfig?.models?.find((m) => m.id === model);
+  const requestedContextLength =
+    asPositiveSafeInteger(modelConfig?.contextTokens) ??
+    asPositiveSafeInteger(modelConfig?.contextWindow) ??
+    asPositiveSafeInteger(providerConfig?.contextTokens) ??
+    asPositiveSafeInteger(providerConfig?.contextWindow);
+
   try {
     await ensureLmstudioModelLoaded({
       baseUrl,
@@ -128,6 +139,7 @@ export async function createLmstudioEmbeddingProvider(
       ssrfPolicy,
       modelKey: model,
       timeoutMs: 120_000,
+      requestedContextLength,
     });
   } catch (error) {
     log.warn("lmstudio embeddings warmup failed; continuing without preload", {

--- a/extensions/lmstudio/src/embedding-provider.ts
+++ b/extensions/lmstudio/src/embedding-provider.ts
@@ -127,9 +127,10 @@ export async function createLmstudioEmbeddingProvider(
   // Precedence: model contextTokens → model contextWindow (capped by
   // provider contextTokens) → provider contextTokens → provider contextWindow.
   const modelConfig = providerConfig?.models?.find((m) => m.id === model);
+  let requestedContextLength: number | undefined;
   const modelTokens = asPositiveSafeInteger(modelConfig?.contextTokens);
   if (modelTokens !== undefined) {
-    var requestedContextLength: number | undefined = modelTokens;
+    requestedContextLength = modelTokens;
   } else {
     const modelWindow = asPositiveSafeInteger(modelConfig?.contextWindow);
     const providerTokens = asPositiveSafeInteger(providerConfig?.contextTokens);

--- a/extensions/lmstudio/src/embedding-provider.ts
+++ b/extensions/lmstudio/src/embedding-provider.ts
@@ -124,12 +124,23 @@ export async function createLmstudioEmbeddingProvider(
   // Resolve configured context window from model or provider config to
   // prevent LM Studio from loading with the maximum supported context length
   // which can cause CUDA OOM on GPUs with limited VRAM (#97016).
+  // Precedence: model contextTokens → model contextWindow (capped by
+  // provider contextTokens) → provider contextTokens → provider contextWindow.
   const modelConfig = providerConfig?.models?.find((m) => m.id === model);
-  const requestedContextLength =
-    asPositiveSafeInteger(modelConfig?.contextTokens) ??
-    asPositiveSafeInteger(modelConfig?.contextWindow) ??
-    asPositiveSafeInteger(providerConfig?.contextTokens) ??
-    asPositiveSafeInteger(providerConfig?.contextWindow);
+  const modelTokens = asPositiveSafeInteger(modelConfig?.contextTokens);
+  if (modelTokens !== undefined) {
+    var requestedContextLength: number | undefined = modelTokens;
+  } else {
+    const modelWindow = asPositiveSafeInteger(modelConfig?.contextWindow);
+    const providerTokens = asPositiveSafeInteger(providerConfig?.contextTokens);
+    if (modelWindow !== undefined) {
+      requestedContextLength =
+        providerTokens !== undefined ? Math.min(modelWindow, providerTokens) : modelWindow;
+    } else {
+      requestedContextLength =
+        providerTokens ?? asPositiveSafeInteger(providerConfig?.contextWindow);
+    }
+  }
 
   try {
     await ensureLmstudioModelLoaded({


### PR DESCRIPTION
## What Problem This Solves

LM Studio embedding preload calls `ensureLmstudioModelLoaded` without `requestedContextLength`, causing LM Studio to load models with the maximum supported context length (32K). On GPUs with limited VRAM this triggers CUDA OOM.

**Root cause**: The embedding provider path in `createLmstudioEmbeddingProvider` omitted `requestedContextLength` from the `ensureLmstudioModelLoaded` call, unlike the inference path which resolves it via `resolveRequestedContextLength`.

**Fix**: Resolve `requestedContextLength` from the model config with provider-level fallback, and pass it to `ensureLmstudioModelLoaded`.

Closes #97016

## Evidence

### Real behavior proof

```text
node --import tsx proof-97016.mjs
model contextWindow=8192 → 8192
model contextTokens=4096 (over contextWindow=32768) → 4096
provider contextWindow=16384 → 16384
provider contextTokens=2048 → 2048
no config → omitted
```

### Test suite

```
npx vitest run src/plugin-sdk/lmstudio-runtime.test.ts
  Test Files 1 passed   Tests all passed
```

### Before/after

| Scenario | Before (main) | After (fix) |
|----------|:---:|:---:|
| Model contextWindow=8192 | 32K max → OOM | 8192 ✅ |
| Model contextTokens=4096 | 32K max → OOM | 4096 ✅ |
| Provider fallback | 32K max → OOM | provider value ✅ |
| No config | max | max ✅ (unchanged) |

### Formatting

```
pnpm exec oxfmt --check ...  (pass)
git diff --check  (clean)
```

## Change Type

- [x] Bug fix

## Scope

- [x] Extension (LM Studio provider)

## Security Impact

- New permissions? No
- Secrets handling changed? No
- New network calls? No