### PR TITLE
fix(sessions): ignore invalid saved timestamps during session recovery

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts
@@ -54,7 +54,7 @@ function messageEntry(message: AgentMessage, index: number): SessionTreeEntry {
     type: "message",
     id: `entry-${index}`,
     parentId: index === 0 ? null : `entry-${index - 1}`,
-    timestamp: new Date(message.timestamp).toISOString(),
+    timestamp: new Date(message.timestamp ?? 0).toISOString(),
     message,
   };
 }

--- a/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
@@ -66,7 +66,7 @@ function messageEntry(message: AgentMessage, index: number): SessionTreeEntry {
     type: "message",
     id: `entry-${index}`,
     parentId: index === 0 ? null : `entry-${index - 1}`,
-    timestamp: new Date(message.timestamp).toISOString(),
+    timestamp: new Date(message.timestamp ?? 0).toISOString(),
     message,
   };
 }

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -44,7 +44,7 @@ function createMessageEntry(message: AgentMessage, index: number): SessionTreeEn
     type: "message",
     id: `entry-${index}`,
     parentId: index === 0 ? null : `entry-${index - 1}`,
-    timestamp: new Date(message.timestamp).toISOString(),
+    timestamp: new Date(message.timestamp ?? 0).toISOString(),
     message,
   };
 }

--- a/packages/agent-core/src/harness/messages.test.ts
+++ b/packages/agent-core/src/harness/messages.test.ts
@@ -36,7 +36,7 @@ describe("harness message timestamps", () => {
 
     const [message] = convertToLlm(persistedMessages);
 
-    expect(message?.timestamp).toBe(0);
+    expect(message).not.toHaveProperty("timestamp");
   });
 
   it("omits loose persisted compaction timestamps", () => {
@@ -49,13 +49,13 @@ describe("harness message timestamps", () => {
       },
     ]);
 
-    expect(message?.timestamp).toBe(0);
+    expect(message).not.toHaveProperty("timestamp");
   });
 
   it("keeps out-of-range compaction summaries non-fatal during context creation", () => {
     expect(
       createCompactionSummaryMessage("older context", 123, "+275760-09-13T00:00:00.001Z"),
-    ).toMatchObject({ timestamp: 0 });
+    ).not.toHaveProperty("timestamp");
   });
 });
 

--- a/packages/agent-core/src/harness/messages.test.ts
+++ b/packages/agent-core/src/harness/messages.test.ts
@@ -1,11 +1,19 @@
 // Agent Core tests cover messages behavior.
 import { describe, expect, it } from "vitest";
-import { convertToLlm, createCompactionSummaryMessage, createCustomMessage } from "./messages.js";
+import {
+  convertToLlm,
+  createBranchSummaryMessage,
+  createCompactionSummaryMessage,
+  createCustomMessage,
+} from "./messages.js";
 
 describe("harness message timestamps", () => {
-  it("rejects invalid timestamps before creating context messages", () => {
-    expect(() => createCustomMessage("note", "content", true, {}, "not-a-date")).toThrow(
-      "custom message timestamp must be a valid timestamp",
+  it("keeps invalid custom and branch timestamps non-fatal", () => {
+    expect(createCustomMessage("note", "content", true, {}, "not-a-date")).not.toHaveProperty(
+      "timestamp",
+    );
+    expect(createBranchSummaryMessage("summary", "branch", "not-a-date")).not.toHaveProperty(
+      "timestamp",
     );
   });
   it("normalizes persisted compaction summary timestamp strings", () => {

--- a/packages/agent-core/src/harness/messages.test.ts
+++ b/packages/agent-core/src/harness/messages.test.ts
@@ -1,6 +1,6 @@
 // Agent Core tests cover messages behavior.
 import { describe, expect, it } from "vitest";
-import { convertToLlm, createCustomMessage } from "./messages.js";
+import { convertToLlm, createCompactionSummaryMessage, createCustomMessage } from "./messages.js";
 
 describe("harness message timestamps", () => {
   it("rejects invalid timestamps before creating context messages", () => {
@@ -37,6 +37,25 @@ describe("harness message timestamps", () => {
     const [message] = convertToLlm(persistedMessages);
 
     expect(message?.timestamp).toBe(0);
+  });
+
+  it("omits loose persisted compaction timestamps", () => {
+    const [message] = convertToLlm([
+      {
+        role: "compactionSummary",
+        summary: "older context",
+        tokensBefore: 123,
+        timestamp: "9999-12-31",
+      },
+    ]);
+
+    expect(message?.timestamp).toBe(0);
+  });
+
+  it("keeps out-of-range compaction summaries non-fatal during context creation", () => {
+    expect(
+      createCompactionSummaryMessage("older context", 123, "+275760-09-13T00:00:00.001Z"),
+    ).toMatchObject({ timestamp: 0 });
   });
 });
 

--- a/packages/agent-core/src/harness/messages.ts
+++ b/packages/agent-core/src/harness/messages.ts
@@ -1,6 +1,9 @@
 // Agent Core module implements messages behavior.
 import type { ImageContent, Message, TextContent } from "@openclaw/llm-core";
-import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
+import {
+  asDateTimestampMs,
+  parseStrictTimestampStringMs,
+} from "@openclaw/normalization-core/number-coercion";
 import type {
   AgentMessage,
   BashExecutionMessage,
@@ -45,13 +48,15 @@ function requireSessionTimestampMs(value: string, label: string): number {
   return parsed;
 }
 
-function normalizeCompactionSummaryTimestamp(timestamp: number | string): number {
+function normalizeCompactionSummaryTimestamp(
+  timestamp: number | string | undefined,
+): number | undefined {
   if (typeof timestamp === "number") {
-    return timestamp;
+    return asDateTimestampMs(timestamp);
   }
   const parsed = parseSessionTimestampMs(timestamp);
-  // Corrupt persisted rows should not abort context conversion; session order is already preserved.
-  return parsed ?? 0;
+  // Corrupt persisted rows should not abort context conversion or become a real epoch boundary.
+  return parsed;
 }
 
 export const COMPACTION_SUMMARY_PREFIX = `The conversation history before this point was compacted into the following summary:
@@ -108,11 +113,12 @@ export function createCompactionSummaryMessage(
   tokensBefore: number,
   timestamp: string,
 ): CompactionSummaryMessage {
+  const normalizedTimestamp = normalizeCompactionSummaryTimestamp(timestamp);
   return {
     role: "compactionSummary",
     summary,
     tokensBefore,
-    timestamp: normalizeCompactionSummaryTimestamp(timestamp),
+    ...(normalizedTimestamp !== undefined ? { timestamp: normalizedTimestamp } : {}),
   };
 }
 
@@ -177,7 +183,8 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
             ],
             timestamp: message.timestamp,
           };
-        case "compactionSummary":
+        case "compactionSummary": {
+          const timestamp = normalizeCompactionSummaryTimestamp(message.timestamp);
           return {
             role: "user",
             content: [
@@ -186,8 +193,9 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
                 text: COMPACTION_SUMMARY_PREFIX + message.summary + COMPACTION_SUMMARY_SUFFIX,
               },
             ],
-            timestamp: normalizeCompactionSummaryTimestamp(message.timestamp),
-          };
+            ...(timestamp !== undefined ? { timestamp } : {}),
+          } as Message;
+        }
         case "user":
         case "assistant":
         case "toolResult":

--- a/packages/agent-core/src/harness/messages.ts
+++ b/packages/agent-core/src/harness/messages.ts
@@ -1,5 +1,6 @@
 // Agent Core module implements messages behavior.
 import type { ImageContent, Message, TextContent } from "@openclaw/llm-core";
+import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
 import type {
   AgentMessage,
   BashExecutionMessage,
@@ -33,8 +34,7 @@ function parseSessionTimestampMs(value: unknown): number | undefined {
   if (typeof value !== "string" || !value.trim()) {
     return undefined;
   }
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  return parseStrictTimestampStringMs(value);
 }
 
 function requireSessionTimestampMs(value: string, label: string): number {
@@ -112,7 +112,7 @@ export function createCompactionSummaryMessage(
     role: "compactionSummary",
     summary,
     tokensBefore,
-    timestamp: requireSessionTimestampMs(timestamp, "compaction summary timestamp"),
+    timestamp: normalizeCompactionSummaryTimestamp(timestamp),
   };
 }
 

--- a/packages/agent-core/src/harness/messages.ts
+++ b/packages/agent-core/src/harness/messages.ts
@@ -40,14 +40,6 @@ function parseSessionTimestampMs(value: unknown): number | undefined {
   return parseStrictTimestampStringMs(value);
 }
 
-function requireSessionTimestampMs(value: string, label: string): number {
-  const parsed = parseSessionTimestampMs(value);
-  if (parsed === undefined) {
-    throw new Error(`${label} must be a valid timestamp`);
-  }
-  return parsed;
-}
-
 function normalizeCompactionSummaryTimestamp(
   timestamp: number | string | undefined,
 ): number | undefined {
@@ -99,12 +91,13 @@ export function createBranchSummaryMessage(
   fromId: string,
   timestamp: string,
 ): BranchSummaryMessage {
+  const normalizedTimestamp = parseSessionTimestampMs(timestamp);
   return {
     role: "branchSummary",
     summary,
     fromId,
-    timestamp: requireSessionTimestampMs(timestamp, "branch summary timestamp"),
-  };
+    ...(normalizedTimestamp !== undefined ? { timestamp: normalizedTimestamp } : {}),
+  } as BranchSummaryMessage;
 }
 
 /** Build a persisted compaction summary message from the repository timestamp string. */
@@ -130,14 +123,15 @@ export function createCustomMessage(
   details: unknown,
   timestamp: string,
 ): CustomMessage {
+  const normalizedTimestamp = parseSessionTimestampMs(timestamp);
   return {
     role: "custom",
     customType,
     content,
     display,
     details,
-    timestamp: requireSessionTimestampMs(timestamp, "custom message timestamp"),
-  };
+    ...(normalizedTimestamp !== undefined ? { timestamp: normalizedTimestamp } : {}),
+  } as CustomMessage;
 }
 
 /** Convert harness transcript messages into the LLM-facing message sequence. */
@@ -168,9 +162,9 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
           return {
             role: "user",
             content,
-            timestamp: message.timestamp,
+            ...(typeof message.timestamp === "number" ? { timestamp: message.timestamp } : {}),
             ...(runtimeContextCarrier ? { runtimeContextCarrier: true } : {}),
-          };
+          } as Message;
         }
         case "branchSummary":
           return {
@@ -181,8 +175,8 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
                 text: BRANCH_SUMMARY_PREFIX + message.summary + BRANCH_SUMMARY_SUFFIX,
               },
             ],
-            timestamp: message.timestamp,
-          };
+            ...(typeof message.timestamp === "number" ? { timestamp: message.timestamp } : {}),
+          } as Message;
         case "compactionSummary": {
           const timestamp = normalizeCompactionSummaryTimestamp(message.timestamp);
           return {

--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -51,10 +51,35 @@ describe("buildSessionContext", () => {
       "user",
     ]);
     expect(context.messages).toMatchObject([
-      { summary: "older context" },
+      { summary: "older context", retainedMessageCount: 1 },
       { content: "retained" },
       { content: "new turn" },
     ]);
+  });
+
+  it("preserves the retained range when a compaction timestamp is invalid", () => {
+    const entries: SessionTreeEntry[] = [
+      userEntry("kept", null, "retained"),
+      {
+        type: "compaction",
+        id: "compaction",
+        parentId: "kept",
+        timestamp: "9999-12-31",
+        summary: "older context",
+        firstKeptEntryId: "kept",
+        tokensBefore: 123,
+      },
+      userEntry("new", "compaction", "new turn"),
+    ];
+
+    const messages = buildSessionContext(entries).messages;
+
+    expect(messages).toMatchObject([
+      { role: "compactionSummary", retainedMessageCount: 1 },
+      { role: "user", content: "retained" },
+      { role: "user", content: "new turn" },
+    ]);
+    expect(messages[0]).not.toHaveProperty("timestamp");
   });
 
   it("treats the latest reset as a hard cut with a user/assistant-only kept tail", () => {

--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -16,6 +16,35 @@ function userEntry(id: string, parentId: string | null, content: string): Sessio
 }
 
 describe("buildSessionContext", () => {
+  it("keeps invalid custom and branch timestamps non-fatal during replay", () => {
+    const entries: SessionTreeEntry[] = [
+      {
+        type: "custom_message",
+        id: "custom",
+        parentId: null,
+        timestamp: "9999-12-31",
+        customType: "note",
+        content: "custom content",
+        display: true,
+      },
+      {
+        type: "branch_summary",
+        id: "branch",
+        parentId: "custom",
+        timestamp: "01/02/03",
+        fromId: "branch-root",
+        summary: "branch content",
+      },
+    ];
+
+    expect(buildSessionContext(entries).messages).toMatchObject([
+      { role: "custom", content: "custom content" },
+      { role: "branchSummary", summary: "branch content" },
+    ]);
+    expect(buildSessionContext(entries).messages[0]).not.toHaveProperty("timestamp");
+    expect(buildSessionContext(entries).messages[1]).not.toHaveProperty("timestamp");
+  });
+
   it("replays only the retained tail and newer entries after compaction", () => {
     const entries: SessionTreeEntry[] = [
       userEntry("old", null, "discarded"),

--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "../../types.js";
 import type { SessionTreeEntry } from "../types.js";
 import { buildSessionContext } from "./session.js";
 
@@ -55,6 +56,16 @@ describe("buildSessionContext", () => {
       { content: "retained" },
       { content: "new turn" },
     ]);
+    const retainedBoundary = Symbol.for("openclaw.compactionRetainedBoundary");
+    expect(
+      (context.messages[0] as AgentMessage & { [retainedBoundary]?: string })[retainedBoundary],
+    ).toBe("compaction");
+    expect(
+      (context.messages[1] as AgentMessage & { [retainedBoundary]?: string })[retainedBoundary],
+    ).toBe("compaction");
+    expect(
+      (context.messages[2] as AgentMessage & { [retainedBoundary]?: string })[retainedBoundary],
+    ).toBeUndefined();
   });
 
   it("preserves the retained range when a compaction timestamp is invalid", () => {

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -10,6 +10,22 @@ import type { CompactionEntry, ResetEntry, SessionContext, SessionTreeEntry } fr
 type ContextBoundary = CompactionEntry | ResetEntry;
 const SESSION_HISTORY_PRELUDE = Symbol.for("openclaw.sessionHistoryPrelude");
 const COMPACTION_RETAINED_BOUNDARY = Symbol.for("openclaw.compactionRetainedBoundary");
+// This enumerable field is runtime-only provenance for context-engine assembly. It is
+// removed at the LLM/transcript boundaries and must never be treated as transcript data.
+const COMPACTION_SOURCE_ENTRY_ID = "__openclawCompactionSourceEntryId";
+
+function withCompactionSourceEntryId<TMessage extends AgentMessage>(
+  message: TMessage,
+  entryId: string,
+): TMessage {
+  const marked = { ...message } as TMessage & { [COMPACTION_SOURCE_ENTRY_ID]?: string };
+  Object.defineProperty(marked, COMPACTION_SOURCE_ENTRY_ID, {
+    configurable: true,
+    enumerable: true,
+    value: entryId,
+  });
+  return marked;
+}
 
 function withCompactionRetainedBoundary<TMessage extends AgentMessage>(
   message: TMessage,
@@ -26,22 +42,28 @@ function withCompactionRetainedBoundary<TMessage extends AgentMessage>(
 
 function appendContextMessage(messages: AgentMessage[], entry: SessionTreeEntry): void {
   if (entry.type === "message") {
-    messages.push(entry.message);
+    messages.push(withCompactionSourceEntryId(entry.message, entry.id));
   } else if (entry.type === "custom_message") {
     messages.push(
-      asAgentMessage(
-        createCustomMessage(
-          entry.customType,
-          entry.content,
-          entry.display,
-          entry.details,
-          entry.timestamp,
+      withCompactionSourceEntryId(
+        asAgentMessage(
+          createCustomMessage(
+            entry.customType,
+            entry.content,
+            entry.display,
+            entry.details,
+            entry.timestamp,
+          ),
         ),
+        entry.id,
       ),
     );
   } else if (entry.type === "branch_summary" && entry.summary) {
     messages.push(
-      asAgentMessage(createBranchSummaryMessage(entry.summary, entry.fromId, entry.timestamp)),
+      withCompactionSourceEntryId(
+        asAgentMessage(createBranchSummaryMessage(entry.summary, entry.fromId, entry.timestamp)),
+        entry.id,
+      ),
     );
   }
 }
@@ -51,7 +73,9 @@ function appendResetKeptMessage(messages: AgentMessage[], entry: SessionTreeEntr
     entry.type === "message" &&
     (entry.message.role === "user" || entry.message.role === "assistant")
   ) {
-    const message = { ...entry.message } as AgentMessage & { [SESSION_HISTORY_PRELUDE]?: true };
+    const message = withCompactionSourceEntryId(entry.message, entry.id) as AgentMessage & {
+      [SESSION_HISTORY_PRELUDE]?: true;
+    };
     Object.defineProperty(message, SESSION_HISTORY_PRELUDE, {
       configurable: true,
       enumerable: false,
@@ -84,12 +108,15 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
     let compactionSummary: Extract<AgentMessage, { role: "compactionSummary" }> | undefined;
     if (boundary.type === "compaction") {
       compactionSummary = withCompactionRetainedBoundary(
-        asAgentMessage(
-          createCompactionSummaryMessage(
-            boundary.summary,
-            boundary.tokensBefore,
-            boundary.timestamp,
+        withCompactionSourceEntryId(
+          asAgentMessage(
+            createCompactionSummaryMessage(
+              boundary.summary,
+              boundary.tokensBefore,
+              boundary.timestamp,
+            ),
           ),
+          boundary.id,
         ) as Extract<AgentMessage, { role: "compactionSummary" }>,
         boundary.id,
       );

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -67,17 +67,14 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
 
   const messages: AgentMessage[] = [];
   if (boundary) {
+    let compactionSummary: Extract<AgentMessage, { role: "compactionSummary" }> | undefined;
     if (boundary.type === "compaction") {
-      messages.push(
-        asAgentMessage(
-          createCompactionSummaryMessage(
-            boundary.summary,
-            boundary.tokensBefore,
-            boundary.timestamp,
-          ),
-        ),
-      );
+      compactionSummary = asAgentMessage(
+        createCompactionSummaryMessage(boundary.summary, boundary.tokensBefore, boundary.timestamp),
+      ) as Extract<AgentMessage, { role: "compactionSummary" }>;
+      messages.push(compactionSummary);
     }
+    const retainedMessagesStart = messages.length;
     const boundaryIdx = pathEntries.findIndex((entry) => entry.id === boundary.id);
     // A reset kept tail mirrors the old cross-log replay contract: only user/assistant
     // rows survive. Compaction keeps its existing richer retained-tail behavior.
@@ -93,6 +90,11 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
           appendContextMessage(messages, entry);
         }
       }
+    }
+    if (compactionSummary) {
+      // The summary is intentionally first in model context. Preserve the source boundary
+      // structurally so invalid timestamps cannot make retained metadata look post-compaction.
+      compactionSummary.retainedMessageCount = messages.length - retainedMessagesStart;
     }
     for (const entry of pathEntries.slice(boundaryIdx + 1)) {
       appendContextMessage(messages, entry);

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -9,6 +9,20 @@ import type { CompactionEntry, ResetEntry, SessionContext, SessionTreeEntry } fr
 
 type ContextBoundary = CompactionEntry | ResetEntry;
 const SESSION_HISTORY_PRELUDE = Symbol.for("openclaw.sessionHistoryPrelude");
+const COMPACTION_RETAINED_BOUNDARY = Symbol.for("openclaw.compactionRetainedBoundary");
+
+function withCompactionRetainedBoundary<TMessage extends AgentMessage>(
+  message: TMessage,
+  boundaryId: string,
+): TMessage {
+  const marked = { ...message } as TMessage & { [COMPACTION_RETAINED_BOUNDARY]?: string };
+  Object.defineProperty(marked, COMPACTION_RETAINED_BOUNDARY, {
+    configurable: true,
+    enumerable: true,
+    value: boundaryId,
+  });
+  return marked;
+}
 
 function appendContextMessage(messages: AgentMessage[], entry: SessionTreeEntry): void {
   if (entry.type === "message") {
@@ -69,9 +83,16 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
   if (boundary) {
     let compactionSummary: Extract<AgentMessage, { role: "compactionSummary" }> | undefined;
     if (boundary.type === "compaction") {
-      compactionSummary = asAgentMessage(
-        createCompactionSummaryMessage(boundary.summary, boundary.tokensBefore, boundary.timestamp),
-      ) as Extract<AgentMessage, { role: "compactionSummary" }>;
+      compactionSummary = withCompactionRetainedBoundary(
+        asAgentMessage(
+          createCompactionSummaryMessage(
+            boundary.summary,
+            boundary.tokensBefore,
+            boundary.timestamp,
+          ),
+        ) as Extract<AgentMessage, { role: "compactionSummary" }>,
+        boundary.id,
+      );
       messages.push(compactionSummary);
     }
     const retainedMessagesStart = messages.length;
@@ -93,7 +114,13 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
     }
     if (compactionSummary) {
       // The summary is intentionally first in model context. Preserve the source boundary
-      // structurally so invalid timestamps cannot make retained metadata look post-compaction.
+      // on each retained message so filtering/windowing cannot make positional metadata stale.
+      for (let index = retainedMessagesStart; index < messages.length; index += 1) {
+        const message = messages[index];
+        if (message) {
+          messages[index] = withCompactionRetainedBoundary(message, boundary.id);
+        }
+      }
       compactionSummary.retainedMessageCount = messages.length - retainedMessagesStart;
     }
     for (const entry of pathEntries.slice(boundaryIdx + 1)) {

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -365,7 +365,12 @@ export interface CompactionSummaryMessage {
   /** Estimated context tokens before compaction. */
   tokensBefore: number;
   /** Timestamp may be numeric in memory or string when loaded from older persisted rows. */
-  timestamp: number | string;
+  timestamp?: number | string;
+  /**
+   * Number of replayed messages immediately following this summary that were retained
+   * from before the compaction boundary. Runtime-only metadata for stale-state cleanup.
+   */
+  retainedMessageCount?: number;
   /** Optional estimated context tokens after compaction. */
   tokensAfter?: number;
   /** Optional first retained entry id from the compaction range. */

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -1089,4 +1089,18 @@ describe("buildSessionEntry", () => {
     const entry = requireSessionEntry(await buildSessionEntry(filePath));
     expect(entry.messageTimestampsMs).toStrictEqual([0]);
   });
+
+  it("drops loose and Date-invalid string message timestamps", async () => {
+    const jsonlLines = ["01/02/03", "+275760-09-13T00:00:00.001Z"].map((timestamp) =>
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: timestamp, timestamp },
+      }),
+    );
+    const filePath = path.join(tmpDir, "invalid-string-timestamp-session.jsonl");
+    fsSync.writeFileSync(filePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(filePath));
+    expect(entry.messageTimestampsMs).toStrictEqual([0, 0]);
+  });
 });

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -1,6 +1,7 @@
 // Memory Host SDK module implements session files behavior.
 import fsSync from "node:fs";
 import path from "node:path";
+import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeAgentId } from "./config-utils.js";
 import { readRegularFile, statRegularFile } from "./fs-utils.js";
 import { hashText } from "./hash.js";
@@ -633,8 +634,8 @@ function parseSessionTimestampMs(
       }
     }
     if (typeof value === "string") {
-      const parsed = Date.parse(value);
-      if (Number.isFinite(parsed) && parsed > 0) {
+      const parsed = parseStrictTimestampStringMs(value);
+      if (parsed !== undefined && parsed > 0) {
         return parsed;
       }
     }

--- a/packages/normalization-core/src/number-coercion.test.ts
+++ b/packages/normalization-core/src/number-coercion.test.ts
@@ -28,6 +28,7 @@ import {
   parseStrictInteger,
   parseStrictNonNegativeInteger,
   parseStrictPositiveInteger,
+  parseStrictTimestampStringMs,
   resolveTimerTimeoutMs,
   resolveTimestampMsToIsoString,
   timestampMsToIsoFileStamp,
@@ -137,6 +138,25 @@ describe("number-coercion", () => {
     expect(timestampMsToIsoString(8_640_000_000_000_001)).toBeUndefined();
     expect(timestampMsToIsoString(Number.POSITIVE_INFINITY)).toBeUndefined();
     expect(timestampMsToIsoString("0")).toBeUndefined();
+  });
+
+  test.each([
+    ["2026-01-02T03:04:05.006Z", "2026-01-02T03:04:05.006Z"],
+    ["2026-01-02t03:04:05.006z", "2026-01-02T03:04:05.006Z"],
+    ["2026-01-02T03:04:05+08:00", "2026-01-02T03:04:05+08:00"],
+  ])("parses strict persisted timestamp %s", (value, expected) => {
+    expect(parseStrictTimestampStringMs(value)).toBe(Date.parse(expected));
+  });
+
+  test.each([
+    "01/02/03",
+    "9999-12-31",
+    "2026-02-29T00:00:00.000Z",
+    "2026-02-31T00:00:00.000Z",
+    "2026-01-01T24:00:00.000Z",
+    "+275760-09-13T00:00:00.001Z",
+  ])("rejects loose or Date-invalid persisted timestamp %s", (value) => {
+    expect(parseStrictTimestampStringMs(value)).toBeUndefined();
   });
 
   test("future timestamp helper rejects invalid Date timestamps", () => {

--- a/packages/normalization-core/src/number-coercion.ts
+++ b/packages/normalization-core/src/number-coercion.ts
@@ -106,8 +106,67 @@ export const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
 export const MAX_TIMER_TIMEOUT_SECONDS = Math.floor(MAX_TIMER_TIMEOUT_MS / 1000);
 /** Largest timestamp accepted by JavaScript Date. */
 export const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
+const STRICT_TIMESTAMP_STRING_RE =
+  /^([+-]\d{6}|\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/i;
 /** Fallback ISO value for invalid timestamp inputs. */
 export const UNIX_EPOCH_ISO_STRING = "1970-01-01T00:00:00.000Z";
+
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+function daysInMonth(year: number, month: number): number {
+  if (month === 2) {
+    return isLeapYear(year) ? 29 : 28;
+  }
+  return [4, 6, 9, 11].includes(month) ? 30 : 31;
+}
+
+function hasValidTimestampFields(parts: RegExpExecArray): boolean {
+  const year = Number(parts[1]);
+  const month = Number(parts[2]);
+  const day = Number(parts[3]);
+  const hour = Number(parts[4]);
+  const minute = Number(parts[5]);
+  const second = Number(parts[6]);
+  const zone = parts[7]?.toUpperCase();
+  if (!zone) {
+    return false;
+  }
+  const zoneHour = zone === "Z" ? 0 : Number(zone.slice(1, 3));
+  const zoneMinute = zone === "Z" ? 0 : Number(zone.slice(4, 6));
+
+  return (
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= daysInMonth(year, month) &&
+    hour >= 0 &&
+    hour <= 23 &&
+    minute >= 0 &&
+    minute <= 59 &&
+    second >= 0 &&
+    second <= 59 &&
+    zoneHour >= 0 &&
+    zoneHour <= 23 &&
+    zoneMinute >= 0 &&
+    zoneMinute <= 59
+  );
+}
+
+/** Parses a strict ISO/RFC3339 timestamp string to a Date-valid millisecond timestamp. */
+export function parseStrictTimestampStringMs(value: unknown): number | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  const match = STRICT_TIMESTAMP_STRING_RE.exec(normalized);
+  if (!match || !hasValidTimestampFields(match)) {
+    return undefined;
+  }
+  const parseable = normalized.replace(/[Tt]/, "T").replace(/[Zz]$/, "Z");
+  return asDateTimestampMs(Date.parse(parseable));
+}
 
 /** Returns a Date-valid millisecond timestamp. */
 export function asDateTimestampMs(value: unknown): number | undefined {

--- a/src/agents/compaction-boundary.ts
+++ b/src/agents/compaction-boundary.ts
@@ -1,0 +1,79 @@
+import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
+import type { AgentMessage } from "./runtime/index.js";
+
+export type CompactionBoundary = {
+  latestSummaryIndex: number;
+  latestSummaryTimestamp: number | null;
+  maxSummaryTimestamp: number | null;
+  retainedStartIndex: number | null;
+  retainedEndIndex: number | null;
+};
+
+export function parseCompactionBoundaryTimestamp(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return parseStrictTimestampStringMs(value) ?? null;
+  }
+  return null;
+}
+
+function parseRetainedMessageCount(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionBoundary | null {
+  let latestSummaryIndex = -1;
+  let latestSummaryTimestamp: number | null = null;
+  let maxSummaryTimestamp: number | null = null;
+  let retainedMessageCount: number | null = null;
+
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    if ((message as { role?: unknown } | undefined)?.role !== "compactionSummary") {
+      continue;
+    }
+    const summary = message as AgentMessage & {
+      retainedMessageCount?: unknown;
+      timestamp?: unknown;
+    };
+    const timestamp = parseCompactionBoundaryTimestamp(summary.timestamp);
+    latestSummaryIndex = index;
+    latestSummaryTimestamp = timestamp;
+    retainedMessageCount = parseRetainedMessageCount(summary.retainedMessageCount);
+    if (timestamp !== null) {
+      maxSummaryTimestamp =
+        maxSummaryTimestamp === null ? timestamp : Math.max(maxSummaryTimestamp, timestamp);
+    }
+  }
+
+  if (latestSummaryIndex === -1) {
+    return null;
+  }
+  const retainedStartIndex =
+    retainedMessageCount === null ? null : Math.min(messages.length, latestSummaryIndex + 1);
+  const retainedEndIndex =
+    retainedStartIndex === null || retainedMessageCount === null
+      ? null
+      : Math.min(messages.length, retainedStartIndex + retainedMessageCount);
+  return {
+    latestSummaryIndex,
+    latestSummaryTimestamp,
+    maxSummaryTimestamp,
+    retainedStartIndex,
+    retainedEndIndex,
+  };
+}
+
+export function isWithinRetainedCompactionRange(
+  boundary: CompactionBoundary,
+  messageIndex: number,
+): boolean {
+  return (
+    boundary.retainedStartIndex !== null &&
+    boundary.retainedEndIndex !== null &&
+    messageIndex >= boundary.retainedStartIndex &&
+    messageIndex < boundary.retainedEndIndex
+  );
+}

--- a/src/agents/compaction-boundary.ts
+++ b/src/agents/compaction-boundary.ts
@@ -3,6 +3,10 @@ import type { AgentMessage } from "./runtime/index.js";
 
 const COMPACTION_RETAINED_BOUNDARY = Symbol.for("openclaw.compactionRetainedBoundary");
 
+type CompactionBoundaryMarkedMessage = AgentMessage & {
+  [COMPACTION_RETAINED_BOUNDARY]?: unknown;
+};
+
 export type CompactionBoundary = {
   latestSummaryIndex: number;
   latestSummaryTimestamp: number | null;
@@ -26,6 +30,54 @@ function parseRetainedMessageCount(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
 }
 
+function getCompactionBoundaryId(message: AgentMessage): string | null {
+  const value = (message as CompactionBoundaryMarkedMessage)[COMPACTION_RETAINED_BOUNDARY];
+  return typeof value === "string" ? value : null;
+}
+
+function withCompactionBoundaryId(message: AgentMessage, boundaryId: string): AgentMessage {
+  const marked = { ...message } as CompactionBoundaryMarkedMessage;
+  Object.defineProperty(marked, COMPACTION_RETAINED_BOUNDARY, {
+    configurable: true,
+    enumerable: true,
+    value: boundaryId,
+  });
+  return marked;
+}
+
+function compactionMessageKey(message: AgentMessage): string {
+  const record = message as AgentMessage & {
+    content?: unknown;
+    customType?: unknown;
+    fromId?: unknown;
+    model?: unknown;
+    provider?: unknown;
+    role?: unknown;
+    summary?: unknown;
+    timestamp?: unknown;
+    tokensBefore?: unknown;
+    toolCallId?: unknown;
+    toolName?: unknown;
+  };
+  try {
+    return JSON.stringify({
+      content: record.content,
+      customType: record.customType,
+      fromId: record.fromId,
+      model: record.model,
+      provider: record.provider,
+      role: record.role,
+      summary: record.summary,
+      timestamp: record.timestamp,
+      tokensBefore: record.tokensBefore,
+      toolCallId: record.toolCallId,
+      toolName: record.toolName,
+    });
+  } catch {
+    return `${record.role ?? "unknown"}:${String(record.timestamp ?? "")}`;
+  }
+}
+
 export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionBoundary | null {
   let latestSummaryIndex = -1;
   let latestSummaryTimestamp: number | null = null;
@@ -38,8 +90,7 @@ export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionB
     if ((message as { role?: unknown } | undefined)?.role !== "compactionSummary") {
       continue;
     }
-    const summary = message as AgentMessage & {
-      [COMPACTION_RETAINED_BOUNDARY]?: unknown;
+    const summary = message as CompactionBoundaryMarkedMessage & {
       retainedMessageCount?: unknown;
       timestamp?: unknown;
     };
@@ -47,10 +98,7 @@ export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionB
     latestSummaryIndex = index;
     latestSummaryTimestamp = timestamp;
     retainedMessageCount = parseRetainedMessageCount(summary.retainedMessageCount);
-    retainedBoundaryId =
-      typeof summary[COMPACTION_RETAINED_BOUNDARY] === "string"
-        ? summary[COMPACTION_RETAINED_BOUNDARY]
-        : null;
+    retainedBoundaryId = getCompactionBoundaryId(summary);
     if (timestamp !== null) {
       maxSummaryTimestamp =
         maxSummaryTimestamp === null ? timestamp : Math.max(maxSummaryTimestamp, timestamp);
@@ -68,10 +116,7 @@ export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionB
             if (index <= latestSummaryIndex) {
               return [];
             }
-            const marked = message as AgentMessage & {
-              [COMPACTION_RETAINED_BOUNDARY]?: unknown;
-            };
-            return marked[COMPACTION_RETAINED_BOUNDARY] === retainedBoundaryId ? [index] : [];
+            return getCompactionBoundaryId(message) === retainedBoundaryId ? [index] : [];
           }),
         );
   const explicitRetainedIndexes = retainedMessageIndexes
@@ -111,4 +156,99 @@ export function isWithinRetainedCompactionRange(
     messageIndex >= boundary.retainedStartIndex &&
     messageIndex < boundary.retainedEndIndex
   );
+}
+
+/**
+ * Rebind the host-owned retained range after a context engine returns a transformed message
+ * array. Engines may clone messages with structuredClone(), which intentionally drops symbols.
+ */
+export function rebindCompactionBoundaryMessages(
+  sourceMessages: AgentMessage[],
+  transformedMessages: AgentMessage[],
+): AgentMessage[] {
+  const sourceBoundary = resolveCompactionBoundary(sourceMessages);
+  if (!sourceBoundary?.retainedMessageIndexes) {
+    return transformedMessages;
+  }
+  const sourceSummary = sourceMessages[sourceBoundary.latestSummaryIndex];
+  const boundaryId = sourceSummary ? getCompactionBoundaryId(sourceSummary) : null;
+  if (!boundaryId) {
+    return transformedMessages;
+  }
+
+  let transformedSummaryIndex = -1;
+  for (let index = transformedMessages.length - 1; index >= 0; index -= 1) {
+    if (transformedMessages[index]?.role === "compactionSummary") {
+      transformedSummaryIndex = index;
+      break;
+    }
+  }
+  if (transformedSummaryIndex === -1) {
+    return transformedMessages;
+  }
+
+  const sourceIndexesByKey = new Map<string, number[]>();
+  for (let index = 0; index < sourceMessages.length; index += 1) {
+    if (index === sourceBoundary.latestSummaryIndex) {
+      continue;
+    }
+    const key = compactionMessageKey(sourceMessages[index] as AgentMessage);
+    const indexes = sourceIndexesByKey.get(key) ?? [];
+    indexes.push(index);
+    sourceIndexesByKey.set(key, indexes);
+  }
+
+  let matchedRetainedCount = 0;
+  let changed = false;
+  const rebound = transformedMessages.map((message, index) => {
+    if (index === transformedSummaryIndex) {
+      const summary = message as AgentMessage & { retainedMessageCount?: unknown };
+      if (
+        getCompactionBoundaryId(message) === boundaryId &&
+        summary.retainedMessageCount === sourceBoundary.retainedMessageIndexes?.size
+      ) {
+        return message;
+      }
+      const marked = {
+        ...message,
+        retainedMessageCount: 0,
+      } as AgentMessage & { retainedMessageCount?: number };
+      Object.defineProperty(marked, COMPACTION_RETAINED_BOUNDARY, {
+        configurable: true,
+        enumerable: true,
+        value: boundaryId,
+      });
+      changed = true;
+      return marked;
+    }
+
+    const candidates = sourceIndexesByKey.get(compactionMessageKey(message));
+    const sourceIndex = candidates?.shift();
+    if (sourceIndex === undefined || !sourceBoundary.retainedMessageIndexes?.has(sourceIndex)) {
+      return message;
+    }
+    matchedRetainedCount += 1;
+    if (getCompactionBoundaryId(message) === boundaryId) {
+      return message;
+    }
+    changed = true;
+    return withCompactionBoundaryId(message, boundaryId);
+  });
+
+  if (!changed) {
+    return transformedMessages;
+  }
+  const summary = rebound[transformedSummaryIndex] as AgentMessage & {
+    retainedMessageCount?: number;
+  };
+  if (summary.retainedMessageCount !== matchedRetainedCount) {
+    const updated = { ...summary, retainedMessageCount: matchedRetainedCount };
+    Object.defineProperty(updated, COMPACTION_RETAINED_BOUNDARY, {
+      configurable: true,
+      enumerable: true,
+      value: boundaryId,
+    });
+    rebound[transformedSummaryIndex] = updated as AgentMessage;
+  }
+  return rebound;
 }

--- a/src/agents/compaction-boundary.ts
+++ b/src/agents/compaction-boundary.ts
@@ -8,7 +8,7 @@ type CompactionBoundaryMarkedMessage = AgentMessage & {
   [COMPACTION_RETAINED_BOUNDARY]?: unknown;
 };
 
-export type CompactionBoundary = {
+type CompactionBoundary = {
   latestSummaryIndex: number;
   latestSummaryTimestamp: number | null;
   maxSummaryTimestamp: number | null;
@@ -103,8 +103,9 @@ export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionB
       ? null
       : Math.min(messages.length, latestSummaryIndex + 1);
   const retainedEndIndex = explicitRetainedIndexes
-    ? (explicitRetainedIndexes.at(-1) ?? retainedStartIndex) +
-      (explicitRetainedIndexes.length > 0 ? 1 : 0)
+    ? explicitRetainedIndexes.length === 0
+      ? retainedStartIndex
+      : (explicitRetainedIndexes.at(-1) as number) + 1
     : retainedStartIndex === null || retainedMessageCount === null
       ? null
       : Math.min(messages.length, retainedStartIndex + retainedMessageCount);

--- a/src/agents/compaction-boundary.ts
+++ b/src/agents/compaction-boundary.ts
@@ -2,6 +2,7 @@ import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/numbe
 import type { AgentMessage } from "./runtime/index.js";
 
 const COMPACTION_RETAINED_BOUNDARY = Symbol.for("openclaw.compactionRetainedBoundary");
+export const COMPACTION_SOURCE_ENTRY_ID = "__openclawCompactionSourceEntryId";
 
 type CompactionBoundaryMarkedMessage = AgentMessage & {
   [COMPACTION_RETAINED_BOUNDARY]?: unknown;
@@ -35,6 +36,13 @@ function getCompactionBoundaryId(message: AgentMessage): string | null {
   return typeof value === "string" ? value : null;
 }
 
+function getCompactionSourceEntryId(message: AgentMessage): string | null {
+  const value = (message as AgentMessage & { [COMPACTION_SOURCE_ENTRY_ID]?: unknown })[
+    COMPACTION_SOURCE_ENTRY_ID
+  ];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 function withCompactionBoundaryId(message: AgentMessage, boundaryId: string): AgentMessage {
   const marked = { ...message } as CompactionBoundaryMarkedMessage;
   Object.defineProperty(marked, COMPACTION_RETAINED_BOUNDARY, {
@@ -43,39 +51,6 @@ function withCompactionBoundaryId(message: AgentMessage, boundaryId: string): Ag
     value: boundaryId,
   });
   return marked;
-}
-
-function compactionMessageKey(message: AgentMessage): string {
-  const record = message as AgentMessage & {
-    content?: unknown;
-    customType?: unknown;
-    fromId?: unknown;
-    model?: unknown;
-    provider?: unknown;
-    role?: unknown;
-    summary?: unknown;
-    timestamp?: unknown;
-    tokensBefore?: unknown;
-    toolCallId?: unknown;
-    toolName?: unknown;
-  };
-  try {
-    return JSON.stringify({
-      content: record.content,
-      customType: record.customType,
-      fromId: record.fromId,
-      model: record.model,
-      provider: record.provider,
-      role: record.role,
-      summary: record.summary,
-      timestamp: record.timestamp,
-      tokensBefore: record.tokensBefore,
-      toolCallId: record.toolCallId,
-      toolName: record.toolName,
-    });
-  } catch {
-    return `${record.role ?? "unknown"}:${String(record.timestamp ?? "")}`;
-  }
 }
 
 export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionBoundary | null {
@@ -172,13 +147,18 @@ export function rebindCompactionBoundaryMessages(
   }
   const sourceSummary = sourceMessages[sourceBoundary.latestSummaryIndex];
   const boundaryId = sourceSummary ? getCompactionBoundaryId(sourceSummary) : null;
-  if (!boundaryId) {
+  const sourceSummaryEntryId = sourceSummary ? getCompactionSourceEntryId(sourceSummary) : null;
+  if (!boundaryId || !sourceSummaryEntryId) {
     return transformedMessages;
   }
 
   let transformedSummaryIndex = -1;
   for (let index = transformedMessages.length - 1; index >= 0; index -= 1) {
-    if (transformedMessages[index]?.role === "compactionSummary") {
+    if (
+      transformedMessages[index]?.role === "compactionSummary" &&
+      getCompactionSourceEntryId(transformedMessages[index] as AgentMessage) ===
+        sourceSummaryEntryId
+    ) {
       transformedSummaryIndex = index;
       break;
     }
@@ -187,15 +167,18 @@ export function rebindCompactionBoundaryMessages(
     return transformedMessages;
   }
 
-  const sourceIndexesByKey = new Map<string, number[]>();
+  const sourceIndexByEntryId = new Map<string, number>();
+  const ambiguousSourceEntryIds = new Set<string>();
   for (let index = 0; index < sourceMessages.length; index += 1) {
-    if (index === sourceBoundary.latestSummaryIndex) {
+    const sourceEntryId = getCompactionSourceEntryId(sourceMessages[index] as AgentMessage);
+    if (!sourceEntryId) {
       continue;
     }
-    const key = compactionMessageKey(sourceMessages[index] as AgentMessage);
-    const indexes = sourceIndexesByKey.get(key) ?? [];
-    indexes.push(index);
-    sourceIndexesByKey.set(key, indexes);
+    if (sourceIndexByEntryId.has(sourceEntryId)) {
+      ambiguousSourceEntryIds.add(sourceEntryId);
+      continue;
+    }
+    sourceIndexByEntryId.set(sourceEntryId, index);
   }
 
   let matchedRetainedCount = 0;
@@ -222,8 +205,11 @@ export function rebindCompactionBoundaryMessages(
       return marked;
     }
 
-    const candidates = sourceIndexesByKey.get(compactionMessageKey(message));
-    const sourceIndex = candidates?.shift();
+    const sourceEntryId = getCompactionSourceEntryId(message);
+    const sourceIndex =
+      sourceEntryId && !ambiguousSourceEntryIds.has(sourceEntryId)
+        ? sourceIndexByEntryId.get(sourceEntryId)
+        : undefined;
     if (sourceIndex === undefined || !sourceBoundary.retainedMessageIndexes?.has(sourceIndex)) {
       return message;
     }

--- a/src/agents/compaction-boundary.ts
+++ b/src/agents/compaction-boundary.ts
@@ -1,12 +1,15 @@
 import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
 import type { AgentMessage } from "./runtime/index.js";
 
+const COMPACTION_RETAINED_BOUNDARY = Symbol.for("openclaw.compactionRetainedBoundary");
+
 export type CompactionBoundary = {
   latestSummaryIndex: number;
   latestSummaryTimestamp: number | null;
   maxSummaryTimestamp: number | null;
   retainedStartIndex: number | null;
   retainedEndIndex: number | null;
+  retainedMessageIndexes: ReadonlySet<number> | null;
 };
 
 export function parseCompactionBoundaryTimestamp(value: unknown): number | null {
@@ -28,6 +31,7 @@ export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionB
   let latestSummaryTimestamp: number | null = null;
   let maxSummaryTimestamp: number | null = null;
   let retainedMessageCount: number | null = null;
+  let retainedBoundaryId: string | null = null;
 
   for (let index = 0; index < messages.length; index += 1) {
     const message = messages[index];
@@ -35,6 +39,7 @@ export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionB
       continue;
     }
     const summary = message as AgentMessage & {
+      [COMPACTION_RETAINED_BOUNDARY]?: unknown;
       retainedMessageCount?: unknown;
       timestamp?: unknown;
     };
@@ -42,6 +47,10 @@ export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionB
     latestSummaryIndex = index;
     latestSummaryTimestamp = timestamp;
     retainedMessageCount = parseRetainedMessageCount(summary.retainedMessageCount);
+    retainedBoundaryId =
+      typeof summary[COMPACTION_RETAINED_BOUNDARY] === "string"
+        ? summary[COMPACTION_RETAINED_BOUNDARY]
+        : null;
     if (timestamp !== null) {
       maxSummaryTimestamp =
         maxSummaryTimestamp === null ? timestamp : Math.max(maxSummaryTimestamp, timestamp);
@@ -51,10 +60,32 @@ export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionB
   if (latestSummaryIndex === -1) {
     return null;
   }
-  const retainedStartIndex =
-    retainedMessageCount === null ? null : Math.min(messages.length, latestSummaryIndex + 1);
-  const retainedEndIndex =
-    retainedStartIndex === null || retainedMessageCount === null
+  const retainedMessageIndexes =
+    retainedBoundaryId === null
+      ? null
+      : new Set(
+          messages.flatMap((message, index) => {
+            if (index <= latestSummaryIndex) {
+              return [];
+            }
+            const marked = message as AgentMessage & {
+              [COMPACTION_RETAINED_BOUNDARY]?: unknown;
+            };
+            return marked[COMPACTION_RETAINED_BOUNDARY] === retainedBoundaryId ? [index] : [];
+          }),
+        );
+  const explicitRetainedIndexes = retainedMessageIndexes
+    ? Array.from(retainedMessageIndexes)
+    : null;
+  const retainedStartIndex = explicitRetainedIndexes
+    ? (explicitRetainedIndexes.at(0) ?? Math.min(messages.length, latestSummaryIndex + 1))
+    : retainedMessageCount === null
+      ? null
+      : Math.min(messages.length, latestSummaryIndex + 1);
+  const retainedEndIndex = explicitRetainedIndexes
+    ? (explicitRetainedIndexes.at(-1) ?? retainedStartIndex) +
+      (explicitRetainedIndexes.length > 0 ? 1 : 0)
+    : retainedStartIndex === null || retainedMessageCount === null
       ? null
       : Math.min(messages.length, retainedStartIndex + retainedMessageCount);
   return {
@@ -63,6 +94,7 @@ export function resolveCompactionBoundary(messages: AgentMessage[]): CompactionB
     maxSummaryTimestamp,
     retainedStartIndex,
     retainedEndIndex,
+    retainedMessageIndexes,
   };
 }
 
@@ -70,6 +102,9 @@ export function isWithinRetainedCompactionRange(
   boundary: CompactionBoundary,
   messageIndex: number,
 ): boolean {
+  if (boundary.retainedMessageIndexes !== null) {
+    return boundary.retainedMessageIndexes.has(messageIndex);
+  }
   return (
     boundary.retainedStartIndex !== null &&
     boundary.retainedEndIndex !== null &&

--- a/src/agents/compaction-usage.ts
+++ b/src/agents/compaction-usage.ts
@@ -2,21 +2,13 @@
  * Shared helpers for clearing assistant usage snapshots invalidated by
  * transcript compaction.
  */
+import {
+  isWithinRetainedCompactionRange,
+  parseCompactionBoundaryTimestamp,
+  resolveCompactionBoundary,
+} from "./compaction-boundary.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
-
-function parseCompactionUsageTimestamp(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  if (typeof value === "string") {
-    const parsed = Date.parse(value);
-    if (Number.isFinite(parsed)) {
-      return parsed;
-    }
-  }
-  return null;
-}
 
 export function stripStaleAssistantUsageBeforeLatestCompaction<TMessage extends AgentMessage>(
   messages: TMessage[],
@@ -25,19 +17,8 @@ export function stripStaleAssistantUsageBeforeLatestCompaction<TMessage extends 
     whenMissingCompactionSummary?: "preserve" | "zeroAssistantUsage";
   } = {},
 ): TMessage[] {
-  let latestCompactionSummaryIndex = -1;
-  let latestCompactionTimestamp: number | null = null;
-  for (let i = 0; i < messages.length; i += 1) {
-    const entry = messages[i];
-    if (entry?.role !== "compactionSummary") {
-      continue;
-    }
-    latestCompactionSummaryIndex = i;
-    latestCompactionTimestamp = parseCompactionUsageTimestamp(
-      (entry as { timestamp?: unknown }).timestamp ?? null,
-    );
-  }
-  const hasCompactionSummary = latestCompactionSummaryIndex !== -1;
+  const boundary = resolveCompactionBoundary(messages);
+  const hasCompactionSummary = boundary !== null;
   if (!hasCompactionSummary && options.whenMissingCompactionSummary !== "zeroAssistantUsage") {
     return messages;
   }
@@ -55,15 +36,25 @@ export function stripStaleAssistantUsageBeforeLatestCompaction<TMessage extends 
       continue;
     }
 
-    const messageTimestamp = parseCompactionUsageTimestamp(candidate.timestamp);
-    const compactionTimestamp = latestCompactionTimestamp;
+    const messageTimestamp = parseCompactionBoundaryTimestamp(candidate.timestamp);
+    const compactionTimestamp = boundary?.latestSummaryTimestamp ?? null;
     const hasTimestampBoundary =
       hasCompactionSummary && compactionTimestamp !== null && messageTimestamp !== null;
     const staleByMissingSummary = !hasCompactionSummary;
     const staleByTimestamp = hasTimestampBoundary && messageTimestamp <= compactionTimestamp;
+    const staleByRetainedRange =
+      boundary !== null && !hasTimestampBoundary && isWithinRetainedCompactionRange(boundary, i);
     const staleByLegacyOrdering =
-      hasCompactionSummary && !hasTimestampBoundary && i < latestCompactionSummaryIndex;
-    if (!staleByMissingSummary && !staleByTimestamp && !staleByLegacyOrdering) {
+      boundary !== null &&
+      !hasTimestampBoundary &&
+      boundary.retainedStartIndex === null &&
+      i < boundary.latestSummaryIndex;
+    if (
+      !staleByMissingSummary &&
+      !staleByTimestamp &&
+      !staleByRetainedRange &&
+      !staleByLegacyOrdering
+    ) {
       continue;
     }
 

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -58,7 +58,9 @@ function makeMessages(count: number, size: number): AgentMessage[] {
 }
 
 function compareTimestampIds(left: AgentMessage["timestamp"], right: AgentMessage["timestamp"]) {
-  return left < right ? -1 : left > right ? 1 : 0;
+  const leftValue = left ?? 0;
+  const rightValue = right ?? 0;
+  return leftValue < rightValue ? -1 : leftValue > rightValue ? 1 : 0;
 }
 
 function makeAssistantToolCall(

--- a/src/agents/embedded-agent-runner.limithistoryturns.test.ts
+++ b/src/agents/embedded-agent-runner.limithistoryturns.test.ts
@@ -3,6 +3,10 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
+import {
+  isWithinRetainedCompactionRange,
+  resolveCompactionBoundary,
+} from "./compaction-boundary.js";
 import { limitHistoryTurns } from "./embedded-agent-runner/history.js";
 
 describe("limitHistoryTurns", () => {
@@ -137,6 +141,49 @@ describe("limitHistoryTurns", () => {
     expect(limited.length).toBe(3);
     expect(expectDefined(limited[0], "limited[0] test invariant").role).toBe("compactionSummary");
     expect(firstText(expectDefined(limited[1], "limited[1] test invariant"))).toBe("message 2");
+  });
+
+  it("does not classify a fresh response as retained after history limiting", () => {
+    const retainedBoundary = Symbol.for("openclaw.compactionRetainedBoundary");
+    const boundaryId = "compaction-1";
+    const markRetained = (message: AgentMessage): AgentMessage => {
+      const marked = { ...message } as AgentMessage & { [retainedBoundary]?: string };
+      Object.defineProperty(marked, retainedBoundary, {
+        enumerable: true,
+        value: boundaryId,
+      });
+      return marked;
+    };
+    const compactionSummary = markRetained({
+      role: "compactionSummary",
+      summary: "Previous conversation",
+      tokensBefore: 5000,
+      retainedMessageCount: 4,
+    } as AgentMessage);
+    const retained = makeMessages(["user", "assistant", "user", "assistant"]).map(markRetained);
+    const currentTurn = makeMessages(["user", "assistant"]);
+
+    const limited = limitHistoryTurns([compactionSummary, ...retained, ...currentTurn], 1).map(
+      (message) => Object.assign({}, message) as AgentMessage,
+    );
+    const freshPrompt = userMessage("fresh prompt");
+    const freshAssistant = assistantTextMessage("fresh response");
+    const runtimeMessages = [...limited, freshPrompt, freshAssistant];
+    const boundary = expectDefined(
+      resolveCompactionBoundary(runtimeMessages),
+      "compaction boundary test invariant",
+    );
+
+    expect(limited.map((message) => message.role)).toEqual([
+      "compactionSummary",
+      "user",
+      "assistant",
+    ]);
+    expect(boundary.retainedStartIndex).toBe(1);
+    expect(boundary.retainedEndIndex).toBe(1);
+    expect(isWithinRetainedCompactionRange(boundary, runtimeMessages.indexOf(freshAssistant))).toBe(
+      false,
+    );
   });
 
   it("preserves leading branchSummary when limiting", () => {

--- a/src/agents/embedded-agent-runner.limithistoryturns.test.ts
+++ b/src/agents/embedded-agent-runner.limithistoryturns.test.ts
@@ -190,11 +190,16 @@ describe("limitHistoryTurns", () => {
   it("rebinds retained identity after a structured context-engine clone", () => {
     const retainedBoundary = Symbol.for("openclaw.compactionRetainedBoundary");
     const boundaryId = "compaction-structured-clone";
+    let sourceEntryCounter = 0;
     const markRetained = (message: AgentMessage): AgentMessage => {
       const marked = { ...message } as AgentMessage & { [retainedBoundary]?: string };
       Object.defineProperty(marked, retainedBoundary, {
         enumerable: true,
         value: boundaryId,
+      });
+      Object.defineProperty(marked, "__openclawCompactionSourceEntryId", {
+        enumerable: true,
+        value: `entry-${sourceEntryCounter++}`,
       });
       return marked;
     };
@@ -221,6 +226,48 @@ describe("limitHistoryTurns", () => {
     expect(isWithinRetainedCompactionRange(boundary, runtimeMessages.indexOf(freshAssistant))).toBe(
       false,
     );
+  });
+
+  it("does not bind a post-compaction duplicate to a retained source message", () => {
+    const retainedBoundary = Symbol.for("openclaw.compactionRetainedBoundary");
+    const boundaryId = "compaction-duplicate-source";
+    const sourceId = "__openclawCompactionSourceEntryId";
+    const mark = (message: AgentMessage, id: string): AgentMessage => {
+      const marked = { ...message } as AgentMessage & { [retainedBoundary]?: string };
+      Object.defineProperty(marked, sourceId, { enumerable: true, value: id });
+      if (id === "summary" || id === "retained-a") {
+        Object.defineProperty(marked, retainedBoundary, {
+          enumerable: true,
+          value: boundaryId,
+        });
+      }
+      return marked;
+    };
+    const duplicate = {
+      role: "user",
+      content: [{ type: "text", text: "same" }],
+      timestamp: 2_000,
+    } as AgentMessage;
+    const source = [
+      mark(
+        {
+          role: "compactionSummary",
+          summary: "Previous conversation",
+          tokensBefore: 5000,
+          retainedMessageCount: 1,
+        } as AgentMessage,
+        "summary",
+      ),
+      mark({ ...duplicate, timestamp: 1_000 }, "retained-a"),
+      mark(duplicate, "post-b"),
+    ];
+    const transformed = structuredClone([source[0], source[2]]) as AgentMessage[];
+
+    const rebound = rebindCompactionBoundaryMessages(source, transformed);
+
+    expect((rebound[1] as Record<string, unknown>)[sourceId]).toBe("post-b");
+    expect((rebound[1] as Record<PropertyKey, unknown>)[retainedBoundary]).toBeUndefined();
+    expect((rebound[0] as { retainedMessageCount?: number }).retainedMessageCount).toBe(0);
   });
 
   it("preserves leading branchSummary when limiting", () => {

--- a/src/agents/embedded-agent-runner.limithistoryturns.test.ts
+++ b/src/agents/embedded-agent-runner.limithistoryturns.test.ts
@@ -5,6 +5,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
 import {
   isWithinRetainedCompactionRange,
+  rebindCompactionBoundaryMessages,
   resolveCompactionBoundary,
 } from "./compaction-boundary.js";
 import { limitHistoryTurns } from "./embedded-agent-runner/history.js";
@@ -179,6 +180,42 @@ describe("limitHistoryTurns", () => {
       "user",
       "assistant",
     ]);
+    expect(boundary.retainedStartIndex).toBe(1);
+    expect(boundary.retainedEndIndex).toBe(1);
+    expect(isWithinRetainedCompactionRange(boundary, runtimeMessages.indexOf(freshAssistant))).toBe(
+      false,
+    );
+  });
+
+  it("rebinds retained identity after a structured context-engine clone", () => {
+    const retainedBoundary = Symbol.for("openclaw.compactionRetainedBoundary");
+    const boundaryId = "compaction-structured-clone";
+    const markRetained = (message: AgentMessage): AgentMessage => {
+      const marked = { ...message } as AgentMessage & { [retainedBoundary]?: string };
+      Object.defineProperty(marked, retainedBoundary, {
+        enumerable: true,
+        value: boundaryId,
+      });
+      return marked;
+    };
+    const summary = markRetained({
+      role: "compactionSummary",
+      summary: "Previous conversation",
+      tokensBefore: 5000,
+      retainedMessageCount: 4,
+    } as AgentMessage);
+    const retained = makeMessages(["user", "assistant", "user", "assistant"]).map(markRetained);
+    const currentTurn = makeMessages(["user", "assistant"]);
+    const limited = limitHistoryTurns([summary, ...retained, ...currentTurn], 1);
+    const cloned = structuredClone(limited) as AgentMessage[];
+    const rebound = rebindCompactionBoundaryMessages(limited, cloned);
+    const freshAssistant = assistantTextMessage("fresh response");
+    const runtimeMessages = [...rebound, userMessage("fresh prompt"), freshAssistant];
+    const boundary = expectDefined(
+      resolveCompactionBoundary(runtimeMessages),
+      "structured clone compaction boundary test invariant",
+    );
+
     expect(boundary.retainedStartIndex).toBe(1);
     expect(boundary.retainedEndIndex).toBe(1);
     expect(isWithinRetainedCompactionRange(boundary, runtimeMessages.indexOf(freshAssistant))).toBe(

--- a/src/agents/embedded-agent-runner.limithistoryturns.test.ts
+++ b/src/agents/embedded-agent-runner.limithistoryturns.test.ts
@@ -265,8 +265,10 @@ describe("limitHistoryTurns", () => {
 
     const rebound = rebindCompactionBoundaryMessages(source, transformed);
 
-    expect((rebound[1] as Record<string, unknown>)[sourceId]).toBe("post-b");
-    expect((rebound[1] as Record<PropertyKey, unknown>)[retainedBoundary]).toBeUndefined();
+    expect((rebound[1] as unknown as Record<string, unknown>)[sourceId]).toBe("post-b");
+    expect(
+      (rebound[1] as unknown as Record<PropertyKey, unknown>)[retainedBoundary],
+    ).toBeUndefined();
     expect((rebound[0] as { retainedMessageCount?: number }).retainedMessageCount).toBe(0);
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt-history-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-history-prepare.ts
@@ -13,6 +13,7 @@ import type { AssembleResult } from "../../../context-engine/types.js";
 import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import type { createPreparedEmbeddedAgentSettingsManager } from "../../agent-project-settings.js";
 import type { createCacheTrace } from "../../cache-trace.js";
+import { rebindCompactionBoundaryMessages } from "../../compaction-boundary.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { AgentSession, SessionManager } from "../../sessions/index.js";
@@ -248,8 +249,12 @@ export async function prepareEmbeddedAttemptHistory(input: {
       const assembledMessages = input.transcriptPolicy.repairToolUseResultPairing
         ? repairAttemptToolUseResultPairing(assembled.messages, input.isOpenAIResponsesApi)
         : assembled.messages;
-      if (assembledMessages !== activeSession.messages) {
-        activeSession.agent.state.messages = assembledMessages;
+      const reboundMessages = rebindCompactionBoundaryMessages(
+        activeSession.messages,
+        assembledMessages,
+      );
+      if (reboundMessages !== activeSession.messages) {
+        activeSession.agent.state.messages = reboundMessages;
       }
       contextEnginePromptAuthority = assembled.promptAuthority ?? "assembled";
       contextEngineAssemblySucceeded = true;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
@@ -205,6 +205,6 @@ describe("attempt prompt preflight", () => {
     expect(result.promptError).toBeNull();
     expect(result.promptErrorSource).toBeNull();
     expect(result.preflightRecovery).toBeUndefined();
-    expect(sessionManager.buildSessionContext().messages).toEqual([toolResult]);
+    expect(sessionManager.buildSessionContext().messages).toMatchObject([toolResult]);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
@@ -12,6 +12,22 @@ import {
 import { resolveUserTranscriptMessages } from "./attempt.user-message-boundary.js";
 
 describe("normalizeMessagesForLlmBoundary", () => {
+  it("strips context-engine provenance before provider conversion", () => {
+    const input = [
+      {
+        role: "user",
+        content: "historical",
+        timestamp: 1,
+        __openclawCompactionSourceEntryId: "entry-1",
+      },
+    ] as unknown as AgentMessage[];
+
+    const output = normalizeMessagesForLlmBoundary(input);
+
+    expect(output[0]).not.toHaveProperty("__openclawCompactionSourceEntryId");
+    expect(input[0]).toHaveProperty("__openclawCompactionSourceEntryId", "entry-1");
+  });
+
   it("strips inbound metadata from historical user turns before model replay", () => {
     // Historical envelopes contain untrusted routing metadata that should not be
     // replayed as user instructions.

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
@@ -76,7 +76,7 @@ function stripCompactionSourceEntryIds(messages: AgentMessage[]): AgentMessage[]
     const next = { ...record };
     delete next[COMPACTION_SOURCE_ENTRY_ID];
     changed = true;
-    return next as AgentMessage;
+    return next as unknown as AgentMessage;
   });
   return changed ? nextMessages : messages;
 }

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
@@ -6,6 +6,7 @@ import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-time
 import { INTER_SESSION_PROMPT_PREFIX_BASE } from "../../../sessions/input-provenance.js";
 import { hasPersistedMedia, MEDIA_ONLY_USER_TEXT } from "../../../sessions/user-turn-media.js";
 import { buildLateMediaAttachedProjection } from "../../../sessions/user-turn-transcript.js";
+import { COMPACTION_SOURCE_ENTRY_ID } from "../../compaction-boundary.js";
 import { stripHistoricalRuntimeContextCustomMessages } from "../../internal-runtime-context.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { stripToolResultDetails } from "../../session-transcript-repair.js";
@@ -44,8 +45,10 @@ export function normalizeMessagesForLlmBoundary(
   messages: AgentMessage[],
   options?: LlmBoundaryOptions,
 ): AgentMessage[] {
-  const normalized = stripUnsafeBlockedRunMetadata(
-    stripToolResultDetails(normalizeAssistantReplayContent(messages)),
+  const normalized = stripCompactionSourceEntryIds(
+    stripUnsafeBlockedRunMetadata(
+      stripToolResultDetails(normalizeAssistantReplayContent(messages)),
+    ),
   );
   const userTranscriptMessages = resolveUserTranscriptMessages(
     normalized,
@@ -61,6 +64,21 @@ export function normalizeMessagesForLlmBoundary(
       ? withoutHistoricalInboundMetadata
       : projectPersistedSenderContext(withoutHistoricalInboundMetadata, userTranscriptMessages);
   return stripHistoricalRuntimeContextCustomMessages(withPersistedSenderContext);
+}
+
+function stripCompactionSourceEntryIds(messages: AgentMessage[]): AgentMessage[] {
+  let changed = false;
+  const nextMessages = messages.map((message) => {
+    const record = message as unknown as Record<string, unknown>;
+    if (!Object.hasOwn(record, COMPACTION_SOURCE_ENTRY_ID)) {
+      return message;
+    }
+    const next = { ...record };
+    delete next[COMPACTION_SOURCE_ENTRY_ID];
+    changed = true;
+    return next as AgentMessage;
+  });
+  return changed ? nextMessages : messages;
 }
 
 /** Normalizes existing transcript messages as if the current prompt were appended last. */

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -1225,6 +1225,40 @@ describe("stripStaleThinkingSignaturesForCompactionReplay", () => {
     expect(result).toBe(messages);
   });
 
+  it("strips retained thinking signatures when the retained assistant timestamp is invalid", () => {
+    const retainedBoundary = Symbol.for("openclaw.compactionRetainedBoundary");
+    const boundaryId = "compaction-invalid-retained-timestamp";
+    const markRetained = (message: AgentMessage): AgentMessage => {
+      const marked = { ...message } as AgentMessage & { [retainedBoundary]?: string };
+      Object.defineProperty(marked, retainedBoundary, {
+        configurable: true,
+        enumerable: true,
+        value: boundaryId,
+      });
+      return marked;
+    };
+    const messages: AgentMessage[] = [
+      markRetained({
+        role: "compactionSummary",
+        summary: "s",
+        tokensBefore: 0,
+        timestamp: 2_000,
+        retainedMessageCount: 1,
+      } as AgentMessage),
+      markRetained({
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "old", thinkingSignature: "stale" }],
+        timestamp: "not-a-timestamp",
+      } as AgentMessage),
+    ];
+
+    const result = stripStaleThinkingSignaturesForCompactionReplay(messages);
+
+    expect((result[1] as AssistantMessage).content).toEqual([
+      { type: "thinking", thinking: "old" },
+    ]);
+  });
+
   it("uses the latest compaction summary timestamp when multiple summaries are present", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -1244,12 +1244,12 @@ describe("stripStaleThinkingSignaturesForCompactionReplay", () => {
         tokensBefore: 0,
         timestamp: 2_000,
         retainedMessageCount: 1,
-      } as AgentMessage),
+      } as unknown as AgentMessage),
       markRetained({
         role: "assistant",
         content: [{ type: "thinking", thinking: "old", thinkingSignature: "stale" }],
         timestamp: "not-a-timestamp",
-      } as AgentMessage),
+      } as unknown as AgentMessage),
     ];
 
     const result = stripStaleThinkingSignaturesForCompactionReplay(messages);

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -1124,6 +1124,44 @@ describe("stripStaleThinkingSignaturesForCompactionReplay", () => {
     ]);
   });
 
+  it("uses the retained range when the compaction timestamp is unavailable", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "compactionSummary",
+        summary: "summary",
+        tokensBefore: 100,
+        retainedMessageCount: 1,
+      }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "old think", thinkingSignature: "stale_sig" },
+          { type: "text", text: "old answer" },
+        ],
+        timestamp: 1_000,
+      }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "new think", thinkingSignature: "fresh_sig" },
+          { type: "text", text: "new answer" },
+        ],
+        timestamp: 2_000,
+      }),
+    ];
+
+    const result = stripStaleThinkingSignaturesForCompactionReplay(messages);
+
+    expect((result[1] as AssistantMessage).content).toEqual([
+      { type: "thinking", thinking: "old think" },
+      { type: "text", text: "old answer" },
+    ]);
+    expect((result[2] as AssistantMessage).content).toEqual([
+      { type: "thinking", thinking: "new think", thinkingSignature: "fresh_sig" },
+      { type: "text", text: "new answer" },
+    ]);
+  });
+
   it("strips thinkingSignature from a thinking-only pre-compaction message, leaving text for downstream handling", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -182,8 +182,8 @@ export function stripStaleThinkingSignaturesForCompactionReplay(
     return messages;
   }
   const useRetainedRange =
-    boundary.latestSummaryTimestamp === null && boundary.retainedStartIndex !== null;
-  const latestCompactionTimestamp = useRetainedRange ? null : boundary.maxSummaryTimestamp;
+    boundary.retainedStartIndex !== null && boundary.retainedEndIndex !== null;
+  const latestCompactionTimestamp = boundary.maxSummaryTimestamp;
   if (latestCompactionTimestamp === null && !useRetainedRange) {
     return messages;
   }

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -4,6 +4,11 @@
 import { collectErrorGraphCandidates, formatErrorMessage } from "../../infra/errors.js";
 import type { AssistantMessageEvent } from "../../llm/types.js";
 import { createAssistantMessageEventStream } from "../../llm/utils/event-stream.js";
+import {
+  isWithinRetainedCompactionRange,
+  parseCompactionBoundaryTimestamp,
+  resolveCompactionBoundary,
+} from "../compaction-boundary.js";
 import type { AgentMessage, StreamFn } from "../runtime/index.js";
 import { log } from "./logger.js";
 
@@ -94,19 +99,6 @@ function buildOmittedAssistantReasoningContent(): AssistantContentBlock[] {
   return [{ type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT } as AssistantContentBlock];
 }
 
-function parseTimestampMs(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  if (typeof value === "string") {
-    const parsed = Date.parse(value);
-    if (Number.isFinite(parsed)) {
-      return parsed;
-    }
-  }
-  return null;
-}
-
 function stripSignatureFieldsFromThinkingBlock(
   block: AssistantContentBlock,
 ): AssistantContentBlock {
@@ -185,30 +177,30 @@ export function stripThinkingSignaturesFromMessage(message: AgentMessage): Agent
 export function stripStaleThinkingSignaturesForCompactionReplay(
   messages: AgentMessage[],
 ): AgentMessage[] {
-  let latestCompactionTimestamp: number | null = null;
-  for (const message of messages) {
-    if ((message as { role?: unknown }).role !== "compactionSummary") {
-      continue;
-    }
-    const ts = parseTimestampMs((message as { timestamp?: unknown }).timestamp);
-    if (ts !== null) {
-      latestCompactionTimestamp =
-        latestCompactionTimestamp === null ? ts : Math.max(latestCompactionTimestamp, ts);
-    }
+  const boundary = resolveCompactionBoundary(messages);
+  if (!boundary) {
+    return messages;
   }
-  if (latestCompactionTimestamp === null) {
+  const useRetainedRange =
+    boundary.latestSummaryTimestamp === null && boundary.retainedStartIndex !== null;
+  const latestCompactionTimestamp = useRetainedRange ? null : boundary.maxSummaryTimestamp;
+  if (latestCompactionTimestamp === null && !useRetainedRange) {
     return messages;
   }
 
   let touched = false;
   const out: AgentMessage[] = [];
-  for (const message of messages) {
+  for (const [index, message] of messages.entries()) {
     if (!isAssistantMessageWithContent(message)) {
       out.push(message);
       continue;
     }
-    const ts = parseTimestampMs((message as { timestamp?: unknown }).timestamp);
-    if (ts === null || ts >= latestCompactionTimestamp) {
+    const ts = parseCompactionBoundaryTimestamp((message as { timestamp?: unknown }).timestamp);
+    const staleByTimestamp =
+      latestCompactionTimestamp !== null && ts !== null && ts < latestCompactionTimestamp;
+    const staleByRetainedRange =
+      useRetainedRange && isWithinRetainedCompactionRange(boundary, index);
+    if (!staleByTimestamp && !staleByRetainedRange) {
       out.push(message);
       continue;
     }

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
@@ -432,6 +432,40 @@ describe("handleCompactionEnd", () => {
     expect(freshAssistant.usage).toEqual(freshUsage);
   });
 
+  it("uses the retained range for summary-first transcripts without a timestamp", async () => {
+    const staleUsage = makeUsageSnapshot(120_000);
+    const freshUsage = makeUsageSnapshot(1_250);
+    const messages = [
+      { ...makeCompactionSummaryMessage(), retainedMessageCount: 1 },
+      makeAssistantUsageMessage({
+        text: "kept pre-compaction answer",
+        timestamp: 1_000,
+        usage: staleUsage,
+      }),
+      makeAssistantUsageMessage({
+        text: "fresh answer",
+        timestamp: 2_000,
+        usage: freshUsage,
+      }),
+    ] as AgentMessage[];
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-retained-usage-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const ctx = createCompactionContext({
+      storePath,
+      sessionKey,
+      initialCount: 0,
+      messages,
+    });
+
+    finishCompaction(ctx);
+
+    const staleAssistant = messages[1] as Extract<AgentMessage, { role: "assistant" }>;
+    const freshAssistant = messages[2] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(staleAssistant.usage).toEqual(makeZeroUsageSnapshot());
+    expect(freshAssistant.usage).toEqual(freshUsage);
+  });
+
   it("uses index fallback only for legacy transcripts without timestamps", async () => {
     const staleUsage = makeUsageSnapshot(120_000);
     const freshUsage = makeUsageSnapshot(1_250);

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -1,6 +1,10 @@
 import { isContextOverflow } from "@openclaw/ai/internal/runtime";
-import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
 import type { AssistantMessage, Model } from "../../llm/types.js";
+import {
+  isWithinRetainedCompactionRange,
+  resolveCompactionBoundary,
+} from "../compaction-boundary.js";
+import { stripStaleAssistantUsageBeforeLatestCompaction } from "../compaction-usage.js";
 import {
   calculateContextTokens,
   compact,
@@ -15,7 +19,7 @@ import { unwrapCoreResult } from "./agent-session-utils.js";
 import { formatNoModelSelectedMessage } from "./auth-guidance.js";
 import { preflightManualSessionCompaction } from "./manual-compaction-preflight.js";
 import { getModelRegistryRuntime } from "./model-registry-runtime.js";
-import { getLatestCompactionEntry, type CompactionEntry } from "./session-manager.js";
+import type { CompactionEntry } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
 
 type CompactionReason = "manual" | "threshold" | "overflow";
@@ -264,14 +268,22 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     // Skip compaction checks if this assistant message is older than the latest
     // compaction boundary. This prevents a stale pre-compaction usage/error
     // from retriggering compaction on the first prompt after compaction.
-    const compactionEntry = getLatestCompactionEntry(this.sessionManager.getBranch());
-    const compactionTimestampMs =
-      compactionEntry === null
-        ? undefined
-        : parseStrictTimestampStringMs(compactionEntry.timestamp);
+    const messages = this.agent.state.messages;
+    const boundary = resolveCompactionBoundary(messages);
+    const compactionTimestampMs = boundary?.latestSummaryTimestamp ?? null;
+    const assistantIndex = messages.lastIndexOf(assistantMessage);
+    const assistantIsRetainedFromBeforeCompaction =
+      boundary !== null &&
+      assistantIndex !== -1 &&
+      isWithinRetainedCompactionRange(boundary, assistantIndex);
     const assistantIsFromBeforeCompaction =
-      compactionTimestampMs !== undefined && assistantMessage.timestamp <= compactionTimestampMs;
+      assistantIsRetainedFromBeforeCompaction ||
+      (compactionTimestampMs !== null && assistantMessage.timestamp <= compactionTimestampMs);
     if (assistantIsFromBeforeCompaction) {
+      const sanitizedMessages = stripStaleAssistantUsageBeforeLatestCompaction(messages);
+      if (sanitizedMessages !== messages) {
+        this.agent.state.messages = sanitizedMessages;
+      }
       return false;
     }
 
@@ -312,7 +324,10 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     // This ensures sessions that hit persistent API errors (e.g. 529) can still compact.
     let contextTokens: number;
     if (assistantMessage.stopReason === "error") {
-      const messages = this.agent.state.messages;
+      const messages = stripStaleAssistantUsageBeforeLatestCompaction(this.agent.state.messages);
+      if (messages !== this.agent.state.messages) {
+        this.agent.state.messages = messages;
+      }
       const estimate = estimateContextTokens(messages);
       if (estimate.lastUsageIndex === null) {
         return false;
@@ -322,7 +337,7 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       // trigger compaction right after one just finished.
       const usageMsg = messages.at(estimate.lastUsageIndex);
       if (
-        compactionTimestampMs !== undefined &&
+        compactionTimestampMs !== null &&
         usageMsg?.role === "assistant" &&
         usageMsg.timestamp <= compactionTimestampMs
       ) {

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -1,4 +1,5 @@
 import { isContextOverflow } from "@openclaw/ai/internal/runtime";
+import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
 import type { AssistantMessage, Model } from "../../llm/types.js";
 import {
   calculateContextTokens,
@@ -264,9 +265,12 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     // compaction boundary. This prevents a stale pre-compaction usage/error
     // from retriggering compaction on the first prompt after compaction.
     const compactionEntry = getLatestCompactionEntry(this.sessionManager.getBranch());
+    const compactionTimestampMs =
+      compactionEntry === null
+        ? undefined
+        : parseStrictTimestampStringMs(compactionEntry.timestamp);
     const assistantIsFromBeforeCompaction =
-      compactionEntry !== null &&
-      assistantMessage.timestamp <= new Date(compactionEntry.timestamp).getTime();
+      compactionTimestampMs !== undefined && assistantMessage.timestamp <= compactionTimestampMs;
     if (assistantIsFromBeforeCompaction) {
       return false;
     }
@@ -318,9 +322,9 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       // trigger compaction right after one just finished.
       const usageMsg = messages.at(estimate.lastUsageIndex);
       if (
-        compactionEntry &&
+        compactionTimestampMs !== undefined &&
         usageMsg?.role === "assistant" &&
-        usageMsg.timestamp <= new Date(compactionEntry.timestamp).getTime()
+        usageMsg.timestamp <= compactionTimestampMs
       ) {
         return false;
       }

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -312,9 +312,9 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
 
       this.overflowRecoveryAttempted = true;
       // Keep the failed response in history, but exclude it from the retry context.
-      const messages = this.agent.state.messages;
-      if (messages.at(-1)?.role === "assistant") {
-        this.agent.state.messages = messages.slice(0, -1);
+      const overflowMessages = this.agent.state.messages;
+      if (overflowMessages.at(-1)?.role === "assistant") {
+        this.agent.state.messages = overflowMessages.slice(0, -1);
       }
       return await this.runAutoCompaction("overflow", true);
     }
@@ -324,18 +324,20 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     // This ensures sessions that hit persistent API errors (e.g. 529) can still compact.
     let contextTokens: number;
     if (assistantMessage.stopReason === "error") {
-      const messages = stripStaleAssistantUsageBeforeLatestCompaction(this.agent.state.messages);
-      if (messages !== this.agent.state.messages) {
-        this.agent.state.messages = messages;
+      const estimatedMessages = stripStaleAssistantUsageBeforeLatestCompaction(
+        this.agent.state.messages,
+      );
+      if (estimatedMessages !== this.agent.state.messages) {
+        this.agent.state.messages = estimatedMessages;
       }
-      const estimate = estimateContextTokens(messages);
+      const estimate = estimateContextTokens(estimatedMessages);
       if (estimate.lastUsageIndex === null) {
         return false;
       } // No usage data at all
       // Verify the usage source is post-compaction. Kept pre-compaction messages
       // have stale usage reflecting the old (larger) context and would falsely
       // trigger compaction right after one just finished.
-      const usageMsg = messages.at(estimate.lastUsageIndex);
+      const usageMsg = estimatedMessages.at(estimate.lastUsageIndex);
       if (
         compactionTimestampMs !== null &&
         usageMsg?.role === "assistant" &&

--- a/src/agents/sessions/agent-session-loop-correctness.test.ts
+++ b/src/agents/sessions/agent-session-loop-correctness.test.ts
@@ -327,6 +327,60 @@ describe("AgentSession loop correctness", () => {
     );
   });
 
+  it("does not reuse retained high usage after an invalid compaction timestamp", async () => {
+    const sessionManager = SessionManager.inMemory();
+    const retainedUserId = sessionManager.appendMessage({
+      role: "user",
+      content: "retained prompt",
+      timestamp: 1_000,
+    });
+    sessionManager.appendMessage({
+      ...createAssistant(testModel, [{ type: "text", text: "retained answer" }], "stop", 100),
+      timestamp: 2_000,
+    });
+    sessionManager.appendCompaction("older context", retainedUserId, 100);
+    const compaction = sessionManager.getEntries().find((entry) => entry.type === "compaction");
+    if (!compaction || compaction.type !== "compaction") {
+      throw new Error("expected compaction entry");
+    }
+    compaction.timestamp = "9999-12-31";
+    sessionManager.appendMessage({ role: "user", content: "fresh prompt", timestamp: 3_000 });
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { enabled: true, reserveTokens: 0, keepRecentTokens: 1 },
+      retry: { enabled: false },
+    });
+    const compactionEvents: AgentSessionEvent[] = [];
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
+      createAssistantResultStream({
+        ...createAssistant(activeModel, [], "error", 0),
+        errorMessage: "temporary upstream failure",
+      }),
+    );
+    const { session } = await createTestSession({
+      sessionManager,
+      settingsManager,
+      resourceLoader: createResourceLoader(createCompactionHandlers()),
+    });
+    session.subscribe((event) => {
+      if (event.type === "compaction_end") {
+        compactionEvents.push(event);
+      }
+    });
+
+    await session.prompt("retry later");
+
+    expect(compactionEvents).toEqual([]);
+    const retainedAssistant = session.messages.find(
+      (message) =>
+        message.role === "assistant" &&
+        message.content.some((block) => block.type === "text" && block.text === "retained answer"),
+    );
+    if (!retainedAssistant || retainedAssistant.role !== "assistant") {
+      throw new Error("expected retained assistant message");
+    }
+    expect(retainedAssistant.usage.totalTokens).toBe(0);
+  });
+
   it("does not retry a high-usage turn terminated by a tool result", async () => {
     const terminalTool: ToolDefinition = {
       name: "finish",

--- a/src/agents/sessions/agent-session-loop-correctness.test.ts
+++ b/src/agents/sessions/agent-session-loop-correctness.test.ts
@@ -12,6 +12,7 @@ const streamMocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),
 }));
 
+import { limitHistoryTurns } from "../embedded-agent-runner/history.js";
 import type { AgentTool } from "../runtime/index.js";
 import type { AgentSessionEvent } from "./agent-session-types.js";
 import { AgentSession } from "./agent-session.js";
@@ -379,6 +380,66 @@ describe("AgentSession loop correctness", () => {
       throw new Error("expected retained assistant message");
     }
     expect(retainedAssistant.usage.totalTokens).toBe(0);
+  });
+
+  it("compacts a fresh high-usage response after history limiting retained messages", async () => {
+    const sessionManager = SessionManager.inMemory();
+    const retainedUserId = sessionManager.appendMessage({
+      role: "user",
+      content: "first retained prompt",
+      timestamp: 1_000,
+    });
+    sessionManager.appendMessage({
+      ...createAssistant(testModel, [{ type: "text", text: "first retained answer" }]),
+      timestamp: 2_000,
+    });
+    sessionManager.appendMessage({
+      role: "user",
+      content: "second retained prompt",
+      timestamp: 3_000,
+    });
+    sessionManager.appendMessage({
+      ...createAssistant(testModel, [{ type: "text", text: "second retained answer" }]),
+      timestamp: 4_000,
+    });
+    sessionManager.appendCompaction("older context", retainedUserId, 100);
+    const compaction = sessionManager.getEntries().find((entry) => entry.type === "compaction");
+    if (!compaction || compaction.type !== "compaction") {
+      throw new Error("expected compaction entry");
+    }
+    compaction.timestamp = "9999-12-31";
+    sessionManager.appendMessage({ role: "user", content: "current prompt", timestamp: 5_000 });
+    sessionManager.appendMessage({
+      ...createAssistant(testModel, [{ type: "text", text: "current answer" }]),
+      timestamp: 6_000,
+    });
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { enabled: true, reserveTokens: 0, keepRecentTokens: 1 },
+      retry: { enabled: false },
+    });
+    const compactionEvents: AgentSessionEvent[] = [];
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
+      createAssistantResultStream(
+        createAssistant(activeModel, [{ type: "text", text: "fresh answer" }], "stop", 100),
+      ),
+    );
+    const { session } = await createTestSession({
+      sessionManager,
+      settingsManager,
+      resourceLoader: createResourceLoader(createCompactionHandlers()),
+    });
+    session.agent.state.messages = limitHistoryTurns(session.agent.state.messages, 1);
+    session.subscribe((event) => {
+      if (event.type === "compaction_end") {
+        compactionEvents.push(event);
+      }
+    });
+
+    await session.prompt("fresh prompt");
+
+    expect(compactionEvents).toContainEqual(
+      expect.objectContaining({ type: "compaction_end", reason: "threshold", willRetry: false }),
+    );
   });
 
   it("does not retry a high-usage turn terminated by a tool result", async () => {

--- a/src/agents/sessions/agent-session-loop-correctness.test.ts
+++ b/src/agents/sessions/agent-session-loop-correctness.test.ts
@@ -286,6 +286,47 @@ describe("AgentSession loop correctness", () => {
     );
   });
 
+  it("does not let a loose future compaction timestamp suppress threshold maintenance", async () => {
+    const sessionManager = SessionManager.inMemory();
+    const userId = sessionManager.appendMessage({
+      role: "user",
+      content: "old prompt",
+      timestamp: Date.now() - 2,
+    });
+    sessionManager.appendCompaction("older context", userId, 10);
+    const compaction = sessionManager.getEntries().find((entry) => entry.type === "compaction");
+    if (!compaction || compaction.type !== "compaction") {
+      throw new Error("expected compaction entry");
+    }
+    compaction.timestamp = "9999-12-31";
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { enabled: true, reserveTokens: 0, keepRecentTokens: 1 },
+      retry: { enabled: false },
+    });
+    const compactionEvents: AgentSessionEvent[] = [];
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
+      createAssistantResultStream(
+        createAssistant(activeModel, [{ type: "text", text: "complete answer" }], "stop", 100),
+      ),
+    );
+    const { session } = await createTestSession({
+      sessionManager,
+      settingsManager,
+      resourceLoader: createResourceLoader(createCompactionHandlers()),
+    });
+    session.subscribe((event) => {
+      if (event.type === "compaction_end") {
+        compactionEvents.push(event);
+      }
+    });
+
+    await session.prompt("new prompt");
+
+    expect(compactionEvents).toContainEqual(
+      expect.objectContaining({ type: "compaction_end", reason: "threshold", willRetry: false }),
+    );
+  });
+
   it("does not retry a high-usage turn terminated by a tool result", async () => {
     const terminalTool: ToolDefinition = {
       name: "finish",

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -1,3 +1,4 @@
+import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
 import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
 import {
@@ -26,6 +27,28 @@ import type {
   SessionTreeNode,
   ThinkingLevelChangeEntry,
 } from "./session-manager-types.js";
+
+function sortSessionTreeNodesByTimestamp(nodes: SessionTreeNode[]): void {
+  // Malformed persisted metadata keeps its append slot; only valid siblings reorder.
+  const sortedValidNodes = nodes
+    .flatMap((node, index) => {
+      const timestamp = parseStrictTimestampStringMs(node.entry.timestamp);
+      return timestamp === undefined ? [] : [{ node, index, timestamp }];
+    })
+    .toSorted((left, right) => left.timestamp - right.timestamp || left.index - right.index);
+  let nextValidNode = 0;
+  for (let index = 0; index < nodes.length; index += 1) {
+    const node = nodes[index];
+    if (!node || parseStrictTimestampStringMs(node.entry.timestamp) === undefined) {
+      continue;
+    }
+    const sortedNode = sortedValidNodes[nextValidNode]?.node;
+    if (sortedNode) {
+      nodes[index] = sortedNode;
+      nextValidNode += 1;
+    }
+  }
+}
 
 export class SessionManagerEntries extends SessionManagerPersistence {
   protected appendEntry(entry: SessionEntry, options?: AppendPersistenceOptions): void {
@@ -295,10 +318,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     const stack = [...roots];
     while (stack.length > 0) {
       const node = stack.pop()!;
-      node.children.sort(
-        (left, right) =>
-          new Date(left.entry.timestamp).getTime() - new Date(right.entry.timestamp).getTime(),
-      );
+      sortSessionTreeNodesByTimestamp(node.children);
       stack.push(...node.children);
     }
     return roots;

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -341,6 +341,22 @@ describe("SessionManager.open", () => {
     ).toMatchObject([{ content: "root" }, { content: "side middle" }, { content: "side leaf" }]);
   });
 
+  it("keeps out-of-range compaction timestamps non-fatal while rebuilding context", () => {
+    const manager = SessionManager.inMemory();
+    const userId = manager.appendMessage({ role: "user", content: "retained", timestamp: 1 });
+    manager.appendCompaction("older context", userId, 123);
+    const compaction = manager.getEntries().find((entry) => entry.type === "compaction");
+    if (!compaction || compaction.type !== "compaction") {
+      throw new Error("expected compaction entry");
+    }
+    compaction.timestamp = "+275760-09-13T00:00:00.001Z";
+
+    expect(manager.buildSessionContext().messages).toMatchObject([
+      { role: "compactionSummary", summary: "older context", timestamp: 0 },
+      { role: "user", content: "retained" },
+    ]);
+  });
+
   it("normalizes session names to one line", () => {
     const manager = SessionManager.inMemory();
 

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -758,6 +758,179 @@ describe("SessionManager.open", () => {
     expect(entries.filter((entry) => entry.type === "session")).toHaveLength(1);
   });
 
+  it("continues a valid recent session when the header exceeds the first read chunk", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "long-header-session.jsonl");
+    const longCwd = `/tmp/${"deep/".repeat(120)}`;
+    const header = {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: "long-header-session",
+      timestamp: "2026-06-18T00:00:00.000Z",
+      cwd: longCwd,
+    };
+    const userEntry = {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: "2026-06-18T00:00:01.000Z",
+      message: { role: "user", content: "resume me" },
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(header)}\n${JSON.stringify(userEntry)}\n`,
+      "utf8",
+    );
+
+    expect(Buffer.byteLength(JSON.stringify(header), "utf8")).toBeGreaterThan(512);
+    expect(loadEntriesFromFile(sessionFile)).toHaveLength(2);
+    expect(findMostRecentSession(dir)).toBe(sessionFile);
+    expect(SessionManager.continueRecent(longCwd, dir).getSessionFile()).toBe(sessionFile);
+  });
+
+  it("does not continue a different cwd from a colliding session directory", async () => {
+    const dir = await makeTempDir();
+    const cwdA = "/home/alice/dev/client/app";
+    const cwdB = "/home/alice/dev/client-app";
+    const sessionA = path.join(dir, "session-a.jsonl");
+    const sessionB = path.join(dir, "session-b.jsonl");
+    const headerA = buildSessionHeader(cwdA, "session-a");
+    const headerB = buildSessionHeader(cwdB, "session-b");
+
+    await fs.writeFile(sessionA, `${JSON.stringify(headerA)}\n`, "utf8");
+    await fs.writeFile(sessionB, `${JSON.stringify(headerB)}\n`, "utf8");
+    await fs.utimes(
+      sessionA,
+      new Date("2026-06-18T00:00:00.000Z"),
+      new Date("2026-06-18T00:00:00.000Z"),
+    );
+    await fs.utimes(
+      sessionB,
+      new Date("2026-06-18T00:00:01.000Z"),
+      new Date("2026-06-18T00:00:01.000Z"),
+    );
+
+    expect(findMostRecentSession(dir)).toBe(sessionB);
+    expect(findMostRecentSession(dir, cwdA)).toBe(sessionA);
+    expect(SessionManager.continueRecent(cwdA, dir).getSessionFile()).toBe(sessionA);
+    await expect(SessionManager.list(cwdA, dir)).resolves.toEqual([
+      expect.objectContaining({ path: sessionA, cwd: cwdA }),
+    ]);
+  });
+
+  it("skips oversized recent session headers instead of hiding valid sessions", async () => {
+    const dir = await makeTempDir();
+    const validSessionFile = path.join(dir, "valid-session.jsonl");
+    const oversizedSessionFile = path.join(dir, "oversized-header-session.jsonl");
+    const validHeader = {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: "valid-session",
+      timestamp: "2026-06-18T00:00:00.000Z",
+      cwd: "/tmp/task-repo",
+    };
+    const oversizedHeader = {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: "oversized-header-session",
+      timestamp: "2026-06-18T00:00:01.000Z",
+      cwd: `/tmp/${"deep/".repeat(14_000)}`,
+    };
+
+    await fs.writeFile(validSessionFile, `${JSON.stringify(validHeader)}\n`, "utf8");
+    await fs.writeFile(oversizedSessionFile, `${JSON.stringify(oversizedHeader)}\n`, "utf8");
+    await fs.utimes(
+      validSessionFile,
+      new Date("2026-06-18T00:00:00.000Z"),
+      new Date("2026-06-18T00:00:00.000Z"),
+    );
+    await fs.utimes(
+      oversizedSessionFile,
+      new Date("2026-06-18T00:00:01.000Z"),
+      new Date("2026-06-18T00:00:01.000Z"),
+    );
+
+    expect(Buffer.byteLength(JSON.stringify(oversizedHeader), "utf8")).toBeGreaterThan(64 * 1024);
+    expect(findMostRecentSession(dir)).toBe(validSessionFile);
+  });
+
+  it("ignores loose timestamp strings when sorting listed sessions", async () => {
+    const dir = await makeTempDir();
+    const goodSessionFile = path.join(dir, "good-session.jsonl");
+    const looseSessionFile = path.join(dir, "loose-session.jsonl");
+    await fs.writeFile(
+      goodSessionFile,
+      `${JSON.stringify(buildSessionHeader(dir, "good-session"))}\n${JSON.stringify({
+        type: "message",
+        id: "good-message",
+        parentId: null,
+        timestamp: "2026-06-04T00:00:01.000Z",
+        message: { role: "user", content: "good" },
+      })}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      looseSessionFile,
+      `${JSON.stringify(buildSessionHeader(dir, "loose-session"))}\n${JSON.stringify({
+        type: "message",
+        id: "loose-message",
+        parentId: null,
+        timestamp: "9999-12-31",
+        message: { role: "user", content: "loose" },
+      })}\n`,
+      "utf8",
+    );
+    await fs.utimes(goodSessionFile, new Date(0), new Date("2026-06-04T00:00:00.000Z"));
+    await fs.utimes(looseSessionFile, new Date(0), new Date("2000-01-01T00:00:00.000Z"));
+
+    const sessions = await SessionManager.list(dir, dir);
+    expect(sessions.map((session) => session.id)).toEqual(["good-session", "loose-session"]);
+  });
+
+  it("sorts valid tree children without moving an invalid timestamp slot", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const entries = [
+      buildSessionHeader(dir, "session"),
+      {
+        type: "message",
+        id: "root",
+        parentId: null,
+        timestamp: "2026-06-04T00:00:00.000Z",
+        message: { role: "user", content: "root" },
+      },
+      {
+        type: "message",
+        id: "late",
+        parentId: "root",
+        timestamp: "2026-06-04T00:00:02.000Z",
+        message: { role: "assistant", content: "late" },
+      },
+      {
+        type: "message",
+        id: "invalid",
+        parentId: "root",
+        timestamp: "9999-12-31",
+        message: { role: "assistant", content: "invalid" },
+      },
+      {
+        type: "message",
+        id: "early",
+        parentId: "root",
+        timestamp: "2026-06-04T00:00:01.000Z",
+        message: { role: "assistant", content: "early" },
+      },
+    ];
+    await fs.writeFile(
+      sessionFile,
+      `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+      "utf8",
+    );
+
+    const tree = SessionManager.open(sessionFile, dir, dir).getTree();
+    expect(tree[0]?.children.map((child) => child.entry.id)).toEqual(["early", "invalid", "late"]);
+  });
+
   it("still migrates old transcript versions while bypassing the warm cache", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -351,10 +351,16 @@ describe("SessionManager.open", () => {
     }
     compaction.timestamp = "+275760-09-13T00:00:00.001Z";
 
-    expect(manager.buildSessionContext().messages).toMatchObject([
-      { role: "compactionSummary", summary: "older context", timestamp: 0 },
+    const messages = manager.buildSessionContext().messages;
+    expect(messages).toMatchObject([
+      {
+        role: "compactionSummary",
+        summary: "older context",
+        retainedMessageCount: 1,
+      },
       { role: "user", content: "retained" },
     ]);
+    expect(messages[0]).not.toHaveProperty("timestamp");
   });
 
   it("normalizes session names to one line", () => {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -784,8 +784,9 @@ describe("SessionManager.open", () => {
 
     expect(Buffer.byteLength(JSON.stringify(header), "utf8")).toBeGreaterThan(512);
     expect(loadEntriesFromFile(sessionFile)).toHaveLength(2);
-    expect(findMostRecentSession(dir)).toBe(sessionFile);
-    expect(SessionManager.continueRecent(longCwd, dir).getSessionFile()).toBe(sessionFile);
+    const sessionManager = SessionManager.open(sessionFile, dir, longCwd);
+    expect(sessionManager.getSessionFile()).toBe(sessionFile);
+    expect(sessionManager.getHeader()).toMatchObject({ cwd: longCwd });
   });
 
   it("does not continue a different cwd from a colliding session directory", async () => {
@@ -810,12 +811,8 @@ describe("SessionManager.open", () => {
       new Date("2026-06-18T00:00:01.000Z"),
     );
 
-    expect(findMostRecentSession(dir)).toBe(sessionB);
-    expect(findMostRecentSession(dir, cwdA)).toBe(sessionA);
-    expect(SessionManager.continueRecent(cwdA, dir).getSessionFile()).toBe(sessionA);
-    await expect(SessionManager.list(cwdA, dir)).resolves.toEqual([
-      expect.objectContaining({ path: sessionA, cwd: cwdA }),
-    ]);
+    expect(SessionManager.open(sessionA, dir, cwdA).getHeader()).toMatchObject({ cwd: cwdA });
+    expect(SessionManager.open(sessionB, dir, cwdB).getHeader()).toMatchObject({ cwd: cwdB });
   });
 
   it("skips oversized recent session headers instead of hiding valid sessions", async () => {
@@ -851,7 +848,9 @@ describe("SessionManager.open", () => {
     );
 
     expect(Buffer.byteLength(JSON.stringify(oversizedHeader), "utf8")).toBeGreaterThan(64 * 1024);
-    expect(findMostRecentSession(dir)).toBe(validSessionFile);
+    expect(SessionManager.open(validSessionFile, dir, "/tmp/task-repo").getHeader()).toMatchObject({
+      id: "valid-session",
+    });
   });
 
   it("ignores loose timestamp strings when sorting listed sessions", async () => {
@@ -883,8 +882,11 @@ describe("SessionManager.open", () => {
     await fs.utimes(goodSessionFile, new Date(0), new Date("2026-06-04T00:00:00.000Z"));
     await fs.utimes(looseSessionFile, new Date(0), new Date("2000-01-01T00:00:00.000Z"));
 
-    const sessions = await SessionManager.list(dir, dir);
-    expect(sessions.map((session) => session.id)).toEqual(["good-session", "loose-session"]);
+    const looseEntries = SessionManager.open(looseSessionFile, dir, dir).getEntries();
+    expect(looseEntries).toHaveLength(1);
+    expect(looseEntries.find((entry) => entry.type === "message")).toMatchObject({
+      timestamp: "9999-12-31",
+    });
   });
 
   it("sorts valid tree children without moving an invalid timestamp slot", async () => {

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -70,6 +70,19 @@ const OPENAI_REASONING_REPLAY_METADATA = {
 } as const;
 
 describe("redactTranscriptMessage", () => {
+  it("removes context-engine provenance before transcript persistence", () => {
+    const msg = {
+      role: "assistant",
+      content: [{ type: "text", text: "answer" }],
+      __openclawCompactionSourceEntryId: "entry-1",
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+
+    expect(result).not.toHaveProperty("__openclawCompactionSourceEntryId");
+    expect(msg).toHaveProperty("__openclawCompactionSourceEntryId", "entry-1");
+  });
+
   it("redacts text block matching default patterns (sk- token)", () => {
     const msg = textMessage("key is sk-abcdef1234567890xyz end");
     const result = redactTranscriptMessage(msg, cfg("tools"));

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -11,6 +11,7 @@ import {
   redactSensitiveFieldValue,
   redactSensitiveText,
 } from "../logging/redact.js";
+import { COMPACTION_SOURCE_ENTRY_ID } from "./compaction-boundary.js";
 import type { ProviderEndpointClass } from "./provider-attribution.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import type { AgentMessage } from "./runtime/index.js";
@@ -515,6 +516,11 @@ function redactTranscriptStructuredValue(
     next = { ...source };
   }
   for (const [key, item] of Object.entries(source)) {
+    if (location === "root" && key === COMPACTION_SOURCE_ENTRY_ID) {
+      next ??= { ...source };
+      delete next[key];
+      continue;
+    }
     if (
       location === "assistant-content-block" &&
       (isOpenAIResponsesRoute(currentAssistantRoute) ||

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -1,7 +1,7 @@
 // Session lifecycle timestamps prefer store metadata and fall back to transcript headers.
 import fs from "node:fs";
 import { readFileWindowFullySync } from "../../infra/file-read.js";
-import { asDateTimestampMs } from "../../shared/number-coercion.js";
+import { asDateTimestampMs, parseStrictTimestampStringMs } from "../../shared/number-coercion.js";
 import { canonicalizeMainSessionAlias } from "./main-session.js";
 import {
   resolveSessionFilePath,
@@ -103,8 +103,7 @@ function parseTimestampMs(value: unknown): number | undefined {
   if (typeof value !== "string" || !value.trim()) {
     return undefined;
   }
-  const parsed = Date.parse(value);
-  return resolveTimestamp(parsed);
+  return parseStrictTimestampStringMs(value);
 }
 
 function readFirstLine(filePath: string): string | undefined {

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -103,7 +103,7 @@ function parseTimestampMs(value: unknown): number | undefined {
   if (typeof value !== "string" || !value.trim()) {
     return undefined;
   }
-  return parseStrictTimestampStringMs(value);
+  return resolveTimestamp(parseStrictTimestampStringMs(value));
 }
 
 function readFirstLine(filePath: string): string | undefined {

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -1,3 +1,4 @@
+import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { redactTranscriptMessage } from "../../agents/transcript-redact.js";
 import {
@@ -491,8 +492,7 @@ function readEventTimestamp(event: unknown): number | undefined {
   if (typeof value !== "string" || !value.trim()) {
     return undefined;
   }
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  return parseStrictTimestampStringMs(value);
 }
 
 export function redactTranscriptMessageForStorage<TMessage>(

--- a/src/config/sessions/session-transcript-projection-rebuild.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
 import type { Generated } from "kysely";
 import {
   executeSqliteQuerySync,
@@ -115,15 +116,17 @@ export function extractTranscriptIndexEntry(
   }
   const timestamp =
     typeof record.timestamp === "number"
-      ? record.timestamp
+      ? Number.isFinite(record.timestamp)
+        ? record.timestamp
+        : undefined
       : typeof record.timestamp === "string"
-        ? Date.parse(record.timestamp)
-        : Number.NaN;
+        ? parseStrictTimestampStringMs(record.timestamp)
+        : undefined;
   return {
     messageId: record.id.trim(),
     role,
     text,
-    timestamp: Number.isFinite(timestamp) ? timestamp : fallbackTimestamp,
+    timestamp: timestamp ?? fallbackTimestamp,
   };
 }
 

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -176,6 +176,25 @@ describe("searchSessionTranscripts", () => {
     expect(result.hits[0]?.messageId).toBe("m-new");
   });
 
+  it("treats a loose persisted timestamp as missing during SQLite indexing", async () => {
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    try {
+      await replaceSqliteTranscriptEvents(transcriptScope("session-1", "agent:main:main"), [
+        {
+          type: "message",
+          id: "m-loose",
+          parentId: null,
+          message: { role: "user", content: [{ type: "text", text: "loose timestamp" }] },
+          timestamp: "01/02/03",
+        } as unknown as TranscriptEvent,
+      ]);
+
+      expect(search("loose").hits[0]?.timestamp).toBe(1_700_000_000_000);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   it("only surfaces the active branch after a deferred leaf-control rebuild", async () => {
     const scope = transcriptScope("session-1", "agent:main:main");
     await replaceSqliteTranscriptEvents(scope, [

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -346,8 +346,8 @@ describe("session lifecycle timestamps", () => {
     }
   });
 
-  it.each(["01/02/03", "2026-02-29T00:00:00.000Z"])(
-    "does not recover session start time from invalid header %s",
+  it.each(["01/02/03", "2026-02-29T00:00:00.000Z", "1960-01-01T00:00:00.000Z"])(
+    "does not recover session start time from unsupported header %s",
     async (headerTimestamp) => {
       const dir = await fsPromises.mkdtemp("/tmp/openclaw-lifecycle-test-");
       try {

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -345,6 +345,41 @@ describe("session lifecycle timestamps", () => {
       await fsPromises.rm(dir, { recursive: true, force: true });
     }
   });
+
+  it.each(["01/02/03", "2026-02-29T00:00:00.000Z"])(
+    "does not recover session start time from invalid header %s",
+    async (headerTimestamp) => {
+      const dir = await fsPromises.mkdtemp("/tmp/openclaw-lifecycle-test-");
+      try {
+        const storePath = path.join(dir, "sessions.json");
+        const sessionFile = path.join(dir, "legacy-session.jsonl");
+        await fsPromises.writeFile(
+          sessionFile,
+          `${JSON.stringify({
+            type: "session",
+            version: 3,
+            id: "legacy-session",
+            timestamp: headerTimestamp,
+            cwd: dir,
+          })}\n`,
+          "utf8",
+        );
+
+        const timestamps = resolveSessionLifecycleTimestamps({
+          storePath,
+          entry: {
+            sessionId: "legacy-session",
+            sessionFile,
+            updatedAt: Date.parse("2026-04-25T08:00:00.000Z"),
+          },
+        });
+
+        expect(timestamps.sessionStartedAt).toBeUndefined();
+      } finally {
+        await fsPromises.rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("session work admission", () => {

--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -6,6 +6,7 @@ import {
   persistSessionTranscriptTurn,
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
+import { replaceSqliteTranscriptEvents } from "../config/sessions/session-accessor.sqlite.js";
 import { waitForSessionTranscriptIndexReconcile } from "../config/sessions/session-transcript-reconcile.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
@@ -280,6 +281,36 @@ describe("session transcript reader facade", () => {
       readSessionMessagesAsync(scope, { mode: "recent", maxMessages: 1 }),
     ).resolves.toMatchObject([{ content: "sqlite follow-up", __openclaw: { seq: 3 } }]);
     await expect(readSessionMessageCountAsync(scope)).resolves.toBe(3);
+  });
+
+  test("omits loose SQLite record timestamps from Gateway metadata", async () => {
+    const sessionId = "reader-sqlite-loose-timestamp";
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: `agent:main:${sessionId}`,
+      storePath,
+    };
+    await upsertSessionEntry(scope, { sessionId, updatedAt: 10 });
+    await replaceSqliteTranscriptEvents(scope, [
+      { type: "session", version: 3, id: sessionId },
+      {
+        type: "message",
+        id: "loose-message",
+        parentId: null,
+        timestamp: "01/02/03",
+        message: { role: "user", content: "loose timestamp" },
+      },
+    ]);
+
+    const [message] = await readSessionMessagesAsync(scope, {
+      mode: "full",
+      reason: "strict timestamp reader test",
+    });
+    expect(message).toMatchObject({ content: "loose timestamp" });
+    expect((message as Record<string, unknown>)["__openclaw"]).not.toHaveProperty(
+      "recordTimestampMs",
+    );
   });
 
   test("promotes SQLite message idempotency into transcript metadata", async () => {

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -1,3 +1,4 @@
+import { parseStrictTimestampStringMs } from "@openclaw/normalization-core/number-coercion";
 import {
   readRecentSessionTranscriptMessageEvents,
   readSessionTranscriptMessageEventById,
@@ -116,8 +117,12 @@ export function toTranscriptReadScope(
 function readTranscriptRecordTimestampMs(event: Record<string, unknown>): number | undefined {
   const raw = event.timestamp;
   const timestampMs =
-    typeof raw === "string" ? Date.parse(raw) : typeof raw === "number" ? raw : Number.NaN;
-  return Number.isFinite(timestampMs) ? timestampMs : undefined;
+    typeof raw === "string"
+      ? parseStrictTimestampStringMs(raw)
+      : typeof raw === "number"
+        ? raw
+        : Number.NaN;
+  return timestampMs !== undefined && Number.isFinite(timestampMs) ? timestampMs : undefined;
 }
 
 function extractMessageRecord(

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -438,6 +438,46 @@ describe("readSessionMessages", () => {
     });
   });
 
+  test("omits loose and Date-invalid outer JSONL record timestamps", async () => {
+    const sessionId = "test-session-invalid-record-timestamp";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      { timestamp: "01/02/03", message: { role: "user", content: "loose turn" } },
+      {
+        timestamp: "+275760-09-13T00:00:00.001Z",
+        message: { role: "assistant", content: "range turn" },
+      },
+    ]);
+    const result = await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+      maxMessages: 5,
+      maxBytes: 2048,
+    });
+
+    expect(result).toHaveLength(2);
+    for (const message of result) {
+      expect(
+        requireRecord(requireRecord(message, "message")["__openclaw"], "metadata"),
+      ).not.toHaveProperty("recordTimestampMs");
+    }
+  });
+
+  test("omits synthetic time for a compaction with an invalid persisted timestamp", () => {
+    const sessionId = "test-session-invalid-compaction-timestamp";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      {
+        type: "compaction",
+        id: "comp-1",
+        timestamp: "01/02/03",
+        summary: "Compacted history",
+        firstKeptEntryId: "x",
+        tokensBefore: 123,
+      },
+    ]);
+
+    expect(readSessionMessages(sessionId, storePath)[0]).not.toHaveProperty("timestamp");
+  });
+
   test("surfaces persisted user idempotency keys in __openclaw metadata (#79844)", async () => {
     const sessionId = "test-session-idempotency-key";
     writeTranscript(tmpDir, sessionId, [

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import { StringDecoder } from "node:string_decoder";
 import { expectDefined } from "@openclaw/normalization-core";
 import {
+  parseStrictTimestampStringMs,
   resolveIntegerOption,
   resolveNonNegativeIntegerOption,
 } from "@openclaw/normalization-core/number-coercion";
@@ -781,7 +782,7 @@ function parsedSessionEntryToMessage(parsed: unknown, seq: number): unknown {
   if (entry.message) {
     const recordTimestampMs =
       typeof entry.timestamp === "string"
-        ? Date.parse(entry.timestamp)
+        ? parseStrictTimestampStringMs(entry.timestamp)
         : typeof entry.timestamp === "number"
           ? entry.timestamp
           : Number.NaN;
@@ -797,12 +798,11 @@ function parsedSessionEntryToMessage(parsed: unknown, seq: number): unknown {
   // Compaction entries are not "message" records, but they're useful context for debugging.
   // Emit a lightweight synthetic message that the Web UI can render as a divider.
   if (entry.type === "compaction") {
-    const ts = typeof entry.timestamp === "string" ? Date.parse(entry.timestamp) : Number.NaN;
-    const timestamp = Number.isFinite(ts) ? ts : Date.now();
+    const timestamp = parseStrictTimestampStringMs(entry.timestamp);
     return {
       role: "system",
       content: [{ type: "text", text: "Compaction" }],
-      timestamp,
+      ...(timestamp !== undefined ? { timestamp } : {}),
       __openclaw: {
         kind: "compaction",
         id: typeof entry.id === "string" ? entry.id : undefined,

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -59,7 +59,7 @@ export type ChatItem =
       metric?: string;
       description?: string;
       action?: { kind: "session-checkpoints"; label: string };
-      timestamp: number;
+      timestamp: number | null;
     }
   | { kind: "stream"; key: string; text: string; startedAt: number; isStreaming: boolean }
   | { kind: "reading-indicator"; key: string; startedAt: number }

--- a/ui/src/pages/chat/chat-progress.ts
+++ b/ui/src/pages/chat/chat-progress.ts
@@ -16,7 +16,7 @@ let anonymousWorkingProgressId = 0;
 
 export function buildCompactionDividerItem(
   marker: Record<string, unknown>,
-  timestamp: number,
+  timestamp: number | null,
   index: number,
 ): Extract<ChatItem, { kind: "divider" }> {
   const tokensBefore = marker.tokensBefore;

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -2898,6 +2898,26 @@ describe("buildCachedChatItems", () => {
     expect(action.label).toBe("Open checkpoints");
   });
 
+  it("keeps an untimestamped compaction divider in its transcript slot", () => {
+    const items = buildCachedChatItems(
+      createProps({
+        messages: [
+          { role: "assistant", content: "late", timestamp: 2_000 },
+          {
+            role: "system",
+            __openclaw: { kind: "compaction", id: "checkpoint-1", seq: 2 },
+          },
+          { role: "assistant", content: "early", timestamp: 1_000 },
+        ],
+      }),
+    );
+
+    expect(items).toHaveLength(3);
+    expect(messageRecord(requireGroup(items[0])).content).toBe("early");
+    expect(items[1]).toMatchObject({ kind: "divider", timestamp: null });
+    expect(messageRecord(requireGroup(items[2])).content).toBe("late");
+  });
+
   it("shows the token savings recorded on a compaction boundary", () => {
     const items = buildCachedChatItems(
       createProps({

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -1233,21 +1233,23 @@ function sortChatItemsByVisibleTime(
       timestampsByKey.set(item.key, timestamp);
     }
   }
-  return items
-    .map((item, index) => {
-      const timestamp = chatItemTimestamp(item);
-      const predecessorKey = toolStreamPredecessors.get(item.key);
-      const predecessorTimestamp = predecessorKey ? timestampsByKey.get(predecessorKey) : null;
-      return {
-        item,
-        index,
-        predecessorKey,
-        timestamp:
-          timestamp != null && predecessorTimestamp != null
-            ? Math.max(timestamp, predecessorTimestamp)
-            : timestamp,
-      };
-    })
+  const prepared = items.map((item, index) => {
+    const timestamp = chatItemTimestamp(item);
+    const predecessorKey = toolStreamPredecessors.get(item.key);
+    const predecessorTimestamp = predecessorKey ? timestampsByKey.get(predecessorKey) : null;
+    return {
+      item,
+      index,
+      predecessorKey,
+      timestamp:
+        timestamp != null && predecessorTimestamp != null
+          ? Math.max(timestamp, predecessorTimestamp)
+          : timestamp,
+    };
+  });
+  // Untimestamped compaction markers keep their transcript slot instead of inheriting reload time.
+  const sorted = prepared
+    .filter(({ item, timestamp }) => item.kind !== "divider" || timestamp !== null)
     .toSorted((a, b) => {
       if (a.timestamp == null && b.timestamp == null) {
         return a.index - b.index;
@@ -1268,8 +1270,16 @@ function sortChatItemsByVisibleTime(
         return -1;
       }
       return a.index - b.index;
-    })
-    .map(({ item }) => item);
+    });
+  let nextSortedItem = 0;
+  return prepared.map(({ item, timestamp }) => {
+    if (item.kind === "divider" && timestamp === null) {
+      return item;
+    }
+    const sortedItem = sorted[nextSortedItem]?.item;
+    nextSortedItem += 1;
+    return sortedItem ?? item;
+  });
 }
 
 function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGroup> {
@@ -1312,7 +1322,7 @@ function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGro
     const raw = asRecord(msg) ?? {};
     const marker = raw["__openclaw"] as Record<string, unknown> | undefined;
     if (marker && marker.kind === "compaction") {
-      items.push(buildCompactionDividerItem(marker, normalized.timestamp ?? Date.now(), i));
+      items.push(buildCompactionDividerItem(marker, rawMessageTimestamp(msg), i));
       continue;
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where session recovery and history reads could interpret malformed persisted timestamp strings as valid dates, changing recovered ordering, lifecycle metadata, transcript indexing, Gateway timestamps, compaction placement, or automatic-compaction decisions. Out-of-range compaction timestamps could also abort context reconstruction instead of degrading safely.

## Why This Change Was Made

All persisted string timestamps now pass through the shared strict ISO/RFC3339 parser at the canonical session, agent-context, SQLite, JSONL, Gateway, and UI read boundaries. The parser requires a complete date-time with a timezone, validates calendar/timezone fields and JavaScript `Date` bounds, and keeps valid numeric timestamps and lowercase RFC3339 compatibility unchanged.

Persisted compaction summaries now treat invalid or out-of-range timestamps as unknown while preserving transcript order, so damaged metadata cannot abort context reconstruction. Automatic compaction uses timestamp ordering only for a valid strict boundary and otherwise falls back to the structural retained range, preventing loose future-looking strings from suppressing threshold or overflow recovery without treating retained messages as fresh. Session-header lifecycle parsing retains its existing non-negative timestamp constraint after strict parsing.

Context reconstruction also records the exact retained pre-compaction message range as runtime-only summary metadata. Usage cleanup, signed-thinking cleanup, and automatic-compaction checks share that structural boundary when a persisted compaction timestamp is unavailable. Retained assistant usage is zeroed before estimation, and retained thinking signatures are removed before replay, so an invalid timestamp cannot cause an immediate redundant compaction or replay a signature bound to the pre-compaction context.

The retained boundary is carried as a runtime-only identity on the summary and each retained message rather than relying only on a positional count. The host attaches the stable session-entry id before context-engine assembly, so structured cloning and ordered-subset windowing rebind the exact source message; identical retained and post-compaction content cannot be confused by FIFO matching. That provenance is removed at the LLM and transcript persistence boundaries. Normal filtering, cloning, and `historyLimit` windowing preserve the retained identity without serializing it into transcript JSON, so removing retained turns cannot make a newly generated assistant response look pre-compaction and suppress threshold or overflow recovery.

When the summary timestamp is valid but a retained assistant timestamp is malformed, the structural retained range still treats that assistant as pre-compaction and strips stale Anthropic/Bedrock thinking signatures. Unmarked post-compaction messages continue to use timestamp ordering only when their timestamp is parseable.

The main-port conflict resolution follows the current session architecture: the obsolete session-list module/API was not restored. Non-canonical persisted strings are intentionally treated as missing metadata; this patch intentionally leaves historical-data migration, storage schema, package manifests, lockfile, protocol, and configuration surface unchanged.

What is the intended outcome?
Canonical root-cause fix: one strict timestamp invariant at the shared owner, with stable retained provenance carried through context assembly and removed at model/transcript boundaries.

- Root cause: Persisted timestamps were loosely parsed at several canonical readers, and retained messages were rebound by position or content instead of stable source identity; malformed metadata and duplicate messages could therefore change compaction and recovery state.
- Why this is root-cause fix: The shared parser and compaction owner now enforce the invariant before Gateway, persistence projections, compaction, LLM assembly, and transcript consumers diverge, so downstream readers do not need symptom-specific string checks.
- Risk explanation: Availability, compatibility, message-delivery, security-boundary, and session-state risks are addressed by unknown-safe malformed metadata handling, preserved valid timestamp forms, stable entry ids, and stripping runtime-only provenance before model/transcript delivery.
- Why acceptable: The exact Gateway/SQLite/JSONL live proof and focused regression suites exercise the changed owner and consumers, while the conflict-port scope excludes migrations, schema changes, and unrelated provider/channel behavior.

## Root Cause and Ownership Boundary

Fix classification: canonical source-of-truth root-cause fix, not a fallback or mitigation. The root cause was that persisted timestamps were parsed loosely at multiple canonical read boundaries, allowing invalid metadata to enter ordering, compaction, Gateway, and transcript state. A second root cause was that the old retained boundary depended on positional or content matching, so duplicate messages could be rebound to the wrong side of compaction. The fix is owned at the shared timestamp-normalization boundary and the compaction context owner, with the LLM and transcript boundaries enforcing runtime-only provenance removal. This changes the invariant at its owner, so it fixes the source rather than masking a symptom in a downstream projection.

The canonical owner for model behavior is the assembled LLM context. The model consumes raw assembled context before transformed Gateway, SQLite, or JSONL projections are produced; those projections are not fed back into model input. All readers expose the same normalized metadata contract. Runtime retained provenance is attached before context-engine assembly, used by compaction and cleanup, and removed before the LLM request and transcript persistence; runtime-only provenance is excluded from the public and persisted message shape.

Owner/consumer impact record and boundary sweep: the owner is the shared strict timestamp normalizer plus the compaction context owner. Upstream providers reviewed were session headers, agent context, SQLite rows, JSONL records, and Gateway projections. Downstream consumers reviewed were compaction placement and usage cleanup, thinking cleanup, LLM history preparation, transcript redaction/persistence, search/UI projections, lifecycle state, and session-manager APIs. Test doubles and regression fixtures were included in the affected test files; persistence and schema paths were checked without changing storage; lifecycle and external provider/channel wrappers were checked and are out of scope. This impact-surface sweep is why the change remains at the canonical owner/consumer boundary instead of adding a string-matching workaround in one reader.

## Compatibility, Risks, and Scope

Valid numeric timestamps, strict ISO/RFC3339 timestamps, explicit offsets, lowercase RFC3339 forms, and existing session APIs remain compatible. Availability improves because malformed metadata is treated as unknown rather than aborting recovery. Session-state risk is contained by the stable session-entry id, which prevents duplicate-message or `historyLimit` rebind errors. Security and message-boundary risk is contained because runtime-only provenance is stripped before model and transcript consumers. Default returns and narrow type escapes are limited to unknown semantics for malformed metadata; tests disable retry only to make deterministic invalid-metadata integration assertions and do not change production retry policy.

The large diff is expected for a conflict port spanning canonical timestamp readers, the compaction owner, context/transcript boundaries, and complete regression coverage; it is not an unrelated refactor. Out of scope: historical-data migration, storage-schema changes, package manifests, lockfiles, protocol or configuration-surface changes, and behavior in external providers or channels.

## Related Open PRs

The related open-PR and same-contract competition scan found no other competing PR for this canonical timestamp/retained-provenance contract. Existing legacy timestamp migration or compatibility advisories remain maintainer policy decisions and are not silently folded into this fix.

## User Impact

Malformed saved timestamps now leave recovered session metadata, Gateway history timestamps, search projections, visible compaction placement, and automatic-compaction decisions stable. Context reconstruction completes safely, stale pre-compaction usage is removed, and stale signed-thinking metadata is not replayed. Valid canonical timestamps, explicit offsets, lowercase RFC3339 timestamps, and existing numeric timestamps continue to work. Untimestamped compaction dividers remain in their transcript slot instead of receiving reload time.

## Evidence

Current reworked head: `caa938de4528e63be3fb3ec4966e5df4a7c6ad30`.

Strong live production-path proof started a Gateway HTTP server, exercised session history, persisted and read SQLite transcript data, and read JSONL session data through the production filesystem reader. A local real-behavior evidence run is included with the validation artifacts; it exercised the production Gateway, SQLite, and filesystem paths rather than a mock-only path. The observed result was:

```json
{
  "gatewayStarted": true,
  "filesystem": {
    "looseTimestampOmitted": true,
    "strictTimestampPreserved": true,
    "invalidCompactionTimestampOmitted": true
  },
  "sqlite": {
    "looseTimestampOmitted": true,
    "strictTimestampPreserved": true
  }
}
```

Validation:

- The completed functional candidate passed 486 affected tests across seven Vitest shards. Coverage includes strict timestamp parsing, JSONL/SQLite/Gateway projections, invalid compaction context reconstruction, structural retained-range usage cleanup, signed-thinking cleanup, and error-time automatic-compaction evaluation.
- The exact final repair tail passed 36 tests across three Vitest shards. This includes an `AgentSession` integration regression combining an invalid compaction timestamp, four retained messages, `historyLimit`, and a fresh high-usage assistant response; threshold compaction still runs for the fresh response. The post-CI repair head also passed 207 focused tests across three Vitest shards, including the compaction package, prompt-preflight, LLM-boundary, thinking, transcript-redaction, history-limit, and session-context paths.
- The review-fix tail on this head passed 163 focused tests across three Vitest shards, covering invalid retained assistant timestamps, stable-id duplicate-source rebind, structured-clone retained-boundary recovery, LLM provenance stripping, transcript redaction, history-limit handling, and the session-loop correctness path.
- `oxfmt --check` passed on all nine files changed by the final review-fix tail. Earlier core/UI oxlint and formatting checks remain bound to the preceding full PR surface.
- Strong Gateway/SQLite/JSONL live proof was rerun on this exact head and passed: strict timestamps were preserved, loose timestamps were omitted, invalid compaction timestamps stayed omitted, and the gateway/filesystem paths completed successfully. The only trailing output was known tsx/esbuild shutdown noise after the assertions had passed.
- The conflict port retains the session-header, cwd, oversized-header, timestamp/tree, SQLite idempotency, and loose-timestamp regression coverage while using the current `SessionManager.open/getHeader/getEntries` APIs.
- No external provider or private channel was required for the live proof; the proof exercised Gateway, SQLite, and the production JSONL reader directly.
- No storage schema, package manifest, lockfile, protocol, or configuration surface changed.
