### PR TITLE
fix: memory_search honors generic embedding providers

### DIFF
--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -2,6 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  clearEmbeddingProviders,
+  registerEmbeddingProvider,
+} from "../plugins/embedding-providers.js";
+import {
   clearMemoryEmbeddingProviders,
   registerMemoryEmbeddingProvider,
 } from "../plugins/memory-embedding-providers.js";
@@ -73,6 +77,7 @@ describe("memory search config", () => {
 
   afterEach(() => {
     clearMemoryEmbeddingProviders();
+    clearEmbeddingProviders();
   });
 
   function configWithDefaultProvider(provider: string): OpenClawConfig {
@@ -225,6 +230,22 @@ describe("memory search config", () => {
     const resolved = resolveMemorySearchConfig(configWithDefaultProvider("local"), "main");
 
     expect(resolved?.provider).toBe("local");
+  });
+
+  it("resolves providers from the generic embedding provider registry", () => {
+    clearMemoryEmbeddingProviders();
+    registerEmbeddingProvider({
+      id: "generic-local",
+      defaultModel: "local-gguf-default",
+      transport: "local",
+      create: async () => ({ provider: null }),
+    });
+
+    const resolved = resolveMemorySearchConfig(configWithDefaultProvider("generic-local"), "main");
+
+    expect(resolved?.provider).toBe("generic-local");
+    expect(resolved?.model).toBe("local-gguf-default");
+    expect(resolved?.remote).toBeUndefined();
   });
 
   it("resolves explicit provider-none", () => {

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   clearEmbeddingProviders,
+  listRegisteredEmbeddingProviders,
   registerEmbeddingProvider,
+  restoreRegisteredEmbeddingProviders,
+  type RegisteredEmbeddingProvider,
 } from "../plugins/embedding-providers.js";
 import {
   clearMemoryEmbeddingProviders,
@@ -14,6 +17,7 @@ import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths
 import { resolveMemorySearchConfig, resolveMemorySearchSyncConfig } from "./memory-search.js";
 
 const asConfig = (cfg: OpenClawConfig): OpenClawConfig => cfg;
+let registeredEmbeddingProvidersSnapshot: RegisteredEmbeddingProvider[];
 
 function registerBaseMemoryEmbeddingProviders(options?: { includeGemini?: boolean }): void {
   // Register provider contracts locally so config tests do not depend on the
@@ -71,13 +75,15 @@ function registerBaseMemoryEmbeddingProviders(options?: { includeGemini?: boolea
 
 describe("memory search config", () => {
   beforeEach(() => {
+    registeredEmbeddingProvidersSnapshot = listRegisteredEmbeddingProviders();
+    clearEmbeddingProviders();
     clearMemoryEmbeddingProviders();
     registerBaseMemoryEmbeddingProviders();
   });
 
   afterEach(() => {
     clearMemoryEmbeddingProviders();
-    clearEmbeddingProviders();
+    restoreRegisteredEmbeddingProviders(registeredEmbeddingProvidersSnapshot);
   });
 
   function configWithDefaultProvider(provider: string): OpenClawConfig {
@@ -233,7 +239,6 @@ describe("memory search config", () => {
   });
 
   it("resolves providers from the generic embedding provider registry", () => {
-    clearMemoryEmbeddingProviders();
     registerEmbeddingProvider({
       id: "generic-local",
       defaultModel: "local-gguf-default",

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -135,6 +135,12 @@ const DEFAULT_REMOTE_BATCH_POLL_INTERVAL_MS = 2_000;
 const DEFAULT_REMOTE_BATCH_TIMEOUT_MINUTES = 60;
 const MAX_REMOTE_BATCH_TIMEOUT_MINUTES = Math.floor(MAX_TIMER_TIMEOUT_MS / 60_000);
 
+type ConfiguredMemoryEmbeddingProvider = {
+  defaultModel?: string;
+  transport?: "local" | "remote";
+  supportsMultimodalEmbeddings?: (params: { model: string }) => boolean;
+};
+
 function resolveRemoteBatchPollIntervalMs(
   overrideValue: number | undefined,
   defaultValue: number | undefined,
@@ -178,10 +184,14 @@ function normalizeSources(
 function getConfiguredMemoryEmbeddingProvider(
   providerId: string,
   cfg: OpenClawConfig,
-): ReturnType<typeof getMemoryEmbeddingProvider> {
+): ConfiguredMemoryEmbeddingProvider | undefined {
   const directAdapter = getMemoryEmbeddingProvider(providerId);
   if (directAdapter) {
     return directAdapter;
+  }
+  const genericAdapter = getEmbeddingProvider(providerId, cfg);
+  if (genericAdapter) {
+    return genericAdapter;
   }
   const providerConfig = findNormalizedProviderValue(cfg.models?.providers, providerId);
   const ownerApi = providerConfig?.api?.trim();


### PR DESCRIPTION
Related: #91902

## What Problem This Solves

Fixes an issue where users configuring memory search with a generic embedding provider would have `memory_search` resolve provider defaults from the memory-specific registry only, so providers registered through the generic embedding provider runtime could miss their configured model and transport metadata.

## Why This Change Was Made

Memory-search config resolution now falls back to the generic embedding provider runtime after checking memory-specific providers. The helper returns only the small provider metadata surface needed for config resolution, so the runtime contracts for generic and memory embedding providers stay separate.

## User Impact

Users with plugin-registered generic embedding providers can use `memory_search` without the config resolver silently ignoring that provider's default model or local/remote transport. This addresses the generic-provider resolver slice of the broader memory index identity issue.

## Evidence

Behavior addressed: `resolveMemorySearchConfig()` now recognizes a generic local embedding provider registered through `registerEmbeddingProvider()` and uses its default model/transport metadata.

Real environment tested: local source checkout on Node 24.15.0.

Exact steps or command run after this patch:

```
pnpm docs:list
pnpm exec oxfmt --check src/agents/memory-search.ts src/agents/memory-search.test.ts
git diff --check
pnpm tsgo:core
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-91902-memory OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/memory/generic-embedding-provider.bridge.test.ts extensions/memory-core/src/memory/generic-embedding-provider.integration.test.ts
.agents/skills/autoreview/scripts/autoreview --mode uncommitted --base upstream/main --engine codex --no-web-search --output /tmp/openclaw-91902-autoreview.txt --json-output /tmp/openclaw-91902-autoreview.json
```

Evidence after fix: added `src/agents/memory-search.test.ts` coverage for a generic local provider registered outside the memory-specific registry; the existing memory-core generic provider bridge/integration proof passed with 2 files and 3 tests; `pnpm tsgo:core` passed; `oxfmt --check` and `git diff --check` passed; autoreview reported no accepted/actionable findings.

Observed result after fix: the new resolver path returns provider `generic-local`, model `local-gguf-default`, and leaves `remote` unset for local transport. The bridge proof also exercises a contract-declared generic embedding plugin registered through the plugin API, verifies it is not in the memory-specific registry, creates the memory embedding provider through the generic bridge, and performs query, batch, and structured document embedding calls. The integration proof exercises the core OpenAI-compatible generic provider through a local HTTP embedding server and verifies the memory bridge sends query/document requests with the expected model, dimensions, input types, and sanitized cache-key headers.

Terminal output from the generic provider bridge/integration proof:

```
RUN  v4.1.8 /Users/.../openclaw-91902

Test Files  2 passed (2)
     Tests  3 passed (3)
  Start at  03:25:27
  Duration  25.27s (transform 16.87s, setup 1.38s, import 23.12s, tests 220ms, environment 0ms)
```

What was not tested: no live DashScope/Voyage gateway run was performed; local Vitest wrapper attempts for `src/agents/memory-search.test.ts` hung or routed to no matching files in this checkout, so CI should be treated as the authoritative focused test run for that new source-level regression test.



### Installed generic provider proof

I also ran an isolated real CLI proof with a temporary native plugin loaded through `plugins.load.paths`. The plugin declared `contracts.embeddingProviders: ["proof-generic"]` and registered the provider through `api.registerEmbeddingProvider()`, not `api.registerMemoryEmbeddingProvider()`.

Exact steps or command run after this patch:

```
PROOF_ROOT=$(mktemp -d /tmp/openclaw-91902-proof.XXXXXX)
# create proof-generic-embedding plugin under $PROOF_ROOT/proof-generic-plugin
# create $PROOF_ROOT/workspace/MEMORY.md with a searchable proof phrase
# create $PROOF_ROOT/state/openclaw.json with:
#   plugins.load.paths = ["$PROOF_ROOT/proof-generic-plugin"]
#   agents.defaults.workspace = "$PROOF_ROOT/workspace"
#   agents.defaults.memorySearch.provider = "proof-generic"
#   agents.defaults.memorySearch.model = "proof-embedding-v1"
#   agents.defaults.memorySearch.fallback = "none"
#   agents.defaults.memorySearch.outputDimensionality = 3
OPENCLAW_CONFIG_PATH=$PROOF_ROOT/state/openclaw.json \
OPENCLAW_STATE_DIR=$PROOF_ROOT/state \
OPENCLAW_HOME=$PROOF_ROOT/home \
pnpm openclaw memory status --deep --index --verbose --agent main

OPENCLAW_CONFIG_PATH=$PROOF_ROOT/state/openclaw.json \
OPENCLAW_STATE_DIR=$PROOF_ROOT/state \
OPENCLAW_HOME=$PROOF_ROOT/home \
pnpm openclaw memory search --query "silver anchor proof" --agent main --max-results 5 --json
```

Evidence after fix:

```
[plugins] loading proof-generic-embedding from .../proof-generic-plugin/index.cjs
[plugins] loaded 1 plugin(s) (1 attempted) in 29.9ms
[memory] embeddings: batch start
[memory] sync: indexing memory files
[memory] embeddings: batch start
Memory index complete.
Memory Search (main)
Provider: proof-generic (requested: proof-generic)
Model: proof-embedding-v1
Sources: memory
Indexed: 1/1 files · 1 chunks
Dirty: no
Embeddings: ready
Vector dims: 3
FTS: ready
Embedding cache: enabled (1 entries)
```

Observed result after fix:

```
{
  "results": [
    {
      "path": "MEMORY.md",
      "startLine": 1,
      "endLine": 4,
      "score": 0.5715486190839927,
      "vectorScore": 0.8164965808391571,
      "textScore": 0.0000033749886094134435,
      "snippet": "# Memory\n\nThe proof-generic embedding provider indexes the silver anchor phrase for OpenClaw memory_search proof.\n",
      "source": "memory"
    }
  ]
}
```


### Verification refresh (2026-07-02)

Refreshed proof on the current PR head `f9f0e35c4867586a5bc9e2497691f9eaf07b7496`.

Commands run:

```bash
node scripts/run-vitest.mjs src/agents/memory-search.test.ts
pnpm exec oxfmt --check src/agents/memory-search.ts src/agents/memory-search.test.ts
git diff --check
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-97095-memory OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/memory-core/src/memory/generic-embedding-provider.bridge.test.ts extensions/memory-core/src/memory/generic-embedding-provider.integration.test.ts
# Isolated CLI proof with temporary plugin loaded through plugins.load.paths; plugin registers proof-generic only via api.registerEmbeddingProvider().
OPENCLAW_CONFIG_PATH=/tmp/.../state/openclaw.json OPENCLAW_STATE_DIR=/tmp/.../state OPENCLAW_HOME=/tmp/.../home pnpm openclaw memory status --deep --index --verbose --agent main
OPENCLAW_CONFIG_PATH=/tmp/.../state/openclaw.json OPENCLAW_STATE_DIR=/tmp/.../state OPENCLAW_HOME=/tmp/.../home pnpm openclaw memory search --query "silver anchor proof" --agent main --max-results 5 --json
```

Observed result after refresh:

```text
src/agents/memory-search.test.ts: 1 file passed, 36 tests passed
oxfmt --check: All matched files use the correct format
git diff --check: passed
generic embedding bridge/integration: 2 files passed, 3 tests passed
[proof] registerEmbeddingProvider proof-generic
Memory index complete.
Provider: proof-generic (requested: proof-generic)
Model: proof-embedding-v1
Indexed: 1/1 files · 1 chunks
Dirty: no
Embeddings: ready
Vector dims: 3
```

`memory search --json` returned the indexed `MEMORY.md` chunk containing the `silver anchor proof` phrase with a positive score, proving the installed generic-provider path can index and search through the real CLI/plugin/config flow on this branch.
