### PR TITLE
fix(llm): preserve structured tool results as text across providers

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -2381,8 +2381,6 @@ describe("anthropic transport stream", () => {
   });
 
   it("serializes structured non-image blocks in tool results as JSON text", async () => {
-    const imageData = Buffer.from("image").toString("base64");
-
     await runTransportStream(
       makeAnthropicTransportModel({ id: "claude-sonnet-4-6" }),
       {
@@ -2427,11 +2425,9 @@ describe("anthropic transport stream", () => {
       userMessage.content,
       (record) => record.type === "tool_result" && record.tool_use_id === "tool_1",
     );
-    // Structured non-image block should be serialized, not dropped
-    expect(toolResult.content).toBe(
-      // No images → returns sanitized text string, not array
-      expect.stringContaining('{"type":"resource"'),
-    );
+    // No images → returns sanitized text string, not array
+    expect(typeof toolResult.content).toBe("string");
+    expect(toolResult.content).toContain('"type":"resource"');
     expect(toolResult.content).toContain("ok");
     expect(toolResult.is_error).toBe(false);
   });

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -2380,6 +2380,116 @@ describe("anthropic transport stream", () => {
     expect(toolResult.is_error).toBe(false);
   });
 
+  it("serializes structured non-image blocks in tool results as JSON text", async () => {
+    const imageData = Buffer.from("image").toString("base64");
+
+    await runTransportStream(
+      makeAnthropicTransportModel({ id: "claude-sonnet-4-6" }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [{ type: "toolCall", id: "tool_1", name: "fetch", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            content: [
+              { type: "text", text: "ok" },
+              {
+                type: "resource",
+                resource: {
+                  uri: "https://example.com/data.json",
+                  mimeType: "application/json",
+                  text: '{"key":"value"}',
+                },
+              },
+            ],
+            isError: false,
+          },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    const toolResult = findRecord(
+      userMessage.content,
+      (record) => record.type === "tool_result" && record.tool_use_id === "tool_1",
+    );
+    // Structured non-image block should be serialized, not dropped
+    expect(toolResult.content).toBe(
+      // No images → returns sanitized text string, not array
+      expect.stringContaining('{"type":"resource"'),
+    );
+    expect(toolResult.content).toContain("ok");
+    expect(toolResult.is_error).toBe(false);
+  });
+
+  it("includes serialized structured blocks alongside images in tool results", async () => {
+    const imageData = Buffer.from("image").toString("base64");
+
+    await runTransportStream(
+      makeAnthropicTransportModel({ id: "claude-sonnet-4-6" }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [{ type: "toolCall", id: "tool_1", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            content: [
+              {
+                type: "resource",
+                resource: {
+                  uri: "https://example.com/data.json",
+                  mimeType: "application/json",
+                  text: '{"key":"value"}',
+                },
+              },
+              { type: "image", data: imageData, mimeType: "image/png" },
+            ],
+            isError: false,
+          },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    const toolResult = findRecord(
+      userMessage.content,
+      (record) => record.type === "tool_result" && record.tool_use_id === "tool_1",
+    );
+    // When images are present, content is an array
+    const textBlock = findRecord(toolResult.content, (record) => record.type === "text");
+    // Structured block should be serialized as text alongside the image
+    expect(textBlock.text).toEqual(expect.stringContaining('{"type":"resource"'));
+    expect(toolResult.is_error).toBe(false);
+  });
+
   it("cancels stalled SSE body reads when the abort signal fires mid-stream", async () => {
     const controller = new AbortController();
     const abortReason = new Error("anthropic test abort");

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -320,15 +320,19 @@ function convertContentBlocks(content: readonly unknown[]) {
     blocks.push({ type: "text", text: "(see attached image)" });
   }
   for (const block of Array.isArray(content) ? content : []) {
-    if (!block || typeof block !== "object") continue;
+    if (!block || typeof block !== "object") {
+      continue;
+    }
     const record = block as Record<string, unknown>;
-    if (record.type !== "image") continue;
+    if (record.type !== "image") {
+      continue;
+    }
     blocks.push({
       type: "image" as const,
       source: {
         type: "base64",
-        media_type: String(record.mimeType || "image/png"),
-        data: String(record.data || ""),
+        media_type: typeof record.mimeType === "string" ? record.mimeType : "image/png",
+        data: typeof record.data === "string" ? record.data : "",
       },
     });
   }

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -13,6 +13,7 @@ import {
   findActiveAnthropicToolTurnAssistantIndex,
 } from "../llm/providers/anthropic-thinking-replay.js";
 import type { AnthropicOptions } from "../llm/providers/anthropic.js";
+import { extractToolResultText } from "../llm/providers/tool-result-text.js";
 import type {
   AssistantMessageDiagnostic,
   Context,
@@ -295,16 +296,16 @@ function toClaudeCodeName(name: string): string {
   return CLAUDE_CODE_TOOL_LOOKUP.get(normalizeLowercaseStringOrEmpty(name)) ?? name;
 }
 
-function convertContentBlocks(
-  content: Array<
-    { type: "text"; text: string } | { type: "image"; data: string; mimeType: string }
-  >,
-) {
-  const hasImages = content.some((item) => item.type === "image");
-  if (!hasImages) {
-    return sanitizeNonEmptyTransportPayloadText(
-      content.map((item) => ("text" in item ? item.text : "")).join("\n"),
+function convertContentBlocks(content: readonly unknown[]) {
+  const text = extractToolResultText(content);
+  const hasImages =
+    Array.isArray(content) &&
+    content.some(
+      (item) =>
+        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
     );
+  if (!hasImages) {
+    return sanitizeNonEmptyTransportPayloadText(text);
   }
   const blocks: Array<
     | { type: "text"; text: string }
@@ -313,27 +314,23 @@ function convertContentBlocks(
         source: { type: "base64"; media_type: string; data: string };
       }
   > = [];
-  let hasTextBlock = false;
-  for (const block of content) {
-    if (block.type === "text") {
-      const text = sanitizeTransportPayloadText(block.text);
-      if (text.trim().length > 0) {
-        blocks.push({ type: "text", text });
-        hasTextBlock = true;
-      }
-    } else {
-      blocks.push({
-        type: "image" as const,
-        source: {
-          type: "base64",
-          media_type: block.mimeType,
-          data: block.data,
-        },
-      });
-    }
+  if (text.trim().length > 0) {
+    blocks.push({ type: "text", text: sanitizeTransportPayloadText(text) });
+  } else {
+    blocks.push({ type: "text", text: "(see attached image)" });
   }
-  if (!hasTextBlock) {
-    return [{ type: "text", text: "(see attached image)" }, ...blocks];
+  for (const block of Array.isArray(content) ? content : []) {
+    if (!block || typeof block !== "object") continue;
+    const record = block as Record<string, unknown>;
+    if (record.type !== "image") continue;
+    blocks.push({
+      type: "image" as const,
+      source: {
+        type: "base64",
+        media_type: String(record.mimeType || "image/png"),
+        data: String(record.data || ""),
+      },
+    });
   }
   return blocks;
 }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5075,6 +5075,74 @@ describe("openai transport stream", () => {
     }
   });
 
+  it("serializes structured tool result content (e.g. json blocks) into Responses function_call_output text", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-responses",
+            provider: "openai",
+            model: "gpt-5.5",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              {
+                type: "toolCall",
+                id: "call_lookup",
+                name: "lookup",
+                arguments: { query: "price" },
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_lookup",
+            toolName: "lookup",
+            content: [{ type: "json", payload: { price: 42, currency: "USD" } }],
+            isError: false,
+            timestamp: 2,
+          },
+          { role: "user", content: "continue", timestamp: 3 },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    ) as {
+      input?: Array<{ type?: string; call_id?: string; output?: unknown }>;
+    };
+
+    const output = params.input?.find((item) => item.type === "function_call_output");
+    expect(output).toBeDefined();
+    expect(output?.call_id).toBe("call_lookup");
+    const outputText = output?.output as string;
+    expect(typeof outputText).toBe("string");
+    expect(outputText).toContain("price");
+    expect(outputText).toContain("42");
+    expect(outputText).not.toBe("(see attached image)");
+  });
+
   it("omits distinct overlong Copilot Responses replay item ids when store is disabled", () => {
     const sharedToolItemPrefix = "iVec" + "A".repeat(160);
     const firstToolCallId = `call_first|${sharedToolItemPrefix}Aa`;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -27,6 +27,7 @@ import { resolveAzureDeploymentNameFromMap } from "../llm/providers/azure-deploy
 import { convertMessages } from "../llm/providers/openai-completions.js";
 import { clampOpenAIPromptCacheKey } from "../llm/providers/openai-prompt-cache.js";
 import { mapOpenAIStopReason } from "../llm/providers/openai-stop-reason.js";
+import { extractToolResultText } from "../llm/providers/tool-result-text.js";
 import type { Api, Context, Model } from "../llm/types.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import { parseStreamingJson } from "../llm/utils/json-parse.js";
@@ -1273,10 +1274,7 @@ function convertResponsesMessages(
         messages.push(...output);
       }
     } else if (msg.role === "toolResult") {
-      const textResult = msg.content
-        .filter((item) => item.type === "text")
-        .map((item) => item.text)
-        .join("\n");
+      const textResult = extractToolResultText(msg.content);
       const hasImages = msg.content.some((item) => item.type === "image");
       const [callId] = msg.toolCallId.split("|");
       messages.push({

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -69,6 +69,7 @@ import { resolveCacheRetention } from "./cache-retention.js";
 import { resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
+import { extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
@@ -123,7 +124,7 @@ const toClaudeCodeName = (name: string) => ccToolLookup.get(name.toLowerCase()) 
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(content: (TextContent | ImageContent)[]):
+function convertContentBlocks(content: readonly unknown[]):
   | string
   | Array<
       | { type: "text"; text: string }
@@ -136,36 +137,51 @@ function convertContentBlocks(content: (TextContent | ImageContent)[]):
           };
         }
     > {
-  // If only text blocks, return as concatenated string for simplicity
-  const hasImages = content.some((c) => c.type === "image");
+  const text = extractToolResultText(content);
+  const hasImages =
+    Array.isArray(content) &&
+    content.some(
+      (item) =>
+        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
+    );
+
   if (!hasImages) {
-    return sanitizeSurrogates(content.map((c) => (c as TextContent).text).join("\n"));
+    return sanitizeSurrogates(text);
   }
 
-  // If we have images, convert to content block array
-  const blocks = content.map((block) => {
-    if (block.type === "text") {
-      return {
-        type: "text" as const,
-        text: sanitizeSurrogates(block.text),
-      };
-    }
-    return {
+  const blocks: Array<
+    | { type: "text"; text: string }
+    | {
+        type: "image";
+        source: {
+          type: "base64";
+          media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+          data: string;
+        };
+      }
+  > = [];
+
+  if (text.trim().length > 0) {
+    blocks.push({ type: "text" as const, text: sanitizeSurrogates(text) });
+  } else {
+    blocks.push({ type: "text" as const, text: "(see attached image)" });
+  }
+
+  for (const block of Array.isArray(content) ? content : []) {
+    if (!block || typeof block !== "object") continue;
+    const record = block as Record<string, unknown>;
+    if (record.type !== "image") continue;
+    blocks.push({
       type: "image" as const,
       source: {
         type: "base64" as const,
-        media_type: block.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
-        data: block.data,
+        media_type: String(record.mimeType || "image/jpeg") as
+          | "image/jpeg"
+          | "image/png"
+          | "image/gif"
+          | "image/webp",
+        data: String(record.data || ""),
       },
-    };
-  });
-
-  // If only images (no text), add placeholder text block
-  const hasText = blocks.some((b) => b.type === "text");
-  if (!hasText) {
-    blocks.unshift({
-      type: "text" as const,
-      text: "(see attached image)",
     });
   }
 

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -43,7 +43,6 @@ import type {
   AssistantMessageEvent,
   CacheRetention,
   Context,
-  ImageContent,
   Message,
   Model,
   ModelThinkingLevel,
@@ -168,19 +167,23 @@ function convertContentBlocks(content: readonly unknown[]):
   }
 
   for (const block of Array.isArray(content) ? content : []) {
-    if (!block || typeof block !== "object") continue;
+    if (!block || typeof block !== "object") {
+      continue;
+    }
     const record = block as Record<string, unknown>;
-    if (record.type !== "image") continue;
+    if (record.type !== "image") {
+      continue;
+    }
     blocks.push({
       type: "image" as const,
       source: {
         type: "base64" as const,
-        media_type: String(record.mimeType || "image/jpeg") as
+        media_type: (typeof record.mimeType === "string" ? record.mimeType : "image/jpeg") as
           | "image/jpeg"
           | "image/png"
           | "image/gif"
           | "image/webp",
-        data: String(record.data || ""),
+        data: typeof record.data === "string" ? record.data : "",
       },
     });
   }

--- a/src/llm/providers/google-shared.convert.test.ts
+++ b/src/llm/providers/google-shared.convert.test.ts
@@ -375,4 +375,29 @@ describe("google-shared convertMessages", () => {
     expect(asRecord(toolCall.functionCall).id).toBeUndefined();
     expect(asRecord(toolResponse.functionResponse).id).toBeUndefined();
   });
+
+  it("serializes structured tool results into function responses", () => {
+    const model = makeModel("gemini-1.5-pro");
+    const context = {
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "session_status",
+          content: [{ type: "json", payload: { sessionKey: "current", status: "ok" } }],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as unknown as Context;
+    const contents = convertMessagesForTest(model, context);
+    const toolResponsePart = contents[0]?.parts?.find(
+      (part) => typeof part === "object" && part !== null && "functionResponse" in part,
+    );
+    expect(toolResponsePart).toBeDefined();
+    const toolResponse = requireRecordProperty(asRecord(toolResponsePart), "functionResponse");
+    expect(asRecord(toolResponse.response).output).toBe(
+      '{"type":"json","payload":{"sessionKey":"current","status":"ok"}}',
+    );
+  });
 });

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -279,7 +279,7 @@ export function convertMessages<T extends GoogleApiType>(
       });
     } else if (msg.role === "toolResult") {
       // Extract text and image content
-      const textResult = extractToolResultText(msg.content as Array<Record<string, unknown>>);
+      const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
         ? msg.content.filter((c): c is ImageContent => c.type === "image")
         : [];

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -32,6 +32,7 @@ import type {
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 export type GoogleApiType = "google-generative-ai" | "google-vertex";
@@ -278,8 +279,7 @@ export function convertMessages<T extends GoogleApiType>(
       });
     } else if (msg.role === "toolResult") {
       // Extract text and image content
-      const textContent = msg.content.filter((c): c is TextContent => c.type === "text");
-      const textResult = textContent.map((c) => c.text).join("\n");
+      const textResult = extractToolResultText(msg.content as Array<Record<string, unknown>>);
       const imageContent = model.input.includes("image")
         ? msg.content.filter((c): c is ImageContent => c.type === "image")
         : [];

--- a/src/llm/providers/mistral.test.ts
+++ b/src/llm/providers/mistral.test.ts
@@ -237,7 +237,7 @@ describe("Mistral provider", () => {
   });
 
   it("serializes structured non-image blocks in tool results as JSON text", async () => {
-    const context = {
+    const testContext = {
       messages: [
         {
           role: "user",
@@ -271,9 +271,9 @@ describe("Mistral provider", () => {
           timestamp: 0,
         },
       ],
-    } satisfies Context;
+    } as unknown as Context;
 
-    const stream = streamMistral(makeMistralModel(), context, {
+    const stream = streamMistral(makeMistralModel(), testContext, {
       apiKey: "sk-mistral-provider",
     });
     await stream.result();
@@ -290,7 +290,7 @@ describe("Mistral provider", () => {
   });
 
   it("serializes structured-only tool results instead of empty fallback", async () => {
-    const context = {
+    const testContext = {
       messages: [
         {
           role: "user",
@@ -322,9 +322,9 @@ describe("Mistral provider", () => {
           timestamp: 0,
         },
       ],
-    } satisfies Context;
+    } as unknown as Context;
 
-    const stream = streamMistral(makeMistralModel(), context, {
+    const stream = streamMistral(makeMistralModel(), testContext, {
       apiKey: "sk-mistral-provider",
     });
     await stream.result();

--- a/src/llm/providers/mistral.test.ts
+++ b/src/llm/providers/mistral.test.ts
@@ -235,4 +235,109 @@ describe("Mistral provider", () => {
     expect(systemMessage?.content).toBe("Stable\nDynamic");
     expect(JSON.stringify(payload)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
   });
+
+  it("serializes structured non-image blocks in tool results as JSON text", async () => {
+    const context = {
+      messages: [
+        {
+          role: "user",
+          content: "hello",
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          provider: "mistral",
+          api: "mistral-conversations",
+          model: "mistral-large-latest",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [{ type: "toolCall", id: "tool_1", name: "fetch", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "tool_1",
+          content: [
+            { type: "text", text: "ok" },
+            {
+              type: "resource",
+              resource: {
+                uri: "https://example.com/data.json",
+                mimeType: "application/json",
+                text: '{"key":"value"}',
+              },
+            },
+          ],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } satisfies Context;
+
+    const stream = streamMistral(makeMistralModel(), context, {
+      apiKey: "sk-mistral-provider",
+    });
+    await stream.result();
+
+    const payload = mistralMockState.payloads[0] as {
+      messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }>;
+    };
+    const toolMessage = payload.messages.find((message) => message.role === "tool");
+    expect(toolMessage).toBeDefined();
+    const toolContent = Array.isArray(toolMessage!.content) ? toolMessage!.content : [];
+    const textBlock = toolContent.find((block) => block.type === "text");
+    expect(textBlock?.text).toEqual(expect.stringContaining('{"type":"resource"'));
+    expect(textBlock?.text).toContain("ok");
+  });
+
+  it("serializes structured-only tool results instead of empty fallback", async () => {
+    const context = {
+      messages: [
+        {
+          role: "user",
+          content: "hello",
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          provider: "mistral",
+          api: "mistral-conversations",
+          model: "mistral-large-latest",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [{ type: "toolCall", id: "tool_1", name: "get_file", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "tool_1",
+          content: [
+            {
+              type: "resource_link",
+              uri: "https://example.com/file.txt",
+              name: "file.txt",
+              mimeType: "text/plain",
+              size: 100,
+            },
+          ],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } satisfies Context;
+
+    const stream = streamMistral(makeMistralModel(), context, {
+      apiKey: "sk-mistral-provider",
+    });
+    await stream.result();
+
+    const payload = mistralMockState.payloads[0] as {
+      messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }>;
+    };
+    const toolMessage = payload.messages.find((message) => message.role === "tool");
+    expect(toolMessage).toBeDefined();
+    const toolContent = Array.isArray(toolMessage!.content) ? toolMessage!.content : [];
+    const textBlock = toolContent.find((block) => block.type === "text");
+    // Structured blocks should provide the output, not an empty fallback
+    expect(textBlock?.text).toEqual(expect.stringContaining('{"type":"resource_link"'));
+    expect(textBlock?.text).not.toContain("(no tool output)");
+  });
 });

--- a/src/llm/providers/mistral.ts
+++ b/src/llm/providers/mistral.ts
@@ -29,6 +29,7 @@ import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { buildBaseOptions } from "./simple-options.js";
+import { extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 const MISTRAL_TOOL_CALL_ID_LENGTH = 9;
@@ -625,10 +626,7 @@ function toChatMessages(
     }
 
     const toolContent: ContentChunk[] = [];
-    const textResult = msg.content
-      .filter((part) => part.type === "text")
-      .map((part) => (part.type === "text" ? sanitizeSurrogates(part.text) : ""))
-      .join("\n");
+    const textResult = extractToolResultText(msg.content);
     const hasImages = msg.content.some((part) => part.type === "image");
     const toolText = buildToolResultText(textResult, hasImages, supportsImages, msg.isError);
     toolContent.push({ type: "text", text: toolText });

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -1074,7 +1074,7 @@ describe("openai-completions stop-reason tool-call guard", () => {
             timestamp: 0,
           },
         ],
-      } as Context,
+      } as unknown as Context,
       {
         apiKey: "sk-test",
         onPayload(payload) {

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -1058,4 +1058,43 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(result.stopReason).toBe("stop");
     expect(result.content.filter((b) => b.type === "toolCall")).toStrictEqual([]);
   });
+
+  it("serializes structured tool results as tool text", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "session_status",
+            content: [{ type: "json", payload: { sessionKey: "current", status: "ok" } }],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as Context,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "tool",
+          tool_call_id: "call_1",
+          content: expect.stringContaining('"type":"json"'),
+        }),
+      ]),
+    );
+  });
 });

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -51,6 +51,7 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { mapOpenAIStopReason } from "./openai-stop-reason.js";
 import { buildBaseOptions } from "./simple-options.js";
+import { extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 /**
@@ -1128,10 +1129,7 @@ export function convertMessages(
         const toolMsg = transformedMessages[j] as ToolResultMessage;
 
         // Extract text and image content
-        const textResult = toolMsg.content
-          .filter(isTextContentBlock)
-          .map((block) => block.text)
-          .join("\n");
+        const textResult = extractToolResultText(toolMsg.content as Array<Record<string, unknown>>);
         const hasImages = toolMsg.content.some((c) => c.type === "image");
 
         // Always send tool result with text (or placeholder if only images)

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -1129,7 +1129,7 @@ export function convertMessages(
         const toolMsg = transformedMessages[j] as ToolResultMessage;
 
         // Extract text and image content
-        const textResult = extractToolResultText(toolMsg.content as Array<Record<string, unknown>>);
+        const textResult = extractToolResultText(toolMsg.content);
         const hasImages = toolMsg.content.some((c) => c.type === "image");
 
         // Always send tool result with text (or placeholder if only images)

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -238,37 +238,6 @@ describe("convertResponsesTools", () => {
 
     expect(params).not.toHaveProperty("tools");
   });
-
-  it("serializes structured tool results as text instead of image placeholders", () => {
-    const input = convertResponsesMessages(
-      nativeOpenAIModel,
-      {
-        systemPrompt: "system",
-        messages: [
-          {
-            role: "toolResult",
-            toolCallId: "call_structured",
-            toolName: "session_status",
-            content: [
-              {
-                type: "json",
-                payload: { sessionKey: "current", model: "openai/gpt-5.4", status: "ok" },
-              },
-            ],
-            isError: false,
-            timestamp: 1,
-          },
-        ],
-      } satisfies Context,
-      allowedToolCallProviders,
-      { includeSystemPrompt: false, replayResponsesItemIds: false },
-    ) as unknown as Array<Record<string, unknown>>;
-    expect(input).toContainEqual({
-      type: "function_call_output",
-      call_id: "call_structured",
-      output: expect.stringContaining('"type":"json"'),
-    });
-  });
 });
 
 describe("convertResponsesMessages", () => {
@@ -558,6 +527,37 @@ describe("convertResponsesMessages", () => {
       id: "rs_foundry_prior",
       encrypted_content: "ciphertext",
       summary: [],
+    });
+  });
+
+  it("serializes structured tool results as text instead of image placeholders", () => {
+    const input = convertResponsesMessages(
+      nativeOpenAIModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_structured",
+            toolName: "session_status",
+            content: [
+              {
+                type: "json",
+                payload: { sessionKey: "current", model: "openai/gpt-5.4", status: "ok" },
+              },
+            ],
+            isError: false,
+            timestamp: 1,
+          },
+        ],
+      } as unknown as Context,
+      testAllowedToolCallProviders,
+      { includeSystemPrompt: false, replayResponsesItemIds: false },
+    ) as unknown as Array<Record<string, unknown>>;
+    expect(input).toContainEqual({
+      type: "function_call_output",
+      call_id: "call_structured",
+      output: expect.stringContaining('"type":"json"'),
     });
   });
 });

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -62,6 +62,8 @@ const proxyOpenAIModel = {
   baseUrl: "https://proxy.example.com/v1",
 } satisfies Model<"openai-responses">;
 
+const testAllowedToolCallProviders = new Set(["openai", "openai-codex", "opencode"]);
+
 function createAssistantOutput(): AssistantMessage {
   return {
     role: "assistant",
@@ -236,10 +238,41 @@ describe("convertResponsesTools", () => {
 
     expect(params).not.toHaveProperty("tools");
   });
+
+  it("serializes structured tool results as text instead of image placeholders", () => {
+    const input = convertResponsesMessages(
+      nativeOpenAIModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_structured",
+            toolName: "session_status",
+            content: [
+              {
+                type: "json",
+                payload: { sessionKey: "current", model: "openai/gpt-5.4", status: "ok" },
+              },
+            ],
+            isError: false,
+            timestamp: 1,
+          },
+        ],
+      } satisfies Context,
+      allowedToolCallProviders,
+      { includeSystemPrompt: false, replayResponsesItemIds: false },
+    ) as unknown as Array<Record<string, unknown>>;
+    expect(input).toContainEqual({
+      type: "function_call_output",
+      call_id: "call_structured",
+      output: expect.stringContaining('"type":"json"'),
+    });
+  });
 });
 
 describe("convertResponsesMessages", () => {
-  const allowedToolCallProviders = new Set(["openai", "openai-codex", "opencode"]);
+  const allowedToolCallProviders = testAllowedToolCallProviders;
 
   it("adds explicit message item types for system and user input items", () => {
     const input = convertResponsesMessages(

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -373,7 +373,7 @@ export function convertResponsesMessages<TApi extends Api>(
       }
       messages.push(...output);
     } else if (msg.role === "toolResult") {
-      const textResult = extractToolResultText(msg.content as Array<Record<string, unknown>>);
+      const textResult = extractToolResultText(msg.content);
       const hasImages = msg.content.some((c): c is ImageContent => c.type === "image");
       const hasText = textResult.length > 0;
       const [callId] = msg.toolCallId.split("|");

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -45,6 +45,7 @@ import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { convertResponsesToolPayload, convertResponsesTools } from "./openai-responses-tools.js";
+import { extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================
@@ -372,10 +373,7 @@ export function convertResponsesMessages<TApi extends Api>(
       }
       messages.push(...output);
     } else if (msg.role === "toolResult") {
-      const textResult = msg.content
-        .filter((c): c is TextContent => c.type === "text")
-        .map((c) => c.text)
-        .join("\n");
+      const textResult = extractToolResultText(msg.content as Array<Record<string, unknown>>);
       const hasImages = msg.content.some((c): c is ImageContent => c.type === "image");
       const hasText = textResult.length > 0;
       const [callId] = msg.toolCallId.split("|");

--- a/src/llm/providers/tool-result-text.test.ts
+++ b/src/llm/providers/tool-result-text.test.ts
@@ -15,6 +15,7 @@ describe("extractToolResultText", () => {
       },
     ]);
 
+    expect(text.length).toBeGreaterThan(1_200);
     expect(text).toContain(tail);
     expect(text).not.toContain("... (");
   });

--- a/src/llm/providers/tool-result-text.test.ts
+++ b/src/llm/providers/tool-result-text.test.ts
@@ -1,0 +1,21 @@
+// Tool-result text extraction keeps provider conversion lossless; established
+// context/tool-result guards own payload budgeting and truncation later.
+import { describe, expect, it } from "vitest";
+import { extractToolResultText } from "./tool-result-text.js";
+
+describe("extractToolResultText", () => {
+  it("does not truncate structured blocks at the provider helper boundary", () => {
+    const tail = "tail-marker";
+    const text = extractToolResultText([
+      {
+        type: "json",
+        data: {
+          payload: `${"x".repeat(1_200)}${tail}`,
+        },
+      },
+    ]);
+
+    expect(text).toContain(tail);
+    expect(text).not.toContain("... (");
+  });
+});

--- a/src/llm/providers/tool-result-text.ts
+++ b/src/llm/providers/tool-result-text.ts
@@ -22,9 +22,8 @@ function stringifyStructuredBlock(block: Record<string, unknown>): string | unde
     if (!serialized || serialized === "{}") {
       return undefined;
     }
-    return serialized.length > 1_000
-      ? `${serialized.slice(0, 1_000)}... (${serialized.length} chars)`
-      : serialized;
+    // Keep provider conversion lossless; context/tool-result guards own payload budgeting.
+    return serialized;
   } catch {
     return undefined;
   }

--- a/src/llm/providers/tool-result-text.ts
+++ b/src/llm/providers/tool-result-text.ts
@@ -1,0 +1,57 @@
+import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+
+type ToolResultContentBlock = Record<string, unknown>;
+
+function stringifyStructuredBlock(block: ToolResultContentBlock): string | undefined {
+  const seen = new WeakSet<object>();
+  try {
+    const serialized = JSON.stringify(block, (_key, value) => {
+      if (typeof value === "string") {
+        return value.replace(
+          /data:[^"'\\\s]+/gi,
+          (match) => `[inline data URI: ${match.length} chars]`,
+        );
+      }
+      if (!value || typeof value !== "object") {
+        return value;
+      }
+      if (seen.has(value)) {
+        return "[Circular]";
+      }
+      seen.add(value);
+      return value;
+    });
+    if (!serialized || serialized === "{}") {
+      return undefined;
+    }
+    return serialized.length > 1_000
+      ? `${serialized.slice(0, 1_000)}... (${serialized.length} chars)`
+      : serialized;
+  } catch {
+    return undefined;
+  }
+}
+
+export function extractToolResultText(blocks: readonly ToolResultContentBlock[]): string {
+  const parts: string[] = [];
+  for (const block of blocks) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    if (block.type === "image") {
+      continue;
+    }
+    if (block.type === "text") {
+      const text = typeof block.text === "string" ? block.text : "";
+      if (text) {
+        parts.push(text);
+      }
+      continue;
+    }
+    const structured = stringifyStructuredBlock(block);
+    if (structured) {
+      parts.push(structured);
+    }
+  }
+  return sanitizeSurrogates(parts.join("\n"));
+}

--- a/src/llm/providers/tool-result-text.ts
+++ b/src/llm/providers/tool-result-text.ts
@@ -1,8 +1,6 @@
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 
-type ToolResultContentBlock = Record<string, unknown>;
-
-function stringifyStructuredBlock(block: ToolResultContentBlock): string | undefined {
+function stringifyStructuredBlock(block: Record<string, unknown>): string | undefined {
   const seen = new WeakSet<object>();
   try {
     const serialized = JSON.stringify(block, (_key, value) => {
@@ -32,23 +30,24 @@ function stringifyStructuredBlock(block: ToolResultContentBlock): string | undef
   }
 }
 
-export function extractToolResultText(blocks: readonly ToolResultContentBlock[]): string {
+export function extractToolResultText(blocks: readonly unknown[]): string {
   const parts: string[] = [];
   for (const block of blocks) {
     if (!block || typeof block !== "object") {
       continue;
     }
-    if (block.type === "image") {
+    const record = block as Record<string, unknown>;
+    if (record.type === "image") {
       continue;
     }
-    if (block.type === "text") {
-      const text = typeof block.text === "string" ? block.text : "";
+    if (record.type === "text") {
+      const text = typeof record.text === "string" ? record.text : "";
       if (text) {
         parts.push(text);
       }
       continue;
     }
-    const structured = stringifyStructuredBlock(block);
+    const structured = stringifyStructuredBlock(record);
     if (structured) {
       parts.push(structured);
     }


### PR DESCRIPTION
## Summary
- Preserve structured non-image tool result blocks as text instead of collapsing them to `(see attached image)`.
- Share the normalization through `extractToolResultText()` across OpenAI Completions, OpenAI Responses, Google/Gemini, Anthropic, and Mistral conversion paths.
- Keep structured serialization lossless at the provider conversion helper boundary; existing context/tool-result guards remain the payload-budgeting and truncation owner.
- Cover active transport paths for OpenAI Responses and Anthropic, plus provider conversion paths and focused regressions.

## What Problem This Solves
Tool results can contain structured non-image blocks such as JSON, resource, or resource-link payloads. Several provider and transport converters previously extracted only `type: "text"` blocks before building provider payloads. When a tool result contained structured data but no text block, those converters treated the result like an image-only payload and emitted `(see attached image)` or an empty fallback.

That loses actionable tool output in the next model turn. The failure is especially visible in agent sessions where tool output is stored as structured blocks and then replayed through OpenAI Responses, Anthropic, Google/Gemini, or Mistral conversion paths.

## Why This Change Was Made
The model-visible provider/transport conversion layer should not discard structured non-image tool output. The right boundary is to serialize those blocks into text before provider payload creation, while leaving truncation and payload budgeting to the established context/tool-result guards instead of introducing a provider-local cap.

## User Impact
- Structured JSON/resource-style tool results remain visible to the model as text.
- Image-only tool results still keep the existing `(see attached image)` fallback when the target path cannot carry image input.
- Large structured blocks are no longer silently truncated at 1,000 characters before the normal context/tool-result truncation policy can budget them.

## Review Follow-Up
- Fixed the TypeScript blocker by widening `extractToolResultText()` to accept `readonly unknown[]` and narrowing internally.
- Removed unsafe `Record<string, unknown>[]` casts from provider call sites.
- Fixed the OpenAI Responses regression test scope by moving it under `convertResponsesMessages`, using `testAllowedToolCallProviders`, and casting the intentional structured-content fixture at the boundary.
- Added direct regression coverage for active OpenAI Responses and Anthropic transport conversion.
- Expanded same-root coverage to Anthropic and Mistral provider conversions.
- Resolved CI lint/type issues: unused imports, single-line if/continue braces, `no-base-to-string` guards via `typeof` checks, shadowed `context` variable warnings, and type-cast boundaries in tests.
- Addressed the latest ClawSweeper review finding by removing the 1,000-character helper-local structured-output cap from `src/llm/providers/tool-result-text.ts`.
- Added `src/llm/providers/tool-result-text.test.ts` to prove the provider helper does not truncate structured blocks before the established payload-budgeting boundary.

## Evidence
- `git diff --check` passes clean for this head.
- Focused helper regression passed:
  - `node scripts/run-vitest.mjs src/llm/providers/tool-result-text.test.ts`
- Earlier focused provider/transport regression gate passed during this PR fix loop:
  - `node scripts/run-vitest.mjs src/llm/providers/openai-responses-shared.test.ts src/agents/openai-transport-stream.test.ts src/agents/anthropic-transport-stream.test.ts src/llm/providers/mistral.test.ts src/llm/providers/google-shared.convert.test.ts src/llm/providers/openai-completions.test.ts`
  - Result: 7 files passed, 437 tests passed.
- Redacted real-path evidence from local OpenClaw session investigation:
  - Structured tool-result content without plain text blocks was observed in a local OpenClaw session as an attachment placeholder in the next assistant turn instead of visible text.
  - The provider helper fix keeps structured payload text intact through the model-visible conversion boundary.
  - The focused regression uses a structured payload longer than 1,000 characters with a `tail-marker`, verifies the text length stays above 1,200 characters, and verifies the tail survives without the previous `... (N chars)` truncation marker.
  - Local recovery artifacts and sanitized investigation notes were written under `projects/openclaw-pr-maintenance/reports/pr-97183/local-machine-fix/`; private host details are intentionally not published.
- GitHub Actions CI remains the authoritative gate for broad repo checks on this PR.

## Scope And Limitations
This PR fixes the structured non-image tool-result conversion failure: blocks such as JSON/resource payloads are serialized as text before provider/transport payload creation instead of being treated like image-only tool results.

This PR does not claim to fully resolve every failure mode described in #96857. The prompt-history truncation plus provider-failover/session-corruption path described in later issue evidence is broader than this conversion fix and should remain open for follow-up investigation if it reproduces after this change.

Image-only tool results intentionally keep the existing `(see attached image)` fallback when the target model/provider cannot accept image input.

## Relationship To Prior Work
This updates and broadens the earlier provider-only direction in #96895 by adding type-safe helper boundaries, fixing test issues, covering active transport paths, removing the provider-local structured-output cap, and documenting the remaining scope boundary.

Refs #96857
