### PR TITLE
Add Herdr state bridge for OpenClaw TUI

### DIFF
--- a/extensions/herdr-state/README.md
+++ b/extensions/herdr-state/README.md
@@ -1,0 +1,39 @@
+# Herdr State Bridge
+
+This bundled extension documents the OpenClaw TUI to Herdr pane-state bridge.
+The runtime sidecar lives in `src/tui/herdr-state-sidecar.ts` because the TUI
+process is the process that inherits `HERDR_PANE_ID` from Herdr.
+
+When `openclaw tui` starts and `HERDR_PANE_ID` is set, OpenClaw starts an
+in-process sidecar that reads the visible Herdr pane and reports:
+
+- `gateway connected | idle` as `idle`
+- Braille spinner plus `| connected` as `working`
+- approval modal text such as `Approve this command?` as `blocked`
+
+Set `OPENCLAW_HERDR_STATE_DISABLE=1` to disable the bridge. Set
+`OPENCLAW_HERDR_STATE_INTERVAL_MS=500` to adjust the polling interval. The
+default is `1000`; values below `250` are clamped.
+
+## Smoke Test
+
+```bash
+herdr server
+herdr pane send-text <pane_id> "clear; openclaw tui"
+herdr pane send-keys <pane_id> Enter
+herdr pane send-text <pane_id> "Hello"
+herdr pane send-keys <pane_id> Enter
+
+herdr pane get <pane_id> | python3 -c "import json,sys; r=json.load(sys.stdin)['result']['pane']; print(r.get('agent'), r.get('agent_status'), r.get('custom_status'))"
+```
+
+Expected transition while the TUI is answering:
+
+```text
+openclaw working 1s
+openclaw working 2s
+openclaw idle
+```
+
+Close the pane, then verify no OpenClaw process remains alive only because of
+the Herdr state bridge.

--- a/extensions/herdr-state/index.ts
+++ b/extensions/herdr-state/index.ts
@@ -1,0 +1,12 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "herdr-state",
+  name: "Herdr State Bridge",
+  description:
+    "Reports OpenClaw TUI idle, working, and blocked state to the containing Herdr pane.",
+  register() {
+    // The bridge is started by src/tui/herdr-state-sidecar.ts because only the
+    // TUI process is guaranteed to inherit HERDR_PANE_ID from Herdr.
+  },
+});

--- a/extensions/herdr-state/openclaw.plugin.json
+++ b/extensions/herdr-state/openclaw.plugin.json
@@ -1,0 +1,14 @@
+{
+  "id": "herdr-state",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefaultOnPlatforms": ["darwin", "linux"],
+  "name": "Herdr State Bridge",
+  "description": "Reports OpenClaw TUI idle, working, and blocked state to the containing Herdr pane.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/herdr-state/package.json
+++ b/extensions/herdr-state/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/herdr-state",
+  "version": "2026.6.10",
+  "description": "Herdr pane state bridge for OpenClaw TUI",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/herdr-state/smoke-test.sh
+++ b/extensions/herdr-state/smoke-test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pane_id="${1:-${HERDR_PANE_ID:-}}"
+if [[ -z "${pane_id}" ]]; then
+  echo "usage: $0 <herdr-pane-id>" >&2
+  exit 64
+fi
+
+herdr pane send-text "${pane_id}" "clear; openclaw tui"
+herdr pane send-keys "${pane_id}" Enter
+sleep 3
+herdr pane send-text "${pane_id}" "Hello"
+herdr pane send-keys "${pane_id}" Enter
+
+for _ in {1..20}; do
+  herdr pane get "${pane_id}" | python3 -c "import json,sys; r=json.load(sys.stdin)['result']['pane']; print(r.get('agent'), r.get('agent_status'), r.get('custom_status'))"
+  sleep 1
+done

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -860,6 +860,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/herdr-state:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/huggingface:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/tui/herdr-state-sidecar.test.ts
+++ b/src/tui/herdr-state-sidecar.test.ts
@@ -1,0 +1,115 @@
+// Tests for Herdr/OpenClaw TUI state bridge detection and lifecycle.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  detectHerdrOpenClawState,
+  readHerdrPane,
+  reportHerdrState,
+  startHerdrStateSidecar,
+} from "./herdr-state-sidecar.js";
+
+describe("herdr state sidecar", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("detects idle, working elapsed labels, blocked approval, and unknown states", () => {
+    expect(detectHerdrOpenClawState("gateway connected | idle")).toEqual({
+      state: "idle",
+      customStatus: "",
+    });
+    expect(detectHerdrOpenClawState("⠼ dillydallying… • 1m 19s | connected")).toEqual({
+      state: "working",
+      customStatus: "1m 19s",
+    });
+    expect(detectHerdrOpenClawState("⠼ pondering… • 8s | connected")).toEqual({
+      state: "working",
+      customStatus: "8s",
+    });
+    expect(detectHerdrOpenClawState("Approve this command? Allow once")).toEqual({
+      state: "blocked",
+      customStatus: "awaiting-approval",
+    });
+    expect(detectHerdrOpenClawState("plain terminal text")).toEqual({
+      state: "unknown",
+      customStatus: "",
+    });
+  });
+
+  it("reads the visible Herdr pane", async () => {
+    const exec = vi.fn(async () => ({ stdout: "content", stderr: "" }));
+
+    await expect(readHerdrPane({ paneId: "pane-1", exec })).resolves.toBe("content");
+
+    expect(exec).toHaveBeenCalledWith(
+      "herdr",
+      ["pane", "read", "pane-1", "--source", "visible", "--lines", "80"],
+      { timeout: 5000 },
+    );
+  });
+
+  it("reports custom OpenClaw state to Herdr", async () => {
+    const exec = vi.fn(async () => ({ stdout: "", stderr: "" }));
+
+    await reportHerdrState({
+      paneId: "pane-1",
+      report: { state: "working", customStatus: "1m 19s" },
+      exec,
+    });
+
+    expect(exec).toHaveBeenCalledWith(
+      "herdr",
+      [
+        "pane",
+        "report-agent",
+        "pane-1",
+        "--source",
+        "custom:openclaw",
+        "--agent",
+        "openclaw",
+        "--state",
+        "working",
+        "--custom-status",
+        "1m 19s",
+      ],
+      { timeout: 5000 },
+    );
+  });
+
+  it("no-ops when Herdr env is missing or the bridge is disabled", () => {
+    expect(startHerdrStateSidecar({ env: {} })).toBeNull();
+    expect(
+      startHerdrStateSidecar({
+        env: { HERDR_PANE_ID: "pane-1", OPENCLAW_HERDR_STATE_DISABLE: "1" },
+      }),
+    ).toBeNull();
+  });
+
+  it("dedupes reports and stops when pane disappears", async () => {
+    vi.useFakeTimers();
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: "gateway connected | idle", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "gateway connected | idle", stderr: "" })
+      .mockRejectedValueOnce(new Error("pane not found"));
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+
+    const handle = startHerdrStateSidecar({
+      env: { HERDR_PANE_ID: "pane-1", OPENCLAW_HERDR_STATE_INTERVAL_MS: "250" },
+      exec,
+      logger,
+    });
+
+    expect(handle).not.toBeNull();
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(250);
+
+    const reportCalls = exec.mock.calls.filter(
+      (call) => call[1]?.[0] === "pane" && call[1]?.[1] === "report-agent",
+    );
+    expect(reportCalls).toHaveLength(1);
+    expect(logger.debug).toHaveBeenCalledWith("herdr-state: pane pane-1 gone; stopping");
+    handle?.stop();
+  });
+});

--- a/src/tui/herdr-state-sidecar.ts
+++ b/src/tui/herdr-state-sidecar.ts
@@ -1,0 +1,180 @@
+// Bridges OpenClaw TUI status text into Herdr pane agent state reports.
+import { execFile, type ExecFileException } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type HerdrOpenClawState = "idle" | "working" | "blocked" | "unknown";
+
+export type HerdrStateReport = {
+  state: HerdrOpenClawState;
+  customStatus: string;
+};
+
+export type HerdrSidecarLogger = Pick<Console, "debug" | "warn">;
+
+export type HerdrSidecarHandle = {
+  stop: () => void;
+};
+
+type HerdrExec = (
+  file: string,
+  args: string[],
+  options: { timeout: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+const IDLE_RE = /gateway connected \| idle/i;
+const SPINNER_RE = /[\u2800-\u28ff]/;
+const APPROVAL_RES = [
+  /approve this command\?/i,
+  /allow once/i,
+  /requires approval/i,
+  /approval required/i,
+];
+
+function isTruthyEnvValue(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function isPaneGoneError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const err = error as ExecFileException & { stderr?: string; stdout?: string };
+  const text = `${err.message ?? ""}\n${err.stderr ?? ""}\n${err.stdout ?? ""}`;
+  return /\b(pane|not found|unknown|no such)\b/i.test(text);
+}
+
+function normalizeHerdrPaneId(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function parsePollingIntervalMs(value: string | undefined): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 1000;
+  }
+  return Math.max(250, Math.floor(parsed));
+}
+
+export function detectHerdrOpenClawState(content: string): HerdrStateReport {
+  if (!content) {
+    return { state: "unknown", customStatus: "" };
+  }
+  for (const approvalRe of APPROVAL_RES) {
+    if (approvalRe.test(content)) {
+      return { state: "blocked", customStatus: "awaiting-approval" };
+    }
+  }
+  if (SPINNER_RE.test(content) && content.includes("| connected")) {
+    const elapsed = /\u2026 \u2022 ((?:\d+m\s+)?\d+s)/.exec(content)?.[1] ?? "thinking";
+    return { state: "working", customStatus: elapsed };
+  }
+  if (IDLE_RE.test(content)) {
+    return { state: "idle", customStatus: "" };
+  }
+  return { state: "unknown", customStatus: "" };
+}
+
+export async function readHerdrPane(params: {
+  paneId: string;
+  exec?: HerdrExec;
+  timeoutMs?: number;
+}): Promise<string> {
+  const run = params.exec ?? execFileAsync;
+  const result = await run(
+    "herdr",
+    ["pane", "read", params.paneId, "--source", "visible", "--lines", "80"],
+    { timeout: params.timeoutMs ?? 5000 },
+  );
+  return result.stdout;
+}
+
+export async function reportHerdrState(params: {
+  paneId: string;
+  report: HerdrStateReport;
+  agentLabel?: string;
+  exec?: HerdrExec;
+  timeoutMs?: number;
+}): Promise<void> {
+  const run = params.exec ?? execFileAsync;
+  const args = [
+    "pane",
+    "report-agent",
+    params.paneId,
+    "--source",
+    "custom:openclaw",
+    "--agent",
+    params.agentLabel ?? "openclaw",
+    "--state",
+    params.report.state,
+  ];
+  if (params.report.customStatus) {
+    args.push("--custom-status", params.report.customStatus);
+  }
+  await run("herdr", args, { timeout: params.timeoutMs ?? 5000 });
+}
+
+export function startHerdrStateSidecar(params?: {
+  env?: NodeJS.ProcessEnv;
+  exec?: HerdrExec;
+  logger?: HerdrSidecarLogger;
+}): HerdrSidecarHandle | null {
+  const env = params?.env ?? process.env;
+  if (isTruthyEnvValue(env.OPENCLAW_HERDR_STATE_DISABLE)) {
+    return null;
+  }
+  const paneId = normalizeHerdrPaneId(env.HERDR_PANE_ID);
+  if (!paneId) {
+    return null;
+  }
+
+  const exec = params?.exec ?? execFileAsync;
+  const logger = params?.logger;
+  const intervalMs = parsePollingIntervalMs(env.OPENCLAW_HERDR_STATE_INTERVAL_MS);
+  let stopped = false;
+  let timer: NodeJS.Timeout | null = null;
+  let lastKey = "";
+
+  const schedule = () => {
+    if (stopped) {
+      return;
+    }
+    timer = setTimeout(tick, intervalMs);
+    timer.unref?.();
+  };
+
+  const tick = async () => {
+    try {
+      const content = await readHerdrPane({ paneId, exec });
+      const report = detectHerdrOpenClawState(content);
+      const key = `${report.state}:${report.customStatus}`;
+      if (key !== lastKey) {
+        await reportHerdrState({ paneId, report, exec });
+        lastKey = key;
+      }
+    } catch (error) {
+      if (isPaneGoneError(error)) {
+        stopped = true;
+        logger?.debug(`herdr-state: pane ${paneId} gone; stopping`);
+        return;
+      }
+      logger?.warn(`herdr-state: ${String(error)}`);
+    } finally {
+      schedule();
+    }
+  };
+
+  schedule();
+  return {
+    stop() {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -36,6 +36,7 @@ import {
 import { getSlashCommands } from "./commands.js";
 import { ChatLog } from "./components/chat-log.js";
 import { CustomEditor } from "./components/custom-editor.js";
+import { startHerdrStateSidecar } from "./herdr-state-sidecar.js";
 import { resolveLocalRunShutdownGraceMs } from "./local-run-shutdown.js";
 import { editorTheme, theme } from "./theme/theme.js";
 import type { TuiBackend } from "./tui-backend.js";
@@ -525,6 +526,12 @@ function resolveEmptySessionInfoDefaults(config: OpenClawConfig): SessionInfo {
 }
 
 export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
+  const herdrStateSidecar = startHerdrStateSidecar({
+    logger: {
+      debug: () => undefined,
+      warn: () => undefined,
+    },
+  });
   const isLocalMode = opts.local === true || opts.backend !== undefined;
   const config = opts.config ?? getRuntimeConfig({ skipPluginValidation: !isLocalMode });
   const emptySessionInfoDefaults = resolveEmptySessionInfoDefaults(config);
@@ -1644,6 +1651,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       if (isLocalMode) {
         setConsoleSubsystemFilter(previousConsoleSubsystemFilter);
       }
+      herdrStateSidecar?.stop();
       cleanupTerminalLossHandler?.();
       cleanupTerminalLossHandler = null;
       process.removeListener("SIGINT", sigintHandler);


### PR DESCRIPTION
## What changed

- Added `src/tui/herdr-state-sidecar.ts`, a TypeScript Herdr pane-state bridge that starts from `openclaw tui` when `HERDR_PANE_ID` is present.
- Added `src/tui/herdr-state-sidecar.test.ts` for idle, working elapsed status, blocked approval text, dedupe, disable flag, and pane-gone shutdown.
- Added `extensions/herdr-state/` with bundled extension metadata, README, and `smoke-test.sh`.
- Updated `src/tui/tui.ts` to start and stop the bridge with the TUI lifecycle.
- Updated `pnpm-lock.yaml` for the new workspace importer.

## Why

WOR-379 needs OpenClaw TUI panes in Herdr to report idle/working/blocked state the same way Hermes panes do. The prior Python spike validated the fingerprints, but `extensions/` is a TypeScript plugin boundary, so this ports the bridge logic into TypeScript while keeping the actual lifecycle hook in the TUI process that receives `HERDR_PANE_ID`.

## Verification run

PASS:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts src/tui/herdr-state-sidecar.test.ts
Test Files  1 passed (1)
Tests  5 passed (5)
```

```text
node scripts/check-extension-plugin-sdk-boundary.mjs --mode=relative-outside-package
No extension plugin-sdk boundary violations found.
node scripts/check-extension-plugin-sdk-boundary.mjs --mode=src-outside-plugin-sdk
No extension plugin-sdk boundary violations found.
node scripts/check-extension-plugin-sdk-boundary.mjs --mode=plugin-sdk-internal
No extension plugin-sdk boundary violations found.
```

```text
pnpm exec oxlint src/tui/herdr-state-sidecar.ts src/tui/herdr-state-sidecar.test.ts src/tui/tui.ts extensions/herdr-state/index.ts
exit 0
```

```text
pnpm tsgo:core && pnpm tsgo:extensions
exit 0
```

PARTIAL:

```text
pnpm test:contracts:plugins
5 failed | 914 passed
```

Failures were pre-existing missing built public artifacts under `dist/extensions/*`, for example `Cannot find module '../../../dist/extensions/openai/provider-policy-api.js'`, `anthropic/provider-contract-api.js`, and `firecrawl/web-fetch-contract-api.js`.

NOT RUN:

Live Herdr smoke could not run from this host because `herdr` is not installed on PATH and no built binary exists at `~/dev/forks/herdr/target/{debug,release}/herdr`.

## Risks / known gaps

- Live acceptance smoke is still blocked on a usable Herdr binary/session from this runtime.
- The bridge still polls `herdr pane read`; event subscription remains a future optimization.
- Blocked-state regexes are based on the spike placeholders and unit coverage, not a fresh live approval modal capture.
