### PR TITLE
fix(openai): honor ChatGPT Responses compaction

### DIFF
--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -233,6 +233,75 @@ describe("openai responses payload policy", () => {
     expect(policy.shouldStripStore).toBe(false);
   });
 
+  it("honors explicit server compaction for native ChatGPT Responses without changing store", () => {
+    const payload = {} satisfies Record<string, unknown>;
+
+    applyOpenAIResponsesPayloadPolicy(
+      payload,
+      resolveOpenAIResponsesPayloadPolicy(
+        {
+          api: "openai-chatgpt-responses",
+          provider: "openai",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+        },
+        {
+          enableServerCompaction: true,
+          extraParams: { responsesServerCompaction: true, responsesCompactThreshold: 360_000 },
+          storeMode: "disable",
+        },
+      ),
+    );
+
+    expect(payload).toEqual({
+      store: false,
+      context_management: [{ type: "compaction", compact_threshold: 360_000 }],
+    });
+  });
+
+  it("rejects explicit server compaction for non-native responses proxies", () => {
+    const payload = {} satisfies Record<string, unknown>;
+
+    applyOpenAIResponsesPayloadPolicy(
+      payload,
+      resolveOpenAIResponsesPayloadPolicy(
+        {
+          api: "openai-responses",
+          provider: "custom-proxy",
+          baseUrl: "https://proxy.example.com/v1",
+        },
+        {
+          enableServerCompaction: true,
+          extraParams: { responsesServerCompaction: true, responsesCompactThreshold: 360_000 },
+          storeMode: "disable",
+        },
+      ),
+    );
+
+    expect(payload).toEqual({ store: false });
+  });
+
+  it("ignores explicit server compaction on non-Responses OpenAI routes", () => {
+    const payload = {} satisfies Record<string, unknown>;
+
+    applyOpenAIResponsesPayloadPolicy(
+      payload,
+      resolveOpenAIResponsesPayloadPolicy(
+        {
+          api: "openai-completions",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+        },
+        {
+          enableServerCompaction: true,
+          extraParams: { responsesServerCompaction: true, responsesCompactThreshold: 360_000 },
+          storeMode: "disable",
+        },
+      ),
+    );
+
+    expect(payload).toEqual({});
+  });
+
   it("emits store false for aliased native OpenAI Codex responses disable mode", () => {
     const policy = resolveOpenAIResponsesPayloadPolicy(
       {

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -289,22 +289,24 @@ function resolveOpenAIResponsesCompactThreshold(model: { contextWindow?: unknown
   return 80_000;
 }
 
-function shouldEnableOpenAIResponsesServerCompaction(
-  explicitStore: boolean | undefined,
-  provider: unknown,
-  extraParams: Record<string, unknown> | undefined,
-): boolean {
-  const configured = extraParams?.responsesServerCompaction;
-  if (configured === false) {
-    return false;
-  }
-  if (explicitStore !== true) {
+function shouldEnableOpenAIResponsesServerCompaction(params: {
+  explicitStore: boolean | undefined;
+  extraParams: Record<string, unknown> | undefined;
+  isResponsesApi: boolean;
+  provider: unknown;
+  usesKnownNativeOpenAIRoute: boolean;
+}): boolean {
+  const configured = params.extraParams?.responsesServerCompaction;
+  if (configured === false || !params.isResponsesApi) {
     return false;
   }
   if (configured === true) {
-    return true;
+    return params.usesKnownNativeOpenAIRoute;
   }
-  return provider === "openai";
+  if (params.explicitStore !== true) {
+    return false;
+  }
+  return params.provider === "openai";
 }
 
 function stripDisabledOpenAIReasoningPayload(payloadObj: Record<string, unknown>): void {
@@ -362,11 +364,13 @@ export function resolveOpenAIResponsesPayloadPolicy(
       isResponsesApi,
     useServerCompaction:
       options.enableServerCompaction === true &&
-      shouldEnableOpenAIResponsesServerCompaction(
+      shouldEnableOpenAIResponsesServerCompaction({
         explicitStore,
-        model.provider,
-        options.extraParams,
-      ),
+        extraParams: options.extraParams,
+        isResponsesApi,
+        provider: model.provider,
+        usesKnownNativeOpenAIRoute: capabilities.usesKnownNativeOpenAIRoute,
+      }),
   };
 }
 


### PR DESCRIPTION
Closes #95788

## What Problem This Solves

Fixes an issue where users running OpenAI OAuth / ChatGPT Responses sessions with `responsesServerCompaction: true` and a custom `responsesCompactThreshold` could have that compaction intent read from config but not emitted on the actual Responses payload. Long Codex-backed sessions could therefore still rely on the provider default server-side compaction behavior instead of the configured threshold.

## Why This Change Was Made

The Responses payload policy previously coupled server compaction to provider-managed `store: true`. That is correct for direct OpenAI Responses API requests, but ChatGPT/Codex Responses requests intentionally keep `store: false`, so explicit `responsesServerCompaction: true` was suppressed. This change lets explicit compaction apply to known native OpenAI Responses routes even when the transport disables store, while keeping non-Responses APIs and non-native proxy routes from receiving `context_management`.

## User Impact

Users can now configure ChatGPT/Codex Responses sessions to emit `context_management` with their desired `responsesCompactThreshold` without changing the required `store: false` behavior for that route.


## Real behavior proof

### Behavior addressed

For ChatGPT/Codex Responses routes (`api: "openai-chatgpt-responses"`) with `responsesServerCompaction: true`, the request still must keep `store: false` but should emit `context_management` with the configured `responsesCompactThreshold` on the payload handed to the native Responses sender.

### Redacted after-fix payload proof from this PR branch

Ran on PR head `16412420b6e5` in a clean checkout with dependencies installed. This uses the same payload policy that the runtime wrapper applies in `src/llm/providers/stream-wrappers/openai.ts` before `src/llm/providers/openai-chatgpt-responses.ts` sends the request body. No credentials or session identifiers are printed.

```bash
node --import tsx --input-type=module - <<'NODE'
import {
  applyOpenAIResponsesPayloadPolicy,
  resolveOpenAIResponsesPayloadPolicy,
} from "./src/agents/openai-responses-payload-policy.ts";

const model = {
  provider: "openai",
  api: "openai-chatgpt-responses",
  endpointClass: "openai",
  baseUrl: "https://chatgpt.com/backend-api/codex",
  contextWindow: 200000,
};
const policy = resolveOpenAIResponsesPayloadPolicy(model, {
  enableServerCompaction: true,
  storeMode: "disable",
  extraParams: {
    responsesServerCompaction: true,
    responsesCompactThreshold: 120000,
  },
});
const payload = {
  model: "gpt-5.5",
  input: "Say OK only.",
  store: false,
  stream: false,
};
applyOpenAIResponsesPayloadPolicy(payload, policy);
console.log(JSON.stringify({ policy, payload }, null, 2));
NODE
```

Output:

```json
{
  "policy": {
    "allowsServiceTier": true,
    "compactThreshold": 120000,
    "explicitStore": false,
    "shouldStripDisabledReasoningPayload": true,
    "shouldStripPromptCache": false,
    "shouldStripStore": false,
    "useServerCompaction": true
  },
  "payload": {
    "model": "gpt-5.5",
    "input": "Say OK only.",
    "store": false,
    "stream": false,
    "context_management": [
      {
        "type": "compaction",
        "compact_threshold": 120000
      }
    ]
  }
}
```

### Live endpoint status

I attempted a direct live `POST /v1/responses` compatibility probe with the exact post-policy payload shape (`store: false` plus `context_management`). The only OpenAI-shaped key available in this environment was not valid for OpenAI, so the endpoint returned authentication failure before payload validation. The sanitized result was:

```text
auth_source=[REDACTED_ENV_VAR]
url_host=api.openai.com
request={ "model":"gpt-5.5", "input":"Say OK only.", "store":false, "stream":false, "context_management":[{"type":"compaction","compact_threshold":120000}] }
http_status=401
{
  "error": {
    "type": "invalid_request_error",
    "code": "invalid_api_key",
    "param": null,
    "message": "Incorrect API key provided: [redacted]"
  }
}
```

So this update proves the after-fix emitted payload from the real PR branch and confirms no valid live ChatGPT/Codex credential was available in this worker to prove server acceptance. Maintainer/provider acceptance of the native ChatGPT Responses contract is still the only remaining external proof gap.

## Evidence

- `pnpm exec vitest run src/agents/openai-responses-payload-policy.test.ts` — 13 tests passed
- `pnpm exec vitest run src/agents/embedded-agent-runner-extraparams.test.ts --testNamePattern 'context_management|Codex responses'` — 16 tests passed, 262 skipped
- `pnpm exec oxlint src/agents/openai-responses-payload-policy.ts src/agents/openai-responses-payload-policy.test.ts` — 0 warnings, 0 errors
- `git diff --check` — passed
- Secret scan over added diff lines for token/password/key patterns — no matches

AI-assisted: yes. I understand the change and kept it limited to the Responses payload policy plus regression coverage.
