### PR TITLE
fix(tools): treat no-op writes and edits as terminal tool-loop failures (fixes #96983)

### DIFF
--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -202,6 +202,21 @@ describe("applyPatch", () => {
     }
   });
 
+  it("applies a real deletion of the sole blank line", async () => {
+    const memory = createMemoryPatchSandbox({ "source.txt": "\n" });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+-
+*** End Patch`;
+
+    const result = await applyPatch(patch, memory.options);
+
+    expect(result.noOp).toBeUndefined();
+    expect(memory.files.get("/sandbox/source.txt")).toBe("");
+    expect(memory.writeFile.mock.calls).toHaveLength(1);
+  });
+
   it("preserves formatting for same-path move no-op hunks", async () => {
     const patch = `*** Begin Patch
 *** Update File: source.txt

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -202,6 +202,26 @@ describe("applyPatch", () => {
     }
   });
 
+  it("preserves formatting for same-path move no-op hunks", async () => {
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+*** Move to: ./source.txt
+@@
+ foo
+-bar
++bar
+*** End Patch`;
+    for (const initial of ["foo\r\nbar\r\n", "foo\nbar"]) {
+      const memory = createMemoryPatchSandbox({ "source.txt": initial });
+
+      const result = await applyPatch(patch, memory.options);
+
+      expect(result.noOp).toBe(true);
+      expect(memory.files.get("/sandbox/source.txt")).toBe(initial);
+      expect(memory.writeFile.mock.calls).toHaveLength(0);
+    }
+  });
+
   it("applies context-only insertions at the requested context", async () => {
     const memory = createMemoryPatchSandbox({
       "source.txt": "alpha\nanchor\nomega\n",

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -183,6 +183,25 @@ describe("applyPatch", () => {
     expect(toolResult.terminate).toBe(true);
   });
 
+  it("preserves line endings and EOF state for no-op update hunks", async () => {
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+ foo
+-bar
++bar
+*** End Patch`;
+    for (const initial of ["foo\r\nbar\r\n", "foo\nbar"]) {
+      const memory = createMemoryPatchSandbox({ "source.txt": initial });
+
+      const result = await applyPatch(patch, memory.options);
+
+      expect(result.noOp).toBe(true);
+      expect(memory.files.get("/sandbox/source.txt")).toBe(initial);
+      expect(memory.writeFile.mock.calls).toHaveLength(0);
+    }
+  });
+
   it("applies context-only insertions at the requested context", async () => {
     const memory = createMemoryPatchSandbox({
       "source.txt": "alpha\nanchor\nomega\n",

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -43,15 +43,16 @@ function createMemoryPatchSandbox(initialFiles: Record<string, string> = {}) {
   const files = new Map<string, string>(
     Object.entries(initialFiles).map(([filePath, contents]) => [`/sandbox/${filePath}`, contents]),
   );
+  const writeFile = vi.fn(async ({ filePath, data }) => {
+    files.set(filePath, Buffer.isBuffer(data) ? data.toString("utf8") : data);
+  });
   const bridge: SandboxFsBridge = {
     resolvePath: ({ filePath }) => ({
       relativePath: filePath,
       containerPath: `/sandbox/${filePath}`,
     }),
     readFile: async ({ filePath }) => Buffer.from(files.get(filePath) ?? "", "utf8"),
-    writeFile: vi.fn(async ({ filePath, data }) => {
-      files.set(filePath, Buffer.isBuffer(data) ? data.toString("utf8") : data);
-    }),
+    writeFile,
     remove: async ({ filePath }) => {
       files.delete(filePath);
     },
@@ -73,6 +74,7 @@ function createMemoryPatchSandbox(initialFiles: Record<string, string> = {}) {
   return {
     files,
     bridge,
+    writeFile,
     options: {
       cwd: "/local/workspace",
       sandbox: {
@@ -174,7 +176,7 @@ describe("applyPatch", () => {
     expect(result.text).toBe("No changes made to source.txt.");
     expect(result.summary).toEqual({ added: [], modified: [], deleted: [] });
     expect(memory.files.get("/sandbox/source.txt")).toBe("foo\nbar\n");
-    expect(memory.bridge.writeFile).not.toHaveBeenCalled();
+    expect(memory.writeFile.mock.calls).toHaveLength(0);
 
     const tool = createApplyPatchTool(memory.options);
     const toolResult = await tool.execute("call-no-op", { input: patch }, undefined);

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -11,7 +11,7 @@ import {
   createRebindableDirectoryAlias,
   withRealpathSymlinkRebindRace,
 } from "../test-utils/symlink-rebind-race.js";
-import { applyPatch } from "./apply-patch.js";
+import { applyPatch, createApplyPatchTool } from "./apply-patch.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
@@ -49,9 +49,9 @@ function createMemoryPatchSandbox(initialFiles: Record<string, string> = {}) {
       containerPath: `/sandbox/${filePath}`,
     }),
     readFile: async ({ filePath }) => Buffer.from(files.get(filePath) ?? "", "utf8"),
-    writeFile: async ({ filePath, data }) => {
+    writeFile: vi.fn(async ({ filePath, data }) => {
       files.set(filePath, Buffer.isBuffer(data) ? data.toString("utf8") : data);
-    },
+    }),
     remove: async ({ filePath }) => {
       files.delete(filePath);
     },
@@ -72,6 +72,7 @@ function createMemoryPatchSandbox(initialFiles: Record<string, string> = {}) {
   };
   return {
     files,
+    bridge,
     options: {
       cwd: "/local/workspace",
       sandbox: {
@@ -153,6 +154,31 @@ describe("applyPatch", () => {
 
     expect(memory.files.get("/sandbox/source.txt")).toBe("foo\nbaz\n");
     expect(result.summary.modified).toEqual(["source.txt"]);
+  });
+
+  it("returns a terminal no-op without rewriting unchanged update hunks", async () => {
+    const memory = createMemoryPatchSandbox({
+      "source.txt": "foo\nbar\n",
+    });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+ foo
+-bar
++bar
+*** End Patch`;
+
+    const result = await applyPatch(patch, memory.options);
+
+    expect(result.noOp).toBe(true);
+    expect(result.text).toBe("No changes made to source.txt.");
+    expect(result.summary).toEqual({ added: [], modified: [], deleted: [] });
+    expect(memory.files.get("/sandbox/source.txt")).toBe("foo\nbar\n");
+    expect(memory.bridge.writeFile).not.toHaveBeenCalled();
+
+    const tool = createApplyPatchTool(memory.options);
+    const toolResult = await tool.execute("call-no-op", { input: patch }, undefined);
+    expect(toolResult.terminate).toBe(true);
   });
 
   it("applies context-only insertions at the requested context", async () => {

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -194,7 +194,7 @@ export async function applyPatch(
         path.resolve(moveTarget.resolved) === path.resolve(target.resolved);
       const destination = moveResolvesToSource ? target.resolved : moveTarget.resolved;
       const existing = moveResolvesToSource ? await fileOps.readFile(target.resolved) : undefined;
-      if (existing === applied && moveResolvesToSource) {
+      if (moveResolvesToSource && normalizeUpdateComparison(existing) === applied) {
         noOpPaths.add(target.display);
       } else {
         noOpPaths.delete(target.display);

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -193,9 +193,14 @@ export async function applyPatch(
       const moveResolvesToSource =
         path.resolve(moveTarget.resolved) === path.resolve(target.resolved);
       const destination = moveResolvesToSource ? target.resolved : moveTarget.resolved;
-      const existing = moveResolvesToSource ? await fileOps.readFile(target.resolved) : undefined;
-      if (moveResolvesToSource && normalizeUpdateComparison(existing) === applied) {
-        noOpPaths.add(target.display);
+      if (moveResolvesToSource) {
+        const existing = await fileOps.readFile(target.resolved);
+        if (normalizeUpdateComparison(existing) === applied) {
+          noOpPaths.add(target.display);
+        } else {
+          noOpPaths.delete(target.display);
+          await fileOps.writeFile(destination, applied);
+        }
       } else {
         noOpPaths.delete(target.display);
         await fileOps.writeFile(destination, applied);

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -71,7 +71,10 @@ type ApplyPatchToolDetails = {
 
 function normalizeUpdateComparison(content: string): string {
   const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-  return normalized.length === 0 || normalized.endsWith("\n") ? normalized : `${normalized}\n`;
+  if (normalized.length === 0 || normalized.endsWith("\n")) {
+    return normalized;
+  }
+  return `${normalized}\n`;
 }
 
 type SandboxApplyPatchConfig = {

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -69,6 +69,11 @@ type ApplyPatchToolDetails = {
   summary: ApplyPatchSummary;
 };
 
+function normalizeUpdateComparison(content: string): string {
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  return normalized.length === 0 || normalized.endsWith("\n") ? normalized : `${normalized}\n`;
+}
+
 type SandboxApplyPatchConfig = {
   root: string;
   bridge: SandboxFsBridge;
@@ -208,7 +213,7 @@ export async function applyPatch(
       }
     } else {
       const existing = await fileOps.readFile(target.resolved);
-      if (existing === applied) {
+      if (normalizeUpdateComparison(existing) === applied) {
         noOpPaths.add(target.display);
       } else {
         noOpPaths.delete(target.display);

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -62,6 +62,7 @@ export type ApplyPatchSummary = {
 type ApplyPatchResult = {
   summary: ApplyPatchSummary;
   text: string;
+  noOp?: boolean;
 };
 
 type ApplyPatchToolDetails = {
@@ -123,6 +124,7 @@ export function createApplyPatchTool(
       return {
         content: [{ type: "text", text: result.text }],
         details: { summary: result.summary },
+        ...(result.noOp ? { terminate: true } : {}),
       };
     },
   };
@@ -148,6 +150,7 @@ export async function applyPatch(
     modified: new Set<string>(),
     deleted: new Set<string>(),
   };
+  const noOpPaths = new Set<string>();
   const fileOps = resolvePatchFileOps(options);
 
   for (const hunk of parsed.hunks) {
@@ -184,28 +187,42 @@ export async function applyPatch(
       await ensureDir(moveTarget.resolved, fileOps);
       const moveResolvesToSource =
         path.resolve(moveTarget.resolved) === path.resolve(target.resolved);
-      await fileOps.writeFile(
-        moveResolvesToSource ? target.resolved : moveTarget.resolved,
-        applied,
-      );
+      const destination = moveResolvesToSource ? target.resolved : moveTarget.resolved;
+      const existing = moveResolvesToSource ? await fileOps.readFile(target.resolved) : undefined;
+      if (existing === applied && moveResolvesToSource) {
+        noOpPaths.add(target.display);
+      } else {
+        noOpPaths.delete(target.display);
+        await fileOps.writeFile(destination, applied);
+      }
       if (!moveResolvesToSource) {
         await fileOps.remove(target.resolved);
       }
-      recordSummary(
-        summary,
-        seen,
-        "modified",
-        moveResolvesToSource ? target.display : moveTarget.display,
-      );
+      if (!noOpPaths.has(target.display)) {
+        recordSummary(
+          summary,
+          seen,
+          "modified",
+          moveResolvesToSource ? target.display : moveTarget.display,
+        );
+      }
     } else {
-      await fileOps.writeFile(target.resolved, applied);
-      recordSummary(summary, seen, "modified", target.display);
+      const existing = await fileOps.readFile(target.resolved);
+      if (existing === applied) {
+        noOpPaths.add(target.display);
+      } else {
+        noOpPaths.delete(target.display);
+        await fileOps.writeFile(target.resolved, applied);
+        recordSummary(summary, seen, "modified", target.display);
+      }
     }
   }
 
+  const noOp = noOpPaths.size > 0 && Object.values(summary).every((paths) => paths.length === 0);
   return {
     summary,
-    text: formatSummary(summary),
+    text: noOp ? `No changes made to ${Array.from(noOpPaths).join(", ")}.` : formatSummary(summary),
+    ...(noOp ? { noOp: true } : {}),
   };
 }
 

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -195,7 +195,7 @@ export async function applyPatch(
       const destination = moveResolvesToSource ? target.resolved : moveTarget.resolved;
       if (moveResolvesToSource) {
         const existing = await fileOps.readFile(target.resolved);
-        if (normalizeUpdateComparison(existing) === applied) {
+        if (normalizeUpdateComparison(existing) === normalizeUpdateComparison(applied)) {
           noOpPaths.add(target.display);
         } else {
           noOpPaths.delete(target.display);
@@ -218,7 +218,7 @@ export async function applyPatch(
       }
     } else {
       const existing = await fileOps.readFile(target.resolved);
-      if (normalizeUpdateComparison(existing) === applied) {
+      if (normalizeUpdateComparison(existing) === normalizeUpdateComparison(applied)) {
         noOpPaths.add(target.display);
       } else {
         noOpPaths.delete(target.display);

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -427,6 +427,34 @@ export interface EditDiffError {
   error: string;
 }
 
+export function validateNoOpEditTargets(
+  normalizedContent: string,
+  noOpEdits: Edit[],
+  realEdits: Edit[],
+  path: string,
+): void {
+  if (noOpEdits.length > 0) {
+    applyEditsToNormalizedContent(
+      normalizedContent,
+      noOpEdits.map((edit) => ({ oldText: edit.oldText, newText: "" })),
+      path,
+    );
+  }
+  const exactNoOpEdits = noOpEdits.filter((edit) =>
+    normalizedContent.includes(normalizeToLF(edit.oldText)),
+  );
+  if (exactNoOpEdits.length > 0 && realEdits.length > 0) {
+    applyEditsToNormalizedContent(
+      normalizedContent,
+      [...exactNoOpEdits, ...realEdits].map((edit) => ({
+        oldText: edit.oldText,
+        newText: "",
+      })),
+      path,
+    );
+  }
+}
+
 /**
  * Compute the diff for one or more edit operations without applying them.
  * Used for preview rendering in the TUI before the tool executes.
@@ -468,9 +496,12 @@ export async function computeEditsDiff(
     // Strip BOM before matching (LLM won't include invisible BOM in oldText)
     const { text: content } = stripBom(rawContent);
     const normalizedContent = normalizeToLF(content);
+    const noOpEdits = edits.filter((edit) => edit.oldText === edit.newText);
+    const realEdits = edits.filter((edit) => edit.oldText !== edit.newText);
+    validateNoOpEditTargets(normalizedContent, noOpEdits, realEdits, path);
     const { baseContent, newContent } = applyEditsToNormalizedContent(
       normalizedContent,
-      edits,
+      realEdits,
       path,
     );
 

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -455,6 +455,29 @@ export function validateNoOpEditTargets(
   }
 }
 
+export function splitNoOpEdits(
+  normalizedContent: string,
+  edits: Edit[],
+  path: string,
+): { noOpEdits: Edit[]; realEdits: Edit[] } {
+  const noOpEdits: Edit[] = [];
+  const realEdits: Edit[] = [];
+  for (const edit of edits) {
+    const fuzzyNoOp = normalizeForFuzzyMatch(edit.oldText) === normalizeForFuzzyMatch(edit.newText);
+    if (edit.oldText === edit.newText || fuzzyNoOp) {
+      applyEditsToNormalizedContent(
+        normalizedContent,
+        [{ oldText: edit.oldText, newText: "" }],
+        path,
+      );
+      noOpEdits.push(edit);
+    } else {
+      realEdits.push(edit);
+    }
+  }
+  return { noOpEdits, realEdits };
+}
+
 /**
  * Compute the diff for one or more edit operations without applying them.
  * Used for preview rendering in the TUI before the tool executes.
@@ -496,8 +519,7 @@ export async function computeEditsDiff(
     // Strip BOM before matching (LLM won't include invisible BOM in oldText)
     const { text: content } = stripBom(rawContent);
     const normalizedContent = normalizeToLF(content);
-    const noOpEdits = edits.filter((edit) => edit.oldText === edit.newText);
-    const realEdits = edits.filter((edit) => edit.oldText !== edit.newText);
+    const { noOpEdits, realEdits } = splitNoOpEdits(normalizedContent, edits, path);
     validateNoOpEditTargets(normalizedContent, noOpEdits, realEdits, path);
     if (realEdits.length === 0) {
       return { diff: "", firstChangedLine: undefined };

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -79,6 +79,13 @@ export interface Edit {
   newText: string;
 }
 
+export class EditNoChangeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EditNoChangeError";
+  }
+}
+
 interface MatchedEdit {
   editIndex: number;
   matchIndex: number;
@@ -179,13 +186,15 @@ function getEmptyOldTextError(path: string, editIndex: number, totalEdits: numbe
   return new Error(`edits[${editIndex}].oldText must not be empty in ${path}.`);
 }
 
-function getNoChangeError(path: string, totalEdits: number): Error {
+function getNoChangeError(path: string, totalEdits: number): EditNoChangeError {
   if (totalEdits === 1) {
-    return new Error(
+    return new EditNoChangeError(
       `No changes made to ${path}. The replacement produced identical content. This might indicate an issue with special characters or the text not existing as expected.`,
     );
   }
-  return new Error(`No changes made to ${path}. The replacements produced identical content.`);
+  return new EditNoChangeError(
+    `No changes made to ${path}. The replacements produced identical content.`,
+  );
 }
 
 /**

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -511,6 +511,9 @@ export async function computeEditsDiff(
     // Generate the diff
     return generateDiffString(baseContent, newContent);
   } catch (err) {
+    if (err instanceof EditNoChangeError) {
+      return { diff: "", firstChangedLine: undefined };
+    }
     return { error: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -499,6 +499,9 @@ export async function computeEditsDiff(
     const noOpEdits = edits.filter((edit) => edit.oldText === edit.newText);
     const realEdits = edits.filter((edit) => edit.oldText !== edit.newText);
     validateNoOpEditTargets(normalizedContent, noOpEdits, realEdits, path);
+    if (realEdits.length === 0) {
+      return { diff: "", firstChangedLine: undefined };
+    }
     const { baseContent, newContent } = applyEditsToNormalizedContent(
       normalizedContent,
       realEdits,

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -197,6 +197,28 @@ describe("edit tool", () => {
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("unchanged content\n");
   });
 
+  it("preserves valid sibling edits when batch contains a no-op entry", async () => {
+    const filePath = await createTempFile("alpha beta gamma\n");
+    const tool = createEditTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      {
+        path: filePath,
+        edits: [
+          { oldText: "alpha", newText: "alpha" }, // no-op
+          { oldText: "gamma", newText: "GAMMA" }, // real change
+        ],
+      },
+      undefined,
+    );
+
+    const tcText = result.content[0];
+    expect("text" in tcText ? tcText.text : "").toContain("Successfully replaced");
+    expect((result as any).terminate).toBeFalsy();
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("alpha beta GAMMA\n");
+  });
+
   it("applies real changes normally (no false positive for no-op)", async () => {
     const filePath = await createTempFile("old content\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -423,6 +423,25 @@ describe("edit tool", () => {
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("bazbar\n");
   });
 
+  it("preserves unrelated whitespace beside a fuzzy-equivalent no-op", async () => {
+    const filePath = await createTempFile("foo  \nkeep  \n");
+    const tool = createEditTool(tmpDir);
+
+    await tool.execute(
+      "call-1",
+      {
+        path: filePath,
+        edits: [
+          { oldText: "foo  ", newText: "foo" },
+          { oldText: "keep", newText: "changed" },
+        ],
+      },
+      undefined,
+    );
+
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("foo  \nchanged  \n");
+  });
+
   it("rejects duplicate no-op entries", async () => {
     const filePath = await createTempFile("foo\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -249,6 +249,44 @@ describe("edit tool", () => {
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("bazbar\n");
   });
 
+  it("rejects duplicate no-op entries", async () => {
+    const filePath = await createTempFile("foo\n");
+    const tool = createEditTool(tmpDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [
+            { oldText: "foo", newText: "foo" },
+            { oldText: "foo", newText: "foo" },
+          ],
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(/overlap/);
+  });
+
+  it("rejects an exact no-op overlapping a real edit", async () => {
+    const filePath = await createTempFile("foo\n");
+    const tool = createEditTool(tmpDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [
+            { oldText: "foo", newText: "foo" },
+            { oldText: "foo", newText: "bar" },
+          ],
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(/overlap/);
+  });
+
   it("preserves valid sibling edits when batch contains a no-op entry", async () => {
     const filePath = await createTempFile("alpha beta gamma\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -230,6 +230,25 @@ describe("edit tool", () => {
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("foo\n");
   });
 
+  it("preserves real sibling edits beside a fuzzy no-op", async () => {
+    const filePath = await createTempFile("foo\u00a0bar\n");
+    const tool = createEditTool(tmpDir);
+
+    await tool.execute(
+      "call-1",
+      {
+        path: filePath,
+        edits: [
+          { oldText: "foo bar", newText: "foo bar" },
+          { oldText: "foo\u00a0", newText: "baz" },
+        ],
+      },
+      undefined,
+    );
+
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("bazbar\n");
+  });
+
   it("preserves valid sibling edits when batch contains a no-op entry", async () => {
     const filePath = await createTempFile("alpha beta gamma\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -178,6 +178,47 @@ describe("edit tool", () => {
     );
   });
 
+  it("filters fuzzy no-op edits from mixed previews", async () => {
+    const readFile = vi.fn(async () => Buffer.from("foo\u00a0bar\n"));
+    const operations: EditOperations = {
+      access: async () => {},
+      readFile,
+      writeFile: async () => {},
+    };
+    const tool = createEditToolDefinition("/workspace", { operations });
+    const args = {
+      path: "remote.txt",
+      edits: [
+        { oldText: "foo bar", newText: "foo bar" },
+        { oldText: "foo\u00a0", newText: "baz" },
+      ],
+    };
+    const context = {
+      args,
+      argsComplete: true,
+      cwd: "/workspace",
+      executionStarted: false,
+      expanded: false,
+      invalidate: vi.fn(),
+      isError: false,
+      isPartial: false,
+      lastComponent: undefined,
+      showImages: false,
+      state: {},
+      toolCallId: "call-preview-mixed",
+    };
+
+    const component = tool.renderCall?.(args, testTheme, context);
+    await vi.waitFor(() => expect(context.invalidate).toHaveBeenCalled());
+
+    expect(
+      (component as { preview?: { error?: string; diff?: string } } | undefined)?.preview,
+    ).toEqual(expect.objectContaining({ diff: expect.stringContaining("bazbar") }));
+    expect(
+      (component as { preview?: { error?: string } } | undefined)?.preview?.error,
+    ).toBeUndefined();
+  });
+
   it("returns terminal no-op when oldText equals newText", async () => {
     const filePath = await createTempFile("unchanged content\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -213,6 +213,31 @@ describe("edit tool", () => {
     ).rejects.toThrow(/Current file contents:\nactual content/);
   });
 
+  it("does not hide unrelated errors that mention no changes", async () => {
+    const filePath = await createTempFile("old content\n");
+    const operations: EditOperations = {
+      access: async (absolutePath) => {
+        await fs.access(absolutePath);
+      },
+      readFile: (absolutePath) => fs.readFile(absolutePath),
+      writeFile: async () => {
+        throw new Error("No changes made to the disk because it is full");
+      },
+    };
+    const tool = createEditTool(tmpDir, { operations });
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: "old", newText: "new" }],
+        },
+        undefined,
+      ),
+    ).rejects.toThrow("No changes made to the disk because it is full");
+  });
+
   it("does not rewrite fuzzy-matched no-op text", async () => {
     const filePath = await createTempFile("foo\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -219,6 +219,44 @@ describe("edit tool", () => {
     ).toBeUndefined();
   });
 
+  it("validates no-op targets in mixed previews", async () => {
+    const readFile = vi.fn(async () => Buffer.from("alpha beta\n"));
+    const operations: EditOperations = {
+      access: async () => {},
+      readFile,
+      writeFile: async () => {},
+    };
+    const tool = createEditToolDefinition("/workspace", { operations });
+    const args = {
+      path: "remote.txt",
+      edits: [
+        { oldText: "missing", newText: "missing" },
+        { oldText: "alpha", newText: "ALPHA" },
+      ],
+    };
+    const context = {
+      args,
+      argsComplete: true,
+      cwd: "/workspace",
+      executionStarted: false,
+      expanded: false,
+      invalidate: vi.fn(),
+      isError: false,
+      isPartial: false,
+      lastComponent: undefined,
+      showImages: false,
+      state: {},
+      toolCallId: "call-preview-invalid-no-op",
+    };
+
+    const component = tool.renderCall?.(args, testTheme, context);
+    await vi.waitFor(() => expect(context.invalidate).toHaveBeenCalled());
+
+    expect((component as { preview?: { error?: string } } | undefined)?.preview?.error).toContain(
+      "Could not find the exact text",
+    );
+  });
+
   it("returns terminal no-op when oldText equals newText", async () => {
     const filePath = await createTempFile("unchanged content\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -191,7 +191,8 @@ describe("edit tool", () => {
       undefined,
     );
 
-    expect(result.content[0].text).toContain("No changes made");
+    const tc0 = result.content[0];
+    expect("text" in tc0 ? tc0.text : "").toContain("No changes made");
     expect((result as any).terminate).toBe(true);
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("unchanged content\n");
   });
@@ -209,7 +210,8 @@ describe("edit tool", () => {
       undefined,
     );
 
-    expect(result.content[0].text).toContain("Successfully replaced");
+    const tc1 = result.content[0];
+    expect("text" in tc1 ? tc1.text : "").toContain("Successfully replaced");
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new content\n");
   });
 });

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -197,6 +197,39 @@ describe("edit tool", () => {
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("unchanged content\n");
   });
 
+  it("does not hide a mismatched no-op edit", async () => {
+    const filePath = await createTempFile("actual content\n");
+    const tool = createEditTool(tmpDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: "missing", newText: "missing" }],
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(/Current file contents:\nactual content/);
+  });
+
+  it("does not rewrite fuzzy-matched no-op text", async () => {
+    const filePath = await createTempFile("foo\n");
+    const tool = createEditTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      {
+        path: filePath,
+        edits: [{ oldText: "foo ", newText: "foo " }],
+      },
+      undefined,
+    );
+
+    expect((result as any).terminate).toBe(true);
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("foo\n");
+  });
+
   it("preserves valid sibling edits when batch contains a no-op entry", async () => {
     const filePath = await createTempFile("alpha beta gamma\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -276,6 +276,41 @@ describe("edit tool", () => {
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("unchanged content\n");
   });
 
+  it("shows an empty preview for an all-no-op edit", async () => {
+    const readFile = vi.fn(async () => Buffer.from("unchanged content\n"));
+    const operations: EditOperations = {
+      access: async () => {},
+      readFile,
+      writeFile: async () => {},
+    };
+    const tool = createEditToolDefinition("/workspace", { operations });
+    const args = {
+      path: "remote.txt",
+      edits: [{ oldText: "unchanged", newText: "unchanged" }],
+    };
+    const context = {
+      args,
+      argsComplete: true,
+      cwd: "/workspace",
+      executionStarted: false,
+      expanded: false,
+      invalidate: vi.fn(),
+      isError: false,
+      isPartial: false,
+      lastComponent: undefined,
+      showImages: false,
+      state: {},
+      toolCallId: "call-preview-no-op",
+    };
+
+    const component = tool.renderCall?.(args, testTheme, context);
+    await vi.waitFor(() => expect(context.invalidate).toHaveBeenCalled());
+
+    expect(
+      (component as { preview?: { error?: string; diff?: string } } | undefined)?.preview,
+    ).toEqual({ diff: "", firstChangedLine: undefined });
+  });
+
   it("does not hide a mismatched no-op edit", async () => {
     const filePath = await createTempFile("actual content\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -311,6 +311,41 @@ describe("edit tool", () => {
     ).toEqual({ diff: "", firstChangedLine: undefined });
   });
 
+  it("shows an empty preview for a fuzzy net no-op", async () => {
+    const readFile = vi.fn(async () => Buffer.from("foo\n"));
+    const operations: EditOperations = {
+      access: async () => {},
+      readFile,
+      writeFile: async () => {},
+    };
+    const tool = createEditToolDefinition("/workspace", { operations });
+    const args = {
+      path: "remote.txt",
+      edits: [{ oldText: "foo ", newText: "foo" }],
+    };
+    const context = {
+      args,
+      argsComplete: true,
+      cwd: "/workspace",
+      executionStarted: false,
+      expanded: false,
+      invalidate: vi.fn(),
+      isError: false,
+      isPartial: false,
+      lastComponent: undefined,
+      showImages: false,
+      state: {},
+      toolCallId: "call-preview-fuzzy-no-op",
+    };
+
+    const component = tool.renderCall?.(args, testTheme, context);
+    await vi.waitFor(() => expect(context.invalidate).toHaveBeenCalled());
+
+    expect(
+      (component as { preview?: { error?: string; diff?: string } } | undefined)?.preview,
+    ).toEqual({ diff: "", firstChangedLine: undefined });
+  });
+
   it("does not hide a mismatched no-op edit", async () => {
     const filePath = await createTempFile("actual content\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -37,7 +37,10 @@ describe("edit tool", () => {
     await expect(
       tool.execute(
         "call-1",
-        { path: filePath, edits: [{ oldText: "missing", newText: "replacement" }] },
+        {
+          path: filePath,
+          edits: [{ oldText: "missing", newText: "replacement" }],
+        },
         undefined,
       ),
     ).rejects.toThrow(/Current file contents:\nactual current content/);
@@ -173,5 +176,40 @@ describe("edit tool", () => {
     expect((component as { preview?: { diff?: string } } | undefined)?.preview?.diff).toContain(
       "remote changed",
     );
+  });
+
+  it("returns terminal no-op when oldText equals newText", async () => {
+    const filePath = await createTempFile("unchanged content\n");
+    const tool = createEditTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      {
+        path: filePath,
+        edits: [{ oldText: "unchanged", newText: "unchanged" }],
+      },
+      undefined,
+    );
+
+    expect(result.content[0].text).toContain("No changes made");
+    expect((result as any).terminate).toBe(true);
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("unchanged content\n");
+  });
+
+  it("applies real changes normally (no false positive for no-op)", async () => {
+    const filePath = await createTempFile("old content\n");
+    const tool = createEditTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      {
+        path: filePath,
+        edits: [{ oldText: "old", newText: "new" }],
+      },
+      undefined,
+    );
+
+    expect(result.content[0].text).toContain("Successfully replaced");
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new content\n");
   });
 });

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -392,7 +392,7 @@ export function createEditToolDefinition(
       void toolCallId;
       void onUpdate;
       void ctx;
-      const { path, edits } = validateEditInput(input);
+      const { path, edits: originalEdits } = validateEditInput(input);
       const absolutePath = resolveToCwd(path, cwd);
 
       return withFileMutationQueue(absolutePath, async () => {
@@ -400,8 +400,10 @@ export function createEditToolDefinition(
           throw new Error("Operation aborted");
         }
 
-        // Pre-execution no-op: oldText === newText means no change.
-        if (edits.some((e) => e.oldText === e.newText)) {
+        // Filter out no-op entries (oldText === newText) before execution.
+        // If all entries are no-op, return a terminal result.
+        const realEdits = originalEdits.filter((e) => e.oldText !== e.newText);
+        if (realEdits.length === 0) {
           return {
             ...textResult(
               `No changes made to ${path}. The replacement text is identical to the original.`,
@@ -435,7 +437,7 @@ export function createEditToolDefinition(
           const normalizedContent = normalizeToLF(content);
           const { baseContent, newContent } = applyEditsToNormalizedContent(
             normalizedContent,
-            edits,
+            realEdits,
             path,
           );
           const finalContent = bom + restoreLineEndings(newContent, originalEnding);
@@ -450,7 +452,7 @@ export function createEditToolDefinition(
             content: [
               {
                 type: "text",
-                text: `Successfully replaced ${edits.length} block(s) in ${path}.`,
+                text: `Successfully replaced ${realEdits.length} block(s) in ${path}.`,
               },
             ],
             details: {
@@ -469,14 +471,14 @@ export function createEditToolDefinition(
             didEditLikelyApply({
               originalContent: rawContent,
               currentContent,
-              edits,
+              edits: realEdits,
             })
           ) {
             return {
               content: [
                 {
                   type: "text",
-                  text: `Successfully replaced ${edits.length} block(s) in ${path}.`,
+                  text: `Successfully replaced ${realEdits.length} block(s) in ${path}.`,
                 },
               ],
               details: { diff: "", patch: "" },

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -424,16 +424,30 @@ export function createEditToolDefinition(
           const { bom, text: content } = stripBom(rawContent);
           const originalEnding = detectLineEnding(content);
           const normalizedContent = normalizeToLF(content);
-          // Validate no-op targets independently so one fuzzy match cannot
-          // normalize away distinctions needed by real sibling edits.
-          for (const edit of originalEdits) {
-            if (edit.oldText === edit.newText) {
-              applyEditsToNormalizedContent(
-                normalizedContent,
-                [{ oldText: edit.oldText, newText: "" }],
-                path,
-              );
-            }
+          const noOpEdits = originalEdits.filter((edit) => edit.oldText === edit.newText);
+          if (noOpEdits.length > 0) {
+            // Validate no-op targets together so duplicate/overlapping no-ops
+            // still fail, without letting fuzzy matches affect real edits.
+            applyEditsToNormalizedContent(
+              normalizedContent,
+              noOpEdits.map((edit) => ({ oldText: edit.oldText, newText: "" })),
+              path,
+            );
+          }
+          const exactNoOpEdits = noOpEdits.filter((edit) =>
+            normalizedContent.includes(normalizeToLF(edit.oldText)),
+          );
+          if (exactNoOpEdits.length > 0 && realEdits.length > 0) {
+            // Preserve the documented overlap contract for exact no-op
+            // targets while keeping fuzzy no-ops out of this pass.
+            applyEditsToNormalizedContent(
+              normalizedContent,
+              [...exactNoOpEdits, ...realEdits].map((edit) => ({
+                oldText: edit.oldText,
+                newText: "",
+              })),
+              path,
+            );
           }
           if (realEdits.length === 0) {
             return {

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -13,6 +13,7 @@ import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { renderDiff } from "../../modes/interactive/components/diff.js";
 import type { AgentTool } from "../../runtime/index.js";
+import { textResult } from "../../tools/common.js";
 import type { ToolDefinition } from "../extensions/types.js";
 import {
   applyEditsToNormalizedContent,
@@ -45,14 +46,18 @@ const replaceEditSchema = Type.Object(
       description:
         "Exact text for one targeted replacement. It must be unique in the original file and must not overlap with any other edits[].oldText in the same call.",
     }),
-    newText: Type.String({ description: "Replacement text for this targeted edit." }),
+    newText: Type.String({
+      description: "Replacement text for this targeted edit.",
+    }),
   },
   { additionalProperties: false },
 );
 
 const editSchema = Type.Object(
   {
-    path: Type.String({ description: "Path to the file to edit (relative or absolute)" }),
+    path: Type.String({
+      description: "Path to the file to edit (relative or absolute)",
+    }),
     edits: Type.Array(replaceEditSchema, {
       description:
         "One or more targeted replacements. Each edit is matched against the original file, not incrementally. Do not include overlapping or nested edits. If two changes touch the same block or nearby lines, merge them into one edit instead.",
@@ -123,7 +128,10 @@ function prepareEditArguments(input: unknown): EditToolInput {
   return { ...rest, edits } as EditToolInput;
 }
 
-function validateEditInput(input: EditToolInput): { path: string; edits: Edit[] } {
+function validateEditInput(input: EditToolInput): {
+  path: string;
+  edits: Edit[];
+} {
   if (!Array.isArray(input.edits) || input.edits.length === 0) {
     throw new Error("Edit tool input is invalid. edits must contain at least one replacement.");
   }
@@ -183,7 +191,12 @@ type RenderableEditArgs = {
 };
 
 type EditToolResultLike = {
-  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+  content: Array<{
+    type: string;
+    text?: string;
+    data?: string;
+    mimeType?: string;
+  }>;
   details?: EditToolDetails;
 };
 
@@ -387,6 +400,17 @@ export function createEditToolDefinition(
           throw new Error("Operation aborted");
         }
 
+        // Pre-execution no-op: oldText === newText means no change.
+        if (edits.some((e) => e.oldText === e.newText)) {
+          return {
+            ...textResult(
+              `No changes made to ${path}. The replacement text is identical to the original.`,
+              undefined,
+            ),
+            terminate: true,
+          };
+        }
+
         try {
           await ops.access(absolutePath);
         } catch (error: unknown) {
@@ -441,7 +465,13 @@ export function createEditToolDefinition(
             .readFile(absolutePath)
             .then((current) => current.toString("utf-8"))
             .catch(() => rawContent);
-          if (didEditLikelyApply({ originalContent: rawContent, currentContent, edits })) {
+          if (
+            didEditLikelyApply({
+              originalContent: rawContent,
+              currentContent,
+              edits,
+            })
+          ) {
             return {
               content: [
                 {
@@ -454,6 +484,16 @@ export function createEditToolDefinition(
           }
           if (normalizedError.message.includes(EDIT_MISMATCH_MESSAGE)) {
             throw appendMismatchHint(normalizedError, currentContent);
+          }
+          // Terminal no-op: the edit produced identical content.
+          if (normalizedError.message.includes("No changes made to")) {
+            return {
+              ...textResult(
+                `No changes made to ${path}. The replacement produced identical content.`,
+                undefined,
+              ),
+              terminate: true,
+            };
           }
           throw normalizedError;
         }
@@ -505,7 +545,10 @@ export function createEditToolDefinition(
           changed =
             setEditPreview(
               callComponent,
-              { diff: resultDiff, firstChangedLine: typedResult.details?.firstChangedLine },
+              {
+                diff: resultDiff,
+                firstChangedLine: typedResult.details?.firstChangedLine,
+              },
               argsKey,
             ) || changed;
         }

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -28,6 +28,7 @@ import {
   normalizeToLF,
   restoreLineEndings,
   stripBom,
+  validateNoOpEditTargets,
 } from "./edit-diff.js";
 import { withFileMutationQueue } from "./file-mutation-queue.js";
 import { resolveToCwd } from "./path-utils.js";
@@ -430,30 +431,7 @@ export function createEditToolDefinition(
           const originalEnding = detectLineEnding(content);
           const normalizedContent = normalizeToLF(content);
           const noOpEdits = originalEdits.filter((edit) => edit.oldText === edit.newText);
-          if (noOpEdits.length > 0) {
-            // Validate no-op targets together so duplicate/overlapping no-ops
-            // still fail, without letting fuzzy matches affect real edits.
-            applyEditsToNormalizedContent(
-              normalizedContent,
-              noOpEdits.map((edit) => ({ oldText: edit.oldText, newText: "" })),
-              path,
-            );
-          }
-          const exactNoOpEdits = noOpEdits.filter((edit) =>
-            normalizedContent.includes(normalizeToLF(edit.oldText)),
-          );
-          if (exactNoOpEdits.length > 0 && realEdits.length > 0) {
-            // Preserve the documented overlap contract for exact no-op
-            // targets while keeping fuzzy no-ops out of this pass.
-            applyEditsToNormalizedContent(
-              normalizedContent,
-              [...exactNoOpEdits, ...realEdits].map((edit) => ({
-                oldText: edit.oldText,
-                newText: "",
-              })),
-              path,
-            );
-          }
+          validateNoOpEditTargets(normalizedContent, noOpEdits, realEdits, path);
           if (realEdits.length === 0) {
             return {
               ...textResult(
@@ -546,17 +524,14 @@ export function createEditToolDefinition(
       if (context.argsComplete && previewInput && !component.preview && !component.previewPending) {
         component.previewPending = true;
         const requestKey = argsKey;
-        void computeEditsDiff(
-          previewInput.path,
-          filterNoOpEdits(previewInput.edits),
-          context.cwd,
-          ops,
-        ).then((preview) => {
-          if (component.previewArgsKey === requestKey) {
-            setEditPreview(component, preview, requestKey);
-            context.invalidate();
-          }
-        });
+        void computeEditsDiff(previewInput.path, previewInput.edits, context.cwd, ops).then(
+          (preview) => {
+            if (component.previewArgsKey === requestKey) {
+              setEditPreview(component, preview, requestKey);
+              context.invalidate();
+            }
+          },
+        );
       }
 
       return buildEditCallComponent(component, args, theme);

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -41,6 +41,10 @@ type EditRenderState = {
   callComponent?: EditCallRenderComponent;
 };
 
+function filterNoOpEdits(edits: Edit[]): Edit[] {
+  return edits.filter((edit) => edit.oldText !== edit.newText);
+}
+
 const replaceEditSchema = Type.Object(
   {
     oldText: Type.String({
@@ -401,7 +405,7 @@ export function createEditToolDefinition(
           throw new Error("Operation aborted");
         }
 
-        const realEdits = originalEdits.filter((e) => e.oldText !== e.newText);
+        const realEdits = filterNoOpEdits(originalEdits);
 
         try {
           await ops.access(absolutePath);
@@ -542,14 +546,17 @@ export function createEditToolDefinition(
       if (context.argsComplete && previewInput && !component.preview && !component.previewPending) {
         component.previewPending = true;
         const requestKey = argsKey;
-        void computeEditsDiff(previewInput.path, previewInput.edits, context.cwd, ops).then(
-          (preview) => {
-            if (component.previewArgsKey === requestKey) {
-              setEditPreview(component, preview, requestKey);
-              context.invalidate();
-            }
-          },
-        );
+        void computeEditsDiff(
+          previewInput.path,
+          filterNoOpEdits(previewInput.edits),
+          context.cwd,
+          ops,
+        ).then((preview) => {
+          if (component.previewArgsKey === requestKey) {
+            setEditPreview(component, preview, requestKey);
+            context.invalidate();
+          }
+        });
       }
 
       return buildEditCallComponent(component, args, theme);

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -27,6 +27,7 @@ import {
   generateUnifiedPatch,
   normalizeToLF,
   restoreLineEndings,
+  splitNoOpEdits,
   stripBom,
   validateNoOpEditTargets,
 } from "./edit-diff.js";
@@ -41,10 +42,6 @@ type EditPreview = EditDiffResult | EditDiffError;
 type EditRenderState = {
   callComponent?: EditCallRenderComponent;
 };
-
-function filterNoOpEdits(edits: Edit[]): Edit[] {
-  return edits.filter((edit) => edit.oldText !== edit.newText);
-}
 
 const replaceEditSchema = Type.Object(
   {
@@ -406,7 +403,7 @@ export function createEditToolDefinition(
           throw new Error("Operation aborted");
         }
 
-        const realEdits = filterNoOpEdits(originalEdits);
+        let realEdits: Edit[] = [];
 
         try {
           await ops.access(absolutePath);
@@ -430,7 +427,9 @@ export function createEditToolDefinition(
           const { bom, text: content } = stripBom(rawContent);
           const originalEnding = detectLineEnding(content);
           const normalizedContent = normalizeToLF(content);
-          const noOpEdits = originalEdits.filter((edit) => edit.oldText === edit.newText);
+          const editSets = splitNoOpEdits(normalizedContent, originalEdits, path);
+          const noOpEdits = editSets.noOpEdits;
+          realEdits = editSets.realEdits;
           validateNoOpEditTargets(normalizedContent, noOpEdits, realEdits, path);
           if (realEdits.length === 0) {
             return {

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -424,13 +424,17 @@ export function createEditToolDefinition(
           const { bom, text: content } = stripBom(rawContent);
           const originalEnding = detectLineEnding(content);
           const normalizedContent = normalizeToLF(content);
-          // Validate every requested target against the original file, but do
-          // not let equal-text entries rewrite content through fuzzy matching.
-          applyEditsToNormalizedContent(
-            normalizedContent,
-            originalEdits.map((edit) => ({ ...edit, newText: "" })),
-            path,
-          );
+          // Validate no-op targets independently so one fuzzy match cannot
+          // normalize away distinctions needed by real sibling edits.
+          for (const edit of originalEdits) {
+            if (edit.oldText === edit.newText) {
+              applyEditsToNormalizedContent(
+                normalizedContent,
+                [{ oldText: edit.oldText, newText: "" }],
+                path,
+              );
+            }
+          }
           if (realEdits.length === 0) {
             return {
               ...textResult(

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -400,18 +400,7 @@ export function createEditToolDefinition(
           throw new Error("Operation aborted");
         }
 
-        // Filter out no-op entries (oldText === newText) before execution.
-        // If all entries are no-op, return a terminal result.
         const realEdits = originalEdits.filter((e) => e.oldText !== e.newText);
-        if (realEdits.length === 0) {
-          return {
-            ...textResult(
-              `No changes made to ${path}. The replacement text is identical to the original.`,
-              undefined,
-            ),
-            terminate: true,
-          };
-        }
 
         try {
           await ops.access(absolutePath);
@@ -435,6 +424,22 @@ export function createEditToolDefinition(
           const { bom, text: content } = stripBom(rawContent);
           const originalEnding = detectLineEnding(content);
           const normalizedContent = normalizeToLF(content);
+          // Validate every requested target against the original file, but do
+          // not let equal-text entries rewrite content through fuzzy matching.
+          applyEditsToNormalizedContent(
+            normalizedContent,
+            originalEdits.map((edit) => ({ ...edit, newText: "" })),
+            path,
+          );
+          if (realEdits.length === 0) {
+            return {
+              ...textResult(
+                `No changes made to ${path}. The replacement text is identical to the original.`,
+                undefined,
+              ),
+              terminate: true,
+            };
+          }
           const { baseContent, newContent } = applyEditsToNormalizedContent(
             normalizedContent,
             realEdits,
@@ -487,7 +492,7 @@ export function createEditToolDefinition(
           if (normalizedError.message.includes(EDIT_MISMATCH_MESSAGE)) {
             throw appendMismatchHint(normalizedError, currentContent);
           }
-          // Terminal no-op: the edit produced identical content.
+          // Terminal no-op: the edit matched but produced identical content.
           if (normalizedError.message.includes("No changes made to")) {
             return {
               ...textResult(

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -19,6 +19,7 @@ import {
   applyEditsToNormalizedContent,
   computeEditsDiff,
   detectLineEnding,
+  EditNoChangeError,
   type Edit,
   type EditDiffError,
   type EditDiffResult,
@@ -511,7 +512,7 @@ export function createEditToolDefinition(
             throw appendMismatchHint(normalizedError, currentContent);
           }
           // Terminal no-op: the edit matched but produced identical content.
-          if (normalizedError.message.includes("No changes made to")) {
+          if (normalizedError instanceof EditNoChangeError) {
             return {
               ...textResult(
                 `No changes made to ${path}. The replacement produced identical content.`,

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -122,4 +122,35 @@ describe("write tool", () => {
 
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("finished\n");
   });
+
+  it("returns terminal no-op when writing identical content to existing file", async () => {
+    const filePath = await createTempPath("identical.txt");
+    await fs.writeFile(filePath, "hello\n", "utf-8");
+    const tool = createWriteTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      { path: "identical.txt", content: "hello\n" },
+      undefined,
+    );
+
+    expect(result.content[0].text).toContain("No changes made");
+    expect((result as any).terminate).toBe(true);
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("hello\n");
+  });
+
+  it("writes different content successfully (no false positive for no-op)", async () => {
+    const filePath = await createTempPath("different.txt");
+    await fs.writeFile(filePath, "old\n", "utf-8");
+    const tool = createWriteTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      { path: "different.txt", content: "new\n" },
+      undefined,
+    );
+
+    expect(result.content[0].text).toContain("Successfully wrote");
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new\n");
+  });
 });

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -134,7 +134,8 @@ describe("write tool", () => {
       undefined,
     );
 
-    expect(result.content[0].text).toContain("No changes made");
+    const tc0 = result.content[0];
+    expect("text" in tc0 ? tc0.text : "").toContain("No changes made");
     expect((result as any).terminate).toBe(true);
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("hello\n");
   });
@@ -150,7 +151,8 @@ describe("write tool", () => {
       undefined,
     );
 
-    expect(result.content[0].text).toContain("Successfully wrote");
+    const tc1 = result.content[0];
+    expect("text" in tc1 ? tc1.text : "").toContain("Successfully wrote");
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new\n");
   });
 });

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -15,6 +15,7 @@ import { Type } from "typebox";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import { getLanguageFromPath, highlightCode } from "../../modes/interactive/theme/theme.js";
 import type { AgentTool } from "../../runtime/index.js";
+import { textResult } from "../../tools/common.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import { withFileMutationQueue } from "./file-mutation-queue.js";
 import { resolveToCwd } from "./path-utils.js";
@@ -28,7 +29,9 @@ import {
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 const writeSchema = Type.Object({
-  path: Type.String({ description: "Path to the file to write (relative or absolute)" }),
+  path: Type.String({
+    description: "Path to the file to write (relative or absolute)",
+  }),
   content: Type.String({ description: "Content to write to the file" }),
 });
 export type { WriteToolInput } from "./tool-contracts.js";
@@ -237,7 +240,12 @@ function formatWriteCall(
 
 function formatWriteResult(
   result: {
-    content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+    content: Array<{
+      type: string;
+      text?: string;
+      data?: string;
+      mimeType?: string;
+    }>;
     isError?: boolean;
   },
   theme: typeof import("../../modes/interactive/theme/theme.js").theme,
@@ -297,7 +305,10 @@ async function readOriginalWriteState(
     const originalText = Buffer.isBuffer(originalContent)
       ? originalContent.toString("utf8")
       : originalContent;
-    return { state: originalText === content ? "same" : "different", beforeStat: stat };
+    return {
+      state: originalText === content ? "same" : "different",
+      beforeStat: stat,
+    };
   } catch {
     return { state: "unknown", beforeStat: stat };
   }
@@ -393,10 +404,20 @@ export function createWriteToolDefinition(
       const dir = dirname(absolutePath);
       return withFileMutationQueue(absolutePath, async () => {
         const precheck = await readOriginalWriteState(absolutePath, content, ops);
+        if (signal?.aborted) {
+          throw new Error("Operation aborted");
+        }
+        // Terminal no-op: file already has identical content.
+        if (precheck.state === "same") {
+          return {
+            ...textResult(
+              `No changes made to ${path}. The file already has identical content.`,
+              undefined,
+            ),
+            terminate: true,
+          };
+        }
         try {
-          if (signal?.aborted) {
-            throw new Error("Operation aborted");
-          }
           await ops.mkdir(dir);
           if (signal?.aborted) {
             throw new Error("Operation aborted");


### PR DESCRIPTION
## What Problem This Solves

Fixes #96983.

When the `write` tool is called with content identical to the existing file, or the `edit` tool produces unchanged content, the agent loop treats these as progress and retries the same no-op mutation indefinitely.

## Why This Change Was Made

- **write tool**: `readOriginalWriteState` already detects identical content. Now returns a terminal no-op result with `terminate: true` instead of proceeding with the write.
- **edit tool**: Filters out entries where `oldText === newText` before execution. If all entries are no-op, returns a terminal result. If only some are no-op, the valid sibling replacements still execute normally.
- Also catches the `No changes made` error from `edit-diff.ts` and converts it to a terminal result.
- Both tools use `terminate: true` to explicitly signal the tool-loop to stop retrying.

## Changes Made

- `src/agents/sessions/tools/write.ts`: Return `{...textResult(...), terminate: true}` when precheck detects identical content.
- `src/agents/sessions/tools/edit.ts`: Filter out no-op entries (`oldText === newText`) before execution, preserving valid sibling edits. Catch `No changes made` error from edit-diff and return terminal result.
- `src/agents/sessions/tools/write.test.ts`: Added 2 regression tests.
- `src/agents/sessions/tools/edit.test.ts`: Added 3 regression tests (all no-op, mixed batch, real changes).

## Evidence

- **Unit tests:** `node scripts/run-vitest.mjs run src/agents/sessions/tools/write.test.ts src/agents/sessions/tools/edit.test.ts` — 14/14 passed

## Real behavior proof

**Environment:** Linux, OpenClaw 2026.6.10, Node 24.13.1

```
WRITE IDENTICAL: No changes made to demo.txt. The file already has identical content. | terminate: true
WRITE DIFFERENT: Successfully wrote 12 bytes to demo.txt
EDIT NO-OP: No changes made to ... The replacement text is identical to the original. | terminate: true
EDIT MIXED BATCH: Successfully replaced 1 block(s) in ... (valid sibling preserved)
EDIT REAL CHANGE: Successfully replaced 1 block(s) in ...
```

- ✅ Write to existing file with identical content → no-op, `terminate: true`, file unchanged
- ✅ Write with different content → normal success
- ✅ Edit with all no-op entries → `terminate: true`, file unchanged
- ✅ Edit with mixed batch (no-op + real) → valid replacements still execute
- ✅ Edit with real changes → normal replace success

**What was not tested:** E2E agent loop with LLM calling write/edit (requires real model inference).

- [x] AI-assisted