### PR TITLE
[codex] fix(agents): accept media input catalog modalities

### DIFF
--- a/extensions/openai/openai-chatgpt-provider.ts
+++ b/extensions/openai/openai-chatgpt-provider.ts
@@ -399,7 +399,10 @@ function withDefaultCodexContextMetadata(params: {
         : params.contextTokens;
   const input = params.model.input?.includes("image")
     ? params.model.input
-    : uniqueValues<"text" | "image">([...(params.model.input ?? ["text"]), "image"]);
+    : uniqueValues<ProviderRuntimeModel["input"][number]>([
+        ...(params.model.input ?? ["text"]),
+        "image",
+      ]);
   return {
     ...params.model,
     input,

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -591,7 +591,10 @@ export interface Model<TApi extends Api = Api> {
    * Missing keys use provider defaults. null marks a level as unsupported.
    */
   thinkingLevelMap?: ThinkingLevelMap;
-  input: ("text" | "image")[];
+  // Input modalities a model accepts. Mirrors the model-registry/config catalog
+  // contract: provider catalog refreshes can carry "video"/"audio", so the type
+  // must admit them or the registry emits values its own Model type forbids.
+  input: ("text" | "image" | "video" | "audio")[];
   cost: {
     input: number; // $/million tokens
     output: number; // $/million tokens

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -1476,8 +1476,9 @@ export interface ProviderModelConfig {
   reasoning: boolean;
   /** Maps OpenClaw thinking levels to provider/model-specific values; null marks a level unsupported. */
   thinkingLevelMap?: Model["thinkingLevelMap"];
-  /** Supported input types. */
-  input: ("text" | "image")[];
+  /** Supported input types. Tied to the canonical Model.input contract so provider
+   * catalog refreshes carrying "video"/"audio" stay assignable here (#97048). */
+  input: Model["input"];
   /** Cost per token (for tracking, can be 0). */
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
   /** Maximum context window size in tokens. */

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -174,6 +174,44 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.find("zai", "glm-5.1")?.name).toBe("GLM 5.1");
   });
 
+  it("accepts audio and video input modalities from generated plugin catalog shards", () => {
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "minimax", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimax.io/v1",
+            api: "openai-completions",
+            apiKey: "MINIMAX_API_KEY",
+            models: [
+              {
+                id: "MiniMax-M3",
+                name: "MiniMax M3",
+                input: ["text", "image", "video", "audio"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ minimax: { type: "api_key", key: "sk-test" } }),
+      modelsPath,
+      { pluginMetadataSnapshot: pluginOwnerSnapshot("minimax", "minimax") },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("minimax", "MiniMax-M3")?.input).toEqual([
+      "text",
+      "image",
+      "video",
+      "audio",
+    ]);
+  });
+
   it("isolates invalid generated plugin catalog shards from valid models", () => {
     const modelsPath = writeModelsJsonWithPluginCatalogs({
       root: {

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -3,12 +3,13 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it } from "vitest";
 import {
   PLUGIN_MODEL_CATALOG_FILE,
   PLUGIN_MODEL_CATALOG_GENERATED_BY,
 } from "../plugin-model-catalog.js";
 import { AuthStorage } from "./auth-storage.js";
+import type { ProviderModelConfig } from "./extensions/index.js";
 import { ModelRegistry } from "./model-registry.js";
 
 const tempDirs: string[] = [];
@@ -210,6 +211,16 @@ describe("ModelRegistry models.json auth", () => {
       "video",
       "audio",
     ]);
+  });
+
+  it("keeps the plugin-facing ProviderModelConfig.input tied to the widened Model.input contract (#97048)", () => {
+    // ProviderModelConfig is the exported session-extension model type plugins
+    // author against; if it narrows below Model.input, catalog shards carrying
+    // "video"/"audio" would type-error at the plugin boundary even though the
+    // registry accepts them at runtime (see the test above).
+    expectTypeOf<ProviderModelConfig["input"]>().toEqualTypeOf<
+      ("text" | "image" | "video" | "audio")[]
+    >();
   });
 
   it("isolates invalid generated plugin catalog shards from valid models", () => {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -935,7 +935,7 @@ export interface ProviderConfigInput {
     baseUrl?: string;
     reasoning: boolean;
     thinkingLevelMap?: Model["thinkingLevelMap"];
-    input: ("text" | "image")[];
+    input: Model["input"];
     cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
     contextWindow: number;
     maxTokens: number;

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -162,7 +162,16 @@ const ModelDefinitionSchema = Type.Object({
   baseUrl: Type.Optional(Type.String({ minLength: 1 })),
   reasoning: Type.Optional(Type.Boolean()),
   thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
-  input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]))),
+  input: Type.Optional(
+    Type.Array(
+      Type.Union([
+        Type.Literal("text"),
+        Type.Literal("image"),
+        Type.Literal("video"),
+        Type.Literal("audio"),
+      ]),
+    ),
+  ),
   cost: Type.Optional(
     Type.Object({
       input: Type.Number(),

--- a/src/commands/models/list.model-row.ts
+++ b/src/commands/models/list.model-row.ts
@@ -1,5 +1,6 @@
-/** Converts registry/catalog models into printable model-list rows. */
 import { modelKey } from "../../agents/model-ref-shared.js";
+/** Converts registry/catalog models into printable model-list rows. */
+import type { Model } from "../../llm/types.js";
 import { isLocalBaseUrl } from "./list.local-url.js";
 import type { ModelRow } from "./list.types.js";
 
@@ -8,7 +9,10 @@ export type ListRowModel = {
   id: string;
   name: string;
   provider: string;
-  input: Array<"text" | "image" | "document">;
+  // Derive from the registry Model contract (text/image/video/audio) plus the
+  // config-catalog-only "document" modality, so a widened Model.input cannot
+  // drift out of the list-row type the registry feeds into.
+  input: Array<Model["input"][number] | "document">;
   baseUrl?: string;
   contextWindow?: number | null;
   contextTokens?: number | null;


### PR DESCRIPTION
## What Problem This Solves

Closes #97048.

OpenClaw's own catalog-fetch path writes generated plugin model catalog shards (`agents/<agent>/agent/plugins/{minimax,nvidia}/catalog.json`) that can carry provider-reported `video` / `audio` input modalities. On gateway start the session model registry validated those shards with a narrower `text`/`image` TypeBox schema, so otherwise-valid generated catalogs were rejected (`Invalid models.json schema`) and their models were dropped before selection — an agent whose **primary** is one of them (e.g. `MiniMax-M3`, `microsoft/phi-4-multimodal-instruct`) silently falls back.

## Why This Change Was Made

This aligns the session model registry with the catalog contract that the rest of OpenClaw already accepts:

1. **Registry validator** — `ModelDefinitionSchema.input` now accepts `text`/`image`/`video`/`audio`, matching the canonical Zod config schema (`src/config/zod-schema.core.ts`) and the catalog-fetch normalizer (`src/agents/model-catalog.ts`).
2. **Type-contract alignment** (no more runtime/type drift) — the registry parses `modelDef.input` straight into the public `Model` shape, so the type must admit what the registry now emits. Widened `Model.input` (`packages/llm-core/src/types.ts`), pointed the registry's `ProviderConfigInput.models[].input` at `Model["input"]`, and derived `ListRowModel.input` from `Model["input"]` (plus the config-catalog-only `document`) so a future widening can't drift out of the model-list row type. `document` is intentionally **not** added to the registry schema, since the registry path does not produce it.

## User Impact

Affected provider catalog refreshes no longer cause MiniMax/NVIDIA-style multimodal models to disappear from the registry solely because the generated input list includes `audio` or `video`. No config or migration changes; the widening is additive and backward-compatible.

AI-assisted: Codex prepared the initial draft; type-contract alignment and runtime proof added in review.

## Evidence

### Real-behavior proof — production loader against on-disk generated catalogs

Drove the production `ModelRegistry.create(...)` path against real `models.json` + `plugins/{minimax,nvidia}/catalog.json` files laid out exactly like an agent plugin catalog, using the issue's offending data (`MiniMax-M3` = `["text","image","video"]`, `microsoft/phi-4-multimodal-instruct` = `["text","image","audio"]`).

**Before (current `main` schema — `text`/`image` only):**
```
model catalog load error: Invalid models.json schema:
  - providers.minimax.models.0.input.2: must be equal to constant
  - providers.minimax.models.0.input.2: must match a schema in anyOf
File: .../plugins/minimax/catalog.json
Invalid models.json schema:
  - providers.nvidia.models.0.input.2: must be equal to constant
  - providers.nvidia.models.0.input.2: must match a schema in anyOf
File: .../plugins/nvidia/catalog.json
minimax/MiniMax-M3: DROPPED
nvidia/phi-4-multimodal-instruct: DROPPED
RESULT: FAIL — catalog rejected
```

**After (this PR):**
```
model catalog load error: (none)
minimax/MiniMax-M3: loaded input=["text","image","video"]
nvidia/phi-4-multimodal-instruct: loaded input=["text","image","audio"]
RESULT: PASS — both multimodal primaries loaded
```

This reproduces the exact gateway error from the issue and confirms the fix on the real loader, not just a unit harness.

### Tests / checks

- Pass (red→green): `node scripts/run-vitest.mjs src/agents/sessions/model-registry.test.ts` — new regression `accepts audio and video input modalities from generated plugin catalog shards` fails on the pre-fix schema with the issue's `must be equal to constant` error and passes with the fix.
- Pass: `node scripts/run-tsgo.mjs -p tsconfig.core.json` — core typecheck clean; confirms the widened `Model.input` ripples only to `ListRowModel`, which is now derived from it.
- Pass: `node scripts/run-vitest.mjs src/config/zod-schema.models.test.ts src/commands/models/list.model-row.test.ts src/commands/models/list.rows.test.ts`.
- Not introduced by this PR: a handful of `src/commands/models/*` tests (e.g. live provider-probe / network-dependent and a known pre-existing `provider-catalog-shared` native-streaming assertion) fail identically on the unmodified PR HEAD; this change is type-only outside the registry schema and does not alter their runtime behavior.
