### PR TITLE
Fix Anthropic extra usage failover classification

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -2854,16 +2854,16 @@ describe("active-memory plugin", () => {
     );
 
     const prependContext = requirePrependContext(result);
-    expect(prependContext).toContain("alpha beta gamma delta epsilon zeta");
+    expect(prependContext).toContain("alpha beta gamma delta epsilon zeta eta…");
     expect(prependContext).toContain("<active_memory_plugin>");
     expect(prependContext).not.toContain("theta");
     expect(prependContext).not.toContain("ignore this user text");
     const lines = getActiveMemoryLines(sessionKey);
     expectLinesToContain(lines, "🧩 Active Memory: status=timeout_partial");
-    expectLinesToContain(lines, "summary=35 chars");
+    expectLinesToContain(lines, "summary=40 chars");
     expectLinesToContain(
       lines,
-      "🔎 Active Memory Debug: timeout_partial: 35 chars recovered (not persisted)",
+      "🔎 Active Memory Debug: timeout_partial: 40 chars recovered (not persisted)",
     );
     expect(lines.join("\n")).not.toContain("alpha beta gamma delta");
   });
@@ -5329,9 +5329,26 @@ describe("active-memory plugin", () => {
 
     const prependContext = requirePrependContext(result);
     expect(prependContext).toContain("alpha beta gamma");
-    expect(prependContext).toContain("alpha beta gamma delta epsilon");
+    expect(prependContext).toContain("alpha beta gamma delta epsilon…");
     expect(prependContext).not.toContain("zetalo");
     expect(prependContext).not.toContain("zetalongword");
+  });
+
+  it("asks recall subagents to mark mutable operational facts stale unless source status is current", async () => {
+    await hooks.before_prompt_build(
+      { prompt: "is autonomous pickup running?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    const prompt = lastEmbeddedPrompt();
+    expect(prompt).toContain("Mutable operational facts");
+    expect(prompt).toContain("source timestamp");
+    expect(prompt).toContain("verify live");
   });
 
   it("uses the configured maxSummaryChars value in the subagent prompt", async () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1084,6 +1084,8 @@ function buildRecallPrompt(params: {
     "Questions like 'what is my favorite food', 'do you remember my flight preferences', or 'what do i usually get' should normally return memory when relevant results exist.",
     "If the provided conversation context already contains recalled-memory summaries, debug output, or prior memory/tool traces, ignore that surfaced text unless the latest user message clearly requires re-checking it.",
     "Return memory only when it would materially help the other model answer the user's latest message.",
+    "Mutable operational facts (cron/job health, automation status, deployments, incidents, service availability) go stale quickly: include the source timestamp when available, say when the memory may be stale, and tell the answering model to verify live before relying on it.",
+    "Do not summarize mutable operational facts as simply current/running/healthy unless the memory result itself contains a current source timestamp and matching health state.",
     "If the connection is weak, broad, or only vaguely related, reply with NONE.",
     "If nothing clearly useful is found, reply with NONE.",
     "Return exactly one of these two forms:",
@@ -2557,18 +2559,23 @@ function truncateSummary(summary: string, maxSummaryChars: number): string {
     return trimmed;
   }
 
-  const bounded = trimmed.slice(0, maxSummaryChars).trimEnd();
-  const nextChar = trimmed.charAt(maxSummaryChars);
+  const ellipsis = "…";
+  if (maxSummaryChars <= ellipsis.length) {
+    return ellipsis.slice(0, Math.max(0, maxSummaryChars));
+  }
+  const contentMaxChars = maxSummaryChars - ellipsis.length;
+  const bounded = trimmed.slice(0, contentMaxChars).trimEnd();
+  const nextChar = trimmed.charAt(contentMaxChars);
   if (!nextChar || /\s/.test(nextChar)) {
-    return bounded;
+    return `${bounded}${ellipsis}`;
   }
 
   const lastBoundary = bounded.search(/\s\S*$/);
   if (lastBoundary > 0) {
-    return bounded.slice(0, lastBoundary).trimEnd();
+    return `${bounded.slice(0, lastBoundary).trimEnd()}${ellipsis}`;
   }
 
-  return bounded;
+  return `${bounded}${ellipsis}`;
 }
 
 function buildMetadata(summary: string | null): string | undefined {

--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -147,6 +147,7 @@ describe("isBillingErrorMessage", () => {
         "This model requires more credits to use",
         "This endpoint require more credits",
         "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+        "Third-party apps now draw from your extra usage, not your plan limits. We've added a $200 credit to get you started. Claim it at claude.ai/settings/usage and keep going.",
         "Extra usage is required for long context requests.",
       ],
       expected: true,
@@ -188,6 +189,12 @@ describe("isBillingErrorMessage", () => {
     },
   ])("$name", ({ samples, expected }) => {
     expectMessageMatches(isBillingErrorMessage, samples, expected);
+  });
+
+  it("does not false-positive on generic extra usage wording", () => {
+    expect(
+      isBillingErrorMessage("This report includes an extra usage section for dashboard context."),
+    ).toBe(false);
   });
 
   it("does not false-positive on long assistant responses mentioning billing keywords", () => {

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -215,6 +215,7 @@ const ERROR_PATTERNS = {
     /requires?\s+more\s+credits/i,
     /out of extra usage/i,
     /draw from your extra usage/i,
+    /claim it at claude\.ai\/settings\/usage/i,
     /extra usage is required(?: for long context requests)?/i,
     // Chinese provider billing messages
     "余额不足",

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -857,6 +857,32 @@ describe("failover-error", () => {
     ).toBe("billing");
   });
 
+  it("classifies Anthropic extra-usage limit errors as billing for model fallback", () => {
+    const message =
+      "Third-party apps now draw from your extra usage, not your plan limits. We've added a $200 credit to get you started. Claim it at claude.ai/settings/usage and keep going.";
+    expect(
+      resolveFailoverReasonFromError({
+        status: 400,
+        provider: "anthropic",
+        message,
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        message: `API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"${message}"}}`,
+      }),
+    ).toBe("billing");
+  });
+
+  it("does not treat unrelated extra-usage wording as billing", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 400,
+        message: "This report includes an extra usage section for dashboard context.",
+      }),
+    ).toBe("format");
+  });
+
   it("infers format errors from error messages", () => {
     expect(
       resolveFailoverReasonFromError({


### PR DESCRIPTION
## Summary
- classify Anthropic direct extra-usage / settings usage-limit messages as billing failures
- preserve fallback behavior for autonomous model fallback chains instead of surfacing generic format/schema-style failures
- add regression coverage for the Anthropic payload and generic non-billing extra-usage wording

## Tests
- `node ../../scripts/run-vitest.mjs run --config ../../test/vitest/vitest.agents-core.config.ts ./failover-error.test.ts`
- `node ../../scripts/run-vitest.mjs run --config ../../test/vitest/vitest.agents-support.config.ts ./embedded-agent-helpers.isbillingerrormessage.test.ts ./embedded-agent-helpers/failover-matches.test.ts`

Jira: FAD-971