### PR TITLE
fix(openai-completions): bound SSE response reads via buildGuardedModelFetch

### DIFF
--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -17,6 +17,7 @@ import {
   type OpenAICompletionsToolChoice,
   type OpenAIToolProjection,
 } from "../../agents/openai-tool-projection.js";
+import { buildGuardedModelFetch } from "../../agents/provider-transport-fetch.js";
 import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
@@ -608,6 +609,7 @@ function createClient(
     baseURL: isCloudflareProvider(model.provider) ? resolveCloudflareBaseUrl(model) : model.baseUrl,
     dangerouslyAllowBrowser: true,
     defaultHeaders,
+    fetch: buildGuardedModelFetch(model),
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

The openai-completions provider creates an OpenAI SDK client without a custom `fetch` option, so all SSE streaming responses from chat completions are read without any byte cap. A buggy or hostile endpoint returning `text/event-stream` with a large or never-ending body is fully buffered into memory — an OOM / DoS vector.

This injects `buildGuardedModelFetch(model)` as the SDK `fetch` option at `src/llm/providers/openai-completions.ts:609`, matching the existing pattern used by the transport-stream path. The shared `sanitizeOpenAISdkSseResponse` now caps oversized SSE buffer boundaries (64 KiB per unterminated event) and oversized JSON bodies synthesized into SSE (16 MiB cumulative, merged in #96989).

## Changes

No new abstraction — reuses the existing `buildGuardedModelFetch` helper from `src/agents/provider-transport-fetch.ts`.

- `src/llm/providers/openai-completions.ts:609` — inject `fetch: buildGuardedModelFetch(model)` into the OpenAI SDK constructor, replacing the SDK default fetch with the guarded provider fetch pipeline (SSRF guard, timeout, retry limiting, SSE sanitization with byte caps).

## Design Rationale

**Why `buildGuardedModelFetch(model)` without resolved base URL?** Unlike the Azure provider (`azure-openai-responses`) which has a multi-source URL resolution cascade (`azureBaseUrl` / `AZURE_OPENAI_BASE_URL` / `azureResourceName` / `model.baseUrl`), the openai-completions provider gets its base URL directly from `model.baseUrl`. The model's own `baseUrl` is the correct origin for SSRF policy. Sibling providers with more complex URL resolution (Azure) use `{...model, baseUrl: resolvedUrl}`; this provider follows the simpler pattern, matching `openai-responses` (#97139).

**Why 64 KiB SSE buffer cap?** Matches the shared `SSE_SANITIZE_BUFFER_MAX_BYTES` constant used by all sibling providers (openai-responses #97139, azure-openai-responses #97217). The cap fires when the SSE sanitizer's internal buffer cannot find a `\n\n` event boundary within 64 KiB of accumulated data — far above any legitimate SSE event size. A single consistent cap value across all OpenAI SDK providers avoids introducing provider-specific thresholds.

**Why a separate PR from openai-responses (#97139)?** The openai-completions API uses a different client constructor path from openai-responses (completions vs responses). While both inject `buildGuardedModelFetch` into the same OpenAI SDK constructor, separating the PRs keeps each API surface independently revertible and reviewable. This follows the campaign pattern: one PR per SDK client.

**Why no non-OK body cap?** The shared `sanitizeOpenAISdkSseResponse` returns `!response.ok` bodies unchanged. For the openai-completions provider, OpenAI API error responses are always small JSON objects (< 1 KiB). A follow-up shared-guard fix (tracked in azure-openai-responses PR #97217) will add a non-OK cap for all providers.

## Real behavior proof

Real-server proof (node:http on 127.0.0.1, chunked transfer, no Content-Length) through the production `buildGuardedModelFetch` pipeline with `openai-completions` model config. Covers 64 KiB SSE buffer cap, 16 MiB JSON synthesis cap, and happy path. Post-#96989 merge — all caps are active on main.

```
=== Real-server proof: openai-completions fetch pipeline ===

  PASS  oversized SSE without boundary: cap error thrown
       error: Error: SSE response exceeded max buffer size (65536 bytes) without event boundary
  PASS  oversized JSON w/o Content-Length: 16 MiB synthesis cap fires
       error: Error: Streaming JSON body exceeded 16777216 bytes while synthesizing SSE frames
  PASS  small SSE: passes through correctly
       body: 20 bytes

=== Results: 3 passed, 0 failed ===
```

Test suite: 78/78 provider-transport-fetch tests pass (including `openai-completions`-model-path coverage). The `openai-completions` JSON synthesis cap is also tested by the existing `"errors on oversized streaming JSON body without content-length in SSE synthesis"` regression test (provider: openrouter, api: openai-completions).

- **Behavior addressed**: The openai-completions provider now routes HTTP through `buildGuardedModelFetch` with SSE buffer caps (64 KiB) and JSON synthesis caps (16 MiB).
- **Real environment tested**: Linux x86_64, Node 22, real node:http server on 127.0.0.1
- **Exact steps or command run after this patch**:
  ```bash
  node --import tsx _proof_openai_completions_bounded.mts
  ```
- **Evidence after fix**: 3/3 assertions pass with real HTTP server, 64 KiB SSE buffer cap fires for unbounded SSE, 16 MiB JSON synthesis cap fires for oversized JSON body, small 20-byte SSE passes through.
- **Observed result after fix**: All three protection layers active through `buildGuardedModelFetch` for openai-completions provider: (1) 64 KiB SSE buffer boundary cap, (2) 16 MiB JSON synthesis cap, (3) SSRF guard, timeout, retry limiting. Small SSE passes through correctly.
- **What was not tested**: Live OpenAI endpoint (proof exercises the same production fetch pipeline against the same attack shape). Negative control (unbounded read without cap) — the proof focuses on positive assertions that caps fire; the existing 78/78 test suite covers the guard-disabled path via the `sanitizeSse: false` test in `provider-transport-fetch.test.ts`.

## Out of scope

Companion to openai-responses (#97139) and azure-openai-responses (#97217), completing the OpenAI SSE guarded-fetch set.

## Risk checklist

- User-visible behavior change? No.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? Yes — OOM/DoS protection via SSRF guard, timeout, and SSE buffer/JSON synthesis byte caps.
- Highest-risk area: SSRF policy enforcement (same guard as transport-stream path).