### PR TITLE
fix(reply): suppress background exec progress payloads

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1866,6 +1866,39 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
+  it("suppresses background exec running tool progress text even when tool summaries are otherwise enabled", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "direct",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolResult?.({
+        text: "Command still running (session sess-123, pid 456). Use process (list/poll/log/write/kill/clear/remove) for follow-up.",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
+
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
   it("delivers deterministic exec approval tool payloads for native commands with progress suppression", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1179,6 +1179,15 @@ export async function dispatchReplyFromConfig(
       ) {
         return null;
       }
+      const text = normalizeOptionalString(payload.text);
+      const isBackgroundExecProgressText =
+        payload.isError !== true &&
+        text?.startsWith("Command still running (session ") === true &&
+        text.includes("). Use process (list/poll/log/write/kill/clear/remove) for follow-up.");
+      if (isBackgroundExecProgressText && suppressDefaultToolProgressMessages) {
+        const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
+        return hasMedia ? { ...payload, text: undefined } : null;
+      }
       if (shouldSendToolSummaries) {
         return payload;
       }


### PR DESCRIPTION
## Summary
- suppress background exec "Command still running" tool progress payloads when preview/default tool-progress suppression is enabled
- keep the change narrowly scoped to outbound delivery filtering in `dispatch-from-config`
- preserve media-only tool payload delivery and leave transcript/internal runtime behavior unchanged

## Testing
- `pnpm vitest run src/auto-reply/reply/dispatch-from-config.test.ts`
