### PR TITLE
Add TrustedRouter provider extension

### DIFF
--- a/docs/providers/trustedrouter.md
+++ b/docs/providers/trustedrouter.md
@@ -1,0 +1,103 @@
+---
+summary: "Use TrustedRouter's attested OpenAI-compatible API from OpenClaw"
+read_when:
+  - You want to run OpenClaw through TrustedRouter
+  - You want attested routing, zero-data-retention routes, or end-to-end encrypted routes
+  - You want an OpenAI-compatible custom provider setup
+title: "TrustedRouter"
+---
+
+TrustedRouter provides an OpenAI-compatible API at `https://api.trustedrouter.com/v1`.
+Use it in OpenClaw as a custom text-inference provider.
+
+## Getting started
+
+<Steps>
+  <Step title="Create a TrustedRouter API key">
+    Sign in to [TrustedRouter](https://trustedrouter.com/console/keys), create an API key,
+    and copy it.
+  </Step>
+  <Step title="Add the provider to your config">
+    ```json5
+    {
+      env: { TRUSTEDROUTER_API_KEY: "sk-tr-..." },
+      models: {
+        mode: "merge",
+        providers: {
+          trustedrouter: {
+            baseUrl: "https://api.trustedrouter.com/v1",
+            apiKey: "TRUSTEDROUTER_API_KEY",
+            api: "openai-completions",
+            models: [
+              {
+                id: "trustedrouter/auto",
+                name: "TrustedRouter Auto",
+                reasoning: true,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+              {
+                id: "trustedrouter/zdr",
+                name: "TrustedRouter ZDR",
+                reasoning: true,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+              {
+                id: "trustedrouter/e2e",
+                name: "TrustedRouter E2E",
+                reasoning: true,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: { primary: "trustedrouter/trustedrouter/auto" },
+        },
+      },
+    }
+    ```
+  </Step>
+  <Step title="Select a TrustedRouter route">
+    ```bash
+    openclaw models set trustedrouter/trustedrouter/auto
+    ```
+  </Step>
+</Steps>
+
+## Model references
+
+When using a custom provider, OpenClaw model refs follow the pattern
+`provider/model`. TrustedRouter model IDs also contain `/`, so the complete
+OpenClaw model ref includes the provider prefix:
+
+| Model ref                         | Notes                                 |
+| --------------------------------- | ------------------------------------- |
+| `trustedrouter/trustedrouter/auto` | Healthy-provider routing and fallback |
+| `trustedrouter/trustedrouter/zdr`  | Zero-data-retention route preference  |
+| `trustedrouter/trustedrouter/e2e`  | End-to-end encrypted route preference |
+
+## Attestation
+
+TrustedRouter publishes hosted gateway trust material at
+[trust.trustedrouter.com](https://trust.trustedrouter.com/). Use that page to
+verify the attested gateway and source links for the hosted API.
+
+## Notes
+
+- This setup uses OpenClaw's OpenAI-compatible chat completions adapter.
+- If you want to expose a direct TrustedRouter model, add it under
+  `models.providers.trustedrouter.models` and select
+  `trustedrouter/<model-id>`.
+- For secret storage, prefer OpenClaw SecretRef or environment-backed secrets
+  instead of committing raw API keys into config.

--- a/extensions/trustedrouter/api.ts
+++ b/extensions/trustedrouter/api.ts
@@ -1,0 +1,10 @@
+/**
+ * Public TrustedRouter provider plugin API exports.
+ */
+export {
+  buildTrustedRouterModelDefinition,
+  TRUSTEDROUTER_BASE_URL,
+  TRUSTEDROUTER_MODEL_CATALOG,
+} from "./models.js";
+export { buildTrustedRouterProvider } from "./provider-catalog.js";
+export { applyTrustedRouterConfig, TRUSTEDROUTER_DEFAULT_MODEL_REF } from "./onboard.js";

--- a/extensions/trustedrouter/index.ts
+++ b/extensions/trustedrouter/index.ts
@@ -1,0 +1,44 @@
+/**
+ * TrustedRouter provider plugin entrypoint.
+ */
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { applyTrustedRouterConfig, TRUSTEDROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildTrustedRouterProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "trustedrouter";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "TrustedRouter Provider",
+  description: "Bundled TrustedRouter provider plugin",
+  provider: {
+    label: "TrustedRouter",
+    docsPath: "/providers/trustedrouter",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "TrustedRouter API key",
+        hint: "Attested, privacy-preserving frontier model routing",
+        optionKey: "trustedrouterApiKey",
+        flagName: "--trustedrouter-api-key",
+        envVar: "TRUSTEDROUTER_API_KEY",
+        promptMessage: "Enter TrustedRouter API key",
+        defaultModel: TRUSTEDROUTER_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyTrustedRouterConfig(cfg),
+        noteMessage: [
+          "TrustedRouter provides attested, privacy-preserving routing to frontier models (Claude, GPT, Gemini, and more).",
+          "Get your API key at: https://trustedrouter.com",
+        ].join("\n"),
+        noteTitle: "TrustedRouter",
+        wizard: {
+          groupLabel: "TrustedRouter",
+          groupHint: "Attested, privacy-preserving frontier model routing",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildTrustedRouterProvider,
+      buildStaticProvider: buildTrustedRouterProvider,
+    },
+  },
+});

--- a/extensions/trustedrouter/models.ts
+++ b/extensions/trustedrouter/models.ts
@@ -1,0 +1,32 @@
+/**
+ * TrustedRouter model catalog helpers derived from the plugin manifest.
+ */
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const TRUSTEDROUTER_MANIFEST_CATALOG = manifest.modelCatalog.providers.trustedrouter;
+
+/** Base URL for TrustedRouter OpenAI-compatible inference. */
+export const TRUSTEDROUTER_BASE_URL = TRUSTEDROUTER_MANIFEST_CATALOG.baseUrl;
+/** TrustedRouter model catalog entries from the plugin manifest. */
+export const TRUSTEDROUTER_MODEL_CATALOG = TRUSTEDROUTER_MANIFEST_CATALOG.models;
+
+/** Builds normalized TrustedRouter catalog model definitions. */
+export function buildTrustedRouterCatalogModels(): ModelDefinitionConfig[] {
+  return buildManifestModelProviderConfig({
+    providerId: "trustedrouter",
+    catalog: TRUSTEDROUTER_MANIFEST_CATALOG,
+  }).models;
+}
+
+/** Builds one normalized TrustedRouter model definition from a manifest entry. */
+export function buildTrustedRouterModelDefinition(
+  model: (typeof TRUSTEDROUTER_MODEL_CATALOG)[number],
+): ModelDefinitionConfig {
+  const providerConfig = buildManifestModelProviderConfig({
+    providerId: "trustedrouter",
+    catalog: { ...TRUSTEDROUTER_MANIFEST_CATALOG, models: [model] },
+  });
+  return providerConfig.models[0];
+}

--- a/extensions/trustedrouter/onboard.ts
+++ b/extensions/trustedrouter/onboard.ts
@@ -1,0 +1,31 @@
+/**
+ * TrustedRouter onboarding config helpers.
+ */
+import {
+  createModelCatalogPresetAppliers,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildTrustedRouterModelDefinition,
+  TRUSTEDROUTER_BASE_URL,
+  TRUSTEDROUTER_MODEL_CATALOG,
+} from "./models.js";
+
+/** Default TrustedRouter model reference used after onboarding. */
+export const TRUSTEDROUTER_DEFAULT_MODEL_REF = "trustedrouter/auto";
+
+const trustedRouterPresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: TRUSTEDROUTER_DEFAULT_MODEL_REF,
+  resolveParams: (_cfg: OpenClawConfig) => ({
+    providerId: "trustedrouter",
+    api: "openai-completions",
+    baseUrl: TRUSTEDROUTER_BASE_URL,
+    catalogModels: TRUSTEDROUTER_MODEL_CATALOG.map(buildTrustedRouterModelDefinition),
+    aliases: [{ modelRef: TRUSTEDROUTER_DEFAULT_MODEL_REF, alias: "TrustedRouter Auto" }],
+  }),
+});
+
+/** Applies TrustedRouter provider/catalog config and default model aliases. */
+export function applyTrustedRouterConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return trustedRouterPresetAppliers.applyConfig(cfg);
+}

--- a/extensions/trustedrouter/openclaw.plugin.json
+++ b/extensions/trustedrouter/openclaw.plugin.json
@@ -1,0 +1,118 @@
+{
+  "id": "trustedrouter",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["trustedrouter"],
+  "providerEndpoints": [
+    {
+      "endpointClass": "trustedrouter-native",
+      "hosts": ["api.trustedrouter.com"]
+    }
+  ],
+  "providerRequest": {
+    "providers": {
+      "trustedrouter": {
+        "family": "trustedrouter"
+      }
+    }
+  },
+  "modelCatalog": {
+    "providers": {
+      "trustedrouter": {
+        "baseUrl": "https://api.trustedrouter.com/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "auto",
+            "name": "TrustedRouter Auto",
+            "input": ["text", "image"],
+            "reasoning": true,
+            "contextWindow": 200000,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "cheap",
+            "name": "TrustedRouter Cheap",
+            "input": ["text"],
+            "reasoning": false,
+            "contextWindow": 200000,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "fusion",
+            "name": "TrustedRouter Fusion",
+            "input": ["text"],
+            "reasoning": true,
+            "contextWindow": 200000,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zdr",
+            "name": "TrustedRouter ZDR",
+            "input": ["text", "image"],
+            "reasoning": true,
+            "contextWindow": 200000,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "trustedrouter": "static"
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "trustedrouter",
+        "envVars": ["TRUSTEDROUTER_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "trustedrouter",
+      "method": "api-key",
+      "choiceId": "trustedrouter-api-key",
+      "choiceLabel": "TrustedRouter API key",
+      "groupId": "trustedrouter",
+      "groupLabel": "TrustedRouter",
+      "groupHint": "Attested, privacy-preserving frontier model routing",
+      "optionKey": "trustedrouterApiKey",
+      "cliFlag": "--trustedrouter-api-key",
+      "cliOption": "--trustedrouter-api-key <key>",
+      "cliDescription": "TrustedRouter API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/trustedrouter/package.json
+++ b/extensions/trustedrouter/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/trustedrouter-provider",
+  "version": "2026.6.26",
+  "private": true,
+  "description": "OpenClaw TrustedRouter provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/trustedrouter/provider-catalog.ts
+++ b/extensions/trustedrouter/provider-catalog.ts
@@ -1,0 +1,14 @@
+/**
+ * TrustedRouter model provider builder.
+ */
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildTrustedRouterCatalogModels, TRUSTEDROUTER_BASE_URL } from "./models.js";
+
+/** Builds the TrustedRouter OpenAI-compatible model provider config. */
+export function buildTrustedRouterProvider(): ModelProviderConfig {
+  return {
+    baseUrl: TRUSTEDROUTER_BASE_URL,
+    api: "openai-completions",
+    models: buildTrustedRouterCatalogModels(),
+  };
+}

--- a/extensions/trustedrouter/tsconfig.json
+++ b/extensions/trustedrouter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}


### PR DESCRIPTION
## What

Adds a bundled **TrustedRouter** provider extension at `extensions/trustedrouter/`, modeled on the existing `extensions/cerebras/` provider.

[TrustedRouter](https://trustedrouter.com) exposes an OpenAI-compatible API (`https://api.trustedrouter.com/v1`) for attested, privacy-preserving routing to frontier models (Claude, GPT, Gemini, and the open-weight panel), including zero-data-retention and confidential routes.

## Changes

- `extensions/trustedrouter/` — provider plugin (manifest + catalog + onboard wiring), `api: openai-completions`
  - Virtual model routes: `auto`, `cheap`, `fusion`, `zdr`
  - Auth via `TRUSTEDROUTER_API_KEY`, base URL `https://api.trustedrouter.com/v1`
- `docs/providers/trustedrouter.md` — setup docs page (matches the plugin's `docsPath`)

## Notes

Follows the single-provider plugin pattern (`defineSingleProviderPluginEntry`) used by Cerebras/other OpenAI-compatible providers, so it slots into the existing model-catalog and onboarding wizard without core changes.
