### PR TITLE
docs(install): add OpenClaw Launch managed hosting option

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1086,6 +1086,7 @@
                   "install/macos-vm",
                   "install/northflank",
                   "install/oracle",
+                  "install/openclawlaunch",
                   "install/railway",
                   "install/raspberry-pi",
                   "install/render",

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -201,6 +201,9 @@ Deploy OpenClaw on a cloud server or VPS:
   <Card title="Northflank" href="/install/northflank">
     Northflank deployment.
   </Card>
+  <Card title="OpenClaw Launch" href="/install/openclawlaunch">
+    Managed hosting, no install.
+  </Card>
 </CardGroup>
 
 ## Update, migrate, or uninstall

--- a/docs/install/openclawlaunch.md
+++ b/docs/install/openclawlaunch.md
@@ -1,0 +1,58 @@
+---
+summary: "Run OpenClaw as a fully managed, hosted instance with OpenClaw Launch"
+read_when:
+  - You want OpenClaw running without provisioning or maintaining a server
+  - You want a hosted Gateway with channels and SSL handled for you
+title: "OpenClaw Launch"
+---
+
+# OpenClaw Launch
+
+[OpenClaw Launch](https://openclawlaunch.com) is a third-party managed hosting service
+for OpenClaw. Instead of installing OpenClaw and running the Gateway on your own machine
+or VPS, you configure a bot in the browser and it deploys a managed, isolated instance
+for you, with channels, storage, and SSL handled automatically.
+
+This is the no-install option. If you prefer to run OpenClaw yourself, see the other
+guides in this section (for example [Docker](/install/docker), [Hetzner](/install/hetzner),
+or any [VPS](/vps)).
+
+<Note>
+OpenClaw Launch is an independent commercial service, not operated by the OpenClaw
+project. Pricing and support are handled by OpenClaw Launch.
+</Note>
+
+## What it handles for you
+
+- Provisioning and running the OpenClaw Gateway in an isolated container
+- Channel setup for Telegram, Discord, WhatsApp, and browser-based web chat
+- TLS/HTTPS certificates and a reverse proxy
+- Persistent storage for chat history and workspace files
+- Updates and basic monitoring
+
+## Prerequisites
+
+- An account at [openclawlaunch.com](https://openclawlaunch.com)
+- An API key from your preferred [model provider](/providers), or use the bundled
+  credits included with a plan
+
+## Deploy
+
+1. Sign in at [openclawlaunch.com](https://openclawlaunch.com).
+2. Configure your bot: pick a model, the channels you want, and any skills.
+3. Click Deploy. A managed instance is provisioned and your bot comes online,
+   typically in under a minute.
+4. Connect a channel (for example, pair a Telegram bot) and start chatting.
+
+## Bring your own keys
+
+You can supply your own model-provider API keys (OpenAI, Anthropic, Google, OpenRouter,
+and others), or use credits included with a plan. Keys are stored encrypted at rest.
+
+## Notes
+
+- Each instance runs in its own container with dedicated storage.
+- Because the Gateway is hosted, you manage configuration through the OpenClaw Launch
+  dashboard rather than a local `openclaw.json`.
+- For self-hosted control over the full OpenClaw CLI and config, use one of the
+  self-install methods in this section instead.


### PR DESCRIPTION
## What

Adds a docs page for running OpenClaw via [OpenClaw Launch](https://openclawlaunch.com), a third-party managed hosting service, and lists it in the Hosting section.

- New page: `docs/install/openclawlaunch.md`
- Card added to the "Hosting and deployment" group in `docs/install/index.md`
- Nav entry added to the "Hosting" group in `docs/docs.json`

## Why

The Hosting section already covers commercial providers where users deploy OpenClaw themselves (Hostinger, DigitalOcean, Railway, Render, Northflank). This adds the fully-managed/no-install option for users who want OpenClaw running without provisioning or maintaining a server.

The page is written factually and clearly flags that OpenClaw Launch is an independent commercial service not operated by the project, with a pointer back to the self-host guides for anyone who'd rather run it themselves.

Happy to adjust wording, placement, or format to match maintainer preferences — or drop it if managed third-party services aren't something you want listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
