### PR TITLE
test(qa): link local e2e tests into QA coverage

### DIFF
--- a/qa/scenarios/channels/native-command-session-target.yaml
+++ b/qa/scenarios/channels/native-command-session-target.yaml
@@ -1,0 +1,23 @@
+title: Native command active session target evidence
+
+scenario:
+  id: native-command-session-target
+  surface: channel-framework
+  category: channel-framework.channel-actions-commands-and-approvals
+  coverage:
+    primary:
+      - channels.native-command-session-target
+  objective: Link native command target-session e2e coverage to channel framework maturity accounting.
+  successCriteria:
+    - Native `/stop` commands use the active target session key instead of the slash-command session.
+    - The target embedded agent run is aborted.
+    - Queued follow-up work for the target session is cleared.
+  docsRefs:
+    - docs/channels/qa-channel.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
+  execution:
+    kind: vitest
+    path: src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
+    summary: Vitest e2e coverage for native command active-session targeting.

--- a/qa/scenarios/config/cli-channel-picker.yaml
+++ b/qa/scenarios/config/cli-channel-picker.yaml
@@ -1,0 +1,23 @@
+title: CLI channel picker evidence
+
+scenario:
+  id: cli-channel-picker
+  surface: cli-install-update-onboard-doctor
+  category: cli-install-update-onboard-doctor.plugin-and-channel-setup
+  coverage:
+    primary:
+      - cli.channel-picker
+  objective: Link channel onboarding picker e2e coverage to CLI maturity accounting.
+  successCriteria:
+    - The channel picker remains usable with broken sibling registry diagnostics.
+    - Hidden setup channels are omitted from selectable choices.
+    - Configured and disabled channel states are presented with the expected actions.
+  docsRefs:
+    - docs/channels/qa-channel.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/commands/onboard-channels.e2e.test.ts
+  execution:
+    kind: vitest
+    path: src/commands/onboard-channels.e2e.test.ts
+    summary: Vitest e2e coverage for channel onboarding picker behavior.

--- a/qa/scenarios/plugins/clawhub-skill-installs.yaml
+++ b/qa/scenarios/plugins/clawhub-skill-installs.yaml
@@ -1,0 +1,22 @@
+title: ClawHub skill install evidence
+
+scenario:
+  id: clawhub-skill-installs
+  surface: clawhub-and-external-plugin-distribution
+  category: clawhub-and-external-plugin-distribution.plugin-lifecycle-and-health
+  coverage:
+    primary:
+      - clawhub.skill-installs
+  objective: Link ClawHub-backed skill install e2e coverage to ClawHub maturity accounting.
+  successCriteria:
+    - The CLI resolves a ClawHub skill install descriptor.
+    - The GitHub-backed skill archive is downloaded and installed into the state directory.
+    - Install telemetry reports the installed skill slug and version.
+  docsRefs:
+    - docs/help/testing.md
+  codeRefs:
+    - src/cli/skills-cli.clawhub-install.e2e.test.ts
+  execution:
+    kind: vitest
+    path: src/cli/skills-cli.clawhub-install.e2e.test.ts
+    summary: Vitest e2e coverage for ClawHub-backed skill installs.

--- a/qa/scenarios/runtime/docker-compose-setup.yaml
+++ b/qa/scenarios/runtime/docker-compose-setup.yaml
@@ -1,0 +1,23 @@
+title: Docker Compose setup evidence
+
+scenario:
+  id: docker-compose-setup
+  surface: docker-podman-hosting
+  category: docker-podman-hosting.container-operations
+  coverage:
+    primary:
+      - docker.compose
+  objective: Link Docker Compose setup e2e coverage to Docker maturity accounting.
+  successCriteria:
+    - Docker Compose gateway and CLI service command shape stays in sync.
+    - Compose service env, token, auth-profile, timezone, and optional env-file defaults stay aligned.
+    - Container-side state, config, and workspace paths override host `.env` values.
+  docsRefs:
+    - docs/install/docker.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/docker-setup.e2e.test.ts
+  execution:
+    kind: vitest
+    path: src/docker-setup.e2e.test.ts
+    summary: Vitest e2e coverage for Docker Compose setup and mount/env contracts.

--- a/qa/scenarios/scheduling/heartbeat-active-hours.yaml
+++ b/qa/scenarios/scheduling/heartbeat-active-hours.yaml
@@ -1,0 +1,23 @@
+title: Heartbeat active-hours scheduling evidence
+
+scenario:
+  id: heartbeat-active-hours
+  surface: automation-cron-hooks-tasks-polling
+  category: automation-cron-hooks-tasks-polling.heartbeat
+  coverage:
+    primary:
+      - automation.active-hours
+      - automation.heartbeat-scheduling
+  objective: Link active-hours heartbeat scheduler e2e coverage to automation maturity accounting.
+  successCriteria:
+    - Heartbeat timers skip quiet-hours phase slots.
+    - In-window phase slots fire without duplicate scheduling loops.
+    - Hot reload recomputes active-hours and timezone schedule changes.
+  docsRefs:
+    - docs/help/testing.md
+  codeRefs:
+    - src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
+  execution:
+    kind: vitest
+    path: src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
+    summary: Vitest e2e coverage for active-hours-aware heartbeat scheduling.

--- a/qa/scenarios/ui/browser-talk-start-stop.yaml
+++ b/qa/scenarios/ui/browser-talk-start-stop.yaml
@@ -1,0 +1,23 @@
+title: Browser realtime Talk start-stop evidence
+
+scenario:
+  id: browser-talk-start-stop
+  surface: browser-control-ui-and-webchat
+  category: browser-control-ui-and-webchat.browser-realtime-talk
+  coverage:
+    primary:
+      - ui.browser-talk-start-stop
+  objective: Link deterministic browser realtime Talk transport start/stop coverage to UI maturity accounting.
+  successCriteria:
+    - Browser Talk starts the Google Live WebSocket transport and reaches listening state.
+    - Stopped transports ignore late WebSocket events.
+    - Active consult shutdown aborts the active run without reviving listening state.
+  docsRefs:
+    - docs/web/control-ui.md
+    - docs/help/testing.md
+  codeRefs:
+    - ui/src/ui/realtime-talk-google-live.test.ts
+  execution:
+    kind: vitest
+    path: ui/src/ui/realtime-talk-google-live.test.ts
+    summary: Vitest coverage for browser realtime Talk transport start and stop behavior.

--- a/qa/scenarios/ui/control-ui-assistant-media-tickets.yaml
+++ b/qa/scenarios/ui/control-ui-assistant-media-tickets.yaml
@@ -1,0 +1,23 @@
+title: Control UI assistant media ticket evidence
+
+scenario:
+  id: control-ui-assistant-media-tickets
+  surface: browser-control-ui-and-webchat
+  category: browser-control-ui-and-webchat.webchat-conversations
+  coverage:
+    primary:
+      - ui.assistant-media-tickets
+  objective: Link scoped assistant media ticket e2e coverage to Control UI maturity accounting.
+  successCriteria:
+    - Gateway metadata requests mint scoped assistant media tickets.
+    - Assistant media fetches without a ticket are rejected.
+    - Tickets cannot be replayed for a different source file.
+  docsRefs:
+    - docs/web/control-ui.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/gateway/control-ui-assistant-media.e2e.test.ts
+  execution:
+    kind: vitest
+    path: src/gateway/control-ui-assistant-media.e2e.test.ts
+    summary: Vitest e2e coverage for scoped Control UI assistant media tickets.


### PR DESCRIPTION
## What Problem This Solves

Existing e2e tests already prove several maturity coverage IDs, but QA scenario inventory did not link them as native QA evidence. That left the coverage score lower than the available proof.

## Why This Change Was Made

This adds small native QA scenario YAML wrappers for deterministic local Vitest e2e tests instead of duplicating test logic. Each wrapper uses an existing taxonomy coverage ID as primary evidence and points to the existing proof file through `scenario.execution.path`.

This intentionally skips candidates where the existing proof was too indirect for primary coverage, including the Anthropic auth-profile row, watchOS generic exec approval, voice-call generic RPC/tool coverage, release-candidate checklist parsing, and live/provider media rows.

## User Impact

QA maturity inventory can now account for 8 additional existing primary coverage IDs when these native scenarios pass:

- `automation.active-hours`
- `automation.heartbeat-scheduling`
- `ui.assistant-media-tickets`
- `ui.browser-talk-start-stop`
- `channels.native-command-session-target`
- `clawhub.skill-installs`
- `cli.channel-picker`
- `docker.compose`

## Evidence

- `pnpm test extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/scorecard-evidence.test.ts`
- `pnpm openclaw qa suite --provider-mode mock-openai --scenario heartbeat-active-hours --scenario control-ui-assistant-media-tickets --scenario browser-talk-start-stop --scenario native-command-session-target --scenario clawhub-skill-installs --scenario cli-channel-picker --scenario docker-compose-setup --output-dir .artifacts/qa-e2e/local-vitest-wrapper-pr1-rerun`
- `pnpm openclaw qa coverage --json > .artifacts/qa-e2e/local-vitest-wrapper-pr1-rerun/qa-coverage.json`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git diff --check -- qa/scenarios`

The final QA evidence run had 7 passing entries covering the 8 primary IDs above. `qa coverage --json` reported `scenarioCount: 136` and `primaryCoverageIdCount: 113` after this change.
