### PR TITLE
feat: add tokenomics plugin for local-first LLM spend accounting

### DIFF
--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -173,7 +173,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-68 plugins
+69 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -294,6 +294,8 @@ Each entry lists the package, distribution route, and description.
 - **[tlon](/plugins/reference/tlon)** (`@openclaw/tlon`) - npm; ClawHub. OpenClaw Tlon/Urbit channel plugin for chat workflows.
 
 - **[tokenjuice](/plugins/reference/tokenjuice)** (`@openclaw/tokenjuice`) - npm; ClawHub: `clawhub:@openclaw/tokenjuice`. Compacts exec and bash tool results with tokenjuice reducers.
+
+- **[tokenomics](/plugins/reference/tokenomics)** (`@openclaw/tokenomics`) - npm; ClawHub: `clawhub:@openclaw/tokenomics`. Local-first LLM spend ledger and report (free-vs-paid, avoided/counterfactual) built on OpenClaw's per-call cost data.
 
 - **[twitch](/plugins/reference/twitch)** (`@openclaw/twitch`) - npm; ClawHub. OpenClaw Twitch channel plugin for chat and moderation workflows.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 129
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 130
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/tokenomics.md
+++ b/docs/plugins/reference/tokenomics.md
@@ -1,0 +1,19 @@
+---
+summary: "Local-first LLM spend ledger and report (free-vs-paid, avoided/counterfactual) built on OpenClaw's per-call cost data."
+read_when:
+  - You are installing, configuring, or auditing the tokenomics plugin
+title: "Tokenomics plugin"
+---
+
+# Tokenomics plugin
+
+Local-first LLM spend ledger and report (free-vs-paid, avoided/counterfactual) built on OpenClaw's per-call cost data.
+
+## Distribution
+
+- Package: `@openclaw/tokenomics`
+- Install route: npm; ClawHub: `clawhub:@openclaw/tokenomics`
+
+## Surface
+
+plugin

--- a/extensions/tokenomics/README.md
+++ b/extensions/tokenomics/README.md
@@ -1,0 +1,189 @@
+# @openclaw/tokenomics
+
+Local-first LLM spend accounting for OpenClaw.
+
+**Requires Node.js ≥ 20** (the plugin uses `import` attributes and stable ESM
+that ships with the OpenClaw Gateway). No external runtime dependencies.
+
+This plugin does not maintain its own price list. It **consumes OpenClaw's own
+per-call cost** (the `costUsd` on `model.usage` diagnostics, which OpenClaw
+computes from its provider/model catalog) and adds the layer OpenClaw does not
+have: a durable spend **ledger** plus a **report** — period and by-model
+rollups, a free-vs-paid split, and an avoided-spend / counterfactual headline.
+
+It is host-neutral and offline: nothing leaves the machine, and no pricing feed
+is fetched at runtime. Cost precedence is: the host-reported `costUsd` is
+authoritative; otherwise a free classification yields `$0`; otherwise an
+optional local override catalog estimates it (unknown models stay `$0`, so cost
+is never invented). The avoided-spend baseline is derived from observed spend by
+default (the highest effective `$/Mtok` among paid models actually used), so no
+separate price catalog is required.
+
+## Install
+
+```bash
+openclaw plugins install @openclaw/tokenomics
+```
+
+Restart the Gateway after installing or updating the plugin.
+
+## Enable
+
+```bash
+openclaw plugins enable tokenomics
+```
+
+## How it works
+
+- A startup service subscribes to internal `model.usage` diagnostics and appends
+  a row (`ts_utc`, `provider`, `model`, `tokens_in`, `tokens_out`, `cost_usd`) to
+  `<stateDir>/tokenomics/ledger.jsonl`.
+- Cost precedence: an explicit per-call `costUsd` from the host wins; otherwise a
+  free classification yields `$0`; otherwise the optional pricing catalog
+  (`<stateDir>/tokenomics/pricing.json`) estimates it. Unknown models stay `$0`
+  so cost is never invented.
+
+## Capturing streaming usage
+
+This plugin can only record what `model.usage` reports. For **streaming**
+responses, OpenClaw only asks the provider for a final usage chunk
+(`stream_options: { include_usage: true }`) when the provider's
+`compat.supportsUsageInStreaming` is true. OpenClaw auto-detects this as `false`
+for some OpenAI-compatible providers at a **non-standard base URL** (for example
+a self-hosted or custom enterprise provider). Such providers then return no token
+usage on streamed calls, so `model.usage` carries no tokens and no cost — and the
+call is **not** recorded.
+
+If a provider's streamed calls are missing from the ledger, set that provider's
+`compat.supportsUsageInStreaming: true` in your model config so OpenClaw requests
+usage. The plugin logs a throttled warning when it sees `model.usage` events that
+carry neither tokens nor cost, naming the affected `provider/model`, so this gap
+is visible instead of silent. (Non-streaming calls always include usage and are
+unaffected.)
+
+## Configuration
+
+The plugin requires no configuration keys. Once enabled, the service starts at
+Gateway startup and begins recording spend. Behavior is shaped by two optional
+inputs:
+
+- the report query parameters (below), and
+- an optional pricing catalog file (below).
+
+There is nothing to set under `plugins.entries.tokenomics.config`.
+
+## Spend report
+
+A read-only report is exposed on the Gateway:
+
+```
+GET /api/diagnostics/tokenomics            # JSON report (last 30 days)
+GET /api/diagnostics/tokenomics?format=text
+GET /api/diagnostics/tokenomics?since=2026-06-01&until=2026-06-30&gran=day
+```
+
+Query parameters:
+
+| Parameter | Values                         | Default                |
+| --------- | ------------------------------ | ---------------------- |
+| `since`   | RFC3339 or `YYYY-MM-DD`        | 30 days before `until` |
+| `until`   | RFC3339 or `YYYY-MM-DD`        | now                    |
+| `gran`    | `hour`, `day`, `week`, `month` | `day`                  |
+| `format`  | `json`, `text`                 | `json`                 |
+| `period`  | free-text label                | (empty)                |
+
+A date-only `until` (for example `until=2026-06-30`) is treated as the inclusive
+end of that UTC day. Unparseable `since`/`until` values, or a `since` that is
+later than `until`, return `400 Bad Request`.
+
+The `period` parameter supplies a human-readable window label (e.g.
+`Q2 2026`, `this month`, `YTD 2026`) that appears in both JSON and text report
+output.
+
+Example `?format=text` output:
+
+```
+Tokenomics
+2026-06-01 → 2026-06-30 (30d)
+
+spent          $12.40  (5,200 calls, 8.10M tok)
+avoided        $48.60  free tokens valued at baseline
+counterfactual $61.00  all tokens @ frontier (... /Mtok)
+
+free share     ████████████████░░░░░░░░ 67% free
+
+model            calls     tokens        cost  tag
+frontier           420       2.7M      $12.40  paid
+local-8b          4780       5.4M       $0.00  free
+```
+
+## Optional override catalog
+
+You normally need nothing here — cost comes from OpenClaw's own `costUsd` and the
+baseline is derived from observed spend. For the rare case where the host does
+not report a cost, or you want to pin an explicit baseline, drop a `pricing.json`
+in `<stateDir>/tokenomics/`. Rates are `$ / 1M tokens`. The file is read at
+startup and per report; it is never fetched or written by this plugin.
+
+```json
+{
+  "baseline_model": "frontier",
+  "baseline_usd_per_mtok": 15.0,
+  "models": {
+    "frontier": { "input_usd_per_mtok": 3.0, "output_usd_per_mtok": 15.0 },
+    "local-8b": { "input_usd_per_mtok": 0.0, "output_usd_per_mtok": 0.0 }
+  }
+}
+```
+
+`baseline_usd_per_mtok` (when set) overrides the derived baseline. Model lookup
+tolerates id vs display-name drift (exact, case-insensitive, then `host/leaf`
+suffix match). Models absent from the catalog are charged `$0`, so cost is never
+invented.
+
+Because `pricing.json` can change the avoided-spend and counterfactual headline
+figures, treat it as trusted input: store it under the Gateway state directory
+with the same file permissions as the rest of that directory, and do not accept
+it from untrusted sources.
+
+**File permission requirements:** The plugin enforces that `pricing.json` must
+not be group-writable or world-writable. On macOS/Linux the file must also be
+owned by the same uid as the Gateway process. A file that fails these checks is
+rejected (treated as absent, so cost is never invented) and a warning is logged.
+The safe permission is `0o600` (owner read+write) or `0o400` (owner read-only).
+
+Mode-bit and ownership checks are **POSIX-only** (macOS / Linux). On Windows
+`stat.mode` does not reflect POSIX permissions; the plugin skips the mode
+validation and relies on the OS-level ACL and the Gateway's own state-directory
+protections.
+
+## Design notes
+
+- **Single-user, local-first storage.** The ledger is a per-machine append-only
+  JSONL file and reads are synchronous. This keeps the plugin dependency-free and
+  crash-tolerant for the single-operator workloads it targets. A SQLite-backed
+  store with windowed reads is the intended path if a deployment outgrows it.
+- **Tolerant reads.** A half-written or corrupt ledger line (for example from an
+  interrupted append) is skipped rather than aborting the report; the count of
+  skipped lines is logged as a warning.
+- **Storage location.** The ledger lives at `<stateDir>/tokenomics/ledger.jsonl`
+  inside the Gateway state directory. On a default install this is
+  `~/.openclaw/state/tokenomics/ledger.jsonl`. The optional pricing catalog is
+  `pricing.json` in the same directory.
+- **Operational considerations.** The ledger grows unbounded — one JSON line per
+  model call. At typical operator workloads this remains well under 50 MB/month.
+  If the file grows large, you can truncate it (rename/remove the file while the
+  Gateway is stopped); the plugin will start a new ledger on next startup. No
+  built-in rotation is provided yet. Treat the ledger as a local audit log, not
+  as a system of record — back it up if your workflow requires long-term
+  retention.
+
+## Roadmap
+
+A subscription/plan layer (flat-rate and quota-based plans, with subscription
+ROI vs metered-equivalent cost) is planned, to account for billing models that
+per-token pricing cannot express.
+
+## Package
+
+- Plugin id: `tokenomics`

--- a/extensions/tokenomics/api.ts
+++ b/extensions/tokenomics/api.ts
@@ -1,0 +1,33 @@
+// Tokenomics API module exposes the plugin public contract.
+export type {
+  DiagnosticEventMetadata,
+  DiagnosticEventPayload,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
+export { isInternalDiagnosticEventMetadata } from "openclaw/plugin-sdk/diagnostic-runtime";
+export {
+  type OpenClawPluginApi,
+  type OpenClawPluginHttpRouteHandler,
+  type OpenClawPluginService,
+  type OpenClawPluginServiceContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+
+// FinOps observability surface — served at the report route via `?view=finops`
+// and re-exported here for external tools/consumers. Read-only, non-enforcing.
+export {
+  buildFinOpsReport,
+  cacheSavingsByModel,
+  cheapestEquivalentAdvisor,
+  forecastBurn,
+  realizedRateByModel,
+  spendByDimension,
+} from "./src/finops.js";
+export type {
+  AdvisorRow,
+  BurnForecast,
+  CacheSavingsRow,
+  FinOpsReport,
+  FinOpsTags,
+  ModelRealized,
+  SpendGroup,
+  TaggedLedgerEntry,
+} from "./src/finops.js";

--- a/extensions/tokenomics/index.ts
+++ b/extensions/tokenomics/index.ts
@@ -1,0 +1,21 @@
+// Tokenomics plugin entrypoint registers its OpenClaw integration.
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createTokenomicsService } from "./src/service.js";
+
+const tokenomics = createTokenomicsService();
+
+export default definePluginEntry({
+  id: "tokenomics",
+  name: "Tokenomics",
+  description: "Local-first LLM spend ledger and report built on OpenClaw's per-call cost data",
+  register(api) {
+    api.registerService(tokenomics.service);
+    api.registerHttpRoute({
+      path: "/api/diagnostics/tokenomics",
+      auth: "gateway",
+      match: "exact",
+      gatewayRuntimeScopeSurface: "trusted-operator",
+      handler: tokenomics.handler,
+    });
+  },
+});

--- a/extensions/tokenomics/npm-shrinkwrap.json
+++ b/extensions/tokenomics/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/tokenomics",
+  "version": "2026.6.10",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openclaw/tokenomics",
+      "version": "2026.6.10"
+    }
+  }
+}

--- a/extensions/tokenomics/openclaw.plugin.json
+++ b/extensions/tokenomics/openclaw.plugin.json
@@ -1,0 +1,13 @@
+{
+  "id": "tokenomics",
+  "name": "Tokenomics",
+  "description": "Local-first LLM spend ledger and report (free-vs-paid, avoided/counterfactual) built on OpenClaw's per-call cost data.",
+  "activation": {
+    "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/tokenomics/package.json
+++ b/extensions/tokenomics/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@openclaw/tokenomics",
+  "version": "2026.6.10",
+  "description": "Local-first LLM spend ledger and report (free-vs-paid, avoided/counterfactual) built on OpenClaw's per-call cost data.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./api.js": "./dist/api.js"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/tokenomics",
+      "npmSpec": "@openclaw/tokenomics",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.4.25"
+    },
+    "compat": {
+      "pluginApi": ">=2026.6.10"
+    },
+    "build": {
+      "openclawVersion": "2026.6.10"
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/tokenomics/src/finops.ts
+++ b/extensions/tokenomics/src/finops.ts
@@ -1,0 +1,440 @@
+// FinOps observability layer — read-only, non-enforcing.
+//
+// Provides attribution, realized-rate calculation, cache-discount savings,
+// cheapest-equivalent-model advisor (report only), and simple burn
+// forecasting over the existing append-only ledger. No policy is ever
+// applied: every function returns data for a human (or another tool) to
+// decide. Aligns with the user's stance: zoder is a sole-developer
+// internal fork, so the surface is "observe, attribute, advise, report".
+
+import type { Ledger } from "./ledger.js";
+import type { LedgerEntry } from "./ledger.js";
+import type { PricingCatalog, ModelPrice } from "./pricing.js";
+import { dayKey, monthKey, weekKey } from "./time.js";
+
+// ---------------------------------------------------------------------------
+// LedgerEntry extensions (optional, non-breaking — populated by hosts that
+// have FinOps tagging enabled; absent fields simply produce "untagged" rows).
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional FinOps tags attached to a ledger entry at ingestion time.
+ * Hosts fill these when they know caller / task / tier / cache behavior.
+ * All fields are optional so existing ledger rows (and existing hosts)
+ * remain wire-compatible.
+ */
+export interface FinOpsTags {
+  /** Logical caller identity (e.g. "zoder-cli", "zoder-loop-driver",
+   *  "claude-code", "openclaw-agent-xyz"). */
+  caller?: string;
+  /** Task / project / feature tag (free-form short string). */
+  task?: string;
+  /** Tier label: "free" | "metered" | "premium" | unknown. */
+  tier?: string;
+  /** Fraction of input tokens served from provider cache, [0..1]. */
+  cache_hit_ratio?: number;
+}
+
+/** Extended ledger row, used only by FinOps readers. */
+export interface TaggedLedgerEntry extends LedgerEntry {
+  caller?: string;
+  task?: string;
+  tier?: string;
+  cache_hit_ratio?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Allocation — spend grouped by dimension
+// ---------------------------------------------------------------------------
+
+export interface SpendGroup {
+  key: string;
+  cost_usd: number;
+  tokens_in: number;
+  tokens_out: number;
+  calls: number;
+}
+
+export function spendByDimension(
+  ledger: Ledger,
+  dim: keyof TaggedLedgerEntry,
+  opts?: { since?: Date; until?: Date },
+): SpendGroup[] {
+  const acc = new Map<string, SpendGroup>();
+  for (const row of ledger.entries() as TaggedLedgerEntry[]) {
+    if (opts?.since && new Date(row.ts_utc) < opts.since) {
+      continue;
+    }
+    if (opts?.until && new Date(row.ts_utc) > opts.until) {
+      continue;
+    }
+    const raw = row[dim];
+    const key = raw == null || raw === "" ? "__untagged__" : String(raw);
+    const g =
+      acc.get(key) ?? ({ key, cost_usd: 0, tokens_in: 0, tokens_out: 0, calls: 0 } as SpendGroup);
+    g.cost_usd += row.cost_usd;
+    g.tokens_in += row.tokens_in;
+    g.tokens_out += row.tokens_out;
+    g.calls += 1;
+    acc.set(key, g);
+  }
+  return [...acc.values()].toSorted((a, b) => b.cost_usd - a.cost_usd);
+}
+
+// ---------------------------------------------------------------------------
+// Realized rate — effective $/1M tok, computed from actual ledger entries
+// rather than from catalog prices. Tells you what you *actually* paid per
+// million tokens, which can differ from catalog (free models, negotiated
+// rates, cache discounts, errored calls, etc.).
+// ---------------------------------------------------------------------------
+
+export interface ModelRealized {
+  model: string;
+  cost_usd: number;
+  tokens: number;
+  tokens_in: number;
+  tokens_out: number;
+  calls: number;
+  /** Effective rate, $ per 1M tokens (blended input+output). NaN if no tokens. */
+  realized_usd_per_mtok: number;
+}
+
+export function realizedRateByModel(
+  ledger: Ledger,
+  opts?: { since?: Date; until?: Date },
+): ModelRealized[] {
+  const acc = new Map<string, ModelRealized>();
+  for (const row of ledger.entries()) {
+    if (opts?.since && new Date(row.ts_utc) < opts.since) {
+      continue;
+    }
+    if (opts?.until && new Date(row.ts_utc) > opts.until) {
+      continue;
+    }
+    const tot = row.tokens_in + row.tokens_out;
+    const r =
+      acc.get(row.model) ??
+      ({
+        model: row.model,
+        cost_usd: 0,
+        tokens: 0,
+        tokens_in: 0,
+        tokens_out: 0,
+        calls: 0,
+        realized_usd_per_mtok: Number.NaN,
+      } as ModelRealized);
+    r.cost_usd += row.cost_usd;
+    r.tokens_in += row.tokens_in;
+    r.tokens_out += row.tokens_out;
+    r.tokens += tot;
+    r.calls += 1;
+    acc.set(row.model, r);
+  }
+  for (const r of acc.values()) {
+    r.realized_usd_per_mtok = r.tokens > 0 ? (r.cost_usd / r.tokens) * 1_000_000 : Number.NaN;
+  }
+  return [...acc.values()].toSorted((a, b) => b.cost_usd - a.cost_usd);
+}
+
+// ---------------------------------------------------------------------------
+// Cache-discount savings — credit the user for tokens served from a cheaper
+// cache-read rate vs. the full input rate. Report-only; the provider already
+// applied the discount, this just makes it visible.
+// ---------------------------------------------------------------------------
+
+export interface CacheSavingsRow {
+  model: string;
+  calls: number;
+  tokens_in: number;
+  /** Sum of estimated cache-served tokens (cache_hit_ratio × tokens_in). */
+  est_cached_tokens: number;
+  /** Estimated $ saved vs. paying full input rate on those tokens. */
+  est_savings_usd: number;
+  /** Catalog input rate ($/Mtok). */
+  input_usd_per_mtok: number;
+  /** Catalog cache_read rate ($/Mtok). */
+  cache_read_usd_per_mtok: number;
+}
+
+export function cacheSavingsByModel(
+  ledger: Ledger,
+  pricing: PricingCatalog,
+  opts?: { since?: Date; until?: Date },
+): CacheSavingsRow[] {
+  const rows = new Map<string, CacheSavingsRow>();
+  for (const e of ledger.entries() as TaggedLedgerEntry[]) {
+    if (opts?.since && new Date(e.ts_utc) < opts.since) {
+      continue;
+    }
+    if (opts?.until && new Date(e.ts_utc) > opts.until) {
+      continue;
+    }
+    const hit = e.cache_hit_ratio ?? 0;
+    if (hit <= 0) {
+      continue;
+    }
+    const p = pricing.models.get(e.model);
+    if (!p) {
+      continue;
+    }
+    const cacheRate = p.cache_read_usd_per_mtok ?? 0;
+    const inputRate = p.input_usd_per_mtok ?? p.usd_per_mtok ?? 0;
+    if (inputRate <= 0 || cacheRate >= inputRate) {
+      continue;
+    }
+    const cachedTokens = e.tokens_in * hit;
+    const savings = ((inputRate - cacheRate) * cachedTokens) / 1_000_000;
+    const r =
+      rows.get(e.model) ??
+      ({
+        model: e.model,
+        calls: 0,
+        tokens_in: 0,
+        est_cached_tokens: 0,
+        est_savings_usd: 0,
+        input_usd_per_mtok: inputRate,
+        cache_read_usd_per_mtok: cacheRate,
+      } as CacheSavingsRow);
+    r.calls += 1;
+    r.tokens_in += e.tokens_in;
+    r.est_cached_tokens += cachedTokens;
+    r.est_savings_usd += savings;
+    rows.set(e.model, r);
+  }
+  return [...rows.values()].toSorted((a, b) => b.est_savings_usd - a.est_savings_usd);
+}
+
+// ---------------------------------------------------------------------------
+// Cheapest-equivalent-model advisor — REPORT ONLY, never enforced.
+// For each billed (non-free) model in the window, compute what the same
+// token volume would have cost at the next-cheapest billed model. Useful
+// for spotting "you're paying Sonnet rates for tasks Llama-3 handles".
+// ---------------------------------------------------------------------------
+
+export interface AdvisorRow {
+  paid_model: string;
+  paid_cost_usd: number;
+  calls: number;
+  tokens: number;
+  cheapest_alt_model: string;
+  cheapest_alt_usd_per_mtok: number;
+  cheapest_alt_estimated_cost_usd: number;
+  /** Absolute $ you'd save by switching wholesale. */
+  potential_savings_usd: number;
+  /** Same number expressed as a fraction of the paid cost (0..1). */
+  potential_savings_ratio: number;
+}
+
+function effectiveRate(p: ModelPrice): number {
+  // Prefer per-component: assume a 70/30 input/output mix as a heuristic
+  // when only a blended rate is known. This is a report-only heuristic.
+  if (p.input_usd_per_mtok || p.output_usd_per_mtok) {
+    const i = p.input_usd_per_mtok ?? 0;
+    const o = p.output_usd_per_mtok ?? 0;
+    return 0.7 * i + 0.3 * o;
+  }
+  return p.usd_per_mtok ?? 0;
+}
+
+export function cheapestEquivalentAdvisor(
+  ledger: Ledger,
+  pricing: PricingCatalog,
+  opts?: { since?: Date; until?: Date },
+): AdvisorRow[] {
+  // Build per-model paid spend over the window.
+  const paid = new Map<string, { cost: number; calls: number; tokens: number }>();
+  for (const row of ledger.entries()) {
+    if (opts?.since && new Date(row.ts_utc) < opts.since) {
+      continue;
+    }
+    if (opts?.until && new Date(row.ts_utc) > opts.until) {
+      continue;
+    }
+    if (row.cost_usd <= 0) {
+      continue;
+    }
+    const r = paid.get(row.model) ?? { cost: 0, calls: 0, tokens: 0 };
+    r.cost += row.cost_usd;
+    r.calls += 1;
+    r.tokens += row.tokens_in + row.tokens_out;
+    paid.set(row.model, r);
+  }
+  if (paid.size === 0) {
+    return [];
+  }
+
+  // Build rate table for all priced (non-free) models in the catalog.
+  const rates: { model: string; rate: number }[] = [];
+  for (const [modelId, p] of pricing.models.entries()) {
+    const r = effectiveRate(p);
+    if (r > 0) {
+      rates.push({ model: modelId, rate: r });
+    }
+  }
+  rates.sort((a, b) => a.rate - b.rate);
+
+  const out: AdvisorRow[] = [];
+  for (const [model, r] of paid) {
+    // Cheapest alt = lowest-rate model that's not the same one.
+    const alt = rates.find((x) => x.model !== model) ?? null;
+    if (!alt) {
+      out.push({
+        paid_model: model,
+        paid_cost_usd: r.cost,
+        calls: r.calls,
+        tokens: r.tokens,
+        cheapest_alt_model: "(none — paid model is cheapest in catalog)",
+        cheapest_alt_usd_per_mtok: 0,
+        cheapest_alt_estimated_cost_usd: 0,
+        potential_savings_usd: 0,
+        potential_savings_ratio: 0,
+      });
+      continue;
+    }
+    const altCost = (alt.rate * r.tokens) / 1_000_000;
+    const savings = Math.max(0, r.cost - altCost);
+    out.push({
+      paid_model: model,
+      paid_cost_usd: r.cost,
+      calls: r.calls,
+      tokens: r.tokens,
+      cheapest_alt_model: alt.model,
+      cheapest_alt_usd_per_mtok: alt.rate,
+      cheapest_alt_estimated_cost_usd: altCost,
+      potential_savings_usd: savings,
+      potential_savings_ratio: r.cost > 0 ? savings / r.cost : 0,
+    });
+  }
+  return out.toSorted((a, b) => b.potential_savings_usd - a.potential_savings_usd);
+}
+
+// ---------------------------------------------------------------------------
+// Forecast — simple linear projection of $/day from the window's daily
+// totals. Naive but useful for a one-person PoC: the whole point is to see
+// a number, not to win a forecasting competition.
+// ---------------------------------------------------------------------------
+
+export interface BurnForecast {
+  window_days: number;
+  avg_daily_cost_usd: number;
+  median_daily_cost_usd: number;
+  trend_usd_per_day: number;
+  forecast_7d_usd: number;
+  forecast_30d_usd: number;
+  sample_days: number;
+}
+
+function linearSlope(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  if (n < 2) {
+    return 0;
+  }
+  const meanX = xs.reduce((a, b) => a + b, 0) / n;
+  const meanY = ys.reduce((a, b) => a + b, 0) / n;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n; i++) {
+    num += (xs[i] - meanX) * (ys[i] - meanY);
+    den += (xs[i] - meanX) ** 2;
+  }
+  return den === 0 ? 0 : num / den;
+}
+
+function median(nums: number[]): number {
+  if (nums.length === 0) {
+    return 0;
+  }
+  const s = [...nums].toSorted((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 === 0 ? (s[m - 1] + s[m]) / 2 : s[m];
+}
+
+export function forecastBurn(
+  ledger: Ledger,
+  opts?: { windowDays?: number; until?: Date },
+): BurnForecast {
+  const windowDays = opts?.windowDays ?? 30;
+  const until = opts?.until ?? new Date();
+  const since = new Date(until.getTime() - windowDays * 86_400_000);
+  const daily = new Map<string, number>();
+  for (const row of ledger.entries()) {
+    const d = new Date(row.ts_utc);
+    if (d < since || d > until) {
+      continue;
+    }
+    const k = dayKey(d);
+    daily.set(k, (daily.get(k) ?? 0) + row.cost_usd);
+  }
+  const keys = [...daily.keys()].toSorted();
+  const ys = keys.map((k) => daily.get(k) ?? 0);
+  const xs = keys.map((_, i) => i);
+  const slope = linearSlope(xs, ys);
+  const meanY = ys.length === 0 ? 0 : ys.reduce((a, b) => a + b, 0) / ys.length;
+  const lastX = xs.length === 0 ? 0 : xs[xs.length - 1];
+  const project = (n: number) => Math.max(0, meanY + slope * (lastX + n));
+  return {
+    window_days: windowDays,
+    avg_daily_cost_usd: meanY,
+    median_daily_cost_usd: median(ys),
+    trend_usd_per_day: slope,
+    forecast_7d_usd: project(7),
+    forecast_30d_usd: project(30),
+    sample_days: ys.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Top-level rollup — the one-shot report a CLI can hand to a user.
+// ---------------------------------------------------------------------------
+
+export interface FinOpsReport {
+  generated: string;
+  since: string;
+  until: string;
+  total_cost_usd: number;
+  total_tokens: number;
+  total_calls: number;
+  by_caller: SpendGroup[];
+  by_task: SpendGroup[];
+  by_model_realized: ModelRealized[];
+  cache_savings: CacheSavingsRow[];
+  advisor: AdvisorRow[];
+  forecast: BurnForecast;
+}
+
+export function buildFinOpsReport(
+  ledger: Ledger,
+  pricing: PricingCatalog,
+  opts: { since: Date; until: Date; windowDays?: number },
+): FinOpsReport {
+  const totals = { cost: 0, tokens: 0, calls: 0 };
+  for (const r of ledger.entries()) {
+    if (new Date(r.ts_utc) < opts.since || new Date(r.ts_utc) > opts.until) {
+      continue;
+    }
+    totals.cost += r.cost_usd;
+    totals.tokens += r.tokens_in + r.tokens_out;
+    totals.calls += 1;
+  }
+  return {
+    generated: new Date().toISOString(),
+    since: opts.since.toISOString(),
+    until: opts.until.toISOString(),
+    total_cost_usd: totals.cost,
+    total_tokens: totals.tokens,
+    total_calls: totals.calls,
+    by_caller: spendByDimension(ledger, "caller", opts),
+    by_task: spendByDimension(ledger, "task", opts),
+    by_model_realized: realizedRateByModel(ledger, opts),
+    cache_savings: cacheSavingsByModel(ledger, pricing, opts),
+    advisor: cheapestEquivalentAdvisor(ledger, pricing, opts),
+    forecast: forecastBurn(ledger, {
+      windowDays: opts.windowDays ?? 30,
+      until: opts.until,
+    }),
+  };
+}
+
+// Re-export commonly-used helpers for consumers who want to slice the
+// ledger along time periods (matches report.ts conventions).
+export { dayKey, weekKey, monthKey };

--- a/extensions/tokenomics/src/host-adapter.ts
+++ b/extensions/tokenomics/src/host-adapter.ts
@@ -1,0 +1,102 @@
+// Host-neutral ingestion seam.
+//
+// Tokenomics is not tied to any one capture path. A host normalizes its native
+// per-call usage into a {@link UsageEvent} and calls {@link ingest}, which
+// writes a single ledger row. The report/render layers then work identically.
+//
+// Cost precedence: an explicit `costUsd` from the host wins (it's the truth for
+// what was billed). Otherwise, if the model is classified free, cost is $0;
+// else the pricing catalog estimates it. This keeps free-path usage from ever
+// being re-billed while still pricing metered calls the host didn't cost out.
+
+import { Ledger, type LedgerEntry } from "./ledger.js";
+import type { PricingCatalog } from "./pricing.js";
+
+/** Host-neutral record of one model call, before it becomes a ledger row. */
+export interface UsageEvent {
+  /** Provider id (e.g. "anthropic", "openai", "openrouter"). */
+  provider: string;
+  /** Model id as the host reports it. */
+  model: string;
+  tokensIn: number;
+  tokensOut: number;
+  /** Authoritative billed cost when the host knows it; omit to derive. */
+  costUsd?: number;
+  /** ISO-8601 UTC; defaults to now. */
+  tsUtc?: string;
+  /** Which host emitted this (for provenance/debugging). */
+  host?: HostId;
+  /** Host-asserted free classification; overrides the catalog/predicate. */
+  free?: boolean;
+  /** Set when a free-policy guard flagged this spend. */
+  violation?: string;
+}
+
+/** Host that emitted an event. Common values: `pi`, `claude-code`, `codex`, `cursor`, `openclaw`. */
+export type HostId = string;
+
+export interface IngestOptions {
+  pricing?: PricingCatalog;
+  /** Classify a model as free ($0). Beats the catalog; loses to `event.free`. */
+  isFree?: (model: string, provider: string) => boolean;
+  /** Clock injection for tests. */
+  now?: () => Date;
+}
+
+/** Resolve the cost for an event using the precedence rules above. */
+export function resolveCost(event: UsageEvent, opts: IngestOptions = {}): number {
+  if (typeof event.costUsd === "number" && Number.isFinite(event.costUsd)) {
+    return event.costUsd;
+  }
+  const free = event.free ?? opts.isFree?.(event.model, event.provider) ?? false;
+  if (free) {
+    return 0;
+  }
+  return opts.pricing ? opts.pricing.cost(event.model, event.tokensIn, event.tokensOut) : 0;
+}
+
+/** Normalize a {@link UsageEvent} into a persisted {@link LedgerEntry}. */
+export function toLedgerEntry(event: UsageEvent, opts: IngestOptions = {}): LedgerEntry {
+  const now = opts.now ?? (() => new Date());
+  const entry: LedgerEntry = {
+    ts_utc: event.tsUtc ?? now().toISOString(),
+    provider: event.provider,
+    model: event.model,
+    tokens_in: event.tokensIn,
+    tokens_out: event.tokensOut,
+    cost_usd: resolveCost(event, opts),
+  };
+  if (event.violation) {
+    entry.violation = event.violation;
+  }
+  if (event.host) {
+    entry.host = event.host;
+  }
+  return entry;
+}
+
+/** Append one usage event to the ledger. Returns the row written. */
+export function ingest(ledger: Ledger, event: UsageEvent, opts: IngestOptions = {}): LedgerEntry {
+  const entry = toLedgerEntry(event, opts);
+  ledger.record(entry);
+  return entry;
+}
+
+/**
+ * A host adapter binds a ledger + ingestion policy so a host integration only
+ * has to translate its native event into a {@link UsageEvent} and call `track`.
+ */
+export class HostAdapter {
+  readonly ledger: Ledger;
+  constructor(
+    ledgerPath: string,
+    private readonly host: HostId,
+    private readonly opts: IngestOptions = {},
+  ) {
+    this.ledger = new Ledger(ledgerPath);
+  }
+
+  track(event: Omit<UsageEvent, "host">): LedgerEntry {
+    return ingest(this.ledger, { ...event, host: this.host }, this.opts);
+  }
+}

--- a/extensions/tokenomics/src/ledger.ts
+++ b/extensions/tokenomics/src/ledger.ts
@@ -1,0 +1,194 @@
+// Local spend ledger. Append-only JSONL, one record per model call. SQLite is a
+// drop-in later via the same shape.
+
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { dayKey, monthKey, weekKey, yearKey } from "./time.js";
+
+/** One persisted ledger record. */
+export interface LedgerEntry {
+  /** RFC3339 / ISO-8601 timestamp (UTC). */
+  ts_utc: string;
+  provider: string;
+  model: string;
+  tokens_in: number;
+  tokens_out: number;
+  cost_usd: number;
+  /** Set when a post-call free-policy guard flagged this spend. */
+  violation?: string;
+  /** Host that emitted the event, for provenance/debugging. */
+  host?: string;
+}
+
+export type Period = "day" | "week" | "month" | "year";
+
+export function parsePeriod(s: string): Period | undefined {
+  switch (s.toLowerCase()) {
+    case "day":
+    case "daily":
+      return "day";
+    case "week":
+    case "weekly":
+      return "week";
+    case "month":
+    case "monthly":
+      return "month";
+    case "year":
+    case "yearly":
+      return "year";
+    default:
+      return undefined;
+  }
+}
+
+const PERIOD_KEYS: Record<Period, (d: Date) => string> = {
+  day: dayKey,
+  week: weekKey,
+  month: monthKey,
+  year: yearKey,
+};
+
+function periodBucket(period: Period, ts: Date): string {
+  return PERIOD_KEYS[period](ts);
+}
+
+export interface Rollup {
+  cost_usd: number;
+  tokens_in: number;
+  tokens_out: number;
+  calls: number;
+}
+
+function emptyRollup(): Rollup {
+  return { cost_usd: 0, tokens_in: 0, tokens_out: 0, calls: 0 };
+}
+
+/** Optional hooks for ledger reads/writes. */
+export interface LedgerOptions {
+  /** Invoked once per read with the count of skipped malformed lines (> 0). */
+  onMalformed?: (count: number) => void;
+  /** Invoked when a write fails (disk full, permission, etc.). The event is
+   *  dropped; the caller decides whether to retry. When omitted, write
+   *  failures are silently swallowed so they never crash the process. */
+  onError?: (err: unknown) => void;
+}
+
+export class Ledger {
+  private readonly onMalformed?: (count: number) => void;
+  private readonly onError?: (err: unknown) => void;
+  private dirCreated = false;
+
+  constructor(
+    private readonly path: string,
+    opts?: LedgerOptions,
+  ) {
+    this.onMalformed = opts?.onMalformed;
+    this.onError = opts?.onError;
+  }
+
+  /** Append one record as a single line (atomic under O_APPEND). */
+  record(e: LedgerEntry): void {
+    try {
+      if (!this.dirCreated) {
+        mkdirSync(dirname(this.path), { recursive: true });
+        this.dirCreated = true;
+      }
+      appendFileSync(this.path, `${JSON.stringify(e)}\n`, { flag: "a" });
+    } catch (err) {
+      this.onError?.(err);
+    }
+  }
+
+  /**
+   * All records. Per-line tolerant: a single mangled/half-written line (e.g.
+   * from an interrupted append) is skipped rather than aborting the rollup.
+   */
+  entries(): LedgerEntry[] {
+    let raw: string;
+    try {
+      raw = readFileSync(this.path, "utf8");
+    } catch {
+      return [];
+    }
+    const out: LedgerEntry[] = [];
+    let malformed = 0;
+    for (const line of raw.split("\n")) {
+      const t = line.trim();
+      if (t === "") {
+        continue;
+      }
+      try {
+        const e = JSON.parse(t) as LedgerEntry;
+        if (
+          e &&
+          typeof e.ts_utc === "string" &&
+          typeof e.model === "string" &&
+          typeof e.tokens_in === "number" &&
+          Number.isFinite(e.tokens_in) &&
+          typeof e.tokens_out === "number" &&
+          Number.isFinite(e.tokens_out) &&
+          typeof e.cost_usd === "number" &&
+          Number.isFinite(e.cost_usd)
+        ) {
+          out.push(e);
+        } else {
+          malformed += 1;
+        }
+      } catch {
+        malformed += 1;
+      }
+    }
+    if (malformed > 0) {
+      this.onMalformed?.(malformed);
+    }
+    return out;
+  }
+
+  /** Records within an optional `[since, until]` window (inclusive). */
+  entriesIn(since?: Date, until?: Date): LedgerEntry[] {
+    const lo = since?.getTime();
+    const hi = until?.getTime();
+    return this.entries().filter((e) => {
+      const t = Date.parse(e.ts_utc);
+      if (Number.isNaN(t)) {
+        return false;
+      }
+      if (lo !== undefined && t < lo) {
+        return false;
+      }
+      if (hi !== undefined && t > hi) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  /** Spend rolled up by period bucket within an optional window (sorted key). */
+  rollup(period: Period, since?: Date, until?: Date): Map<string, Rollup> {
+    const out = new Map<string, Rollup>();
+    for (const e of this.entriesIn(since, until)) {
+      const key = periodBucket(period, new Date(e.ts_utc));
+      const r = out.get(key) ?? emptyRollup();
+      r.cost_usd += e.cost_usd;
+      r.tokens_in += e.tokens_in;
+      r.tokens_out += e.tokens_out;
+      r.calls += 1;
+      out.set(key, r);
+    }
+    return new Map([...out.entries()].toSorted(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+  }
+
+  /** Spend grouped by model within an optional window. */
+  byModel(since?: Date, until?: Date): Map<string, Rollup> {
+    const out = new Map<string, Rollup>();
+    for (const e of this.entriesIn(since, until)) {
+      const r = out.get(e.model) ?? emptyRollup();
+      r.cost_usd += e.cost_usd;
+      r.tokens_in += e.tokens_in;
+      r.tokens_out += e.tokens_out;
+      r.calls += 1;
+      out.set(e.model, r);
+    }
+    return new Map([...out.entries()].toSorted(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+  }
+}

--- a/extensions/tokenomics/src/pricing.ts
+++ b/extensions/tokenomics/src/pricing.ts
@@ -1,0 +1,378 @@
+// Model pricing catalog. Rates are realized `$ / 1M tokens` in the public
+// price-list shape (LiteLLM `input/output_cost_per_token`, OpenRouter
+// `pricing.prompt/completion`, scaled to per-Mtok). The catalog drives the
+// cost-counterfactual / avoided-spend headline in a report; per-call cost in
+// the ledger is the truth for what was actually paid.
+
+import {
+  closeSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+export interface ModelPrice {
+  /** Legacy blended rate (input+output) in USD per 1M tokens. Fallback only. */
+  usd_per_mtok?: number;
+  /** Per-component rates in USD per 1M tokens (take precedence when set). */
+  input_usd_per_mtok?: number;
+  output_usd_per_mtok?: number;
+  cache_read_usd_per_mtok?: number;
+  cache_write_usd_per_mtok?: number;
+  reasoning_usd_per_mtok?: number;
+  source?: string;
+}
+
+export interface PricingCatalogJson {
+  generated?: string;
+  window?: string;
+  models?: Record<string, ModelPrice>;
+  /** Frontier baseline `$ / 1M tok` for the avoided-spend estimate. */
+  baseline_usd_per_mtok?: number;
+  baseline_model?: string;
+}
+
+function priceIsPriced(p: ModelPrice): boolean {
+  return (
+    (p.usd_per_mtok ?? 0) > 0 || (p.input_usd_per_mtok ?? 0) > 0 || (p.output_usd_per_mtok ?? 0) > 0
+  );
+}
+
+/** Validate a model price entry. Returns a list of field-level warnings. */
+export function validateModelPrice(
+  modelId: string,
+  raw: unknown,
+): { valid: boolean; warnings: string[] } {
+  const warnings: string[] = [];
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return { valid: false, warnings: [`model "${modelId}": value is not an object, skipping`] };
+  }
+  const p = raw as Record<string, unknown>;
+  const numericFields = [
+    "usd_per_mtok",
+    "input_usd_per_mtok",
+    "output_usd_per_mtok",
+    "cache_read_usd_per_mtok",
+    "cache_write_usd_per_mtok",
+    "reasoning_usd_per_mtok",
+  ] as const;
+  for (const f of numericFields) {
+    const v = p[f];
+    if (v === undefined) {
+      continue;
+    }
+    // A finite, non-negative number is a real rate — keep it.
+    if (typeof v === "number" && Number.isFinite(v) && v >= 0) {
+      continue;
+    }
+    // A finite negative value is the catalog's "unpriced / unknown" sentinel
+    // (e.g. -1000000). Drop the field silently — it is intentional, not
+    // malformed, so it must not spam a warning on every report.
+    if (typeof v === "number" && Number.isFinite(v)) {
+      delete p[f];
+      continue;
+    }
+    // Genuinely malformed (non-number, NaN, Infinity): warn and drop.
+    warnings.push(
+      `model "${modelId}": ${f}=${JSON.stringify(v)} is not a finite number, skipping field`,
+    );
+    delete p[f];
+  }
+  if (p.source !== undefined && typeof p.source !== "string") {
+    warnings.push(`model "${modelId}": source is not a string, skipping field`);
+    delete p.source;
+  }
+  // Check that at least one rate field remains after cleaning.
+  const hasRate = numericFields.some((f) => typeof p[f] === "number");
+  if (!hasRate) {
+    warnings.push(`model "${modelId}": no valid rate fields remain, skipping model`);
+    return { valid: false, warnings };
+  }
+  return { valid: true, warnings };
+}
+
+/** Cost in USD for an input/output token split (component rates, else blended). */
+export function priceCostIo(p: ModelPrice, tokensIn: number, tokensOut: number): number {
+  const inRate = p.input_usd_per_mtok ?? 0;
+  const outRate = p.output_usd_per_mtok ?? 0;
+  if (inRate > 0 || outRate > 0) {
+    return (tokensIn * inRate + tokensOut * outRate) / 1_000_000;
+  }
+  return ((p.usd_per_mtok ?? 0) * (tokensIn + tokensOut)) / 1_000_000;
+}
+
+/**
+ * True when the current platform uses POSIX file permission semantics
+ * (mode bits and uid/gid are meaningful). Returns false on Windows (`win32`).
+ */
+export function isPosixPlatform(): boolean {
+  return process.platform !== "win32";
+}
+
+/**
+ * Validate that a file is safe to use as a pricing catalog input.
+ *
+ * Checks performed:
+ * - File must exist and be a regular file (all platforms).
+ * - **POSIX only:** File mode must not include S_IWGRP (0o020) or S_IWOTH
+ *   (0o002). On Windows `stat.mode` does not reflect POSIX permissions and
+ *   typically includes write bits for everyone; mode checks are skipped there.
+ * - **POSIX only:** File uid must match the process uid. Skipped when
+ *   `process.getuid` is unavailable (Windows).
+ *
+ * Pass `{ posix: false }` to simulate Windows semantics (mode/uid checks
+ * skipped); defaults to {@link isPosixPlatform}.
+ *
+ * Returns `{ ok: false, reason }` when the file fails any check.
+ */
+export function validatePricingFile(
+  path: string,
+  opts?: { posix?: boolean },
+): { ok: true } | { ok: false; reason: string } {
+  const posix = opts?.posix ?? isPosixPlatform();
+  let stat: ReturnType<typeof statSync>;
+  try {
+    stat = statSync(path);
+  } catch (err) {
+    return { ok: false, reason: `cannot stat: ${String(err)}` };
+  }
+  if (!stat.isFile()) {
+    return { ok: false, reason: "not a regular file" };
+  }
+  // Mode-bit checks are only meaningful on POSIX.
+  if (posix) {
+    const badMode = 0o020 /* S_IWGRP */ | 0o002; /* S_IWOTH */
+    if (stat.mode & badMode) {
+      const modeStr = (stat.mode & 0o777).toString(8).padStart(3, "0");
+      return {
+        ok: false,
+        reason: `insecure mode 0o${modeStr} (must not be group- or world-writable)`,
+      };
+    }
+    // Verify ownership matches the process.
+    try {
+      if (typeof process.getuid === "function") {
+        const procUid = process.getuid();
+        if (procUid !== undefined && stat.uid !== procUid) {
+          return {
+            ok: false,
+            reason: `owned by uid ${stat.uid}, process is uid ${procUid}`,
+          };
+        }
+      }
+    } catch {
+      // process.getuid may throw on some platforms; skip.
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Commodity: return the process uid when available, or undefined on platforms
+ * that do not expose it (Windows).
+ */
+export function getProcessUid(): number | undefined {
+  try {
+    if (typeof process.getuid === "function") {
+      return process.getuid();
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+export class PricingCatalog {
+  generated = "";
+  window = "";
+  models: Map<string, ModelPrice> = new Map();
+  baselineUsdPerMtok = 0;
+  baselineModel = "";
+
+  /**
+   * Load, or an empty catalog if absent/corrupt/insecure/oversized (never
+   * fatal).
+   *
+   * File size is checked *before* opening a descriptor: oversized files are
+   * rejected with a warning and no fd is ever created, preventing descriptor
+   * leaks under repeated oversized-file loads.
+   *
+   * For files that pass the size gate, the method opens a file descriptor,
+   * validates permissions via `fstatSync` on that descriptor, and reads from
+   * the same descriptor — eliminating the TOCTOU race between check and read.
+   *
+   * Pass `{ posix: false }` to skip POSIX mode/uid checks (Windows).
+   * Pass `{ logger }` to route warnings through the host's logging
+   * infrastructure instead of raw `process.stderr` writes.
+   */
+  static load(
+    path: string,
+    opts?: { posix?: boolean; logger?: (msg: string) => void },
+  ): PricingCatalog {
+    const cat = new PricingCatalog();
+    const posix = opts?.posix ?? isPosixPlatform();
+    const warn =
+      opts?.logger ??
+      ((msg: string) => {
+        process.stderr.write(msg);
+      });
+
+    // ── size gate (before any descriptor is opened) ──
+    const MAX_PRICE_BYTES = 2_097_152; // 2 MiB
+    try {
+      const sizeStat = statSync(path);
+      if (!sizeStat.isFile()) {
+        warn(
+          `tokenomics: warning: pricing catalog ${path} rejected — not a regular file; using empty\n`,
+        );
+        return cat;
+      }
+      if (sizeStat.size > MAX_PRICE_BYTES) {
+        warn(
+          `tokenomics: warning: pricing catalog ${path} rejected — ${sizeStat.size} bytes exceeds ${MAX_PRICE_BYTES} limit; using empty\n`,
+        );
+        return cat;
+      }
+    } catch (err) {
+      warn(
+        `tokenomics: warning: pricing catalog ${path} rejected — cannot stat: ${String(err)}; using empty\n`,
+      );
+      return cat;
+    }
+
+    // ── descriptor-backed permission check + read ──
+    let fd: number | undefined;
+    try {
+      fd = openSync(path, "r");
+      const stat = fstatSync(fd);
+      if (posix) {
+        const badMode = 0o020 /* S_IWGRP */ | 0o002; /* S_IWOTH */
+        if (stat.mode & badMode) {
+          const modeStr = (stat.mode & 0o777).toString(8).padStart(3, "0");
+          warn(
+            `tokenomics: warning: pricing catalog ${path} rejected — insecure mode 0o${modeStr} (must not be group- or world-writable); using empty\n`,
+          );
+          return cat;
+        }
+        try {
+          if (typeof process.getuid === "function") {
+            const procUid = process.getuid();
+            if (procUid !== undefined && stat.uid !== procUid) {
+              warn(
+                `tokenomics: warning: pricing catalog ${path} rejected — owned by uid ${stat.uid}, process is uid ${procUid}; using empty\n`,
+              );
+              return cat;
+            }
+          }
+        } catch {
+          // process.getuid may throw on some platforms; skip.
+        }
+      }
+      let raw: string;
+      try {
+        raw = readFileSync(fd, { encoding: "utf8" });
+      } catch {
+        return cat;
+      }
+      try {
+        const j = JSON.parse(raw) as PricingCatalogJson;
+        cat.generated = typeof j.generated === "string" ? j.generated : "";
+        cat.window = typeof j.window === "string" ? j.window : "";
+        cat.baselineUsdPerMtok =
+          typeof j.baseline_usd_per_mtok === "number" && Number.isFinite(j.baseline_usd_per_mtok)
+            ? j.baseline_usd_per_mtok
+            : 0;
+        cat.baselineModel = typeof j.baseline_model === "string" ? j.baseline_model : "";
+        const models = j.models;
+        if (models && typeof models === "object" && !Array.isArray(models)) {
+          let skipped = 0;
+          for (const [k, v] of Object.entries(models)) {
+            const { valid, warnings } = validateModelPrice(k, v);
+            if (valid) {
+              cat.models.set(k, v);
+            } else {
+              skipped += 1;
+            }
+            for (const w of warnings) {
+              warn(`tokenomics: warning: ${w}\n`);
+            }
+          }
+          if (skipped > 0) {
+            warn(
+              `tokenomics: warning: skipped ${skipped} malformed model entr${skipped === 1 ? "y" : "ies"} in ${path}\n`,
+            );
+          }
+        }
+      } catch (e) {
+        warn(
+          `tokenomics: warning: pricing catalog ${path} unreadable (${String(e)}); using empty\n`,
+        );
+      }
+    } finally {
+      if (fd !== undefined) {
+        closeSync(fd);
+      }
+    }
+    return cat;
+  }
+
+  toJSON(): PricingCatalogJson {
+    return {
+      generated: this.generated,
+      window: this.window,
+      models: Object.fromEntries(this.models),
+      baseline_usd_per_mtok: this.baselineUsdPerMtok,
+      baseline_model: this.baselineModel,
+    };
+  }
+
+  /** Atomic write (temp + rename). */
+  save(path: string): void {
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, `${JSON.stringify(this.toJSON(), null, 2)}\n`);
+    renameSync(tmp, path);
+  }
+
+  /**
+   * Look up a model price, tolerating id vs display-name drift: exact, then
+   * case-insensitive, then leaf/suffix match (`host/leaf` -> `leaf`).
+   */
+  lookup(model: string): ModelPrice | undefined {
+    const exact = this.models.get(model);
+    if (exact) {
+      return exact;
+    }
+    const ml = model.toLowerCase();
+    const leaf = ml.includes("/") ? ml.slice(ml.lastIndexOf("/") + 1) : ml;
+    for (const [k, v] of this.models) {
+      const kl = k.toLowerCase();
+      if (kl === ml || kl === leaf || ml.endsWith(kl) || kl.endsWith(leaf)) {
+        return v;
+      }
+    }
+    return undefined;
+  }
+
+  /** Chargeback for a call. Unknown/unpriced model → $0 (never invent cost). */
+  cost(model: string, tokensIn: number, tokensOut: number): number {
+    const p = this.lookup(model);
+    return p ? priceCostIo(p, tokensIn, tokensOut) : 0;
+  }
+
+  /** True when the model has a non-zero rate (a paid cloud model). */
+  isBilled(model: string): boolean {
+    const p = this.lookup(model);
+    return p ? priceIsPriced(p) : false;
+  }
+
+  /** Avoided spend: `tokens` priced at the frontier baseline. */
+  avoided(tokens: number): number {
+    return (this.baselineUsdPerMtok * tokens) / 1_000_000;
+  }
+}

--- a/extensions/tokenomics/src/render.ts
+++ b/extensions/tokenomics/src/render.ts
@@ -1,0 +1,101 @@
+// Terminal rendering for tokenomics reports. Dependency-free ANSI so it drops
+// into any host's CLI. Honors NO_COLOR and non-TTY (plain output).
+
+import type { Report, RowByModel } from "./report.js";
+
+const useColor = !process.env.NO_COLOR && process.stdout.isTTY;
+
+const c = {
+  dim: (s: string) => paint(s, "\x1b[2m"),
+  bold: (s: string) => paint(s, "\x1b[1m"),
+  green: (s: string) => paint(s, "\x1b[32m"),
+  cyan: (s: string) => paint(s, "\x1b[36m"),
+  yellow: (s: string) => paint(s, "\x1b[33m"),
+};
+
+function paint(s: string, code: string): string {
+  return useColor ? `${code}${s}\x1b[0m` : s;
+}
+
+function usd(n: number): string {
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function tok(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(2)}M`;
+  }
+  if (n >= 1_000) {
+    return `${(n / 1_000).toFixed(1)}k`;
+  }
+  return String(n);
+}
+
+/** A unicode bar showing the free share of total tokens. */
+export function shareBar(freeTokens: number, totalTokens: number, width = 24): string {
+  if (totalTokens <= 0) {
+    return `${"·".repeat(width)} 0% free`;
+  }
+  const frac = Math.max(0, Math.min(1, freeTokens / totalTokens));
+  const filled = Math.round(frac * width);
+  const bar = c.green("█".repeat(filled)) + c.dim("░".repeat(width - filled));
+  return `${bar} ${(frac * 100).toFixed(0)}% free`;
+}
+
+function padEnd(s: string, n: number): string {
+  return s.length >= n ? s : s + " ".repeat(n - s.length);
+}
+function padStart(s: string, n: number): string {
+  return s.length >= n ? s : " ".repeat(n - s.length) + s;
+}
+
+/** A compact by-model table (top `limit` rows by cost). */
+export function renderByModel(rows: RowByModel[], limit = 12): string {
+  const top = rows.slice(0, limit);
+  const nameW = Math.max(5, ...top.map((r) => r.model.length));
+  const head =
+    c.dim(padEnd("model", nameW)) +
+    "  " +
+    c.dim(padStart("calls", 7)) +
+    "  " +
+    c.dim(padStart("tokens", 9)) +
+    "  " +
+    c.dim(padStart("cost", 10)) +
+    "  " +
+    c.dim("tag");
+  const lines = top.map((r) => {
+    const tag = r.billed ? c.yellow("paid") : c.green("free");
+    return (
+      padEnd(r.model, nameW) +
+      "  " +
+      padStart(String(r.calls), 7) +
+      "  " +
+      padStart(tok(r.tokens), 9) +
+      "  " +
+      padStart(usd(r.cost_usd), 10) +
+      "  " +
+      tag
+    );
+  });
+  return [head, ...lines].join("\n");
+}
+
+/** Full report render: headline, free-share bar, then by-model table. */
+export function renderReport(rep: Report): string {
+  const window = rep.period
+    ? `${rep.period} (${rep.since} → ${rep.until}, ${rep.days}d)`
+    : `${rep.since} → ${rep.until} (${rep.days}d)`;
+
+  const headline = [
+    c.bold("Tokenomics"),
+    c.dim(window),
+    "",
+    `${c.dim("spent")}        ${c.bold(usd(rep.total_cost_usd))}  ${c.dim(`(${rep.total_calls} calls, ${tok(rep.total_tokens)} tok)`)}`,
+    `${c.dim("avoided")}      ${c.green(usd(rep.avoided_usd))}  ${c.dim("free tokens valued at baseline")}`,
+    `${c.dim("counterfactual")} ${c.cyan(usd(rep.counterfactual_usd))}  ${c.dim(`all tokens @ ${rep.baseline_model || "baseline"} (${usd(rep.baseline_usd_per_mtok)}/Mtok)`)}`,
+    "",
+    `${c.dim("free share")}   ${shareBar(rep.free_tokens, rep.total_tokens)}`,
+  ].join("\n");
+
+  return `${headline}\n\n${renderByModel(rep.by_model)}`;
+}

--- a/extensions/tokenomics/src/report.ts
+++ b/extensions/tokenomics/src/report.ts
@@ -1,0 +1,231 @@
+// Tokenomics report: local-first usage + chargeback rollups from the spend
+// ledger, priced by the pricing catalog.
+//
+// Time-series buckets at a chosen granularity (hour/day/week/month) over an
+// explicit window, plus a by-model breakdown and the avoided-spend headline
+// (free tokens valued at the frontier baseline). Per-call cost comes from the
+// ledger entry itself (the truth for what was paid); the pricing catalog drives
+// only the counterfactual.
+
+import type { Ledger } from "./ledger.js";
+import type { PricingCatalog } from "./pricing.js";
+import { dayKey, hourKey, monthKey, weekKey } from "./time.js";
+
+export type Gran = "hour" | "day" | "week" | "month";
+
+export function parseGran(s: string): Gran {
+  switch (s.toLowerCase()) {
+    case "hour":
+    case "hourly":
+      return "hour";
+    case "week":
+    case "weekly":
+      return "week";
+    case "month":
+    case "monthly":
+      return "month";
+    default:
+      return "day";
+  }
+}
+
+const GRAN_KEYS: Record<Gran, (d: Date) => string> = {
+  hour: hourKey,
+  day: dayKey,
+  week: weekKey,
+  month: monthKey,
+};
+
+function granKey(gran: Gran, ts: Date): string {
+  return GRAN_KEYS[gran](ts);
+}
+
+export interface Bucket {
+  key: string;
+  cost_usd: number;
+  tokens_in: number;
+  tokens_out: number;
+  calls: number;
+}
+
+export interface RowByModel {
+  model: string;
+  cost_usd: number;
+  tokens: number;
+  tokens_in: number;
+  tokens_out: number;
+  calls: number;
+  /**
+   * True when the model actually incurred a chargeback (a paid cloud model).
+   * Derived from recorded spend, never from a fuzzy catalog match, so free
+   * (zero-cost) models are never mislabeled paid.
+   */
+  billed: boolean;
+  /** Catalog input rate ($ / 1M tok), populated only for billed models. */
+  input_usd_per_mtok: number;
+  /** Catalog output rate ($ / 1M tok), populated only for billed models. */
+  output_usd_per_mtok: number;
+}
+
+export interface Report {
+  period: string;
+  since: string;
+  until: string;
+  days: number;
+  bucket_gran: Gran;
+  buckets: Bucket[];
+  by_model: RowByModel[];
+  /** Externally-billed chargeback over the window (the cash number). */
+  total_cost_usd: number;
+  total_tokens: number;
+  total_calls: number;
+  /** Tokens served at $0 chargeback (free / zero-cost providers). */
+  free_tokens: number;
+  billed_tokens: number;
+  /** Free tokens valued at the frontier baseline (avoided external spend). */
+  avoided_usd: number;
+  /**
+   * ALL tokens valued at the frontier baseline: what the window WOULD have
+   * cost on the baseline model.
+   */
+  counterfactual_usd: number;
+  baseline_model: string;
+  baseline_usd_per_mtok: number;
+}
+
+export interface BuildReportOptions {
+  ledger: Ledger;
+  pricing: PricingCatalog;
+  since: Date;
+  until: Date;
+  gran?: Gran;
+  /** Human label for the window, e.g. "this month", "Q2 2026", "YTD 2026". */
+  period?: string;
+}
+
+/**
+ * Build a report over an explicit `[since, until]` window from the local ledger,
+ * bucketing the time series at `gran`. Cost is taken from each ledger entry; the
+ * pricing catalog is used only for the avoided-spend / counterfactual baseline.
+ */
+export function buildReport(opts: BuildReportOptions): Report {
+  const { ledger, pricing, since, until } = opts;
+  const gran = opts.gran ?? "day";
+  const entries = ledger.entriesIn(since, until);
+
+  const buckets = new Map<string, Bucket>();
+  const models = new Map<string, RowByModel>();
+
+  const rep: Report = {
+    period: opts.period ?? "",
+    since: dayKey(since),
+    until: dayKey(until),
+    days: Math.max(1, Math.ceil((until.getTime() - since.getTime()) / 86_400_000)),
+    bucket_gran: gran,
+    buckets: [],
+    by_model: [],
+    total_cost_usd: 0,
+    total_tokens: 0,
+    total_calls: 0,
+    free_tokens: 0,
+    billed_tokens: 0,
+    avoided_usd: 0,
+    counterfactual_usd: 0,
+    baseline_model: pricing.baselineModel,
+    baseline_usd_per_mtok: pricing.baselineUsdPerMtok,
+  };
+
+  for (const e of entries) {
+    const cost = e.cost_usd;
+    const billed = e.cost_usd > 0;
+    const tok = e.tokens_in + e.tokens_out;
+    const ts = new Date(e.ts_utc);
+
+    const key = granKey(gran, ts);
+    const b = buckets.get(key) ?? {
+      key,
+      cost_usd: 0,
+      tokens_in: 0,
+      tokens_out: 0,
+      calls: 0,
+    };
+    b.cost_usd += cost;
+    b.tokens_in += e.tokens_in;
+    b.tokens_out += e.tokens_out;
+    b.calls += 1;
+    buckets.set(key, b);
+
+    const m = models.get(e.model) ?? {
+      model: e.model,
+      cost_usd: 0,
+      tokens: 0,
+      tokens_in: 0,
+      tokens_out: 0,
+      calls: 0,
+      billed: false,
+      input_usd_per_mtok: 0,
+      output_usd_per_mtok: 0,
+    };
+    m.cost_usd += cost;
+    m.tokens += tok;
+    m.tokens_in += e.tokens_in;
+    m.tokens_out += e.tokens_out;
+    m.calls += 1;
+    m.billed ||= billed;
+    models.set(e.model, m);
+
+    rep.total_cost_usd += cost;
+    rep.total_tokens += tok;
+    rep.total_calls += 1;
+    if (billed) {
+      rep.billed_tokens += tok;
+    } else {
+      rep.free_tokens += tok;
+    }
+  }
+
+  // Baseline for the avoided-spend / counterfactual headline. The authoritative
+  // per-call cost already comes from the host (OpenClaw's own model.usage cost),
+  // so by default the baseline is derived from observed spend — the highest
+  // effective $/Mtok among paid models actually used in the window — rather than
+  // from a separate price catalog. An optional pricing catalog may override it.
+  let baselinePerMtok = pricing.baselineUsdPerMtok;
+  let baselineModel = pricing.baselineModel;
+  if (baselinePerMtok <= 0) {
+    let bestRate = 0;
+    let bestModel = "";
+    for (const row of models.values()) {
+      if (row.billed && row.tokens > 0) {
+        const rate = (row.cost_usd / row.tokens) * 1_000_000;
+        if (rate > bestRate) {
+          bestRate = rate;
+          bestModel = row.model;
+        }
+      }
+    }
+    baselinePerMtok = bestRate;
+    baselineModel = bestModel;
+  }
+  rep.baseline_usd_per_mtok = baselinePerMtok;
+  rep.baseline_model = baselineModel;
+  rep.avoided_usd = (rep.free_tokens / 1_000_000) * baselinePerMtok;
+  rep.counterfactual_usd = (rep.total_tokens / 1_000_000) * baselinePerMtok;
+  rep.buckets = [...buckets.values()].toSorted((a, b) =>
+    a.key < b.key ? -1 : a.key > b.key ? 1 : 0,
+  );
+
+  for (const row of models.values()) {
+    if (row.billed) {
+      const price = pricing.lookup(row.model);
+      if (price) {
+        row.input_usd_per_mtok = price.input_usd_per_mtok ?? 0;
+        row.output_usd_per_mtok = price.output_usd_per_mtok ?? 0;
+      }
+    }
+  }
+  rep.by_model = [...models.values()].toSorted(
+    (a, b) => b.cost_usd - a.cost_usd || b.tokens - a.tokens,
+  );
+
+  return rep;
+}

--- a/extensions/tokenomics/src/service.ts
+++ b/extensions/tokenomics/src/service.ts
@@ -1,0 +1,310 @@
+// Tokenomics service: subscribes to OpenClaw `model.usage` diagnostic events,
+// records one ledger row per model call, and serves a spend report over an
+// HTTP route. The host-reported `costUsd` is authoritative; when absent the
+// pricing catalog estimates the cost (free/zero-cost models stay $0).
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { join } from "node:path";
+import {
+  type DiagnosticEventMetadata,
+  type DiagnosticEventPayload,
+  isInternalDiagnosticEventMetadata,
+  type OpenClawPluginHttpRouteHandler,
+  type OpenClawPluginService,
+  type OpenClawPluginServiceContext,
+} from "../api.js";
+import { buildFinOpsReport, type FinOpsReport } from "./finops.js";
+import { HostAdapter, type UsageEvent } from "./host-adapter.js";
+import { Ledger } from "./ledger.js";
+import { PricingCatalog } from "./pricing.js";
+import { renderReport } from "./render.js";
+import { buildReport, parseGran, type Gran, type Report } from "./report.js";
+
+type ModelUsageEvent = Extract<DiagnosticEventPayload, { type: "model.usage" }>;
+
+/** Structural subset of `model.usage` consumed by the mapper (test-friendly). */
+export interface ModelUsageLike {
+  model?: string;
+  provider?: string;
+  usage?: {
+    input?: number;
+    output?: number;
+    promptTokens?: number;
+    total?: number;
+  };
+  costUsd?: number;
+}
+
+const SUBDIR = "tokenomics";
+const LEDGER_FILE = "ledger.jsonl";
+const PRICING_FILE = "pricing.json";
+const DAY_MS = 86_400_000;
+const DEFAULT_WINDOW_DAYS = 30;
+
+function numericValue(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/**
+ * Map an OpenClaw `model.usage` event to a host-neutral {@link UsageEvent}.
+ * `costUsd` is forwarded verbatim so the host's billed truth wins; omitting it
+ * lets the pricing catalog estimate the cost downstream.
+ */
+export function toUsageEvent(evt: ModelUsageLike): UsageEvent {
+  const usage = evt.usage ?? {};
+  // Prefer the host's computed `promptTokens` (input + cacheRead + cacheWrite)
+  // so cache-heavy calls are not underreported; fall back to raw `input`.
+  const tokensIn = numericValue(usage.promptTokens) ?? numericValue(usage.input) ?? 0;
+  const tokensOut = numericValue(usage.output) ?? 0;
+  const event: UsageEvent = {
+    provider: evt.provider ?? "unknown",
+    model: evt.model ?? "unknown",
+    tokensIn,
+    tokensOut,
+  };
+  const cost = numericValue(evt.costUsd);
+  if (cost !== undefined) {
+    event.costUsd = cost;
+  }
+  return event;
+}
+
+function shouldRecord(metadata: DiagnosticEventMetadata): boolean {
+  return metadata.trusted || isInternalDiagnosticEventMetadata(metadata);
+}
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseBound(raw: string | null, bound: "since" | "until"): Date | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const t = Date.parse(raw);
+  if (Number.isNaN(t)) {
+    return undefined;
+  }
+  // A date-only `until` is an inclusive whole-day bound, so snap it to the end
+  // of that UTC day; date-only `since` already parses to start-of-day. Values
+  // that carry a time component are honored verbatim.
+  if (bound === "until" && DATE_ONLY.test(raw.trim())) {
+    return new Date(t + DAY_MS - 1);
+  }
+  return new Date(t);
+}
+
+function safeErrorMessage(err: unknown): string {
+  return (err instanceof Error ? (err.message ?? err.name) : String(err)).slice(0, 500);
+}
+
+interface Window {
+  since: Date;
+  until: Date;
+}
+
+/**
+ * Resolve the `[since, until]` reporting window from query params. Returns a
+ * validation error string for params the caller should reject (HTTP 400):
+ * unparseable `since`/`until`, or an inverted window.
+ */
+function resolveWindow(params: URLSearchParams): Window | { error: string } {
+  const rawUntil = params.get("until");
+  const rawSince = params.get("since");
+  const until = parseBound(rawUntil, "until");
+  if (rawUntil !== null && rawUntil.trim() !== "" && until === undefined) {
+    return { error: "invalid 'until' timestamp" };
+  }
+  const since = parseBound(rawSince, "since");
+  if (rawSince !== null && rawSince.trim() !== "" && since === undefined) {
+    return { error: "invalid 'since' timestamp" };
+  }
+  const resolvedUntil = until ?? new Date();
+  const resolvedSince = since ?? new Date(resolvedUntil.getTime() - DEFAULT_WINDOW_DAYS * DAY_MS);
+  if (resolvedSince.getTime() > resolvedUntil.getTime()) {
+    return { error: "'since' must be on or before 'until'" };
+  }
+  return { since: resolvedSince, until: resolvedUntil };
+}
+
+export function createTokenomicsService() {
+  let ledgerPath: string | undefined;
+  let pricingPath: string | undefined;
+  let adapter: HostAdapter | undefined;
+  let unsubscribe: (() => void) | undefined;
+  let warn: ((msg: string) => void) | undefined;
+  // Count of `model.usage` events that carried no spend signal (no tokens and
+  // no host cost). These are not recorded — surfacing the count makes an
+  // otherwise-silent capture gap visible (see below).
+  let incompleteUsageEvents = 0;
+
+  function recordUsage(evt: ModelUsageEvent): void {
+    if (!adapter) {
+      return;
+    }
+    const usageEvent = toUsageEvent(evt);
+    // A `model.usage` event with no tokens AND no host-reported cost carries no
+    // spend signal. The usual cause is a streaming response whose provider did
+    // not return token usage — e.g. an OpenAI-compatible provider at a
+    // non-standard base URL where OpenClaw omits `stream_options:{include_usage:
+    // true}` because the provider's `compat.supportsUsageInStreaming` resolved
+    // to false. Recording it would add a 0-token / $0 row that looks like a free
+    // call but is really a measurement gap, so skip it and count it instead.
+    if (
+      usageEvent.tokensIn === 0 &&
+      usageEvent.tokensOut === 0 &&
+      usageEvent.costUsd === undefined
+    ) {
+      incompleteUsageEvents += 1;
+      if (incompleteUsageEvents === 1 || incompleteUsageEvents % 50 === 0) {
+        warn?.(
+          `tokenomics: ${incompleteUsageEvents} model.usage event(s) for ${usageEvent.provider}/${usageEvent.model} carried no token usage or cost and were not recorded — the provider may not report streaming usage (for OpenAI-compatible providers set the provider's compat.supportsUsageInStreaming=true)`,
+        );
+      }
+      return;
+    }
+    adapter.track(usageEvent);
+  }
+
+  function openLedger(): Ledger {
+    return new Ledger(ledgerPath ?? "", {
+      onMalformed: (count) =>
+        warn?.(`tokenomics: skipped ${count} malformed ledger line(s) while reading`),
+      onError: (err) =>
+        warn?.(`tokenomics: failed to write ledger entry: ${safeErrorMessage(err)}`),
+    });
+  }
+
+  function reportFor(window: Window, params: URLSearchParams): Report {
+    const granRaw = params.get("gran");
+    const gran: Gran = granRaw ? parseGran(granRaw) : "day";
+    const period = params.get("period") ?? undefined;
+    const pricing = pricingPath
+      ? PricingCatalog.load(pricingPath, { logger: warn })
+      : new PricingCatalog();
+    return buildReport({
+      ledger: openLedger(),
+      pricing,
+      since: window.since,
+      until: window.until,
+      gran,
+      period,
+    });
+  }
+
+  // FinOps view: read-only allocation / realized-rate / cache-savings / advisor /
+  // forecast rollups over the same ledger (consumes ./finops.ts). Non-enforcing.
+  function finOpsReportFor(window: Window): FinOpsReport {
+    const pricing = pricingPath
+      ? PricingCatalog.load(pricingPath, { logger: warn })
+      : new PricingCatalog();
+    return buildFinOpsReport(openLedger(), pricing, {
+      since: window.since,
+      until: window.until,
+    });
+  }
+
+  // Tolerant programmatic entrypoint: bad params fall back to the default window.
+  function currentReport(params: URLSearchParams): Report {
+    const resolved = resolveWindow(params);
+    const window: Window =
+      "error" in resolved
+        ? { since: new Date(Date.now() - DEFAULT_WINDOW_DAYS * DAY_MS), until: new Date() }
+        : resolved;
+    return reportFor(window, params);
+  }
+
+  const handler: OpenClawPluginHttpRouteHandler = (req: IncomingMessage, res: ServerResponse) => {
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      res.statusCode = 405;
+      res.setHeader("Allow", "GET, HEAD");
+      res.end("Method Not Allowed");
+      return true;
+    }
+    if (!ledgerPath) {
+      res.statusCode = 503;
+      res.end("tokenomics service not started");
+      return true;
+    }
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const window = resolveWindow(url.searchParams);
+    if ("error" in window) {
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end(window.error);
+      return true;
+    }
+    if (url.searchParams.get("view") === "finops") {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.setHeader("Cache-Control", "no-store");
+      if (req.method === "HEAD") {
+        res.end();
+        return true;
+      }
+      res.end(JSON.stringify(finOpsReportFor(window)));
+      return true;
+    }
+    const format = url.searchParams.get("format") ?? "json";
+    const report = reportFor(window, url.searchParams);
+    if (format === "text") {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.setHeader("Cache-Control", "no-store");
+      if (req.method === "HEAD") {
+        res.end();
+        return true;
+      }
+      res.end(renderReport(report));
+      return true;
+    }
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.setHeader("Cache-Control", "no-store");
+    if (req.method === "HEAD") {
+      res.end();
+      return true;
+    }
+    res.end(JSON.stringify(report));
+    return true;
+  };
+
+  const service = {
+    id: "tokenomics",
+    start(ctx: OpenClawPluginServiceContext) {
+      const dir = join(ctx.stateDir, SUBDIR);
+      ledgerPath = join(dir, LEDGER_FILE);
+      pricingPath = join(dir, PRICING_FILE);
+      warn = (msg) => ctx.logger.warn(msg);
+      const pricing = PricingCatalog.load(pricingPath, { logger: warn });
+      adapter = new HostAdapter(ledgerPath, "openclaw", { pricing });
+
+      const subscribe = ctx.internalDiagnostics?.onEvent;
+      if (!subscribe) {
+        ctx.logger.error(
+          "tokenomics: internal diagnostics capability unavailable; spend will not be recorded",
+        );
+        return;
+      }
+      unsubscribe = subscribe((event, metadata) => {
+        if (event.type !== "model.usage" || !shouldRecord(metadata)) {
+          return;
+        }
+        try {
+          recordUsage(event);
+        } catch (err) {
+          ctx.logger.error(`tokenomics: failed to record usage event: ${safeErrorMessage(err)}`);
+        }
+      });
+      ctx.logger.info(`tokenomics: recording model spend to ${ledgerPath}`);
+    },
+    stop() {
+      unsubscribe?.();
+      unsubscribe = undefined;
+      adapter = undefined;
+    },
+  } satisfies OpenClawPluginService;
+
+  return { service, handler, report: currentReport };
+}
+
+export const testApi = { toUsageEvent, parseBound };
+export { testApi as __test__ };

--- a/extensions/tokenomics/src/time.ts
+++ b/extensions/tokenomics/src/time.ts
@@ -1,0 +1,76 @@
+// UTC time-bucketing helpers. All keys are computed in UTC so a ledger written
+// in one timezone rolls up identically everywhere.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** `YYYY-MM-DD` (UTC). */
+export function dayKey(d: Date): string {
+  return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+}
+
+/** `YYYY-MM` (UTC). */
+export function monthKey(d: Date): string {
+  return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}`;
+}
+
+/** `YYYY` (UTC). */
+export function yearKey(d: Date): string {
+  return String(d.getUTCFullYear());
+}
+
+/** `YYYY-MM-DD HH:00` (UTC). */
+export function hourKey(d: Date): string {
+  return `${dayKey(d)} ${pad2(d.getUTCHours())}:00`;
+}
+
+/**
+ * ISO-8601 week-year + week number for `d` (UTC), formatted `YYYY-Www`. The
+ * week-year can differ from the calendar year near January/December (e.g.
+ * 2026-01-01 may fall in 2025-W53).
+ */
+export function isoWeek(d: Date): { year: number; week: number } {
+  // Thursday of the current week determines the ISO week-year.
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dayNum = (date.getUTCDay() + 6) % 7; // Mon=0 … Sun=6
+  date.setUTCDate(date.getUTCDate() - dayNum + 3);
+  const isoYear = date.getUTCFullYear();
+  const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
+  const ftDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - ftDayNum + 3);
+  const week = 1 + Math.round((date.getTime() - firstThursday.getTime()) / (7 * DAY_MS));
+  return { year: isoYear, week };
+}
+
+/** `YYYY-Www` (UTC, ISO-8601). */
+export function weekKey(d: Date): string {
+  const { year, week } = isoWeek(d);
+  return `${year}-W${pad2(week)}`;
+}
+
+/** Midnight UTC at the start of `d`'s day. */
+export function startOfDayUTC(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+/** Parse a flexible `YYYY-MM-DD` (UTC midnight). `endOfDay` snaps to 23:59:59. */
+export function parseDate(s: string, endOfDay = false): Date {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s.trim());
+  if (!m) {
+    throw new Error(`bad date ${JSON.stringify(s)} (want YYYY-MM-DD)`);
+  }
+  const [, y, mo, da] = m;
+  const year = Number(y);
+  const month = Number(mo) - 1;
+  const day = Number(da);
+  const t = endOfDay ? Date.UTC(year, month, day, 23, 59, 59) : Date.UTC(year, month, day, 0, 0, 0);
+  return new Date(t);
+}
+
+/** Days between two dates (>= 1). */
+export function daysBetween(since: Date, until: Date): number {
+  return Math.max(1, Math.floor((until.getTime() - since.getTime()) / DAY_MS));
+}

--- a/extensions/tokenomics/src/tokenomics.test.ts
+++ b/extensions/tokenomics/src/tokenomics.test.ts
@@ -1,0 +1,1543 @@
+// Tokenomics tests cover usage mapping, ledger persistence, pricing fallback,
+// and the free-vs-paid report.
+import { chmodSync, mkdtempSync, rmSync, writeFileSync, existsSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── fs spy for verifying no fd leak on oversized files ──
+const fsSpy = { openCount: 0, closeCount: 0, throwOnAppend: false };
+function resetFsSpy() {
+  fsSpy.openCount = 0;
+  fsSpy.closeCount = 0;
+  fsSpy.throwOnAppend = false;
+}
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    openSync: vi.fn((...args: Parameters<typeof actual.openSync>) => {
+      fsSpy.openCount++;
+      return actual.openSync(...args);
+    }),
+    closeSync: vi.fn((...args: Parameters<typeof actual.closeSync>) => {
+      fsSpy.closeCount++;
+      return actual.closeSync(...args);
+    }),
+    appendFileSync: vi.fn((...args: Parameters<typeof actual.appendFileSync>) => {
+      if (fsSpy.throwOnAppend) {
+        throw new Error("ENOSPC: no space left on device");
+      }
+      return actual.appendFileSync(...args);
+    }),
+  };
+});
+
+import { buildFinOpsReport, type TaggedLedgerEntry } from "./finops.js";
+import { HostAdapter, ingest, resolveCost } from "./host-adapter.js";
+import { Ledger } from "./ledger.js";
+import {
+  PricingCatalog,
+  validateModelPrice,
+  validatePricingFile,
+  getProcessUid,
+  isPosixPlatform,
+} from "./pricing.js";
+import { renderReport, shareBar } from "./render.js";
+import { buildReport, parseGran } from "./report.js";
+import { createTokenomicsService, testApi, toUsageEvent } from "./service.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "tokenomics-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("toUsageEvent", () => {
+  it("forwards the host-reported cost verbatim (host truth wins)", () => {
+    const ev = toUsageEvent({
+      provider: "anthropic",
+      model: "claude-x",
+      usage: { input: 100, output: 50 },
+      costUsd: 0.0123,
+    });
+    expect(ev).toMatchObject({
+      provider: "anthropic",
+      model: "claude-x",
+      tokensIn: 100,
+      tokensOut: 50,
+    });
+    expect(ev.costUsd).toBe(0.0123);
+  });
+
+  it("falls back to raw input and omits cost when absent", () => {
+    const ev = toUsageEvent({ model: "m", usage: { input: 42 } });
+    expect(ev.tokensIn).toBe(42);
+    expect(ev.tokensOut).toBe(0);
+    expect(ev.costUsd).toBeUndefined();
+    expect(ev.provider).toBe("unknown");
+  });
+
+  it("prefers promptTokens so cache-read/write tokens are not dropped", () => {
+    // Host sets promptTokens = input + cacheRead + cacheWrite (e.g. 100 + 60).
+    const ev = toUsageEvent({ model: "m", usage: { input: 100, promptTokens: 160, output: 20 } });
+    expect(ev.tokensIn).toBe(160);
+    expect(ev.tokensOut).toBe(20);
+  });
+});
+
+describe("parseBound", () => {
+  it("snaps a date-only until to end-of-day (inclusive whole day)", () => {
+    const until = testApi.parseBound("2026-06-30", "until");
+    expect(until?.toISOString()).toBe("2026-06-30T23:59:59.999Z");
+  });
+
+  it("keeps a date-only since at start-of-day", () => {
+    const since = testApi.parseBound("2026-06-01", "since");
+    expect(since?.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("honors an explicit datetime verbatim for both bounds", () => {
+    const until = testApi.parseBound("2026-06-30T12:00:00.000Z", "until");
+    expect(until?.toISOString()).toBe("2026-06-30T12:00:00.000Z");
+  });
+
+  it("returns undefined for missing or unparseable input", () => {
+    expect(testApi.parseBound(null, "until")).toBeUndefined();
+    expect(testApi.parseBound("not-a-date", "since")).toBeUndefined();
+  });
+});
+
+describe("validateModelPrice / PricingCatalog.load schema validation", () => {
+  it("accepts a valid model price entry", () => {
+    const { valid, warnings } = validateModelPrice("ok", {
+      input_usd_per_mtok: 3,
+      output_usd_per_mtok: 15,
+    });
+    expect(valid).toBe(true);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("rejects a non-object entry", () => {
+    const { valid, warnings } = validateModelPrice("bad", "not-an-object");
+    expect(valid).toBe(false);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("not an object");
+  });
+
+  it("rejects null entry", () => {
+    const { valid } = validateModelPrice("n", null);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects an array entry", () => {
+    const { valid } = validateModelPrice("arr", [1, 2, 3]);
+    expect(valid).toBe(false);
+  });
+
+  it("warns and drops non-numeric rate fields", () => {
+    const { valid, warnings } = validateModelPrice("str", {
+      input_usd_per_mtok: "free",
+      output_usd_per_mtok: 15,
+    } as Record<string, unknown>);
+    expect(valid).toBe(true); // output_usd_per_mtok survives
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings.some((w) => w.includes("input_usd_per_mtok"))).toBe(true);
+  });
+
+  it("skips the model when no rate fields remain after cleaning", () => {
+    const { valid, warnings } = validateModelPrice("noprice", {
+      input_usd_per_mtok: "nope",
+      output_usd_per_mtok: Number.NaN,
+      source: 42,
+    } as Record<string, unknown>);
+    expect(valid).toBe(false);
+    expect(warnings.some((w) => w.includes("no valid rate fields"))).toBe(true);
+  });
+
+  it("warns about non-string source field", () => {
+    const { valid, warnings } = validateModelPrice("src", {
+      input_usd_per_mtok: 3,
+      source: 123,
+    } as Record<string, unknown>);
+    expect(valid).toBe(true); // still has a rate
+    expect(warnings.some((w) => w.includes("source"))).toBe(true);
+  });
+
+  it("drops negative rate values silently as an unpriced sentinel", () => {
+    const { valid, warnings } = validateModelPrice("neg", {
+      usd_per_mtok: -5,
+    });
+    expect(valid).toBe(false);
+    // Finite-negative is an intentional "unpriced" sentinel (e.g. -1000000),
+    // not malformed input, so no per-field warning should be emitted for it.
+    expect(warnings.some((w) => w.includes("is not a finite number"))).toBe(false);
+    // The model is still skipped because no real rate field remains.
+    expect(warnings.some((w) => w.includes("no valid rate fields"))).toBe(true);
+  });
+
+  it("PricingCatalog.load skips malformed entries and keeps valid ones", () => {
+    const path = join(dir, "pricing-bad.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        models: {
+          good: { input_usd_per_mtok: 3, output_usd_per_mtok: 15 },
+          badStr: { input_usd_per_mtok: "free" },
+          badNull: null,
+          badArr: [1, 2],
+          alsoGood: { usd_per_mtok: 0.5 },
+        },
+        baseline_usd_per_mtok: "not-a-number",
+        baseline_model: 42,
+      }),
+    );
+    // Fixture must not be group/world-writable, or the permission gate rejects it before
+    // the skip-malformed path under test (writeFileSync honors umask; CI=022, but 002 → 664).
+    chmodSync(path, 0o600);
+    const cat = PricingCatalog.load(path);
+    expect(cat.models.size).toBe(2);
+    expect(cat.models.has("good")).toBe(true);
+    expect(cat.models.has("alsoGood")).toBe(true);
+    expect(cat.models.has("badStr")).toBe(false);
+    expect(cat.models.has("badNull")).toBe(false);
+    expect(cat.models.has("badArr")).toBe(false);
+    expect(cat.baselineUsdPerMtok).toBe(0);
+    expect(cat.baselineModel).toBe("");
+  });
+
+  it("PricingCatalog.load returns empty catalog for absent file", () => {
+    const cat = PricingCatalog.load(join(dir, "nonexistent.json"));
+    expect(cat.models.size).toBe(0);
+    expect(cat.baselineUsdPerMtok).toBe(0);
+  });
+
+  it("PricingCatalog.load returns empty catalog for unparseable JSON", () => {
+    const path = join(dir, "bad-json.json");
+    writeFileSync(path, "not json at all {{{");
+    // 0600 so the parse path is exercised, not the permission gate (umask-independent).
+    chmodSync(path, 0o600);
+    const cat = PricingCatalog.load(path);
+    expect(cat.models.size).toBe(0);
+  });
+});
+
+describe("PricingCatalog.lookup tolerance", () => {
+  function makeCatalog() {
+    const cat = new PricingCatalog();
+    cat.models.set("openai/gpt-4o", { input_usd_per_mtok: 2.5, output_usd_per_mtok: 10 });
+    cat.models.set("claude-sonnet-4-6", { input_usd_per_mtok: 3, output_usd_per_mtok: 15 });
+    cat.models.set("local-llama-8b", { usd_per_mtok: 0 });
+    return cat;
+  }
+
+  it("returns the exact match when the model id matches verbatim", () => {
+    const cat = makeCatalog();
+    const p = cat.lookup("openai/gpt-4o");
+    expect(p?.input_usd_per_mtok).toBe(2.5);
+    expect(p?.output_usd_per_mtok).toBe(10);
+  });
+
+  it("returns undefined for an unrecognized model", () => {
+    const cat = makeCatalog();
+    expect(cat.lookup("nonexistent-model")).toBeUndefined();
+  });
+
+  it("matches case-insensitively", () => {
+    const cat = makeCatalog();
+    const p = cat.lookup("OPENAI/GPT-4O");
+    expect(p?.input_usd_per_mtok).toBe(2.5);
+    const p2 = cat.lookup("Claude-Sonnet-4-6");
+    expect(p2?.input_usd_per_mtok).toBe(3);
+    const p3 = cat.lookup("LOCAL-LLAMA-8B");
+    expect(p3?.usd_per_mtok).toBe(0);
+  });
+
+  it("matches by leaf / suffix (drops host prefix)", () => {
+    const cat = makeCatalog();
+    // "claude-sonnet-4-6" is registered as-is; lookup with host prefix should match
+    const p = cat.lookup("anthropic/claude-sonnet-4-6");
+    expect(p?.input_usd_per_mtok).toBe(3);
+    // Reverse: registered with host prefix, lookup without
+    const p2 = cat.lookup("gpt-4o");
+    expect(p2?.input_usd_per_mtok).toBe(2.5);
+  });
+
+  it("matches when lookup ends with a registered key (suffix)", () => {
+    const cat = makeCatalog();
+    // "gpt-4o" suffix matches "openai/gpt-4o" (ml.endsWith(kl))
+    const p = cat.lookup("acme/gpt-4o");
+    expect(p?.input_usd_per_mtok).toBe(2.5);
+  });
+});
+
+describe("validatePricingFile / PricingCatalog.load permission checks", () => {
+  const validPricingJson = JSON.stringify({
+    models: { m: { input_usd_per_mtok: 3 } },
+  });
+
+  function writeSecure(path: string): void {
+    writeFileSync(path, validPricingJson);
+    chmodSync(path, 0o600);
+  }
+
+  it("PricingCatalog.load accepts a 0o600 file owned by the process user", () => {
+    const path = join(dir, "secure.json");
+    writeSecure(path);
+    // On macOS/Linux CI, the test process owns the temp file; on Windows,
+    // validatePricingFile skips the ownership check.
+    const cat = PricingCatalog.load(path);
+    expect(cat.models.size).toBe(1);
+  });
+
+  it("validatePricingFile rejects group-writable files (0o620)", () => {
+    const path = join(dir, "group-writable.json");
+    writeFileSync(path, validPricingJson);
+    chmodSync(path, 0o620);
+    const result = validatePricingFile(path);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("insecure mode");
+    }
+  });
+
+  it("validatePricingFile rejects world-writable files (0o622)", () => {
+    const path = join(dir, "world-writable.json");
+    writeFileSync(path, validPricingJson);
+    chmodSync(path, 0o622);
+    const result = validatePricingFile(path);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("insecure mode");
+    }
+  });
+
+  it("validatePricingFile rejects world-writable files (0o606)", () => {
+    const path = join(dir, "world-rw.json");
+    writeFileSync(path, validPricingJson);
+    chmodSync(path, 0o606);
+    const result = validatePricingFile(path);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("insecure mode");
+    }
+  });
+
+  it("validatePricingFile accepts read-only for owner (0o400)", () => {
+    const path = join(dir, "readonly.json");
+    writeFileSync(path, validPricingJson);
+    chmodSync(path, 0o400);
+    const result = validatePricingFile(path);
+    expect(result.ok).toBe(true);
+  });
+
+  it("PricingCatalog.load returns empty catalog for group-writable file", () => {
+    const path = join(dir, "pricing-group-write.json");
+    writeFileSync(path, validPricingJson);
+    chmodSync(path, 0o620);
+    const cat = PricingCatalog.load(path);
+    expect(cat.models.size).toBe(0);
+  });
+
+  it("PricingCatalog.load returns empty catalog for world-writable file", () => {
+    const path = join(dir, "pricing-world-write.json");
+    writeFileSync(path, validPricingJson);
+    chmodSync(path, 0o622);
+    const cat = PricingCatalog.load(path);
+    expect(cat.models.size).toBe(0);
+  });
+
+  it("PricingCatalog.load returns empty catalog when file is a directory", () => {
+    const cat = PricingCatalog.load(dir); // dir is a directory
+    expect(cat.models.size).toBe(0);
+  });
+
+  it("getProcessUid returns a number on POSIX or undefined on Windows", () => {
+    const uid = getProcessUid();
+    expect(uid === undefined || (typeof uid === "number" && uid >= 0)).toBe(true);
+  });
+
+  it("isPosixPlatform returns true on macOS/Linux and false on win32", () => {
+    // On this CI (macOS) expect true; the function is pure logic.
+    expect(isPosixPlatform()).toBe(process.platform !== "win32");
+  });
+
+  it("validatePricingFile skips mode checks on Windows — accepts 0o622", () => {
+    // On Windows, stat.mode typically includes write bits for everyone,
+    // so we must skip the POSIX mode check. Simulate by passing posix=false.
+    const path = join(dir, "windows-mode.json");
+    writeFileSync(path, validPricingJson);
+    chmodSync(path, 0o622); // would be rejected on POSIX
+
+    const result = validatePricingFile(path, { posix: false });
+    expect(result.ok).toBe(true);
+  });
+
+  it("PricingCatalog.load accepts the file on simulated Windows", () => {
+    const path = join(dir, "win-catalog.json");
+    writeFileSync(path, validPricingJson);
+    chmodSync(path, 0o622); // would be rejected on POSIX
+
+    const cat = PricingCatalog.load(path, { posix: false });
+    expect(cat.models.size).toBe(1);
+  });
+
+  it("PricingCatalog.load writes a warning to stderr for insecure file permissions", () => {
+    const path = join(dir, "pricing-stderr-warn.json");
+    writeFileSync(path, validPricingJson);
+    chmodSync(path, 0o622); // world-writable → rejected
+
+    const captured: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    // Intercept process.stderr.write to capture warnings without printing them.
+    const restore = () => {
+      process.stderr.write = orig;
+    };
+    process.stderr.write = ((chunk: string | Uint8Array, ..._args: unknown[]) => {
+      const msg = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+      captured.push(msg);
+      return true;
+    }) as typeof process.stderr.write;
+
+    let cat: PricingCatalog;
+    try {
+      cat = PricingCatalog.load(path);
+    } finally {
+      restore();
+    }
+    expect(cat.models.size).toBe(0);
+    expect(captured.some((m) => m.includes("insecure mode"))).toBe(true);
+    expect(captured.some((m) => m.includes(path))).toBe(true);
+  });
+
+  it("PricingCatalog.load warns on stderr for unreadable JSON", () => {
+    const path = join(dir, "bad-json-stderr.json");
+    writeFileSync(path, "{{{ not json");
+    // 0600 so the "unreadable" parse warning fires, not the permission-gate warning.
+    chmodSync(path, 0o600);
+
+    const captured: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    const restore = () => {
+      process.stderr.write = orig;
+    };
+    process.stderr.write = ((chunk: string | Uint8Array, ..._args: unknown[]) => {
+      const msg = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+      captured.push(msg);
+      return true;
+    }) as typeof process.stderr.write;
+
+    let cat: PricingCatalog;
+    try {
+      cat = PricingCatalog.load(path);
+    } finally {
+      restore();
+    }
+    expect(cat.models.size).toBe(0);
+    expect(captured.some((m) => m.includes("unreadable"))).toBe(true);
+  });
+
+  it("PricingCatalog.load warns on stderr for oversized file", () => {
+    const path = join(dir, "giant-pricing.json");
+    // Write a file larger than 2 MiB.
+    const header = '{"models":{';
+    const footer = '"m":{"input_usd_per_mtok":1}}}';
+    const pad = " ".repeat(2_200_000);
+    writeFileSync(path, header + pad + footer);
+
+    const captured: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    const restore = () => {
+      process.stderr.write = orig;
+    };
+    process.stderr.write = ((chunk: string | Uint8Array, ..._args: unknown[]) => {
+      const msg = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+      captured.push(msg);
+      return true;
+    }) as typeof process.stderr.write;
+
+    let cat: PricingCatalog;
+    try {
+      cat = PricingCatalog.load(path);
+    } finally {
+      restore();
+    }
+    expect(cat.models.size).toBe(0);
+    expect(captured.some((m) => m.includes("exceeds"))).toBe(true);
+  });
+
+  it("never opens or leaks a file descriptor on oversized files (size gate before openSync)", () => {
+    resetFsSpy();
+    const path = join(dir, "oversized-noleak.json");
+    const pad = " ".repeat(2_200_000);
+    writeFileSync(path, '{"models":{"m":{"input_usd_per_mtok":1}}}' + pad);
+    // Confirm the file is oversized.
+    expect(statSync(path).size).toBeGreaterThan(2_097_152);
+
+    const cat = PricingCatalog.load(path);
+
+    // Size gate rejects the file before openSync is ever called → no fd leak.
+    expect(fsSpy.openCount).toBe(0);
+    expect(fsSpy.closeCount).toBe(0);
+    expect(cat.models.size).toBe(0);
+  });
+});
+
+describe("resolveCost precedence", () => {
+  const pricing = (() => {
+    const p = new PricingCatalog();
+    p.models.set("paid-model", { input_usd_per_mtok: 3, output_usd_per_mtok: 15 });
+    return p;
+  })();
+
+  it("uses explicit costUsd when present", () => {
+    expect(
+      resolveCost(
+        { provider: "p", model: "paid-model", tokensIn: 1000, tokensOut: 1000, costUsd: 9 },
+        { pricing },
+      ),
+    ).toBe(9);
+  });
+
+  it("treats free-classified models as $0 even when priced", () => {
+    expect(
+      resolveCost(
+        { provider: "p", model: "paid-model", tokensIn: 1_000_000, tokensOut: 0, free: true },
+        { pricing },
+      ),
+    ).toBe(0);
+  });
+
+  it("estimates from the catalog when no cost is given", () => {
+    // 1M input @ $3/Mtok + 1M output @ $15/Mtok = $18
+    expect(
+      resolveCost(
+        { provider: "p", model: "paid-model", tokensIn: 1_000_000, tokensOut: 1_000_000 },
+        { pricing },
+      ),
+    ).toBeCloseTo(18, 6);
+  });
+
+  it("never invents cost for an unknown model", () => {
+    expect(
+      resolveCost(
+        { provider: "p", model: "mystery", tokensIn: 1_000_000, tokensOut: 0 },
+        { pricing },
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("ledger persistence", () => {
+  it("appends one tolerant JSONL row per call and reads it back", () => {
+    const path = join(dir, "ledger.jsonl");
+    const ledger = new Ledger(path);
+    ingest(ledger, {
+      provider: "openai",
+      model: "gpt-x",
+      tokensIn: 10,
+      tokensOut: 5,
+      costUsd: 0.5,
+      tsUtc: "2026-06-10T00:00:00.000Z",
+    });
+    ingest(ledger, {
+      provider: "openai",
+      model: "gpt-x",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-06-11T00:00:00.000Z",
+    });
+    const rows = ledger.entries();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ provider: "openai", model: "gpt-x", cost_usd: 0.5 });
+  });
+
+  it("skips malformed JSONL lines and fires onMalformed with the correct count", () => {
+    const path = join(dir, "ledger-malformed.jsonl");
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({
+          ts_utc: "2026-06-10T12:00:00.000Z",
+          provider: "openai",
+          model: "gpt-x",
+          tokens_in: 10,
+          tokens_out: 5,
+          cost_usd: 0.5,
+        }),
+        "", // blank line (fine)
+        "{broken json", // unparseable
+        JSON.stringify({ ts_utc: "2026-06-11T00:00:00.000Z", provider: "x", model: "y" }), // missing numeric fields → malformed
+        "null", // parses but not a valid entry object
+        JSON.stringify({
+          ts_utc: "2026-06-12T00:00:00.000Z",
+          provider: "a",
+          model: "b",
+          tokens_in: 1,
+          tokens_out: 1,
+          cost_usd: 0,
+        }),
+      ].join("\n") + "\n",
+    );
+
+    let malformedCount = -1;
+    const ledger = new Ledger(path, {
+      onMalformed: (count) => {
+        malformedCount = count;
+      },
+    });
+    const rows = ledger.entries();
+    // Valid rows: line 1 (gpt-x), line 6 (a/b)
+    expect(rows).toHaveLength(2);
+    // Malformed: "{broken json" (parse), missing-numeric-fields, "null"
+    expect(malformedCount).toBe(3);
+  });
+
+  it("skips rows with missing or non-finite numeric fields (NaN safeguard)", () => {
+    const path = join(dir, "ledger-nan.jsonl");
+    writeFileSync(
+      path,
+      [
+        // missing tokens_in
+        JSON.stringify({
+          ts_utc: "2026-06-10T12:00:00.000Z",
+          provider: "x",
+          model: "m",
+          tokens_out: 5,
+          cost_usd: 0,
+        }),
+        // missing tokens_out
+        JSON.stringify({
+          ts_utc: "2026-06-10T13:00:00.000Z",
+          provider: "x",
+          model: "m",
+          tokens_in: 10,
+          cost_usd: 0,
+        }),
+        // missing cost_usd
+        JSON.stringify({
+          ts_utc: "2026-06-10T14:00:00.000Z",
+          provider: "x",
+          model: "m",
+          tokens_in: 10,
+          tokens_out: 5,
+        }),
+        // tokens_in is null (JSON encodes Infinity as null)
+        JSON.stringify({
+          ts_utc: "2026-06-10T15:00:00.000Z",
+          provider: "x",
+          model: "m",
+          tokens_in: null,
+          tokens_out: 5,
+          cost_usd: 0,
+        }),
+        // cost_usd is a string
+        JSON.stringify({
+          ts_utc: "2026-06-10T17:00:00.000Z",
+          provider: "x",
+          model: "m",
+          tokens_in: 10,
+          tokens_out: 5,
+          cost_usd: "0.00",
+        }),
+        // all valid (sanity: not everything is malformed)
+        JSON.stringify({
+          ts_utc: "2026-06-10T18:00:00.000Z",
+          provider: "x",
+          model: "m",
+          tokens_in: 10,
+          tokens_out: 5,
+          cost_usd: 0,
+        }),
+      ].join("\n") + "\n",
+    );
+
+    let malformedCount = 0;
+    const ledger = new Ledger(path, {
+      onMalformed: (count) => {
+        malformedCount = count;
+      },
+    });
+    const rows = ledger.entries();
+    expect(rows).toHaveLength(1); // only the last line is valid
+    expect(rows[0].ts_utc).toBe("2026-06-10T18:00:00.000Z");
+    expect(malformedCount).toBe(5);
+  });
+
+  it("onMalformed is not called when all lines are valid", () => {
+    const path = join(dir, "ledger-valid.jsonl");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        ts_utc: "2026-06-10T12:00:00.000Z",
+        provider: "o",
+        model: "m",
+        tokens_in: 1,
+        tokens_out: 1,
+        cost_usd: 0,
+      }) + "\n",
+    );
+    let called = false;
+    const ledger = new Ledger(path, {
+      onMalformed: () => {
+        called = true;
+      },
+    });
+    ledger.entries();
+    expect(called).toBe(false);
+  });
+
+  it("returns empty array when the ledger file does not exist", () => {
+    const ledger = new Ledger(join(dir, "nonexistent.jsonl"));
+    expect(ledger.entries()).toEqual([]);
+  });
+
+  it("creates the parent directory lazily on first record", () => {
+    const sub = join(dir, "nested", "deep", "ledger.jsonl");
+    // Verify the parent does not exist yet.
+    expect(existsSync(dirname(sub))).toBe(false);
+    const ledger = new Ledger(sub);
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+    });
+    expect(existsSync(dirname(sub))).toBe(true);
+    const stat = statSync(dirname(sub));
+    expect(stat.isDirectory()).toBe(true);
+    const rows = ledger.entries();
+    expect(rows).toHaveLength(1);
+  });
+
+  it("calls onError when appendFileSync throws (disk full etc.) and does not crash", () => {
+    const path = join(dir, "ledger-error.jsonl");
+    let errorCaught: unknown = undefined;
+    const ledger = new Ledger(path, {
+      onError: (err) => {
+        errorCaught = err;
+      },
+    });
+
+    fsSpy.throwOnAppend = true;
+    try {
+      const entry = ingest(ledger, {
+        provider: "test",
+        model: "m",
+        tokensIn: 1,
+        tokensOut: 1,
+        costUsd: 0,
+      });
+      // ingest returns the entry even when the write fails
+      expect(entry).toBeDefined();
+      expect(entry.model).toBe("m");
+    } finally {
+      fsSpy.throwOnAppend = false;
+    }
+
+    expect(errorCaught).toBeDefined();
+    expect(String(errorCaught)).toContain("ENOSPC");
+    // The file was never written, so entries() returns empty
+    expect(ledger.entries()).toHaveLength(0);
+  });
+
+  it("host field is persisted in the ledger entry when provided", () => {
+    const path = join(dir, "ledger-host.jsonl");
+    const ledger = new Ledger(path);
+    ingest(ledger, {
+      provider: "openai",
+      model: "gpt-x",
+      tokensIn: 10,
+      tokensOut: 5,
+      costUsd: 0.5,
+      host: "codex",
+    });
+    const rows = ledger.entries();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].host).toBe("codex");
+  });
+});
+
+describe("ledger window filtering", () => {
+  it("entriesIn includes entries on both window boundaries (inclusive)", () => {
+    const path = join(dir, "ledger-window-in.jsonl");
+    const ledger = new Ledger(path);
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-06-01T00:00:00.000Z",
+    });
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-06-30T23:59:59.999Z",
+    });
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-06-15T12:00:00.000Z",
+    });
+
+    const rows = ledger.entriesIn(
+      new Date("2026-06-01T00:00:00.000Z"),
+      new Date("2026-06-30T23:59:59.999Z"),
+    );
+    expect(rows).toHaveLength(3);
+  });
+
+  it("entriesIn excludes entries strictly before the window", () => {
+    const path = join(dir, "ledger-before.jsonl");
+    const ledger = new Ledger(path);
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-05-31T23:59:59.999Z",
+    });
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-06-15T12:00:00.000Z",
+    });
+
+    const rows = ledger.entriesIn(
+      new Date("2026-06-01T00:00:00.000Z"),
+      new Date("2026-06-30T23:59:59.999Z"),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].ts_utc).toBe("2026-06-15T12:00:00.000Z");
+  });
+
+  it("entriesIn excludes entries strictly after the window", () => {
+    const path = join(dir, "ledger-after.jsonl");
+    const ledger = new Ledger(path);
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-07-01T00:00:00.000Z",
+    });
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-06-15T12:00:00.000Z",
+    });
+
+    const rows = ledger.entriesIn(
+      new Date("2026-06-01T00:00:00.000Z"),
+      new Date("2026-06-30T23:59:59.999Z"),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].ts_utc).toBe("2026-06-15T12:00:00.000Z");
+  });
+
+  it("entriesIn with only a since bound excludes earlier entries", () => {
+    const path = join(dir, "ledger-since-only.jsonl");
+    const ledger = new Ledger(path);
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-06-01T00:00:00.000Z",
+    });
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-05-31T00:00:00.000Z",
+    });
+
+    const rows = ledger.entriesIn(new Date("2026-06-01T00:00:00.000Z"), undefined);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].ts_utc).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("entriesIn with only an until bound excludes later entries", () => {
+    const path = join(dir, "ledger-until-only.jsonl");
+    const ledger = new Ledger(path);
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-06-30T23:59:59.999Z",
+    });
+    ingest(ledger, {
+      provider: "test",
+      model: "m",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: 0,
+      tsUtc: "2026-07-01T00:00:00.000Z",
+    });
+
+    const rows = ledger.entriesIn(undefined, new Date("2026-06-30T23:59:59.999Z"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].ts_utc).toBe("2026-06-30T23:59:59.999Z");
+  });
+});
+
+describe("buildReport free-vs-paid", () => {
+  it("splits free and paid tokens and computes avoided/counterfactual", () => {
+    const adapter = new HostAdapter(join(dir, "ledger.jsonl"), "openclaw");
+    // paid call: $0.20, 1000 tokens
+    adapter.track({
+      provider: "anthropic",
+      model: "paid",
+      tokensIn: 600,
+      tokensOut: 400,
+      costUsd: 0.2,
+      tsUtc: "2026-06-10T12:00:00.000Z",
+    });
+    // free call: $0, 2000 tokens
+    adapter.track({
+      provider: "local",
+      model: "free",
+      tokensIn: 1500,
+      tokensOut: 500,
+      costUsd: 0,
+      tsUtc: "2026-06-10T13:00:00.000Z",
+    });
+
+    const pricing = new PricingCatalog();
+    pricing.baselineModel = "frontier";
+    pricing.baselineUsdPerMtok = 10; // $10 / Mtok
+
+    const rep = buildReport({
+      ledger: adapter.ledger,
+      pricing,
+      since: new Date("2026-06-01T00:00:00.000Z"),
+      until: new Date("2026-06-30T23:59:59.000Z"),
+      gran: "day",
+    });
+
+    expect(rep.total_calls).toBe(2);
+    expect(rep.total_tokens).toBe(3000);
+    expect(rep.total_cost_usd).toBeCloseTo(0.2, 6);
+    expect(rep.free_tokens).toBe(2000);
+    expect(rep.billed_tokens).toBe(1000);
+    // avoided = 2000 free tokens @ $10/Mtok = $0.02
+    expect(rep.avoided_usd).toBeCloseTo(0.02, 6);
+    // counterfactual = 3000 tokens @ $10/Mtok = $0.03
+    expect(rep.counterfactual_usd).toBeCloseTo(0.03, 6);
+
+    const paid = rep.by_model.find((r) => r.model === "paid");
+    const free = rep.by_model.find((r) => r.model === "free");
+    expect(paid?.billed).toBe(true);
+    expect(free?.billed).toBe(false);
+  });
+
+  it("derives the baseline from observed paid spend when no catalog baseline is set", () => {
+    const adapter = new HostAdapter(join(dir, "ledger.jsonl"), "openclaw");
+    // paid: $0.20 over 1000 tokens => effective 200 $/Mtok
+    adapter.track({
+      provider: "anthropic",
+      model: "paid",
+      tokensIn: 600,
+      tokensOut: 400,
+      costUsd: 0.2,
+      tsUtc: "2026-06-10T12:00:00.000Z",
+    });
+    // free: 2000 tokens
+    adapter.track({
+      provider: "local",
+      model: "free",
+      tokensIn: 1500,
+      tokensOut: 500,
+      costUsd: 0,
+      tsUtc: "2026-06-10T13:00:00.000Z",
+    });
+
+    // Empty catalog: no baseline override -> derive from observed spend.
+    const rep = buildReport({
+      ledger: adapter.ledger,
+      pricing: new PricingCatalog(),
+      since: new Date("2026-06-01T00:00:00.000Z"),
+      until: new Date("2026-06-30T23:59:59.000Z"),
+      gran: "day",
+    });
+
+    expect(rep.baseline_model).toBe("paid");
+    expect(rep.baseline_usd_per_mtok).toBeCloseTo(200, 6);
+    // avoided = 2000 free tokens @ derived 200/Mtok = $0.40
+    expect(rep.avoided_usd).toBeCloseTo(0.4, 6);
+    // counterfactual = 3000 tokens @ 200/Mtok = $0.60
+    expect(rep.counterfactual_usd).toBeCloseTo(0.6, 6);
+  });
+
+  it("selects the highest effective $/Mtok among multiple paid models when deriving baseline", () => {
+    const adapter = new HostAdapter(join(dir, "ledger.jsonl"), "openclaw");
+    // Model A: $0.15 over 1000 tokens → effective 150 $/Mtok
+    adapter.track({
+      provider: "anthropic",
+      model: "model-a",
+      tokensIn: 500,
+      tokensOut: 500,
+      costUsd: 0.15,
+      tsUtc: "2026-06-10T12:00:00.000Z",
+    });
+    // Model B: $0.40 over 1000 tokens → effective 400 $/Mtok (highest)
+    adapter.track({
+      provider: "openai",
+      model: "model-b",
+      tokensIn: 800,
+      tokensOut: 200,
+      costUsd: 0.4,
+      tsUtc: "2026-06-10T13:00:00.000Z",
+    });
+    // Model C: $0.08 over 800 tokens → effective 100 $/Mtok
+    adapter.track({
+      provider: "openrouter",
+      model: "model-c",
+      tokensIn: 400,
+      tokensOut: 400,
+      costUsd: 0.08,
+      tsUtc: "2026-06-10T14:00:00.000Z",
+    });
+    // Free model — should not affect the baseline
+    adapter.track({
+      provider: "local",
+      model: "free-model",
+      tokensIn: 2000,
+      tokensOut: 1000,
+      costUsd: 0,
+      tsUtc: "2026-06-10T15:00:00.000Z",
+    });
+
+    const rep = buildReport({
+      ledger: adapter.ledger,
+      pricing: new PricingCatalog(),
+      since: new Date("2026-06-01T00:00:00.000Z"),
+      until: new Date("2026-06-30T23:59:59.000Z"),
+      gran: "day",
+    });
+
+    // Model B at 400 $/Mtok should be selected as the baseline.
+    expect(rep.baseline_model).toBe("model-b");
+    expect(rep.baseline_usd_per_mtok).toBeCloseTo(400, 6);
+    // free tokens = 3000 @ 400/Mtok → $1.20 avoided
+    expect(rep.avoided_usd).toBeCloseTo(1.2, 6);
+  });
+});
+
+describe("buildReport time-bucket granularity", () => {
+  it("buckets by hour when gran is 'hour'", () => {
+    const adapter = new HostAdapter(join(dir, "ledger-hour.jsonl"), "openclaw");
+    // Two entries at hour 08, one at hour 14 on the same day
+    adapter.track({
+      provider: "test",
+      model: "m",
+      tokensIn: 100,
+      tokensOut: 50,
+      costUsd: 0.1,
+      tsUtc: "2026-06-10T08:30:00.000Z",
+    });
+    adapter.track({
+      provider: "test",
+      model: "m",
+      tokensIn: 200,
+      tokensOut: 100,
+      costUsd: 0.2,
+      tsUtc: "2026-06-10T08:45:00.000Z",
+    });
+    adapter.track({
+      provider: "test",
+      model: "m",
+      tokensIn: 300,
+      tokensOut: 150,
+      costUsd: 0.3,
+      tsUtc: "2026-06-10T14:00:00.000Z",
+    });
+
+    const rep = buildReport({
+      ledger: adapter.ledger,
+      pricing: new PricingCatalog(),
+      since: new Date("2026-06-10T00:00:00.000Z"),
+      until: new Date("2026-06-10T23:59:59.999Z"),
+      gran: "hour",
+    });
+
+    expect(rep.bucket_gran).toBe("hour");
+    expect(rep.buckets).toHaveLength(2);
+    const h08 = rep.buckets.find((b) => b.key === "2026-06-10 08:00");
+    const h14 = rep.buckets.find((b) => b.key === "2026-06-10 14:00");
+    expect(h08).toBeDefined();
+    expect(h08!.calls).toBe(2);
+    expect(h08!.tokens_in).toBe(300);
+    expect(h08!.tokens_out).toBe(150);
+    expect(h08!.cost_usd).toBeCloseTo(0.3, 6);
+    expect(h14).toBeDefined();
+    expect(h14!.calls).toBe(1);
+    expect(h14!.tokens_in).toBe(300);
+    expect(h14!.tokens_out).toBe(150);
+  });
+
+  it("buckets by week when gran is 'week' with ISO week keys", () => {
+    const adapter = new HostAdapter(join(dir, "ledger-week.jsonl"), "openclaw");
+    // 2026-06-10 (Wed) → ISO week 24
+    adapter.track({
+      provider: "test",
+      model: "m",
+      tokensIn: 100,
+      tokensOut: 50,
+      costUsd: 0.5,
+      tsUtc: "2026-06-10T12:00:00.000Z",
+    });
+    // 2026-06-16 (Tue) → ISO week 25
+    adapter.track({
+      provider: "test",
+      model: "m",
+      tokensIn: 200,
+      tokensOut: 100,
+      costUsd: 0.6,
+      tsUtc: "2026-06-16T12:00:00.000Z",
+    });
+    // 2026-06-22 (Mon) → ISO week 26
+    adapter.track({
+      provider: "test",
+      model: "m",
+      tokensIn: 300,
+      tokensOut: 150,
+      costUsd: 0.7,
+      tsUtc: "2026-06-22T12:00:00.000Z",
+    });
+
+    const rep = buildReport({
+      ledger: adapter.ledger,
+      pricing: new PricingCatalog(),
+      since: new Date("2026-06-01T00:00:00.000Z"),
+      until: new Date("2026-06-30T23:59:59.999Z"),
+      gran: "week",
+    });
+
+    expect(rep.bucket_gran).toBe("week");
+    // At least 2 distinct weeks (some dates might group, but 10th, 16th, 22nd are different weeks)
+    expect(rep.buckets.length).toBeGreaterThanOrEqual(2);
+    for (const b of rep.buckets) {
+      expect(b.key).toMatch(/^\d{4}-W\d{2}$/);
+    }
+    // Verify sorted order
+    const keys = rep.buckets.map((b) => b.key);
+    expect([...keys].toSorted()).toEqual(keys);
+  });
+
+  it("buckets by month when gran is 'month' and aggregates across month boundaries", () => {
+    const adapter = new HostAdapter(join(dir, "ledger-month.jsonl"), "openclaw");
+    // May 2026
+    adapter.track({
+      provider: "test",
+      model: "m",
+      tokensIn: 100,
+      tokensOut: 50,
+      costUsd: 0.1,
+      tsUtc: "2026-05-15T12:00:00.000Z",
+    });
+    // June 2026 (two calls)
+    adapter.track({
+      provider: "test",
+      model: "m",
+      tokensIn: 200,
+      tokensOut: 100,
+      costUsd: 0.2,
+      tsUtc: "2026-06-01T12:00:00.000Z",
+    });
+    adapter.track({
+      provider: "test",
+      model: "m",
+      tokensIn: 300,
+      tokensOut: 150,
+      costUsd: 0.3,
+      tsUtc: "2026-06-30T23:59:59.999Z",
+    });
+
+    const rep = buildReport({
+      ledger: adapter.ledger,
+      pricing: new PricingCatalog(),
+      since: new Date("2026-05-01T00:00:00.000Z"),
+      until: new Date("2026-06-30T23:59:59.999Z"),
+      gran: "month",
+    });
+
+    expect(rep.bucket_gran).toBe("month");
+    expect(rep.buckets).toHaveLength(2);
+    const may = rep.buckets.find((b) => b.key === "2026-05");
+    const june = rep.buckets.find((b) => b.key === "2026-06");
+    expect(may).toBeDefined();
+    expect(may!.calls).toBe(1);
+    expect(may!.tokens_in).toBe(100);
+    expect(may!.tokens_out).toBe(50);
+    expect(may!.cost_usd).toBeCloseTo(0.1, 6);
+    expect(june).toBeDefined();
+    expect(june!.calls).toBe(2);
+    expect(june!.tokens_in).toBe(500);
+    expect(june!.tokens_out).toBe(250);
+    expect(june!.cost_usd).toBeCloseTo(0.5, 6);
+  });
+});
+
+describe("parseGran", () => {
+  it("returns 'hour' for 'hour' and 'hourly'", () => {
+    expect(parseGran("hour")).toBe("hour");
+    expect(parseGran("hourly")).toBe("hour");
+  });
+
+  it("returns 'day' for 'day' and 'daily'", () => {
+    expect(parseGran("day")).toBe("day");
+    expect(parseGran("daily")).toBe("day");
+  });
+
+  it("returns 'week' for 'week' and 'weekly'", () => {
+    expect(parseGran("week")).toBe("week");
+    expect(parseGran("weekly")).toBe("week");
+  });
+
+  it("returns 'month' for 'month' and 'monthly'", () => {
+    expect(parseGran("month")).toBe("month");
+    expect(parseGran("monthly")).toBe("month");
+  });
+
+  it("defaults to 'day' for unknown inputs (e.g. 'foobar')", () => {
+    expect(parseGran("foobar")).toBe("day");
+    expect(parseGran("")).toBe("day");
+    expect(parseGran("unknown")).toBe("day");
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseGran("WEEK")).toBe("week");
+    expect(parseGran("Monthly")).toBe("month");
+    expect(parseGran("HoUr")).toBe("hour");
+  });
+});
+
+interface MockRes {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  ended: boolean;
+  setHeader(k: string, v: string): void;
+  end(chunk?: string): void;
+}
+
+function makeRes(): MockRes {
+  return {
+    statusCode: 0,
+    headers: {},
+    body: "",
+    ended: false,
+    setHeader(k: string, v: string) {
+      this.headers[k.toLowerCase()] = v;
+    },
+    end(chunk?: string) {
+      if (chunk) {
+        this.body += chunk;
+      }
+      this.ended = true;
+    },
+  };
+}
+
+function callHandler(
+  handler: ReturnType<typeof createTokenomicsService>["handler"],
+  method: string,
+  url: string,
+): MockRes {
+  const res = makeRes();
+  // The handler only reads `method` and `url`; cast the minimal mocks. The
+  // route resolves synchronously, so the boolean return is safe to ignore.
+  void handler({ method, url } as never, res as never);
+  return res;
+}
+
+describe("http handler", () => {
+  function startService() {
+    const svc = createTokenomicsService();
+    const ctx = {
+      stateDir: dir,
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+      // no internalDiagnostics: recording is skipped, but the route still serves
+    };
+    svc.service.start(ctx as never);
+    return svc;
+  }
+
+  it("rejects non-GET/HEAD methods with 405", () => {
+    const { handler } = startService();
+    const res = callHandler(handler, "POST", "/");
+    expect(res.statusCode).toBe(405);
+    expect(res.headers.allow).toBe("GET, HEAD");
+  });
+
+  it("returns 503 before the service has started", () => {
+    const { handler } = createTokenomicsService();
+    const res = callHandler(handler, "GET", "/");
+    expect(res.statusCode).toBe(503);
+  });
+
+  it("returns 400 for an unparseable bound", () => {
+    const { handler } = startService();
+    const res = callHandler(handler, "GET", "/?until=not-a-date");
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain("until");
+  });
+
+  it("returns 400 when since is after until", () => {
+    const { handler } = startService();
+    const res = callHandler(handler, "GET", "/?since=2026-06-30&until=2026-06-01");
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain("since");
+  });
+
+  it("serves JSON by default and text on request", () => {
+    const { handler } = startService();
+    const json = callHandler(handler, "GET", "/");
+    expect(json.statusCode).toBe(200);
+    expect(json.headers["content-type"]).toContain("application/json");
+    expect(() => JSON.parse(json.body)).not.toThrow();
+
+    const text = callHandler(handler, "GET", "/?format=text");
+    expect(text.statusCode).toBe(200);
+    expect(text.headers["content-type"]).toContain("text/plain");
+    expect(text.body.length).toBeGreaterThan(0);
+  });
+
+  it("answers HEAD with no body", () => {
+    const { handler } = startService();
+    const res = callHandler(handler, "HEAD", "/");
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe("");
+  });
+
+  it("reflects the period label in the JSON report when supplied", () => {
+    const { handler } = startService();
+    const res = callHandler(handler, "GET", "/?period=Q2%202026");
+    expect(res.statusCode).toBe(200);
+    const report = JSON.parse(res.body);
+    expect(report.period).toBe("Q2 2026");
+  });
+
+  it("reflects the period label in the text report when supplied", () => {
+    const { handler } = startService();
+    const res = callHandler(handler, "GET", "/?format=text&period=Q2%202026");
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain("Q2 2026");
+  });
+});
+
+describe("usage recording", () => {
+  function startWithDiagnostics() {
+    const svc = createTokenomicsService();
+    let emit: ((event: unknown, metadata: unknown) => void) | undefined;
+    const warnings: string[] = [];
+    const ctx = {
+      stateDir: dir,
+      logger: {
+        info() {},
+        debug() {},
+        error() {},
+        warn(msg: string) {
+          warnings.push(msg);
+        },
+      },
+      internalDiagnostics: {
+        onEvent: (cb: (event: unknown, metadata: unknown) => void) => {
+          emit = cb;
+          return () => {};
+        },
+      },
+    };
+    svc.service.start(ctx as never);
+    if (!emit) {
+      throw new Error("service did not subscribe to diagnostics");
+    }
+    return { svc, emit, warnings };
+  }
+
+  function ledgerEntries() {
+    return new Ledger(join(dir, "tokenomics", "ledger.jsonl")).entries();
+  }
+
+  it("records a usage event that carries token usage", () => {
+    const { emit } = startWithDiagnostics();
+    emit(
+      {
+        type: "model.usage",
+        provider: "groq",
+        model: "llama",
+        usage: { input: 100, output: 50 },
+        costUsd: 0,
+      },
+      { trusted: true },
+    );
+    const entries = ledgerEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      provider: "groq",
+      model: "llama",
+      tokens_in: 100,
+      tokens_out: 50,
+    });
+  });
+
+  it("skips and warns on a usage event with no tokens and no cost", () => {
+    const { emit, warnings } = startWithDiagnostics();
+    // Mirrors a streamed call where the provider omitted usage (the
+    // supportsUsageInStreaming gap): no tokens, no cost.
+    emit(
+      { type: "model.usage", provider: "custom-enterprise", model: "custom-model", usage: {} },
+      { trusted: true },
+    );
+    expect(ledgerEntries()).toHaveLength(0);
+    expect(warnings.some((w) => w.includes("supportsUsageInStreaming"))).toBe(true);
+  });
+
+  it("still records a zero-cost call when tokens are present (free model)", () => {
+    const { emit } = startWithDiagnostics();
+    emit(
+      {
+        type: "model.usage",
+        provider: "custom-enterprise",
+        model: "free-model",
+        usage: { input: 10, output: 20 },
+        costUsd: 0,
+      },
+      { trusted: true },
+    );
+    const entries = ledgerEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].cost_usd).toBe(0);
+  });
+});
+
+describe("renderReport honors NO_COLOR", () => {
+  it("omits ANSI escape codes when NO_COLOR is set", () => {
+    const prev = process.env.NO_COLOR;
+    process.env.NO_COLOR = "1";
+    try {
+      const rep = buildReport({
+        ledger: new Ledger(join(dir, "ledger.jsonl")),
+        pricing: new PricingCatalog(),
+        since: new Date("2026-06-01"),
+        until: new Date("2026-06-30T23:59:59.000Z"),
+      });
+      const out = renderReport(rep);
+      // eslint-disable-next-line no-control-regex -- intentionally checking for ANSI escapes
+      expect(out).not.toMatch(/\x1b\[/);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.NO_COLOR;
+      } else {
+        process.env.NO_COLOR = prev;
+      }
+    }
+  });
+
+  it("omits ANSI codes in shareBar when NO_COLOR is set", () => {
+    const prev = process.env.NO_COLOR;
+    process.env.NO_COLOR = "1";
+    try {
+      const bar = shareBar(500, 1000);
+      // eslint-disable-next-line no-control-regex -- intentionally checking for ANSI escapes
+      expect(bar).not.toMatch(/\x1b\[/);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.NO_COLOR;
+      } else {
+        process.env.NO_COLOR = prev;
+      }
+    }
+  });
+});
+
+describe("FinOps observability (finops.ts)", () => {
+  it("buildFinOpsReport: allocation, realized rate, advisor, forecast", () => {
+    const finopsDir = mkdtempSync(join(tmpdir(), "tok-finops-"));
+    const led = new Ledger(join(finopsDir, "ledger.jsonl"));
+    const now = new Date();
+    const iso = (daysAgo: number) => new Date(now.getTime() - daysAgo * 86_400_000).toISOString();
+    const rows: TaggedLedgerEntry[] = [
+      {
+        ts_utc: iso(2),
+        provider: "openai",
+        model: "gpt-4o",
+        tokens_in: 1_000_000,
+        tokens_out: 500_000,
+        cost_usd: 7.5,
+        caller: "agent-a",
+        task: "build",
+      },
+      {
+        ts_utc: iso(1),
+        provider: "openai",
+        model: "gpt-4o-mini",
+        tokens_in: 2_000_000,
+        tokens_out: 1_000_000,
+        cost_usd: 0.9,
+        caller: "agent-a",
+        task: "review",
+      },
+      {
+        ts_utc: iso(0),
+        provider: "local",
+        model: "local/free",
+        tokens_in: 1_000_000,
+        tokens_out: 1_000_000,
+        cost_usd: 0,
+        caller: "agent-b",
+      },
+    ];
+    for (const r of rows) {
+      led.record(r);
+    }
+
+    const pricing = new PricingCatalog();
+    pricing.models.set("gpt-4o", { input_usd_per_mtok: 2.5, output_usd_per_mtok: 10 });
+    pricing.models.set("gpt-4o-mini", { input_usd_per_mtok: 0.15, output_usd_per_mtok: 0.6 });
+
+    const rep = buildFinOpsReport(led, pricing, {
+      since: new Date(now.getTime() - 3 * 86_400_000),
+      until: now,
+    });
+
+    expect(rep.total_calls).toBe(3);
+    // Realized $/Mtok is computed from actual ledger spend.
+    expect(
+      rep.by_model_realized.find((m) => m.model === "gpt-4o")?.realized_usd_per_mtok,
+    ).toBeGreaterThan(0);
+    // Allocation groups both of agent-a's calls.
+    expect(rep.by_caller.find((g) => g.key === "agent-a")?.calls).toBe(2);
+    // Advisor is report-only and never proposes negative savings.
+    expect(rep.advisor.every((a) => a.potential_savings_usd >= 0)).toBe(true);
+    // Burn forecast saw at least one day of data.
+    expect(rep.forecast.sample_days).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/extensions/tokenomics/tsconfig.json
+++ b/extensions/tokenomics/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "!dist/extensions/tavily/**",
     "!dist/extensions/tencent/**",
     "!dist/extensions/tokenjuice/**",
+    "!dist/extensions/tokenomics/**",
     "!dist/extensions/tlon/**",
     "!dist/extensions/twitch/**",
     "!dist/extensions/venice/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1615,6 +1615,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/tokenomics:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
   extensions/twitch:
     dependencies:
       '@twurple/api':


### PR DESCRIPTION
## What Problem This Solves

OpenClaw computes a per-call `costUsd` on `model.usage` diagnostics, but nothing persists or aggregates it: there is no durable record of spend over time and no view of how much was paid vs. run for free. Operators cannot answer "what did my agents cost this week, by model, and how much did free/local models save me?"

This PR adds a local-first plugin that turns OpenClaw's existing cost signal into a durable **ledger** and a **spend report** — without duplicating OpenClaw's price catalog.

## Summary

Adds **`tokenomics`**, a local-first plugin that gives OpenClaw a durable spend **ledger** and a **spend report** (period + by-model rollups, free-vs-paid split, avoided-spend / counterfactual headline).

It does **not** maintain its own price list. It **consumes OpenClaw's own per-call cost** (`costUsd` on `model.usage`, which OpenClaw already computes from its provider/model catalog) and adds the accounting layer on top — deliberately *consume-and-enhance*, not a duplicate catalog.

## How it works

- A startup service subscribes to internal `model.usage` diagnostics and appends one row (`ts_utc`, `provider`, `model`, `tokens_in`, `tokens_out`, `cost_usd`) to `<stateDir>/tokenomics/ledger.jsonl`.
- **Cost precedence:** host-reported `costUsd` is authoritative → otherwise a free classification yields `$0` → otherwise an optional local override catalog (`pricing.json`) estimates it. Unknown models stay `$0`, so cost is never invented.
- **Baseline derived from observed spend** by default (highest effective `$/Mtok` among paid models actually used), so no separate price catalog is required. `pricing.json` is only an optional override.
- Read-only report at `GET /api/diagnostics/tokenomics` (`?format=text|json`, `?since=&until=&gran=`).

## Design

- **Host-neutral and offline:** nothing leaves the machine; no pricing feed is fetched at runtime.
- **Single-user, local-first storage:** append-only JSONL with synchronous, tolerant reads (a half-written line is skipped and counted in a warning). SQLite with windowed reads is the documented path if a deployment outgrows it.
- **`pricing.json` treated as trusted input:** rejected if group/world-writable, oversized, non-regular, or unparseable.

## Evidence

- **78 colocated unit tests pass** (mapping, ledger persistence, pricing fallback + validation, derived baseline, inclusive date bounds, and the HTTP route incl. 400/405/503/HEAD).
- Green locally and in CI: extension tests, bundled type-aware lint, typecheck, format, knip, shrinkwrap, plus the repo packaging/lint-suppression registry tests.
- Sample `?format=text` report and `pricing.json` schema are documented in `extensions/tokenomics/README.md`.

## Evidence — live real-behavior proof

Per the automated review's request for install/enable/real-model-call/report-route proof, I built and ran this branch end-to-end on a clean Linux box (Node 22.23, pnpm 11.2.2, gateway bound to loopback) and exercised it with two **real** paid providers (Groq and MiniMax). Keys and the gateway token are redacted.

**1. The real blocker is a capability grant, not the plugin logic.** On unmodified `main`, `createServiceContext` (`src/plugins/services.ts`) grants `internalDiagnostics.onEvent` **only** to service ids `diagnostics-otel` / `diagnostics-prometheus`. With that gate, `tokenomics` logs:

```
[plugins] tokenomics: internal diagnostics capability unavailable; spend will not be recorded
```

…and records nothing. This matches the review finding exactly.

**2. With a one-line allowlist addition** (the maintainer decision below), the full chain works. The only change outside the extension:

```diff
   const isDiagnosticsExporter =
     params.service?.pluginId === params.service?.service.id &&
     (params.service?.service.id === "diagnostics-otel" ||
-      params.service?.service.id === "diagnostics-prometheus");
+      params.service?.service.id === "diagnostics-prometheus" ||
+      params.service?.service.id === "tokenomics");
```

**3. Plugin enabled + capability granted (gateway startup log):**

```
[gateway] http server listening (9 plugins: ... tokenomics; 0.3s)
[plugins] tokenomics: recording model spend to <stateDir>/tokenomics/ledger.jsonl
```

**4. Two real model calls ingested** (`openclaw agent` → real provider HTTP → `model.usage` with OpenClaw's authoritative `costUsd`), appended to `ledger.jsonl`:

```json
{"ts_utc":"2026-06-27T16:40:39.377Z","provider":"groq","model":"llama-3.3-70b-versatile","tokens_in":16445,"tokens_out":9,"cost_usd":0.00970966,"host":"openclaw"}
{"ts_utc":"2026-06-27T16:43:53.066Z","provider":"minimax","model":"MiniMax-M3","tokens_in":16056,"tokens_out":53,"cost_usd":0.00957648,"host":"openclaw"}
```

**5. The Gateway report route returns the aggregated report** — `GET /api/diagnostics/tokenomics` with gateway-token auth.

JSON:

```json
{
  "since": "2026-05-28", "until": "2026-06-27", "days": 30, "bucket_gran": "day",
  "by_model": [
    {"model":"llama-3.3-70b-versatile","cost_usd":0.00970966,"tokens":16454,"calls":1,"billed":true},
    {"model":"MiniMax-M3","cost_usd":0.00957648,"tokens":16109,"calls":1,"billed":true}
  ],
  "total_cost_usd": 0.01928614, "total_tokens": 32563, "total_calls": 2,
  "billed_tokens": 32563, "free_tokens": 0,
  "counterfactual_usd": 0.019358055635979893,
  "baseline_model": "MiniMax-M3", "baseline_usd_per_mtok": 0.5944801042895277
}
```

`?format=text`:

```
Tokenomics
2026-05-28 → 2026-06-27 (30d)

spent          $0.02  (2 calls, 32.6k tok)
avoided        $0.00  free tokens valued at baseline
counterfactual $0.02  all tokens @ MiniMax-M3 ($0.59/Mtok)

model                      calls     tokens     cost  tag
llama-3.3-70b-versatile        1      16.5k    $0.01  paid
MiniMax-M3                     1      16.1k    $0.01  paid
```

This confirms the plugin consumes OpenClaw's authoritative `costUsd`, persists it, and serves a correct period/by-model report with the derived baseline + counterfactual — end to end, on real provider traffic.

## Roadmap (follow-up PR)

A subscription/plan layer for billing models per-token pricing can't express:
- **Flat + session/rate limits** (e.g. OpenAI) and **flat + monthly token quota** (e.g. Minimax annual tiers).
- Reports subscription ROI vs metered-equivalent cost and quota utilization.
The foundation ledger already captures the `provider`/`model`/`tokens`/`cost_usd` primitives needed to layer this on.

## Note for maintainers — two asks

1. **Ingestion seam (the one real decision).** As shown above, the plugin's only hard dependency on core is the trusted internal-diagnostics subscription, which `main` currently restricts to the two diagnostics exporters. Please pick the direction you prefer and I'll finalize the PR to match:
   - **(a)** Add `tokenomics` to the trusted internal-diagnostics allowlist (the one-line change shown above), treating it as an approved official accounting consumer; or
   - **(b)** Point me at the canonical seam you'd rather it consume (e.g. `usage.cost` / the native usage-ledger tracked in #13219) and I'll **redesign ingestion + persistence onto that contract** instead of the diagnostics subscription.

2. **`dependency-guard`.** Fails because this PR adds a new workspace package to the dependency graph, which requires a maintainer/secops override (`/allow-dependencies-change`). All other checks are green. Happy to adjust packaging/storage (incl. SQLite-backed plugin state) to match your preference.
