### PR TITLE
Fix voice-call streaming provider resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **OpenAI Realtime Codex auth:** reuse external Codex OAuth profiles for Realtime voice sessions when no explicit OpenAI API key is configured.
+- **Talk transcription providers:** cold-load explicitly configured Voice Call streaming providers, including runtime aliases, when another provider registry is already active, keeping catalog and session selection aligned. (#97170, #97738) Thanks @solavrc.
 - **Android Canvas navigation:** block device-local loopback and unspecified main-frame web targets across direct, user, JavaScript, and redirect navigation while preserving remote, LAN, emulator-host, and bundled canvases. (#99874) Thanks @ly85206559.
 - **Android network recovery:** reconnect Gateway sessions immediately when Android regains a validated network instead of waiting for the current reconnect backoff. (#100347) Thanks @ly85206559.
 - **Android Voice layout:** keep Voice settings controls within their intended width so nested cards do not overflow or clip on constrained screens. (#100491) Thanks @IWhatsskill.

--- a/src/gateway/server-methods/talk-shared.ts
+++ b/src/gateway/server-methods/talk-shared.ts
@@ -15,7 +15,10 @@ import {
 } from "../../../packages/speech-core/voice-models.js";
 import type { TalkRealtimeConfig } from "../../config/types.gateway.js";
 import type { OpenClawConfig } from "../../config/types.js";
-import { listRealtimeTranscriptionProviders } from "../../realtime-transcription/provider-registry.js";
+import {
+  getRealtimeTranscriptionProvider,
+  listRealtimeTranscriptionProviders,
+} from "../../realtime-transcription/provider-registry.js";
 import type { RealtimeTranscriptionProviderConfig } from "../../realtime-transcription/provider-types.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME } from "../../talk/agent-run-control-shared.js";
@@ -127,6 +130,27 @@ export function getVoiceCallStreamingConfig(config: OpenClawConfig): {
   return getVoiceCallProviderConfig(config, "streaming");
 }
 
+export function listTalkTranscriptionProviders(
+  config: OpenClawConfig,
+  configuredProviderIds: Iterable<string | undefined>,
+) {
+  const providers = listRealtimeTranscriptionProviders(config);
+  for (const providerId of configuredProviderIds) {
+    const configuredProvider = getRealtimeTranscriptionProvider(providerId, config);
+    if (
+      configuredProvider &&
+      !providers.some(
+        (provider) =>
+          normalizeOptionalLowercaseString(provider.id) ===
+          normalizeOptionalLowercaseString(configuredProvider.id),
+      )
+    ) {
+      providers.push(configuredProvider);
+    }
+  }
+  return providers;
+}
+
 type RealtimeProviderWithConfig<TConfig extends Record<string, unknown>> = VoiceModelProvider & {
   resolveConfig?: (ctx: { cfg: OpenClawConfig; rawConfig: TConfig }) => TConfig;
   isConfigured: (ctx: { cfg: OpenClawConfig; providerConfig: TConfig }) => boolean;
@@ -233,11 +257,12 @@ export function buildTalkTranscriptionConfig(config: OpenClawConfig, requestedPr
   const streamingConfig = getVoiceCallStreamingConfig(config);
   const provider = normalizeOptionalString(requestedProvider) ?? streamingConfig.provider;
   const providerConfigs = streamingConfig.providers ?? {};
+  const configuredProviderIds = [provider, ...Object.keys(providerConfigs)];
   const voiceModelDefault = resolveConfiguredVoiceModelDefaultRef({
     config,
     provider,
     providerConfigs,
-    providers: listRealtimeTranscriptionProviders(config),
+    providers: listTalkTranscriptionProviders(config, configuredProviderIds),
   });
   return {
     provider: provider ?? voiceModelDefault?.provider,
@@ -260,18 +285,16 @@ export function resolveConfiguredRealtimeTranscriptionProvider(params: {
   providerConfigs: Record<string, RealtimeTranscriptionProviderConfig>;
   defaultModel?: string;
 }) {
-  const providers = listRealtimeTranscriptionProviders(params.config);
   const normalizedConfigured = normalizeOptionalLowercaseString(params.configuredProviderId);
+  const providers = normalizedConfigured
+    ? [getRealtimeTranscriptionProvider(normalizedConfigured, params.config)].filter(
+        (provider) => provider !== undefined,
+      )
+    : listTalkTranscriptionProviders(params.config, Object.keys(params.providerConfigs));
   // An explicit provider is authoritative; automatic selection is stable by
   // provider order so the same config picks the same transcription backend.
   const orderedProviders = normalizedConfigured
-    ? providers.filter(
-        (provider) =>
-          normalizeOptionalLowercaseString(provider.id) === normalizedConfigured ||
-          (provider.aliases ?? []).some(
-            (alias) => normalizeOptionalLowercaseString(alias) === normalizedConfigured,
-          ),
-      )
+    ? providers
     : providers.toSorted((a, b) => (a.autoSelectOrder ?? 1000) - (b.autoSelectOrder ?? 1000));
   for (const provider of orderedProviders) {
     const rawConfig = getVoiceProviderConfig({

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   canonicalizeRealtimeTranscriptionProviderId: vi.fn((providerId: string | undefined) =>
     providerId === "openai-realtime" ? "openai" : providerId?.trim().toLowerCase(),
   ),
+  getRealtimeTranscriptionProvider: vi.fn(),
   listRealtimeTranscriptionProviders: vi.fn(() => []),
   resolveConfiguredRealtimeVoiceProvider: vi.fn(),
   createTalkRealtimeRelaySession: vi.fn(),
@@ -65,6 +66,7 @@ vi.mock("../../talk/provider-registry.js", () => ({
 
 vi.mock("../../realtime-transcription/provider-registry.js", () => ({
   canonicalizeRealtimeTranscriptionProviderId: mocks.canonicalizeRealtimeTranscriptionProviderId,
+  getRealtimeTranscriptionProvider: mocks.getRealtimeTranscriptionProvider,
   listRealtimeTranscriptionProviders: mocks.listRealtimeTranscriptionProviders,
 }));
 
@@ -159,6 +161,21 @@ function expectRespondError(mock: ReturnType<typeof vi.fn>, expected: Record<str
   expect(mockCallArg(mock, 0, 1)).toBeUndefined();
   return expectRecordFields(mockCallArg(mock, 0, 2), expected);
 }
+
+beforeEach(() => {
+  mocks.getRealtimeTranscriptionProvider.mockImplementation((providerId: string | undefined) => {
+    const normalized = providerId?.trim().toLowerCase();
+    const providers = mocks.listRealtimeTranscriptionProviders() as Array<{
+      id: string;
+      aliases?: string[];
+    }>;
+    return providers.find(
+      (provider) =>
+        provider.id.toLowerCase() === normalized ||
+        provider.aliases?.some((alias) => alias.toLowerCase() === normalized),
+    );
+  });
+});
 
 describe("talk.catalog handler", () => {
   beforeEach(() => {
@@ -451,6 +468,60 @@ describe("talk.catalog handler", () => {
         ],
       },
       realtime: { ready: true, activeProvider: "realtime-fast" },
+    });
+  });
+
+  it("includes a provider-map transcription provider missing from the active registry", async () => {
+    const openai = {
+      id: "openai",
+      label: "OpenAI Realtime Transcription",
+      isConfigured: vi.fn(() => false),
+    };
+    const xai = {
+      id: "xai",
+      label: "xAI Realtime Transcription",
+      resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
+      isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "xai-key"),
+    };
+    mocks.listRealtimeTranscriptionProviders.mockReturnValue([openai] as never);
+    mocks.getRealtimeTranscriptionProvider.mockImplementation((providerId: string | undefined) =>
+      providerId === "xai" ? (xai as never) : undefined,
+    );
+
+    const respond = vi.fn();
+    await talkHandlers["talk.catalog"]({
+      req: { type: "req", id: "1", method: "talk.catalog" },
+      params: {},
+      client: { connect: { scopes: ["operator.read"] } } as never,
+      isWebchatConnect: () => false,
+      respond: respond as never,
+      context: {
+        getRuntimeConfig: () =>
+          ({
+            plugins: {
+              entries: {
+                "voice-call": {
+                  config: {
+                    streaming: {
+                      providers: { xai: { apiKey: "xai-key" } },
+                    },
+                  },
+                },
+              },
+            },
+          }) as OpenClawConfig,
+      } as never,
+    });
+
+    expect(mockCallArg(respond, 0, 1)).toMatchObject({
+      transcription: {
+        ready: true,
+        activeProvider: "xai",
+        providers: [
+          { id: "openai", configured: false },
+          { id: "xai", configured: true },
+        ],
+      },
     });
   });
 
@@ -1662,6 +1733,66 @@ describe("talk.session unified handlers", () => {
     expect(mocks.stopTalkTranscriptionRelaySession).toHaveBeenCalledWith({
       transcriptionSessionId: "stt-unified-1",
       connId: "conn-1",
+    });
+  });
+
+  it("creates transcription sessions with an aliased provider missing from the active registry", async () => {
+    const openai = {
+      id: "openai",
+      aliases: ["openai-realtime"],
+      label: "OpenAI Realtime Transcription",
+      resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
+      isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "openai-key"),
+      createSession: vi.fn(),
+    };
+    mocks.listRealtimeTranscriptionProviders.mockReturnValue([
+      { id: "xai", label: "xAI Realtime Transcription", isConfigured: () => true },
+    ] as never);
+    mocks.getRealtimeTranscriptionProvider.mockImplementation((providerId: string | undefined) =>
+      providerId === "openai-realtime" ? (openai as never) : undefined,
+    );
+    mocks.createTalkTranscriptionRelaySession.mockReturnValue({
+      provider: "openai",
+      mode: "transcription",
+      transport: "gateway-relay",
+      transcriptionSessionId: "stt-openai-1",
+      audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+      expiresAt: 1_797_986_400,
+    });
+
+    const respond = vi.fn();
+    await talkHandlers["talk.session.create"]({
+      req: { type: "req", id: "1", method: "talk.session.create" },
+      params: { mode: "transcription", transport: "gateway-relay", brain: "none" },
+      client: { connId: "conn-1" } as never,
+      isWebchatConnect: () => false,
+      respond: respond as never,
+      context: {
+        getRuntimeConfig: () =>
+          ({
+            plugins: {
+              entries: {
+                "voice-call": {
+                  config: {
+                    streaming: {
+                      provider: "openai-realtime",
+                      providers: { openai: { apiKey: "openai-key" } },
+                    },
+                  },
+                },
+              },
+            },
+          }) as OpenClawConfig,
+      } as never,
+    });
+
+    expectRespondOk(respond, {
+      provider: "openai",
+      transcriptionSessionId: "stt-openai-1",
+    });
+    expect(mockCallArg(mocks.createTalkTranscriptionRelaySession)).toMatchObject({
+      provider: openai,
+      providerConfig: { apiKey: "openai-key" },
     });
   });
 

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -34,10 +34,7 @@ import type {
 } from "../../config/types.gateway.js";
 import type { OpenClawConfig, TtsConfig, TtsProviderConfigMap } from "../../config/types.js";
 import { resolveProviderRawConfig } from "../../plugin-sdk/provider-selection-runtime.js";
-import {
-  canonicalizeRealtimeTranscriptionProviderId,
-  listRealtimeTranscriptionProviders,
-} from "../../realtime-transcription/provider-registry.js";
+import { canonicalizeRealtimeTranscriptionProviderId } from "../../realtime-transcription/provider-registry.js";
 import {
   canonicalizeRealtimeVoiceProviderId,
   listRealtimeVoiceProviders,
@@ -63,6 +60,7 @@ import {
   buildTalkRealtimeConfig,
   buildTalkTranscriptionConfig,
   configuredOrFalse,
+  listTalkTranscriptionProviders,
   resolveConfiguredRealtimeTranscriptionProvider,
 } from "./talk-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -286,12 +284,19 @@ function buildTalkCatalog(config: OpenClawConfig) {
     transcription: {
       ready: transcriptionSelection.ready,
       ...(activeTranscriptionProvider ? { activeProvider: activeTranscriptionProvider } : {}),
-      providers: listRealtimeTranscriptionProviders(config).map((provider) => {
+      providers: listTalkTranscriptionProviders(config, [
+        transcriptionConfig.provider,
+        ...Object.keys(transcriptionConfig.providers),
+      ]).map((provider) => {
         const rawConfig = getVoiceProviderConfig({
           providerConfigs: transcriptionConfig.providers,
           provider,
           configuredProviderId:
-            provider.id === activeTranscriptionProvider ? transcriptionConfig.provider : undefined,
+            activeTranscriptionProvider &&
+            normalizeOptionalLowercaseString(provider.id) ===
+              normalizeOptionalLowercaseString(activeTranscriptionProvider)
+              ? transcriptionConfig.provider
+              : undefined,
         });
         const rawConfigWithModel =
           transcriptionConfig.model && rawConfig.model === undefined

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -1278,6 +1278,79 @@ describe("resolvePluginCapabilityProviders", () => {
     expectActiveRegistryLookup(["google"]);
   });
 
+  it("cold-loads a capability provider by runtime alias", () => {
+    const active = createEmptyPluginRegistry();
+    active.realtimeTranscriptionProviders.push({
+      pluginId: "deepgram",
+      pluginName: "Deepgram",
+      source: "test",
+      provider: { id: "deepgram", label: "Deepgram" },
+    } as never);
+    const loaded = createEmptyPluginRegistry();
+    loaded.realtimeTranscriptionProviders.push({
+      pluginId: "openai",
+      pluginName: "OpenAI",
+      source: "test",
+      provider: {
+        id: "openai",
+        aliases: [" OpenAI-Realtime "],
+        label: "OpenAI",
+      },
+    } as never);
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "deepgram",
+          origin: "bundled",
+          contracts: { realtimeTranscriptionProviders: ["deepgram"] },
+        },
+        {
+          id: "openai",
+          origin: "bundled",
+          contracts: { realtimeTranscriptionProviders: ["openai"] },
+        },
+      ] as never,
+      diagnostics: [],
+    });
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? active : loaded,
+    );
+
+    const provider = resolvePluginCapabilityProvider({
+      key: "realtimeTranscriptionProviders",
+      providerId: "openai-realtime",
+    });
+
+    expect(provider?.id).toBe("openai");
+    expectActiveRegistryLookup(["deepgram", "openai"]);
+  });
+
+  it("prefers a canonical provider id over an earlier provider alias", () => {
+    const active = createEmptyPluginRegistry();
+    active.speechProviders.push(
+      {
+        pluginId: "microsoft",
+        pluginName: "Microsoft",
+        source: "test",
+        provider: { id: "microsoft", aliases: [" EDGE "], label: "Microsoft" },
+      } as never,
+      {
+        pluginId: "edge",
+        pluginName: "Edge",
+        source: "test",
+        provider: { id: "edge", label: "Edge" },
+      } as never,
+    );
+    mocks.resolveRuntimePluginRegistry.mockReturnValue(active);
+
+    const provider = resolvePluginCapabilityProvider({
+      key: "speechProviders",
+      providerId: "edge",
+    });
+
+    expect(provider?.id).toBe("edge");
+  });
+
   it("does not merge unrelated bundled capability providers when cfg requests one provider", () => {
     const active = createEmptyPluginRegistry();
     active.speechProviders.push({

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -24,6 +24,7 @@ import {
   type ConfigScopedRuntimeCache,
 } from "./plugin-cache-primitives.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
+import { normalizeCapabilityProviderId } from "./provider-registry-shared.js";
 import type { PluginRegistry } from "./registry-types.js";
 
 type CapabilityProviderRegistryKey =
@@ -219,11 +220,30 @@ function findProviderById<K extends CapabilityProviderRegistryKey>(
   entries: PluginRegistry[K],
   providerId: string,
 ): CapabilityProviderForKey<K> | undefined {
+  const normalizedProviderId = normalizeCapabilityProviderId(providerId);
+  if (!normalizedProviderId) {
+    return undefined;
+  }
   const providerEntries = entries as unknown as Array<{
-    provider: CapabilityProviderForKey<K> & { id?: unknown };
+    provider: CapabilityProviderForKey<K> & { id?: unknown; aliases?: unknown };
   }>;
   for (const entry of providerEntries) {
-    if (entry.provider.id === providerId) {
+    if (
+      typeof entry.provider.id === "string" &&
+      normalizeCapabilityProviderId(entry.provider.id) === normalizedProviderId
+    ) {
+      return entry.provider;
+    }
+  }
+  for (const entry of providerEntries) {
+    const aliases = Array.isArray(entry.provider.aliases) ? entry.provider.aliases : [];
+    if (
+      aliases.some(
+        (alias) =>
+          typeof alias === "string" &&
+          normalizeCapabilityProviderId(alias) === normalizedProviderId,
+      )
+    ) {
       return entry.provider;
     }
   }
@@ -523,13 +543,19 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
     return activeProvider;
   }
 
-  const pluginIds = resolveCapabilityPluginIds({
+  let pluginIds = resolveCapabilityPluginIds({
     key: params.key,
     cfg: params.cfg,
     providerId: params.providerId,
   });
   if (pluginIds.runtimePluginIds.length === 0) {
-    return undefined;
+    // Manifest contracts index canonical provider ids, while runtime providers
+    // may expose aliases. Fall back to the capability owners so a configured
+    // alias can still resolve when its provider is absent from the active registry.
+    pluginIds = resolveCapabilityPluginIds({ key: params.key, cfg: params.cfg });
+    if (pluginIds.runtimePluginIds.length === 0) {
+      return undefined;
+    }
   }
 
   const compatConfig = resolveCapabilityProviderConfig({


### PR DESCRIPTION
Fixes #97738

## What Problem This Solves

`talk.catalog` reports `transcription.activeProvider` from the Talk/voice-call streaming config, but realtime transcription provider listing could return only the already-active runtime registry providers.

In a Gateway configured with `plugins.entries["voice-call"].config.streaming.provider = "xai"`, the failure mode was:

1. Gateway starts and can discover the xAI realtime transcription provider.
2. Another path activates an OpenAI-only runtime registry.
3. `talk.catalog` still reports `activeProvider: "xai"`, but `transcription.providers` only contains `openai`.
4. `talk.session.create` for Review voice then fails with `Realtime transcription provider "xai" is not configured`.

Root cause: Talk/voice-call streaming provider IDs were not consistently carried into realtime transcription provider resolution. The first version of this PR fixed catalog/config building, but `talk.session.create` still re-listed providers without the Talk-requested provider set, so the session path could still miss a cold provider when the active registry only contained OpenAI.

This patch keeps Talk-owned provider selection in Talk code. The generic capability resolver accepts explicit `requestedProviderIds`, and Talk passes its configured transcription provider IDs through both catalog and session resolution. It also reads both supported Voice Call config entry IDs: `voice-call` and `@openclaw/voice-call`.

## Implementation Notes

- Adds a generic `requestedProviderIds` option to `resolvePluginCapabilityProviders`.
- Keeps `voice-call` / `@openclaw/voice-call` streaming config parsing in `talk-shared.ts`.
- Uses the same requested provider set for `talk.catalog`, `buildTalkTranscriptionConfig`, and `resolveConfiguredRealtimeTranscriptionProvider`.
- Adds regression coverage for active OpenAI-only registry plus configured xAI Voice Call streaming.
- Adds regression coverage for scoped `plugins.entries["@openclaw/voice-call"]` config.

## Evidence

Current head: `7e648d9b51fe08476a59ffb54dbc93a07bd0f412` after merging upstream `main` (`5d8293c1fe404f607b3ecddcb9f12d1753a4de51`).

Current local validation on this branch after the upstream-main merge:

```text
node scripts/test-projects.mjs src/gateway/server-methods/talk.test.ts src/plugins/capability-provider-runtime.test.ts
Test Files  3 passed (3)
Tests       156 passed (156)
```

```text
pnpm exec oxfmt --check --threads=1 src/plugins/capability-provider-runtime.ts src/gateway/server-methods/talk-shared.ts src/gateway/server-methods/talk.ts src/gateway/server-methods/talk.test.ts src/plugins/capability-provider-runtime.test.ts src/realtime-transcription/provider-registry.ts src/gateway/server-methods/talk-session.ts
All matched files use the correct format.
```

```text
pnpm exec oxlint src/plugins/capability-provider-runtime.ts src/gateway/server-methods/talk-shared.ts src/gateway/server-methods/talk.ts src/gateway/server-methods/talk.test.ts src/plugins/capability-provider-runtime.test.ts src/realtime-transcription/provider-registry.ts src/gateway/server-methods/talk-session.ts
# passed
```

Real Gateway proof, redacted, using the same local config/auth state with `voice-call.streaming.provider = "xai"`:

Before the completed fix, installed Gateway `2026.6.10 (aa69b12)`:

```json
{
  "activeProvider": "xai",
  "providers": [
    {
      "id": "openai",
      "configured": true,
      "transports": ["gateway-relay"],
      "brains": ["none"],
      "defaultModel": "gpt-4o-transcribe"
    }
  ]
}
```

```json
{
  "ok": false,
  "error": {
    "code": "UNAVAILABLE",
    "message": "Error: Realtime transcription provider \"xai\" is not configured"
  }
}
```

After the completed fix, patched source Gateway on a separate local port with channels skipped:

```json
{
  "activeProvider": "xai",
  "providers": [
    {
      "id": "xai",
      "configured": true,
      "transports": ["gateway-relay"],
      "brains": ["none"]
    }
  ]
}
```

```json
{
  "provider": "xai",
  "mode": "transcription",
  "transport": "gateway-relay",
  "audio": {
    "inputEncoding": "g711_ulaw",
    "inputSampleRateHz": 8000
  },
  "brain": "none"
}
```


## Minimal Config / OAuth State Check

I also verified the provider/config interaction separately from the full local plugin set.

Minimal config used for the clean check:

```json
{
  "gateway": {
    "mode": "local",
    "bind": "loopback",
    "auth": { "mode": "none" },
    "tailscale": { "mode": "off" }
  },
  "plugins": {
    "allow": ["voice-call", "xai"],
    "entries": {
      "voice-call": {
        "enabled": true,
        "config": {
          "streaming": {
            "enabled": true,
            "provider": "xai",
            "providers": {
              "xai": { "endpointingMs": 800 }
            }
          }
        }
      },
      "xai": { "enabled": true }
    }
  }
}
```

`openclaw config validate --json` passed with no warnings for that config.

With an empty temporary state dir, the same config returns the xAI provider but marks it unconfigured, as expected because no API key or OAuth profile exists there:

```json
{
  "activeProvider": "xai",
  "providers": [
    { "id": "xai", "configured": false }
  ]
}
```

With the same minimal config and the existing local OpenClaw state/auth store, the xAI OAuth profile is used. No `XAI_API_KEY` or `OPENAI_API_KEY` was present in `~/.openclaw/.env` during this check.

```json
{
  "activeProvider": "xai",
  "providers": [
    {
      "id": "xai",
      "label": "xAI Realtime Transcription",
      "configured": true,
      "modes": ["transcription"],
      "transports": ["gateway-relay"],
      "brains": ["none"]
    }
  ]
}
```

```json
{
  "provider": "xai",
  "mode": "transcription",
  "transport": "gateway-relay",
  "audio": {
    "inputEncoding": "g711_ulaw",
    "inputSampleRateHz": 8000
  },
  "brain": "none"
}
```

This confirms the expected X Premium / xAI OAuth state path works independently of the full local plugin set. The original failure is provider resolution under an already-active provider registry, not missing xAI credentials or an incorrect Voice Call config shape.

## Behavior Changes Beyond the Fix

These are deliberate behavior changes that go beyond the narrow xAI session-resolution bug. Calling them out explicitly so maintainers can accept them consciously:

1. **Speech provider request collection filters `models.providers` keys to resolvable speech providers.** `collectRequestedSpeechProviderIds` previously added every `models.providers` key (chat-model providers such as `anthropic`) to the speech cold-load request set, which polluted the requested scope. It now keeps only the keys that resolve to a speech-provider plugin through manifest contracts, so shared model-provider auth such as `models.providers.google.apiKey` (Google TTS) stays requested and cold-loadable under a partial active speech registry, while unrelated chat model providers like `anthropic` are excluded.

2. **Talk now reads `plugins.entries["@openclaw/voice-call"]` streaming config.** The scoped package entry id was previously ignored by Talk (only `voice-call` was read), while doctor/update tooling already treats both ids as the same plugin. Precedence when both entries define streaming config: the scoped entry's `provider` wins, and `providers` maps are merged per key with the scoped entry overriding. A scoped entry with `enabled: false` is ignored, so stale disabled scoped config cannot override an enabled legacy entry; the legacy `voice-call` entry keeps its pre-existing read-regardless semantics. Impact: installs that still carry a stale scoped entry alongside the unscoped one can see the scoped values drive transcription provider selection after upgrade. The `realtime` section intentionally still reads only `voice-call` so the realtime catalog does not advertise an active provider it cannot list.

3. **`requestedProviderIds` on the shared capability resolver is additive-only.** With an active registry it cold-loads requested providers the registry is missing and merges them in; with no active registry the load stays unscoped. Requested ids never narrow which providers are visible, so `autoSelectOrder` fallback keeps seeing every installed provider.
