### PR TITLE
[codex] Fix Telegram album sibling media context

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -245,6 +245,7 @@ export const registerTelegramHandlers = ({
     dispatchDedupeKeys: string[];
     spooledReplayParticipants: TelegramSpooledReplayDeferredParticipant[];
   };
+  type PromptContextMessageSelection = ReadonlyMap<string, "include" | "exclude">;
 
   const mediaGroupBuffer = new Map<string, BufferedMediaGroupEntry>();
   const mediaGroupProcessingByKey = new Map<string, Promise<void>>();
@@ -950,8 +951,10 @@ export const registerTelegramHandlers = ({
       }
 
       const allMedia: TelegramMediaRef[] = [];
+      const promptContextMessageSelection = new Map<string, "include" | "exclude">();
       let skippedCount = 0;
       for (const { ctx, msg } of entry.messages) {
+        const sourceMessageId = String(msg.message_id);
         let media;
         try {
           media = await resolveMedia({
@@ -966,6 +969,7 @@ export const registerTelegramHandlers = ({
           runtime.log?.(
             warn(`media group: skipping photo that failed to fetch: ${String(mediaErr)}`),
           );
+          promptContextMessageSelection.set(sourceMessageId, "exclude");
           skippedCount++;
           continue;
         }
@@ -974,11 +978,11 @@ export const registerTelegramHandlers = ({
             path: media.path,
             contentType: media.contentType,
             stickerMetadata: media.stickerMetadata,
-            ...(typeof msg.message_id === "number"
-              ? { sourceMessageId: String(msg.message_id) }
-              : {}),
+            sourceMessageId,
           });
+          promptContextMessageSelection.set(sourceMessageId, "include");
         } else {
+          promptContextMessageSelection.set(sourceMessageId, "exclude");
           skippedCount++;
         }
       }
@@ -1003,25 +1007,11 @@ export const registerTelegramHandlers = ({
         }).catch(() => {});
       }
 
-      // Only successfully downloaded album items have hydrated prompt media.
-      // Skipped siblings still have raw telegram:file refs in the cache.
-      const allAlbumMessageIds = entry.messages.flatMap(({ msg }) =>
-        typeof msg.message_id === "number" ? [String(msg.message_id)] : [],
-      );
-      const hydratedAlbumMessageIds = allMedia.flatMap((media) =>
-        media.sourceMessageId ? [media.sourceMessageId] : [],
-      );
-      const hydratedAlbumMessageIdSet = new Set(hydratedAlbumMessageIds);
-      const skippedAlbumMessageIds = allAlbumMessageIds.filter(
-        (messageId) => !hydratedAlbumMessageIdSet.has(messageId),
-      );
-
       const result = await processMessageWithReplyChain({
         ctx: primaryEntry.ctx,
         msg: primaryEntry.msg,
         allMedia,
-        promptContextExtraMessageIds: hydratedAlbumMessageIds,
-        promptContextExcludedMessageIds: skippedAlbumMessageIds,
+        promptContextMessageSelection,
         storeAllowFrom: entry.storeAllowFrom,
         options: {
           ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
@@ -1249,8 +1239,7 @@ export const registerTelegramHandlers = ({
     replyChainNodes: TelegramCachedMessageNode[],
     options?: TelegramMessageContextOptions,
     mediaByMessageId?: ReadonlyMap<string, TelegramMediaRef>,
-    extraMessageIds?: readonly string[],
-    excludedMessageIds?: readonly string[],
+    selectedMessageIds?: PromptContextMessageSelection,
   ): Promise<TelegramPromptContextEntry[]> => {
     const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
     const groupHistoryContextMode = isGroup
@@ -1312,22 +1301,18 @@ export const registerTelegramHandlers = ({
         entry.node.messageId ? [[entry.node.messageId, entry] as const] : [],
       ),
     );
-    const excludedMessageIdSet = new Set(excludedMessageIds ?? []);
-    for (const excludedMessageId of excludedMessageIdSet) {
-      conversationContextById.delete(excludedMessageId);
-    }
-    for (const extraMessageId of new Set(extraMessageIds ?? [])) {
-      if (
-        extraMessageId === messageId ||
-        excludedMessageIdSet.has(extraMessageId) ||
-        conversationContextById.has(extraMessageId)
-      ) {
+    for (const [selectedMessageId, selection] of selectedMessageIds ?? []) {
+      if (selection === "exclude") {
+        conversationContextById.delete(selectedMessageId);
+        continue;
+      }
+      if (selectedMessageId === messageId || conversationContextById.has(selectedMessageId)) {
         continue;
       }
       const node = await messageCache.get({
         accountId,
         chatId: msg.chat.id,
-        messageId: extraMessageId,
+        messageId: selectedMessageId,
       });
       if (node?.messageId) {
         conversationContextById.set(node.messageId, { node });
@@ -1419,8 +1404,7 @@ export const registerTelegramHandlers = ({
     ctx: TelegramContext;
     msg: Message;
     allMedia: TelegramMediaRef[];
-    promptContextExtraMessageIds?: string[];
-    promptContextExcludedMessageIds?: string[];
+    promptContextMessageSelection?: PromptContextMessageSelection;
     storeAllowFrom: string[];
     options?: TelegramMessageContextOptions;
     dispatchDedupeKeys?: string[];
@@ -1525,8 +1509,7 @@ export const registerTelegramHandlers = ({
         replyChainNodes,
         params.options,
         promptContextMediaByMessageId,
-        params.promptContextExtraMessageIds,
-        params.promptContextExcludedMessageIds,
+        params.promptContextMessageSelection,
       );
       const result = await processMessage(
         params.ctx,
@@ -2318,9 +2301,6 @@ export const registerTelegramHandlers = ({
             path: media.path,
             contentType: media.contentType,
             stickerMetadata: media.stickerMetadata,
-            ...(typeof msg.message_id === "number"
-              ? { sourceMessageId: String(msg.message_id) }
-              : {}),
           },
         ]
       : [];

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -951,7 +951,7 @@ export const registerTelegramHandlers = ({
 
       const allMedia: TelegramMediaRef[] = [];
       let skippedCount = 0;
-      for (const { ctx } of entry.messages) {
+      for (const { ctx, msg } of entry.messages) {
         let media;
         try {
           media = await resolveMedia({
@@ -974,6 +974,9 @@ export const registerTelegramHandlers = ({
             path: media.path,
             contentType: media.contentType,
             stickerMetadata: media.stickerMetadata,
+            ...(typeof msg.message_id === "number"
+              ? { sourceMessageId: String(msg.message_id) }
+              : {}),
           });
         } else {
           skippedCount++;
@@ -1004,6 +1007,9 @@ export const registerTelegramHandlers = ({
         ctx: primaryEntry.ctx,
         msg: primaryEntry.msg,
         allMedia,
+        promptContextExtraMessageIds: entry.messages.flatMap(({ msg }) =>
+          typeof msg.message_id === "number" ? [String(msg.message_id)] : [],
+        ),
         storeAllowFrom: entry.storeAllowFrom,
         options: {
           ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
@@ -1231,6 +1237,7 @@ export const registerTelegramHandlers = ({
     replyChainNodes: TelegramCachedMessageNode[],
     options?: TelegramMessageContextOptions,
     mediaByMessageId?: ReadonlyMap<string, TelegramMediaRef>,
+    extraMessageIds?: readonly string[],
   ): Promise<TelegramPromptContextEntry[]> => {
     const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
     const groupHistoryContextMode = isGroup
@@ -1287,7 +1294,25 @@ export const registerTelegramHandlers = ({
         ? { includeNode: buildMentionOnlyGroupHistoryPredicate({ ctx, msg, threadId }) }
         : {}),
     });
-    const cachePromptMessages = conversationContext.map((entry) =>
+    const conversationContextById = new Map(
+      conversationContext.flatMap((entry) =>
+        entry.node.messageId ? [[entry.node.messageId, entry] as const] : [],
+      ),
+    );
+    for (const extraMessageId of new Set(extraMessageIds ?? [])) {
+      if (extraMessageId === messageId || conversationContextById.has(extraMessageId)) {
+        continue;
+      }
+      const node = await messageCache.get({
+        accountId,
+        chatId: msg.chat.id,
+        messageId: extraMessageId,
+      });
+      if (node?.messageId) {
+        conversationContextById.set(node.messageId, { node });
+      }
+    }
+    const cachePromptMessages = Array.from(conversationContextById.values()).map((entry) =>
       toPromptContextMessage(
         entry.node,
         { replyTarget: entry.isReplyTarget },
@@ -1373,6 +1398,7 @@ export const registerTelegramHandlers = ({
     ctx: TelegramContext;
     msg: Message;
     allMedia: TelegramMediaRef[];
+    promptContextExtraMessageIds?: string[];
     storeAllowFrom: string[];
     options?: TelegramMessageContextOptions;
     dispatchDedupeKeys?: string[];
@@ -1450,15 +1476,15 @@ export const registerTelegramHandlers = ({
       const promptContextMediaByMessageId = new Map<string, TelegramMediaRef>();
       const currentMessageId =
         typeof params.msg.message_id === "number" ? String(params.msg.message_id) : undefined;
-      const currentMedia = params.allMedia[0];
-      const currentPromptMediaPath = currentMedia?.path
-        ? resolveTelegramPromptMediaPath(currentMedia.path)
-        : undefined;
-      if (currentMessageId && currentMedia && currentPromptMediaPath) {
-        promptContextMediaByMessageId.set(currentMessageId, {
-          ...currentMedia,
-          path: currentPromptMediaPath,
-        });
+      for (const [index, media] of params.allMedia.entries()) {
+        const messageId = media.sourceMessageId ?? (index === 0 ? currentMessageId : undefined);
+        const promptMediaPath = media.path ? resolveTelegramPromptMediaPath(media.path) : undefined;
+        if (messageId && promptMediaPath) {
+          promptContextMediaByMessageId.set(messageId, {
+            ...media,
+            path: promptMediaPath,
+          });
+        }
       }
       for (const entry of replyChain) {
         const promptMediaPath = entry.mediaPath
@@ -1477,6 +1503,7 @@ export const registerTelegramHandlers = ({
         replyChainNodes,
         params.options,
         promptContextMediaByMessageId,
+        params.promptContextExtraMessageIds,
       );
       const result = await processMessage(
         params.ctx,
@@ -2268,6 +2295,9 @@ export const registerTelegramHandlers = ({
             path: media.path,
             contentType: media.contentType,
             stickerMetadata: media.stickerMetadata,
+            ...(typeof msg.message_id === "number"
+              ? { sourceMessageId: String(msg.message_id) }
+              : {}),
           },
         ]
       : [];

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1003,13 +1003,25 @@ export const registerTelegramHandlers = ({
         }).catch(() => {});
       }
 
+      // Only successfully downloaded album items have hydrated prompt media.
+      // Skipped siblings still have raw telegram:file refs in the cache.
+      const allAlbumMessageIds = entry.messages.flatMap(({ msg }) =>
+        typeof msg.message_id === "number" ? [String(msg.message_id)] : [],
+      );
+      const hydratedAlbumMessageIds = allMedia.flatMap((media) =>
+        media.sourceMessageId ? [media.sourceMessageId] : [],
+      );
+      const hydratedAlbumMessageIdSet = new Set(hydratedAlbumMessageIds);
+      const skippedAlbumMessageIds = allAlbumMessageIds.filter(
+        (messageId) => !hydratedAlbumMessageIdSet.has(messageId),
+      );
+
       const result = await processMessageWithReplyChain({
         ctx: primaryEntry.ctx,
         msg: primaryEntry.msg,
         allMedia,
-        promptContextExtraMessageIds: entry.messages.flatMap(({ msg }) =>
-          typeof msg.message_id === "number" ? [String(msg.message_id)] : [],
-        ),
+        promptContextExtraMessageIds: hydratedAlbumMessageIds,
+        promptContextExcludedMessageIds: skippedAlbumMessageIds,
         storeAllowFrom: entry.storeAllowFrom,
         options: {
           ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
@@ -1238,6 +1250,7 @@ export const registerTelegramHandlers = ({
     options?: TelegramMessageContextOptions,
     mediaByMessageId?: ReadonlyMap<string, TelegramMediaRef>,
     extraMessageIds?: readonly string[],
+    excludedMessageIds?: readonly string[],
   ): Promise<TelegramPromptContextEntry[]> => {
     const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
     const groupHistoryContextMode = isGroup
@@ -1299,8 +1312,16 @@ export const registerTelegramHandlers = ({
         entry.node.messageId ? [[entry.node.messageId, entry] as const] : [],
       ),
     );
+    const excludedMessageIdSet = new Set(excludedMessageIds ?? []);
+    for (const excludedMessageId of excludedMessageIdSet) {
+      conversationContextById.delete(excludedMessageId);
+    }
     for (const extraMessageId of new Set(extraMessageIds ?? [])) {
-      if (extraMessageId === messageId || conversationContextById.has(extraMessageId)) {
+      if (
+        extraMessageId === messageId ||
+        excludedMessageIdSet.has(extraMessageId) ||
+        conversationContextById.has(extraMessageId)
+      ) {
         continue;
       }
       const node = await messageCache.get({
@@ -1399,6 +1420,7 @@ export const registerTelegramHandlers = ({
     msg: Message;
     allMedia: TelegramMediaRef[];
     promptContextExtraMessageIds?: string[];
+    promptContextExcludedMessageIds?: string[];
     storeAllowFrom: string[];
     options?: TelegramMessageContextOptions;
     dispatchDedupeKeys?: string[];
@@ -1504,6 +1526,7 @@ export const registerTelegramHandlers = ({
         params.options,
         promptContextMediaByMessageId,
         params.promptContextExtraMessageIds,
+        params.promptContextExcludedMessageIds,
       );
       const result = await processMessage(
         params.ctx,

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -16,6 +16,9 @@ export type TelegramMediaRef = {
   path: string;
   contentType?: string;
   stickerMetadata?: StickerMetadata;
+  // Album flushes process one captioned primary message while sibling messages
+  // remain in the prompt cache; keep their ids so context can hydrate each one.
+  sourceMessageId?: string;
 };
 
 export type TelegramMessageContextOptions = {

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -16,8 +16,6 @@ export type TelegramMediaRef = {
   path: string;
   contentType?: string;
   stickerMetadata?: StickerMetadata;
-  // Album flushes process one captioned primary message while sibling messages
-  // remain in the prompt cache; keep their ids so context can hydrate each one.
   sourceMessageId?: string;
 };
 

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -652,7 +652,7 @@ describe("telegram media groups", () => {
 
       readRemoteMediaBufferSpy.mockImplementation(
         async (params: { url?: string; filePathHint?: string }) => {
-          const url = String(params.url ?? "");
+          const url = params.url ?? "";
           if (url.includes("album-partial-1.png")) {
             throw new Error(`Telegram media exceeds 20 MB limit: ${url}`);
           }

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -11,7 +11,11 @@ import {
   watchTelegramFetch,
 } from "./bot.media.test-utils.js";
 
-type ReplyPayload = { Body: string; MediaPaths?: string[] } & Record<string, unknown>;
+type ReplyPayload = {
+  Body: string;
+  MediaPaths?: string[];
+  UntrustedStructuredContext?: unknown[];
+} & Record<string, unknown>;
 type MockWithCalls = { mock: { calls: unknown[][] } };
 
 function mockCall(mock: MockWithCalls, index: number): unknown[] {
@@ -29,6 +33,33 @@ function replyPayload(replySpy: ReturnType<typeof vi.fn>, index = 0): ReplyPaylo
     throw new Error(`expected reply payload ${index}`);
   }
   return payload as ReplyPayload;
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`expected ${label} record`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`expected ${label} array`);
+  }
+  return value;
+}
+
+function conversationMessages(payload: ReplyPayload): Map<unknown, Record<string, unknown>> {
+  const [conversationContext] = requireArray(
+    payload.UntrustedStructuredContext,
+    "structured context",
+  );
+  const contextRecord = requireRecord(conversationContext, "conversation context");
+  const contextPayload = requireRecord(contextRecord.payload, "conversation context payload");
+  const messages = requireArray(contextPayload.messages, "conversation context messages").map(
+    (message, index) => requireRecord(message, `conversation context message ${index + 1}`),
+  );
+  return new Map(messages.map((message) => [message.message_id, message]));
 }
 
 function downloadRequest(
@@ -490,6 +521,106 @@ describe("telegram media groups", () => {
           scenario.assert(replySpy);
         }
       } finally {
+        setTimeoutSpy.mockRestore();
+        clearTimeoutSpy.mockRestore();
+        fetchSpy.mockRestore();
+      }
+    },
+    MEDIA_GROUP_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "hydrates every captioned album sibling in prompt context",
+    async () => {
+      const runtimeError = vi.fn();
+      const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
+      const fetchSpy = mockTelegramPngDownload();
+      let nextTimerHandle = 1;
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
+        const handle = nextTimerHandle;
+        nextTimerHandle += 1;
+        return handle as unknown as ReturnType<typeof setTimeout>;
+      });
+      const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+      const savedPaths = [
+        "/tmp/media/inbound/album-context-1.png",
+        "/tmp/media/inbound/album-context-2.png",
+        "/tmp/media/inbound/album-context-3.png",
+      ];
+
+      try {
+        for (const path of savedPaths) {
+          setNextSavedMediaPath({ path, contentType: "image/png" });
+        }
+
+        for (const message of [
+          {
+            message: {
+              chat: { id: 42, type: "private" as const },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 301,
+              caption: "Here is the complete album",
+              date: 1736380800,
+              media_group_id: "album-context",
+              photo: [{ file_id: "album-photo-1" }],
+            },
+            getFile: async () => ({ file_path: "photos/album-context-1.png" }),
+          },
+          {
+            message: {
+              chat: { id: 42, type: "private" as const },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 302,
+              date: 1736380801,
+              media_group_id: "album-context",
+              photo: [{ file_id: "album-photo-2" }],
+            },
+            getFile: async () => ({ file_path: "photos/album-context-2.png" }),
+          },
+          {
+            message: {
+              chat: { id: 42, type: "private" as const },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 303,
+              date: 1736380802,
+              media_group_id: "album-context",
+              photo: [{ file_id: "album-photo-3" }],
+            },
+            getFile: async () => ({ file_path: "photos/album-context-3.png" }),
+          },
+        ]) {
+          await handler({
+            message: message.message,
+            me: { username: "openclaw_bot" },
+            getFile: message.getFile,
+          });
+        }
+
+        await flushActiveScheduledTimersForDelay({
+          setTimeoutSpy,
+          clearTimeoutSpy,
+          delayMs: TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs,
+          expectedCount: 1,
+        });
+        await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
+
+        expect(runtimeError).not.toHaveBeenCalled();
+        const payload = replyPayload(replySpy);
+        expect(payload.Body).toContain("Here is the complete album");
+        expect(payload.MediaPaths).toEqual(savedPaths);
+        const messagesById = conversationMessages(payload);
+        expect(messagesById.get("302")?.media_path).toBe("media://inbound/album-context-2.png");
+        expect(messagesById.get("302")?.media_ref).toBeUndefined();
+        expect(messagesById.get("303")?.media_path).toBe("media://inbound/album-context-3.png");
+        expect(messagesById.get("303")?.media_ref).toBeUndefined();
+      } finally {
+        for (const timer of resolveActiveScheduledTimersForDelay(
+          setTimeoutSpy,
+          clearTimeoutSpy,
+          TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs,
+        )) {
+          clearTimeout(timer.handle);
+        }
         setTimeoutSpy.mockRestore();
         clearTimeoutSpy.mockRestore();
         fetchSpy.mockRestore();

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -1,7 +1,10 @@
 // Telegram tests cover bot.mediaownloads media file path no file download plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { telegramBotDepsForTest } from "./bot.media.e2e-harness.js";
-import { setNextSavedMediaPath } from "./bot.media.e2e-harness.js";
+import {
+  readRemoteMediaBufferSpy,
+  setNextSavedMediaPath,
+  telegramBotDepsForTest,
+} from "./bot.media.e2e-harness.js";
 import {
   TELEGRAM_TEST_TIMINGS,
   createBotHandler,
@@ -624,6 +627,120 @@ describe("telegram media groups", () => {
         setTimeoutSpy.mockRestore();
         clearTimeoutSpy.mockRestore();
         fetchSpy.mockRestore();
+      }
+    },
+    MEDIA_GROUP_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "omits skipped album siblings from prompt context",
+    async () => {
+      const runtimeError = vi.fn();
+      const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
+      let nextTimerHandle = 1;
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
+        const handle = nextTimerHandle;
+        nextTimerHandle += 1;
+        return handle as unknown as ReturnType<typeof setTimeout>;
+      });
+      const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+      const savedPaths = [
+        "/tmp/media/inbound/album-partial-2.png",
+        "/tmp/media/inbound/album-partial-3.png",
+      ];
+      const pngBytes = Buffer.from(new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+
+      readRemoteMediaBufferSpy.mockImplementation(
+        async (params: { url?: string; filePathHint?: string }) => {
+          const url = String(params.url ?? "");
+          if (url.includes("album-partial-1.png")) {
+            throw new Error(`Telegram media exceeds 20 MB limit: ${url}`);
+          }
+          return {
+            buffer: pngBytes,
+            contentType: "image/png",
+            fileName: params.filePathHint,
+          };
+        },
+      );
+
+      try {
+        for (const path of savedPaths) {
+          setNextSavedMediaPath({ path, contentType: "image/png" });
+        }
+
+        for (const message of [
+          {
+            message: {
+              chat: { id: 42, type: "private" as const },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 501,
+              date: 1736380800,
+              media_group_id: "album-partial-context",
+              photo: [{ file_id: "album-partial-photo-1" }],
+            },
+            getFile: async () => ({ file_path: "photos/album-partial-1.png" }),
+          },
+          {
+            message: {
+              chat: { id: 42, type: "private" as const },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 502,
+              caption: "Here is a partial album",
+              date: 1736380801,
+              media_group_id: "album-partial-context",
+              photo: [{ file_id: "album-partial-photo-2" }],
+            },
+            getFile: async () => ({ file_path: "photos/album-partial-2.png" }),
+          },
+          {
+            message: {
+              chat: { id: 42, type: "private" as const },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 503,
+              date: 1736380802,
+              media_group_id: "album-partial-context",
+              photo: [{ file_id: "album-partial-photo-3" }],
+            },
+            getFile: async () => ({ file_path: "photos/album-partial-3.png" }),
+          },
+        ]) {
+          await handler({
+            message: message.message,
+            me: { username: "openclaw_bot" },
+            getFile: message.getFile,
+          });
+        }
+
+        await flushActiveScheduledTimersForDelay({
+          setTimeoutSpy,
+          clearTimeoutSpy,
+          delayMs: TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs,
+          expectedCount: 1,
+        });
+        await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
+
+        expect(runtimeError).not.toHaveBeenCalled();
+        const payload = replyPayload(replySpy);
+        expect(payload.Body).toContain("Here is a partial album");
+        expect(payload.MediaPaths).toEqual(savedPaths);
+        const messagesById = conversationMessages(payload);
+        expect(messagesById.get("501")).toBeUndefined();
+        expect(messagesById.get("503")?.media_path).toBe("media://inbound/album-partial-3.png");
+        expect(messagesById.get("503")?.media_ref).toBeUndefined();
+        expect(JSON.stringify(payload.UntrustedStructuredContext)).not.toContain(
+          "telegram:file/album-partial-photo-1",
+        );
+      } finally {
+        for (const timer of resolveActiveScheduledTimersForDelay(
+          setTimeoutSpy,
+          clearTimeoutSpy,
+          TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs,
+        )) {
+          clearTimeout(timer.handle);
+        }
+        setTimeoutSpy.mockRestore();
+        clearTimeoutSpy.mockRestore();
       }
     },
     MEDIA_GROUP_TEST_TIMEOUT_MS,


### PR DESCRIPTION
## What Problem This Solves

Fixes #96846.

Telegram media groups/album updates can choose one captioned message as the primary turn while sibling album messages remain in the prompt-context cache. Before this change, only the primary/current media path was available for prompt-context hydration, so sibling album photos could still surface as raw `telegram:file/...` references that models cannot read.

Partial album download failures also needed a guard: skipped album siblings may still have cached raw Telegram file refs, so they must not be added as extra prompt-context messages or re-enter via the normal recent-context window.

## Why This Change Was Made

The Telegram plugin already buffers media groups and downloads every album item for the current turn. The missing handoff was between the buffered album items and the conversation prompt context. This change keeps the originating Telegram message id on each downloaded inbound media reference, then explicitly includes only successfully hydrated album sibling cache nodes when building the prompt context so selected siblings can be mapped to a `media://inbound/...` path.

For partial-download albums, the prompt context now derives extra album ids from hydrated `sourceMessageId` values and excludes skipped album message ids from the selected context map. That keeps failed-download siblings from resurfacing as unreadable raw Telegram refs through recent context.

The fix stays inside the Telegram plugin boundary and preserves the existing single-media fallback: media without a source message id still maps only the first item to the current message, matching prior behavior.

## User Impact

Telegram users can send a photo album instead of resending images one by one. The current turn still carries all successfully downloaded album `MediaPaths`, and prompt context for album sibling messages now uses readable inbound media paths instead of unreadable Telegram file references. If some album items cannot be fetched, successfully downloaded siblings still reach the model while skipped siblings stay out of model-facing context.

## Evidence

- Added a source-level regression test for a caption-first Telegram album where later sibling messages enter prompt context. The test verifies all current-turn media paths are present and the sibling context entries use `media://inbound/...` with no `telegram:file/...` fallback.
- Added partial-download regression coverage for a three-photo album where the first image download fails and the later caption/sibling images succeed. The test verifies the skipped earlier sibling is absent from prompt context, the successful sibling is represented as `media://inbound/...`, and no raw `telegram:file/album-partial-photo-1` ref reaches structured prompt context.
- Pre-fix source repro: the original regression test failed with `media_path` undefined for an album sibling; the partial-download guard prevents the skipped-download path from reintroducing raw cached refs.
- CI repair on latest head: `check-lint` reported `typescript(no-unnecessary-type-conversion)` for an unnecessary `String(...)` in the new regression test. Removed the no-op conversion and reran the local bundled-extension oxlint lane.
- `node scripts/run-bundled-extension-oxlint.mjs`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts extensions/telegram/src/bot.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts -- --reporter=verbose`
- `node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts`
- `git diff --check`
- Autoreview: local review for the P2 repair returned clean with no accepted/actionable findings; the follow-up CI lint repair was also reviewed clean with no accepted/actionable findings.
- Live Telegram proof, 2026-06-26 22:58 Asia/Shanghai: ran this branch locally at `44d8e52391` and sent a Telegram mobile photo album to `@NianJiuopenclawbot`. Gateway ingress logged one album turn with `mediaCount=5` and `<media:image> (5 images)`.
- The persisted session user message for that turn had `MediaPaths` length 5. The model then issued an `image` tool call containing five unique `media://inbound/*.jpg` image paths, and the corresponding tool result completed with `isError=false` and the same five unique inbound media paths. The current turn/tool messages had `telegram:file` count 0.
- DeepSeek model transport returned HTTP 200 for the album turn and for the follow-up model call after the image tool result.
<img width="582" height="1280" alt="image" src="https://github.com/user-attachments/assets/6905f8d1-c51f-4607-b09e-d4332dad5e9f" />

