### PR TITLE
fix: avoid live transcript rollover during active daily reset

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -29,6 +29,7 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
+import { createReplyOperation, testing as replyRunRegistryTesting } from "./reply-run-registry.js";
 import { drainFormattedSystemEvents } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 import { initSessionState } from "./session.js";
@@ -467,6 +468,7 @@ beforeEach(() => {
 });
 afterEach(async () => {
   resetSystemEventsForTest();
+  replyRunRegistryTesting.resetReplyRunRegistry();
   await sessionMcpTesting.resetSessionMcpRuntimeManager();
 });
 describe("initSessionState guarded initialization", () => {
@@ -3704,6 +3706,93 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         entry.startsWith(`${existingSessionId}.jsonl.reset.`),
       );
       expect(archived).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps an active reply run on the current transcript across an implicit daily reset boundary", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+      const storePath = await createStorePath("openclaw-active-run-daily-rollover-");
+      const sessionKey = "agent:main:telegram:dm:active-run-daily-user";
+      const existingSessionId = "active-run-daily-session";
+      const transcriptPath = path.join(path.dirname(storePath), `${existingSessionId}.jsonl`);
+
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: new Date(2026, 0, 18, 3, 0, 0).getTime(),
+        },
+      });
+      await fs.writeFile(transcriptPath, '{"type":"message"}\n', "utf8");
+
+      const activeOperation = createReplyOperation({
+        sessionKey,
+        sessionId: existingSessionId,
+        resetTriggered: false,
+      });
+
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const activeResult = await initSessionState({
+        ctx: {
+          Body: "hello",
+          RawBody: "hello",
+          CommandBody: "hello",
+          From: "user-active-run",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(activeResult.isNewSession).toBe(false);
+      expect(activeResult.sessionId).toBe(existingSessionId);
+      expect(await fs.stat(transcriptPath).catch(() => null)).not.toBeNull();
+      const archivedWhileActive = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
+        entry.startsWith(`${existingSessionId}.jsonl.reset.`),
+      );
+      expect(archivedWhileActive).toHaveLength(0);
+
+      activeOperation.complete();
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          ...activeResult.sessionEntry,
+          sessionId: existingSessionId,
+          updatedAt: new Date(2026, 0, 18, 3, 0, 0).getTime(),
+          lastInteractionAt: new Date(2026, 0, 18, 3, 0, 0).getTime(),
+          sessionStartedAt: new Date(2026, 0, 18, 3, 0, 0).getTime(),
+        },
+      });
+
+      const rolloverResult = await initSessionState({
+        ctx: {
+          Body: "hello again",
+          RawBody: "hello again",
+          CommandBody: "hello again",
+          From: "user-active-run",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(rolloverResult.isNewSession).toBe(true);
+      expect(rolloverResult.sessionId).not.toBe(existingSessionId);
+      expect(await fs.stat(transcriptPath).catch(() => null)).toBeNull();
+      const archivedAfterCompletion = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
+        entry.startsWith(`${existingSessionId}.jsonl.reset.`),
+      );
+      expect(archivedAfterCompletion).toHaveLength(1);
     } finally {
       vi.useRealTimers();
     }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -72,6 +72,7 @@ import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
+import { isReplyRunActiveForSessionId } from "./reply-run-registry.js";
 import { isResetAuthorizedForContext } from "./reset-authorization.js";
 import {
   maybeRetireLegacyMainDeliveryRoute,
@@ -495,7 +496,12 @@ async function initSessionStateAttemptLocked(
   // resume signal is allowed to suppress configured idle/daily rollover.
   const reconnectResumeRequested =
     params.resumeRequestedSession === true && requestedCurrentSession;
-  const skipImplicitExpiry = hasProviderOwnedSession(entry) && resetPolicy.configured !== true;
+  const activeReplyRunForCurrentEntry = Boolean(
+    entry?.sessionId && isReplyRunActiveForSessionId(entry.sessionId),
+  );
+  const skipImplicitExpiry =
+    (hasProviderOwnedSession(entry) || activeReplyRunForCurrentEntry) &&
+    resetPolicy.configured !== true;
   const lifecycleTimestamps = resolveSessionLifecycleTimestamps({
     entry,
     agentId,
@@ -544,9 +550,11 @@ async function initSessionStateAttemptLocked(
       (softResetAllowed && canReuseExistingEntry)) &&
       !terminalMainTranscriptNewerThanRegistry);
   // Capture the current session entry before any reset so its transcript can be
-  // archived afterward.  We need to do this for both explicit resets (/new, /reset)
-  // and for scheduled/daily resets where the session has become stale (!freshEntry).
-  // Without this, daily-reset transcripts are left as orphaned files on disk (#35481).
+  // archived afterward. We intentionally suppress implicit stale rollover while a
+  // reply run is still active for this session, otherwise a daily boundary can rename
+  // the live transcript mid-run and split the running turn's output across files (#96546).
+  // We still archive both explicit resets (/new, /reset) and scheduled/daily resets
+  // once the active run has finished so stale transcripts are not left orphaned (#35481).
   const previousSessionEntry = (resetTriggered || !freshEntry) && entry ? { ...entry } : undefined;
   const previousSessionEndReason = resetTriggered
     ? resolveExplicitSessionEndReason(matchedResetTriggerLower)


### PR DESCRIPTION
## Summary
- keep the current session/transcript when a reply run is still active across an implicit daily rollover
- allow the stale daily rollover to happen normally once the active run has finished
- add regression coverage for the active-run daily-boundary case

## Testing
- pnpm vitest run src/auto-reply/reply/session.test.ts -t "active reply run on the current transcript across an implicit daily reset boundary|archives the old session transcript on daily/scheduled reset \(stale session\)"

Fixes openclaw/openclaw#96546