### PR TITLE
fix(cron): classify empty fallback results so isolated cron chains recover

### DIFF
--- a/src/cron/isolated-agent/run-execution.runtime.ts
+++ b/src/cron/isolated-agent/run-execution.runtime.ts
@@ -8,6 +8,10 @@ export { resolveCronAgentLane } from "../../agents/lanes.js";
 export { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
 export { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 export { runWithModelFallback } from "../../agents/model-fallback.js";
+export {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 export { isCliProvider } from "../../agents/model-selection-cli.js";
 export { normalizeVerboseLevel } from "../../auto-reply/thinking.shared.js";
 export { resolveSessionTranscriptPath } from "../../config/sessions/paths.js";

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -20,10 +20,12 @@ import {
 import { resolveCronPayloadOutcome } from "./helpers.js";
 import {
   getCliSessionId,
+  classifyEmbeddedAgentRunResultForModelFallback,
   ensureSelectedAgentHarnessPlugin,
   isCliProvider,
   LiveSessionModelSwitchError,
   logWarn,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
   normalizeVerboseLevel,
   registerAgentRunContext,
   resolveBootstrapWarningSignaturesSeen,
@@ -295,6 +297,18 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      // Isolated cron runs share the same embedded/CLI result shape as live agent
+      // turns, so classify empty/zero-token/reasoning-only results the same way.
+      // Without this, a fallback model that returns a clean stop with no visible
+      // reply is treated as success and the fallback chain stops, leaving the cron
+      // job silently broken (see #97115).
+      classifyResult: ({ provider: providerLocal, model: modelLocal, result: resultLocal }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider: providerLocal,
+          model: modelLocal,
+          result: resultLocal,
+        }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());

--- a/src/cron/isolated-agent/run.fallback-classification.test.ts
+++ b/src/cron/isolated-agent/run.fallback-classification.test.ts
@@ -1,0 +1,107 @@
+// Regression tests for isolated-cron model fallback result classification (#97115).
+//
+// The isolated cron runWithModelFallback call must pass the embedded-result
+// classifier (and exhaustion merger), matching the live agent turn path. Without
+// them, a fallback model that returns a clean stop with no visible reply is
+// treated as success and the fallback chain stops, silently breaking cron jobs.
+import { describe, expect, it } from "vitest";
+import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  resolveAgentModelFallbacksOverrideMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function requireModelFallbackRequest(): {
+  classifyResult?: unknown;
+  mergeExhaustedResult?: unknown;
+} {
+  const request = runWithModelFallbackMock.mock.calls[0]?.[0] as
+    | {
+        classifyResult?: unknown;
+        mergeExhaustedResult?: unknown;
+      }
+    | undefined;
+  if (!request) {
+    throw new Error("Expected model fallback request");
+  }
+  return request;
+}
+
+describe("runCronIsolatedAgentTurn — fallback result classification (#97115)", () => {
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
+
+  it("passes a classifyResult callback into the model fallback request", async () => {
+    resolveAgentModelFallbacksOverrideMock.mockReturnValue(["anthropic/claude-sonnet-4-6"]);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          payload: { kind: "agentTurn", message: "test" },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+    expect(typeof requireModelFallbackRequest().classifyResult).toBe("function");
+  });
+
+  it("passes a mergeExhaustedResult callback into the model fallback request", async () => {
+    resolveAgentModelFallbacksOverrideMock.mockReturnValue(["anthropic/claude-sonnet-4-6"]);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          payload: { kind: "agentTurn", message: "test" },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+    expect(typeof requireModelFallbackRequest().mergeExhaustedResult).toBe("function");
+  });
+
+  it("classifies an empty embedded result as a fallback-eligible failure", async () => {
+    resolveAgentModelFallbacksOverrideMock.mockReturnValue(["anthropic/claude-sonnet-4-6"]);
+
+    await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          payload: { kind: "agentTurn", message: "test" },
+        }),
+      }),
+    );
+
+    const { classifyResult } = requireModelFallbackRequest();
+    if (typeof classifyResult !== "function") {
+      throw new Error("classifyResult was not forwarded to the fallback request");
+    }
+    // A fallback model that returns a clean stop with zero visible output must be
+    // classified as a failure so the chain continues to the next candidate.
+    const classification = await (
+      classifyResult as (args: {
+        provider: string;
+        model: string;
+        result: unknown;
+      }) => Promise<{ code: string; reason: string } | null>
+    )({
+      provider: "google",
+      model: "gemini-3.5-flash",
+      result: {
+        payloads: [],
+        meta: {
+          agentHarnessResultClassification: "empty",
+          finalAssistantVisibleText: "",
+        },
+      },
+    });
+
+    expect(classification).not.toBeNull();
+    expect(classification?.code).toBe("empty_result");
+  });
+});

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -2,6 +2,10 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { vi, type Mock } from "vitest";
 import { resolveFastModeState as resolveFastModeStateImpl } from "../../agents/fast-mode.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
 
@@ -238,6 +242,10 @@ vi.mock("./run-execution.runtime.js", () => ({
   resolveCronAgentLane: resolveCronAgentLaneMock,
   LiveSessionModelSwitchError,
   runWithModelFallback: runWithModelFallbackMock,
+  // Delegate the forwarded fallback classifier/merger to the real helpers so the
+  // isolated cron path exercises the genuine classification behavior under test.
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
   isCliProvider: isCliProviderMock,
   runEmbeddedAgent: runEmbeddedAgentMock,
   countActiveDescendantRuns: countActiveDescendantRunsMock,


### PR DESCRIPTION
## What Problem This Solves

Isolated cron `agentTurn` jobs with model fallback chains fail silently instead of recovering. When the primary model times out or a fallback model returns a clean `stopReason: "stop"` with zero visible output, the cron harness treats that empty result as a successful attempt, so `runWithModelFallback` stops iterating and never tries the next candidate. The cron job then ends with "Agent couldn't generate a response" while the fallback chain never engaged (#97115).

## Why This Change Was Made

The live agent turn path (`src/agents/agent-command.ts`) passes `classifyResult` and `mergeExhaustedResult` into `runWithModelFallback` so that empty / reasoning-only / generic-external-runner-failure results are classified as fallback-eligible failures and the chain advances. The isolated cron path (`src/cron/isolated-agent/run-executor.ts`) calls the same `runWithModelFallback` but omits both callbacks, so every `ok`-shaped result is accepted as success.

Cron runs use the same embedded/CLI result shape (`EmbeddedAgentRunResult`) as live turns — both `runCliAgent` and `runEmbeddedAgent` return `EmbeddedAgentRunResult` — so the same classifier applies. This change forwards `classifyResult` and `mergeExhaustedResult` into the cron fallback request using the exact same helpers (`classifyEmbeddedAgentRunResultForModelFallback` + `mergeEmbeddedAgentRunResultForModelFallbackExhaustion`) the agent-command path already uses, so empty/zero-token fallback results no longer terminate the chain.

No new config surface, no behavior change for successful runs — only empty/zero-output results that previously masqueraded as success now trigger the next fallback candidate.

## User Impact

Cron jobs configured with model fallback chains (e.g. `deepseek → minimax → google/gemini`) will actually recover when a provider returns an empty/zero-token response, instead of silently failing and caching the broken model for subsequent runs. Long-running scheduled jobs become reliable again.

## Real behavior proof

**Behavior addressed:** Isolated cron `runWithModelFallback` now forwards the embedded-result classifier so a zero-token/empty fallback result is treated as a failure and the chain continues, matching the live agent turn path.

**Environment tested:** Static source inspection against `openclaw/openclaw` main (`65fec9d`) and the fix branch, plus a regression test asserting the classifier callbacks are forwarded. Local vitest runtime execution was not available in this environment (the sandboxed host sits behind a corporate proxy that blocks the npm registry, so `node_modules` could not be installed and `node --import tsx` / `pnpm test` could not run); CI on this PR is the runtime proof of record.

**Steps run after the patch:**
1. Confirmed via the GitHub contents API that main's `src/cron/isolated-agent/run-executor.ts` contains `0` occurrences of `classifyResult`, while the sibling `src/agents/agent-command.ts` contains it — proving the cron path omitted the classifier.
2. Added `src/cron/isolated-agent/run.fallback-classification.test.ts` asserting the cron `runWithModelFallback` request now carries `classifyResult` (function), `mergeExhaustedResult` (function), and that `classifyResult` classifies an empty embedded result (`agentHarnessResultClassification: "empty"`, no visible text) as `{ code: "empty_result" }`.

**Evidence after fix:**

```text
# main (before): cron fallback path omits the classifier
$ gh api repos/openclaw/openclaw/contents/src/cron/isolated-agent/run-executor.ts?ref=65fec9d --jq '.content' | base64 -d | grep -c classifyResult
0

# sibling agent-command.ts on the same main SHA already wires it
$ gh api repos/openclaw/openclaw/contents/src/agents/agent-command.ts?ref=65fec9d --jq '.content' | base64 -d | grep -c classifyResult
1

# fix branch: cron path now forwards classifyResult + mergeExhaustedResult
$ grep -n 'classifyResult\|mergeExhaustedResult' src/cron/isolated-agent/run-executor.ts
305:      classifyResult: ({ provider: providerLocal, model: modelLocal, result: resultLocal }) =>
311:      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
```

The forwarded `classifyResult` delegates to `classifyEmbeddedAgentRunResultForModelFallback`, which returns `{ code: "empty_result", reason: "format" }` for an embedded result whose `meta.agentHarnessResultClassification === "empty"`. `runFallbackAttempt` converts a non-null classification into an error (model-fallback.ts:427-447), so the chain advances to the next candidate instead of accepting the empty result.

**Observed result after the fix:** The isolated cron `runWithModelFallback` request now carries `classifyResult` and `mergeExhaustedResult`, so an empty/zero-token fallback result is classified as a failure and the fallback chain continues — parity with the live agent turn path. Full vitest run deferred to CI (local runtime unavailable behind the corporate proxy).

**Not tested:** Live cron execution against a real Google Gemini / non-OpenRouter provider returning a zero-token response, and the shared-AbortController dimension of #97115 (this PR addresses only the result-classification gap; the shared `AbortController` across the fallback chain is a separate failure mode that would need its own scoped change). Local `pnpm test` / `node --import tsx` runtime execution.

Closes #97115
