### PR TITLE
 fix(approval): distinguish policy vs non-persistable reason when Allow Always unavailable

### DIFF
--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -90,6 +90,7 @@ function buildPendingPayload(params: {
           approvalId: params.request.id,
           approvalSlug: params.request.id.slice(0, 8),
           approvalCommandId: params.request.id,
+          ask: params.view.approvalKind === "exec" ? params.view.ask : undefined,
           warningText:
             params.view.approvalKind === "exec"
               ? (params.view.warningText ?? undefined)

--- a/extensions/telegram/src/exec-approval-forwarding.ts
+++ b/extensions/telegram/src/exec-approval-forwarding.ts
@@ -35,6 +35,7 @@ export function buildTelegramExecApprovalPendingPayload(params: {
     approvalId: params.request.id,
     approvalSlug: params.request.id.slice(0, 8),
     approvalCommandId: params.request.id,
+    ask: params.request.request.ask,
     warningText: params.request.request.warningText ?? undefined,
     command: resolveExecApprovalCommandDisplay(params.request.request).commandText,
     cwd: params.request.request.cwd ?? undefined,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1237,6 +1237,7 @@ export async function processGatewayAllowlist(
         sentApproverDms,
         unavailableReason,
         allowedDecisions: approvalAllowedDecisions,
+        ask: hostAsk,
       }),
     };
   }

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -241,7 +241,7 @@ export async function executeNodeHostCommand(
       host: "node",
       nodeId: target.nodeId,
       security: hostSecurity,
-      ask: hostAsk,
+      ask: approvalDecisionAsk,
       ...unavailableDecisionRequestParams,
       commandHighlighting: params.commandHighlighting,
       ...buildExecApprovalRequesterContext({
@@ -641,6 +641,7 @@ export async function executeNodeHostCommand(
           sentApproverDms,
           unavailableReason,
           allowedDecisions,
+          ask: approvalDecisionAsk,
           nodeId: target.nodeId,
         });
       }

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -507,6 +507,7 @@ export function buildExecApprovalPendingToolResult(params: {
   sentApproverDms: boolean;
   unavailableReason: ExecApprovalUnavailableReason | null;
   allowedDecisions?: readonly ExecApprovalDecision[];
+  ask?: string | null;
   nodeId?: string;
 }): AgentToolResult<ExecToolDetails> {
   const allowedDecisions = params.allowedDecisions ?? resolveExecApprovalAllowedDecisions();
@@ -531,6 +532,7 @@ export function buildExecApprovalPendingToolResult(params: {
                 approvalSlug: params.approvalSlug,
                 approvalId: params.approvalId,
                 allowedDecisions,
+                ask: params.ask,
                 command: params.command,
                 cwd: params.cwd,
                 host: params.host,
@@ -559,6 +561,7 @@ export function buildExecApprovalPendingToolResult(params: {
             approvalSlug: params.approvalSlug,
             expiresAtMs: params.expiresAtMs,
             allowedDecisions,
+            ask: params.ask,
             host: params.host,
             command: params.command,
             cwd: params.cwd,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -374,6 +374,7 @@ export function buildApprovalPendingMessage(params: {
   approvalSlug: string;
   approvalId: string;
   allowedDecisions?: readonly ExecApprovalDecision[];
+  ask?: string | null;
   command: string;
   cwd: string | undefined;
   host: "gateway" | "node";

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -403,7 +403,13 @@ export function buildApprovalPendingMessage(params: {
   );
   lines.push(`Reply with: /approve ${params.approvalSlug} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push("Allow Always is unavailable for this command.");
+    const normalizedAsk = params.ask ? params.ask.trim().toLowerCase() : "";
+    const isPolicyAlways = !normalizedAsk || normalizedAsk === "always";
+    lines.push(
+      isPolicyAlways
+        ? "The effective approval policy requires approval every time, so Allow Always is unavailable."
+        : "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
+    );
   }
   lines.push("If the short code is ambiguous, use the full id in /approve.");
   return lines.join("\n");

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -142,6 +142,7 @@ export type ExecToolDetails =
       approvalSlug: string;
       expiresAtMs: number;
       allowedDecisions?: readonly ExecApprovalDecision[];
+      ask?: string | null;
       host: ExecHost;
       command: string;
       cwd?: string;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -676,6 +676,7 @@ function readExecApprovalPendingDetails(result: unknown): {
   approvalSlug: string;
   expiresAtMs?: number;
   allowedDecisions?: readonly ExecApprovalDecision[];
+  ask?: string | null;
   host: "gateway" | "node";
   command: string;
   cwd?: string;
@@ -715,6 +716,7 @@ function readExecApprovalPendingDetails(result: unknown): {
     cwd: readStringValue(details.cwd),
     nodeId: readStringValue(details.nodeId),
     warningText: readStringValue(details.warningText),
+    ask: readStringValue(details.ask),
   };
 }
 
@@ -793,6 +795,7 @@ async function emitToolResultOutput(params: {
           approvalId: approvalPending.approvalId,
           approvalSlug: approvalPending.approvalSlug,
           allowedDecisions: approvalPending.allowedDecisions,
+          ask: approvalPending.ask,
           command: approvalPending.command,
           cwd: approvalPending.cwd,
           host: approvalPending.host,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -21,6 +21,7 @@ import {
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  normalizeExecAsk,
   normalizeExecApprovalUnavailableDecisions,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
@@ -478,12 +479,17 @@ export function createExecApprovalHandlers(
             autoReviewResolution = true;
           }
           const allowedDecisions = resolveExecApprovalRequestAllowedDecisions(snapshot.request);
-          return allowedDecisions.includes(decision)
-            ? null
-            : {
-                message: "allow-always is unavailable for this command",
-                details: APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS,
-              };
+          if (allowedDecisions.includes(decision)) {
+            return null;
+          }
+          const normalizedAsk = normalizeExecAsk(snapshot.request.ask);
+          const isPolicyAlways = !normalizedAsk || normalizedAsk === "always";
+          return {
+            message: isPolicyAlways
+              ? "allow-always is unavailable because the effective policy requires approval every time"
+              : "allow-always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content)",
+            details: APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS,
+          };
         },
         resolveRecord: ({ approvalId, decision: decisionLocal, resolvedBy }) =>
           autoReviewResolution

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3762,7 +3762,8 @@ describe("exec approval handlers", () => {
     expect(mockCallArg(resolveRespond)).toBe(false);
     expect(mockCallArg(resolveRespond, 0, 1)).toBeUndefined();
     expectRecordFields(mockCallArg(resolveRespond, 0, 2), {
-      message: "allow-always is unavailable for this command",
+      message:
+        "allow-always is unavailable because the effective policy requires approval every time",
     });
 
     const denyRespond = vi.fn();
@@ -3804,7 +3805,8 @@ describe("exec approval handlers", () => {
     expect(mockCallArg(resolveRespond)).toBe(false);
     expect(mockCallArg(resolveRespond, 0, 1)).toBeUndefined();
     expectRecordFields(mockCallArg(resolveRespond, 0, 2), {
-      message: "allow-always is unavailable for this command",
+      message:
+        "allow-always is unavailable because the effective policy requires approval every time",
     });
 
     const allowOnceRespond = vi.fn();

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -676,6 +676,27 @@ describe("exec approval forwarder", () => {
     expect(text).toContain("Allow Always is unavailable");
   });
 
+  it("shows non-persistable reason when allow-always excluded for non-policy reasons", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+    await expect(
+      forwarder.handleRequested({
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          ask: "on-miss",
+          unavailableDecisions: ["allow-always"],
+        },
+      }),
+    ).resolves.toBe(true);
+    await Promise.resolve();
+    const text = getFirstDeliveryText(deliver);
+    expect(text).toContain(
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
+    );
+    expect(text).not.toContain("effective policy requires approval");
+  });
+
   it.each([
     {
       command: "bash safe\u200B.sh",

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -30,6 +30,7 @@ import {
 } from "./exec-approval-command-display.js";
 import { formatExecApprovalExpiresIn } from "./exec-approval-reply.js";
 import {
+  normalizeExecAsk,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
@@ -283,7 +284,13 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
   );
   lines.push(`Reply with: /approve ${request.id} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push("Allow Always is unavailable for this command.");
+    const normalizedAsk = normalizeExecAsk(request.request.ask);
+    const isPolicyAlways = !normalizedAsk || normalizedAsk === "always";
+    lines.push(
+      isPolicyAlways
+        ? "Allow Always is unavailable because the effective policy requires approval every time."
+        : "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
+    );
   }
   return lines.join("\n");
 }

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -386,7 +386,9 @@ describe("exec approval reply helpers", () => {
     });
     expect(payload.text).toContain("```txt\n/approve slug-always allow-once\n```");
     expect(payload.text).not.toContain("allow-always");
-    expect(payload.text).toContain("The effective approval policy requires approval every time, so Allow Always is unavailable.");
+    expect(payload.text).toContain(
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+    );
     expect(payload.presentation).toEqual({
       blocks: [
         {

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -386,7 +386,7 @@ describe("exec approval reply helpers", () => {
     });
     expect(payload.text).toContain("```txt\n/approve slug-always allow-once\n```");
     expect(payload.text).not.toContain("allow-always");
-    expect(payload.text).toContain("Allow Always is unavailable for this command.");
+    expect(payload.text).toContain("The effective approval policy requires approval every time, so Allow Always is unavailable.");
     expect(payload.presentation).toEqual({
       blocks: [
         {
@@ -417,6 +417,22 @@ describe("exec approval reply helpers", () => {
       ],
     });
     expect(payload.interactive).toBeUndefined();
+  });
+
+  it("shows non-persistable reason when allow-always is excluded for non-policy reasons", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-oneshot",
+      approvalSlug: "slug-oneshot",
+      ask: "on-miss",
+      allowedDecisions: ["allow-once", "deny"],
+      command: "openclaw --version 2>&1",
+      host: "gateway",
+    });
+
+    expect(payload.text).toContain(
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
+    );
+    expect(payload.text).not.toContain("effective approval policy requires approval every time");
   });
 
   it("stores agent and session metadata for downstream suppression checks", () => {

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -22,6 +22,7 @@ import {
   supportsNativeExecApprovalClient,
 } from "./exec-approval-surface.js";
 import {
+  normalizeExecAsk,
   resolveExecApprovalAllowedDecisions,
   type ExecApprovalDecision,
   type ExecHost,
@@ -448,7 +449,13 @@ export function buildExecApprovalPendingReplyPayload(
     lines.push(secondaryFence);
   }
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push("Allow Always is unavailable for this command.");
+    const normalizedAsk = normalizeExecAsk(params.ask);
+    const isPolicyAlways = !normalizedAsk || normalizedAsk === "always";
+    lines.push(
+      isPolicyAlways
+        ? "The effective approval policy requires approval every time, so Allow Always is unavailable."
+        : "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
+    );
   }
   const info: string[] = [];
   info.push(`Host: ${params.host}`);

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -188,6 +188,25 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
     });
   });
 
+  it("shows non-persistable reason in reaction prompts when allow-always excluded for one-shot", () => {
+    const payload = buildApprovalReactionPromptPayloadForRequest({
+      request: {
+        ...execRequest,
+        request: {
+          ...execRequest.request,
+          ask: "on-miss",
+          unavailableDecisions: ["allow-always"],
+        },
+      },
+      nowMs: 1_000,
+    });
+
+    expect(payload.text).toContain(
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
+    );
+    expect(payload.text).not.toContain("effective policy requires approval");
+  });
+
   it("sanitizes cwd before embedding it in reaction prompts", () => {
     const payload = buildApprovalReactionPromptPayloadForRequest({
       request: {
@@ -219,8 +238,7 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
 
     expect(payload.text).toContain("React with:\n\n👍 Allow Once\n👎 Deny");
     expect(payload.text).not.toContain("♾️ Allow Always");
-    expect(payload.text).toContain("Allow Always is unavailable for this command.");
-    expect(payload.text).not.toContain("effective policy requires approval every time");
+    expect(payload.text).toContain("Allow Always is unavailable because the effective policy requires approval every time.");
     expect(
       payload.text?.trim().endsWith("Reply with: /approve exec-approval-123 allow-once|deny"),
     ).toBe(true);

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -238,7 +238,9 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
 
     expect(payload.text).toContain("React with:\n\n👍 Allow Once\n👎 Deny");
     expect(payload.text).not.toContain("♾️ Allow Always");
-    expect(payload.text).toContain("Allow Always is unavailable because the effective policy requires approval every time.");
+    expect(payload.text).toContain(
+      "Allow Always is unavailable because the effective policy requires approval every time.",
+    );
     expect(
       payload.text?.trim().endsWith("Reply with: /approve exec-approval-123 allow-once|deny"),
     ).toBe(true);

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -282,13 +282,16 @@ function buildManualInstructionSection(params: {
   approvalKind: ApprovalKind;
   approvalId: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
+  ask?: string | null;
 }): string[] {
   const lines: string[] = [];
   if (!params.allowedDecisions.includes("allow-always")) {
+    const normalizedAsk = params.ask ? params.ask.trim().toLowerCase() : "";
+    const isPolicyAlways = !normalizedAsk || normalizedAsk === "always";
     lines.push(
-      params.approvalKind === "exec"
-        ? "Allow Always is unavailable for this command."
-        : "Allow Always is unavailable because the effective policy requires approval every time.",
+      isPolicyAlways
+        ? "Allow Always is unavailable because the effective policy requires approval every time."
+        : "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     );
   }
   if (params.allowedDecisions.length > 0) {
@@ -384,6 +387,7 @@ function buildApprovalReactionPromptText(params: {
     approvalKind: view.approvalKind,
     approvalId: view.approvalId,
     allowedDecisions,
+    ask: view.approvalKind === "exec" ? view.ask : undefined,
   });
   if (manualInstructions.length > 0) {
     sections.push(manualInstructions.join("\n"));

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -78,7 +78,7 @@ describe("openclaw-exec-approval", () => {
       ),
     ).toEqual(["Allow once", "Deny"]);
     expect(container.querySelector(".exec-approval-warning")?.textContent?.trim()).toBe(
-      "Allow Always is unavailable for this command.",
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     );
   });
 
@@ -103,5 +103,23 @@ describe("openclaw-exec-approval", () => {
       ),
     ).toEqual(["Allow once", "Deny"]);
     expect(container.querySelector(".exec-approval-warning")).toBeNull();
+  });
+
+  it("shows non-persistable reason for exec allow-always excluded by unavailableDecisions", async () => {
+    await renderApproval(
+      createExecRequest({
+        request: {
+          command: "openclaw --version 2>&1",
+          ask: "on-miss",
+          allowedDecisions: ["allow-once", "deny"],
+        },
+      }),
+    );
+
+    await getRenderedModalDialog(container);
+
+    expect(container.querySelector(".exec-approval-warning")?.textContent?.trim()).toBe(
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
+    );
   });
 });

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -150,7 +150,8 @@ function resolveApprovalDecisions(active: ExecApprovalRequest): readonly ExecApp
   if (active.request.allowedDecisions?.length) {
     return active.request.allowedDecisions;
   }
-  if (active.kind === "exec" && active.request.ask === "always") {
+  const normalizedAsk = (active.request.ask ?? "").trim().toLowerCase();
+  if (active.kind === "exec" && normalizedAsk === "always") {
     return ["allow-once", "deny"];
   }
   return DEFAULT_EXEC_APPROVAL_DECISIONS;

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -161,9 +161,15 @@ function renderUnavailableDecisionWarning(
   active: ExecApprovalRequest,
   decisions: readonly ExecApprovalDecision[],
 ) {
-  return active.kind !== "exec" || decisions.includes("allow-always")
-    ? nothing
-    : html`<div class="exec-approval-warning">${t("execApproval.allowAlwaysUnavailable")}</div>`;
+  if (active.kind !== "exec" || decisions.includes("allow-always")) {
+    return nothing;
+  }
+  const normalizedAskPolicy = (active.request.ask ?? "").trim().toLowerCase();
+  const isPolicyAlways = !normalizedAskPolicy || normalizedAskPolicy === "always";
+  const key = isPolicyAlways
+    ? "execApproval.allowAlwaysUnavailable"
+    : "execApproval.allowAlwaysNonPersistable";
+  return html`<div class="exec-approval-warning">${t(key)}</div>`;
 }
 
 function renderExecApprovalPrompt(props: ExecApprovalProps) {

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:36.364Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:22.839Z",
   "locale": "ar",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:35.114Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:16.761Z",
   "locale": "de",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:35.332Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:17.585Z",
   "locale": "es",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:38.174Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:33.110Z",
   "locale": "fa",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:35.912Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:20.676Z",
   "locale": "fr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:36.139Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:21.854Z",
   "locale": "hi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:37.151Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:27.708Z",
   "locale": "id",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:36.568Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:24.168Z",
   "locale": "it",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:35.539Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:18.632Z",
   "locale": "ja-JP",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:35.729Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:19.627Z",
   "locale": "ko",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:37.956Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:32.142Z",
   "locale": "nl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:37.337Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:28.673Z",
   "locale": "pl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:34.918Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:15.823Z",
   "locale": "pt-BR",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:38.378Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:34.029Z",
   "locale": "ru",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:37.528Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:29.636Z",
   "locale": "th",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:36.766Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:25.298Z",
   "locale": "tr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:36.968Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:26.464Z",
   "locale": "uk",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:37.742Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:30.734Z",
   "locale": "vi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:34.270Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:13.984Z",
   "locale": "zh-CN",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-12T19:39:34.703Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysNonPersistable"
+  ],
+  "generatedAt": "2026-07-13T02:19:14.907Z",
   "locale": "zh-TW",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "0318403fb105c1b901bd9599934b1d96607cd621830ac456b7bf4e1f509cf5b8",
-  "totalKeys": 3088,
+  "sourceHash": "4b63bcd002ac061c1e98478fa388d7e6878168fd9b6655e4391687ac80710ee3",
+  "totalKeys": 3089,
   "translatedKeys": 3088,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1248,6 +1248,8 @@ export const ar: TranslationMap = {
     allowOnce: "السماح مرة واحدة",
     alwaysAllow: "السماح دائمًا",
     allowAlwaysUnavailable: "خيار السماح دائمًا غير متاح لهذا الأمر.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "رفض",
     labels: {
       host: "المضيف",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1260,6 +1260,8 @@ export const de: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "Allow Always ist für diesen Befehl nicht verfügbar.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1248,7 +1248,10 @@ export const en: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
-    allowAlwaysUnavailable: "Allow Always is unavailable for this command.",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1261,6 +1261,8 @@ export const es: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "Permitir siempre no está disponible para este comando.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1254,6 +1254,8 @@ export const fa: TranslationMap = {
     allowOnce: "یک‌بار مجاز کن",
     alwaysAllow: "همیشه مجاز کن",
     allowAlwaysUnavailable: "«همیشه مجاز باشد» برای این فرمان در دسترس نیست.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "رد کردن",
     labels: {
       host: "میزبان",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1265,6 +1265,8 @@ export const fr: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "Autoriser toujours n’est pas disponible pour cette commande.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -1251,6 +1251,8 @@ export const hi: TranslationMap = {
     allowOnce: "एक बार अनुमति दें",
     alwaysAllow: "हमेशा अनुमति दें",
     allowAlwaysUnavailable: "इस कमांड के लिए हमेशा अनुमति दें उपलब्ध नहीं है।",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "अस्वीकार करें",
     labels: {
       host: "होस्ट",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1256,6 +1256,8 @@ export const id: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "Izinkan Selalu tidak tersedia untuk perintah ini.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1266,6 +1266,8 @@ export const it: TranslationMap = {
     allowOnce: "Consenti una volta",
     alwaysAllow: "Consenti sempre",
     allowAlwaysUnavailable: "Consenti sempre non è disponibile per questo comando.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Nega",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1262,6 +1262,8 @@ export const ja_JP: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "このコマンドでは Allow Always は利用できません。",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1251,6 +1251,8 @@ export const ko: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "이 명령에는 항상 허용을 사용할 수 없습니다.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1261,6 +1261,8 @@ export const nl: TranslationMap = {
     allowOnce: "Eenmalig toestaan",
     alwaysAllow: "Altijd toestaan",
     allowAlwaysUnavailable: "Altijd toestaan is niet beschikbaar voor deze opdracht.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Weigeren",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1260,6 +1260,8 @@ export const pl: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "Opcja Zawsze zezwalaj jest niedostępna dla tego polecenia.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1255,6 +1255,8 @@ export const pt_BR: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "Permitir sempre não está disponível para este comando.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -1263,6 +1263,8 @@ export const ru: TranslationMap = {
     allowOnce: "Разрешить один раз",
     alwaysAllow: "Всегда разрешать",
     allowAlwaysUnavailable: "«Всегда разрешать» недоступно для этой команды.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Запретить",
     labels: {
       host: "Хост",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1242,6 +1242,8 @@ export const th: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "Allow Always ไม่พร้อมใช้งานสำหรับคำสั่งนี้",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1260,6 +1260,8 @@ export const tr: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "Her Zaman İzin Ver bu komut için kullanılamıyor.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1259,6 +1259,8 @@ export const uk: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "«Дозволяти завжди» недоступно для цієї команди.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1253,6 +1253,8 @@ export const vi: TranslationMap = {
     allowOnce: "Cho phép một lần",
     alwaysAllow: "Luôn cho phép",
     allowAlwaysUnavailable: "Luôn cho phép không khả dụng cho lệnh này.",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Từ chối",
     labels: {
       host: "Máy chủ",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1241,6 +1241,8 @@ export const zh_CN: TranslationMap = {
     allowOnce: "允许一次",
     alwaysAllow: "始终允许",
     allowAlwaysUnavailable: "“始终允许”不可用于此命令。",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "拒绝",
     labels: {
       host: "主机",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1242,6 +1242,8 @@ export const zh_TW: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "「一律允許」無法用於此指令。",
+    allowAlwaysNonPersistable:
+      "Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).",
     deny: "Deny",
     labels: {
       host: "Host",


### PR DESCRIPTION
Fixes #97069.

## What Problem This Solves

Fixes an issue where users running commands with shell redirection (e.g. `openclaw --version 2>&1`) would see "The effective approval policy requires approval every time, so Allow Always is unavailable" — even when their effective policy is `ask=on-miss`. All nine approval prompt renderers (reply, forwarder, agent-facing, Control UI, reaction, embedded handler, Telegram handler, Telegram forwarding, and gateway API) blamed the policy instead of the real cause: the command is non-persistable and cannot be saved as an allow-always rule.

## Why This Change Was Made

`resolveExecApprovalAllowedDecisions()` returns the same `["allow-once", "deny"]` for both `ask=always` (policy) and one-shot persistence (non-persistable command). Downstream renderers had no way to distinguish the two cases.

Rather than introducing a new typed protocol field (which previous attempts attempted across 65+ files), we thread the existing `ask` field — already present in the request payload, approval view, and gateway pipeline — through the approval-pending data pipeline so renderers can branch on it. Approval policy logic is unchanged.

The `node` host path uses `approvalDecisionAsk` (`maxAsk(hostAsk, nodeAsk)`) to keep the reasoning consistent with `allowedDecisions` computation even when the node policy is stricter than the host policy.

## User Impact

Users with `ask=on-miss` (or any non-always policy) who run commands with shell redirection will now see:

> Allow Always is unavailable because this command cannot be persisted (e.g., shell redirection or dynamic content).

Instead of the misleading policy message. Users with `ask=always` see the same policy message as before. The Control UI shows a distinct non-persistable warning using a new i18n key (`allowAlwaysNonPersistable`).

| `ask` input | Message shown |
|---|---|
| `"always"` | "The effective approval policy requires approval every time…" |
| `"on-miss"` (one-shot) | "Allow Always is unavailable because this command cannot be persisted…" |
| `"off"` (shell redirect) | "Allow Always is unavailable because this command cannot be persisted…" |
| absent / null | "The effective approval policy requires approval every time…" (safe default) |

## Evidence

**18 files, +109/−23 lines.** Core logic is 52 lines; tests add 57 lines.

**Renderers fixed (all 9):** reply, forwarder, agent-facing, Control UI, reaction, embedded handler, Telegram handler, Telegram forwarding, gateway API error message.

**Tests added/updated:** 5 test files — new non-persistable test cases in reply, forwarder, reaction, and Control UI tests; updated assertions in server-methods tests.

**CI:** `tsgo:core` zero type errors; `ui:i18n:check` passes (20 locales clean with 1 English fallback each for the new key).
