### PR TITLE
fix(agent-core): ignore truncated tool calls

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -476,6 +476,45 @@ describe("google transport stream", () => {
     expect(result.content[2]).toHaveProperty("thoughtSignature", "Y2FsbF9zaWdfMQ==");
   });
 
+  it("preserves MAX_TOKENS when the partial response contains a function call", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [{ functionCall: { name: "lookup", args: { q: "hello" } } }],
+              },
+              finishReason: "MAX_TOKENS",
+            },
+          ],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+          tools: [
+            {
+              name: "lookup",
+              description: "Look up a value",
+              parameters: { type: "object" },
+            },
+          ],
+        } as Parameters<typeof streamFn>[1],
+        { apiKey: "gemini-api-key" } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("length");
+    expect(result.content).toEqual([expect.objectContaining({ type: "toolCall", name: "lookup" })]);
+  });
+
   it("strips redundant google provider prefixes from Gemini API model paths", async () => {
     guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
 

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -1404,7 +1404,12 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
           }
           if (typeof candidate?.finishReason === "string") {
             output.stopReason = mapStopReasonString(candidate.finishReason);
-            if (output.content.some((block) => block.type === "toolCall")) {
+            // MAX_TOKENS can leave a complete-looking partial call. Only a normal
+            // Google stop may promote parsed calls into an executable tool-use turn.
+            if (
+              output.stopReason === "stop" &&
+              output.content.some((block) => block.type === "toolCall")
+            ) {
               output.stopReason = "toolUse";
             }
           }

--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -98,13 +98,13 @@ describe("buildAssistantMessage", () => {
     expect(msg.stopReason).toBe("length");
   });
 
-  it("keeps tool use authoritative over a length stop", () => {
+  it("keeps a length stop authoritative over complete-looking tool calls", () => {
     const response = makeOllamaResponse({
       done_reason: "length",
       tool_calls: [{ function: { name: "read", arguments: { path: "README.md" } } }],
     });
     const msg = buildAssistantMessage(response, MODEL_INFO);
-    expect(msg.stopReason).toBe("toolUse");
+    expect(msg.stopReason).toBe("length");
   });
 });
 
@@ -280,6 +280,32 @@ describe("createOllamaStreamFn thinking events", () => {
     };
     expect(done.reason).toBe("length");
     expect(done.message?.stopReason).toBe("length");
+  });
+
+  it("preserves a native length stop when the partial response contains tool calls", async () => {
+    const events = await streamOllamaEvents(
+      [
+        makeOllamaResponse({
+          done_reason: "length",
+          tool_calls: [{ function: { name: "read", arguments: { path: "README.md" } } }],
+        }),
+      ],
+      {},
+      {
+        messages: [{ role: "user", content: "test" }],
+        tools: [{ name: "read", description: "Read files", parameters: { type: "object" } }],
+      } as never,
+    );
+
+    const done = events.find((event) => event.type === "done") as {
+      reason?: string;
+      message?: { content?: Array<Record<string, unknown>>; stopReason?: string };
+    };
+    expect(done.reason).toBe("length");
+    expect(done.message?.stopReason).toBe("length");
+    expect(done.message?.content).toEqual([
+      expect.objectContaining({ type: "toolCall", name: "read" }),
+    ]);
   });
 
   it("uses generic stream timeout for Ollama request timeout", async () => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -656,10 +656,15 @@ function estimateTokensFromChars(chars: number): number {
 }
 
 function resolveOllamaStopReason(response: OllamaChatResponse) {
+  // Ollama's length terminal means generation hit its token limit, even when
+  // the partial response already contains a complete-looking tool call.
+  if (response.done_reason === "length") {
+    return "length" as const;
+  }
   if (response.message.tool_calls?.length) {
     return "toolUse" as const;
   }
-  return response.done_reason === "length" ? ("length" as const) : ("stop" as const);
+  return "stop" as const;
 }
 
 function estimateOllamaPromptTokens(params: {

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -164,6 +164,126 @@ describe("agentLoop streaming updates", () => {
       expect(update.assistantMessageEvent).not.toHaveProperty("partial");
     }
   });
+
+  it("does not execute tool calls from a max-token-truncated assistant turn", async () => {
+    const execute = vi.fn(
+      async (): Promise<AgentToolResult<unknown>> => ({
+        content: [{ type: "text", text: "should not run" }],
+        details: {},
+      }),
+    );
+    const contexts: Context[] = [];
+    let streamCalls = 0;
+    const streamFn: StreamFn = async (_model, context) => {
+      contexts.push(context);
+      streamCalls += 1;
+      const stream = createAssistantMessageEventStream();
+      if (streamCalls > 1) {
+        const message: AssistantMessage = {
+          role: "assistant",
+          content: [{ type: "text", text: "continued" }],
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage: TEST_USAGE,
+          stopReason: "stop",
+          timestamp: 2,
+        };
+        queueMicrotask(() => {
+          stream.push({ type: "done", reason: "stop", message });
+        });
+        return stream;
+      }
+      const toolCall = {
+        type: "toolCall" as const,
+        id: "call-truncated-spawn",
+        name: "sessions_spawn",
+        arguments: {},
+      };
+      const message: AssistantMessage = {
+        role: "assistant",
+        content: [{ type: "text", text: "spawning" }, toolCall],
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage: TEST_USAGE,
+        stopReason: "length",
+        timestamp: 1,
+      };
+
+      queueMicrotask(() => {
+        stream.push({ type: "start", partial: { ...message, content: [] } });
+        stream.push({ type: "toolcall_start", contentIndex: 1, partial: message });
+        stream.push({
+          type: "toolcall_end",
+          contentIndex: 1,
+          toolCall,
+          partial: message,
+        });
+        stream.push({ type: "done", reason: "length", message });
+      });
+
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "spawn specialists", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [
+          {
+            name: "sessions_spawn",
+            label: "sessions_spawn",
+            description: "Spawn a child session",
+            parameters: Type.Object({}, { additionalProperties: false }),
+            execute,
+          },
+        ],
+      },
+      {
+        ...config,
+        getFollowUpMessages: async () =>
+          streamCalls === 1 ? [{ role: "user", content: "continue", timestamp: 2 }] : [],
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+    const messages = await stream.result();
+    const truncatedMessageEnd = events.find(
+      (event): event is Extract<AgentEvent, { type: "message_end" }> =>
+        event.type === "message_end" &&
+        event.message.role === "assistant" &&
+        event.message.stopReason === "length",
+    );
+    const replayedTruncatedMessage = contexts[1]?.messages[1];
+
+    if (!truncatedMessageEnd || !replayedTruncatedMessage) {
+      throw new Error("expected the truncated assistant message to be emitted and replayed");
+    }
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(events.some((event) => event.type === "tool_execution_start")).toBe(false);
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    expect(messages[1]).toMatchObject({ role: "assistant", stopReason: "length" });
+    expect(messages[1]).not.toMatchObject({
+      content: expect.arrayContaining([expect.objectContaining({ type: "toolCall" })]),
+    });
+    expect(truncatedMessageEnd.message).not.toMatchObject({
+      content: expect.arrayContaining([expect.objectContaining({ type: "toolCall" })]),
+    });
+    expect(replayedTruncatedMessage).toMatchObject({ role: "assistant", stopReason: "length" });
+    expect(replayedTruncatedMessage).not.toMatchObject({
+      content: expect.arrayContaining([expect.objectContaining({ type: "toolCall" })]),
+    });
+  });
 });
 
 describe("runAgentLoop deferred tool hydration", () => {
@@ -936,7 +1056,7 @@ describe("agentLoop thinking state", () => {
         totalTokens: 0,
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
       },
-      stopReason: "stop",
+      stopReason: content.some((item) => item.type === "toolCall") ? "toolUse" : "stop",
       timestamp: 1,
     };
   }
@@ -968,7 +1088,7 @@ describe("agentLoop thinking state", () => {
             : [{ type: "text", text: "done" }];
         stream.push({
           type: "done",
-          reason: "stop",
+          reason: content.some((item) => item.type === "toolCall") ? "toolUse" : "stop",
           message: makeAssistantMessage(activeModel, content),
         });
         stream.end();

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -80,6 +80,14 @@ function resolveAssistantMessageUpdate(
   return currentMessage;
 }
 
+function removeNonExecutableToolCalls(message: AssistantMessage): AssistantMessage {
+  if (message.stopReason === "toolUse") {
+    return message;
+  }
+  const content = message.content.filter((item) => item.type !== "toolCall");
+  return content.length === message.content.length ? message : { ...message, content };
+}
+
 /**
  * Start an agent loop with a new prompt message.
  * The prompt is added to the context and events are emitted for it.
@@ -342,12 +350,12 @@ async function runLoop(
         return;
       }
 
-      // Check for tool calls
+      // Only completed toolUse turns dispatch; length/stop can carry partial stream blocks.
       const toolCalls = message.content.filter((c) => c.type === "toolCall");
 
       const toolResults: ToolResultMessage[] = [];
       hasMoreToolCalls = false;
-      if (toolCalls.length > 0) {
+      if (message.stopReason === "toolUse" && toolCalls.length > 0) {
         const executedToolBatch = await executeToolCalls(
           currentContext,
           message,
@@ -508,7 +516,7 @@ async function streamAssistantResponse(
 
       case "done":
       case "error": {
-        const finalMessage = await response.result();
+        const finalMessage = removeNonExecutableToolCalls(await response.result());
         if (addedPartial) {
           context.messages[context.messages.length - 1] = finalMessage;
         } else {
@@ -523,7 +531,7 @@ async function streamAssistantResponse(
     }
   }
 
-  const finalMessage = await response.result();
+  const finalMessage = removeNonExecutableToolCalls(await response.result());
   if (addedPartial) {
     context.messages[context.messages.length - 1] = finalMessage;
   } else {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2843,6 +2843,125 @@ describe("openai transport stream", () => {
     },
   );
 
+  it("does not authorize recovered DeepSeek DSML calls when the stream omits a terminal", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-no-terminal",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/partial.md"}</|DSML|invoke></|DSML|tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.stopReason).toBe("stop");
+    expect(output.content).toEqual([]);
+  });
+
+  it("emits recovered DeepSeek content-filter terminals as errors", async () => {
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-deepseek-dsml-content-filter",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "deepseek-v4-pro",
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  content:
+                    '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/partial.md"}</|DSML|invoke></|DSML|tool_calls>',
+                },
+                finish_reason: "content_filter",
+              },
+            ],
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = {
+        ...createDeepSeekCompletionsModel(),
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } satisfies Model<"openai-completions">;
+      const stream = createOpenAICompletionsTransportStreamFn()(
+        model,
+        {
+          systemPrompt: "system",
+          messages: [{ role: "user", content: "Read the file", timestamp: Date.now() }],
+          tools: [],
+        } as never,
+        { apiKey: "test-key" } as never,
+      );
+
+      const terminalEvents: Array<{
+        type: string;
+        reason?: string;
+        error?: Record<string, unknown>;
+      }> = [];
+      for await (const event of stream as AsyncIterable<{
+        type: string;
+        reason?: string;
+        error?: Record<string, unknown>;
+      }>) {
+        if (event.type === "done" || event.type === "error") {
+          terminalEvents.push(event);
+        }
+      }
+
+      expect(terminalEvents).toEqual([
+        expect.objectContaining({
+          type: "error",
+          reason: "error",
+          error: expect.objectContaining({
+            stopReason: "error",
+            errorMessage: "Provider finish_reason: content_filter",
+            content: [],
+          }),
+        }),
+      ]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("parses repeated DeepSeek DSML name attributes consistently", async () => {
     // Guards the cached attribute matchers: repeated parses must stay identical
     // (no stale RegExp lastIndex) across separate stream invocations.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -44,6 +44,7 @@ function createDeepSeekCompletionsModel(): Model<"openai-completions"> {
     api: "openai-completions",
     provider: "deepseek",
     baseUrl: "https://api.deepseek.com",
+    compat: { thinkingFormat: "deepseek" },
     reasoning: true,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -1468,7 +1469,7 @@ describe("openai transport stream", () => {
       name: "qwen-coder-plus",
       api: "openai-completions",
       provider: "qwen",
-      baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      baseUrl: "",
       reasoning: false,
       input: ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -2801,6 +2802,46 @@ describe("openai transport stream", () => {
     ]);
     expect(JSON.stringify(events)).not.toContain("DSML");
   });
+
+  it.each([
+    { finishReason: "length", stopReason: "length" },
+    { finishReason: "content_filter", stopReason: "error" },
+  ])(
+    "does not authorize recovered DeepSeek DSML calls after $finishReason",
+    async ({ finishReason, stopReason }) => {
+      const model = createDeepSeekCompletionsModel();
+      const output = createAssistantOutput(model);
+      expect(testing.getCompat(model).thinkingFormat).toBe("deepseek");
+
+      await testing.processOpenAICompletionsStream(
+        streamChunks([
+          {
+            id: "chatcmpl-deepseek-dsml-terminal",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: model.id,
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  content:
+                    '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/partial.md"}</|DSML|invoke></|DSML|tool_calls>',
+                },
+                logprobs: null,
+                finish_reason: finishReason,
+              },
+            ],
+          },
+        ]),
+        output,
+        model,
+        { push() {} },
+      );
+
+      expect(output.stopReason).toBe(stopReason);
+      expect(output.content).toEqual([]);
+    },
+  );
 
   it("parses repeated DeepSeek DSML name attributes consistently", async () => {
     // Guards the cached attribute matchers: repeated parses must stay identical
@@ -6716,6 +6757,7 @@ describe("openai transport stream", () => {
         api: "openai-completions",
         provider: "qwen",
         baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        compat: { supportsUsageInStreaming: true },
         reasoning: true,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -6745,6 +6787,7 @@ describe("openai transport stream", () => {
         api: "openai-completions",
         provider: "generic",
         baseUrl: "https://coding.dashscope.aliyuncs.com/v1",
+        compat: { supportsUsageInStreaming: true },
         reasoning: true,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -98,6 +98,8 @@ import { stripSystemPromptCacheBoundary } from "./system-prompt-cache-boundary.j
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
   assignTransportErrorDetails,
+  failTransportStream,
+  finalizeTransportStream,
   mergeTransportMetadata,
   sanitizeTransportPayloadText,
 } from "./transport-stream-shared.js";
@@ -2801,15 +2803,9 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           signal: options?.signal,
           emitReasoning,
         });
-        if (options?.signal?.aborted) {
-          throw new Error("Request was aborted");
-        }
-        stream.push({ type: "done", reason: output.stopReason as never, message: output as never });
-        stream.end();
+        finalizeTransportStream({ stream, output, signal: options?.signal });
       } catch (error) {
-        assignTransportErrorDetails(output, error, options?.signal);
-        stream.push({ type: "error", reason: output.stopReason as never, error: output as never });
-        stream.end();
+        failTransportStream({ stream, output, signal: options?.signal, error });
       }
     })();
     return eventStream as unknown as ReturnType<StreamFn>;
@@ -2975,11 +2971,6 @@ async function processOpenAICompletionsStream(
     if (switchingToolCall) {
       currentBlock = null;
       flushPendingPostToolCallDeltas();
-    }
-    // Recovery may run after this chunk's finish reason was parsed. Preserve
-    // length/error terminals so complete-looking partial DSML never executes.
-    if (output.stopReason === "stop") {
-      output.stopReason = "toolUse";
     }
     recoveredDeepSeekToolCallIndex += 1;
     const block: ToolCallBlock = {
@@ -3250,6 +3241,8 @@ async function processOpenAICompletionsStream(
   if (output.stopReason === "toolUse" && !hasToolCalls) {
     output.stopReason = "stop";
   }
+  // Tool-call recovery is executable only after an explicit provider terminal.
+  // EOF alone can mean transport truncation, even when the recovered call parses.
   if (sawStopFinishReason && output.stopReason === "stop" && hasToolCalls && !hasVisibleText) {
     output.stopReason = "toolUse";
   }

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2976,7 +2976,11 @@ async function processOpenAICompletionsStream(
       currentBlock = null;
       flushPendingPostToolCallDeltas();
     }
-    output.stopReason = "toolUse";
+    // Recovery may run after this chunk's finish reason was parsed. Preserve
+    // length/error terminals so complete-looking partial DSML never executes.
+    if (output.stopReason === "stop") {
+      output.stopReason = "toolUse";
+    }
     recoveredDeepSeekToolCallIndex += 1;
     const block: ToolCallBlock = {
       type: "toolCall",

--- a/src/llm/providers/google-shared.test.ts
+++ b/src/llm/providers/google-shared.test.ts
@@ -136,6 +136,42 @@ describe("consumeGoogleGenerateContentStream", () => {
     expect(output.usage.cost.total).toBeGreaterThan(0);
   });
 
+  it("preserves MAX_TOKENS when the partial response contains a function call", async () => {
+    const output = createOutput();
+    const stream = new AssistantMessageEventStream();
+    const terminalReason = (async () => {
+      for await (const event of stream) {
+        if (event.type === "done") {
+          return event.reason;
+        }
+      }
+      return undefined;
+    })();
+
+    await consumeGoogleGenerateContentStream({
+      chunks: chunks([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [{ functionCall: { name: "lookup", args: { query: "cats" } } }],
+              },
+              finishReason: FinishReason.MAX_TOKENS,
+            },
+          ],
+        } as GenerateContentResponse,
+      ]),
+      model,
+      output,
+      stream,
+      nextToolCallId: (name) => `generated-${name}`,
+    });
+
+    expect(await terminalReason).toBe("length");
+    expect(output.stopReason).toBe("length");
+    expect(output.content).toEqual([expect.objectContaining({ type: "toolCall", name: "lookup" })]);
+  });
+
   it("generates a new id when Google repeats a streamed tool-call id", async () => {
     const output = createOutput();
     const stream = new AssistantMessageEventStream();

--- a/src/llm/providers/google-shared.test.ts
+++ b/src/llm/providers/google-shared.test.ts
@@ -159,7 +159,7 @@ describe("consumeGoogleGenerateContentStream", () => {
               finishReason: FinishReason.MAX_TOKENS,
             },
           ],
-        } as GenerateContentResponse,
+        } as unknown as GenerateContentResponse,
       ]),
       model,
       output,

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -875,7 +875,12 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
 
     if (candidate?.finishReason) {
       params.output.stopReason = mapStopReason(candidate.finishReason);
-      if (params.output.content.some((block) => block.type === "toolCall")) {
+      // MAX_TOKENS can leave a complete-looking partial call. Only a normal
+      // Google stop may promote parsed calls into an executable tool-use turn.
+      if (
+        params.output.stopReason === "stop" &&
+        params.output.content.some((block) => block.type === "toolCall")
+      ) {
         params.output.stopReason = "toolUse";
       }
     }

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -385,7 +385,7 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     ]);
   });
 
-  it("promotes complete under-cap text tool calls for non-stop terminal reasons", async () => {
+  it("does not promote complete-looking text tool calls after a length stop", async () => {
     const rawToolText = '[tool:read] {"path":"/tmp/file.txt"}';
     const baseStreamFn: StreamFn = () =>
       createEventStream([
@@ -410,14 +410,13 @@ describe("createPlainTextToolCallCompatWrapper", () => {
       events.push(event);
     }
 
-    expect(events.map((event) => (event as { type?: string }).type)).toEqual([
-      "toolcall_start",
-      "toolcall_delta",
-      "done",
-    ]);
-    const done = events.at(-1) as { reason?: unknown; message?: { stopReason?: unknown } };
-    expect(done.reason).toBe("toolUse");
-    expect(done.message?.stopReason).toBe("toolUse");
+    expect(events.map((event) => (event as { type?: string }).type)).toEqual(["done"]);
+    const done = events.at(-1) as {
+      reason?: unknown;
+      message?: { content?: unknown; stopReason?: unknown };
+    };
+    expect(done.reason).toBe("length");
+    expect(done.message).toMatchObject({ content: rawToolText, stopReason: "length" });
   });
 
   it("passes through bracketed text when no configured tool names match", async () => {

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -138,6 +138,7 @@ function createProviderToolNameMatcher(toolNames: Set<string>): PlainTextToolCal
 
 function normalizeProviderDoneMessage(
   message: unknown,
+  reason: unknown,
   toolNames: Set<string>,
   matcher: PlainTextToolCallNameMatcher,
 ): PlainTextToolCallMessageNormalization {
@@ -148,6 +149,11 @@ function normalizeProviderDoneMessage(
   });
   if (scrubbedMessage) {
     return { kind: "scrubbed", message: scrubbedMessage };
+  }
+  // Token-limit and error terminals can leave complete-looking tool syntax.
+  // Only normal completion or explicit tool use may promote it into an executable call.
+  if (reason !== "stop" && reason !== "toolUse") {
+    return undefined;
   }
   const promotedMessage = promotePlainTextToolCalls(message, toolNames);
   return promotedMessage ? { kind: "promoted", message: promotedMessage } : undefined;
@@ -184,8 +190,8 @@ function wrapPlainTextToolCallStream(
             return events;
           },
           matcher,
-          normalizeDoneMessage: ({ message }) =>
-            normalizeProviderDoneMessage(message, toolNames, matcher),
+          normalizeDoneMessage: ({ message, reason }) =>
+            normalizeProviderDoneMessage(message, reason, toolNames, matcher),
           stopAfterDone: true,
         },
       );


### PR DESCRIPTION
## What Problem This Solves

Closes #97091. A model response that reaches a length, error, or aborted terminal while still emitting tool calls can contain incomplete calls. Those calls must not execute, persist, or replay as valid tool use.

This supersedes #97092. The contributor fork cannot accept maintainer pushes, so this branch preserves @galiniliev's work and coauthor credit while carrying the review fixes.

## Why This Change Was Made

- Make `toolUse` the final agent-loop authorization gate for tool dispatch.
- Remove tool-call blocks from non-executable terminal messages before events, persistence, return, and next-turn replay.
- Preserve explicit `length` and `error` terminals across Google, Ollama, shared OpenAI-compatible, and DeepSeek DSML normalization instead of reclassifying them from parsed calls.
- Require an observed provider terminal before recovered DSML calls become executable, so EOF cannot authorize a complete-looking partial call.
- Emit provider failures through the shared `error` terminal path rather than a successful `done` event.
- Keep completed tool-use behavior unchanged.

## User Impact

Truncated or failed generations no longer execute partial tool calls, including unintended child-session spawns. Complete tool calls still execute normally.

## Evidence

- `node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts src/plugin-sdk/provider-stream-shared.test.ts src/llm/providers/google-shared.test.ts src/agents/openai-transport-stream.test.ts extensions/google/transport-stream.test.ts extensions/ollama/src/stream.test.ts` — 451 tests passed across four shards.
- `oxfmt --check` and `oxlint --deny-warnings` passed for all 12 changed files.
- `git diff --check origin/main...HEAD` passed.
- Fresh autoreview after all accepted fixes: no findings; patch correct at 0.96 confidence.
