### PR TITLE
fix: suppress final text after message tool delivery

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -148,6 +148,10 @@ import {
   resolveOutboundSessionRoute,
 } from "../../infra/outbound/outbound-session.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
+import {
+  createSourceDeliveryPlan,
+  resolveSourceDeliveryOutcome,
+} from "../../infra/outbound/source-delivery-plan.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import {
   dispatchCronDelivery,
@@ -378,6 +382,36 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       payloads: [{ text: "Fallback cron summary." }],
       skipQueue: true,
     });
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+  });
+
+  it("keeps final assistant text private after a verified message-tool-owned send", async () => {
+    const sourceDelivery = createSourceDeliveryPlan({
+      owner: "message_tool",
+      reason: "room_event",
+      target: { channel: "telegram", to: "123456" },
+    });
+    const params = makeBaseParams({ synthesizedText: "Private trailing summary." });
+    params.sourceDeliveryOutcome = resolveSourceDeliveryOutcome(sourceDelivery, {
+      didSendViaMessageTool: true,
+      messageToolSentTargets: [
+        {
+          tool: "message",
+          provider: "telegram",
+          to: "123456",
+          text: "Visible message-tool reply.",
+        },
+      ],
+    });
+
+    expect(sourceDelivery.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(params.sourceDeliveryOutcome.verifiedMessageToolDelivery).toBe(true);
+    expect(params.sourceDeliveryOutcome.satisfiesSourceDelivery).toBe(true);
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
     expect(state.deliveryAttempted).toBe(true);
     expect(state.delivered).toBe(true);
   });

--- a/src/infra/outbound/source-delivery-plan.test.ts
+++ b/src/infra/outbound/source-delivery-plan.test.ts
@@ -89,6 +89,67 @@ describe("source delivery plan", () => {
     ]);
   });
 
+  it("satisfies message-tool-owned source delivery after a verified send to the planned target", () => {
+    const contract = createSourceDeliveryPlan({
+      owner: "message_tool",
+      reason: "room_event",
+      target: { channel: "discord", to: "channel:1467271397540630621" },
+    });
+
+    const outcome = resolveSourceDeliveryOutcome(contract, {
+      didSendViaMessageTool: true,
+      messageToolSentTargets: [
+        {
+          tool: "message",
+          provider: "discord",
+          to: "channel:1467271397540630621",
+          text: "sent through message tool",
+        },
+      ],
+    });
+
+    expect(outcome.verifiedMessageToolDelivery).toBe(true);
+    expect(outcome.satisfiesSourceDelivery).toBe(true);
+    expect(outcome.unverifiedMessageToolDelivery).toBe(false);
+    expect(outcome.visibleDeliveries).toEqual([
+      {
+        via: "message_tool",
+        verifiedTarget: true,
+        target: {
+          tool: "message",
+          provider: "discord",
+          to: "channel:1467271397540630621",
+          text: "sent through message tool",
+        },
+      },
+    ]);
+  });
+
+  it("keeps message-tool-owned delivery unsatisfied when the send target does not match", () => {
+    const contract = createSourceDeliveryPlan({
+      owner: "message_tool",
+      reason: "room_event",
+      target: { channel: "discord", to: "channel:1467271397540630621" },
+    });
+
+    const outcome = resolveSourceDeliveryOutcome(contract, {
+      didSendViaMessageTool: true,
+      messageToolSentTargets: [
+        {
+          tool: "message",
+          provider: "discord",
+          to: "channel:999",
+          text: "sent somewhere else",
+        },
+      ],
+    });
+
+    expect(outcome.verifiedMessageToolDelivery).toBe(false);
+    expect(outcome.satisfiesSourceDelivery).toBe(false);
+    expect(outcome.unverifiedMessageToolDelivery).toBe(true);
+    expect(outcome.visibleDeliveries[0]?.verifiedTarget).toBe(false);
+  });
+
   it("keeps unverified message-tool sends visible to fallback/error handling", () => {
     const contract = createSourceDeliveryPlan({
       owner: "message_tool_then_direct_fallback",

--- a/src/infra/outbound/source-delivery-plan.ts
+++ b/src/infra/outbound/source-delivery-plan.ts
@@ -260,11 +260,13 @@ export function resolveSourceDeliveryOutcome(
   const hasVerifiedMessageToolDelivery = visibleDeliveries.some(
     (delivery) => didSendViaMessageTool && delivery.verifiedTarget,
   );
+  const satisfiesSourceDeliveryWithMessageTool =
+    hasVerifiedMessageToolDelivery &&
+    (isMessageToolOwnedDelivery(plan.owner) || plan.fallback.skipWhenMessageToolSentToTarget);
   return {
     visibleDeliveries,
     verifiedMessageToolDelivery: hasVerifiedMessageToolDelivery,
-    satisfiesSourceDelivery:
-      plan.fallback.skipWhenMessageToolSentToTarget && hasVerifiedMessageToolDelivery,
+    satisfiesSourceDelivery: satisfiesSourceDeliveryWithMessageTool,
     unverifiedMessageToolDelivery:
       didSendViaMessageTool && sentTargets.length > 0 && !hasVerifiedMessageToolDelivery,
   };


### PR DESCRIPTION
## What Problem This Solves
OpenClaw could successfully send a visible source reply through the `message` tool, then still treat the private final assistant text as unsatisfied source delivery. In message-tool-owned flows, that let a trailing final-summary message leak through the later direct delivery path.

## Why This Change Was Made
`resolveSourceDeliveryOutcome` already verified whether the message tool sent to the planned target, but `satisfiesSourceDelivery` only honored that verified send when direct fallback skip was configured. This PR makes verified message-tool delivery satisfy source delivery whenever the source-delivery plan owner is message-tool-owned, while preserving the existing direct fallback skip behavior for direct-fallback plans.

## User Impact
Users should no longer see a duplicate or summarizing final assistant message after the agent has already replied through the message tool. Wrong-target or unverified message-tool sends remain unsatisfied, so configured direct fallback/error handling can still run.

## Evidence
- Added regression coverage in `src/infra/outbound/source-delivery-plan.test.ts` for a verified Discord `owner: "message_tool"` send to `channel:1467271397540630621` and for the mismatched-target guard.
- Added delivery-dispatch coverage in `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` proving final assistant text stays private after a verified message-tool-owned send.
- Red test before fix: `pnpm test src/infra/outbound/source-delivery-plan.test.ts` failed because `satisfiesSourceDelivery` was `false` despite `verifiedMessageToolDelivery: true`.
- Post-fix/post-merge: `pnpm test src/infra/outbound/source-delivery-plan.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` passed 2 shards, 97 tests.
- Post-merge: `pnpm build` passed.
- `git diff --check` passed.
