### PR TITLE
fix(auto-reply): gate restart silence on recovery ownership

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -10,7 +10,12 @@ import type { SessionEntry } from "../../config/sessions.js";
 import type { ModelDefinitionConfig } from "../../config/types.models.js";
 import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
 import { loggingState } from "../../logging/state.js";
-import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
+import {
+  CommandLaneClearedError,
+  GatewayDrainingError,
+  markGatewayDraining,
+  resetCommandQueueStateForTest,
+} from "../../process/command-queue.js";
 import {
   createUserTurnTranscriptRecorder,
   type PersistedUserTurnMessage,
@@ -6089,6 +6094,132 @@ describe("runAgentTurnWithFallback", () => {
     const failCall = requireMockCall(failMock, 0, "reply operation fail");
     expect(failCall[0]).toBe("command_lane_cleared");
     expect(failCall[1]).toBeInstanceOf(CommandLaneClearedError);
+  });
+
+  it.each([
+    {
+      label: "drain wrapped by fallback while recovery is armed",
+      makeError: () => new GatewayDrainingError(),
+      code: "gateway_draining",
+      errorClass: GatewayDrainingError,
+      drainGateway: false,
+      isRestartRecoveryArmed: () => true,
+    },
+    {
+      label: "cleared lane wrapped by fallback while recovery is armed",
+      makeError: () => new CommandLaneClearedError("session:main"),
+      code: "command_lane_cleared",
+      errorClass: CommandLaneClearedError,
+      drainGateway: false,
+      isRestartRecoveryArmed: () => true,
+    },
+  ])(
+    "keeps fallback-wrapped restart terminal silent when $label",
+    async ({ makeError, code, errorClass, drainGateway, isRestartRecoveryArmed }) => {
+      const restartError = makeError();
+      const { replyOperation, failMock } = createMockReplyOperation();
+      state.runWithModelFallbackMock.mockRejectedValueOnce(
+        Object.assign(new Error("fallback exhausted"), {
+          name: "FallbackSummaryError",
+          attempts: [{ provider: "anthropic", model: "claude", error: restartError }],
+          soonestCooldownExpiry: null,
+          cause: restartError,
+        }),
+      );
+      if (drainGateway) {
+        markGatewayDraining();
+      }
+      try {
+        const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+        const result = await runAgentTurnWithFallback({
+          commandBody: "hello",
+          followupRun: createFollowupRun(),
+          sessionCtx: {
+            Provider: "whatsapp",
+            MessageSid: "msg",
+          } as unknown as TemplateContext,
+          replyOperation,
+          opts: {},
+          typingSignals: createMockTypingSignaler(),
+          blockReplyPipeline: null,
+          blockStreamingEnabled: false,
+          resolvedBlockStreamingBreak: "message_end",
+          applyReplyToMode: (payload) => payload,
+          shouldEmitToolResult: () => true,
+          shouldEmitToolOutput: () => false,
+          pendingToolTasks: new Set(),
+          resetSessionAfterRoleOrderingConflict: async () => false,
+          isHeartbeat: false,
+          sessionKey: "main",
+          getActiveSessionEntry: () => undefined,
+          resolvedVerboseLevel: "off",
+          isRestartRecoveryArmed,
+        });
+
+        expect(result.kind).toBe("final");
+        if (result.kind === "final") {
+          expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
+        }
+        const failCall = requireMockCall(failMock, 0, "reply operation fail");
+        expect(failCall[0]).toBe(code);
+        expect(failCall[1]).toBeInstanceOf(errorClass);
+      } finally {
+        resetCommandQueueStateForTest();
+      }
+    },
+  );
+
+  it("keeps fallback-wrapped drain visible when global drain has not durably owned recovery", async () => {
+    const restartError = new GatewayDrainingError();
+    const { replyOperation, failMock } = createMockReplyOperation();
+    state.runWithModelFallbackMock.mockRejectedValueOnce(
+      Object.assign(new Error("fallback exhausted"), {
+        name: "FallbackSummaryError",
+        attempts: [{ provider: "anthropic", model: "claude", error: restartError }],
+        soonestCooldownExpiry: null,
+        cause: restartError,
+      }),
+    );
+    markGatewayDraining();
+    try {
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback({
+        commandBody: "hello",
+        followupRun: createFollowupRun(),
+        sessionCtx: {
+          Provider: "whatsapp",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+        replyOperation,
+        opts: {},
+        typingSignals: createMockTypingSignaler(),
+        blockReplyPipeline: null,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        applyReplyToMode: (payload) => payload,
+        shouldEmitToolResult: () => true,
+        shouldEmitToolOutput: () => false,
+        pendingToolTasks: new Set(),
+        resetSessionAfterRoleOrderingConflict: async () => false,
+        isHeartbeat: false,
+        sessionKey: "main",
+        getActiveSessionEntry: () => undefined,
+        resolvedVerboseLevel: "off",
+        isRestartRecoveryArmed: () => false,
+      });
+
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        expect(result.payload.text).toBe(
+          "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
+        );
+      }
+      const failCall = requireMockCall(failMock, 0, "reply operation fail");
+      expect(failCall[0]).toBe("gateway_draining");
+      expect(failCall[1]).toBeInstanceOf(GatewayDrainingError);
+    } finally {
+      resetCommandQueueStateForTest();
+    }
   });
 
   it("stays silent (NO_REPLY) when the reply operation was aborted for restart", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1410,6 +1410,21 @@ function buildRestartLifecycleReplyText(): string {
   return "⚠️ Gateway is restarting. Please wait a few seconds and try again.";
 }
 
+// Drain/restart terminals stay silent only after restart recovery owns delivery
+// for this turn. A process-global drain alone is not enough: if no durable
+// recovery context exists, the visible restart notice is still the only outcome
+// the user can rely on.
+function buildRestartLifecycleReplyPayload(params: {
+  isRestartRecoveryArmed?: () => boolean;
+}): ReplyPayload {
+  if (params.isRestartRecoveryArmed?.() === true) {
+    return { text: SILENT_REPLY_TOKEN };
+  }
+  return markAgentRunFailureReplyPayload({
+    text: buildRestartLifecycleReplyText(),
+  });
+}
+
 function resolveRestartLifecycleError(
   err: unknown,
 ): GatewayDrainingError | CommandLaneClearedError | undefined {
@@ -3142,19 +3157,11 @@ export async function runAgentTurnWithFallback(params: {
       // bookkeeping for drain/lane-cleared is still recorded.
       if (isReplyOperationRestartAbort(params.replyOperation)) {
         takePendingLifecycleTerminal()?.emit("end", err);
-        if (params.isRestartRecoveryArmed?.() !== true) {
-          return {
-            kind: "final",
-            payload: markAgentRunFailureReplyPayload({
-              text: buildRestartLifecycleReplyText(),
-            }),
-          };
-        }
         return {
           kind: "final",
-          payload: {
-            text: SILENT_REPLY_TOKEN,
-          },
+          payload: buildRestartLifecycleReplyPayload({
+            isRestartRecoveryArmed: params.isRestartRecoveryArmed,
+          }),
         };
       }
 
@@ -3174,8 +3181,8 @@ export async function runAgentTurnWithFallback(params: {
         params.replyOperation?.fail("gateway_draining", restartLifecycleError);
         return {
           kind: "final",
-          payload: markAgentRunFailureReplyPayload({
-            text: buildRestartLifecycleReplyText(),
+          payload: buildRestartLifecycleReplyPayload({
+            isRestartRecoveryArmed: params.isRestartRecoveryArmed,
           }),
         };
       }
@@ -3185,8 +3192,8 @@ export async function runAgentTurnWithFallback(params: {
         params.replyOperation?.fail("command_lane_cleared", restartLifecycleError);
         return {
           kind: "final",
-          payload: markAgentRunFailureReplyPayload({
-            text: buildRestartLifecycleReplyText(),
+          payload: buildRestartLifecycleReplyPayload({
+            isRestartRecoveryArmed: params.isRestartRecoveryArmed,
           }),
         };
       }

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -25,8 +25,13 @@ import {
   registerMemoryCapability,
   type MemoryFlushPlanResolver,
 } from "../../plugins/memory-state.js";
-import { GatewayDrainingError } from "../../process/command-queue.js";
+import {
+  GatewayDrainingError,
+  markGatewayDraining,
+  resetCommandQueueStateForTest,
+} from "../../process/command-queue.js";
 import type { TemplateContext } from "../templating.js";
+import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import { scheduleFollowupDrain } from "./queue.js";
 import {
@@ -487,6 +492,117 @@ describe("runReplyAgent auto-compaction token update", () => {
     });
 
     expectReplyText(result, "⚠️ Gateway is restarting. Please wait a few seconds and try again.");
+  });
+
+  it("keeps a globally draining preflight visible until recovery owns delivery", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-preflight-drain-global-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 200_000,
+    };
+    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+    // Drain globally without marking abortedLastRun or persisting recovery
+    // delivery. The global gateway-draining flag is not enough to go silent,
+    // because recovery has not yet owned a user-visible delivery route.
+    compactState.compactEmbeddedAgentSessionMock.mockImplementationOnce(async () => {
+      markGatewayDraining();
+      throw new GatewayDrainingError();
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath,
+      sessionEntry,
+    });
+    try {
+      const result = await runReplyAgent({
+        commandBody: "hello",
+        followupRun,
+        queueKey: sessionKey,
+        resolvedQueue,
+        shouldSteer: false,
+        shouldFollowup: false,
+        isActive: false,
+        isStreaming: false,
+        typing,
+        sessionCtx,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+        storePath,
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 200_000,
+        resolvedVerboseLevel: "off",
+        isNewSession: false,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: "instant",
+      });
+
+      expectReplyText(result, "⚠️ Gateway is restarting. Please wait a few seconds and try again.");
+    } finally {
+      resetCommandQueueStateForTest();
+    }
+  });
+
+  it("keeps a globally draining preflight silent once recovery owns delivery", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-preflight-drain-owned-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 200_000,
+      abortedLastRun: true,
+      restartRecoveryDeliveryContext: {
+        channel: "telegram",
+        to: "chat-123",
+        threadId: "topic-2",
+      },
+    };
+    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+    compactState.compactEmbeddedAgentSessionMock.mockImplementationOnce(async () => {
+      markGatewayDraining();
+      throw new GatewayDrainingError();
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath,
+      sessionEntry,
+    });
+    try {
+      const result = await runReplyAgent({
+        commandBody: "hello",
+        followupRun,
+        queueKey: sessionKey,
+        resolvedQueue,
+        shouldSteer: false,
+        shouldFollowup: false,
+        isActive: false,
+        isStreaming: false,
+        typing,
+        sessionCtx,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+        storePath,
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 200_000,
+        resolvedVerboseLevel: "off",
+        isNewSession: false,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: "instant",
+      });
+
+      expectReplyText(result, SILENT_REPLY_TOKEN);
+    } finally {
+      resetCommandQueueStateForTest();
+    }
   });
 
   it("starts queued followup drain only after clearing the active reply operation", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1563,8 +1563,17 @@ export async function runReplyAgent(params: {
       }
     }
   };
+  const hasRestartRecoveryDeliveryContext = (entry: SessionEntry | undefined): boolean => {
+    if (!entry) {
+      return false;
+    }
+    const deliveryContext = normalizeDeliveryContext(
+      entry.restartRecoveryDeliveryContext ?? entry.pendingFinalDeliveryContext,
+    );
+    return Boolean(deliveryContext);
+  };
   const isRestartRecoveryArmed = (): boolean => {
-    if (!trackedRestartRecoveryDeliveryContext || !sessionKey || !storePath) {
+    if (!sessionKey || !storePath) {
       return false;
     }
     const persisted = loadSessionEntry({
@@ -1573,7 +1582,29 @@ export async function runReplyAgent(params: {
       clone: false,
       hydrateSkillPromptRefs: false,
     });
-    return persisted?.abortedLastRun === true || activeSessionEntry?.abortedLastRun === true;
+    const abortedForRestart =
+      persisted?.abortedLastRun === true || activeSessionEntry?.abortedLastRun === true;
+    if (!abortedForRestart) {
+      return false;
+    }
+    if (trackedRestartRecoveryDeliveryContext) {
+      return true;
+    }
+    return (
+      hasRestartRecoveryDeliveryContext(persisted) ||
+      hasRestartRecoveryDeliveryContext(activeSessionEntry)
+    );
+  };
+  // Stay silent for drain/restart terminals only once restart recovery owns a
+  // durable delivery route. The global drain flag can explain why a
+  // GatewayDrainingError surfaced, but it is not itself delivery ownership.
+  const buildRestartLifecycleReplyPayload = (): ReplyPayload => {
+    if (isRestartRecoveryArmed()) {
+      return { text: SILENT_REPLY_TOKEN };
+    }
+    return markReplyPayloadForSourceSuppressionDelivery({
+      text: RESTART_LIFECYCLE_REPLY_TEXT,
+    });
   };
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied;
@@ -2565,30 +2596,15 @@ export async function runReplyAgent(params: {
       replyOperation.result?.kind === "aborted" &&
       replyOperation.result.code === "aborted_for_restart"
     ) {
-      if (isRestartRecoveryArmed()) {
-        return returnWithQueuedFollowupDrain({ text: SILENT_REPLY_TOKEN });
-      }
-      return returnWithQueuedFollowupDrain(
-        markReplyPayloadForSourceSuppressionDelivery({
-          text: RESTART_LIFECYCLE_REPLY_TEXT,
-        }),
-      );
+      return returnWithQueuedFollowupDrain(buildRestartLifecycleReplyPayload());
     }
     if (error instanceof GatewayDrainingError) {
       replyOperation.fail("gateway_draining", error);
-      return returnWithQueuedFollowupDrain(
-        markReplyPayloadForSourceSuppressionDelivery({
-          text: RESTART_LIFECYCLE_REPLY_TEXT,
-        }),
-      );
+      return returnWithQueuedFollowupDrain(buildRestartLifecycleReplyPayload());
     }
     if (error instanceof CommandLaneClearedError) {
       replyOperation.fail("command_lane_cleared", error);
-      return returnWithQueuedFollowupDrain(
-        markReplyPayloadForSourceSuppressionDelivery({
-          text: RESTART_LIFECYCLE_REPLY_TEXT,
-        }),
-      );
+      return returnWithQueuedFollowupDrain(buildRestartLifecycleReplyPayload());
     }
     const knownFailurePayload = buildKnownAgentRunFailureReplyPayload({
       err: error,


### PR DESCRIPTION
## What Problem This Solves

Gateway restart recovery can mark a session as interrupted while an auto-reply run is failing through preflight or model fallback drain paths. The visible `Gateway is restarting` terminal reply is wrong once recovery already owns delivery for the interrupted turn, because it makes the owed reply look abandoned and invites a manual duplicate retry.

The unsafe boundary is the opposite case: a process-global gateway drain by itself is not proof that restart recovery can resume and deliver the turn. Preflight can fail before any persisted restart or pending delivery context exists, so that case must stay visible.

This PR gates restart-drain silence on durable recovery ownership:

- silent when the session is aborted for restart and has a persisted restart-recovery or pending delivery context;
- silent when the current run already persisted its restart-recovery delivery context and restart recovery marked the run aborted;
- visible when the gateway is merely globally draining but recovery has not durably owned delivery.

## Summary

- Remove process-global drain as an independent `NO_REPLY` condition.
- Preserve silent restart terminals only after recovery has a persisted delivery route for the interrupted turn.
- Add regressions for fallback-wrapped `GatewayDrainingError` / `CommandLaneClearedError`, preflight global-drain-without-ownership, and preflight global-drain-with-persisted-recovery-context.

## Evidence

Clean PR worktree based on live `origin/main`:

- `pnpm vitest run src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` -> 268 passed
- `pnpm tsgo:core` -> passed
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/agent-runner-execution.test.ts` -> passed

Reviewer-addressed boundary:

- The branch no longer treats process-global gateway drain alone as enough to suppress the visible restart notice.
- The unowned global-drain test now expects the visible restart notice.
- The owned recovery-context test expects `NO_REPLY` only after persisted restart-recovery delivery context exists.

Known unrelated/local limits:

- Earlier repo-wide format/type sweeps had unrelated pre-existing failures outside these files. This PR was verified with focused tests, focused format, and `tsgo:core`.
- Automated native Telegram/Mantis proof may still need maintainer environment support because the prior run could not reproduce the restart-drain timing in its capture setup.