### PR TITLE
fix(bedrock): apply model maxTokens to adaptive-thinking and Fable 5 requests

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -512,6 +512,31 @@ describe("Bedrock Fable contract", () => {
 
     expect(activityCount).toBeGreaterThan(0);
   });
+
+  it("sends model.maxTokens via streamSimpleBedrock for Fable 5", async () => {
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        { messageStop: { stopReason: "end_turn" } },
+      ]),
+    } as never);
+    const model = fableModel(); // maxTokens: 128000
+
+    await streamSimpleBedrock(model, context(), {
+      reasoning: "high",
+      temperature: 0.2,
+    }).result();
+
+    const command = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    const maxTokens = (command.input?.inferenceConfig as Record<string, unknown>)
+      ?.maxTokens as number;
+
+    // Before fix: 4096 (options.maxTokens default, model.maxTokens ignored).
+    // After fix: 128000 from model.maxTokens via adjustMaxTokensForThinking.
+    expect(maxTokens).toBe(128_000);
+    expect(maxTokens).toBeGreaterThan(4096);
+  });
 });
 
 describe("Bedrock canonical Claude aliases", () => {
@@ -570,6 +595,44 @@ describe("Bedrock canonical Claude aliases", () => {
           output_config: { effort: expectedEffort },
         },
       });
+      // Adaptive-thinking path must populate inferenceConfig.maxTokens
+      // from model.maxTokens (via adjustMaxTokensForThinking) instead of
+      // leaving the legacy 4096 default.
+      const maxTokens = (command.input?.inferenceConfig as Record<string, unknown>)
+        ?.maxTokens as number;
+      expect(maxTokens).toBeGreaterThan(0);
     },
   );
+
+  it("sends model.maxTokens in inferenceConfig for high-context adaptive models", async () => {
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        { messageStop: { stopReason: "end_turn" } },
+      ]),
+    } as never);
+    const model = bedrockModel({
+      id: "us.anthropic.claude-opus-4-8",
+      name: "Claude Opus 4.8",
+      maxTokens: 200_000,
+      contextWindow: 1_000_000,
+    });
+
+    await streamSimpleBedrock(
+      model,
+      { messages: [{ role: "user", content: "Reply briefly.", timestamp: 0 }] } as never,
+      { reasoning: "high", temperature: 0.2 },
+    ).result();
+
+    const command = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    const maxTokens = (command.input?.inferenceConfig as Record<string, unknown>)
+      ?.maxTokens as number;
+
+    // Before fix: this was 4096 (options.maxTokens default).
+    // After fix: adjustMaxTokensForThinking uses model.maxTokens (200000)
+    // when no explicit caller cap is set.
+    expect(maxTokens).toBe(200_000);
+    expect(maxTokens).toBeGreaterThan(4096);
+  });
 });

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -254,6 +254,54 @@ describe("Bedrock thinking effort mapping", () => {
       ),
     ).toBe("xhigh");
   });
+
+  it("derives maxTokens from model.maxTokens for adaptive-thinking Claude models", () => {
+    const model = bedrockModel({
+      id: "us.anthropic.claude-opus-4-8",
+      name: "Claude Opus 4.8",
+      maxTokens: 200_000,
+    });
+    const options = testing.resolveSimpleBedrockOptions(model, {
+      reasoning: "high",
+    });
+
+    // adaptive-thinking branch must call adjustMaxTokensForThinking,
+    // which uses model.maxTokens (200k) when no explicit caller cap is set.
+    expect(options.maxTokens).toBeGreaterThan(4096);
+    expect(options.maxTokens).toBe(200_000);
+    expect(options.thinkingBudgets?.high).toBeGreaterThan(0);
+  });
+
+  it("honors explicit caller maxTokens even for adaptive-thinking models", () => {
+    const model = bedrockModel({
+      id: "us.anthropic.claude-opus-4-8",
+      name: "Claude Opus 4.8",
+      maxTokens: 200_000,
+    });
+    const options = testing.resolveSimpleBedrockOptions(model, {
+      reasoning: "high",
+      maxTokens: 8000,
+    });
+
+    // Explicit caller cap (8000 + thinking budget fits inside model cap 200k)
+    expect(options.maxTokens).toBeGreaterThan(4096);
+    expect(options.maxTokens).toBeLessThan(200_000);
+  });
+
+  it("handles adaptive thinking with medium effort correctly", () => {
+    const model = bedrockModel({
+      id: "us.anthropic.claude-opus-4-8",
+      name: "Claude Opus 4.8",
+      maxTokens: 200_000,
+    });
+    const options = testing.resolveSimpleBedrockOptions(model, {
+      reasoning: "medium",
+    });
+
+    expect(options.maxTokens).toBe(200_000);
+    expect(options.reasoning).toBe("medium");
+    expect(options.thinkingBudgets?.medium).toBeGreaterThan(0);
+  });
 });
 
 describe("Bedrock Fable contract", () => {
@@ -314,6 +362,30 @@ describe("Bedrock Fable contract", () => {
       },
       additionalModelResponseFieldPaths: ["/stop_details"],
     });
+  });
+
+  it("derives maxTokens from model.maxTokens for Fable 5 option resolution", () => {
+    const model = fableModel();
+    const options = testing.resolveSimpleBedrockOptions(model, { reasoning: "high" });
+
+    // Fable 5 branch must call adjustMaxTokensForThinking which uses
+    // model.maxTokens (128_000) when no explicit caller cap is set.
+    expect(options.maxTokens).toBeGreaterThan(4096);
+    expect(options.maxTokens).toBe(128_000);
+    expect(options.reasoning).toBe("high");
+    expect(options.thinkingBudgets?.high).toBeGreaterThan(0);
+  });
+
+  it("honors explicit caller maxTokens for Fable 5", () => {
+    const model = fableModel();
+    const options = testing.resolveSimpleBedrockOptions(model, {
+      reasoning: "high",
+      maxTokens: 16000,
+    });
+
+    // 16000 + thinking budget (16384) fits inside 128_000
+    expect(options.maxTokens).toBeGreaterThan(4096);
+    expect(options.maxTokens).toBeLessThan(128_000);
   });
 
   it("preserves explicit tool disabling", async () => {
@@ -492,7 +564,7 @@ describe("Bedrock canonical Claude aliases", () => {
       const command = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
       expect(command.input).toMatchObject({
         modelId: "production-claude",
-        inferenceConfig: {},
+        inferenceConfig: { maxTokens: expect.any(Number) },
         additionalModelRequestFields: {
           thinking: { type: "adaptive", display: "summarized" },
           output_config: { effort: expectedEffort },

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -359,10 +359,21 @@ function resolveSimpleBedrockOptions(
 ): BedrockOptions {
   const base = buildBaseOptions(model, options, undefined);
   if (usesClaudeFable5BedrockContract(model)) {
+    const reasoning = options?.reasoning ?? "high";
+    const adjusted = adjustMaxTokensForThinking(
+      base.maxTokens,
+      model.maxTokens,
+      reasoning,
+      options?.thinkingBudgets,
+    );
     return {
       ...base,
-      reasoning: options?.reasoning ?? "high",
-      thinkingBudgets: options?.thinkingBudgets,
+      maxTokens: adjusted.maxTokens,
+      reasoning,
+      thinkingBudgets: {
+        ...options?.thinkingBudgets,
+        [clampReasoning(reasoning)!]: adjusted.thinkingBudget,
+      },
     } satisfies BedrockOptions;
   }
   if (!options?.reasoning) {
@@ -378,10 +389,20 @@ function resolveSimpleBedrockOptions(
 
   if (isAnthropicClaudeModel(model)) {
     if (supportsAdaptiveThinking(model)) {
+      const adjusted = adjustMaxTokensForThinking(
+        base.maxTokens,
+        model.maxTokens,
+        options.reasoning,
+        options.thinkingBudgets,
+      );
       return {
         ...base,
+        maxTokens: adjusted.maxTokens,
         reasoning: options.reasoning,
-        thinkingBudgets: options.thinkingBudgets,
+        thinkingBudgets: {
+          ...options.thinkingBudgets,
+          [clampReasoning(options.reasoning)!]: adjusted.thinkingBudget,
+        },
       } satisfies BedrockOptions;
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #97176 — Amazon Bedrock Claude models using adaptive thinking (Opus 4.8, Fable 5) are hard-capped at 4096 output tokens. At higher thinking levels the thinking block alone consumes the budget, causing `stop_reason: "length"` before any answer or tool call is delivered.

## Why This Change Was Made

Root cause: `resolveSimpleBedrockOptions` in `extensions/amazon-bedrock/stream.runtime.ts` only calls `adjustMaxTokensForThinking()` for the **non-adaptive Claude branch**. The **Fable 5 branch** (line 361) and **adaptive-thinking branch** (line 391) both return `base` with reasoning/thinkingBudgets set but never derive `maxTokens` from `model.maxTokens` — leaving it at the 4096 default.

Fix: Apply `adjustMaxTokensForThinking()` in all three Claude branches so `model.maxTokens` is consulted uniformly. When no explicit caller cap is set (`base.maxTokens` is undefined), the helper uses `model.maxTokens` directly; when a cap exists, it fits the thinking budget inside it.

| Branch | Before | After |
|--------|--------|-------|
| Fable 5 | `base.maxTokens` (4096) | `adjusted.maxTokens` (model cap) |
| Adaptive thinking | `base.maxTokens` (4096) | `adjusted.maxTokens` (model cap) |
| Non-adaptive Claude | `adjusted.maxTokens` ✓ | unchanged |

## Evidence

### Source-level reproduction (current `main`)

```typescript
// extensions/amazon-bedrock/stream.runtime.ts:361-367
if (usesClaudeFable5BedrockContract(model)) {
  return { ...base, reasoning: ..., thinkingBudgets: ... };
  // ^ base.maxTokens is 4096 (options?.maxTokens ?? default)
  //   model.maxTokens is 200000+ but never consulted
}

// extensions/amazon-bedrock/stream.runtime.ts:391-407
if (supportsAdaptiveThinking(model)) {
  return { ...base, reasoning: ..., thinkingBudgets: ... };
  // ^ same: base.maxTokens stays at 4096
}
```

Non-adaptive Claude branch (lines 411-427) correctly calls `adjustMaxTokensForThinking()` — this fix extends that same pattern.

`adjustMaxTokensForThinking` contract ([simple-options.ts:42-71](src/llm/providers/simple-options.ts#L42-L71)):
- `baseMaxTokens === undefined` → returns `modelMaxTokens`
- `baseMaxTokens` set → returns `Math.min(baseMaxTokens + thinkingBudget, modelMaxTokens)`
- Always reserves ≥1024 tokens for output after thinking

### After fix

```
Opus 4.8 (maxTokens 200000, thinking high): maxTokens=200000, thinkingBudget=16384
Fable 5 (maxTokens 128000, thinking high): maxTokens=128000, thinkingBudget=16384
```

### Tests

```sh
node scripts/run-vitest.mjs run extensions/amazon-bedrock/stream.runtime.test.ts extensions/amazon-bedrock/index.test.ts
# 2 files, 73 tests passed
npx oxlint --deny=warn extensions/amazon-bedrock/stream.runtime.ts
# ok
```

## Risk checklist

- [x] Only Bedrock Converse provider affected — 1 file changed
- [x] Reuses existing `adjustMaxTokensForThinking` helper (same as non-adaptive branch)
- [x] Explicit `options.maxTokens` still acts as a cap (helper preserves `Math.min`)
- [x] No config, schema, or SDK changes
- [x] All 73 Bedrock tests pass

## Proof limitations

Live AWS Bedrock proof is not practical in this contributor PR. The fix is source-reproducible:
- ClawSweeper confirmed the source gap on `main` in the canonical issue review
- The non-adaptive Claude branch already proves the same `adjustMaxTokensForThinking` pattern works
- AWS SDK contract supports `inferenceConfig.maxTokens` (verified in ClawSweeper review)

## Current review state

Ready for ClawSweeper review. Triple-stack labeling (queueable-fix, fix-shape-clear, source-repro) on the canonical issue.