### PR TITLE
fix(context-engine): keep background maintenance from blocking new messages

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1808,7 +1808,7 @@ src/agents/embedded-agent-runner/compact.queued.ts	5
 src/agents/embedded-agent-runner/compaction-diagnostics.ts	5
 src/agents/embedded-agent-runner/compaction-hooks.ts	1
 src/agents/embedded-agent-runner/compaction-session-agent.ts	7
-src/agents/embedded-agent-runner/context-engine-maintenance.ts	3
+src/agents/embedded-agent-runner/context-engine-maintenance.ts	2
 src/agents/embedded-agent-runner/delivery-evidence.ts	12
 src/agents/embedded-agent-runner/direct-compaction-preparation.ts	1
 src/agents/embedded-agent-runner/empty-assistant-turn.ts	1

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -294,10 +294,11 @@ Background `maintain()` implementations should accept `abortSignal` and stop
 promptly when it aborts. OpenClaw requests cancellation when a foreground turn
 is waiting for deferred maintenance. If a selected plugin engine does not
 settle after a short cleanup grace, OpenClaw quarantines it for the current
-Gateway process and continues through the default context engine after any
-already-admitted transcript rewrite finishes. The default engine cannot be
-quarantined; OpenClaw stops the waiting turn with recovery guidance instead of
-starting an overlapping engine operation.
+Gateway process and stops the waiting turn with recovery guidance. A later
+retry can use the default context engine only after the original maintenance
+call and every already-admitted transcript rewrite have settled. The default
+engine cannot be quarantined; OpenClaw likewise stops the waiting turn instead
+of starting an overlapping engine operation.
 
 ### Runtime settings
 

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -129,7 +129,7 @@ export default function register(api) {
       id: "my-engine",
       name: "My Context Engine",
       ownsCompaction: true,
-      acceptedHostParams: ["sessionKey", "runtimeContext"],
+      acceptedHostParams: ["sessionKey", "runtimeContext", "abortSignal"],
       transcriptSemantics: {
         currentTurnFence: "before-current-turn-entry-v1",
         turnAdvancementIdempotency: "atomic-idempotent-v1",
@@ -215,11 +215,11 @@ Required members:
 
 Set `info.acceptedHostParams` to restrict the host-added lifecycle fields the
 engine receives. Current keys are `sessionKey`, `prompt`, `runtimeSettings`,
-`sessionTarget`, and `runtimeContext`. OpenClaw intersects the declaration with
-the fields available for each lifecycle method, so undeclared or unknown keys
-are never injected. Engines without this declaration receive every current
-host field; declare an explicit list, including `[]`, when the engine validates
-a narrower input shape.
+`sessionTarget`, `runtimeContext`, and `abortSignal`. OpenClaw intersects the
+declaration with the fields available for each lifecycle method, so undeclared
+or unknown keys are never injected. Engines without this declaration receive
+every current host field; declare an explicit list, including `[]`, when the
+engine validates a narrower input shape.
 
 For durable admitted turns, declare both transcript semantics:
 
@@ -289,6 +289,15 @@ Optional members:
 | `prepareSubagentSpawn(params)` | Method | Set up shared state for a child session before it starts.                                                                                    |
 | `onSubagentEnded(params)`      | Method | Clean up after a subagent ends.                                                                                                              |
 | `dispose()`                    | Method | Release resources. Called during gateway shutdown or plugin reload - not per-session.                                                        |
+
+Background `maintain()` implementations should accept `abortSignal` and stop
+promptly when it aborts. OpenClaw requests cancellation when a foreground turn
+is waiting for deferred maintenance. If a selected plugin engine does not
+settle after a short cleanup grace, OpenClaw quarantines it for the current
+Gateway process and continues through the default context engine after any
+already-admitted transcript rewrite finishes. The default engine cannot be
+quarantined; OpenClaw stops the waiting turn with recovery guidance instead of
+starting an overlapping engine operation.
 
 ### Runtime settings
 

--- a/src/agents/context-engine-maintenance-error.ts
+++ b/src/agents/context-engine-maintenance-error.ts
@@ -1,0 +1,31 @@
+const DEFERRED_MAINTENANCE_BLOCKED_ERROR = Symbol.for(
+  "openclaw.contextEngineDeferredMaintenanceBlockedError",
+);
+
+export class DeferredContextEngineMaintenanceBlockedError extends Error {
+  readonly [DEFERRED_MAINTENANCE_BLOCKED_ERROR] = true;
+  readonly userMessage: string;
+
+  constructor(params: { quarantined: boolean }) {
+    const detail = params.quarantined
+      ? "Deferred maintenance did not stop. The context engine was quarantined, but this turn was stopped to avoid overlapping engine operations. Retry after maintenance finishes or restart the gateway."
+      : "Deferred maintenance did not stop. The active context engine cannot be quarantined, so this turn was stopped to avoid overlapping engine operations. Retry after maintenance finishes or restart the gateway.";
+    super(detail);
+    this.name = "DeferredContextEngineMaintenanceBlockedError";
+    this.userMessage = `⚠️ ${detail}`;
+  }
+}
+
+/** Reads the producer-owned recovery copy across duplicated runtime chunks. */
+export function resolveDeferredContextEngineMaintenanceBlockedMessage(
+  error: unknown,
+): string | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const candidate = error as Record<PropertyKey, unknown>;
+  return candidate[DEFERRED_MAINTENANCE_BLOCKED_ERROR] === true &&
+    typeof candidate.userMessage === "string"
+    ? candidate.userMessage
+    : undefined;
+}

--- a/src/agents/context-engine-maintenance-error.ts
+++ b/src/agents/context-engine-maintenance-error.ts
@@ -20,12 +20,16 @@ export class DeferredContextEngineMaintenanceBlockedError extends Error {
 export function resolveDeferredContextEngineMaintenanceBlockedMessage(
   error: unknown,
 ): string | undefined {
-  if (!error || typeof error !== "object") {
+  if (typeof error !== "object" || error === null) {
     return undefined;
   }
-  const candidate = error as Record<PropertyKey, unknown>;
-  return candidate[DEFERRED_MAINTENANCE_BLOCKED_ERROR] === true &&
-    typeof candidate.userMessage === "string"
-    ? candidate.userMessage
+  if (
+    !(DEFERRED_MAINTENANCE_BLOCKED_ERROR in error) ||
+    error[DEFERRED_MAINTENANCE_BLOCKED_ERROR] !== true
+  ) {
+    return undefined;
+  }
+  return "userMessage" in error && typeof error.userMessage === "string"
+    ? error.userMessage
     : undefined;
 }

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -321,6 +321,21 @@ export const rotateTranscriptAfterCompactionMock: Mock<
 }));
 export const enqueueCommandInLaneMock = vi.fn((_lane: unknown, task: () => unknown) => task());
 export const waitForDeferredTurnMaintenanceForSessionMock = vi.fn(async () => undefined);
+async function runContextEngineMaintenanceMockImpl(params?: {
+  contextEngine?: { info?: { turnMaintenanceMode?: string } };
+  reason?: string;
+  onDeferredMaintenance?: (promise: Promise<void>) => void;
+  onDeferredMaintenanceFailure?: (error: unknown) => void;
+}): Promise<undefined> {
+  if (
+    params?.reason === "turn" &&
+    params.contextEngine?.info?.turnMaintenanceMode === "background"
+  ) {
+    params.onDeferredMaintenance?.(Promise.resolve());
+  }
+  return undefined;
+}
+export const runContextEngineMaintenanceMock = vi.fn(runContextEngineMaintenanceMockImpl);
 
 function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
@@ -552,6 +567,8 @@ export function resetCompactSessionStateMocks(): void {
   enqueueCommandInLaneMock.mockImplementation((_lane: unknown, task: () => unknown) => task());
   waitForDeferredTurnMaintenanceForSessionMock.mockReset();
   waitForDeferredTurnMaintenanceForSessionMock.mockResolvedValue(undefined);
+  runContextEngineMaintenanceMock.mockReset();
+  runContextEngineMaintenanceMock.mockImplementation(runContextEngineMaintenanceMockImpl);
   listRegisteredPluginAgentPromptGuidanceMock.mockReset();
   listRegisteredPluginAgentPromptGuidanceMock.mockImplementation((params?: { surface?: string }) =>
     params?.surface === "subagent"
@@ -706,15 +723,10 @@ export async function loadCompactHooksHarness(): Promise<{
     return { ...actual, resolveCliBackendConfig: resolveCliBackendConfigMock };
   });
 
-  vi.doMock("./context-engine-maintenance.js", async () => {
-    const actual = await vi.importActual<typeof import("./context-engine-maintenance.js")>(
-      "./context-engine-maintenance.js",
-    );
-    return {
-      ...actual,
-      waitForDeferredTurnMaintenanceForSession: waitForDeferredTurnMaintenanceForSessionMock,
-    };
-  });
+  vi.doMock("./context-engine-maintenance.js", () => ({
+    runContextEngineMaintenance: runContextEngineMaintenanceMock,
+    waitForDeferredTurnMaintenanceForSession: waitForDeferredTurnMaintenanceForSessionMock,
+  }));
 
   vi.doMock("../harness/policy.js", () => ({
     resolveAgentHarnessPolicy: resolveAgentHarnessPolicyMock,

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -320,6 +320,7 @@ export const rotateTranscriptAfterCompactionMock: Mock<
   rotated: false,
 }));
 export const enqueueCommandInLaneMock = vi.fn((_lane: unknown, task: () => unknown) => task());
+export const waitForDeferredTurnMaintenanceForSessionMock = vi.fn(async () => undefined);
 
 function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
@@ -549,6 +550,8 @@ export function resetCompactSessionStateMocks(): void {
   rotateTranscriptAfterCompactionMock.mockResolvedValue({ rotated: false });
   enqueueCommandInLaneMock.mockReset();
   enqueueCommandInLaneMock.mockImplementation((_lane: unknown, task: () => unknown) => task());
+  waitForDeferredTurnMaintenanceForSessionMock.mockReset();
+  waitForDeferredTurnMaintenanceForSessionMock.mockResolvedValue(undefined);
   listRegisteredPluginAgentPromptGuidanceMock.mockReset();
   listRegisteredPluginAgentPromptGuidanceMock.mockImplementation((params?: { surface?: string }) =>
     params?.surface === "subagent"
@@ -701,6 +704,16 @@ export async function loadCompactHooksHarness(): Promise<{
   vi.doMock("../cli-backends.js", async () => {
     const actual = await vi.importActual<typeof import("../cli-backends.js")>("../cli-backends.js");
     return { ...actual, resolveCliBackendConfig: resolveCliBackendConfigMock };
+  });
+
+  vi.doMock("./context-engine-maintenance.js", async () => {
+    const actual = await vi.importActual<typeof import("./context-engine-maintenance.js")>(
+      "./context-engine-maintenance.js",
+    );
+    return {
+      ...actual,
+      waitForDeferredTurnMaintenanceForSession: waitForDeferredTurnMaintenanceForSessionMock,
+    };
   });
 
   vi.doMock("../harness/policy.js", () => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -53,6 +53,7 @@ import {
   resolveSessionAgentIdsMock,
   rotateTranscriptAfterCompactionMock,
   runCliAgentMock,
+  runContextEngineMaintenanceMock,
   selectAgentHarnessForPreparedModelProvidersMock,
   selectAgentHarnessMock,
   shouldPreferExplicitConfigApiKeyAuthMock,
@@ -3200,16 +3201,10 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     }
   });
 
-  it("runs maintain after successful compaction with a transcript rewrite helper", async () => {
-    const maintain = vi.fn(async (_params?: unknown) => ({
-      changed: false,
-      bytesFreed: 0,
-      rewrittenEntries: 0,
-    }));
+  it("hands successful compaction to maintenance with its runtime context", async () => {
     resolveContextEngineMock.mockResolvedValue({
       info: { ownsCompaction: true },
       compact: contextEngineCompactMock,
-      maintain,
     } as never);
 
     const result = await compactEmbeddedAgentSession(
@@ -3217,16 +3212,17 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     );
 
     expect(result.ok).toBe(true);
-    const runtimeContext = (
-      maintain.mock.calls.at(0)?.[0] as { runtimeContext?: Record<string, unknown> } | undefined
-    )?.runtimeContext;
-    expectRecordFields(mockCallArg(maintain), {
+    const maintenanceParams = mockCallArg(runContextEngineMaintenanceMock) as {
+      runtimeContext?: Record<string, unknown>;
+    };
+    expectRecordFields(maintenanceParams, {
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
+      reason: "compaction",
     });
+    const runtimeContext = maintenanceParams.runtimeContext;
     expect(runtimeContext?.workspaceDir).toBe(TEST_WORKSPACE_DIR);
     expect(runtimeContext?.cwd).toBe("/tmp/task-repo");
-    expect(runtimeContext?.rewriteTranscriptEntries).toBeTypeOf("function");
   });
 
   it("resolves the effective compaction model before manual engine-owned compaction", async () => {
@@ -4254,19 +4250,15 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
 
   it("fails deferred budget compaction when background maintenance is not scheduled", async () => {
     const dispose = vi.fn(async () => {});
-    const maintain = vi.fn(async () => ({
-      changed: false,
-      bytesFreed: 0,
-      rewrittenEntries: 0,
-    }));
     resolveContextEngineMock.mockResolvedValue({
       info: { ownsCompaction: true, turnMaintenanceMode: "background" },
       compact: contextEngineCompactMock,
       dispose,
-      maintain,
+      maintain: vi.fn(),
     } as never);
-    enqueueCommandInLaneMock.mockImplementationOnce(() => {
-      throw new Error("scheduler offline");
+    runContextEngineMaintenanceMock.mockImplementationOnce(async (params) => {
+      params?.onDeferredMaintenanceFailure?.(new Error("scheduler offline"));
+      return undefined;
     });
 
     const result = await compactEmbeddedAgentSession(
@@ -4281,7 +4273,6 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(result.reason).toBe("failed to schedule background context-engine maintenance");
     expect(result.failure?.reason).toBe("deferred_compaction_not_scheduled");
     expect(dispose).toHaveBeenCalledTimes(1);
-    expect(maintain).not.toHaveBeenCalled();
     expect(contextEngineCompactMock).not.toHaveBeenCalled();
   });
 
@@ -5105,16 +5096,10 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("reuses a delegated compaction successor session identity", async () => {
-    const maintain = vi.fn(async (_params?: unknown) => ({
-      changed: false,
-      bytesFreed: 0,
-      rewrittenEntries: 0,
-    }));
     const delegatedSessionId = "delegated-session";
     resolveContextEngineMock.mockResolvedValue({
       info: { ownsCompaction: false },
       compact: contextEngineCompactMock,
-      maintain,
     } as never);
     contextEngineCompactMock.mockResolvedValue({
       ok: true,
@@ -5134,7 +5119,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(result.ok).toBe(true);
     expect(result.result?.sessionId).toBe(delegatedSessionId);
     expect(result.result?.sessionFile).toBeUndefined();
-    expectRecordFields(mockCallArg(maintain), {
+    expectRecordFields(mockCallArg(runContextEngineMaintenanceMock), {
       sessionId: delegatedSessionId,
       sessionFile: TEST_SESSION_KEY,
       sessionTarget: expect.objectContaining({ sessionId: delegatedSessionId }),
@@ -5142,17 +5127,11 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("keeps a partial structured successor in the active transcript store", async () => {
-    const maintain = vi.fn(async (_params?: unknown) => ({
-      changed: false,
-      bytesFreed: 0,
-      rewrittenEntries: 0,
-    }));
     const delegatedSessionId = "delegated-session";
     const storePath = "/tmp/custom-active-sessions.json";
     resolveContextEngineMock.mockResolvedValue({
       info: { ownsCompaction: false },
       compact: contextEngineCompactMock,
-      maintain,
     } as never);
     contextEngineCompactMock.mockResolvedValue({
       ok: true,
@@ -5174,7 +5153,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     );
 
     expect(result.ok).toBe(true);
-    expectRecordFields(mockCallArg(maintain), {
+    expectRecordFields(mockCallArg(runContextEngineMaintenanceMock), {
       sessionId: delegatedSessionId,
       sessionTarget: expect.objectContaining({
         agentId: "main",
@@ -5308,18 +5287,12 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("preserves a deprecated SQLite marker successor for legacy maintenance", async () => {
-    const maintain = vi.fn(async (_params?: unknown) => ({
-      changed: false,
-      bytesFreed: 0,
-      rewrittenEntries: 0,
-    }));
     const delegatedSessionId = "delegated-marker-session";
     const storePath = "/tmp/sessions.json";
     const marker = `sqlite:main:${delegatedSessionId}:${storePath}`;
     resolveContextEngineMock.mockResolvedValue({
       info: { ownsCompaction: false },
       compact: contextEngineCompactMock,
-      maintain,
     } as never);
     contextEngineCompactMock.mockResolvedValue({
       ok: true,
@@ -5332,7 +5305,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
 
     await compactEmbeddedAgentSession(wrappedCompactionArgs());
 
-    expectRecordFields(mockCallArg(maintain), {
+    expectRecordFields(mockCallArg(runContextEngineMaintenanceMock), {
       sessionFile: marker,
       sessionId: delegatedSessionId,
       sessionTarget: expect.objectContaining({
@@ -5362,11 +5335,6 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("rebinds a deprecated SQLite marker successor over the retained active entry", async () => {
-    const maintain = vi.fn(async (_params?: unknown) => ({
-      changed: false,
-      bytesFreed: 0,
-      rewrittenEntries: 0,
-    }));
     const delegatedSessionId = "delegated-marker-session";
     const dir = await mkdtemp(join(tmpdir(), "openclaw-compaction-marker-successor-"));
     const storePath = join(dir, "sessions.json");
@@ -5374,7 +5342,6 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     resolveContextEngineMock.mockResolvedValue({
       info: { ownsCompaction: false },
       compact: contextEngineCompactMock,
-      maintain,
     } as never);
     contextEngineCompactMock.mockResolvedValue({
       ok: true,
@@ -5401,7 +5368,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         }),
       );
 
-      expectRecordFields(mockCallArg(maintain), {
+      expectRecordFields(mockCallArg(runContextEngineMaintenanceMock), {
         sessionId: delegatedSessionId,
         sessionTarget: expect.objectContaining({
           agentId: "main",
@@ -5460,15 +5427,9 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("keeps a delegated result that echoes the current transcript on the active transcript", async () => {
-    const maintain = vi.fn(async (_params?: unknown) => ({
-      changed: false,
-      bytesFreed: 0,
-      rewrittenEntries: 0,
-    }));
     resolveContextEngineMock.mockResolvedValue({
       info: { ownsCompaction: false },
       compact: contextEngineCompactMock,
-      maintain,
     } as never);
     contextEngineCompactMock.mockResolvedValue({
       ok: true,
@@ -5488,7 +5449,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(rotateTranscriptAfterCompactionMock).not.toHaveBeenCalled();
     expect(result.result?.sessionId).toBeUndefined();
     expect(result.result?.sessionFile).toBeUndefined();
-    expectRecordFields(mockCallArg(maintain), {
+    expectRecordFields(mockCallArg(runContextEngineMaintenanceMock), {
       sessionId: TEST_SESSION_ID,
       sessionFile: TEST_SESSION_KEY,
     });

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -64,6 +64,7 @@ import {
   sessionCompactImpl,
   sessionManualCompactionMock,
   triggerInternalHookMock,
+  waitForDeferredTurnMaintenanceForSessionMock,
 } from "./compact.hooks.harness.js";
 import {
   abortEmbeddedAgentRun,
@@ -2854,6 +2855,25 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "marie-clawndo" }),
     );
+  });
+
+  it("fails queued compaction before resolving an engine when deferred maintenance is blocked", async () => {
+    waitForDeferredTurnMaintenanceForSessionMock.mockRejectedValueOnce(
+      new Error(
+        "Deferred maintenance did not stop. This turn was stopped to avoid overlapping engine operations.",
+      ),
+    );
+
+    const result = await compactEmbeddedAgentSession(wrappedCompactionArgs({ trigger: "manual" }));
+
+    expect(result).toEqual({
+      ok: false,
+      compacted: false,
+      reason:
+        "Deferred maintenance did not stop. This turn was stopped to avoid overlapping engine operations.",
+    });
+    expect(resolveContextEngineMock).not.toHaveBeenCalled();
+    expect(contextEngineCompactMock).not.toHaveBeenCalled();
   });
 
   it("disposes the context engine once when route materialization rejects", async () => {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -57,7 +57,10 @@ import {
 } from "./compaction-safety-timeout.js";
 import { resolveContextEngineCompactionSuccessor } from "./compaction-successor.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
-import { runContextEngineMaintenance } from "./context-engine-maintenance.js";
+import {
+  runContextEngineMaintenance,
+  waitForDeferredTurnMaintenanceForSession,
+} from "./context-engine-maintenance.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveTieredModel } from "./model-resolution.js";
@@ -275,6 +278,15 @@ export async function compactEmbeddedAgentSession(
       compacted: false,
       reason: MANUAL_COMPACTION_ACTIVE_RUN_REASON,
       failure: { reason: "active_run" },
+    };
+  }
+  try {
+    await waitForDeferredTurnMaintenanceForSession(resolvedParams.sessionKey);
+  } catch (error) {
+    return {
+      ok: false,
+      compacted: false,
+      reason: formatErrorMessage(error),
     };
   }
 

--- a/src/agents/embedded-agent-runner/context-engine-maintenance-abort-signal.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance-abort-signal.ts
@@ -1,0 +1,88 @@
+/**
+ * Process-scoped abort-signal wiring for deferred context-engine turn
+ * maintenance. A single set of SIGINT/SIGTERM handlers fans termination out to
+ * every in-flight maintenance run so a waiting shutdown never leaks listeners.
+ */
+
+// Shared per-process store of live abort controllers plus their signal
+// handlers; keyed off the process object so tests can inject a fake process.
+export const DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY = Symbol.for(
+  "openclaw.contextEngineTurnMaintenanceAbortState",
+);
+
+type DeferredTurnMaintenanceSignal = "SIGINT" | "SIGTERM";
+export type DeferredTurnMaintenanceProcessLike = Pick<NodeJS.Process, "on" | "off"> &
+  Partial<Pick<NodeJS.Process, "listenerCount" | "kill" | "pid">> & {
+    [DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY]?: DeferredTurnMaintenanceAbortState;
+  };
+type DeferredTurnMaintenanceAbortState = {
+  controllers: Set<AbortController>;
+  cleanupHandlers: Map<DeferredTurnMaintenanceSignal, () => void>;
+};
+
+export function unregisterDeferredTurnMaintenanceAbortSignalHandlers(
+  processLike: DeferredTurnMaintenanceProcessLike,
+  state: DeferredTurnMaintenanceAbortState,
+): void {
+  for (const [signal, handler] of state.cleanupHandlers) {
+    processLike.off(signal, handler);
+  }
+  state.cleanupHandlers.clear();
+}
+
+export function createDeferredTurnMaintenanceAbortSignal(params?: {
+  processLike?: DeferredTurnMaintenanceProcessLike;
+}): {
+  abortSignal: AbortSignal;
+  abort: (reason: Error) => void;
+  dispose: () => void;
+} {
+  const processLike = (params?.processLike ?? process) as DeferredTurnMaintenanceProcessLike;
+  const state = (processLike[DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY] ??= {
+    controllers: new Set<AbortController>(),
+    cleanupHandlers: new Map<DeferredTurnMaintenanceSignal, () => void>(),
+  });
+  const handleTerminationSignal = (signalName: DeferredTurnMaintenanceSignal) => {
+    const shouldReraise = processLike.listenerCount?.(signalName) === 1;
+    for (const activeController of state.controllers) {
+      if (!activeController.signal.aborted) {
+        activeController.abort(
+          new Error(`received ${signalName} while waiting for deferred maintenance`),
+        );
+      }
+    }
+    state.controllers.clear();
+    unregisterDeferredTurnMaintenanceAbortSignalHandlers(processLike, state);
+    if (shouldReraise && typeof processLike.kill === "function") {
+      try {
+        processLike.kill(processLike.pid ?? process.pid, signalName);
+      } catch {
+        // Ignore shutdown-path failures.
+      }
+    }
+  };
+  if (state.cleanupHandlers.size === 0) {
+    for (const signal of ["SIGINT", "SIGTERM"] as const) {
+      const handler = () => handleTerminationSignal(signal);
+      state.cleanupHandlers.set(signal, handler);
+      processLike.on(signal, handler);
+    }
+  }
+
+  const controller = new AbortController();
+  state.controllers.add(controller);
+  return {
+    abortSignal: controller.signal,
+    abort: (reason) => {
+      if (!controller.signal.aborted) {
+        controller.abort(reason);
+      }
+    },
+    dispose: () => {
+      state.controllers.delete(controller);
+      if (state.controllers.size === 0) {
+        unregisterDeferredTurnMaintenanceAbortSignalHandlers(processLike, state);
+      }
+    },
+  };
+}

--- a/src/agents/embedded-agent-runner/context-engine-maintenance-abort-signal.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance-abort-signal.ts
@@ -37,7 +37,7 @@ export function createDeferredTurnMaintenanceAbortSignal(params?: {
   abort: (reason: Error) => void;
   dispose: () => void;
 } {
-  const processLike = (params?.processLike ?? process) as DeferredTurnMaintenanceProcessLike;
+  const processLike: DeferredTurnMaintenanceProcessLike = params?.processLike ?? process;
   const state = (processLike[DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY] ??= {
     controllers: new Set<AbortController>(),
     cleanupHandlers: new Map<DeferredTurnMaintenanceSignal, () => void>(),

--- a/src/agents/embedded-agent-runner/context-engine-maintenance-fence.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance-fence.ts
@@ -1,0 +1,38 @@
+export type DeferredMaintenanceWriteFence = {
+  run: <T>(operation: () => Promise<T>) => Promise<T>;
+  close: (reason: Error) => Promise<void>;
+};
+
+// Closing rejects late rewrites and drains already-admitted host transcript writes
+// before fallback maintenance or foreground reads can enter the session.
+export function createDeferredMaintenanceWriteFence(): DeferredMaintenanceWriteFence {
+  let closedReason: Error | undefined;
+  let activeWrites = 0;
+  let resolveDrain: (() => void) | undefined;
+  let drain = Promise.resolve();
+  return {
+    run: async <T>(operation: () => Promise<T>) => {
+      if (closedReason) {
+        throw closedReason;
+      }
+      if (activeWrites++ === 0) {
+        drain = new Promise<void>((resolve) => {
+          resolveDrain = resolve;
+        });
+      }
+      try {
+        return await operation();
+      } finally {
+        activeWrites -= 1;
+        if (activeWrites === 0) {
+          resolveDrain?.();
+          resolveDrain = undefined;
+        }
+      }
+    },
+    close: async (reason) => {
+      closedReason ??= reason;
+      await drain;
+    },
+  };
+}

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test-support.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test-support.ts
@@ -9,7 +9,8 @@ type ContextEngineMaintenanceTestApi = {
   createDeferredTurnMaintenanceAbortSignal(params?: {
     processLike?: DeferredTurnMaintenanceProcessLike;
   }): {
-    abortSignal?: AbortSignal;
+    abortSignal: AbortSignal;
+    abort: (reason: Error) => void;
     dispose: () => void;
   };
   resetDeferredTurnMaintenanceStateForTest(): void;
@@ -24,7 +25,8 @@ function getTestApi(): ContextEngineMaintenanceTestApi {
 export function createDeferredTurnMaintenanceAbortSignal(params?: {
   processLike?: DeferredTurnMaintenanceProcessLike;
 }): {
-  abortSignal?: AbortSignal;
+  abortSignal: AbortSignal;
+  abort: (reason: Error) => void;
   dispose: () => void;
 } {
   return getTestApi().createDeferredTurnMaintenanceAbortSignal(params);

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -3,6 +3,15 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerLegacyContextEngine } from "../../context-engine/legacy.registration.js";
+import {
+  registerContextEngineForOwner,
+  resolveContextEngine,
+} from "../../context-engine/registry.js";
+import {
+  captureContextEngineRegistryStateForTests,
+  resetContextEngineRuntimeQuarantineForTests,
+} from "../../context-engine/registry.test-support.js";
 import type { ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
 import { enqueueCommandInLane, markGatewayDraining } from "../../process/command-queue.js";
@@ -1211,7 +1220,7 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
-  it("waits at the same-session read checkpoint before deferred maintenance rewrites", async () => {
+  it("preempts deferred maintenance at the same-session read checkpoint", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();
       try {
@@ -1301,15 +1310,225 @@ describe("runContextEngineMaintenance", () => {
             "maintenance-start",
             "foreground-before-read-checkpoint",
             "maintenance-before-rewrite",
-            "rewrite",
-            "maintenance-after-rewrite",
             "foreground-read",
           ]),
         );
 
         expect(maintain).toHaveBeenCalledTimes(1);
+        expect(rewriteTranscriptEntriesInSessionManagerMock).not.toHaveBeenCalled();
         await foregroundTurn;
       } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  it("fails a waiting turn without overlapping an unquarantinable maintenance run", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-", async () => {
+      vi.useFakeTimers();
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+        resetSystemEventsForTest();
+
+        const sessionKey = "agent:main:session-preempt-blocked";
+        let releaseMaintenance: (() => void) | undefined;
+        let receivedAbortSignal: AbortSignal | undefined;
+        let maintenanceRuntimeContext: ContextEngineRuntimeContext | undefined;
+        const maintain = vi.fn(async (params?: unknown) => {
+          const callParams = params as {
+            abortSignal?: AbortSignal;
+            runtimeContext?: ContextEngineRuntimeContext;
+          };
+          receivedAbortSignal = callParams.abortSignal;
+          maintenanceRuntimeContext = callParams.runtimeContext;
+          await new Promise<void>((resolve) => {
+            releaseMaintenance = resolve;
+          });
+          return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+        });
+        const backgroundEngine = {
+          info: {
+            id: "unquarantinable-test",
+            name: "Unquarantinable Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-preempt-blocked",
+          sessionKey,
+          sessionFile: "/tmp/session-preempt-blocked.jsonl",
+          reason: "turn",
+        });
+        await waitForAssertion(() => expect(maintain).toHaveBeenCalledOnce());
+
+        const foregroundWait = expect(
+          waitForDeferredTurnMaintenanceForSession(sessionKey),
+        ).rejects.toThrow("this turn was stopped to avoid overlapping engine operations");
+        await flushAsyncWork();
+        expect(receivedAbortSignal?.aborted).toBe(true);
+        if (!maintenanceRuntimeContext?.rewriteTranscriptEntries) {
+          throw new Error("Expected maintenance runtime rewrite helper");
+        }
+        await expect(
+          maintenanceRuntimeContext.rewriteTranscriptEntries({ replacements: [] }),
+        ).rejects.toThrow("waiting foreground turn");
+        await vi.advanceTimersByTimeAsync(1_001);
+        await foregroundWait;
+        const task = listTasksForOwnerKey(sessionKey).find(
+          (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(task?.status).toBe("timed_out");
+        await vi.advanceTimersByTimeAsync(11_000);
+        expect(peekSystemEvents(sessionKey).join("\n")).not.toContain(
+          "Deferred maintenance is still running.",
+        );
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-preempt-blocked",
+          sessionKey,
+          sessionFile: "/tmp/session-preempt-blocked.jsonl",
+          reason: "turn",
+        });
+        expect(maintain).toHaveBeenCalledOnce();
+
+        if (!releaseMaintenance) {
+          throw new Error("Expected maintenance release callback to be initialized");
+        }
+        releaseMaintenance();
+        await flushAsyncWork();
+        expect(task && getTaskById(task.taskId)?.status).toBe("timed_out");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  it("drains admitted rewrites before routing foreground compaction maintenance to fallback", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-", async () => {
+      vi.useFakeTimers();
+      const restoreRegistry = captureContextEngineRegistryStateForTests();
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+        resetContextEngineRuntimeQuarantineForTests();
+        registerLegacyContextEngine();
+
+        const sessionKey = "agent:main:session-preempt-fallback";
+        const engineId = "preempt-fallback-engine";
+        let releaseMaintenance: (() => void) | undefined;
+        let releaseRewriteRead: (() => void) | undefined;
+        let rewriteReadStarted: (() => void) | undefined;
+        const rewriteStarted = new Promise<void>((resolve) => {
+          rewriteReadStarted = resolve;
+        });
+        resolveRuntimeTranscriptReadTargetMock.mockImplementationOnce(
+          async (scope: Record<string, unknown>) => {
+            rewriteReadStarted?.();
+            await new Promise<void>((resolve) => {
+              releaseRewriteRead = resolve;
+            });
+            return {
+              agentId: scope.agentId ?? "main",
+              sessionId: scope.sessionId,
+              sessionKey: scope.sessionKey,
+              storePath: scope.storePath ?? "/tmp/default-openclaw.sqlite",
+            };
+          },
+        );
+        const maintain = vi.fn(async (params?: unknown) => {
+          const runtimeContext = (params as { runtimeContext?: ContextEngineRuntimeContext })
+            .runtimeContext;
+          void runtimeContext
+            ?.rewriteTranscriptEntries?.({ replacements: [] })
+            .catch(() => undefined);
+          await new Promise<void>((resolve) => {
+            releaseMaintenance = resolve;
+          });
+          return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+        });
+        registerContextEngineForOwner(
+          engineId,
+          () => ({
+            info: {
+              id: engineId,
+              name: "Preempt Fallback Engine",
+              turnMaintenanceMode: "background" as const,
+              acceptedHostParams: ["sessionKey", "runtimeContext", "abortSignal"],
+            },
+            ingest: vi.fn(async () => ({ ingested: true })),
+            assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+            compact: async () => ({ ok: true, compacted: false }),
+            maintain,
+          }),
+          `test:${engineId}`,
+        );
+        const contextEngine = await resolveContextEngine({
+          plugins: { slots: { contextEngine: engineId } },
+        });
+
+        await runContextEngineMaintenance({
+          contextEngine,
+          sessionId: "session-preempt-fallback",
+          sessionKey,
+          sessionFile: "/tmp/session-preempt-fallback.jsonl",
+          reason: "turn",
+        });
+        await rewriteStarted;
+
+        let foregroundReleased = false;
+        const foregroundMaintenance = runContextEngineMaintenance({
+          contextEngine,
+          sessionId: "session-preempt-fallback",
+          sessionKey,
+          sessionFile: "/tmp/session-preempt-fallback.jsonl",
+          reason: "compaction",
+        }).then((result) => {
+          foregroundReleased = true;
+          return result;
+        });
+        await vi.advanceTimersByTimeAsync(1_001);
+        expect(contextEngine.info.id).toBe("legacy");
+        expect(foregroundReleased).toBe(false);
+        expect(maintain).toHaveBeenCalledOnce();
+
+        if (!releaseRewriteRead) {
+          throw new Error("Expected transcript read release callback to be initialized");
+        }
+        releaseRewriteRead();
+        await expect(foregroundMaintenance).resolves.toEqual({
+          changed: false,
+          bytesFreed: 0,
+          rewrittenEntries: 0,
+          reason: "context engine downgraded to legacy",
+        });
+        expect(foregroundReleased).toBe(true);
+        expect(maintain).toHaveBeenCalledOnce();
+
+        if (!releaseMaintenance) {
+          throw new Error("Expected maintenance release callback to be initialized");
+        }
+        releaseMaintenance();
+        await flushAsyncWork();
+        const task = listTasksForOwnerKey(sessionKey).find(
+          (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(task?.status).toBe("timed_out");
+      } finally {
+        resetDeferredTurnMaintenanceStateForTest();
+        restoreRegistry();
         vi.useRealTimers();
       }
     });

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -1432,6 +1432,88 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
+  it("preempts an abort-ignoring same-session deferred run on the normal inbound foreground path", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-", async () => {
+      vi.useFakeTimers();
+      try {
+        resetDeferredMaintenanceHarnessState();
+        resetSystemEventsForTest();
+
+        // run-orchestrator.ts:189 (normal inbound admission, inside
+        // enqueueSession before enqueueGlobal/lease.begin()) and
+        // cli-runner.ts:818 (CLI next turn) both admit a foreground run through
+        // this same helper. Preempting here proves the production foreground
+        // path is covered, not only the manual /compact path
+        // (compact.queued.ts:271).
+        const sessionKey = "agent:main:session-inbound-preempt";
+        const otherSessionKey = "agent:main:session-inbound-preempt-other";
+
+        const wedged = createControlledMaintenance();
+        const wedgedEngine = createBackgroundContextEngine(wedged.maintain, {
+          id: "inbound-preempt-wedge",
+          name: "Inbound Preempt Wedge Engine",
+        });
+        const scheduled = await scheduleDeferredMaintenance({
+          contextEngine: wedgedEngine,
+          sessionId: "session-inbound-preempt",
+          sessionKey,
+          sessionFile: "/tmp/session-inbound-preempt.jsonl",
+          reason: "turn",
+        });
+        const wedgedParams = await wedged.started;
+
+        // A different session's in-flight run must stay untouched by a wait on S.
+        const other = createControlledMaintenance();
+        const otherEngine = createBackgroundContextEngine(other.maintain, {
+          id: "inbound-preempt-other",
+          name: "Inbound Preempt Other Engine",
+        });
+        const otherScheduled = await scheduleDeferredMaintenance({
+          contextEngine: otherEngine,
+          sessionId: "session-inbound-preempt-other",
+          sessionKey: otherSessionKey,
+          sessionFile: "/tmp/session-inbound-preempt-other.jsonl",
+          reason: "turn",
+        });
+        const otherParams = await other.started;
+
+        // The successor turn admits through the same helper the inbound path
+        // calls; the abort-ignoring wedge never yields, so the wait fails closed.
+        const foregroundWait = expect(
+          waitForDeferredTurnMaintenanceForSession(sessionKey),
+        ).rejects.toThrow("this turn was stopped to avoid overlapping engine operations");
+        await flushAsyncWork();
+
+        // preemptForForeground() fired against the S lane's run.
+        expect(wedgedParams.abortSignal?.aborted).toBe(true);
+        // The wait targeted only the S lane, so S2's run is not aborted.
+        expect(otherParams.abortSignal?.aborted).toBe(false);
+
+        // Bounded by the preempt grace: the wait settles instead of hanging on
+        // the maintenance run that ignores its abort signal.
+        await vi.advanceTimersByTimeAsync(1_001);
+        await foregroundWait;
+
+        expect(wedged.maintain).toHaveBeenCalledTimes(1);
+        expect(scheduled.isSettled()).toBe(false);
+        expect(otherScheduled.isSettled()).toBe(false);
+        expect(otherParams.abortSignal?.aborted).toBe(false);
+        const timedOutTask = listTasksForOwnerKey(sessionKey).find(
+          (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(timedOutTask?.status).toBe("timed_out");
+
+        // Drain both wedged runs so harness teardown stays clean.
+        wedged.release();
+        other.release();
+        await scheduled.completion;
+        await otherScheduled.completion;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it("keeps fallback serialized behind a quarantined maintenance run", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -1145,6 +1145,80 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
+  it("cancels a superseded maintenance task when the owner session key is bare", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-bare-owner-", async () => {
+      vi.useFakeTimers();
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+
+        // A non-agent-scoped session key yields no agent id on its own, so the
+        // owner-scoped cleanup fails closed unless the run forwards the resolved
+        // agent identity as callerAgentId. The legacy task carries an explicit
+        // requesterAgentId so the task side already knows its owner agent.
+        const bareSessionKey = "legacy-bare-session";
+        const legacyTask = createQueuedTaskRunCore({
+          runtime: "acp",
+          taskKind: TURN_MAINTENANCE_TASK_KIND,
+          sourceId: TURN_MAINTENANCE_TASK_KIND,
+          requesterSessionKey: bareSessionKey,
+          ownerKey: bareSessionKey,
+          requesterAgentId: "main",
+          scopeKind: "session",
+          label: "Context engine turn maintenance",
+          task: "Deferred context-engine maintenance after turn.",
+          notifyPolicy: "silent",
+          deliveryStatus: "pending",
+          preferMetadata: true,
+        });
+        expect(legacyTask.status).not.toBe("cancelled");
+
+        const maintain = vi.fn(async () => ({
+          changed: false,
+          bytesFreed: 0,
+          rewrittenEntries: 0,
+        }));
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-bare-owner",
+          sessionKey: bareSessionKey,
+          sessionFile: "/tmp/session-bare-owner.jsonl",
+          reason: "turn",
+          config: {},
+        });
+
+        await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
+
+        // Before the fix the cleanup silently no-op'd and the legacy task stayed
+        // non-terminal; forwarding the agent identity now reaches a terminal state.
+        const cancelledLegacyTask = requireRecord(getTaskById(legacyTask.taskId), "legacy task");
+        expectRecordFields(cancelledLegacyTask, {
+          status: "cancelled",
+          notifyPolicy: "silent",
+        });
+        expect(String(cancelledLegacyTask.terminalSummary)).toContain("Superseded");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it("cancels the queued task when deferred scheduling is rejected", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -12,12 +12,13 @@ import {
   captureContextEngineRegistryStateForTests,
   resetContextEngineRuntimeQuarantineForTests,
 } from "../../context-engine/registry.test-support.js";
-import type { ContextEngineRuntimeContext } from "../../context-engine/types.js";
+import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
 import { enqueueCommandInLane, markGatewayDraining } from "../../process/command-queue.js";
 import * as commandQueueModule from "../../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { createDeferred } from "../../shared/deferred.js";
 import { createQueuedTaskRunCore as createQueuedTaskRunOrNull } from "../../tasks/task-executor.js";
 import { getTaskFlowById } from "../../tasks/task-flow-registry.js";
 import { getTaskById, listTasksForOwnerKey } from "../../tasks/task-registry.js";
@@ -63,6 +64,80 @@ let runContextEngineMaintenance: typeof import("./context-engine-maintenance.js"
 // Keep this literal aligned with the production module; tests use dynamic
 // import reloading, so they cannot safely import the constant directly.
 const TURN_MAINTENANCE_TASK_KIND = "context_engine_turn_maintenance";
+const NO_MAINTENANCE_CHANGES = {
+  changed: false,
+  bytesFreed: 0,
+  rewrittenEntries: 0,
+} as const;
+
+type ContextEngineMaintainParams = Parameters<NonNullable<ContextEngine["maintain"]>>[0];
+
+function createBackgroundContextEngine(
+  maintain: NonNullable<ContextEngine["maintain"]>,
+  info: Partial<ContextEngine["info"]> = {},
+): ContextEngine {
+  return {
+    info: {
+      id: info.id ?? "test",
+      name: info.name ?? "Test Engine",
+      ...info,
+      turnMaintenanceMode: "background",
+    },
+    ingest: async () => ({ ingested: true }),
+    assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+    compact: async () => ({ ok: true, compacted: false }),
+    maintain,
+  };
+}
+
+function createControlledMaintenance(options?: {
+  onStart?: (params: ContextEngineMaintainParams) => void;
+  onRelease?: (params: ContextEngineMaintainParams) => Promise<void> | void;
+}) {
+  const started = createDeferred<ContextEngineMaintainParams>();
+  const release = createDeferred();
+  const maintain = vi.fn(async (params: ContextEngineMaintainParams) => {
+    started.resolve(params);
+    options?.onStart?.(params);
+    await release.promise;
+    await options?.onRelease?.(params);
+    return NO_MAINTENANCE_CHANGES;
+  });
+  return {
+    maintain,
+    started: started.promise,
+    release: () => release.resolve(),
+  };
+}
+
+async function scheduleDeferredMaintenance(
+  params: Omit<Parameters<typeof runContextEngineMaintenance>[0], "onDeferredMaintenance">,
+) {
+  let completion: Promise<void> | undefined;
+  let settled = false;
+  await runContextEngineMaintenance({
+    ...params,
+    onDeferredMaintenance: (promise) => {
+      completion = promise;
+      void promise.then(() => {
+        settled = true;
+      });
+    },
+  });
+  if (!completion) {
+    throw new Error("Expected deferred maintenance to be scheduled");
+  }
+  return {
+    completion,
+    isSettled: () => settled,
+  };
+}
+
+function resetDeferredMaintenanceHarnessState(): void {
+  resetCommandQueueStateForTest();
+  resetTaskRegistryForTests({ persist: false });
+  resetTaskFlowRegistryForTests({ persist: false });
+}
 
 async function flushAsyncWork(times = 4): Promise<void> {
   for (let index = 0; index < times; index += 1) {
@@ -1222,40 +1297,29 @@ describe("runContextEngineMaintenance", () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();
       try {
-        resetCommandQueueStateForTest();
-        resetTaskRegistryForTests({ persist: false });
-        resetTaskFlowRegistryForTests({ persist: false });
+        resetDeferredMaintenanceHarnessState();
 
         const sessionKey = "agent:main:session-rewrite-priority";
         const sessionLane = resolveSessionLane(sessionKey);
         const events: string[] = [];
-        let allowRewrite: (() => void) | undefined;
-        const maintain = vi.fn(async (params?: unknown) => {
-          events.push("maintenance-start");
-          await new Promise<void>((resolve) => {
-            allowRewrite = resolve;
-          });
-          events.push("maintenance-before-rewrite");
-          await (
-            params as { runtimeContext?: ContextEngineRuntimeContext }
-          ).runtimeContext?.rewriteTranscriptEntries?.({
-            replacements: [
-              {
-                entryId: "entry-1",
-                message: castAgentMessage({
-                  role: "assistant",
-                  content: [{ type: "text", text: "done" }],
-                  timestamp: 2,
-                }),
-              },
-            ],
-          });
-          events.push("maintenance-after-rewrite");
-          return {
-            changed: false,
-            bytesFreed: 0,
-            rewrittenEntries: 0,
-          };
+        const controlled = createControlledMaintenance({
+          onStart: () => events.push("maintenance-start"),
+          onRelease: async (params) => {
+            events.push("maintenance-before-rewrite");
+            await params.runtimeContext?.rewriteTranscriptEntries?.({
+              replacements: [
+                {
+                  entryId: "entry-1",
+                  message: castAgentMessage({
+                    role: "assistant",
+                    content: [{ type: "text", text: "done" }],
+                    timestamp: 2,
+                  }),
+                },
+              ],
+            });
+            events.push("maintenance-after-rewrite");
+          },
         });
 
         rewriteTranscriptEntriesInSessionManagerMock.mockImplementationOnce((_params?: unknown) => {
@@ -1267,30 +1331,15 @@ describe("runContextEngineMaintenance", () => {
           };
         });
 
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
-
         await runContextEngineMaintenance({
-          contextEngine: backgroundEngine,
+          contextEngine: createBackgroundContextEngine(controlled.maintain),
           sessionId: "session-rewrite-priority",
           sessionKey,
           sessionFile: "/tmp/session-rewrite-priority.jsonl",
           reason: "turn",
         });
 
-        await waitForAssertion(() => expect(events).toContain("maintenance-start"));
+        await controlled.started;
 
         const foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
           events.push("foreground-before-read-checkpoint");
@@ -1298,10 +1347,7 @@ describe("runContextEngineMaintenance", () => {
           events.push("foreground-read");
         });
 
-        if (!allowRewrite) {
-          throw new Error("Expected maintenance rewrite release callback to be initialized");
-        }
-        allowRewrite();
+        controlled.release();
 
         await waitForAssertion(() =>
           expect(events).toEqual([
@@ -1312,7 +1358,7 @@ describe("runContextEngineMaintenance", () => {
           ]),
         );
 
-        expect(maintain).toHaveBeenCalledTimes(1);
+        expect(controlled.maintain).toHaveBeenCalledTimes(1);
         expect(rewriteTranscriptEntriesInSessionManagerMock).not.toHaveBeenCalled();
         await foregroundTurn;
       } finally {
@@ -1325,73 +1371,38 @@ describe("runContextEngineMaintenance", () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();
       try {
-        resetCommandQueueStateForTest();
-        resetTaskRegistryForTests({ persist: false });
-        resetTaskFlowRegistryForTests({ persist: false });
+        resetDeferredMaintenanceHarnessState();
         resetSystemEventsForTest();
 
         const sessionKey = "agent:main:session-preempt-blocked";
-        let releaseMaintenance: (() => void) | undefined;
-        let receivedAbortSignal: AbortSignal | undefined;
-        let maintenanceRuntimeContext: ContextEngineRuntimeContext | undefined;
-        const maintain = vi.fn(async (params?: unknown) => {
-          const callParams = params as {
-            abortSignal?: AbortSignal;
-            runtimeContext?: ContextEngineRuntimeContext;
-          };
-          receivedAbortSignal = callParams.abortSignal;
-          maintenanceRuntimeContext = callParams.runtimeContext;
-          await new Promise<void>((resolve) => {
-            releaseMaintenance = resolve;
-          });
-          return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+        const controlled = createControlledMaintenance();
+        const backgroundEngine = createBackgroundContextEngine(controlled.maintain, {
+          id: "unquarantinable-test",
+          name: "Unquarantinable Test Engine",
         });
-        const backgroundEngine = {
-          info: {
-            id: "unquarantinable-test",
-            name: "Unquarantinable Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
-
-        let deferredMaintenance: Promise<void> | undefined;
-        let deferredMaintenanceSettled = false;
-        await runContextEngineMaintenance({
+        const scheduled = await scheduleDeferredMaintenance({
           contextEngine: backgroundEngine,
           sessionId: "session-preempt-blocked",
           sessionKey,
           sessionFile: "/tmp/session-preempt-blocked.jsonl",
           reason: "turn",
-          onDeferredMaintenance: (promise) => {
-            deferredMaintenance = promise;
-            void promise.then(() => {
-              deferredMaintenanceSettled = true;
-            });
-          },
         });
-        await waitForAssertion(() => expect(maintain).toHaveBeenCalledOnce());
+        const maintenanceParams = await controlled.started;
 
         const foregroundWait = expect(
           waitForDeferredTurnMaintenanceForSession(sessionKey),
         ).rejects.toThrow("this turn was stopped to avoid overlapping engine operations");
         await flushAsyncWork();
-        expect(receivedAbortSignal?.aborted).toBe(true);
-        if (!maintenanceRuntimeContext?.rewriteTranscriptEntries) {
+        expect(maintenanceParams.abortSignal?.aborted).toBe(true);
+        if (!maintenanceParams.runtimeContext?.rewriteTranscriptEntries) {
           throw new Error("Expected maintenance runtime rewrite helper");
         }
         await expect(
-          maintenanceRuntimeContext.rewriteTranscriptEntries({ replacements: [] }),
+          maintenanceParams.runtimeContext.rewriteTranscriptEntries({ replacements: [] }),
         ).rejects.toThrow("waiting foreground turn");
         await vi.advanceTimersByTimeAsync(1_001);
         await foregroundWait;
-        expect(deferredMaintenanceSettled).toBe(false);
+        expect(scheduled.isSettled()).toBe(false);
         const task = listTasksForOwnerKey(sessionKey).find(
           (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );
@@ -1408,18 +1419,12 @@ describe("runContextEngineMaintenance", () => {
           sessionFile: "/tmp/session-preempt-blocked.jsonl",
           reason: "turn",
         });
-        expect(maintain).toHaveBeenCalledOnce();
-        expect(deferredMaintenanceSettled).toBe(false);
+        expect(controlled.maintain).toHaveBeenCalledOnce();
+        expect(scheduled.isSettled()).toBe(false);
 
-        if (!releaseMaintenance) {
-          throw new Error("Expected maintenance release callback to be initialized");
-        }
-        releaseMaintenance();
-        if (!deferredMaintenance) {
-          throw new Error("Expected deferred maintenance promise to be captured");
-        }
-        await deferredMaintenance;
-        expect(deferredMaintenanceSettled).toBe(true);
+        controlled.release();
+        await scheduled.completion;
+        expect(scheduled.isSettled()).toBe(true);
         expect(task && getTaskById(task.taskId)?.status).toBe("timed_out");
       } finally {
         vi.useRealTimers();
@@ -1432,23 +1437,17 @@ describe("runContextEngineMaintenance", () => {
       vi.useFakeTimers();
       const restoreRegistry = captureContextEngineRegistryStateForTests();
       try {
-        resetCommandQueueStateForTest();
-        resetTaskRegistryForTests({ persist: false });
-        resetTaskFlowRegistryForTests({ persist: false });
+        resetDeferredMaintenanceHarnessState();
         resetContextEngineRuntimeQuarantineForTests();
         registerLegacyContextEngine();
 
         const sessionKey = "agent:main:session-preempt-fallback";
         const engineId = "preempt-fallback-engine";
-        let releaseMaintenance: (() => void) | undefined;
         let releaseRewriteRead: (() => void) | undefined;
-        let rewriteReadStarted: (() => void) | undefined;
-        const rewriteStarted = new Promise<void>((resolve) => {
-          rewriteReadStarted = resolve;
-        });
+        const rewriteStarted = createDeferred();
         resolveRuntimeTranscriptReadTargetMock.mockImplementationOnce(
           async (scope: Record<string, unknown>) => {
-            rewriteReadStarted?.();
+            rewriteStarted.resolve();
             await new Promise<void>((resolve) => {
               releaseRewriteRead = resolve;
             });
@@ -1460,53 +1459,34 @@ describe("runContextEngineMaintenance", () => {
             };
           },
         );
-        const maintain = vi.fn(async (params?: unknown) => {
-          const runtimeContext = (params as { runtimeContext?: ContextEngineRuntimeContext })
-            .runtimeContext;
-          void runtimeContext
-            ?.rewriteTranscriptEntries?.({ replacements: [] })
-            .catch(() => undefined);
-          await new Promise<void>((resolve) => {
-            releaseMaintenance = resolve;
-          });
-          return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+        const controlled = createControlledMaintenance({
+          onStart: (params) => {
+            void params.runtimeContext
+              ?.rewriteTranscriptEntries?.({ replacements: [] })
+              .catch(() => undefined);
+          },
         });
         registerContextEngineForOwner(
           engineId,
-          () => ({
-            info: {
+          () =>
+            createBackgroundContextEngine(controlled.maintain, {
               id: engineId,
               name: "Preempt Fallback Engine",
-              turnMaintenanceMode: "background" as const,
               acceptedHostParams: ["sessionKey", "runtimeContext", "abortSignal"],
-            },
-            ingest: vi.fn(async () => ({ ingested: true })),
-            assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
-            compact: async () => ({ ok: true, compacted: false }),
-            maintain,
-          }),
+            }),
           `test:${engineId}`,
         );
         const contextEngine = await resolveContextEngine({
           plugins: { slots: { contextEngine: engineId } },
         });
-        let deferredMaintenance: Promise<void> | undefined;
-        let deferredMaintenanceSettled = false;
-
-        await runContextEngineMaintenance({
+        const scheduled = await scheduleDeferredMaintenance({
           contextEngine,
           sessionId: "session-preempt-fallback",
           sessionKey,
           sessionFile: "/tmp/session-preempt-fallback.jsonl",
           reason: "turn",
-          onDeferredMaintenance: (promise) => {
-            deferredMaintenance = promise;
-            void promise.then(() => {
-              deferredMaintenanceSettled = true;
-            });
-          },
         });
-        await rewriteStarted;
+        await rewriteStarted.promise;
 
         const foregroundMaintenance = runContextEngineMaintenance({
           contextEngine,
@@ -1520,16 +1500,16 @@ describe("runContextEngineMaintenance", () => {
         );
         await vi.advanceTimersByTimeAsync(1_001);
         expect(contextEngine.info.id).toBe("legacy");
-        expect(maintain).toHaveBeenCalledOnce();
+        expect(controlled.maintain).toHaveBeenCalledOnce();
         await foregroundFailure;
-        expect(deferredMaintenanceSettled).toBe(false);
+        expect(scheduled.isSettled()).toBe(false);
 
         if (!releaseRewriteRead) {
           throw new Error("Expected transcript read release callback to be initialized");
         }
         releaseRewriteRead();
         await flushAsyncWork();
-        expect(deferredMaintenanceSettled).toBe(false);
+        expect(scheduled.isSettled()).toBe(false);
 
         await expect(
           runContextEngineMaintenance({
@@ -1540,18 +1520,12 @@ describe("runContextEngineMaintenance", () => {
             reason: "compaction",
           }),
         ).rejects.toThrow("this turn was stopped to avoid overlapping engine operations");
-        expect(maintain).toHaveBeenCalledOnce();
-        expect(deferredMaintenanceSettled).toBe(false);
+        expect(controlled.maintain).toHaveBeenCalledOnce();
+        expect(scheduled.isSettled()).toBe(false);
 
-        if (!releaseMaintenance) {
-          throw new Error("Expected maintenance release callback to be initialized");
-        }
-        releaseMaintenance();
-        if (!deferredMaintenance) {
-          throw new Error("Expected deferred maintenance promise to be captured");
-        }
-        await deferredMaintenance;
-        expect(deferredMaintenanceSettled).toBe(true);
+        controlled.release();
+        await scheduled.completion;
+        expect(scheduled.isSettled()).toBe(true);
 
         await expect(
           runContextEngineMaintenance({
@@ -1567,7 +1541,7 @@ describe("runContextEngineMaintenance", () => {
           rewrittenEntries: 0,
           reason: "context engine downgraded to legacy",
         });
-        expect(maintain).toHaveBeenCalledOnce();
+        expect(controlled.maintain).toHaveBeenCalledOnce();
         const task = listTasksForOwnerKey(sessionKey).find(
           (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -18,7 +18,7 @@ import { enqueueCommandInLane, markGatewayDraining } from "../../process/command
 import * as commandQueueModule from "../../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
-import { createDeferred } from "../../shared/deferred.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { createQueuedTaskRunCore as createQueuedTaskRunOrNull } from "../../tasks/task-executor.js";
 import { getTaskFlowById } from "../../tasks/task-flow-registry.js";
 import { getTaskById, listTasksForOwnerKey } from "../../tasks/task-registry.js";
@@ -94,8 +94,8 @@ function createControlledMaintenance(options?: {
   onStart?: (params: ContextEngineMaintainParams) => void;
   onRelease?: (params: ContextEngineMaintainParams) => Promise<void> | void;
 }) {
-  const started = createDeferred<ContextEngineMaintainParams>();
-  const release = createDeferred();
+  const started = createDeferredCore<ContextEngineMaintainParams>();
+  const release = createDeferredCore();
   const maintain = vi.fn(async (params: ContextEngineMaintainParams) => {
     started.resolve(params);
     options?.onStart?.(params);
@@ -1526,7 +1526,7 @@ describe("runContextEngineMaintenance", () => {
         const sessionKey = "agent:main:session-preempt-fallback";
         const engineId = "preempt-fallback-engine";
         let releaseRewriteRead: (() => void) | undefined;
-        const rewriteStarted = createDeferred();
+        const rewriteStarted = createDeferredCore();
         resolveRuntimeTranscriptReadTargetMock.mockImplementationOnce(
           async (scope: Record<string, unknown>) => {
             rewriteStarted.resolve();

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -603,7 +603,6 @@ describe("runContextEngineMaintenance", () => {
           compact: async () => ({ ok: true, compacted: false }),
           maintain,
         } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
-
         await runContextEngineMaintenance({
           contextEngine: backgroundEngine,
           sessionId: "session-2",
@@ -1041,7 +1040,6 @@ describe("runContextEngineMaintenance", () => {
           compact: async () => ({ ok: true, compacted: false }),
           maintain,
         } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
-
         await runContextEngineMaintenance({
           contextEngine: backgroundEngine,
           sessionId: "session-legacy",
@@ -1363,12 +1361,20 @@ describe("runContextEngineMaintenance", () => {
           maintain,
         } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
 
+        let deferredMaintenance: Promise<void> | undefined;
+        let deferredMaintenanceSettled = false;
         await runContextEngineMaintenance({
           contextEngine: backgroundEngine,
           sessionId: "session-preempt-blocked",
           sessionKey,
           sessionFile: "/tmp/session-preempt-blocked.jsonl",
           reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            deferredMaintenance = promise;
+            void promise.then(() => {
+              deferredMaintenanceSettled = true;
+            });
+          },
         });
         await waitForAssertion(() => expect(maintain).toHaveBeenCalledOnce());
 
@@ -1385,6 +1391,7 @@ describe("runContextEngineMaintenance", () => {
         ).rejects.toThrow("waiting foreground turn");
         await vi.advanceTimersByTimeAsync(1_001);
         await foregroundWait;
+        expect(deferredMaintenanceSettled).toBe(false);
         const task = listTasksForOwnerKey(sessionKey).find(
           (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );
@@ -1402,12 +1409,17 @@ describe("runContextEngineMaintenance", () => {
           reason: "turn",
         });
         expect(maintain).toHaveBeenCalledOnce();
+        expect(deferredMaintenanceSettled).toBe(false);
 
         if (!releaseMaintenance) {
           throw new Error("Expected maintenance release callback to be initialized");
         }
         releaseMaintenance();
-        await flushAsyncWork();
+        if (!deferredMaintenance) {
+          throw new Error("Expected deferred maintenance promise to be captured");
+        }
+        await deferredMaintenance;
+        expect(deferredMaintenanceSettled).toBe(true);
         expect(task && getTaskById(task.taskId)?.status).toBe("timed_out");
       } finally {
         vi.useRealTimers();
@@ -1415,7 +1427,7 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
-  it("drains admitted rewrites before routing foreground compaction maintenance to fallback", async () => {
+  it("keeps fallback serialized behind a quarantined maintenance run", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();
       const restoreRegistry = captureContextEngineRegistryStateForTests();
@@ -1478,6 +1490,8 @@ describe("runContextEngineMaintenance", () => {
         const contextEngine = await resolveContextEngine({
           plugins: { slots: { contextEngine: engineId } },
         });
+        let deferredMaintenance: Promise<void> | undefined;
+        let deferredMaintenanceSettled = false;
 
         await runContextEngineMaintenance({
           contextEngine,
@@ -1485,43 +1499,75 @@ describe("runContextEngineMaintenance", () => {
           sessionKey,
           sessionFile: "/tmp/session-preempt-fallback.jsonl",
           reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            deferredMaintenance = promise;
+            void promise.then(() => {
+              deferredMaintenanceSettled = true;
+            });
+          },
         });
         await rewriteStarted;
 
-        let foregroundReleased = false;
         const foregroundMaintenance = runContextEngineMaintenance({
           contextEngine,
           sessionId: "session-preempt-fallback",
           sessionKey,
           sessionFile: "/tmp/session-preempt-fallback.jsonl",
           reason: "compaction",
-        }).then((result) => {
-          foregroundReleased = true;
-          return result;
         });
+        const foregroundFailure = expect(foregroundMaintenance).rejects.toThrow(
+          "this turn was stopped to avoid overlapping engine operations",
+        );
         await vi.advanceTimersByTimeAsync(1_001);
         expect(contextEngine.info.id).toBe("legacy");
-        expect(foregroundReleased).toBe(false);
         expect(maintain).toHaveBeenCalledOnce();
+        await foregroundFailure;
+        expect(deferredMaintenanceSettled).toBe(false);
 
         if (!releaseRewriteRead) {
           throw new Error("Expected transcript read release callback to be initialized");
         }
         releaseRewriteRead();
-        await expect(foregroundMaintenance).resolves.toEqual({
-          changed: false,
-          bytesFreed: 0,
-          rewrittenEntries: 0,
-          reason: "context engine downgraded to legacy",
-        });
-        expect(foregroundReleased).toBe(true);
+        await flushAsyncWork();
+        expect(deferredMaintenanceSettled).toBe(false);
+
+        await expect(
+          runContextEngineMaintenance({
+            contextEngine,
+            sessionId: "session-preempt-fallback",
+            sessionKey,
+            sessionFile: "/tmp/session-preempt-fallback.jsonl",
+            reason: "compaction",
+          }),
+        ).rejects.toThrow("this turn was stopped to avoid overlapping engine operations");
         expect(maintain).toHaveBeenCalledOnce();
+        expect(deferredMaintenanceSettled).toBe(false);
 
         if (!releaseMaintenance) {
           throw new Error("Expected maintenance release callback to be initialized");
         }
         releaseMaintenance();
-        await flushAsyncWork();
+        if (!deferredMaintenance) {
+          throw new Error("Expected deferred maintenance promise to be captured");
+        }
+        await deferredMaintenance;
+        expect(deferredMaintenanceSettled).toBe(true);
+
+        await expect(
+          runContextEngineMaintenance({
+            contextEngine,
+            sessionId: "session-preempt-fallback",
+            sessionKey,
+            sessionFile: "/tmp/session-preempt-fallback.jsonl",
+            reason: "compaction",
+          }),
+        ).resolves.toEqual({
+          changed: false,
+          bytesFreed: 0,
+          rewrittenEntries: 0,
+          reason: "context engine downgraded to legacy",
+        });
+        expect(maintain).toHaveBeenCalledOnce();
         const task = listTasksForOwnerKey(sessionKey).find(
           (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -35,6 +35,7 @@ import {
   findTaskByRunIdForOwner,
   updateTaskNotifyPolicyForOwner,
 } from "../../tasks/task-owner-access.js";
+import { DeferredContextEngineMaintenanceBlockedError } from "../context-engine-maintenance-error.js";
 import { findActiveSessionTask } from "../session-async-task-status.js";
 import { SessionManager } from "../sessions/index.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
@@ -688,11 +689,7 @@ function scheduleDeferredTurnMaintenance(
           error: preemptionError,
         });
         state.phase = quarantined ? "quarantined" : "blocked";
-        state.waitError = new Error(
-          quarantined
-            ? "Deferred maintenance did not stop. The context engine was quarantined, but this turn was stopped to avoid overlapping engine operations. Retry after maintenance finishes or restart the gateway."
-            : "Deferred maintenance did not stop. The active context engine cannot be quarantined, so this turn was stopped to avoid overlapping engine operations. Retry after maintenance finishes or restart the gateway.",
-        );
+        state.waitError = new DeferredContextEngineMaintenanceBlockedError({ quarantined });
         terminalizePreemption(preemptionError, state.waitError.message);
         // Fail the waiting turn, but keep the run barrier closed until the
         // original plugin call and every admitted host write have settled.

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -23,6 +23,7 @@ import {
   GatewayDrainingError,
   isGatewayDraining,
 } from "../../process/command-queue.js";
+import { createDeferred } from "../../shared/deferred.js";
 import {
   completeTaskRunByRunId,
   createQueuedTaskRun,
@@ -85,20 +86,7 @@ type DeferredTurnMaintenanceScheduleParams = ContextEngineMaintenanceParams & {
   onScheduleFailure?: (error: unknown) => void;
 };
 
-type DeferredTurnMaintenanceRunState = {
-  phase: "running" | "preempting" | "blocked" | "quarantined" | "settled";
-  barrier: Promise<void>;
-  releaseBarrier: () => void;
-  foregroundBarrier: Promise<void>;
-  releaseForegroundBarrier: () => void;
-  waitError?: Error;
-  preemptionTimer?: ReturnType<typeof setTimeout>;
-  requestForegroundPreemption: () => void;
-  rerunRequested: boolean;
-  latestParams: DeferredTurnMaintenanceScheduleParams;
-};
-
-const activeDeferredTurnMaintenanceRuns = new Map<string, DeferredTurnMaintenanceRunState>();
+const activeDeferredTurnMaintenanceRuns = new Map<string, DeferredTurnMaintenanceRun>();
 
 type DeferredTurnMaintenanceSignal = "SIGINT" | "SIGTERM";
 type DeferredTurnMaintenanceProcessLike = Pick<NodeJS.Process, "on" | "off"> &
@@ -190,10 +178,8 @@ function createDeferredTurnMaintenanceAbortSignal(params?: {
 }
 
 function resetDeferredTurnMaintenanceStateForTest(): void {
-  for (const state of activeDeferredTurnMaintenanceRuns.values()) {
-    if (state.preemptionTimer) {
-      clearTimeout(state.preemptionTimer);
-    }
+  for (const run of activeDeferredTurnMaintenanceRuns.values()) {
+    run.dispose();
   }
   activeDeferredTurnMaintenanceRuns.clear();
   const processLike = process as DeferredTurnMaintenanceProcessLike;
@@ -224,11 +210,7 @@ export async function waitForDeferredTurnMaintenanceForSession(sessionKey?: stri
   if (!activeRun) {
     return;
   }
-  activeRun.requestForegroundPreemption();
-  await activeRun.foregroundBarrier;
-  if (activeRun.waitError) {
-    throw activeRun.waitError;
-  }
+  await activeRun.preemptForForeground();
 }
 
 function buildTurnMaintenanceTaskDescriptor(params: {
@@ -256,6 +238,201 @@ function buildTurnMaintenanceTaskDescriptor(params: {
     deliveryStatus: params.deliveryStatus ?? "not_applicable",
     preferMetadata: true,
   });
+}
+
+function makeTurnMaintenanceTaskVisible(params: {
+  sessionKey: string;
+  runId: string;
+  notifyPolicy: "done_only" | "state_changes";
+}): void {
+  buildTurnMaintenanceTaskDescriptor({
+    ...params,
+    deliveryStatus: "pending",
+  });
+}
+
+class DeferredTurnMaintenancePreemptedError extends Error {
+  constructor() {
+    super("Deferred context-engine maintenance did not yield to a waiting foreground turn.");
+    this.name = "DeferredTurnMaintenancePreemptedError";
+  }
+}
+
+function isForegroundMaintenancePreemption(signal: AbortSignal): boolean {
+  return signal.reason instanceof DeferredTurnMaintenancePreemptedError;
+}
+
+class DeferredTurnMaintenanceRun {
+  private readonly completionDeferred = createDeferred();
+  private readonly physicalSettlement = createDeferred();
+  readonly completion = this.completionDeferred.promise;
+  private readonly schedulerAbort = createDeferredTurnMaintenanceAbortSignal();
+  private readonly writeFence = createDeferredMaintenanceWriteFence();
+  private pendingRerun?: DeferredTurnMaintenanceScheduleParams;
+  private preemption?: Promise<void>;
+  private preemptionTimer?: ReturnType<typeof setTimeout>;
+  private writeDrain: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly params: DeferredTurnMaintenanceScheduleParams,
+    private readonly sessionKey: string,
+    private readonly lane: string,
+    private readonly runId: string,
+    private readonly taskId: string,
+  ) {}
+
+  coalesce(next: DeferredTurnMaintenanceScheduleParams): void {
+    const superseded = this.pendingRerun;
+    this.pendingRerun = { ...next, sessionKey: this.sessionKey };
+    if (
+      superseded?.disposeContextEngineAfterMaintenance &&
+      superseded.contextEngine !== next.contextEngine
+    ) {
+      void disposeDeferredMaintenanceContextEngine(superseded.contextEngine);
+    }
+  }
+
+  start(): boolean {
+    let worker: Promise<void>;
+    try {
+      worker = enqueueCommandInLane(this.lane, () =>
+        runDeferredTurnMaintenanceWorker({
+          ...this.params,
+          sessionKey: this.sessionKey,
+          runId: this.runId,
+          abortSignal: this.schedulerAbort.abortSignal,
+          writeFence: this.writeFence,
+        }),
+      );
+    } catch (error) {
+      activeDeferredTurnMaintenanceRuns.delete(this.sessionKey);
+      this.dispose();
+      this.cancelFailedTask(error);
+      this.physicalSettlement.resolve();
+      this.completionDeferred.resolve();
+      return false;
+    }
+    void this.track(worker);
+    return true;
+  }
+
+  preemptForForeground(): Promise<void> {
+    this.preemption ??= this.runForegroundPreemption();
+    return this.preemption;
+  }
+
+  dispose(): void {
+    if (this.preemptionTimer) {
+      clearTimeout(this.preemptionTimer);
+      this.preemptionTimer = undefined;
+    }
+    this.schedulerAbort.dispose();
+  }
+
+  private async runForegroundPreemption(): Promise<void> {
+    const preemptionError = new DeferredTurnMaintenancePreemptedError();
+    this.schedulerAbort.abort(preemptionError);
+    this.writeDrain = this.writeFence.close(preemptionError);
+    if (await this.settlesWithinPreemptionGrace()) {
+      return;
+    }
+
+    const quarantined = quarantineResolvedContextEngine({
+      contextEngine: this.params.contextEngine,
+      operation: "maintain",
+      error: preemptionError,
+    });
+    const blockedError = new DeferredContextEngineMaintenanceBlockedError({ quarantined });
+    makeTurnMaintenanceTaskVisible({
+      sessionKey: this.sessionKey,
+      runId: this.runId,
+      notifyPolicy: "state_changes",
+    });
+    const endedAt = Date.now();
+    failTaskRunByRunId({
+      runId: this.runId,
+      runtime: "acp",
+      sessionKey: this.sessionKey,
+      status: "timed_out",
+      endedAt,
+      lastEventAt: endedAt,
+      error: preemptionError.message,
+      progressSummary: "Deferred maintenance did not yield to a waiting turn.",
+      terminalSummary: blockedError.message,
+    });
+    throw blockedError;
+  }
+
+  private async settlesWithinPreemptionGrace(): Promise<boolean> {
+    const timeout = createDeferred<boolean>();
+    this.preemptionTimer = setTimeout(() => {
+      this.preemptionTimer = undefined;
+      timeout.resolve(false);
+    }, TURN_MAINTENANCE_PREEMPT_GRACE_MS);
+    this.preemptionTimer.unref?.();
+    try {
+      return await Promise.race([
+        this.physicalSettlement.promise.then(() => true),
+        timeout.promise,
+      ]);
+    } finally {
+      if (this.preemptionTimer) {
+        clearTimeout(this.preemptionTimer);
+        this.preemptionTimer = undefined;
+      }
+    }
+  }
+
+  private async track(worker: Promise<void>): Promise<void> {
+    try {
+      await worker;
+    } catch (error) {
+      this.params.onScheduleFailure?.(error);
+      this.cancelFailedTask(error);
+    }
+
+    try {
+      // Do not await the initially settled drain: that yield would let a new
+      // preemption install a real drain after we had already snapshotted it.
+      if (this.preemption) {
+        await this.writeDrain;
+      }
+      this.dispose();
+      if (activeDeferredTurnMaintenanceRuns.get(this.sessionKey) !== this) {
+        this.physicalSettlement.resolve();
+        return;
+      }
+
+      activeDeferredTurnMaintenanceRuns.delete(this.sessionKey);
+      this.physicalSettlement.resolve();
+      const interrupted = this.schedulerAbort.abortSignal.aborted;
+      const pendingRerun = this.pendingRerun;
+      if (pendingRerun && !interrupted) {
+        await scheduleDeferredTurnMaintenance(pendingRerun);
+      } else if (pendingRerun?.disposeContextEngineAfterMaintenance) {
+        await disposeDeferredMaintenanceContextEngine(pendingRerun.contextEngine);
+      }
+    } catch (error) {
+      this.params.onScheduleFailure?.(error);
+      log.warn(
+        `failed to settle deferred context engine maintenance: ${formatErrorMessage(error)}`,
+      );
+    } finally {
+      this.physicalSettlement.resolve();
+      this.completionDeferred.resolve();
+    }
+  }
+
+  private cancelFailedTask(error: unknown): void {
+    const errorMessage = formatErrorMessage(error);
+    log.warn(`failed to schedule deferred context engine maintenance: ${errorMessage}`);
+    cancelTaskByIdForOwner({
+      taskId: this.taskId,
+      callerOwnerKey: this.sessionKey,
+      endedAt: Date.now(),
+      terminalSummary: `Deferred maintenance could not be scheduled: ${errorMessage}`,
+    });
+  }
 }
 
 /**
@@ -376,7 +553,6 @@ async function runDeferredTurnMaintenanceWorker(
     runId: string;
     abortSignal: AbortSignal;
     writeFence: DeferredMaintenanceWriteFence;
-    wasForegroundPreempted: () => boolean;
   },
 ): Promise<void> {
   let surfacedUserNotice = false;
@@ -389,11 +565,10 @@ async function runDeferredTurnMaintenanceWorker(
   };
   const taskRun = { runId: params.runId, runtime: "acp" as const, sessionKey: params.sessionKey };
   const makeTaskVisible = (notifyPolicy: "done_only" | "state_changes") =>
-    buildTurnMaintenanceTaskDescriptor({
+    makeTurnMaintenanceTaskVisible({
       sessionKey: params.sessionKey,
       runId: params.runId,
       notifyPolicy,
-      deliveryStatus: "pending",
     });
 
   try {
@@ -449,17 +624,13 @@ async function runDeferredTurnMaintenanceWorker(
       const task = findTaskByRunIdForOwner({
         runId: params.runId,
         callerOwnerKey: params.sessionKey,
-        callerAgentId: params.agentId,
-        config: params.config,
       });
       if (task?.status === "queued" || task?.status === "running") {
         cancelTaskByIdForOwner({
           taskId: task.taskId,
           callerOwnerKey: params.sessionKey,
-          callerAgentId: params.agentId,
-          config: params.config,
           endedAt: Date.now(),
-          terminalSummary: params.wasForegroundPreempted()
+          terminalSummary: isForegroundMaintenancePreemption(params.abortSignal)
             ? "Deferred maintenance yielded to a waiting foreground turn."
             : "Deferred maintenance cancelled during shutdown.",
         });
@@ -503,16 +674,8 @@ function scheduleDeferredTurnMaintenance(
 
   const activeRun = activeDeferredTurnMaintenanceRuns.get(sessionKey);
   if (activeRun) {
-    const supersededParams = activeRun.rerunRequested ? activeRun.latestParams : undefined;
-    activeRun.rerunRequested = true;
-    activeRun.latestParams = { ...params, sessionKey };
-    if (
-      supersededParams?.disposeContextEngineAfterMaintenance &&
-      supersededParams.contextEngine !== params.contextEngine
-    ) {
-      void disposeDeferredMaintenanceContextEngine(supersededParams.contextEngine);
-    }
-    return activeRun.barrier;
+    activeRun.coalesce({ ...params, sessionKey });
+    return activeRun.completion;
   }
 
   const existingTask = findActiveSessionTask({
@@ -525,15 +688,11 @@ function scheduleDeferredTurnMaintenance(
     updateTaskNotifyPolicyForOwner({
       taskId: existingTask.taskId,
       callerOwnerKey: sessionKey,
-      callerAgentId: params.agentId,
-      config: params.config,
       notifyPolicy: "silent",
     });
     cancelTaskByIdForOwner({
       taskId: existingTask.taskId,
       callerOwnerKey: sessionKey,
-      callerAgentId: params.agentId,
-      config: params.config,
       endedAt: Date.now(),
       terminalSummary: "Superseded by refreshed deferred maintenance task.",
     });
@@ -555,154 +714,14 @@ function scheduleDeferredTurnMaintenance(
       `taskId=${task.taskId} sessionKey=${sessionKey} lane=${lane}`,
   );
 
-  const cancelFailedTask = (error: unknown) => {
-    const errorMessage = formatErrorMessage(error);
-    log.warn(`failed to schedule deferred context engine maintenance: ${errorMessage}`);
-    cancelTaskByIdForOwner({
-      taskId: task.taskId,
-      callerOwnerKey: sessionKey,
-      callerAgentId: params.agentId,
-      config: params.config,
-      endedAt: Date.now(),
-      terminalSummary: `Deferred maintenance could not be scheduled: ${errorMessage}`,
-    });
-  };
-  const schedulerAbort = createDeferredTurnMaintenanceAbortSignal();
-  const writeFence = createDeferredMaintenanceWriteFence();
-  let foregroundPreempted = false;
-  let preemptionWriteDrain: Promise<void> | undefined;
-  let releaseBarrier = () => {};
-  const barrier = new Promise<void>((resolve) => {
-    releaseBarrier = resolve;
-  });
-  let releaseForegroundBarrier = () => {};
-  const foregroundBarrier = new Promise<void>((resolve) => {
-    releaseForegroundBarrier = resolve;
-  });
-  const terminalizePreemption = (error: Error, terminalSummary: string) => {
-    buildTurnMaintenanceTaskDescriptor({
-      sessionKey,
-      runId: task.runId,
-      notifyPolicy: "state_changes",
-      deliveryStatus: "pending",
-    });
-    const endedAt = Date.now();
-    failTaskRunByRunId({
-      runId: task.runId!,
-      runtime: "acp",
-      sessionKey,
-      status: "timed_out",
-      endedAt,
-      lastEventAt: endedAt,
-      error: error.message,
-      progressSummary: "Deferred maintenance did not yield to a waiting turn.",
-      terminalSummary,
-    });
-  };
-  let runPromise: Promise<void>;
-  try {
-    runPromise = enqueueCommandInLane(lane, () =>
-      runDeferredTurnMaintenanceWorker({
-        ...params,
-        sessionKey,
-        runId: task.runId!,
-        abortSignal: schedulerAbort.abortSignal,
-        writeFence,
-        wasForegroundPreempted: () => foregroundPreempted,
-      }),
-    );
-  } catch (err) {
-    schedulerAbort.dispose();
-    cancelFailedTask(err);
+  const run = new DeferredTurnMaintenanceRun(params, sessionKey, lane, task.runId!, task.taskId);
+  // Registration precedes queue admission so a foreground waiter can never
+  // miss a physical run that has already been handed to the lane.
+  activeDeferredTurnMaintenanceRuns.set(sessionKey, run);
+  if (!run.start()) {
     return undefined;
   }
-  const cleanupDeferredTurnMaintenance = async () => {
-    let current = activeDeferredTurnMaintenanceRuns.get(sessionKey);
-    if (current !== state) {
-      return;
-    }
-    if (preemptionWriteDrain) {
-      await preemptionWriteDrain;
-      current = activeDeferredTurnMaintenanceRuns.get(sessionKey);
-      if (current !== state) {
-        return;
-      }
-    }
-    schedulerAbort.dispose();
-    current.phase = "settled";
-    if (current.preemptionTimer) {
-      clearTimeout(current.preemptionTimer);
-      current.preemptionTimer = undefined;
-    }
-    const shutdownTriggered = schedulerAbort.abortSignal.aborted;
-    const rerunParams =
-      current.rerunRequested && !shutdownTriggered ? current.latestParams : undefined;
-    const discardedRerunParams =
-      current.rerunRequested && shutdownTriggered ? current.latestParams : undefined;
-    activeDeferredTurnMaintenanceRuns.delete(sessionKey);
-    if (rerunParams) {
-      await scheduleDeferredTurnMaintenance(rerunParams);
-    } else if (discardedRerunParams?.disposeContextEngineAfterMaintenance) {
-      await disposeDeferredMaintenanceContextEngine(discardedRerunParams.contextEngine);
-    }
-    current.releaseBarrier();
-    current.releaseForegroundBarrier();
-  };
-  const trackedPromise = runPromise
-    .catch((err: unknown) => {
-      params.onScheduleFailure?.(err);
-      cancelFailedTask(err);
-    })
-    .then(cleanupDeferredTurnMaintenance, async (error: unknown) => {
-      await cleanupDeferredTurnMaintenance();
-      throw error;
-    });
-  const state: DeferredTurnMaintenanceRunState = {
-    phase: "running",
-    barrier,
-    releaseBarrier,
-    foregroundBarrier,
-    releaseForegroundBarrier,
-    requestForegroundPreemption: () => {
-      if (state.phase !== "running") {
-        return;
-      }
-      state.phase = "preempting";
-      foregroundPreempted = true;
-      const preemptionError = new Error(
-        "Deferred context-engine maintenance did not yield to a waiting foreground turn.",
-      );
-      schedulerAbort.abort(preemptionError);
-      const writeDrain = writeFence.close(preemptionError);
-      preemptionWriteDrain = writeDrain;
-      state.preemptionTimer = setTimeout(() => {
-        state.preemptionTimer = undefined;
-        if (
-          state.phase !== "preempting" ||
-          activeDeferredTurnMaintenanceRuns.get(sessionKey) !== state
-        ) {
-          return;
-        }
-        const quarantined = quarantineResolvedContextEngine({
-          contextEngine: params.contextEngine,
-          operation: "maintain",
-          error: preemptionError,
-        });
-        state.phase = quarantined ? "quarantined" : "blocked";
-        state.waitError = new DeferredContextEngineMaintenanceBlockedError({ quarantined });
-        terminalizePreemption(preemptionError, state.waitError.message);
-        // Fail the waiting turn, but keep the run barrier closed until the
-        // original plugin call and every admitted host write have settled.
-        state.releaseForegroundBarrier();
-      }, TURN_MAINTENANCE_PREEMPT_GRACE_MS);
-      state.preemptionTimer.unref?.();
-    },
-    rerunRequested: false,
-    latestParams: { ...params, sessionKey },
-  };
-  activeDeferredTurnMaintenanceRuns.set(sessionKey, state);
-  void trackedPromise;
-  return barrier;
+  return run.completion;
 }
 
 /**

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -6,7 +6,10 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import { publishTranscriptUpdate } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveContextEngineOwnerPluginId } from "../../context-engine/registry.js";
+import {
+  quarantineResolvedContextEngine,
+  resolveContextEngineOwnerPluginId,
+} from "../../context-engine/registry.js";
 import type {
   ContextEngine,
   ContextEngineMaintenanceResult,
@@ -42,10 +45,17 @@ import { resolveRuntimeTranscriptReadTarget } from "./transcript-runtime-state.j
 const TURN_MAINTENANCE_TASK_KIND = "context_engine_turn_maintenance";
 const TURN_MAINTENANCE_LANE_PREFIX = "context-engine-turn-maintenance:";
 const TURN_MAINTENANCE_LONG_WAIT_MS = 10_000;
+// A waiting user turn should only pay for cooperative abort cleanup, not the
+// background maintenance operation's otherwise unbounded runtime.
+const TURN_MAINTENANCE_PREEMPT_GRACE_MS = 1_000;
 const DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY = Symbol.for(
   "openclaw.contextEngineTurnMaintenanceAbortState",
 );
 type SessionManagerRewriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
+type DeferredMaintenanceWriteFence = {
+  run: <T>(operation: () => Promise<T>) => Promise<T>;
+  close: (reason: Error) => Promise<void>;
+};
 
 type ContextEngineMaintenanceParams = {
   contextEngine?: ContextEngine;
@@ -75,12 +85,51 @@ type DeferredTurnMaintenanceScheduleParams = ContextEngineMaintenanceParams & {
 };
 
 type DeferredTurnMaintenanceRunState = {
-  promise: Promise<void>;
+  phase: "running" | "preempting" | "blocked" | "quarantined" | "settled";
+  barrier: Promise<void>;
+  releaseBarrier: () => void;
+  waitError?: Error;
+  preemptionTimer?: ReturnType<typeof setTimeout>;
+  requestForegroundPreemption: () => void;
   rerunRequested: boolean;
   latestParams: DeferredTurnMaintenanceScheduleParams;
 };
 
 const activeDeferredTurnMaintenanceRuns = new Map<string, DeferredTurnMaintenanceRunState>();
+
+// Closing rejects late rewrites and drains already-admitted host transcript writes
+// before fallback maintenance or foreground reads can enter the session.
+function createDeferredMaintenanceWriteFence(): DeferredMaintenanceWriteFence {
+  let closedReason: Error | undefined;
+  let activeWrites = 0;
+  let resolveDrain: (() => void) | undefined;
+  let drain = Promise.resolve();
+  return {
+    run: async <T>(operation: () => Promise<T>) => {
+      if (closedReason) {
+        throw closedReason;
+      }
+      if (activeWrites++ === 0) {
+        drain = new Promise<void>((resolve) => {
+          resolveDrain = resolve;
+        });
+      }
+      try {
+        return await operation();
+      } finally {
+        activeWrites -= 1;
+        if (activeWrites === 0) {
+          resolveDrain?.();
+          resolveDrain = undefined;
+        }
+      }
+    },
+    close: async (reason) => {
+      closedReason ??= reason;
+      await drain;
+    },
+  };
+}
 
 type DeferredTurnMaintenanceSignal = "SIGINT" | "SIGTERM";
 type DeferredTurnMaintenanceProcessLike = Pick<NodeJS.Process, "on" | "off"> &
@@ -118,6 +167,7 @@ function createDeferredTurnMaintenanceAbortSignal(params?: {
   processLike?: DeferredTurnMaintenanceProcessLike;
 }): {
   abortSignal: AbortSignal;
+  abort: (reason: Error) => void;
   dispose: () => void;
 } {
   const processLike = (params?.processLike ?? process) as DeferredTurnMaintenanceProcessLike;
@@ -156,6 +206,11 @@ function createDeferredTurnMaintenanceAbortSignal(params?: {
   state.controllers.add(controller);
   return {
     abortSignal: controller.signal,
+    abort: (reason) => {
+      if (!controller.signal.aborted) {
+        controller.abort(reason);
+      }
+    },
     dispose: () => {
       state.controllers.delete(controller);
       if (state.controllers.size === 0) {
@@ -166,6 +221,11 @@ function createDeferredTurnMaintenanceAbortSignal(params?: {
 }
 
 function resetDeferredTurnMaintenanceStateForTest(): void {
+  for (const state of activeDeferredTurnMaintenanceRuns.values()) {
+    if (state.preemptionTimer) {
+      clearTimeout(state.preemptionTimer);
+    }
+  }
   activeDeferredTurnMaintenanceRuns.clear();
   const processLike = process as DeferredTurnMaintenanceProcessLike;
   const state = processLike[DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY];
@@ -191,7 +251,15 @@ export async function waitForDeferredTurnMaintenanceForSession(sessionKey?: stri
   if (!normalizedSessionKey) {
     return;
   }
-  await activeDeferredTurnMaintenanceRuns.get(normalizedSessionKey)?.promise;
+  const activeRun = activeDeferredTurnMaintenanceRuns.get(normalizedSessionKey);
+  if (!activeRun) {
+    return;
+  }
+  activeRun.requestForegroundPreemption();
+  await activeRun.barrier;
+  if (activeRun.waitError) {
+    throw activeRun.waitError;
+  }
 }
 
 function buildTurnMaintenanceTaskDescriptor(params: {
@@ -230,6 +298,7 @@ function buildContextEngineMaintenanceRuntimeContext(
     allowDeferredCompactionExecution?: boolean;
     purpose?: string;
     contextEnginePluginId?: string;
+    writeFence?: DeferredMaintenanceWriteFence;
   },
 ): ContextEngineRuntimeContext {
   return {
@@ -245,42 +314,49 @@ function buildContextEngineMaintenanceRuntimeContext(
     ...(params.sessionTarget ? { sessionTarget: params.sessionTarget } : {}),
     ...(params.allowDeferredCompactionExecution ? { allowDeferredCompactionExecution: true } : {}),
     rewriteTranscriptEntries: async (request) => {
-      const runtimeAgentId = params.sessionTarget?.agentId ?? params.agentId;
-      const runtimeSessionKey = normalizeOptionalString(
-        params.sessionTarget?.sessionKey ?? params.sessionKey,
-      );
-      if (!runtimeSessionKey) {
-        throw new Error("Context-engine transcript rewrite requires a session key");
-      }
-      const runtimeStorePath =
-        params.sessionTarget?.storePath ??
-        (runtimeAgentId
-          ? resolveSessionStorePathCore(params.config?.session?.store, { agentId: runtimeAgentId })
-          : undefined);
-      let runtimeTarget: Awaited<ReturnType<typeof resolveRuntimeTranscriptReadTarget>> | undefined;
-      let sessionManager = params.sessionManager;
-      if (!sessionManager) {
-        runtimeTarget = await resolveRuntimeTranscriptReadTarget({
-          sessionId: params.sessionTarget?.sessionId ?? params.sessionId,
-          sessionKey: runtimeSessionKey,
-          sessionFile: params.sessionFile,
-          ...(runtimeAgentId ? { agentId: runtimeAgentId } : {}),
-          ...(runtimeStorePath ? { storePath: runtimeStorePath } : {}),
-        });
-        sessionManager = SessionManager.open(runtimeTarget);
-      }
-      const rewriteSessionManagerEntries = () =>
-        rewriteTranscriptEntriesInSessionManager({
-          sessionManager,
-          replacements: request.replacements,
-        });
-      const result = params.withSessionManagerRewriteLock
-        ? await params.withSessionManagerRewriteLock(rewriteSessionManagerEntries)
-        : rewriteSessionManagerEntries();
-      if (result.changed && runtimeTarget) {
-        await publishTranscriptUpdate(runtimeTarget);
-      }
-      return result;
+      const rewrite = async () => {
+        const runtimeAgentId = params.sessionTarget?.agentId ?? params.agentId;
+        const runtimeSessionKey = normalizeOptionalString(
+          params.sessionTarget?.sessionKey ?? params.sessionKey,
+        );
+        if (!runtimeSessionKey) {
+          throw new Error("Context-engine transcript rewrite requires a session key");
+        }
+        const runtimeStorePath =
+          params.sessionTarget?.storePath ??
+          (runtimeAgentId
+            ? resolveSessionStorePathCore(params.config?.session?.store, {
+                agentId: runtimeAgentId,
+              })
+            : undefined);
+        let runtimeTarget:
+          | Awaited<ReturnType<typeof resolveRuntimeTranscriptReadTarget>>
+          | undefined;
+        let sessionManager = params.sessionManager;
+        if (!sessionManager) {
+          runtimeTarget = await resolveRuntimeTranscriptReadTarget({
+            sessionId: params.sessionTarget?.sessionId ?? params.sessionId,
+            sessionKey: runtimeSessionKey,
+            sessionFile: params.sessionFile,
+            ...(runtimeAgentId ? { agentId: runtimeAgentId } : {}),
+            ...(runtimeStorePath ? { storePath: runtimeStorePath } : {}),
+          });
+          sessionManager = SessionManager.open(runtimeTarget);
+        }
+        const rewriteSessionManagerEntries = () =>
+          rewriteTranscriptEntriesInSessionManager({
+            sessionManager,
+            replacements: request.replacements,
+          });
+        const result = params.withSessionManagerRewriteLock
+          ? await params.withSessionManagerRewriteLock(rewriteSessionManagerEntries)
+          : rewriteSessionManagerEntries();
+        if (result.changed && runtimeTarget) {
+          await publishTranscriptUpdate(runtimeTarget);
+        }
+        return result;
+      };
+      return params.writeFence ? await params.writeFence.run(rewrite) : await rewrite();
     },
   };
 }
@@ -289,17 +365,21 @@ async function executeContextEngineMaintenance(
   params: ContextEngineMaintenanceParams & {
     contextEngine: ContextEngine;
     executionMode: "foreground" | "background";
+    abortSignal?: AbortSignal;
+    writeFence?: DeferredMaintenanceWriteFence;
   },
 ): Promise<ContextEngineMaintenanceResult | undefined> {
   if (typeof params.contextEngine.maintain !== "function") {
     return undefined;
   }
+  params.abortSignal?.throwIfAborted();
   const result = await params.contextEngine.maintain({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     sessionTarget: params.sessionTarget,
     sessionFile: params.sessionFile,
     runtimeSettings: params.runtimeSettings,
+    abortSignal: params.abortSignal,
     runtimeContext: buildContextEngineMaintenanceRuntimeContext({
       ...params,
       sessionManager: params.executionMode === "background" ? undefined : params.sessionManager,
@@ -308,8 +388,10 @@ async function executeContextEngineMaintenance(
       allowDeferredCompactionExecution: params.executionMode === "background",
       purpose: `context-engine.${params.reason}.maintenance`,
       contextEnginePluginId: resolveContextEngineOwnerPluginId(params.contextEngine),
+      writeFence: params.writeFence,
     }),
   });
+  params.abortSignal?.throwIfAborted();
   if (result.changed) {
     log.info(
       `[context-engine] maintenance(${params.reason}) changed transcript ` +
@@ -323,11 +405,19 @@ async function executeContextEngineMaintenance(
 async function runDeferredTurnMaintenanceWorker(
   params: DeferredTurnMaintenanceScheduleParams & {
     runId: string;
+    abortSignal: AbortSignal;
+    writeFence: DeferredMaintenanceWriteFence;
+    wasForegroundPreempted: () => boolean;
   },
 ): Promise<void> {
   let surfacedUserNotice = false;
   let longRunningTimer: ReturnType<typeof setTimeout> | undefined;
-  const shutdownAbort = createDeferredTurnMaintenanceAbortSignal();
+  const stopLongRunningProgress = () => {
+    if (longRunningTimer) {
+      clearTimeout(longRunningTimer);
+      longRunningTimer = undefined;
+    }
+  };
   const taskRun = { runId: params.runId, runtime: "acp" as const, sessionKey: params.sessionKey };
   const makeTaskVisible = (notifyPolicy: "done_only" | "state_changes") =>
     buildTurnMaintenanceTaskDescriptor({
@@ -361,10 +451,17 @@ async function runDeferredTurnMaintenanceWorker(
         log.warn(`failed to surface deferred maintenance progress: ${String(error)}`);
       }
     }, TURN_MAINTENANCE_LONG_WAIT_MS);
+    if (params.abortSignal.aborted) {
+      stopLongRunningProgress();
+    } else {
+      params.abortSignal.addEventListener("abort", stopLongRunningProgress, { once: true });
+    }
 
     const result = await executeContextEngineMaintenance({
       ...params,
       executionMode: "background",
+      abortSignal: params.abortSignal,
+      writeFence: params.writeFence,
     });
     const endedAt = Date.now();
     completeTaskRunByRunId({
@@ -379,21 +476,23 @@ async function runDeferredTurnMaintenanceWorker(
         : "No transcript changes were needed.",
     });
   } catch (err) {
-    if (shutdownAbort.abortSignal.aborted) {
+    if (params.abortSignal.aborted) {
       const task = findTaskByRunIdForOwner({
         runId: params.runId,
         callerOwnerKey: params.sessionKey,
         callerAgentId: params.agentId,
         config: params.config,
       });
-      if (task) {
+      if (task?.status === "queued" || task?.status === "running") {
         cancelTaskByIdForOwner({
           taskId: task.taskId,
           callerOwnerKey: params.sessionKey,
           callerAgentId: params.agentId,
           config: params.config,
           endedAt: Date.now(),
-          terminalSummary: "Deferred maintenance cancelled during shutdown.",
+          terminalSummary: params.wasForegroundPreempted()
+            ? "Deferred maintenance yielded to a waiting foreground turn."
+            : "Deferred maintenance cancelled during shutdown.",
         });
       }
       return;
@@ -413,10 +512,8 @@ async function runDeferredTurnMaintenanceWorker(
     });
     log.warn(`deferred context engine maintenance failed: ${reason}`);
   } finally {
-    if (longRunningTimer) {
-      clearTimeout(longRunningTimer);
-    }
-    shutdownAbort.dispose();
+    params.abortSignal.removeEventListener("abort", stopLongRunningProgress);
+    stopLongRunningProgress();
     if (params.disposeContextEngineAfterMaintenance) {
       await disposeDeferredMaintenanceContextEngine(params.contextEngine);
     }
@@ -446,7 +543,7 @@ function scheduleDeferredTurnMaintenance(
     ) {
       void disposeDeferredMaintenanceContextEngine(supersededParams.contextEngine);
     }
-    return activeRun.promise;
+    return activeRun.barrier;
   }
 
   const existingTask = findActiveSessionTask({
@@ -502,10 +599,44 @@ function scheduleDeferredTurnMaintenance(
     });
   };
   const schedulerAbort = createDeferredTurnMaintenanceAbortSignal();
+  const writeFence = createDeferredMaintenanceWriteFence();
+  let foregroundPreempted = false;
+  let preemptionWriteDrain: Promise<void> | undefined;
+  let releaseBarrier = () => {};
+  const barrier = new Promise<void>((resolve) => {
+    releaseBarrier = resolve;
+  });
+  const terminalizePreemption = (error: Error, terminalSummary: string) => {
+    buildTurnMaintenanceTaskDescriptor({
+      sessionKey,
+      runId: task.runId,
+      notifyPolicy: "state_changes",
+      deliveryStatus: "pending",
+    });
+    const endedAt = Date.now();
+    failTaskRunByRunId({
+      runId: task.runId!,
+      runtime: "acp",
+      sessionKey,
+      status: "timed_out",
+      endedAt,
+      lastEventAt: endedAt,
+      error: error.message,
+      progressSummary: "Deferred maintenance did not yield to a waiting turn.",
+      terminalSummary,
+    });
+  };
   let runPromise: Promise<void>;
   try {
     runPromise = enqueueCommandInLane(lane, () =>
-      runDeferredTurnMaintenanceWorker({ ...params, sessionKey, runId: task.runId! }),
+      runDeferredTurnMaintenanceWorker({
+        ...params,
+        sessionKey,
+        runId: task.runId!,
+        abortSignal: schedulerAbort.abortSignal,
+        writeFence,
+        wasForegroundPreempted: () => foregroundPreempted,
+      }),
     );
   } catch (err) {
     schedulerAbort.dispose();
@@ -513,10 +644,22 @@ function scheduleDeferredTurnMaintenance(
     return undefined;
   }
   const cleanupDeferredTurnMaintenance = async () => {
-    schedulerAbort.dispose();
-    const current = activeDeferredTurnMaintenanceRuns.get(sessionKey);
+    let current = activeDeferredTurnMaintenanceRuns.get(sessionKey);
     if (current !== state) {
       return;
+    }
+    if (preemptionWriteDrain) {
+      await preemptionWriteDrain;
+      current = activeDeferredTurnMaintenanceRuns.get(sessionKey);
+      if (current !== state) {
+        return;
+      }
+    }
+    schedulerAbort.dispose();
+    current.phase = "settled";
+    if (current.preemptionTimer) {
+      clearTimeout(current.preemptionTimer);
+      current.preemptionTimer = undefined;
     }
     const shutdownTriggered = schedulerAbort.abortSignal.aborted;
     const rerunParams =
@@ -529,6 +672,7 @@ function scheduleDeferredTurnMaintenance(
     } else if (discardedRerunParams?.disposeContextEngineAfterMaintenance) {
       await disposeDeferredMaintenanceContextEngine(discardedRerunParams.contextEngine);
     }
+    current.releaseBarrier();
   };
   const trackedPromise = runPromise
     .catch((err: unknown) => {
@@ -540,13 +684,67 @@ function scheduleDeferredTurnMaintenance(
       throw error;
     });
   const state: DeferredTurnMaintenanceRunState = {
-    promise: trackedPromise,
+    phase: "running",
+    barrier,
+    releaseBarrier,
+    requestForegroundPreemption: () => {
+      if (state.phase !== "running") {
+        return;
+      }
+      state.phase = "preempting";
+      foregroundPreempted = true;
+      const preemptionError = new Error(
+        "Deferred context-engine maintenance did not yield to a waiting foreground turn.",
+      );
+      schedulerAbort.abort(preemptionError);
+      const writeDrain = writeFence.close(preemptionError);
+      preemptionWriteDrain = writeDrain;
+      state.preemptionTimer = setTimeout(() => {
+        state.preemptionTimer = undefined;
+        if (
+          state.phase !== "preempting" ||
+          activeDeferredTurnMaintenanceRuns.get(sessionKey) !== state
+        ) {
+          return;
+        }
+        const quarantined = quarantineResolvedContextEngine({
+          contextEngine: params.contextEngine,
+          operation: "maintain",
+          error: preemptionError,
+        });
+        if (!quarantined) {
+          state.phase = "blocked";
+          state.waitError = new Error(
+            "Deferred maintenance did not stop. The active context engine cannot be quarantined, so this turn was stopped to avoid overlapping engine operations. Retry after maintenance finishes or restart the gateway.",
+          );
+          terminalizePreemption(preemptionError, state.waitError.message);
+          state.releaseBarrier();
+          return;
+        }
+        terminalizePreemption(
+          preemptionError,
+          "Deferred maintenance timed out. The context engine is being quarantined; this session will continue with the default fallback after admitted transcript writes finish.",
+        );
+        void writeDrain.then(() => {
+          if (
+            state.phase !== "preempting" ||
+            activeDeferredTurnMaintenanceRuns.get(sessionKey) !== state
+          ) {
+            return;
+          }
+          state.phase = "quarantined";
+          schedulerAbort.dispose();
+          state.releaseBarrier();
+        });
+      }, TURN_MAINTENANCE_PREEMPT_GRACE_MS);
+      state.preemptionTimer.unref?.();
+    },
     rerunRequested: false,
     latestParams: { ...params, sessionKey },
   };
   activeDeferredTurnMaintenanceRuns.set(sessionKey, state);
   void trackedPromise;
-  return trackedPromise;
+  return barrier;
 }
 
 /**
@@ -589,6 +787,10 @@ export async function runContextEngineMaintenance(
       log.warn(`failed to schedule deferred context engine maintenance: ${String(err)}`);
     }
     return undefined;
+  }
+
+  if (executionMode !== "background") {
+    await waitForDeferredTurnMaintenanceForSession(params.sessionKey ?? params.sessionId);
   }
 
   try {

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -257,8 +257,8 @@ class DeferredTurnMaintenanceRun {
 
   private async runForegroundPreemption(): Promise<void> {
     const preemptionError = new DeferredTurnMaintenancePreemptedError();
-    this.schedulerAbort.abort(preemptionError);
     this.writeDrain = this.writeFence.close(preemptionError);
+    this.schedulerAbort.abort(preemptionError);
     if (await this.settlesWithinPreemptionGrace()) {
       return;
     }

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -41,6 +41,12 @@ import { findActiveSessionTask } from "../session-async-task-status.js";
 import { SessionManager } from "../sessions/index.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
 import {
+  createDeferredTurnMaintenanceAbortSignal,
+  DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY,
+  type DeferredTurnMaintenanceProcessLike,
+  unregisterDeferredTurnMaintenanceAbortSignalHandlers,
+} from "./context-engine-maintenance-abort-signal.js";
+import {
   createDeferredMaintenanceWriteFence,
   type DeferredMaintenanceWriteFence,
 } from "./context-engine-maintenance-fence.js";
@@ -54,9 +60,6 @@ const TURN_MAINTENANCE_LONG_WAIT_MS = 10_000;
 // A waiting user turn should only pay for cooperative abort cleanup, not the
 // background maintenance operation's otherwise unbounded runtime.
 const TURN_MAINTENANCE_PREEMPT_GRACE_MS = 1_000;
-const DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY = Symbol.for(
-  "openclaw.contextEngineTurnMaintenanceAbortState",
-);
 type SessionManagerRewriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
 
 type ContextEngineMaintenanceParams = {
@@ -88,26 +91,6 @@ type DeferredTurnMaintenanceScheduleParams = ContextEngineMaintenanceParams & {
 
 const activeDeferredTurnMaintenanceRuns = new Map<string, DeferredTurnMaintenanceRun>();
 
-type DeferredTurnMaintenanceSignal = "SIGINT" | "SIGTERM";
-type DeferredTurnMaintenanceProcessLike = Pick<NodeJS.Process, "on" | "off"> &
-  Partial<Pick<NodeJS.Process, "listenerCount" | "kill" | "pid">> & {
-    [DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY]?: DeferredTurnMaintenanceAbortState;
-  };
-type DeferredTurnMaintenanceAbortState = {
-  controllers: Set<AbortController>;
-  cleanupHandlers: Map<DeferredTurnMaintenanceSignal, () => void>;
-};
-
-function unregisterDeferredTurnMaintenanceAbortSignalHandlers(
-  processLike: DeferredTurnMaintenanceProcessLike,
-  state: DeferredTurnMaintenanceAbortState,
-): void {
-  for (const [signal, handler] of state.cleanupHandlers) {
-    processLike.off(signal, handler);
-  }
-  state.cleanupHandlers.clear();
-}
-
 async function disposeDeferredMaintenanceContextEngine(
   contextEngine: ContextEngine,
 ): Promise<void> {
@@ -118,63 +101,6 @@ async function disposeDeferredMaintenanceContextEngine(
       errorMessage: formatErrorMessage(err),
     });
   }
-}
-
-function createDeferredTurnMaintenanceAbortSignal(params?: {
-  processLike?: DeferredTurnMaintenanceProcessLike;
-}): {
-  abortSignal: AbortSignal;
-  abort: (reason: Error) => void;
-  dispose: () => void;
-} {
-  const processLike = (params?.processLike ?? process) as DeferredTurnMaintenanceProcessLike;
-  const state = (processLike[DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY] ??= {
-    controllers: new Set<AbortController>(),
-    cleanupHandlers: new Map<DeferredTurnMaintenanceSignal, () => void>(),
-  });
-  const handleTerminationSignal = (signalName: DeferredTurnMaintenanceSignal) => {
-    const shouldReraise = processLike.listenerCount?.(signalName) === 1;
-    for (const activeController of state.controllers) {
-      if (!activeController.signal.aborted) {
-        activeController.abort(
-          new Error(`received ${signalName} while waiting for deferred maintenance`),
-        );
-      }
-    }
-    state.controllers.clear();
-    unregisterDeferredTurnMaintenanceAbortSignalHandlers(processLike, state);
-    if (shouldReraise && typeof processLike.kill === "function") {
-      try {
-        processLike.kill(processLike.pid ?? process.pid, signalName);
-      } catch {
-        // Ignore shutdown-path failures.
-      }
-    }
-  };
-  if (state.cleanupHandlers.size === 0) {
-    for (const signal of ["SIGINT", "SIGTERM"] as const) {
-      const handler = () => handleTerminationSignal(signal);
-      state.cleanupHandlers.set(signal, handler);
-      processLike.on(signal, handler);
-    }
-  }
-
-  const controller = new AbortController();
-  state.controllers.add(controller);
-  return {
-    abortSignal: controller.signal,
-    abort: (reason) => {
-      if (!controller.signal.aborted) {
-        controller.abort(reason);
-      }
-    },
-    dispose: () => {
-      state.controllers.delete(controller);
-      if (state.controllers.size === 0) {
-        unregisterDeferredTurnMaintenanceAbortSignalHandlers(processLike, state);
-      }
-    },
-  };
 }
 
 function resetDeferredTurnMaintenanceStateForTest(): void {

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -23,6 +23,7 @@ import {
   GatewayDrainingError,
   isGatewayDraining,
 } from "../../process/command-queue.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import {
   completeTaskRunByRunId,
@@ -36,6 +37,7 @@ import {
   findTaskByRunIdForOwner,
   updateTaskNotifyPolicyForOwner,
 } from "../../tasks/task-owner-access.js";
+import { resolveSessionAgentId } from "../agent-scope.js";
 import { DeferredContextEngineMaintenanceBlockedError } from "../context-engine-maintenance-error.js";
 import { findActiveSessionTask } from "../session-async-task-status.js";
 import { SessionManager } from "../sessions/index.js";
@@ -164,6 +166,29 @@ function buildTurnMaintenanceTaskDescriptor(params: {
     deliveryStatus: params.deliveryStatus ?? "not_applicable",
     preferMetadata: true,
   });
+}
+
+/**
+ * Resolve the owner agent identity used when cancelling or superseding a
+ * deferred-maintenance task. The owner-scoped task APIs fail closed when they
+ * cannot resolve the caller's agent id, and a bare (non-agent-scoped) session
+ * key yields none on its own. Forwarding the config-resolved agent id keeps
+ * cleanup from silently no-op'ing and leaving the maintenance task non-terminal.
+ */
+function resolveDeferredMaintenanceOwnerAgentId(
+  sessionKey: string,
+  config?: OpenClawConfig,
+): string | undefined {
+  const parsedAgentId = parseAgentSessionKey(sessionKey)?.agentId;
+  if (parsedAgentId || !config) {
+    return parsedAgentId;
+  }
+  try {
+    return resolveSessionAgentId({ sessionKey, config });
+  } catch {
+    // Ambiguous rosters keep the pre-existing fail-closed behavior.
+    return undefined;
+  }
 }
 
 function makeTurnMaintenanceTaskVisible(params: {
@@ -355,6 +380,7 @@ class DeferredTurnMaintenanceRun {
     cancelTaskByIdForOwner({
       taskId: this.taskId,
       callerOwnerKey: this.sessionKey,
+      callerAgentId: resolveDeferredMaintenanceOwnerAgentId(this.sessionKey, this.params.config),
       endedAt: Date.now(),
       terminalSummary: `Deferred maintenance could not be scheduled: ${errorMessage}`,
     });
@@ -547,14 +573,20 @@ async function runDeferredTurnMaintenanceWorker(
     });
   } catch (err) {
     if (params.abortSignal.aborted) {
+      const callerAgentId = resolveDeferredMaintenanceOwnerAgentId(
+        params.sessionKey,
+        params.config,
+      );
       const task = findTaskByRunIdForOwner({
         runId: params.runId,
         callerOwnerKey: params.sessionKey,
+        callerAgentId,
       });
       if (task?.status === "queued" || task?.status === "running") {
         cancelTaskByIdForOwner({
           taskId: task.taskId,
           callerOwnerKey: params.sessionKey,
+          callerAgentId,
           endedAt: Date.now(),
           terminalSummary: isForegroundMaintenancePreemption(params.abortSignal)
             ? "Deferred maintenance yielded to a waiting foreground turn."
@@ -611,14 +643,17 @@ function scheduleDeferredTurnMaintenance(
   });
   const reusableTask = existingTask?.runId?.trim() ? existingTask : undefined;
   if (existingTask && !reusableTask) {
+    const callerAgentId = resolveDeferredMaintenanceOwnerAgentId(sessionKey, params.config);
     updateTaskNotifyPolicyForOwner({
       taskId: existingTask.taskId,
       callerOwnerKey: sessionKey,
+      callerAgentId,
       notifyPolicy: "silent",
     });
     cancelTaskByIdForOwner({
       taskId: existingTask.taskId,
       callerOwnerKey: sessionKey,
+      callerAgentId,
       endedAt: Date.now(),
       terminalSummary: "Superseded by refreshed deferred maintenance task.",
     });

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -23,7 +23,7 @@ import {
   GatewayDrainingError,
   isGatewayDraining,
 } from "../../process/command-queue.js";
-import { createDeferred } from "../../shared/deferred.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import {
   completeTaskRunByRunId,
   createQueuedTaskRun,
@@ -189,8 +189,8 @@ function isForegroundMaintenancePreemption(signal: AbortSignal): boolean {
 }
 
 class DeferredTurnMaintenanceRun {
-  private readonly completionDeferred = createDeferred();
-  private readonly physicalSettlement = createDeferred();
+  private readonly completionDeferred = createDeferredCore();
+  private readonly physicalSettlement = createDeferredCore();
   readonly completion = this.completionDeferred.promise;
   private readonly schedulerAbort = createDeferredTurnMaintenanceAbortSignal();
   private readonly writeFence = createDeferredMaintenanceWriteFence();
@@ -290,7 +290,7 @@ class DeferredTurnMaintenanceRun {
   }
 
   private async settlesWithinPreemptionGrace(): Promise<boolean> {
-    const timeout = createDeferred<boolean>();
+    const timeout = createDeferredCore<boolean>();
     this.preemptionTimer = setTimeout(() => {
       this.preemptionTimer = undefined;
       timeout.resolve(false);

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -88,6 +88,8 @@ type DeferredTurnMaintenanceRunState = {
   phase: "running" | "preempting" | "blocked" | "quarantined" | "settled";
   barrier: Promise<void>;
   releaseBarrier: () => void;
+  foregroundBarrier: Promise<void>;
+  releaseForegroundBarrier: () => void;
   waitError?: Error;
   preemptionTimer?: ReturnType<typeof setTimeout>;
   requestForegroundPreemption: () => void;
@@ -222,7 +224,7 @@ export async function waitForDeferredTurnMaintenanceForSession(sessionKey?: stri
     return;
   }
   activeRun.requestForegroundPreemption();
-  await activeRun.barrier;
+  await activeRun.foregroundBarrier;
   if (activeRun.waitError) {
     throw activeRun.waitError;
   }
@@ -572,6 +574,10 @@ function scheduleDeferredTurnMaintenance(
   const barrier = new Promise<void>((resolve) => {
     releaseBarrier = resolve;
   });
+  let releaseForegroundBarrier = () => {};
+  const foregroundBarrier = new Promise<void>((resolve) => {
+    releaseForegroundBarrier = resolve;
+  });
   const terminalizePreemption = (error: Error, terminalSummary: string) => {
     buildTurnMaintenanceTaskDescriptor({
       sessionKey,
@@ -639,6 +645,7 @@ function scheduleDeferredTurnMaintenance(
       await disposeDeferredMaintenanceContextEngine(discardedRerunParams.contextEngine);
     }
     current.releaseBarrier();
+    current.releaseForegroundBarrier();
   };
   const trackedPromise = runPromise
     .catch((err: unknown) => {
@@ -653,6 +660,8 @@ function scheduleDeferredTurnMaintenance(
     phase: "running",
     barrier,
     releaseBarrier,
+    foregroundBarrier,
+    releaseForegroundBarrier,
     requestForegroundPreemption: () => {
       if (state.phase !== "running") {
         return;
@@ -678,30 +687,16 @@ function scheduleDeferredTurnMaintenance(
           operation: "maintain",
           error: preemptionError,
         });
-        if (!quarantined) {
-          state.phase = "blocked";
-          state.waitError = new Error(
-            "Deferred maintenance did not stop. The active context engine cannot be quarantined, so this turn was stopped to avoid overlapping engine operations. Retry after maintenance finishes or restart the gateway.",
-          );
-          terminalizePreemption(preemptionError, state.waitError.message);
-          state.releaseBarrier();
-          return;
-        }
-        terminalizePreemption(
-          preemptionError,
-          "Deferred maintenance timed out. The context engine is being quarantined; this session will continue with the default fallback after admitted transcript writes finish.",
+        state.phase = quarantined ? "quarantined" : "blocked";
+        state.waitError = new Error(
+          quarantined
+            ? "Deferred maintenance did not stop. The context engine was quarantined, but this turn was stopped to avoid overlapping engine operations. Retry after maintenance finishes or restart the gateway."
+            : "Deferred maintenance did not stop. The active context engine cannot be quarantined, so this turn was stopped to avoid overlapping engine operations. Retry after maintenance finishes or restart the gateway.",
         );
-        void writeDrain.then(() => {
-          if (
-            state.phase !== "preempting" ||
-            activeDeferredTurnMaintenanceRuns.get(sessionKey) !== state
-          ) {
-            return;
-          }
-          state.phase = "quarantined";
-          schedulerAbort.dispose();
-          state.releaseBarrier();
-        });
+        terminalizePreemption(preemptionError, state.waitError.message);
+        // Fail the waiting turn, but keep the run barrier closed until the
+        // original plugin call and every admitted host write have settled.
+        state.releaseForegroundBarrier();
       }, TURN_MAINTENANCE_PREEMPT_GRACE_MS);
       state.preemptionTimer.unref?.();
     },

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -38,6 +38,10 @@ import {
 import { findActiveSessionTask } from "../session-async-task-status.js";
 import { SessionManager } from "../sessions/index.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
+import {
+  createDeferredMaintenanceWriteFence,
+  type DeferredMaintenanceWriteFence,
+} from "./context-engine-maintenance-fence.js";
 import { log } from "./logger.js";
 import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
 import { resolveRuntimeTranscriptReadTarget } from "./transcript-runtime-state.js";
@@ -52,10 +56,6 @@ const DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY = Symbol.for(
   "openclaw.contextEngineTurnMaintenanceAbortState",
 );
 type SessionManagerRewriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
-type DeferredMaintenanceWriteFence = {
-  run: <T>(operation: () => Promise<T>) => Promise<T>;
-  close: (reason: Error) => Promise<void>;
-};
 
 type ContextEngineMaintenanceParams = {
   contextEngine?: ContextEngine;
@@ -96,40 +96,6 @@ type DeferredTurnMaintenanceRunState = {
 };
 
 const activeDeferredTurnMaintenanceRuns = new Map<string, DeferredTurnMaintenanceRunState>();
-
-// Closing rejects late rewrites and drains already-admitted host transcript writes
-// before fallback maintenance or foreground reads can enter the session.
-function createDeferredMaintenanceWriteFence(): DeferredMaintenanceWriteFence {
-  let closedReason: Error | undefined;
-  let activeWrites = 0;
-  let resolveDrain: (() => void) | undefined;
-  let drain = Promise.resolve();
-  return {
-    run: async <T>(operation: () => Promise<T>) => {
-      if (closedReason) {
-        throw closedReason;
-      }
-      if (activeWrites++ === 0) {
-        drain = new Promise<void>((resolve) => {
-          resolveDrain = resolve;
-        });
-      }
-      try {
-        return await operation();
-      } finally {
-        activeWrites -= 1;
-        if (activeWrites === 0) {
-          resolveDrain?.();
-          resolveDrain = undefined;
-        }
-      }
-    },
-    close: async (reason) => {
-      closedReason ??= reason;
-      await drain;
-    },
-  };
-}
 
 type DeferredTurnMaintenanceSignal = "SIGINT" | "SIGTERM";
 type DeferredTurnMaintenanceProcessLike = Pick<NodeJS.Process, "on" | "off"> &

--- a/src/agents/harness/context-engine-logical-turn.ts
+++ b/src/agents/harness/context-engine-logical-turn.ts
@@ -94,9 +94,14 @@ export async function createContextEngineLogicalTurnLease(params: {
       return;
     }
     warned = true;
+    // Quarantine persists for the process; only transient per-turn degradation is retried next turn.
+    const isQuarantined = resolution.configuredQuarantined === true;
+    const persistence = isQuarantined
+      ? `"${sanitizeForLog(resolution.configuredId)}" is quarantined and stays disabled until restart or re-registration.`
+      : `"${sanitizeForLog(resolution.configuredId)}" will be retried next turn.`;
     (params.warn ?? console.warn)(
       `[context-engine] Context engine "${sanitizeForLog(resolution.configuredId)}" degraded to "${sanitizeForLog(resolution.fallback.registeredId)}" for this logical turn: ${sanitizeForLog(reason)}. ` +
-        `The "${sanitizeForLog(resolution.fallback.registeredId)}" engine will handle only this turn; configuration is unchanged, and "${sanitizeForLog(resolution.configuredId)}" will be retried next turn.`,
+        `The "${sanitizeForLog(resolution.fallback.registeredId)}" engine will handle only this turn; configuration is unchanged, and ${persistence}`,
     );
   };
 

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -5,6 +5,7 @@ import { resolveManifestActivationPlan } from "../../plugins/activation-planner.
 import {
   isTestDefaultMemorySlotDisabled,
   resolveEffectivePluginActivationState,
+  resolveSelectedContextEnginePluginIdFromConfig,
 } from "../../plugins/config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "../../plugins/default-enablement.js";
 import {
@@ -27,7 +28,6 @@ import {
   resolveBundledProviderCompatPluginIds,
   resolveOwningPluginIdsForProviderRef,
 } from "../../plugins/providers.js";
-import { defaultSlotIdForKey } from "../../plugins/slots.js";
 import {
   isDefaultAgentRuntimeId,
   OPENCLAW_AGENT_RUNTIME_ID,
@@ -228,17 +228,11 @@ function resolveSelectedContextEnginePluginIds(params: {
 }): string[] {
   const registry = loadPluginRegistrySnapshot(params);
   const plugins = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
-  const contextEngineSlot = plugins.slots.contextEngine;
-  if (
-    !plugins.enabled ||
-    typeof contextEngineSlot !== "string" ||
-    contextEngineSlot === defaultSlotIdForKey("contextEngine") ||
-    plugins.deny.includes(contextEngineSlot) ||
-    plugins.entries[contextEngineSlot]?.enabled === false
-  ) {
-    return [];
-  }
-  return [contextEngineSlot];
+  const pluginId = resolveSelectedContextEnginePluginIdFromConfig(
+    plugins,
+    plugins.slots.contextEngine,
+  );
+  return pluginId ? [pluginId] : [];
 }
 
 /** Resolve manifest owners required by one selected non-core harness runtime. */

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -232,7 +232,10 @@ function resolveSelectedContextEnginePluginIds(params: {
     plugins,
     plugins.slots.contextEngine,
   );
-  return pluginId ? [pluginId] : [];
+  if (!pluginId || restrictiveAllowlistOmitsPlugin(params.config, pluginId)) {
+    return [];
+  }
+  return [pluginId];
 }
 
 /** Resolve manifest owners required by one selected non-core harness runtime. */

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -5,7 +5,6 @@ import { resolveManifestActivationPlan } from "../../plugins/activation-planner.
 import {
   isTestDefaultMemorySlotDisabled,
   resolveEffectivePluginActivationState,
-  resolveSelectedContextEnginePluginId,
 } from "../../plugins/config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "../../plugins/default-enablement.js";
 import {
@@ -28,6 +27,7 @@ import {
   resolveBundledProviderCompatPluginIds,
   resolveOwningPluginIdsForProviderRef,
 } from "../../plugins/providers.js";
+import { defaultSlotIdForKey } from "../../plugins/slots.js";
 import {
   isDefaultAgentRuntimeId,
   OPENCLAW_AGENT_RUNTIME_ID,
@@ -222,6 +222,25 @@ function resolveSelectedProviderOwnerPluginIds(params: {
   return providerOwnerPluginIds.filter((pluginId) => safeProviderOwnerPluginIds.includes(pluginId));
 }
 
+function resolveSelectedContextEnginePluginIds(params: {
+  config: OpenClawConfig | undefined;
+  workspaceDir: string;
+}): string[] {
+  const registry = loadPluginRegistrySnapshot(params);
+  const plugins = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
+  const contextEngineSlot = plugins.slots.contextEngine;
+  if (
+    !plugins.enabled ||
+    typeof contextEngineSlot !== "string" ||
+    contextEngineSlot === defaultSlotIdForKey("contextEngine") ||
+    plugins.deny.includes(contextEngineSlot) ||
+    plugins.entries[contextEngineSlot]?.enabled === false
+  ) {
+    return [];
+  }
+  return [contextEngineSlot];
+}
+
 /** Resolve manifest owners required by one selected non-core harness runtime. */
 export function resolveAgentHarnessOwnerPluginIds(params: {
   runtime: string;
@@ -321,8 +340,10 @@ export function resolveAgentRuntimePluginLoadPlan(params: {
     workspaceDir: params.workspaceDir,
     metadataSnapshot: params.metadataSnapshot,
   });
-  const contextEnginePluginId = resolveSelectedContextEnginePluginId(params.config);
-  const contextEnginePluginIds = contextEnginePluginId ? [contextEnginePluginId] : [];
+  const contextEnginePluginIds = resolveSelectedContextEnginePluginIds({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  });
   const basePluginIds = (params.basePluginIds ?? []).filter(
     (pluginId) => !restrictiveAllowlistOmitsPlugin(params.config, pluginId),
   );

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -304,6 +304,23 @@ describe("harness runtime plugins", () => {
     },
   );
 
+  it("keeps the selected context-engine owner in the prepared runtime", () => {
+    const plan = resolveAgentRuntimePluginLoadPlan({
+      config: {
+        plugins: {
+          allow: ["unrelated-plugin"],
+          slots: { contextEngine: "custom-context-engine" },
+        },
+      },
+      workspaceDir: "/tmp/workspace",
+      selections: [],
+    });
+
+    expect(plan.pluginIds).toEqual(["custom-context-engine"]);
+    expect(plan.config?.plugins?.allow).toEqual(["unrelated-plugin", "custom-context-engine"]);
+    expect(plan.config?.plugins?.entries?.["custom-context-engine"]).toEqual({ enabled: true });
+  });
+
   it("keeps standalone activation unrestricted when no complete startup base exists", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({
       config: {

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -304,7 +304,7 @@ describe("harness runtime plugins", () => {
     },
   );
 
-  it("keeps the selected context-engine owner in the prepared runtime", () => {
+  it("drops a context-engine owner omitted by a restrictive allowlist", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({
       config: {
         plugins: {
@@ -316,8 +316,25 @@ describe("harness runtime plugins", () => {
       selections: [],
     });
 
-    expect(plan.pluginIds).toEqual(["custom-context-engine"]);
-    expect(plan.config?.plugins?.allow).toEqual(["unrelated-plugin", "custom-context-engine"]);
+    expect(plan.pluginIds ?? []).not.toContain("custom-context-engine");
+    expect(plan.config?.plugins?.allow).toEqual(["unrelated-plugin"]);
+    expect(plan.config?.plugins?.entries?.["custom-context-engine"]).toBeUndefined();
+  });
+
+  it("keeps a context-engine owner explicitly allowed by a restrictive allowlist", () => {
+    const plan = resolveAgentRuntimePluginLoadPlan({
+      config: {
+        plugins: {
+          allow: ["custom-context-engine"],
+          slots: { contextEngine: "custom-context-engine" },
+        },
+      },
+      workspaceDir: "/tmp/workspace",
+      selections: [],
+    });
+
+    expect(plan.pluginIds ?? []).toContain("custom-context-engine");
+    expect(plan.config?.plugins?.allow).toContain("custom-context-engine");
     expect(plan.config?.plugins?.entries?.["custom-context-engine"]).toEqual({ enabled: true });
   });
 

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -133,13 +133,13 @@ describe("agent runtime plugin registries", () => {
       metadataSnapshot,
     });
     expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith({
-      activate: false,
       config,
       activationSourceConfig: config,
       env,
       discovery: metadataSnapshot.discovery,
       installRecords: {},
       manifestRegistry: metadataSnapshot.manifestRegistry,
+      handleRegistrationMode: "runtime",
       workspaceDir: "/tmp/workspace",
       runtimeOptions: { allowGatewaySubagentBinding: true },
     });
@@ -153,9 +153,9 @@ describe("agent runtime plugin registries", () => {
     expect(loadAgentRuntimePluginRegistryHandle(params)).toEqual({ handle: true });
     expect(hoisted.resolveAgentRuntimePluginLoadPlan).not.toHaveBeenCalled();
     expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith({
-      activate: false,
       activationSourceConfig: params.config,
       config: params.config,
+      handleRegistrationMode: "runtime",
       onlyPluginIds: [],
       runtimeOptions: undefined,
       workspaceDir: "/tmp/workspace",
@@ -252,12 +252,12 @@ describe("agent runtime plugin registries", () => {
       metadataSnapshot: snapshot,
     });
     expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith({
-      activate: false,
       activationSourceConfig: config,
       channelPluginLoadIntent: "full",
       config,
       discovery: snapshot.discovery,
       env,
+      handleRegistrationMode: "runtime",
       installRecords: {},
       manifestRegistry: snapshot.manifestRegistry,
       onlyPluginIds: ["codex", "memory-core"],

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -104,9 +104,15 @@ export function loadAgentRuntimePluginRegistryHandle(
   params: AgentRuntimePluginRegistryParams,
 ): PluginRegistry {
   const load = resolveAgentRuntimePluginRegistryLoad(params);
-  // Discovery-only load: full mode can replace process-global sandbox backends.
-  // Adopt full-only runtime capabilities from the matching composition-root owners.
-  const pluginRegistry = loadPluginRegistryHandle({ ...load.loadOptions, activate: false });
+  // Register full runtime capabilities into this caller-owned handle without
+  // globally activating it: loadPluginRegistryHandle already forces activate:false,
+  // so runtime mode gives runtime-capable engines usable from the handle while
+  // skipping the full-activation-only side effects that replace process-global
+  // sandbox backends. Composition-root registrations are then adopted below.
+  const pluginRegistry = loadPluginRegistryHandle({
+    ...load.loadOptions,
+    handleRegistrationMode: "runtime",
+  });
   const activeRegistry = getActivePluginRegistry();
   if (!activeRegistry) {
     return pluginRegistry;

--- a/src/auto-reply/reply/agent-runner-failure-reply.test.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.test.ts
@@ -1,12 +1,23 @@
 import { describe, expect, it } from "vitest";
+import { DeferredContextEngineMaintenanceBlockedError } from "../../agents/context-engine-maintenance-error.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import {
   buildEmptyInteractiveReplyPayload,
+  buildExternalRunFailureReply,
   buildPreflightCompactionFailureText,
 } from "./agent-runner-failure-reply.js";
 
 const EMPTY_INTERACTIVE_REPLY_TEXT =
   "I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.";
+
+it("preserves deferred maintenance recovery guidance without verbose errors", () => {
+  const error = new DeferredContextEngineMaintenanceBlockedError({ quarantined: true });
+
+  expect(buildExternalRunFailureReply({ message: error.message, error })).toEqual({
+    text: error.userMessage,
+    isGenericRunnerFailure: false,
+  });
+});
 
 describe("buildEmptyInteractiveReplyPayload", () => {
   const baseParams = {

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -6,6 +6,7 @@ import {
   classifyOAuthRefreshFailureError,
   formatOAuthRefreshFailureLoginCommandMarkdown,
 } from "../../agents/auth-profiles/oauth-refresh-failure.js";
+import { resolveDeferredContextEngineMaintenanceBlockedMessage } from "../../agents/context-engine-maintenance-error.js";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
 import { renderUserFacingText } from "../../agents/embedded-agent-helpers/user-facing-text.js";
 import { classifyCompactionReason } from "../../agents/embedded-agent-runner/compact-reasons.js";
@@ -216,6 +217,11 @@ export function buildExternalRunFailureReply(
   const message = typeof input === "string" ? input : input.message;
   const error = typeof input === "string" ? undefined : input.error;
   const normalizedMessage = collapseRepeatedFailureDetail(message);
+  const deferredMaintenanceBlockedMessage =
+    resolveDeferredContextEngineMaintenanceBlockedMessage(error);
+  if (deferredMaintenanceBlockedMessage) {
+    return { text: deferredMaintenanceBlockedMessage, isGenericRunnerFailure: false };
+  }
   const failoverFacts =
     options?.failoverFacts ??
     resolveReplyFailoverFacts(error ?? normalizedMessage, normalizedMessage);

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -24,6 +24,7 @@ import {
   setActivePluginRegistry,
   withPluginRegistrationContext,
 } from "../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { UserTurnTranscriptAdmissionReceipt } from "../sessions/user-turn-transcript.types.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 // ---------------------------------------------------------------------------
@@ -39,9 +40,9 @@ import { LegacyContextEngine } from "./legacy.js";
 import { registerLegacyContextEngine } from "./legacy.registration.js";
 import {
   activateContextEngineRegistrations,
+  adoptRuntimeContextEngineRegistrations,
   getContextEngineRegistration,
   listContextEngineQuarantines,
-  promoteMatchingRuntimeContextEngineRegistrations,
   registerContextEngineForOwner,
   registerContextEngineInRegistry,
   resolveContextEngine,
@@ -1319,7 +1320,7 @@ describe("Read-only plugin discovery registrations", () => {
 
     // The active gateway registry is loaded in full mode and owns the runtime-safe factory.
     const activeRuntimeRegistry = createEmptyPluginRegistry();
-    activeRuntimeRegistry.plugins.push({ id: pluginId, source } as PluginRecord);
+    activeRuntimeRegistry.plugins.push({ id: pluginId, source, status: "loaded" } as PluginRecord);
     registerContextEngineInRegistry(
       activeRuntimeRegistry,
       engineId,
@@ -1346,7 +1347,7 @@ describe("Read-only plugin discovery registrations", () => {
     // read-only. Its discovery-mode factory is construction-unsafe: promotion must replace it
     // before any resolve constructs it.
     const preparedHandle = requireActivePluginRegistry();
-    preparedHandle.plugins.push({ id: pluginId, source } as PluginRecord);
+    preparedHandle.plugins.push({ id: pluginId, source, status: "loaded" } as PluginRecord);
     registerContextEngineInRegistry(
       preparedHandle,
       engineId,
@@ -1358,11 +1359,25 @@ describe("Read-only plugin discovery registrations", () => {
       { allowSameOwnerRefresh: true, lifecycle: "readOnlyDiscovery" },
     );
 
-    promoteMatchingRuntimeContextEngineRegistrations(preparedHandle, activeRuntimeRegistry);
+    const adoptedHandle = adoptRuntimeContextEngineRegistrations(
+      preparedHandle,
+      activeRuntimeRegistry,
+    );
 
-    const engine = await resolveContextEngine(configWithSlot(engineId));
+    // Copy-on-write: adoption returns a fresh clone and leaves the prepared discovery
+    // handle untouched, so the construction-unsafe factory stays confined to the discovery
+    // snapshot while the runtime-safe factory is reachable only through the clone.
+    expect(adoptedHandle).not.toBe(preparedHandle);
+    expect(preparedHandle.contextEngines.get(engineId)?.lifecycle).toBe("readOnlyDiscovery");
+    expect(adoptedHandle.contextEngines.get(engineId)?.lifecycle).toBe("runtime");
 
-    // Promotion carried the runtime-safe factory in, so resolve constructs the right engine...
+    // Resolve reads the active/scoped registry, so bind the adopted clone the way agent
+    // runtime plugins do before resolving.
+    const engine = await withPluginRuntimeRegistryScope(adoptedHandle, () =>
+      resolveContextEngine(configWithSlot(engineId)),
+    );
+
+    // Adoption carried the runtime-safe factory in, so resolve constructs the right engine...
     expect(engine.info.id).toBe("lossless-claw");
     expect(runtimeSafeCalls).toBeGreaterThanOrEqual(1);
     // ...and never touches the construction-unsafe discovery factory or records a quarantine.

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -18,6 +18,7 @@ import {
   registerTestMemoryPromptBuilder,
 } from "../plugins/memory-state.test-fixtures.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { PluginRecord } from "../plugins/registry-types.js";
 import {
   requireActivePluginRegistry,
   setActivePluginRegistry,
@@ -40,6 +41,7 @@ import {
   activateContextEngineRegistrations,
   getContextEngineRegistration,
   listContextEngineQuarantines,
+  promoteMatchingRuntimeContextEngineRegistrations,
   registerContextEngineForOwner,
   registerContextEngineInRegistry,
   resolveContextEngine,
@@ -1305,6 +1307,67 @@ describe("Read-only plugin discovery registrations", () => {
     expect(stillRuntimeEngine.info.id).toBe("lossless-claw");
     expect(readOnlyFactoryCalls).toBe(0);
     expect(runtimeFactoryCalls).toBe(2);
+  });
+
+  it("resolves a promoted runtime factory without constructing the private discovery factory", async () => {
+    const engineId = uniqueEngineId("promoted-engine");
+    const pluginId = "promoted-claw";
+    const owner = `plugin:${pluginId}`;
+    const source = "npm:promoted-claw@1.0.0";
+    let runtimeSafeCalls = 0;
+    let throwingDiscoveryCalls = 0;
+
+    // The active gateway registry is loaded in full mode and owns the runtime-safe factory.
+    const activeRuntimeRegistry = createEmptyPluginRegistry();
+    activeRuntimeRegistry.plugins.push({ id: pluginId, source } as PluginRecord);
+    registerContextEngineInRegistry(
+      activeRuntimeRegistry,
+      engineId,
+      () => {
+        runtimeSafeCalls += 1;
+        return {
+          info: { id: "lossless-claw", name: "Lossless Claw" },
+          async ingest() {
+            return { ingested: true };
+          },
+          async assemble({ messages }: { messages: AgentMessage[] }) {
+            return { messages, estimatedTokens: 0 };
+          },
+          async compact() {
+            return { ok: true, compacted: false };
+          },
+        } satisfies ContextEngine;
+      },
+      owner,
+      { allowSameOwnerRefresh: true, lifecycle: "runtime" },
+    );
+
+    // The private prepared-runtime handle (what resolve reads) registers the same engine
+    // read-only. Its discovery-mode factory is construction-unsafe: promotion must replace it
+    // before any resolve constructs it.
+    const preparedHandle = requireActivePluginRegistry();
+    preparedHandle.plugins.push({ id: pluginId, source } as PluginRecord);
+    registerContextEngineInRegistry(
+      preparedHandle,
+      engineId,
+      () => {
+        throwingDiscoveryCalls += 1;
+        throw new Error("private discovery-mode factory must never be constructed");
+      },
+      owner,
+      { allowSameOwnerRefresh: true, lifecycle: "readOnlyDiscovery" },
+    );
+
+    promoteMatchingRuntimeContextEngineRegistrations(preparedHandle, activeRuntimeRegistry);
+
+    const engine = await resolveContextEngine(configWithSlot(engineId));
+
+    // Promotion carried the runtime-safe factory in, so resolve constructs the right engine...
+    expect(engine.info.id).toBe("lossless-claw");
+    expect(runtimeSafeCalls).toBeGreaterThanOrEqual(1);
+    // ...and never touches the construction-unsafe discovery factory or records a quarantine.
+    expect(throwingDiscoveryCalls).toBe(0);
+    expect(listContextEngineQuarantines().some((entry) => entry.engineId === engineId)).toBe(false);
   });
 });
 

--- a/src/context-engine/host-param-projection.test.ts
+++ b/src/context-engine/host-param-projection.test.ts
@@ -3,6 +3,7 @@ import type { AgentMessage } from "../agents/runtime/index.js";
 import { registerLegacyContextEngine } from "./legacy.registration.js";
 import {
   listContextEngineQuarantines,
+  quarantineResolvedContextEngine,
   registerContextEngineForOwner,
   resolveContextEngine,
   resolveLogicalTurnContextEngines,
@@ -23,13 +24,17 @@ function registerProbeEngine(params: {
   compactCalls: Array<Record<string, unknown>>;
   commitTurnCalls?: Array<Record<string, unknown>>;
   maintainCalls?: Array<Record<string, unknown>>;
+  factoryCalls?: unknown[];
   rejectAssemble?: boolean;
 }): string {
   const engineId = `host-param-probe-${++engineCounter}`;
   registerContextEngineForOwner(
     engineId,
-    () =>
-      ({
+    () => {
+      // Record each factory invocation so tests can prove a quarantined slot is
+      // served from the fallback without re-running the wedged custom factory.
+      params.factoryCalls?.push(engineId);
+      return {
         info: {
           id: engineId,
           name: "Host Param Probe",
@@ -57,7 +62,8 @@ function registerProbeEngine(params: {
           params.maintainCalls?.push({ ...callParams });
           return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
         },
-      }) satisfies ContextEngine,
+      } satisfies ContextEngine;
+    },
     `test:${engineId}`,
   );
   return engineId;
@@ -344,5 +350,53 @@ describe("context-engine host parameter projection", () => {
       { sessionId: "session-1", messages: [message] },
       { sessionId: "session-2", messages: [message] },
     ]);
+  });
+
+  it("quarantines a logical-turn engine and honors it on the next turn", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const factoryCalls: unknown[] = [];
+    const engineId = registerProbeEngine({ assembleCalls: [], compactCalls: [], factoryCalls });
+
+    const first = await resolveLogicalTurnContextEngines({
+      plugins: { slots: { contextEngine: engineId } },
+    });
+    // Gap A: logical-turn refs carry defaultEngineId, so a wedged maintenance run can quarantine.
+    expect(first.configuredFailure).toBeUndefined();
+    expect(first.configured.registeredId).toBe(engineId);
+    expect(factoryCalls).toHaveLength(1);
+    const recorded = quarantineResolvedContextEngine({
+      contextEngine: first.configured.engine,
+      operation: "maintain",
+      error: new Error("deferred maintenance timed out"),
+    });
+    expect(recorded).toBe(true);
+
+    // Gap B: the quarantined engine is skipped for the fallback until restart, not re-resolved.
+    const second = await resolveLogicalTurnContextEngines({
+      plugins: { slots: { contextEngine: engineId } },
+    });
+    expect(second.configured.registeredId).toBe(second.fallback.registeredId);
+    expect(second.configuredFailure).toContain("is quarantined");
+    expect(second.configuredFailure).toContain("deferred maintenance timed out");
+    // The wedged custom factory must not run again while quarantined; the fallback serves the turn.
+    expect(factoryCalls).toHaveLength(1);
+    await Promise.allSettled([
+      first.configured.engine.dispose?.(),
+      first.fallback.engine.dispose?.(),
+      second.fallback.engine.dispose?.(),
+    ]);
+  });
+
+  it("never quarantines the default logical-turn engine", async () => {
+    const resolution = await resolveLogicalTurnContextEngines();
+    // The fallback/default ref must not carry self-quarantine metadata.
+    const recorded = quarantineResolvedContextEngine({
+      contextEngine: resolution.fallback.engine,
+      operation: "maintain",
+      error: new Error("default engine wedged"),
+    });
+    expect(recorded).toBe(false);
+    expect(listContextEngineQuarantines()).toEqual([]);
+    await resolution.fallback.engine.dispose?.();
   });
 });

--- a/src/context-engine/host-param-projection.test.ts
+++ b/src/context-engine/host-param-projection.test.ts
@@ -22,6 +22,7 @@ function registerProbeEngine(params: {
   assembleCalls: Array<Record<string, unknown>>;
   compactCalls: Array<Record<string, unknown>>;
   commitTurnCalls?: Array<Record<string, unknown>>;
+  maintainCalls?: Array<Record<string, unknown>>;
   rejectAssemble?: boolean;
 }): string {
   const engineId = `host-param-probe-${++engineCounter}`;
@@ -52,6 +53,10 @@ function registerProbeEngine(params: {
           params.commitTurnCalls?.push({ ...callParams });
           return { status: "committed" };
         },
+        async maintain(callParams) {
+          params.maintainCalls?.push({ ...callParams });
+          return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+        },
       }) satisfies ContextEngine,
     `test:${engineId}`,
   );
@@ -59,6 +64,7 @@ function registerProbeEngine(params: {
 }
 
 async function invokeHostParamMethods(engine: ContextEngine) {
+  const abortController = new AbortController();
   await engine.assemble({
     sessionId: "session-1",
     sessionKey: "agent:main:session-1",
@@ -72,6 +78,11 @@ async function invokeHostParamMethods(engine: ContextEngine) {
     sessionTarget: { agentId: "main", sessionId: "session-1" },
     runtimeSettings,
     runtimeContext: { tokenBudget: 1000 },
+  });
+  await engine.maintain?.({
+    sessionId: "session-1",
+    sessionFile: "/tmp/session-1.jsonl",
+    abortSignal: abortController.signal,
   });
 }
 
@@ -99,6 +110,7 @@ describe("context-engine host parameter projection", () => {
   it("passes declared current host parameters", async () => {
     const assembleCalls: Array<Record<string, unknown>> = [];
     const compactCalls: Array<Record<string, unknown>> = [];
+    const maintainCalls: Array<Record<string, unknown>> = [];
     const engineId = registerProbeEngine({
       acceptedHostParams: [
         "sessionKey",
@@ -106,9 +118,11 @@ describe("context-engine host parameter projection", () => {
         "runtimeSettings",
         "sessionTarget",
         "runtimeContext",
+        "abortSignal",
       ],
       assembleCalls,
       compactCalls,
+      maintainCalls,
     });
 
     await invokeHostParamMethods(
@@ -126,6 +140,7 @@ describe("context-engine host parameter projection", () => {
       runtimeSettings,
       runtimeContext: { tokenBudget: 1000 },
     });
+    expect(maintainCalls[0]?.abortSignal).toBeInstanceOf(AbortSignal);
   });
 
   it("projects host parameters on fresh logical-turn engines", async () => {
@@ -245,7 +260,8 @@ describe("context-engine host parameter projection", () => {
   it("passes every host parameter to resolved undeclared engines", async () => {
     const assembleCalls: Array<Record<string, unknown>> = [];
     const compactCalls: Array<Record<string, unknown>> = [];
-    const engineId = registerProbeEngine({ assembleCalls, compactCalls });
+    const maintainCalls: Array<Record<string, unknown>> = [];
+    const engineId = registerProbeEngine({ assembleCalls, compactCalls, maintainCalls });
     const engine = await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
 
     await invokeHostParamMethods(engine);
@@ -263,6 +279,7 @@ describe("context-engine host parameter projection", () => {
       runtimeSettings,
       runtimeContext: { tokenBudget: 1000 },
     });
+    expect(maintainCalls[0]?.abortSignal).toBeInstanceOf(AbortSignal);
   });
 
   it("does not retry validator-shaped engine failures", async () => {

--- a/src/context-engine/quarantine-state.ts
+++ b/src/context-engine/quarantine-state.ts
@@ -11,7 +11,7 @@ import {
 
 const CONTEXT_ENGINE_REGISTRY_STATE = Symbol.for("openclaw.contextEngineRegistryState");
 
-export type ContextEngineRuntimeQuarantine = {
+type ContextEngineRuntimeQuarantine = {
   engineId: string;
   owner?: string;
   operation: string;

--- a/src/context-engine/quarantine-state.ts
+++ b/src/context-engine/quarantine-state.ts
@@ -1,0 +1,89 @@
+// Process-global runtime quarantine state for context engines: when a resolved
+// custom engine fails a guarded operation it is recorded here and skipped for the
+// rest of the process, with a best-effort persisted mirror for diagnostics.
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import {
+  clearPersistedContextEngineQuarantineForProcess,
+  listPersistedContextEngineQuarantines,
+  recordPersistedContextEngineQuarantine,
+} from "./quarantine-health.js";
+
+const CONTEXT_ENGINE_REGISTRY_STATE = Symbol.for("openclaw.contextEngineRegistryState");
+
+export type ContextEngineRuntimeQuarantine = {
+  engineId: string;
+  owner?: string;
+  operation: string;
+  reason: string;
+  failedAt: Date;
+};
+
+type ContextEngineRegistryState = {
+  quarantinedEngines: Map<string, ContextEngineRuntimeQuarantine>;
+};
+
+// Keep context-engine registrations process-global so duplicated dist chunks
+// still share one registry map at runtime.
+const contextEngineRegistryState = resolveGlobalSingleton<ContextEngineRegistryState>(
+  CONTEXT_ENGINE_REGISTRY_STATE,
+  () => ({
+    quarantinedEngines: new Map(),
+  }),
+);
+
+export function recordContextEngineQuarantine(params: {
+  engineId: string;
+  owner?: string;
+  operation: string;
+  error: unknown;
+  defaultEngineId: string;
+}): ContextEngineRuntimeQuarantine {
+  const existing = contextEngineRegistryState.quarantinedEngines.get(params.engineId);
+  if (existing) {
+    // First failure wins so logs and diagnostics point at the root cause, not follow-on fallback use.
+    return existing;
+  }
+
+  const quarantine: ContextEngineRuntimeQuarantine = {
+    engineId: params.engineId,
+    operation: params.operation,
+    reason: params.error instanceof Error ? params.error.message : String(params.error),
+    failedAt: new Date(),
+    ...(params.owner ? { owner: params.owner } : {}),
+  };
+  contextEngineRegistryState.quarantinedEngines.set(params.engineId, quarantine);
+  try {
+    recordPersistedContextEngineQuarantine(quarantine);
+  } catch {
+    // Quarantine behavior must not depend on the best-effort health mirror.
+  }
+  const ownerSuffix = params.owner ? ` owner=${sanitizeForLog(params.owner)}` : "";
+  console.error(
+    `[context-engine] Context engine "${sanitizeForLog(params.engineId)}"${ownerSuffix} failed during ${sanitizeForLog(params.operation)}: ` +
+      `${sanitizeForLog(quarantine.reason)}; quarantining it for this process and falling back to default engine "${params.defaultEngineId}".`,
+  );
+  return quarantine;
+}
+
+export function getContextEngineQuarantine(
+  engineId: string,
+): ContextEngineRuntimeQuarantine | undefined {
+  return contextEngineRegistryState.quarantinedEngines.get(engineId);
+}
+
+export function listContextEngineQuarantines(): ContextEngineRuntimeQuarantine[] {
+  const quarantines = Array.from(
+    contextEngineRegistryState.quarantinedEngines.values(),
+    ({ failedAt, ...quarantine }) => ({ ...quarantine, failedAt: new Date(failedAt) }),
+  );
+  const seenEngineIds = new Set(quarantines.map((entry) => entry.engineId));
+  return quarantines.concat(
+    listPersistedContextEngineQuarantines().filter(({ engineId }) => !seenEngineIds.has(engineId)),
+  );
+}
+
+export function clearContextEngineRuntimeQuarantine(engineId: string): void {
+  contextEngineRegistryState.quarantinedEngines.delete(engineId);
+  clearPersistedContextEngineQuarantineForProcess(engineId, process.pid);
+}

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -46,11 +46,12 @@ const GUARDED_CONTEXT_ENGINE_METHODS = new Set<PropertyKey>(
   ),
 );
 export const CONTEXT_ENGINE_HOST_PARAMS = new Set(
-  "sessionKey prompt runtimeSettings sessionTarget runtimeContext".split(" "),
+  "sessionKey prompt runtimeSettings sessionTarget runtimeContext abortSignal".split(" "),
 );
 type ResolvedContextEngineMetadata = {
   owner: string;
   engineId: string;
+  defaultEngineId?: string;
 };
 
 const resolvedEngineMetadata = new WeakMap<ContextEngine, ResolvedContextEngineMetadata>();
@@ -471,6 +472,26 @@ function pluginIdFromContextEngineOwner(owner: string): string | undefined {
     return undefined;
   }
   return owner.slice("plugin:".length).trim() || undefined;
+}
+
+/** Quarantine a resolved custom engine after a host-owned lifecycle failure. */
+export function quarantineResolvedContextEngine(params: {
+  contextEngine: ContextEngine;
+  operation: "maintain";
+  error: unknown;
+}): boolean {
+  const metadata = resolvedEngineMetadata.get(params.contextEngine);
+  if (!metadata?.defaultEngineId) {
+    return false;
+  }
+  recordContextEngineQuarantine({
+    engineId: metadata.engineId,
+    owner: metadata.owner,
+    operation: params.operation,
+    error: params.error,
+    defaultEngineId: metadata.defaultEngineId,
+  });
+  return true;
 }
 
 function describeResolvedContextEngineContractError(

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -1,5 +1,4 @@
 // Context-engine registry owns engine registration, resolution, compatibility, and quarantine.
-import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { createAbortError } from "../infra/abort-signal.js";
 import type {
@@ -11,12 +10,11 @@ import type {
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import { getActivePluginRegistry, requireActivePluginRegistry } from "../plugins/runtime.js";
 import { defaultSlotIdForKey } from "../plugins/slots.js";
-import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
-  clearPersistedContextEngineQuarantineForProcess,
-  listPersistedContextEngineQuarantines,
-  recordPersistedContextEngineQuarantine,
-} from "./quarantine-health.js";
+  clearContextEngineRuntimeQuarantine,
+  getContextEngineQuarantine,
+  recordContextEngineQuarantine,
+} from "./quarantine-state.js";
 import type {
   BootstrapResult,
   ContextEngine,
@@ -26,6 +24,7 @@ import type {
 } from "./types.js";
 
 export type { ContextEngineFactory } from "../plugins/registry-contribution-types.js";
+export { listContextEngineQuarantines } from "./quarantine-state.js";
 
 /**
  * Runtime context passed to context engine factories during resolution.
@@ -207,29 +206,7 @@ function wrapResolvedContextEngine(
 // Registry (module-level singleton)
 // ---------------------------------------------------------------------------
 
-const CONTEXT_ENGINE_REGISTRY_STATE = Symbol.for("openclaw.contextEngineRegistryState");
 const CORE_CONTEXT_ENGINE_OWNER = "core";
-
-type ContextEngineRuntimeQuarantine = {
-  engineId: string;
-  owner?: string;
-  operation: string;
-  reason: string;
-  failedAt: Date;
-};
-
-type ContextEngineRegistryState = {
-  quarantinedEngines: Map<string, ContextEngineRuntimeQuarantine>;
-};
-
-// Keep context-engine registrations process-global so duplicated dist chunks
-// still share one registry map at runtime.
-const contextEngineRegistryState = resolveGlobalSingleton<ContextEngineRegistryState>(
-  CONTEXT_ENGINE_REGISTRY_STATE,
-  () => ({
-    quarantinedEngines: new Map(),
-  }),
-);
 
 const getContextEngines = () => requireActivePluginRegistry().contextEngines;
 
@@ -241,60 +218,6 @@ function requireContextEngineOwner(owner: string): string {
     );
   }
   return normalizedOwner;
-}
-
-function recordContextEngineQuarantine(params: {
-  engineId: string;
-  owner?: string;
-  operation: string;
-  error: unknown;
-  defaultEngineId: string;
-}): ContextEngineRuntimeQuarantine {
-  const existing = contextEngineRegistryState.quarantinedEngines.get(params.engineId);
-  if (existing) {
-    // First failure wins so logs and diagnostics point at the root cause, not follow-on fallback use.
-    return existing;
-  }
-
-  const quarantine: ContextEngineRuntimeQuarantine = {
-    engineId: params.engineId,
-    operation: params.operation,
-    reason: params.error instanceof Error ? params.error.message : String(params.error),
-    failedAt: new Date(),
-    ...(params.owner ? { owner: params.owner } : {}),
-  };
-  contextEngineRegistryState.quarantinedEngines.set(params.engineId, quarantine);
-  try {
-    recordPersistedContextEngineQuarantine(quarantine);
-  } catch {
-    // Quarantine behavior must not depend on the best-effort health mirror.
-  }
-  const ownerSuffix = params.owner ? ` owner=${sanitizeForLog(params.owner)}` : "";
-  console.error(
-    `[context-engine] Context engine "${sanitizeForLog(params.engineId)}"${ownerSuffix} failed during ${sanitizeForLog(params.operation)}: ` +
-      `${sanitizeForLog(quarantine.reason)}; quarantining it for this process and falling back to default engine "${params.defaultEngineId}".`,
-  );
-  return quarantine;
-}
-
-function getContextEngineQuarantine(engineId: string): ContextEngineRuntimeQuarantine | undefined {
-  return contextEngineRegistryState.quarantinedEngines.get(engineId);
-}
-
-export function listContextEngineQuarantines(): ContextEngineRuntimeQuarantine[] {
-  const quarantines = Array.from(
-    contextEngineRegistryState.quarantinedEngines.values(),
-    ({ failedAt, ...quarantine }) => ({ ...quarantine, failedAt: new Date(failedAt) }),
-  );
-  const seenEngineIds = new Set(quarantines.map((entry) => entry.engineId));
-  return quarantines.concat(
-    listPersistedContextEngineQuarantines().filter(({ engineId }) => !seenEngineIds.has(engineId)),
-  );
-}
-
-function clearContextEngineRuntimeQuarantine(engineId: string): void {
-  contextEngineRegistryState.quarantinedEngines.delete(engineId);
-  clearPersistedContextEngineQuarantineForProcess(engineId, process.pid);
 }
 
 /**

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -613,6 +613,9 @@ export type LogicalTurnContextEngineResolution = {
   configured: ResolvedContextEngineRef;
   configuredId: string;
   configuredFailure?: string;
+  // Set only when the configured slot was skipped because it is process-quarantined,
+  // so consumers pick the persistence wording without re-parsing configuredFailure.
+  configuredQuarantined?: boolean;
   fallback: ResolvedContextEngineRef;
 };
 
@@ -632,6 +635,7 @@ function resolvedContextEngineRef(params: {
 async function resolveRawContextEngineRef(
   engineId: string,
   factoryCtx: ContextEngineFactoryContext,
+  defaultEngineId?: string,
 ): Promise<ResolvedContextEngineRef> {
   const entry = getContextEngines().get(engineId);
   if (!entry) {
@@ -651,6 +655,9 @@ async function resolveRawContextEngineRef(
   const projectedEngine = wrapContextEngineHostParamProjection(engine, {
     engineId,
     owner: entry.owner,
+    // Non-default engines carry the fallback id so a wedged/timed-out maintenance
+    // run can quarantine this slot; the default engine must never self-quarantine.
+    ...(defaultEngineId && defaultEngineId !== engineId ? { defaultEngineId } : {}),
   });
   return resolvedContextEngineRef({
     engine: projectedEngine,
@@ -660,8 +667,12 @@ async function resolveRawContextEngineRef(
 }
 
 /**
- * Resolve fresh engines for one logical turn without consulting or mutating
- * process quarantine. A failed configured engine is retried by the next turn.
+ * Resolve fresh engines for one logical turn. Transient per-turn host-support
+ * degradation (missing capability, absent fence/commit) is not recorded and is
+ * retried by the next turn. Genuine process-level quarantine — a wedged or
+ * timed-out maintenance run or lifecycle failure recorded against this slot — is
+ * honored here: the configured engine is skipped in favor of the fallback and
+ * stays skipped until process restart or re-registration.
  */
 export async function resolveLogicalTurnContextEngines(
   config?: OpenClawConfig,
@@ -679,6 +690,16 @@ export async function resolveLogicalTurnContextEngines(
   const fallback = await resolveRawContextEngineRef(defaultEngineId, factoryCtx);
   if (configuredEngineId === defaultEngineId) {
     return { configured: fallback, configuredId: configuredEngineId, fallback };
+  }
+  const quarantine = getContextEngineQuarantine(configuredEngineId);
+  if (quarantine) {
+    return {
+      configured: fallback,
+      configuredId: configuredEngineId,
+      configuredFailure: `context engine "${configuredEngineId}" is quarantined: ${quarantine.reason}`,
+      configuredQuarantined: true,
+      fallback,
+    };
   }
   const entry = getContextEngines().get(configuredEngineId);
   if (!entry) {
@@ -698,7 +719,11 @@ export async function resolveLogicalTurnContextEngines(
     };
   }
   try {
-    const configured = await resolveRawContextEngineRef(configuredEngineId, factoryCtx);
+    const configured = await resolveRawContextEngineRef(
+      configuredEngineId,
+      factoryCtx,
+      defaultEngineId,
+    );
     return {
       configured,
       configuredId: configuredEngineId,

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -379,6 +379,8 @@ export interface ContextEngine {
     sessionFile: string;
     runtimeSettings?: ContextEngineRuntimeSettings;
     runtimeContext?: ContextEngineRuntimeContext;
+    /** Aborted when a foreground turn needs deferred maintenance to yield. */
+    abortSignal?: AbortSignal;
   }): Promise<ContextEngineMaintenanceResult>;
 
   /**

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -379,7 +379,18 @@ export interface ContextEngine {
     sessionFile: string;
     runtimeSettings?: ContextEngineRuntimeSettings;
     runtimeContext?: ContextEngineRuntimeContext;
-    /** Aborted when a foreground turn needs deferred maintenance to yield. */
+    /**
+     * Optional host-owned abort signal, aborted when a foreground turn needs a
+     * deferred maintenance run to yield (and also on gateway shutdown); a
+     * separate bounded grace timeout then decides quarantine and stamps the task
+     * `timed_out` if the run has not settled. This is an additive, optional host
+     * parameter, so existing engines remain compatible without changes:
+     * declaring it is opt-in, and honoring it is a cooperative optimization, not
+     * a correctness obligation. If an engine ignores the signal (or never
+     * declares awareness of it), the host still bounds the run and recovers on
+     * the fallback engine, so no engine is required to change. Engines that do
+     * honor it SHOULD stop work and reject/return promptly once it aborts.
+     */
     abortSignal?: AbortSignal;
   }): Promise<ContextEngineMaintenanceResult>;
 

--- a/src/plugins/loader-load-context.ts
+++ b/src/plugins/loader-load-context.ts
@@ -231,6 +231,9 @@ function buildCacheKey(params: {
   const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
   const discoveryMode = params.toolDiscovery === true ? "tool-discovery" : "default-discovery";
   const activationMode = params.activate === false ? "snapshot" : "active";
+  // Runtime handles are cached apart from plain discovery handles: post-load promotion mutates
+  // a runtime handle's context-engine registrations, so it must not share a cached registry with
+  // a read-only discovery handle.
   const handleRegistrationMode = params.handleRegistrationMode;
   const cacheIdentity = `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify(
     {
@@ -412,8 +415,6 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     channelPluginLoadIntent,
     preferBuiltPluginArtifacts,
     shouldActivate: options.activate !== false,
-    shouldRegisterRuntimeCapabilities:
-      options.activate !== false || handleRegistrationMode === "runtime",
     shouldLoadModules: options.loadModules !== false,
     runtimeSubagentMode,
     installRecords,

--- a/src/plugins/loader-load-context.ts
+++ b/src/plugins/loader-load-context.ts
@@ -22,6 +22,7 @@ import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
 import type {
   ChannelPluginLoadIntent,
+  PluginHandleRegistrationMode,
   PluginLoadOptions,
   PluginRuntimeSubagentMode,
 } from "./loader-types.js";
@@ -191,6 +192,7 @@ function buildCacheKey(params: {
   coreGatewayMethodNames?: string[];
   allowProcessHomeSessionCatalogs?: boolean;
   activate?: boolean;
+  handleRegistrationMode: PluginHandleRegistrationMode;
 }): string {
   const discoveryContext = resolvePluginDiscoveryContext({
     workspaceDir: params.workspaceDir,
@@ -229,6 +231,7 @@ function buildCacheKey(params: {
   const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
   const discoveryMode = params.toolDiscovery === true ? "tool-discovery" : "default-discovery";
   const activationMode = params.activate === false ? "snapshot" : "active";
+  const handleRegistrationMode = params.handleRegistrationMode;
   const cacheIdentity = `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify(
     {
       bundledPackage,
@@ -240,7 +243,7 @@ function buildCacheKey(params: {
       activationMetadataKey: params.activationMetadataKey ?? "",
       allowProcessHomeSessionCatalogs: params.allowProcessHomeSessionCatalogs !== false,
     },
-  )}::${serializePluginIdScope(params.onlyPluginIds)}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${params.channelPluginLoadIntent}::${bundledArtifactMode}::${rawConfigEnvMode}::${moduleLoadMode}::${discoveryMode}::${params.runtimeSubagentMode ?? "default"}::${params.runtimeBindingIdentity ?? "{}"}::${params.pluginSdkResolution ?? "auto"}::${JSON.stringify(params.coreGatewayMethodNames ?? [])}::${activationMode}`;
+  )}::${serializePluginIdScope(params.onlyPluginIds)}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${params.channelPluginLoadIntent}::${bundledArtifactMode}::${rawConfigEnvMode}::${moduleLoadMode}::${discoveryMode}::${params.runtimeSubagentMode ?? "default"}::${params.runtimeBindingIdentity ?? "{}"}::${params.pluginSdkResolution ?? "auto"}::${JSON.stringify(params.coreGatewayMethodNames ?? [])}::${activationMode}::${handleRegistrationMode}`;
   return createHash("sha256").update(cacheIdentity).digest("hex");
 }
 
@@ -328,6 +331,7 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const requireSetupEntryForSetupOnlyChannelPlugins =
     options.requireSetupEntryForSetupOnlyChannelPlugins === true;
   const channelPluginLoadIntent = options.channelPluginLoadIntent ?? "full";
+  const handleRegistrationMode = options.handleRegistrationMode ?? "discovery";
   const preferBuiltPluginArtifacts = options.preferBuiltPluginArtifacts === true;
   const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
   const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
@@ -391,6 +395,7 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     coreGatewayMethodNames,
     allowProcessHomeSessionCatalogs: options.allowProcessHomeSessionCatalogs,
     activate: options.activate,
+    handleRegistrationMode,
   });
   return {
     env,
@@ -407,6 +412,8 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     channelPluginLoadIntent,
     preferBuiltPluginArtifacts,
     shouldActivate: options.activate !== false,
+    shouldRegisterRuntimeCapabilities:
+      options.activate !== false || handleRegistrationMode === "runtime",
     shouldLoadModules: options.loadModules !== false,
     runtimeSubagentMode,
     installRecords,

--- a/src/plugins/loader-registration-plan.ts
+++ b/src/plugins/loader-registration-plan.ts
@@ -15,6 +15,12 @@ export type PluginRegistrationPlan = {
   runRuntimeCapabilityPolicy: boolean;
   /** Register metadata that only belongs to live activation. */
   runFullActivationOnlyRegistrations: boolean;
+  /**
+   * Register runtime-usable capabilities (context engine lifecycle='runtime') while the
+   * public `mode` stays 'discovery'. A private runtime handle needs this so plugin
+   * side-effect branches gated on `registrationMode === 'full'` do not fire.
+   */
+  registerRuntimeCapableCapabilities: boolean;
 };
 
 /** Converts loader intent into explicit entrypoint and activation behavior. */
@@ -40,6 +46,7 @@ export function resolvePluginRegistrationPlan(params: {
       loadSetupRuntimeEntry: false,
       runRuntimeCapabilityPolicy: false,
       runFullActivationOnlyRegistrations: false,
+      registerRuntimeCapableCapabilities: false,
     };
   }
   if (
@@ -58,6 +65,7 @@ export function resolvePluginRegistrationPlan(params: {
       loadSetupRuntimeEntry: false,
       runRuntimeCapabilityPolicy: true,
       runFullActivationOnlyRegistrations: false,
+      registerRuntimeCapableCapabilities: false,
     };
   }
   const loadSetupRuntimeEntry =
@@ -77,14 +85,19 @@ export function resolvePluginRegistrationPlan(params: {
       loadSetupRuntimeEntry: true,
       runRuntimeCapabilityPolicy: false,
       runFullActivationOnlyRegistrations: false,
+      registerRuntimeCapableCapabilities: false,
     };
   }
-  const mode = params.shouldRegisterRuntimeCapabilities ? "full" : "discovery";
+  // Public activation signal is 'full' only when this load globally activates the plugin.
+  // The runtime-capable axis is separate: a private runtime handle registers runtime-usable
+  // capabilities while keeping 'discovery' as the public mode plugins observe.
+  const mode = params.shouldActivate ? "full" : "discovery";
   return {
     mode,
     loadSetupEntry: false,
     loadSetupRuntimeEntry: false,
     runRuntimeCapabilityPolicy: true,
     runFullActivationOnlyRegistrations: params.shouldActivate,
+    registerRuntimeCapableCapabilities: params.shouldRegisterRuntimeCapabilities,
   };
 }

--- a/src/plugins/loader-registration-plan.ts
+++ b/src/plugins/loader-registration-plan.ts
@@ -26,6 +26,7 @@ export function resolvePluginRegistrationPlan(params: {
   shouldLoadModules: boolean;
   validateOnly: boolean;
   shouldActivate: boolean;
+  shouldRegisterRuntimeCapabilities: boolean;
   manifestRecord: PluginManifestRecord;
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -78,12 +79,12 @@ export function resolvePluginRegistrationPlan(params: {
       runFullActivationOnlyRegistrations: false,
     };
   }
-  const mode = params.shouldActivate ? "full" : "discovery";
+  const mode = params.shouldRegisterRuntimeCapabilities ? "full" : "discovery";
   return {
     mode,
     loadSetupEntry: false,
     loadSetupRuntimeEntry: false,
     runRuntimeCapabilityPolicy: true,
-    runFullActivationOnlyRegistrations: mode === "full",
+    runFullActivationOnlyRegistrations: params.shouldActivate,
   };
 }

--- a/src/plugins/loader-registration-plan.ts
+++ b/src/plugins/loader-registration-plan.ts
@@ -15,12 +15,6 @@ export type PluginRegistrationPlan = {
   runRuntimeCapabilityPolicy: boolean;
   /** Register metadata that only belongs to live activation. */
   runFullActivationOnlyRegistrations: boolean;
-  /**
-   * Register runtime-usable capabilities (context engine lifecycle='runtime') while the
-   * public `mode` stays 'discovery'. A private runtime handle needs this so plugin
-   * side-effect branches gated on `registrationMode === 'full'` do not fire.
-   */
-  registerRuntimeCapableCapabilities: boolean;
 };
 
 /** Converts loader intent into explicit entrypoint and activation behavior. */
@@ -32,7 +26,6 @@ export function resolvePluginRegistrationPlan(params: {
   shouldLoadModules: boolean;
   validateOnly: boolean;
   shouldActivate: boolean;
-  shouldRegisterRuntimeCapabilities: boolean;
   manifestRecord: PluginManifestRecord;
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -46,7 +39,6 @@ export function resolvePluginRegistrationPlan(params: {
       loadSetupRuntimeEntry: false,
       runRuntimeCapabilityPolicy: false,
       runFullActivationOnlyRegistrations: false,
-      registerRuntimeCapableCapabilities: false,
     };
   }
   if (
@@ -65,7 +57,6 @@ export function resolvePluginRegistrationPlan(params: {
       loadSetupRuntimeEntry: false,
       runRuntimeCapabilityPolicy: true,
       runFullActivationOnlyRegistrations: false,
-      registerRuntimeCapableCapabilities: false,
     };
   }
   const loadSetupRuntimeEntry =
@@ -85,12 +76,12 @@ export function resolvePluginRegistrationPlan(params: {
       loadSetupRuntimeEntry: true,
       runRuntimeCapabilityPolicy: false,
       runFullActivationOnlyRegistrations: false,
-      registerRuntimeCapableCapabilities: false,
     };
   }
   // Public activation signal is 'full' only when this load globally activates the plugin.
-  // The runtime-capable axis is separate: a private runtime handle registers runtime-usable
-  // capabilities while keeping 'discovery' as the public mode plugins observe.
+  // A private runtime handle keeps 'discovery' as the public mode plugins observe, so
+  // full-only side-effect branches do not fire; its selected context engine becomes
+  // runtime-usable through promotion from the active registry, not direct activation here.
   const mode = params.shouldActivate ? "full" : "discovery";
   return {
     mode,
@@ -98,6 +89,5 @@ export function resolvePluginRegistrationPlan(params: {
     loadSetupRuntimeEntry: false,
     runRuntimeCapabilityPolicy: true,
     runFullActivationOnlyRegistrations: params.shouldActivate,
-    registerRuntimeCapableCapabilities: params.shouldRegisterRuntimeCapabilities,
   };
 }

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -524,6 +524,7 @@ export function loadRuntimePluginCandidate(params: {
     pluginConfig: validatedConfig.value,
     hookPolicy: entry?.hooks,
     registrationMode: registrationPlan.mode,
+    registerRuntimeCapableCapabilities: registrationPlan.registerRuntimeCapableCapabilities,
   });
   const beforeRegister = performance.now();
   let registerFailed = false;

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -257,6 +257,7 @@ export function loadRuntimePluginCandidate(params: {
     shouldLoadModules: context.shouldLoadModules,
     validateOnly: params.validateOnly,
     shouldActivate: context.shouldActivate,
+    shouldRegisterRuntimeCapabilities: context.shouldRegisterRuntimeCapabilities,
     manifestRecord,
     cfg: context.cfg,
     env: context.env,

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -257,7 +257,6 @@ export function loadRuntimePluginCandidate(params: {
     shouldLoadModules: context.shouldLoadModules,
     validateOnly: params.validateOnly,
     shouldActivate: context.shouldActivate,
-    shouldRegisterRuntimeCapabilities: context.shouldRegisterRuntimeCapabilities,
     manifestRecord,
     cfg: context.cfg,
     env: context.env,
@@ -524,7 +523,6 @@ export function loadRuntimePluginCandidate(params: {
     pluginConfig: validatedConfig.value,
     hookPolicy: entry?.hooks,
     registrationMode: registrationPlan.mode,
-    registerRuntimeCapableCapabilities: registrationPlan.registerRuntimeCapableCapabilities,
   });
   const beforeRegister = performance.now();
   let registerFailed = false;

--- a/src/plugins/loader-types.ts
+++ b/src/plugins/loader-types.ts
@@ -10,6 +10,7 @@ import type { PluginLogger } from "./types.js";
 
 export type PluginRuntimeSubagentMode = "default" | "explicit" | "gateway-bindable";
 export type ChannelPluginLoadIntent = "full" | "setup";
+export type PluginHandleRegistrationMode = "discovery" | "runtime";
 
 /** Inputs shared by runtime, snapshot, and CLI-metadata plugin loading. */
 export type PluginLoadOptions = {
@@ -44,6 +45,8 @@ export type PluginLoadOptions = {
   /** Prefer bundled JavaScript artifacts over source TypeScript entrypoints. */
   preferBuiltPluginArtifacts?: boolean;
   toolDiscovery?: boolean;
+  /** Register runtime-owned capabilities in a private handle without activating it globally. */
+  handleRegistrationMode?: PluginHandleRegistrationMode;
   activate?: boolean;
   loadModules?: boolean;
   throwOnLoadError?: boolean;

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -24,6 +24,8 @@ import {
 import {
   makePluginLoaderTempDir,
   resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
 } from "./loader.test-fixtures.js";
 import { buildMemoryPromptSection, registerMemoryCapability } from "./memory-state.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
@@ -59,6 +61,44 @@ it("keeps injected instance runtime surfaces independent of the broad runtime mo
   expect(runtime.nodes).toBe(nodes);
   expect(runtime.subagent).toBe(subagent);
   expect(loadPluginModule).not.toHaveBeenCalled();
+});
+
+it("registers runtime capabilities in an explicitly runtime-owned private handle", () => {
+  useNoBundledPlugins();
+  const root = loadAndActivateRootPluginRegistry({ cache: false, config: {} });
+  const plugin = writePlugin({
+    id: "private-runtime-context-engine",
+    body: `module.exports = {
+      id: "private-runtime-context-engine",
+      register(api) {
+        if (api.registrationMode === "full") {
+          api.registerContextEngine("private-runtime-engine", () => ({
+            info: { id: "private-runtime-engine", name: "Private runtime engine" },
+          }));
+        }
+      },
+    };`,
+  });
+
+  const handle = loadPluginRegistryHandle({
+    cache: false,
+    config: {
+      plugins: {
+        allow: [plugin.id],
+        load: { paths: [plugin.file] },
+      },
+    },
+    onlyPluginIds: [plugin.id],
+    handleRegistrationMode: "runtime",
+  });
+
+  expect(handle.contextEngines.get("private-runtime-engine")).toEqual(
+    expect.objectContaining({
+      owner: `plugin:${plugin.id}`,
+      lifecycle: "runtime",
+    }),
+  );
+  expect(getActivePluginRegistry()).toBe(root);
 });
 
 function requireMemoryEmbeddingProvider(providerId: string) {
@@ -112,6 +152,19 @@ describe("resolvePluginLoadCacheContext", () => {
     }).cacheKey;
 
     expect(isolatedKey).not.toBe(processHomeKey);
+  });
+
+  it("partitions discovery and private runtime registration handles", () => {
+    const discovery = resolvePluginLoadCacheContext({ config: {}, activate: false });
+    const runtime = resolvePluginLoadCacheContext({
+      config: {},
+      activate: false,
+      handleRegistrationMode: "runtime",
+    });
+
+    expect(discovery.shouldRegisterRuntimeCapabilities).toBe(false);
+    expect(runtime.shouldRegisterRuntimeCapabilities).toBe(true);
+    expect(runtime.cacheKey).not.toBe(discovery.cacheKey);
   });
 
   it("partitions full and setup channel plugin load intent", () => {

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -63,7 +63,7 @@ it("keeps injected instance runtime surfaces independent of the broad runtime mo
   expect(loadPluginModule).not.toHaveBeenCalled();
 });
 
-it("registers runtime capabilities in an explicitly runtime-owned private handle", () => {
+it("keeps a private runtime handle's context engine read-only for promotion", () => {
   useNoBundledPlugins();
   const root = loadAndActivateRootPluginRegistry({ cache: false, config: {} });
   const plugin = writePlugin({
@@ -71,8 +71,10 @@ it("registers runtime capabilities in an explicitly runtime-owned private handle
     body: `module.exports = {
       id: "private-runtime-context-engine",
       register(api) {
-        // Pure capability registration must run without the public 'full' signal so a
-        // private runtime handle can register a runtime-usable engine.
+        // Capability registration runs without the public 'full' signal, but a private
+        // runtime handle over a discovery-mode plugin must stay read-only: the runtime-safe
+        // factory arrives via promotion from the active registry, not by force-marking
+        // this discovery registration 'runtime'.
         api.registerContextEngine("private-runtime-engine", () => ({
           info: { id: "private-runtime-engine", name: "Private runtime engine" },
         }));
@@ -102,11 +104,13 @@ it("registers runtime capabilities in an explicitly runtime-owned private handle
     handleRegistrationMode: "runtime",
   });
 
-  // Runtime-usable lifecycle without presenting 'full': resolve() will not fall back to legacy.
+  // Discovery-mode registration stays read-only even for a runtime handle. resolve() honors
+  // the read-only-discovery contract and never force-constructs the discovery factory;
+  // promotion from the active registry supplies the runtime-safe factory when one exists.
   expect(handle.contextEngines.get("private-runtime-engine")).toEqual(
     expect.objectContaining({
       owner: `plugin:${plugin.id}`,
-      lifecycle: "runtime",
+      lifecycle: "readOnlyDiscovery",
     }),
   );
   // The plugin observed 'discovery', so its full-only side-effect branch never ran.
@@ -211,8 +215,9 @@ describe("resolvePluginLoadCacheContext", () => {
       handleRegistrationMode: "runtime",
     });
 
-    expect(discovery.shouldRegisterRuntimeCapabilities).toBe(false);
-    expect(runtime.shouldRegisterRuntimeCapabilities).toBe(true);
+    // A runtime handle is cached apart from a plain discovery handle so post-load promotion,
+    // which mutates the runtime handle's context-engine registrations, never leaks into a
+    // cached read-only discovery registry.
     expect(runtime.cacheKey).not.toBe(discovery.cacheKey);
   });
 

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -71,10 +71,20 @@ it("registers runtime capabilities in an explicitly runtime-owned private handle
     body: `module.exports = {
       id: "private-runtime-context-engine",
       register(api) {
+        // Pure capability registration must run without the public 'full' signal so a
+        // private runtime handle can register a runtime-usable engine.
+        api.registerContextEngine("private-runtime-engine", () => ({
+          info: { id: "private-runtime-engine", name: "Private runtime engine" },
+        }));
+        // A genuine full-only side effect stays gated on the public activation signal and
+        // must not fire for a private runtime handle.
         if (api.registrationMode === "full") {
-          api.registerContextEngine("private-runtime-engine", () => ({
-            info: { id: "private-runtime-engine", name: "Private runtime engine" },
-          }));
+          api.registerTool({
+            name: "full_only_side_effect",
+            description: "must not register for a private runtime handle",
+            parameters: { type: "object", properties: {} },
+            execute() { return { content: [{ type: "text", text: "ok" }] }; },
+          }, { name: "full_only_side_effect" });
         }
       },
     };`,
@@ -92,13 +102,52 @@ it("registers runtime capabilities in an explicitly runtime-owned private handle
     handleRegistrationMode: "runtime",
   });
 
+  // Runtime-usable lifecycle without presenting 'full': resolve() will not fall back to legacy.
   expect(handle.contextEngines.get("private-runtime-engine")).toEqual(
     expect.objectContaining({
       owner: `plugin:${plugin.id}`,
       lifecycle: "runtime",
     }),
   );
+  // The plugin observed 'discovery', so its full-only side-effect branch never ran.
+  expect(handle.tools.flatMap((entry) => entry.names)).not.toContain("full_only_side_effect");
   expect(getActivePluginRegistry()).toBe(root);
+});
+
+it("registers a context engine read-only for a plain discovery handle", () => {
+  useNoBundledPlugins();
+  loadAndActivateRootPluginRegistry({ cache: false, config: {} });
+  const plugin = writePlugin({
+    id: "discovery-context-engine",
+    body: `module.exports = {
+      id: "discovery-context-engine",
+      register(api) {
+        api.registerContextEngine("discovery-engine", () => ({
+          info: { id: "discovery-engine", name: "Discovery engine" },
+        }));
+      },
+    };`,
+  });
+
+  const handle = loadPluginRegistryHandle({
+    cache: false,
+    config: {
+      plugins: {
+        allow: [plugin.id],
+        load: { paths: [plugin.file] },
+      },
+    },
+    onlyPluginIds: [plugin.id],
+  });
+
+  // No runtime-capability signal: the engine stays discovery-only and resolve() falls back
+  // to the default engine until runtime activation registers it.
+  expect(handle.contextEngines.get("discovery-engine")).toEqual(
+    expect.objectContaining({
+      owner: `plugin:${plugin.id}`,
+      lifecycle: "readOnlyDiscovery",
+    }),
+  );
 });
 
 function requireMemoryEmbeddingProvider(providerId: string) {

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -138,16 +138,10 @@ export function createPluginApiFactory(
       pluginConfig?: Record<string, unknown>;
       hookPolicy?: PluginTypedHookPolicy;
       registrationMode?: PluginRegistrationMode;
-      registerRuntimeCapableCapabilities?: boolean;
     },
   ): OpenClawPluginApi => {
     const registrationMode = params.registrationMode ?? "full";
     const registrationCapabilities = resolvePluginRegistrationCapabilities(registrationMode);
-    // Runtime-capability registration is a separate axis from the public 'full' signal:
-    // a private runtime handle registers runtime-usable capabilities while presenting
-    // 'discovery' to plugins. Default to the public mode for callers that do not split them.
-    const runtimeCapableCapabilities =
-      params.registerRuntimeCapableCapabilities ?? registrationMode === "full";
     setPluginRuntimeRecord(record);
     const sideEffectGuard = createPluginSideEffectGuard(record.id);
     const isLoadedRecordInRegistry = () =>
@@ -239,7 +233,7 @@ export function createPluginApiFactory(
                 registerConversationBindingResolvedHandler(record, handler),
               registerCommand: (command) => registerCommand(record, command),
               registerContextEngine: (id, factory) =>
-                registerContextEngine(record, id, factory, runtimeCapableCapabilities),
+                registerContextEngine(record, id, factory, registrationMode === "full"),
               registerCompactionProvider: (provider) =>
                 registerCompactionProvider(record, provider),
               registerCodexAppServerExtensionFactory: (factory) => {

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -138,10 +138,16 @@ export function createPluginApiFactory(
       pluginConfig?: Record<string, unknown>;
       hookPolicy?: PluginTypedHookPolicy;
       registrationMode?: PluginRegistrationMode;
+      registerRuntimeCapableCapabilities?: boolean;
     },
   ): OpenClawPluginApi => {
     const registrationMode = params.registrationMode ?? "full";
     const registrationCapabilities = resolvePluginRegistrationCapabilities(registrationMode);
+    // Runtime-capability registration is a separate axis from the public 'full' signal:
+    // a private runtime handle registers runtime-usable capabilities while presenting
+    // 'discovery' to plugins. Default to the public mode for callers that do not split them.
+    const runtimeCapableCapabilities =
+      params.registerRuntimeCapableCapabilities ?? registrationMode === "full";
     setPluginRuntimeRecord(record);
     const sideEffectGuard = createPluginSideEffectGuard(record.id);
     const isLoadedRecordInRegistry = () =>
@@ -233,7 +239,7 @@ export function createPluginApiFactory(
                 registerConversationBindingResolvedHandler(record, handler),
               registerCommand: (command) => registerCommand(record, command),
               registerContextEngine: (id, factory) =>
-                registerContextEngine(record, id, factory, registrationMode),
+                registerContextEngine(record, id, factory, runtimeCapableCapabilities),
               registerCompactionProvider: (provider) =>
                 registerCompactionProvider(record, provider),
               registerCodexAppServerExtensionFactory: (factory) => {

--- a/src/plugins/registry-registrars-capabilities.ts
+++ b/src/plugins/registry-registrars-capabilities.ts
@@ -4,7 +4,7 @@ import { registerPluginInteractiveHandlerInRegistry } from "./interactive-regist
 import type { PluginRegistryState } from "./registry-state.js";
 import type { PluginRecord } from "./registry-types.js";
 import { defaultSlotIdForKey } from "./slots.js";
-import type { OpenClawPluginApi, PluginRegistrationMode } from "./types.js";
+import type { OpenClawPluginApi } from "./types.js";
 
 export function createCapabilityRegistrars(state: PluginRegistryState) {
   const { registry, pushDiagnostic } = state;
@@ -53,7 +53,7 @@ export function createCapabilityRegistrars(state: PluginRegistryState) {
     record: PluginRecord,
     id: Parameters<OpenClawPluginApi["registerContextEngine"]>[0],
     factory: Parameters<OpenClawPluginApi["registerContextEngine"]>[1],
-    registrationMode: PluginRegistrationMode,
+    runtimeCapable: boolean,
   ) => {
     const normalizedId = normalizeOptionalString(id) ?? "";
     if (!normalizedId) {
@@ -90,7 +90,10 @@ export function createCapabilityRegistrars(state: PluginRegistryState) {
       `plugin:${record.id}`,
       {
         allowSameOwnerRefresh: true,
-        lifecycle: registrationMode === "full" ? "runtime" : "readOnlyDiscovery",
+        // Runtime-capable registration (live activation or a private runtime handle) makes
+        // the engine usable; discovery-only registration stays readOnlyDiscovery so resolve
+        // falls back to the default engine until runtime activation registers it.
+        lifecycle: runtimeCapable ? "runtime" : "readOnlyDiscovery",
       },
     );
     if (!result.ok) {

--- a/src/plugins/registry-registrars-capabilities.ts
+++ b/src/plugins/registry-registrars-capabilities.ts
@@ -53,7 +53,7 @@ export function createCapabilityRegistrars(state: PluginRegistryState) {
     record: PluginRecord,
     id: Parameters<OpenClawPluginApi["registerContextEngine"]>[0],
     factory: Parameters<OpenClawPluginApi["registerContextEngine"]>[1],
-    runtimeCapable: boolean,
+    fullyActivated: boolean,
   ) => {
     const normalizedId = normalizeOptionalString(id) ?? "";
     if (!normalizedId) {
@@ -90,10 +90,11 @@ export function createCapabilityRegistrars(state: PluginRegistryState) {
       `plugin:${record.id}`,
       {
         allowSameOwnerRefresh: true,
-        // Runtime-capable registration (live activation or a private runtime handle) makes
-        // the engine usable; discovery-only registration stays readOnlyDiscovery so resolve
-        // falls back to the default engine until runtime activation registers it.
-        lifecycle: runtimeCapable ? "runtime" : "readOnlyDiscovery",
+        // Only genuine live activation (registrationMode==='full') registers a runtime factory.
+        // A private runtime handle over a discovery-mode plugin stays readOnlyDiscovery so resolve
+        // never force-constructs a discovery-conditioned factory; promotion from the active
+        // registry supplies the runtime-safe factory when the plugin is active there.
+        lifecycle: fullyActivated ? "runtime" : "readOnlyDiscovery",
       },
     );
     if (!result.ok) {


### PR DESCRIPTION
## What Problem This Solves

Deferred context-engine maintenance can outlive an idle session and block the next message. This PR makes that boundary safe and visible:

- a foreground message or manual `/compact` asks maintenance to stop and allows one second for cooperative cleanup
- if the engine ignores cancellation, the waiting turn fails promptly with retry/restart guidance instead of hanging or silently doing nothing
- fallback stays serialized behind the original engine call and admitted transcript writes
- late writes are rejected, and the maintenance task remains `timed_out`
- the selected installed context-engine plugin is made usable in the prepared runtime via promotion from the active registry, so the engine that owns this behavior is available for recovery without mutating the process-wide registry and without force-constructing a discovery-mode factory
- an operator's restrictive `plugins.allow` is now honored end-to-end: when the allow list excludes the selected context-engine plugin, the prepared runtime drops that owner and falls back to the core engine instead of rewriting the allow list to include it

Those are two parts of one operational fix: safe maintenance recovery, and loading the selected engine into the runtime where that recovery runs — without broadening the operator's execution allowlist. No config, environment variable, command-queue policy, notification policy, or persistent state is added.

## Discovery-mode context-engine registrations stay read-only

The prepared-runtime handle presents `registrationMode: "discovery"` to plugins (so full-only side effects — broker acquisition, WSL probes, HTTP routes — do not fire during gateway prewarm) while still needing the selected context engine usable at runtime for wedge recovery. A context-engine registration now becomes `lifecycle: "runtime"` only for genuine full activation (`registrationMode === "full"`); a discovery-mode registration — including one made under a private runtime handle — stays `readOnlyDiscovery`.

This honors the documented read-only-discovery contract (`src/plugins/plugin-registration.types.ts`; discovery registration skips runtime resources): the resolver short-circuits a `readOnlyDiscovery` slot and falls back to the default engine **without constructing the registered factory**, so a discovery-conditioned, construction-unsafe factory is never built. The selected engine still reaches the prepared handle as runtime-usable through the existing promotion mechanism: `promoteMatchingRuntimeContextEngineRegistrations` (`src/context-engine/registry.ts`, called from `src/agents/runtime-plugins.ts`) carries the genuinely full-activated, runtime-safe factory from the active gateway registry into the prepared handle's read-only slot. Directly marking the private discovery registration `runtime` (the earlier approach) both risked constructing a discovery-only factory and defeated this promotion (which only replaces slots that are still `readOnlyDiscovery`), so switching the lifecycle decision to `registrationMode === "full"` is strictly safer and keeps the recovery path intact.

A regression pins the contract: an active registry holds a runtime-safe factory for the engine, the private prepared handle's discovery-mode registration uses a factory that throws if constructed, and resolving the configured engine under the prepared registry uses the promoted runtime-safe factory (called at least once), never constructs the throwing discovery factory (zero calls), and records no quarantine. A companion loader test asserts a private runtime handle's context-engine registration stays `readOnlyDiscovery`.

## Why This Change Was Made

The deferred-maintenance scheduler owns invocation, preemption, settlement, rerun coalescing, and the host-write fence. The context-engine registry owns quarantine and fallback routing. The prepared-runtime loader owns the private runtime-capable plugin registry and the allow-list boundary for that private handle. The reply boundary carries the producer-owned recovery message to the channel.

OpenAI Codex needs no protocol field. Direct source inspection found no maintenance-debt or cancellation field in `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:95-180`; thread-start processing consumes the existing shape in `codex-rs/app-server/src/request_processors/thread_processor.rs:810-865`. OpenClaw's shared lifecycle therefore owns this behavior.

## Compatibility: `abortSignal` and undeclared engines

The additive `abortSignal` on `maintain()` does not break existing undeclared context-engine plugins, because host-parameter projection to undeclared engines is intentional current behavior, not an accidental leak:

- The projection rule (`src/context-engine/registry.ts`, `projectContextEngineHostParams`) returns the full host-parameter set to any engine that does not declare `acceptedHostParams`. This is the deliberate model after `refactor(context-engine): retire legacy host param default` (#122434), which removed the previous date-gated legacy narrowing (its removal window closed 2026-08-12). The retired narrowing is recorded in the compat registry (`src/plugins/compat/registry-records.ts`) as `status: "removed"`, with the note that engines without `acceptedHostParams` now receive all current host fields.
- The public contract documents this: `docs/concepts/context-engine.md` states that engines without an `acceptedHostParams` declaration receive every current host field, and that an engine validating a narrower input shape should declare an explicit list (including `[]`). An engine that strictly rejects unknown keys therefore declares `acceptedHostParams` and is never sent `abortSignal` unless it lists it. The default `legacy` engine declares `[...CONTEXT_ENGINE_HOST_PARAMS]`, explicitly opting in.
- The `maintain().abortSignal` field is documented in `src/context-engine/types.ts` as additive, optional, and cooperative: an engine that ignores it (or never declares awareness of it) is still bounded by the host and recovered on the fallback engine, so no engine is required to change. The registry wrapper enforces this — a `maintain()` throw is caught, the slot is quarantined, and the fallback engine serves the turn.
- Upstream tests already assert this is intended: `src/context-engine/host-param-projection.test.ts` asserts that fresh and resolved undeclared engines receive every host parameter, including `abortSignal`.

Gating `abortSignal` behind an explicit `acceptedHostParams` membership would contradict #122434, the documented contract, and those tests, and would also weaken this fix: the normal-inbound foreground-preemption regression (`src/agents/embedded-agent-runner/context-engine-maintenance.test.ts`) drives an undeclared background engine and asserts its `abortSignal` fires so the foreground turn is released. Removing the signal from undeclared engines would strip the cooperative-yield path from exactly the default case #96703 targets, to protect a strict-but-undeclared engine that the quarantine + fallback machinery already protects and that the contract already directs to declare `acceptedHostParams`.

## User Impact

Before this change, a background maintenance task that never settled could hold a queued interactive message indefinitely, so the user's next message or manual `/compact` appeared to hang with no feedback. After this change, the foreground turn is released promptly: it either proceeds once maintenance yields, or fails fast with visible retry/restart guidance while the stuck task is quarantined to the fallback engine and its late writes are rejected. Operators who configure a restrictive `plugins.allow` continue to see that allow list respected — a custom context-engine plugin omitted from the allow list is not silently loaded or force-enabled; the runtime falls back to the core engine instead. No user-facing configuration changes; behavior is safe by default.

## Evidence

Exact head: `0074d2fb81c804b344b8a6524f7abe1c07a97316`

The fixed behavior was exercised at head `0074d2fb81c804b344b8a6524f7abe1c07a97316` against the real maintenance modules driven through the production admission helper, not a single unit assertion. The reproduce entrypoint reads the live git head and asserts it equals the pinned code SHA before the driver runs. A background-mode context engine whose `maintain()` ignores its abort signal and never self-settles — the exact wedged condition from the report — is registered through the real plugin registry, resolved via the real `resolveContextEngine`, and scheduled as real deferred turn-maintenance; a second same-session foreground admission then goes through the exact production helper `waitForDeferredTurnMaintenanceForSession` (`src/agents/embedded-agent-runner/run-orchestrator.ts:188`). The real code paths under test are `context-engine-maintenance.ts` (deferred run, foreground preemption, bounded grace, `timed_out` terminal state), `context-engine-maintenance-abort-signal.ts` (real `AbortController` wiring), `context-engine-maintenance-fence.ts` (write-fence close/drain and late-write rejection), `context-engine-maintenance-error.ts` (visible recovery guidance), `context-engine/registry.ts` quarantine + fallback routing with `legacy.registration.ts`/`legacy.ts`, `process/command-queue.ts` per-session lane serialization, and the `tasks/*` task-registry terminal status. Only true leaf I/O boundaries are stubbed — the capability lookup, the transcript-rewrite sink, `SessionManager.open`, and the runtime transcript read target — identical to the shipped unit tests; nothing in the preemption, fence, quarantine, or serialization path is stubbed. `performance.now`, `setTimeout`, and the real `TURN_MAINTENANCE_PREEMPT_GRACE_MS=1000` grace are the real wall clock (no faked time).

```json
{"schemaVersion":"wedge-maint-proof/1","verdict":"PASS","headSha":"0074d2fb81c804b344b8a6524f7abe1c07a97316","ranInContainer":true,"containerImage":"docker.io/library/node:24-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059","containerNode":"v24.18.0","wedgedEngine":"background turnMaintenanceMode engine whose maintain() ignores abortSignal and never self-settles","boundedGraceClockMs":1000,"blockedTurn":{"visibleRecoveryGuidance":"⚠️ Deferred maintenance did not stop. The context engine was quarantined, but this turn was stopped to avoid overlapping engine operations. Retry after maintenance finishes or restart the gateway.","elapsedMs":1031,"providerCallsWhileBlocked":0},"recovery":{"abortObserved":true,"quarantinedToFallback":true,"fallbackEngine":"legacy","originalEngine":"wedge-maint-proof-engine","originalEngineMaintainCalls":1,"lateHostRewriteRejected":true,"hostRewriteSinkCalls":0,"originalSettledBeforeFallback":false,"visibleFallbackReply":"Background task timed out: Context engine turn maintenance (run turn-mai).","taskStatus":"timed_out","taskStatusStable":true},"successorResult":{"changed":false,"enteredWedgedEngine":false,"blocked":true,"reason":"successor did not enter the wedged engine before prior run exited (serialized)"},"boundariesReal":["context-engine-maintenance.ts (deferred run, foreground preemption, bounded grace, timed_out terminal)","context-engine-maintenance-abort-signal.ts (real AbortController + signal handlers)","context-engine-maintenance-fence.ts (write fence close/drain, late-write rejection)","context-engine-maintenance-error.ts (visible recovery guidance)","context-engine/registry.ts (real resolveContextEngine + quarantineResolvedContextEngine + fallback routing)","context-engine/legacy.registration.ts + legacy.ts (real fallback engine)","process/command-queue.ts (real per-session lane serialization + task terminal status)","tasks/* task-registry + detached-task-runtime (real terminal status persistence)","waitForDeferredTurnMaintenanceForSession (the run-orchestrator.ts:189 admission helper)","real wall clock: performance.now(), real setTimeout, real TURN_MAINTENANCE_PREEMPT_GRACE_MS=1000ms"],"boundariesStubbed":["context-engine-capabilities.resolveContextEngineCapabilities (LLM/tool capability lookup — pure leaf lookup)","transcript-rewrite.rewriteTranscriptEntriesInSessionManager (transcript write sink — leaf I/O)","sessions/index.SessionManager.open (durable session store open — leaf I/O)","transcript-runtime-state.resolveRuntimeTranscriptReadTarget (runtime transcript read target — leaf I/O)"]}
```

The blocked foreground turn is released within the bounded grace (the real wall clock advanced ~1031 ms, just past the 1000 ms `TURN_MAINTENANCE_PREEMPT_GRACE_MS`, before release — versus hanging forever on the never-settling run), with no additional engine `maintain()` calls during the blocked window. The successor maintenance only enters after the prior run exits and observes the engine downgraded to `legacy`.

Foreground-preemption teardown now closes the deferred-maintenance write fence before firing the scheduler abort (previously abort ran first). Closing the fence first makes any write initiated from a synchronous abort listener a guaranteed no-op via the fence-closed rejection, instead of slipping past a still-open fence and landing a late transcript rewrite after preemption has begun. The two statements have no `await` between them, so both effects (fence closed, controller aborted) land in one synchronous tick and any suspended async worker observes them atomically regardless of order; the only observable difference is the synchronous-abort-listener write path, where close-first is strictly safer and never worse. The maintenance/command-queue unit tests remain green (`abortSignal.aborted` after preemption and the post-preemption fence-closed rewrite rejection both hold under the new ordering), and no test asserts the old abort-then-close sequence.

Logical-turn resolver now honors quarantine on the production recovery path. Normal embedded runs resolve their context engine through `resolveLogicalTurnContextEngines`, but that resolver previously neither attached the default-engine metadata needed to record a quarantine nor consulted existing quarantine state, so a wedged or timed-out deferred-maintenance run failed to quarantine the engine and the next logical turn re-resolved the same stuck engine instead of recovering on the fallback. The configured (non-default) logical-turn wrapper now carries the default engine id so a host-owned maintenance failure quarantines that slot (the default engine still never self-quarantines), and a quarantined configured engine is skipped in favor of the fallback until process restart or re-registration. The skip is recorded as a typed resolution field so the operator warning selects the correct persistence wording without re-parsing the failure text. Successor-turn regressions assert that after quarantine the next logical turn is served by the fallback (`legacy`) with a quarantine failure reason and the wedged custom factory is not re-invoked, and that the default engine is never quarantined.

Foreground preemption covers the normal inbound path, not only manual compaction. The mechanism lives in the shared `waitForDeferredTurnMaintenanceForSession` helper (which triggers `preemptForForeground` on the in-flight run), and the normal inbound admission calls it inside `runEmbeddedAgentInternal` before the global lane and before the context-engine lease begins, while the CLI next-same-session inference calls the same helper before its run; the manual `/compact` queued path adds one further call for its own lifecycle. A regression drives that shared helper against a wedged, abort-ignoring same-session maintenance run and asserts the run is preempted (its abort signal fires and the wait settles within the bounded grace instead of hanging), while an unrelated session's in-flight maintenance run is left untouched — proving the preemption is scoped to the matching session lane.

Restrictive-allowlist behavior is now enforced end-to-end for the selected context-engine owner. `resolveSelectedContextEnginePluginIds` in `src/agents/harness/runtime-plugin-load-plan.ts` now consults the same `restrictiveAllowlistOmitsPlugin` guard the memory-slot and codex-harness siblings already use, so a non-empty `plugins.allow` that omits the selected engine id causes the resolver to return no owner; the prepared runtime then falls back to the core engine without materializing the allow list or force-activating the excluded plugin. An empty or absent `plugins.allow` remains nonrestrictive (the guard is `allow.length > 0 && !allow.includes(pluginId)`), so operators without an allow list keep the same custom-vs-core selection as before, and denylist / `enabled: false` remain honored by the shared slot resolver ahead of this guard. A paired pair of regressions in `src/agents/harness/runtime-plugin.test.ts` drives the guard end-to-end through `resolveAgentRuntimePluginLoadPlan`: the omitted case asserts the engine is dropped from `plan.pluginIds`, `plugins.allow` stays `['unrelated-plugin']` unchanged, and no forced `entries` entry is added; the explicitly-allowed case asserts the engine is kept in `plan.pluginIds`, listed in `plugins.allow`, and enabled in `entries`. A fresh independent autoreview on the guard commit confirmed the fix is at the correct layer (the plan resolver, not the shared slot resolver), does not regress the empty-allowlist or denylist paths, and the two regressions exercise the behavior through the production helper.

Deferred-maintenance task cleanup now forwards the owner agent identity. The owner-scoped task APIs fail closed when they cannot resolve the caller agent id, and a bare (non-agent-scoped) session key yields none on its own; the cancel and supersede cleanup paths in `context-engine-maintenance.ts` previously passed only the bare session key as `callerOwnerKey`, so for bare-key sessions the cleanup lookup could silently no-op and leave the maintenance task non-terminal. The cleanup paths now resolve the agent identity from the session key (session-key parse first, config roster only where a config is already in scope) and forward it as `callerAgentId`, so cancelled and superseded maintenance tasks reach a terminal state reliably. This closes the pre-existing bare-key cleanup gap (upstream main uses the same bare-key pattern); behavior for agent-scoped session keys is unchanged. A regression registers a maintenance task under a bare owner key, drives the supersede path, and asserts the task reaches `cancelled` with `notifyPolicy: silent`; removing the identity forwarding fails the regression with the task left `queued`.

Additional validation:

- exact-head behavior proof against the real maintenance modules through the production `waitForDeferredTurnMaintenanceForSession` admission path, at head `0074d2fb81` — passed (bounded release ~1031 ms, `timed_out` terminal, quarantine→`legacy`, late host rewrite rejected, successor serialized)
- bare-key owner cleanup regression (superseded maintenance task under a bare owner key reaches the `cancelled` terminal state through the forwarded agent identity; identity removal reproduces the silent no-op) — passed (`context-engine-maintenance.test.ts`)
- normal-inbound foreground preemption regression (shared admission helper, same-session lane, unrelated session isolated) — passed
- restrictive-allowlist regression pair (omitted-owner drops to core fallback with allow unchanged; explicitly-allowed owner still loads and force-enables) — passed (`runtime-plugin.test.ts`)
- exact-head discovery-mode read-only regression (active registry runtime-safe factory promoted into the prepared handle; private discovery factory throws if constructed — promoted factory called ≥1, throwing discovery factory called 0, no quarantine) — passed (`context-engine.test.ts`)
- private-runtime-handle lifecycle regression (a runtime handle's discovery-mode context engine stays `readOnlyDiscovery` for promotion) — passed (`loader.runtime-registry.test.ts`)
- logical-turn disposal lifecycle (owned deferred engines disposed only after their maintenance run finishes; quarantine honored on the next logical turn) — passed (`context-engine-maintenance.test.ts`, `host-param-projection.test.ts`)
- focused maintenance, compaction, prepared-runtime, plugin-selection, and runtime-registry regressions — passed (loader.runtime-registry, context-engine, host-param-projection, context-engine-maintenance suites green)
- full changed-file gate, including TypeScript (tsgo core + core-test) and lint (oxlint/oxfmt) — passed
- structured branch autoreview after the restrictive-allowlist fix — clean; no actionable findings
- `git diff --check` — passed

## Size and cleanup

Every production line maps to the single operational invariant: a wedged or timed-out configured-engine maintenance run must yield to a foreground turn, be bounded, recover onto the default engine, reject its late writes, tell the operator, and not broaden the operator's execution allowlist along the way. The net production delta overstates new logic — a large share of `context-engine-maintenance.ts` is the abort-signal machinery relocated to a sibling file (counted as a deletion here and an addition there) and the `rewriteTranscriptEntries` body re-routed through the fence; the genuinely new machinery is the single `DeferredTurnMaintenanceRun` owner that replaces the previous closure-based pseudo-state machine, consolidating completion, abort, fencing, rerun, timeout, and drain behavior.

Scope maps to the fix, area by area:

- `context-engine-maintenance.ts` + `context-engine-maintenance-fence.ts` + `context-engine-maintenance-abort-signal.ts` — the fix core: foreground preempt, bounded 1 s grace, `timed_out` terminal state, and a write fence that drains admitted writes so the preempted run and the fallback cannot both write the transcript.
- `context-engine/registry.ts` (quarantine + `defaultEngineId` plumbing) and the logical-turn resolver — the recovery half: a non-default engine that wedged is skipped for the default on the next turn, and the default engine never self-quarantines.
- `context-engine-maintenance-error.ts` + `agent-runner-failure-reply.ts` + `context-engine-logical-turn.ts` — turn the blocked admission into visible operator retry/restart guidance with correct quarantined-vs-retried wording (no silent dead-end).
- `context-engine/types.ts` — additive, optional `abortSignal` on the public `maintain()` host contract; existing engines require no change.
- `compact.queued.ts` — applies the same wait/serialize on the manual `/compact` sibling path so the wedge does not simply relocate.
- `context-engine-maintenance.ts` cleanup identity forwarding — resolves and forwards the owner agent identity on the cancel/supersede task-cleanup paths so bare-key sessions reach the task terminal state reliably (pre-existing gap; no behavior change for agent-scoped keys).
- plugin loader / runtime-registration cluster (`loader-*.ts`, `registry-api.ts`, `registry-registrars-capabilities.ts`, `runtime-plugin-load-plan.ts`, `runtime-plugins.ts`) — the reachability precondition for recovery: the selected installed context engine reaches the prepared runtime handle as runtime-usable through promotion of the genuinely full-activated, runtime-safe factory from the active registry, while the private handle still presents `discovery` to plugins and a discovery-mode registration stays `readOnlyDiscovery` (so no discovery-only factory is force-constructed). It also honors a restrictive `plugins.allow` end-to-end for the selected context-engine owner by mirroring the memory-slot guard. Without this reachability the private runtime would fall back to legacy/discovery-only behavior instead of the engine that actually wedged, so it cannot be split out without weakening the fix. The public `full` activation signal is the sole gate for a runtime context-engine lifecycle, so full-only side-effect branches do not fire during gateway prewarm.

No config, environment variable, command-queue policy, notification policy, or persistent state is added.














