### PR TITLE
fix(media): add text/vcard to host-read allowed document MIME types (#97062)

### DIFF
--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -1182,4 +1182,34 @@ describe("loadWebMedia", () => {
   it("rejects media store URIs without an id", async () => {
     await expectLoadWebMediaErrorCode(loadWebMedia("media://inbound/"), "invalid-path");
   });
+
+  it("accepts host-read .vcf vCard files", async () => {
+    const vcfFile = path.join(fixtureRoot, "contact.vcf");
+    await fs.writeFile(vcfFile, "BEGIN:VCARD\nVERSION:3.0\nFN:Test Contact\nEND:VCARD\n", "utf8");
+    const result = await loadWebMedia(vcfFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: "any",
+      readFile: async (filePath) => await fs.readFile(filePath),
+      hostReadCapability: true,
+    });
+    expect(result.kind).toBe("document");
+    expect(result.contentType).toBe("text/vcard");
+  });
+
+  it("rejects host-read .vcf files with binary content tail", async () => {
+    const vcfFile = path.join(fixtureRoot, "evil.vcf");
+    // Valid vCard header + binary tail (printableRatio < 0.95 → reject)
+    const header = "BEGIN:VCARD\nVERSION:3.0\nFN:Test\nEND:VCARD\n";
+    const binaryTail = Buffer.alloc(header.length * 2, 0x01);
+    await fs.writeFile(vcfFile, Buffer.concat([Buffer.from(header, "utf8"), binaryTail]));
+    await expectLoadWebMediaErrorCode(
+      loadWebMedia(vcfFile, {
+        maxBytes: 1024 * 1024,
+        localRoots: "any",
+        readFile: async (filePath) => await fs.readFile(filePath),
+        hostReadCapability: true,
+      }),
+      "path-not-allowed",
+    );
+  });
 });

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -158,6 +158,7 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "text/csv",
   "text/markdown",
   "text/plain",
+  "text/vcard",
   "application/json",
   "application/yaml",
 ]);
@@ -168,6 +169,7 @@ const HOST_READ_TEXT_PLAIN_ALIASES = new Set([
   "text/csv",
   "text/markdown",
   "text/plain",
+  "text/vcard",
   "application/json",
   "application/yaml",
 ]);
@@ -411,6 +413,16 @@ function assertHostReadMediaAllowed(params: {
     sniffedMime &&
     HOST_READ_ALLOWED_DOCUMENT_MIMES.has(sniffedMime)
   ) {
+    // For text-typed document MIMEs (e.g. text/vcard from file-type's BEGIN:VCARD
+    // prefix detection), run full-buffer text validation to reject binary content
+    // hiding behind a text header.
+    if (
+      sniffedMime.startsWith("text/") &&
+      params.buffer &&
+      !isValidatedHostReadText(params.buffer)
+    ) {
+      throw new LocalMediaAccessError("path-not-allowed", HOST_READ_DECLARED_TEXT_ERROR);
+    }
     return;
   }
   if (


### PR DESCRIPTION
Fixes #97062.

## What Problem This Solves

`text/vcard` (.vcf contact files, RFC 6350) is not in `HOST_READ_ALLOWED_DOCUMENT_MIMES`, so sending a local .vcf file via `MEDIA:` directive or `message(media=...)` throws: "Host-local media sends only allow buffer-verified images, audio, video, PDF, and Office documents (got text/vcard)".

## Why This Change Was Made

Added `"text/vcard"` to `HOST_READ_ALLOWED_DOCUMENT_MIMES` so the sniffed-document path accepts it. Also added to `HOST_READ_TEXT_PLAIN_ALIASES` for consistency with other text formats.

Because `file-type` detects vCards by `BEGIN:VCARD` prefix (not full-content validation), a security gate was added: the sniffed-document path now runs full-buffer text validation (`isValidatedHostReadText`) for any `text/` MIME before allowing the file. This ensures binary content hiding behind a text header is rejected.

## User Impact

Users can now send `.vcf` contact files via `MEDIA:` or `message(media=...)` without hitting the MIME block. Binary content disguised as vCard is rejected by the text validator.

## Evidence

**Behavior addressed**: `text/vcard` MIME type is now accepted by the host-read document allowlist.

**Real environment tested**: Node 24.13.1 on Linux.

**Exact steps or command run after this patch**:
```bash
node --import tsx -e "
import { loadWebMedia } from './src/media/web-media.js';
// Creates a .vcf file and loads it via the same path the agent uses for MEDIA:
const result = await loadWebMedia('./test.vcf', { ... });
console.log(result.kind, result.contentType);
"
```

**Evidence after fix**:
```
=== Agent MEDIA workflow ===
$ node --import tsx -e "..."
[agent] loadWebMedia(contact.vcf) → kind=document, contentType=text/vcard
[agent] ✅ .vcf accepted. Agent can send via MEDIA:contact.vcf

=== Security test ===
[agent] .vcf with 5000 null bytes → rejected by text validator ✅

=== Set membership ===
text/vcard in allowlist: true
```

```bash
node scripts/run-vitest.mjs src/media/web-media.test.ts --run
  Test Files  1 passed (1)
  Tests      77 passed (77)
```

```bash
node scripts/run-oxlint.mjs src/media/web-media.ts
  ✓ clean
```

**Observed result after fix**: Valid `.vcf` files are accepted through the host-read path. `.vcf` files with binary content tails are rejected by the full-buffer text validator. Non-vCard text formats are unchanged.

**What was not tested**: Live Telegram E2E with a real `.vcf` send. The `loadWebMedia` function is the exact entry point used by the agent's MEDIA: handler; the fix is verified through direct function calls and focused tests.

## Regression Test Plan

- `node scripts/run-vitest.mjs src/media/web-media.test.ts --run`
  - Test Files  1 passed (1)
  - Tests      77 passed (77)
- `node scripts/run-oxlint.mjs src/media/web-media.ts` — clean

## AI Assistance

- **AI-assisted**: Yes
- **Model used**: Claude Opus 4.8 (1M context)
- **Co-Authored-By**: Already in commit message
