### PR TITLE
ci: right-size runner registration caps

### DIFF
--- a/.agents/skills/openclaw-ci-limits/SKILL.md
+++ b/.agents/skills/openclaw-ci-limits/SKILL.md
@@ -13,12 +13,13 @@ registration edge limit.
 
 - The scarce resource is Blacksmith runner registrations, not Blacksmith vCPU
   capacity.
-- GitHub runner registrations are capped at 1,500 per 5 minutes per repository,
-  organization, or enterprise. The `openclaw` organization shares one bucket.
+- GitHub runner registrations for `openclaw` are currently capped at 3,000 per
+  5 minutes per repository, organization, or enterprise. The `openclaw`
+  organization shares one bucket.
 - Core REST quota does not draw down this bucket. Check
   `actions_runner_registration` separately; core quota can be healthy while
   runner registration is throttled.
-- Use 1,000 registrations per 5 minutes as the operating target. Leave the last
+- Use 2,000 registrations per 5 minutes as the operating target. Leave the last
   third for other repos, retries, and burst overlap.
 - Jobs that route, notify, summarize, choose shards, or run short CodeQL quality
   scans should stay on GitHub-hosted runners unless measured evidence says
@@ -87,7 +88,7 @@ admission. The debounce only suppresses pushes that arrive while
 registrations are spent even if a later push cancels the run. If timing is
 uncertain, count every sequential push in the window.
 
-Reject a change unless the org-level worst case stays below 1,000 registrations
+Reject a change unless the org-level worst case stays below 2,000 registrations
 per 5 minutes with headroom for ClawSweeper, ClawHub, Clownfish, OpenClaw RTT,
 and Clawbench.
 
@@ -127,8 +128,8 @@ These are intentionally guarded by `test/scripts/ci-workflow-guards.test.ts`:
 - `runner-admission` on `ubuntu-24.04` with
   `OPENCLAW_MAIN_CI_DEBOUNCE_SECONDS=90`.
 - `preflight` and `security-fast` needing `runner-admission`.
-- CI matrix caps: fast/check lanes at 8, compact Node PR plan at current caps,
-  Windows and Android at 2.
+- CI matrix caps: fast/check lanes at 12, Node test shards at 24, Windows and
+  Android at 2.
 - `build-artifacts` on `blacksmith-16vcpu-ubuntu-2404`.
 - lower-weight Node/check shards on `blacksmith-4vcpu-ubuntu-2404`.
 - heavy retained Linux/Android shards on `blacksmith-8vcpu-ubuntu-2404`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -858,7 +858,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 12
       matrix: ${{ fromJson(needs.preflight.outputs.checks_fast_core_matrix) }}
     steps:
       - name: Checkout
@@ -977,7 +977,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 12
       matrix: ${{ fromJson(needs.preflight.outputs.plugin_contracts_matrix) }}
     steps:
       - name: Checkout
@@ -1058,7 +1058,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 12
       matrix: ${{ fromJson(needs.preflight.outputs.channel_contracts_matrix) }}
     steps:
       - name: Checkout
@@ -1212,8 +1212,8 @@ jobs:
     strategy:
       fail-fast: false
       # The canonical main path waits for the admission debounce above, so
-      # modestly widen this large matrix without recreating registration bursts.
-      max-parallel: 16
+      # widen this large matrix within the current runner-registration budget.
+      max-parallel: 24
       matrix: ${{ fromJson(needs.preflight.outputs.checks_node_core_nondist_matrix) }}
     steps:
       - name: Checkout
@@ -1351,7 +1351,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 12
       matrix:
         include:
           - check_name: check-guards
@@ -1493,7 +1493,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 12
       matrix:
         include:
           - check_name: check-additional-boundaries-a

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -90,9 +90,9 @@ Scope logic lives in `scripts/ci-changed-scope.mjs` and is covered by unit tests
 
 The slowest Node test families are split or balanced so each job stays small without over-reserving runners: plugin contracts and channel contracts each run as two weighted Blacksmith-backed shards with the standard GitHub runner fallback, core unit fast/support lanes run separately, core runtime infra is split between state, process/config, shared, and three cron domain shards, auto-reply runs as balanced workers (with the reply subtree split into agent-runner, dispatch, and commands/state-routing shards), and agentic gateway/server configs are split across chat/auth/model/http-plugin/runtime/startup lanes instead of waiting on built artifacts. Normal CI then packs only isolated infra include-pattern shards into deterministic bundles of at most 64 test files, reducing the Node matrix without merging non-isolated command/cron, stateful agents-core, or gateway/server suites; heavy fixed suites stay on 8 vCPU while the bundled and lower-weight lanes use 4 vCPU. Pull requests on the canonical repository use an additional compact admission plan: the same per-config groups run in isolated subprocesses inside the current 34-job Linux Node plan, so a single PR does not register the full 70-plus-job Node matrix. `main` pushes, manual dispatches, and release gates retain the full matrix. Broad browser, QA, media, and miscellaneous plugin tests use their dedicated Vitest configs instead of the shared plugin catch-all. Include-pattern shards record timing entries using the CI shard name, so `.artifacts/vitest-shard-timings.json` can distinguish a whole config from a filtered shard. `check-additional-*` keeps package-boundary compile/canary work together and separates runtime topology architecture from gateway watch coverage; the boundary guard list is striped into one prompt-heavy shard and one combined shard for the remaining guard stripes, each running selected independent guards concurrently and printing per-check timings. The expensive Codex happy-path prompt snapshot drift check runs as its own additional job for manual CI and for prompt-affecting changes only, so normal unrelated Node changes do not wait behind cold prompt snapshot generation and the boundary shards stay balanced while prompt drift is still pinned to the PR that caused it; the same flag skips prompt snapshot Vitest generation inside the built-artifact core support-boundary shard. Gateway watch, channel tests, and the core support-boundary shard run concurrently inside `build-artifacts` after `dist/` and `dist-runtime/` are already built.
 
-Once admitted, canonical Linux CI permits up to 12 concurrent Node jobs and 8 for
-the smaller fast/check lanes; Windows and Android stay at two because those
-runner pools are narrower.
+Once admitted, canonical Linux CI permits up to 24 concurrent Node test jobs and
+12 for the smaller fast/check lanes; Windows and Android stay at two because
+those runner pools are narrower.
 
 The compact PR plan emits 18 Node jobs for the current suite: whole-config
 groups are batched in isolated subprocesses with a 120-minute batch timeout,
@@ -145,17 +145,17 @@ gh workflow run full-release-validation.yml --ref main -f ref=<branch-or-sha>
 
 ## Runner registration budget
 
-GitHub caps self-hosted runner registrations at 1,500 runners per 5 minutes per
-repository, organization, or enterprise. The limit is shared by all Blacksmith
-runner registrations in the `openclaw` organization, so adding another
-Blacksmith installation does not add a new bucket.
+OpenClaw's current GitHub runner-registration bucket allows 3,000 self-hosted
+runner registrations per 5 minutes. The limit is shared by all Blacksmith runner
+registrations in the `openclaw` organization, so adding another Blacksmith
+installation does not add a new bucket.
 
 Treat Blacksmith labels as the scarce resource for burst control. Jobs that
 only route, notify, summarize, select shards, or run short CodeQL scans should
 stay on GitHub-hosted runners unless they have measured Blacksmith-specific
 needs. Any new Blacksmith matrix, larger `max-parallel`, or high-frequency
 workflow must show its worst-case registration count and keep the org-level
-target below 1,000 registrations per 5 minutes, leaving headroom for concurrent
+target below 2,000 registrations per 5 minutes, leaving headroom for concurrent
 repositories and retried jobs.
 
 Canonical-repo CI keeps Blacksmith as the default runner path for normal push and pull-request runs. `workflow_dispatch` and non-canonical repository runs use GitHub-hosted runners, but normal canonical runs do not currently probe Blacksmith queue health or automatically fall back to GitHub-hosted labels when Blacksmith is unavailable.

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -182,12 +182,12 @@ describe("ci workflow guards", () => {
     expect(workflow.concurrency["cancel-in-progress"]).toContain(
       "github.event_name == 'pull_request'",
     );
-    expect(workflow.jobs["checks-fast-core"].strategy["max-parallel"]).toBe(8);
-    expect(workflow.jobs["checks-node-core-test-nondist-shard"].strategy["max-parallel"]).toBe(16);
-    expect(workflow.jobs["checks-fast-plugin-contracts-shard"].strategy["max-parallel"]).toBe(8);
-    expect(workflow.jobs["checks-fast-channel-contracts-shard"].strategy["max-parallel"]).toBe(8);
-    expect(workflow.jobs["check-shard"].strategy["max-parallel"]).toBe(8);
-    expect(workflow.jobs["check-additional-shard"].strategy["max-parallel"]).toBe(8);
+    expect(workflow.jobs["checks-fast-core"].strategy["max-parallel"]).toBe(12);
+    expect(workflow.jobs["checks-node-core-test-nondist-shard"].strategy["max-parallel"]).toBe(24);
+    expect(workflow.jobs["checks-fast-plugin-contracts-shard"].strategy["max-parallel"]).toBe(12);
+    expect(workflow.jobs["checks-fast-channel-contracts-shard"].strategy["max-parallel"]).toBe(12);
+    expect(workflow.jobs["check-shard"].strategy["max-parallel"]).toBe(12);
+    expect(workflow.jobs["check-additional-shard"].strategy["max-parallel"]).toBe(12);
     expect(workflow.jobs["checks-windows"].strategy["max-parallel"]).toBe(2);
     expect(workflow.jobs.android.strategy["max-parallel"]).toBe(2);
   });


### PR DESCRIPTION
## What Problem This Solves

GitHub increased the OpenClaw runner-registration bucket to 3,000 self-hosted registrations per 5 minutes. Our CI limits and maintainer guidance were still sized around the older 1,500 bucket, leaving safe throughput on the table while main CI remained slower than needed.

## Why This Change Was Made

This keeps the existing burst protections, main-push debounce, compact PR plan, and platform caps, but right-sizes the Linux CI max-parallel values for the new bucket. The operating target moves from 1,000 to 2,000 registrations per 5 minutes so we still reserve roughly one-third of the org bucket for ClawSweeper, ClawHub, retries, and overlapping repo activity.

## User Impact

Main and PR CI should admit more Linux work once a run passes the debounce, without adding jobs or moving CodeQL back to Blacksmith. Windows and Android stay capped at two.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`
- `node scripts/check-workflows.mjs`
- `node scripts/docs-list.js`
- `./node_modules/.bin/oxfmt --check .github/workflows/ci.yml docs/ci.md test/scripts/ci-workflow-guards.test.ts .agents/skills/openclaw-ci-limits/SKILL.md`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean

Operational note: attempted to cancel 77 stale queued OpenClaw Actions runs older than 24h. GitHub returned backend 500s for normal cancel and force-cancel; sample force-cancel request id: `10DD:262C01:388DA56:396FE3F:6A3F0152`.
