### PR TITLE
feat(i18n): refresh all native locale artifacts

### DIFF
--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -24,7 +24,7 @@ permissions:
 
 concurrency:
   group: control-ui-locale-refresh-${{ github.event_name == 'push' && github.ref || github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || github.event_name == 'release' && format('release-{0}', github.event.release.tag_name) || format('{0}-{1}', github.event_name, github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]' }}
 
 jobs:
   plan:

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -8,6 +8,7 @@ on:
       - apps/android/app/src/main/**
       - apps/ios/**
       - apps/macos/Sources/**
+      - apps/macos/Package.swift
       - apps/shared/OpenClawKit/Sources/**
       - apps/.i18n/native-source.json
       - scripts/control-ui-i18n.ts
@@ -29,7 +30,29 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        locale: [hi, ru]
+        locale:
+          [
+            zh-CN,
+            zh-TW,
+            pt-BR,
+            de,
+            es,
+            ja-JP,
+            ko,
+            fr,
+            hi,
+            ar,
+            it,
+            tr,
+            uk,
+            id,
+            pl,
+            th,
+            vi,
+            nl,
+            fa,
+            ru,
+          ]
     runs-on: ubuntu-latest
     name: Refresh native ${{ matrix.locale }}
     steps:

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -13,6 +13,7 @@ on:
       - apps/.i18n/native-source.json
       - scripts/control-ui-i18n.ts
       - scripts/native-app-i18n.ts
+      - ui/src/i18n/.i18n/glossary.*.json
       - .github/workflows/native-app-locale-refresh.yml
   workflow_dispatch:
 

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -52,6 +52,7 @@ jobs:
             nl,
             fa,
             ru,
+            sv,
           ]
     runs-on: ubuntu-latest
     name: Refresh native ${{ matrix.locale }}

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -1,0 +1,96 @@
+name: Native App Locale Refresh
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - apps/android/app/src/main/**
+      - apps/ios/**
+      - apps/macos/Sources/**
+      - apps/shared/OpenClawKit/Sources/**
+      - apps/.i18n/native-source.json
+      - scripts/control-ui-i18n.ts
+      - scripts/native-app-i18n.ts
+      - .github/workflows/native-app-locale-refresh.yml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: native-app-locale-refresh-${{ github.event_name == 'push' && github.ref || format('manual-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+jobs:
+  refresh:
+    if: github.repository == 'openclaw/openclaw' && (github.event_name != 'push' || github.actor != 'github-actions[bot]')
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        locale: [hi, ru]
+    runs-on: ubuntu-latest
+    name: Refresh native ${{ matrix.locale }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: true
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Ensure translation provider secrets exist
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "Missing OPENCLAW_DOCS_I18N_OPENAI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY secret."
+            exit 1
+          fi
+
+      - name: Refresh native locale artifact
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENCLAW_CONTROL_UI_I18N_PROVIDER: ${{ secrets.ANTHROPIC_API_KEY != '' && 'anthropic' || 'openai' }}
+          OPENCLAW_CONTROL_UI_I18N_MODEL: ${{ secrets.ANTHROPIC_API_KEY != '' && 'claude-opus-4-8' || vars.OPENCLAW_CI_OPENAI_MODEL_BARE }}
+          OPENCLAW_CONTROL_UI_I18N_THINKING: low
+          OPENCLAW_CONTROL_UI_I18N_AUTH_OPTIONAL: "0"
+          LOCALE: ${{ matrix.locale }}
+        run: node --import tsx scripts/native-app-i18n.ts sync --write --locale "${LOCALE}"
+
+      - name: Commit and push locale artifact
+        env:
+          LOCALE: ${{ matrix.locale }}
+          TARGET_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- apps/.i18n/native; then
+            echo "No native locale changes for ${LOCALE}."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A apps/.i18n/native apps/.i18n/native-source.json
+          git commit --no-verify -m "chore(i18n): refresh native ${LOCALE} locale"
+
+          for attempt in 1 2 3 4 5; do
+            git fetch origin "${TARGET_BRANCH}"
+            git rebase --autostash "origin/${TARGET_BRANCH}"
+            if git push origin HEAD:"${TARGET_BRANCH}"; then
+              exit 0
+            fi
+            echo "Push attempt ${attempt} for ${LOCALE} failed; retrying."
+            sleep $((attempt * 2))
+          done
+
+          echo "Failed to push ${LOCALE} native locale update after retries."
+          exit 1

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -22,7 +22,7 @@ permissions:
 
 concurrency:
   group: native-app-locale-refresh-${{ github.event_name == 'push' && github.ref || format('manual-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]' }}
 
 jobs:
   refresh:

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   refresh:
-    if: github.repository == 'openclaw/openclaw' && (github.event_name != 'push' || github.actor != 'github-actions[bot]')
+    if: github.repository == 'openclaw/openclaw' && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') && (github.event_name != 'push' || github.actor != 'github-actions[bot]')
     strategy:
       fail-fast: false
       max-parallel: 2

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -95,7 +95,7 @@ jobs:
           TARGET_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- apps/.i18n/native; then
+          if ! git status --porcelain -- apps/.i18n/native apps/.i18n/native-source.json | grep -q .; then
             echo "No native locale changes for ${LOCALE}."
             exit 0
           fi

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -282,6 +282,8 @@ function prettyLanguageLabel(locale: string): string {
       return "Persian";
     case "ru":
       return "Russian";
+    case "sv":
+      return "Swedish";
     case "de":
       return "German";
     case "es":

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -1493,6 +1493,63 @@ async function translateBatch(
   throw lastError ?? new Error("translation failed");
 }
 
+export type NativeTranslationEntry = {
+  id: string;
+  source: string;
+  sourcePath: string;
+};
+
+export async function translateNativeEntries(
+  entries: readonly NativeTranslationEntry[],
+  targetLocale: string,
+  glossary: readonly GlossaryEntry[] = [],
+): Promise<Map<string, string>> {
+  if (!hasTranslationProvider()) {
+    throw new Error("native app translation requires OPENAI_API_KEY or ANTHROPIC_API_KEY");
+  }
+  const pending = entries.map((entry) => ({
+    cacheKey: cacheKey(entry.id, hashText(entry.source), targetLocale),
+    key: entry.id,
+    text: entry.source,
+    textHash: hashText(entry.source),
+  }));
+  const batches = buildTranslationBatches(pending);
+  let client: TranslationClient | null = null;
+  const clientAccess: ClientAccess = {
+    async getClient() {
+      if (!client) {
+        client = await TranslationClient.create(buildSystemPrompt(targetLocale, glossary));
+      }
+      return client;
+    },
+    async resetClient() {
+      if (!client) {
+        return;
+      }
+      await client.close();
+      client = null;
+    },
+  };
+  try {
+    const translated = new Map<string, string>();
+    for (const [batchIndex, batch] of batches.entries()) {
+      const result = await translateBatch(clientAccess, batch, {
+        locale: targetLocale,
+        localeCount: 1,
+        localeIndex: 1,
+        batchCount: batches.length,
+        batchIndex: batchIndex + 1,
+      });
+      for (const [id, value] of result) {
+        translated.set(id, value);
+      }
+    }
+    return translated;
+  } finally {
+    await clientAccess.resetClient();
+  }
+}
+
 type SyncOutcome = {
   changed: boolean;
   fallbackCount: number;

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -511,6 +511,12 @@ function enclosingCallName(source: string, offset: number): string | null {
   return null;
 }
 
+function structuralTokenSignature(source: string): string {
+  const interpolations = [...source.matchAll(/\\\([^)]*\)/gu)].map((match) => match[0]);
+  const lineBreaks = (source.match(/\n/gu) ?? []).length;
+  return JSON.stringify({ interpolations, lineBreaks });
+}
+
 function addCandidate(
   entries: Candidate[],
   surface: NativeI18nSurface,
@@ -923,6 +929,13 @@ async function syncNativeLocale(locale: string, entries: NativeI18nEntry[]) {
         translated.get(entry.id) ?? previousById.get(entry.id)?.translated ?? entry.source,
     })),
   };
+  for (const entry of artifact.entries) {
+    if (structuralTokenSignature(entry.source) !== structuralTokenSignature(entry.translated)) {
+      throw new Error(
+        `native translation changed placeholders or line breaks for ${locale}:${entry.id}`,
+      );
+    }
+  }
   await mkdir(TRANSLATIONS_DIR, { recursive: true });
   await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
   process.stdout.write(

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -45,6 +45,12 @@ type NativeTranslationArtifact = {
   locale: string;
   version: 1;
 };
+type NativeTranslator = typeof translateNativeEntries;
+type NativeLocaleSyncOptions = {
+  glossary?: Array<{ source: string; target: string }>;
+  translate?: NativeTranslator;
+  translationsDir?: string;
+};
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "..");
@@ -920,13 +926,19 @@ async function loadGlossary(locale: string): Promise<Array<{ source: string; tar
   }
 }
 
-async function syncNativeLocale(locale: string, entries: NativeI18nEntry[]) {
+export async function syncNativeLocale(
+  locale: string,
+  entries: NativeI18nEntry[],
+  options: NativeLocaleSyncOptions = {},
+) {
   // Native runtime resources are owned by the Android and Apple slices; these
   // artifacts keep the shared translation-memory handoff current between them.
-  const artifactPath = path.join(TRANSLATIONS_DIR, `${locale}.json`);
+  const artifactPath = path.join(options.translationsDir ?? TRANSLATIONS_DIR, `${locale}.json`);
+  let previousRaw = "";
   let previous: NativeTranslationArtifact = { entries: [], locale, version: 1 };
   try {
-    previous = JSON.parse(await readFile(artifactPath, "utf8")) as NativeTranslationArtifact;
+    previousRaw = await readFile(artifactPath, "utf8");
+    previous = JSON.parse(previousRaw) as NativeTranslationArtifact;
   } catch {
     // The first refresh creates the locale artifact.
   }
@@ -942,7 +954,11 @@ async function syncNativeLocale(locale: string, entries: NativeI18nEntry[]) {
       sourcePath: entry.path,
     }));
   const translated = pending.length
-    ? await translateNativeEntries(pending, locale, await loadGlossary(locale))
+    ? await (options.translate ?? translateNativeEntries)(
+        pending,
+        locale,
+        options.glossary ?? (await loadGlossary(locale)),
+      )
     : new Map<string, string>();
   const artifact: NativeTranslationArtifact = {
     version: 1,
@@ -961,11 +977,16 @@ async function syncNativeLocale(locale: string, entries: NativeI18nEntry[]) {
       );
     }
   }
-  await mkdir(TRANSLATIONS_DIR, { recursive: true });
-  await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+  const rendered = `${JSON.stringify(artifact, null, 2)}\n`;
+  const changed = previousRaw !== rendered;
+  if (changed) {
+    await mkdir(path.dirname(artifactPath), { recursive: true });
+    await writeFile(artifactPath, rendered, "utf8");
+  }
   process.stdout.write(
-    `native-app-i18n: locale=${locale} entries=${entries.length} translated=${translated.size}\n`,
+    `native-app-i18n: locale=${locale} entries=${entries.length} translated=${translated.size} changed=${changed}\n`,
   );
+  return { changed, translated: translated.size };
 }
 
 async function main() {

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -51,6 +51,11 @@ type NativeLocaleSyncOptions = {
   translate?: NativeTranslator;
   translationsDir?: string;
 };
+type NativeI18nCommand = {
+  command: "check" | "sync";
+  locale?: string;
+  write: boolean;
+};
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "..");
@@ -971,21 +976,37 @@ export async function syncNativeLocale(
   return { changed, translated: translated.size };
 }
 
-async function main() {
-  const [command, ...args] = process.argv.slice(2);
+export function parseNativeI18nCommand(argv: string[]): NativeI18nCommand {
+  const [command, ...args] = argv;
   if (command !== "check" && command !== "sync") {
     throw new Error(
       "usage: node --import tsx scripts/native-app-i18n.ts check|sync [--write] [--locale <code>]",
     );
   }
-  await syncNativeI18n({
-    checkOnly: command === "check",
-    write: command === "sync" && process.argv.includes("--write"),
-  });
-  const localeFlag = args.indexOf("--locale");
-  const locale = localeFlag >= 0 ? args[localeFlag + 1] : undefined;
+  let locale: string | undefined;
+  let write = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--write") {
+      write = true;
+      continue;
+    }
+    if (argument === "--locale") {
+      if (locale) {
+        throw new Error("native locale refresh accepts only one `--locale` value");
+      }
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        throw new Error("native locale refresh requires a locale value after `--locale`");
+      }
+      locale = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unsupported native i18n argument: ${argument}`);
+  }
   if (locale) {
-    if (command !== "sync" || !process.argv.includes("--write")) {
+    if (command !== "sync" || !write) {
       throw new Error("native locale refresh requires `sync --write --locale <code>`");
     }
     if (!NATIVE_I18N_LOCALE_SET.has(locale)) {
@@ -993,7 +1014,21 @@ async function main() {
         `unsupported native locale "${locale}". Expected one of: ${NATIVE_I18N_LOCALES.join(", ")}`,
       );
     }
-    await syncNativeLocale(locale, await collectNativeI18nEntries());
+  }
+  if (command === "check" && write) {
+    throw new Error("native i18n check does not accept `--write`");
+  }
+  return { command, locale, write };
+}
+
+async function main() {
+  const parsed = parseNativeI18nCommand(process.argv.slice(2));
+  await syncNativeI18n({
+    checkOnly: parsed.command === "check",
+    write: parsed.command === "sync" && parsed.write,
+  });
+  if (parsed.locale) {
+    await syncNativeLocale(parsed.locale, await collectNativeI18nEntries());
   }
 }
 

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -42,6 +42,7 @@ export type NativeI18nEntry = {
 type Candidate = Omit<NativeI18nEntry, "id">;
 type NativeTranslationArtifact = {
   entries: Array<{ id: string; source: string; translated: string }>;
+  glossaryHash: string;
   locale: string;
   version: 1;
 };
@@ -923,8 +924,15 @@ export async function syncNativeLocale(
   // Native runtime resources are owned by the Android and Apple slices; these
   // artifacts keep the shared translation-memory handoff current between them.
   const artifactPath = path.join(options.translationsDir ?? TRANSLATIONS_DIR, `${locale}.json`);
+  const glossary = options.glossary ?? (await loadGlossary(locale));
+  const glossaryHash = createHash("sha256").update(JSON.stringify(glossary)).digest("hex");
   let previousRaw = "";
-  let previous: NativeTranslationArtifact = { entries: [], locale, version: 1 };
+  let previous: NativeTranslationArtifact = {
+    entries: [],
+    glossaryHash: "",
+    locale,
+    version: 1,
+  };
   try {
     previousRaw = await readFile(artifactPath, "utf8");
     previous = JSON.parse(previousRaw) as NativeTranslationArtifact;
@@ -932,10 +940,13 @@ export async function syncNativeLocale(
     // The first refresh creates the locale artifact.
   }
   const previousById = new Map(previous.entries.map((entry) => [entry.id, entry]));
+  const glossaryChanged = previous.glossaryHash !== glossaryHash;
   const pending = entries
     .filter((entry) => {
       const current = previousById.get(entry.id);
-      return !current || current.source !== entry.source || !current.translated.trim();
+      return (
+        glossaryChanged || !current || current.source !== entry.source || !current.translated.trim()
+      );
     })
     .map((entry) => ({
       id: entry.id,
@@ -943,15 +954,12 @@ export async function syncNativeLocale(
       sourcePath: entry.path,
     }));
   const translated = pending.length
-    ? await (options.translate ?? translateNativeEntries)(
-        pending,
-        locale,
-        options.glossary ?? (await loadGlossary(locale)),
-      )
+    ? await (options.translate ?? translateNativeEntries)(pending, locale, glossary)
     : new Map<string, string>();
   const artifact: NativeTranslationArtifact = {
     version: 1,
     locale,
+    glossaryHash,
     entries: entries.map((entry) => ({
       id: entry.id,
       source: entry.source,

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -154,6 +154,7 @@ const GENERATED_PATH_RE = /(?:^|[\\/])(?:build|\.gradle|\.build|DerivedData)(?:$
 const EXCLUDED_PATH_RE = /(?:^|[\\/])(?:Tests?|UITests?|test|Preview(?:s)?)(?:$|[\\/])/u;
 const EXCLUDED_FILE_RE = /(?:Tests?|UITests?|Previews?|Testing)\.(?:swift|kt|kts)$/u;
 const BUILD_SETTING_RE = /\$\([A-Za-z0-9_.-]+\)/gu;
+const NATIVE_I18N_LOCALE_SET = new Set<string>(NATIVE_I18N_LOCALES);
 
 function isTranslatableCandidate(source: string, kind: string): boolean {
   if (BUILD_SETTING_RE.test(source)) {
@@ -518,8 +519,27 @@ function enclosingCallName(source: string, offset: number): string | null {
 function structuralTokenSignature(source: string): string {
   const swift = extractSwiftInterpolations(source);
   const kotlin = extractKotlinInterpolations(source);
+  const buildSettings = source.match(BUILD_SETTING_RE) ?? [];
   const lineBreaks = (source.match(/\n/gu) ?? []).length;
-  return JSON.stringify({ swift, kotlin, lineBreaks });
+  return JSON.stringify({ swift, kotlin, buildSettings, lineBreaks });
+}
+
+function isTranslatableCandidate(source: string, kind: string): boolean {
+  if (BUILD_SETTING_RE.test(source)) {
+    BUILD_SETTING_RE.lastIndex = 0;
+    return false;
+  }
+  BUILD_SETTING_RE.lastIndex = 0;
+  if (/^[a-z0-9_.:/$-]+$/u.test(source) || /^[A-Z0-9_.:/$-]+$/u.test(source)) {
+    return false;
+  }
+  if (kind === "conditional-branch" && /^[a-z]+(?:[A-Z][A-Za-z0-9]*)+$/u.test(source)) {
+    return false;
+  }
+  if (/[{}[\]]/u.test(source) && !/(?:\\\(|\$\{)/u.test(source)) {
+    return false;
+  }
+  return kind !== "plist-string" || /\s/u.test(source);
 }
 
 function addCandidate(
@@ -964,6 +984,11 @@ async function main() {
   if (locale) {
     if (command !== "sync" || !process.argv.includes("--write")) {
       throw new Error("native locale refresh requires `sync --write --locale <code>`");
+    }
+    if (!NATIVE_I18N_LOCALE_SET.has(locale)) {
+      throw new Error(
+        `unsupported native locale "${locale}". Expected one of: ${NATIVE_I18N_LOCALES.join(", ")}`,
+      );
     }
     await syncNativeLocale(locale, await collectNativeI18nEntries());
   }

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -72,6 +72,7 @@ const SOURCE_ROOTS: Record<NativeI18nSurface, string[]> = {
 
 const ANDROID_EXTENSIONS = new Set([".kt", ".kts"]);
 const APPLE_EXTENSIONS = new Set([".swift", ".plist"]);
+const NATIVE_FORMAT_RE = /%(?:\d+\$)?[@a-z]/giu;
 const APPLE_UI_MULTILINE_CALLS =
   /(?:Text|Label|Button|TextField|SecureField|Picker|Section|LabeledContent|Toggle|Menu|ShareLink|Link|TextEditor|ProgressView|Gauge|DisclosureGroup|ControlGroup|DatePicker|Stepper)\s*\(\s*"""([\s\S]*?)"""/gu;
 const APPLE_CALL_START = /\b([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*/gu;
@@ -530,9 +531,10 @@ function enclosingCallName(source: string, offset: number): string | null {
 function structuralTokenSignature(source: string): string {
   const swift = extractSwiftInterpolations(source)?.toSorted();
   const kotlin = extractKotlinInterpolations(source)?.toSorted();
+  const nativeFormat = [...source.matchAll(NATIVE_FORMAT_RE)].map((match) => match[0]).toSorted();
   const buildSettings = (source.match(BUILD_SETTING_RE) ?? []).toSorted();
   const lineBreaks = (source.match(/\n/gu) ?? []).length;
-  return JSON.stringify({ swift, kotlin, buildSettings, lineBreaks });
+  return JSON.stringify({ swift, kotlin, nativeFormat, buildSettings, lineBreaks });
 }
 
 function addCandidate(

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -512,9 +512,10 @@ function enclosingCallName(source: string, offset: number): string | null {
 }
 
 function structuralTokenSignature(source: string): string {
-  const interpolations = [...source.matchAll(/\\\([^)]*\)/gu)].map((match) => match[0]);
+  const swift = extractSwiftInterpolations(source);
+  const kotlin = extractKotlinInterpolations(source);
   const lineBreaks = (source.match(/\n/gu) ?? []).length;
-  return JSON.stringify({ interpolations, lineBreaks });
+  return JSON.stringify({ swift, kotlin, lineBreaks });
 }
 
 function addCandidate(

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -50,9 +50,13 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "..");
 const OUTPUT_PATH = path.join(ROOT, "apps", ".i18n", "native-source.json");
 const TRANSLATIONS_DIR = path.join(ROOT, "apps", ".i18n", "native");
-const SOURCE_ROOTS: Record<NativeI18nSurface, string> = {
-  android: path.join(ROOT, "apps", "android", "app", "src", "main"),
-  apple: path.join(ROOT, "apps", "ios"),
+const SOURCE_ROOTS: Record<NativeI18nSurface, string[]> = {
+  android: [path.join(ROOT, "apps", "android", "app", "src", "main")],
+  apple: [
+    path.join(ROOT, "apps", "ios"),
+    path.join(ROOT, "apps", "macos", "Sources"),
+    path.join(ROOT, "apps", "shared", "OpenClawKit", "Sources"),
+  ],
 };
 
 const ANDROID_EXTENSIONS = new Set([".kt", ".kts"]);

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -523,29 +523,11 @@ function enclosingCallName(source: string, offset: number): string | null {
 }
 
 function structuralTokenSignature(source: string): string {
-  const swift = extractSwiftInterpolations(source);
-  const kotlin = extractKotlinInterpolations(source);
-  const buildSettings = source.match(BUILD_SETTING_RE) ?? [];
+  const swift = extractSwiftInterpolations(source)?.toSorted();
+  const kotlin = extractKotlinInterpolations(source)?.toSorted();
+  const buildSettings = (source.match(BUILD_SETTING_RE) ?? []).toSorted();
   const lineBreaks = (source.match(/\n/gu) ?? []).length;
   return JSON.stringify({ swift, kotlin, buildSettings, lineBreaks });
-}
-
-function isTranslatableCandidate(source: string, kind: string): boolean {
-  if (BUILD_SETTING_RE.test(source)) {
-    BUILD_SETTING_RE.lastIndex = 0;
-    return false;
-  }
-  BUILD_SETTING_RE.lastIndex = 0;
-  if (/^[a-z0-9_.:/$-]+$/u.test(source) || /^[A-Z0-9_.:/$-]+$/u.test(source)) {
-    return false;
-  }
-  if (kind === "conditional-branch" && /^[a-z]+(?:[A-Z][A-Za-z0-9]*)+$/u.test(source)) {
-    return false;
-  }
-  if (/[{}[\]]/u.test(source) && !/(?:\\\(|\$\{)/u.test(source)) {
-    return false;
-  }
-  return kind !== "plist-string" || /\s/u.test(source);
 }
 
 function addCandidate(

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { translateNativeEntries } from "./control-ui-i18n.ts";
 
 export type NativeI18nSurface = "android" | "apple";
 
@@ -39,17 +40,19 @@ export type NativeI18nEntry = {
 };
 
 type Candidate = Omit<NativeI18nEntry, "id">;
+type NativeTranslationArtifact = {
+  entries: Array<{ id: string; source: string; translated: string }>;
+  locale: string;
+  version: 1;
+};
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "..");
 const OUTPUT_PATH = path.join(ROOT, "apps", ".i18n", "native-source.json");
-const SOURCE_ROOTS: Record<NativeI18nSurface, string[]> = {
-  android: [path.join(ROOT, "apps", "android", "app", "src", "main")],
-  apple: [
-    path.join(ROOT, "apps", "ios"),
-    path.join(ROOT, "apps", "macos", "Sources"),
-    path.join(ROOT, "apps", "shared", "OpenClawKit", "Sources"),
-  ],
+const TRANSLATIONS_DIR = path.join(ROOT, "apps", ".i18n", "native");
+const SOURCE_ROOTS: Record<NativeI18nSurface, string> = {
+  android: path.join(ROOT, "apps", "android", "app", "src", "main"),
+  apple: path.join(ROOT, "apps", "ios"),
 };
 
 const ANDROID_EXTENSIONS = new Set([".kt", ".kts"]);
@@ -873,15 +876,77 @@ export async function syncNativeI18n(options: { checkOnly: boolean; write: boole
   process.stdout.write(`native-app-i18n: entries=${count} changed=${current !== expected}\n`);
 }
 
+async function loadGlossary(locale: string): Promise<Array<{ source: string; target: string }>> {
+  try {
+    return JSON.parse(
+      await readFile(
+        path.join(ROOT, "ui", "src", "i18n", ".i18n", `glossary.${locale}.json`),
+        "utf8",
+      ),
+    ) as Array<{ source: string; target: string }>;
+  } catch {
+    return [];
+  }
+}
+
+async function syncNativeLocale(locale: string, entries: NativeI18nEntry[]) {
+  const artifactPath = path.join(TRANSLATIONS_DIR, `${locale}.json`);
+  let previous: NativeTranslationArtifact = { entries: [], locale, version: 1 };
+  try {
+    previous = JSON.parse(await readFile(artifactPath, "utf8")) as NativeTranslationArtifact;
+  } catch {
+    // The first refresh creates the locale artifact.
+  }
+  const previousById = new Map(previous.entries.map((entry) => [entry.id, entry]));
+  const pending = entries
+    .filter((entry) => {
+      const current = previousById.get(entry.id);
+      return !current || current.source !== entry.source || !current.translated.trim();
+    })
+    .map((entry) => ({
+      id: entry.id,
+      source: entry.source,
+      sourcePath: entry.path,
+    }));
+  const translated = pending.length
+    ? await translateNativeEntries(pending, locale, await loadGlossary(locale))
+    : new Map<string, string>();
+  const artifact: NativeTranslationArtifact = {
+    version: 1,
+    locale,
+    entries: entries.map((entry) => ({
+      id: entry.id,
+      source: entry.source,
+      translated:
+        translated.get(entry.id) ?? previousById.get(entry.id)?.translated ?? entry.source,
+    })),
+  };
+  await mkdir(TRANSLATIONS_DIR, { recursive: true });
+  await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+  process.stdout.write(
+    `native-app-i18n: locale=${locale} entries=${entries.length} translated=${translated.size}\n`,
+  );
+}
+
 async function main() {
-  const [command] = process.argv.slice(2);
+  const [command, ...args] = process.argv.slice(2);
   if (command !== "check" && command !== "sync") {
-    throw new Error("usage: node --import tsx scripts/native-app-i18n.ts check|sync [--write]");
+    throw new Error(
+      "usage: node --import tsx scripts/native-app-i18n.ts check|sync [--write] [--locale <code>]",
+    );
   }
   await syncNativeI18n({
     checkOnly: command === "check",
     write: command === "sync" && process.argv.includes("--write"),
   });
+  const localeFlag = args.indexOf("--locale");
+  const locale = localeFlag >= 0 ? args[localeFlag + 1] : undefined;
+  if (locale) {
+    if (command !== "sync" || !process.argv.includes("--write")) {
+      throw new Error("native locale refresh requires `sync --write --locale <code>`");
+    }
+    await syncNativeLocale(locale, await collectNativeI18nEntries());
+  }
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -890,6 +890,8 @@ async function loadGlossary(locale: string): Promise<Array<{ source: string; tar
 }
 
 async function syncNativeLocale(locale: string, entries: NativeI18nEntry[]) {
+  // Native runtime resources are owned by the Android and Apple slices; these
+  // artifacts keep the shared translation-memory handoff current between them.
   const artifactPath = path.join(TRANSLATIONS_DIR, `${locale}.json`);
   let previous: NativeTranslationArtifact = { entries: [], locale, version: 1 };
   try {

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -911,6 +911,7 @@ describe("test-projects args", () => {
           "test/scripts/ios-team-id.test.ts",
           "test/scripts/ios-version.test.ts",
           "test/scripts/kitchen-sink-rpc-walk.test.ts",
+          "test/scripts/native-app-i18n.test.ts",
           "test/scripts/onboard-config-fixtures.test.ts",
           "test/scripts/parallels-lib-helpers.test.ts",
           "test/scripts/parallels-smoke-model.test.ts",

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -9,6 +9,7 @@ const CACHE_V5 = "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
 const UPLOAD_ARTIFACT_V7 = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
 const OPENGREP_PR_DIFF_WORKFLOW = ".github/workflows/opengrep-precise.yml";
 const OPENGREP_FULL_WORKFLOW = ".github/workflows/opengrep-precise-full.yml";
+const NATIVE_APP_LOCALE_REFRESH_WORKFLOW = ".github/workflows/native-app-locale-refresh.yml";
 
 function readCiWorkflow() {
   return parse(readFileSync(".github/workflows/ci.yml", "utf8"));
@@ -116,6 +117,22 @@ describe("ci workflow guards", () => {
 
   it("pins every external GitHub Action reference to a full commit SHA", () => {
     expect(findUnpinnedExternalActions()).toEqual([]);
+  });
+
+  it("keeps native locale refreshes main-only and rebases before retrying pushes", () => {
+    const source = readFileSync(NATIVE_APP_LOCALE_REFRESH_WORKFLOW, "utf8");
+    const workflow = parse(source);
+    const refresh = workflow.jobs.refresh;
+    const commitStep = refresh.steps.find(
+      (step: { name?: string }) => step.name === "Commit and push locale artifact",
+    );
+
+    expect(refresh.if).toContain("github.ref == 'refs/heads/main'");
+    expect(refresh.strategy.matrix.locale).toContain("sv");
+    expect(commitStep.run).toContain("for attempt in 1 2 3 4 5");
+    expect(commitStep.run).toContain('git fetch origin "${TARGET_BRANCH}"');
+    expect(commitStep.run).toContain('git rebase --autostash "origin/${TARGET_BRANCH}"');
+    expect(commitStep.run).toContain('git push origin HEAD:"${TARGET_BRANCH}"');
   });
 
   it("fails OpenGrep SARIF artifact uploads when reports are missing", () => {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -129,6 +129,7 @@ describe("ci workflow guards", () => {
 
     expect(refresh.if).toContain("github.ref == 'refs/heads/main'");
     expect(refresh.strategy.matrix.locale).toContain("sv");
+    expect(workflow.on.push.paths).toContain("ui/src/i18n/.i18n/glossary.*.json");
     expect(commitStep.run).toContain("for attempt in 1 2 3 4 5");
     expect(commitStep.run).toContain('git fetch origin "${TARGET_BRANCH}"');
     expect(commitStep.run).toContain('git rebase --autostash "origin/${TARGET_BRANCH}"');

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -9,6 +9,7 @@ const CACHE_V5 = "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
 const UPLOAD_ARTIFACT_V7 = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
 const OPENGREP_PR_DIFF_WORKFLOW = ".github/workflows/opengrep-precise.yml";
 const OPENGREP_FULL_WORKFLOW = ".github/workflows/opengrep-precise-full.yml";
+const CONTROL_UI_LOCALE_REFRESH_WORKFLOW = ".github/workflows/control-ui-locale-refresh.yml";
 const NATIVE_APP_LOCALE_REFRESH_WORKFLOW = ".github/workflows/native-app-locale-refresh.yml";
 
 function readCiWorkflow() {
@@ -119,7 +120,8 @@ describe("ci workflow guards", () => {
     expect(findUnpinnedExternalActions()).toEqual([]);
   });
 
-  it("keeps native locale refreshes main-only and rebases before retrying pushes", () => {
+  it("keeps locale refresh bots from cancelling active refresh matrices", () => {
+    const controlUiWorkflow = parse(readFileSync(CONTROL_UI_LOCALE_REFRESH_WORKFLOW, "utf8"));
     const source = readFileSync(NATIVE_APP_LOCALE_REFRESH_WORKFLOW, "utf8");
     const workflow = parse(source);
     const refresh = workflow.jobs.refresh;
@@ -129,6 +131,12 @@ describe("ci workflow guards", () => {
 
     expect(refresh.if).toContain("github.ref == 'refs/heads/main'");
     expect(refresh.strategy.matrix.locale).toContain("sv");
+    expect(controlUiWorkflow.concurrency["cancel-in-progress"]).toContain(
+      "github.actor != 'github-actions[bot]'",
+    );
+    expect(workflow.concurrency["cancel-in-progress"]).toContain(
+      "github.actor != 'github-actions[bot]'",
+    );
     expect(workflow.on.push.paths).toContain("ui/src/i18n/.i18n/glossary.*.json");
     expect(commitStep.run).toContain("for attempt in 1 2 3 4 5");
     expect(commitStep.run).toContain('git fetch origin "${TARGET_BRANCH}"');

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -197,6 +197,50 @@ describe("native app i18n inventory", () => {
     }
   });
 
+  it("rejects native printf placeholder drift", async () => {
+    const translationsDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-native-i18n-"));
+    const cases = [
+      {
+        entry: {
+          id: "native.android.certificate",
+          kind: "ui-call",
+          line: 1,
+          path: "apps/android/example.kt",
+          source: "Old fingerprint: %1$s\nNew fingerprint: %2$s",
+          surface: "android",
+        },
+        translated: "Gammalt fingeravtryck: %1$s",
+      },
+      {
+        entry: {
+          id: "native.apple.failure",
+          kind: "ui-call",
+          line: 1,
+          path: "apps/ios/example.swift",
+          source: "Send failed: %@",
+          surface: "apple",
+        },
+        translated: "Sändningen misslyckades",
+      },
+    ] satisfies Array<{ entry: NativeI18nEntry; translated: string }>;
+
+    try {
+      for (const { entry, translated } of cases) {
+        await expect(
+          syncNativeLocale("sv", [entry], {
+            glossary: [],
+            translationsDir,
+            translate: async () => new Map([[entry.id, translated]]),
+          }),
+        ).rejects.toThrow(
+          `native translation changed placeholders or line breaks for sv:${entry.id}`,
+        );
+      }
+    } finally {
+      await rm(translationsDir, { force: true, recursive: true });
+    }
+  });
+
   it("validates locale refresh arguments before write paths run", () => {
     expect(parseNativeI18nCommand(["sync", "--write", "--locale", "sv"])).toEqual({
       command: "sync",

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   collectNativeI18nEntries,
   NATIVE_I18N_LOCALES,
+  parseNativeI18nCommand,
   syncNativeLocale,
   type NativeI18nEntry,
 } from "../../scripts/native-app-i18n.ts";
@@ -194,5 +195,25 @@ describe("native app i18n inventory", () => {
     } finally {
       await rm(translationsDir, { force: true, recursive: true });
     }
+  });
+
+  it("validates locale refresh arguments before write paths run", () => {
+    expect(parseNativeI18nCommand(["sync", "--write", "--locale", "sv"])).toEqual({
+      command: "sync",
+      locale: "sv",
+      write: true,
+    });
+    expect(() => parseNativeI18nCommand(["sync", "--write", "--locale"])).toThrow(
+      "requires a locale value",
+    );
+    expect(() => parseNativeI18nCommand(["sync", "--write", "--locale", "--write"])).toThrow(
+      "requires a locale value",
+    );
+    expect(() => parseNativeI18nCommand(["sync", "--write", "--locale", "xx"])).toThrow(
+      "unsupported native locale",
+    );
+    expect(() => parseNativeI18nCommand(["check", "--locale", "sv"])).toThrow(
+      "requires `sync --write",
+    );
   });
 });

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -193,6 +193,23 @@ describe("native app i18n inventory", () => {
       expect(second).toEqual({ changed: false, translated: 0 });
       expect(await readFile(artifactPath, "utf8")).toBe(firstContents);
       expect((await stat(artifactPath)).mtimeMs).toBe(firstModifiedAt);
+
+      const refreshed = await syncNativeLocale("sv", entries, {
+        glossary: [{ source: "Request", target: "Begäran" }],
+        translationsDir,
+        translate: async (pending) =>
+          new Map(pending.map((entry) => [entry.id, `refreshed:${entry.source}`])),
+      });
+
+      expect(refreshed).toEqual({ changed: true, translated: 4 });
+      const refreshedArtifact = JSON.parse(await readFile(artifactPath, "utf8")) as {
+        entries: Array<{ translated: string }>;
+        glossaryHash: string;
+      };
+      expect(refreshedArtifact.glossaryHash).toMatch(/^[a-f0-9]{64}$/u);
+      expect(
+        refreshedArtifact.entries.every((entry) => entry.translated.startsWith("refreshed:")),
+      ).toBe(true);
     } finally {
       cleanupTempDirs(tempDirs);
     }

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -1,5 +1,13 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { collectNativeI18nEntries, NATIVE_I18N_LOCALES } from "../../scripts/native-app-i18n.ts";
+import {
+  collectNativeI18nEntries,
+  NATIVE_I18N_LOCALES,
+  syncNativeLocale,
+  type NativeI18nEntry,
+} from "../../scripts/native-app-i18n.ts";
 
 describe("native app i18n inventory", () => {
   it("collects stable Android and Apple UI entries", async () => {
@@ -111,5 +119,59 @@ describe("native app i18n inventory", () => {
     expect(entries.some((entry) => entry.path.endsWith("Info.plist"))).toBe(true);
     expect(NATIVE_I18N_LOCALES).toHaveLength(21);
     expect(NATIVE_I18N_LOCALES).toContain("sv");
+  });
+
+  it("creates a first-run locale artifact and leaves a complete artifact unchanged", async () => {
+    const translationsDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-native-i18n-"));
+    const entries: NativeI18nEntry[] = [
+      {
+        id: "native.android.hello",
+        kind: "ui-call",
+        line: 1,
+        path: "apps/android/example.kt",
+        source: "Hello",
+        surface: "android",
+      },
+      {
+        id: "native.apple.request",
+        kind: "ui-call",
+        line: 2,
+        path: "apps/ios/example.swift",
+        source: "Request ID: \\(requestId)",
+        surface: "apple",
+      },
+    ];
+
+    try {
+      const first = await syncNativeLocale("sv", entries, {
+        glossary: [],
+        translationsDir,
+        translate: async (pending) =>
+          new Map(
+            pending.map((entry) => [
+              entry.id,
+              entry.id.endsWith("hello") ? "Hej" : "Begärans-ID: \\(requestId)",
+            ]),
+          ),
+      });
+      expect(first).toEqual({ changed: true, translated: 2 });
+
+      const artifactPath = path.join(translationsDir, "sv.json");
+      const firstContents = await readFile(artifactPath, "utf8");
+      const firstModifiedAt = (await stat(artifactPath)).mtimeMs;
+      const second = await syncNativeLocale("sv", entries, {
+        glossary: [],
+        translationsDir,
+        translate: async () => {
+          throw new Error("no-op refresh must not call the provider");
+        },
+      });
+
+      expect(second).toEqual({ changed: false, translated: 0 });
+      expect(await readFile(artifactPath, "utf8")).toBe(firstContents);
+      expect((await stat(artifactPath)).mtimeMs).toBe(firstModifiedAt);
+    } finally {
+      await rm(translationsDir, { force: true, recursive: true });
+    }
   });
 });

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -140,6 +140,22 @@ describe("native app i18n inventory", () => {
         source: "Request ID: \\(requestId)",
         surface: "apple",
       },
+      {
+        id: "native.android.count",
+        kind: "ui-call",
+        line: 3,
+        path: "apps/android/example.kt",
+        source: "Showing ${visibleApps.size} of ${apps.size}",
+        surface: "android",
+      },
+      {
+        id: "native.apple.permissions",
+        kind: "ui-call",
+        line: 4,
+        path: "apps/ios/example.swift",
+        source: "\\(granted) of \\(total) permissions granted",
+        surface: "apple",
+      },
     ];
 
     try {
@@ -148,13 +164,18 @@ describe("native app i18n inventory", () => {
         translationsDir,
         translate: async (pending) =>
           new Map(
-            pending.map((entry) => [
-              entry.id,
-              entry.id.endsWith("hello") ? "Hej" : "Begärans-ID: \\(requestId)",
-            ]),
+            pending.map((entry) => {
+              const translated = {
+                "native.android.hello": "Hej",
+                "native.apple.request": "Begärans-ID: \\(requestId)",
+                "native.android.count": "${apps.size} totalt, ${visibleApps.size} visas",
+                "native.apple.permissions": "Av \\(total) behörigheter har \\(granted) beviljats",
+              }[entry.id];
+              return [entry.id, translated ?? entry.source];
+            }),
           ),
       });
-      expect(first).toEqual({ changed: true, translated: 2 });
+      expect(first).toEqual({ changed: true, translated: 4 });
 
       const artifactPath = path.join(translationsDir, "sv.json");
       const firstContents = await readFile(artifactPath, "utf8");

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -1,5 +1,4 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
-import os from "node:os";
+import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -9,6 +8,7 @@ import {
   syncNativeLocale,
   type NativeI18nEntry,
 } from "../../scripts/native-app-i18n.ts";
+import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 describe("native app i18n inventory", () => {
   it("collects stable Android and Apple UI entries", async () => {
@@ -123,7 +123,8 @@ describe("native app i18n inventory", () => {
   });
 
   it("creates a first-run locale artifact and leaves a complete artifact unchanged", async () => {
-    const translationsDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-native-i18n-"));
+    const tempDirs: string[] = [];
+    const translationsDir = makeTempDir(tempDirs, "openclaw-native-i18n-");
     const entries: NativeI18nEntry[] = [
       {
         id: "native.android.hello",
@@ -193,12 +194,13 @@ describe("native app i18n inventory", () => {
       expect(await readFile(artifactPath, "utf8")).toBe(firstContents);
       expect((await stat(artifactPath)).mtimeMs).toBe(firstModifiedAt);
     } finally {
-      await rm(translationsDir, { force: true, recursive: true });
+      cleanupTempDirs(tempDirs);
     }
   });
 
   it("rejects native printf placeholder drift", async () => {
-    const translationsDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-native-i18n-"));
+    const tempDirs: string[] = [];
+    const translationsDir = makeTempDir(tempDirs, "openclaw-native-i18n-");
     const cases = [
       {
         entry: {
@@ -237,7 +239,7 @@ describe("native app i18n inventory", () => {
         );
       }
     } finally {
-      await rm(translationsDir, { force: true, recursive: true });
+      cleanupTempDirs(tempDirs);
     }
   });
 

--- a/ui/src/i18n/.i18n/glossary.sv.json
+++ b/ui/src/i18n/.i18n/glossary.sv.json
@@ -1,0 +1,42 @@
+[
+  {
+    "source": "OpenClaw",
+    "target": "OpenClaw"
+  },
+  {
+    "source": "Gateway",
+    "target": "Gateway"
+  },
+  {
+    "source": "Control UI",
+    "target": "Control UI"
+  },
+  {
+    "source": "Skills",
+    "target": "Skills"
+  },
+  {
+    "source": "Tailscale",
+    "target": "Tailscale"
+  },
+  {
+    "source": "WhatsApp",
+    "target": "WhatsApp"
+  },
+  {
+    "source": "Telegram",
+    "target": "Telegram"
+  },
+  {
+    "source": "Discord",
+    "target": "Discord"
+  },
+  {
+    "source": "Signal",
+    "target": "Signal"
+  },
+  {
+    "source": "iMessage",
+    "target": "iMessage"
+  }
+]


### PR DESCRIPTION
## What Problem This Solves

Native app locale work needs the same provider-backed translation process as Control UI, not a separate manual path or a Russian/Hindi-only workflow.

## Why This Change Was Made

Reuse the existing translation client, provider/model environment, glossary prompt, batching, retries, and authenticated CI commit/rebase loop for the complete 21-locale native matrix. The workflow refreshes deterministic translation-memory artifacts under `apps/.i18n/native` whenever Android or Apple source changes and correctly commits first-run artifacts.

Argument validation happens before writes, placeholder signatures preserve counts while allowing grammatical reordering, and Swedish uses the same protected-brand glossary process as the other locales.

## User Impact

Native inventory changes are translated through the Control UI process for Simplified Chinese, Traditional Chinese, Brazilian Portuguese, German, Spanish, Japanese, Korean, French, Hindi, Arabic, Italian, Turkish, Ukrainian, Indonesian, Polish, Thai, Vietnamese, Dutch, Persian, Russian, and Swedish.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/native-app-i18n.test.ts` (35 tests)
- `node --import tsx scripts/native-app-i18n.ts check` (`2,318` entries)
- Workflow matrix: `21` locales, `max-parallel: 2`, authenticated fetch/rebase/push retry loop
- `git diff --check`
- Fresh autoreview: no accepted/actionable findings

This PR is stacked on #97110.
