### PR TITLE
docs: add 'Add to Slack' OAuth button to Slack channel setup page

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -84,6 +84,10 @@ openclaw plugins install @openclaw/slack
 
 ## Quick setup
 
+<a href="https://slack.com/oauth/v2/authorize?client_id=10815128009479.10859195249184&scope=reactions:read,app_mentions:read,chat:write,commands,im:history,reactions:write&user_scope="><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
+
+Or set up manually using the steps below.
+
 <Tabs>
   <Tab title="Socket Mode (default)">
     <Steps>


### PR DESCRIPTION
## Summary

Adds the official "Add to Slack" OAuth button to the top of the Quick setup section in `docs/channels/slack.md`.

The button is placed right before the manual setup tabs so users can one-click install the app into their workspace without going through the manual app creation flow.

## Change

- Added the `<a>` + `<img>` button block (using the official Slack platform CDN images at 1x/2x) immediately after the `## Quick setup` heading
- Added a short "Or set up manually using the steps below." line to preserve the manual flow for users who need custom scopes or a self-hosted app

## OAuth URL

The button uses the client ID and scope set provided:
```
client_id=10815128009479.10859195249184
scope=reactions:read,app_mentions:read,chat:write,commands,im:history,reactions:write
```