### PR TITLE
Fix ACP manual-spawn task tracking

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import type { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import {
   registerExecApprovalFollowupRuntimeHandoff,
   resetExecApprovalFollowupRuntimeHandoffsForTests,
@@ -48,6 +49,7 @@ const mocks = vi.hoisted(() => ({
   getLatestSubagentRunByChildSessionKey: vi.fn(),
   replaceSubagentRunAfterSteer: vi.fn(),
   resolveExplicitAgentSessionKey: vi.fn(),
+  readAcpSessionMeta: vi.fn<typeof readAcpSessionMeta>(() => undefined),
   listAgentIds: vi.fn(() => ["main"]),
   loadConfigReturn: {} as Record<string, unknown>,
   loadVoiceWakeRoutingConfig: vi.fn(),
@@ -100,6 +102,16 @@ vi.mock("../../commands/agent.js", () => ({
   agentCommand: mocks.agentCommand,
   agentCommandFromIngress: mocks.agentCommand,
 }));
+
+vi.mock("../../acp/runtime/session-meta.js", async () => {
+  const actual = await vi.importActual<typeof import("../../acp/runtime/session-meta.js")>(
+    "../../acp/runtime/session-meta.js",
+  );
+  return {
+    ...actual,
+    readAcpSessionMeta: mocks.readAcpSessionMeta,
+  };
+});
 
 vi.mock("../../config/config.js", async () => {
   const actual =
@@ -483,6 +495,25 @@ function backendGatewayClient(): AgentHandlerArgs["client"] {
   } as AgentHandlerArgs["client"];
 }
 
+// Operator-write client that is NOT the in-process backend ACP spawn caller:
+// a control-UI connection with the same operator.write scope. It can set
+// acpTurnSource but owns no replacement `acp` task row, so CLI tracking stays on.
+function operatorWriteGatewayClient(): AgentHandlerArgs["client"] {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: "openclaw-control-ui",
+        version: "test",
+        platform: "test",
+        mode: "ui",
+      },
+      scopes: ["operator.write"],
+    },
+  } as AgentHandlerArgs["client"];
+}
+
 async function waitForAgentCommandCall<
   T extends AgentCommandCall = AgentCommandCall,
 >(): Promise<T> {
@@ -576,6 +607,7 @@ describe("gateway agent handler", () => {
     mocks.emitGatewaySessionEndPluginHook.mockReset();
     mocks.emitGatewaySessionStartPluginHook.mockReset();
     mocks.resolveExplicitAgentSessionKey.mockReset().mockReturnValue(undefined);
+    mocks.readAcpSessionMeta.mockReset().mockReturnValue(undefined);
     mocks.listAgentIds.mockReset().mockReturnValue(["main"]);
     mocks.getChannelPlugin.mockReset();
     mocks.sendDurableMessageBatch.mockReset();
@@ -4683,6 +4715,277 @@ describe("gateway agent handler", () => {
     });
   });
 
+  describe("ACP manual-spawn child turn task tracking", () => {
+    function mockAcpChildSessionEntry(childSessionKey: string) {
+      mocks.loadSessionEntry.mockReturnValue({
+        cfg: {},
+        storePath: "/tmp/sessions.json",
+        entry: { sessionId: "acp-child-session", updatedAt: Date.now() },
+        canonicalKey: childSessionKey,
+      });
+      mocks.updateSessionStore.mockResolvedValue(undefined);
+      mocks.agentCommand.mockResolvedValue({
+        payloads: [{ text: "ok" }],
+        meta: { durationMs: 100 },
+      });
+    }
+
+    function spyDetachedCreateRunningTaskRun() {
+      const defaultRuntime = getDetachedTaskLifecycleRuntime();
+      const createRunningTaskRunSpy = vi.fn(
+        (...args: Parameters<typeof defaultRuntime.createRunningTaskRun>) =>
+          defaultRuntime.createRunningTaskRun(...args),
+      );
+      setDetachedTaskLifecycleRuntime({
+        ...defaultRuntime,
+        createRunningTaskRun: createRunningTaskRunSpy,
+      });
+      return createRunningTaskRunSpy;
+    }
+
+    const confirmedAcpMeta: NonNullable<ReturnType<typeof readAcpSessionMeta>> = {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "runtime-1",
+      mode: "persistent",
+      state: "idle",
+      lastActivityAt: Date.now(),
+    };
+
+    it("suppresses the gateway CLI task row for confirmed ACP manual-spawn child turns", async () => {
+      await withTempDir({ prefix: "openclaw-gateway-acp-suppress-" }, async (root) => {
+        useTestStateDir(root);
+        resetTaskRegistryForTests();
+        const childSessionKey = "agent:main:acp:child-confirmed";
+        mockAcpChildSessionEntry(childSessionKey);
+        mocks.readAcpSessionMeta.mockReturnValue(confirmedAcpMeta);
+        const createRunningTaskRunSpy = spyDetachedCreateRunningTaskRun();
+
+        await invokeAgent(
+          {
+            message: "acp manual spawn child turn",
+            sessionKey: childSessionKey,
+            acpTurnSource: "manual_spawn",
+            idempotencyKey: "acp-manual-spawn-confirmed",
+          },
+          { reqId: "acp-manual-spawn-confirmed", client: backendGatewayClient() },
+        );
+        await waitForAgentCommandCall();
+
+        expect(createRunningTaskRunSpy).not.toHaveBeenCalled();
+        expect(findTaskByRunId("acp-manual-spawn-confirmed")).toBeUndefined();
+      });
+    });
+
+    it("keeps CLI tracking when a non-backend operator-write caller sets acpTurnSource", async () => {
+      await withTempDir({ prefix: "openclaw-gateway-acp-operator-write-" }, async (root) => {
+        useTestStateDir(root);
+        resetTaskRegistryForTests();
+        const childSessionKey = "agent:main:acp:child-operator-write";
+        mockAcpChildSessionEntry(childSessionKey);
+        // Persisted ACP metadata is present and the turn looks like a manual
+        // spawn, but the caller is an operator-write control-UI client, not the
+        // in-process backend ACP spawn path. That caller never creates a
+        // replacement `acp` row, so CLI tracking must stay on to avoid losing the
+        // run entirely.
+        mocks.readAcpSessionMeta.mockReturnValue(confirmedAcpMeta);
+        const createRunningTaskRunSpy = spyDetachedCreateRunningTaskRun();
+
+        await invokeAgent(
+          {
+            message: "operator-write acp manual spawn",
+            sessionKey: childSessionKey,
+            acpTurnSource: "manual_spawn",
+            idempotencyKey: "acp-operator-write",
+          },
+          { reqId: "acp-operator-write", client: operatorWriteGatewayClient() },
+        );
+        await waitForAgentCommandCall();
+
+        expect(createRunningTaskRunSpy).toHaveBeenCalledTimes(1);
+        expectRecordFields(mockCallArg(createRunningTaskRunSpy), {
+          runtime: "cli",
+          runId: "acp-operator-write",
+          childSessionKey,
+        });
+        await waitForAssertion(() => {
+          expectRecordFields(findTaskByRunId("acp-operator-write"), {
+            runtime: "cli",
+            childSessionKey,
+          });
+        });
+      });
+    });
+
+    it("keeps CLI tracking for ACP-shaped manual-spawn turns without persisted ACP metadata", async () => {
+      await withTempDir({ prefix: "openclaw-gateway-acp-no-meta-" }, async (root) => {
+        useTestStateDir(root);
+        resetTaskRegistryForTests();
+        const childSessionKey = "agent:main:acp:child-missing-meta";
+        mockAcpChildSessionEntry(childSessionKey);
+        mocks.readAcpSessionMeta.mockReturnValue(undefined);
+        const createRunningTaskRunSpy = spyDetachedCreateRunningTaskRun();
+
+        await invokeAgent(
+          {
+            message: "acp shaped turn without metadata",
+            sessionKey: childSessionKey,
+            acpTurnSource: "manual_spawn",
+            idempotencyKey: "acp-manual-spawn-no-meta",
+          },
+          { reqId: "acp-manual-spawn-no-meta", client: backendGatewayClient() },
+        );
+        await waitForAgentCommandCall();
+
+        expect(createRunningTaskRunSpy).toHaveBeenCalledTimes(1);
+        expectRecordFields(mockCallArg(createRunningTaskRunSpy), {
+          runtime: "cli",
+          runId: "acp-manual-spawn-no-meta",
+          childSessionKey,
+        });
+        await waitForAssertion(() => {
+          expectRecordFields(findTaskByRunId("acp-manual-spawn-no-meta"), {
+            runtime: "cli",
+            childSessionKey,
+          });
+        });
+      });
+    });
+
+    it("keeps dispatch and CLI tracking when ACP metadata read fails", async () => {
+      await withTempDir({ prefix: "openclaw-gateway-acp-meta-throw-" }, async (root) => {
+        useTestStateDir(root);
+        resetTaskRegistryForTests();
+        const childSessionKey = "agent:main:acp:child-meta-throw";
+        mockAcpChildSessionEntry(childSessionKey);
+        const metadataError = new Error("state db unavailable");
+        mocks.readAcpSessionMeta.mockImplementation(() => {
+          throw metadataError;
+        });
+        const createRunningTaskRunSpy = spyDetachedCreateRunningTaskRun();
+        const context = makeContext();
+
+        await invokeAgent(
+          {
+            message: "acp manual spawn metadata throw",
+            sessionKey: childSessionKey,
+            acpTurnSource: "manual_spawn",
+            idempotencyKey: "acp-manual-spawn-meta-throw",
+          },
+          { reqId: "acp-manual-spawn-meta-throw", context, client: backendGatewayClient() },
+        );
+        await waitForAgentCommandCall();
+
+        expect(createRunningTaskRunSpy).toHaveBeenCalledTimes(1);
+        expectRecordFields(mockCallArg(createRunningTaskRunSpy), {
+          runtime: "cli",
+          runId: "acp-manual-spawn-meta-throw",
+          childSessionKey,
+        });
+        await waitForAssertion(() => {
+          expectRecordFields(findTaskByRunId("acp-manual-spawn-meta-throw"), {
+            runtime: "cli",
+            childSessionKey,
+            status: "succeeded",
+            terminalSummary: "completed",
+          });
+        });
+        const warnMock = context.logGateway.warn as ReturnType<typeof vi.fn>;
+        expect(
+          warnMock.mock.calls.some(([message]) => {
+            return (
+              typeof message === "string" &&
+              message.includes("failed to read ACP session metadata") &&
+              message.includes("falling back to cli task tracking")
+            );
+          }),
+        ).toBe(true);
+      });
+    });
+
+    it("keeps CLI tracking for ACP-shaped turns that are not manual spawns", async () => {
+      await withTempDir({ prefix: "openclaw-gateway-acp-not-manual-spawn-" }, async (root) => {
+        useTestStateDir(root);
+        resetTaskRegistryForTests();
+        const childSessionKey = "agent:main:acp:child-not-spawn";
+        mockAcpChildSessionEntry(childSessionKey);
+        // Metadata is present but the turn lacks acpTurnSource, so the spawn
+        // control plane does not own this row; CLI tracking must stay on.
+        mocks.readAcpSessionMeta.mockReturnValue(confirmedAcpMeta);
+        const createRunningTaskRunSpy = spyDetachedCreateRunningTaskRun();
+
+        await invokeAgent(
+          {
+            message: "acp shaped non-spawn turn",
+            sessionKey: childSessionKey,
+            idempotencyKey: "acp-not-manual-spawn",
+          },
+          { reqId: "acp-not-manual-spawn", client: backendGatewayClient() },
+        );
+        await waitForAgentCommandCall();
+
+        expect(createRunningTaskRunSpy).toHaveBeenCalledTimes(1);
+        expectRecordFields(mockCallArg(createRunningTaskRunSpy), {
+          runtime: "cli",
+          runId: "acp-not-manual-spawn",
+          childSessionKey,
+        });
+      });
+    });
+
+    it("does not affect plugin-subagent tracking for confirmed ACP conditions", async () => {
+      await withTempDir({ prefix: "openclaw-gateway-acp-plugin-subagent-" }, async (root) => {
+        useTestStateDir(root);
+        resetTaskRegistryForTests();
+        resetSubagentRegistryForTests({ persist: false });
+        const childSessionKey = "agent:main:acp:plugin-child";
+        const runId = "acp-plugin-subagent-run";
+        mockAcpChildSessionEntry(childSessionKey);
+        mocks.readAcpSessionMeta.mockReturnValue(confirmedAcpMeta);
+        const createRunningTaskRunSpy = spyDetachedCreateRunningTaskRun();
+
+        const baseClient = requireValue(backendGatewayClient(), "expected backend client");
+        const pluginClient: AgentHandlerArgs["client"] = {
+          connect: baseClient.connect,
+          internal: {
+            ...baseClient.internal,
+            agentRunTracking: "plugin_subagent",
+            pluginRuntimeOwnerId: "memory-core",
+          },
+        };
+
+        await invokeAgent(
+          {
+            message: "plugin subagent over acp child",
+            sessionKey: childSessionKey,
+            acpTurnSource: "manual_spawn",
+            idempotencyKey: runId,
+          },
+          { reqId: runId, client: pluginClient },
+        );
+        await waitForAgentCommandCall();
+
+        // plugin_subagent precedence means the run is tracked through the
+        // subagent registry as a `subagent` row, never a duplicate `cli` row.
+        expect(createRunningTaskRunSpy).toHaveBeenCalledTimes(1);
+        expectRecordFields(mockCallArg(createRunningTaskRunSpy), {
+          runtime: "subagent",
+          runId,
+        });
+        expect(
+          listTaskRecords().some((task) => task.runId === runId && task.runtime === "cli"),
+        ).toBe(false);
+        await waitForAssertion(() => {
+          expectRecordFields(getSubagentRunByChildSessionKey(childSessionKey), {
+            runId,
+            childSessionKey,
+            label: "plugin:memory-core",
+          });
+        });
+      });
+    });
+  });
+
   it("logs a swallowed finalize error without blocking the background run", async () => {
     await withTempDir({ prefix: "openclaw-gateway-agent-finalize-throw-" }, async (root) => {
       useTestStateDir(root);
@@ -5669,6 +5972,7 @@ describe("gateway agent handler chat.abort integration", () => {
     mocks.getLatestSubagentRunByChildSessionKey.mockReset();
     mocks.replaceSubagentRunAfterSteer.mockReset();
     mocks.resolveExplicitAgentSessionKey.mockReset().mockReturnValue(undefined);
+    mocks.readAcpSessionMeta.mockReset().mockReturnValue(undefined);
     mocks.listAgentIds.mockReset().mockReturnValue(["main"]);
     mocks.getChannelPlugin.mockReset();
     mocks.sendDurableMessageBatch.mockReset();

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -13,6 +13,7 @@ import {
 import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
   hasGatewayClientCap,
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import {
@@ -581,13 +582,63 @@ function resolveGatewayAgentTaskTrackingMode(params: {
   client: GatewayRequestHandlerOptions["client"];
   sessionKey?: string;
   inputProvenance?: InputProvenance;
+  confirmedAcpManualSpawn?: boolean;
 }): GatewayAgentTaskTrackingMode {
   if (!params.sessionKey?.trim() || params.inputProvenance?.kind === "inter_session") {
     return "none";
   }
-  return params.client?.internal?.agentRunTracking === "plugin_subagent"
-    ? "plugin_subagent"
-    : "cli";
+  if (params.client?.internal?.agentRunTracking === "plugin_subagent") {
+    return "plugin_subagent";
+  }
+  // A confirmed ACP manual-spawn child turn already owns its requester-visible
+  // `acp` task row from the spawn control plane (src/agents/acp-spawn.ts). The
+  // Gateway CLI path runs that same childRunId, so tracking it here would emit a
+  // duplicate row for one run. Suppress only the CLI branch; plugin-subagent and
+  // normal CLI tracking stay intact.
+  if (params.confirmedAcpManualSpawn) {
+    return "none";
+  }
+  return "cli";
+}
+
+function isTrustedBackendAcpSpawnClient(client: GatewayRequestHandlerOptions["client"]): boolean {
+  // The ACP spawn control plane reaches the gateway through the in-process
+  // backend client (src/gateway/call.ts -> mode "backend", id "gateway-client").
+  // Only that caller creates the replacement `acp` task row, so CLI suppression
+  // is gated to it. An operator-write UI/CLI/mobile or device-token client that
+  // merely sets acpTurnSource owns no such row and must keep CLI tracking.
+  return (
+    client?.connect?.client?.id === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT &&
+    client.connect.client.mode === GATEWAY_CLIENT_MODES.BACKEND &&
+    client.isDeviceTokenAuth !== true
+  );
+}
+
+function isConfirmedAcpManualSpawnTaskOwner(params: {
+  acpTurnSource?: string;
+  sessionKey?: string;
+  client: GatewayRequestHandlerOptions["client"];
+  logGateway: Pick<GatewayRequestContext["logGateway"], "warn">;
+}): boolean {
+  const sessionKey = params.sessionKey;
+  if (
+    !isTrustedBackendAcpSpawnClient(params.client) ||
+    params.acpTurnSource !== "manual_spawn" ||
+    sessionKey == null ||
+    !isAcpSessionKey(sessionKey)
+  ) {
+    return false;
+  }
+  try {
+    return readAcpSessionMeta({ sessionKey }) != null;
+  } catch (err) {
+    params.logGateway.warn(
+      `failed to read ACP session metadata for manual-spawn task tracking ${sessionKey}; falling back to cli task tracking: ${formatForLog(
+        err,
+      )}`,
+    );
+    return false;
+  }
 }
 
 async function registerPluginSubagentRunFromGateway(params: {
@@ -2508,10 +2559,21 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
 
       const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
+      // Confirmed only when the caller is the trusted in-process backend ACP
+      // spawn client, the turn is an ACP manual spawn, the canonical session key
+      // is ACP-shaped, and persisted ACP metadata exists for it; the spawn
+      // control plane owns that childRunId's `acp` task row in those cases.
+      const confirmedAcpManualSpawn = isConfirmedAcpManualSpawnTaskOwner({
+        acpTurnSource: request.acpTurnSource,
+        sessionKey: resolvedSessionKey,
+        client,
+        logGateway: context.logGateway,
+      });
       const taskTrackingMode = resolveGatewayAgentTaskTrackingMode({
         client,
         sessionKey: resolvedSessionKey,
         inputProvenance,
+        confirmedAcpManualSpawn,
       });
       let dispatchTaskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent"> =
         taskTrackingMode === "cli" ? "cli" : "none";


### PR DESCRIPTION
## What Problem This Solves

ACP manual-spawn child turns can create duplicate requester-visible task rows because the Gateway CLI task-tracking path runs alongside the ACP spawn control plane for the same child run.

This showed up in runtime smoke as multiple `task_runs` rows for one ACP manual-spawn run, including a duplicate `runtime = cli` child-owned row in addition to ACP/subagent rows.

## Why This Change Was Made

A confirmed ACP manual-spawn child turn already owns its requester-visible `acp` task row from the spawn control plane. The Gateway CLI path should not emit a second row for the same child run.

The suppression is intentionally narrow:

- keep `plugin_subagent` tracking precedence;
- keep ordinary CLI tracking;
- keep ACP-shaped turns without persisted ACP metadata tracked as CLI;
- make ACP metadata confirmation best-effort, so metadata read/open/query failures fall back to normal CLI tracking instead of blocking the child run;
- gate suppression to the trusted in-process backend ACP spawn caller (`gateway-client` + `backend`, excluding device-token clients), so public/operator-write callers cannot hide CLI rows by setting `acpTurnSource`;
- suppress only confirmed ACP manual-spawn child turns with persisted ACP session metadata.

## User Impact

This reduces duplicate/noisy task-ledger rows for manual ACP spawns while preserving normal task visibility for plugin subagents, ordinary CLI agent runs, and non-backend operator-write callers.

## Evidence

Focused regression test added in `src/gateway/server-methods/agent.test.ts` covering:

- confirmed trusted-backend ACP manual-spawn child turn suppresses the Gateway CLI task row;
- non-backend operator-write caller setting `acpTurnSource: "manual_spawn"` with persisted ACP metadata still keeps CLI tracking;
- ACP-shaped manual-spawn without persisted ACP metadata keeps CLI tracking;
- ACP metadata read failure keeps dispatch alive, creates/finalizes the CLI row, and logs the fallback;
- ACP-shaped non-manual-spawn keeps CLI tracking;
- plugin-subagent tracking still wins and does not emit a duplicate CLI row.

Local proof from this branch:

```text
pnpm test src/gateway/server-methods/agent.test.ts -t "ACP manual-spawn child turn task tracking"

Test Files  2 passed (2)
Tests       12 passed | 330 skipped (342)
```

Type-check proof:

```text
pnpm tsgo:test

passed
```

Formatting proof:

```text
npx oxfmt --check --threads=1 src/gateway/server-methods/agent.ts src/gateway/server-methods/agent.test.ts

All matched files use the correct format.
```

## Known Baseline Test Caveat

A wider local run of `pnpm test src/gateway/server-methods/agent.test.ts` currently fails in the existing test `tracks plugin SDK subagent agent runs through the subagent registry only`, where `cleanupCompletedAt` remains `undefined`.

I verified the same focused test fails on fresh `origin/main` before this PR, so it is an existing adjacent baseline issue, not caused by this change.

## Real Behavior Proof

After-fix ACP manual-spawn runtime smoke was run against a real installed OpenClaw gateway using the normal parent `sessions_spawn` path with ACP runtime and Claude route. The child turn completed successfully.

Redacted task-ledger proof for the exact smoke label:

```text
runtime   status     delivery_status  child           parent
--------  ---------  ---------------  --------------  ------
acp       succeeded  session_queued   redacted-child  none
subagent  succeeded  delivered        redacted-child  none
acp       succeeded  not_applicable   redacted-child  none
```

Duplicate CLI-row check for the same smoke label:

```text
cli_rows
--------
0
```

Gateway health was checked after the smoke and reported healthy.

## Secrets / Unrelated Changes

No secrets, config changes, generated files, runtime hotfixes, or unrelated files are included.
