### PR TITLE
feat(media): allow host-read vCard (.vcf) files

### DIFF
--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -132,6 +132,13 @@ describe("mime detection", () => {
       }),
       expected: "application/yaml",
     },
+    {
+      name: "maps vCard files to text/vcard",
+      input: async () => ({
+        filePath: "/tmp/contact.vcf",
+      }),
+      expected: "text/vcard",
+    },
   ] as const)("$name", async ({ input, expected }) => {
     await expectDetectedMime({
       input: await input(),
@@ -396,6 +403,7 @@ describe("mimeTypeFromFilePath", () => {
     { filePath: "clip.wmv", expected: "video/x-ms-wmv" },
     { filePath: "https://cdn.example.com/bad%E0%A4%A%2Emp4", expected: undefined },
     { filePath: "debug.log", expected: "text/plain" },
+    { filePath: "contact.vcf", expected: "text/vcard" },
     { filePath: "config.yml", expected: "application/yaml" },
     { filePath: "config.yaml", expected: "application/yaml" },
     { filePath: "page.xml", expected: "text/xml" },
@@ -439,6 +447,8 @@ describe("extensionForMime", () => {
     { mime: "video/quicktime", expected: ".mov" },
     { mime: "application/pdf", expected: ".pdf" },
     { mime: "application/yaml", expected: ".yaml" },
+    { mime: "text/vcard", expected: ".vcf" },
+    { mime: "Text/VCard", expected: ".vcf" },
     { mime: "text/plain", expected: ".txt" },
     { mime: "text/markdown", expected: ".md" },
     { mime: "text/html", expected: ".html" },
@@ -533,6 +543,7 @@ describe("mediaKindFromMime", () => {
 
   it.each([
     { mime: "text/plain", expected: "document" },
+    { mime: "text/vcard", expected: "document" },
     { mime: "text/csv", expected: "document" },
     { mime: "text/html; charset=utf-8", expected: "document" },
     { mime: "model/gltf+json", expected: undefined },

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -52,6 +52,7 @@ const EXT_BY_MIME: Record<string, string> = {
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
   "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+  "text/vcard": ".vcf",
   "text/csv": ".csv",
   "text/plain": ".txt",
   "text/markdown": ".md",

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -1069,6 +1069,12 @@ describe("loadWebMedia", () => {
       body: "ok: true\n",
       contentType: "application/yaml",
     },
+    {
+      label: "vCard",
+      fileName: "contact.vcf",
+      body: "BEGIN:VCARD\nFN:Test Contact\nEND:VCARD\n",
+      contentType: "text/vcard",
+    },
   ])("allows host-read $label files", async ({ fileName, body, contentType }) => {
     const result = await loadDocumentWithHostRead(fileName, body);
     expect(result.kind).toBe("document");
@@ -1091,6 +1097,25 @@ describe("loadWebMedia", () => {
     );
   });
 
+  it("rejects vCard files with a valid header and binary tail", async () => {
+    const fakeVcf = path.join(fixtureRoot, "evil.vcf");
+    const vcfHeader = Buffer.from("BEGIN:VCARD\n", "utf8");
+    const binaryTail = Buffer.alloc(9000);
+    for (let i = 0; i < binaryTail.length; i += 1) {
+      binaryTail[i] = (i % 255) + 1;
+    }
+    await fs.writeFile(fakeVcf, Buffer.concat([vcfHeader, binaryTail]));
+    await expectLoadWebMediaErrorCode(
+      loadWebMedia(fakeVcf, {
+        maxBytes: 1024 * 1024,
+        localRoots: "any",
+        readFile: async (filePath) => await fs.readFile(filePath),
+        hostReadCapability: true,
+      }),
+      "path-not-allowed",
+    );
+  });
+
   it.each([
     { label: "CSV", fileName: "opaque.csv" },
     { label: "HTML", fileName: "opaque.html" },
@@ -1099,6 +1124,7 @@ describe("loadWebMedia", () => {
     { label: "JSON", fileName: "opaque.json" },
     { label: "YAML", fileName: "opaque.yaml" },
     { label: "YML", fileName: "opaque.yml" },
+    { label: "vCard", fileName: "opaque.vcf" },
   ])("rejects opaque non-NUL binary data disguised as $label", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
     const opaqueBinary = Buffer.alloc(9000);

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -175,12 +175,14 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "text/csv",
   "text/markdown",
   "text/plain",
+  "text/vcard",
   "application/json",
   "application/yaml",
 ]);
 // file-type returns undefined (no magic bytes) for plain-text formats like CSV,
 // Markdown, TXT, JSON, and YAML, so host-read needs an explicit "this really
-// decodes as text" fallback.
+// decodes as text" fallback. text/vcard is recognized by file-type and does not
+// need the alias path.
 const HOST_READ_TEXT_PLAIN_ALIASES = new Set([
   "text/csv",
   "text/markdown",
@@ -570,6 +572,19 @@ function assertHostReadMediaAllowed(params: {
     sniffedMime &&
     HOST_READ_ALLOWED_DOCUMENT_MIMES.has(sniffedMime)
   ) {
+    // file-type reads only the first ~1MB. For text/* sniffed documents the
+    // prefix alone is not trustworthy — a valid header (e.g. "BEGIN:VCARD")
+    // can precede arbitrary binary data. Require full-buffer text validation
+    // before accepting text-based sniffed MIMEs.
+    if (sniffedMime.startsWith("text/")) {
+      if (params.buffer && isValidatedHostReadText(params.buffer)) {
+        return;
+      }
+      throw new LocalMediaAccessError(
+        "path-not-allowed",
+        `Host-local text/${sniffedMime.slice(5)} media sends require buffer-verified plain-text content.`,
+      );
+    }
     return;
   }
   if (


### PR DESCRIPTION

Closes #97062

## What Problem This Solves

Fixes an issue where users sending a local `.vcf` (vCard) contact file via the `MEDIA:` directive or `message(media=...)` would see:

```
Host-local media sends only allow buffer-verified images, audio, video, PDF, and Office documents (got text/vcard)
```


The only workaround was to manually base64-encode every file as `message(buffer=...)`, which is unnecessary friction for a standard RFC 6350 plain-text format.

## Why This Change Was Made

`file-type` (the MIME sniffing library OpenClaw uses) already recognizes vCard content and returns `text/vcard`. The missing piece was that `text/vcard` was not present in the host-read document allowlist. The fix adds it:

- **`packages/media-core/src/mime.ts`**: `EXT_BY_MIME` — enables `mimeTypeFromFilePath` to resolve `.vcf` → `text/vcard`, and `extensionForMime` to resolve `text/vcard` → `.vcf`
- **`src/media/web-media.ts`**: `HOST_READ_ALLOWED_DOCUMENT_MIMES` — allows the sniffed MIME to pass through `assertHostReadMediaAllowed`

`HOST_READ_TEXT_PLAIN_ALIASES` is intentionally unchanged. Unlike CSV, Markdown, TXT, JSON, and YAML (which have no magic bytes), `file-type` already detects vCard content, so `text/vcard` takes the standard sniffed-MIME path, not the plain-text alias fallback.

This is a narrowly scoped fix. Only the host-read send path is changed; `input_file` MIME lists, file-transfer plugin, UI MIME maps, and docs remain untouched.

### Security boundary hardening (added in review)

Both Codex review and a source review flagged that `file-type` only reads the first ~1MB prefix. A buffer starting with `BEGIN:VCARD\n` sniffs as `text/vcard`, but the remaining bytes could be arbitrary binary data. The sniffed-document allowlist path previously returned immediately on match without full-buffer validation for any MIME type.

The fix adds a guard in `assertHostReadMediaAllowed`: when a sniffed document MIME starts with `text/`, the full buffer must pass `isValidatedHostReadText` (printable character ratio > 0.95) before the file is accepted. This closes the prefix-only detection window for `text/vcard` and any future `text/*` MIME additions.

## User Impact

Users can send local `.vcf` contact files through `MEDIA:` directives and `message(media=...)` without workarounds. The file loads as a `text/vcard` document and can be delivered normally to channels that support contact sharing.

## Evidence

### Real behavior proof

Using the patched `loadWebMedia` (the internal API behind `MEDIA:` / `message(media=...)`) to verify the fix end-to-end:

**Setup:**
```bash
# Create a standard .vcf contact file
cat > /tmp/proof.vcf << EOF
BEGIN:VCARD
VERSION:3.0
FN:Test Contact
TEL:+1-555-0000
END:VCARD
EOF
```

**Test 1 — valid .vcf accepted:**
```
$ npx tsx proof-vcf.mjs

--- Test 1: valid .vcf via loadWebMedia ---
kind: document
contentType: text/vcard
buffer.length: 66
fileName: proof.vcf
STATUS: PASS
```

**Test 2 — malicious .vcf (BEGIN:VCARD header + binary tail) rejected:**
```
--- Test 2: malicious .vcf with binary tail ---
error: Host-local text/vcard media sends require buffer-verified plain-text content.
STATUS: PASS (correctly rejected)
```

### Tests

All tests pass (`pnpm test` runs two Vitest shards):

**`packages/media-core/src/mime.test.ts`** — 100/100 passed

New test cases added alongside existing YAML entries in each parameterized suite:

| describe | Test | Verifies |
|----------|------|----------|
| `mime detection` | `maps vCard files to text/vcard` | `detectMime({ filePath: "/tmp/contact.vcf" })` returns `"text/vcard"` |
| `mimeTypeFromFilePath` | `maps contact.vcf` | `mimeTypeFromFilePath("contact.vcf")` returns `"text/vcard"` |
| `extensionForMime` | `maps text/vcard` | `extensionForMime("text/vcard")` returns `".vcf"` |
| `extensionForMime` | `maps Text/VCard` | `extensionForMime("Text/VCard")` returns `".vcf"` (case-insensitive normalisation) |
| `mediaKindFromMime` | `classifies text/vcard` | `mediaKindFromMime("text/vcard")` returns `"document"` |

**`src/media/web-media.test.ts`** — 78/78 passed (one new regression test added during review)

| Test | Input | Asserts |
|------|-------|---------|
| `allows host-read vCard files` | `contact.vcf` with valid VCF content (BEGIN:VCARD / END:VCARD) | Returns `kind: "document"`, `contentType: "text/vcard"` |
| `rejects vCard files with a valid header and binary tail` | `evil.vcf` with `BEGIN:VCARD\n` prefix + 9000 bytes non-NUL binary tail | Throws `"path-not-allowed"` — regression guard against prefix-only file-type detection |
| `rejects opaque non-NUL binary data disguised as vCard` | `opaque.vcf` with non-printable binary content (non-NUL bytes only) | Throws `"path-not-allowed"` |

### Format and lint

```
$ oxfmt --check All matched files use the correct format.

$ oxlint Found 0 warnings and 0 errors.
```

---


This PR is AI-assisted. Analysis, implementation, and testing were performed using opencode with human review by the author.
