### PR TITLE
[codex] Accept audio and video model catalog inputs

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -591,7 +591,7 @@ export interface Model<TApi extends Api = Api> {
    * Missing keys use provider defaults. null marks a level as unsupported.
    */
   thinkingLevelMap?: ThinkingLevelMap;
-  input: ("text" | "image")[];
+  input: ("text" | "image" | "audio" | "video")[];
   cost: {
     input: number; // $/million tokens
     output: number; // $/million tokens

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -1477,7 +1477,7 @@ export interface ProviderModelConfig {
   /** Maps OpenClaw thinking levels to provider/model-specific values; null marks a level unsupported. */
   thinkingLevelMap?: Model["thinkingLevelMap"];
   /** Supported input types. */
-  input: ("text" | "image")[];
+  input: Model["input"];
   /** Cost per token (for tracking, can be 0). */
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
   /** Maximum context window size in tokens. */

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -174,6 +174,44 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.find("zai", "glm-5.1")?.name).toBe("GLM 5.1");
   });
 
+  it("preserves audio and video inputs from generated plugin catalog shards", () => {
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "minimax", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimax.io/anthropic",
+            api: "anthropic-messages",
+            apiKey: "MINIMAX_API_KEY",
+            models: [
+              {
+                id: "MiniMax-M3",
+                name: "MiniMax M3",
+                input: ["text", "image", "video", "audio"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ minimax: { type: "api_key", key: "sk-test" } }),
+      modelsPath,
+      { pluginMetadataSnapshot: pluginOwnerSnapshot("minimax", "minimax") },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("minimax", "MiniMax-M3")?.input).toEqual([
+      "text",
+      "image",
+      "video",
+      "audio",
+    ]);
+  });
+
   it("isolates invalid generated plugin catalog shards from valid models", () => {
     const modelsPath = writeModelsJsonWithPluginCatalogs({
       root: {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -152,6 +152,12 @@ const ProviderAuthModeSchema = Type.Union([
   Type.Literal("token"),
 ]);
 type ProviderAuthMode = Static<typeof ProviderAuthModeSchema>;
+const ModelInputSchema = Type.Union([
+  Type.Literal("text"),
+  Type.Literal("image"),
+  Type.Literal("audio"),
+  Type.Literal("video"),
+]);
 
 // Schema for custom model definition
 // Most fields are optional with sensible defaults for local models (Ollama, LM Studio, etc.)
@@ -162,7 +168,7 @@ const ModelDefinitionSchema = Type.Object({
   baseUrl: Type.Optional(Type.String({ minLength: 1 })),
   reasoning: Type.Optional(Type.Boolean()),
   thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
-  input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]))),
+  input: Type.Optional(Type.Array(ModelInputSchema)),
   cost: Type.Optional(
     Type.Object({
       input: Type.Number(),
@@ -926,7 +932,7 @@ export interface ProviderConfigInput {
     baseUrl?: string;
     reasoning: boolean;
     thinkingLevelMap?: Model["thinkingLevelMap"];
-    input: ("text" | "image")[];
+    input: Model["input"];
     cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
     contextWindow: number;
     maxTokens: number;

--- a/src/commands/models/list.model-row.ts
+++ b/src/commands/models/list.model-row.ts
@@ -8,7 +8,7 @@ export type ListRowModel = {
   id: string;
   name: string;
   provider: string;
-  input: Array<"text" | "image" | "document">;
+  input: Array<"text" | "image" | "audio" | "video" | "document">;
   baseUrl?: string;
   contextWindow?: number | null;
   contextTokens?: number | null;

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -241,4 +241,44 @@ describe("appendConfiguredProviderRows", () => {
     expect(mocks.normalizeProviderResolvedModelWithPlugin).toHaveBeenCalledOnce();
     expect(requireOnlyRow(rows).input).toBe("text+image");
   });
+
+  it("preserves audio and video inputs for configured provider models", async () => {
+    const rows: ModelRow[] = [];
+
+    await appendConfiguredProviderRows({
+      rows,
+      seenKeys: new Set(),
+      context: {
+        cfg: {
+          models: {
+            providers: {
+              minimax: {
+                api: "anthropic-messages",
+                baseUrl: "https://api.minimax.io/anthropic",
+                models: [
+                  {
+                    id: "MiniMax-M3",
+                    name: "MiniMax M3",
+                    reasoning: true,
+                    input: ["text", "image", "video", "audio"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 1_000_000,
+                    maxTokens: 131_072,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-agent",
+        authIndex,
+        configuredByKey: new Map(),
+        discoveredKeys: new Set(),
+        filter: { provider: "minimax", local: false },
+        skipRuntimeModelSuppression: true,
+      },
+    });
+
+    expect(requireOnlyRow(rows).input).toBe("text+image+video+audio");
+  });
 });

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -211,10 +211,11 @@ async function appendVisibleRow(params: {
 
 function resolveConfiguredModelInput(params: {
   model: Partial<ModelDefinitionConfig>;
-}): Array<"text" | "image"> {
+}): ListRowModel["input"] {
   const input = Array.isArray(params.model.input)
     ? params.model.input.filter(
-        (item): item is "text" | "image" => item === "text" || item === "image",
+        (item): item is Exclude<ListRowModel["input"][number], "document"> =>
+          item === "text" || item === "image" || item === "audio" || item === "video",
       )
     : [];
   return input.length > 0 ? input : ["text"];
@@ -239,7 +240,11 @@ function toConfiguredProviderListModel(params: {
 function toListRowInput(input: readonly string[] | undefined): ListRowModel["input"] {
   const parsed = input?.filter(
     (item): item is ListRowModel["input"][number] =>
-      item === "text" || item === "image" || item === "document",
+      item === "text" ||
+      item === "image" ||
+      item === "audio" ||
+      item === "video" ||
+      item === "document",
   );
   return parsed?.length ? parsed : ["text"];
 }

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -24,6 +24,27 @@ describe("ModelsConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts audio and video input modalities for configured models", () => {
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        minimax: {
+          baseUrl: "https://api.minimax.io/anthropic",
+          api: "anthropic-messages",
+          apiKey: "MINIMAX_API_KEY",
+          models: [
+            {
+              id: "MiniMax-M3",
+              name: "MiniMax M3",
+              input: ["text", "image", "video", "audio"],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("accepts compat.requiresReasoningContentOnAssistantMessages (issue #89660)", () => {
     // The field is consumed at runtime (detectCompat/getCompat) and is present
     // in the ModelCompat type, but was missing from the strict Zod schema, so a


### PR DESCRIPTION
## What Problem This Solves

Fixes #97048.

Generated plugin catalog shards can include `audio` and `video` input modalities for models such as MiniMax-M3 and phi-4 multimodal. The session model registry schema only accepted `text` and `image`, so those generated shards could be rejected and the provider could fall back to an older or incomplete catalog.

## Why This Change Was Made

The canonical model input type and the session registry/config validation paths now accept `audio` and `video` alongside `text` and `image`. The model-list rendering path also preserves those modalities so configured and generated model metadata stay consistent.

## User Impact

Generated catalogs with MiniMax-M3 or similar multimodal models no longer get dropped only because they advertise audio/video inputs. Real MiniMax M3 API verification is still left to the maintainer/user-provided API key.

## Evidence

- `node scripts/run-vitest.mjs src/agents/sessions/model-registry.test.ts src/config/zod-schema.models.test.ts src/commands/models/list.rows.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `git diff --check`

Known local proof note: `node scripts/run-vitest.mjs src/plugin-sdk/provider-catalog-shared.test.ts` was also tried, but unrelated native streaming usage capability assertions failed there and were not used as proof for this PR.
