### PR TITLE
doctor: add memory search lint findings

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -59,6 +59,7 @@ export {
   ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles,
   getRuntimeAuthProfileStoreSnapshot,
+  hasAuthProfileStoreSourceForProvider,
   hasAnyAuthProfileStoreSource,
   hasLocalAuthProfileStoreSource,
   loadAuthProfileStoreForSecretsRuntime,

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -212,7 +212,7 @@ function parseCredentialEntry(
   if (!AUTH_PROFILE_TYPES.has(typed.type as AuthProfileCredential["type"])) {
     return { ok: false, reason: "invalid_type" };
   }
-  const provider = typed.provider ?? fallbackProvider;
+  const provider = typed.provider || fallbackProvider;
   const normalizedProvider = typeof provider === "string" ? normalizeProviderId(provider) : "";
   if (!normalizedProvider) {
     return { ok: false, reason: "missing_provider" };
@@ -246,7 +246,7 @@ function warnRejectedCredentialEntries(source: string, rejected: RejectedCredent
   });
 }
 
-function coerceLegacyAuthStore(raw: unknown): LegacyAuthStore | null {
+export function coerceLegacyAuthStore(raw: unknown): LegacyAuthStore | null {
   if (!isRecord(raw)) {
     return null;
   }

--- a/src/agents/auth-profiles/source-check.test.ts
+++ b/src/agents/auth-profiles/source-check.test.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hasAuthProfileStoreSourceForProvider } from "./source-check.js";
+
+describe("hasAuthProfileStoreSourceForProvider", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  async function withAgentStore(profiles: Record<string, unknown>) {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const stateDir = path.join(root, "state");
+    const agentDir = path.join(root, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(stateDir, { recursive: true });
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    await fs.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      JSON.stringify({ version: 1, profiles }),
+    );
+    return { agentDir };
+  }
+
+  async function withLegacyAuthStore(profiles: Record<string, unknown>) {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const stateDir = path.join(root, "state");
+    const agentDir = path.join(root, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(stateDir, { recursive: true });
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    await fs.writeFile(path.join(agentDir, "auth.json"), JSON.stringify(profiles));
+    return { agentDir };
+  }
+
+  it("counts provider-specific usable credentials", async () => {
+    const { agentDir } = await withAgentStore({
+      "openai:default": { type: "api_key", provider: "openai", key: "sk-test" },
+    });
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(true);
+  });
+
+  it("counts legacy auth stores with alias fields and fallback providers", async () => {
+    const { agentDir } = await withLegacyAuthStore({
+      openai: { mode: "apiKey", apiKey: "sk-test" },
+    });
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(true);
+  });
+
+  it("ignores malformed provider fields instead of throwing", async () => {
+    const { agentDir } = await withAgentStore({
+      "openai:default": { type: "api_key", key: "sk-test" },
+      "openai:other": { type: "api_key", provider: 123, key: "sk-test" },
+    });
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
+  });
+
+  it("does not count profile ids that are bound to a different credential provider", async () => {
+    const { agentDir } = await withAgentStore({
+      "openai:default": { type: "api_key", provider: "anthropic", key: "sk-test" },
+    });
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
+  });
+
+  it("honors configured profile order constraints", async () => {
+    const { agentDir } = await withAgentStore({
+      "openai:default": { type: "api_key", provider: "openai", key: "sk-test" },
+      "openai:expired": {
+        type: "token",
+        provider: "openai",
+        token: "expired-token",
+        expires: Date.now() - 1000,
+      },
+    });
+
+    expect(
+      hasAuthProfileStoreSourceForProvider("openai", agentDir, {
+        profileIds: ["openai:expired"],
+      }),
+    ).toBe(false);
+    expect(
+      hasAuthProfileStoreSourceForProvider("openai", agentDir, {
+        profileIds: ["openai:default"],
+      }),
+    ).toBe(true);
+  });
+
+  it("treats explicit empty profile order as no usable profile", async () => {
+    const { agentDir } = await withAgentStore({
+      "openai:default": { type: "api_key", provider: "openai", key: "sk-test" },
+    });
+
+    expect(
+      hasAuthProfileStoreSourceForProvider("openai", agentDir, {
+        profileIds: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("does not count empty provider profiles as credential evidence", async () => {
+    const { agentDir } = await withAgentStore({
+      "openai:default": { type: "api_key", provider: "openai" },
+    });
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
+  });
+
+  it("does not count expired token profiles as credential evidence", async () => {
+    const { agentDir } = await withAgentStore({
+      "openai:token": {
+        type: "token",
+        provider: "openai",
+        token: "expired-token",
+        expires: Date.now() - 1000,
+      },
+    });
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
+  });
+});

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -3,17 +3,19 @@
  * These checks intentionally avoid loading secret-bearing credential payloads.
  */
 import fs from "node:fs";
+import { evaluateStoredCredentialEligibility } from "./credential-state.js";
 import {
   resolveAuthStatePath,
   resolveAuthStorePath,
   resolveLegacyAuthStorePath,
 } from "./path-resolve.js";
+import { coerceLegacyAuthStore, coercePersistedAuthProfileStore } from "./persisted.js";
 import {
   getRuntimeAuthProfileStoreSnapshot,
   hasAnyRuntimeAuthProfileStoreSource,
 } from "./runtime-snapshots.js";
 import { readPersistedAuthProfileStateRaw, readPersistedAuthProfileStoreRaw } from "./sqlite.js";
-import type { AuthProfileStore } from "./types.js";
+import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
 
 // Auth-profile source checks look at runtime snapshots, JSON compatibility
 // files, legacy files, and SQLite stores without materializing secret values.
@@ -37,24 +39,47 @@ function normalizeProvider(provider: string): string {
   return provider.trim().toLowerCase();
 }
 
-function rawStoreHasProviderProfile(raw: unknown, provider: string): boolean {
-  if (!raw || typeof raw !== "object") {
+function isAuthProfileCredential(value: unknown): value is AuthProfileCredential {
+  if (!value || typeof value !== "object") {
     return false;
   }
-  const profiles = (raw as { profiles?: unknown }).profiles;
-  if (!profiles || typeof profiles !== "object") {
+  const credential = value as { provider?: unknown; type?: unknown };
+  const type = credential.type;
+  return (
+    typeof credential.provider === "string" &&
+    (type === "api_key" || type === "token" || type === "oauth")
+  );
+}
+
+function isEligibleProviderCredential(rawCredential: unknown, expectedProvider: string): boolean {
+  if (!isAuthProfileCredential(rawCredential)) {
+    return false;
+  }
+  return (
+    normalizeProvider(rawCredential.provider) === expectedProvider &&
+    evaluateStoredCredentialEligibility({ credential: rawCredential }).eligible
+  );
+}
+
+function coerceRawStoreProfiles(raw: unknown): Record<string, AuthProfileCredential> | null {
+  return coercePersistedAuthProfileStore(raw)?.profiles ?? coerceLegacyAuthStore(raw);
+}
+
+function rawStoreHasProviderProfile(
+  raw: unknown,
+  provider: string,
+  profileIds?: readonly string[],
+): boolean {
+  const profiles = coerceRawStoreProfiles(raw);
+  if (!profiles) {
     return false;
   }
   const expected = normalizeProvider(provider);
-  for (const [profileId, rawCredential] of Object.entries(profiles)) {
-    if (normalizeProvider(profileId).startsWith(`${expected}:`)) {
+  const credentials =
+    profileIds?.map((profileId) => profiles[profileId]) ?? Object.values(profiles);
+  for (const rawCredential of credentials) {
+    if (isEligibleProviderCredential(rawCredential, expected)) {
       return true;
-    }
-    if (rawCredential && typeof rawCredential === "object") {
-      const rawProvider = (rawCredential as { provider?: unknown }).provider;
-      if (typeof rawProvider === "string" && normalizeProvider(rawProvider) === expected) {
-        return true;
-      }
     }
   }
   return false;
@@ -63,8 +88,9 @@ function rawStoreHasProviderProfile(raw: unknown, provider: string): boolean {
 function runtimeStoreHasProviderProfile(
   store: AuthProfileStore | undefined,
   provider: string,
+  profileIds?: readonly string[],
 ): boolean {
-  return rawStoreHasProviderProfile(store, provider);
+  return rawStoreHasProviderProfile(store, provider, profileIds);
 }
 
 /** Returns true when any local/runtime/main auth profile source exists. */
@@ -104,22 +130,45 @@ export function hasLocalAuthProfileStoreSource(agentDir?: string): boolean {
   );
 }
 
+type AuthProfileSourceForProviderOptions = {
+  /** Optional hard order/profile constraint from config auth.order. */
+  profileIds?: readonly string[];
+};
+
 /** Returns true when a read-only auth-profile source contains a profile for a provider. */
-export function hasAuthProfileStoreSourceForProvider(provider: string, agentDir?: string): boolean {
+export function hasAuthProfileStoreSourceForProvider(
+  provider: string,
+  agentDir?: string,
+  options?: AuthProfileSourceForProviderOptions,
+): boolean {
   if (!normalizeProvider(provider)) {
     return false;
   }
+  const profileIds = options?.profileIds;
+  if (profileIds?.length === 0) {
+    return false;
+  }
   const localRuntimeStore = getRuntimeAuthProfileStoreSnapshot(agentDir);
-  if (runtimeStoreHasProviderProfile(localRuntimeStore, provider)) {
+  if (runtimeStoreHasProviderProfile(localRuntimeStore, provider, profileIds)) {
     return true;
   }
-  if (rawStoreHasProviderProfile(readJsonFile(resolveAuthStorePath(agentDir)), provider)) {
+  if (
+    rawStoreHasProviderProfile(readJsonFile(resolveAuthStorePath(agentDir)), provider, profileIds)
+  ) {
     return true;
   }
-  if (rawStoreHasProviderProfile(readJsonFile(resolveLegacyAuthStorePath(agentDir)), provider)) {
+  if (
+    rawStoreHasProviderProfile(
+      readJsonFile(resolveLegacyAuthStorePath(agentDir)),
+      provider,
+      profileIds,
+    )
+  ) {
     return true;
   }
-  if (rawStoreHasProviderProfile(readPersistedAuthProfileStoreRaw(agentDir), provider)) {
+  if (
+    rawStoreHasProviderProfile(readPersistedAuthProfileStoreRaw(agentDir), provider, profileIds)
+  ) {
     return true;
   }
 
@@ -127,14 +176,16 @@ export function hasAuthProfileStoreSourceForProvider(provider: string, agentDir?
     return false;
   }
   const mainRuntimeStore = getRuntimeAuthProfileStoreSnapshot();
-  if (runtimeStoreHasProviderProfile(mainRuntimeStore, provider)) {
+  if (runtimeStoreHasProviderProfile(mainRuntimeStore, provider, profileIds)) {
     return true;
   }
-  if (rawStoreHasProviderProfile(readJsonFile(resolveAuthStorePath()), provider)) {
+  if (rawStoreHasProviderProfile(readJsonFile(resolveAuthStorePath()), provider, profileIds)) {
     return true;
   }
-  if (rawStoreHasProviderProfile(readJsonFile(resolveLegacyAuthStorePath()), provider)) {
+  if (
+    rawStoreHasProviderProfile(readJsonFile(resolveLegacyAuthStorePath()), provider, profileIds)
+  ) {
     return true;
   }
-  return rawStoreHasProviderProfile(readPersistedAuthProfileStoreRaw(), provider);
+  return rawStoreHasProviderProfile(readPersistedAuthProfileStoreRaw(), provider, profileIds);
 }

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -50,13 +50,11 @@ function rawStoreHasProviderProfile(raw: unknown, provider: string): boolean {
     if (normalizeProvider(profileId).startsWith(`${expected}:`)) {
       return true;
     }
-    if (
-      rawCredential &&
-      typeof rawCredential === "object" &&
-      normalizeProvider(String((rawCredential as { provider?: unknown }).provider ?? "")) ===
-        expected
-    ) {
-      return true;
+    if (rawCredential && typeof rawCredential === "object") {
+      const rawProvider = (rawCredential as { provider?: unknown }).provider;
+      if (typeof rawProvider === "string" && normalizeProvider(rawProvider) === expected) {
+        return true;
+      }
     }
   }
   return false;

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -13,6 +13,7 @@ import {
   hasAnyRuntimeAuthProfileStoreSource,
 } from "./runtime-snapshots.js";
 import { readPersistedAuthProfileStateRaw, readPersistedAuthProfileStoreRaw } from "./sqlite.js";
+import type { AuthProfileStore } from "./types.js";
 
 // Auth-profile source checks look at runtime snapshots, JSON compatibility
 // files, legacy files, and SQLite stores without materializing secret values.
@@ -22,6 +23,50 @@ function hasStoredAuthProfileFiles(agentDir?: string): boolean {
     fs.existsSync(resolveAuthStatePath(agentDir)) ||
     fs.existsSync(resolveLegacyAuthStorePath(agentDir))
   );
+}
+
+function readJsonFile(pathname: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(pathname, "utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeProvider(provider: string): string {
+  return provider.trim().toLowerCase();
+}
+
+function rawStoreHasProviderProfile(raw: unknown, provider: string): boolean {
+  if (!raw || typeof raw !== "object") {
+    return false;
+  }
+  const profiles = (raw as { profiles?: unknown }).profiles;
+  if (!profiles || typeof profiles !== "object") {
+    return false;
+  }
+  const expected = normalizeProvider(provider);
+  for (const [profileId, rawCredential] of Object.entries(profiles)) {
+    if (normalizeProvider(profileId).startsWith(`${expected}:`)) {
+      return true;
+    }
+    if (
+      rawCredential &&
+      typeof rawCredential === "object" &&
+      normalizeProvider(String((rawCredential as { provider?: unknown }).provider ?? "")) ===
+        expected
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function runtimeStoreHasProviderProfile(
+  store: AuthProfileStore | undefined,
+  provider: string,
+): boolean {
+  return rawStoreHasProviderProfile(store, provider);
 }
 
 /** Returns true when any local/runtime/main auth profile source exists. */
@@ -59,4 +104,39 @@ export function hasLocalAuthProfileStoreSource(agentDir?: string): boolean {
   return Boolean(
     readPersistedAuthProfileStoreRaw(agentDir) || readPersistedAuthProfileStateRaw(agentDir),
   );
+}
+
+/** Returns true when a read-only auth-profile source contains a profile for a provider. */
+export function hasAuthProfileStoreSourceForProvider(provider: string, agentDir?: string): boolean {
+  if (!normalizeProvider(provider)) {
+    return false;
+  }
+  const localRuntimeStore = getRuntimeAuthProfileStoreSnapshot(agentDir);
+  if (runtimeStoreHasProviderProfile(localRuntimeStore, provider)) {
+    return true;
+  }
+  if (rawStoreHasProviderProfile(readJsonFile(resolveAuthStorePath(agentDir)), provider)) {
+    return true;
+  }
+  if (rawStoreHasProviderProfile(readJsonFile(resolveLegacyAuthStorePath(agentDir)), provider)) {
+    return true;
+  }
+  if (rawStoreHasProviderProfile(readPersistedAuthProfileStoreRaw(agentDir), provider)) {
+    return true;
+  }
+
+  if (!agentDir) {
+    return false;
+  }
+  const mainRuntimeStore = getRuntimeAuthProfileStoreSnapshot();
+  if (runtimeStoreHasProviderProfile(mainRuntimeStore, provider)) {
+    return true;
+  }
+  if (rawStoreHasProviderProfile(readJsonFile(resolveAuthStorePath()), provider)) {
+    return true;
+  }
+  if (rawStoreHasProviderProfile(readJsonFile(resolveLegacyAuthStorePath()), provider)) {
+    return true;
+  }
+  return rawStoreHasProviderProfile(readPersistedAuthProfileStoreRaw(), provider);
 }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -1010,7 +1010,11 @@ export function ensureAuthProfileStoreForLocalUpdate(agentDir?: string): AuthPro
   });
 }
 
-export { hasAnyAuthProfileStoreSource, hasLocalAuthProfileStoreSource } from "./source-check.js";
+export {
+  hasAnyAuthProfileStoreSource,
+  hasAuthProfileStoreSourceForProvider,
+  hasLocalAuthProfileStoreSource,
+} from "./source-check.js";
 
 /** Return the current runtime auth-profile snapshot for an agent dir. */
 export function getRuntimeAuthProfileStoreSnapshot(

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -10,6 +10,7 @@ const resolveAgentWorkspaceDir = vi.hoisted(() => vi.fn(() => "/tmp/agent-defaul
 const resolveMemorySearchConfig = vi.hoisted(() => vi.fn());
 const resolveApiKeyForProvider = vi.hoisted(() => vi.fn());
 const hasAnyAuthProfileStoreSource = vi.hoisted(() => vi.fn(() => true));
+const hasAuthProfileStoreSourceForProvider = vi.hoisted(() => vi.fn(() => true));
 const getActiveMemorySearchManager = vi.hoisted(() => vi.fn());
 const resolveActiveMemoryBackendConfig = vi.hoisted(() => vi.fn());
 type CheckQmdBinaryAvailability = typeof checkQmdBinaryAvailabilityFn;
@@ -45,6 +46,7 @@ vi.mock("../agents/model-auth.js", () => ({
 
 vi.mock("../agents/auth-profiles.js", () => ({
   hasAnyAuthProfileStoreSource,
+  hasAuthProfileStoreSourceForProvider,
 }));
 
 vi.mock("../plugins/memory-runtime.js", () => ({
@@ -172,6 +174,8 @@ describe("noteMemorySearchHealth", () => {
     resolveApiKeyForProvider.mockRejectedValue(new Error("missing key"));
     hasAnyAuthProfileStoreSource.mockReset();
     hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    hasAuthProfileStoreSourceForProvider.mockReset();
+    hasAuthProfileStoreSourceForProvider.mockReturnValue(true);
     getActiveMemorySearchManager.mockReset();
     resolveActiveMemoryBackendConfig.mockReset();
     resolveActiveMemoryBackendConfig.mockImplementation(
@@ -963,11 +967,41 @@ describe("noteMemorySearchHealth", () => {
     });
 
     expect(note).not.toHaveBeenCalled();
+    expect(hasAuthProfileStoreSourceForProvider).toHaveBeenCalledWith(
+      "openai",
+      "/tmp/agent-default",
+    );
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
+  it("warns for empty auth profile sources when lint skips profile resolution", async () => {
+    hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    hasAuthProfileStoreSourceForProvider.mockReturnValue(false);
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      skipAuthProfileResolution: true,
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    const message = firstNoteMessage();
+    expect(message).toContain('provider is set to "openai"');
+    expect(message).toContain("OPENAI_API_KEY");
+    expect(hasAuthProfileStoreSourceForProvider).toHaveBeenCalledWith(
+      "openai",
+      "/tmp/agent-default",
+    );
     expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
   });
 
   it("warns without resolving auth profiles when lint skips profile resolution and no auth store exists", async () => {
     hasAnyAuthProfileStoreSource.mockReturnValue(false);
+    hasAuthProfileStoreSourceForProvider.mockReturnValue(false);
     resolveMemorySearchConfig.mockReturnValue({
       provider: "openai",
       model: "text-embedding-3-small",

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -502,10 +502,12 @@ describe("noteMemorySearchHealth", () => {
     });
   });
 
-  it("skips QMD binary probing when requested by lint collection", async () => {
+  it("skips QMD binary probing while preserving QMD session export warnings", async () => {
     const qmdCfg = { memory: { backend: "qmd", qmd: { command: "custom-qmd" } } } as OpenClawConfig;
     resolveMemorySearchConfig.mockReturnValue({
       provider: "auto",
+      sources: ["memory", "sessions"],
+      experimental: { sessionMemory: true },
       local: {},
       remote: {},
     });
@@ -517,7 +519,8 @@ describe("noteMemorySearchHealth", () => {
 
     expect(noteWorkspaceMemoryHealth).not.toHaveBeenCalled();
     expect(checkQmdBinaryAvailability).not.toHaveBeenCalled();
-    expect(note).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledTimes(1);
+    expect(firstNoteMessage()).toContain("QMD session transcript export is not enabled");
   });
 
   it("warns when QMD backend is active but the qmd binary is unavailable", async () => {

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -206,6 +206,27 @@ describe("noteMemorySearchHealth", () => {
     expect(message).toContain("openclaw plugins install @openclaw/llama-cpp-provider");
   });
 
+  it("supports silent structured collection through an injected note sink", async () => {
+    const noteFn = vi.fn();
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      includeWorkspaceMemoryHealth: false,
+      noteFn,
+    });
+
+    expect(noteWorkspaceMemoryHealth).not.toHaveBeenCalled();
+    expect(note).not.toHaveBeenCalled();
+    expect(noteFn).toHaveBeenCalledWith(
+      expect.stringContaining('Memory search provider is set to "local"'),
+      "Memory search",
+    );
+  });
+
   it("warns when local provider with default model but gateway probe reports not ready", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",
@@ -475,6 +496,24 @@ describe("noteMemorySearchHealth", () => {
       env: process.env,
       cwd: "/tmp/agent-default/workspace",
     });
+  });
+
+  it("skips QMD binary probing when requested by lint collection", async () => {
+    const qmdCfg = { memory: { backend: "qmd", qmd: { command: "custom-qmd" } } } as OpenClawConfig;
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(qmdCfg, {
+      includeWorkspaceMemoryHealth: false,
+      skipQmdBinaryProbe: true,
+    });
+
+    expect(noteWorkspaceMemoryHealth).not.toHaveBeenCalled();
+    expect(checkQmdBinaryAvailability).not.toHaveBeenCalled();
+    expect(note).not.toHaveBeenCalled();
   });
 
   it("warns when QMD backend is active but the qmd binary is unavailable", async () => {
@@ -907,6 +946,25 @@ describe("noteMemorySearchHealth", () => {
     });
 
     expect(note).not.toHaveBeenCalled();
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve auth profiles when requested by lint callers", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      skipAuthProfileResolution: true,
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    const message = firstNoteMessage();
+    expect(message).toContain('provider is set to "openai"');
+    expect(message).toContain("OPENAI_API_KEY");
     expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
   });
 

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -949,7 +949,25 @@ describe("noteMemorySearchHealth", () => {
     expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
   });
 
-  it("does not resolve auth profiles when requested by lint callers", async () => {
+  it("does not warn for auth-profile-backed credentials when lint skips profile resolution", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      skipAuthProfileResolution: true,
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
+  it("warns without resolving auth profiles when lint skips profile resolution and no auth store exists", async () => {
+    hasAnyAuthProfileStoreSource.mockReturnValue(false);
     resolveMemorySearchConfig.mockReturnValue({
       provider: "openai",
       model: "text-embedding-3-small",

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -11,6 +11,7 @@ const resolveMemorySearchConfig = vi.hoisted(() => vi.fn());
 const resolveApiKeyForProvider = vi.hoisted(() => vi.fn());
 const hasAnyAuthProfileStoreSource = vi.hoisted(() => vi.fn(() => true));
 const hasAuthProfileStoreSourceForProvider = vi.hoisted(() => vi.fn(() => true));
+const isConfiguredAwsSdkAuthProfileForProvider = vi.hoisted(() => vi.fn(() => false));
 const getActiveMemorySearchManager = vi.hoisted(() => vi.fn());
 const resolveActiveMemoryBackendConfig = vi.hoisted(() => vi.fn());
 type CheckQmdBinaryAvailability = typeof checkQmdBinaryAvailabilityFn;
@@ -47,6 +48,7 @@ vi.mock("../agents/model-auth.js", () => ({
 vi.mock("../agents/auth-profiles.js", () => ({
   hasAnyAuthProfileStoreSource,
   hasAuthProfileStoreSourceForProvider,
+  isConfiguredAwsSdkAuthProfileForProvider,
 }));
 
 vi.mock("../plugins/memory-runtime.js", () => ({
@@ -176,6 +178,8 @@ describe("noteMemorySearchHealth", () => {
     hasAnyAuthProfileStoreSource.mockReturnValue(true);
     hasAuthProfileStoreSourceForProvider.mockReset();
     hasAuthProfileStoreSourceForProvider.mockReturnValue(true);
+    isConfiguredAwsSdkAuthProfileForProvider.mockReset();
+    isConfiguredAwsSdkAuthProfileForProvider.mockReturnValue(false);
     getActiveMemorySearchManager.mockReset();
     resolveActiveMemoryBackendConfig.mockReset();
     resolveActiveMemoryBackendConfig.mockImplementation(
@@ -974,6 +978,121 @@ describe("noteMemorySearchHealth", () => {
       "openai",
       "/tmp/agent-default",
     );
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
+  it("honors configured auth order when lint skips profile resolution", async () => {
+    hasAuthProfileStoreSourceForProvider.mockReturnValue(false);
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      local: {},
+      remote: {},
+    });
+    const orderedCfg = {
+      ...cfg,
+      auth: { order: { openai: ["openai:expired"] } },
+    } as OpenClawConfig;
+
+    await noteMemorySearchHealth(orderedCfg, {
+      skipAuthProfileResolution: true,
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    expect(hasAuthProfileStoreSourceForProvider).toHaveBeenCalledWith(
+      "openai",
+      "/tmp/agent-default",
+      { profileIds: ["openai:expired"] },
+    );
+    expect(firstNoteMessage()).toContain('provider is set to "openai"');
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
+  it("warns for explicit empty auth order when lint skips profile resolution", async () => {
+    hasAuthProfileStoreSourceForProvider.mockReturnValue(false);
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      local: {},
+      remote: {},
+    });
+    const orderedCfg = {
+      ...cfg,
+      auth: { order: { openai: [] } },
+    } as OpenClawConfig;
+
+    await noteMemorySearchHealth(orderedCfg, {
+      skipAuthProfileResolution: true,
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    expect(hasAuthProfileStoreSourceForProvider).toHaveBeenCalledWith(
+      "openai",
+      "/tmp/agent-default",
+      { profileIds: [] },
+    );
+    expect(firstNoteMessage()).toContain('provider is set to "openai"');
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
+  it("does not warn for Bedrock aws-sdk provider auth when lint skips profile resolution", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "bedrock",
+      model: "amazon.titan-embed-text-v2:0",
+      local: {},
+      remote: {},
+    });
+    const bedrockCfg = {
+      ...cfg,
+      models: {
+        providers: {
+          "amazon-bedrock": { auth: "aws-sdk", models: [] },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await noteMemorySearchHealth(bedrockCfg, {
+      skipAuthProfileResolution: true,
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+    expect(hasAuthProfileStoreSourceForProvider).not.toHaveBeenCalled();
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
+  it("does not warn for ordered Bedrock aws-sdk auth profiles when lint skips profile resolution", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "bedrock",
+      model: "amazon.titan-embed-text-v2:0",
+      local: {},
+      remote: {},
+    });
+    const bedrockCfg = {
+      ...cfg,
+      models: {
+        providers: {
+          "amazon-bedrock": { auth: "aws-sdk", models: [] },
+        },
+      },
+      auth: {
+        profiles: {
+          "amazon-bedrock:default": {
+            provider: "amazon-bedrock",
+            mode: "aws-sdk",
+          },
+        },
+        order: { "amazon-bedrock": ["amazon-bedrock:default"] },
+      },
+    } as unknown as OpenClawConfig;
+
+    await noteMemorySearchHealth(bedrockCfg, {
+      skipAuthProfileResolution: true,
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+    expect(hasAuthProfileStoreSourceForProvider).not.toHaveBeenCalled();
     expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
   });
 

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -674,7 +674,7 @@ async function hasApiKeyForProvider(
     return true;
   }
   if (opts?.skipProfileResolution === true) {
-    return false;
+    return authProviderId !== "amazon-bedrock" && hasAnyAuthProfileStoreSource(agentDir);
   }
   if (authProviderId !== "amazon-bedrock" && !hasAnyAuthProfileStoreSource(agentDir)) {
     return false;

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -403,9 +403,16 @@ export async function noteMemorySearchHealth(
       error?: string;
       skipped?: boolean;
     };
+    noteFn?: typeof note;
+    includeWorkspaceMemoryHealth?: boolean;
+    skipQmdBinaryProbe?: boolean;
+    skipAuthProfileResolution?: boolean;
   },
 ): Promise<void> {
-  await noteWorkspaceMemoryHealth(cfg);
+  const noteFn = opts?.noteFn ?? note;
+  if (opts?.includeWorkspaceMemoryHealth !== false) {
+    await noteWorkspaceMemoryHealth(cfg);
+  }
 
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
@@ -413,7 +420,7 @@ export async function noteMemorySearchHealth(
   const hasRemoteApiKey = hasConfiguredMemorySecretInput(resolved?.remote?.apiKey);
 
   if (!resolved) {
-    note("Memory search is explicitly disabled (enabled: false).", "Memory search");
+    noteFn("Memory search is explicitly disabled (enabled: false).", "Memory search");
     return;
   }
   const provider =
@@ -429,10 +436,13 @@ export async function noteMemorySearchHealth(
     if (hasActiveAlternateMemoryPluginSlot(cfg)) {
       return;
     }
-    note("No active memory plugin is registered for the current config.", "Memory search");
+    noteFn("No active memory plugin is registered for the current config.", "Memory search");
     return;
   }
   if (backendConfig.backend === "qmd") {
+    if (opts?.skipQmdBinaryProbe === true) {
+      return;
+    }
     const qmdCheck = await checkQmdBinaryAvailability({
       command: backendConfig.qmd?.command ?? "qmd",
       env: process.env,
@@ -441,7 +451,7 @@ export async function noteMemorySearchHealth(
     if (!qmdCheck.available) {
       const workspaceProbeFailed = resolveQmdBinaryUnavailableReason(qmdCheck) === "workspace-cwd";
       const probeError = qmdCheck.error.trim();
-      note(
+      noteFn(
         [
           workspaceProbeFailed
             ? "QMD memory backend is configured, but the agent workspace directory could not be used for the QMD startup probe."
@@ -497,7 +507,7 @@ export async function noteMemorySearchHealth(
       return;
     }
     const detail = opts?.gatewayMemoryProbe?.error?.trim();
-    note(
+    noteFn(
       [
         hasExplicitLocalModel
           ? 'Memory search provider is set to "local" and a local model path is configured, but local embeddings are not confirmed ready.'
@@ -524,7 +534,7 @@ export async function noteMemorySearchHealth(
     isOpenAICompatibleMemoryProvider(provider, cfg) &&
     !resolveOpenAICompatibleMemoryBaseUrl(provider, cfg, resolved.remote?.baseUrl)
   ) {
-    note(
+    noteFn(
       [
         `Memory search provider is set to "${provider}" but no OpenAI-compatible embeddings endpoint was configured.`,
         "Set agents.defaults.memorySearch.remote.baseUrl to the /v1 endpoint for your embeddings server.",
@@ -540,7 +550,7 @@ export async function noteMemorySearchHealth(
   }
 
   if (isOpenAICompatibleMemoryProvider(provider, cfg) && !normalizeOptionalString(resolved.model)) {
-    note(
+    noteFn(
       [
         `Memory search provider is set to "${provider}" but no OpenAI-compatible embedding model was configured.`,
         "Set agents.defaults.memorySearch.model to the embedding model id your server expects.",
@@ -570,7 +580,7 @@ export async function noteMemorySearchHealth(
       return;
     }
     const gatewayProbeWarning = buildGatewayProbeWarning(opts?.gatewayMemoryProbe);
-    note(
+    noteFn(
       [
         gatewayProbeWarning
           ? `Memory search provider "${provider}" is configured, but the gateway reports embeddings are not ready.`
@@ -586,12 +596,17 @@ export async function noteMemorySearchHealth(
   }
 
   // Remote provider — check for API key. Legacy provider: "auto" resolves to OpenAI.
-  if (hasRemoteApiKey || (await hasApiKeyForProvider(provider, cfg, agentDir))) {
+  if (
+    hasRemoteApiKey ||
+    (await hasApiKeyForProvider(provider, cfg, agentDir, {
+      skipProfileResolution: opts?.skipAuthProfileResolution === true,
+    }))
+  ) {
     return;
   }
 
   if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
-    note(
+    noteFn(
       [
         `Memory search provider is set to "${provider}" but the API key was not found in the CLI environment.`,
         "The running gateway reports memory embeddings are ready for the default agent.",
@@ -604,7 +619,7 @@ export async function noteMemorySearchHealth(
   const gatewayProbeWarning = buildGatewayProbeWarning(opts?.gatewayMemoryProbe);
   const envVar = resolvePrimaryMemoryProviderEnvVar(provider);
 
-  note(
+  noteFn(
     [
       `Memory search provider is set to "${provider}" but no API key was found.`,
       `Semantic recall will not work without a valid API key.`,
@@ -648,6 +663,7 @@ async function hasApiKeyForProvider(
   provider: string,
   cfg: OpenClawConfig,
   agentDir: string,
+  opts?: { skipProfileResolution?: boolean },
 ): Promise<boolean> {
   const metadata = resolveMemoryEmbeddingProviderDoctorMetadata(provider);
   const authProviderId = metadata?.authProviderId ?? provider;
@@ -656,6 +672,9 @@ async function hasApiKeyForProvider(
     resolveUsableCustomProviderApiKey({ cfg, provider: authProviderId })
   ) {
     return true;
+  }
+  if (opts?.skipProfileResolution === true) {
+    return false;
   }
   if (authProviderId !== "amazon-bedrock" && !hasAnyAuthProfileStoreSource(agentDir)) {
     return false;

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -13,6 +13,7 @@ import {
 import {
   hasAnyAuthProfileStoreSource,
   hasAuthProfileStoreSourceForProvider,
+  isConfiguredAwsSdkAuthProfileForProvider,
 } from "../agents/auth-profiles.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import {
@@ -140,6 +141,19 @@ function resolveSuggestedRemoteMemoryProvider(): string | undefined {
   return listAutoSelectMemoryEmbeddingProviderDoctorMetadata().find(
     (provider) => provider.transport === "remote",
   )?.providerId;
+}
+
+function hasConfiguredAwsSdkAuthForProvider(provider: string, cfg: OpenClawConfig): boolean {
+  const providerConfig = findNormalizedProviderValue(cfg.models?.providers, provider);
+  if (providerConfig?.auth === "aws-sdk") {
+    return true;
+  }
+  const orderedProfileIds = findNormalizedProviderValue(cfg.auth?.order, provider);
+  const profileIds =
+    orderedProfileIds ?? (cfg.auth?.profiles ? Object.keys(cfg.auth.profiles) : []);
+  return profileIds.some((profileId) =>
+    isConfiguredAwsSdkAuthProfileForProvider({ cfg, provider, profileId }),
+  );
 }
 
 function isOpenAICompatibleMemoryProvider(providerId: string, cfg: OpenClawConfig): boolean {
@@ -677,10 +691,15 @@ async function hasApiKeyForProvider(
     return true;
   }
   if (opts?.skipProfileResolution === true) {
-    return (
-      authProviderId !== "amazon-bedrock" &&
-      hasAuthProfileStoreSourceForProvider(authProviderId, agentDir)
-    );
+    if (authProviderId === "amazon-bedrock") {
+      return hasConfiguredAwsSdkAuthForProvider(authProviderId, cfg);
+    }
+    const orderedProfileIds = findNormalizedProviderValue(cfg.auth?.order, authProviderId);
+    return orderedProfileIds === undefined
+      ? hasAuthProfileStoreSourceForProvider(authProviderId, agentDir)
+      : hasAuthProfileStoreSourceForProvider(authProviderId, agentDir, {
+          profileIds: orderedProfileIds,
+        });
   }
   if (authProviderId !== "amazon-bedrock" && !hasAnyAuthProfileStoreSource(agentDir)) {
     return false;

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -443,42 +443,42 @@ export async function noteMemorySearchHealth(
     return;
   }
   if (backendConfig.backend === "qmd") {
-    if (opts?.skipQmdBinaryProbe === true) {
-      return;
-    }
-    const qmdCheck = await checkQmdBinaryAvailability({
-      command: backendConfig.qmd?.command ?? "qmd",
-      env: process.env,
-      cwd: resolveAgentWorkspaceDir(cfg, agentId),
-    });
-    if (!qmdCheck.available) {
-      const workspaceProbeFailed = resolveQmdBinaryUnavailableReason(qmdCheck) === "workspace-cwd";
-      const probeError = qmdCheck.error.trim();
-      noteFn(
-        [
-          workspaceProbeFailed
-            ? "QMD memory backend is configured, but the agent workspace directory could not be used for the QMD startup probe."
-            : `QMD memory backend is configured, but the qmd binary could not be started (${backendConfig.qmd?.command ?? "qmd"}).`,
-          probeError ? `Probe error: ${probeError}` : null,
-          "",
-          "Fix (pick one):",
-          workspaceProbeFailed
-            ? "- Create the missing workspace directory or update the agent workspace path to an existing directory."
-            : "- Install the supported QMD package: npm install -g @tobilu/qmd (or bun install -g @tobilu/qmd)",
-          workspaceProbeFailed
-            ? "- Verify the resolved workspace path for the affected agent before retrying."
-            : `- Set an explicit binary path: ${formatCliCommand("openclaw config set memory.qmd.command /absolute/path/to/qmd")}`,
-          `- Or switch back to builtin memory: ${formatCliCommand("openclaw config set memory.backend builtin")}`,
-          "",
-          `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
-        ]
-          .filter(Boolean)
-          .join("\n"),
-        "Memory search",
-      );
+    if (opts?.skipQmdBinaryProbe !== true) {
+      const qmdCheck = await checkQmdBinaryAvailability({
+        command: backendConfig.qmd?.command ?? "qmd",
+        env: process.env,
+        cwd: resolveAgentWorkspaceDir(cfg, agentId),
+      });
+      if (!qmdCheck.available) {
+        const workspaceProbeFailed =
+          resolveQmdBinaryUnavailableReason(qmdCheck) === "workspace-cwd";
+        const probeError = qmdCheck.error.trim();
+        noteFn(
+          [
+            workspaceProbeFailed
+              ? "QMD memory backend is configured, but the agent workspace directory could not be used for the QMD startup probe."
+              : `QMD memory backend is configured, but the qmd binary could not be started (${backendConfig.qmd?.command ?? "qmd"}).`,
+            probeError ? `Probe error: ${probeError}` : null,
+            "",
+            "Fix (pick one):",
+            workspaceProbeFailed
+              ? "- Create the missing workspace directory or update the agent workspace path to an existing directory."
+              : "- Install the supported QMD package: npm install -g @tobilu/qmd (or bun install -g @tobilu/qmd)",
+            workspaceProbeFailed
+              ? "- Verify the resolved workspace path for the affected agent before retrying."
+              : `- Set an explicit binary path: ${formatCliCommand("openclaw config set memory.qmd.command /absolute/path/to/qmd")}`,
+            `- Or switch back to builtin memory: ${formatCliCommand("openclaw config set memory.backend builtin")}`,
+            "",
+            `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+          "Memory search",
+        );
+      }
     }
     if (resolved.sources?.includes("sessions") && cfg.memory?.qmd?.sessions?.enabled !== true) {
-      note(
+      noteFn(
         [
           "QMD memory backend is configured and the default agent resolves memorySearch.sources with sessions,",
           "but QMD session transcript export is not enabled (memory.qmd.sessions.enabled is not true).",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -10,7 +10,10 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
-import { hasAnyAuthProfileStoreSource } from "../agents/auth-profiles.js";
+import {
+  hasAnyAuthProfileStoreSource,
+  hasAuthProfileStoreSourceForProvider,
+} from "../agents/auth-profiles.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import {
   resolveApiKeyForProvider,
@@ -674,7 +677,10 @@ async function hasApiKeyForProvider(
     return true;
   }
   if (opts?.skipProfileResolution === true) {
-    return authProviderId !== "amazon-bedrock" && hasAnyAuthProfileStoreSource(agentDir);
+    return (
+      authProviderId !== "amazon-bedrock" &&
+      hasAuthProfileStoreSourceForProvider(authProviderId, agentDir)
+    );
   }
   if (authProviderId !== "amazon-bedrock" && !hasAnyAuthProfileStoreSource(agentDir)) {
     return false;

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   collectAuthProfileHealthFindings: vi.fn(async () => []),
   noteAuthProfileHealth: vi.fn().mockResolvedValue(undefined),
   noteLegacyCodexProviderOverride: vi.fn(),
+  noteMemorySearchHealth: vi.fn().mockResolvedValue(undefined),
   buildGatewayConnectionDetails: vi.fn(() => ({ message: "gateway details" })),
   resolveSecretInputRef: vi.fn((params: { value?: unknown }) => ({
     ref:
@@ -149,6 +150,12 @@ vi.mock("../commands/doctor-auth.js", () => ({
   collectAuthProfileHealthFindings: mocks.collectAuthProfileHealthFindings,
   noteAuthProfileHealth: mocks.noteAuthProfileHealth,
   noteLegacyCodexProviderOverride: mocks.noteLegacyCodexProviderOverride,
+}));
+
+vi.mock("../commands/doctor-memory-search.js", () => ({
+  maybeRepairMemoryRecallHealth: vi.fn().mockResolvedValue(undefined),
+  noteMemoryRecallHealth: vi.fn().mockResolvedValue(undefined),
+  noteMemorySearchHealth: mocks.noteMemorySearchHealth,
 }));
 
 vi.mock("../gateway/call.js", () => ({
@@ -334,6 +341,8 @@ describe("doctor health contributions", () => {
     mocks.noteAuthProfileHealth.mockClear();
     mocks.noteAuthProfileHealth.mockResolvedValue(undefined);
     mocks.noteLegacyCodexProviderOverride.mockClear();
+    mocks.noteMemorySearchHealth.mockClear();
+    mocks.noteMemorySearchHealth.mockResolvedValue(undefined);
     mocks.buildGatewayConnectionDetails.mockClear();
     mocks.buildGatewayConnectionDetails.mockReturnValue({ message: "gateway details" });
     mocks.resolveSecretInputRef.mockClear();
@@ -1117,6 +1126,66 @@ describe("doctor health contributions", () => {
       checksRun: 1,
       checksSkipped: 0,
     });
+  });
+
+  it("collects memory-search notes as structured findings", async () => {
+    const contribution = requireDoctorContribution("doctor:memory-search");
+    const check = contribution.healthChecks[0] as HealthCheck;
+    mocks.noteMemorySearchHealth.mockImplementationOnce(async (_cfg, opts) => {
+      opts.noteFn(
+        [
+          'Memory search provider is set to "openai" but no API key was found.',
+          "Semantic recall will not work without a valid API key.",
+          "Fix (pick one):",
+          "- Set OPENAI_API_KEY in your environment",
+        ].join("\n"),
+        "Memory search",
+      );
+    });
+
+    const findings = await check.detect({
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      cfg: {},
+    });
+
+    expect(contribution.healthCheckIds).toEqual(["core/doctor/memory-search"]);
+    expect((check as HealthCheck & { defaultEnabled?: boolean }).defaultEnabled).toBe(false);
+    expect(mocks.noteMemorySearchHealth).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        includeWorkspaceMemoryHealth: false,
+        skipQmdBinaryProbe: true,
+        skipAuthProfileResolution: true,
+        gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
+        noteFn: expect.any(Function),
+      }),
+    );
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/memory-search",
+        severity: "warning",
+        path: "agents.defaults.memorySearch.provider",
+        message: 'Memory search provider is set to "openai" but no API key was found.',
+        fixHint: expect.stringContaining("OPENAI_API_KEY"),
+      }),
+    ]);
+  });
+
+  it("does not report disabled memory search as a lint warning", async () => {
+    const contribution = requireDoctorContribution("doctor:memory-search");
+    const check = contribution.healthChecks[0] as HealthCheck;
+    mocks.noteMemorySearchHealth.mockImplementationOnce(async (_cfg, opts) => {
+      opts.noteFn("Memory search is explicitly disabled (enabled: false).", "Memory search");
+    });
+
+    const findings = await check.detect({
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      cfg: {},
+    });
+
+    expect(findings).toEqual([]);
   });
 
   it("uses legacy run when a contribution also declares structured health", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1034,6 +1034,66 @@ async function runMemorySearchHealthContribution(ctx: DoctorHealthFlowContext): 
   }
 }
 
+function memorySearchNoteToFinding(message: string): HealthFinding | null {
+  const lines = message.split("\n");
+  const firstLine = (lines[0] ?? message).trim();
+  if (firstLine === "Memory search is explicitly disabled (enabled: false).") {
+    return null;
+  }
+  const fixHint = lines
+    .slice(1)
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim();
+  return {
+    checkId: "core/doctor/memory-search",
+    severity: "warning",
+    message: firstLine,
+    path: inferMemorySearchFindingPath(firstLine),
+    ...(fixHint ? { fixHint } : {}),
+  };
+}
+
+function inferMemorySearchFindingPath(message: string): string {
+  if (message.includes("No active memory plugin")) {
+    return "plugins.slots.memory";
+  }
+  if (message.includes("QMD memory backend")) {
+    return "memory.backend";
+  }
+  if (message.includes("OpenAI-compatible embeddings endpoint")) {
+    return "agents.defaults.memorySearch.remote.baseUrl";
+  }
+  if (message.includes("OpenAI-compatible embedding model")) {
+    return "agents.defaults.memorySearch.model";
+  }
+  return "agents.defaults.memorySearch.provider";
+}
+
+async function collectMemorySearchHealthFindings(
+  ctx: Parameters<HealthCheck["detect"]>[0],
+): Promise<readonly HealthFinding[]> {
+  const { noteMemorySearchHealth } = await import("../commands/doctor-memory-search.js");
+  const notes: string[] = [];
+  await noteMemorySearchHealth(ctx.cfg, {
+    includeWorkspaceMemoryHealth: false,
+    skipQmdBinaryProbe: true,
+    skipAuthProfileResolution: true,
+    gatewayMemoryProbe: {
+      checked: false,
+      ready: false,
+      skipped: true,
+    },
+    noteFn: (message) => {
+      notes.push(String(message));
+    },
+  });
+  return notes.flatMap((message) => {
+    const finding = memorySearchNoteToFinding(message);
+    return finding ? [finding] : [];
+  });
+}
+
 async function runDevicePairingHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteDevicePairingHealth } = await import("../commands/doctor-device-pairing.js");
   await noteDevicePairingHealth({
@@ -1658,6 +1718,11 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:memory-search",
       label: "Memory search",
+      healthChecks: {
+        description: "Memory search provider and backend readiness are captured as findings.",
+        defaultEnabled: false,
+        detect: collectMemorySearchHealthFindings,
+      },
       run: runMemorySearchHealthContribution,
     }),
     createDoctorHealthContribution({


### PR DESCRIPTION
## Summary
- Adds `core/doctor/memory-search` as a structured Doctor lint finding source.
- Reuses the existing memory-search doctor note logic through an injected note sink so legacy `openclaw doctor` output stays unchanged.
- Keeps the new structured check opt-in/default-off: it is available through `--only core/doctor/memory-search` or `--all`, but plain `doctor --lint` does not run it.
- Keeps lint read-only/safe: skips informational disabled-memory notes, treats unprobed key-optional readiness as skipped, suppresses configured QMD binary probing, and avoids auth-profile/OAuth resolution from lint detection.
- Fixes the selected-lint auth-profile false positive: when provider-specific eligible auth-profile sources exist but profile resolution is intentionally skipped, memory-search lint stays quiet; empty, expired, malformed, unrelated, or auth-order-excluded auth-profile sources still report missing credentials.
- Preserves Bedrock AWS SDK auth in read-only lint mode without resolving secret-bearing auth profiles.
- Fixes QMD selected lint so skipping the configured QMD binary spawn still preserves QMD session-export config warnings.

## Contract / Safety
- No plugin SDK/public contract changes (`plugin-sdk:surface:check` and `plugin-sdk:check-exports` clean).
- No repair behavior or data model change.
- Default `openclaw doctor --lint` behavior is unchanged for memory search because `core/doctor/memory-search` has `defaultEnabled: false`.
- `openclaw doctor --lint --only core/doctor/memory-search` reports config/env findings from read-only config/env state only; it does not execute configured QMD commands or refresh/persist auth profiles.

## Real behavior proof

Behavior or issue addressed:
Default-disabled structured Doctor lint for memory search, including selected missing-key warnings, default-off behavior, QMD no-spawn behavior while preserving QMD session-export warnings, and the provider-specific auth-profile credential-source fix.

Real environment tested:
WSL2 Ubuntu 24.04 source checkout. Source CLI proof below was run at `91077da25eb478f4eca69aa6d06286f994feb05a`; the branch has since been rebased and hardened through Codex review at `21971737b72a36390bf619a676f130ff8dc8968e` with additional focused regression coverage for auth-source eligibility, auth-order constraints, legacy auth coercion, and Bedrock AWS SDK lint behavior. The CLI proof used isolated `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` temp directories. Provider key env vars were unset for the proof commands. QMD proof used a marker-writing fake QMD command to prove lint did not spawn it.

Exact steps or command run after this patch:
1. `pnpm -s openclaw doctor --lint --json --only core/doctor/memory-search` with memory search enabled for OpenAI and no OpenAI API key.
2. `pnpm -s openclaw doctor --lint --json` on the same config to prove default lint does not include `core/doctor/memory-search`.
3. `pnpm -s openclaw doctor --lint --json --only core/doctor/memory-search` with `memory.backend=qmd`, `memorySearch.sources` including `sessions`, `memory.qmd.sessions.enabled: false`, and `memory.qmd.command` pointed at a marker-writing script.
4. `pnpm -s openclaw doctor --lint --json --only core/doctor/memory-search` with the missing-key config plus an empty isolated auth-profile source file.
5. `pnpm -s openclaw doctor --lint --json --only core/doctor/memory-search` with the same missing-key config plus an isolated provider-specific `openai:default` auth-profile source file.

Evidence after fix:

```text
## selected-missing-key
exit=1
{
  "totalFindings": 1,
  "memoryFindings": 1,
  "firstMemory": {
    "checkId": "core/doctor/memory-search",
    "severity": "warning",
    "path": "agents.defaults.memorySearch.provider",
    "target": null,
    "message": "Memory search provider is set to "openai" but no API key was found."
  }
}

## default-off
exit=1
{
  "totalFindings": 34,
  "memoryFindings": 0
}

## qmd-no-spawn-preserves-warning
exit=1
{
  "totalFindings": 1,
  "memoryFindings": 1,
  "firstMemory": {
    "checkId": "core/doctor/memory-search",
    "severity": "warning",
    "path": "memory.backend",
    "target": null,
    "message": "QMD memory backend is configured and the default agent resolves memorySearch.sources with sessions,"
  }
}
QMD_MARKER_EXISTS=no

## empty-auth-profile-source-still-warns
exit=1
{
  "totalFindings": 1,
  "memoryFindings": 1,
  "firstMemory": {
    "checkId": "core/doctor/memory-search",
    "severity": "warning",
    "path": "agents.defaults.memorySearch.provider",
    "target": null,
    "message": "Memory search provider is set to "openai" but no API key was found."
  }
}

## provider-auth-profile-source-skipped
exit=0
{
  "totalFindings": 0,
  "memoryFindings": 0,
  "firstMemory": {
    "checkId": null,
    "severity": null,
    "path": null,
    "target": null,
    "message": null
  }
}
```

Observed result after fix:
Selected `core/doctor/memory-search` reports the expected missing-key warning when config/env/provider-specific auth-profile source state cannot satisfy credentials. Plain default lint reports zero memory-search findings. QMD selected lint does not spawn the configured QMD command and still reports the QMD session transcript export warning. A provider-specific auth-profile source keeps selected lint quiet without resolving or mutating auth profiles; an empty auth-profile source does not.

What was not tested:
Packaged installer/runtime proof. This is source CLI proof plus focused unit/type/lint coverage for a default-off Doctor lint detector.

## Validation
- `node scripts/run-vitest.mjs run src/agents/auth-profiles/source-check.test.ts src/commands/doctor-memory-search.test.ts src/flows/doctor-health-contributions.test.ts --reporter=verbose` (3 shards, 125 tests)
- `./node_modules/.bin/oxfmt --check src/agents/auth-profiles.ts src/agents/auth-profiles/persisted.ts src/agents/auth-profiles/source-check.ts src/agents/auth-profiles/source-check.test.ts src/agents/auth-profiles/store.ts src/commands/doctor-memory-search.test.ts src/commands/doctor-memory-search.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-contributions.ts`
- `node scripts/run-oxlint.mjs src/agents/auth-profiles.ts src/agents/auth-profiles/persisted.ts src/agents/auth-profiles/source-check.ts src/agents/auth-profiles/source-check.test.ts src/agents/auth-profiles/store.ts src/commands/doctor-memory-search.test.ts src/commands/doctor-memory-search.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-contributions.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `pnpm plugin-sdk:check-exports`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main` at `21971737b72a36390bf619a676f130ff8dc8968e`: no actionable correctness issues.
- Source CLI proof above on `91077da25eb478f4eca69aa6d06286f994feb05a`; post-proof Codex-review fixes are covered by the added focused tests listed above.

## Not Tested
- Packaged installer/runtime proof; this is source CLI + focused unit/type/lint coverage for a default-off Doctor lint detector.
