### PR TITLE
[codex] fix Feishu login QR rendering

### DIFF
--- a/extensions/feishu/src/app-registration.test.ts
+++ b/extensions/feishu/src/app-registration.test.ts
@@ -1,14 +1,19 @@
 // Feishu tests cover app registration plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { beginAppRegistration, pollAppRegistration } from "./app-registration.js";
+import { beginAppRegistration, pollAppRegistration, printQrCode } from "./app-registration.js";
 
-const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+const { fetchWithSsrFGuardMock, renderQrTerminalMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
+  renderQrTerminalMock: vi.fn(async () => "terminal-qr"),
 }));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+vi.mock("./qr-terminal.js", () => ({
+  renderQrTerminal: renderQrTerminalMock,
 }));
 
 function mockFeishuJson(payload: unknown) {
@@ -23,6 +28,7 @@ describe("Feishu app registration", () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     fetchWithSsrFGuardMock.mockReset();
+    renderQrTerminalMock.mockClear();
   });
 
   it("defaults unsafe begin polling lifetimes from provider responses", async () => {
@@ -58,5 +64,17 @@ describe("Feishu app registration", () => {
 
     await vi.runOnlyPendingTimersAsync();
     await expect(poll).resolves.toEqual({ status: "timeout" });
+  });
+
+  it("prints scan-to-create QR codes with compact terminal rendering", async () => {
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await printQrCode("https://accounts.feishu.cn/verify?device_code=long-device-code");
+
+    expect(renderQrTerminalMock).toHaveBeenCalledWith(
+      "https://accounts.feishu.cn/verify?device_code=long-device-code",
+      { small: true },
+    );
+    expect(writeSpy).toHaveBeenCalledWith("terminal-qr\n");
   });
 });

--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -266,7 +266,7 @@ export async function pollAppRegistration(params: {
  * otherwise the pattern is corrupted and cannot be scanned.
  */
 export async function printQrCode(url: string): Promise<void> {
-  const output = await renderQrTerminal(url);
+  const output = await renderQrTerminal(url, { small: true });
   process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
 }
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw channels login --channel feishu` can render an oversized and distorted terminal QR code during the scan-to-create setup path. The Feishu registration URL is long enough that the default full terminal QR renderer becomes roughly twice as wide as the compact renderer, which can wrap in normal terminal windows and make the QR code unscannable.

## Why This Change Was Made

Feishu's app-registration QR print path was calling `renderQrTerminal(url)` without compact mode. The shared media runtime already supports compact half-block QR rendering, and WhatsApp login already uses that mode for terminal QR display. This change routes Feishu scan-to-create QR output through the same compact renderer by passing `{ small: true }`.

The regression test locks the Feishu print path to compact rendering and keeps the stdout newline behavior intact.

## User Impact

Users who choose QR scanning in `openclaw channels login --channel feishu` should now see a QR code that fits normal terminal widths and remains scannable instead of a huge wrapped block.

## Evidence

Automated checks:

- `pnpm test extensions/feishu/src/app-registration.test.ts -- --reporter=verbose`
- `pnpm test src/media/qr-terminal.render.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 extensions/feishu/src/app-registration.ts extensions/feishu/src/app-registration.test.ts`
- `pnpm changed:lanes --json`
- `pnpm test:changed`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` reported no accepted/actionable findings.

Manual terminal behavior proof:

- Before: simulated Feishu registration URL length `402` rendered with default `qrcode` terminal mode as `75` rows and max `150` visible columns.

- After: the same URL rendered through Feishu `printQrCode` as `38` rows and max `75` visible columns, using compact half-block QR output.

Real behavior screenshots:

- Before fix screenshot: <!-- upload before screenshot here -->
<img width="981" height="785" alt="截屏2026-06-27 02 48 08" src="https://github.com/user-attachments/assets/50a5457a-bcda-4926-bd1c-3e6adfc9c110" />

- After fix screenshot: <!-- upload after screenshot here -->
<img width="968" height="623" alt="截屏2026-06-27 02 50 44" src="https://github.com/user-attachments/assets/4f0242cf-d511-4d63-a076-e37371073ced" />