### PR TITLE
fix(clawhub): reject mutable GitHub skill refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **ClawHub GitHub skill pinning:** reject mutable resolver refs before download and carry one normalized full commit SHA through archive download, install policy, origin, and lock metadata. (#97157) Thanks @yetval.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **ClawHub GitHub skill pinning:** reject mutable resolver refs before download and carry one normalized full commit SHA through archive download, install policy, origin, and lock metadata. (#97157) Thanks @yetval.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -1363,6 +1363,7 @@ describe("skills-clawhub", () => {
 
   it("installs GitHub-backed ClawHub skills from the pinned resolver source path", async () => {
     const commit = "b".repeat(40);
+    const paddedCommit = `  ${commit.toUpperCase()}\n`;
     fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
       ok: true,
       slug: "aiq-deploy",
@@ -1370,7 +1371,7 @@ describe("skills-clawhub", () => {
       github: {
         repo: "NVIDIA/skills",
         path: "skills/aiq-deploy",
-        commit,
+        commit: paddedCommit,
         contentHash: "hash-aiq-deploy",
         sourceUrl: `https://github.com/NVIDIA/skills/tree/${commit}/skills/aiq-deploy`,
       },
@@ -1415,6 +1416,32 @@ describe("skills-clawhub", () => {
       version: commit,
       targetDir: "/tmp/workspace/skills/aiq-deploy",
     });
+  });
+
+  it("rejects a mutable GitHub ref before downloading a ClawHub skill", async () => {
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "aiq-deploy",
+      installKind: "github",
+      github: {
+        repo: "NVIDIA/skills",
+        path: "skills/aiq-deploy",
+        commit: "main",
+        contentHash: "hash-aiq-deploy",
+        sourceUrl: "https://github.com/NVIDIA/skills/tree/main/skills/aiq-deploy",
+      },
+    });
+
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "aiq-deploy",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? "" : result.error).toContain("expected a full 40-character commit SHA");
+    expect(downloadClawHubGitHubSkillArchiveMock).not.toHaveBeenCalled();
+    expect(withExtractedArchiveRootMock).not.toHaveBeenCalled();
+    expect(installPackageDirMock).not.toHaveBeenCalled();
   });
 
   it("passes forceInstall to the ClawHub install resolver", async () => {

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -1246,16 +1246,25 @@ async function installGitHubResolution(params: {
 function assertInstallResolutionAllowed(
   resolution: ClawHubSkillInstallResolutionResponse,
 ): Extract<ClawHubSkillInstallResolutionResponse, { ok: true }> {
-  if (resolution.ok) {
+  if (!resolution.ok) {
+    if (resolution.reason === "ambiguous_slug") {
+      const message = resolution.message ? ` ${resolution.message}` : "";
+      throw new Error(
+        `Skill "${resolution.slug}" is ambiguous on ClawHub. Install an owner-qualified skill, for example: openclaw skills install @owner/${resolution.slug}.${message}`,
+      );
+    }
+    throw new Error(resolution.message || `Skill "${resolution.slug}" is not installable.`);
+  }
+  if (resolution.installKind !== "github") {
     return resolution;
   }
-  if (resolution.reason === "ambiguous_slug") {
-    const message = resolution.message ? ` ${resolution.message}` : "";
+  const commit = normalizeGitHubCommitSegment(resolution.github.commit)?.toLowerCase();
+  if (!commit) {
     throw new Error(
-      `Skill "${resolution.slug}" is ambiguous on ClawHub. Install an owner-qualified skill, for example: openclaw skills install @owner/${resolution.slug}.${message}`,
+      `Skill "${resolution.slug}" resolved to a mutable or invalid GitHub source ref; expected a full 40-character commit SHA.`,
     );
   }
-  throw new Error(resolution.message || `Skill "${resolution.slug}" is not installable.`);
+  return { ...resolution, github: { ...resolution.github, commit } };
 }
 
 async function ensureClawHubSkillTrustAcknowledged(


### PR DESCRIPTION
## What Problem This Solves

ClawHub marks GitHub-backed skill resolutions as immutable but OpenClaw trusted the resolver's `github.commit` string without enforcing a full commit SHA. A branch or tag such as `main` could therefore be downloaded, installed, and persisted as `mutable: false`, allowing the installed code to move behind an allegedly pinned identity.

This behavior is present in current `main`, stable `v2026.6.11`, and beta `v2026.7.1-beta.5`.

## Why This Change Was Made

- Validate the successful GitHub resolution once in `assertInstallResolutionAllowed`, before any download or filesystem side effect.
- Normalize the accepted commit to one trimmed, lowercase, 40-hex SHA in the returned resolution.
- Let version selection, GitHub codeload, install policy, origin metadata, lock metadata, and telemetry consume that same canonical object.
- Keep archive resolutions and direct `git:` installs unchanged; direct Git installs intentionally support mutable refs and record them as mutable.

The submitted later-stage validation was moved to the resolver acceptance boundary so downstream callers cannot accidentally reuse the raw ref.

## User Impact

Normal ClawHub GitHub-backed installs continue unchanged. A custom or malformed resolver response containing a branch, tag, short SHA, or other non-pinned ref now fails with clear guidance before download. This enforces ClawHub's documented 40-character commit contract; it adds no config, migration, or fallback surface.

## Evidence

- Existing pinned-install test now proves padded uppercase input is normalized and the canonical SHA reaches download, policy, origin, and installed version.
- New negative test proves `main` fails before archive download, extraction, policy evaluation, or installation.
- `oxfmt` and `git diff --check` pass.
- Autoreview: clean, 0.96 confidence.
- Official ClawHub protocol specifies a 40-character commit SHA; a live resolver sample returned a full SHA, while GitHub codeload accepts both a branch and SHA, proving client-side enforcement is necessary.
- Exact-head sanitized AWS focused tests passed 142 tests with two platform skips; `check:changed` passed.
- An actual CLI fixture returning mutable ref `main` failed before archive download or filesystem metadata.
- A live public ClawHub install carried resolver SHA `f6075a5060ed3c86536055700d95eb68655162ee` unchanged through codeload, origin, and lock metadata.
- Exact-head hosted CI passed 45 jobs with 11 routine skips and zero failures; CodeQL passed.

Root `CHANGELOG.md` is release-owned, so the release-note context and @yetval credit are carried here and in the replacement commit.
