### PR TITLE
fix(otel): extend duration histogram buckets

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2428,6 +2428,10 @@ describe("diagnostics-otel service", () => {
     expect(harnessDuration?.[1]?.["openclaw.outcome"]).toBe("completed");
     expect(Object.hasOwn(harnessDuration?.[1] ?? {}, "openclaw.runId")).toBe(false);
     expect(Object.hasOwn(harnessDuration?.[1] ?? {}, "openclaw.sessionKey")).toBe(false);
+    const harnessDurationBoundaries = histogramCreateOptions("openclaw.harness.duration_ms")?.advice
+      ?.explicitBucketBoundaries;
+    expect(harnessDurationBoundaries).toContain(30_000);
+    expect(harnessDurationBoundaries?.at(-1)).toBe(600_000);
     const toolDuration = lastHistogramRecord("openclaw.tool.execution.duration_ms");
     expect(toolDuration?.[0]).toBe(20);
     expect(toolDuration?.[1]?.["openclaw.tool.source"]).toBe("core");

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -90,6 +90,13 @@ const GEN_AI_TOKEN_USAGE_BUCKETS = [
 const GEN_AI_OPERATION_DURATION_BUCKETS = [
   0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 ];
+// Keep percentile queries useful for long operations instead of collapsing them
+// into OpenTelemetry's default final finite bucket at 10 seconds.
+const DURATION_HISTOGRAM_ADVICE = {
+  explicitBucketBoundaries: [
+    5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000, 300000, 600000,
+  ],
+};
 const MAX_RETAINED_TRUSTED_SPAN_CONTEXTS = 1024;
 const RETAINED_TRUSTED_SPAN_CONTEXT_TIMEOUT_MS = 5_000;
 
@@ -1546,10 +1553,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const durationHistogram = meter.createHistogram("openclaw.run.duration_ms", {
         unit: "ms",
         description: "Agent run duration",
+        advice: DURATION_HISTOGRAM_ADVICE,
       });
       const harnessDurationHistogram = meter.createHistogram("openclaw.harness.duration_ms", {
         unit: "ms",
         description: "Agent harness lifecycle duration",
+        advice: DURATION_HISTOGRAM_ADVICE,
       });
       const contextHistogram = meter.createHistogram("openclaw.context.tokens", {
         unit: "1",
@@ -1566,6 +1575,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const webhookDurationHistogram = meter.createHistogram("openclaw.webhook.duration_ms", {
         unit: "ms",
         description: "Webhook processing duration",
+        advice: DURATION_HISTOGRAM_ADVICE,
       });
       const messageQueuedCounter = meter.createCounter("openclaw.message.queued", {
         unit: "1",
@@ -1594,6 +1604,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         {
           unit: "ms",
           description: "Inbound message dispatch duration",
+          advice: DURATION_HISTOGRAM_ADVICE,
         },
       );
       const messageProcessedCounter = meter.createCounter("openclaw.message.processed", {
@@ -1603,6 +1614,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const messageDurationHistogram = meter.createHistogram("openclaw.message.duration_ms", {
         unit: "ms",
         description: "Message processing duration",
+        advice: DURATION_HISTOGRAM_ADVICE,
       });
       const messageDeliveryStartedCounter = meter.createCounter(
         "openclaw.message.delivery.started",
@@ -1616,6 +1628,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         {
           unit: "ms",
           description: "Outbound message delivery duration",
+          advice: DURATION_HISTOGRAM_ADVICE,
         },
       );
       const queueDepthHistogram = meter.createHistogram("openclaw.queue.depth", {
@@ -1625,6 +1638,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const queueWaitHistogram = meter.createHistogram("openclaw.queue.wait_ms", {
         unit: "ms",
         description: "Queue wait time before execution",
+        advice: DURATION_HISTOGRAM_ADVICE,
       });
       const laneEnqueueCounter = meter.createCounter("openclaw.queue.lane.enqueue", {
         unit: "1",
@@ -1649,6 +1663,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const sessionStuckAgeHistogram = meter.createHistogram("openclaw.session.stuck_age_ms", {
         unit: "ms",
         description: "Age of stuck sessions",
+        advice: DURATION_HISTOGRAM_ADVICE,
       });
       const sessionRecoveryRequestedCounter = meter.createCounter(
         "openclaw.session.recovery.requested",
@@ -1669,6 +1684,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         {
           unit: "ms",
           description: "Age of sessions selected for recovery",
+          advice: DURATION_HISTOGRAM_ADVICE,
         },
       );
       const talkEventCounter = meter.createCounter("openclaw.talk.event", {
@@ -1678,6 +1694,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const talkEventDurationHistogram = meter.createHistogram("openclaw.talk.event.duration_ms", {
         unit: "ms",
         description: "Talk event duration when reported",
+        advice: DURATION_HISTOGRAM_ADVICE,
       });
       const talkAudioBytesHistogram = meter.createHistogram("openclaw.talk.audio.bytes", {
         unit: "By",
@@ -1698,6 +1715,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const modelCallDurationHistogram = meter.createHistogram("openclaw.model_call.duration_ms", {
         unit: "ms",
         description: "Model call duration",
+        advice: DURATION_HISTOGRAM_ADVICE,
       });
       const modelCallRequestBytesHistogram = meter.createHistogram(
         "openclaw.model_call.request_bytes",
@@ -1718,6 +1736,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         {
           unit: "ms",
           description: "Elapsed time before the first streamed model response event",
+          advice: DURATION_HISTOGRAM_ADVICE,
         },
       );
       const modelFailoverCounter = meter.createCounter("openclaw.model.failover", {
@@ -1729,6 +1748,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         {
           unit: "ms",
           description: "Tool execution duration",
+          advice: DURATION_HISTOGRAM_ADVICE,
         },
       );
       const toolExecutionBlockedCounter = meter.createCounter("openclaw.tool.execution.blocked", {
@@ -1738,6 +1758,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const execProcessDurationHistogram = meter.createHistogram("openclaw.exec.duration_ms", {
         unit: "ms",
         description: "Exec process duration",
+        advice: DURATION_HISTOGRAM_ADVICE,
       });
       const memoryRssHistogram = meter.createHistogram("openclaw.memory.rss_bytes", {
         unit: "By",
@@ -1790,6 +1811,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         {
           unit: "ms",
           description: "P99 event-loop delay reported by diagnostic liveness warnings",
+          advice: DURATION_HISTOGRAM_ADVICE,
         },
       );
       const livenessEventLoopDelayMaxHistogram = meter.createHistogram(
@@ -1797,6 +1819,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         {
           unit: "ms",
           description: "Maximum event-loop delay reported by diagnostic liveness warnings",
+          advice: DURATION_HISTOGRAM_ADVICE,
         },
       );
       const livenessEventLoopUtilizationHistogram = meter.createHistogram(


### PR DESCRIPTION
## What Problem This Solves

OpenTelemetry's default millisecond histogram has no finite bucket above 10 seconds. Percentile queries therefore report exactly 10 seconds when long-running harness or agent operations fall into the final unbounded bucket, hiding the real p95.

## Why This Change Was Made

Apply explicit duration boundaries through 10 minutes to all millisecond OTEL histograms. The boundaries match the existing Prometheus diagnostics exporter, keeping percentile behavior consistent across both telemetry paths.

## User Impact

Operators can see useful p50 and p95 values for long-running harness, model, tool, message, queue, and other duration metrics instead of a false 10-second plateau. New samples are affected; previously aggregated samples cannot be recovered.

## Evidence

- Added a regression assertion that the harness duration histogram includes a 30-second bucket and ends at 10 minutes.
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts` — 95 tests passed.
- `./node_modules/.bin/oxfmt --check extensions/diagnostics-otel/src/service.ts extensions/diagnostics-otel/src/service.test.ts` — passed.
- The normal `pnpm test` wrapper could not start tests because dependency reconciliation was blocked by Socket Firewall with HTTP 403 for `acpx@0.11.2`; no policy bypass was attempted.
