### PR TITLE
fix(telegram): retain socket failure context

### DIFF
--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -957,7 +957,7 @@ describe("resolveTelegramFetch", () => {
     expect(eighthDispatcher).toBe(firstDispatcher);
     expect(ninthDispatcher).toBe(firstDispatcher);
     expectPinnedFallbackIpDispatcher(3);
-    expectLoggerMessageContaining(loggerWarn, "fetch fallback: DNS-resolved IP unreachable");
+    expectLoggerMessageContaining(loggerWarn, "fetch fallback: primary connection path failed");
     expectLoggerMessageContaining(
       loggerDebug,
       "fetch fallback: recovered from attempt 2 to attempt 0",
@@ -1191,6 +1191,31 @@ describe("resolveTelegramFetch", () => {
     );
 
     expect(undiciFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not automatically retry structured EADDRNOTAVAIL fetch failures", async () => {
+    const fetchError = buildFetchFallbackError("EADDRNOTAVAIL");
+    undiciFetch.mockRejectedValue(fetchError);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, STICKY_IPV4_FALLBACK_NETWORK);
+
+    await expect(resolved("https://api.telegram.org/botx/sendMessage")).rejects.toThrow(
+      "fetch failed",
+    );
+
+    expect(undiciFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves EADDRNOTAVAIL in forced fallback diagnostics", () => {
+    const transport = resolveTelegramTransport(undefined, STICKY_IPV4_FALLBACK_NETWORK);
+    const fetchError = buildFetchFallbackError("EADDRNOTAVAIL");
+
+    expect(transport.forceFallback?.("probe timeout/network error", fetchError)).toBe(true);
+    expect(transport.forceFallback?.("probe timeout/network error", fetchError)).toBe(true);
+
+    expectLoggerMessageContaining(loggerWarn, "primary connection path failed");
+    expectLoggerMessageContaining(loggerWarn, "codes=EADDRNOTAVAIL");
+    expectNoLoggerMessageContaining(loggerWarn, "DNS-resolved IP unreachable");
   });
 
   it("retries sticky fallback when the local network is down during connect", async () => {

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -488,9 +488,10 @@ export type TelegramTransport = {
   dispatcherAttempts?: TelegramDispatcherAttempt[];
   /**
    * Promote this transport to its next fallback dispatcher before the next
-   * request. Returns false when no fallback path exists.
+   * request. The original error, when available, is retained in diagnostics.
+   * Returns false when no fallback path exists.
    */
-  forceFallback?: (reason: string) => boolean;
+  forceFallback?: (reason: string, err?: unknown) => boolean;
   /**
    * Release all dispatchers owned by this transport and the TCP sockets they
    * hold. Safe to call multiple times; subsequent calls resolve immediately.
@@ -563,7 +564,8 @@ function createTelegramTransportAttempts(params: {
     },
     exportAttempt: { dispatcherPolicy: fallbackIpPolicy },
     logLevel: "warn",
-    logMessage: "fetch fallback: DNS-resolved IP unreachable; trying alternative Telegram API IP",
+    logMessage:
+      "fetch fallback: primary connection path failed; trying alternative Telegram API IP",
   });
 
   return attempts;
@@ -864,8 +866,8 @@ export function resolveTelegramTransport(
     fetch: resolvedFetch,
     sourceFetch,
     dispatcherAttempts: transportAttempts.map((attempt) => attempt.exportAttempt),
-    forceFallback: (reason: string) =>
-      promoteStickyAttempt(stickyAttemptIndex + 1, new Error("forced fallback"), reason),
+    forceFallback: (reason: string, err?: unknown) =>
+      promoteStickyAttempt(stickyAttemptIndex + 1, err ?? new Error("forced fallback"), reason),
     close,
   };
 }

--- a/extensions/telegram/src/probe.test.ts
+++ b/extensions/telegram/src/probe.test.ts
@@ -362,7 +362,7 @@ describe("probeTelegram retry logic", () => {
 
       const result = await probePromise;
       expect(result.ok).toBe(true);
-      expect(localForceFallback).toHaveBeenCalledWith("probe timeout/network error");
+      expect(localForceFallback).toHaveBeenCalledWith("probe timeout/network error", timeoutError);
       expect(fetchMock).toHaveBeenCalledTimes(3); // 1 failed + 1 getMe success + 1 webhook
     } finally {
       vi.useRealTimers();

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -162,7 +162,8 @@ export async function probeTelegram(
         // On timeout or network error, promote the transport to its IPv4
         // fallback dispatcher so the next retry (and all future probes
         // sharing this cached transport) skip the stalled IPv6 path.
-        transport.forceFallback?.("probe timeout/network error");
+        // Keep the original socket code in transport fallback diagnostics.
+        transport.forceFallback?.("probe timeout/network error", err);
         if (i < 2) {
           const remainingAfterAttemptMs = resolveRemainingBudgetMs();
           if (remainingAfterAttemptMs <= 0) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #94620. Supersedes #96830 while preserving @zhangguiping-xydt's contribution credit.

When a Telegram startup probe fails and explicitly promotes the transport fallback, the transport currently discards the original error. That produces `codes=none` and can pair a local socket failure with the inaccurate claim that a DNS-resolved IP was unreachable.

## Why This Change Was Made

- Pass the original probe error into `forceFallback` so the existing transport diagnostic reports its structured socket code.
- Describe the failed primary connection path without asserting an unproven DNS cause.
- Preserve the existing fallback policy: a direct structured `EADDRNOTAVAIL` fetch failure is not automatically retried, while a probe can still promote the alternate IPv4 or pinned-IP path.

The original proposal disabled probe fallback for `EADDRNOTAVAIL`. Maintainer review found that too broad: Linux ephemeral-port allocation is destination-sensitive, so a different remote Telegram IP can still provide a usable socket tuple. Keeping recovery while preserving the real error is the bounded owner-local fix.

## User Impact

Telegram startup fallback logs now retain `EADDRNOTAVAIL` and avoid misleading DNS wording. Existing alternate-IP recovery remains available, including when a different destination tuple can recover from local port pressure.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/fetch.test.ts extensions/telegram/src/probe.test.ts`
  - 2 files passed; 56 tests passed on current `main`.
- `node_modules/.bin/oxfmt --check extensions/telegram/src/fetch.ts extensions/telegram/src/probe.ts extensions/telegram/src/fetch.test.ts extensions/telegram/src/probe.test.ts`
  - passed.
- `node_modules/.bin/oxlint --deny-warnings extensions/telegram/src/fetch.ts extensions/telegram/src/probe.ts extensions/telegram/src/fetch.test.ts extensions/telegram/src/probe.test.ts`
  - 0 warnings; 0 errors.
- `git diff --check`
  - passed.
- Fresh Codex autoreview
  - clean; no accepted/actionable findings.
- Darwin real-kernel proof
  - produced `EADDRNOTAVAIL` (`errno=-49`); direct fallback was false; two explicit promotions returned true and retained `codes=EADDRNOTAVAIL`.
- Blacksmith Testbox `tbx_01kw38m62y2gccvpbgy5kafgx8`
  - Linux real-kernel proof produced `EADDRNOTAVAIL` (`errno=-99`) with the same fallback decisions.
  - the four-file change passed `pnpm check:changed` for the extension and extension-test lanes.
