### PR TITLE
ci(docker): publish releases to Docker Hub

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing release tag to backfill (for example v2026.3.22)
+        description: Existing stable or beta release tag to backfill (for example v2026.3.22 or v2026.3.22-beta.1)
         required: true
         type: string
 
@@ -591,7 +591,8 @@ jobs:
               browser_tags+=("${GHCR_IMAGE}:${version}-browser")
               dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:${version}-browser")
             fi
-            # Manual backfills should only republish the requested version tags.
+            # Beta releases and manual backfills publish only immutable version tags;
+            # do not advance latest/main aliases from those flows.
             if [[ "${IS_MANUAL_BACKFILL}" != "1" && "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$ ]]; then
               tags+=("${GHCR_IMAGE}:latest" "${GHCR_IMAGE}:main")
               slim_tags+=("${GHCR_IMAGE}:slim" "${GHCR_IMAGE}:main-slim")
@@ -776,6 +777,8 @@ jobs:
               arm64_refs+=("${GHCR_IMAGE}:${version}-browser-arm64")
               dockerhub_arm64_refs+=("${DOCKERHUB_IMAGE}:${version}-browser-arm64")
             fi
+            # Beta releases and manual backfills publish only immutable version tags;
+            # do not advance latest/main aliases from those flows.
             if [[ "${IS_MANUAL_BACKFILL}" != "1" && "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$ ]]; then
               multi_refs+=("${GHCR_IMAGE}:latest" "${GHCR_IMAGE}:main")
               slim_multi_refs+=("${GHCR_IMAGE}:slim" "${GHCR_IMAGE}:main-slim")

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -26,6 +26,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  DOCKERHUB_REGISTRY: docker.io
+  DOCKERHUB_IMAGE_NAME: openclaw/openclaw
 
 jobs:
   validate_manual_backfill:
@@ -67,12 +69,30 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
         run: echo "Approved Docker backfill for $RELEASE_TAG"
 
+  validate_publish_config:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Validate Docker Hub publish credentials
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
+            echo "::error::Docker Hub publishing requires DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets."
+            exit 1
+          fi
+          echo "Docker Hub publishing configured for ${DOCKERHUB_IMAGE}."
+
   # KEEP THIS WORKFLOW ON GITHUB-HOSTED RUNNERS.
   # DO NOT MOVE IT BACK TO BLACKSMITH WITHOUT RE-VALIDATING TAG BUILDS AND BACKFILLS.
   # Build amd64 image. Default and slim tags point to the same slim runtime.
   build-amd64:
-    needs: [approve_manual_backfill]
-    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
+    needs: [approve_manual_backfill, validate_publish_config]
+    if: ${{ always() && needs.validate_publish_config.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
     # WARNING: DO NOT REVERT THIS TO A BLACKSMITH RUNNER WITHOUT RE-VALIDATING TAG BACKFILLS.
     runs-on: ubuntu-24.04
     permissions:
@@ -117,28 +137,39 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Resolve image tags (amd64)
         id: tags
         shell: bash
         env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
         run: |
           set -euo pipefail
           tags=()
           slim_tags=()
           browser_tags=()
+          images=("${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}")
           browser_supported=0
           if grep -q '^ARG OPENCLAW_INSTALL_BROWSER' Dockerfile; then
             browser_supported=1
           fi
           if [[ "${SOURCE_REF}" == refs/tags/v* ]]; then
             version="${SOURCE_REF#refs/tags/v}"
-            tags+=("${IMAGE}:${version}-amd64")
-            slim_tags+=("${IMAGE}:${version}-slim-amd64")
-            if [[ "${browser_supported}" == "1" ]]; then
-              browser_tags+=("${IMAGE}:${version}-browser-amd64")
-            fi
+            for image in "${images[@]}"; do
+              tags+=("${image}:${version}-amd64")
+              slim_tags+=("${image}:${version}-slim-amd64")
+              if [[ "${browser_supported}" == "1" ]]; then
+                browser_tags+=("${image}:${version}-browser-amd64")
+              fi
+            done
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No amd64 tags resolved for ref ${SOURCE_REF}"
@@ -281,8 +312,8 @@ jobs:
 
   # Build arm64 image. Default and slim tags point to the same slim runtime.
   build-arm64:
-    needs: [approve_manual_backfill]
-    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
+    needs: [approve_manual_backfill, validate_publish_config]
+    if: ${{ always() && needs.validate_publish_config.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
     # WARNING: DO NOT REVERT THIS TO A BLACKSMITH RUNNER WITHOUT RE-VALIDATING TAG BACKFILLS.
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -327,28 +358,39 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Resolve image tags (arm64)
         id: tags
         shell: bash
         env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
         run: |
           set -euo pipefail
           tags=()
           slim_tags=()
           browser_tags=()
+          images=("${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}")
           browser_supported=0
           if grep -q '^ARG OPENCLAW_INSTALL_BROWSER' Dockerfile; then
             browser_supported=1
           fi
           if [[ "${SOURCE_REF}" == refs/tags/v* ]]; then
             version="${SOURCE_REF#refs/tags/v}"
-            tags+=("${IMAGE}:${version}-arm64")
-            slim_tags+=("${IMAGE}:${version}-slim-arm64")
-            if [[ "${browser_supported}" == "1" ]]; then
-              browser_tags+=("${IMAGE}:${version}-browser-arm64")
-            fi
+            for image in "${images[@]}"; do
+              tags+=("${image}:${version}-arm64")
+              slim_tags+=("${image}:${version}-slim-arm64")
+              if [[ "${browser_supported}" == "1" ]]; then
+                browser_tags+=("${image}:${version}-browser-arm64")
+              fi
+            done
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No arm64 tags resolved for ref ${SOURCE_REF}"
@@ -491,8 +533,8 @@ jobs:
 
   # Create multi-platform manifests
   create-manifest:
-    needs: [approve_manual_backfill, build-amd64, build-arm64]
-    if: ${{ always() && needs.build-amd64.result == 'success' && needs.build-arm64.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
+    needs: [approve_manual_backfill, validate_publish_config, build-amd64, build-arm64]
+    if: ${{ always() && needs.validate_publish_config.result == 'success' && needs.build-amd64.result == 'success' && needs.build-arm64.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.approve_manual_backfill.result == 'success') }}
     # WARNING: DO NOT REVERT THIS TO A BLACKSMITH RUNNER WITHOUT RE-VALIDATING TAG BACKFILLS.
     runs-on: ubuntu-24.04
     permissions:
@@ -512,11 +554,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Resolve manifest tags
         id: tags
         shell: bash
         env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
           IS_MANUAL_BACKFILL: ${{ github.event_name == 'workflow_dispatch' && '1' || '0' }}
         run: |
@@ -524,23 +574,32 @@ jobs:
           tags=()
           slim_tags=()
           browser_tags=()
+          dockerhub_tags=()
+          dockerhub_slim_tags=()
+          dockerhub_browser_tags=()
           browser_supported=0
           if grep -q '^ARG OPENCLAW_INSTALL_BROWSER' Dockerfile; then
             browser_supported=1
           fi
           if [[ "${SOURCE_REF}" == refs/tags/v* ]]; then
             version="${SOURCE_REF#refs/tags/v}"
-            tags+=("${IMAGE}:${version}")
-            slim_tags+=("${IMAGE}:${version}-slim")
+            tags+=("${GHCR_IMAGE}:${version}")
+            slim_tags+=("${GHCR_IMAGE}:${version}-slim")
+            dockerhub_tags+=("${DOCKERHUB_IMAGE}:${version}")
+            dockerhub_slim_tags+=("${DOCKERHUB_IMAGE}:${version}-slim")
             if [[ "${browser_supported}" == "1" ]]; then
-              browser_tags+=("${IMAGE}:${version}-browser")
+              browser_tags+=("${GHCR_IMAGE}:${version}-browser")
+              dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:${version}-browser")
             fi
             # Manual backfills should only republish the requested version tags.
             if [[ "${IS_MANUAL_BACKFILL}" != "1" && "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$ ]]; then
-              tags+=("${IMAGE}:latest" "${IMAGE}:main")
-              slim_tags+=("${IMAGE}:slim" "${IMAGE}:main-slim")
+              tags+=("${GHCR_IMAGE}:latest" "${GHCR_IMAGE}:main")
+              slim_tags+=("${GHCR_IMAGE}:slim" "${GHCR_IMAGE}:main-slim")
+              dockerhub_tags+=("${DOCKERHUB_IMAGE}:latest" "${DOCKERHUB_IMAGE}:main")
+              dockerhub_slim_tags+=("${DOCKERHUB_IMAGE}:slim" "${DOCKERHUB_IMAGE}:main-slim")
               if [[ "${browser_supported}" == "1" ]]; then
-                browser_tags+=("${IMAGE}:latest-browser" "${IMAGE}:main-browser")
+                browser_tags+=("${GHCR_IMAGE}:latest-browser" "${GHCR_IMAGE}:main-browser")
+                dockerhub_browser_tags+=("${DOCKERHUB_IMAGE}:latest-browser" "${DOCKERHUB_IMAGE}:main-browser")
               fi
             fi
           fi
@@ -555,13 +614,23 @@ jobs:
             echo "browser<<EOF"
             printf "%s\n" "${browser_tags[@]}"
             echo "EOF"
+            echo "dockerhub<<EOF"
+            printf "%s\n" "${dockerhub_tags[@]}" "${dockerhub_slim_tags[@]}"
+            echo "EOF"
+            echo "dockerhub_browser<<EOF"
+            printf "%s\n" "${dockerhub_browser_tags[@]}"
+            echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create and push manifest
         shell: bash
         env:
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
           TAGS: ${{ steps.tags.outputs.value }}
           BROWSER_TAGS: ${{ steps.tags.outputs.browser }}
+          DOCKERHUB_TAGS: ${{ steps.tags.outputs.dockerhub }}
+          DOCKERHUB_BROWSER_TAGS: ${{ steps.tags.outputs.dockerhub_browser }}
           AMD64_DIGEST: ${{ needs.build-amd64.outputs.digest }}
           ARM64_DIGEST: ${{ needs.build-arm64.outputs.digest }}
           AMD64_BROWSER_DIGEST: ${{ needs.build-amd64.outputs.browser_digest }}
@@ -570,6 +639,8 @@ jobs:
           set -euo pipefail
           mapfile -t tags <<< "${TAGS}"
           mapfile -t browser_tags <<< "${BROWSER_TAGS}"
+          mapfile -t dockerhub_tags <<< "${DOCKERHUB_TAGS}"
+          mapfile -t dockerhub_browser_tags <<< "${DOCKERHUB_BROWSER_TAGS}"
           create_manifest() {
             local amd64_digest="$1"
             local arm64_digest="$2"
@@ -582,8 +653,20 @@ jobs:
             docker buildx imagetools create "${args[@]}" "$amd64_digest" "$arm64_digest"
           }
           create_manifest "${AMD64_DIGEST}" "${ARM64_DIGEST}" "${tags[@]}"
+          if [[ "${SOURCE_REF}" != refs/tags/v* ]]; then
+            echo "::error::No Docker Hub source refs resolved for ref ${SOURCE_REF}"
+            exit 1
+          fi
+          version="${SOURCE_REF#refs/tags/v}"
+          create_manifest "${DOCKERHUB_IMAGE}:${version}-amd64" "${DOCKERHUB_IMAGE}:${version}-arm64" "${dockerhub_tags[@]}"
           if [[ -n "${BROWSER_TAGS}" ]]; then
             create_manifest "${AMD64_BROWSER_DIGEST}" "${ARM64_BROWSER_DIGEST}" "${browser_tags[@]}"
+          fi
+          if [[ -n "${DOCKERHUB_BROWSER_TAGS}" ]]; then
+            create_manifest \
+              "${DOCKERHUB_IMAGE}:${version}-browser-amd64" \
+              "${DOCKERHUB_IMAGE}:${version}-browser-arm64" \
+              "${dockerhub_browser_tags[@]}"
           fi
 
   verify-attestations:
@@ -628,11 +711,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Resolve image refs
         id: refs
         shell: bash
         env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
           IS_MANUAL_BACKFILL: ${{ github.event_name == 'workflow_dispatch' && '1' || '0' }}
         run: |
@@ -641,6 +732,10 @@ jobs:
           slim_multi_refs=()
           amd64_refs=()
           arm64_refs=()
+          dockerhub_multi_refs=()
+          dockerhub_slim_multi_refs=()
+          dockerhub_amd64_refs=()
+          dockerhub_arm64_refs=()
           browser_supported=0
           if [[ "${SOURCE_REF}" == refs/tags/v* ]]; then
             tag="${SOURCE_REF#refs/tags/}"
@@ -653,30 +748,46 @@ jobs:
           fi
           if [[ "${SOURCE_REF}" == refs/tags/v* ]]; then
             version="${SOURCE_REF#refs/tags/v}"
-            multi_refs+=("${IMAGE}:${version}")
-            slim_multi_refs+=("${IMAGE}:${version}-slim")
+            multi_refs+=("${GHCR_IMAGE}:${version}")
+            slim_multi_refs+=("${GHCR_IMAGE}:${version}-slim")
+            dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:${version}")
+            dockerhub_slim_multi_refs+=("${DOCKERHUB_IMAGE}:${version}-slim")
             amd64_refs+=(
-              "${IMAGE}:${version}-amd64"
-              "${IMAGE}:${version}-slim-amd64"
+              "${GHCR_IMAGE}:${version}-amd64"
+              "${GHCR_IMAGE}:${version}-slim-amd64"
+            )
+            dockerhub_amd64_refs+=(
+              "${DOCKERHUB_IMAGE}:${version}-amd64"
+              "${DOCKERHUB_IMAGE}:${version}-slim-amd64"
             )
             arm64_refs+=(
-              "${IMAGE}:${version}-arm64"
-              "${IMAGE}:${version}-slim-arm64"
+              "${GHCR_IMAGE}:${version}-arm64"
+              "${GHCR_IMAGE}:${version}-slim-arm64"
+            )
+            dockerhub_arm64_refs+=(
+              "${DOCKERHUB_IMAGE}:${version}-arm64"
+              "${DOCKERHUB_IMAGE}:${version}-slim-arm64"
             )
             if [[ "${browser_supported}" == "1" ]]; then
-              multi_refs+=("${IMAGE}:${version}-browser")
-              amd64_refs+=("${IMAGE}:${version}-browser-amd64")
-              arm64_refs+=("${IMAGE}:${version}-browser-arm64")
+              multi_refs+=("${GHCR_IMAGE}:${version}-browser")
+              dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:${version}-browser")
+              amd64_refs+=("${GHCR_IMAGE}:${version}-browser-amd64")
+              dockerhub_amd64_refs+=("${DOCKERHUB_IMAGE}:${version}-browser-amd64")
+              arm64_refs+=("${GHCR_IMAGE}:${version}-browser-arm64")
+              dockerhub_arm64_refs+=("${DOCKERHUB_IMAGE}:${version}-browser-arm64")
             fi
             if [[ "${IS_MANUAL_BACKFILL}" != "1" && "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$ ]]; then
-              multi_refs+=("${IMAGE}:latest" "${IMAGE}:main")
-              slim_multi_refs+=("${IMAGE}:slim" "${IMAGE}:main-slim")
+              multi_refs+=("${GHCR_IMAGE}:latest" "${GHCR_IMAGE}:main")
+              slim_multi_refs+=("${GHCR_IMAGE}:slim" "${GHCR_IMAGE}:main-slim")
+              dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:latest" "${DOCKERHUB_IMAGE}:main")
+              dockerhub_slim_multi_refs+=("${DOCKERHUB_IMAGE}:slim" "${DOCKERHUB_IMAGE}:main-slim")
               if [[ "${browser_supported}" == "1" ]]; then
-                multi_refs+=("${IMAGE}:latest-browser" "${IMAGE}:main-browser")
+                multi_refs+=("${GHCR_IMAGE}:latest-browser" "${GHCR_IMAGE}:main-browser")
+                dockerhub_multi_refs+=("${DOCKERHUB_IMAGE}:latest-browser" "${DOCKERHUB_IMAGE}:main-browser")
               fi
             fi
           fi
-          if [[ ${#multi_refs[@]} -eq 0 || ${#amd64_refs[@]} -eq 0 || ${#arm64_refs[@]} -eq 0 ]]; then
+          if [[ ${#multi_refs[@]} -eq 0 || ${#amd64_refs[@]} -eq 0 || ${#arm64_refs[@]} -eq 0 || ${#dockerhub_multi_refs[@]} -eq 0 || ${#dockerhub_amd64_refs[@]} -eq 0 || ${#dockerhub_arm64_refs[@]} -eq 0 ]]; then
             echo "::error::No Docker image refs resolved for ref ${SOURCE_REF}"
             exit 1
           fi
@@ -690,6 +801,15 @@ jobs:
             echo "arm64<<EOF"
             printf "%s\n" "${arm64_refs[@]}"
             echo "EOF"
+            echo "dockerhub_multi<<EOF"
+            printf "%s\n" "${dockerhub_multi_refs[@]}" "${dockerhub_slim_multi_refs[@]}"
+            echo "EOF"
+            echo "dockerhub_amd64<<EOF"
+            printf "%s\n" "${dockerhub_amd64_refs[@]}"
+            echo "EOF"
+            echo "dockerhub_arm64<<EOF"
+            printf "%s\n" "${dockerhub_arm64_refs[@]}"
+            echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Verify Docker attestations
@@ -698,11 +818,17 @@ jobs:
           MULTI_REFS: ${{ steps.refs.outputs.multi }}
           AMD64_REFS: ${{ steps.refs.outputs.amd64 }}
           ARM64_REFS: ${{ steps.refs.outputs.arm64 }}
+          DOCKERHUB_MULTI_REFS: ${{ steps.refs.outputs.dockerhub_multi }}
+          DOCKERHUB_AMD64_REFS: ${{ steps.refs.outputs.dockerhub_amd64 }}
+          DOCKERHUB_ARM64_REFS: ${{ steps.refs.outputs.dockerhub_arm64 }}
         run: |
           set -euo pipefail
           mapfile -t multi_refs <<< "${MULTI_REFS}"
           mapfile -t amd64_refs <<< "${AMD64_REFS}"
           mapfile -t arm64_refs <<< "${ARM64_REFS}"
+          mapfile -t dockerhub_multi_refs <<< "${DOCKERHUB_MULTI_REFS}"
+          mapfile -t dockerhub_amd64_refs <<< "${DOCKERHUB_AMD64_REFS}"
+          mapfile -t dockerhub_arm64_refs <<< "${DOCKERHUB_ARM64_REFS}"
 
           node scripts/verify-docker-attestations.mjs \
             --platform linux/amd64 \
@@ -714,3 +840,13 @@ jobs:
           node scripts/verify-docker-attestations.mjs \
             --platform linux/arm64 \
             "${arm64_refs[@]}"
+          node scripts/verify-docker-attestations.mjs \
+            --platform linux/amd64 \
+            --platform linux/arm64 \
+            "${dockerhub_multi_refs[@]}"
+          node scripts/verify-docker-attestations.mjs \
+            --platform linux/amd64 \
+            "${dockerhub_amd64_refs[@]}"
+          node scripts/verify-docker-attestations.mjs \
+            --platform linux/arm64 \
+            "${dockerhub_arm64_refs[@]}"

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -40,9 +40,21 @@ Docker is **optional**. Use it only if you want a containerized gateway or to va
     ./scripts/docker/setup.sh
     ```
 
-    Pre-built images are published at the
+    Pre-built images are published first to the
     [GitHub Container Registry](https://github.com/openclaw/openclaw/pkgs/container/openclaw).
-    Common tags: `main`, `latest`, `<version>` (e.g. `2026.2.26`).
+    GHCR is the primary registry for release automation, pinned deployments,
+    and provenance checks. The same release workflow also publishes an official
+    Docker Hub mirror at `openclaw/openclaw` for hosts that prefer Docker Hub:
+
+    ```bash
+    export OPENCLAW_IMAGE="openclaw/openclaw:latest"
+    ./scripts/docker/setup.sh
+    ```
+
+    Use `ghcr.io/openclaw/openclaw` or `openclaw/openclaw`. Avoid community
+    Docker Hub mirrors because OpenClaw does not control their release timing,
+    rebuilds, or retention policy. Common official tags: `main`, `latest`,
+    `<version>` (e.g. `2026.2.26`).
 
   </Step>
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -54,7 +54,8 @@ Docker is **optional**. Use it only if you want a containerized gateway or to va
     Use `ghcr.io/openclaw/openclaw` or `openclaw/openclaw`. Avoid community
     Docker Hub mirrors because OpenClaw does not control their release timing,
     rebuilds, or retention policy. Common official tags: `main`, `latest`,
-    `<version>` (e.g. `2026.2.26`).
+    `<version>` (e.g. `2026.2.26`), and beta versions such as
+    `2026.2.26-beta.1`. Beta tags do not move `latest` or `main`.
 
   </Step>
 

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -137,7 +137,7 @@ OPENCLAW_NAMESPACE=my-namespace ./scripts/k8s/deploy.sh
 Edit the `image` field in `scripts/k8s/manifests/deployment.yaml`:
 
 ```yaml
-image: ghcr.io/openclaw/openclaw:latest # or pin to a specific version from https://github.com/openclaw/openclaw/releases
+image: ghcr.io/openclaw/openclaw:latest # primary; official Docker Hub mirror: openclaw/openclaw:latest
 ```
 
 ### Expose beyond port-forward

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -366,6 +366,19 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("DOCKERHUB_MULTI_REFS: ${{ steps.refs.outputs.dockerhub_multi }}");
   });
 
+  it("publishes beta Docker tags without advancing latest aliases", async () => {
+    const workflow = await readFile(dockerReleaseWorkflowPath, "utf8");
+
+    expect(workflow).toContain("Existing stable or beta release tag to backfill");
+    expect(workflow).toContain('! "${RELEASE_TAG}" =~ ^v[0-9]{4}');
+    expect(workflow).toContain("(-beta\\.[1-9][0-9]*)?");
+    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}");
+    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-slim");
+    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-browser");
+    expect(workflow.split("do not advance latest/main aliases from those flows")).toHaveLength(3);
+    expect(workflow.split('"$version" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+)?$')).toHaveLength(3);
+  });
+
   it("smokes runtime workspace templates before Docker release manifests publish", async () => {
     const workflow = await readFile(dockerReleaseWorkflowPath, "utf8");
 

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -332,9 +332,12 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("Build and push amd64 browser image");
     expect(workflow).toContain("Build and push arm64 browser image");
     expect(workflow).toContain("OPENCLAW_INSTALL_BROWSER=1");
-    expect(workflow).toContain('${IMAGE}:${version}-browser"');
-    expect(workflow).toContain('${IMAGE}:latest-browser"');
-    expect(workflow).toContain('${IMAGE}:main-browser"');
+    expect(workflow).toContain('${GHCR_IMAGE}:${version}-browser"');
+    expect(workflow).toContain('${DOCKERHUB_IMAGE}:${version}-browser"');
+    expect(workflow).toContain('${GHCR_IMAGE}:latest-browser"');
+    expect(workflow).toContain('${DOCKERHUB_IMAGE}:latest-browser"');
+    expect(workflow).toContain('${GHCR_IMAGE}:main-browser"');
+    expect(workflow).toContain('${DOCKERHUB_IMAGE}:main-browser"');
     expect(workflow).not.toContain("main-browser-amd64");
     expect(workflow).not.toContain("main-browser-arm64");
     expect(workflow).toContain("Smoke test amd64 browser image");
@@ -344,6 +347,23 @@ describe("Dockerfile", () => {
     expect(workflow).toContain("if: steps.tags.outputs.browser != ''");
     expect(workflow).toContain('git show "${SOURCE_REF}:Dockerfile"');
     expect(workflow).toContain('if [[ -n "${BROWSER_TAGS}" ]]; then');
+  });
+
+  it("publishes official Docker releases to GHCR and Docker Hub", async () => {
+    const workflow = await readFile(dockerReleaseWorkflowPath, "utf8");
+
+    expect(workflow).toContain("REGISTRY: ghcr.io");
+    expect(workflow).toContain("DOCKERHUB_REGISTRY: docker.io");
+    expect(workflow).toContain("DOCKERHUB_IMAGE_NAME: openclaw/openclaw");
+    expect(workflow).toContain("Validate Docker Hub publish credentials");
+    expect(workflow).toContain("DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets");
+    expect(workflow).toContain("Login to GitHub Container Registry");
+    expect(workflow).toContain("Login to Docker Hub");
+    expect(workflow).toContain('images=("${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}")');
+    expect(workflow).toContain("DOCKERHUB_TAGS: ${{ steps.tags.outputs.dockerhub }}");
+    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-amd64");
+    expect(workflow).toContain("${DOCKERHUB_IMAGE}:${version}-arm64");
+    expect(workflow).toContain("DOCKERHUB_MULTI_REFS: ${{ steps.refs.outputs.dockerhub_multi }}");
   });
 
   it("smokes runtime workspace templates before Docker release manifests publish", async () => {


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's official Docker release workflow only published images to GHCR, while Docker Hub had no official `openclaw/openclaw` release image. That left users who search or deploy from Docker Hub pointed at community mirrors instead of a release surface controlled by the project.

## Why This Change Was Made

This keeps GHCR as the primary registry and adds Docker Hub as an official mirror for the same stable and beta release tags, architecture-specific tags, manifests, and attestation verification path. The workflow now fails fast if `DOCKERHUB_USERNAME` or `DOCKERHUB_TOKEN` are missing, so release operators do not get a partial publish by accident.

Beta releases publish immutable versioned tags, including browser/slim/arch variants, but do not advance `latest` or `main`. Manual backfills keep the same version-only behavior.

The docs continue to recommend GHCR first, but now show `openclaw/openclaw` as the official Docker Hub mirror and warn against unofficial community mirrors.

## User Impact

Users can pull official OpenClaw images from either:

```sh
docker pull ghcr.io/openclaw/openclaw:latest
docker pull openclaw/openclaw:latest
```

Beta users can also pull explicit beta tags without affecting stable aliases:

```sh
docker pull ghcr.io/openclaw/openclaw:2026.6.9-beta.1
docker pull openclaw/openclaw:2026.6.9-beta.1
```

Release operators keep GHCR as the primary source while publishing the Docker Hub mirror from the same workflow and verification steps.

## Evidence

- Docker Hub repository exists and is public: `openclaw/openclaw`.
- GitHub release secrets are present: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`.
- `node -e "const fs=require('fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/docker-release.yml','utf8')); console.log('docker-release yaml ok')"`
- `git diff --check origin/main..HEAD`
- `pnpm_config_verify_deps_before_run=false pnpm test:serial src/dockerfile.test.ts test/scripts/ci-workflow-guards.test.ts` - 56 tests passed.
- `pnpm_config_verify_deps_before_run=false pnpm docs:check-mdx`
- `pnpm_config_verify_deps_before_run=false pnpm format:docs:check`
- `OPENCLAW_TESTBOX=1 pnpm_config_verify_deps_before_run=false pnpm check:changed` - passed in Testbox `tbx_01kw35vsyj4ef9h02v9vxzj7mv`, Actions run https://github.com/openclaw/openclaw/actions/runs/28271904813.
