### PR TITLE
[codex] Explain one-shot exec approval prompts

### DIFF
--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -157,6 +157,9 @@ export const ExecApprovalRequestParamsSchema = Type.Object(
         maxItems: 1,
       }),
     ),
+    allowAlwaysUnavailableReason: Type.Optional(
+      Type.String({ enum: ["approval-policy-always", "non-persistable-command"] }),
+    ),
     commandSpans: Type.Optional(
       Type.Array(
         Type.Object(

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -12,6 +12,7 @@ import {
   normalizeOptionalString as parseString,
 } from "@openclaw/normalization-core/string-coerce";
 import type {
+  ExecApprovalAllowAlwaysUnavailableReason,
   ExecApprovalCommandSpan,
   ExecApprovalUnavailableDecision,
   ExecAsk,
@@ -57,6 +58,7 @@ type RequestExecApprovalDecisionParams = {
   warningText?: string;
   commandSpans?: ExecApprovalCommandSpan[];
   unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason | null;
   agentId?: string;
   resolvedPath?: string;
   sessionKey?: string;
@@ -92,6 +94,9 @@ function buildExecApprovalRequestToolParams(
     commandSpans: params.commandSpans,
     ...(params.unavailableDecisions?.length
       ? { unavailableDecisions: params.unavailableDecisions }
+      : {}),
+    ...(params.allowAlwaysUnavailableReason
+      ? { allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason }
       : {}),
     agentId: params.agentId,
     resolvedPath: params.resolvedPath,
@@ -199,6 +204,7 @@ type HostExecApprovalParams = {
   warningText?: string;
   commandSpans?: ExecApprovalCommandSpan[];
   unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason | null;
   commandHighlighting?: boolean;
   agentId?: string;
   resolvedPath?: string;
@@ -309,6 +315,7 @@ async function buildHostApprovalDecisionParams(
     warningText: params.warningText,
     commandSpans,
     unavailableDecisions: params.unavailableDecisions,
+    allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason,
     ...buildExecApprovalRequesterContext({
       agentId: params.agentId,
       sessionKey: params.sessionKey,

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -102,6 +102,22 @@ const resolveExecApprovalUnavailableDecisionsMock = vi.hoisted(() =>
         : [],
   ),
 );
+const resolveExecApprovalAllowAlwaysUnavailableReasonMock = vi.hoisted(() =>
+  vi.fn(
+    (params?: {
+      ask?: string | null;
+      allowAlwaysPersistence?: { kind: string } | null;
+    }): "approval-policy-always" | "non-persistable-command" | null => {
+      if (params?.ask === "always") {
+        return "approval-policy-always";
+      }
+      if (params?.allowAlwaysPersistence?.kind === "one-shot") {
+        return "non-persistable-command";
+      }
+      return null;
+    },
+  ),
+);
 const buildEnforcedShellCommandMock = vi.hoisted(() =>
   vi.fn((): { ok: boolean; reason?: string; command?: string } => ({
     ok: false,
@@ -161,6 +177,8 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => ({
   resolveApprovalAuditTrustPath: vi.fn(() => null),
   resolveAllowAlwaysPatterns: vi.fn(() => []),
   resolveExecApprovalAllowedDecisions: resolveExecApprovalAllowedDecisionsMock,
+  resolveExecApprovalAllowAlwaysUnavailableReason:
+    resolveExecApprovalAllowAlwaysUnavailableReasonMock,
   resolveExecApprovalUnavailableDecisions: resolveExecApprovalUnavailableDecisionsMock,
   addAllowlistEntry: vi.fn(),
   addDurableCommandApproval: vi.fn(),
@@ -811,6 +829,7 @@ describe("processGatewayAllowlist", () => {
     expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
       expect.objectContaining({
         allowedDecisions: ["allow-once", "deny"],
+        allowAlwaysUnavailableReason: "non-persistable-command",
       }),
     );
   });

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -24,6 +24,7 @@ import {
   recordAllowlistMatchesUse,
   resolveApprovalAuditTrustPath,
   resolveAllowAlwaysPersistenceDecision,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   resolveExecApprovalUnavailableDecisions,
   requiresExecApproval,
 } from "../infra/exec-approvals.js";
@@ -597,9 +598,16 @@ export async function processGatewayAllowlist(
     ask: hostAsk,
     allowAlwaysPersistence: effectiveAllowAlwaysPersistence,
   });
+  const allowAlwaysUnavailableReason = resolveExecApprovalAllowAlwaysUnavailableReason({
+    ask: hostAsk,
+    allowAlwaysPersistence: effectiveAllowAlwaysPersistence,
+  });
   const unavailableDecisionRequestParams =
     approvalUnavailableDecisions.length > 0
-      ? { unavailableDecisions: approvalUnavailableDecisions }
+      ? {
+          unavailableDecisions: approvalUnavailableDecisions,
+          allowAlwaysUnavailableReason,
+        }
       : {};
   if (requiresSecurityAuditSuppressionApproval) {
     params.warnings.push(
@@ -1015,6 +1023,7 @@ export async function processGatewayAllowlist(
         sentApproverDms,
         unavailableReason,
         allowedDecisions: approvalAllowedDecisions,
+        allowAlwaysUnavailableReason,
       }),
     };
   }

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -164,6 +164,22 @@ const resolveExecApprovalUnavailableDecisionsMock = vi.hoisted(() =>
         : [],
   ),
 );
+const resolveExecApprovalAllowAlwaysUnavailableReasonMock = vi.hoisted(() =>
+  vi.fn(
+    (params?: {
+      ask?: string | null;
+      allowAlwaysPersistence?: { kind: string } | null;
+    }): "approval-policy-always" | "non-persistable-command" | null => {
+      if (params?.ask === "always") {
+        return "approval-policy-always";
+      }
+      if (params?.allowAlwaysPersistence?.kind === "one-shot") {
+        return "non-persistable-command";
+      }
+      return null;
+    },
+  ),
+);
 const resolveExecHostApprovalContextMock = vi.hoisted(() =>
   vi.fn(() => ({
     approvals: { allowlist: [] as ExecAllowlistEntry[], file: { version: 1, agents: {} } },
@@ -222,6 +238,8 @@ vi.mock("../infra/exec-approvals.js", () => ({
   resolveAllowAlwaysPersistenceDecision: resolveAllowAlwaysPersistenceDecisionMock,
   resolveAllowAlwaysPatternCoverage: resolveAllowAlwaysPatternCoverageMock,
   resolveExecApprovalAllowedDecisions: resolveExecApprovalAllowedDecisionsMock,
+  resolveExecApprovalAllowAlwaysUnavailableReason:
+    resolveExecApprovalAllowAlwaysUnavailableReasonMock,
   resolveExecApprovalUnavailableDecisions: resolveExecApprovalUnavailableDecisionsMock,
   resolveExecApprovalsFromFile: resolveExecApprovalsFromFileMock,
   maxAsk: (a: ExecAsk, b: ExecAsk): ExecAsk => {
@@ -1791,9 +1809,13 @@ describe("executeNodeHostCommand", () => {
       },
     });
     expect(requireRegisteredApprovalRequest().unavailableDecisions).toEqual(["allow-always"]);
+    expect(requireRegisteredApprovalRequest().allowAlwaysUnavailableReason).toBe(
+      "approval-policy-always",
+    );
     expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
       expect.objectContaining({
         allowedDecisions: ["allow-once", "deny"],
+        allowAlwaysUnavailableReason: "approval-policy-always",
       }),
     );
   });
@@ -2247,9 +2269,13 @@ describe("executeNodeHostCommand", () => {
       allowAlwaysPersistence: { kind: "one-shot", reasons: ["unplanned"] },
     });
     expect(requireRegisteredApprovalRequest().unavailableDecisions).toEqual(["allow-always"]);
+    expect(requireRegisteredApprovalRequest().allowAlwaysUnavailableReason).toBe(
+      "non-persistable-command",
+    );
     expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
       expect.objectContaining({
         allowedDecisions: ["allow-once", "deny"],
+        allowAlwaysUnavailableReason: "non-persistable-command",
       }),
     );
   });

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -11,6 +11,7 @@ import {
   maxAsk,
   requiresExecApproval,
   resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   resolveExecApprovalUnavailableDecisions,
 } from "../infra/exec-approvals.js";
 import { defaultExecAutoReviewer, type ExecAutoReviewInput } from "../infra/exec-auto-review.js";
@@ -142,8 +143,12 @@ export async function executeNodeHostCommand(
     ask: approvalDecisionAsk,
     allowAlwaysPersistence,
   });
+  const allowAlwaysUnavailableReason = resolveExecApprovalAllowAlwaysUnavailableReason({
+    ask: approvalDecisionAsk,
+    allowAlwaysPersistence,
+  });
   const unavailableDecisionRequestParams =
-    unavailableDecisions.length > 0 ? { unavailableDecisions } : {};
+    unavailableDecisions.length > 0 ? { unavailableDecisions, allowAlwaysUnavailableReason } : {};
   const requiresAsk =
     requiresExecApproval({
       ask: hostAsk,
@@ -456,6 +461,7 @@ export async function executeNodeHostCommand(
           sentApproverDms,
           unavailableReason,
           allowedDecisions,
+          allowAlwaysUnavailableReason,
           nodeId: target.nodeId,
         });
       }

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -18,6 +18,7 @@ import {
   resolveExecApprovals,
   resolveExecApprovalsTranscriptPath,
   type ExecAsk,
+  type ExecApprovalAllowAlwaysUnavailableReason,
   type ExecApprovalDecision,
   type ExecSecurity,
 } from "../infra/exec-approvals.js";
@@ -503,6 +504,7 @@ export function buildExecApprovalPendingToolResult(params: {
   sentApproverDms: boolean;
   unavailableReason: ExecApprovalUnavailableReason | null;
   allowedDecisions?: readonly ExecApprovalDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason | null;
   nodeId?: string;
 }): AgentToolResult<ExecToolDetails> {
   const allowedDecisions = params.allowedDecisions ?? resolveExecApprovalAllowedDecisions();
@@ -525,6 +527,7 @@ export function buildExecApprovalPendingToolResult(params: {
                 approvalSlug: params.approvalSlug,
                 approvalId: params.approvalId,
                 allowedDecisions,
+                allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason,
                 command: params.command,
                 cwd: params.cwd,
                 host: params.host,
@@ -553,6 +556,7 @@ export function buildExecApprovalPendingToolResult(params: {
             approvalSlug: params.approvalSlug,
             expiresAtMs: params.expiresAtMs,
             allowedDecisions,
+            allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason ?? undefined,
             host: params.host,
             command: params.command,
             cwd: params.cwd,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -13,9 +13,12 @@ import {
 } from "../infra/event-session-routing.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  describeExecApprovalAllowAlwaysUnavailableReason,
+  describeExecApprovalBackgroundModeUnavailableReason,
   resolveExecApprovalAllowedDecisions,
-  type ExecHost,
+  type ExecApprovalAllowAlwaysUnavailableReason,
   type ExecApprovalDecision,
+  type ExecHost,
   type ExecTarget,
 } from "../infra/exec-approvals.js";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
@@ -368,6 +371,7 @@ export function buildApprovalPendingMessage(params: {
   approvalSlug: string;
   approvalId: string;
   allowedDecisions?: readonly ExecApprovalDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason | null;
   command: string;
   cwd: string | undefined;
   host: "gateway" | "node";
@@ -397,12 +401,12 @@ export function buildApprovalPendingMessage(params: {
   lines.push(
     allowedDecisions.includes("allow-always")
       ? "Background mode requires pre-approved policy (allow-always or ask=off)."
-      : "Background mode requires an effective policy that allows pre-approval (for example ask=off).",
+      : describeExecApprovalBackgroundModeUnavailableReason(params.allowAlwaysUnavailableReason),
   );
   lines.push(`Reply with: /approve ${params.approvalSlug} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
     lines.push(
-      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+      describeExecApprovalAllowAlwaysUnavailableReason(params.allowAlwaysUnavailableReason),
     );
   }
   lines.push("If the short code is ambiguous, use the full id in /approve.");

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -135,6 +135,7 @@ export type ExecToolDetails =
       approvalSlug: string;
       expiresAtMs: number;
       allowedDecisions?: readonly ExecApprovalDecision[];
+      allowAlwaysUnavailableReason?: "approval-policy-always" | "non-persistable-command";
       host: ExecHost;
       command: string;
       cwd?: string;

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -250,7 +250,7 @@ function expectPendingApprovalText(
     expect(pendingText).toContain(
       (options.allowedDecisions ?? "").includes("allow-always")
         ? "Background mode requires pre-approved policy"
-        : "Background mode requires an effective policy that allows pre-approval",
+        : "Background mode note: non-interactive runs cannot wait for chat approvals",
     );
   }
   return details;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -579,6 +579,7 @@ function readExecApprovalPendingDetails(result: unknown): {
   approvalSlug: string;
   expiresAtMs?: number;
   allowedDecisions?: readonly ExecApprovalDecision[];
+  allowAlwaysUnavailableReason?: "approval-policy-always" | "non-persistable-command";
   host: "gateway" | "node";
   command: string;
   cwd?: string;
@@ -613,6 +614,11 @@ function readExecApprovalPendingDetails(result: unknown): {
             decision === "allow-once" || decision === "allow-always" || decision === "deny",
         )
       : undefined,
+    allowAlwaysUnavailableReason:
+      details.allowAlwaysUnavailableReason === "approval-policy-always" ||
+      details.allowAlwaysUnavailableReason === "non-persistable-command"
+        ? details.allowAlwaysUnavailableReason
+        : undefined,
     host,
     command,
     cwd: readStringValue(details.cwd),
@@ -692,6 +698,7 @@ async function emitToolResultOutput(params: {
           approvalId: approvalPending.approvalId,
           approvalSlug: approvalPending.approvalSlug,
           allowedDecisions: approvalPending.allowedDecisions,
+          allowAlwaysUnavailableReason: approvalPending.allowAlwaysUnavailableReason,
           command: approvalPending.command,
           cwd: approvalPending.cwd,
           host: approvalPending.host,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -21,7 +21,10 @@ import {
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  describeExecApprovalAllowAlwaysUnavailableReason,
+  normalizeExecApprovalAllowAlwaysUnavailableReason,
   normalizeExecApprovalUnavailableDecisions,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
@@ -171,6 +174,7 @@ export function createExecApprovalHandlers(
         ask?: string;
         warningText?: string | null;
         unavailableDecisions?: string[];
+        allowAlwaysUnavailableReason?: string;
         commandSpans?: {
           startIndex: number;
           endIndex: number;
@@ -305,6 +309,9 @@ export function createExecApprovalHandlers(
       const unavailableDecisions = normalizeExecApprovalUnavailableDecisions(
         p.unavailableDecisions,
       );
+      const allowAlwaysUnavailableReason =
+        normalizeExecApprovalAllowAlwaysUnavailableReason(p.allowAlwaysUnavailableReason) ??
+        resolveExecApprovalAllowAlwaysUnavailableReason({ ask: p.ask ?? null });
       const request = {
         command: sanitizedCommandText,
         commandPreview:
@@ -324,6 +331,10 @@ export function createExecApprovalHandlers(
         commandAnalysis,
         commandSpans,
         unavailableDecisions: unavailableDecisions.length > 0 ? unavailableDecisions : undefined,
+        allowAlwaysUnavailableReason:
+          unavailableDecisions.length > 0 && allowAlwaysUnavailableReason
+            ? allowAlwaysUnavailableReason
+            : undefined,
         allowedDecisions: resolveExecApprovalRequestAllowedDecisions({
           ask: p.ask ?? null,
           unavailableDecisions,
@@ -458,8 +469,9 @@ export function createExecApprovalHandlers(
           return allowedDecisions.includes(decision)
             ? null
             : {
-                message:
-                  "allow-always is unavailable because the effective policy requires approval every time",
+                message: describeExecApprovalAllowAlwaysUnavailableReason(
+                  snapshot.request.allowAlwaysUnavailableReason,
+                ),
                 details: APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS,
               };
         },

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -2646,6 +2646,7 @@ describe("exec approval handlers", () => {
         validateExecApprovalRequestParams({
           ...baseParams,
           unavailableDecisions: ["allow-always"],
+          allowAlwaysUnavailableReason: "non-persistable-command",
         }),
       ).toBe(true);
     });
@@ -3345,7 +3346,7 @@ describe("exec approval handlers", () => {
     expect(mockCallArg(resolveRespond, 0, 1)).toBeUndefined();
     expectRecordFields(mockCallArg(resolveRespond, 0, 2), {
       message:
-        "allow-always is unavailable because the effective policy requires approval every time",
+        "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     });
 
     const denyRespond = vi.fn();
@@ -3371,6 +3372,7 @@ describe("exec approval handlers", () => {
       params: {
         twoPhase: true,
         unavailableDecisions: ["allow-always"],
+        allowAlwaysUnavailableReason: "non-persistable-command",
       },
     });
     const { id } = await waitForRequestedExecApprovalPayload(broadcasts);
@@ -3388,7 +3390,7 @@ describe("exec approval handlers", () => {
     expect(mockCallArg(resolveRespond, 0, 1)).toBeUndefined();
     expectRecordFields(mockCallArg(resolveRespond, 0, 2), {
       message:
-        "allow-always is unavailable because the effective policy requires approval every time",
+        "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     });
 
     const allowOnceRespond = vi.fn();
@@ -3414,11 +3416,13 @@ describe("exec approval handlers", () => {
       params: {
         twoPhase: true,
         unavailableDecisions: ["allow-always"],
+        allowAlwaysUnavailableReason: "non-persistable-command",
       },
     });
     const { id, request } = await waitForRequestedExecApprovalPayload(broadcasts);
 
     expect(request.allowedDecisions).toEqual(["allow-once", "deny"]);
+    expect(request.allowAlwaysUnavailableReason).toBe("non-persistable-command");
 
     const denyRespond = vi.fn();
     await resolveExecApproval({

--- a/src/infra/approval-view-model.ts
+++ b/src/infra/approval-view-model.ts
@@ -72,6 +72,7 @@ function buildExecViewBase<TPhase extends ApprovalPhase>(
     metadata: buildExecMetadata(request),
     ask: request.request.ask ?? null,
     agentId: request.request.agentId ?? null,
+    allowAlwaysUnavailableReason: request.request.allowAlwaysUnavailableReason,
     warningText: request.request.warningText ?? null,
     commandAnalysis: request.request.commandAnalysis ?? null,
     commandText,

--- a/src/infra/approval-view-model.types.ts
+++ b/src/infra/approval-view-model.types.ts
@@ -40,6 +40,7 @@ export type ExecApprovalViewBase = ApprovalViewBase & {
   approvalKind: "exec";
   ask?: string | null;
   agentId?: string | null;
+  allowAlwaysUnavailableReason?: "approval-policy-always" | "non-persistable-command";
   warningText?: string | null;
   commandAnalysis?: CommandExplanationSummary | null;
   commandText: string;

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -645,6 +645,29 @@ describe("exec approval forwarder", () => {
     expect(text).toContain("Allow Always is unavailable");
   });
 
+  it("explains non-persistable commands in forwarded fallback text", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+    await expect(
+      forwarder.handleRequested({
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          allowedDecisions: ["allow-once", "deny"],
+          unavailableDecisions: ["allow-always"],
+          allowAlwaysUnavailableReason: "non-persistable-command",
+        },
+      }),
+    ).resolves.toBe(true);
+    await Promise.resolve();
+    const text = getFirstDeliveryText(deliver);
+    expect(text).toContain("Reply with: /approve req-1 allow-once|deny");
+    expect(text).toContain(
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
+    );
+    expect(text).not.toContain("effective policy still requires per-run approval");
+  });
+
   it.each([
     {
       command: "bash safe\u200B.sh",

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -32,6 +32,8 @@ import {
 } from "./exec-approval-command-display.js";
 import { formatExecApprovalExpiresIn } from "./exec-approval-reply.js";
 import {
+  describeExecApprovalAllowAlwaysUnavailableReason,
+  describeExecApprovalBackgroundModeUnavailableReason,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
@@ -289,12 +291,16 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
   lines.push(
     allowedDecisions.includes("allow-always")
       ? "Background mode note: non-interactive runs cannot wait for chat approvals; use pre-approved policy (allow-always or ask=off)."
-      : "Background mode note: non-interactive runs cannot wait for chat approvals; the effective policy still requires per-run approval unless ask=off.",
+      : describeExecApprovalBackgroundModeUnavailableReason(
+          request.request.allowAlwaysUnavailableReason,
+        ),
   );
   lines.push(`Reply with: /approve ${request.id} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
     lines.push(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
+      describeExecApprovalAllowAlwaysUnavailableReason(
+        request.request.allowAlwaysUnavailableReason,
+      ),
     );
   }
   return lines.join("\n");

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -222,6 +222,7 @@ describe("exec approval reply helpers", () => {
             approvalSlug: " slug-1 ",
             agentId: " agent-1 ",
             allowedDecisions: ["allow-once", "bad", "deny", "allow-always", 3],
+            allowAlwaysUnavailableReason: "non-persistable-command",
             sessionKey: " session-1 ",
           },
         },
@@ -232,6 +233,7 @@ describe("exec approval reply helpers", () => {
       approvalKind: "exec",
       agentId: "agent-1",
       allowedDecisions: ["allow-once", "deny", "allow-always"],
+      allowAlwaysUnavailableReason: "non-persistable-command",
       sessionKey: "session-1",
     });
   });
@@ -366,6 +368,27 @@ describe("exec approval reply helpers", () => {
       ],
     });
     expect(payload.interactive).toBeUndefined();
+  });
+
+  it("explains non-persistable commands when allow-always is unavailable", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-one-shot",
+      approvalSlug: "slug-one",
+      allowedDecisions: ["allow-once", "deny"],
+      allowAlwaysUnavailableReason: "non-persistable-command",
+      command: "openclaw --version 2>&1",
+      host: "gateway",
+    });
+
+    expect(payload.text).toContain(
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
+    );
+    expect(payload.text).not.toContain("requires approval every time");
+    expect(payload.channelData).toMatchObject({
+      execApproval: {
+        allowAlwaysUnavailableReason: "non-persistable-command",
+      },
+    });
   });
 
   it("stores agent and session metadata for downstream suppression checks", () => {

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -18,7 +18,9 @@ import {
   supportsNativeExecApprovalClient,
 } from "./exec-approval-surface.js";
 import {
+  describeExecApprovalAllowAlwaysUnavailableReason,
   resolveExecApprovalAllowedDecisions,
+  type ExecApprovalAllowAlwaysUnavailableReason,
   type ExecApprovalDecision,
   type ExecHost,
 } from "./exec-approvals.js";
@@ -35,6 +37,7 @@ export type ExecApprovalReplyMetadata = {
   approvalKind: "exec" | "plugin";
   agentId?: string;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
   sessionKey?: string;
 };
 
@@ -53,6 +56,7 @@ export type ExecApprovalPendingReplyParams = {
   ask?: string | null;
   agentId?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason | null;
   command: string;
   cwd?: string;
   host: ExecHost;
@@ -335,6 +339,11 @@ export function getExecApprovalReplyMetadata(
           value === "allow-once" || value === "allow-always" || value === "deny",
       )
     : undefined;
+  const allowAlwaysUnavailableReason =
+    record.allowAlwaysUnavailableReason === "approval-policy-always" ||
+    record.allowAlwaysUnavailableReason === "non-persistable-command"
+      ? record.allowAlwaysUnavailableReason
+      : undefined;
   const agentId = normalizeOptionalString(record.agentId);
   const sessionKey = normalizeOptionalString(record.sessionKey);
   return {
@@ -343,6 +352,7 @@ export function getExecApprovalReplyMetadata(
     approvalKind,
     agentId,
     allowedDecisions,
+    allowAlwaysUnavailableReason,
     sessionKey,
   };
 }
@@ -377,7 +387,7 @@ export function buildExecApprovalPendingReplyPayload(
   }
   if (!allowedDecisions.includes("allow-always")) {
     lines.push(
-      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+      describeExecApprovalAllowAlwaysUnavailableReason(params.allowAlwaysUnavailableReason),
     );
   }
   const info: string[] = [];
@@ -409,6 +419,7 @@ export function buildExecApprovalPendingReplyPayload(
         approvalKind: "exec",
         agentId: normalizeOptionalString(params.agentId),
         allowedDecisions,
+        allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason ?? undefined,
         sessionKey: normalizeOptionalString(params.sessionKey),
       },
     },

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -26,6 +26,7 @@ let normalizeExecTarget: typeof import("./exec-approvals.js").normalizeExecTarge
 let normalizeExecSecurity: typeof import("./exec-approvals.js").normalizeExecSecurity;
 let requiresExecApproval: typeof import("./exec-approvals.js").requiresExecApproval;
 let normalizeExecApprovalUnavailableDecisions: typeof import("./exec-approvals.js").normalizeExecApprovalUnavailableDecisions;
+let resolveExecApprovalAllowAlwaysUnavailableReason: typeof import("./exec-approvals.js").resolveExecApprovalAllowAlwaysUnavailableReason;
 let resolveExecApprovalUnavailableDecisions: typeof import("./exec-approvals.js").resolveExecApprovalUnavailableDecisions;
 let resolveExecApprovalRequestAllowedDecisions: typeof import("./exec-approvals.js").resolveExecApprovalRequestAllowedDecisions;
 let resolveExecModeFromPolicy: typeof import("./exec-approvals.js").resolveExecModeFromPolicy;
@@ -54,6 +55,8 @@ async function loadActualExecApprovalModules(): Promise<void> {
   requiresExecApproval = execApprovals.requiresExecApproval;
   normalizeExecApprovalUnavailableDecisions =
     execApprovals.normalizeExecApprovalUnavailableDecisions;
+  resolveExecApprovalAllowAlwaysUnavailableReason =
+    execApprovals.resolveExecApprovalAllowAlwaysUnavailableReason;
   resolveExecApprovalUnavailableDecisions = execApprovals.resolveExecApprovalUnavailableDecisions;
   resolveExecApprovalRequestAllowedDecisions =
     execApprovals.resolveExecApprovalRequestAllowedDecisions;
@@ -263,6 +266,19 @@ describe("exec approvals policy helpers", () => {
         allowAlwaysPersistence: { kind: "one-shot", reasons: ["no-reusable-pattern"] },
       }),
     ).toEqual(["allow-always"]);
+  });
+
+  it("explains why allow-always is unavailable", () => {
+    expect(resolveExecApprovalAllowAlwaysUnavailableReason({ ask: "always" })).toBe(
+      "approval-policy-always",
+    );
+    expect(
+      resolveExecApprovalAllowAlwaysUnavailableReason({
+        ask: "on-miss",
+        allowAlwaysPersistence: { kind: "one-shot", reasons: ["no-reusable-pattern"] },
+      }),
+    ).toBe("non-persistable-command");
+    expect(resolveExecApprovalAllowAlwaysUnavailableReason({ ask: "on-miss" })).toBeNull();
   });
 
   it.each([

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -221,6 +221,7 @@ export type ExecApprovalRequestPayload = {
   commandAnalysis?: CommandExplanationSummary | null;
   commandSpans?: ExecApprovalCommandSpan[];
   unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
   allowedDecisions?: readonly ExecApprovalDecision[];
   agentId?: string | null;
   resolvedPath?: string | null;
@@ -1783,10 +1784,17 @@ export const OPTIONAL_EXEC_APPROVAL_DECISIONS = [
   "allow-always",
 ] as const satisfies readonly ExecApprovalDecision[];
 export type ExecApprovalUnavailableDecision = (typeof OPTIONAL_EXEC_APPROVAL_DECISIONS)[number];
+export type ExecApprovalAllowAlwaysUnavailableReason =
+  | "approval-policy-always"
+  | "non-persistable-command";
 
 const OPTIONAL_EXEC_APPROVAL_DECISION_SET: ReadonlySet<string> = new Set(
   OPTIONAL_EXEC_APPROVAL_DECISIONS,
 );
+const EXEC_APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_REASON_SET: ReadonlySet<string> = new Set([
+  "approval-policy-always",
+  "non-persistable-command",
+]);
 
 function isOptionalExecApprovalDecision(
   decision: string,
@@ -1814,6 +1822,50 @@ export function normalizeExecApprovalUnavailableDecisions(
 ): readonly ExecApprovalUnavailableDecision[] {
   const unavailable = collectExecApprovalUnavailableDecisionSet(decisions);
   return OPTIONAL_EXEC_APPROVAL_DECISIONS.filter((decision) => unavailable.has(decision));
+}
+
+export function normalizeExecApprovalAllowAlwaysUnavailableReason(
+  reason?: string | null,
+): ExecApprovalAllowAlwaysUnavailableReason | null {
+  return reason && EXEC_APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_REASON_SET.has(reason)
+    ? (reason as ExecApprovalAllowAlwaysUnavailableReason)
+    : null;
+}
+
+export function resolveExecApprovalAllowAlwaysUnavailableReason(params?: {
+  ask?: string | null;
+  allowAlwaysPersistence?: AllowAlwaysPersistenceDecision | null;
+}): ExecApprovalAllowAlwaysUnavailableReason | null {
+  const ask = normalizeExecAsk(params?.ask);
+  if (ask === "always") {
+    return "approval-policy-always";
+  }
+  if (params?.allowAlwaysPersistence?.kind === "one-shot") {
+    return "non-persistable-command";
+  }
+  return null;
+}
+
+export function describeExecApprovalAllowAlwaysUnavailableReason(reason?: string | null): string {
+  switch (normalizeExecApprovalAllowAlwaysUnavailableReason(reason)) {
+    case "non-persistable-command":
+      return "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.";
+    case "approval-policy-always":
+    case null:
+      return "The effective approval policy requires approval every time, so Allow Always is unavailable.";
+  }
+}
+
+export function describeExecApprovalBackgroundModeUnavailableReason(
+  reason?: string | null,
+): string {
+  switch (normalizeExecApprovalAllowAlwaysUnavailableReason(reason)) {
+    case "non-persistable-command":
+      return "Background mode note: non-interactive runs cannot wait for chat approvals, and this command cannot be pre-approved with Allow Always.";
+    case "approval-policy-always":
+    case null:
+      return "Background mode note: non-interactive runs cannot wait for chat approvals; the effective policy still requires per-run approval unless ask=off.";
+  }
 }
 
 export function resolveExecApprovalAllowedDecisions(params?: {

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -174,7 +174,7 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
     expect(payload.text).toContain("Allow Once: /approve plugin:approval-123 allow-once");
     expect(payload.text).toContain("Deny: /approve plugin:approval-123 deny");
     expect(payload.text).toContain(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     );
     expect(
       payload.text?.trim().endsWith("Reply with: /approve plugin:approval-123 allow-once|deny"),

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -12,6 +12,7 @@ import {
   type ExecApprovalPendingReplyParams,
   type ExecApprovalReplyDecision,
 } from "../infra/exec-approval-reply.js";
+import { describeExecApprovalAllowAlwaysUnavailableReason } from "../infra/exec-approvals.js";
 import type { PluginApprovalRequest } from "../infra/plugin-approvals.js";
 import {
   buildApprovalPendingReplyPayload,
@@ -208,11 +209,12 @@ function buildDecisionText(allowedDecisions: readonly ExecApprovalReplyDecision[
 function buildManualInstructionSection(params: {
   approvalId: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
+  allowAlwaysUnavailableReason?: "approval-policy-always" | "non-persistable-command" | null;
 }): string[] {
   const lines: string[] = [];
   if (!params.allowedDecisions.includes("allow-always")) {
     lines.push(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
+      describeExecApprovalAllowAlwaysUnavailableReason(params.allowAlwaysUnavailableReason),
     );
   }
   if (params.allowedDecisions.length > 0) {
@@ -307,6 +309,8 @@ function buildApprovalReactionPromptText(params: {
   const manualInstructions = buildManualInstructionSection({
     approvalId: view.approvalId,
     allowedDecisions,
+    allowAlwaysUnavailableReason:
+      view.approvalKind === "exec" ? view.allowAlwaysUnavailableReason : null,
   });
   if (manualInstructions.length > 0) {
     sections.push(manualInstructions.join("\n"));

--- a/src/plugin-sdk/approval-renderers.ts
+++ b/src/plugin-sdk/approval-renderers.ts
@@ -29,6 +29,8 @@ export function buildApprovalPendingReplyPayload(params: {
   agentId?: string | null;
   /** Decisions rendered as buttons and accepted by the approval command. */
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
+  /** Optional reason shown when Allow Always is hidden for exec approvals. */
+  allowAlwaysUnavailableReason?: "approval-policy-always" | "non-persistable-command" | null;
   /** Optional session key associated with the approval request. */
   sessionKey?: string | null;
   /** Channel-specific metadata merged with the shared approval metadata. */
@@ -50,6 +52,7 @@ export function buildApprovalPendingReplyPayload(params: {
         approvalKind: params.approvalKind ?? "exec",
         agentId: normalizeOptionalString(params.agentId),
         allowedDecisions,
+        allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason ?? undefined,
         sessionKey: normalizeOptionalString(params.sessionKey),
         state: "pending",
       },

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.496Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:35.688Z",
   "locale": "ar",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:19.968Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:35.036Z",
   "locale": "de",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.073Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:35.168Z",
   "locale": "es",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:21.449Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:36.889Z",
   "locale": "fa",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.388Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:35.555Z",
   "locale": "fr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.917Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:36.231Z",
   "locale": "id",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.601Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:35.814Z",
   "locale": "it",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.179Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:35.297Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.285Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:35.426Z",
   "locale": "ko",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:21.341Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:36.760Z",
   "locale": "nl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:21.022Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:36.362Z",
   "locale": "pl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:19.858Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:34.901Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:21.129Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:36.491Z",
   "locale": "th",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.705Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:35.948Z",
   "locale": "tr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.812Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:36.090Z",
   "locale": "uk",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:21.236Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:36.623Z",
   "locale": "vi",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:18.876Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:34.612Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:19.747Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableNonPersistable"
+  ],
+  "generatedAt": "2026-06-26T18:12:34.770Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "0af2f98f7a3d7134b5866665135705768778dbf73d4630cad5fb26f5e409f352",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -370,6 +370,8 @@ export const ar: TranslationMap = {
     alwaysAllow: "السماح دائمًا",
     allowAlwaysUnavailable:
       "تتطلب سياسة الموافقة السارية الحصول على الموافقة في كل مرة، لذا فإن خيار السماح دائمًا غير متاح.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "رفض",
     labels: {
       host: "المضيف",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -374,6 +374,8 @@ export const de: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "Die wirksame Genehmigungsrichtlinie erfordert jedes Mal eine Genehmigung, daher ist Immer erlauben nicht verfügbar.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -369,6 +369,8 @@ export const en: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -371,6 +371,8 @@ export const es: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "La política de aprobación efectiva requiere aprobación cada vez, por lo que Permitir siempre no está disponible.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -372,6 +372,8 @@ export const fa: TranslationMap = {
     alwaysAllow: "همیشه مجاز کن",
     allowAlwaysUnavailable:
       "سیاست تأیید مؤثر هر بار به تأیید نیاز دارد، بنابراین «همیشه مجاز باشد» در دسترس نیست.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "رد کردن",
     labels: {
       host: "میزبان",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -373,6 +373,8 @@ export const fr: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "La politique d’approbation effective exige une approbation à chaque fois, donc Autoriser toujours n’est pas disponible.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -371,6 +371,8 @@ export const id: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "Kebijakan persetujuan yang berlaku mengharuskan persetujuan setiap kali, sehingga Izinkan Selalu tidak tersedia.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -373,6 +373,8 @@ export const it: TranslationMap = {
     alwaysAllow: "Consenti sempre",
     allowAlwaysUnavailable:
       "Il criterio di approvazione effettivo richiede l’approvazione ogni volta, quindi Consenti sempre non è disponibile.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Nega",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -374,6 +374,8 @@ export const ja_JP: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "有効な承認ポリシーでは毎回承認が必要なため、Allow Always は利用できません。",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -370,6 +370,8 @@ export const ko: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "유효한 승인 정책이 매번 승인을 요구하므로, 항상 허용을 사용할 수 없습니다.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -373,6 +373,8 @@ export const nl: TranslationMap = {
     alwaysAllow: "Altijd toestaan",
     allowAlwaysUnavailable:
       "Het effectieve goedkeuringsbeleid vereist elke keer goedkeuring, dus Altijd toestaan is niet beschikbaar.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Weigeren",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -372,6 +372,8 @@ export const pl: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "Obowiązująca zasada zatwierdzania wymaga zatwierdzenia za każdym razem, więc opcja Zawsze zezwalaj jest niedostępna.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -371,6 +371,8 @@ export const pt_BR: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "A política de aprovação efetiva exige aprovação todas as vezes, portanto Permitir sempre não está disponível.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -369,6 +369,8 @@ export const th: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "นโยบายการอนุมัติที่มีผลบังคับใช้กำหนดให้ต้องอนุมัติทุกครั้ง ดังนั้น Allow Always จึงไม่พร้อมใช้งาน",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -373,6 +373,8 @@ export const tr: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "Geçerli onay ilkesi her seferinde onay gerektiriyor, bu nedenle Her Zaman İzin Ver kullanılamıyor.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -372,6 +372,8 @@ export const uk: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "Чинна політика схвалення вимагає схвалення щоразу, тому «Дозволяти завжди» недоступно.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -371,6 +371,8 @@ export const vi: TranslationMap = {
     alwaysAllow: "Luôn cho phép",
     allowAlwaysUnavailable:
       "Chính sách phê duyệt có hiệu lực yêu cầu phê duyệt mọi lần, vì vậy Không cho phép Luôn cho phép.",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Từ chối",
     labels: {
       host: "Máy chủ",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -368,6 +368,8 @@ export const zh_CN: TranslationMap = {
     allowOnce: "允许一次",
     alwaysAllow: "始终允许",
     allowAlwaysUnavailable: "有效的批准策略要求每次都批准，因此“始终允许”不可用。",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "拒绝",
     labels: {
       host: "主机",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -368,6 +368,8 @@ export const zh_TW: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "有效的核准政策要求每次都需核准，因此「一律允許」無法使用。",
+    allowAlwaysUnavailableNonPersistable:
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -67,12 +67,14 @@ describe("parseExecApprovalRequested", () => {
       request: {
         command: "pwd",
         allowedDecisions: ["allow-once", "bad", "deny", "allow-always"],
+        allowAlwaysUnavailableReason: "non-persistable-command",
       },
       createdAtMs: 1000,
       expiresAtMs: 2000,
     });
 
     expect(result?.request.allowedDecisions).toEqual(["allow-once", "deny", "allow-always"]);
+    expect(result?.request.allowAlwaysUnavailableReason).toBe("non-persistable-command");
   });
 });
 

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -15,9 +15,13 @@ export type ExecApprovalRequestPayload = {
     endIndex: number;
   }[];
   allowedDecisions?: readonly ExecApprovalDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
 };
 
 export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
+export type ExecApprovalAllowAlwaysUnavailableReason =
+  | "approval-policy-always"
+  | "non-persistable-command";
 
 export type ExecApprovalRequest = {
   id: string;
@@ -103,6 +107,14 @@ function parseAllowedDecisions(value: unknown): ExecApprovalDecision[] | undefin
   return decisions.length > 0 ? decisions : undefined;
 }
 
+function parseAllowAlwaysUnavailableReason(
+  value: unknown,
+): ExecApprovalAllowAlwaysUnavailableReason | undefined {
+  return value === "approval-policy-always" || value === "non-persistable-command"
+    ? value
+    : undefined;
+}
+
 export function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | null {
   if (!isRecord(payload)) {
     return null;
@@ -135,6 +147,9 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
       commandSpans: parseCommandSpans(request.commandSpans, command.length),
       allowedDecisions: parseAllowedDecisions(request.allowedDecisions),
+      allowAlwaysUnavailableReason: parseAllowAlwaysUnavailableReason(
+        request.allowAlwaysUnavailableReason,
+      ),
     },
     createdAtMs,
     expiresAtMs,
@@ -188,6 +203,9 @@ export function parsePluginApprovalRequested(payload: unknown): ExecApprovalRequ
       agentId: typeof request.agentId === "string" ? request.agentId : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
       allowedDecisions: parseAllowedDecisions(request.allowedDecisions),
+      allowAlwaysUnavailableReason: parseAllowAlwaysUnavailableReason(
+        request.allowAlwaysUnavailableReason,
+      ),
     },
     pluginTitle: title,
     pluginDescription: description,

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -158,6 +158,20 @@ describe("approval and confirmation modals", () => {
     );
   });
 
+  it("explains non-persistable exec approvals", async () => {
+    const request = createExecRequest();
+    request.request.allowedDecisions = ["allow-once", "deny"];
+    request.request.allowAlwaysUnavailableReason = "non-persistable-command";
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
+
+    await getRenderedDialog();
+
+    expect(container.querySelector(".exec-approval-warning")?.textContent?.trim()).toBe(
+      "This command cannot be safely saved as an Allow Always rule, so Allow Always is unavailable.",
+    );
+  });
+
   it("falls back to ask when exec approval decisions are omitted", async () => {
     const request = createExecRequest();
     request.request.ask = "always";

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -153,9 +153,14 @@ function renderUnavailableDecisionWarning(
   active: ExecApprovalRequest,
   decisions: readonly ExecApprovalDecision[],
 ) {
-  return active.kind !== "exec" || decisions.includes("allow-always")
-    ? nothing
-    : html`<div class="exec-approval-warning">${t("execApproval.allowAlwaysUnavailable")}</div>`;
+  if (active.kind !== "exec" || decisions.includes("allow-always")) {
+    return nothing;
+  }
+  const message =
+    active.request.allowAlwaysUnavailableReason === "non-persistable-command"
+      ? t("execApproval.allowAlwaysUnavailableNonPersistable")
+      : t("execApproval.allowAlwaysUnavailable");
+  return html`<div class="exec-approval-warning">${message}</div>`;
 }
 
 export function renderExecApprovalPrompt(state: AppViewState) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #97069.

Redirected or otherwise non-persistable exec commands such as `openclaw --version 2>&1` can correctly hide Allow Always, but the prompt blamed the effective approval policy. That made `ask=on-miss` look like `ask=always` even though the hidden button was caused by one-shot command persistence safety.

## Why This Change Was Made

The exec approval request only carried `unavailableDecisions: ["allow-always"]`, so Control UI, forwarded chat approvals, native/reaction prompts, and gateway resolve errors could not tell whether Allow Always was hidden by policy or because the command could not be safely persisted.

This adds a typed `allowAlwaysUnavailableReason` and threads it through the gateway protocol, exec hosts, pending tool details, approval view model, forwarded/native rendering, reaction metadata, and i18n copy. Codex upstream was checked in `../codex/codex-rs/app-server-protocol/src/protocol/common.rs` and `../codex/codex-rs/app-server-protocol/src/protocol/v2/item.rs`; the upstream app-server approval params do not carry OpenClaw Allow Always persistence reasons, so this stays in OpenClaw's gateway approval protocol and renderers.

## User Impact

Users still get the same safe one-shot behavior for redirected/non-persistable commands, but the prompt now explains that the command cannot be safely saved as an Allow Always rule instead of incorrectly saying the effective approval policy requires approval every time.

## Evidence

- `node scripts/run-vitest.mjs packages/gateway-protocol/src/exec-approvals-validators.test.ts src/infra/exec-approvals-policy.test.ts src/gateway/server-methods/server-methods.test.ts src/infra/exec-approval-reply.test.ts src/infra/exec-approval-forwarder.test.ts ui/src/ui/controllers/exec-approval.test.ts ui/src/ui/views/exec-approval.test.ts src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts src/plugin-sdk/approval-reaction-runtime.test.ts src/plugin-sdk/approval-renderers.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/infra/approval-view-model.test.ts` passed 6 Vitest shards in 34.98s.
- `pnpm ui:i18n:check` passed.
- `pnpm changed:lanes --json` reported `core`, `coreTests`, `extensions`, and `extensionTests` lanes.
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed` passed guards and core/core-test/extensions/extension-test typechecks; it was interrupted during core lint so this PR could be pushed at maintainer request.
- `.agents/skills/autoreview/scripts/autoreview --mode local` reported clean: no accepted/actionable findings.
- Remote Testbox delegation via `pnpm check:changed` was blocked locally because Crabbox 0.18.0 is below the blacksmith-testbox minimum of 0.22.0.
