### PR TITLE
fix(ollama): strip markerless Kimi reasoning preambles

### DIFF
--- a/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
+++ b/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
@@ -8,6 +8,10 @@ import type {
 const INLINE_REASONING_MIN_PREFIX_CHARS = 80;
 const INLINE_REASONING_MAX_PENDING_CHARS = 512;
 const INLINE_REASONING_BOUNDARY_RE = /(^|\s)\uFE0F\s*/u;
+const MARKERLESS_REASONING_BOUNDARY_RE = /\n\s*\n/u;
+const MARKERLESS_REASONING_PREFIX_RE =
+  /^The user is\b(?=[\s\S]*\b(?:(?:my|[A-Za-z]+(?:'s|')?) previous response|conversation history|previous message)\b)/iu;
+const MARKERLESS_REASONING_PLANNING_RE = /\bI should\b/iu;
 
 type InlineReasoningVisibleTextResolution =
   | { kind: "visible"; text: string; bypassInlineReasoning?: boolean }
@@ -27,6 +31,11 @@ function resolveInlineReasoningVisibleText(params: {
 }): InlineReasoningVisibleTextResolution {
   const match = INLINE_REASONING_BOUNDARY_RE.exec(params.text);
   if (!match) {
+    const markerlessResolution = resolveMarkerlessReasoningVisibleText(params.text);
+    if (markerlessResolution) {
+      return markerlessResolution;
+    }
+
     if (!params.final && params.text.length <= INLINE_REASONING_MAX_PENDING_CHARS) {
       return { kind: "pending" };
     }
@@ -47,6 +56,43 @@ function resolveInlineReasoningVisibleText(params: {
   }
 
   return params.final ? { kind: "visible", text: params.text } : { kind: "pending" };
+}
+
+function resolveMarkerlessReasoningVisibleText(
+  text: string,
+): InlineReasoningVisibleTextResolution | undefined {
+  const match = MARKERLESS_REASONING_BOUNDARY_RE.exec(text);
+  if (!match) {
+    return undefined;
+  }
+
+  const prefix = text.slice(0, match.index).trim();
+  const answer = text.slice(match.index + match[0].length).trim();
+  if (
+    prefix.length < INLINE_REASONING_MIN_PREFIX_CHARS ||
+    !MARKERLESS_REASONING_PREFIX_RE.test(prefix) ||
+    !containsUnquotedMarkerlessPlanningPhrase(prefix)
+  ) {
+    return undefined;
+  }
+
+  return { kind: "visible", text: answer };
+}
+
+function containsUnquotedMarkerlessPlanningPhrase(text: string): boolean {
+  let quoted = false;
+  let candidate = "";
+  for (const char of text) {
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (quoted) {
+      continue;
+    }
+    candidate += char;
+  }
+  return MARKERLESS_REASONING_PLANNING_RE.test(candidate);
 }
 
 export function createKimiInlineReasoningSanitizer(): OllamaVisibleContentSanitizer {

--- a/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
+++ b/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
@@ -11,7 +11,8 @@ const INLINE_REASONING_BOUNDARY_RE = /(^|\s)\uFE0F\s*/u;
 const MARKERLESS_REASONING_BOUNDARY_RE = /\n\s*\n/u;
 const MARKERLESS_REASONING_PREFIX_RE =
   /^The user is\b(?=[\s\S]*\b(?:(?:my|[A-Za-z]+(?:'s|')?) previous response|conversation history|previous message)\b)/iu;
-const MARKERLESS_REASONING_PLANNING_RE = /\bI should\b/iu;
+const MARKERLESS_REASONING_PLANNING_RE =
+  /\bI should\s+(?:answer|call|check|decide|inspect|keep|not|play along|reason|reply|respond|think|use)\b/iu;
 
 type InlineReasoningVisibleTextResolution =
   | { kind: "visible"; text: string; bypassInlineReasoning?: boolean }

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1065,6 +1065,175 @@ describe("buildAssistantMessage", () => {
     expect(result.content).toEqual([]);
   });
 
+  it("strips markerless Kimi reasoning paragraph before visible text", () => {
+    const response = {
+      model: "kimi-k2.5:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "The user is laughing at my previous response. They made a joke and I answered too literally. I should play along and acknowledge the joke in a fun way.\n\n[NOVA] You got me. That was a good joke.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.5:cloud",
+    });
+    expect(result.content).toEqual([
+      { type: "text", text: "[NOVA] You got me. That was a good joke." },
+    ]);
+  });
+
+  it("strips markerless Kimi reasoning when no visible text follows", () => {
+    const response = {
+      model: "kimi-k2.5:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "The user is laughing at my previous response. They made a joke and I answered too literally. I should play along and acknowledge the joke in a fun way.\n\n",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.5:cloud",
+    });
+    expect(result.content).toEqual([]);
+  });
+
+  it("keeps explicit Kimi boundary precedence after a markerless reasoning paragraph", () => {
+    const response = {
+      model: "kimi-k2.5:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "The user is laughing at my previous response. They made a joke and I answered too literally. I should play along and acknowledge the joke in a fun way.\n\nI should keep reasoning privately before answering. ️Final answer.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.5:cloud",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "Final answer." }]);
+  });
+
+  it("strips markerless Kimi reasoning when the prefix contains a possessive apostrophe", () => {
+    const response = {
+      model: "kimi-k2.5:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "The user is asking about Alice's previous response. I should answer without showing this private planning paragraph.\n\nVisible answer.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.5:cloud",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "Visible answer." }]);
+  });
+
+  it("strips markerless Kimi reasoning when the prefix contains a trailing possessive apostrophe", () => {
+    const response = {
+      model: "kimi-k2.5:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "The user is asking about James' previous response. I should answer without showing this private planning paragraph.\n\nVisible answer.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.5:cloud",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "Visible answer." }]);
+  });
+
+  it("preserves ordinary Kimi text that starts with The user", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "The user can configure the plugin from settings.\n\nThis summary is part of the visible answer.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "The user can configure the plugin from settings.\n\nThis summary is part of the visible answer.",
+      },
+    ]);
+  });
+
+  it("preserves Kimi answers that quote the user's I should text", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          'The user wrote: "I should rotate the API key before deploy." That is a reasonable plan.\n\nHere is the safest sequence.',
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: 'The user wrote: "I should rotate the API key before deploy." That is a reasonable plan.\n\nHere is the safest sequence.',
+      },
+    ]);
+  });
+
+  it("preserves quoted user text that matches markerless Kimi context cues", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          'The user is asking about my previous response and the conversation history. They wrote: "I should rotate the API key before deploy." That quoted text is part of the answer.\n\nHere is the safest sequence.',
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: 'The user is asking about my previous response and the conversation history. They wrote: "I should rotate the API key before deploy." That quoted text is part of the answer.\n\nHere is the safest sequence.',
+      },
+    ]);
+  });
+
   it("does not strip inline boundary marker on non-kimi models", () => {
     const response = {
       model: "qwen3:32b",
@@ -2042,6 +2211,93 @@ describe("createOllamaStreamFn streaming events", () => {
     }
   });
 
+  it("strips markerless Kimi reasoning before streaming visible text", async () => {
+    const controlledFetch = createControlledNdjsonFetch();
+    fetchWithSsrFGuardMock.mockImplementation(controlledFetch.fetchImpl);
+
+    try {
+      const stream = await createOllamaTestStream({
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "kimi-k2.5:cloud", provider: "ollama" },
+      });
+      const iterator = stream[Symbol.asyncIterator]();
+
+      controlledFetch.pushLine(
+        JSON.stringify({
+          model: "kimi-k2.5:cloud",
+          created_at: "t",
+          message: {
+            role: "assistant",
+            content:
+              "The user is laughing at my previous response. They made a joke and I answered too literally. I should play along and acknowledge the joke in a fun way.",
+          },
+          done: false,
+        }),
+      );
+
+      const pendingStartEvent = iterator.next();
+      expect(
+        await Promise.race([
+          pendingStartEvent.then(() => "event" as const),
+          new Promise<"timeout">((resolve) => {
+            setTimeout(() => resolve("timeout"), 100);
+          }),
+        ]),
+      ).toBe("timeout");
+
+      controlledFetch.pushLine(
+        JSON.stringify({
+          model: "kimi-k2.5:cloud",
+          created_at: "t",
+          message: { role: "assistant", content: "\n\n[NOVA] You got me." },
+          done: false,
+        }),
+      );
+
+      const startEvent = await pendingStartEvent;
+      expectIteratorEvent(startEvent, { type: "start", done: false });
+
+      const textStartEvent = await nextEventWithin(iterator);
+      expect(textStartEvent).not.toBe("timeout");
+      expectIteratorEvent(textStartEvent, { type: "text_start", done: false });
+
+      const textDeltaEvent = await nextEventWithin(iterator);
+      expect(textDeltaEvent).not.toBe("timeout");
+      expectIteratorEvent(textDeltaEvent, {
+        type: "text_delta",
+        delta: "[NOVA] You got me.",
+        done: false,
+      });
+
+      controlledFetch.pushLine(
+        '{"model":"kimi-k2.5:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
+      );
+      controlledFetch.close();
+
+      const textEndEvent = await nextEventWithin(iterator);
+      expect(textEndEvent).not.toBe("timeout");
+      expectIteratorEvent(textEndEvent, {
+        type: "text_end",
+        content: "[NOVA] You got me.",
+        done: false,
+      });
+
+      const doneEvent = await nextEventWithin(iterator);
+      expect(doneEvent).not.toBe("timeout");
+      expectIteratorEvent(doneEvent, { type: "done", done: false });
+      if (doneEvent !== "timeout" && doneEvent.done === false) {
+        const value = requireRecord(doneEvent.value, "done value");
+        expect(JSON.stringify(value)).not.toContain("The user is laughing");
+      }
+
+      const streamEnd = await nextEventWithin(iterator);
+      expect(streamEnd).not.toBe("timeout");
+      expectIteratorEvent(streamEnd, { done: true });
+    } finally {
+      fetchWithSsrFGuardMock.mockReset();
+    }
+  });
+
   it("keeps Kimi deltas append-only after the bounded sanitizer window is bypassed", async () => {
     const longPrefix = "This Kimi cloud output has streamed past the sanitizer window. ".repeat(10);
     await withMockNdjsonFetch(
@@ -2272,6 +2528,55 @@ describe("createOllamaStreamFn streaming events", () => {
             },
           ]);
           expect(JSON.stringify(doneEvent)).not.toContain("I should think privately");
+        }
+      },
+    );
+  });
+
+  it("does not leak markerless Kimi reasoning when a blank boundary is followed by tool calls only", async () => {
+    const hiddenPrefix =
+      "The user is laughing at my previous response. They made a joke and I answered too literally. " +
+      "I should call a tool before showing any visible text.";
+    await withMockNdjsonFetch(
+      [
+        JSON.stringify({
+          model: "kimi-k2.5:cloud",
+          created_at: "t",
+          message: { role: "assistant", content: `${hiddenPrefix}\n\n` },
+          done: false,
+        }),
+        JSON.stringify({
+          model: "kimi-k2.5:cloud",
+          created_at: "t",
+          message: {
+            role: "assistant",
+            content: "",
+            tool_calls: [{ function: { name: "bash", arguments: { command: "ls" } } }],
+          },
+          done: false,
+        }),
+        '{"model":"kimi-k2.5:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          model: { id: "kimi-k2.5:cloud", provider: "ollama" },
+        });
+        const events = await collectStreamEvents(stream);
+
+        expect(events.map((e) => e.type)).toEqual(["done"]);
+        const doneEvent = events.at(-1);
+        expect(doneEvent?.type).toBe("done");
+        if (doneEvent?.type === "done") {
+          expect(doneEvent.message.content).toEqual([
+            {
+              type: "toolCall",
+              id: expect.any(String),
+              name: "bash",
+              arguments: { command: "ls" },
+            },
+          ]);
+          expect(JSON.stringify(doneEvent)).not.toContain("The user is laughing");
         }
       },
     );

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1162,6 +1162,44 @@ describe("buildAssistantMessage", () => {
     expect(result.content).toEqual([{ type: "text", text: "Visible answer." }]);
   });
 
+  it("strips markerless Kimi reasoning when the prefix references conversation history", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "The user is asking about the conversation history. I should inspect the prior turn before answering.\n\nVisible answer.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "Visible answer." }]);
+  });
+
+  it("strips markerless Kimi reasoning when the prefix references the previous message", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "The user is asking about the previous message. I should respond without exposing this planning step.\n\nVisible answer.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "Visible answer." }]);
+  });
+
   it("preserves ordinary Kimi text that starts with The user", () => {
     const response = {
       model: "kimi-k2.6:cloud",
@@ -1230,6 +1268,30 @@ describe("buildAssistantMessage", () => {
       {
         type: "text",
         text: 'The user is asking about my previous response and the conversation history. They wrote: "I should rotate the API key before deploy." That quoted text is part of the answer.\n\nHere is the safest sequence.',
+      },
+    ]);
+  });
+
+  it("preserves visible Kimi prose that discusses conversation history", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "The user is asking about the conversation history, and I should clarify what is visible in this chat before listing the options.\n\nOnly the current thread is available here.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "The user is asking about the conversation history, and I should clarify what is visible in this chat before listing the options.\n\nOnly the current thread is available here.",
       },
     ]);
   });


### PR DESCRIPTION
## Summary

- Fixes #91804 by extending the Ollama/Kimi cloud visible-content sanitizer to handle the reporter's markerless reasoning preamble shape.
- Keeps the fix provider-local under `extensions/ollama`: the explicit Kimi `️` boundary still wins first, and the new markerless path only strips a first paragraph that starts with the observed `The user is...` assistant-analysis form plus assistant context cues.
- Adds regressions for final messages, streaming deltas, empty visible answers, tool-call-only continuations, mixed markerless + explicit-boundary output, possessive previous-response cues, and false-positive preservation cases.

## Verification

- `node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts` -> 113 passed
- `node --import tsx /tmp/openclaw-91804-ollama-stream-proof.mjs` -> `REAL_STREAM_PATH_PROOF: passed`
- `pnpm exec oxfmt --check --threads=1 extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts extensions/ollama/src/stream-runtime.test.ts`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts extensions/ollama/src/stream-runtime.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

Remote changed-gate note: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox ... corepack pnpm check:changed` could not start because the local Crabbox binary failed the wrapper's basic `--version`/`--help` sanity checks before provisioning.

## Real behavior proof

Behavior addressed: Kimi cloud responses that put a markerless internal reasoning paragraph in `message.content` before a blank line and the visible answer no longer expose that first paragraph through the Ollama final-message or streaming visible-content path.

Real environment tested: Local OpenClaw checkout on this PR branch, Node 24.15.0, using the real `extensions/ollama/src/stream.ts` `buildAssistantMessage` path, the Ollama stream runtime test harness, and a local Ollama-compatible `/api/chat` NDJSON server exercised through the real `createOllamaStreamFn` stream parser/event builder.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts`; `node --import tsx /tmp/openclaw-91804-ollama-stream-proof.mjs`; direct `pnpm exec tsx` smoke import of `buildAssistantMessage` with reporter-shaped Kimi content, mixed explicit-boundary content, and a false-positive quoted-user case.

Evidence after fix: The stream proof returned `REAL_STREAM_PATH_PROOF: passed`. The local compatible server received a real OpenClaw Ollama request with `model: "kimi-k2.5:cloud"` and `stream: true`, then returned NDJSON where the first chunk had no `thinking` or `reasoning` field and placed `The user is ...` markerless reasoning directly in `message.content` before a blank-line boundary. OpenClaw emitted only `[NOVA] You got me. That was a good joke.` in `text_delta`, `text_end`, and final `done.message.content`; the hidden prefix was absent from all emitted events. The smoke output also shows the reporter-shaped final content emits only `[NOVA] You got me.`, the mixed markerless + explicit-boundary case emits only `Final answer.`, and the quoted-user text `The user wrote: "I should rotate..."` is preserved. The focused Vitest file passed 113 tests including the new streaming, final-message, possessive cue, conversation-history strip, and false-positive regressions.

Observed result after fix: Kimi markerless assistant-analysis preambles matching the reported shape are stripped before visible `text_delta`, `text_end`, and final `done` message content; empty-answer and tool-call-only continuations do not leak the hidden paragraph; ordinary visible text that starts with `The user` is preserved.

What was not tested: Live Ollama Cloud + Kimi + Telegram proof on this exact PR head. This checkout has no usable `OLLAMA_API_KEY`, and the available Crabbox wrapper failed before remote provisioning, so live provider/channel proof still needs maintainer infrastructure or a redacted raw Ollama/Kimi response capture. The added stream proof is through OpenClaw's real Ollama stream path against a local Ollama-compatible NDJSON server; it is not a natural live vendor capture.

## Risk

- False positives are constrained by keeping the change inside the Kimi cloud sanitizer, requiring the observed assistant-analysis prefix shape, and preserving normal `The user can...` and quoted `I should...` cases.
- The safest long-term fix is still a structured provider marker or raw Kimi wire evidence; this patch only covers the high-confidence markerless reporter artifact without adding a global delivery sanitizer.
