### PR TITLE
fix(matrix): truncate thread starter body on code-point boundaries

### DIFF
--- a/extensions/matrix/src/matrix/monitor/thread-context.test.ts
+++ b/extensions/matrix/src/matrix/monitor/thread-context.test.ts
@@ -23,6 +23,23 @@ describe("matrix thread context", () => {
     ).toBe("Thread starter body");
   });
 
+  it("truncates long thread starter bodies on code-point boundaries", () => {
+    const summary = summarizeMatrixThreadStarterEvent({
+      event_id: "$root",
+      sender: "@alice:example.org",
+      type: "m.room.message",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        // 496 "a" + astral emoji (surrogate pair at units 496-497) + tail.
+        // A raw slice(0, 497) would cut the pair and leave a lone high surrogate.
+        body: `${"a".repeat(496)}\u{1F600}bcd`,
+      },
+    } as MatrixRawEvent);
+    expect(summary).toBe(`${"a".repeat(496)}...`);
+    expect(summary && /[\uD800-\uDFFF]/.test(summary)).toBe(false);
+  });
+
   it("marks media-only thread starter events instead of returning bare filenames", () => {
     expect(
       summarizeMatrixThreadStarterEvent({

--- a/extensions/matrix/src/matrix/monitor/thread-context.ts
+++ b/extensions/matrix/src/matrix/monitor/thread-context.ts
@@ -1,4 +1,5 @@
 // Matrix plugin module implements thread context behavior.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixClient } from "../sdk.js";
 import { summarizeMatrixMessageContextEvent, trimMatrixMaybeString } from "./context-summary.js";
 import type { MatrixRawEvent } from "./types.js";
@@ -17,7 +18,7 @@ function truncateThreadStarterBody(value: string): string {
   if (value.length <= MAX_THREAD_STARTER_BODY_LENGTH) {
     return value;
   }
-  return `${value.slice(0, MAX_THREAD_STARTER_BODY_LENGTH - 3)}...`;
+  return `${sliceUtf16Safe(value, 0, MAX_THREAD_STARTER_BODY_LENGTH - 3)}...`;
 }
 
 export function summarizeMatrixThreadStarterEvent(event: MatrixRawEvent): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Matrix thread-starter previews truncate long bodies by raw UTF-16 code-unit slice. If the boundary lands inside an astral character such as an emoji, the preview keeps a lone surrogate and renders mojibake in the agent's thread context.

## Why This Change Was Made

`truncateThreadStarterBody` is the canonical producer of the bounded thread-starter body. This reuses the existing public `sliceUtf16Safe` helper (via `openclaw/plugin-sdk/text-utility-runtime`, the same path Discord/Slack/iMessage already use) so the cut backs up to a valid surrogate boundary while preserving the 500-code-unit limit and `...` suffix.

## User Impact

Long Matrix thread starters no longer split emoji or other astral characters at the truncation boundary. Short bodies and BMP-only text retain their existing output.

## Evidence

- **Current `main` reproduces the defect:** body `"a"×496 + 😀 (U+1F600) + "bcd"`, `MAX_THREAD_STARTER_BODY_LENGTH=500`, so the cut at `497` lands mid-pair and leaves a lone high surrogate (U+D83D) before the ellipsis.
- **Regression test fails against pre-fix source, passes with the fix.** Verified by reverting only the source change and rerunning: the new test goes red (`× truncates long thread starter bodies on code-point boundaries`), then green once the fix is restored.
- **Focused Matrix suite on this branch:** `6/6` passed (`node scripts/run-vitest.mjs extensions/matrix/src/matrix/monitor/thread-context.test.ts`).
- **`git diff --check`** clean.

## Scope

Exactly **2 files, +19/-1** — `thread-context.ts` and its regression test. No unrelated changes.

## Provenance and Credit

Clean re-creation of #96407 / #96961 (both auto-closed — #96961 by the dirty-branch guard after an unrelated commit contaminated the branch). This branch is rebased fresh onto current `main` with only the Matrix two-file fix. Preserves @ly-wang19's original authorship; rebased by @Bartok9.
