### PR TITLE
fix(feishu): preserve identity on aborted startup probe

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -459,8 +459,16 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   const botOpenIdSource = params.botOpenIdSource ?? { kind: "fetch" };
   const botIdentity =
     botOpenIdSource.kind === "prefetched"
-      ? { botOpenId: botOpenIdSource.botOpenId, botName: botOpenIdSource.botName }
+      ? {
+          kind: "resolved" as const,
+          botOpenId: botOpenIdSource.botOpenId,
+          botName: botOpenIdSource.botName,
+        }
       : await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
+  if (botIdentity.kind === "aborted") {
+    log(`feishu[${accountId}]: bot identity probe aborted; stopping monitor startup`);
+    return;
+  }
   const { botOpenId } = applyBotIdentityState(accountId, botIdentity);
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
 

--- a/extensions/feishu/src/monitor.bot-identity.ts
+++ b/extensions/feishu/src/monitor.bot-identity.ts
@@ -2,7 +2,10 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { RuntimeEnv } from "../runtime-api.js";
 import { waitForAbortableDelay } from "./async.js";
-import { fetchBotIdentityForMonitor, type FeishuMonitorBotIdentity } from "./monitor.startup.js";
+import {
+  fetchBotIdentityForMonitor,
+  type FeishuResolvedMonitorBotIdentity,
+} from "./monitor.startup.js";
 import { setFeishuBotIdentityState } from "./monitor.state.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -12,7 +15,7 @@ const BOT_IDENTITY_RETRY_DELAYS_MS = [60_000, 120_000, 300_000, 600_000, 900_000
 
 export function applyBotIdentityState(
   accountId: string,
-  identity: FeishuMonitorBotIdentity,
+  identity: FeishuResolvedMonitorBotIdentity,
 ): { botOpenId?: string; botName?: string } {
   const botOpenId = normalizeOptionalString(identity.botOpenId);
   const botName = normalizeOptionalString(identity.botName);
@@ -42,6 +45,9 @@ async function retryBotIdentityProbe(
     }
 
     const identity = await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
+    if (identity.kind === "aborted") {
+      return;
+    }
     const resolved = applyBotIdentityState(accountId, identity);
     if (resolved.botOpenId) {
       log(

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
 import { resolveStartupProbeTimeoutMs } from "./monitor.startup.js";
+import { botNames, botOpenIds, setFeishuBotIdentityState } from "./monitor.state.js";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
 
@@ -227,6 +228,46 @@ describe("Feishu monitor startup preflight", () => {
       expect(started).toEqual(["alpha"]);
     } finally {
       abortController.abort();
+    }
+  });
+
+  it("does not let an aborted single-account identity probe clear replacement identity", async () => {
+    const started: string[] = [];
+    probeFeishuMock.mockImplementation(
+      (account: { accountId: string }, options: { abortSignal?: AbortSignal }) => {
+        started.push(account.accountId);
+        return new Promise((resolve) => {
+          options.abortSignal?.addEventListener(
+            "abort",
+            () => resolve({ ok: false, error: "probe aborted" }),
+            { once: true },
+          );
+        });
+      },
+    );
+
+    const abortController = new AbortController();
+    const monitorPromise = monitorFeishuProvider({
+      config: buildMultiAccountWebsocketConfig(["alpha"]),
+      accountId: "alpha",
+      abortSignal: abortController.signal,
+    });
+
+    try {
+      await waitForStartedAccount(started, "alpha");
+
+      abortController.abort();
+      setFeishuBotIdentityState("alpha", {
+        botOpenId: "ou_replacement",
+        botName: "Replacement",
+      });
+      await monitorPromise;
+
+      expect(botOpenIds.get("alpha")).toBe("ou_replacement");
+      expect(botNames.get("alpha")).toBe("Replacement");
+    } finally {
+      abortController.abort();
+      await monitorPromise;
     }
   });
 });

--- a/extensions/feishu/src/monitor.startup.ts
+++ b/extensions/feishu/src/monitor.startup.ts
@@ -30,10 +30,13 @@ type FetchBotOpenIdOptions = {
   timeoutMs?: number;
 };
 
-export type FeishuMonitorBotIdentity = {
+export type FeishuResolvedMonitorBotIdentity = {
+  kind: "resolved";
   botOpenId?: string;
   botName?: string;
 };
+
+export type FeishuMonitorBotIdentity = FeishuResolvedMonitorBotIdentity | { kind: "aborted" };
 
 function isTimeoutErrorMessage(message: string | undefined): boolean {
   const lower = normalizeLowercaseStringOrEmpty(message);
@@ -49,7 +52,7 @@ export async function fetchBotIdentityForMonitor(
   options: FetchBotOpenIdOptions = {},
 ): Promise<FeishuMonitorBotIdentity> {
   if (options.abortSignal?.aborted) {
-    return {};
+    return { kind: "aborted" };
   }
 
   const timeoutMs = options.timeoutMs ?? FEISHU_STARTUP_BOT_INFO_TIMEOUT_MS;
@@ -58,12 +61,15 @@ export async function fetchBotIdentityForMonitor(
     abortSignal: options.abortSignal,
   });
   if (result.ok) {
-    return { botOpenId: result.botOpenId, botName: result.botName };
+    return { kind: "resolved", botOpenId: result.botOpenId, botName: result.botName };
   }
 
   const probeError = result.error ?? undefined;
-  if (options.abortSignal?.aborted || isAbortErrorMessage(probeError)) {
-    return {};
+  if (options.abortSignal?.aborted) {
+    return { kind: "aborted" };
+  }
+  if (isAbortErrorMessage(probeError)) {
+    return { kind: "resolved" };
   }
 
   if (isTimeoutErrorMessage(probeError)) {
@@ -72,5 +78,5 @@ export async function fetchBotIdentityForMonitor(
       `feishu[${account.accountId}]: bot info probe timed out after ${timeoutMs}ms; continuing startup`,
     );
   }
-  return {};
+  return { kind: "resolved" };
 }

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -74,12 +74,12 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     }
 
     // Probe sequentially so large multi-account startups do not burst Feishu's bot-info endpoint.
-    const { botOpenId, botName } = await fetchBotIdentityForMonitor(account, {
+    const botIdentity = await fetchBotIdentityForMonitor(account, {
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
     });
 
-    if (opts.abortSignal?.aborted) {
+    if (botIdentity.kind === "aborted" || opts.abortSignal?.aborted) {
       log("feishu: abort signal received during startup preflight; stopping startup");
       break;
     }
@@ -91,7 +91,11 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         channelRuntime: opts.channelRuntime,
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
-        botOpenIdSource: { kind: "prefetched", botOpenId, botName },
+        botOpenIdSource: {
+          kind: "prefetched",
+          botOpenId: botIdentity.botOpenId,
+          botName: botIdentity.botName,
+        },
       }),
     );
   }


### PR DESCRIPTION
Closes #77717

## What Problem This Solves

Fixes an issue where users running Feishu WebSocket accounts could have a config reload abort the startup bot identity probe, allowing the stopped lifecycle to write an unknown bot identity and skip recovery. Affected accounts could miss messages until a full gateway restart.

## Why This Change Was Made

The Feishu startup probe now returns an explicit aborted result instead of using the same empty object shape as a resolved-but-unknown bot identity.

Root-cause proof from current `main` before this PR:

- `fetchBotIdentityForMonitor` returned `{}` when the supplied abort signal was already aborted or became aborted during the probe.
- `monitorSingleAccount` passed that empty identity into `applyBotIdentityState`, which wrote an empty `botOpenId` for the account.
- `monitorSingleAccount` then skipped `startBotIdentityRecovery` because the same lifecycle abort signal was already aborted.
- `startBotIdentityRecovery` uses that same abort signal for retry cancellation, so passing an already-aborted signal would not recover identity either.

This PR keeps active unknown-identity behavior on the existing recovery path, but treats abort-driven probe cancellation as monitor shutdown: aborted probes stop startup before applying empty identity state. Background recovery also exits without applying identity state if its probe observes an abort.

This stays inside the Feishu monitor lifecycle boundary. It does not change core gateway behavior, config shape, Feishu credentials handling, or recovery retry timing.

AI-assisted: yes, implemented with Codex.

## User Impact

Feishu accounts are protected from stale aborted startup probes clearing replacement identity during reloads. Operators should no longer need a full gateway restart to recover from this race when the replacement monitor lifecycle has already written fresh identity state.

Existing timeout and non-abort unknown-identity behavior remains recovery-based for active lifecycles.

## Evidence

### Regression Coverage

Added a focused regression test in `extensions/feishu/src/monitor.startup.test.ts`:

- starts a single Feishu account monitor with an identity probe that resolves only after abort
- aborts the old lifecycle
- writes replacement identity before the stale old monitor continuation resumes
- awaits the old monitor and asserts the replacement `botOpenId`/`botName` is still present

That models the reported stale-lifecycle race directly. On the previous implementation, the stale old monitor continuation would apply the empty identity result and clear the replacement identity.

### Local Validation

- `node scripts/run-vitest.mjs extensions/feishu`  
  Result: **72 test files passed, 964 tests passed**
- `node scripts/run-vitest.mjs extensions/feishu/src/monitor.startup.test.ts extensions/feishu/src/monitor.cleanup.test.ts extensions/feishu/src/monitor.reaction.test.ts`  
  Result: **3 test files passed, 43 tests passed**
- `pnpm tsgo:extensions`  
  Result: passed
- `pnpm tsgo:extensions:test`  
  Result: passed
- `pnpm format:check extensions/feishu/src/monitor.account.ts extensions/feishu/src/monitor.bot-identity.ts extensions/feishu/src/monitor.startup.test.ts extensions/feishu/src/monitor.startup.ts extensions/feishu/src/monitor.ts`  
  Result: passed
- `git diff --check`  
  Result: passed
- `.agents/skills/autoreview/scripts/autoreview --mode local`  
  Result: clean, no actionable findings

### GitHub / Automation Proof

- PR evidence gate `Real behavior proof` succeeded for head SHA `0bd851635f1578e176d21758fc291869cbf8ef0c`: https://github.com/openclaw/openclaw/actions/runs/28277060739
- Socket Security PR checks succeeded for the same PR head.

### Not Run / Blocked

- Live Feishu tenant restart/reload proof was not run because Feishu credentials are not available in this environment.
- Remote changed-check proof was attempted but blocked by local proof infrastructure access:
  - Blacksmith Testbox via Crabbox: blocked because the `blacksmith` CLI is not installed in this environment.
  - Direct AWS Crabbox fallback: blocked because this environment is not logged into the OpenClaw Crabbox broker.
