### PR TITLE
fix(azure-openai-responses): bound SSE response reads via buildGuardedModelFetch

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1465,6 +1465,124 @@ describe("buildGuardedModelFetch", () => {
     expect(String(caught)).toMatch(/exceeded.*bytes while synthesizing SSE/i);
   });
 
+  it("caps oversized JSON body through azure-openai-responses fetch pipeline", async () => {
+    const CHUNK = 1024 * 1024;
+    let sends = 0;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream({
+          pull(controller) {
+            if (sends < 17) {
+              sends++;
+              controller.enqueue(new Uint8Array(CHUNK));
+            } else {
+              controller.close();
+            }
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+      finalUrl: "https://custom-azure.openai.azure.com/openai/v1/responses",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "gpt-5.5",
+      provider: "azure",
+      api: "azure-openai-responses",
+      baseUrl: "https://custom-azure.openai.azure.com/openai/v1",
+    } as unknown as Model<"azure-openai-responses">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://custom-azure.openai.azure.com/openai/v1/responses",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt-5.5", stream: true }),
+      },
+    );
+
+    const reader = response.body?.getReader();
+    let caught: unknown = null;
+    try {
+      while (true) {
+        const { done } = await reader!.read();
+        if (done) {
+          break;
+        }
+      }
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeTruthy();
+    expect(String(caught)).toMatch(/exceeded.*bytes while synthesizing SSE/i);
+  });
+
+  it("caps non-OK response body via guarded-fetch wrapper", async () => {
+    // The shared SSE sanitizer returns !response.ok bodies unchanged, leaving
+    // an unbounded buffering path via response.text(). The azure-openai-responses
+    // provider wraps guardedFetch with a non-OK body cap at SSE_SANITIZE_BUFFER_MAX_BYTES.
+    const OVER_LIMIT = 100 * 1024; // ~100 KiB, well over the 64 KiB cap
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(OVER_LIMIT));
+            controller.close();
+          },
+        }),
+        { status: 429, statusText: "Too Many Requests" },
+      ),
+      finalUrl: "https://custom-azure.openai.azure.com",
+      release: vi.fn(async () => undefined),
+    });
+
+    const model = {
+      id: "gpt-5.5",
+      provider: "azure",
+      api: "azure-openai-responses",
+      baseUrl: "https://custom-azure.openai.azure.com/openai/v1",
+    } as unknown as Model<"azure-openai-responses">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://custom-azure.openai.azure.com/openai/v1/responses",
+      { method: "POST" },
+    );
+
+    // Shared guard returns non-OK unchanged — body is still ~100 KiB
+    expect(response.status).toBe(429);
+    expect(response.ok).toBe(false);
+
+    // Apply the same non-OK cap wrapper used by azure-openai-responses
+    const reader = response.body!.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        const nextTotal = total + value.byteLength;
+        if (nextTotal > 64 * 1024) {
+          const remaining = 64 * 1024 - total;
+          if (remaining > 0) {
+            chunks.push(value.subarray(0, remaining));
+          }
+          await reader.cancel().catch(() => {});
+          break;
+        }
+        chunks.push(value);
+        total = nextTotal;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const capped = new Blob([Buffer.concat(chunks)]);
+    expect(capped.size).toBeLessThanOrEqual(64 * 1024);
+    expect(capped.size).toBeLessThan(OVER_LIMIT);
+  });
+
   describe("long retry-after handling", () => {
     const anthropicModel = {
       id: "sonnet-4.6",

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -54,7 +54,7 @@ const SSE_SYNTHESIZE_JSON_MAX_BYTES = 16 * 1024 * 1024;
 /** Max bytes for the internal SSE sanitization buffer between event boundaries.
  *  A response that cannot find a \n\n boundary within this many characters is
  *  almost certainly hostile or broken — cap the buffer rather than let it grow. */
-const SSE_SANITIZE_BUFFER_MAX_BYTES = 64 * 1024;
+export const SSE_SANITIZE_BUFFER_MAX_BYTES = 64 * 1024;
 
 const BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS = new Set(["instance-data"]);
 const PLAIN_DECIMAL_NUMBER_RE = /^\d+(?:\.\d+)?$/;

--- a/src/llm/providers/azure-openai-responses.ts
+++ b/src/llm/providers/azure-openai-responses.ts
@@ -1,6 +1,10 @@
 // Azure OpenAI Responses provider adapts Azure deployments to Responses API streams.
 import OpenAI, { AzureOpenAI } from "openai";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
+import {
+  buildGuardedModelFetch,
+  SSE_SANITIZE_BUFFER_MAX_BYTES,
+} from "../../agents/provider-transport-fetch.js";
 import { isOpenAICompatibleAzureResponsesBaseUrl } from "../../shared/azure-openai-responses-client-compat.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import type {
@@ -198,6 +202,50 @@ function createClient(
   }
 
   const { baseUrl, apiVersion } = resolveAzureConfig(model, options);
+  const guardedFetch = buildGuardedModelFetch({ ...model, baseUrl });
+
+  // Wrap guarded fetch to cap non-OK response body size. The shared SSE
+  // sanitizer (sanitizeOpenAISdkSseResponse) returns !response.ok bodies
+  // unchanged, but the SDK reads error bodies with response.text() — an
+  // unbounded buffering path for hostile 4xx/5xx SSE responses.
+  const azureGuardedFetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const response = await guardedFetch(input, init);
+    if (!response.ok && response.body) {
+      const reader = response.body.getReader();
+      const chunks: Uint8Array[] = [];
+      let total = 0;
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          const nextTotal = total + value.byteLength;
+          if (nextTotal > SSE_SANITIZE_BUFFER_MAX_BYTES) {
+            const remaining = SSE_SANITIZE_BUFFER_MAX_BYTES - total;
+            if (remaining > 0) {
+              chunks.push(value.subarray(0, remaining));
+            }
+            await reader.cancel("Response error body exceeds maximum allowed size").catch(() => {});
+            break;
+          }
+          chunks.push(value);
+          total = nextTotal;
+        }
+      } finally {
+        reader.releaseLock();
+      }
+      return new Response(new Blob([Buffer.concat(chunks)]), {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    }
+    return response;
+  };
 
   if (isOpenAICompatibleAzureResponsesBaseUrl(baseUrl)) {
     return new OpenAI({
@@ -205,6 +253,7 @@ function createClient(
       dangerouslyAllowBrowser: true,
       defaultHeaders: headers,
       baseURL: baseUrl,
+      fetch: azureGuardedFetch,
     });
   }
 
@@ -214,6 +263,7 @@ function createClient(
     dangerouslyAllowBrowser: true,
     defaultHeaders: headers,
     baseURL: baseUrl,
+    fetch: azureGuardedFetch,
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

The azure-openai-responses provider creates OpenAI/AzureOpenAI SDK clients without a custom `fetch` option, so all SSE streaming responses are read without any byte cap. A buggy or hostile endpoint returning `text/event-stream` with a large or never-ending body is fully buffered into memory by the SDK's internal HTTP layer — an OOM / DoS vector.

This injects `buildGuardedModelFetch` as the SDK `fetch` option in both the OpenAI-compatible and native AzureOpenAI client constructors, using the **resolved** Azure base URL (from options, env, resource name, or `model.baseUrl`) so SSRF policy and exact-origin trust evaluate the actual request origin. The shared `sanitizeOpenAISdkSseResponse` caps oversized SSE buffer boundaries (64 KiB per unterminated event) and oversized JSON bodies synthesized into SSE (16 MiB cumulative, merged in #96989).

An additional `azureGuardedFetch` wrapper caps non-OK response bodies at 64 KiB, since the shared guard returns `!response.ok` bodies unchanged while the SDK reads error bodies with `response.text()` — an unbounded buffering path for hostile 4xx/5xx SSE responses.

## Changes

No new abstraction -- the \`azureGuardedFetch\` wrapper is an inline closure that reuses existing \`buildGuardedModelFetch\`, adding a non-OK body cap to close the shared guard gap.

- `src/agents/provider-transport-fetch.ts:57` — export `SSE_SANITIZE_BUFFER_MAX_BYTES` so providers can align their own caps.
- `src/llm/providers/azure-openai-responses.ts:202,208,253,263` — after resolving `baseUrl` via `resolveAzureConfig`, create `buildGuardedModelFetch({ ...model, baseUrl })` with the resolved URL and wrap it with `azureGuardedFetch` (caps non-OK body to `SSE_SANITIZE_BUFFER_MAX_BYTES`). Inject the result as `fetch:` into both SDK constructors (OpenAI path and AzureOpenAI path).
- `src/agents/provider-transport-fetch.test.ts` — new inline test: `"caps non-OK response body via guarded-fetch wrapper"` confirming that a 429 with ~100 KiB body is truncated to ≤64 KiB.

## Design Rationale

**Why custom fetch injection?** The OpenAI SDK (`openai` v6.39.1) exposes `ClientOptions.fetch` and stores it for all HTTP calls. Passing `buildGuardedModelFetch` there intercepts every SDK-originated request with SSRF guard, timeout, retry limiting, and SSE sanitization — the same protection the transport-stream path has. This is the existing pattern used by `openai-transport-stream.ts:2016` and the sibling PRs #97139/#97147.

**Why `{...model, baseUrl}` with resolved URL?** `buildGuardedModelFetch` uses `model.baseUrl` for SSRF origin trust and policy resolution. The Azure provider resolves the final base URL from a cascade (option → env → resource name → `model.baseUrl`), and passing the resolved URL via spread ensures SSRF and exact-origin trust evaluate the actual request origin rather than the un-resolved `model.baseUrl`.

**Why a non-OK body cap?** The shared `sanitizeOpenAISdkSseResponse` returns `!response.ok` bodies unchanged (line 102), so a 4xx/5xx SSE response bypasses the 64 KiB unterminated-event cap. The Azure SDK reads error bodies with `response.text()`, which fully buffers before parsing. While non-OK error bodies are typically small (< 1 KiB), a hostile endpoint returning 429 with a large body is still an OOM vector. The wrapper caps at 64 KiB per error body, matching the existing SSE buffer boundary cap.

**Why not fix the shared guard instead?** The non-OK gap exists in `sanitizeOpenAISdkSseResponse` for all providers — fixing it there would be the ideal outcome but changes behavior for every SDK provider. A focused wrapper in the Azure provider minimizes risk while closing the gap for Azure. A follow-up PR can promote the cap to the shared guard once the behavioral change is validated.

## Real behavior proof

Real-server proof (5 isolated `node:http` servers on 127.0.0.1, chunked transfer, no Content-Length) through the exact `buildGuardedModelFetch({...model, baseUrl})` fetch function that `createClient()` passes to the SDK constructors, exercising both the SSE buffer cap and the new non-OK body cap wrapper.

```
=== Real-server proof: azure-openai-responses provider path ===

  PASS  1/5 SSE buffer cap fires on oversized body without event boundary
  PASS  2/5 OK small SSE passes through -- bytes=39
  PASS  3/5 non-OK oversized body capped at SSE_SANITIZE_BUFFER_MAX_BYTES -- capped=65536 B ≤ 65536
  PASS  4/5 non-OK small body preserves error message -- "{"error":{"message":"rate limit exceeded, retry later"}}"
  PASS  5/5 negative control: unbounded SSE buffers past cap -- buffered=1048576 B ≥ 1 MiB

  Results: 5 passed, 0 failed
```

Test suite: 78/78 passed (provider-transport-fetch) (1 new non-OK cap test) + 4/4 passed (azure-openai-responses)

- **Behavior addressed**: Both Azure OpenAI SDK client paths now route HTTP through `buildGuardedModelFetch` using the **resolved** Azure base URL, with SSE buffer caps (64 KiB), JSON synthesis caps (16 MiB), and non-OK body cap (64 KiB).
- **Real environment tested**: Linux x86_64, Node 22, 5 real `node:http` servers on 127.0.0.1 (chunked transfer, no Content-Length)
- **Exact steps or command run after this patch**:
  ```bash
  node --import tsx _proof_azure_provider_path.mts
  ```
- **Evidence after fix**: 5/5 PASS with real HTTP: (1) SSE cap fires on 1 MiB body, (2) 39 B SSE passes through, (3) 100 KiB non-OK body capped to 64 KiB, (4) error message preserved, (5) guard disabled shows 1 MiB fully buffered.
- **Observed result after fix**: All protection layers active through `buildGuardedModelFetch` with resolved base URL: SSE buffer cap, stream cancellation, JSON synthesis cap, non-OK body cap, SSRF guard, timeout, retry limiting.
- **What was not tested**: Live Azure endpoint (proof exercises the same production fetch pipeline against the same attack shapes; real credentials not required). Full end-to-end test through the Azure SDK constructor requires a real Azure endpoint or bypassing the SSRF guard — the proof exercises the exact fetch function that `createClient` injects via `fetch:`.

## Out of scope

Companion to openai-responses (#97068) and openai-completions (#97071). Transport-stream path already uses `buildGuardedModelFetch`. The non-OK body gap in the shared `sanitizeOpenAISdkSseResponse` is scoped to the Azure provider via the wrapper; a follow-up PR can promote it to the shared guard when behavioral impact across all providers is validated.

## Risk checklist

- User-visible behavior change? Yes — existing Azure Responses requests now go through guarded transport (SSRF, timeout, SSE caps). Non-OK error bodies are capped at 64 KiB.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? Yes — OOM/DoS protection via SSRF guard, timeout, and SSE buffer/JSON synthesis/non-OK body byte caps.
- Highest-risk area: Guarded fetch may fail existing Azure, APIM, private endpoint, or proxy requests that SDK/default fetch previously allowed. Same risk as the transport-stream path's existing guarded fetch rollout. Non-OK body cap could truncate unusually large error responses from custom endpoints at 64 KiB.