### PR TITLE
fix(reply): retry stalled compacted direct sessions after reset

### DIFF
--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -10,6 +10,7 @@ export type AgentLifecycleTerminalBackstop = {
     extraData?: Record<string, unknown>,
   ) => void;
   getDeferredError: () => string | undefined;
+  getDeferredMetadata: () => Record<string, unknown>;
   note: (evt: { stream: string; data: Record<string, unknown> }) => void;
 };
 
@@ -116,6 +117,7 @@ export function createAgentLifecycleTerminalBackstop(params: {
   return {
     emit,
     getDeferredError: () => deferredError,
+    getDeferredMetadata: () => ({ ...deferredTerminalMetadata }),
     note,
   };
 }

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1325,6 +1325,45 @@ describe("runAgentTurnWithFallback", () => {
     expect(embeddedCall.abortSignal).toBe(replyOperation.abortSignal);
   });
 
+  it("defers blocked terminated timeouts so stalled direct-session reset can retry", async () => {
+    const { replyOperation, failMock, retainFailureUntilCompleteMock } = createMockReplyOperation();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: {
+          phase: "finishing",
+          error: "LLM request timed out.",
+          aborted: false,
+          livenessState: "blocked",
+        },
+      });
+      throw new FailoverError("LLM request timed out.", {
+        reason: "timeout",
+        provider: "openai",
+        model: "gpt-5.5",
+        rawError: "terminated",
+      });
+    });
+    const shouldDeferRunFailure = vi.fn(() => true);
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      shouldDeferRunFailure,
+    });
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.meta).toMatchObject({
+        aborted: true,
+        livenessState: "blocked",
+      });
+    }
+    expect(shouldDeferRunFailure).toHaveBeenCalledOnce();
+    expect(failMock).not.toHaveBeenCalled();
+    expect(retainFailureUntilCompleteMock).not.toHaveBeenCalled();
+  });
+
   it("passes the hydrated run account to embedded execution", async () => {
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "ok" }],

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -3860,6 +3860,7 @@ describe("runAgentTurnWithFallback", () => {
       flush: vi.fn(async () => {}),
       stop: vi.fn(),
       hasBuffered: vi.fn(() => true),
+      hasPendingDelivery: vi.fn(() => false),
       didStream: vi.fn(() => false),
       isAborted: vi.fn(() => false),
       hasSentPayload: vi.fn(() => false),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -41,6 +41,7 @@ import {
 } from "../../agents/embedded-agent-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
 import { isMessagingToolSendAction } from "../../agents/embedded-agent-messaging.js";
+import { isRunnerAbortError } from "../../agents/embedded-agent-runner/abort.js";
 import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
 import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
@@ -333,6 +334,32 @@ function readNullableNumberValue(value: unknown): number | null | undefined {
     return null;
   }
   return readFiniteNumberValue(value);
+}
+
+function isAbortLikeRunFailure(value: unknown): boolean {
+  if (isRunnerAbortError(value)) {
+    return true;
+  }
+  const message =
+    typeof value === "string"
+      ? value
+      : value && typeof value === "object" && "message" in value
+        ? String((value as { message?: unknown }).message ?? "")
+        : "";
+  return /aborted/i.test(message);
+}
+
+function isDiagnosticBlockedTerminatedTimeout(params: {
+  error: unknown;
+  deferredMetadata: Record<string, unknown>;
+}): boolean {
+  if (!isFailoverError(params.error) || params.error.reason !== "timeout") {
+    return false;
+  }
+  return (
+    readStringValue(params.deferredMetadata.livenessState) === "blocked" &&
+    readStringValue(params.error.rawError)?.toLowerCase() === "terminated"
+  );
 }
 
 function isCommandToolName(name: string | undefined): boolean {
@@ -1596,6 +1623,7 @@ export async function runAgentTurnWithFallback(params: {
   replyMediaContext?: ReplyMediaContext;
   onCompactionNoticePayload?: (payload: ReplyPayload) => Promise<void> | void;
   isRestartRecoveryArmed?: () => boolean;
+  shouldDeferRunFailure?: (outcome: Extract<AgentRunLoopResult, { kind: "success" }>) => boolean;
 }): Promise<AgentRunLoopResult> {
   const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
   let didLogHeartbeatStrip = false;
@@ -1806,6 +1834,21 @@ export async function runAgentTurnWithFallback(params: {
     pendingLifecycleTerminal = undefined;
     return terminal;
   };
+  const buildSuccessfulOutcome = (): Extract<AgentRunLoopResult, { kind: "success" }> => ({
+    kind: "success",
+    runId,
+    runResult,
+    fallbackProvider,
+    fallbackModel,
+    ...(fallbackExhausted ? { fallbackExhausted: true as const } : {}),
+    fallbackAttempts,
+    didLogHeartbeatStrip,
+    autoCompactionCount,
+    directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
+    directlySentBlockPayloads: directlySentBlockPayloads.filter(
+      (payload): payload is ReplyPayload => payload !== undefined,
+    ),
+  });
   let transientHttpRetriesRemaining = 1;
   const consumeTransientHttpRetry = () => transientHttpRetriesRemaining-- > 0;
   let liveModelSwitchRetries = 0;
@@ -2985,6 +3028,9 @@ export async function runAgentTurnWithFallback(params: {
       // of silently rotating the session key to a new session id.
       const embeddedError = runResult.meta?.error;
       const deferredLifecycleError = settledLifecycleTerminal?.getDeferredError();
+      const shouldDeferEmbeddedRunFailure =
+        (embeddedError !== undefined || deferredLifecycleError !== undefined) &&
+        params.shouldDeferRunFailure?.(buildSuccessfulOutcome());
       const userFacingErrorPayload = runResult.payloads?.find(
         (payload) => payload.isError === true && typeof payload.text === "string",
       )?.text;
@@ -3059,7 +3105,7 @@ export async function runAgentTurnWithFallback(params: {
         });
         params.replyOperation?.retainFailureUntilComplete();
         params.replyOperation?.fail("run_failed", exhaustionError);
-      } else if (deferredLifecycleError || embeddedError) {
+      } else if ((deferredLifecycleError || embeddedError) && !shouldDeferEmbeddedRunFailure) {
         const terminalError = new Error(terminalErrorMessage ?? "Agent run failed");
         emitSettledLifecycleError(terminalError, terminalMetadata);
         params.replyOperation?.retainFailureUntilComplete();
@@ -3240,6 +3286,38 @@ export async function runAgentTurnWithFallback(params: {
         continue;
       }
 
+      const deferredLifecycleError = pendingLifecycleTerminal?.backstop.getDeferredError();
+      const deferredLifecycleMetadata =
+        pendingLifecycleTerminal?.backstop.getDeferredMetadata() ?? {};
+      const abortLikeThrownFailure =
+        isAbortLikeRunFailure(err) ||
+        isAbortLikeRunFailure(deferredLifecycleError) ||
+        (isFailoverError(err) && isAbortLikeRunFailure(err.rawError));
+      const diagnosticBlockedTimeout = isDiagnosticBlockedTerminatedTimeout({
+        error: err,
+        deferredMetadata: deferredLifecycleMetadata,
+      });
+      if (abortLikeThrownFailure || diagnosticBlockedTimeout) {
+        runResult = {
+          payloads: [{ text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT, isError: true }],
+          meta: {
+            ...deferredLifecycleMetadata,
+            durationMs: 0,
+            aborted: true,
+            livenessState: "blocked",
+            agentMeta: {
+              sessionId: params.followupRun.run.sessionId,
+              provider: fallbackProvider,
+              model: fallbackModel,
+            },
+          },
+        };
+        if (params.shouldDeferRunFailure?.(buildSuccessfulOutcome())) {
+          takePendingLifecycleTerminal()?.emit("end", runResult);
+          break;
+        }
+      }
+
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
       // Only classify as rate-limit when we have concrete evidence from the
       // underlying error. FallbackSummaryError messages embed per-attempt
@@ -3404,19 +3482,5 @@ export async function runAgentTurnWithFallback(params: {
     }
   }
 
-  return {
-    kind: "success",
-    runId,
-    runResult,
-    fallbackProvider,
-    fallbackModel,
-    ...(fallbackExhausted ? { fallbackExhausted: true as const } : {}),
-    fallbackAttempts,
-    didLogHeartbeatStrip,
-    autoCompactionCount,
-    directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
-    directlySentBlockPayloads: directlySentBlockPayloads.filter(
-      (payload): payload is ReplyPayload => payload !== undefined,
-    ),
-  };
+  return buildSuccessfulOutcome();
 }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -344,7 +344,7 @@ function isAbortLikeRunFailure(value: unknown): boolean {
     typeof value === "string"
       ? value
       : value && typeof value === "object" && "message" in value
-        ? String((value as { message?: unknown }).message ?? "")
+        ? (readStringValue((value as { message?: unknown }).message) ?? "")
         : "";
   return /aborted/i.test(message);
 }

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -852,6 +852,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => ["file:///tmp/voice.ogg"],
     };
 
@@ -891,6 +892,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => ["file:///tmp/outbound/voice.ogg"],
     };
 
@@ -914,6 +916,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
     // The pipeline streamed some partial content, but the final text payload was
@@ -942,6 +945,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
     // The final text-only payload matches what the pipeline already sent,
@@ -967,6 +971,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
 
@@ -990,6 +995,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
     const presentation = {
@@ -1020,6 +1026,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
 
@@ -1046,6 +1053,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => ["/tmp/generated.png"],
     };
 
@@ -1094,6 +1102,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasPendingDelivery: () => false,
       getSentMediaUrls: () => [],
     };
 

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -44,10 +44,10 @@ export async function resetReplyRunSession(params: {
   onActiveSessionEntry: (entry: SessionEntry) => void;
   onNewSession: (newSessionId: string, nextSessionFile: string) => void;
 }): Promise<boolean> {
-  if (!params.sessionKey || !params.activeSessionStore || !params.storePath) {
+  if (!params.sessionKey || !params.storePath) {
     return false;
   }
-  const prevEntry = params.activeSessionStore[params.sessionKey] ?? params.activeSessionEntry;
+  const prevEntry = params.activeSessionStore?.[params.sessionKey] ?? params.activeSessionEntry;
   if (!prevEntry) {
     return false;
   }
@@ -89,7 +89,9 @@ export async function resetReplyRunSession(params: {
     params.messageThreadId,
   );
   nextEntry.sessionFile = nextSessionFile;
-  params.activeSessionStore[params.sessionKey] = nextEntry;
+  if (params.activeSessionStore) {
+    params.activeSessionStore[params.sessionKey] = nextEntry;
+  }
   try {
     await deps.persistSessionResetLifecycle({
       agentId,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2963,8 +2963,11 @@ describe("runReplyAgent transient HTTP retry", () => {
         payloads: [{ text: "LLM request failed.", isError: true }],
         meta: {
           aborted: true,
-          livenessState: "blocked",
           durationMs: 383_000,
+          error: {
+            kind: "incomplete_turn",
+            message: "Request was aborted",
+          },
           agentMeta: {
             sessionId: "stalled-session",
             provider: "codex-lb",
@@ -3036,7 +3039,6 @@ describe("runReplyAgent transient HTTP retry", () => {
       typing,
       sessionCtx,
       sessionEntry,
-      sessionStore,
       sessionKey,
       storePath,
       defaultModel: "anthropic/claude-opus-4-6",
@@ -3055,20 +3057,19 @@ describe("runReplyAgent transient HTTP retry", () => {
     expectRecordFields(payload, { text: "Recovered response" }, "reply result");
     expect(followupRun.run.sessionId).toBe("reset-session");
     expect(followupRun.run.suppressNextUserMessagePersistence).toBeUndefined();
-    expect(sessionStore[sessionKey]?.sessionId).toBe("reset-session");
-    expect(sessionStore[sessionKey]?.systemSent).toBe(false);
-    expect(sessionStore[sessionKey]?.totalTokens).toBeUndefined();
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(persisted[sessionKey]?.sessionId).toBe("reset-session");
+    expect(persisted[sessionKey]?.systemSent).toBe(false);
+    expect(persisted[sessionKey]?.totalTokens).toBeUndefined();
     expect(refreshQueuedFollowupSessionMock).toHaveBeenCalledWith({
       key: sessionKey,
       previousSessionId: "stalled-session",
       nextSessionId: "reset-session",
-      nextSessionFile: sessionStore[sessionKey]?.sessionFile,
+      nextSessionFile: persisted[sessionKey]?.sessionFile,
     });
     expect(runtimeErrorMock).toHaveBeenCalledWith(
       "Stalled direct session aborted without visible output. Resetting hot session main stalled-session -> reset-session and retrying once.",
     );
-    const persisted = loadSessionStore(storePath);
-    expect(persisted[sessionKey]?.sessionId).toBe("reset-session");
   });
 
   it("does not reset when a stalled direct session has pending block delivery", async () => {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2953,7 +2953,8 @@ describe("runReplyAgent transient HTTP retry", () => {
     setAgentRunnerSessionResetTestDeps({
       generateSecureUuid: () => "reset-session",
       persistSessionResetLifecycle: async (params) => {
-        await saveSessionStore(params.storePath, { [params.sessionKey]: params.nextEntry });
+        saveSessionStore(params.storePath, { [params.sessionKey]: params.nextEntry });
+        return { replayedMessages: 0 };
       },
     });
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2953,7 +2953,7 @@ describe("runReplyAgent transient HTTP retry", () => {
     setAgentRunnerSessionResetTestDeps({
       generateSecureUuid: () => "reset-session",
       persistSessionResetLifecycle: async (params) => {
-        saveSessionStore(params.storePath, { [params.sessionKey]: params.nextEntry });
+        await saveSessionStore(params.storePath, { [params.sessionKey]: params.nextEntry });
         return { replayedMessages: 0 };
       },
     });
@@ -3065,7 +3065,7 @@ describe("runReplyAgent transient HTTP retry", () => {
     expect(runtimeErrorMock).toHaveBeenCalledWith(
       "Stalled direct session aborted without visible output. Resetting hot session main stalled-session -> reset-session and retrying once.",
     );
-    const persisted = await loadSessionStore(storePath);
+    const persisted = loadSessionStore(storePath);
     expect(persisted[sessionKey]?.sessionId).toBe("reset-session");
   });
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2972,8 +2972,9 @@ describe("runReplyAgent transient HTTP retry", () => {
           },
         },
       })
-      .mockImplementationOnce(async () => {
+      .mockImplementationOnce(async (params) => {
         expect(replyRunRegistry.resolveSessionId(sessionKey)).toBe("reset-session");
+        expect(params.suppressNextUserMessagePersistence).toBe(true);
         return {
           payloads: [{ text: "Recovered response" }],
           meta: {
@@ -3053,6 +3054,7 @@ describe("runReplyAgent transient HTTP retry", () => {
       : result;
     expectRecordFields(payload, { text: "Recovered response" }, "reply result");
     expect(followupRun.run.sessionId).toBe("reset-session");
+    expect(followupRun.run.suppressNextUserMessagePersistence).toBeUndefined();
     expect(sessionStore[sessionKey]?.sessionId).toBe("reset-session");
     expect(sessionStore[sessionKey]?.systemSent).toBe(false);
     expect(sessionStore[sessionKey]?.totalTokens).toBeUndefined();

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -208,6 +208,7 @@ vi.mock("./private-message-tool-final.js", async (importOriginal) => {
   return { ...actual, warnPrivateMessageToolFinal: warnPrivateFinalSpy };
 });
 
+import { setAgentRunnerSessionResetTestDeps } from "./agent-runner-session-reset.js";
 import { runReplyAgent } from "./agent-runner.js";
 
 type RunWithModelFallbackParams = {
@@ -255,6 +256,7 @@ function firstMockCallArg(mock: MockCallSource, label: string): unknown {
 
 beforeEach(() => {
   vi.useRealTimers();
+  setAgentRunnerSessionResetTestDeps();
   registerCliBackendsForTest();
   clearRuntimeConfigSnapshot();
   resetDiagnosticEventsForTest();
@@ -292,6 +294,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setAgentRunnerSessionResetTestDeps();
   cliBackendsTesting.resetDepsForTest();
   clearRuntimeConfigSnapshot();
   resetDiagnosticEventsForTest();
@@ -2932,6 +2935,253 @@ describe("runReplyAgent response usage footer", () => {
 });
 
 describe("runReplyAgent transient HTTP retry", () => {
+  it("resets and retries once after a stalled compacted direct session aborts without output", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stalled-direct-reset-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "stalled-session",
+      updatedAt: Date.now(),
+      sessionFile: path.join(tmp, "stalled-session.jsonl"),
+      systemSent: true,
+      chatType: "direct",
+      compactionCount: 2,
+      totalTokens: 1_000,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await saveSessionStore(storePath, sessionStore);
+    setAgentRunnerSessionResetTestDeps({
+      generateSecureUuid: () => "reset-session",
+      persistSessionResetLifecycle: async (params) => {
+        await saveSessionStore(params.storePath, { [params.sessionKey]: params.nextEntry });
+      },
+    });
+
+    runEmbeddedAgentMock
+      .mockResolvedValueOnce({
+        payloads: [{ text: "LLM request failed.", isError: true }],
+        meta: {
+          aborted: true,
+          livenessState: "blocked",
+          durationMs: 383_000,
+          agentMeta: {
+            sessionId: "stalled-session",
+            provider: "codex-lb",
+            model: "gpt-5.5",
+          },
+        },
+      })
+      .mockImplementationOnce(async () => {
+        expect(replyRunRegistry.resolveSessionId(sessionKey)).toBe("reset-session");
+        return {
+          payloads: [{ text: "Recovered response" }],
+          meta: {
+            agentMeta: {
+              sessionId: "reset-session",
+              provider: "codex-lb",
+              model: "gpt-5.5",
+            },
+          },
+        };
+      });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "chat:1",
+      AccountId: "primary",
+      MessageSid: "msg",
+      ChatType: "direct",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        sessionId: "stalled-session",
+        sessionKey,
+        messageProvider: "telegram",
+        sessionFile: sessionEntry.sessionFile,
+        workspaceDir: "/tmp",
+        config: createCliBackendTestConfig(),
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    const payload = Array.isArray(result)
+      ? result.find((entry) => entry?.text === "Recovered response")
+      : result;
+    expectRecordFields(payload, { text: "Recovered response" }, "reply result");
+    expect(followupRun.run.sessionId).toBe("reset-session");
+    expect(sessionStore[sessionKey]?.sessionId).toBe("reset-session");
+    expect(sessionStore[sessionKey]?.systemSent).toBe(false);
+    expect(sessionStore[sessionKey]?.totalTokens).toBeUndefined();
+    expect(refreshQueuedFollowupSessionMock).toHaveBeenCalledWith({
+      key: sessionKey,
+      previousSessionId: "stalled-session",
+      nextSessionId: "reset-session",
+      nextSessionFile: sessionStore[sessionKey]?.sessionFile,
+    });
+    expect(runtimeErrorMock).toHaveBeenCalledWith(
+      "Stalled direct session aborted without visible output. Resetting hot session main stalled-session -> reset-session and retrying once.",
+    );
+    const persisted = await loadSessionStore(storePath);
+    expect(persisted[sessionKey]?.sessionId).toBe("reset-session");
+  });
+
+  it("does not reset when a stalled direct session has buffered block output", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stalled-direct-buffered-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "stalled-session",
+      updatedAt: Date.now(),
+      sessionFile: path.join(tmp, "stalled-session.jsonl"),
+      systemSent: true,
+      chatType: "direct",
+      compactionCount: 2,
+      totalTokens: 1_000,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await saveSessionStore(storePath, sessionStore);
+
+    const onBlockReply = vi.fn();
+    runEmbeddedAgentMock.mockImplementationOnce(async (params) => {
+      const block = params.onBlockReply as ((payload: { text?: string }) => void) | undefined;
+      block?.({ text: "Buffered answer" });
+      return {
+        payloads: [{ text: "LLM request failed.", isError: true }],
+        meta: {
+          aborted: true,
+          livenessState: "blocked",
+          agentMeta: {
+            sessionId: "stalled-session",
+            provider: "codex-lb",
+            model: "gpt-5.5",
+          },
+        },
+      };
+    });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "chat:1",
+      AccountId: "primary",
+      MessageSid: "msg",
+      ChatType: "direct",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        sessionId: "stalled-session",
+        sessionKey,
+        messageProvider: "telegram",
+        sessionFile: sessionEntry.sessionFile,
+        workspaceDir: "/tmp",
+        config: createCliBackendTestConfig(),
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      opts: { onBlockReply },
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: true,
+      blockReplyChunking: {
+        minChars: 100,
+        maxChars: 200,
+        breakPreference: "paragraph",
+      },
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Buffered answer" }),
+      expect.any(Object),
+    );
+    expect(followupRun.run.sessionId).toBe("stalled-session");
+    expect(sessionStore[sessionKey]?.sessionId).toBe("stalled-session");
+    expect(refreshQueuedFollowupSessionMock).not.toHaveBeenCalled();
+    expect(runtimeErrorMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("Stalled direct session aborted without visible output"),
+    );
+  });
+
   it("retries once after transient 521 HTML failure and then succeeds", async () => {
     vi.useFakeTimers();
     runEmbeddedAgentMock

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -3069,7 +3069,7 @@ describe("runReplyAgent transient HTTP retry", () => {
     expect(persisted[sessionKey]?.sessionId).toBe("reset-session");
   });
 
-  it("does not reset when a stalled direct session has buffered block output", async () => {
+  it("does not reset when a stalled direct session has pending block delivery", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stalled-direct-buffered-"));
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
@@ -3085,10 +3085,17 @@ describe("runReplyAgent transient HTTP retry", () => {
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await saveSessionStore(storePath, sessionStore);
 
-    const onBlockReply = vi.fn();
+    let resolveBlockDelivery: (() => void) | undefined;
+    const blockDelivery = new Promise<void>((resolve) => {
+      resolveBlockDelivery = resolve;
+    });
+    const onBlockReply = vi.fn(() => blockDelivery);
     runEmbeddedAgentMock.mockImplementationOnce(async (params) => {
-      const block = params.onBlockReply as ((payload: { text?: string }) => void) | undefined;
-      block?.({ text: "Buffered answer" });
+      const block = params.onBlockReply as
+        | ((payload: { text?: string; mediaUrls?: string[] }) => void)
+        | undefined;
+      block?.({ text: "Visible answer", mediaUrls: ["file://visible.png"] });
+      setImmediate(() => resolveBlockDelivery?.());
       return {
         payloads: [{ text: "LLM request failed.", isError: true }],
         meta: {
@@ -3172,7 +3179,7 @@ describe("runReplyAgent transient HTTP retry", () => {
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     expect(onBlockReply).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Buffered answer" }),
+      expect.objectContaining({ text: expect.stringContaining("Visible answer") }),
       expect.any(Object),
     );
     expect(followupRun.run.sessionId).toBe("stalled-session");

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1900,10 +1900,21 @@ export async function runReplyAgent(params: {
       });
       if (didReset) {
         replyOperation.updateSessionId(followupRun.run.sessionId);
-        runOutcome = await traceAgentPhase(
-          "reply.run_agent_turn_after_session_reset",
-          runAgentTurn,
-        );
+        const previousUserPersistenceSuppression =
+          followupRun.run.suppressNextUserMessagePersistence;
+        followupRun.run.suppressNextUserMessagePersistence = true;
+        try {
+          runOutcome = await traceAgentPhase(
+            "reply.run_agent_turn_after_session_reset",
+            runAgentTurn,
+          );
+        } finally {
+          if (previousUserPersistenceSuppression === undefined) {
+            delete followupRun.run.suppressNextUserMessagePersistence;
+          } else {
+            followupRun.run.suppressNextUserMessagePersistence = previousUserPersistenceSuppression;
+          }
+        }
         emitAgentEvent({
           runId: runOutcome.kind === "success" ? runOutcome.runId : retryLifecycleRunId,
           sessionKey,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -23,7 +23,6 @@ import { deriveContextPromptTokens, hasNonzeroUsage, normalizeUsage } from "../.
 import { enqueueCommitmentExtraction } from "../../commitments/runtime.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
-  loadSessionStore,
   resolveSessionPluginStatusLines,
   resolveSessionPluginTraceLines,
   type SessionEntry,
@@ -365,7 +364,6 @@ function shouldAutoResetRetryStalledDirectSession(params: {
     params.isHeartbeat ||
     !params.sessionKey ||
     !params.storePath ||
-    !params.activeSessionStore ||
     !isDirectChatSession({
       sessionKey: params.sessionKey,
       sessionEntry: params.activeSessionEntry,
@@ -1330,7 +1328,7 @@ export async function runReplyAgent(params: {
   } = params;
 
   let activeSessionEntry = sessionEntry;
-  let activeSessionStore = sessionStore;
+  const activeSessionStore = sessionStore;
   let activeIsNewSession = isNewSession;
   const effectiveResetTriggered = resetTriggered === true;
   const activeRunQueueMode = effectiveResetTriggered ? "interrupt" : resolvedQueue.mode;
@@ -1351,16 +1349,6 @@ export async function runReplyAgent(params: {
       config: followupRun.run.config,
       attributes: traceAttributes,
     });
-  const ensureActiveSessionStore = (): Record<string, SessionEntry> | undefined => {
-    if (activeSessionStore || !storePath || !sessionKey) {
-      return activeSessionStore;
-    }
-    // Gateway direct turns can arrive with a session entry but no mutable store;
-    // reset/retry must still rotate the canonical persisted session.
-    activeSessionStore = loadSessionStore(storePath, { skipCache: true });
-    activeSessionEntry = activeSessionStore[sessionKey] ?? activeSessionEntry;
-    return activeSessionStore;
-  };
   const effectiveShouldSteer = !isHeartbeat && !effectiveResetTriggered && shouldSteer;
   const effectiveShouldFollowup = !effectiveResetTriggered && shouldFollowup;
   const typingSignals = createTypingSignaler({
@@ -1875,23 +1863,18 @@ export async function runReplyAgent(params: {
         toolProgressDetail,
         replyMediaContext,
         isRestartRecoveryArmed,
-        shouldDeferRunFailure: (outcome) => {
-          const resetRetrySessionStore =
-            !activeSessionStore && isReplayableStalledDirectSessionAbort(outcome.runResult.meta)
-              ? ensureActiveSessionStore()
-              : activeSessionStore;
-          return shouldAutoResetRetryStalledDirectSession({
+        shouldDeferRunFailure: (outcome) =>
+          shouldAutoResetRetryStalledDirectSession({
             isHeartbeat,
             sessionKey,
             storePath,
-            activeSessionStore: resetRetrySessionStore,
+            activeSessionStore,
             activeSessionEntry,
             sessionCtx,
             runOutcome: outcome,
             blockReplyPipeline,
             pendingToolTasks,
-          });
-        },
+          }),
       });
     let runOutcome = await traceAgentPhase("reply.run_agent_turn", runAgentTurn);
 
@@ -1906,17 +1889,12 @@ export async function runReplyAgent(params: {
       await blockReplyPipeline.flush({ force: true });
     }
 
-    const resetRetryNeedsSessionStore =
-      !activeSessionStore && isReplayableStalledDirectSessionAbort(runOutcome.runResult.meta);
-    const resetRetrySessionStore = resetRetryNeedsSessionStore
-      ? ensureActiveSessionStore()
-      : activeSessionStore;
     if (
       shouldAutoResetRetryStalledDirectSession({
         isHeartbeat,
         sessionKey,
         storePath,
-        activeSessionStore: resetRetrySessionStore,
+        activeSessionStore,
         activeSessionEntry,
         sessionCtx,
         runOutcome,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -10,6 +10,7 @@ import {
 } from "../../agents/agent-scope.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import { isRunnerAbortError } from "../../agents/embedded-agent-runner/abort.js";
 import { hasVisibleAgentPayload } from "../../agents/embedded-agent-runner/delivery-evidence.js";
 import {
   formatEmbeddedAgentQueueFailureSummary,
@@ -22,6 +23,7 @@ import { deriveContextPromptTokens, hasNonzeroUsage, normalizeUsage } from "../.
 import { enqueueCommitmentExtraction } from "../../commitments/runtime.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  loadSessionStore,
   resolveSessionPluginStatusLines,
   resolveSessionPluginTraceLines,
   type SessionEntry,
@@ -374,9 +376,7 @@ function shouldAutoResetRetryStalledDirectSession(params: {
     return false;
   }
   if (
-    runResult.meta?.aborted !== true ||
-    runResult.meta?.error !== undefined ||
-    runResult.meta?.livenessState !== "blocked" ||
+    !isReplayableStalledDirectSessionAbort(runResult.meta) ||
     params.runOutcome.fallbackExhausted === true ||
     params.runOutcome.fallbackAttempts.length > 0 ||
     params.pendingToolTasks.size > 0 ||
@@ -394,6 +394,20 @@ function shouldAutoResetRetryStalledDirectSession(params: {
     successfulCronAdds: runResult.successfulCronAdds,
     didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
   });
+}
+
+function isReplayableStalledDirectSessionAbort(
+  meta: SuccessfulAgentRunOutcome["runResult"]["meta"] | undefined,
+): boolean {
+  const livenessState = meta?.livenessState;
+  // Diagnostic stuck-session recovery can abort an owned silent model call
+  // before the embedded runner attaches terminal liveness. The delivery,
+  // fallback, direct-chat, and compaction gates keep that replay one-shot.
+  return (
+    meta?.aborted === true &&
+    (meta.error === undefined || isRunnerAbortError(meta.error)) &&
+    (livenessState === "blocked" || livenessState === undefined)
+  );
 }
 
 function resolveConfiguredFallbackModel(params: {
@@ -1316,7 +1330,7 @@ export async function runReplyAgent(params: {
   } = params;
 
   let activeSessionEntry = sessionEntry;
-  const activeSessionStore = sessionStore;
+  let activeSessionStore = sessionStore;
   let activeIsNewSession = isNewSession;
   const effectiveResetTriggered = resetTriggered === true;
   const activeRunQueueMode = effectiveResetTriggered ? "interrupt" : resolvedQueue.mode;
@@ -1337,6 +1351,16 @@ export async function runReplyAgent(params: {
       config: followupRun.run.config,
       attributes: traceAttributes,
     });
+  const ensureActiveSessionStore = (): Record<string, SessionEntry> | undefined => {
+    if (activeSessionStore || !storePath || !sessionKey) {
+      return activeSessionStore;
+    }
+    // Gateway direct turns can arrive with a session entry but no mutable store;
+    // reset/retry must still rotate the canonical persisted session.
+    activeSessionStore = loadSessionStore(storePath, { skipCache: true });
+    activeSessionEntry = activeSessionStore[sessionKey] ?? activeSessionEntry;
+    return activeSessionStore;
+  };
   const effectiveShouldSteer = !isHeartbeat && !effectiveResetTriggered && shouldSteer;
   const effectiveShouldFollowup = !effectiveResetTriggered && shouldFollowup;
   const typingSignals = createTypingSignaler({
@@ -1851,6 +1875,23 @@ export async function runReplyAgent(params: {
         toolProgressDetail,
         replyMediaContext,
         isRestartRecoveryArmed,
+        shouldDeferRunFailure: (outcome) => {
+          const resetRetrySessionStore =
+            !activeSessionStore && isReplayableStalledDirectSessionAbort(outcome.runResult.meta)
+              ? ensureActiveSessionStore()
+              : activeSessionStore;
+          return shouldAutoResetRetryStalledDirectSession({
+            isHeartbeat,
+            sessionKey,
+            storePath,
+            activeSessionStore: resetRetrySessionStore,
+            activeSessionEntry,
+            sessionCtx,
+            runOutcome: outcome,
+            blockReplyPipeline,
+            pendingToolTasks,
+          });
+        },
       });
     let runOutcome = await traceAgentPhase("reply.run_agent_turn", runAgentTurn);
 
@@ -1865,12 +1906,17 @@ export async function runReplyAgent(params: {
       await blockReplyPipeline.flush({ force: true });
     }
 
+    const resetRetryNeedsSessionStore =
+      !activeSessionStore && isReplayableStalledDirectSessionAbort(runOutcome.runResult.meta);
+    const resetRetrySessionStore = resetRetryNeedsSessionStore
+      ? ensureActiveSessionStore()
+      : activeSessionStore;
     if (
       shouldAutoResetRetryStalledDirectSession({
         isHeartbeat,
         sessionKey,
         storePath,
-        activeSessionStore,
+        activeSessionStore: resetRetrySessionStore,
         activeSessionEntry,
         sessionCtx,
         runOutcome,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -68,6 +68,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildKnownAgentRunFailureReplyPayload,
+  type AgentRunLoopResult,
   runAgentTurnWithFallback,
 } from "./agent-runner-execution.js";
 import {
@@ -261,7 +262,11 @@ function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
 }
 
 function hasSuccessfulSideEffectDelivery(params: {
-  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
+  blockReplyPipeline: {
+    hasBuffered: () => boolean;
+    didStream: () => boolean;
+    isAborted: () => boolean;
+  } | null;
   directlySentBlockKeys?: Set<string>;
   messagingToolSentTexts?: string[];
   messagingToolSentMediaUrls?: string[];
@@ -279,19 +284,114 @@ function hasSuccessfulSideEffectDelivery(params: {
 }
 
 function hasSuccessfulSourceReplyDelivery(params: {
-  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
+  blockReplyPipeline: {
+    hasBuffered: () => boolean;
+    didStream: () => boolean;
+    isAborted: () => boolean;
+  } | null;
   directlySentBlockKeys?: Set<string>;
   messagingToolSentTexts?: string[];
   messagingToolSentMediaUrls?: string[];
   messagingToolSentTargets?: unknown[];
 }): boolean {
   return (
+    (params.blockReplyPipeline?.hasBuffered() && !params.blockReplyPipeline.isAborted()) ||
     (params.blockReplyPipeline?.didStream() && !params.blockReplyPipeline.isAborted()) ||
     (params.directlySentBlockKeys?.size ?? 0) > 0 ||
     hasNonEmptyStringArray(params.messagingToolSentTexts) ||
     hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
     hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets)
   );
+}
+
+type SuccessfulAgentRunOutcome = Extract<AgentRunLoopResult, { kind: "success" }>;
+
+function hasCompactionHistory(entry: SessionEntry | undefined): boolean {
+  return (
+    (typeof entry?.compactionCount === "number" && entry.compactionCount > 0) ||
+    (Array.isArray(entry?.compactionCheckpoints) && entry.compactionCheckpoints.length > 0)
+  );
+}
+
+function isDirectChatSession(params: {
+  sessionKey?: string;
+  sessionEntry?: SessionEntry;
+  sessionCtx: TemplateContext;
+}): boolean {
+  return (
+    params.sessionEntry?.chatType === "direct" ||
+    params.sessionCtx.ChatType === "direct" ||
+    params.sessionKey?.includes(":direct:") === true
+  );
+}
+
+function hasNonErrorVisibleReplyPayload(payloads: ReplyPayload[] | undefined): boolean {
+  return (payloads ?? []).some((payload) => {
+    if (payload.isError === true || payload.isReasoning === true) {
+      return false;
+    }
+    return (
+      (typeof payload.text === "string" && payload.text.trim().length > 0) ||
+      (typeof payload.mediaUrl === "string" && payload.mediaUrl.trim().length > 0) ||
+      (Array.isArray(payload.mediaUrls) &&
+        payload.mediaUrls.some((url) => url.trim().length > 0)) ||
+      payload.presentation !== undefined ||
+      payload.interactive !== undefined
+    );
+  });
+}
+
+function shouldAutoResetRetryStalledDirectSession(params: {
+  isHeartbeat: boolean;
+  sessionKey?: string;
+  storePath?: string;
+  activeSessionStore?: Record<string, SessionEntry>;
+  activeSessionEntry?: SessionEntry;
+  sessionCtx: TemplateContext;
+  runOutcome: SuccessfulAgentRunOutcome;
+  blockReplyPipeline: {
+    hasBuffered: () => boolean;
+    didStream: () => boolean;
+    isAborted: () => boolean;
+  } | null;
+  pendingToolTasks: Set<Promise<void>>;
+}): boolean {
+  const runResult = params.runOutcome.runResult;
+  if (
+    params.isHeartbeat ||
+    !params.sessionKey ||
+    !params.storePath ||
+    !params.activeSessionStore ||
+    !isDirectChatSession({
+      sessionKey: params.sessionKey,
+      sessionEntry: params.activeSessionEntry,
+      sessionCtx: params.sessionCtx,
+    }) ||
+    !hasCompactionHistory(params.activeSessionEntry)
+  ) {
+    return false;
+  }
+  if (
+    runResult.meta?.aborted !== true ||
+    runResult.meta?.error !== undefined ||
+    runResult.meta?.livenessState !== "blocked" ||
+    params.runOutcome.fallbackExhausted === true ||
+    params.runOutcome.fallbackAttempts.length > 0 ||
+    params.pendingToolTasks.size > 0 ||
+    hasNonErrorVisibleReplyPayload(runResult.payloads)
+  ) {
+    return false;
+  }
+  return !hasSuccessfulSideEffectDelivery({
+    blockReplyPipeline: params.blockReplyPipeline,
+    directlySentBlockKeys: params.runOutcome.directlySentBlockKeys,
+    messagingToolSentTexts: runResult.messagingToolSentTexts,
+    messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
+    messagingToolSentTargets: runResult.messagingToolSentTargets,
+    didSendViaMessagingTool: runResult.didSendViaMessagingTool,
+    successfulCronAdds: runResult.successfulCronAdds,
+    didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
+  });
 }
 
 function resolveConfiguredFallbackModel(params: {
@@ -1720,7 +1820,7 @@ export async function runReplyAgent(params: {
     replyOperation.setPhase("running");
     const runStartedAt = Date.now();
     await persistRestartRecoveryDeliveryContext();
-    const runOutcome = await traceAgentPhase("reply.run_agent_turn", () =>
+    const runAgentTurn = () =>
       runAgentTurnWithFallback({
         commandBody,
         transcriptCommandBody,
@@ -1749,14 +1849,92 @@ export async function runReplyAgent(params: {
         toolProgressDetail,
         replyMediaContext,
         isRestartRecoveryArmed,
-      }),
-    );
+      });
+    let runOutcome = await traceAgentPhase("reply.run_agent_turn", runAgentTurn);
 
     if (runOutcome.kind === "final") {
       if (!replyOperation.result) {
         replyOperation.fail("run_failed", new Error("reply operation exited with final payload"));
       }
       return returnWithQueuedFollowupDrain(runOutcome.payload);
+    }
+
+    if (
+      shouldAutoResetRetryStalledDirectSession({
+        isHeartbeat,
+        sessionKey,
+        storePath,
+        activeSessionStore,
+        activeSessionEntry,
+        sessionCtx,
+        runOutcome,
+        blockReplyPipeline,
+        pendingToolTasks,
+      })
+    ) {
+      const previousSessionId = followupRun.run.sessionId;
+      const retryLifecycleRunId = runOutcome.runId;
+      const compactionCount = activeSessionEntry?.compactionCount;
+      emitAgentEvent({
+        runId: retryLifecycleRunId,
+        sessionKey,
+        sessionId: previousSessionId,
+        stream: "lifecycle",
+        data: {
+          phase: "auto_session_reset_retry",
+          outcome: "attempting",
+          reason: "stalled_direct_session_abort",
+          compactionCount,
+        },
+      });
+      const didReset = await resetSession({
+        failureLabel: "stalled direct session abort",
+        buildLogMessage: (nextSessionId) =>
+          `Stalled direct session aborted without visible output. Resetting hot session ${sessionKey} ${previousSessionId} -> ${nextSessionId} and retrying once.`,
+      });
+      if (didReset) {
+        replyOperation.updateSessionId(followupRun.run.sessionId);
+        runOutcome = await traceAgentPhase(
+          "reply.run_agent_turn_after_session_reset",
+          runAgentTurn,
+        );
+        emitAgentEvent({
+          runId: runOutcome.kind === "success" ? runOutcome.runId : retryLifecycleRunId,
+          sessionKey,
+          sessionId: followupRun.run.sessionId,
+          stream: "lifecycle",
+          data: {
+            phase: "auto_session_reset_retry",
+            outcome: "completed",
+            reason: "stalled_direct_session_abort",
+            previousSessionId,
+            sessionId: followupRun.run.sessionId,
+            compactionCount,
+          },
+        });
+        if (runOutcome.kind === "final") {
+          if (!replyOperation.result) {
+            replyOperation.fail(
+              "run_failed",
+              new Error("reply operation exited with final payload"),
+            );
+          }
+          return returnWithQueuedFollowupDrain(runOutcome.payload);
+        }
+      } else {
+        emitAgentEvent({
+          runId: retryLifecycleRunId,
+          sessionKey,
+          sessionId: previousSessionId,
+          stream: "lifecycle",
+          data: {
+            phase: "auto_session_reset_retry",
+            outcome: "skipped",
+            reason: "reset_unavailable",
+            compactionCount,
+          },
+        });
+      }
     }
 
     const {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -264,6 +264,7 @@ function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
 function hasSuccessfulSideEffectDelivery(params: {
   blockReplyPipeline: {
     hasBuffered: () => boolean;
+    hasPendingDelivery: () => boolean;
     didStream: () => boolean;
     isAborted: () => boolean;
   } | null;
@@ -351,6 +352,7 @@ function shouldAutoResetRetryStalledDirectSession(params: {
   runOutcome: SuccessfulAgentRunOutcome;
   blockReplyPipeline: {
     hasBuffered: () => boolean;
+    hasPendingDelivery: () => boolean;
     didStream: () => boolean;
     isAborted: () => boolean;
   } | null;
@@ -1857,6 +1859,10 @@ export async function runReplyAgent(params: {
         replyOperation.fail("run_failed", new Error("reply operation exited with final payload"));
       }
       return returnWithQueuedFollowupDrain(runOutcome.payload);
+    }
+
+    if (blockReplyPipeline?.hasPendingDelivery() === true && !blockReplyPipeline.isAborted()) {
+      await blockReplyPipeline.flush({ force: true });
     }
 
     if (

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -16,6 +16,7 @@ export type BlockReplyPipeline = {
   flush: (options?: { force?: boolean }) => Promise<void>;
   stop: () => void;
   hasBuffered: () => boolean;
+  hasPendingDelivery: () => boolean;
   didStream: () => boolean;
   isAborted: () => boolean;
   hasSentPayload: (payload: ReplyPayload) => boolean;
@@ -323,6 +324,7 @@ export function createBlockReplyPipeline(params: {
     flush,
     stop,
     hasBuffered: () => coalescer?.hasBuffered() || bufferedPayloads.length > 0,
+    hasPendingDelivery: () => pendingKeys.size > 0,
     didStream: () => didStream,
     isAborted: () => aborted,
     hasSentExactPayload: (payload) => sentContentKeys.has(createBlockReplyContentKey(payload)),


### PR DESCRIPTION
## What Problem This Solves

Fixes #90516.

Long-lived direct chat sessions with compaction history can wedge during an embedded model call. OpenClaw already emits blocked lifecycle diagnostics, but the real Gateway path can surface the diagnostic abort as `FailoverError(reason=timeout, rawError=terminated)` and mark `agent.wait` as failed before the outer reset/retry guard gets a chance to rotate the hot session.

## Why This Change Was Made

This keeps the recovery narrow: compacted direct sessions only, no visible output, no pending tool work, no fallback attempt, no prior reset, and no side-effect delivery evidence. When those guards match, the execution layer defers the terminal failure to the reply runner, the reply runner rotates the hot session once through the session lifecycle accessor, and retries the same inbound turn without duplicating user-message persistence.

The lifecycle backstop now exposes deferred terminal metadata so the execution layer can recognize the real diagnostic shape (`livenessState: blocked` plus `timeout/terminated`) without guessing from a generic timeout string. The reset helper no longer requires callers to expose a mutable whole-session store; if Gateway supplies only the active session entry, persistence still stays centralized in `persistSessionResetLifecycle`.

## User Impact

A Telegram/WebChat/direct-chat user whose compacted session stalls should receive the recovered assistant reply after one automatic reset/retry instead of immediately seeing `LLM request timed out.` or `LLM request failed.`. Non-direct chats, non-compacted sessions, attempts with visible output, fallback attempts, pending tools, and pending block delivery keep the existing failure behavior.

## Real behavior proof

Behavior addressed: A compacted direct session whose first embedded OpenAI Responses stream stalls silently is reset and retried once instead of surfacing the first run's timeout/error to the user.

Real environment tested: Local macOS source checkout, Node 24.15.0, branch `fix/90516-stalled-session-reset-retry` at `a8442e4571b805f64bf7bdbfe46ce8304c4233e0`. No live provider key or channel credential was used; the provider endpoint was a local OpenAI Responses SSE mock behind the real Gateway process.

Exact steps or command run after this patch:
1. `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts`
2. `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
3. `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-lifecycle-terminal.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner-session-reset.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
4. `pnpm run lint:tmp:session-accessor-boundary`
5. `pnpm exec oxlint src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner-session-reset.ts`
6. `git diff --check`
7. `pnpm tsgo:core:test`
8. `.agents/skills/autoreview/scripts/autoreview --mode local`
9. Local Gateway proof: start a real `openclaw gateway` via `createOpenClawTestInstance`, configure diagnostics with `stuckSessionWarnMs=1000` and `stuckSessionAbortMs=1000`, prewrite session store key `agent:qa:webchat:direct:proof-90516` with `sessionId=stalled-session`, `chatType=direct`, `channel=webchat`, `compactionCount=2`, `systemSent=true`, and `totalTokens=1000`; point `openai/gpt-5.5` at a local `/v1/responses` mock whose first SSE response never emits model output and whose second SSE response returns `RESET_RETRY_OK`; send `chat.send` over Gateway and wait with `agent.wait`.

Evidence after fix: The real Gateway proof returned `chat.send -> {"runId":"proof-90516-run","status":"started"}` and `agent.wait -> {"runId":"proof-90516-run","status":"ok"}`. The local provider mock received exactly 2 `/v1/responses` requests; the first silent SSE request was closed by diagnostic recovery, and the second returned `RESET_RETRY_OK`. The persisted session store changed from `stalled-session` to `fd5c357b-5533-46d3-b436-713fff9de9c7`, with `systemSent:false`, `totalTokens:10`, and `compactionCount:2`. Agent lifecycle events showed `finishing` with `error:"LLM request timed out."`, `aborted:false`, `livenessState:"blocked"`; then synthetic `end` with `aborted:true`, `livenessState:"blocked"`; then `auto_session_reset_retry` `attempting`; then the second run emitted `RESET_RETRY_OK`; then `auto_session_reset_retry` `completed` with `previousSessionId:"stalled-session"` and the new session id.

Observed result after fix: The user-visible run completed successfully after one reset/retry, no generic timeout payload was delivered as the final outcome, and the proof stderr did not contain the temporary `RUN_THROW_RESET_DEBUG` marker.

What was not tested: This proof does not use real Telegram credentials or a live OpenAI key. The covered behavior is the shared Gateway/direct-chat/reply-runner path with a local OpenAI Responses-compatible SSE provider mock.
