### PR TITLE
fix(validation): preserve null in anyOf unions instead of coercing to empty string (fixes #96716)

### DIFF
--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -39,4 +39,29 @@ describe("validateToolArguments", () => {
       }),
     ).toThrow(/Validation failed for tool "decimal-tool"/);
   });
+
+  it("preserves null in anyOf [{type: string}, {type: null}] without coercing to empty string (#96716)", () => {
+    const tool = {
+      name: "nullable-tool",
+      description: "test tool",
+      parameters: {
+        type: "object",
+        properties: {
+          insight_id: { anyOf: [{ type: "string" }, { type: "null" }] },
+          cluster_name: { type: "string" },
+        },
+        required: ["cluster_name"],
+        additionalProperties: false,
+      },
+    } as Tool;
+
+    expect(
+      validateToolArguments(tool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "nullable-tool",
+        arguments: { insight_id: null, cluster_name: "testenv" },
+      }),
+    ).toEqual({ insight_id: null, cluster_name: "testenv" });
+  });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -205,6 +205,21 @@ function applySchemaArrayCoercion(value: unknown[], schema: JsonSchemaObject): v
 }
 
 function coerceWithUnionSchema(value: unknown, schemas: JsonSchemaObject[]): unknown {
+  // When value is null, check if any union member accepts null directly
+  // (type: "null") before falling through to coercion.  Without this check,
+  // anyOf [{type: "string"}, {type: "null"}] coerces null → "" via the
+  // string branch and never reaches the null branch.
+  if (value === null) {
+    for (const schema of schemas) {
+      const types = getSchemaTypes(schema);
+      if (types.includes("null")) {
+        const validator = getSubSchemaValidator(schema);
+        if (!validator || validator.Check(value)) {
+          return value;
+        }
+      }
+    }
+  }
   for (const schema of schemas) {
     const candidate = structuredClone(value);
     const coerced = coerceWithJsonSchema(candidate, schema);


### PR DESCRIPTION
## What Problem This Solves

Fixes #96716.

MCP tool calls with optional arguments set to JSON null fail via OpenClaw but succeed via other MCP clients. Root cause: when a JSON schema uses `anyOf [{type: string}, {type: null}]`, the union coercion (`coerceWithUnionSchema`) tries the string branch first, which coerces `null` to `""` (a valid string), and returns that before ever trying the `{type: null}` branch. The MCP server receives `""` instead of `null`, triggering a different code path.

## Why This Change Was Made

`coerceWithUnionSchema` iterated schemas in order and applied `coerceWithJsonSchema` before validating. For `anyOf [{type: string}, {type: null}]` with value `null`, the first schema coerces `null → ""` and the validator passes — so the null branch is never tried.

The fix is narrowly scoped: **when value is `null`, check if any union member accepts null directly (`type: "null"`) before falling through to coercion.** This only adds behavior for the `null` case, without affecting other union types like `number | string`.

## Changes Made

- `packages/llm-core/src/validation.ts`: Added null-first check in `coerceWithUnionSchema`.
- `packages/llm-core/src/validation.test.ts`: Added regression test.

## Evidence

- **Unit tests:** `node scripts/run-vitest.mjs run packages/llm-core/src/validation.test.ts` — 3/3 passed

## Real behavior proof

**Schema: `insight_id: anyOf [{type: string}, {type: null}]` (from issue #96716)**

```
Input:      {"insight_id":null,"cluster_name":"testenv-cluster"}
Validated:  {"insight_id":null,"cluster_name":"testenv-cluster"}
✅ insight_id preserved as null — MCP server receives null, not empty string
```

**Before fix (simulated):** null would be coerced to `""` via the string branch, causing the MCP server to error.

**After fix:** null matches `{type: null}` directly and is preserved.

- ✅ Null values in `anyOf [string, null]` schemas preserved as null
- ✅ Normal string values unchanged
- ✅ Non-nullable type coercion (number, integer) still works
- ✅ Only affects null values — no impact on other union types

**What was not tested:** End-to-end with a real remote MCP server (the fix is in the shared validation layer — all tool calls benefit from it).

- [x] AI-assisted