### PR TITLE
fix(agent-core): ignore truncated assistant tool calls

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -164,6 +164,120 @@ describe("agentLoop streaming updates", () => {
       expect(update.assistantMessageEvent).not.toHaveProperty("partial");
     }
   });
+
+  it("does not execute tool calls from a max-token-truncated assistant turn", async () => {
+    const execute = vi.fn(
+      async (): Promise<AgentToolResult<unknown>> => ({
+        content: [{ type: "text", text: "should not run" }],
+        details: {},
+      }),
+    );
+    const contexts: Context[] = [];
+    let streamCalls = 0;
+    const streamFn: StreamFn = async (_model, context) => {
+      contexts.push(context);
+      streamCalls += 1;
+      const stream = createAssistantMessageEventStream();
+      if (streamCalls > 1) {
+        const message: AssistantMessage = {
+          role: "assistant",
+          content: [{ type: "text", text: "continued" }],
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage: TEST_USAGE,
+          stopReason: "stop",
+          timestamp: 2,
+        };
+        queueMicrotask(() => {
+          stream.push({ type: "done", reason: "stop", message });
+        });
+        return stream;
+      }
+      const toolCall = {
+        type: "toolCall" as const,
+        id: "call-truncated-spawn",
+        name: "sessions_spawn",
+        arguments: {},
+      };
+      const message: AssistantMessage = {
+        role: "assistant",
+        content: [{ type: "text", text: "spawning" }, toolCall],
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage: TEST_USAGE,
+        stopReason: "length",
+        timestamp: 1,
+      };
+
+      queueMicrotask(() => {
+        stream.push({ type: "start", partial: { ...message, content: [] } });
+        stream.push({ type: "toolcall_start", contentIndex: 1, partial: message });
+        stream.push({
+          type: "toolcall_end",
+          contentIndex: 1,
+          toolCall,
+          partial: message,
+        });
+        stream.push({ type: "done", reason: "length", message });
+      });
+
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "spawn specialists", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [
+          {
+            name: "sessions_spawn",
+            label: "sessions_spawn",
+            description: "Spawn a child session",
+            parameters: Type.Object({}, { additionalProperties: false }),
+            execute,
+          },
+        ],
+      },
+      {
+        ...config,
+        getFollowUpMessages: async () =>
+          streamCalls === 1 ? [{ role: "user", content: "continue", timestamp: 2 }] : [],
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+    const messages = await stream.result();
+    const truncatedMessageEnd = events.find(
+      (event): event is Extract<AgentEvent, { type: "message_end" }> =>
+        event.type === "message_end" &&
+        event.message.role === "assistant" &&
+        event.message.stopReason === "length",
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(events.some((event) => event.type === "tool_execution_start")).toBe(false);
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    expect(messages[1]).toMatchObject({ role: "assistant", stopReason: "length" });
+    expect(messages[1]).not.toMatchObject({
+      content: expect.arrayContaining([expect.objectContaining({ type: "toolCall" })]),
+    });
+    expect(truncatedMessageEnd?.message).not.toMatchObject({
+      content: expect.arrayContaining([expect.objectContaining({ type: "toolCall" })]),
+    });
+    expect(contexts[1]?.messages[1]).not.toMatchObject({
+      content: expect.arrayContaining([expect.objectContaining({ type: "toolCall" })]),
+    });
+  });
 });
 
 describe("runAgentLoop deferred tool hydration", () => {
@@ -936,7 +1050,7 @@ describe("agentLoop thinking state", () => {
         totalTokens: 0,
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
       },
-      stopReason: "stop",
+      stopReason: content.some((item) => item.type === "toolCall") ? "toolUse" : "stop",
       timestamp: 1,
     };
   }
@@ -968,7 +1082,7 @@ describe("agentLoop thinking state", () => {
             : [{ type: "text", text: "done" }];
         stream.push({
           type: "done",
-          reason: "stop",
+          reason: content.some((item) => item.type === "toolCall") ? "toolUse" : "stop",
           message: makeAssistantMessage(activeModel, content),
         });
         stream.end();

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -80,6 +80,14 @@ function resolveAssistantMessageUpdate(
   return currentMessage;
 }
 
+function removeNonExecutableToolCalls(message: AssistantMessage): AssistantMessage {
+  if (message.stopReason === "toolUse") {
+    return message;
+  }
+  const content = message.content.filter((item) => item.type !== "toolCall");
+  return content.length === message.content.length ? message : { ...message, content };
+}
+
 /**
  * Start an agent loop with a new prompt message.
  * The prompt is added to the context and events are emitted for it.
@@ -342,12 +350,12 @@ async function runLoop(
         return;
       }
 
-      // Check for tool calls
+      // Only completed toolUse turns dispatch; length/stop can carry partial stream blocks.
       const toolCalls = message.content.filter((c) => c.type === "toolCall");
 
       const toolResults: ToolResultMessage[] = [];
       hasMoreToolCalls = false;
-      if (toolCalls.length > 0) {
+      if (message.stopReason === "toolUse" && toolCalls.length > 0) {
         const executedToolBatch = await executeToolCalls(
           currentContext,
           message,
@@ -508,7 +516,7 @@ async function streamAssistantResponse(
 
       case "done":
       case "error": {
-        const finalMessage = await response.result();
+        const finalMessage = removeNonExecutableToolCalls(await response.result());
         if (addedPartial) {
           context.messages[context.messages.length - 1] = finalMessage;
         } else {
@@ -523,7 +531,7 @@ async function streamAssistantResponse(
     }
   }
 
-  const finalMessage = await response.result();
+  const finalMessage = removeNonExecutableToolCalls(await response.result());
   if (addedPartial) {
     context.messages[context.messages.length - 1] = finalMessage;
   } else {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running streamed agent tool calls could execute an unintended partial tool call when an assistant turn stopped at the output limit while producing a tool-call batch.

Closes #97091

## Why This Change Was Made

The agent loop now treats only finalized `toolUse` assistant turns as executable. Non-`toolUse` final assistant messages have tool-call blocks removed before they are committed to context or emitted as `message_end`, so truncated `length` turns cannot dispatch side-effectful tools or leave dangling tool-call replay state.

## User Impact

Users get safer streamed tool-call behavior: a max-token-truncated assistant turn can preserve visible assistant text, but it will not launch accidental child sessions or poison the next model request with unmatched tool calls.

## Evidence

Before evidence:

```text
2026-06-26T02:17:44.026Z extra sessions_spawn accepted
  childSessionKey: [redacted child session key]
  runId: [redacted run id]
  mode: run
  taskName: absent

2026-06-26T02:17:46.897Z accidental child first log record
2026-06-26T02:25:40.519Z accidental child last log record
duration: about 7m54s
assistant tool calls: 87
tool results: 87
tool names: exec=81, process=4, read=2
```

Focused regression proof after fix:

```text
$ node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts
[test] starting test/vitest/vitest.unit.config.ts

 RUN  v4.1.8 /home/galini/GitHub/worktrees/bug-047-truncated-tool-call-commit

 Test Files  1 passed (1)
      Tests  16 passed (16)
   Start at  19:02:13
   Duration  977ms (transform 445ms, setup 321ms, import 348ms, tests 117ms, environment 0ms)

[test] passed 1 Vitest shard in 8.91s
```

Patch hygiene:

```text
$ git diff --check
# no output
```

Autoreview:

```text
$ .agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.82)
```

## Real behavior proof

Behavior addressed: A max-token-truncated assistant turn with a partial `sessions_spawn` tool call no longer executes the tool call and no longer leaves a dangling tool call in the committed assistant message, emitted `message_end`, or next-turn replay context.

Real environment tested: Local OpenClaw source worktree using the agent-core runtime seam and the real `createAssistantMessageEventStream` event protocol.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`.

Evidence after fix:

```text
$ node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts
[test] starting test/vitest/vitest.unit.config.ts

 RUN  v4.1.8 /home/galini/GitHub/worktrees/bug-047-truncated-tool-call-commit

 Test Files  1 passed (1)
      Tests  16 passed (16)
   Start at  19:02:13
   Duration  977ms (transform 445ms, setup 321ms, import 348ms, tests 117ms, environment 0ms)

[test] passed 1 Vitest shard in 8.91s
```

Observed result after fix: The new regression verifies that a `stopReason: "length"` assistant message containing a `sessions_spawn` tool-call block does not emit `tool_execution_start`, does not call the tool implementation, removes the tool-call block from the returned assistant message, removes it from the `message_end` event, and removes it from the follow-up turn's replay context.

What was not tested: I did not rerun the original live Telegram/GitHub Copilot parent session because it depends on private channel credentials and reproducing a provider max-token truncation at the same point in a live tool-call batch.
