### PR TITLE
ci: log macOS Swift build phases

### DIFF
--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -194,7 +194,9 @@ cd "$ROOT_DIR/apps/macos"
 echo "🔨 Building $PRODUCT ($BUILD_CONFIG) [${BUILD_ARCHS[*]}]"
 for arch in "${BUILD_ARCHS[@]}"; do
   BUILD_PATH="$(build_path_for_arch "$arch")"
+  echo "🔨 Building $PRODUCT ($BUILD_CONFIG) [$arch]"
   swift build -c "$BUILD_CONFIG" --product "$PRODUCT" --build-path "$BUILD_PATH" --arch "$arch" -Xlinker -rpath -Xlinker @executable_path/../Frameworks
+  echo "🔨 Building $MLX_TTS_HELPER_PRODUCT ($BUILD_CONFIG) [$arch]"
   swift build --package-path "$MLX_TTS_HELPER_ROOT" -c "$BUILD_CONFIG" --product "$MLX_TTS_HELPER_PRODUCT" --build-path "$(helper_build_path_for_arch "$arch")" --arch "$arch"
 done
 


### PR DESCRIPTION
## What Problem This Solves

The macOS packaging log currently looks like it repeats the same SwiftPM fetch/build work without saying why. Release packaging actually builds the app and MLX TTS helper for each release architecture, so the repeated Swift output is expected but hard to read.

## Why This Change Was Made

This adds explicit log lines before each existing Swift build invocation in `scripts/package-mac-app.sh`, naming the product, configuration, and architecture being built. It does not change the build commands or packaging behavior.

## User Impact

Maintainers inspecting macOS release runs can distinguish the app/helper and arm64/x86_64 phases without digging into the script.

## Evidence

- `bash -n scripts/package-mac-app.sh`
- `git diff --check`
