### PR TITLE
fix #97069: [Bug]: Approval prompt wrongly says effective policy requires approval for one-shot commands

### DIFF
--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -645,6 +645,25 @@ describe("exec approval forwarder", () => {
     expect(text).toContain("Allow Always is unavailable");
   });
 
+  it("shows one-shot message when command cannot be persisted (#97069)", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+    await expect(
+      forwarder.handleRequested({
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          ask: "on-miss",
+          unavailableDecisions: ["allow-always"],
+        },
+      }),
+    ).resolves.toBe(true);
+    await Promise.resolve();
+    const text = getFirstDeliveryText(deliver);
+    expect(text).toContain("Allow Always is unavailable because this command is not eligible for persistent reuse");
+    expect(text).not.toContain("effective policy requires approval every time");
+  });
+
   it.each([
     {
       command: "bash safe\u200B.sh",

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -289,12 +289,16 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
   lines.push(
     allowedDecisions.includes("allow-always")
       ? "Background mode note: non-interactive runs cannot wait for chat approvals; use pre-approved policy (allow-always or ask=off)."
-      : "Background mode note: non-interactive runs cannot wait for chat approvals; the effective policy still requires per-run approval unless ask=off.",
+      : request.request.ask === "always"
+        ? "Background mode note: non-interactive runs cannot wait for chat approvals; the effective policy still requires per-run approval unless ask=off."
+        : "Background mode note: non-interactive runs cannot wait for chat approvals; this command cannot be pre-approved for persistent reuse.",
   );
   lines.push(`Reply with: /approve ${request.id} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
     lines.push(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
+      request.request.ask === "always"
+        ? "Allow Always is unavailable because the effective policy requires approval every time."
+        : "Allow Always is unavailable because this command is not eligible for persistent reuse (e.g., shell redirection).",
     );
   }
   return lines.join("\n");

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -316,7 +316,7 @@ describe("exec approval reply helpers", () => {
     expect(payload.text).not.toContain("C:\\Users\\alice");
   });
 
-  it("omits allow-always actions when the effective policy requires approval every time", () => {
+  it("omits allow-always and shows policy message when ask=always (#97069)", () => {
     const payload = buildExecApprovalPendingReplyPayload({
       approvalId: "req-ask-always",
       approvalSlug: "slug-always",
@@ -338,6 +338,22 @@ describe("exec approval reply helpers", () => {
     expect(payload.text).toContain(
       "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     );
+  });
+
+  it("omits allow-always and shows one-shot message when command is not persistable (#97069)", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-one-shot",
+      approvalSlug: "slug-one-shot",
+      ask: "on-miss",
+      allowedDecisions: ["allow-once", "deny"],
+      command: "openclaw --version 2>&1",
+      host: "gateway",
+    });
+
+    expect(payload.text).not.toContain("allow-always");
+    expect(payload.text).toContain(
+      "This command is not eligible for Allow Always (e.g., shell redirection cannot be persisted for reuse).",
+    );
     expect(payload.presentation).toEqual({
       blocks: [
         {
@@ -347,18 +363,18 @@ describe("exec approval reply helpers", () => {
               label: "Allow Once",
               action: {
                 type: "command",
-                command: "/approve req-ask-always allow-once",
+                command: "/approve req-one-shot allow-once",
               },
-              value: "/approve req-ask-always allow-once",
+              value: "/approve req-one-shot allow-once",
               style: "success",
             },
             {
               label: "Deny",
               action: {
                 type: "command",
-                command: "/approve req-ask-always deny",
+                command: "/approve req-one-shot deny",
               },
-              value: "/approve req-ask-always deny",
+              value: "/approve req-one-shot deny",
               style: "danger",
             },
           ],

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -377,7 +377,9 @@ export function buildExecApprovalPendingReplyPayload(
   }
   if (!allowedDecisions.includes("allow-always")) {
     lines.push(
-      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+      params.ask === "always"
+        ? "The effective approval policy requires approval every time, so Allow Always is unavailable."
+        : "This command is not eligible for Allow Always (e.g., shell redirection cannot be persisted for reuse).",
     );
   }
   const info: string[] = [];


### PR DESCRIPTION
## Summary

- Problem: When `allow-always` is unavailable because the command is one-shot (e.g., shell redirection `2>&1`), the approval prompt misleadingly says "the effective approval policy requires approval every time" — even when the actual policy is `ask=on-miss`. This confuses users into thinking their policy is misconfigured (#97069).
- Solution: Check the `ask` setting in the message builder. If `ask === "always"`, show the existing policy message. Otherwise, show a message explaining the command cannot be persisted.
- What changed: `exec-approval-reply.ts` and `exec-approval-forwarder.ts` — conditional messages in 3 locations. Two new tests.
- What did NOT change: no API, config, schema, or behavior changes. The `allow-always` button still correctly disappears for one-shot commands.

## Maintainer checklist
- Fix classification: Root-cause bug fix in exec approval message rendering
- Maintainer-ready confidence: High — 56/56 tests pass

## Real behavior proof

**Behavior or issue addressed:**
Approval prompt wrongly says "effective policy requires approval every time" for one-shot commands (shell redirection).

**Real environment tested:**
- Platform: Linux x86_64
- Node.js: v22.22.0
- Runtime: Vitest v4.1.8
- Branch: fix/approval-prompt-message-97069 (0e9b6735c)

**Exact steps or command run after the patch:**
```
node scripts/run-vitest.mjs src/infra/exec-approval-reply.test.ts src/infra/exec-approval-forwarder.test.ts --reporter=verbose
```

**After-fix evidence:**
```
 Test Files  2 passed (2)
      Tests  56 passed (56)
   Duration  8.42s
```

**Observed result after fix:**
- ask=always: "The effective approval policy requires approval every time..." (unchanged) ✓
- ask=on-miss + one-shot: "This command is not eligible for Allow Always (e.g., shell redirection cannot be persisted for reuse)" ✓
- Forwarder: "Allow Always is unavailable because this command is not eligible for persistent reuse" ✓

**What was not tested:**
- End-to-end exec approval flow with real gateway (requires live OpenClaw instance)