### PR TITLE
fix(ollama): preserve custom memory provider endpoints

### DIFF
--- a/extensions/ollama/src/embedding-provider.test.ts
+++ b/extensions/ollama/src/embedding-provider.test.ts
@@ -764,8 +764,8 @@ describe("ollama embedding provider", () => {
     expect(headers?.Authorization).toBeUndefined();
   });
 
-  it("includes outputDimensionality in the memory embedding cache identity", async () => {
-    const result = await ollamaMemoryEmbeddingProviderAdapter.create({
+  it("preserves the legacy identity only for the default Ollama endpoint", async () => {
+    const defaultEndpoint = await ollamaMemoryEmbeddingProviderAdapter.create({
       config: {} as OpenClawConfig,
       provider: "ollama",
       model: "nomic-embed-text",
@@ -773,12 +773,90 @@ describe("ollama embedding provider", () => {
       remote: { baseUrl: "http://127.0.0.1:11434" },
       outputDimensionality: 2,
     });
+    const customEndpoint = await ollamaMemoryEmbeddingProviderAdapter.create({
+      config: {} as OpenClawConfig,
+      provider: "ollama",
+      model: "nomic-embed-text",
+      fallback: "none",
+      remote: { baseUrl: "http://10.0.0.5:11434" },
+      outputDimensionality: 2,
+    });
 
-    expect(result.runtime?.cacheKeyData).toMatchObject({
+    expect(defaultEndpoint.runtime?.cacheKeyData).toEqual({
       provider: "ollama",
       model: "nomic-embed-text",
       outputDimensionality: 2,
     });
+    expect(customEndpoint.runtime?.cacheKeyData).toEqual({
+      provider: "ollama",
+      baseUrl: "http://10.0.0.5:11434",
+      model: "nomic-embed-text",
+      outputDimensionality: 2,
+    });
+  });
+
+  it("keys custom endpoints by non-secret headers while excluding credentials", async () => {
+    const fetchMock = mockEmbeddingFetch([1, 0]);
+
+    const result = await ollamaMemoryEmbeddingProviderAdapter.create({
+      config: {
+        models: {
+          providers: {
+            "ollama-cpu": {
+              api: "ollama",
+              baseUrl: "https://ollama-cpu.home.lab",
+              headers: {
+                "X-Ollama-Tenant": "tenant-a",
+                "X-Api-Key": "super-secret", // pragma: allowlist secret
+              },
+              models: [],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      provider: "ollama-cpu",
+      model: "qwen3-embedding:4b",
+      fallback: "none",
+    });
+
+    await result.provider!.embedQuery("hello");
+    expectEmbeddingFetch(fetchMock, "https://ollama-cpu.home.lab/api/embed", {
+      model: "qwen3-embedding:4b",
+      input:
+        "Instruct: Given a user query, retrieve relevant memory notes and documents\nQuery:hello",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Ollama-Tenant": "tenant-a",
+        "X-Api-Key": "super-secret", // pragma: allowlist secret
+      },
+    });
+    expect(result.runtime?.cacheKeyData).toMatchObject({
+      provider: "ollama-cpu",
+      baseUrl: "https://ollama-cpu.home.lab",
+      model: "qwen3-embedding:4b",
+      headersHash: expect.stringMatching(/^[a-f0-9]{64}$/u),
+    });
+    expect(JSON.stringify(result.runtime?.cacheKeyData)).not.toContain("tenant-a");
+    expect(JSON.stringify(result.runtime?.cacheKeyData)).not.toContain("super-secret");
+
+    const otherTenant = await ollamaMemoryEmbeddingProviderAdapter.create({
+      config: {
+        models: {
+          providers: {
+            "ollama-cpu": {
+              api: "ollama",
+              baseUrl: "https://ollama-cpu.home.lab",
+              headers: { "X-Ollama-Tenant": "tenant-b" },
+              models: [],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      provider: "ollama-cpu",
+      model: "qwen3-embedding:4b",
+      fallback: "none",
+    });
+    expect(otherTenant.runtime?.cacheKeyData).not.toEqual(result.runtime?.cacheKeyData);
   });
 
   it("preserves configured provider aliases in the memory adapter", async () => {

--- a/extensions/ollama/src/memory-embedding-adapter.ts
+++ b/extensions/ollama/src/memory-embedding-adapter.ts
@@ -1,9 +1,22 @@
 // Ollama plugin module implements memory embedding adapter behavior.
-import type { MemoryEmbeddingProviderAdapter } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import { createHash } from "node:crypto";
+import {
+  sanitizeEmbeddingCacheHeaders,
+  type MemoryEmbeddingProviderAdapter,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import { OLLAMA_DEFAULT_BASE_URL } from "./defaults.js";
 import {
   DEFAULT_OLLAMA_EMBEDDING_MODEL,
   createOllamaEmbeddingProvider,
 } from "./embedding-provider.js";
+
+const OLLAMA_EMBEDDING_CACHE_EXCLUDED_HEADERS = ["authorization", "content-type", "x-api-key"];
+
+function hashEmbeddingCacheHeaders(headers: Array<[string, string]>): string | undefined {
+  return headers.length > 0
+    ? createHash("sha256").update(JSON.stringify(headers)).digest("hex")
+    : undefined;
+}
 
 export const ollamaMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {
   id: "ollama",
@@ -17,6 +30,17 @@ export const ollamaMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapte
       provider: providerId,
       fallback: "none",
     });
+    const identityHeaders = sanitizeEmbeddingCacheHeaders(
+      client.headers,
+      OLLAMA_EMBEDDING_CACHE_EXCLUDED_HEADERS,
+    );
+    const headersHash = hashEmbeddingCacheHeaders(identityHeaders);
+    // The shipped default identity already names this exact endpoint. Preserve it so ordinary
+    // local installs do not rebuild; explicit/custom routes need endpoint-scoped identity.
+    const usesLegacyDefaultIdentity =
+      providerId === "ollama" &&
+      client.baseUrl === OLLAMA_DEFAULT_BASE_URL &&
+      headersHash === undefined;
     return {
       provider,
       runtime: {
@@ -24,8 +48,10 @@ export const ollamaMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapte
         inlineBatchTimeoutMs: 10 * 60_000,
         cacheKeyData: {
           provider: providerId,
+          ...(usesLegacyDefaultIdentity ? {} : { baseUrl: client.baseUrl }),
           model: client.model,
           outputDimensionality: client.outputDimensionality,
+          ...(headersHash ? { headersHash } : {}),
         },
       },
     };

--- a/packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.test.ts
+++ b/packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeEmbeddingCacheHeaders } from "./embedding-provider-adapter-utils.js";
+
+describe("sanitizeEmbeddingCacheHeaders", () => {
+  it("removes only explicitly excluded header names", () => {
+    expect(
+      sanitizeEmbeddingCacheHeaders(
+        {
+          Authorization: "Bearer redacted", // pragma: allowlist secret
+          "X-Api-Key": "redacted", // pragma: allowlist secret
+          "X-Api-Key-Routing": "tenant-a",
+          "X-Token-Bucket": "batch-a",
+        },
+        ["authorization", "x-api-key"],
+      ),
+    ).toEqual([
+      ["X-Api-Key-Routing", "tenant-a"],
+      ["X-Token-Bucket", "batch-a"],
+    ]);
+  });
+});

--- a/packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.ts
+++ b/packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.ts
@@ -8,7 +8,7 @@ export function isMissingEmbeddingApiKeyError(err: unknown): boolean {
   return err instanceof Error && err.message.includes("No API key found for provider");
 }
 
-/** Return stable cache headers after removing provider-specific secret headers. */
+/** Return stable cache headers after removing adapter-declared secret headers. */
 export function sanitizeEmbeddingCacheHeaders(
   headers: Record<string, string>,
   excludedHeaderNames: string[],


### PR DESCRIPTION
## What Problem This Solves

Fixes the residual cache-identity gap from #97055.

The provider-routing fixes are already on `main`, but the Ollama memory adapter still keyed embeddings only by provider, model, and output dimensionality. Re-pointing one provider id to another Ollama endpoint—or changing a non-secret tenant/backend header—could therefore reuse stale embeddings from the old route.

## Why This Change Was Made

- Custom Ollama providers and explicit/custom endpoints now include the resolved base URL in their canonical memory index identity.
- Behavior-affecting custom headers participate through a deterministic SHA-256 digest; raw header names and values are not retained in cache identity data.
- Known credential and protocol-only headers are excluded before hashing, so ordinary credential rotation and built-in `Content-Type` do not churn the index.
- The shipped identity is preserved for the implicit/default `ollama` endpoint with no custom identity headers, avoiding a needless rebuild for ordinary local installations.

This matches the endpoint-scoped identity principle already used by the LM Studio adapter while keeping the compatibility exception tightly bounded to the existing default route.

## User Impact

- Re-pointing a custom or explicitly routed Ollama memory provider produces a new provider key, so normal memory status detects the mismatch and the standard indexing flow rebuilds against the correct endpoint.
- The implicit default `ollama` endpoint keeps its existing key and does not rebuild merely because of this upgrade.
- Custom tenant/backend header changes produce distinct keys without storing raw values.

## Evidence

Exact head: `03deca91e7c0106d8fae5d9fe99b6aacdd583507`

- `node scripts/run-vitest.mjs extensions/ollama/src/embedding-provider.test.ts packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.test.ts` — 29 tests passed.
- Local `node scripts/check-changed.mjs -- <four changed files>` fallback — all core/extension typecheck, lint, formatting, dependency, boundary, database, sidecar, cycle, webhook, and pairing gates passed.
- Blacksmith Testbox reached the broad lint lane but its control-plane list request timed out; no code finding occurred (run 29815109732).
- AutoReview initially found raw custom-header exposure; the branch was changed to store only a digest, retested, and the final review reported no accepted/actionable findings.
- Contributor proof demonstrated the real memory CLI/SQLite mismatch → rebuild → clean status → successful search flow after switching one provider id between two loopback Ollama-protocol endpoints. That custom-endpoint behavior is preserved by this revision.

## Compatibility

No config, dependency, protocol, or schema change. Existing implicit/default Ollama indexes retain their provider key. Only configurations whose endpoint identity must become distinguishable receive a new key and rebuild through the existing rebuildable-cache flow.

Co-authored-by: harjoth <harjoth.khara@gmail.com>
