### PR TITLE
fix(memory-wiki): gracefully handle unparsable YAML frontmatter in vault scans (#96125)

### DIFF
--- a/extensions/memory-wiki/src/apply.test.ts
+++ b/extensions/memory-wiki/src/apply.test.ts
@@ -180,39 +180,55 @@ describe("applyMemoryWikiMutation", () => {
     await expect(fs.readFile(brokenPath, "utf8")).resolves.toBe(brokenPage);
   });
 
-  it("rejects a malformed write target without replacing its metadata (#96125)", async () => {
-    const { rootDir, config } = await createVault({
-      prefix: "memory-wiki-apply-invalid-target-",
-    });
-    await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });
-    const targetPath = path.join(rootDir, "syntheses", "conflicted.md");
-    const original = [
-      "---",
-      "pageType: synthesis",
-      "id: synthesis.conflicted",
-      "sourceIds:",
-      '  - **MEMORY.md line 235**:"some quoted, value"',
-      "---",
-      "",
-      "# Conflicted",
-      "",
-      "Keep this body.",
-    ].join("\n");
-    await fs.writeFile(targetPath, original, "utf8");
+  it.each([
+    {
+      name: "syntax-error",
+      frontmatterLines: [
+        "pageType: synthesis",
+        "id: synthesis.conflicted",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+      ],
+      error: "Unexpected scalar",
+    },
+    {
+      name: "sequence-root",
+      frontmatterLines: ["- pageType: synthesis", "  id: synthesis.conflicted"],
+      error: "Wiki frontmatter must be a YAML mapping",
+    },
+  ])(
+    "rejects a malformed write target without replacing its metadata ($name) (#96125)",
+    async ({ frontmatterLines, error }) => {
+      const { rootDir, config } = await createVault({
+        prefix: "memory-wiki-apply-invalid-target-",
+      });
+      await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });
+      const targetPath = path.join(rootDir, "syntheses", "conflicted.md");
+      const original = [
+        "---",
+        ...frontmatterLines,
+        "---",
+        "",
+        "# Conflicted",
+        "",
+        "Keep this body.",
+      ].join("\n");
+      await fs.writeFile(targetPath, original, "utf8");
 
-    await expect(
-      applyMemoryWikiMutation({
-        config,
-        mutation: {
-          op: "create_synthesis",
-          title: "Conflicted",
-          body: "Replacement body.",
-          sourceIds: ["source.new"],
-        },
-      }),
-    ).rejects.toThrow("Unexpected scalar");
-    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(original);
-  });
+      await expect(
+        applyMemoryWikiMutation({
+          config,
+          mutation: {
+            op: "create_synthesis",
+            title: "Conflicted",
+            body: "Replacement body.",
+            sourceIds: ["source.new"],
+          },
+        }),
+      ).rejects.toThrow(error);
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(original);
+    },
+  );
 
   it("updates page metadata without overwriting existing human notes", async () => {
     const { rootDir, config } = await createVault({

--- a/extensions/memory-wiki/src/apply.test.ts
+++ b/extensions/memory-wiki/src/apply.test.ts
@@ -143,6 +143,77 @@ describe("applyMemoryWikiMutation", () => {
     );
   });
 
+  it("applies a write when an unrelated vault page has malformed frontmatter (#96125)", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-apply-unrelated-invalid-",
+    });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
+    const brokenPath = path.join(rootDir, "sources", "broken.md");
+    const brokenPage = [
+      "---",
+      "pageType: source",
+      "id: source.broken",
+      "sourceIds:",
+      '  - **MEMORY.md line 235**:"some quoted, value"',
+      "---",
+      "",
+      "# Broken",
+    ].join("\n");
+    await fs.writeFile(brokenPath, brokenPage, "utf8");
+
+    const result = await applyMemoryWikiMutation({
+      config,
+      mutation: {
+        op: "create_synthesis",
+        title: "Healthy Synthesis",
+        body: "Healthy summary body.",
+        sourceIds: ["source.healthy"],
+      },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.compile.pageCounts.source).toBe(0);
+    expect(result.compile.pageCounts.synthesis).toBe(1);
+    expect(result.compile.frontmatterErrors).toEqual([
+      expect.objectContaining({ relativePath: "sources/broken.md" }),
+    ]);
+    await expect(fs.readFile(brokenPath, "utf8")).resolves.toBe(brokenPage);
+  });
+
+  it("rejects a malformed write target without replacing its metadata (#96125)", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-apply-invalid-target-",
+    });
+    await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });
+    const targetPath = path.join(rootDir, "syntheses", "conflicted.md");
+    const original = [
+      "---",
+      "pageType: synthesis",
+      "id: synthesis.conflicted",
+      "sourceIds:",
+      '  - **MEMORY.md line 235**:"some quoted, value"',
+      "---",
+      "",
+      "# Conflicted",
+      "",
+      "Keep this body.",
+    ].join("\n");
+    await fs.writeFile(targetPath, original, "utf8");
+
+    await expect(
+      applyMemoryWikiMutation({
+        config,
+        mutation: {
+          op: "create_synthesis",
+          title: "Conflicted",
+          body: "Replacement body.",
+          sourceIds: ["source.new"],
+        },
+      }),
+    ).rejects.toThrow("Unexpected scalar");
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(original);
+  });
+
   it("updates page metadata without overwriting existing human notes", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-apply-",

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -172,6 +172,64 @@ describe("compileMemoryWikiVault", () => {
     ).resolves.not.toContain("syntheses/broken.md");
   });
 
+  it.each([
+    {
+      name: "root index with syntax-error frontmatter",
+      relativePath: "index.md",
+      frontmatterLines: [
+        "pageType: report",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+      ],
+      error: "Unexpected scalar",
+    },
+    {
+      name: "root index with sequence-root frontmatter",
+      relativePath: "index.md",
+      frontmatterLines: ["- pageType: report"],
+      error: "Wiki frontmatter must be a YAML mapping",
+    },
+    {
+      name: "directory index with syntax-error frontmatter",
+      relativePath: "sources/index.md",
+      frontmatterLines: [
+        "pageType: report",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+      ],
+      error: "Unexpected scalar",
+    },
+    {
+      name: "directory index with scalar-root frontmatter",
+      relativePath: "sources/index.md",
+      frontmatterLines: ["report"],
+      error: "Wiki frontmatter must be a YAML mapping",
+    },
+  ])(
+    "rejects $name without changing its bytes",
+    async ({ relativePath, frontmatterLines, error }) => {
+      const { rootDir, config } = await createVault({
+        rootDir: nextCaseRoot(),
+        initialize: true,
+        config: { render: { createDashboards: false } },
+      });
+      const targetPath = path.join(rootDir, relativePath);
+      const original = [
+        "---",
+        ...frontmatterLines,
+        "---",
+        "",
+        "# Existing Index",
+        "",
+        "Keep this body.",
+      ].join("\n");
+      await fs.writeFile(targetPath, original, "utf8");
+
+      await expect(compileMemoryWikiVault(config)).rejects.toThrow(error);
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(original);
+    },
+  );
+
   it("discovers pages in nested subdirectories during compile", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -121,6 +121,57 @@ describe("compileMemoryWikiVault", () => {
     ).resolves.toContain('"text":"Alpha is the canonical source page."');
   });
 
+  it("excludes malformed pages from indexes, digests, counts, and page writes (#96125)", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+      config: { render: { createDashboards: false } },
+    });
+    const brokenPath = path.join(rootDir, "syntheses", "broken.md");
+    const brokenPage = [
+      "---",
+      "pageType: synthesis",
+      "id: synthesis.broken",
+      "sourceIds:",
+      '  - **MEMORY.md line 235**:"some quoted, value"',
+      "---",
+      "",
+      "# Broken",
+      "",
+      "Body that compile must not rewrite.",
+    ].join("\n");
+    await fs.writeFile(brokenPath, brokenPage, "utf8");
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "healthy.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "synthesis",
+          id: "synthesis.healthy",
+          title: "Healthy",
+          sourceIds: ["source.alpha"],
+        },
+        body: "# Healthy\n",
+      }),
+      "utf8",
+    );
+
+    const result = await compileMemoryWikiVault(config);
+
+    expect(result.frontmatterErrors).toHaveLength(1);
+    expect(result.frontmatterErrors[0]).toMatchObject({
+      relativePath: "syntheses/broken.md",
+    });
+    expect(result.pageCounts.synthesis).toBe(1);
+    expect(result.pages.map((page) => page.relativePath)).not.toContain("syntheses/broken.md");
+    await expect(fs.readFile(brokenPath, "utf8")).resolves.toBe(brokenPage);
+    await expect(fs.readFile(path.join(rootDir, "index.md"), "utf8")).resolves.not.toContain(
+      "Broken",
+    );
+    await expect(
+      fs.readFile(path.join(rootDir, ".openclaw-wiki", "cache", "agent-digest.json"), "utf8"),
+    ).resolves.not.toContain("syntheses/broken.md");
+  });
+
   it("discovers pages in nested subdirectories during compile", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -34,9 +34,10 @@ import {
   isUnmanagedRawSourceSummary,
   parseWikiMarkdown,
   renderWikiMarkdown,
-  toWikiPageSummary,
+  scanWikiPageSummary,
   type WikiClaim,
   type WikiClaimEvidence,
+  type WikiPageFrontmatterError,
   type WikiPageKind,
   type WikiPageSummary,
   type WikiRelationship,
@@ -352,6 +353,7 @@ export type CompileMemoryWikiResult = {
   vaultRoot: string;
   pageCounts: Record<WikiPageKind, number>;
   pages: WikiPageSummary[];
+  frontmatterErrors: WikiPageFrontmatterError[];
   claimCount: number;
   updatedFiles: string[];
 };
@@ -377,7 +379,10 @@ async function collectMarkdownFiles(rootDir: string, relativeDir: string): Promi
     .toSorted((left, right) => left.localeCompare(right));
 }
 
-async function readPageSummaries(rootDir: string): Promise<WikiPageSummary[]> {
+async function readPageSummaries(rootDir: string): Promise<{
+  pages: WikiPageSummary[];
+  frontmatterErrors: WikiPageFrontmatterError[];
+}> {
   const filePaths = (
     await Promise.all(COMPILE_PAGE_GROUPS.map((group) => collectMarkdownFiles(rootDir, group.dir)))
   ).flat();
@@ -389,7 +394,7 @@ async function readPageSummaries(rootDir: string): Promise<WikiPageSummary[]> {
         () => fs.readFile(absolutePath, "utf8"),
         `read wiki page ${absolutePath}`,
       );
-      return toWikiPageSummary({ absolutePath, relativePath, raw });
+      return scanWikiPageSummary({ absolutePath, relativePath, raw });
     }),
     limit: READ_PAGE_SUMMARIES_CONCURRENCY,
     errorMode: "stop",
@@ -398,9 +403,14 @@ async function readPageSummaries(rootDir: string): Promise<WikiPageSummary[]> {
     throw readResult.firstError;
   }
 
-  return readResult.results
-    .flatMap((page) => (page ? [page] : []))
-    .toSorted((left, right) => left.title.localeCompare(right.title));
+  return {
+    pages: readResult.results
+      .flatMap((result) => (result.status === "valid" ? [result.page] : []))
+      .toSorted((left, right) => left.title.localeCompare(right.title)),
+    frontmatterErrors: readResult.results.flatMap((result) =>
+      result.status === "invalid-frontmatter" ? [result.error] : [],
+    ),
+  };
 }
 
 function buildPageCounts(pages: WikiPageSummary[]): Record<WikiPageKind, number> {
@@ -1380,10 +1390,12 @@ export async function compileMemoryWikiVault(
   const managedImportedSourcePagePaths = new Set(
     Object.values(sourceSyncState.entries).map((entry) => entry.pagePath.split(path.sep).join("/")),
   );
-  let pages = await readPageSummaries(rootDir);
+  let scan = await readPageSummaries(rootDir);
+  let pages = scan.pages;
   const updatedFiles = await refreshPageRelatedBlocks({ config, pages });
   if (updatedFiles.length > 0) {
-    pages = await readPageSummaries(rootDir);
+    scan = await readPageSummaries(rootDir);
+    pages = scan.pages;
   }
   const dashboardUpdatedFiles = await refreshDashboardPages({
     config,
@@ -1393,7 +1405,8 @@ export async function compileMemoryWikiVault(
   });
   updatedFiles.push(...dashboardUpdatedFiles);
   if (dashboardUpdatedFiles.length > 0) {
-    pages = await readPageSummaries(rootDir);
+    scan = await readPageSummaries(rootDir);
+    pages = scan.pages;
   }
   const counts = buildPageCounts(pages);
   const digestUpdatedFiles = await writeAgentDigestArtifacts({
@@ -1449,6 +1462,7 @@ export async function compileMemoryWikiVault(
     vaultRoot: rootDir,
     pageCounts: counts,
     pages,
+    frontmatterErrors: scan.frontmatterErrors,
     claimCount: pages.reduce((total, page) => total + page.claims.length, 0),
     updatedFiles,
   };

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -920,6 +920,9 @@ async function writeManagedMarkdownFile(params: {
 }): Promise<boolean> {
   const root = await fsRoot(params.rootDir);
   const original = await root.readText(params.relativePath).catch(() => `# ${params.title}\n`);
+  // Generated indexes bypass page discovery. Parse existing content here so
+  // managed-block updates cannot rewrite malformed frontmatter.
+  parseWikiMarkdown(original);
   const updated = replaceManagedMarkdownBlock({
     original,
     heading: "## Generated",

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -493,4 +493,45 @@ describe("lintMemoryWikiVault", () => {
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("### Contradictions");
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("### Open Questions");
   });
+
+  it("reports unparsable frontmatter as a lint issue instead of failing the whole vault (#96125)", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-invalid-frontmatter-",
+    });
+    await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "broken.md"),
+      [
+        "---",
+        "pageType: synthesis",
+        "id: synthesis.broken",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+        "---",
+        "",
+        "# Broken",
+        "",
+        "Body text.",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "healthy.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "synthesis",
+          id: "synthesis.healthy",
+          title: "Healthy",
+          sourceIds: ["source.alpha"],
+        },
+        body: "# Healthy\n",
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(issueCodesForPath(result, "syntheses/broken.md")).toEqual(["invalid-frontmatter"]);
+    expect(issueCodesForPath(result, "syntheses/healthy.md")).not.toContain("invalid-frontmatter");
+  });
 });

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -538,28 +538,44 @@ describe("lintMemoryWikiVault", () => {
     );
   });
 
-  it("rejects a malformed lint report without changing its bytes", async () => {
-    const { rootDir, config } = await createVault({
-      prefix: "memory-wiki-lint-malformed-report-",
-    });
-    const reportPath = path.join(rootDir, "reports", "lint.md");
-    await fs.mkdir(path.dirname(reportPath), { recursive: true });
-    const malformedReport = [
-      "---",
-      "pageType: report",
-      "id: report.lint",
-      "sourceIds:",
-      '  - **MEMORY.md line 235**:"some quoted, value"',
-      "---",
-      "",
-      "# Lint Report",
-      "",
-      "Existing report body.",
-      "",
-    ].join("\n");
-    await fs.writeFile(reportPath, malformedReport, "utf8");
+  it.each([
+    {
+      name: "syntax-error",
+      frontmatterLines: [
+        "pageType: report",
+        "id: report.lint",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+      ],
+      error: "Unexpected scalar",
+    },
+    {
+      name: "sequence-root",
+      frontmatterLines: ["- pageType: report", "  id: report.lint"],
+      error: "Wiki frontmatter must be a YAML mapping",
+    },
+  ])(
+    "rejects a malformed lint report without changing its bytes ($name)",
+    async ({ frontmatterLines, error }) => {
+      const { rootDir, config } = await createVault({
+        prefix: "memory-wiki-lint-malformed-report-",
+      });
+      const reportPath = path.join(rootDir, "reports", "lint.md");
+      await fs.mkdir(path.dirname(reportPath), { recursive: true });
+      const malformedReport = [
+        "---",
+        ...frontmatterLines,
+        "---",
+        "",
+        "# Lint Report",
+        "",
+        "Existing report body.",
+        "",
+      ].join("\n");
+      await fs.writeFile(reportPath, malformedReport, "utf8");
 
-    await expect(lintMemoryWikiVault(config)).rejects.toThrow("Unexpected scalar");
-    await expect(fs.readFile(reportPath, "utf8")).resolves.toBe(malformedReport);
-  });
+      await expect(lintMemoryWikiVault(config)).rejects.toThrow(error);
+      await expect(fs.readFile(reportPath, "utf8")).resolves.toBe(malformedReport);
+    },
+  );
 });

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -533,5 +533,8 @@ describe("lintMemoryWikiVault", () => {
 
     expect(issueCodesForPath(result, "syntheses/broken.md")).toEqual(["invalid-frontmatter"]);
     expect(issueCodesForPath(result, "syntheses/healthy.md")).not.toContain("invalid-frontmatter");
+    await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain(
+      "Frontmatter failed to parse: Unexpected scalar",
+    );
   });
 });

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -537,4 +537,29 @@ describe("lintMemoryWikiVault", () => {
       "Frontmatter failed to parse: Unexpected scalar",
     );
   });
+
+  it("rejects a malformed lint report without changing its bytes", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-malformed-report-",
+    });
+    const reportPath = path.join(rootDir, "reports", "lint.md");
+    await fs.mkdir(path.dirname(reportPath), { recursive: true });
+    const malformedReport = [
+      "---",
+      "pageType: report",
+      "id: report.lint",
+      "sourceIds:",
+      '  - **MEMORY.md line 235**:"some quoted, value"',
+      "---",
+      "",
+      "# Lint Report",
+      "",
+      "Existing report body.",
+      "",
+    ].join("\n");
+    await fs.writeFile(reportPath, malformedReport, "utf8");
+
+    await expect(lintMemoryWikiVault(config)).rejects.toThrow("Unexpected scalar");
+    await expect(fs.readFile(reportPath, "utf8")).resolves.toBe(malformedReport);
+  });
 });

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -24,6 +24,7 @@ type MemoryWikiLintIssue = {
   severity: "error" | "warning";
   category: "structure" | "provenance" | "links" | "contradictions" | "open-questions" | "quality";
   code:
+    | "invalid-frontmatter"
     | "missing-id"
     | "duplicate-id"
     | "missing-page-type"
@@ -100,6 +101,20 @@ function collectPageIssues(
   const claimHealth = collectWikiClaimHealth(pages);
 
   for (const page of pages) {
+    if (page.frontmatterError) {
+      issues.push({
+        severity: "error",
+        category: "structure",
+        code: "invalid-frontmatter",
+        path: page.relativePath,
+        message: `Frontmatter failed to parse: ${page.frontmatterError}`,
+      });
+      // Frontmatter-derived fields are empty as a result of the parse
+      // failure; skip checks that would otherwise pile on misleading
+      // "missing field" issues for the same root cause.
+      continue;
+    }
+
     const requiresStructuredPageMetadata = !isUnmanagedRawSourcePage(
       page,
       managedImportedSourcePagePaths,

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -101,20 +101,6 @@ function collectPageIssues(
   const claimHealth = collectWikiClaimHealth(pages);
 
   for (const page of pages) {
-    if (page.frontmatterError) {
-      issues.push({
-        severity: "error",
-        category: "structure",
-        code: "invalid-frontmatter",
-        path: page.relativePath,
-        message: `Frontmatter failed to parse: ${page.frontmatterError}`,
-      });
-      // Frontmatter-derived fields are empty as a result of the parse
-      // failure; skip checks that would otherwise pile on misleading
-      // "missing field" issues for the same root cause.
-      continue;
-    }
-
     const requiresStructuredPageMetadata = !isUnmanagedRawSourcePage(
       page,
       managedImportedSourcePagePaths,
@@ -403,7 +389,18 @@ export async function lintMemoryWikiVault(
   const managedImportedSourcePagePaths = new Set(
     Object.values(sourceSyncState.entries).map((entry) => entry.pagePath.split(path.sep).join("/")),
   );
-  const issues = collectPageIssues(compileResult.pages, managedImportedSourcePagePaths);
+  const issues = [
+    ...compileResult.frontmatterErrors.map(
+      (error): MemoryWikiLintIssue => ({
+        severity: "error",
+        category: "structure",
+        code: "invalid-frontmatter",
+        path: error.relativePath,
+        message: `Frontmatter failed to parse: ${error.message}`,
+      }),
+    ),
+    ...collectPageIssues(compileResult.pages, managedImportedSourcePagePaths),
+  ].toSorted((left, right) => left.path.localeCompare(right.path));
   const issuesByCategory = buildIssuesByCategory(issues);
   const reportPath = await writeLintReport(config.vault.path, issues);
 

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -15,6 +15,7 @@ import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { appendMemoryWikiLog } from "./log.js";
 import {
   isUnmanagedRawSourceSummary,
+  parseWikiMarkdown,
   renderWikiMarkdown,
   type WikiPageSummary,
 } from "./markdown.js";
@@ -370,6 +371,9 @@ async function writeLintReport(rootDir: string, issues: MemoryWikiLintIssue[]): 
       body: "# Lint Report\n",
     }),
   );
+  // The lint report is itself a wiki page. Keep its metadata fail-closed before
+  // replacing the managed body so malformed frontmatter is never rewritten.
+  parseWikiMarkdown(original);
   const updated = replaceManagedMarkdownBlock({
     original,
     heading: "## Generated",

--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -421,4 +421,66 @@ describe("toWikiPageSummary", () => {
       },
     ]);
   });
+
+  it("degrades to empty frontmatter instead of throwing on unparsable YAML (#96125)", () => {
+    const raw = [
+      "---",
+      "pageType: synthesis",
+      "id: synthesis.test",
+      "sourceIds:",
+      '  - **MEMORY.md line 235**:"some quoted, value"',
+      "---",
+      "",
+      "# Test Title",
+      "",
+      "Body text that should be preserved.",
+    ].join("\n");
+
+    const summary = toWikiPageSummary({
+      absolutePath: "/tmp/wiki/syntheses/test.md",
+      relativePath: "syntheses/test.md",
+      raw,
+    });
+    if (!summary) {
+      throw new Error("expected wiki summary");
+    }
+
+    expect(summary.frontmatterError).toBeTruthy();
+    expect(summary.hasFrontmatter).toBe(true);
+    // Frontmatter-derived fields fall back to empty.
+    expect(summary.id).toBeUndefined();
+    expect(summary.sourceIds).toEqual([]);
+    // Body is preserved.
+    expect(summary.title).toBe("Test Title");
+  });
+
+  it("preserves frontmatter and body for valid YAML (#96125 control)", () => {
+    const raw = [
+      "---",
+      "pageType: synthesis",
+      "id: synthesis.healthy",
+      "sourceIds:",
+      "  - source.alpha",
+      "---",
+      "",
+      "# Healthy Page",
+      "",
+      "Healthy body.",
+    ].join("\n");
+
+    const summary = toWikiPageSummary({
+      absolutePath: "/tmp/wiki/syntheses/healthy.md",
+      relativePath: "syntheses/healthy.md",
+      raw,
+    });
+    if (!summary) {
+      throw new Error("expected wiki summary");
+    }
+
+    expect(summary.frontmatterError).toBeUndefined();
+    expect(summary.hasFrontmatter).toBe(true);
+    expect(summary.id).toBe("synthesis.healthy");
+    expect(summary.sourceIds).toEqual(["source.alpha"]);
+    expect(summary.pageType).toBe("synthesis");
+  });
 });

--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -454,6 +454,26 @@ describe("toWikiPageSummary", () => {
     expect(() => parseWikiMarkdown(raw)).toThrow("Unexpected scalar");
   });
 
+  it.each([
+    { name: "sequence", frontmatter: "- pageType: synthesis" },
+    { name: "scalar", frontmatter: "synthesis" },
+  ])("reports and excludes $name frontmatter roots from page scans", ({ frontmatter }) => {
+    const raw = ["---", frontmatter, "---", "", "# Invalid Root"].join("\n");
+    const params = {
+      absolutePath: "/tmp/wiki/syntheses/invalid-root.md",
+      relativePath: "syntheses/invalid-root.md",
+      raw,
+    };
+    const result = scanWikiPageSummary(params);
+    if (result.status !== "invalid-frontmatter") {
+      throw new Error("expected invalid frontmatter result");
+    }
+
+    expect(result.error.message).toBe("Wiki frontmatter must be a YAML mapping");
+    expect(toWikiPageSummary(params)).toBeNull();
+    expect(() => parseWikiMarkdown(raw)).toThrow("Wiki frontmatter must be a YAML mapping");
+  });
+
   it("preserves frontmatter and body for valid YAML (#96125 control)", () => {
     const raw = [
       "---",

--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -3,7 +3,9 @@ import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   createWikiPageFilename,
+  parseWikiMarkdown,
   renderWikiMarkdown,
+  scanWikiPageSummary,
   slugifyWikiSegment,
   toWikiPageSummary,
   WIKI_RAW_SOURCE_MARKER,
@@ -422,7 +424,7 @@ describe("toWikiPageSummary", () => {
     ]);
   });
 
-  it("degrades to empty frontmatter instead of throwing on unparsable YAML (#96125)", () => {
+  it("reports and excludes unparsable frontmatter from page scans (#96125)", () => {
     const raw = [
       "---",
       "pageType: synthesis",
@@ -436,22 +438,20 @@ describe("toWikiPageSummary", () => {
       "Body text that should be preserved.",
     ].join("\n");
 
-    const summary = toWikiPageSummary({
+    const params = {
       absolutePath: "/tmp/wiki/syntheses/test.md",
       relativePath: "syntheses/test.md",
       raw,
-    });
-    if (!summary) {
-      throw new Error("expected wiki summary");
+    };
+    const result = scanWikiPageSummary(params);
+    if (result.status !== "invalid-frontmatter") {
+      throw new Error("expected invalid frontmatter result");
     }
 
-    expect(summary.frontmatterError).toBeTruthy();
-    expect(summary.hasFrontmatter).toBe(true);
-    // Frontmatter-derived fields fall back to empty.
-    expect(summary.id).toBeUndefined();
-    expect(summary.sourceIds).toEqual([]);
-    // Body is preserved.
-    expect(summary.title).toBe("Test Title");
+    expect(result.error.relativePath).toBe("syntheses/test.md");
+    expect(result.error.message).toContain("Unexpected scalar");
+    expect(toWikiPageSummary(params)).toBeNull();
+    expect(() => parseWikiMarkdown(raw)).toThrow("Unexpected scalar");
   });
 
   it("preserves frontmatter and body for valid YAML (#96125 control)", () => {
@@ -477,8 +477,8 @@ describe("toWikiPageSummary", () => {
       throw new Error("expected wiki summary");
     }
 
-    expect(summary.frontmatterError).toBeUndefined();
     expect(summary.hasFrontmatter).toBe(true);
+    expect(summary.title).toBe("Healthy Page");
     expect(summary.id).toBe("synthesis.healthy");
     expect(summary.sourceIds).toEqual(["source.alpha"]);
     expect(summary.pageType).toBe("synthesis");

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -189,12 +189,14 @@ export function parseWikiMarkdown(content: string): ParsedWikiMarkdown {
     return { hasFrontmatter: false, frontmatter: {}, body: content };
   }
   const parsed = YAML.parse(match[1]) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    // Every writer spreads this value back into YAML. Reject non-mapping roots
+    // so an edit cannot silently replace scalar or sequence frontmatter.
+    throw new TypeError("Wiki frontmatter must be a YAML mapping");
+  }
   return {
     hasFrontmatter: true,
-    frontmatter:
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : {},
+    frontmatter: parsed as Record<string, unknown>,
     body: content.slice(match[0].length),
   };
 }

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -79,6 +79,8 @@ export type WikiPageSummary = {
   kind: WikiPageKind;
   title: string;
   hasFrontmatter: boolean;
+  /** Set when frontmatter YAML failed to parse; frontmatter-derived fields fall back to empty. */
+  frontmatterError?: string;
   id?: string;
   pageType?: string;
   entityType?: string;
@@ -173,19 +175,27 @@ export function createWikiPageFilename(stem: string, extension = ".md"): string 
   return `${capWikiValueWithHash(stem, maxStemBytes, "page")}${normalizedExtension}`;
 }
 
-export function parseWikiMarkdown(content: string): ParsedWikiMarkdown {
+function splitWikiFrontmatterBlock(content: string): { yamlSource: string; body: string } | null {
   const match = content.match(FRONTMATTER_PATTERN);
   if (!match) {
+    return null;
+  }
+  return { yamlSource: match[1] ?? "", body: content.slice(match[0].length) };
+}
+
+export function parseWikiMarkdown(content: string): ParsedWikiMarkdown {
+  const split = splitWikiFrontmatterBlock(content);
+  if (!split) {
     return { hasFrontmatter: false, frontmatter: {}, body: content };
   }
-  const parsed = YAML.parse(match[1]) as unknown;
+  const parsed = YAML.parse(split.yamlSource) as unknown;
   return {
     hasFrontmatter: true,
     frontmatter:
       parsed && typeof parsed === "object" && !Array.isArray(parsed)
         ? (parsed as Record<string, unknown>)
         : {},
-    body: content.slice(match[0].length),
+    body: split.body,
   };
 }
 
@@ -622,7 +632,24 @@ export function toWikiPageSummary(params: {
   if (!kind) {
     return null;
   }
-  const parsed = parseWikiMarkdown(params.raw);
+  // A page with unparsable YAML frontmatter must not crash vault-wide scans
+  // (compile/lint/query/status) over unrelated pages; degrade to empty
+  // frontmatter and surface the failure via WikiPageSummary.frontmatterError.
+  // Callers that call parseWikiMarkdown directly (apply, chatgpt-import) still
+  // throw on bad frontmatter so edits never silently overwrite metadata.
+  let parsed: ParsedWikiMarkdown;
+  let frontmatterError: string | undefined;
+  try {
+    parsed = parseWikiMarkdown(params.raw);
+  } catch (error) {
+    frontmatterError = error instanceof Error ? error.message : String(error);
+    const fallback = splitWikiFrontmatterBlock(params.raw);
+    parsed = {
+      hasFrontmatter: true,
+      frontmatter: {},
+      body: fallback?.body ?? params.raw,
+    };
+  }
   const title =
     (typeof parsed.frontmatter.title === "string" && parsed.frontmatter.title.trim()) ||
     extractTitleFromMarkdown(parsed.body) ||
@@ -643,6 +670,7 @@ export function toWikiPageSummary(params: {
     kind,
     title,
     hasFrontmatter: parsed.hasFrontmatter,
+    ...(frontmatterError ? { frontmatterError } : {}),
     id: normalizeOptionalString(parsed.frontmatter.id),
     pageType: normalizeOptionalString(parsed.frontmatter.pageType),
     entityType: normalizeOptionalString(parsed.frontmatter.entityType),

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -73,14 +73,17 @@ export type WikiRelationship = {
   updatedAt?: string;
 };
 
+export type WikiPageFrontmatterError = {
+  relativePath: string;
+  message: string;
+};
+
 export type WikiPageSummary = {
   absolutePath: string;
   relativePath: string;
   kind: WikiPageKind;
   title: string;
   hasFrontmatter: boolean;
-  /** Set when frontmatter YAML failed to parse; frontmatter-derived fields fall back to empty. */
-  frontmatterError?: string;
   id?: string;
   pageType?: string;
   entityType?: string;
@@ -110,6 +113,11 @@ export type WikiPageSummary = {
   lastRefreshedAt?: string;
   updatedAt?: string;
 };
+
+export type WikiPageSummaryScanResult =
+  | { status: "valid"; page: WikiPageSummary }
+  | { status: "invalid-frontmatter"; error: WikiPageFrontmatterError }
+  | { status: "ignored" };
 
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 const OBSIDIAN_LINK_PATTERN = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
@@ -175,27 +183,19 @@ export function createWikiPageFilename(stem: string, extension = ".md"): string 
   return `${capWikiValueWithHash(stem, maxStemBytes, "page")}${normalizedExtension}`;
 }
 
-function splitWikiFrontmatterBlock(content: string): { yamlSource: string; body: string } | null {
+export function parseWikiMarkdown(content: string): ParsedWikiMarkdown {
   const match = content.match(FRONTMATTER_PATTERN);
   if (!match) {
-    return null;
-  }
-  return { yamlSource: match[1] ?? "", body: content.slice(match[0].length) };
-}
-
-export function parseWikiMarkdown(content: string): ParsedWikiMarkdown {
-  const split = splitWikiFrontmatterBlock(content);
-  if (!split) {
     return { hasFrontmatter: false, frontmatter: {}, body: content };
   }
-  const parsed = YAML.parse(split.yamlSource) as unknown;
+  const parsed = YAML.parse(match[1]) as unknown;
   return {
     hasFrontmatter: true,
     frontmatter:
       parsed && typeof parsed === "object" && !Array.isArray(parsed)
         ? (parsed as Record<string, unknown>)
         : {},
-    body: split.body,
+    body: content.slice(match[0].length),
   };
 }
 
@@ -623,31 +623,27 @@ export function inferWikiPageKind(relativePath: string): WikiPageKind | null {
   return null;
 }
 
-export function toWikiPageSummary(params: {
+export function scanWikiPageSummary(params: {
   absolutePath: string;
   relativePath: string;
   raw: string;
-}): WikiPageSummary | null {
+}): WikiPageSummaryScanResult {
   const kind = inferWikiPageKind(params.relativePath);
   if (!kind) {
-    return null;
+    return { status: "ignored" };
   }
-  // A page with unparsable YAML frontmatter must not crash vault-wide scans
-  // (compile/lint/query/status) over unrelated pages; degrade to empty
-  // frontmatter and surface the failure via WikiPageSummary.frontmatterError.
-  // Callers that call parseWikiMarkdown directly (apply, chatgpt-import) still
-  // throw on bad frontmatter so edits never silently overwrite metadata.
   let parsed: ParsedWikiMarkdown;
-  let frontmatterError: string | undefined;
   try {
     parsed = parseWikiMarkdown(params.raw);
   } catch (error) {
-    frontmatterError = error instanceof Error ? error.message : String(error);
-    const fallback = splitWikiFrontmatterBlock(params.raw);
-    parsed = {
-      hasFrontmatter: true,
-      frontmatter: {},
-      body: fallback?.body ?? params.raw,
+    // Vault scans exclude malformed pages from derived state, while direct parse callers
+    // stay strict so write paths cannot replace unparsed metadata with empty fields.
+    return {
+      status: "invalid-frontmatter",
+      error: {
+        relativePath: params.relativePath.split(path.sep).join("/"),
+        message: error instanceof Error ? error.message : String(error),
+      },
     };
   }
   const title =
@@ -665,45 +661,56 @@ export function toWikiPageSummary(params: {
     detectUnmanagedRawSourceBody(parsed.body);
 
   return {
-    absolutePath: params.absolutePath,
-    relativePath: params.relativePath.split(path.sep).join("/"),
-    kind,
-    title,
-    hasFrontmatter: parsed.hasFrontmatter,
-    ...(frontmatterError ? { frontmatterError } : {}),
-    id: normalizeOptionalString(parsed.frontmatter.id),
-    pageType: normalizeOptionalString(parsed.frontmatter.pageType),
-    entityType: normalizeOptionalString(parsed.frontmatter.entityType),
-    canonicalId: normalizeOptionalString(parsed.frontmatter.canonicalId),
-    aliases: normalizeSingleOrTrimmedStringList(parsed.frontmatter.aliases),
-    sourceIds: normalizeSourceIds(parsed.frontmatter.sourceIds),
-    linkTargets: extractWikiLinks(params.raw, params.relativePath.split(path.sep).join("/")),
-    claims: normalizeWikiClaims(parsed.frontmatter.claims),
-    contradictions: normalizeSingleOrTrimmedStringList(parsed.frontmatter.contradictions),
-    questions: normalizeSingleOrTrimmedStringList(parsed.frontmatter.questions),
-    confidence:
-      typeof parsed.frontmatter.confidence === "number" &&
-      Number.isFinite(parsed.frontmatter.confidence)
-        ? parsed.frontmatter.confidence
-        : undefined,
-    privacyTier: normalizeOptionalString(parsed.frontmatter.privacyTier),
-    personCard: normalizeWikiPersonCard(parsed.frontmatter.personCard),
-    relationships: normalizeWikiRelationships(parsed.frontmatter.relationships),
-    bestUsedFor: normalizeSingleOrTrimmedStringList(parsed.frontmatter.bestUsedFor),
-    notEnoughFor: normalizeSingleOrTrimmedStringList(parsed.frontmatter.notEnoughFor),
-    sourceType: normalizeOptionalString(parsed.frontmatter.sourceType),
-    provenanceMode: normalizeOptionalString(parsed.frontmatter.provenanceMode),
-    ...(importedSourceBody ? { importedSourceBody } : {}),
-    ...(generatedSourceBody ? { generatedSourceBody } : {}),
-    ...(unmanagedRawSourceBody ? { unmanagedRawSourceBody } : {}),
-    sourcePath: normalizeOptionalString(parsed.frontmatter.sourcePath),
-    bridgeRelativePath: normalizeOptionalString(parsed.frontmatter.bridgeRelativePath),
-    bridgeWorkspaceDir: normalizeOptionalString(parsed.frontmatter.bridgeWorkspaceDir),
-    unsafeLocalConfiguredPath: normalizeOptionalString(
-      parsed.frontmatter.unsafeLocalConfiguredPath,
-    ),
-    unsafeLocalRelativePath: normalizeOptionalString(parsed.frontmatter.unsafeLocalRelativePath),
-    lastRefreshedAt: normalizeOptionalString(parsed.frontmatter.lastRefreshedAt),
-    updatedAt: normalizeOptionalString(parsed.frontmatter.updatedAt),
+    status: "valid",
+    page: {
+      absolutePath: params.absolutePath,
+      relativePath: params.relativePath.split(path.sep).join("/"),
+      kind,
+      title,
+      hasFrontmatter: parsed.hasFrontmatter,
+      id: normalizeOptionalString(parsed.frontmatter.id),
+      pageType: normalizeOptionalString(parsed.frontmatter.pageType),
+      entityType: normalizeOptionalString(parsed.frontmatter.entityType),
+      canonicalId: normalizeOptionalString(parsed.frontmatter.canonicalId),
+      aliases: normalizeSingleOrTrimmedStringList(parsed.frontmatter.aliases),
+      sourceIds: normalizeSourceIds(parsed.frontmatter.sourceIds),
+      linkTargets: extractWikiLinks(params.raw, params.relativePath.split(path.sep).join("/")),
+      claims: normalizeWikiClaims(parsed.frontmatter.claims),
+      contradictions: normalizeSingleOrTrimmedStringList(parsed.frontmatter.contradictions),
+      questions: normalizeSingleOrTrimmedStringList(parsed.frontmatter.questions),
+      confidence:
+        typeof parsed.frontmatter.confidence === "number" &&
+        Number.isFinite(parsed.frontmatter.confidence)
+          ? parsed.frontmatter.confidence
+          : undefined,
+      privacyTier: normalizeOptionalString(parsed.frontmatter.privacyTier),
+      personCard: normalizeWikiPersonCard(parsed.frontmatter.personCard),
+      relationships: normalizeWikiRelationships(parsed.frontmatter.relationships),
+      bestUsedFor: normalizeSingleOrTrimmedStringList(parsed.frontmatter.bestUsedFor),
+      notEnoughFor: normalizeSingleOrTrimmedStringList(parsed.frontmatter.notEnoughFor),
+      sourceType: normalizeOptionalString(parsed.frontmatter.sourceType),
+      provenanceMode: normalizeOptionalString(parsed.frontmatter.provenanceMode),
+      ...(importedSourceBody ? { importedSourceBody } : {}),
+      ...(generatedSourceBody ? { generatedSourceBody } : {}),
+      ...(unmanagedRawSourceBody ? { unmanagedRawSourceBody } : {}),
+      sourcePath: normalizeOptionalString(parsed.frontmatter.sourcePath),
+      bridgeRelativePath: normalizeOptionalString(parsed.frontmatter.bridgeRelativePath),
+      bridgeWorkspaceDir: normalizeOptionalString(parsed.frontmatter.bridgeWorkspaceDir),
+      unsafeLocalConfiguredPath: normalizeOptionalString(
+        parsed.frontmatter.unsafeLocalConfiguredPath,
+      ),
+      unsafeLocalRelativePath: normalizeOptionalString(parsed.frontmatter.unsafeLocalRelativePath),
+      lastRefreshedAt: normalizeOptionalString(parsed.frontmatter.lastRefreshedAt),
+      updatedAt: normalizeOptionalString(parsed.frontmatter.updatedAt),
+    },
   };
+}
+
+export function toWikiPageSummary(params: {
+  absolutePath: string;
+  relativePath: string;
+  raw: string;
+}): WikiPageSummary | null {
+  const result = scanWikiPageSummary(params);
+  return result.status === "valid" ? result.page : null;
 }

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -209,6 +209,38 @@ describe("searchMemoryWiki", () => {
     expect(getActiveMemorySearchManagerMock).not.toHaveBeenCalled();
   });
 
+  it("skips malformed pages while searching the rest of the vault (#96125)", async () => {
+    const { rootDir, config } = await createQueryVault({ initialize: true });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "broken.md"),
+      [
+        "---",
+        "pageType: source",
+        "id: source.broken",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+        "---",
+        "",
+        "# Broken",
+        "",
+        "poison needle",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "healthy.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.healthy", title: "Healthy Source" },
+        body: "# Healthy Source\n\nhealthy needle\n",
+      }),
+      "utf8",
+    );
+
+    const results = await searchMemoryWiki({ config, query: "needle" });
+
+    expect(collectWikiResultPaths(results)).toEqual(["sources/healthy.md"]);
+  });
+
   it("uses the default search limit for non-finite maxResults", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/status.test.ts
+++ b/extensions/memory-wiki/src/status.test.ts
@@ -125,6 +125,43 @@ describe("resolveMemoryWikiStatus", () => {
     expect(status.sourceCounts.native).toBe(2);
   });
 
+  it("excludes malformed pages from status counts (#96125)", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-status-invalid-frontmatter-",
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "broken.md"),
+      [
+        "---",
+        "pageType: source",
+        "id: source.broken",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+        "---",
+        "",
+        "# Broken",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "healthy.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.healthy", title: "Healthy" },
+        body: "# Healthy\n",
+      }),
+      "utf8",
+    );
+
+    const status = await resolveMemoryWikiStatus(config, {
+      pathExists: async () => true,
+      resolveCommand: async () => null,
+    });
+
+    expect(status.pageCounts.source).toBe(1);
+    expect(status.sourceCounts.native).toBe(1);
+  });
+
   it("counts source provenance from the vault", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-status-",

--- a/extensions/memory-wiki/src/status.ts
+++ b/extensions/memory-wiki/src/status.ts
@@ -5,7 +5,7 @@ import { listActiveMemoryPublicArtifacts } from "openclaw/plugin-sdk/memory-host
 import { pathExists } from "openclaw/plugin-sdk/security-runtime";
 import type { OpenClawConfig } from "../api.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { inferWikiPageKind, toWikiPageSummary, type WikiPageKind } from "./markdown.js";
+import { toWikiPageSummary, type WikiPageKind } from "./markdown.js";
 import { probeObsidianCli } from "./obsidian.js";
 
 type MemoryWikiStatusWarning = {
@@ -97,37 +97,35 @@ async function collectVaultCounts(vaultPath: string): Promise<{
       }
       const absolutePath = path.join(entry.parentPath ?? dirPath, entry.name);
       const relativeToVault = path.relative(vaultPath, absolutePath).split(path.sep).join("/");
-      const kind = inferWikiPageKind(relativeToVault);
-      if (kind) {
-        pageCounts[kind] += 1;
+      const raw = await fs.readFile(absolutePath, "utf8").catch(() => null);
+      if (raw === null) {
+        continue;
       }
-      if (dir === "sources") {
-        const raw = await fs.readFile(absolutePath, "utf8").catch(() => null);
-        if (!raw) {
-          continue;
-        }
-        const page = toWikiPageSummary({
-          absolutePath,
-          relativePath: relativeToVault,
-          raw,
-        });
-        if (!page) {
-          continue;
-        }
-        if (page.sourceType === "memory-bridge-events") {
-          sourceCounts.bridgeEvents += 1;
-        } else if (page.sourceType === "memory-bridge") {
-          sourceCounts.bridge += 1;
-        } else if (
-          page.provenanceMode === "unsafe-local" ||
-          page.sourceType === "memory-unsafe-local"
-        ) {
-          sourceCounts.unsafeLocal += 1;
-        } else if (!page.sourceType) {
-          sourceCounts.native += 1;
-        } else {
-          sourceCounts.other += 1;
-        }
+      const page = toWikiPageSummary({
+        absolutePath,
+        relativePath: relativeToVault,
+        raw,
+      });
+      if (!page) {
+        continue;
+      }
+      pageCounts[page.kind] += 1;
+      if (page.kind !== "source") {
+        continue;
+      }
+      if (page.sourceType === "memory-bridge-events") {
+        sourceCounts.bridgeEvents += 1;
+      } else if (page.sourceType === "memory-bridge") {
+        sourceCounts.bridge += 1;
+      } else if (
+        page.provenanceMode === "unsafe-local" ||
+        page.sourceType === "memory-unsafe-local"
+      ) {
+        sourceCounts.unsafeLocal += 1;
+      } else if (!page.sourceType) {
+        sourceCounts.native += 1;
+      } else {
+        sourceCounts.other += 1;
       }
     }
   }


### PR DESCRIPTION
Related to #96125. Supersedes #96177.

## What Problem This Solves

A single memory-wiki page with malformed YAML frontmatter caused vault-wide compile, query, lint, status, and apply workflows to throw. Returning a degraded empty-metadata summary would avoid the crash but contaminate derived indexes, digests, counts, and query results, and could let writers erase metadata.

## Why This Change Was Made

The final implementation separates tolerant scans from strict writes:

- `scanWikiPageSummary` returns a closed valid / invalid-frontmatter / ignored result.
- Compile, query, and status consume only valid summaries; lint receives structured parse failures separately.
- Syntax-invalid YAML and parseable non-mapping roots are both invalid frontmatter.
- `parseWikiMarkdown` remains strict for direct edits, dashboards, lint reports, and generated root/directory indexes, preserving malformed targets byte-for-byte.

This keeps one bad page from disabling read-only vault workflows without manufacturing a valid-looking page or weakening write safety.

## User Impact

- Healthy pages continue to compile, search, lint, and count when another page has invalid frontmatter.
- Invalid pages are excluded from indexes, digests, counts, related-block writes, and query results.
- Lint reports the invalid file and parse reason.
- Apply and every managed Markdown writer fail closed when their own target is invalid.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-wiki/src/markdown.test.ts extensions/memory-wiki/src/compile.test.ts extensions/memory-wiki/src/lint.test.ts extensions/memory-wiki/src/query.test.ts extensions/memory-wiki/src/status.test.ts extensions/memory-wiki/src/apply.test.ts` — 6 files, 98 tests passed.
- Blacksmith Testbox-through-Crabbox `tbx_01kwdez3sef8w1dqe4m4v40c6j`: `env CI=1 corepack pnpm test extensions/memory-wiki` — 31 files, 209 tests passed.
- Same Testbox: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed` — passed extension typecheck/lint and repository guards.
- Azure Crabbox lease `cbx_06c4ea5d0f42`, run `run_64bc6a1334b3`: real CLI init/compile/search/lint/status/apply scenario passed, including malformed-target byte preservation.
- Final exact-head autoreview on `e9d0dccff3` — no findings; patch correct at 0.94 confidence.

## What Was Not Tested

No external provider credentials or network service are involved in this plugin-local parser and filesystem behavior. No proof gap remains for the changed surface.
