### PR TITLE
fix(session-memory): strip orphan plain-text role lines from session-memory transcripts

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { buildSessionStartupContextPrelude } from "../../../auto-reply/reply/startup-context.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { writeWorkspaceFile } from "../../../test-helpers/workspace.js";
 import { withEnvAsync } from "../../../test-utils/env.js";
@@ -289,6 +290,70 @@ describe("session-memory hook", () => {
     expect(memoryContent).not.toContain("<tool_call>");
     expect(memoryContent).not.toContain("secret.md");
     expect(memoryContent).not.toContain("NO_REPLY");
+  });
+
+  it("keeps leaked role scaffolding out of saved and next-session memory context", async () => {
+    const timestamp = new Date("2026-06-30T12:00:00.000Z");
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Keep this example:\n```text\nuser\nassistant:\n```" },
+      {
+        role: "assistant",
+        content: [
+          "Visible answer.",
+          "user",
+          "I need",
+          "assistant:",
+          "Incomplete.",
+          "",
+          "The word below is intentional prose:",
+          "system",
+          "Keep it.",
+          "",
+          "```text",
+          "user",
+          "assistant:",
+          "system",
+          "```",
+        ].join("\n"),
+      },
+    ]);
+    const { tempDir, sessionFile } = await writeSessionTranscript({
+      name: "role-leak.jsonl",
+      content: sessionContent,
+    });
+    const cfg = {
+      agents: { defaults: { workspace: tempDir, userTimezone: "UTC" } },
+    } satisfies OpenClawConfig;
+    const { memoryContent } = await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg,
+      timestamp,
+      previousSessionEntry: { sessionId: "role-leak", sessionFile },
+    });
+
+    const nextSessionContext = await buildSessionStartupContextPrelude({
+      workspaceDir: tempDir,
+      cfg,
+      nowMs: timestamp.getTime(),
+    });
+
+    expect(memoryContent).toContain(
+      "**assistant:**\n\n> Visible answer.\n> user\n> I need\n> assistant:\n> Incomplete.",
+    );
+    expect(memoryContent).not.toContain("\nuser\nI need");
+    expect(memoryContent).not.toContain("\nassistant:\nIncomplete");
+    expect(memoryContent).toContain("The word below is intentional prose:\n> system\n> Keep it.");
+    expect(memoryContent).toContain("> ```text\n> user\n> assistant:\n> system\n> ```");
+    expect(nextSessionContext).toContain("[Startup context loaded by runtime]");
+    expect(nextSessionContext).toContain(
+      "**assistant:**\n\n> Visible answer.\n> user\n> I need\n> assistant:\n> Incomplete.",
+    );
+    expect(nextSessionContext).not.toContain("\nuser\nI need");
+    expect(nextSessionContext).not.toContain("\nassistant:\nIncomplete");
+    expect(nextSessionContext).toContain(
+      "The word below is intentional prose:\n> system\n> Keep it.",
+    );
+    expect(nextSessionContext).toContain("> user\n> assistant:\n> system");
   });
 
   it("does not call the model provider for a filename slug by default", async () => {

--- a/src/hooks/bundled/session-memory/transcript.test.ts
+++ b/src/hooks/bundled/session-memory/transcript.test.ts
@@ -80,4 +80,54 @@ describe("session-memory transcript extraction", () => {
       "assistant: Answer [REMOVED_SPECIAL_TOKEN]",
     );
   });
+
+  it("strips orphan plain-text role lines but preserves embedded mentions", () => {
+    // Lines whose sole content is a bare role word → stripped (may leave blank lines).
+    expect(
+      sanitizeSessionMemoryTranscriptText(
+        "user\nVisible log output\nassistant\nIncomplete\nsystem\nShutting down",
+      ),
+    ).toBe("Visible log output\n\nIncomplete\n\nShutting down");
+
+    // Role word followed only by a colon → stripped (may leave blank lines).
+    expect(
+      sanitizeSessionMemoryTranscriptText("user:\nStatus: ok\nassistant:\nsystem: Ready"),
+    ).toBe("Status: ok\n\nsystem: Ready");
+
+    // Role word embedded as part of a sentence → preserved.
+    expect(
+      sanitizeSessionMemoryTranscriptText(
+        "The user submitted a form and the assistant confirmed.",
+      ),
+    ).toBe("The user submitted a form and the assistant confirmed.");
+
+    // Role word as a standalone line with leading/trailing whitespace → stripped.
+    expect(sanitizeSessionMemoryTranscriptText("  user  \nHello\n  assistant  ")).toBe("Hello");
+
+    // Pure role-line input → returns null (no meaningful content).
+    expect(sanitizeSessionMemoryTranscriptText("user\nassistant\nsystem")).toBeNull();
+    expect(sanitizeSessionMemoryTranscriptText("user:\nassistant:\nsystem:")).toBeNull();
+  });
+
+  it("strips orphan role lines from session content when present in transcript", async () => {
+    const transcriptPath = await writeTranscript(
+      [
+        message("user", "What is the server status?\nuser\nTell me more"),
+        message(
+          "assistant",
+          "assistant\nEverything is running normally.\nsystem\nAll services green.",
+        ),
+      ].join("\n"),
+    );
+
+    const memoryContent = await getRecentSessionContent(transcriptPath);
+
+    expect(memoryContent).toContain("user: What is the server status?\n\nTell me more");
+    expect(memoryContent).not.toContain("\nuser:");
+    expect(memoryContent).not.toMatch(/^\s*(?:user|assistant|system)\s*:?\s*$/m);
+    expect(memoryContent).toContain("assistant: Everything is running normally");
+    expect(memoryContent).toContain("All services green.");
+    expect(memoryContent).not.toContain("\nassistant\n");
+    expect(memoryContent).not.toContain("\nsystem\n");
+  });
 });

--- a/src/hooks/bundled/session-memory/transcript.test.ts
+++ b/src/hooks/bundled/session-memory/transcript.test.ts
@@ -96,9 +96,7 @@ describe("session-memory transcript extraction", () => {
 
     // Role word embedded as part of a sentence → preserved.
     expect(
-      sanitizeSessionMemoryTranscriptText(
-        "The user submitted a form and the assistant confirmed.",
-      ),
+      sanitizeSessionMemoryTranscriptText("The user submitted a form and the assistant confirmed."),
     ).toBe("The user submitted a form and the assistant confirmed.");
 
     // Role word as a standalone line with leading/trailing whitespace → stripped.

--- a/src/hooks/bundled/session-memory/transcript.test.ts
+++ b/src/hooks/bundled/session-memory/transcript.test.ts
@@ -81,51 +81,173 @@ describe("session-memory transcript extraction", () => {
     );
   });
 
-  it("strips orphan plain-text role lines but preserves embedded mentions", () => {
-    // Lines whose sole content is a bare role word → stripped (may leave blank lines).
-    expect(
-      sanitizeSessionMemoryTranscriptText(
-        "user\nVisible log output\nassistant\nIncomplete\nsystem\nShutting down",
-      ),
-    ).toBe("Visible log output\n\nIncomplete\n\nShutting down");
+  it("preserves role-shaped prose and code before transcript framing", () => {
+    for (const text of [
+      "user\nVisible log output\nassistant\nIncomplete\nsystem\nShutting down",
+      "  USER:\r\nStatus: ok\r\nassistant\r\nIncomplete\r\nSYSTEM:\r\nReady",
+      "user\nassistant\nsystem",
+      "user:\nassistant:\nsystem:",
+      "assistant",
+      "Visible answer\n    assistant:\nIncomplete",
+      "1. label\n\n   assistant:  \n   detail",
+      "Example: `one\nassistant\ntwo`",
+      "Example: `one\nassistant\ntruncated",
+      "[x](https://e/`)\nassistant\n`tail",
+    ]) {
+      expect(sanitizeSessionMemoryTranscriptText(text)).toBe(text);
+    }
+  });
 
-    // Role word followed only by a colon → stripped (may leave blank lines).
-    expect(
-      sanitizeSessionMemoryTranscriptText("user:\nStatus: ok\nassistant:\nsystem: Ready"),
-    ).toBe("Status: ok\n\nsystem: Ready");
-
-    // Role word embedded as part of a sentence → preserved.
+  it("preserves ambiguous prose, user-authored text, and fenced code role lines", () => {
+    const prose = "The next line names the configured role:\nuser\nKeep it verbatim.";
+    expect(sanitizeSessionMemoryTranscriptText(prose)).toBe(prose);
     expect(
       sanitizeSessionMemoryTranscriptText("The user submitted a form and the assistant confirmed."),
     ).toBe("The user submitted a form and the assistant confirmed.");
 
-    // Role word as a standalone line with leading/trailing whitespace → stripped.
-    expect(sanitizeSessionMemoryTranscriptText("  user  \nHello\n  assistant  ")).toBe("Hello");
+    const userText = "user\nHuman-authored example\nassistant:\nExpected response";
+    expect(sanitizeSessionMemoryTranscriptText(userText)).toBe(userText);
 
-    // Pure role-line input → returns null (no meaningful content).
-    expect(sanitizeSessionMemoryTranscriptText("user\nassistant\nsystem")).toBeNull();
-    expect(sanitizeSessionMemoryTranscriptText("user:\nassistant:\nsystem:")).toBeNull();
+    for (const code of [
+      ["```text", "user", "assistant:", "system", "```"].join("\n"),
+      ["  ```text", "  user", "  assistant:", "  system", "  ```"].join("\n"),
+      "  ```text\r\n  user\r\n  assistant:\r\n  ````",
+      ["Example:", "", "    user", "    assistant:", "\tsystem"].join("\n"),
+      ["Example:", "", "  \tuser", "   \tassistant:", " \tsystem"].join("\n"),
+      ["- ```text", "  user", "  assistant:", "  ```"].join("\n"),
+      ["1. ~~~text", "   system", "   user:", "   ~~~"].join("\n"),
+      ["> ```text", "> user", "> assistant:", "> ```"].join("\n"),
+    ]) {
+      expect(sanitizeSessionMemoryTranscriptText(code)).toBe(code);
+    }
+
+    const nestedFenceLookalike = [
+      "~~~text",
+      "  ```example",
+      "~~~",
+      "assistant:",
+      "Visible after the fence.",
+    ].join("\n");
+    expect(sanitizeSessionMemoryTranscriptText(nestedFenceLookalike)).toBe(nestedFenceLookalike);
+
+    const indentedClose = [
+      "```text",
+      "body",
+      "  ```",
+      "assistant:",
+      "Visible after the fence.",
+    ].join("\n");
+    expect(sanitizeSessionMemoryTranscriptText(indentedClose)).toBe(indentedClose);
+
+    const bareCarriageReturns = "```text\ruser\r```\rassistant:\rafter";
+    expect(sanitizeSessionMemoryTranscriptText(bareCarriageReturns)).toBe(bareCarriageReturns);
   });
 
-  it("strips orphan role lines from session content when present in transcript", async () => {
+  it("preserves leading code blocks through transcript role framing", async () => {
+    const transcriptPath = await writeTranscript(
+      [
+        message("assistant", "  ```text\n  user\n  assistant:\n  ```"),
+        message("assistant", "    system\n    user:"),
+      ].join("\n"),
+    );
+
+    await expect(getRecentSessionContent(transcriptPath)).resolves.toBe(
+      [
+        "**assistant:**",
+        "",
+        ">   ```text",
+        ">   user",
+        ">   assistant:",
+        ">   ```",
+        "",
+        "**assistant:**",
+        "",
+        ">     system",
+        ">     user:",
+      ].join("\n"),
+    );
+  });
+
+  it("isolates a truncated fence at the transcript message boundary", async () => {
+    const transcriptPath = await writeTranscript(
+      [
+        message("assistant", "```text\nuser\ntruncated"),
+        message("assistant", "Visible next response"),
+      ].join("\n"),
+    );
+
+    await expect(getRecentSessionContent(transcriptPath)).resolves.toBe(
+      [
+        "**assistant:**",
+        "",
+        "> ```text",
+        "> user",
+        "> truncated",
+        "",
+        "assistant: Visible next response",
+      ].join("\n"),
+    );
+  });
+
+  it("ends a prose blockquote before ordinary following entries", async () => {
+    const transcriptPath = await writeTranscript(
+      [
+        message("assistant", "Visible answer\nuser\nLast paragraph line"),
+        message("user", "Normal follow-up"),
+        message("assistant", "Normal response"),
+      ].join("\n"),
+    );
+
+    await expect(getRecentSessionContent(transcriptPath)).resolves.toBe(
+      [
+        "**assistant:**",
+        "",
+        "> Visible answer",
+        "> user",
+        "> Last paragraph line",
+        "",
+        "user: Normal follow-up",
+        "assistant: Normal response",
+      ].join("\n"),
+    );
+  });
+
+  it("quotes assistant role lines while retaining user-authored content", async () => {
     const transcriptPath = await writeTranscript(
       [
         message("user", "What is the server status?\nuser\nTell me more"),
         message(
           "assistant",
-          "assistant\nEverything is running normally.\nsystem\nAll services green.",
+          [
+            "assistant",
+            "Everything is running normally.",
+            "system:",
+            "All services green.",
+            "",
+            "The next line is intentional prose:",
+            "user",
+            "Keep it.",
+            "",
+            "```text",
+            "assistant",
+            "system:",
+            "```",
+          ].join("\n"),
         ),
       ].join("\n"),
     );
 
     const memoryContent = await getRecentSessionContent(transcriptPath);
 
-    expect(memoryContent).toContain("user: What is the server status?\n\nTell me more");
-    expect(memoryContent).not.toContain("\nuser:");
-    expect(memoryContent).not.toMatch(/^\s*(?:user|assistant|system)\s*:?\s*$/m);
-    expect(memoryContent).toContain("assistant: Everything is running normally");
+    expect(memoryContent).toContain("user: What is the server status?\nuser\nTell me more");
+    expect(memoryContent).toContain(
+      "**assistant:**\n\n> assistant\n> Everything is running normally",
+    );
     expect(memoryContent).toContain("All services green.");
-    expect(memoryContent).not.toContain("\nassistant\n");
-    expect(memoryContent).not.toContain("\nsystem\n");
+    expect(memoryContent).not.toContain("\nassistant\nEverything is running normally");
+    expect(memoryContent).not.toContain("\nsystem:\nAll services green");
+    expect(memoryContent).toContain("> system:\n> All services green");
+    expect(memoryContent).toContain("The next line is intentional prose:\n> user\n> Keep it.");
+    expect(memoryContent).toContain("> ```text\n> assistant\n> system:\n> ```");
   });
 });

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -16,6 +16,14 @@ const SESSION_MEMORY_ROLE_DIRECTIVE_TAG_RE = /<\/?(?:system|assistant|user)\b[^>
 const SESSION_MEMORY_MEDIA_PLACEHOLDER_RE = /(^|\n)\s*<media:[^>]+>(?:\s*\([^)]*\))?\s*/gi;
 const SESSION_MEMORY_TRAILING_NO_REPLY_RE = /(?:^|\n)\s*NO_REPLY\s*$/i;
 
+// Strip orphan plain-text role-token lines (e.g. a line containing only "user",
+// "assistant", or "system") that leak from quantized-local-model SSE streams.
+// These are distinct from XML role directives (/<system>...</system>/ etc.) which
+// are already removed above by SESSION_MEMORY_ROLE_DIRECTIVE_BLOCK/TAG_RE.
+// The /m flag anchors ^/$ to line boundaries so we only match lines whose sole
+// content after trimming is a bare role word (optionally followed by a colon).
+const SESSION_MEMORY_ORPHAN_ROLE_LINE_RE = /^\s*(?:user|assistant|system)\s*:?\s*$/gim;
+
 function isNoReplyMarker(text: string): boolean {
   const trimmed = text.trim();
   return /^NO_REPLY$/i.test(trimmed) || /^\{\s*"action"\s*:\s*"NO_REPLY"\s*\}$/i.test(trimmed);
@@ -31,6 +39,7 @@ export function sanitizeSessionMemoryTranscriptText(text: string): string | null
     .replace(SESSION_MEMORY_ROLE_DIRECTIVE_TAG_RE, "")
     .replace(SESSION_MEMORY_MEDIA_PLACEHOLDER_RE, "$1")
     .replace(SESSION_MEMORY_TRAILING_NO_REPLY_RE, "")
+    .replace(SESSION_MEMORY_ORPHAN_ROLE_LINE_RE, "")
     .trim();
 
   return withoutArtifacts || null;

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -15,14 +15,8 @@ const SESSION_MEMORY_ROLE_DIRECTIVE_BLOCK_RE = /<(system|assistant|user)\b[^>]*>
 const SESSION_MEMORY_ROLE_DIRECTIVE_TAG_RE = /<\/?(?:system|assistant|user)\b[^>]*>/gi;
 const SESSION_MEMORY_MEDIA_PLACEHOLDER_RE = /(^|\n)\s*<media:[^>]+>(?:\s*\([^)]*\))?\s*/gi;
 const SESSION_MEMORY_TRAILING_NO_REPLY_RE = /(?:^|\n)\s*NO_REPLY\s*$/i;
-
-// Strip orphan plain-text role-token lines (e.g. a line containing only "user",
-// "assistant", or "system") that leak from quantized-local-model SSE streams.
-// These are distinct from XML role directives (/<system>...</system>/ etc.) which
-// are already removed above by SESSION_MEMORY_ROLE_DIRECTIVE_BLOCK/TAG_RE.
-// The /m flag anchors ^/$ to line boundaries so we only match lines whose sole
-// content after trimming is a bare role word (optionally followed by a colon).
-const SESSION_MEMORY_ORPHAN_ROLE_LINE_RE = /^\s*(?:user|assistant|system)\s*:?\s*$/gim;
+const SESSION_MEMORY_ROLE_LINE_RE =
+  /^[ \t]*(?:user|assistant|system)[ \t]*:?[ \t]*(?:\r\n|[\r\n]|$)/im;
 
 function isNoReplyMarker(text: string): boolean {
   const trimmed = text.trim();
@@ -38,11 +32,12 @@ export function sanitizeSessionMemoryTranscriptText(text: string): string | null
     .replace(SESSION_MEMORY_ROLE_DIRECTIVE_BLOCK_RE, "")
     .replace(SESSION_MEMORY_ROLE_DIRECTIVE_TAG_RE, "")
     .replace(SESSION_MEMORY_MEDIA_PLACEHOLDER_RE, "$1")
-    .replace(SESSION_MEMORY_TRAILING_NO_REPLY_RE, "")
-    .replace(SESSION_MEMORY_ORPHAN_ROLE_LINE_RE, "")
-    .trim();
+    .replace(SESSION_MEMORY_TRAILING_NO_REPLY_RE, "");
+  const withoutBoundaryBlankLines = withoutArtifacts
+    .replace(/^(?:[ \t]*(?:\r\n|[\r\n]))+/, "")
+    .replace(/(?:(?:\r\n|[\r\n])[ \t]*)+$/, "");
 
-  return withoutArtifacts || null;
+  return withoutBoundaryBlankLines.trim() ? withoutBoundaryBlankLines : null;
 }
 
 function extractTextMessageContent(content: unknown): string | undefined {
@@ -62,6 +57,16 @@ function extractTextMessageContent(content: unknown): string | undefined {
     }
   }
   return undefined;
+}
+
+function formatTranscriptMessage(role: "user" | "assistant", text: string): string {
+  if (role === "assistant" && SESSION_MEMORY_ROLE_LINE_RE.test(text)) {
+    // Keep model bytes intact inside one container. Role-shaped lines become
+    // non-standalone, and open code fences end at this message boundary.
+    const quoted = `> ${text.replace(/\r\n|[\r\n]/g, (lineBreak) => `${lineBreak}> `)}`;
+    return `**assistant:**\n\n${quoted}\n`;
+  }
+  return `${role}: ${text}`;
 }
 
 export async function getRecentSessionContent(
@@ -90,7 +95,7 @@ export async function getRecentSessionContent(
             const text = extractTextMessageContent(msg.content);
             const sanitized = text ? sanitizeSessionMemoryTranscriptText(text) : null;
             if (sanitized && !sanitized.startsWith("/")) {
-              allMessages.push(`${role}: ${sanitized}`);
+              allMessages.push(formatTranscriptMessage(role, sanitized));
             }
           }
         }
@@ -99,7 +104,7 @@ export async function getRecentSessionContent(
       }
     }
 
-    return allMessages.slice(-messageCount).join("\n");
+    return allMessages.slice(-messageCount).join("\n").replace(/\n+$/, "");
   } catch {
     return null;
   }


### PR DESCRIPTION
Related to #69943.

Original reproduction and narrow sanitizer proposal by @SunnyShu0925. Maintainer refinement keeps that contribution while moving the final behavior to containment rather than deletion.

## What Problem This Solves

Some model/provider paths can leave a line whose entire visible content is `user`, `assistant`, or `system` (optionally followed by `:`) inside an assistant message. The canonical session transcript correctly preserves the finalized model output, but the session-memory hook previously copied those lines verbatim into a durable daily memory file. When that memory is later loaded as startup context, the standalone role-looking lines can be interpreted as chat-template framing and reinforce malformed future output.

The merged sanitizer from #95791 covers special tokens, tool/function blocks, XML role tags, media placeholders, and trailing `NO_REPLY`, but not plain role-only lines.

## Why This Change Was Made

The final fix belongs at the session-memory transcript projection boundary, not global model-output normalization:

- canonical assistant history should retain the provider's finalized bytes;
- user-authored prose and code must never be rewritten merely because a line is a role word;
- the invariant needed here is narrower: persisted session-memory must not contain standalone assistant-origin role framing.

If an assistant message contains a standalone role-shaped line, the projection now preserves the entire sanitized assistant message under a bold `assistant` label and prefixes every line with Markdown blockquote syntax. This makes the suspicious lines non-standalone without deleting legitimate prose, fenced or indented code, lists, blockquotes, inline code, whitespace, or incomplete fences. User messages are unchanged.

Detection covers `user`, `assistant`, and `system`, case-insensitively, with optional colons, surrounding horizontal whitespace, and LF, CRLF, or bare-CR line endings. A synthetic separator prevents the following transcript entry from becoming a CommonMark lazy continuation of the quote.

## User Impact

New session-memory files no longer persist assistant-origin role markers as active-looking standalone lines. Legitimate role-word prose and code remain readable, and canonical session history is not destructively normalized.

This is intentionally the bounded prevention portion of #69943. Recovery or quarantine of memory files that were already poisoned remains a separate product/migration decision in the canonical issue.

## Evidence

Current candidate: `2adf5ea8b83da17758c4b8f7d08b34240f70315c`.

Focused regression proof:

```console
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs \
  src/hooks/bundled/session-memory/transcript.test.ts \
  src/hooks/bundled/session-memory/handler.test.ts

Test Files  2 passed (2)
Tests       34 passed (34)
```

The handler integration test writes a realistic session JSONL containing leaked role scaffolding and legitimate prose/code, runs the real session-memory hook, reads the persisted Markdown, then loads it through `buildSessionStartupContextPrelude`. It proves the persisted and next-session forms retain content while no assistant-origin role marker remains standalone.

Remote broad checks:

- Azure Crabbox `check:changed`: passed, run `run_7cb68c206a8e`, lease `cbx_74df910223ed` (`Standard_D32ds_v6`).
- Blacksmith Testbox `test:changed`: touched hook shard passed 48/48 tests, including all 34 focused tests. The broad run reached 51 Vitest shards and stopped on one unrelated old-base `memory-core` expectation (`s3`); current `main` already expects `s3`, so the serialized prepare sync resolves that stale-base mismatch. Testbox `tbx_01kweejk5bvkx893dw5c17da7z` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/28506053790)).

Closest safe real/E2E proof:

- A temporary repo-native harness started the real Gateway process, connected through public WebChat `chat.send`, used a deterministic local Responses endpoint to emit the role leak, invoked `/reset`, loaded the compiled bundled session-memory hook, inspected the persisted memory file, and passed that exact file through the production startup-context reader.
- Local: 1/1 passed.
- Blacksmith Testbox: 1/1 passed, `tbx_01kweh4zcxzbjpynx9w4383p9x` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/28508650545)). The temporary harness and packaged-hook metadata were removed after proof; the PR remains limited to the three session-memory files.

Additional gates:

- `git diff --check`: passed.
- `node scripts/plugin-sdk-surface-report.mjs --check`: passed.
- Azure remote lint, typecheck, import-cycle, storage, and changed-path guards: passed in `check:changed`.
- Fresh autoreview on the exact pushed candidate: no findings; patch correct (0.93 confidence).

## Scope and landing note

The PR head is intentionally not synced here because final sync/prepare/merge is serialized across maintainer workers. During prepare, conflict resolution must preserve current-main reset-archive recovery and delivery-mirror duplicate suppression in the same transcript helper; the focused and broad gates should then be rerun on the synced head.
