### PR TITLE
fix #96840: [Bug]: Targetless message.send fails with 'Action send requires a target' in WebChat despite docs stating source-reply sink should handle it

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -603,10 +603,9 @@ export function buildEmbeddedRunPayloads(params: {
     };
   }> = [];
 
-  const sourceReplyPayloads =
-    params.sourceReplyDeliveryMode === "message_tool_only"
-      ? (params.messagingToolSourceReplyPayloads ?? [])
-      : [];
+  // Internal source replies always need transcript/UI mirror payloads. Only a
+  // message_tool_only run suppresses the separate automatic final answer.
+  const sourceReplyPayloads = params.messagingToolSourceReplyPayloads ?? [];
   const sourceReplyStartIndex = replyItems.length;
   sourceReplyPayloads.forEach((payload, index) => {
     const text = normalizeOptionalString(payload.text) ?? "";
@@ -647,7 +646,7 @@ export function buildEmbeddedRunPayloads(params: {
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts =
     params.didSendDeterministicApprovalPrompt === true ||
-    hasSourceReplyPayload ||
+    (params.sourceReplyDeliveryMode === "message_tool_only" && hasSourceReplyPayload) ||
     deliveredSourceReplyViaMessageTool;
   const nonEmptyAssistantTexts = params.assistantTexts.filter((text) => text.trim().length > 0);
   const currentAssistant = params.currentAssistant ?? undefined;

--- a/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
+++ b/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
@@ -1,0 +1,82 @@
+// Integration coverage for targetless WebChat tool sends through the internal
+// source-reply sink and embedded-run payload projection.
+import { describe, expect, it } from "vitest";
+import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import { buildReplyPayloads } from "../../auto-reply/reply/agent-runner-payloads.js";
+import { buildEmbeddedRunPayloads } from "../embedded-agent-runner/run/payloads.js";
+import { extractMessagingToolSourceReplyPayload } from "../embedded-agent-subscribe.tools.js";
+import { createMessageTool } from "./message-tool.js";
+
+describe("WebChat message tool internal source reply", () => {
+  it("projects a real targetless send and preserves the automatic final reply", async () => {
+    const tool = createMessageTool({
+      config: {},
+      currentChannelProvider: "webchat",
+      sourceReplyDeliveryMode: "automatic",
+      agentSessionKey: "agent:main:webchat:dm:dashboard",
+      runId: "webchat-run",
+      getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
+      resolveCommandSecretRefsViaGateway: async ({ config }) => ({
+        resolvedConfig: config,
+        diagnostics: [],
+        targetStatesByPath: {},
+        hadUnresolvedTargets: false,
+      }),
+    });
+
+    const toolResult = await tool.execute("message-call", {
+      action: "send",
+      message: "Visible progress from the message tool.",
+    });
+    expect(toolResult.details).toMatchObject({
+      channel: "webchat",
+      target: "current-run",
+      sourceReplyDeliveryMode: "message_tool_only",
+      sourceReplySink: "internal-ui",
+      sourceReply: { text: "Visible progress from the message tool." },
+    });
+
+    const sourceReply = extractMessagingToolSourceReplyPayload(toolResult);
+    expect(sourceReply).toMatchObject({ text: "Visible progress from the message tool." });
+
+    const embeddedPayloads = buildEmbeddedRunPayloads({
+      assistantTexts: ["Visible automatic final reply."],
+      toolMetas: [],
+      lastAssistant: undefined,
+      currentAssistant: undefined,
+      sessionKey: "agent:main:webchat:dm:dashboard",
+      sourceReplyDeliveryMode: "automatic",
+      messagingToolSourceReplyPayloads: sourceReply ? [sourceReply] : [],
+      runId: "webchat-run",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+      toolResultFormat: "plain",
+    });
+    const { replyPayloads: payloads } = await buildReplyPayloads({
+      payloads: embeddedPayloads,
+      isHeartbeat: false,
+      didLogHeartbeatStrip: false,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      replyToMode: "off",
+      messagingToolSentTexts: ["Visible progress from the message tool."],
+    });
+
+    expect(payloads.map((payload) => payload.text)).toEqual([
+      "Visible progress from the message tool.",
+      "Visible automatic final reply.",
+    ]);
+    expect(getReplyPayloadMetadata(payloads[0] as object)).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplyTranscriptMirror: {
+        sessionKey: "agent:main:webchat:dm:dashboard",
+        text: "Visible progress from the message tool.",
+        idempotencyKey: "webchat-run:internal-source-reply:0",
+      },
+    });
+    expect(getReplyPayloadMetadata(payloads[1] as object)?.sourceReplyTranscriptMirror).toBe(
+      undefined,
+    );
+  });
+});

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -526,6 +526,38 @@ describe("message tool secret scoping", () => {
     expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
   });
 
+  it("defaults internal WebChat message tool sends to the source-reply sink", async () => {
+    mockSendResult();
+
+    const input = await executeSend({
+      action: { message: "hi" },
+      toolOptions: {
+        currentChannelProvider: "webchat",
+        agentSessionKey: "agent:main:webchat:dm:dashboard",
+      },
+    });
+
+    expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
+    expect(input?.params).toMatchObject({ action: "send", message: "hi" });
+  });
+
+  it("preserves explicit automatic delivery for internal WebChat message tools", async () => {
+    mockSendResult();
+
+    const input = await executeSend({
+      action: { message: "hi" },
+      toolOptions: {
+        currentChannelProvider: "webchat",
+        sourceReplyDeliveryMode: "automatic",
+        agentSessionKey: "agent:main:webchat:dm:dashboard",
+      },
+    });
+
+    expect(input?.sourceReplyDeliveryMode).toBe("automatic");
+    expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
+  });
+
   it("passes current inbound audio to the outbound runner", async () => {
     mockSendResult();
 

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -542,7 +542,7 @@ describe("message tool secret scoping", () => {
     expect(input?.params).toMatchObject({ action: "send", message: "hi" });
   });
 
-  it("preserves explicit automatic delivery for internal WebChat message tools", async () => {
+  it("keeps automatic WebChat final-answer guidance while selecting the tool-local sink", async () => {
     mockSendResult();
 
     const input = await executeSend({
@@ -554,8 +554,14 @@ describe("message tool secret scoping", () => {
       },
     });
 
-    expect(input?.sourceReplyDeliveryMode).toBe("automatic");
+    expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
+    const tool = createMessageTool({
+      currentChannelProvider: "webchat",
+      sourceReplyDeliveryMode: "automatic",
+      agentSessionKey: "agent:main:webchat:dm:dashboard",
+    });
+    expect(tool.description).not.toContain("Normal final answers stay private");
   });
 
   it("passes current inbound audio to the outbound runner", async () => {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -59,7 +59,7 @@ import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { POLL_CREATION_PARAM_DEFS, SHARED_POLL_CREATION_PARAM_NAMES } from "../../poll-params.js";
 import { normalizeAccountId, parseSessionDeliveryRoute } from "../../routing/session-key.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
-import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listAllChannelSupportedActions, listChannelSupportedActions } from "../channel-tools.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
@@ -1147,6 +1147,12 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
   const replyToMode = options?.replyToMode ?? (currentThreadTs ? "all" : undefined);
   const agentAccountId =
     resolveAgentAccountId(options?.agentAccountId) ?? effectiveCurrentChannel.accountId;
+  const currentChannelIsInternal =
+    normalizeMessageChannel(effectiveCurrentChannel.currentChannelProvider) ===
+    INTERNAL_MESSAGE_CHANNEL;
+  const sourceReplyDeliveryMode =
+    options?.sourceReplyDeliveryMode ??
+    (currentChannelIsInternal ? "message_tool_only" : undefined);
   const resolvedAgentId =
     options?.agentId ??
     (options?.agentSessionKey
@@ -1181,7 +1187,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
     sessionId: options?.sessionId,
     agentId: resolvedAgentId,
     requireExplicitTarget: options?.requireExplicitTarget,
-    sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
+    sourceReplyDeliveryMode,
     requesterSenderId: options?.requesterSenderId,
     senderIsOwner: options?.senderIsOwner,
   });
@@ -1387,7 +1393,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           sessionId: options?.sessionId,
           agentId: resolvedAgentId,
           sandboxRoot: options?.sandboxRoot,
-          sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
+          sourceReplyDeliveryMode,
           inboundEventKind: options?.inboundEventKind,
           inboundAudio: options?.currentInboundAudio,
           abortSignal: signal,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1150,9 +1150,11 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
   const currentChannelIsInternal =
     normalizeMessageChannel(effectiveCurrentChannel.currentChannelProvider) ===
     INTERNAL_MESSAGE_CHANNEL;
-  const sourceReplyDeliveryMode =
-    options?.sourceReplyDeliveryMode ??
-    (currentChannelIsInternal ? "message_tool_only" : undefined);
+  // WebChat tool sends use the private sink without changing the run-level
+  // contract: ordinary final answers must remain automatic and visible.
+  const sourceReplySinkDeliveryMode = currentChannelIsInternal
+    ? "message_tool_only"
+    : options?.sourceReplyDeliveryMode;
   const resolvedAgentId =
     options?.agentId ??
     (options?.agentSessionKey
@@ -1187,7 +1189,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
     sessionId: options?.sessionId,
     agentId: resolvedAgentId,
     requireExplicitTarget: options?.requireExplicitTarget,
-    sourceReplyDeliveryMode,
+    sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
     requesterSenderId: options?.requesterSenderId,
     senderIsOwner: options?.senderIsOwner,
   });
@@ -1393,7 +1395,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           sessionId: options?.sessionId,
           agentId: resolvedAgentId,
           sandboxRoot: options?.sandboxRoot,
-          sourceReplyDeliveryMode,
+          sourceReplyDeliveryMode: sourceReplySinkDeliveryMode,
           inboundEventKind: options?.inboundEventKind,
           inboundAudio: options?.currentInboundAudio,
           abortSignal: signal,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -303,6 +303,13 @@ export async function buildReplyPayloads(params: {
     });
     dedupedPayloads = [];
     for (const payload of silentFilteredPayloads) {
+      const payloadMetadata = getReplyPayloadMetadata(payload);
+      // Source mirrors exist because an internal sink send must reach the UI and
+      // transcript; that send is not outbound evidence for dropping the mirror.
+      if (payloadMetadata?.sourceReplyTranscriptMirror) {
+        dedupedPayloads.push(payload);
+        continue;
+      }
       const decision = dedupeRuntime.resolveMessagingToolPayloadDedupe({
         config: params.config,
         messageProvider,
@@ -311,11 +318,9 @@ export async function buildReplyPayloads(params: {
         originatingThreadId: params.originatingThreadId,
         replyToId: payload.replyToId,
         replyToIsExplicit: Boolean(
-          getReplyPayloadMetadata(payload)?.replyToIdExplicit ||
-          payload.replyToTag ||
-          payload.replyToCurrent,
+          payloadMetadata?.replyToIdExplicit || payload.replyToTag || payload.replyToCurrent,
         ),
-        replyDelivery: getReplyPayloadMetadata(payload)?.replyDelivery,
+        replyDelivery: payloadMetadata?.replyDelivery,
         accountId,
       });
       if (!decision.shouldDedupePayloads) {

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -271,6 +271,50 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps a targetless message-tool source reply beside the automatic final reply", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      const prompt = "send progress through the message tool and then finish";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      const sendRequest = await gateway.waitForRequest("chat.send");
+      const params = requireRecord(sendRequest.params);
+      expect(params).toMatchObject({ sessionKey: "main", message: prompt, deliver: false });
+      const runId = requireString(params.idempotencyKey, "chat send idempotency key");
+
+      await gateway.emitChatFinal({
+        runId,
+        text: "Visible progress from the targetless message tool.",
+      });
+      await page
+        .getByText("Visible progress from the targetless message tool.")
+        .waitFor({ timeout: 10_000 });
+
+      await gateway.emitChatFinal({ runId, text: "Visible automatic final reply." });
+      await page.getByText("Visible automatic final reply.").waitFor({ timeout: 10_000 });
+      const bubbleTexts = await page.locator(".chat-thread .chat-bubble").allTextContents();
+      for (const expectedText of [
+        prompt,
+        "Visible progress from the targetless message tool.",
+        "Visible automatic final reply.",
+      ]) {
+        expect(bubbleTexts.some((text) => text.includes(expectedText))).toBe(true);
+      }
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("keeps the composer clear when a stale native input replay arrives after send", async () => {
     const context = await newBrowserContext({
       locale: "en-US",


### PR DESCRIPTION
Closes #96840

Related: #96850 (closed as superseded)

## What Problem This Solves

Fixes an issue where users in an active WebChat conversation could not use a targetless `message.send`: OpenClaw returned `Action send requires a target` instead of showing the tool message in the current chat. The fix also preserves the ordinary automatic final answer after the tool message.

## Why This Change Was Made

WebChat direct runs intentionally use automatic final replies, while targetless message-tool sends need the existing current-run internal source sink. This change keeps those contracts separate: the tool send selects the internal sink locally, confirmed source replies are projected into the transcript/UI, and source-mirror payloads bypass outbound-message dedupe. Explicit external routes and `message_tool_only` runs keep their existing behavior.

No config, schema, dependency, migration, reusable WebChat outbound channel, or protocol change is included.

## User Impact

Agents can send visible progress or intermediate results with targetless `message.send` in the current WebChat conversation and still provide a normal visible final answer. External routed sends are unaffected.

## Evidence

The permanent integration executes the real path:

`createMessageTool` → `runMessageAction` current-run sink → tool-result extraction → embedded payload construction → final reply dedupe.

It proves the result contains both the source mirror and the automatic final, even when matching message-tool sent-text evidence is present.

Focused proof:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts --configLoader runner src/agents/tools/message-tool.internal-source-reply.integration.test.ts --reporter=dot --maxWorkers=1` — 1/1 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts --configLoader runner src/auto-reply/reply/agent-runner-payloads.test.ts --reporter=dot --maxWorkers=1` — 65/65 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "keeps a targetless message-tool source reply beside the automatic final reply" --reporter=verbose --maxWorkers=1` — Chromium 1 passed, 16 skipped.
- Sibling message-tool, embedded-payload, source-delivery, outbound-validation, and Gateway mirror-projection suites passed.
- Remote `check:changed` passed on Blacksmith Testbox provider `blacksmith-testbox`, id `tbx_01kwder0yyzbvqg0k1em246p6t`, Actions run [28483225303](https://github.com/openclaw/openclaw/actions/runs/28483225303).
- Fresh final autoreview traced the full sink/extraction/payload/dedupe/Gateway/UI path and returned zero findings (0.96 confidence).
- Deterministic local Chromium screenshots/video were captured as uncommitted proof artifacts and were not pushed to the repository.
