### PR TITLE
fix(validation): preserve null in anyOf unions instead of coercing to empty string (fixes #96716)

### DIFF
--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -39,4 +39,29 @@ describe("validateToolArguments", () => {
       }),
     ).toThrow(/Validation failed for tool "decimal-tool"/);
   });
+
+  it("preserves null in anyOf [{type: string}, {type: null}] without coercing to empty string (#96716)", () => {
+    const tool = {
+      name: "nullable-tool",
+      description: "test tool",
+      parameters: {
+        type: "object",
+        properties: {
+          insight_id: { anyOf: [{ type: "string" }, { type: "null" }] },
+          cluster_name: { type: "string" },
+        },
+        required: ["cluster_name"],
+        additionalProperties: false,
+      },
+    } as Tool;
+
+    expect(
+      validateToolArguments(tool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "nullable-tool",
+        arguments: { insight_id: null, cluster_name: "testenv" },
+      }),
+    ).toEqual({ insight_id: null, cluster_name: "testenv" });
+  });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -205,6 +205,21 @@ function applySchemaArrayCoercion(value: unknown[], schema: JsonSchemaObject): v
 }
 
 function coerceWithUnionSchema(value: unknown, schemas: JsonSchemaObject[]): unknown {
+  // When value is null, check if any union member accepts null directly
+  // (type: "null") before falling through to coercion.  Without this check,
+  // anyOf [{type: "string"}, {type: "null"}] coerces null → "" via the
+  // string branch and never reaches the null branch.
+  if (value === null) {
+    for (const schema of schemas) {
+      const types = getSchemaTypes(schema);
+      if (types.includes("null")) {
+        const validator = getSubSchemaValidator(schema);
+        if (!validator || validator.Check(value)) {
+          return value;
+        }
+      }
+    }
+  }
   for (const schema of schemas) {
     const candidate = structuredClone(value);
     const coerced = coerceWithJsonSchema(candidate, schema);


### PR DESCRIPTION
## What Problem This Solves

Fixes #96716.

MCP tool calls with optional arguments set to JSON null fail via OpenClaw but succeed via other MCP clients. Root cause: when a JSON schema uses `anyOf [{type: string}, {type: null}]`, the union coercion tries the string branch first, which coerces `null` to `""` before the `{type: null}` branch is tried.

## Why This Change Was Made

`coerceWithUnionSchema` iterated schemas in order and applied `coerceWithJsonSchema` before validating. For `anyOf [{type: string}, {type: null}]` with `null`, the first schema coerces `null → ""` and the validator passes. The fix adds a null-first check: when value is `null`, check if any union member accepts null directly before falling through to coercion.

## Changes Made

- `packages/llm-core/src/validation.ts`: Added null-first check in `coerceWithUnionSchema`.
- `packages/llm-core/src/validation.test.ts`: Added regression test.

## Evidence

- **Unit tests:** `node scripts/run-vitest.mjs run packages/llm-core/src/validation.test.ts` — 3/3 passed

## Real behavior proof

A real HTTP MCP server was started, arguments were validated through the fix, then sent to the server:

```
✅ REAL PROOF: MCP server received insight_id=null (not empty string)
```

**Before fix:** `null` → `""` via string coercion before the null branch was tried → MCP server receives `""`

**After fix:** `null` → matched `{type: null}` directly → preserved as `null` → MCP server receives `null`

3 regression scenarios also verified:
- ✅ Normal string values unchanged
- ✅ Non-nullable schemas still coerce `null → ""` as expected
- ✅ Numeric coercion preserved

- [x] AI-assisted