### PR TITLE
Doctor: expose auth profile findings

### DIFF
--- a/src/commands/doctor-auth.hints.test.ts
+++ b/src/commands/doctor-auth.hints.test.ts
@@ -2,7 +2,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  collectAuthProfileHealthFindings,
   formatOAuthRefreshFailureDoctorLine,
+  legacyCodexProviderOverrideToHealthFinding,
   noteLegacyCodexProviderOverride,
   resolveUnusableProfileHint,
 } from "./doctor-auth.js";
@@ -125,6 +127,52 @@ describe("resolveUnusableProfileHint", () => {
       expect.stringContaining("models.providers.openai-codex"),
       "Codex OAuth",
     );
+  });
+
+  it("maps legacy Codex overrides to structured auth profile findings", () => {
+    expect(
+      legacyCodexProviderOverrideToHealthFinding({
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      }),
+    ).toMatchObject({
+      checkId: "core/doctor/auth-profiles",
+      severity: "warning",
+      message:
+        "Legacy openai-codex transport override can shadow configured Codex OAuth credentials.",
+      path: "models.providers.openai-codex",
+      target: "openai-codex",
+    });
+  });
+
+  it("collects legacy Codex override structured findings", async () => {
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: doctorFixtureConfig({
+        auth: {
+          profiles: {
+            "openai:default": {
+              provider: "openai",
+              mode: "oauth",
+            },
+          },
+        },
+        models: {
+          providers: {
+            "openai-codex": {
+              api: "openai-responses",
+            },
+          },
+        },
+      }),
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/auth-profiles",
+        path: "models.providers.openai-codex",
+        target: "openai-codex",
+      }),
+    ]);
   });
 
   it("warns when a legacy Codex override shadows stored legacy OAuth state", () => {

--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -3,21 +3,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
-type MockAuthProfileStore = {
-  version: number;
-  profiles: Record<
-    string,
-    | { type: "oauth"; provider: string; access: string; refresh: string; expires: number }
-    | { type: "api_key"; provider: string; key: string }
-  >;
-};
-
 const authProfileMocks = vi.hoisted(() => ({
   ensureAuthProfileStore: vi.fn<
-    (agentDir?: string, options?: { allowKeychainPrompt?: boolean }) => MockAuthProfileStore
+    (
+      agentDir?: string,
+      options?: { allowKeychainPrompt?: boolean; readOnly?: boolean },
+    ) => AuthProfileStore
   >(() => {
     throw new Error("unexpected auth profile load");
   }),
@@ -38,7 +33,7 @@ vi.mock("../agents/auth-profiles.js", () => ({
 vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: vi.fn() }));
 
 import { note } from "../../packages/terminal-core/src/note.js";
-import { noteAuthProfileHealth } from "./doctor-auth.js";
+import { collectAuthProfileHealthFindings, noteAuthProfileHealth } from "./doctor-auth.js";
 
 const noteMock = vi.mocked(note);
 
@@ -67,6 +62,10 @@ describe("noteAuthProfileHealth", () => {
     fs.writeFileSync(path.join(agentDir, "auth-profiles.json"), "{}\n", "utf8");
   }
 
+  function expectedAuthStorePath(agentDir: string): string {
+    return path.join(agentDir, "openclaw-agent.sqlite");
+  }
+
   function expiredStore(profileId: string, expires: number) {
     return {
       version: 1,
@@ -79,8 +78,142 @@ describe("noteAuthProfileHealth", () => {
           expires,
         },
       },
-    };
+    } satisfies AuthProfileStore;
   }
+
+  it("maps expired stored auth profiles to structured findings without refreshing", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const mainDir = path.join(tempDir, "main-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue(
+      expiredStore("openai:default", now - 60_000),
+    );
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: {
+          list: [{ id: "main", default: true, agentDir: mainDir }],
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(authProfileMocks.resolveApiKeyForProfile).not.toHaveBeenCalled();
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/auth-profiles",
+        severity: "warning",
+        message: "Auth profile openai:default is expired (0m).",
+        path: expectedAuthStorePath(mainDir),
+        target: "openai:default",
+      }),
+    ]);
+  });
+
+  it("maps disabled auth profiles to structured findings", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const mainDir = path.join(tempDir, "main-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(now + 5 * 60_000);
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+      usageStats: {
+        "openai:billing": {
+          disabledUntil: now + 5 * 60_000,
+          disabledReason: "billing",
+        },
+      },
+    } satisfies AuthProfileStore);
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: {
+          list: [{ id: "main", default: true, agentDir: mainDir }],
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/auth-profiles",
+        message: "Auth profile openai:billing is disabled:billing (5m).",
+        path: expectedAuthStorePath(mainDir),
+        target: "openai:billing",
+        fixHint: "Top up credits (provider billing) or switch provider.",
+      }),
+    ]);
+  });
+
+  it("maps malformed API-key auth profiles to structured findings", async () => {
+    const mainDir = path.join(tempDir, "main-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        "zai:default": {
+          type: "api_key",
+          provider: "zai",
+          key: "openclaw onboard --auth-choice zai-coding-global",
+        },
+      },
+    } satisfies AuthProfileStore);
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: {
+          list: [{ id: "main", default: true, agentDir: mainDir }],
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/auth-profiles",
+        severity: "warning",
+        message: "Auth profile zai:default is missing [malformed_api_key].",
+        path: expectedAuthStorePath(mainDir),
+        target: "zai:default",
+        requirement: "malformed_api_key",
+        fixHint: "Paste the API key value, not an OpenClaw onboarding command.",
+      }),
+    ]);
+  });
+
+  it("labels structured auth profile findings by agent when multiple stores are checked", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const mainDir = path.join(tempDir, "main-agent");
+    const coderDir = path.join(tempDir, "coder-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockImplementation((agentDir) => {
+      if (agentDir === mainDir) {
+        return expiredStore("openai:main", now - 60_000);
+      }
+      if (agentDir === coderDir) {
+        return expiredStore("openai:coder", now - 60_000);
+      }
+      throw new Error(`unexpected agent dir: ${agentDir ?? "<default>"}`);
+    });
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", default: true, agentDir: mainDir },
+            { id: "coder", agentDir: coderDir },
+          ],
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(findings.map((finding) => finding.message)).toEqual([
+      "Agent main auth profile openai:main is expired (0m).",
+      "Agent coder auth profile openai:coder is expired (0m).",
+    ]);
+  });
   it("skips external auth profile resolution when no auth source exists", async () => {
     await noteAuthProfileHealth({
       cfg: { channels: { telegram: { enabled: true } } } as OpenClawConfig,
@@ -209,7 +342,7 @@ describe("noteAuthProfileHealth", () => {
     writeAuthStore(agentDir);
     authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
     authProfileMocks.ensureAuthProfileStore.mockImplementation(
-      (receivedAgentDir): MockAuthProfileStore => {
+      (receivedAgentDir): AuthProfileStore => {
         if (receivedAgentDir === agentDir) {
           return {
             version: 1,

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -26,8 +26,10 @@ import {
   classifyOAuthRefreshFailure,
   type OAuthRefreshFailureReason,
 } from "../agents/auth-profiles/oauth-refresh-failure.js";
+import { resolveAuthStorePathForDisplay } from "../agents/auth-profiles/path-resolve.js";
 import { buildProviderAuthRecoveryHint } from "../agents/provider-auth-recovery-hint.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HealthFinding } from "../flows/health-checks.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { isRecord } from "../utils.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
@@ -37,6 +39,7 @@ const LEGACY_CODEX_PROVIDER_ID = "openai-codex";
 const CODEX_OAUTH_WARNING_TITLE = "Codex OAuth";
 const OPENAI_BASE_URL = "https://api.openai.com/v1";
 const LEGACY_CODEX_APIS = new Set(["openai-responses", "openai-completions"]);
+const AUTH_PROFILES_CHECK_ID = "core/doctor/auth-profiles";
 const DOCTOR_REAUTH_PROVIDER_ALIASES: Readonly<Record<string, string>> = {
   [LEGACY_CODEX_PROVIDER_ID]: OPENAI_PROVIDER_ID,
 };
@@ -50,7 +53,7 @@ function hasConfiguredCodexOAuthProfile(cfg: OpenClawConfig): boolean {
 }
 
 function hasStoredCodexOAuthProfile(): boolean {
-  const store = ensureAuthProfileStore(undefined, { allowKeychainPrompt: false });
+  const store = ensureAuthProfileStore(undefined, { allowKeychainPrompt: false, readOnly: true });
   return Object.values(store.profiles).some(
     (profile) =>
       (profile.provider === OPENAI_PROVIDER_ID || profile.provider === LEGACY_CODEX_PROVIDER_ID) &&
@@ -112,6 +115,22 @@ function buildCodexProviderOverrideWarning(providerOverride: unknown): string {
     "- Custom proxies and header-only overrides can stay; this warning only targets old OpenAI transport settings.",
   );
   return lines.join("\n");
+}
+
+export function legacyCodexProviderOverrideToHealthFinding(
+  providerOverride: unknown,
+): HealthFinding {
+  const message =
+    "Legacy openai-codex transport override can shadow configured Codex OAuth credentials.";
+  const details = buildCodexProviderOverrideWarning(providerOverride);
+  return {
+    checkId: AUTH_PROFILES_CHECK_ID,
+    severity: "warning",
+    message,
+    path: `models.providers.${LEGACY_CODEX_PROVIDER_ID}`,
+    target: LEGACY_CODEX_PROVIDER_ID,
+    fixHint: details,
+  };
 }
 
 /** Emits a warning when legacy Codex transport overrides can shadow configured Codex OAuth. */
@@ -261,6 +280,169 @@ async function formatAuthIssueLine(
   const hint = await resolveAuthIssueHint(issue, cfg, store);
   const reason = issue.reasonCode ? ` [${issue.reasonCode}]` : "";
   return `- ${issue.profileId}: ${issue.status}${reason}${remaining}${hint ? ` — ${hint}` : ""}`;
+}
+
+function resolveAuthProfileStorePath(target: AuthProfileHealthTarget): string {
+  return resolveAuthStorePathForDisplay(target.agentDir);
+}
+
+function authProfileIssueToHealthFinding(params: {
+  issue: AuthIssue;
+  target: AuthProfileHealthTarget;
+  labelAgents: boolean;
+  hint: string | null;
+}): HealthFinding {
+  const remaining =
+    params.issue.remainingMs !== undefined
+      ? ` (${formatRemainingShort(params.issue.remainingMs)})`
+      : "";
+  const reason = params.issue.reasonCode ? ` [${params.issue.reasonCode}]` : "";
+  const owner = params.labelAgents ? `Agent ${params.target.agentId} auth profile` : "Auth profile";
+  return {
+    checkId: AUTH_PROFILES_CHECK_ID,
+    severity: "warning",
+    message: `${owner} ${params.issue.profileId} is ${params.issue.status}${reason}${remaining}.`,
+    path: resolveAuthProfileStorePath(params.target),
+    target: params.issue.profileId,
+    ...(params.issue.reasonCode ? { requirement: params.issue.reasonCode } : {}),
+    fixHint:
+      params.hint ??
+      (params.issue.status === "expiring"
+        ? "Run `openclaw doctor --fix` to refresh expiring OAuth profiles, or re-authenticate static tokens."
+        : "Run `openclaw doctor --fix` to refresh OAuth profiles, or re-authenticate this provider."),
+  };
+}
+
+function authProfileCooldownToHealthFinding(params: {
+  profileId: string;
+  target: AuthProfileHealthTarget;
+  labelAgents: boolean;
+  kind: string;
+  remaining: string;
+  hint: string;
+}): HealthFinding {
+  return {
+    checkId: AUTH_PROFILES_CHECK_ID,
+    severity: "warning",
+    message: params.labelAgents
+      ? `Agent ${params.target.agentId} auth profile ${params.profileId} is ${params.kind} (${params.remaining}).`
+      : `Auth profile ${params.profileId} is ${params.kind} (${params.remaining}).`,
+    path: resolveAuthProfileStorePath(params.target),
+    target: params.profileId,
+    fixHint: params.hint,
+  };
+}
+
+async function collectAuthProfileHealthFindingsForTarget(params: {
+  cfg: OpenClawConfig;
+  allowKeychainPrompt: boolean;
+  target: AuthProfileHealthTarget;
+  labelAgents: boolean;
+}): Promise<readonly HealthFinding[]> {
+  const store = ensureAuthProfileStore(params.target.agentDir, {
+    allowKeychainPrompt: params.allowKeychainPrompt,
+    readOnly: true,
+  });
+  const findings: HealthFinding[] = [];
+  const now = Date.now();
+  for (const profileId of Object.keys(store.usageStats ?? {})) {
+    const until = resolveProfileUnusableUntilForDisplay(store, profileId);
+    if (!until || now >= until) {
+      continue;
+    }
+    const stats = store.usageStats?.[profileId];
+    const remaining = formatRemainingShort(until - now);
+    const disabledActive = typeof stats?.disabledUntil === "number" && now < stats.disabledUntil;
+    const kind = disabledActive
+      ? `disabled${stats.disabledReason ? `:${stats.disabledReason}` : ""}`
+      : "cooldown";
+    const hint = resolveUnusableProfileHint({
+      kind: disabledActive ? "disabled" : "cooldown",
+      reason: stats?.disabledReason,
+    });
+    findings.push(
+      authProfileCooldownToHealthFinding({
+        profileId,
+        target: params.target,
+        labelAgents: params.labelAgents,
+        kind,
+        remaining,
+        hint,
+      }),
+    );
+  }
+
+  const summary = buildAuthHealthSummary({
+    store,
+    cfg: params.cfg,
+    warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+    allowKeychainPrompt: params.allowKeychainPrompt,
+  });
+  const issues = summary.profiles.filter((profile) => {
+    if (profile.type === "api_key") {
+      return profile.status === "missing";
+    }
+    return (
+      (profile.type === "oauth" || profile.type === "token") &&
+      (profile.status === "expired" ||
+        profile.status === "expiring" ||
+        profile.status === "missing")
+    );
+  });
+  for (const issue of issues) {
+    const authIssue: AuthIssue = {
+      profileId: issue.profileId,
+      provider: issue.provider,
+      status: issue.status,
+      reasonCode: issue.reasonCode,
+      remainingMs: issue.remainingMs,
+    };
+    findings.push(
+      authProfileIssueToHealthFinding({
+        issue: authIssue,
+        target: params.target,
+        labelAgents: params.labelAgents,
+        hint: await resolveAuthIssueHint(authIssue, params.cfg, store),
+      }),
+    );
+  }
+  return findings;
+}
+
+/** Collects read-only structured findings for auth profile health. */
+export async function collectAuthProfileHealthFindings(params: {
+  cfg: OpenClawConfig;
+  allowKeychainPrompt?: boolean;
+}): Promise<readonly HealthFinding[]> {
+  const configuredProfiles = Object.keys(params.cfg.auth?.profiles ?? {}).length > 0;
+  const targets = listAuthProfileHealthTargets(params.cfg);
+  const activeTargets = targets.filter((target) =>
+    target.isDefault
+      ? hasAnyAuthProfileStoreSource(target.agentDir) || configuredProfiles
+      : hasLocalAuthProfileStoreSource(target.agentDir),
+  );
+  const findings: HealthFinding[] = [];
+  const labelAgents = activeTargets.length > 1;
+  for (const target of activeTargets) {
+    findings.push(
+      ...(await collectAuthProfileHealthFindingsForTarget({
+        cfg: params.cfg,
+        allowKeychainPrompt: params.allowKeychainPrompt ?? false,
+        target,
+        labelAgents,
+      })),
+    );
+  }
+
+  const providerOverride = params.cfg.models?.providers?.[LEGACY_CODEX_PROVIDER_ID];
+  if (
+    providerOverride &&
+    hasLegacyCodexTransportOverride(providerOverride) &&
+    (hasConfiguredCodexOAuthProfile(params.cfg) || hasStoredCodexOAuthProfile())
+  ) {
+    findings.push(legacyCodexProviderOverrideToHealthFinding(providerOverride));
+  }
+  return findings;
 }
 
 async function noteAuthProfileHealthForTarget(params: {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   maybeRepairGatewayDaemon: vi.fn().mockResolvedValue(undefined),
   maybeRepairLegacyOAuthProfileIds: vi.fn(async (cfg: unknown) => cfg),
   maybeRepairLegacyOAuthSidecarProfiles: vi.fn().mockResolvedValue(undefined),
+  collectAuthProfileHealthFindings: vi.fn(async () => []),
   noteAuthProfileHealth: vi.fn().mockResolvedValue(undefined),
   noteLegacyCodexProviderOverride: vi.fn(),
   buildGatewayConnectionDetails: vi.fn(() => ({ message: "gateway details" })),
@@ -145,6 +146,7 @@ vi.mock("../commands/doctor-auth-oauth-sidecar.js", () => ({
 }));
 
 vi.mock("../commands/doctor-auth.js", () => ({
+  collectAuthProfileHealthFindings: mocks.collectAuthProfileHealthFindings,
   noteAuthProfileHealth: mocks.noteAuthProfileHealth,
   noteLegacyCodexProviderOverride: mocks.noteLegacyCodexProviderOverride,
 }));
@@ -327,6 +329,8 @@ describe("doctor health contributions", () => {
     mocks.maybeRepairLegacyOAuthProfileIds.mockImplementation(async (cfg: unknown) => cfg);
     mocks.maybeRepairLegacyOAuthSidecarProfiles.mockClear();
     mocks.maybeRepairLegacyOAuthSidecarProfiles.mockResolvedValue(undefined);
+    mocks.collectAuthProfileHealthFindings.mockClear();
+    mocks.collectAuthProfileHealthFindings.mockResolvedValue([]);
     mocks.noteAuthProfileHealth.mockClear();
     mocks.noteAuthProfileHealth.mockResolvedValue(undefined);
     mocks.noteLegacyCodexProviderOverride.mockClear();
@@ -1004,6 +1008,32 @@ describe("doctor health contributions", () => {
     expect(mocks.maybeRepairCanonicalApiKeyFieldAlias).toHaveBeenCalledWith({
       cfg: ctx.cfg,
       prompter: ctx.prompter,
+    });
+  });
+
+  it("registers auth profile health as an opt-in structured check", async () => {
+    const contribution = requireDoctorContribution("doctor:auth-profiles");
+    const [check] = contribution.healthChecks;
+
+    expect(contribution.healthCheckIds).toEqual(["core/doctor/auth-profiles"]);
+    expect(check).toMatchObject({
+      id: "core/doctor/auth-profiles",
+      kind: "core",
+      defaultEnabled: false,
+    });
+    if (!check || !("detect" in check)) {
+      throw new Error("expected split auth profile health check");
+    }
+
+    await check.detect({
+      mode: "lint",
+      cfg: { auth: { profiles: {} } },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    });
+
+    expect(mocks.collectAuthProfileHealthFindings).toHaveBeenCalledWith({
+      cfg: { auth: { profiles: {} } },
+      allowKeychainPrompt: false,
     });
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1222,6 +1222,19 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:auth-profiles",
       label: "Auth profiles",
+      healthChecks: {
+        id: "core/doctor/auth-profiles",
+        kind: "core",
+        description: "Auth profile cooldown, expiry, missing credential, and legacy override state",
+        defaultEnabled: false,
+        async detect(ctx) {
+          const { collectAuthProfileHealthFindings } = await import("../commands/doctor-auth.js");
+          return collectAuthProfileHealthFindings({
+            cfg: ctx.cfg,
+            allowKeychainPrompt: false,
+          });
+        },
+      },
       run: runAuthProfileHealth,
     }),
     createDoctorHealthContribution({


### PR DESCRIPTION
## What Problem This Solves

Doctor has a mature auth-profile health path, but its findings were not available through the structured lint surface. That left profile expiry, missing credentials, cooldown/disabled state, and legacy Codex provider overrides outside the `doctor --lint --only/--all` workflow.

## Why This Change Was Made

This adds an opt-in structured health check, `core/doctor/auth-profiles`, wired through the existing `doctor:auth-profiles` contribution. Detection is read-only and mirrors existing auth-profile health behavior; the existing mutating repair flow remains in `runAuthProfileHealth` and the legacy repair helpers.

The check is `defaultEnabled: false`, so it is not part of default Doctor lint. It is discoverable through explicit lint selection such as `--only core/doctor/auth-profiles` and `--all`.

After ClawSweeper's P2 path finding, structured auth-profile findings now report the canonical SQLite auth store display path from `resolveAuthStorePathForDisplay(...)`, not the legacy `auth-profiles.json` path.

## User Impact

- No public SDK/plugin/config contract changes.
- Default `doctor --lint` behavior is unchanged for auth profiles.
- Users who explicitly opt in can now get structured findings for auth-profile cooldown, disabled state, expiry, missing credentials, and legacy Codex override shadowing.
- Auth-profile findings point at the current `openclaw-agent.sqlite` auth store path.
- Keychain prompts are disabled for structured detection.

## Evidence

Focused tests:

```text
node scripts/run-vitest.mjs run src/commands/doctor-auth.profile-health.test.ts src/commands/doctor-auth.hints.test.ts src/flows/doctor-health-contributions.test.ts --reporter=verbose
```

Result after the path fix: 2 Vitest shards passed, 68 tests total.

ClawSweeper-requested path resolver proof:

```text
node scripts/run-vitest.mjs run src/agents/auth-profiles/paths-direct-import.test.ts --reporter=verbose
```

Result: 1 Vitest shard passed, 9 tests total.

Formatting/lint/type/API checks:

```text
.\node_modules\.bin\oxfmt.CMD --check src/commands/doctor-auth.ts src/commands/doctor-auth.profile-health.test.ts src/commands/doctor-auth.hints.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts src/agents/auth-profiles/paths-direct-import.test.ts
.\node_modules\.bin\oxlint.CMD src/commands/doctor-auth.ts src/commands/doctor-auth.profile-health.test.ts src/commands/doctor-auth.hints.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts src/agents/auth-profiles/paths-direct-import.test.ts
pnpm tsgo:core
node scripts/plugin-sdk-surface-report.mjs --check
git diff --check
```

All passed.

Source CLI proof with isolated temp state/config and a seeded expired OAuth profile in the canonical SQLite auth store:

```text
node scripts/run-node.mjs doctor --lint --json --only core/doctor/auth-profiles
```

Observed exit code `1` and one structured warning for `core/doctor/auth-profiles` with:

```text
path: <temp-state>\agents\main\agent\openclaw-agent.sqlite
target: openai:default
message: Auth profile openai:default is expired (0m).
```

Legacy override source CLI proof was also run with isolated temp state/config and a legacy `openai-codex` override. It produced one structured warning at `models.providers.openai-codex`, as expected for the config override finding.

Default lint was also probed with isolated state. The worktree was noisy from unrelated fresh-checkout missing gateway/skills/UI state, but the auth-profile check was not included by default, matching `defaultEnabled: false` and the contribution tests.

Codex review after the path fix:

```text
codex review --uncommitted
```

Result: no accepted/actionable findings; the review reported that the change consistently switches auth profile health findings from the legacy JSON path to the SQLite auth store display path.

Known validation note: a broader test-source `tsgo` probe reached unrelated missing optional dependency/type errors in ACP/MCP/fs-safe test files. The local test-source type issue introduced by this branch was fixed; `pnpm tsgo:core` and focused tests passed.

Commit note: this linked worktree repeatedly lost `node_modules` after source CLI/build helper paths. The commit was amended with `--no-verify` after the explicit validation above passed.


Post-rebase note: rebased cleanly after #97075 merged to head `c90657345e546f14b925e4856400ac07bab5221d`; diff unchanged at 5 files, +377/-13. Post-rebase hosted checks are green/skipped, including Real behavior proof.
