### PR TITLE
fix(secrets): add audit check severity threshold

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -36,8 +36,10 @@ If your plan includes `exec` SecretRefs/providers, pass `--allow-exec` on both t
 Exit codes for CI/gates:
 
 - `audit --check` returns `1` on findings.
-- Unresolved refs return `2` (regardless of `--check`).
 - Store validation and disclosure-policy failures return `2`; `store get` returns `3` when the name is missing.
+- `audit --check --severity-min warn` keeps `info` findings visible in the report but returns `0` unless a `warn` or `error` finding is present.
+- `--severity-min` defaults to `info`, preserving the existing behavior where any finding fails `--check`.
+- Unresolved refs return `2`, regardless of the selected severity threshold.
 
 Related: [Secrets Management](/gateway/secrets) · [1Password plugin](/plugins/onepassword) · [SecretRef Credential Surface](/reference/secretref-credential-surface) · [Security](/gateway/security)
 
@@ -165,9 +167,19 @@ Sensitive provider header detection is name-heuristic based: it flags headers wh
 ```bash
 openclaw secrets audit
 openclaw secrets audit --check
+openclaw secrets audit --check --severity-min warn
 openclaw secrets audit --json
 openclaw secrets audit --allow-exec
 ```
+
+Exit behavior:
+
+- `--check` exits non-zero when findings meet `--severity-min`.
+- `--severity-min <severity>` accepts `info`, `warn`, or `warning`.
+- `--severity-min` defaults to `info`, so plain `--check` still exits `1` on any finding.
+- Use `--severity-min warn` when `info` findings, such as legacy residue reminders, should stay visible but should not fail the automation gate.
+- Warning and error findings still fail `--check --severity-min warn`; `error` is intentionally not accepted as a threshold.
+- Unresolved refs exit with code `2` even when the selected threshold would otherwise ignore lower-severity findings.
 
 Report shape:
 

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -21,6 +21,15 @@ const mocks = await vi.hoisted(async () => {
   return {
     callGatewayFromCli: vi.fn(),
     runSecretsAudit: vi.fn(),
+    parseSecretsAuditCheckSeverity: vi.fn((value: string) => {
+      if (value === "warn" || value === "warning") {
+        return "warning";
+      }
+      if (value === "info") {
+        return value;
+      }
+      return null;
+    }),
     resolveSecretsAuditExitCode: vi.fn(),
     runSecretsConfigureInteractive: vi.fn(),
     runSecretsApply: vi.fn(),
@@ -32,6 +41,7 @@ const mocks = await vi.hoisted(async () => {
 const {
   callGatewayFromCli,
   runSecretsAudit,
+  parseSecretsAuditCheckSeverity,
   resolveSecretsAuditExitCode,
   runSecretsConfigureInteractive,
   runSecretsApply,
@@ -53,8 +63,9 @@ vi.mock("../runtime.js", () => ({
 
 vi.mock("../secrets/audit.js", () => ({
   runSecretsAudit: (options: unknown) => mocks.runSecretsAudit(options),
-  resolveSecretsAuditExitCode: (report: unknown, check: boolean) =>
-    mocks.resolveSecretsAuditExitCode(report, check),
+  parseSecretsAuditCheckSeverity: (value: string) => mocks.parseSecretsAuditCheckSeverity(value),
+  resolveSecretsAuditExitCode: (report: unknown, check: boolean, severityMin: unknown) =>
+    mocks.resolveSecretsAuditExitCode(report, check, severityMin),
 }));
 
 vi.mock("../secrets/configure.js", () => ({
@@ -181,6 +192,7 @@ describe("secrets CLI", () => {
     runtimeErrors.length = 0;
     callGatewayFromCli.mockReset();
     runSecretsAudit.mockReset();
+    parseSecretsAuditCheckSeverity.mockClear();
     resolveSecretsAuditExitCode.mockReset();
     runSecretsConfigureInteractive.mockReset();
     runSecretsApply.mockReset();
@@ -261,6 +273,47 @@ describe("secrets CLI", () => {
       throw new Error("Expected secrets audit result for exit-code resolution");
     }
     expect(exitCodeCall[1]).toBe(true);
+    expect(exitCodeCall[2]).toBe("info");
+  });
+
+  it("forwards --severity-min to secrets audit check exit resolution", async () => {
+    runSecretsAudit.mockResolvedValue({
+      version: 1,
+      status: "findings",
+      filesScanned: [],
+      summary: {
+        plaintextCount: 0,
+        unresolvedRefCount: 0,
+        shadowedRefCount: 0,
+        legacyResidueCount: 1,
+      },
+      resolution: {
+        refsChecked: 0,
+        skippedExecRefs: 0,
+        resolvabilityComplete: true,
+      },
+      findings: [],
+    });
+    resolveSecretsAuditExitCode.mockReturnValue(0);
+
+    await createProgram().parseAsync(["secrets", "audit", "--check", "--severity-min", "warn"], {
+      from: "user",
+    });
+    expect(parseSecretsAuditCheckSeverity).toHaveBeenCalledWith("warn");
+    const exitCodeCall = mockCall(resolveSecretsAuditExitCode);
+    expect(exitCodeCall[1]).toBe(true);
+    expect(exitCodeCall[2]).toBe("warning");
+  });
+
+  it("rejects --severity-min values that would let warn findings pass", async () => {
+    await expect(
+      createProgram().parseAsync(["secrets", "audit", "--check", "--severity-min", "error"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("__exit__:2");
+    expect(runSecretsAudit).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain("Invalid --severity-min value");
+    expect(runtimeErrors.at(-1)).not.toContain("warn/warning..");
   });
 
   it("forwards --allow-exec to secrets audit", async () => {

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -21,6 +21,7 @@ type SecretsAuditOptions = {
   check?: boolean;
   json?: boolean;
   allowExec?: boolean;
+  severityMin?: string;
 };
 type SecretsConfigureOptions = {
   apply?: boolean;
@@ -159,7 +160,12 @@ export function registerSecretsCli(program: Command): void {
   secrets
     .command("audit")
     .description("Audit plaintext secrets, unresolved refs, and precedence drift")
-    .option("--check", "Exit non-zero when findings are present", false)
+    .option("--check", "Exit non-zero when findings meet --severity-min", false)
+    .option(
+      "--severity-min <severity>",
+      "Minimum finding severity that causes --check to fail: info or warn/warning",
+      "info",
+    )
     .option(
       "--allow-exec",
       "Allow exec SecretRef resolution during audit (may execute provider commands)",
@@ -168,8 +174,12 @@ export function registerSecretsCli(program: Command): void {
     .option("--json", "Output JSON", false)
     .action(async (opts: SecretsAuditOptions) => {
       try {
-        const { resolveSecretsAuditExitCode, runSecretsAudit } =
+        const { parseSecretsAuditCheckSeverity, resolveSecretsAuditExitCode, runSecretsAudit } =
           await import("../secrets/audit.js");
+        const severityMin = parseSecretsAuditCheckSeverity(opts.severityMin ?? "info");
+        if (severityMin === null) {
+          throw new Error("Invalid --severity-min value. Expected one of: info, warn/warning");
+        }
         const report = await runSecretsAudit({
           allowExec: Boolean(opts.allowExec),
         });
@@ -182,7 +192,7 @@ export function registerSecretsCli(program: Command): void {
           if (report.findings.length > 0) {
             for (const finding of report.findings.slice(0, 20)) {
               defaultRuntime.log(
-                `- [${finding.code}] ${finding.file}:${finding.jsonPath} ${finding.message}`,
+                `- [${finding.severity}:${finding.code}] ${finding.file}:${finding.jsonPath} ${finding.message}`,
               );
             }
             if (report.findings.length > 20) {
@@ -195,7 +205,7 @@ export function registerSecretsCli(program: Command): void {
             );
           }
         }
-        const exitCode = resolveSecretsAuditExitCode(report, Boolean(opts.check));
+        const exitCode = resolveSecretsAuditExitCode(report, Boolean(opts.check), severityMin);
         if (exitCode !== 0) {
           defaultRuntime.exit(exitCode);
         }

--- a/src/secrets/audit-exit-code.ts
+++ b/src/secrets/audit-exit-code.ts
@@ -1,0 +1,46 @@
+/** Exit-code helpers for `openclaw secrets audit --check`. */
+import {
+  healthFindingMeetsSeverity,
+  parseHealthFindingSeverity,
+  type HealthFindingSeverity,
+} from "../flows/health-checks.js";
+
+type SecretsAuditSeverity = "info" | "warn" | "error"; // pragma: allowlist secret
+
+type SecretsAuditCheckSeverity = Extract<HealthFindingSeverity, "info" | "warning">;
+
+type SecretsAuditExitReport = {
+  summary: {
+    unresolvedRefCount: number;
+  };
+  findings: Array<{
+    severity: SecretsAuditSeverity;
+  }>;
+};
+
+function normalizeSecretsAuditSeverity(severity: SecretsAuditSeverity): HealthFindingSeverity {
+  return severity === "warn" ? "warning" : severity;
+}
+
+export function parseSecretsAuditCheckSeverity(value: string): SecretsAuditCheckSeverity | null {
+  const severity = parseHealthFindingSeverity(value === "warn" ? "warning" : value);
+  return severity === "info" || severity === "warning" ? severity : null;
+}
+
+/** Maps audit results to CLI exit codes. */
+export function resolveSecretsAuditExitCode(
+  report: SecretsAuditExitReport,
+  check: boolean,
+  severityMin: SecretsAuditCheckSeverity = "info",
+): number {
+  if (report.summary.unresolvedRefCount > 0) {
+    return 2;
+  }
+  const hasBlockingFinding = report.findings.some((finding) =>
+    healthFindingMeetsSeverity(
+      { severity: normalizeSecretsAuditSeverity(finding.severity) },
+      severityMin,
+    ),
+  );
+  return check && hasBlockingFinding ? 1 : 0;
+}

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -17,8 +17,14 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
-import { runSecretsAudit } from "./audit.js";
+import {
+  parseSecretsAuditCheckSeverity,
+  resolveSecretsAuditExitCode,
+  runSecretsAudit,
+} from "./audit.js";
 import { writeSecretStoreEntry } from "./store/secret-store.js";
+
+type SecretsAuditReport = Awaited<ReturnType<typeof runSecretsAudit>>;
 
 type AuditFixture = {
   rootDir: string;
@@ -334,6 +340,88 @@ describe("secrets audit", () => {
           entry.jsonPath === "models.providers.referenced.apiKey",
       ),
     ).toBe(false);
+  });
+
+  it("parses audit check severity thresholds", () => {
+    expect(parseSecretsAuditCheckSeverity("info")).toBe("info");
+    expect(parseSecretsAuditCheckSeverity("warn")).toBe("warning");
+    expect(parseSecretsAuditCheckSeverity("warning")).toBe("warning");
+    expect(parseSecretsAuditCheckSeverity("error")).toBeNull();
+    expect(parseSecretsAuditCheckSeverity("critical")).toBeNull();
+  });
+
+  it("maps check exit codes using the requested severity threshold", () => {
+    const infoOnlyReport: SecretsAuditReport = {
+      version: 1,
+      status: "findings",
+      resolution: {
+        refsChecked: 0,
+        skippedExecRefs: 0,
+        resolvabilityComplete: true,
+      },
+      filesScanned: [],
+      summary: {
+        plaintextCount: 0,
+        unresolvedRefCount: 0,
+        shadowedRefCount: 0,
+        storeResidueCount: 0,
+        legacyResidueCount: 1,
+      },
+      findings: [
+        {
+          code: "LEGACY_RESIDUE",
+          severity: "info",
+          file: "openclaw-agent.sqlite",
+          jsonPath: "profiles.openai:default",
+          message: "OAuth credentials are present.",
+        },
+      ],
+    };
+    const warnReport: SecretsAuditReport = {
+      ...infoOnlyReport,
+      summary: {
+        plaintextCount: 1,
+        unresolvedRefCount: 0,
+        shadowedRefCount: 0,
+        storeResidueCount: 0,
+        legacyResidueCount: 0,
+      },
+      findings: [
+        {
+          code: "PLAINTEXT_FOUND",
+          severity: "warn",
+          file: "openclaw.json",
+          jsonPath: "gateway.auth.token",
+          message: "Gateway token is stored as plaintext.",
+        },
+      ],
+    };
+    const unresolvedReport: SecretsAuditReport = {
+      ...infoOnlyReport,
+      status: "unresolved",
+      summary: {
+        plaintextCount: 0,
+        unresolvedRefCount: 1,
+        shadowedRefCount: 0,
+        storeResidueCount: 0,
+        legacyResidueCount: 0,
+      },
+      findings: [
+        {
+          code: "REF_UNRESOLVED",
+          severity: "error",
+          file: "openclaw.json",
+          jsonPath: "gateway.auth.token",
+          message: "SecretRef could not be resolved.",
+        },
+      ],
+    };
+
+    expect(resolveSecretsAuditExitCode(infoOnlyReport, false)).toBe(0);
+    expect(resolveSecretsAuditExitCode(infoOnlyReport, true)).toBe(1);
+    expect(resolveSecretsAuditExitCode(infoOnlyReport, true, "warning")).toBe(0);
+    expect(resolveSecretsAuditExitCode(warnReport, true, "warning")).toBe(1);
+    expect(resolveSecretsAuditExitCode(unresolvedReport, false, "warning")).toBe(2);
   });
 
   it("does not inspect or mutate legacy auth.json during audit", async () => {

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -119,6 +119,7 @@ type AuditCollector = {
 
 const REF_RESOLVE_FALLBACK_CONCURRENCY = 8;
 const MAX_AUDIT_MODELS_JSON_BYTES = 5 * 1024 * 1024;
+
 function addFinding(collector: AuditCollector, finding: SecretsAuditFinding): void {
   collector.findings.push(finding);
 }
@@ -729,13 +730,4 @@ export async function runSecretsAudit(
   };
 }
 
-/** Maps audit results to CLI exit codes. */
-export function resolveSecretsAuditExitCode(report: SecretsAuditReport, check: boolean): number {
-  if (report.summary.unresolvedRefCount > 0) {
-    return 2;
-  }
-  if (check && report.findings.length > 0) {
-    return 1;
-  }
-  return 0;
-}
+export { parseSecretsAuditCheckSeverity, resolveSecretsAuditExitCode } from "./audit-exit-code.js";


### PR DESCRIPTION
## Summary
- add `openclaw secrets audit --severity-min <info|warn|warning>` for check-mode exit behavior
- keep the default threshold at `info` so existing `--check` behavior remains backward-compatible
- document the new CLI threshold behavior and add focused unit coverage

## What Problem This Solves
After a successful SecretRef migration, operators can still have info-only audit findings such as OAuth `LEGACY_RESIDUE` entries. Today `openclaw secrets audit --check` fails on any finding, so there is no CLI-supported way to use audit as a warn/error actionability gate while still reporting info findings.

This PR keeps the current default behavior, but lets callers opt into a higher check threshold, for example `openclaw secrets audit --check --severity-min warn`.

## Scope
This is intentionally narrow. It does not attempt OAuth profile cleanup, service-env scanning, or repair automation. Related background: #92522.

## Evidence
- Local 2026.6.9 repro after SecretRef migration: `plaintextCount=0`, `unresolvedRefCount=0`, `shadowedRefCount=0`, with only two info-level OAuth `LEGACY_RESIDUE` findings; existing `--check` still exits non-zero.
- Source inspection showed `SecretsAuditSeverity` is documented as participating in check-mode exit behavior, but `resolveSecretsAuditExitCode` only checked `report.findings.length`.
- Added focused unit coverage for parsing `info` / `warn` / `warning`, rejecting `error`, preserving default `--check` behavior, ignoring info-only findings at `warn` threshold, failing warn findings at `warn` threshold, and keeping unresolved refs at exit code 2.
- Updated `docs/cli/secrets.md` to document `--severity-min`, its default, accepted values, rejected `error` threshold, and unresolved-ref exit priority.
- Current-head redacted CLI proof below was generated from PR head `d559424026194f26dab4bd06c7670e733094968a`.

Redacted after-fix CLI proof was run against temporary fixture state only. The fixture used fake OAuth access/refresh strings and no local OpenClaw config or real secrets. Command labels below are normalized to `openclaw` for readability. Temporary absolute paths are normalized to `$TMPDIR/openclaw-pr-97162-proof-*`.

```console
## info-only default check
command: openclaw secrets audit --json --check
exit=1
{
  "version": 1,
  "status": "findings",
  "resolution": {
    "refsChecked": 0,
    "skippedExecRefs": 0,
    "resolvabilityComplete": true
  },
  "filesScanned": [
    "$TMPDIR/openclaw-pr-97162-proof-info-*/.openclaw/agents/main/agent/openclaw-agent.sqlite",
    "$TMPDIR/openclaw-pr-97162-proof-info-*/.openclaw/openclaw.json"
  ],
  "summary": {
    "plaintextCount": 0,
    "unresolvedRefCount": 0,
    "shadowedRefCount": 0,
    "storeResidueCount": 0,
    "legacyResidueCount": 1
  },
  "findings": [
    {
      "code": "LEGACY_RESIDUE",
      "severity": "info",
      "file": "$TMPDIR/openclaw-pr-97162-proof-info-*/.openclaw/agents/main/agent/openclaw-agent.sqlite",
      "jsonPath": "profiles.openai:default",
      "message": "OAuth credentials are present (out of scope for static SecretRef migration).",
      "provider": "openai",
      "profileId": "openai:default"
    }
  ]
}

## info-only warn threshold
command: openclaw secrets audit --json --check --severity-min warn
exit=0
{
  "version": 1,
  "status": "findings",
  "resolution": {
    "refsChecked": 0,
    "skippedExecRefs": 0,
    "resolvabilityComplete": true
  },
  "filesScanned": [
    "$TMPDIR/openclaw-pr-97162-proof-info-*/.openclaw/agents/main/agent/openclaw-agent.sqlite",
    "$TMPDIR/openclaw-pr-97162-proof-info-*/.openclaw/openclaw.json"
  ],
  "summary": {
    "plaintextCount": 0,
    "unresolvedRefCount": 0,
    "shadowedRefCount": 0,
    "storeResidueCount": 0,
    "legacyResidueCount": 1
  },
  "findings": [
    {
      "code": "LEGACY_RESIDUE",
      "severity": "info",
      "file": "$TMPDIR/openclaw-pr-97162-proof-info-*/.openclaw/agents/main/agent/openclaw-agent.sqlite",
      "jsonPath": "profiles.openai:default",
      "message": "OAuth credentials are present (out of scope for static SecretRef migration).",
      "provider": "openai",
      "profileId": "openai:default"
    }
  ]
}

## rejected error threshold
command: openclaw secrets audit --json --check --severity-min error
exit=2
Secrets audit failed: Invalid --severity-min value. Expected one of: info, warn/warning. Run openclaw doctor to inspect config and credential state.

## unresolved priority with warn threshold
command: openclaw secrets audit --json --check --severity-min warn
exit=2
{
  "version": 1,
  "status": "unresolved",
  "resolution": {
    "refsChecked": 1,
    "skippedExecRefs": 0,
    "resolvabilityComplete": true
  },
  "filesScanned": [
    "$TMPDIR/openclaw-pr-97162-proof-unresolved-*/.openclaw/openclaw.json"
  ],
  "summary": {
    "plaintextCount": 0,
    "unresolvedRefCount": 1,
    "shadowedRefCount": 0,
    "storeResidueCount": 0,
    "legacyResidueCount": 0
  },
  "findings": [
    {
      "code": "REF_UNRESOLVED",
      "severity": "error",
      "file": "$TMPDIR/openclaw-pr-97162-proof-unresolved-*/.openclaw/openclaw.json",
      "jsonPath": "models.providers.fixture.apiKey",
      "message": "Failed to resolve file:filemain:/providers/fixture/apiKey (secrets.providers.filemain.path is not readable: $TMPDIR/openclaw-pr-97162-proof-unresolved-*/missing-secrets.json | ENOENT: no such file or directory, lstat '$TMPDIR/openclaw-pr-97162-proof-unresolved-*/missing-secrets.json' | ENOENT | secrets.providers.filemain.path is not readable: $TMPDIR/openclaw-pr-97162-proof-unresolved-*/missing-secrets.json | not-found | ENOENT: no such file or directory, lstat '$TMPDIR/openclaw-pr-97162-proof-unresolved-*/missing-secrets.json' | ENOENT).",
      "provider": "fixture"
    }
  ]
}
```

## Test plan
- `node --import tsx scripts/test-projects.mts src/secrets/audit.test.ts src/cli/secrets-cli.test.ts src/cli/help-cold-imports.test.ts`
- `pnpm format:docs -- docs/cli/secrets.md`
- `pnpm exec oxlint src/secrets/audit.ts src/secrets/audit-exit-code.ts src/cli/secrets-cli.ts src/secrets/audit.test.ts src/cli/secrets-cli.test.ts`
- `node --import tsx scripts/run-oxlint-shards.mts --split-core --threads=1`
- `pnpm tsgo:test:src`
- `git diff --check`
- `node scripts/check-no-conflict-markers.mjs`
- current-head redacted CLI fixture proof above
- upstream PR CI
