### PR TITLE
fix(llm-core): coerce JSON-stringified array/object tool arguments

### DIFF
--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -39,4 +39,52 @@ describe("validateToolArguments", () => {
       }),
     ).toThrow(/Validation failed for tool "decimal-tool"/);
   });
+
+  const tagsTool = {
+    name: "tags-tool",
+    description: "test tool",
+    parameters: {
+      type: "object",
+      properties: {
+        content: { type: "string" },
+        tags: { anyOf: [{ type: "array", items: { type: "string" } }, { type: "null" }] },
+        meta: { type: "object", additionalProperties: { type: "string" } },
+      },
+      required: ["content"],
+      additionalProperties: false,
+    },
+  } as Tool;
+
+  it("coerces JSON-stringified array parameters (issue #96916)", () => {
+    expect(
+      validateToolArguments(tagsTool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "tags-tool",
+        arguments: { content: "test memory", tags: '["test","debug"]' },
+      }),
+    ).toEqual({ content: "test memory", tags: ["test", "debug"] });
+  });
+
+  it("coerces JSON-stringified object parameters", () => {
+    expect(
+      validateToolArguments(tagsTool, {
+        type: "toolCall",
+        id: "call-2",
+        name: "tags-tool",
+        arguments: { content: "x", meta: '{"a":"b"}' },
+      }),
+    ).toEqual({ content: "x", meta: { a: "b" } });
+  });
+
+  it("leaves ordinary string values untouched", () => {
+    expect(
+      validateToolArguments(tagsTool, {
+        type: "toolCall",
+        id: "call-3",
+        name: "tags-tool",
+        arguments: { content: "hello world" },
+      }),
+    ).toEqual({ content: "hello world" });
+  });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -160,6 +160,41 @@ function coercePrimitiveByType(value: unknown, type: string): unknown {
       }
       return value;
     }
+    case "array": {
+      // Some providers (e.g. MiMo, Ollama) serialize array arguments as JSON
+      // strings. Parse them back so schema validation sees a real array.
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (trimmed.startsWith("[")) {
+          try {
+            const parsed = JSON.parse(trimmed);
+            if (Array.isArray(parsed)) {
+              return parsed;
+            }
+          } catch {
+            // Not valid JSON; leave the value untouched for normal validation.
+          }
+        }
+      }
+      return value;
+    }
+    case "object": {
+      // Mirror the array case for object-typed parameters serialized as JSON strings.
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (trimmed.startsWith("{")) {
+          try {
+            const parsed = JSON.parse(trimmed);
+            if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+              return parsed;
+            }
+          } catch {
+            // Not valid JSON; leave the value untouched for normal validation.
+          }
+        }
+      }
+      return value;
+    }
     default:
       return value;
   }


### PR DESCRIPTION
Fixes #96916.

## What Problem This Solves

Some providers (e.g. Xiaomi MiMo, Ollama) serialize array/object tool-call arguments as JSON **strings** — for example `"tags": "[\"test\",\"debug\"]"` instead of `"tags": ["test","debug"]`. `validateToolArguments` could not coerce these back, so every MCP tool with an `array`- or `object`-typed parameter failed validation with errors like `tags: must be array` / `must be null` / `must match a schema in anyOf`.

The root cause is in `packages/llm-core/src/validation.ts`: `coercePrimitiveByType` handles `number`, `integer`, `boolean`, `string`, and `null`, but has no case for `array` or `object`, so a JSON-stringified container falls through unchanged (including inside `anyOf`/`oneOf` via `coerceWithUnionSchema`) and fails schema validation.

## What Changed

Added `array` and `object` cases to `coercePrimitiveByType`:

- When the schema expects an `array`/`object` and the value is a string that looks like a JSON container (`[…]` / `{…}`), it is `JSON.parse`d and used only if the parsed type matches.
- If the string is not valid JSON or the parsed type does not match, the original value is returned untouched, so ordinary string values and existing validation behavior are unaffected.

Because this slots into the existing coercion pipeline, parsed containers are then recursively coerced by `applySchemaArrayCoercion` / `applySchemaObjectCoercion`, and the `anyOf: [array, null]` shape from the report resolves correctly.

## Evidence

Added three focused unit tests to `packages/llm-core/src/validation.test.ts` and ran the file with the real TypeBox validator (`vitest run`):

```
 RUN  v3.2.6  packages/llm-core

 ✓ src/validation.test.ts (5 tests) 6ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

The new tests cover:

- coercing a JSON-stringified array parameter under `anyOf: [array, null]` — the exact scenario from #96916 (`tags: "[\"test\",\"debug\"]"` → `["test","debug"]`)
- coercing a JSON-stringified object parameter (`'{"a":"b"}'` → `{ a: "b" }`)
- leaving an ordinary string value untouched (regression guard)

The two pre-existing tests in the same file continue to pass, confirming no regression to the current numeric-string coercion behavior.
