### PR TITLE
fix: preserve web tools across stripped secrets refresh

### DIFF
--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -269,7 +269,7 @@ describe("createOpenClawTools browser plugin integration", () => {
         },
         diagnostics: [],
       },
-      webToolsFromFastPath: false,
+      webToolsProvenance: "resolved",
     });
 
     resolveOpenClawPluginToolsForOptions({

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -269,6 +269,7 @@ describe("createOpenClawTools browser plugin integration", () => {
         },
         diagnostics: [],
       },
+      webToolsFromFastPath: false,
     });
 
     resolveOpenClawPluginToolsForOptions({

--- a/src/gateway/server-aux-handlers.test.ts
+++ b/src/gateway/server-aux-handlers.test.ts
@@ -44,7 +44,7 @@ function createSnapshot(config: OpenClawConfig): PreparedSecretsRuntimeSnapshot 
       fetch: { providerSource: "none", diagnostics: [] },
       diagnostics: [],
     },
-    webToolsFromFastPath: false,
+    webToolsProvenance: "resolved",
   };
 }
 

--- a/src/gateway/server-aux-handlers.test.ts
+++ b/src/gateway/server-aux-handlers.test.ts
@@ -44,6 +44,7 @@ function createSnapshot(config: OpenClawConfig): PreparedSecretsRuntimeSnapshot 
       fetch: { providerSource: "none", diagnostics: [] },
       diagnostics: [],
     },
+    webToolsFromFastPath: false,
   };
 }
 

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1276,7 +1276,7 @@ describe("gateway Gmail hot reload handlers", () => {
         authStores: [],
         warnings: [],
         webTools: createEmptyRuntimeWebToolsMetadata(),
-        webToolsFromFastPath: false,
+        webToolsProvenance: "resolved",
       })) as never,
       resolveSharedGatewaySessionGenerationForConfig: () => undefined,
       sharedGatewaySessionGenerationState: { current: undefined, required: null },
@@ -1322,7 +1322,7 @@ describe("gateway Gmail hot reload handlers", () => {
       authStores: [],
       warnings: [],
       webTools: createEmptyRuntimeWebToolsMetadata(),
-      webToolsFromFastPath: false,
+      webToolsProvenance: "resolved",
     });
     hoisted.startGmailWatcherWithLogs.mockRejectedValueOnce(new Error("start failed"));
     const reloader = startManagedGatewayConfigReloader({
@@ -1388,7 +1388,7 @@ describe("gateway Gmail hot reload handlers", () => {
         authStores: [],
         warnings: [],
         webTools: createEmptyRuntimeWebToolsMetadata(),
-        webToolsFromFastPath: false,
+        webToolsProvenance: "resolved",
       })) as never,
       resolveSharedGatewaySessionGenerationForConfig: () => undefined,
       sharedGatewaySessionGenerationState: { current: undefined, required: null },
@@ -1497,7 +1497,7 @@ describe("gateway Gmail hot reload handlers", () => {
           authStores: [],
           warnings: [],
           webTools: createEmptyRuntimeWebToolsMetadata(),
-          webToolsFromFastPath: false,
+          webToolsProvenance: "resolved",
         };
       }) as never,
       resolveSharedGatewaySessionGenerationForConfig: () => undefined,

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1275,7 +1275,8 @@ describe("gateway Gmail hot reload handlers", () => {
         config,
         authStores: [],
         warnings: [],
-        webTools: {},
+        webTools: createEmptyRuntimeWebToolsMetadata(),
+        webToolsFromFastPath: false,
       })) as never,
       resolveSharedGatewaySessionGenerationForConfig: () => undefined,
       sharedGatewaySessionGenerationState: { current: undefined, required: null },
@@ -1321,6 +1322,7 @@ describe("gateway Gmail hot reload handlers", () => {
       authStores: [],
       warnings: [],
       webTools: createEmptyRuntimeWebToolsMetadata(),
+      webToolsFromFastPath: false,
     });
     hoisted.startGmailWatcherWithLogs.mockRejectedValueOnce(new Error("start failed"));
     const reloader = startManagedGatewayConfigReloader({
@@ -1385,7 +1387,8 @@ describe("gateway Gmail hot reload handlers", () => {
         config,
         authStores: [],
         warnings: [],
-        webTools: {},
+        webTools: createEmptyRuntimeWebToolsMetadata(),
+        webToolsFromFastPath: false,
       })) as never,
       resolveSharedGatewaySessionGenerationForConfig: () => undefined,
       sharedGatewaySessionGenerationState: { current: undefined, required: null },
@@ -1493,7 +1496,8 @@ describe("gateway Gmail hot reload handlers", () => {
           config,
           authStores: [],
           warnings: [],
-          webTools: {},
+          webTools: createEmptyRuntimeWebToolsMetadata(),
+          webToolsFromFastPath: false,
         };
       }) as never,
       resolveSharedGatewaySessionGenerationForConfig: () => undefined,

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -87,7 +87,7 @@ function preparedSnapshot(config: OpenClawConfig): PreparedSecretsRuntimeSnapsho
       },
       diagnostics: [],
     },
-    webToolsFromFastPath: false,
+    webToolsProvenance: "resolved",
   };
 }
 

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -87,6 +87,7 @@ function preparedSnapshot(config: OpenClawConfig): PreparedSecretsRuntimeSnapsho
       },
       diagnostics: [],
     },
+    webToolsFromFastPath: false,
   };
 }
 

--- a/src/secrets/runtime-command-secrets.test.ts
+++ b/src/secrets/runtime-command-secrets.test.ts
@@ -68,7 +68,7 @@ function activateMinimalSecretsRuntimeSnapshot(params: {
     authStores: [],
     warnings: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
-    webToolsFromFastPath: false,
+    webToolsProvenance: "resolved",
   };
   activateSecretsRuntimeSnapshotState({
     snapshot,

--- a/src/secrets/runtime-command-secrets.test.ts
+++ b/src/secrets/runtime-command-secrets.test.ts
@@ -68,6 +68,7 @@ function activateMinimalSecretsRuntimeSnapshot(params: {
     authStores: [],
     warnings: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
+    webToolsFromFastPath: false,
   };
   activateSecretsRuntimeSnapshotState({
     snapshot,

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -273,7 +273,7 @@ export function prepareSecretsRuntimeFastPathSnapshot(params: {
     authStores,
     warnings: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
-    webToolsFromFastPath: true,
+    webToolsProvenance: "canonical-fast-path",
   };
   return {
     snapshot,

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -273,6 +273,7 @@ export function prepareSecretsRuntimeFastPathSnapshot(params: {
     authStores,
     warnings: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
+    webToolsFromFastPath: true,
   };
   return {
     snapshot,

--- a/src/secrets/runtime-state.test.ts
+++ b/src/secrets/runtime-state.test.ts
@@ -32,7 +32,7 @@ describe("secrets runtime state", () => {
         fetch: { providerSource: "none", diagnostics: [] },
         diagnostics: [],
       },
-      webToolsFromFastPath: false,
+      webToolsProvenance: "resolved",
     };
 
     activateSecretsRuntimeSnapshotState({

--- a/src/secrets/runtime-state.test.ts
+++ b/src/secrets/runtime-state.test.ts
@@ -32,6 +32,7 @@ describe("secrets runtime state", () => {
         fetch: { providerSource: "none", diagnostics: [] },
         diagnostics: [],
       },
+      webToolsFromFastPath: false,
     };
 
     activateSecretsRuntimeSnapshotState({

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -21,6 +21,22 @@ import {
 } from "./runtime-web-tools-state.js";
 import type { RuntimeWebToolsMetadata } from "./runtime-web-tools.types.js";
 
+/**
+ * Provenance of a snapshot's web-tool metadata. Only a stripped fast-path
+ * refresh of an already-active snapshot may preserve prior active metadata;
+ * `resolved` and `canonical-fast-path` snapshots are authoritative and clear it.
+ *
+ * - `resolved`: full SecretRef/web-tool resolver ran; metadata is authoritative.
+ * - `canonical-fast-path`: fresh fast-path prepare from a full config (initial
+ *   activation or a genuine web-config deletion); empty metadata is authoritative.
+ * - `stripped-refresh`: fast-path prepare produced while refreshing an active
+ *   snapshot, so the incoming config may be a writer's partial/stripped view.
+ */
+export type WebToolsMetadataProvenance =
+  | "resolved"
+  | "canonical-fast-path"
+  | "stripped-refresh";
+
 /** Prepared secrets runtime snapshot activated for fast secret resolution. */
 export type PreparedSecretsRuntimeSnapshot = {
   sourceConfig: OpenClawConfig;
@@ -28,7 +44,7 @@ export type PreparedSecretsRuntimeSnapshot = {
   authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
   warnings: SecretResolverWarning[];
   webTools: RuntimeWebToolsMetadata;
-  webToolsFromFastPath: boolean;
+  webToolsProvenance: WebToolsMetadataProvenance;
 };
 
 /** Context needed to refresh active secrets runtime snapshots without losing plugin origin data. */
@@ -80,7 +96,7 @@ function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecret
     })),
     warnings: snapshot.warnings.map((warning) => ({ ...warning })),
     webTools: structuredClone(snapshot.webTools),
-    webToolsFromFastPath: snapshot.webToolsFromFastPath,
+    webToolsProvenance: snapshot.webToolsProvenance,
   };
 }
 

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -28,6 +28,7 @@ export type PreparedSecretsRuntimeSnapshot = {
   authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
   warnings: SecretResolverWarning[];
   webTools: RuntimeWebToolsMetadata;
+  webToolsFromFastPath: boolean;
 };
 
 /** Context needed to refresh active secrets runtime snapshots without losing plugin origin data. */
@@ -79,6 +80,7 @@ function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecret
     })),
     warnings: snapshot.warnings.map((warning) => ({ ...warning })),
     webTools: structuredClone(snapshot.webTools),
+    webToolsFromFastPath: snapshot.webToolsFromFastPath,
   };
 }
 

--- a/src/secrets/runtime-web-tools-state.test.ts
+++ b/src/secrets/runtime-web-tools-state.test.ts
@@ -7,6 +7,7 @@ import {
   type PreparedSecretsRuntimeSnapshot,
 } from "./runtime.js";
 import { createEmptyRuntimeWebToolsMetadata } from "./runtime-fast-path.js";
+import type { WebToolsMetadataProvenance } from "./runtime-state.js";
 import {
   clearActiveRuntimeWebToolsMetadata,
   getActiveRuntimeWebToolsMetadata,
@@ -42,7 +43,7 @@ function populatedSearchMetadata(provider: string): RuntimeWebToolsMetadata {
 function preparedSnapshot(params: {
   sourceConfig: OpenClawConfig;
   webTools?: RuntimeWebToolsMetadata;
-  webToolsFromFastPath: boolean;
+  webToolsProvenance: WebToolsMetadataProvenance;
 }): PreparedSecretsRuntimeSnapshot {
   return {
     sourceConfig: params.sourceConfig,
@@ -50,7 +51,7 @@ function preparedSnapshot(params: {
     authStores: [],
     warnings: [],
     webTools: params.webTools ?? createEmptyRuntimeWebToolsMetadata(),
-    webToolsFromFastPath: params.webToolsFromFastPath,
+    webToolsProvenance: params.webToolsProvenance,
   };
 }
 
@@ -94,7 +95,7 @@ describe("runtime web tools state", () => {
     expect(second.search.selectedProvider).toBe("gemini");
   });
 
-  it("preserves populated web metadata across repeated stripped fast-path refreshes", () => {
+  function activateResolvedBraveSearch(): void {
     activateSecretsRuntimeSnapshot(
       preparedSnapshot({
         sourceConfig: asConfig({
@@ -105,95 +106,95 @@ describe("runtime web tools state", () => {
           },
         }),
         webTools: populatedSearchMetadata("brave"),
-        webToolsFromFastPath: false,
+        webToolsProvenance: "resolved",
       }),
     );
+  }
 
+  it("preserves populated web metadata across repeated stripped fast-path refreshes", () => {
+    activateResolvedBraveSearch();
+
+    // A writer's stripped refresh re-prepares the active snapshot from a partial
+    // config view; provenance marks it stripped so prior metadata survives.
     activateSecretsRuntimeSnapshot(
       preparedSnapshot({
         sourceConfig: asConfig({}),
-        webToolsFromFastPath: true,
+        webToolsProvenance: "stripped-refresh",
       }),
     );
     activateSecretsRuntimeSnapshot(
       preparedSnapshot({
         sourceConfig: asConfig({}),
-        webToolsFromFastPath: true,
+        webToolsProvenance: "stripped-refresh",
       }),
     );
 
     expect(activeSearchProvider()).toBe("brave");
   });
 
-  it.each([
-    {
-      name: "tools.web",
-      sourceConfig: asConfig({
-        tools: {
-          web: {},
-        },
-      }),
-    },
-    {
-      name: "plugins.entries",
-      sourceConfig: asConfig({
-        plugins: {
-          entries: {},
-        },
-      }),
-    },
-  ])("clears web metadata when a fast-path refresh includes an explicit empty $name", ({
-    sourceConfig,
-  }) => {
-    activateSecretsRuntimeSnapshot(
-      preparedSnapshot({
-        sourceConfig: asConfig({
-          tools: {
-            web: {
-              search: { provider: "brave" },
-            },
-          },
-        }),
-        webTools: populatedSearchMetadata("brave"),
-        webToolsFromFastPath: false,
-      }),
-    );
+  it("clears web metadata when a canonical fast-path config deletes web surfaces", () => {
+    activateResolvedBraveSearch();
 
-    activateSecretsRuntimeSnapshot(
-      preparedSnapshot({
-        sourceConfig,
-        webToolsFromFastPath: true,
-      }),
-    );
+    // P1: a genuine web-config deletion fast-paths to an empty no-container config
+    // identical in shape to a stripped refresh. Provenance keeps it authoritative
+    // so the deleted web tools clear instead of leaving stale `web_search` active.
     activateSecretsRuntimeSnapshot(
       preparedSnapshot({
         sourceConfig: asConfig({}),
-        webToolsFromFastPath: true,
+        webToolsProvenance: "canonical-fast-path",
       }),
     );
 
     expect(activeSearchProvider()).toBeUndefined();
   });
 
-  it("clears web metadata when the full resolver returns empty metadata", () => {
+  it("clears web metadata when a real canonical prepare of an empty config runs", async () => {
+    activateResolvedBraveSearch();
+
+    // P1 end-to-end: the real prepare path must assign `canonical-fast-path` to a
+    // fresh empty config so deleting web config clears active web metadata.
+    const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
+    const deleted = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({}),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-web-tools-state"],
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    expect(deleted.webToolsProvenance).toBe("canonical-fast-path");
+
+    activateSecretsRuntimeSnapshot(deleted);
+    expect(activeSearchProvider()).toBeUndefined();
+  });
+
+  it("preserves web metadata when a stripped refresh carries an unrelated plugin entry", () => {
+    activateResolvedBraveSearch();
+
+    // P1: an unrelated `plugins.entries` write must not clear web tools. Preservation
+    // is provenance-gated, not container-gated, so a stripped refresh whose config
+    // only touches an unrelated plugin entry still keeps the active web metadata.
     activateSecretsRuntimeSnapshot(
       preparedSnapshot({
         sourceConfig: asConfig({
-          tools: {
-            web: {
-              search: { provider: "brave" },
+          plugins: {
+            entries: {
+              "unrelated-plugin": { config: { someUnrelatedSetting: true } },
             },
           },
         }),
-        webTools: populatedSearchMetadata("brave"),
-        webToolsFromFastPath: false,
+        webToolsProvenance: "stripped-refresh",
       }),
     );
+
+    expect(activeSearchProvider()).toBe("brave");
+  });
+
+  it("clears web metadata when the full resolver returns empty metadata", () => {
+    activateResolvedBraveSearch();
 
     activateSecretsRuntimeSnapshot(
       preparedSnapshot({
         sourceConfig: asConfig({}),
-        webToolsFromFastPath: false,
+        webToolsProvenance: "resolved",
       }),
     );
 

--- a/src/secrets/runtime-web-tools-state.test.ts
+++ b/src/secrets/runtime-web-tools-state.test.ts
@@ -1,13 +1,62 @@
 /** Tests clone isolation for active web-tool metadata state. */
 import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  activateSecretsRuntimeSnapshot,
+  clearSecretsRuntimeSnapshot,
+  type PreparedSecretsRuntimeSnapshot,
+} from "./runtime.js";
+import { createEmptyRuntimeWebToolsMetadata } from "./runtime-fast-path.js";
 import {
   clearActiveRuntimeWebToolsMetadata,
   getActiveRuntimeWebToolsMetadata,
   setActiveRuntimeWebToolsMetadata,
 } from "./runtime-web-tools-state.js";
+import type { RuntimeWebToolsMetadata } from "./runtime-web-tools.types.js";
+
+function asConfig(value: unknown): OpenClawConfig {
+  return value as OpenClawConfig;
+}
+
+function activeSearchProvider(): string | undefined {
+  return getActiveRuntimeWebToolsMetadata()?.search.selectedProvider;
+}
+
+function populatedSearchMetadata(provider: string): RuntimeWebToolsMetadata {
+  return {
+    search: {
+      providerConfigured: provider,
+      providerSource: "configured",
+      selectedProvider: provider,
+      selectedProviderKeySource: "secretRef",
+      diagnostics: [],
+    },
+    fetch: {
+      providerSource: "none",
+      diagnostics: [],
+    },
+    diagnostics: [],
+  };
+}
+
+function preparedSnapshot(params: {
+  sourceConfig: OpenClawConfig;
+  webTools?: RuntimeWebToolsMetadata;
+  webToolsFromFastPath: boolean;
+}): PreparedSecretsRuntimeSnapshot {
+  return {
+    sourceConfig: params.sourceConfig,
+    config: structuredClone(params.sourceConfig),
+    authStores: [],
+    warnings: [],
+    webTools: params.webTools ?? createEmptyRuntimeWebToolsMetadata(),
+    webToolsFromFastPath: params.webToolsFromFastPath,
+  };
+}
 
 describe("runtime web tools state", () => {
   afterEach(() => {
+    clearSecretsRuntimeSnapshot();
     clearActiveRuntimeWebToolsMetadata();
   });
 
@@ -43,5 +92,111 @@ describe("runtime web tools state", () => {
     }
     expect(second.search.providerConfigured).toBe("gemini");
     expect(second.search.selectedProvider).toBe("gemini");
+  });
+
+  it("preserves populated web metadata across repeated stripped fast-path refreshes", () => {
+    activateSecretsRuntimeSnapshot(
+      preparedSnapshot({
+        sourceConfig: asConfig({
+          tools: {
+            web: {
+              search: { provider: "brave" },
+            },
+          },
+        }),
+        webTools: populatedSearchMetadata("brave"),
+        webToolsFromFastPath: false,
+      }),
+    );
+
+    activateSecretsRuntimeSnapshot(
+      preparedSnapshot({
+        sourceConfig: asConfig({}),
+        webToolsFromFastPath: true,
+      }),
+    );
+    activateSecretsRuntimeSnapshot(
+      preparedSnapshot({
+        sourceConfig: asConfig({}),
+        webToolsFromFastPath: true,
+      }),
+    );
+
+    expect(activeSearchProvider()).toBe("brave");
+  });
+
+  it.each([
+    {
+      name: "tools.web",
+      sourceConfig: asConfig({
+        tools: {
+          web: {},
+        },
+      }),
+    },
+    {
+      name: "plugins.entries",
+      sourceConfig: asConfig({
+        plugins: {
+          entries: {},
+        },
+      }),
+    },
+  ])("clears web metadata when a fast-path refresh includes an explicit empty $name", ({
+    sourceConfig,
+  }) => {
+    activateSecretsRuntimeSnapshot(
+      preparedSnapshot({
+        sourceConfig: asConfig({
+          tools: {
+            web: {
+              search: { provider: "brave" },
+            },
+          },
+        }),
+        webTools: populatedSearchMetadata("brave"),
+        webToolsFromFastPath: false,
+      }),
+    );
+
+    activateSecretsRuntimeSnapshot(
+      preparedSnapshot({
+        sourceConfig,
+        webToolsFromFastPath: true,
+      }),
+    );
+    activateSecretsRuntimeSnapshot(
+      preparedSnapshot({
+        sourceConfig: asConfig({}),
+        webToolsFromFastPath: true,
+      }),
+    );
+
+    expect(activeSearchProvider()).toBeUndefined();
+  });
+
+  it("clears web metadata when the full resolver returns empty metadata", () => {
+    activateSecretsRuntimeSnapshot(
+      preparedSnapshot({
+        sourceConfig: asConfig({
+          tools: {
+            web: {
+              search: { provider: "brave" },
+            },
+          },
+        }),
+        webTools: populatedSearchMetadata("brave"),
+        webToolsFromFastPath: false,
+      }),
+    );
+
+    activateSecretsRuntimeSnapshot(
+      preparedSnapshot({
+        sourceConfig: asConfig({}),
+        webToolsFromFastPath: false,
+      }),
+    );
+
+    expect(activeSearchProvider()).toBeUndefined();
   });
 });

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -111,7 +111,7 @@ describe("secrets runtime fast path", () => {
         store: emptyAuthStore(),
       },
     ]);
-    expect(snapshot.webToolsFromFastPath).toBe(true);
+    expect(snapshot.webToolsProvenance).toBe("canonical-fast-path");
   });
 
   it("uses the fast path when web fetch only configures runtime limits", async () => {
@@ -141,7 +141,7 @@ describe("secrets runtime fast path", () => {
 
     expect(runtimePrepareImportMock).not.toHaveBeenCalled();
     expect(snapshot.webTools.fetch.providerSource).toBe("none");
-    expect(snapshot.webToolsFromFastPath).toBe(true);
+    expect(snapshot.webToolsProvenance).toBe("canonical-fast-path");
   });
 
   it("uses the fast path when web fetch is explicitly disabled", async () => {
@@ -186,7 +186,7 @@ describe("secrets runtime fast path", () => {
     });
 
     expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
-    expect(snapshot.webToolsFromFastPath).toBe(false);
+    expect(snapshot.webToolsProvenance).toBe("resolved");
   });
 
   it("keeps explicit web fetch provider config on the resolver path", async () => {
@@ -208,7 +208,7 @@ describe("secrets runtime fast path", () => {
     });
 
     expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
-    expect(snapshot.webToolsFromFastPath).toBe(false);
+    expect(snapshot.webToolsProvenance).toBe("resolved");
   });
 
   it("marks startup-only fast-path snapshots as fast-path web metadata", async () => {
@@ -221,7 +221,7 @@ describe("secrets runtime fast path", () => {
       loadAuthStore: emptyAuthStore,
     });
 
-    expect(result?.snapshot.webToolsFromFastPath).toBe(true);
+    expect(result?.snapshot.webToolsProvenance).toBe("canonical-fast-path");
   });
 
   it.each([

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -111,6 +111,7 @@ describe("secrets runtime fast path", () => {
         store: emptyAuthStore(),
       },
     ]);
+    expect(snapshot.webToolsFromFastPath).toBe(true);
   });
 
   it("uses the fast path when web fetch only configures runtime limits", async () => {
@@ -140,6 +141,7 @@ describe("secrets runtime fast path", () => {
 
     expect(runtimePrepareImportMock).not.toHaveBeenCalled();
     expect(snapshot.webTools.fetch.providerSource).toBe("none");
+    expect(snapshot.webToolsFromFastPath).toBe(true);
   });
 
   it("uses the fast path when web fetch is explicitly disabled", async () => {
@@ -167,7 +169,7 @@ describe("secrets runtime fast path", () => {
   it("uses the resolver path when an auth profile store contains a SecretRef", async () => {
     const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
 
-    await prepareSecretsRuntimeSnapshot({
+    const snapshot = await prepareSecretsRuntimeSnapshot({
       config: asConfig({}),
       env: {},
       agentDirs: ["/tmp/openclaw-agent-main"],
@@ -184,12 +186,13 @@ describe("secrets runtime fast path", () => {
     });
 
     expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
+    expect(snapshot.webToolsFromFastPath).toBe(false);
   });
 
   it("keeps explicit web fetch provider config on the resolver path", async () => {
     const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
 
-    await prepareSecretsRuntimeSnapshot({
+    const snapshot = await prepareSecretsRuntimeSnapshot({
       config: asConfig({
         tools: {
           web: {
@@ -205,6 +208,20 @@ describe("secrets runtime fast path", () => {
     });
 
     expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
+    expect(snapshot.webToolsFromFastPath).toBe(false);
+  });
+
+  it("marks startup-only fast-path snapshots as fast-path web metadata", async () => {
+    const { prepareSecretsRuntimeFastPathSnapshot } = await import("./runtime-fast-path.js");
+
+    const result = prepareSecretsRuntimeFastPathSnapshot({
+      config: asConfig({}),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: emptyAuthStore,
+    });
+
+    expect(result?.snapshot.webToolsFromFastPath).toBe(true);
   });
 
   it.each([

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -39,15 +39,11 @@ import type { RuntimeWebToolsMetadata } from "./runtime-web-tools.types.js";
 export type { SecretResolverWarning } from "./runtime-shared.js";
 export type { PreparedSecretsRuntimeSnapshot } from "./runtime-state.js";
 
-// Resolver-backed source config is the only proof that active web metadata
-// belongs to a prior full pass; stripped fast-path writes may preserve it.
-let lastFullResolverSourceConfig: OpenClawConfig | null = null;
 let runtimeManifestPromise: Promise<typeof import("./runtime-manifest.runtime.js")> | null = null;
 let runtimePreparePromise: Promise<typeof import("./runtime-prepare.runtime.js")> | null = null;
 
 function clearSecretsRuntimeActivationAuxState(): void {
   clearRuntimeAuthProfileStoreSnapshots();
-  lastFullResolverSourceConfig = null;
 }
 
 registerSecretsRuntimeStateClearHook(clearSecretsRuntimeActivationAuxState);
@@ -124,20 +120,6 @@ function shouldLoadPluginMetadataForSecrets(config: OpenClawConfig): boolean {
   );
 }
 
-function hasRuntimeWebToolMetadataContainer(config: OpenClawConfig): boolean {
-  const tools = config.tools;
-  if (tools && typeof tools === "object" && !Array.isArray(tools) && "web" in tools) {
-    return true;
-  }
-  const plugins = config.plugins;
-  return (
-    Boolean(plugins) &&
-    typeof plugins === "object" &&
-    !Array.isArray(plugins) &&
-    "entries" in plugins
-  );
-}
-
 function hasResolvedRuntimeWebToolsMetadata(metadata: RuntimeWebToolsMetadata): boolean {
   return (
     metadata.search.providerSource !== "none" ||
@@ -156,11 +138,14 @@ function shouldPreserveActiveRuntimeWebToolsMetadata(
   snapshot: PreparedSecretsRuntimeSnapshot,
   activeWebTools: RuntimeWebToolsMetadata | null,
 ): activeWebTools is RuntimeWebToolsMetadata {
+  // Only a stripped fast-path refresh of an already-active snapshot may keep the
+  // prior metadata. A `canonical-fast-path` prepare (initial activation or a real
+  // web-config deletion) is authoritative and must clear, so deleted web surfaces
+  // do not leave stale `web_search`/`web_fetch` tools active. Provenance, not the
+  // incoming config shape, drives this: an unrelated plugin-entry stripped refresh
+  // still preserves because the decision never inspects the incoming containers.
   return (
-    snapshot.webToolsFromFastPath &&
-    !hasRuntimeWebToolMetadataContainer(snapshot.sourceConfig) &&
-    lastFullResolverSourceConfig !== null &&
-    hasRuntimeWebToolMetadataContainer(lastFullResolverSourceConfig) &&
+    snapshot.webToolsProvenance === "stripped-refresh" &&
     activeWebTools !== null &&
     hasResolvedRuntimeWebToolsMetadata(activeWebTools)
   );
@@ -190,6 +175,12 @@ export async function prepareSecretsRuntimeSnapshot(params: {
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins" | "manifestRegistry">;
   /** Test override for discovered loadable plugins and their origins. */
   loadablePluginOrigins?: ReadonlyMap<string, PluginOrigin>;
+  /**
+   * Set only by the refresh path re-preparing an already-active snapshot. Marks
+   * a resulting fast-path snapshot as a stripped refresh so activation may keep
+   * prior web metadata; fresh (canonical) prepares omit it and clear instead.
+   */
+  refreshOrigin?: boolean;
 }): Promise<PreparedSecretsRuntimeSnapshot> {
   const runtimeEnv = mergeSecretsRuntimeEnv(params.env);
   const sourceConfig = structuredClone(params.config);
@@ -217,7 +208,9 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       authStores,
       warnings: [],
       webTools: createEmptyRuntimeWebToolsMetadata(),
-      webToolsFromFastPath: true,
+      webToolsProvenance: params.refreshOrigin
+        ? ("stripped-refresh" as const)
+        : ("canonical-fast-path" as const),
     };
     setPreparedSecretsRuntimeSnapshotRefreshContext(snapshot, {
       env: runtimeEnv,
@@ -304,7 +297,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       resolvedConfig,
       context,
     }),
-    webToolsFromFastPath: false,
+    webToolsProvenance: "resolved" as const,
   };
   setPreparedSecretsRuntimeSnapshotRefreshContext(snapshot, {
     env: runtimeEnv,
@@ -357,6 +350,7 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
           agentDirs: resolveRefreshAgentDirs(sourceConfig, activeRefreshContext),
           includeAuthStoreRefs: includeAuthStoreRefs ?? activeRefreshContext.includeAuthStoreRefs,
           loadablePluginOrigins: activeRefreshContext.loadablePluginOrigins,
+          refreshOrigin: true,
           ...(activeRefreshContext.manifestRegistry
             ? { manifestRegistry: activeRefreshContext.manifestRegistry }
             : {}),
@@ -381,6 +375,7 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
             agentDirs: resolveRefreshAgentDirs(sourceConfig, activeRefreshContext),
             includeAuthStoreRefs: includeAuthStoreRefs ?? activeRefreshContext.includeAuthStoreRefs,
             loadablePluginOrigins: activeRefreshContext.loadablePluginOrigins,
+            refreshOrigin: true,
             ...(activeRefreshContext.manifestRegistry
               ? { manifestRegistry: activeRefreshContext.manifestRegistry }
               : {}),
@@ -397,11 +392,6 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
       },
     },
   });
-  if (!snapshotToActivate.webToolsFromFastPath) {
-    lastFullResolverSourceConfig = structuredClone(snapshotToActivate.sourceConfig);
-  } else if (hasRuntimeWebToolMetadataContainer(snapshotToActivate.sourceConfig)) {
-    lastFullResolverSourceConfig = null;
-  }
 }
 
 export async function refreshActiveSecretsRuntimeSnapshot(): Promise<boolean> {
@@ -416,6 +406,7 @@ export async function refreshActiveSecretsRuntimeSnapshot(): Promise<boolean> {
     agentDirs: resolveRefreshAgentDirs(activeSnapshot.sourceConfig, activeRefreshContext),
     includeAuthStoreRefs: activeRefreshContext.includeAuthStoreRefs,
     loadablePluginOrigins: activeRefreshContext.loadablePluginOrigins,
+    refreshOrigin: true,
     ...(activeRefreshContext.manifestRegistry
       ? { manifestRegistry: activeRefreshContext.manifestRegistry }
       : {}),

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -39,10 +39,18 @@ import type { RuntimeWebToolsMetadata } from "./runtime-web-tools.types.js";
 export type { SecretResolverWarning } from "./runtime-shared.js";
 export type { PreparedSecretsRuntimeSnapshot } from "./runtime-state.js";
 
-registerSecretsRuntimeStateClearHook(clearRuntimeAuthProfileStoreSnapshots);
-
+// Resolver-backed source config is the only proof that active web metadata
+// belongs to a prior full pass; stripped fast-path writes may preserve it.
+let lastFullResolverSourceConfig: OpenClawConfig | null = null;
 let runtimeManifestPromise: Promise<typeof import("./runtime-manifest.runtime.js")> | null = null;
 let runtimePreparePromise: Promise<typeof import("./runtime-prepare.runtime.js")> | null = null;
+
+function clearSecretsRuntimeActivationAuxState(): void {
+  clearRuntimeAuthProfileStoreSnapshots();
+  lastFullResolverSourceConfig = null;
+}
+
+registerSecretsRuntimeStateClearHook(clearSecretsRuntimeActivationAuxState);
 
 function loadRuntimeManifestHelpers() {
   runtimeManifestPromise ??= import("./runtime-manifest.runtime.js");
@@ -116,6 +124,61 @@ function shouldLoadPluginMetadataForSecrets(config: OpenClawConfig): boolean {
   );
 }
 
+function hasRuntimeWebToolMetadataContainer(config: OpenClawConfig): boolean {
+  const tools = config.tools;
+  if (tools && typeof tools === "object" && !Array.isArray(tools) && "web" in tools) {
+    return true;
+  }
+  const plugins = config.plugins;
+  return (
+    Boolean(plugins) &&
+    typeof plugins === "object" &&
+    !Array.isArray(plugins) &&
+    "entries" in plugins
+  );
+}
+
+function hasResolvedRuntimeWebToolsMetadata(metadata: RuntimeWebToolsMetadata): boolean {
+  return (
+    metadata.search.providerSource !== "none" ||
+    metadata.fetch.providerSource !== "none" ||
+    Boolean(metadata.search.providerConfigured) ||
+    Boolean(metadata.search.selectedProvider) ||
+    Boolean(metadata.fetch.providerConfigured) ||
+    Boolean(metadata.fetch.selectedProvider) ||
+    metadata.search.diagnostics.length > 0 ||
+    metadata.fetch.diagnostics.length > 0 ||
+    metadata.diagnostics.length > 0
+  );
+}
+
+function shouldPreserveActiveRuntimeWebToolsMetadata(
+  snapshot: PreparedSecretsRuntimeSnapshot,
+  activeWebTools: RuntimeWebToolsMetadata | null,
+): activeWebTools is RuntimeWebToolsMetadata {
+  return (
+    snapshot.webToolsFromFastPath &&
+    !hasRuntimeWebToolMetadataContainer(snapshot.sourceConfig) &&
+    lastFullResolverSourceConfig !== null &&
+    hasRuntimeWebToolMetadataContainer(lastFullResolverSourceConfig) &&
+    activeWebTools !== null &&
+    hasResolvedRuntimeWebToolsMetadata(activeWebTools)
+  );
+}
+
+function snapshotWithRuntimeWebToolsForActivation(
+  snapshot: PreparedSecretsRuntimeSnapshot,
+): PreparedSecretsRuntimeSnapshot {
+  const activeWebTools = getActiveRuntimeWebToolsMetadataFromState();
+  if (!shouldPreserveActiveRuntimeWebToolsMetadata(snapshot, activeWebTools)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    webTools: activeWebTools,
+  };
+}
+
 /** Prepares a secrets runtime snapshot and records refresh context for later activation. */
 export async function prepareSecretsRuntimeSnapshot(params: {
   config: OpenClawConfig;
@@ -154,6 +217,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       authStores,
       warnings: [],
       webTools: createEmptyRuntimeWebToolsMetadata(),
+      webToolsFromFastPath: true,
     };
     setPreparedSecretsRuntimeSnapshotRefreshContext(snapshot, {
       env: runtimeEnv,
@@ -240,6 +304,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       resolvedConfig,
       context,
     }),
+    webToolsFromFastPath: false,
   };
   setPreparedSecretsRuntimeSnapshotRefreshContext(snapshot, {
     env: runtimeEnv,
@@ -254,13 +319,15 @@ export async function prepareSecretsRuntimeSnapshot(params: {
 
 /** Activates a prepared secrets runtime snapshot for fast runtime lookup. */
 export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): void {
+  const snapshotToActivate = snapshotWithRuntimeWebToolsForActivation(snapshot);
   const refreshContext =
+    getPreparedSecretsRuntimeSnapshotRefreshContext(snapshotToActivate) ??
     getPreparedSecretsRuntimeSnapshotRefreshContext(snapshot) ??
     getActiveSecretsRuntimeRefreshContext() ??
     ({
       env: { ...process.env } as Record<string, string | undefined>,
       explicitAgentDirs: null,
-      includeAuthStoreRefs: snapshot.authStores.length > 0,
+      includeAuthStoreRefs: snapshotToActivate.authStores.length > 0,
       loadAuthStore: loadAuthProfileStoreForSecretsRuntime,
       loadablePluginOrigins: new Map<string, PluginOrigin>(),
     } satisfies SecretsRuntimeRefreshContext);
@@ -275,7 +342,7 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
     return isDeepStrictEqual(candidate.sourceConfig, sourceConfig) ? candidate : null;
   };
   activateSecretsRuntimeSnapshotState({
-    snapshot,
+    snapshot: snapshotToActivate,
     refreshContext,
     refreshHandler: {
       preflight: async ({ sourceConfig, includeAuthStoreRefs }) => {
@@ -330,6 +397,11 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
       },
     },
   });
+  if (!snapshotToActivate.webToolsFromFastPath) {
+    lastFullResolverSourceConfig = structuredClone(snapshotToActivate.sourceConfig);
+  } else if (hasRuntimeWebToolMetadataContainer(snapshotToActivate.sourceConfig)) {
+    lastFullResolverSourceConfig = null;
+  }
 }
 
 export async function refreshActiveSecretsRuntimeSnapshot(): Promise<boolean> {

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -491,7 +491,7 @@ describe("web search runtime", () => {
         },
         diagnostics: [],
       },
-      webToolsFromFastPath: false,
+      webToolsProvenance: "resolved",
     });
 
     await expect(
@@ -668,7 +668,7 @@ describe("web search runtime", () => {
         },
         diagnostics: [],
       },
-      webToolsFromFastPath: false,
+      webToolsProvenance: "resolved",
     });
 
     await expect(
@@ -710,7 +710,7 @@ describe("web search runtime", () => {
         },
         diagnostics: [],
       },
-      webToolsFromFastPath: false,
+      webToolsProvenance: "resolved",
     });
 
     await expect(
@@ -755,7 +755,7 @@ describe("web search runtime", () => {
         },
         diagnostics: [],
       },
-      webToolsFromFastPath: false,
+      webToolsProvenance: "resolved",
     });
 
     await expect(

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -491,6 +491,7 @@ describe("web search runtime", () => {
         },
         diagnostics: [],
       },
+      webToolsFromFastPath: false,
     });
 
     await expect(
@@ -667,6 +668,7 @@ describe("web search runtime", () => {
         },
         diagnostics: [],
       },
+      webToolsFromFastPath: false,
     });
 
     await expect(
@@ -708,6 +710,7 @@ describe("web search runtime", () => {
         },
         diagnostics: [],
       },
+      webToolsFromFastPath: false,
     });
 
     await expect(
@@ -752,6 +755,7 @@ describe("web search runtime", () => {
         },
         diagnostics: [],
       },
+      webToolsFromFastPath: false,
     });
 
     await expect(


### PR DESCRIPTION
## What Problem This Solves

Fixes #77826. A stripped runtime config write can take the secrets runtime fast path and produce empty web-tool metadata. Activating that snapshot used to overwrite the still-valid web search/fetch metadata from the previous full resolver pass, so web tools could disappear after a config write even though the real config still owned them.

## Why This Change Was Made

Prepared secrets snapshots now carry explicit provenance for whether web-tool metadata came from the fast path. During activation, a stripped fast-path snapshot may preserve populated active web-tool metadata only when the previous full resolver source config contained a web-tool metadata container. Full resolver snapshots and explicit empty `tools.web` / `plugins.entries` containers remain authoritative clears.

The duplicate preflight checked exact issue-number PR searches and root-cause keywords. I found only closed or superseded work (#77859, #78067, #78268, #82562) and no active PR owning #77826.

## User Impact

Users keep configured web search/fetch tools after config writes that omit unrelated web-tool surfaces. Explicitly clearing web/plugin containers still removes the active metadata, so this does not turn stale provider credentials into a hidden fallback.

## Evidence

- `node scripts/run-vitest.mjs src/secrets/runtime.fast-path.test.ts src/secrets/runtime-web-tools-state.test.ts src/config/runtime-snapshot.test.ts`
- `git diff --check`

Structured autoreview was attempted before this draft, but the Codex app rejected the helper because it would export repository diffs to an external review/model service under the current workspace policy. I did not route around that policy.

AI assistance disclosure: this draft PR was prepared with Codex assistance. No redacted agent transcript is included because the transcript workflow requires explicit user approval before adding local session logs to a PR body.


---

**Runtime proof — captured before/after (negative-control harness, Node 22):**

Beyond the colocated unit tests, the fix was exercised through the REAL secrets-runtime state machine — `prepareSecretsRuntimeSnapshot` (resolver + fast path), `activateSecretsRuntimeSnapshot`, and the **real config-write refresh handler** `finalizeRuntimeSnapshotWrite` (`src/config/runtime-snapshot.ts:294`, the exact path the gateway invokes on every config write). This is an internal-state bug, so there is no external boundary to mock — the harness controls only config inputs and reads back `getActiveRuntimeWebToolsMetadata()`. Same harness, run on `main` and on this branch.

_Before — unfixed `main` (exit 1):_

```
Scenario 1  stripped fast-path refresh must PRESERVE active web tools
  active BEFORE refresh: search.selectedProvider="brave" providerSource="configured"
  active AFTER  refresh: search.selectedProvider=undefined providerSource="none"
  [FAIL] stripped refresh did NOT preserve active web_search  (the #77826 bug)
RESULT: FAIL — #77826 bug signature.
```

_After — this branch (exit 0):_

```
Scenario 1 (stripped refresh)                  active AFTER: selectedProvider="brave"     [PASS] preserved
Scenario 2 (canonical web-config deletion, P1) active AFTER: selectedProvider=undefined   [PASS] cleared
Scenario 3 (stripped refresh + plugin entry)   active AFTER: selectedProvider="brave"     [PASS] preserved
RESULT: PASS — stripped refreshes preserve active web tools; canonical deletion still clears.
```

Same harness + inputs: Scenarios 1 & 3 flip from `undefined`/`"none"` (clobbered) on `main` to `"brave"` (preserved) on this branch, while Scenario 2 (the P1 deletion-clears) holds on both. Supporting colocated tests (`runtime-web-tools-state.test.ts`, `runtime.fast-path.test.ts`): 16 passed.

**What was not tested:** no live external web-search/fetch HTTP call (the defect is purely internal snapshot-activation state); the config-write refresh is driven via the real `finalizeRuntimeSnapshotWrite` handler rather than a full live gateway hot-reload (same handler the gateway uses).
