### PR TITLE
fix(cost): estimate usage cost when API returns cost.total=0 but pricing is known

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -300,6 +300,64 @@ describe("session cost usage", () => {
     });
   });
 
+  it("estimates cost when pricing is known but API returns cost.total=0 (DeepSeek V4)", async () => {
+    const root = await makeSessionCostRoot("cost-known-pricing-api-zero");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // DeepSeek V4 returns cost.total=0 in API response, but the model has known
+    // positive pricing configured. The scan should estimate cost from token counts
+    // rather than accepting the $0 as fact (#97047).
+    const entry = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "deepseek",
+        model: "deepseek-v4-flash",
+        usage: {
+          input: 95029,
+          output: 465,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 95494,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-dsv4.jsonl"),
+      transcriptText("sess-dsv4", entry),
+      "utf-8",
+    );
+
+    // Positive pricing is configured for DeepSeek V4
+    const config = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                cost: { input: 0.14, output: 0.28, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    clearGatewayModelPricingCacheState();
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.totals.totalTokens).toBe(95494);
+      // Cost should be estimated from tokens and known pricing, not stuck at $0.
+      expect(summary.totals.totalCost).toBeGreaterThan(0);
+      expect(summary.totals.missingCostEntries).toBe(0);
+    });
+  });
+
   it("treats a pre-upgrade (older-version) durable cache as stale so unpriced usage is rebuilt", async () => {
     const root = await makeSessionCostRoot("cost-cache-upgrade");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -78,7 +78,7 @@ export type {
 // caches written by older builds are rebuilt instead of served stale. Bumped to 4:
 // unpriced (unknown) zero-cost usage now counts toward missingCostEntries, so a warm
 // cache from a pre-change build would otherwise keep reporting the old complete-$0 totals.
-const USAGE_COST_CACHE_VERSION = 4;
+const USAGE_COST_CACHE_VERSION = 5;
 const USAGE_COST_CACHE_FILE = ".usage-cost-cache.json";
 const USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS = 10_000;
 const USAGE_COST_CACHE_TEMP_FILE_GRACE_MS = USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS;

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1165,8 +1165,10 @@ async function scanTranscriptFile(params: {
         // above.
         entry.costTotal = undefined;
         entry.costBreakdown = undefined;
-      } else if (entry.costTotal === undefined) {
-        // Fill in missing cost estimates.
+      } else if (entry.costTotal === undefined || entry.costTotal === 0) {
+        // Fill in missing or zero cost estimates. Some providers (e.g. DeepSeek V4)
+        // return cost.total=0 but have known pricing; treat $0 as missing so the
+        // estimate path runs (#97047).
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
       }
     }


### PR DESCRIPTION
## What Problem This Solves

DeepSeek V4 API returns token usage but **no `cost` field** in completion responses. OpenClaw has known positive pricing configured, but the cost scan logic treats the missing/zero cost as fact — Control UI "Spend" shows ¥0.00 for all DeepSeek V4 usage.

**Root cause**: `scanTranscriptFile` only estimates when `costTotal === undefined`. When the API omits cost data (resulting in `cost.total: 0`), and pricing is known, the $0 is kept as-is.

**Fix**: Extend estimate condition to `costTotal === undefined || costTotal === 0`, plus bump `USAGE_COST_CACHE_VERSION` 4→5.

Closes #97047

## Evidence

### Real API proof — DeepSeek V4 Flash

```
$ curl -s https://api.deepseek.com/v1/chat/completions \
  -d "{\"model\":\"deepseek-v4-flash\",\"max_tokens\":10,\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}"

cost field: MISSING | tokens: 15
```

DeepSeek V4 returns token usage but NO cost field → OpenClaw records cost.total=0 → without fix, pricing skipped → Control UI shows ¥0.00.

### Before/after

| | Before | After |
|------|--------|-------|
| API response | cost field MISSING | cost field MISSING |
| scanTranscriptFile | costTotal===0 → skip estimate | costTotal===0 → **trigger estimate** |
| Control UI Spend | ¥0.00 | **computed from tokens × pricing** |

### Test suite

```
npx vitest run src/infra/session-cost-usage.test.ts
  Tests passed (includes "estimates cost when API returns cost.total=0")
```

### Formatting

```
pnpm exec oxfmt --check ...  (pass)
git diff --check  (clean)
```

## Change Type
- [x] Bug fix
## Scope
- [x] Infrastructure (cost/usage aggregation)
## Security Impact
- New permissions? No · Secrets changed? No · New network calls? No