### PR TITLE
[codex] Suppress heartbeat inbound metadata

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2359,6 +2359,8 @@ describe("runPreparedReply media-only handling", () => {
           Provider: "heartbeat",
           Surface: "heartbeat",
           ChatType: "direct",
+          OriginatingChannel: "qqbot",
+          OriginatingTo: "c2c:683F2ADDE4414658153CECAC0F93EDDE",
         },
         sessionCtx: {
           Body: heartbeatPrompt,
@@ -2366,13 +2368,20 @@ describe("runPreparedReply media-only handling", () => {
           Provider: "heartbeat",
           Surface: "heartbeat",
           ChatType: "direct",
+          OriginatingChannel: "qqbot",
+          OriginatingTo: "c2c:683F2ADDE4414658153CECAC0F93EDDE",
         },
       }),
     );
 
     const call = requireLastRunReplyAgentCall();
+    expect(buildInboundUserContextPrefix).not.toHaveBeenCalled();
     expect(call?.commandBody).toContain(heartbeatPrompt);
+    expect(call?.commandBody).not.toContain("Conversation info (untrusted metadata):");
+    expect(call?.commandBody).not.toContain("c2c:683F2ADDE4414658153CECAC0F93EDDE");
     expect(call?.followupRun.prompt).toContain(heartbeatPrompt);
+    expect(call?.followupRun.prompt).not.toContain("Conversation info (untrusted metadata):");
+    expect(call?.followupRun.prompt).not.toContain("c2c:683F2ADDE4414658153CECAC0F93EDDE");
     expect(call?.transcriptCommandBody).toBe("[OpenClaw heartbeat poll]");
     expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw heartbeat poll]");
   });

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2348,42 +2348,47 @@ describe("runPreparedReply media-only handling", () => {
 
   it("keeps heartbeat prompts out of visible transcript prompt", async () => {
     const heartbeatPrompt = "Read HEARTBEAT.md and run any due maintenance.";
+    const syntheticRouteId = "c2c:683F2ADDE4414658153CECAC0F93EDDE";
+    const syntheticProviders = ["heartbeat", "cron-event", "exec-event"] as const;
 
-    await runPreparedReply(
-      baseParams({
-        opts: { isHeartbeat: true },
-        ctx: {
-          Body: heartbeatPrompt,
-          RawBody: heartbeatPrompt,
-          CommandBody: heartbeatPrompt,
-          Provider: "heartbeat",
-          Surface: "heartbeat",
-          ChatType: "direct",
-          OriginatingChannel: "qqbot",
-          OriginatingTo: "c2c:683F2ADDE4414658153CECAC0F93EDDE",
-        },
-        sessionCtx: {
-          Body: heartbeatPrompt,
-          BodyStripped: heartbeatPrompt,
-          Provider: "heartbeat",
-          Surface: "heartbeat",
-          ChatType: "direct",
-          OriginatingChannel: "qqbot",
-          OriginatingTo: "c2c:683F2ADDE4414658153CECAC0F93EDDE",
-        },
-      }),
-    );
+    for (const syntheticProvider of syntheticProviders) {
+      await runPreparedReply(
+        baseParams({
+          opts: { isHeartbeat: true },
+          ctx: {
+            Body: heartbeatPrompt,
+            RawBody: heartbeatPrompt,
+            CommandBody: heartbeatPrompt,
+            Provider: syntheticProvider,
+            Surface: syntheticProvider,
+            ChatType: "direct",
+            OriginatingChannel: "qqbot",
+            OriginatingTo: syntheticRouteId,
+          },
+          sessionCtx: {
+            Body: heartbeatPrompt,
+            BodyStripped: heartbeatPrompt,
+            Provider: syntheticProvider,
+            Surface: syntheticProvider,
+            ChatType: "direct",
+            OriginatingChannel: "qqbot",
+            OriginatingTo: syntheticRouteId,
+          },
+        }),
+      );
 
-    const call = requireLastRunReplyAgentCall();
+      const call = requireLastRunReplyAgentCall();
+      expect(call?.commandBody).toContain(heartbeatPrompt);
+      expect(call?.commandBody).not.toContain("Conversation info (untrusted metadata):");
+      expect(call?.commandBody).not.toContain(syntheticRouteId);
+      expect(call?.followupRun.prompt).toContain(heartbeatPrompt);
+      expect(call?.followupRun.prompt).not.toContain("Conversation info (untrusted metadata):");
+      expect(call?.followupRun.prompt).not.toContain(syntheticRouteId);
+      expect(call?.transcriptCommandBody).toBe("[OpenClaw heartbeat poll]");
+      expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw heartbeat poll]");
+    }
+
     expect(buildInboundUserContextPrefix).not.toHaveBeenCalled();
-    expect(call?.commandBody).toContain(heartbeatPrompt);
-    expect(call?.commandBody).not.toContain("Conversation info (untrusted metadata):");
-    expect(call?.commandBody).not.toContain("c2c:683F2ADDE4414658153CECAC0F93EDDE");
-    expect(call?.followupRun.prompt).toContain(heartbeatPrompt);
-    expect(call?.followupRun.prompt).not.toContain("Conversation info (untrusted metadata):");
-    expect(call?.followupRun.prompt).not.toContain("c2c:683F2ADDE4414658153CECAC0F93EDDE");
-    expect(call?.transcriptCommandBody).toBe("[OpenClaw heartbeat poll]");
-    expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw heartbeat poll]");
   });
 
   it("uses persisted Discord chat metadata for system-event CLI static prompt identity", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -721,18 +721,20 @@ export async function runPreparedReply(
     ? (bareResetPromptState?.prompt ?? "")
     : stripPromptThinkingDirectives(baseBody);
   const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
-  const inboundUserContext = buildInboundUserContextPrefix(
-    isNewSession
-      ? {
-          ...sessionCtx,
-          ...(normalizeOptionalString(sessionCtx.ThreadHistoryBody)
-            ? { InboundHistory: undefined, ThreadStarterBody: undefined }
-            : {}),
-        }
-      : { ...sessionCtx, ThreadStarterBody: undefined },
-    envelopeOptions,
-    { sourceReplyDeliveryMode },
-  );
+  const inboundUserContext = isHeartbeat
+    ? ""
+    : buildInboundUserContextPrefix(
+        isNewSession
+          ? {
+              ...sessionCtx,
+              ...(normalizeOptionalString(sessionCtx.ThreadHistoryBody)
+                ? { InboundHistory: undefined, ThreadStarterBody: undefined }
+                : {}),
+            }
+          : { ...sessionCtx, ThreadStarterBody: undefined },
+        envelopeOptions,
+        { sourceReplyDeliveryMode },
+      );
   const inboundUserContextPromptJoiner = resolveInboundUserContextPromptJoiner(sessionCtx);
   const hasUserBody =
     baseBodyFinal.trim().length > 0 ||


### PR DESCRIPTION
## What Problem This Solves

Fixes #97067.

Cron-driven heartbeat turns could inherit the resolved delivery route in `OriginatingTo` and then build a user-role `Conversation info (untrusted metadata)` block from that synthetic route. When the stored route was an unqualified channel target such as `c2c:...`, the heartbeat prompt looked like partial inbound chat metadata instead of a plain scheduled heartbeat turn.

## Why This Change Was Made

Heartbeat runs are synthetic system turns, not real inbound channel messages. The heartbeat prompt already carries the required model-facing instruction, and routing/delivery policy still uses the session context separately. Suppressing the inbound user-context block for heartbeat runs avoids presenting last-channel delivery metadata as untrusted per-message metadata while leaving normal inbound metadata behavior unchanged.

## User Impact

Agents should no longer see heartbeat polls wrapped in partial `Conversation info` metadata, reducing false prompt-injection warnings and avoiding noisy cross-channel alert broadcasts caused by those warnings.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts` — 83 passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply/inbound-meta.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts` — 56 passed + 43 passed.
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.

Redacted after-fix prompt proof from the model prompt assembly path, run against the same `isHeartbeat: true` branch with `OriginatingChannel=qqbot` and a redacted `c2c:*` route id present in ctx/sessionCtx:

```text
pnpm exec vitest run src/auto-reply/reply/get-reply-run.media-only.test.ts --config test/vitest/vitest.auto-reply.config.ts --reporter verbose -t "keeps heartbeat prompts out of visible transcript prompt"

[heartbeat-proof] provider=heartbeat conversation_info=absent route_id=absent prompt_preview="Read HEARTBEAT.md and run any due maintenance."
[heartbeat-proof] provider=cron-event conversation_info=absent route_id=absent prompt_preview="Read HEARTBEAT.md and run any due maintenance."
[heartbeat-proof] provider=exec-event conversation_info=absent route_id=absent prompt_preview="Read HEARTBEAT.md and run any due maintenance."

Test Files  1 passed (1)
Tests  1 passed | 82 skipped (83)
```

The committed regression now covers all three synthetic providers produced by the heartbeat runner (`heartbeat`, `cron-event`, and `exec-event`) and asserts both `commandBody` and `followupRun.prompt` lack `Conversation info (untrusted metadata):` and the raw route id.

Screenshot
<img width="926" height="707" alt="image" src="https://github.com/user-attachments/assets/73b1a4ec-a0e9-476a-a145-d4ee250aed22" />

