### PR TITLE
fix: deliver message-tool-only final reports without proof

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -346,13 +346,10 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expect(payloads[0]?.text).toBe("Long report generated in final answer.");
     expect(getReplyPayloadMetadata(payloads[0] as object)).toMatchObject({
       deliverDespiteSourceReplySuppression: true,
-      sourceReplyTranscriptMirror: {
-        sessionKey: "agent:main",
-        agentId: "main",
-        text: "Long report generated in final answer.",
-        idempotencyKey: "run-1:message-tool-only-final-fallback:0",
-      },
     });
+    expect(
+      getReplyPayloadMetadata(payloads[0] as object)?.sourceReplyTranscriptMirror,
+    ).toBeUndefined();
   });
 
   it("falls back when message-tool-only final text followed an unproved message-tool send", () => {
@@ -369,13 +366,10 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expect(payloads[0]?.text).toBe("Report text that still needs delivery.");
     expect(getReplyPayloadMetadata(payloads[0] as object)).toMatchObject({
       deliverDespiteSourceReplySuppression: true,
-      sourceReplyTranscriptMirror: {
-        sessionKey: "agent:main",
-        agentId: "main",
-        text: "Report text that still needs delivery.",
-        idempotencyKey: "run-1:message-tool-only-final-fallback:0",
-      },
     });
+    expect(
+      getReplyPayloadMetadata(payloads[0] as object)?.sourceReplyTranscriptMirror,
+    ).toBeUndefined();
   });
 
   it("ignores accumulated internal/status text after the final answer", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -333,6 +333,51 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("falls back to native source delivery when message-tool-only final text was not sent", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Long report generated in final answer."],
+      sourceReplyDeliveryMode: "message_tool_only",
+      sessionKey: "agent:main",
+      agentId: "main",
+      runId: "run-1",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Long report generated in final answer.");
+    expect(getReplyPayloadMetadata(payloads[0] as object)).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplyTranscriptMirror: {
+        sessionKey: "agent:main",
+        agentId: "main",
+        text: "Long report generated in final answer.",
+        idempotencyKey: "run-1:message-tool-only-final-fallback:0",
+      },
+    });
+  });
+
+  it("falls back when message-tool-only final text followed an unproved message-tool send", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Report text that still needs delivery."],
+      didSendViaMessagingTool: true,
+      sourceReplyDeliveryMode: "message_tool_only",
+      sessionKey: "agent:main",
+      agentId: "main",
+      runId: "run-1",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Report text that still needs delivery.");
+    expect(getReplyPayloadMetadata(payloads[0] as object)).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplyTranscriptMirror: {
+        sessionKey: "agent:main",
+        agentId: "main",
+        text: "Report text that still needs delivery.",
+        idempotencyKey: "run-1:message-tool-only-final-fallback:0",
+      },
+    });
+  });
+
   it("ignores accumulated internal/status text after the final answer", () => {
     const payloads = buildPayloads({
       assistantTexts: [

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -316,6 +316,10 @@ export function buildEmbeddedRunPayloads(params: {
   const deliveredSourceReplyViaMessageTool =
     params.sourceReplyDeliveryMode === "message_tool_only" &&
     params.didDeliverSourceReplyViaMessageTool === true;
+  const shouldDeliverMessageToolOnlyAssistantFallback =
+    params.sourceReplyDeliveryMode === "message_tool_only" &&
+    !hasSourceReplyPayload &&
+    !deliveredSourceReplyViaMessageTool;
 
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts =
@@ -526,6 +530,15 @@ export function buildEmbeddedRunPayloads(params: {
       replyToId,
       replyToTag,
       replyToCurrent,
+      ...(shouldDeliverMessageToolOnlyAssistantFallback
+        ? {
+            sourceReplyMirror: {
+              idempotencyKey: params.runId
+                ? `${params.runId}:message-tool-only-final-fallback:${replyItems.length}`
+                : undefined,
+            },
+          }
+        : {}),
     });
     hasUserFacingAssistantReply = true;
     if (cleanedText && hasExplicitMutatingToolFailureAcknowledgement(cleanedText)) {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -271,6 +271,7 @@ export function buildEmbeddedRunPayloads(params: {
     interactive?: ReplyPayload["interactive"];
     channelData?: Record<string, unknown>;
     nonTerminalToolErrorWarning?: boolean;
+    deliverDespiteSourceReplySuppression?: boolean;
     sourceReplyMirror?: {
       idempotencyKey?: string;
     };
@@ -532,11 +533,7 @@ export function buildEmbeddedRunPayloads(params: {
       replyToCurrent,
       ...(shouldDeliverMessageToolOnlyAssistantFallback
         ? {
-            sourceReplyMirror: {
-              idempotencyKey: params.runId
-                ? `${params.runId}:message-tool-only-final-fallback:${replyItems.length}`
-                : undefined,
-            },
+            deliverDespiteSourceReplySuppression: true,
           }
         : {}),
     });
@@ -641,6 +638,9 @@ export function buildEmbeddedRunPayloads(params: {
       }
       if (item.channelData) {
         payload.channelData = item.channelData;
+      }
+      if (item.deliverDespiteSourceReplySuppression) {
+        markReplyPayloadForSourceSuppressionDelivery(payload);
       }
       if (item.sourceReplyMirror) {
         // Source-reply mirrors are transcript artifacts, not channel sends.


### PR DESCRIPTION
## Summary
- fall back to native source delivery when `message_tool_only` final assistant text was not actually delivered by the message tool
- keep message-tool-delivered replies private when delivery proof exists
- add regression coverage for missing and unproved message-tool delivery

## What Problem This Solves
A long final report can be written into the session transcript while Telegram receives nothing if the run is in `message_tool_only` mode and no delivery proof exists. The completion/report path treated the requested delivery mode or attempted message-tool path as enough, even when no actual message-tool delivery proof existed.

The first pass caught the missing proof condition, and a live System-topic follow-up exposed the important detail: the fallback must be a real sendable payload marked for delivery despite source-reply suppression, not a transcript-only mirror. This keeps the lean native OpenClaw path: use the existing source-delivery path rather than adding a new queue, wrapper, or monitor.

## Evidence
- Local regression test on current `origin/main`-based PR branch after rebase: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.test.ts` passed 1 file / 38 tests.
- Formatting check after rebase: `npx oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/payloads.ts src/agents/embedded-agent-runner/run/payloads.test.ts` passed.
- PR branch is rebased onto current `origin/main` and the diff is limited to `src/agents/embedded-agent-runner/run/payloads.ts` and `src/agents/embedded-agent-runner/run/payloads.test.ts`.
- Production symptom prompting the fix: final report text existed in the session transcript, but the Telegram-visible delivery mirror was absent for the long final report while a later short status message did have delivery proof.

## Test
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.test.ts`
- `npx oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/payloads.ts src/agents/embedded-agent-runner/run/payloads.test.ts`