### PR TITLE
feat: add OpenPhone Android node attention support

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -211,6 +211,15 @@ Dangerous or privacy-heavy commands such as `camera.snap`, `camera.clip`, and
 `gateway.nodes.allowCommands`. `gateway.nodes.denyCommands` always wins over
 defaults and extra allowlist entries.
 
+OpenPhone Android nodes identify as `platform: "android"` with
+`deviceFamily: "OpenPhone"`. The gateway treats them as Android nodes and
+allows read-only OpenPhone commands such as `openphone.screen.get`,
+`openphone.local.screen_understanding`, and `openphone.jobs.list` when the node
+declares them. Phone-mutating or privacy-heavy commands, including UI input,
+app/url opens, calendar writes, and SMS search/send, still require explicit
+`gateway.nodes.allowCommands` opt-in and remain subject to the phone's local
+confirmation and policy checks.
+
 Plugin-owned node commands can add a Gateway node-invoke policy. That policy
 runs after the allowlist check and before forwarding to the node, so raw
 `node.invoke`, CLI helpers, and dedicated agent tools share the same plugin
@@ -219,6 +228,31 @@ permission boundary. Dangerous plugin node commands still require explicit
 
 After a node changes its declared command list, reject the old device pairing
 and approve the new request so the gateway stores the updated command snapshot.
+
+### OpenPhone attention events
+
+OpenPhone Android nodes can ask the gateway agent to handle a phone-originated
+task by sending:
+
+```json
+{
+  "event": "openphone.attention.requested",
+  "payload": {
+    "attention_id": "attn_...",
+    "phone_session_id": "phone_sess_...",
+    "source": "chat",
+    "text": "Open settings and show me battery usage",
+    "autonomy": "reviewed",
+    "include_screen": true
+  }
+}
+```
+
+The gateway routes this event into an agent run using the OpenPhone node
+session key. If `sessionKey` is omitted, the gateway uses
+`openphone:<nodeId>:<phone_session_id>` when `phone_session_id` is present, or
+`openphone:<nodeId>` otherwise. The node can subscribe to the same session with
+`chat.subscribe` to receive existing `chat` and `agent` session fanout events.
 
 ## Config (`openclaw.json`)
 
@@ -235,7 +269,7 @@ Node-related settings live under `gateway.nodes` and `tools.exec`:
         autoApproveCidrs: ["192.168.1.0/24"],
       },
       // Opt into dangerous/privacy-heavy node commands (camera.snap, etc.).
-      allowCommands: ["camera.snap", "screen.record"],
+      allowCommands: ["camera.snap", "screen.record", "openphone.ui.tap"],
       // Block exact command names even if defaults or allowCommands include them.
       denyCommands: ["camera.clip"],
     },

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -269,7 +269,7 @@ Node-related settings live under `gateway.nodes` and `tools.exec`:
         autoApproveCidrs: ["192.168.1.0/24"],
       },
       // Opt into dangerous/privacy-heavy node commands (camera.snap, etc.).
-      allowCommands: ["camera.snap", "screen.record", "openphone.ui.tap"],
+      allowCommands: ["camera.snap", "screen.record"],
       // Block exact command names even if defaults or allowCommands include them.
       denyCommands: ["camera.clip"],
     },

--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -192,7 +192,7 @@ describe("gateway/node-command-policy", () => {
 
     expect(allowlist.has("device.info")).toBe(true);
     expect(allowlist.has("device.apps")).toBe(true);
-    expect(allowlist.has("canvas.snapshot")).toBe(true);
+    expect(allowlist.has("canvas.snapshot")).toBe(false);
     expect(allowlist.has("openphone.screen.get")).toBe(true);
     expect(allowlist.has("openphone.local.screen_understanding")).toBe(true);
     expect(allowlist.has("openphone.jobs.list")).toBe(true);
@@ -211,7 +211,7 @@ describe("gateway/node-command-policy", () => {
         declaredCommands: ["canvas.snapshot"],
         allowlist,
       }),
-    ).toEqual({ ok: true });
+    ).toEqual({ ok: false, reason: "command not allowlisted" });
   });
 
   it("keeps explicitly approved host commands for desktop platforms", () => {

--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -176,6 +176,44 @@ describe("gateway/node-command-policy", () => {
     expect(macAllowlist.has("screen.snapshot")).toBe(false);
   });
 
+  it("recognizes OpenPhone Android nodes and allows read-only OpenPhone commands", () => {
+    const cfg = {} as OpenClawConfig;
+    const allowlist = resolveNodeCommandAllowlist(cfg, {
+      platform: "android",
+      deviceFamily: "OpenPhone",
+      commands: [
+        "canvas.snapshot",
+        "openphone.screen.get",
+        "openphone.jobs.list",
+        "openphone.ui.tap",
+        "sms.search",
+      ],
+    });
+
+    expect(allowlist.has("device.info")).toBe(true);
+    expect(allowlist.has("device.apps")).toBe(true);
+    expect(allowlist.has("canvas.snapshot")).toBe(true);
+    expect(allowlist.has("openphone.screen.get")).toBe(true);
+    expect(allowlist.has("openphone.local.screen_understanding")).toBe(true);
+    expect(allowlist.has("openphone.jobs.list")).toBe(true);
+    expect(allowlist.has("openphone.ui.tap")).toBe(false);
+    expect(allowlist.has("sms.search")).toBe(false);
+    expect(
+      isNodeCommandAllowed({
+        command: "openphone.screen.get",
+        declaredCommands: ["openphone.screen.get"],
+        allowlist,
+      }),
+    ).toEqual({ ok: true });
+    expect(
+      isNodeCommandAllowed({
+        command: "canvas.snapshot",
+        declaredCommands: ["canvas.snapshot"],
+        allowlist,
+      }),
+    ).toEqual({ ok: true });
+  });
+
   it("keeps explicitly approved host commands for desktop platforms", () => {
     const cfg = {} as OpenClawConfig;
     const cases = [

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -50,7 +50,6 @@ const SMS_DANGEROUS_COMMANDS = ["sms.send", "sms.search"];
 const TALK_PTT_COMMANDS = ["talk.ptt.start", "talk.ptt.stop", "talk.ptt.cancel", "talk.ptt.once"];
 
 const OPENPHONE_ANDROID_READ_COMMANDS = [
-  "canvas.snapshot",
   "openphone.screen.get",
   "openphone.local.screen_understanding",
   "openphone.jobs.list",

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -49,6 +49,13 @@ const SMS_DANGEROUS_COMMANDS = ["sms.send", "sms.search"];
 
 const TALK_PTT_COMMANDS = ["talk.ptt.start", "talk.ptt.stop", "talk.ptt.cancel", "talk.ptt.once"];
 
+const OPENPHONE_ANDROID_READ_COMMANDS = [
+  "canvas.snapshot",
+  "openphone.screen.get",
+  "openphone.local.screen_understanding",
+  "openphone.jobs.list",
+];
+
 // iOS nodes don't implement system.run/which, but they do support notifications.
 const IOS_SYSTEM_COMMANDS = [NODE_SYSTEM_NOTIFY_COMMAND];
 
@@ -143,7 +150,7 @@ const DEVICE_FAMILY_TOKEN_RULES: ReadonlyArray<{
   tokens: readonly string[];
 }> = [
   { id: "ios", tokens: ["iphone", "ipad", "ios"] },
-  { id: "android", tokens: ["android"] },
+  { id: "android", tokens: ["android", "openphone"] },
   { id: "macos", tokens: ["mac"] },
   { id: "windows", tokens: ["windows"] },
   { id: "linux", tokens: ["linux"] },
@@ -164,7 +171,7 @@ function platformMatchesDeviceFamily(
     case "ios":
       return family === "" || /^(?:iphone|ipad|ios)$/.test(family);
     case "android":
-      return family === "" || family === "android";
+      return family === "" || /^(?:android|openphone)$/.test(family);
     case "macos":
       return family === "mac";
     case "windows":
@@ -322,6 +329,16 @@ function hasTalkSurface(node?: NodeCommandPolicyNode): boolean {
   );
 }
 
+function isOpenPhoneAndroidNode(node: NodeCommandPolicyNode | undefined): boolean {
+  if (!node) {
+    return false;
+  }
+  return (
+    normalizePlatformId(node.platform, node.deviceFamily) === "android" &&
+    normalizeDeviceMetadataForPolicy(node.deviceFamily) === "openphone"
+  );
+}
+
 function resolveNodeCommandAllowlistInternal(
   cfg: OpenClawConfig,
   node?: NodeCommandPolicyNode,
@@ -334,6 +351,7 @@ function resolveNodeCommandAllowlistInternal(
     includeDesktopHostCommands: options?.includeDesktopHostCommands,
   });
   const talkCommands = hasTalkSurface(node) ? TALK_PTT_COMMANDS : [];
+  const openPhoneCommands = isOpenPhoneAndroidNode(node) ? OPENPHONE_ANDROID_READ_COMMANDS : [];
   const pluginDefaults = listDefaultPluginNodeCommands(platformId);
   const approved = filterApprovedRuntimeCommands({
     platformId,
@@ -345,7 +363,7 @@ function resolveNodeCommandAllowlistInternal(
   // Dangerous plugin commands are excluded from plugin defaults. Explicit
   // gateway.nodes.allowCommands below can still opt them in for operators.
   const allow = new Set(
-    [...base, ...talkCommands, ...pluginDefaults, ...approved, ...extra]
+    [...base, ...talkCommands, ...openPhoneCommands, ...pluginDefaults, ...approved, ...extra]
       .map((cmd) => cmd.trim())
       .filter((cmd) => cmd && !dangerousPluginCommands.has(cmd)),
   );

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -764,6 +764,122 @@ describe("node exec events", () => {
   });
 });
 
+describe("openphone attention events", () => {
+  beforeEach(() => {
+    resetNodeEventDeduplicationForTests();
+    agentCommandMock.mockClear();
+    canonicalizeSessionEntryAliasesMock.mockClear();
+    loadSessionEntryMock.mockClear();
+    agentCommandMock.mockResolvedValue({ status: "ok" } as never);
+    canonicalizeSessionEntryAliasesMock.mockImplementation(async ({ target, update }) => {
+      const entry = update ? await update(undefined) : undefined;
+      return { canonicalKey: target.canonicalKey, entry };
+    });
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => buildSessionLookup(sessionKey));
+  });
+
+  it("dispatches OpenPhone attention events as node agent runs", async () => {
+    const addChatRun = vi.fn();
+    const nodeSubscribe = vi.fn();
+    const ctx = buildCtx();
+    ctx.addChatRun = addChatRun;
+    ctx.nodeSubscribe = nodeSubscribe;
+
+    const result = await handleNodeEvent(ctx, "pixel-1", {
+      event: "openphone.attention.requested",
+      payloadJSON: JSON.stringify({
+        attention_id: "attn-1",
+        phone_session_id: "phone-sess-1",
+        source: "classic_voice",
+        autonomy: "reviewed",
+        text: "Open settings and show battery usage",
+        include_screen: true,
+        context: {
+          foreground_package: "com.android.launcher3",
+        },
+      }),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      event: "openphone.attention.requested",
+      handled: true,
+      reason: "dispatched",
+    });
+    expect(loadSessionEntryMock).toHaveBeenCalledWith("openphone:pixel-1:phone-sess-1");
+    expect(canonicalizeSessionEntryAliasesMock).toHaveBeenCalledTimes(1);
+    expect(nodeSubscribe).toHaveBeenCalledWith("pixel-1", "openphone:pixel-1:phone-sess-1");
+    expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    const opts = mockCallArg(agentCommandMock);
+    expectFields(opts, {
+      sessionKey: "openphone:pixel-1:phone-sess-1",
+      deliver: false,
+      messageChannel: "node",
+      thinking: "low",
+    });
+    const optsRecord = opts as Record<string, unknown>;
+    expect(String(optsRecord.message)).toContain("Open settings and show battery usage");
+    expect(String(optsRecord.message)).toContain("OpenPhone request context:");
+    expect(String(optsRecord.message)).toContain("OpenPhone device-control instructions:");
+    expect(String(optsRecord.message)).toContain('node="pixel-1"');
+    expect(String(optsRecord.message)).toContain('invokeCommand="openphone.screen.get"');
+    expect(String(optsRecord.message)).toContain("Before answering screen/app/UI questions");
+    expectFields(optsRecord.inputProvenance, {
+      kind: "external_user",
+      sourceChannel: "openphone",
+      sourceTool: "gateway.openphone.attention",
+    });
+    expect(addChatRun).toHaveBeenCalledTimes(1);
+    const [runId, runMetadata] = mockCall(addChatRun) ?? [];
+    expect(runId).toBe(optsRecord.runId);
+    expectFields(runMetadata, {
+      sessionKey: "openphone:pixel-1:phone-sess-1",
+      clientRunId: "openphone-attn-1",
+    });
+  });
+
+  it("dedupes repeated OpenPhone attention ids from the same node", async () => {
+    const ctx = buildCtx();
+    const payloadJSON = JSON.stringify({
+      attention_id: "attn-dupe",
+      phone_session_id: "phone-sess-dupe",
+      text: "Summarize my screen",
+    });
+
+    await handleNodeEvent(ctx, "pixel-dupe", {
+      event: "openphone.attention.requested",
+      payloadJSON,
+    });
+    const result = await handleNodeEvent(ctx, "pixel-dupe", {
+      event: "openphone.attention.requested",
+      payloadJSON,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      event: "openphone.attention.requested",
+      handled: true,
+      reason: "duplicate_attention",
+    });
+    expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    expect(canonicalizeSessionEntryAliasesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores OpenPhone attention events without text", async () => {
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "pixel-empty", {
+      event: "openphone.attention.requested",
+      payloadJSON: JSON.stringify({
+        attention_id: "attn-empty",
+        phone_session_id: "phone-sess-empty",
+      }),
+    });
+
+    expect(agentCommandMock).not.toHaveBeenCalled();
+    expect(canonicalizeSessionEntryAliasesMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("voice transcript events", () => {
   beforeEach(() => {
     agentCommandMock.mockClear();

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -796,6 +796,10 @@ describe("openphone attention events", () => {
         include_screen: true,
         context: {
           foreground_package: "com.android.launcher3",
+          screen_preflight: {
+            available: true,
+            visible_text: ["Lock screen", "Fri, Jun 26"],
+          },
         },
       }),
     });
@@ -820,7 +824,10 @@ describe("openphone attention events", () => {
     const optsRecord = opts as Record<string, unknown>;
     expect(String(optsRecord.message)).toContain("Open settings and show battery usage");
     expect(String(optsRecord.message)).toContain("OpenPhone request context:");
+    expect(String(optsRecord.message)).toContain("OpenPhone screen preflight observation:");
+    expect(String(optsRecord.message)).toContain("Lock screen");
     expect(String(optsRecord.message)).toContain("OpenPhone device-control instructions:");
+    expect(String(optsRecord.message)).toContain("use it as the current phone screen context");
     expect(String(optsRecord.message)).toContain('node="pixel-1"');
     expect(String(optsRecord.message)).toContain('invokeCommand="openphone.screen.get"');
     expect(String(optsRecord.message)).toContain("Before answering screen/app/UI questions");

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -829,6 +829,7 @@ describe("openphone attention events", () => {
       thinking: "low",
     });
     const optsRecord = opts as Record<string, unknown>;
+    expect(optsRecord.transcriptMessage).toBe("Open settings and show battery usage");
     expect(String(optsRecord.message)).toContain("Open settings and show battery usage");
     expect(String(optsRecord.message)).toContain("OpenPhone request context:");
     expect(String(optsRecord.message)).toContain("OpenPhone screen preflight observation:");
@@ -885,6 +886,41 @@ describe("openphone attention events", () => {
     });
     expect(agentCommandMock).toHaveBeenCalledTimes(1);
     expect(canonicalizeSessionEntryAliasesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dedupe retryable OpenPhone attention ids before run admission", async () => {
+    const ctx = buildCtx();
+    const payloadJSON = JSON.stringify({
+      attention_id: "attn-retry",
+      phone_session_id: "phone-sess-retry",
+      text: "Summarize my screen",
+    });
+    canonicalizeSessionEntryAliasesMock
+      .mockRejectedValueOnce(new Error("session store unavailable"))
+      .mockImplementation(async ({ target, update }) => {
+        const entry = update ? await update(undefined) : undefined;
+        return { canonicalKey: target.canonicalKey, entry };
+      });
+
+    await expect(
+      handleNodeEvent(ctx, "pixel-retry", {
+        event: "openphone.attention.requested",
+        payloadJSON,
+      }),
+    ).rejects.toThrow("session store unavailable");
+
+    const result = await handleNodeEvent(ctx, "pixel-retry", {
+      event: "openphone.attention.requested",
+      payloadJSON,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      event: "openphone.attention.requested",
+      handled: true,
+      reason: "dispatched",
+    });
+    expect(agentCommandMock).toHaveBeenCalledTimes(1);
   });
 
   it("ignores OpenPhone attention events without text", async () => {

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -799,6 +799,13 @@ describe("openphone attention events", () => {
           screen_preflight: {
             available: true,
             visible_text: ["Lock screen", "Fri, Jun 26"],
+            screenshot: {
+              encoding: "base64",
+              mime_type: "image/png",
+              width: 360,
+              height: 780,
+              data: "iVBORw0KGgo=",
+            },
           },
         },
       }),
@@ -826,11 +833,19 @@ describe("openphone attention events", () => {
     expect(String(optsRecord.message)).toContain("OpenPhone request context:");
     expect(String(optsRecord.message)).toContain("OpenPhone screen preflight observation:");
     expect(String(optsRecord.message)).toContain("Lock screen");
+    expect(String(optsRecord.message)).toContain("[base64 chars=12]");
+    expect(String(optsRecord.message)).not.toContain("iVBORw0KGgo=");
     expect(String(optsRecord.message)).toContain("OpenPhone device-control instructions:");
     expect(String(optsRecord.message)).toContain("use it as the current phone screen context");
+    expect(String(optsRecord.message)).toContain("screenshot is attached");
     expect(String(optsRecord.message)).toContain('node="pixel-1"');
     expect(String(optsRecord.message)).toContain('invokeCommand="openphone.screen.get"');
+    expect(String(optsRecord.message)).toContain('\\"include_screenshot\\":true');
     expect(String(optsRecord.message)).toContain("Before answering screen/app/UI questions");
+    expect(optsRecord.images).toEqual([
+      { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+    ]);
+    expect(optsRecord.imageOrder).toEqual(["inline"]);
     expectFields(optsRecord.inputProvenance, {
       kind: "external_user",
       sourceChannel: "openphone",

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -153,6 +153,26 @@ function compactOpenPhoneContextForPrompt(raw: unknown): string {
   return encoded.length <= 4000 ? encoded : `${encoded.slice(0, 3999)}…`;
 }
 
+function compactOpenPhoneScreenPreflightForPrompt(raw: unknown): string {
+  if (typeof raw !== "object" || raw === null) {
+    return "";
+  }
+  const preflight = (raw as Record<string, unknown>).screen_preflight;
+  if (typeof preflight !== "object" || preflight === null) {
+    return "";
+  }
+  let encoded = "";
+  try {
+    encoded = JSON.stringify(preflight);
+  } catch {
+    return "";
+  }
+  if (!encoded || encoded === "{}") {
+    return "";
+  }
+  return encoded.length <= 6000 ? encoded : `${encoded.slice(0, 5999)}…`;
+}
+
 function buildOpenPhoneAttentionMessage(params: {
   nodeId: string;
   text: string;
@@ -167,6 +187,7 @@ function buildOpenPhoneAttentionMessage(params: {
   const source = normalizeLowercaseStringOrEmpty(params.obj.source) || "openphone";
   const autonomy = normalizeLowercaseStringOrEmpty(params.obj.autonomy) || "";
   const context = compactOpenPhoneContextForPrompt(params.obj.context);
+  const screenPreflight = compactOpenPhoneScreenPreflightForPrompt(params.obj.context);
   const requestContext: Record<string, unknown> = {
     nodeId: params.nodeId,
     sessionKey: params.sessionKey,
@@ -188,7 +209,10 @@ function buildOpenPhoneAttentionMessage(params: {
     nodeId: params.nodeId,
     includeScreen: params.obj.include_screen === true,
   });
-  return `${params.text}\n\nOpenPhone request context:\n${JSON.stringify(requestContext)}\n\n${instructions}`;
+  const preflightBlock = screenPreflight
+    ? `\n\nOpenPhone screen preflight observation:\n${screenPreflight}`
+    : "";
+  return `${params.text}\n\nOpenPhone request context:\n${JSON.stringify(requestContext)}${preflightBlock}\n\n${instructions}`;
 }
 
 function buildOpenPhoneAttentionToolingInstructions(params: {
@@ -203,6 +227,7 @@ function buildOpenPhoneAttentionToolingInstructions(params: {
   });
   const lines = [
     "OpenPhone device-control instructions:",
+    "- If an OpenPhone screen preflight observation is present above, use it as the current phone screen context before using workspace/bootstrap context.",
     `- The user is asking from a live OpenPhone Android node. Target node: ${params.nodeId}.`,
     "- Use the `nodes` tool to inspect or control this phone. Do not claim you cannot see the phone when the relevant node tool is available.",
     `- To read the current phone screen, call \`nodes\` with action=\"invoke\", node=\"${params.nodeId}\", invokeCommand=\"openphone.screen.get\", invokeParamsJson=${JSON.stringify(screenInvokeParams)}.`,

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -51,12 +51,15 @@ const MAX_EXEC_EVENT_OUTPUT_CHARS = 180;
 const MAX_NOTIFICATION_EVENT_TEXT_CHARS = 120;
 const VOICE_TRANSCRIPT_DEDUPE_WINDOW_MS = 1500;
 const MAX_RECENT_VOICE_TRANSCRIPTS = 200;
+const OPENPHONE_ATTENTION_DEDUPE_WINDOW_MS = 10 * 60 * 1000;
+const MAX_RECENT_OPENPHONE_ATTENTIONS = 1024;
 const EXEC_FINISHED_RUN_DEDUPE_WINDOW_MS = 10 * 60 * 1000;
 const MAX_RECENT_EXEC_FINISHED_RUNS = 2000;
 const NODE_PRESENCE_PERSIST_MIN_INTERVAL_MS = 60_000;
 const MAX_RECENT_NODE_PRESENCE_KEYS = 1024;
 
 const recentVoiceTranscripts = new Map<string, { fingerprint: string; ts: number }>();
+const recentOpenPhoneAttentions = new Map<string, number>();
 const recentExecFinishedRuns = new Map<string, number>();
 const recentNodePresencePersistAt = new Map<string, number>();
 
@@ -81,6 +84,137 @@ function dispatchNodeAgentCommand(
   void agentCommandFromIngress(input, defaultRuntime, ctx.deps).catch((err: unknown) => {
     ctx.logGateway.warn(`agent failed node=${nodeId}: ${formatForLog(err)}`);
   });
+}
+
+function resolveOpenPhoneAttentionSessionKey(
+  nodeId: string,
+  obj: Record<string, unknown>,
+): string {
+  const explicit =
+    normalizeOptionalString(obj.sessionKey) ?? normalizeOptionalString(obj.session_key);
+  if (explicit) {
+    return explicit;
+  }
+  const phoneSessionId =
+    normalizeOptionalString(obj.phone_session_id) ??
+    normalizeOptionalString(obj.phoneSessionId) ??
+    normalizeOptionalString(obj.sessionId);
+  return phoneSessionId ? `openphone:${nodeId}:${phoneSessionId}` : `openphone:${nodeId}`;
+}
+
+function resolveOpenPhoneAttentionId(obj: Record<string, unknown>): string {
+  return (
+    normalizeOptionalString(obj.attention_id) ??
+    normalizeOptionalString(obj.attentionId) ??
+    normalizeOptionalString(obj.eventId) ??
+    ""
+  );
+}
+
+function shouldDropDuplicateOpenPhoneAttention(params: {
+  nodeId: string;
+  attentionId: string;
+  now: number;
+}): boolean {
+  if (!params.attentionId) {
+    return false;
+  }
+  const fingerprint = `${params.nodeId}:${params.attentionId}`;
+  const previousTs = recentOpenPhoneAttentions.get(fingerprint);
+  if (
+    typeof previousTs === "number" &&
+    params.now - previousTs <= OPENPHONE_ATTENTION_DEDUPE_WINDOW_MS
+  ) {
+    return true;
+  }
+
+  recentOpenPhoneAttentions.set(fingerprint, params.now);
+  pruneBoundedTimestampMap(recentOpenPhoneAttentions, {
+    now: params.now,
+    ttlMs: OPENPHONE_ATTENTION_DEDUPE_WINDOW_MS,
+    maxEntries: MAX_RECENT_OPENPHONE_ATTENTIONS,
+  });
+  return false;
+}
+
+function compactOpenPhoneContextForPrompt(raw: unknown): string {
+  if (typeof raw !== "object" || raw === null) {
+    return "";
+  }
+  let encoded = "";
+  try {
+    encoded = JSON.stringify(raw);
+  } catch {
+    return "";
+  }
+  if (!encoded || encoded === "{}") {
+    return "";
+  }
+  return encoded.length <= 4000 ? encoded : `${encoded.slice(0, 3999)}…`;
+}
+
+function buildOpenPhoneAttentionMessage(params: {
+  nodeId: string;
+  text: string;
+  sessionKey: string;
+  obj: Record<string, unknown>;
+}): string {
+  const phoneSessionId =
+    normalizeOptionalString(params.obj.phone_session_id) ??
+    normalizeOptionalString(params.obj.phoneSessionId) ??
+    normalizeOptionalString(params.obj.sessionId) ??
+    "";
+  const source = normalizeLowercaseStringOrEmpty(params.obj.source) || "openphone";
+  const autonomy = normalizeLowercaseStringOrEmpty(params.obj.autonomy) || "";
+  const context = compactOpenPhoneContextForPrompt(params.obj.context);
+  const requestContext: Record<string, unknown> = {
+    nodeId: params.nodeId,
+    sessionKey: params.sessionKey,
+    source,
+  };
+  if (phoneSessionId) {
+    requestContext.phoneSessionId = phoneSessionId;
+  }
+  if (autonomy) {
+    requestContext.autonomy = autonomy;
+  }
+  if (params.obj.include_screen === true) {
+    requestContext.includeScreen = true;
+  }
+  if (context) {
+    requestContext.contextJson = context;
+  }
+  const instructions = buildOpenPhoneAttentionToolingInstructions({
+    nodeId: params.nodeId,
+    includeScreen: params.obj.include_screen === true,
+  });
+  return `${params.text}\n\nOpenPhone request context:\n${JSON.stringify(requestContext)}\n\n${instructions}`;
+}
+
+function buildOpenPhoneAttentionToolingInstructions(params: {
+  nodeId: string;
+  includeScreen: boolean;
+}): string {
+  const screenInvokeParams = JSON.stringify({
+    include_screenshot: false,
+    include_activity: true,
+    include_ui_tree: true,
+    reason: "answer the OpenPhone user from the current phone screen",
+  });
+  const lines = [
+    "OpenPhone device-control instructions:",
+    `- The user is asking from a live OpenPhone Android node. Target node: ${params.nodeId}.`,
+    "- Use the `nodes` tool to inspect or control this phone. Do not claim you cannot see the phone when the relevant node tool is available.",
+    `- To read the current phone screen, call \`nodes\` with action=\"invoke\", node=\"${params.nodeId}\", invokeCommand=\"openphone.screen.get\", invokeParamsJson=${JSON.stringify(screenInvokeParams)}.`,
+    "- For phone actions, call `nodes` with action=\"invoke\" and the matching OpenPhone command, for example openphone.url.open, openphone.app.open, openphone.ui.tap, openphone.ui.type_text, or notifications.open.",
+    "- Mutating phone actions may require local user confirmation on the Android device; wait for the tool result and report whether it was approved, denied, or completed.",
+  ];
+  if (params.includeScreen) {
+    lines.push(
+      "- This request asked to include the screen. Before answering screen/app/UI questions, read the phone screen with openphone.screen.get.",
+    );
+  }
+  return lines.join("\n");
 }
 
 function resolveVoiceTranscriptFingerprint(obj: Record<string, unknown>, text: string): string {
@@ -219,6 +353,7 @@ function pruneBoundedTimestampMap(
 
 export function resetNodeEventDeduplicationForTests() {
   recentVoiceTranscripts.clear();
+  recentOpenPhoneAttentions.clear();
   recentExecFinishedRuns.clear();
   recentNodePresencePersistAt.clear();
 }
@@ -383,6 +518,74 @@ export const handleNodeEvent = async (
   opts?: { connId?: string; deviceId?: string },
 ): Promise<NodeEventHandleResult | undefined> => {
   switch (evt.event) {
+    case "openphone.attention.requested": {
+      const obj = parsePayloadObject(evt.payloadJSON);
+      if (!obj) {
+        return undefined;
+      }
+      const text =
+        normalizeOptionalString(obj.text) ?? normalizeOptionalString(obj.message) ?? "";
+      if (!text || text.length > 20_000) {
+        return undefined;
+      }
+      const attentionId = resolveOpenPhoneAttentionId(obj);
+      const now = Date.now();
+      if (
+        shouldDropDuplicateOpenPhoneAttention({
+          nodeId,
+          attentionId,
+          now,
+        })
+      ) {
+        return {
+          ok: true,
+          event: evt.event,
+          handled: true,
+          reason: "duplicate_attention",
+        };
+      }
+
+      const sessionKeyRaw = resolveOpenPhoneAttentionSessionKey(nodeId, obj);
+      const { storePath, entry, canonicalKey, storeKeys } = loadSessionEntry(sessionKeyRaw);
+      const sessionId = entry?.sessionId ?? randomUUID();
+      await touchSessionStore({
+        storePath,
+        canonicalKey,
+        storeKeys,
+        entry,
+        sessionId,
+        now,
+      });
+      const runId = randomUUID();
+      const clientRunId = attentionId ? `openphone-${attentionId}` : `openphone-${randomUUID()}`;
+      ctx.nodeSubscribe(nodeId, canonicalKey);
+      ctx.addChatRun(runId, {
+        sessionKey: canonicalKey,
+        clientRunId,
+      });
+
+      dispatchNodeAgentCommand(ctx, nodeId, {
+        runId,
+        message: buildOpenPhoneAttentionMessage({
+          nodeId,
+          text,
+          sessionKey: canonicalKey,
+          obj,
+        }),
+        sessionId,
+        sessionKey: canonicalKey,
+        thinking: "low",
+        deliver: false,
+        messageChannel: "node",
+        inputProvenance: {
+          kind: "external_user",
+          sourceChannel: "openphone",
+          sourceTool: "gateway.openphone.attention",
+        },
+        allowModelOverride: false,
+      });
+      return { ok: true, event: evt.event, handled: true, reason: "dispatched" };
+    }
     case "voice.transcript": {
       const obj = parsePayloadObject(evt.payloadJSON);
       if (!obj) {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -166,7 +166,7 @@ function resolveOpenPhoneAttentionId(obj: Record<string, unknown>): string {
   );
 }
 
-function shouldDropDuplicateOpenPhoneAttention(params: {
+function hasRecentOpenPhoneAttention(params: {
   nodeId: string;
   attentionId: string;
   now: number;
@@ -182,6 +182,18 @@ function shouldDropDuplicateOpenPhoneAttention(params: {
   ) {
     return true;
   }
+  return false;
+}
+
+function rememberOpenPhoneAttention(params: {
+  nodeId: string;
+  attentionId: string;
+  now: number;
+}): void {
+  if (!params.attentionId) {
+    return;
+  }
+  const fingerprint = `${params.nodeId}:${params.attentionId}`;
 
   recentOpenPhoneAttentions.set(fingerprint, params.now);
   pruneBoundedTimestampMap(recentOpenPhoneAttentions, {
@@ -189,7 +201,6 @@ function shouldDropDuplicateOpenPhoneAttention(params: {
     ttlMs: OPENPHONE_ATTENTION_DEDUPE_WINDOW_MS,
     maxEntries: MAX_RECENT_OPENPHONE_ATTENTIONS,
   });
-  return false;
 }
 
 function compactOpenPhoneContextForPrompt(raw: unknown): string {
@@ -611,7 +622,7 @@ export const handleNodeEvent = async (
       const attentionId = resolveOpenPhoneAttentionId(obj);
       const now = Date.now();
       if (
-        shouldDropDuplicateOpenPhoneAttention({
+        hasRecentOpenPhoneAttention({
           nodeId,
           attentionId,
           now,
@@ -645,6 +656,11 @@ export const handleNodeEvent = async (
         sessionKey: canonicalKey,
         clientRunId,
       });
+      rememberOpenPhoneAttention({
+        nodeId,
+        attentionId,
+        now,
+      });
 
       dispatchNodeAgentCommand(ctx, nodeId, {
         runId,
@@ -654,6 +670,7 @@ export const handleNodeEvent = async (
           sessionKey: canonicalKey,
           obj,
         }),
+        transcriptMessage: text,
         sessionId,
         sessionKey: canonicalKey,
         thinking: "low",

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -71,6 +71,7 @@ export type NodeEventHandleResult = {
 };
 
 type NodeAgentCommandInput = Parameters<typeof agentCommandFromIngress>[0];
+type NodeAgentCommandImage = { type: "image"; data: string; mimeType: string };
 
 function normalizeFiniteInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : null;
@@ -86,10 +87,64 @@ function dispatchNodeAgentCommand(
   });
 }
 
-function resolveOpenPhoneAttentionSessionKey(
-  nodeId: string,
-  obj: Record<string, unknown>,
-): string {
+function redactOpenPhoneImageBytes(raw: unknown): unknown {
+  if (typeof raw !== "object" || raw === null) {
+    return raw;
+  }
+  let copy: unknown;
+  try {
+    copy = JSON.parse(JSON.stringify(raw)) as unknown;
+  } catch {
+    return raw;
+  }
+  if (typeof copy !== "object" || copy === null) {
+    return copy;
+  }
+  const preflight = (copy as Record<string, unknown>).screen_preflight;
+  if (typeof preflight !== "object" || preflight === null) {
+    return copy;
+  }
+  const screenshot = (preflight as Record<string, unknown>).screenshot;
+  if (typeof screenshot !== "object" || screenshot === null) {
+    return copy;
+  }
+  const data = (screenshot as Record<string, unknown>).data;
+  if (typeof data === "string" && data.length > 0) {
+    (screenshot as Record<string, unknown>).data = `[base64 chars=${data.length}]`;
+  }
+  return copy;
+}
+
+function redactOpenPhonePreflightImageBytes(preflight: unknown): unknown {
+  const redacted = redactOpenPhoneImageBytes({ screen_preflight: preflight });
+  return typeof redacted === "object" && redacted !== null
+    ? ((redacted as Record<string, unknown>).screen_preflight ?? preflight)
+    : preflight;
+}
+
+function extractOpenPhoneAttentionImages(raw: unknown): NodeAgentCommandImage[] {
+  if (typeof raw !== "object" || raw === null) {
+    return [];
+  }
+  const preflight = (raw as Record<string, unknown>).screen_preflight;
+  if (typeof preflight !== "object" || preflight === null) {
+    return [];
+  }
+  const screenshot = (preflight as Record<string, unknown>).screenshot;
+  if (typeof screenshot !== "object" || screenshot === null) {
+    return [];
+  }
+  const record = screenshot as Record<string, unknown>;
+  const data = normalizeOptionalString(record.data);
+  const encoding = normalizeLowercaseStringOrEmpty(record.encoding) || "base64";
+  const mimeType = normalizeLowercaseStringOrEmpty(record.mime_type) || "image/jpeg";
+  if (!data || encoding !== "base64" || !mimeType.startsWith("image/")) {
+    return [];
+  }
+  return [{ type: "image", data, mimeType }];
+}
+
+function resolveOpenPhoneAttentionSessionKey(nodeId: string, obj: Record<string, unknown>): string {
   const explicit =
     normalizeOptionalString(obj.sessionKey) ?? normalizeOptionalString(obj.session_key);
   if (explicit) {
@@ -143,7 +198,7 @@ function compactOpenPhoneContextForPrompt(raw: unknown): string {
   }
   let encoded = "";
   try {
-    encoded = JSON.stringify(raw);
+    encoded = JSON.stringify(redactOpenPhoneImageBytes(raw));
   } catch {
     return "";
   }
@@ -163,7 +218,7 @@ function compactOpenPhoneScreenPreflightForPrompt(raw: unknown): string {
   }
   let encoded = "";
   try {
-    encoded = JSON.stringify(preflight);
+    encoded = JSON.stringify(redactOpenPhonePreflightImageBytes(preflight));
   } catch {
     return "";
   }
@@ -220,7 +275,7 @@ function buildOpenPhoneAttentionToolingInstructions(params: {
   includeScreen: boolean;
 }): string {
   const screenInvokeParams = JSON.stringify({
-    include_screenshot: false,
+    include_screenshot: true,
     include_activity: true,
     include_ui_tree: true,
     reason: "answer the OpenPhone user from the current phone screen",
@@ -228,10 +283,11 @@ function buildOpenPhoneAttentionToolingInstructions(params: {
   const lines = [
     "OpenPhone device-control instructions:",
     "- If an OpenPhone screen preflight observation is present above, use it as the current phone screen context before using workspace/bootstrap context.",
+    "- If an OpenPhone screenshot is attached, treat it as the rendered full-screen phone view and use accessibility metadata only as supporting context.",
     `- The user is asking from a live OpenPhone Android node. Target node: ${params.nodeId}.`,
     "- Use the `nodes` tool to inspect or control this phone. Do not claim you cannot see the phone when the relevant node tool is available.",
     `- To read the current phone screen, call \`nodes\` with action=\"invoke\", node=\"${params.nodeId}\", invokeCommand=\"openphone.screen.get\", invokeParamsJson=${JSON.stringify(screenInvokeParams)}.`,
-    "- For phone actions, call `nodes` with action=\"invoke\" and the matching OpenPhone command, for example openphone.url.open, openphone.app.open, openphone.ui.tap, openphone.ui.type_text, or notifications.open.",
+    '- For phone actions, call `nodes` with action="invoke" and the matching OpenPhone command, for example openphone.url.open, openphone.app.open, openphone.ui.tap, openphone.ui.type_text, or notifications.open.',
     "- Mutating phone actions may require local user confirmation on the Android device; wait for the tool result and report whether it was approved, denied, or completed.",
   ];
   if (params.includeScreen) {
@@ -548,8 +604,7 @@ export const handleNodeEvent = async (
       if (!obj) {
         return undefined;
       }
-      const text =
-        normalizeOptionalString(obj.text) ?? normalizeOptionalString(obj.message) ?? "";
+      const text = normalizeOptionalString(obj.text) ?? normalizeOptionalString(obj.message) ?? "";
       if (!text || text.length > 20_000) {
         return undefined;
       }
@@ -583,6 +638,8 @@ export const handleNodeEvent = async (
       });
       const runId = randomUUID();
       const clientRunId = attentionId ? `openphone-${attentionId}` : `openphone-${randomUUID()}`;
+      const images = extractOpenPhoneAttentionImages(obj.context);
+      const imageOrder: PromptImageOrderEntry[] = images.map((): PromptImageOrderEntry => "inline");
       ctx.nodeSubscribe(nodeId, canonicalKey);
       ctx.addChatRun(runId, {
         sessionKey: canonicalKey,
@@ -601,6 +658,8 @@ export const handleNodeEvent = async (
         sessionKey: canonicalKey,
         thinking: "low",
         deliver: false,
+        images,
+        imageOrder,
         messageChannel: "node",
         inputProvenance: {
           kind: "external_user",


### PR DESCRIPTION
## What Problem This Solves
OpenPhone Android nodes need a supported gateway path to ask OpenClaw to handle phone-originated tasks and to expose safe read-only phone commands by default.

## Why This Change Was Made
This adds OpenPhone Android node recognition, read-only OpenPhone command defaults, and an `openphone.attention.requested` event handler that starts an agent run, subscribes the node to the session, redacts screenshot bytes from prompt text, and attaches screenshot images as model images. Mutating commands still require explicit allowlist and phone-side policy/confirmation.

## User Impact
Users can select OpenClaw as the remote runtime from OpenPhone and have OpenClaw receive phone-originated requests with screen context. Operators keep explicit control over mutating or privacy-heavy phone commands.

## Evidence
- `node scripts/run-with-env.mjs OPENCLAW_GATEWAY_PROJECT_SHARDS=1 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-node-events.test.ts src/gateway/node-command-policy.test.ts` passed (4 files, 86 tests).
- `pnpm tsgo:core` passed.
- `git diff --check origin/main...HEAD` passed.
- Strict branch diff secret scan for private keys, cloud keys, GitHub tokens, OpenAI-style keys, JWTs: no hits.
- Live OpenPhone/OpenClaw smoke: Android node connected through gateway and `openphone.attention.requested` ping returned an OpenClaw terminal response.

AI-assisted: yes. I understand the changes.
