### PR TITLE
fix(cost): recalculate usage cost if api returns confident zero (DeepSeek V4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Welcome to the lobster tank! 🦞
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!
-2. **New features / architecture** → Start a [GitHub Issue](https://github.com/openclaw/openclaw/issues/new/choose) or ask in Discord first. Most features are not accepted and should be third party plugins instead using our plugin SDK.
+2. **New features / architecture** → Start a [GitHub Issue](https://github.com/openclaw/openclaw/issues/new/choose) or ask in Discord first. Most features are not accepted and should be third-party plugins instead using our plugin SDK.
 3. **Refactor-only PRs** → Don't open a PR. We are not accepting refactor-only changes unless a maintainer explicitly asks for them as part of a concrete fix.
 4. **Test/CI-only PRs for known `main` failures** → Don't open a PR. The Maintainer team is already tracking those failures, and PRs that only tweak tests or CI to chase them will be closed unless they are required to validate a new fix.
 5. **Questions** → Discord [#help](https://discord.com/channels/1456350064065904867/1459642797895319552) / [#users-helping-users](https://discord.com/channels/1456350064065904867/1459007081603403828)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Welcome to the lobster tank! 🦞
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!
-2. **New features / architecture** → Start a [GitHub Issue](https://github.com/openclaw/openclaw/issues/new/choose) or ask in Discord first. Most features are not accepted and should be third-party plugins instead using our plugin SDK.
+2. **New features / architecture** → Start a [GitHub Issue](https://github.com/openclaw/openclaw/issues/new/choose) or ask in Discord first. Most features are not accepted and should be third party plugins instead using our plugin SDK.
 3. **Refactor-only PRs** → Don't open a PR. We are not accepting refactor-only changes unless a maintainer explicitly asks for them as part of a concrete fix.
 4. **Test/CI-only PRs for known `main` failures** → Don't open a PR. The Maintainer team is already tracking those failures, and PRs that only tweak tests or CI to chase them will be closed unless they are required to validate a new fix.
 5. **Questions** → Discord [#help](https://discord.com/channels/1456350064065904867/1459642797895319552) / [#users-helping-users](https://discord.com/channels/1456350064065904867/1459007081603403828)

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -300,6 +300,68 @@ describe("session cost usage", () => {
     });
   });
 
+  it("estimates cost from pricing grid when API returns cost.total: 0 but pricing is known (DeepSeek V4 regression)", async () => {
+    const root = await makeSessionCostRoot("cost-deepseek-zero-api");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // DeepSeek V4 (and similar providers) return usage.cost.total: 0 in their API
+    // responses even when tokens are consumed. The fix must override that $0 with a
+    // local estimate whenever the model has a known pricing config.
+    const entry = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "deepseek",
+        model: "deepseek-chat",
+        usage: {
+          input: 1000,
+          output: 500,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 1500,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-1.jsonl"),
+      transcriptText("sess-1", entry),
+      "utf-8",
+    );
+
+    // Configure a known non-zero pricing for DeepSeek — $0.14/M input, $0.28/M output
+    // (representative of deepseek-chat at the time of the bug report).
+    const config = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-chat",
+                cost: { input: 0.00000014, output: 0.00000028, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    clearGatewayModelPricingCacheState();
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.totals.totalTokens).toBe(1500);
+      // The API returned 0 but pricing is known, so the cost must be estimated:
+      // 1000 * 0.00000014 + 500 * 0.00000028 = 0.00014 + 0.00014 = 0.00028
+      expect(summary.totals.totalCost).toBeCloseTo(0.00028, 8);
+      // A known-priced model with an API-zero response is NOT a missing-cost entry;
+      // it gets a real estimate instead.
+      expect(summary.totals.missingCostEntries).toBe(0);
+    });
+  });
+
   it("treats a pre-upgrade (older-version) durable cache as stale so unpriced usage is rebuilt", async () => {
     const root = await makeSessionCostRoot("cost-cache-upgrade");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -339,7 +339,7 @@ describe("session cost usage", () => {
       {
         provider: "deepseek",
         model: "deepseek-chat",
-        pricing: { input: 0.00000014, output: 0.00000028, cacheRead: 0, cacheWrite: 0 },
+        pricing: { input: 0.14, output: 0.28, cacheRead: 0, cacheWrite: 0 },
       },
     ]);
 

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -334,24 +334,17 @@ describe("session cost usage", () => {
 
     // Configure a known non-zero pricing for DeepSeek — $0.14/M input, $0.28/M output
     // (representative of deepseek-chat at the time of the bug report).
-    const config = {
-      models: {
-        providers: {
-          deepseek: {
-            models: [
-              {
-                id: "deepseek-chat",
-                cost: { input: 0.00000014, output: 0.00000028, cacheRead: 0, cacheWrite: 0 },
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
-
     clearGatewayModelPricingCacheState();
+    setGatewayModelPricingForTest([
+      {
+        provider: "deepseek",
+        model: "deepseek-chat",
+        pricing: { input: 0.00000014, output: 0.00000028, cacheRead: 0, cacheWrite: 0 },
+      },
+    ]);
+
     await withStateDir(root, async () => {
-      const summary = await loadCostUsageSummary({ days: 30, config });
+      const summary = await loadCostUsageSummary({ days: 30 });
       expect(summary.totals.totalTokens).toBe(1500);
       // The API returned 0 but pricing is known, so the cost must be estimated:
       // 1000 * 0.00000014 + 500 * 0.00000028 = 0.00014 + 0.00014 = 0.00028

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -795,12 +795,12 @@ function buildSessionCostSummaryFromCacheEntry(params: {
   );
   const toolUsage: SessionToolUsage | undefined = toolUsageMap.size
     ? {
-        totalCalls: Array.from(toolUsageMap.values()).reduce((sum, count) => sum + count, 0),
-        uniqueTools: toolUsageMap.size,
-        tools: Array.from(toolUsageMap.entries())
-          .map(([name, count]) => ({ name, count }))
-          .toSorted((a, b) => b.count - a.count),
-      }
+      totalCalls: Array.from(toolUsageMap.values()).reduce((sum, count) => sum + count, 0),
+      uniqueTools: toolUsageMap.size,
+      tools: Array.from(toolUsageMap.entries())
+        .map(([name, count]) => ({ name, count }))
+        .toSorted((a, b) => b.count - a.count),
+    }
     : undefined;
   const modelUsage = Array.from(modelUsageMap.values()).toSorted((a, b) => {
     const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
@@ -1165,8 +1165,16 @@ async function scanTranscriptFile(params: {
         // above.
         entry.costTotal = undefined;
         entry.costBreakdown = undefined;
-      } else if (entry.costTotal === undefined) {
-        // Fill in missing cost estimates.
+      } else if (
+        entry.costTotal === undefined ||
+        (entry.costTotal === 0 &&
+          isModelPricingKnown(cost) &&
+          computeUsageTokenTotals(entry.usage).totalTokens > 0)
+      ) {
+        // Fill in missing cost estimates, and override an API-reported zero cost
+        // when the model has known pricing and tokens were consumed. Some providers
+        // (e.g. DeepSeek V4) return usage.cost.total: 0 even for non-zero token
+        // usage, causing the Control UI Spend panel to show $0 for real spend.
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
       }
     }
@@ -1215,8 +1223,8 @@ export function resolveExistingUsageSessionFile(params: {
     params.sessionFile ??
     (params.sessionId
       ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
-          agentId: params.agentId,
-        })
+        agentId: params.agentId,
+      })
       : undefined);
 
   if (candidate && fs.existsSync(candidate)) {
@@ -1355,16 +1363,16 @@ async function scanUsageFileForCache(params: {
   const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
   const appendOnlyPreviousCandidate =
     params.previous &&
-    params.previous.filePath === params.file.filePath &&
-    params.previous.size > 0 &&
-    params.previous.size < params.file.size &&
-    params.previous.pricingFingerprint === pricingFingerprint &&
-    params.previous.mtimeMs <= params.file.mtimeMs
+      params.previous.filePath === params.file.filePath &&
+      params.previous.size > 0 &&
+      params.previous.size < params.file.size &&
+      params.previous.pricingFingerprint === pricingFingerprint &&
+      params.previous.mtimeMs <= params.file.mtimeMs
       ? params.previous
       : undefined;
   const appendOnlyPrevious =
     appendOnlyPreviousCandidate &&
-    (!params.includeSessionSummary || appendOnlyPreviousCandidate.transcriptEntries)
+      (!params.includeSessionSummary || appendOnlyPreviousCandidate.transcriptEntries)
       ? appendOnlyPreviousCandidate
       : undefined;
   const totals = emptyTotals();
@@ -1377,7 +1385,7 @@ async function scanUsageFileForCache(params: {
   let countedRecords = 0;
   const startOffset =
     appendOnlyPrevious &&
-    (await canReadJsonlFromOffset(params.file.filePath, appendOnlyPrevious.size))
+      (await canReadJsonlFromOffset(params.file.filePath, appendOnlyPrevious.size))
       ? appendOnlyPrevious.size
       : undefined;
 
@@ -1429,34 +1437,34 @@ async function scanUsageFileForCache(params: {
     parseUsageCountedSessionIdFromFileName(path.basename(params.file.filePath)) ?? undefined;
   const combinedTranscriptEntries = shouldTrackTranscriptEntries
     ? [
-        ...((appendOnlyPrevious && startOffset !== undefined
-          ? appendOnlyPrevious.transcriptEntries
-          : undefined) ?? []),
-        ...(transcriptEntries ?? []),
-      ]
+      ...((appendOnlyPrevious && startOffset !== undefined
+        ? appendOnlyPrevious.transcriptEntries
+        : undefined) ?? []),
+      ...(transcriptEntries ?? []),
+    ]
     : undefined;
   const sessionSummary =
     combinedTranscriptEntries &&
-    (params.includeSessionSummary || appendOnlyPrevious?.sessionSummary)
+      (params.includeSessionSummary || appendOnlyPrevious?.sessionSummary)
       ? (buildSessionCostSummaryFromCacheEntry({
-          entry: {
-            filePath: params.file.filePath,
-            size: params.file.size,
-            mtimeMs: params.file.mtimeMs,
-            pricingFingerprint,
-            scannedAt: Date.now(),
-            parsedRecords,
-            countedRecords,
-            usageEntries,
-            transcriptEntries: combinedTranscriptEntries,
-            totals,
-            sessionId,
-          },
+        entry: {
+          filePath: params.file.filePath,
+          size: params.file.size,
+          mtimeMs: params.file.mtimeMs,
+          pricingFingerprint,
+          scannedAt: Date.now(),
+          parsedRecords,
+          countedRecords,
+          usageEntries,
+          transcriptEntries: combinedTranscriptEntries,
+          totals,
           sessionId,
-          sessionFile: params.file.filePath,
-          startMs: Number.NEGATIVE_INFINITY,
-          endMs: Number.POSITIVE_INFINITY,
-        }) ?? undefined)
+        },
+        sessionId,
+        sessionFile: params.file.filePath,
+        startMs: Number.NEGATIVE_INFINITY,
+        endMs: Number.POSITIVE_INFINITY,
+      }) ?? undefined)
       : undefined;
 
   if (appendOnlyPrevious && startOffset !== undefined) {
@@ -1752,22 +1760,22 @@ export async function loadSessionCostSummaryFromCache(params: {
   ) {
     summary = entry
       ? buildSessionCostSummaryFromCacheEntry({
-          entry,
+        entry,
+        sessionId: params.sessionId,
+        sessionFile: params.sessionFile,
+        startMs: params.startMs,
+        endMs: params.endMs,
+      })
+      : params.refreshMode === "sync-when-empty"
+        ? await loadSessionCostSummary({
           sessionId: params.sessionId,
+          sessionEntry: params.sessionEntry,
           sessionFile: params.sessionFile,
+          config: params.config,
+          agentId: params.agentId,
           startMs: params.startMs,
           endMs: params.endMs,
         })
-      : params.refreshMode === "sync-when-empty"
-        ? await loadSessionCostSummary({
-            sessionId: params.sessionId,
-            sessionEntry: params.sessionEntry,
-            sessionFile: params.sessionFile,
-            config: params.config,
-            agentId: params.agentId,
-            startMs: params.startMs,
-            endMs: params.endMs,
-          })
         : null;
   }
   return {
@@ -1840,12 +1848,12 @@ export async function loadSessionCostSummariesFromCache(params: {
     ) {
       return entry
         ? buildSessionCostSummaryFromCacheEntry({
-            entry,
-            sessionId: session.sessionId,
-            sessionFile: session.sessionFile,
-            startMs: params.startMs,
-            endMs: params.endMs,
-          })
+          entry,
+          sessionId: session.sessionId,
+          sessionFile: session.sessionFile,
+          startMs: params.startMs,
+          endMs: params.endMs,
+        })
         : null;
     }
     return summary;
@@ -2245,9 +2253,9 @@ export async function loadSessionCostSummary(params: {
           entry.costBreakdown?.total ??
           (entry.costBreakdown
             ? (entry.costBreakdown.input ?? 0) +
-              (entry.costBreakdown.output ?? 0) +
-              (entry.costBreakdown.cacheRead ?? 0) +
-              (entry.costBreakdown.cacheWrite ?? 0)
+            (entry.costBreakdown.output ?? 0) +
+            (entry.costBreakdown.cacheRead ?? 0) +
+            (entry.costBreakdown.cacheWrite ?? 0)
             : (entry.costTotal ?? 0));
 
         const quarterBucket = getUtcQuarterHourBucketKey(entry.timestamp);
@@ -2350,22 +2358,22 @@ export async function loadSessionCostSummary(params: {
 
   const toolUsage: SessionToolUsage | undefined = toolUsageMap.size
     ? {
-        totalCalls: Array.from(toolUsageMap.values()).reduce((sum, count) => sum + count, 0),
-        uniqueTools: toolUsageMap.size,
-        tools: Array.from(toolUsageMap.entries())
-          .map(([name, count]) => ({ name, count }))
-          .toSorted((a, b) => b.count - a.count),
-      }
+      totalCalls: Array.from(toolUsageMap.values()).reduce((sum, count) => sum + count, 0),
+      uniqueTools: toolUsageMap.size,
+      tools: Array.from(toolUsageMap.entries())
+        .map(([name, count]) => ({ name, count }))
+        .toSorted((a, b) => b.count - a.count),
+    }
     : undefined;
 
   const modelUsage = modelUsageMap.size
     ? Array.from(modelUsageMap.values()).toSorted((a, b) => {
-        const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
-        if (costDiff !== 0) {
-          return costDiff;
-        }
-        return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
-      })
+      const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
+      if (costDiff !== 0) {
+        return costDiff;
+      }
+      return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
+    })
     : undefined;
 
   return {
@@ -2635,9 +2643,9 @@ export async function loadSessionLogs(params: {
           tokens =
             usage.total ??
             (usage.input ?? 0) +
-              (usage.output ?? 0) +
-              (usage.cacheRead ?? 0) +
-              (usage.cacheWrite ?? 0);
+            (usage.output ?? 0) +
+            (usage.cacheRead ?? 0) +
+            (usage.cacheWrite ?? 0);
           const breakdown = extractCostBreakdown(usageRaw);
           if (breakdown?.total !== undefined) {
             cost = breakdown.total;

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1176,6 +1176,7 @@ async function scanTranscriptFile(params: {
         // (e.g. DeepSeek V4) return usage.cost.total: 0 even for non-zero token
         // usage, causing the Control UI Spend panel to show $0 for real spend.
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
+        entry.costBreakdown = undefined;
       }
     }
 


### PR DESCRIPTION
## What Problem This Solves
DeepSeek V4 explicitly returns usage.cost.total: 0 even when tokens are consumed. Because isModelPricingKnown is true, the system skips recalculating the cost if it's explicitly 0, assuming it's accurate. This causes the Control UI Spend tracking to show \.

## Why This Change Was Made
Modified the fallback condition so that if entry.costTotal === 0 AND pricing is known AND tokens are > 0, it ignores the confident zero and calculates the estimate locally. I also cleared entry.costBreakdown so downstream aggregations don't reuse the 0.

## Evidence
Added a unit test reproducing the exact DeepSeek V4 API response structure and verified that the estimation runs correctly.