### PR TITLE
Persist gateway restart audit events

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -2616,7 +2616,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/infra/restart.ts: findGatewayPidsOnPortSync",
   "src/infra/restart.ts: GatewayRestartEmitResult",
   "src/infra/restart.ts: RestartAttempt",
-  "src/infra/restart.ts: RestartAuditInfo",
   "src/infra/restart.ts: RestartDeferralHooks",
   "src/infra/restart.ts: RestartEmitHooks",
   "src/infra/restart.ts: testing",

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -211,6 +211,11 @@ describe("gateway tool restart continuation", () => {
     expect(restartArgs.delayMs).toBe(250);
     expect(restartArgs.reason).toBe("continue after reboot");
     expect(restartArgs.sessionKey).toBe("agent:main:main");
+    expect(restartArgs.audit).toEqual({
+      source: "gateway.tool.restart",
+      sessionKey: "agent:main:main",
+    });
+    expect(JSON.stringify(restartArgs.audit)).not.toContain("continue after reboot");
     expect(typeof restartArgs.emitHooks?.beforeEmit).toBe("function");
     expect(typeof restartArgs.emitHooks?.afterEmitRejected).toBe("function");
     expect(result?.details).toMatchObject({

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -239,6 +239,10 @@ export function createGatewayTool(opts?: {
         const scheduled = scheduleGatewaySigusr1Restart({
           delayMs,
           reason,
+          audit: {
+            source: "gateway.tool.restart",
+            sessionKey,
+          },
           // Ownership and sentinel routing use the same trusted session identity,
           // so model-supplied params cannot queue work into another session.
           sessionKey,

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -760,6 +760,10 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
     let sentinelWritten = false;
     scheduleGatewaySigusr1Restart({
       reason: "/restart",
+      audit: {
+        source: "slash.restart",
+        sessionKey: sentinelPayload?.sessionKey,
+      },
       // Sibling session-routing guard: /restart writes a session-scoped sentinel
       // with continuation, so the scheduler must own the pending slot under the
       // same key to avoid cross-session continuation overwrite (#86742).

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -302,6 +302,7 @@ export async function resolveGatewayConfigRestartWriteResult(params: {
         reason: params.mode,
         audit: {
           actor: params.actor.actor,
+          source: "gateway.config.write",
           deviceId: params.actor.deviceId,
           clientIp: params.actor.clientIp,
           changedPaths: params.changedPaths,

--- a/src/gateway/server-methods/restart.test.ts
+++ b/src/gateway/server-methods/restart.test.ts
@@ -56,11 +56,14 @@ function mockScheduledRestart(preflight: { safe: boolean; summary: string }) {
 }
 
 function expectRestartRequest(skipDeferral: boolean) {
-  expect(requestSafeGatewayRestart).toHaveBeenCalledWith({
-    reason: "operator",
-    delayMs: 0,
-    skipDeferral,
-  });
+  expect(requestSafeGatewayRestart).toHaveBeenCalledWith(
+    expect.objectContaining({
+      audit: { source: "gateway.restart.request" },
+      reason: "operator",
+      delayMs: 0,
+      skipDeferral,
+    }),
+  );
 }
 
 describe("gateway.restart.request handler", () => {
@@ -106,6 +109,7 @@ describe("gateway.restart.request handler", () => {
     await invokeRestartRequest({ reason: "x".repeat(199) + "🧠tail" });
 
     expect(requestSafeGatewayRestart).toHaveBeenCalledWith({
+      audit: { source: "gateway.restart.request" },
       reason: "x".repeat(199),
       delayMs: 0,
       skipDeferral: false,

--- a/src/gateway/server-methods/restart.ts
+++ b/src/gateway/server-methods/restart.ts
@@ -40,6 +40,9 @@ export const restartHandlers: GatewayRequestHandlers = {
       reason: normalizeReason(params.reason),
       delayMs: 0,
       skipDeferral: normalizeSkipDeferral(params.skipDeferral),
+      audit: {
+        source: "gateway.restart.request",
+      },
     });
     respond(true, result);
   },

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -270,6 +270,7 @@ export const updateHandlers: GatewayRequestHandlers = {
               skipCooldown: true,
               audit: {
                 actor: actor.actor,
+                source: "gateway.update.run",
                 deviceId: actor.deviceId,
                 clientIp: actor.clientIp,
                 changedPaths: [],
@@ -403,6 +404,7 @@ export const updateHandlers: GatewayRequestHandlers = {
             skipCooldown: updateWasPackageSwap,
             audit: {
               actor: actor.actor,
+              source: "gateway.update.run",
               deviceId: actor.deviceId,
               clientIp: actor.clientIp,
               changedPaths: [],

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1,6 +1,9 @@
 /**
  * Gateway config reload handler tests.
  */
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
 import {
@@ -51,7 +54,12 @@ import {
   getActiveSecretsRuntimeSnapshotRevision,
   type PreparedSecretsRuntimeSnapshot,
 } from "../secrets/runtime.js";
+import {
+  closeOpenClawStateDatabase,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { diffConfigPaths } from "./config-diff.js";
 import {
   buildGatewayReloadPlan,
@@ -1405,6 +1413,7 @@ describe("gateway hot reload superseded tail recovery", () => {
       expect(requestRecoveryRestart).toHaveBeenCalledWith(
         "config reload: hot reload recovery: context window cache reload",
         undefined,
+        expect.objectContaining({ source: "config_reload" }),
       );
     } finally {
       handlers.stopRestartRetries();
@@ -2025,9 +2034,9 @@ describe("gateway restart deferral preflight", () => {
       });
       rearmed.settle("committed");
 
-      expect(requestRecoveryRestart.mock.calls).toEqual([
-        ["config reload: hot reload recovery: channel restart (discord)"],
-      ]);
+      expect(requestRecoveryRestart.mock.calls.map(([reason, intent]) => [reason, intent])).toEqual(
+        [["config reload: hot reload recovery: channel restart (discord)", undefined]],
+      );
     } finally {
       hoisted.activeTaskBlockers.length = 0;
       stopRestartRetries();
@@ -2096,7 +2105,11 @@ describe("gateway restart deferral preflight", () => {
       hoisted.activeTaskBlockers.length = 0;
       await vi.advanceTimersByTimeAsync(500);
       expect(requestRecoveryRestart).toHaveBeenCalledOnce();
-      expect(requestRecoveryRestart).toHaveBeenCalledWith("config reload: gateway.port", undefined);
+      expect(requestRecoveryRestart).toHaveBeenCalledWith(
+        "config reload: gateway.port",
+        undefined,
+        expect.objectContaining({ source: "config_reload" }),
+      );
 
       pauseGatewayRestartForConfigCandidate();
       const accepted = acceptRestartConfig(configA);
@@ -2427,10 +2440,12 @@ describe("gateway restart deferral preflight", () => {
       await vi.advanceTimersByTimeAsync(500);
       await vi.advanceTimersByTimeAsync(1_000);
 
-      expect(requestRecoveryRestart.mock.calls).toEqual([
-        ["config reload: gateway.port", { force: true, reason: "config reload forced restart" }],
-        ["config reload: gateway.port", { force: true, reason: "config reload forced restart" }],
-      ]);
+      expect(requestRecoveryRestart.mock.calls.map(([reason, intent]) => [reason, intent])).toEqual(
+        [
+          ["config reload: gateway.port", { force: true, reason: "config reload forced restart" }],
+          ["config reload: gateway.port", { force: true, reason: "config reload forced restart" }],
+        ],
+      );
       expect(
         logReload.warn.mock.calls.filter(([message]) =>
           message.includes("deferring until 1 background task run(s) complete"),
@@ -2943,6 +2958,216 @@ describe("gateway restart deferral preflight", () => {
       vi.useRealTimers();
       process.removeListener("SIGUSR1", signalSpy);
       restartTesting.resetSigusr1State();
+    }
+  });
+
+  it("threads config reload audit context through immediate restart emission", async () => {
+    restartTesting.resetSigusr1State();
+    const events: Array<Record<string, unknown>> = [];
+    restartTesting.setRestartAuditEventWriterOverride((event) => {
+      events.push(event as unknown as Record<string, unknown>);
+    });
+    const logReload = { info: vi.fn(), warn: vi.fn() };
+    const { requestGatewayRestart } = createReloadHandlersForTest(logReload);
+    const signalSpy = vi.fn();
+    process.once("SIGUSR1", signalSpy);
+    vi.useFakeTimers();
+    try {
+      requestGatewayRestart(
+        {
+          changedPaths: ["gateway.port"],
+          restartGateway: true,
+          restartReasons: ["gateway.port"],
+          hotReasons: [],
+          reloadHooks: false,
+          restartGmailWatcher: false,
+          restartCron: false,
+          restartHeartbeat: false,
+          restartHealthMonitor: false,
+          reloadPlugins: false,
+          restartChannels: new Set(),
+          disposeMcpRuntimes: false,
+          noopPaths: [],
+        },
+        {
+          gateway: { reload: { deferralTimeoutMs: 1_000 } },
+        },
+      );
+
+      expect(signalSpy).toHaveBeenCalledTimes(1);
+      expect(events).not.toContainEqual(expect.objectContaining({ eventType: "emit_requested" }));
+      await vi.advanceTimersByTimeAsync(0);
+      const emitEvent = events.find((event) => event.eventType === "emit_requested");
+      expect(emitEvent).toEqual(
+        expect.objectContaining({
+          eventType: "emit_requested",
+          reason: "config.reload",
+          source: "config_reload",
+          audit: expect.objectContaining({
+            source: "config_reload",
+            changedPaths: ["gateway.port"],
+          }),
+          preflight: expect.objectContaining({
+            active: expect.objectContaining({ totalActive: 0 }),
+            activeDetails: [],
+          }),
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+      process.removeListener("SIGUSR1", signalSpy);
+      restartTesting.resetSigusr1State();
+    }
+  });
+
+  it("threads config reload audit context through deferred forced restart emission", async () => {
+    restartTesting.resetSigusr1State();
+    const events: Array<Record<string, unknown>> = [];
+    restartTesting.setRestartAuditEventWriterOverride((event) => {
+      events.push(event as unknown as Record<string, unknown>);
+    });
+    const logReload = { info: vi.fn(), warn: vi.fn() };
+    const { requestGatewayRestart } = createReloadHandlersForTest(logReload);
+    hoisted.activeTaskCount.value = 1;
+    hoisted.activeTaskBlockers.push({
+      taskId: "task-nightly",
+      runId: "run-nightly",
+      status: "running",
+      runtime: "cron",
+      label: "nightly sync",
+      title: "refresh all accounts",
+    });
+    const signalSpy = vi.fn();
+    process.once("SIGUSR1", signalSpy);
+    vi.useFakeTimers();
+
+    try {
+      requestGatewayRestart(
+        {
+          changedPaths: ["gateway.port"],
+          restartGateway: true,
+          restartReasons: ["gateway.port"],
+          hotReasons: [],
+          reloadHooks: false,
+          restartGmailWatcher: false,
+          restartCron: false,
+          restartHeartbeat: false,
+          restartHealthMonitor: false,
+          reloadPlugins: false,
+          restartChannels: new Set(),
+          disposeMcpRuntimes: false,
+          noopPaths: [],
+        },
+        {
+          gateway: { reload: { deferralTimeoutMs: 1_000 } },
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.runOnlyPendingTimersAsync();
+      await Promise.resolve();
+
+      expect(signalSpy).toHaveBeenCalledTimes(1);
+      const emitEvent = events.find((event) => event.eventType === "emit_requested");
+      expect(logReload.warn).toHaveBeenCalledWith(
+        expect.stringContaining("title=refresh all accounts"),
+      );
+      expect(emitEvent).toEqual(
+        expect.objectContaining({
+          eventType: "emit_requested",
+          reason: "config.reload",
+          source: "config_reload",
+          audit: expect.objectContaining({
+            source: "config_reload",
+            changedPaths: ["gateway.port"],
+          }),
+          preflight: expect.objectContaining({
+            active: expect.objectContaining({ activeTasks: 1, totalActive: 1 }),
+            activeDetails: ["1 background task run(s)"],
+            taskBlockers: expect.stringContaining("taskId=task-nightly"),
+          }),
+        }),
+      );
+      expect(JSON.stringify(emitEvent?.preflight)).not.toContain("refresh all accounts");
+    } finally {
+      hoisted.activeTaskCount.value = 0;
+      hoisted.activeTaskBlockers.length = 0;
+      vi.useRealTimers();
+      process.removeListener("SIGUSR1", signalSpy);
+      restartTesting.resetSigusr1State();
+    }
+  });
+
+  it("keeps active task titles out of config reload restart audit rows", async () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-config-reload-audit-"));
+    const taskTitle = "refresh all accounts";
+    restartTesting.resetSigusr1State();
+    const logReload = { info: vi.fn(), warn: vi.fn() };
+    const { requestGatewayRestart } = createReloadHandlersForTest(logReload);
+    hoisted.activeTaskCount.value = 1;
+    hoisted.activeTaskBlockers.push({
+      taskId: "task-nightly",
+      runId: "run-nightly",
+      status: "running",
+      runtime: "cron",
+      label: "nightly sync",
+      title: taskTitle,
+    });
+    const signalSpy = vi.fn();
+    process.once("SIGUSR1", signalSpy);
+    vi.useFakeTimers();
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        requestGatewayRestart(
+          {
+            changedPaths: ["gateway.port"],
+            restartGateway: true,
+            restartReasons: ["gateway.port"],
+            hotReasons: [],
+            reloadHooks: false,
+            restartGmailWatcher: false,
+            restartCron: false,
+            restartHeartbeat: false,
+            restartHealthMonitor: false,
+            reloadPlugins: false,
+            restartChannels: new Set(),
+            disposeMcpRuntimes: false,
+            noopPaths: [],
+          },
+          {
+            gateway: { reload: { deferralTimeoutMs: 1_000 } },
+          },
+        );
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        await vi.runOnlyPendingTimersAsync();
+        await Promise.resolve();
+
+        expect(signalSpy).toHaveBeenCalledTimes(1);
+        const { db } = openOpenClawStateDatabase({ env: process.env });
+        const row = db
+          .prepare(
+            "SELECT audit_json, preflight_json FROM gateway_restart_audit ORDER BY created_at DESC LIMIT 1",
+          )
+          .get() as {
+          audit_json: string | null;
+          preflight_json: string | null;
+        };
+        closeOpenClawStateDatabase();
+
+        expect(row.audit_json).toContain("task-nightly");
+        expect(row.preflight_json).toContain("task-nightly");
+        expect(JSON.stringify(row)).not.toContain(taskTitle);
+      });
+    } finally {
+      hoisted.activeTaskCount.value = 0;
+      hoisted.activeTaskBlockers.length = 0;
+      vi.useRealTimers();
+      process.removeListener("SIGUSR1", signalSpy);
+      restartTesting.resetSigusr1State();
+      closeOpenClawStateDatabase();
+      rmSync(stateDir, { force: true, recursive: true });
     }
   });
 
@@ -3999,9 +4224,9 @@ describe("gateway Gmail hot reload handlers", () => {
         diffConfigPaths(harness.initialConfig, harness.deferredConfig),
       );
       await vi.waitFor(() =>
-        expect(harness.requestRecoveryRestart.mock.calls).toEqual([
-          [`config reload: ${deferredPlan.restartReasons.join(", ")}`, undefined],
-        ]),
+        expect(
+          harness.requestRecoveryRestart.mock.calls.map(([reason, intent]) => [reason, intent]),
+        ).toEqual([[`config reload: ${deferredPlan.restartReasons.join(", ")}`, undefined]]),
       );
     } finally {
       hoisted.activeTaskBlockers.length = 0;
@@ -4249,9 +4474,9 @@ describe("gateway Gmail hot reload handlers", () => {
         activate: false,
       });
       await vi.waitFor(() =>
-        expect(harness.requestRecoveryRestart.mock.calls).toEqual([
-          [`config reload: ${deferredPlan.restartReasons.join(", ")}`, undefined],
-        ]),
+        expect(
+          harness.requestRecoveryRestart.mock.calls.map(([reason, intent]) => [reason, intent]),
+        ).toEqual([[`config reload: ${deferredPlan.restartReasons.join(", ")}`, undefined]]),
       );
     } finally {
       releaseEmissionPreflight();
@@ -4335,9 +4560,9 @@ describe("gateway Gmail hot reload handlers", () => {
       hoisted.activeTaskBlockers.length = 0;
       await vi.advanceTimersByTimeAsync(500);
 
-      expect(harness.requestRecoveryRestart.mock.calls).toEqual([
-        ["config reload: gateway.bind", undefined],
-      ]);
+      expect(
+        harness.requestRecoveryRestart.mock.calls.map(([reason, intent]) => [reason, intent]),
+      ).toEqual([["config reload: gateway.bind", undefined]]);
     } finally {
       hoisted.activeTaskBlockers.length = 0;
       await harness.reloader.stop();
@@ -6066,6 +6291,8 @@ describe("deferred channel reload abort generation", () => {
 
     expect(requestRecoveryRestart).toHaveBeenCalledWith(
       expect.stringContaining("hot reload recovery: plugin channel rollback"),
+      undefined,
+      expect.objectContaining({ source: "config_reload" }),
     );
   });
 

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -3014,9 +3014,9 @@ describe("gateway restart deferral preflight", () => {
         }),
       );
     } finally {
-      vi.useRealTimers();
       process.removeListener("SIGUSR1", signalSpy);
       restartTesting.resetSigusr1State();
+      vi.useRealTimers();
     }
   });
 
@@ -3092,9 +3092,9 @@ describe("gateway restart deferral preflight", () => {
     } finally {
       hoisted.activeTaskCount.value = 0;
       hoisted.activeTaskBlockers.length = 0;
-      vi.useRealTimers();
       process.removeListener("SIGUSR1", signalSpy);
       restartTesting.resetSigusr1State();
+      vi.useRealTimers();
     }
   });
 
@@ -3163,9 +3163,9 @@ describe("gateway restart deferral preflight", () => {
     } finally {
       hoisted.activeTaskCount.value = 0;
       hoisted.activeTaskBlockers.length = 0;
-      vi.useRealTimers();
       process.removeListener("SIGUSR1", signalSpy);
       restartTesting.resetSigusr1State();
+      vi.useRealTimers();
       closeOpenClawStateDatabase();
       rmSync(stateDir, { force: true, recursive: true });
     }
@@ -3750,7 +3750,7 @@ describe("gateway Gmail hot reload handlers", () => {
       sourceFingerprint: "source-hash-next",
       writtenAtMs: Date.now(),
     });
-    await vi.runAllTimersAsync();
+    await vi.runOnlyPendingTimersAsync();
 
     expect(activateRuntimeSecrets).toHaveBeenCalledTimes(1);
     expect(activateRuntimeSecrets).toHaveBeenCalledWith(nextConfig, {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -28,6 +28,8 @@ import {
   deferGatewayRestartUntilIdle,
   type GatewayRestartEmitter,
   type GatewayRestartIntent,
+  type RestartAuditEvent,
+  type RestartAuditInfo,
   type RestartDeferralHandle,
   resolveGatewayRestartDeferralTimeoutMs,
   setGatewaySigusr1RestartPolicy,
@@ -45,7 +47,10 @@ import {
   type PreparedSecretsRuntimeSnapshot,
 } from "../secrets/runtime-state.js";
 import { getInspectableActiveTaskRestartBlockers } from "../tasks/task-registry.maintenance.js";
-import { formatActiveTaskRestartBlocker } from "../tasks/task-restart-blocker.js";
+import {
+  type ActiveTaskRestartBlocker,
+  formatActiveTaskRestartBlocker,
+} from "../tasks/task-restart-blocker.js";
 import { isRecord } from "../utils.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
 import type { ChannelKind } from "./config-reload-plan.js";
@@ -473,14 +478,58 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     }
     return details;
   };
-  const formatTaskBlockers = () => {
+  const formatDurableTaskRestartBlocker = (task: ActiveTaskRestartBlocker) => {
+    const details = [
+      `taskId=${task.taskId}`,
+      task.runId ? `runId=${task.runId}` : null,
+      `status=${task.status}`,
+      `runtime=${task.runtime}`,
+      task.label ? `label=${task.label}` : null,
+    ].filter((value): value is string => Boolean(value));
+    return details.join(" ");
+  };
+  const formatTaskBlockers = (opts: { includeTitle?: boolean } = {}) => {
     const blockers = getInspectableActiveTaskRestartBlockers();
     if (blockers.length === 0) {
       return null;
     }
-    const shown = blockers.slice(0, 8).map(formatActiveTaskRestartBlocker);
+    const formatter =
+      opts.includeTitle === false
+        ? formatDurableTaskRestartBlocker
+        : formatActiveTaskRestartBlocker;
+    const shown = blockers.slice(0, 8).map(formatter);
     const omitted = blockers.length - shown.length;
     return omitted > 0 ? `${shown.join("; ")}; +${omitted} more` : shown.join("; ");
+  };
+  const buildConfigRestartAudit = (
+    plan: GatewayReloadPlan,
+    active: ReturnType<typeof getActiveCounts>,
+  ): RestartAuditEvent => {
+    const taskBlockers = formatTaskBlockers({ includeTitle: false });
+    const activeDetails = formatActiveDetails(active);
+    const audit: RestartAuditInfo = {
+      source: "config_reload",
+      changedPaths: plan.changedPaths,
+      context: {
+        restartReasons: plan.restartReasons,
+        hotReasons: plan.hotReasons,
+        reloadHooks: plan.reloadHooks,
+        reloadPlugins: plan.reloadPlugins,
+        restartChannels: [...plan.restartChannels],
+      },
+      preflight: {
+        active,
+        activeDetails,
+        ...(taskBlockers ? { taskBlockers } : {}),
+      },
+    };
+    return {
+      eventType: "scheduled",
+      reason: "config.reload",
+      source: "config_reload",
+      audit,
+      preflight: audit.preflight,
+    };
   };
   const waitForActiveWorkBeforeChannelReload = async (
     channels: Iterable<ChannelKind>,
@@ -1210,6 +1259,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
   const scheduleRestartEmissionRetry = (retry: {
     reason: string;
     intent?: GatewayRestartIntent;
+    auditEvent?: RestartAuditEvent;
     requestGeneration: number;
     prepareForEmit?: () => Promise<boolean>;
   }) => {
@@ -1235,7 +1285,11 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
           scheduleRestartEmissionRetry(retry);
           return;
         }
-        const emitResult = params.requestRecoveryRestart?.(retry.reason, retry.intent);
+        const emitResult = params.requestRecoveryRestart?.(
+          retry.reason,
+          retry.intent,
+          retry.auditEvent,
+        );
         if (emitResult && emitResult.status !== "failed") {
           markRestartEmissionSettled();
         }
@@ -1362,6 +1416,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     };
 
     const active = getActiveCounts();
+    const auditEvent = buildConfigRestartAudit(plan, active);
 
     if (active.totalActive > 0 || options?.prepareRuntimeConfig) {
       // Avoid spinning up duplicate polling loops from repeated config changes.
@@ -1408,7 +1463,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
               failedEmission = { reason: resolvedReason, intent };
               return { status: "failed" };
             }
-            const emitResult = requestRecoveryRestart(resolvedReason, intent);
+            const emitResult = requestRecoveryRestart(resolvedReason, intent, auditEvent);
             if (emitResult.status !== "failed") {
               markRestartEmissionSettled();
             }
@@ -1427,6 +1482,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
             params.logReload.warn("gateway restart recovery emission failed; retrying");
             scheduleRestartEmissionRetry({
               ...failedEmission,
+              auditEvent,
               requestGeneration,
               prepareForEmit,
             });
@@ -1475,7 +1531,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     // The managed reloader owns independent root admission until onRestart
     // returns. Extend that fence across signal delivery until the run loop
     // atomically promotes it to one-way restart drain.
-    const emitResult = requestRecoveryRestart(restartReason);
+    const emitResult = requestRecoveryRestart(restartReason, undefined, auditEvent);
     if (emitResult.status !== "failed") {
       markRestartEmissionSettled();
     }
@@ -1484,6 +1540,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       if (restartRecoveryAvailable) {
         scheduleRestartEmissionRetry({
           reason: restartReason,
+          auditEvent,
           requestGeneration,
           prepareForEmit,
         });

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -139,7 +139,7 @@ describe("infra runtime", () => {
       expect(consumeGatewaySigusr1RestartAuthorization()).toBe(true);
       expect(consumeGatewaySigusr1RestartAuthorization()).toBe(false);
 
-      await vi.runAllTimersAsync();
+      await vi.runOnlyPendingTimersAsync();
     });
 
     it("holds root admission from scheduled emission until the signal is handled", async () => {
@@ -175,6 +175,93 @@ describe("infra runtime", () => {
       expect(isGatewaySigusr1RestartExternallyAllowed()).toBe(false);
       setGatewaySigusr1RestartPolicy({ allowExternal: true });
       expect(isGatewaySigusr1RestartExternallyAllowed()).toBe(true);
+    });
+
+    it("defers audit persistence until after the restart signal returns", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      const auditWriter = vi.fn();
+      testing.setRestartAuditWriterOverride(auditWriter);
+      try {
+        expect(emitGatewayRestart()).toBe(true);
+        expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+        expect(auditWriter).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(auditWriter).toHaveBeenCalledWith("emit_requested");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("lets zero-delay restarts emit before scheduled audit persistence", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      const auditWriter = vi.fn((eventType: string) => {
+        if (eventType === "scheduled") {
+          expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+        }
+      });
+      testing.setRestartAuditWriterOverride(auditWriter);
+      try {
+        scheduleGatewaySigusr1Restart({
+          delayMs: 0,
+          reason: "zero-delay audit ordering",
+          skipCooldown: true,
+        });
+
+        expect(auditWriter).not.toHaveBeenCalledWith("scheduled");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+        await vi.runOnlyPendingTimersAsync();
+        expect(auditWriter).toHaveBeenCalledWith("scheduled");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("carries scheduler audit metadata into emit audit rows", async () => {
+      const handler = () => {};
+      const events: Array<Record<string, unknown>> = [];
+      process.on("SIGUSR1", handler);
+      testing.setRestartAuditEventWriterOverride((event) => {
+        events.push(event as unknown as Record<string, unknown>);
+      });
+      try {
+        scheduleGatewaySigusr1Restart({
+          delayMs: 1_000,
+          reason: "config reload forced restart",
+          sessionKey: "agent:main:session-A",
+          skipCooldown: true,
+          audit: {
+            source: "gateway.config.write",
+            actor: "test-runner",
+            preflight: { check: "passed" },
+          },
+        });
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        await vi.runOnlyPendingTimersAsync();
+
+        const emitEvent = events.find((event) => event.eventType === "emit_requested");
+        expect(emitEvent).toEqual(
+          expect.objectContaining({
+            eventType: "emit_requested",
+            reason: "config.reload",
+            sessionKey: "agent:main:session-A",
+            source: "gateway.config.write",
+            audit: expect.objectContaining({
+              actor: "test-runner",
+              source: "gateway.config.write",
+              preflight: { check: "passed" },
+            }),
+          }),
+        );
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
     });
 
     it("suppresses duplicate emit until the restart cycle is marked handled", () => {
@@ -480,6 +567,39 @@ describe("infra runtime", () => {
         expect(firstHooks).not.toHaveBeenCalled();
         expect(latestHooks).toHaveBeenCalledTimes(1);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("re-arms an earlier restart before persisting its reschedule audit", async () => {
+      const sessionAHooks = vi.fn(async () => {});
+      const sessionBHooks = vi.fn(async () => {});
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      scheduleGatewaySigusr1Restart({
+        delayMs: 1_000,
+        sessionKey: "agent:main:session-A",
+        emitHooks: { beforeEmit: sessionAHooks },
+      });
+      const auditWriter = vi.fn((eventType: string) => {
+        if (eventType === "rescheduled") {
+          expect(sessionBHooks).toHaveBeenCalledTimes(1);
+          expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+        }
+      });
+      testing.setRestartAuditWriterOverride(auditWriter);
+
+      try {
+        scheduleGatewaySigusr1Restart({
+          delayMs: 0,
+          sessionKey: "agent:main:session-A",
+          emitHooks: { beforeEmit: sessionBHooks },
+        });
+        expect(auditWriter).not.toHaveBeenCalledWith("rescheduled");
+        await vi.runOnlyPendingTimersAsync();
+        expect(auditWriter).toHaveBeenCalledWith("rescheduled");
       } finally {
         process.removeListener("SIGUSR1", handler);
       }
@@ -1045,6 +1165,33 @@ describe("infra runtime", () => {
         expect(beforeEmit).toHaveBeenCalledTimes(1);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
         expect(peekGatewaySigusr1RestartReason()).toBe("gateway.restart.safe");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("starts an active deferral bypass before persisting its audit event", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        setPreRestartDeferralCheck(() => 5);
+        scheduleGatewaySigusr1Restart({ delayMs: 0, reason: "config.patch" });
+        await vi.advanceTimersByTimeAsync(0);
+        const auditWriter = vi.fn((eventType: string) => {
+          if (eventType === "bypassed_deferral") {
+            expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+          }
+        });
+        testing.setRestartAuditWriterOverride(auditWriter);
+
+        scheduleGatewaySigusr1Restart({
+          delayMs: 0,
+          reason: "update.run",
+          skipDeferral: true,
+        });
+        await Promise.resolve();
+        expect(auditWriter).toHaveBeenCalledWith("bypassed_deferral");
       } finally {
         process.removeListener("SIGUSR1", handler);
       }

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -1190,7 +1190,7 @@ describe("infra runtime", () => {
           reason: "update.run",
           skipDeferral: true,
         });
-        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(0);
         expect(auditWriter).toHaveBeenCalledWith("bypassed_deferral");
       } finally {
         process.removeListener("SIGUSR1", handler);

--- a/src/infra/restart-coordinator.test.ts
+++ b/src/infra/restart-coordinator.test.ts
@@ -194,10 +194,67 @@ describe("safe gateway restart coordinator", () => {
     });
 
     expect(result.status).toBe("deferred");
-    expect(scheduleGatewaySigusr1Restart).toHaveBeenCalledWith({
+    expect(scheduleGatewaySigusr1Restart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: expect.objectContaining({
+          preflight: expect.objectContaining({
+            safe: false,
+            summary: "restart deferred: 1 queued or active operation(s)",
+          }),
+          source: "requestSafeGatewayRestart",
+        }),
+        delayMs: 0,
+        reason: "test.safe",
+      }),
+    );
+  });
+
+  it("keeps active task titles out of durable restart audit metadata", () => {
+    scheduleGatewaySigusr1Restart.mockReturnValueOnce({
+      ok: true,
+      pid: 123,
+      signal: "SIGUSR1",
       delayMs: 0,
-      reason: "test.safe",
+      mode: "emit",
+      coalesced: false,
+      cooldownMsApplied: 0,
     });
+    const taskTitle = "Build private customer branch";
+
+    const result = requestSafeGatewayRestart({
+      reason: "test.audit-safe-preflight",
+      inspect: {
+        getQueueSize: () => 0,
+        getPendingReplies: () => 0,
+        getEmbeddedRuns: () => 0,
+        getCronRuns: () => 0,
+        getActiveTasks: () => 1,
+        getTaskBlockers: () => [
+          {
+            taskId: "task-1",
+            runId: "run-1",
+            status: "running",
+            runtime: "acp",
+            label: "build",
+            title: taskTitle,
+          },
+        ],
+      },
+    });
+
+    expect(result.preflight.summary).toContain(taskTitle);
+    const scheduled = scheduleGatewaySigusr1Restart.mock.calls.at(-1)?.[0] as {
+      audit?: { context?: Record<string, unknown>; preflight?: { blockers?: unknown[] } };
+    };
+    const persistedAuditMetadata = JSON.stringify(scheduled.audit);
+    const auditBlocker = scheduled.audit?.preflight?.blockers?.[0] as
+      | { message?: string; task?: { title?: string } }
+      | undefined;
+    expect(persistedAuditMetadata).toContain("taskId=task-1");
+    expect(persistedAuditMetadata).not.toContain(taskTitle);
+    expect(String(scheduled.audit?.context?.preflightSummary)).not.toContain(taskTitle);
+    expect(auditBlocker?.message).not.toContain(taskTitle);
+    expect(auditBlocker?.task?.title).toBeUndefined();
   });
 
   it("surfaces coalesced restart requests", () => {
@@ -251,12 +308,18 @@ describe("safe gateway restart coordinator", () => {
 
     expect(result.status).toBe("scheduled");
     expect(result.preflight.safe).toBe(false);
-    expect(scheduleGatewaySigusr1Restart).toHaveBeenCalledWith({
-      delayMs: 0,
-      preservePendingEmitHooksOnDeferralBypass: true,
-      reason: "test.skip-deferral",
-      skipDeferral: true,
-    });
+    expect(scheduleGatewaySigusr1Restart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: expect.objectContaining({
+          preflight: expect.objectContaining({ safe: false }),
+          source: "requestSafeGatewayRestart",
+        }),
+        delayMs: 0,
+        preservePendingEmitHooksOnDeferralBypass: true,
+        reason: "test.skip-deferral",
+        skipDeferral: true,
+      }),
+    );
   });
 
   it("omits skipDeferral when not requested", () => {
@@ -282,9 +345,15 @@ describe("safe gateway restart coordinator", () => {
       },
     });
 
-    expect(scheduleGatewaySigusr1Restart).toHaveBeenCalledWith({
-      delayMs: 0,
-      reason: "test.no-skip",
-    });
+    expect(scheduleGatewaySigusr1Restart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: expect.objectContaining({
+          preflight: expect.objectContaining({ safe: true }),
+          source: "requestSafeGatewayRestart",
+        }),
+        delayMs: 0,
+        reason: "test.no-skip",
+      }),
+    );
   });
 });

--- a/src/infra/restart-coordinator.ts
+++ b/src/infra/restart-coordinator.ts
@@ -1,10 +1,15 @@
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import type { ActiveTaskRestartBlocker } from "../tasks/task-restart-blocker.js";
 import {
   createGatewayActiveWorkSnapshot,
   type GatewayActiveWorkBlocker,
   type GatewayActiveWorkInspectors,
 } from "./gateway-active-work.js";
-import { scheduleGatewaySigusr1Restart, type ScheduledRestart } from "./restart.js";
+import {
+  scheduleGatewaySigusr1Restart,
+  type RestartAuditInfo,
+  type ScheduledRestart,
+} from "./restart.js";
 
 // Safe restart coordination checks active local work before scheduling SIGUSR1
 // restarts, while still allowing explicit deferral bypasses for operators.
@@ -55,6 +60,51 @@ export type SafeGatewayRestartRequestResult = {
   restart: ScheduledRestart;
 };
 
+function formatDurableTaskBlocker(task: ActiveTaskRestartBlocker): string {
+  return [
+    `taskId=${task.taskId}`,
+    task.runId ? `runId=${task.runId}` : null,
+    `status=${task.status}`,
+    `runtime=${task.runtime}`,
+    task.label ? `label=${task.label}` : null,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+}
+
+function createAuditSafeRestartBlocker(
+  blocker: SafeGatewayRestartBlocker,
+): SafeGatewayRestartBlocker {
+  if (blocker.kind !== "task" || !blocker.task) {
+    return { ...blocker };
+  }
+  const task: ActiveTaskRestartBlocker = {
+    taskId: blocker.task.taskId,
+    status: blocker.task.status,
+    runtime: blocker.task.runtime,
+    ...(blocker.task.runId ? { runId: blocker.task.runId } : {}),
+    ...(blocker.task.label ? { label: blocker.task.label } : {}),
+  };
+  return {
+    ...blocker,
+    message: formatDurableTaskBlocker(task),
+    task,
+  };
+}
+
+function createAuditSafeGatewayRestartPreflight(
+  preflight: SafeGatewayRestartPreflight,
+): SafeGatewayRestartPreflight {
+  const blockers = preflight.blockers.map(createAuditSafeRestartBlocker);
+  return {
+    ...preflight,
+    blockers,
+    summary:
+      blockers.length === 0
+        ? "safe to restart now"
+        : `restart deferred: ${blockers.map((blocker) => blocker.message).join("; ")}`,
+  };
+}
 export function createSafeGatewayRestartPreflight(
   inspectors: Partial<SafeRestartInspectors> = {},
 ): SafeGatewayRestartPreflight {
@@ -110,13 +160,26 @@ export function requestSafeGatewayRestart(
     skipDeferral?: boolean;
     preservePendingEmitHooks?: boolean;
     inspect?: Partial<SafeRestartInspectors>;
+    audit?: RestartAuditInfo;
   } = {},
 ): SafeGatewayRestartRequestResult {
   const preflight = createSafeGatewayRestartPreflight(opts.inspect);
+  const auditPreflight = createAuditSafeGatewayRestartPreflight(preflight);
   const skipDeferral = opts.skipDeferral === true;
+  const reason = opts.reason ?? "gateway.restart.safe";
   const restart = scheduleGatewaySigusr1Restart({
     delayMs: opts.delayMs ?? 0,
-    reason: opts.reason ?? "gateway.restart.safe",
+    reason,
+    audit: {
+      ...opts.audit,
+      source: "requestSafeGatewayRestart",
+      preflight: auditPreflight,
+      context: {
+        ...opts.audit?.context,
+        preflightSummary: auditPreflight.summary,
+        preflightCounts: preflight.counts,
+      },
+    },
     ...(opts.preservePendingEmitHooks === true || skipDeferral
       ? { preservePendingEmitHooksOnDeferralBypass: true }
       : {}),

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -1,4 +1,7 @@
 // Covers gateway restart process and supervisor paths.
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureFullEnv, withEnv } from "../test-utils/env.js";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
@@ -29,6 +32,7 @@ vi.mock("./ports-lsof.js", () => ({
 }));
 
 vi.mock("../config/paths.js", () => ({
+  STATE_DIR: "/tmp/openclaw-state",
   resolveGatewayPort: (...args: unknown[]) => resolveGatewayPortMock(...args),
   resolveStateDir: (env: NodeJS.ProcessEnv = process.env) =>
     env.OPENCLAW_STATE_DIR ?? "/tmp/openclaw-state",
@@ -36,7 +40,14 @@ vi.mock("../config/paths.js", () => ({
 
 const { testing, cleanStaleGatewayProcessesSync, findGatewayPidsOnPortSync } =
   await import("./restart-stale-pids.js");
-const { triggerOpenClawRestart } = await import("./restart.js");
+const {
+  testing: restartTesting,
+  scheduleGatewaySigusr1Restart,
+  triggerOpenClawRestart,
+} = await import("./restart.js");
+const { requestSafeGatewayRestart } = await import("./restart-coordinator.js");
+const { closeOpenClawStateDatabase, openOpenClawStateDatabase } =
+  await import("../state/openclaw-state-db.js");
 
 let currentTimeMs = 0;
 const envSnapshot = captureFullEnv();
@@ -74,6 +85,198 @@ function requireFirstSpawnSyncCall(): [unknown, unknown, unknown] {
   }
   return call as [unknown, unknown, unknown];
 }
+
+describe("restart diagnostics", () => {
+  it("redacts session keys in restart warning fields", () => {
+    const redacted = restartTesting.formatRestartSessionKeyForLog(
+      "agent:main:discord:channel:1515157916540211291",
+    );
+
+    expect(redacted).toMatch(/^<redacted:[a-f0-9]{12}>$/);
+    expect(redacted).not.toContain("discord");
+    expect(redacted).not.toContain("1515157916540211291");
+    expect(restartTesting.formatRestartSessionKeyForLog(undefined)).toBe("unspecified");
+  });
+
+  it("keeps truncated restart audit payloads valid JSON", () => {
+    const serialized = restartTesting.serializeRestartAuditJson({
+      context: `quote-heavy:${'\\"'.repeat(15_000)}`,
+    });
+
+    expect(serialized).not.toBeNull();
+    expect(serialized?.length).toBeLessThanOrEqual(20_000);
+    expect(() => JSON.parse(serialized ?? "")).not.toThrow();
+    expect(JSON.parse(serialized ?? "")).toEqual(
+      expect.objectContaining({
+        truncated: true,
+        originalLength: expect.any(Number),
+        preview: expect.any(String),
+      }),
+    );
+  });
+
+  it("redacts session keys in durable restart audit storage", () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-restart-audit-test-"));
+    const sessionKey = "agent:main:discord:channel:1515157916540211291";
+    try {
+      withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+        const result = scheduleGatewaySigusr1Restart({
+          delayMs: 60_000,
+          reason: "model supplied private restart explanation",
+          sessionKey,
+          skipCooldown: true,
+          audit: {
+            source: "gateway.tool.restart",
+            sessionKey,
+            context: {
+              nestedSessionKey: sessionKey,
+              token: {
+                value: "secret-token-value",
+                nested: ["secret-token-in-array"],
+              },
+              credentials: [
+                {
+                  password: "nested-password-value",
+                },
+              ],
+            },
+            preflight: {
+              requesterSessionKey: sessionKey,
+              authorization: {
+                scheme: "Bearer",
+                value: "secret-authorization-value",
+              },
+            },
+          },
+        });
+
+        expect(result.ok).toBe(true);
+        const { db } = openOpenClawStateDatabase({ env: process.env });
+        const row = db
+          .prepare(
+            "SELECT reason, source, session_key, audit_json, preflight_json FROM gateway_restart_audit ORDER BY created_at DESC LIMIT 1",
+          )
+          .get() as {
+          reason: string | null;
+          source: string | null;
+          session_key: string | null;
+          audit_json: string | null;
+          preflight_json: string | null;
+        };
+        closeOpenClawStateDatabase();
+        restartTesting.resetSigusr1State();
+
+        expect(row.reason).toBe("gateway.tool.restart");
+        expect(row.source).toBe("gateway.tool.restart");
+        expect(row.session_key).toMatch(/^<redacted:[a-f0-9]{12}>$/);
+        expect(row.audit_json).toContain("<redacted:");
+        expect(row.audit_json).toContain('"token":"<redacted>"');
+        expect(row.audit_json).toContain('"credentials":"<redacted>"');
+        expect(row.preflight_json).toContain("<redacted:");
+        expect(row.preflight_json).toContain('"authorization":"<redacted>"');
+        expect(JSON.stringify(row)).not.toContain("1515157916540211291");
+        expect(JSON.stringify(row)).not.toContain("secret-token-value");
+        expect(JSON.stringify(row)).not.toContain("secret-token-in-array");
+        expect(JSON.stringify(row)).not.toContain("nested-password-value");
+        expect(JSON.stringify(row)).not.toContain("secret-authorization-value");
+        expect(JSON.stringify(row)).not.toContain("model supplied private restart explanation");
+      });
+    } finally {
+      restartTesting.resetSigusr1State();
+      closeOpenClawStateDatabase();
+      rmSync(stateDir, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps active task titles out of durable restart audit rows", () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-restart-audit-task-"));
+    const taskTitle = "Investigate private customer outage prompt";
+    try {
+      withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+        const result = requestSafeGatewayRestart({
+          delayMs: 60_000,
+          reason: "test restart audit task title redaction",
+          inspect: {
+            getQueueSize: () => 0,
+            getPendingReplies: () => 0,
+            getEmbeddedRuns: () => 0,
+            getCronRuns: () => 0,
+            getActiveTasks: () => 1,
+            getTaskBlockers: () => [
+              {
+                taskId: "task-privacy",
+                runId: "run-privacy",
+                status: "running",
+                runtime: "acp",
+                label: "investigation",
+                title: taskTitle,
+              },
+            ],
+          },
+        });
+
+        expect(result.preflight.summary).toContain(taskTitle);
+        const { db } = openOpenClawStateDatabase({ env: process.env });
+        const row = db
+          .prepare(
+            "SELECT audit_json, preflight_json FROM gateway_restart_audit ORDER BY created_at DESC LIMIT 1",
+          )
+          .get() as {
+          audit_json: string | null;
+          preflight_json: string | null;
+        };
+        closeOpenClawStateDatabase();
+        restartTesting.resetSigusr1State();
+
+        expect(row.audit_json).toContain("task-privacy");
+        expect(row.preflight_json).toContain("task-privacy");
+        expect(JSON.stringify(row)).not.toContain(taskTitle);
+      });
+    } finally {
+      restartTesting.resetSigusr1State();
+      closeOpenClawStateDatabase();
+      rmSync(stateDir, { force: true, recursive: true });
+    }
+  });
+
+  it("bounds durable restart audit retention to the newest rows", () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-restart-audit-retention-"));
+    const maxRows = restartTesting.gatewayRestartAuditMaxRows;
+    const baseNowMs = 1_700_000_000_000;
+    let nowMs = baseNowMs;
+    vi.spyOn(Date, "now").mockImplementation(() => nowMs++);
+    try {
+      withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+        for (let index = 0; index < maxRows + 3; index += 1) {
+          const result = scheduleGatewaySigusr1Restart({
+            delayMs: 60_000,
+            reason: `retention-${index}`,
+            skipCooldown: true,
+            audit: { source: "gateway.tool.restart" },
+          });
+          expect(result.ok).toBe(true);
+        }
+
+        const { db } = openOpenClawStateDatabase({ env: process.env });
+        const rows = db
+          .prepare(
+            "SELECT created_at FROM gateway_restart_audit ORDER BY created_at ASC, event_key ASC",
+          )
+          .all() as Array<{ created_at: number }>;
+        closeOpenClawStateDatabase();
+        restartTesting.resetSigusr1State();
+
+        expect(rows).toHaveLength(maxRows);
+        expect(rows[0]?.created_at).toBeGreaterThanOrEqual(baseNowMs + 3);
+        expect(rows.at(-1)?.created_at).toBeGreaterThan(rows[0]?.created_at ?? 0);
+      });
+    } finally {
+      restartTesting.resetSigusr1State();
+      closeOpenClawStateDatabase();
+      rmSync(stateDir, { force: true, recursive: true });
+    }
+  });
+});
 
 describe.runIf(process.platform !== "win32")("findGatewayPidsOnPortSync", () => {
   it("parses lsof output and filters non-openclaw/current processes", () => {

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -1,7 +1,9 @@
 // Coordinates gateway restart requests across supported supervisors.
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getRuntimeConfig } from "../config/config.js";
 import {
@@ -42,9 +44,11 @@ const RESTART_COOLDOWN_MS = 30_000;
 const LAUNCHCTL_ALREADY_LOADED_EXIT_CODE = 37;
 const GATEWAY_RESTART_INTENT_KEY = "gateway-restart";
 const GATEWAY_RESTART_INTENT_TTL_MS = 60_000;
+const GATEWAY_RESTART_AUDIT_MAX_ROWS = 512;
 
 const restartLog = createSubsystemLogger("restart");
 type GatewayRestartIntentDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_intent">;
+type GatewayRestartAuditDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_audit">;
 
 export { findGatewayPidsOnPortSync };
 
@@ -63,6 +67,7 @@ let pendingRestartDueAt = 0;
 let pendingRestartReason: string | undefined;
 let pendingRestartEmitHooks: RestartEmitHooks | undefined;
 let pendingRestartSessionKey: string | undefined;
+let pendingRestartAudit: RestartAuditEvent | undefined;
 let pendingRestartSkipDeferral = false;
 let pendingRestartPreparing = false;
 let pendingRestartSignalAdmission: GatewayRestartSignalAdmissionLease | null = null;
@@ -87,6 +92,7 @@ function clearPendingScheduledRestart(): void {
   pendingRestartReason = undefined;
   pendingRestartEmitHooks = undefined;
   pendingRestartSessionKey = undefined;
+  pendingRestartAudit = undefined;
   pendingRestartSkipDeferral = false;
   pendingRestartPreparing = false;
 }
@@ -107,14 +113,23 @@ function armPendingRestartTimer(requestedDueAt: number, nowMs: number): void {
     () => {
       const scheduledReason = pendingRestartReason;
       const scheduledSkipDeferral = pendingRestartSkipDeferral;
+      const scheduledAudit = pendingRestartAudit;
       pendingRestartTimer = null;
       pendingRestartDueAt = 0;
       pendingRestartReason = undefined;
+      pendingRestartAudit = undefined;
       pendingRestartSkipDeferral = false;
       pendingRestartPreparing = true;
       const pendingCheck = preRestartCheck;
       if (scheduledSkipDeferral || !pendingCheck) {
-        void emitPreparedGatewayRestart(undefined, scheduledReason);
+        void emitPreparedGatewayRestart(
+          undefined,
+          scheduledReason,
+          undefined,
+          undefined,
+          undefined,
+          scheduledAudit,
+        );
         return;
       }
       const cfg = getRuntimeConfig();
@@ -124,6 +139,7 @@ function armPendingRestartTimer(requestedDueAt: number, nowMs: number): void {
       deferGatewayRestartUntilIdle({
         getPendingCount: pendingCheck,
         maxWaitMs: deferralTimeoutMs,
+        auditEvent: scheduledAudit,
         reason: scheduledReason,
         timeoutIntent: { force: true, ...(scheduledReason ? { reason: scheduledReason } : {}) },
       });
@@ -156,9 +172,13 @@ export function resetGatewayRestartStateForInProcessRestart(): void {
 
 export type RestartAuditInfo = {
   actor?: string;
+  source?: string;
   deviceId?: string;
   clientIp?: string;
+  sessionKey?: string;
   changedPaths?: string[];
+  context?: Record<string, unknown>;
+  preflight?: unknown;
 };
 
 type GatewayRestartIntentPayload = {
@@ -345,6 +365,300 @@ function summarizeChangedPaths(paths: string[] | undefined, maxPaths = 6): strin
   return `${head},+${paths.length - maxPaths} more`;
 }
 
+type RestartAuditEventType =
+  | "scheduled"
+  | "coalesced"
+  | "rescheduled"
+  | "bypassed_deferral"
+  | "emit_requested"
+  | "emit_failed";
+
+function normalizeRestartAuditString(value: string | undefined, max = 200): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized.slice(0, max) : null;
+}
+
+function formatRestartSessionKeyForLog(value: string | undefined): string {
+  const normalized = normalizeRestartAuditString(value, 512);
+  if (!normalized) {
+    return "unspecified";
+  }
+  const fingerprint = createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+  return `<redacted:${fingerprint}>`;
+}
+
+function isRestartAuditSensitiveKey(key: string): boolean {
+  return /(?:session[_-]?key|authorization|token|secret|credential|api[_-]?key|cookie)/i.test(key);
+}
+
+function sanitizeRestartAuditValueForStorage(value: unknown, keyHint?: string): unknown {
+  if (keyHint && /session[_-]?key/i.test(keyHint)) {
+    return typeof value === "string" ? formatRestartSessionKeyForLog(value) : "<redacted>";
+  }
+  if (keyHint && isRestartAuditSensitiveKey(keyHint)) {
+    return "<redacted>";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeRestartAuditValueForStorage(entry, keyHint));
+  }
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    sanitized[key] = sanitizeRestartAuditValueForStorage(entry, key);
+  }
+  return sanitized;
+}
+
+function serializeRestartAuditJson(value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  try {
+    const text = JSON.stringify(sanitizeRestartAuditValueForStorage(value));
+    if (text.length <= 20_000) {
+      return text;
+    }
+    const envelope = (preview: string) =>
+      JSON.stringify({
+        truncated: true,
+        originalLength: text.length,
+        preview,
+      });
+    let low = 0;
+    let high = Math.min(text.length, 20_000);
+    while (low < high) {
+      const mid = Math.ceil((low + high) / 2);
+      if (envelope(text.slice(0, mid)).length <= 20_000) {
+        low = mid;
+      } else {
+        high = mid - 1;
+      }
+    }
+    return envelope(text.slice(0, low));
+  } catch {
+    return JSON.stringify({ error: "unserializable" });
+  }
+}
+
+export type RestartAuditEvent = {
+  eventType: RestartAuditEventType;
+  reason?: string;
+  source?: string;
+  mode?: string;
+  delayMs?: number;
+  dueAt?: number;
+  cooldownMs?: number;
+  coalesced?: boolean;
+  sessionKey?: string;
+  audit?: RestartAuditInfo;
+  preflight?: unknown;
+};
+
+type RestartAuditSourceCode =
+  | "config_reload"
+  | "gateway.config.write"
+  | "gateway.restart.request"
+  | "gateway.tool.restart"
+  | "gateway.update.run"
+  | "requestSafeGatewayRestart"
+  | "signal.sigusr1"
+  | "slash.restart"
+  | "unknown";
+
+type RestartAuditReasonCode =
+  | "config.reload"
+  | "gateway.restart.request"
+  | "gateway.restart.safe"
+  | "gateway.tool.restart"
+  | "gateway.update"
+  | "signal.sigusr1"
+  | "slash.restart"
+  | "unknown";
+
+function normalizeRestartAuditSourceCode(opts: RestartAuditEvent): RestartAuditSourceCode {
+  const source = normalizeRestartAuditString(opts.source ?? opts.audit?.source);
+  switch (source) {
+    case "config_reload":
+    case "gateway.config.write":
+    case "gateway.restart.request":
+    case "gateway.tool.restart":
+    case "gateway.update.run":
+    case "requestSafeGatewayRestart":
+    case "signal.sigusr1":
+    case "slash.restart":
+      return source;
+    case null:
+      break;
+  }
+
+  const reason = normalizeRestartAuditString(opts.reason);
+  if (reason === "SIGUSR1") {
+    return "signal.sigusr1";
+  }
+  if (reason === "/restart") {
+    return "slash.restart";
+  }
+  if (reason === "update.run" || reason === "update.auto") {
+    return "gateway.update.run";
+  }
+  return "unknown";
+}
+
+function normalizeRestartAuditReasonCode(
+  opts: RestartAuditEvent,
+  source: RestartAuditSourceCode,
+): RestartAuditReasonCode {
+  switch (source) {
+    case "config_reload":
+    case "gateway.config.write":
+      return "config.reload";
+    case "gateway.restart.request":
+      return "gateway.restart.request";
+    case "gateway.tool.restart":
+      return "gateway.tool.restart";
+    case "gateway.update.run":
+      return "gateway.update";
+    case "requestSafeGatewayRestart":
+      return "gateway.restart.safe";
+    case "signal.sigusr1":
+      return "signal.sigusr1";
+    case "slash.restart":
+      return "slash.restart";
+    case "unknown":
+      break;
+  }
+
+  const reason = normalizeRestartAuditString(opts.reason);
+  if (
+    reason === "config.apply" ||
+    reason === "config.patch" ||
+    reason?.startsWith("config reload")
+  ) {
+    return "config.reload";
+  }
+  if (reason === "gateway.restart.safe") {
+    return "gateway.restart.safe";
+  }
+  if (reason === "update.run" || reason === "update.auto") {
+    return "gateway.update";
+  }
+  if (reason === "SIGUSR1") {
+    return "signal.sigusr1";
+  }
+  if (reason === "/restart") {
+    return "slash.restart";
+  }
+  return "unknown";
+}
+
+function normalizeRestartAuditEventForStorage(opts: RestartAuditEvent): RestartAuditEvent {
+  const source = normalizeRestartAuditSourceCode(opts);
+  return {
+    ...opts,
+    reason: normalizeRestartAuditReasonCode(opts, source),
+    source,
+  };
+}
+
+let restartAuditWriterOverride: ((opts: RestartAuditEvent) => void) | null = null;
+
+function pruneGatewayRestartAuditRowsSync(
+  db: DatabaseSync,
+  kysely: ReturnType<typeof getNodeSqliteKysely<GatewayRestartAuditDatabase>>,
+): void {
+  const retainedRows = kysely
+    .selectFrom("gateway_restart_audit")
+    .select("event_key")
+    .orderBy("created_at", "desc")
+    .orderBy("event_key", "desc")
+    .limit(GATEWAY_RESTART_AUDIT_MAX_ROWS);
+  executeSqliteQuerySync(
+    db,
+    kysely.deleteFrom("gateway_restart_audit").where("event_key", "not in", retainedRows),
+  );
+}
+
+function writeGatewayRestartAuditEventSync(opts: RestartAuditEvent): void {
+  const storedEvent = normalizeRestartAuditEventForStorage(opts);
+  if (restartAuditWriterOverride) {
+    restartAuditWriterOverride(storedEvent);
+    return;
+  }
+  const createdAt = Date.now();
+  const eventKey = `${createdAt}-${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
+  const auditJson = serializeRestartAuditJson(storedEvent.audit);
+  const preflightJson = serializeRestartAuditJson(
+    storedEvent.preflight ?? storedEvent.audit?.preflight,
+  );
+  try {
+    runOpenClawStateWriteTransaction(
+      ({ db }) => {
+        const kysely = getNodeSqliteKysely<GatewayRestartAuditDatabase>(db);
+        executeSqliteQuerySync(
+          db,
+          kysely.insertInto("gateway_restart_audit").values({
+            audit_json: auditJson,
+            coalesced: storedEvent.coalesced === undefined ? null : storedEvent.coalesced ? 1 : 0,
+            cooldown_ms:
+              typeof storedEvent.cooldownMs === "number" && Number.isFinite(storedEvent.cooldownMs)
+                ? Math.floor(storedEvent.cooldownMs)
+                : null,
+            created_at: createdAt,
+            delay_ms:
+              typeof storedEvent.delayMs === "number" && Number.isFinite(storedEvent.delayMs)
+                ? Math.floor(storedEvent.delayMs)
+                : null,
+            due_at:
+              typeof storedEvent.dueAt === "number" && Number.isFinite(storedEvent.dueAt)
+                ? Math.floor(storedEvent.dueAt)
+                : null,
+            event_key: eventKey,
+            event_type: storedEvent.eventType,
+            mode: normalizeRestartAuditString(storedEvent.mode, 80) ?? null,
+            pid: process.pid,
+            preflight_json: preflightJson,
+            reason: storedEvent.reason ?? null,
+            session_key:
+              formatRestartSessionKeyForLog(
+                storedEvent.sessionKey ?? storedEvent.audit?.sessionKey,
+              ) === "unspecified"
+                ? null
+                : formatRestartSessionKeyForLog(
+                    storedEvent.sessionKey ?? storedEvent.audit?.sessionKey,
+                  ),
+            source: storedEvent.source ?? null,
+          }),
+        );
+        pruneGatewayRestartAuditRowsSync(db, kysely);
+      },
+      { env: process.env },
+    );
+  } catch (err) {
+    restartLog.warn(`failed to write gateway restart audit event: ${String(err)}`);
+  }
+}
+
+function writeGatewayRestartAuditEventAfterRestartCriticalPath(opts: RestartAuditEvent): void {
+  const write = () => writeGatewayRestartAuditEventSync(opts);
+  const handle = setTimeout(write, 0);
+  handle.unref?.();
+}
+
+function writeGatewayRestartScheduleAuditEvent(opts: RestartAuditEvent): void {
+  const delayMs =
+    typeof opts.delayMs === "number" && Number.isFinite(opts.delayMs) ? opts.delayMs : undefined;
+  if (delayMs !== undefined && delayMs <= 0) {
+    writeGatewayRestartAuditEventAfterRestartCriticalPath(opts);
+    return;
+  }
+  writeGatewayRestartAuditEventSync(opts);
+}
+
 function formatRestartAudit(audit: RestartAuditInfo | undefined): string {
   const actor = typeof audit?.actor === "string" && audit.actor.trim() ? audit.actor.trim() : null;
   const deviceId =
@@ -352,9 +666,17 @@ function formatRestartAudit(audit: RestartAuditInfo | undefined): string {
   const clientIp =
     typeof audit?.clientIp === "string" && audit.clientIp.trim() ? audit.clientIp.trim() : null;
   const changed = summarizeChangedPaths(audit?.changedPaths);
+  const source = normalizeRestartAuditString(audit?.source);
+  const sessionKey = formatRestartSessionKeyForLog(audit?.sessionKey);
   const fields = [];
   if (actor) {
     fields.push(`actor=${actor}`);
+  }
+  if (source) {
+    fields.push(`source=${source}`);
+  }
+  if (sessionKey !== "unspecified") {
+    fields.push(`sessionKey=${sessionKey}`);
   }
   if (deviceId) {
     fields.push(`device=${deviceId}`);
@@ -385,6 +707,7 @@ export function setPreRestartDeferralCheck(fn: () => number): void {
 export function emitGatewayRestart(
   reasonOverride?: string,
   intent?: GatewayRestartIntent,
+  auditEvent?: RestartAuditEvent,
 ): boolean {
   if (hasUnconsumedRestartSignal()) {
     clearActiveDeferralPolls();
@@ -420,11 +743,26 @@ export function emitGatewayRestart(
       process.kill(process.pid, "SIGUSR1");
     }
   } catch {
-    // Roll back the cycle marker so future restart requests can still proceed.
+    // Roll back first so audit storage cannot delay restart availability.
     rollBackGatewayRestartEmission();
+    const auditReason = emittedRestartReason ?? auditEvent?.reason;
+    writeGatewayRestartAuditEventSync({
+      ...auditEvent,
+      eventType: "emit_failed",
+      reason: auditReason,
+      source: auditEvent?.source ?? intent?.reason ?? reasonOverride ?? auditReason,
+    });
     return false;
   }
   lastRestartEmittedAt = Date.now();
+  // Restart progress must never wait for the shared state database.
+  const auditReason = emittedRestartReason ?? auditEvent?.reason;
+  writeGatewayRestartAuditEventAfterRestartCriticalPath({
+    ...auditEvent,
+    eventType: "emit_requested",
+    reason: auditReason,
+    source: auditEvent?.source ?? intent?.reason ?? reasonOverride ?? auditReason,
+  });
   return true;
 }
 
@@ -437,11 +775,12 @@ export function emitGatewayRestart(
 function emitGatewayRestartWithSignalAdmission(
   reasonOverride?: string,
   intent?: GatewayRestartIntent,
+  auditEvent?: RestartAuditEvent,
 ): boolean {
   const signalAdmission = pendingRestartSignalAdmission ?? beginGatewayRestartSignalAdmission();
   pendingRestartSignalAdmission = signalAdmission;
   const hadUnconsumedRestartSignal = hasUnconsumedRestartSignal();
-  const emitted = emitGatewayRestart(reasonOverride, intent);
+  const emitted = emitGatewayRestart(reasonOverride, intent, auditEvent);
   if (!emitted && !hadUnconsumedRestartSignal) {
     clearPendingRestartSignalAdmission();
   }
@@ -452,9 +791,10 @@ function emitGatewayRestartWithSignalAdmission(
 export function requestGatewayRestartWithSignalAdmission(
   reasonOverride?: string,
   intent?: GatewayRestartIntent,
+  auditEvent?: RestartAuditEvent,
 ): GatewayRestartEmitResult {
   const hadUnconsumedRestartSignal = hasUnconsumedRestartSignal();
-  if (emitGatewayRestartWithSignalAdmission(reasonOverride, intent)) {
+  if (emitGatewayRestartWithSignalAdmission(reasonOverride, intent, auditEvent)) {
     return { status: "emitted" };
   }
   return { status: hadUnconsumedRestartSignal ? "coalesced" : "failed" };
@@ -563,6 +903,7 @@ export type RestartDeferralHandle = {
 export type GatewayRestartEmitter = (
   reasonOverride?: string,
   intent?: GatewayRestartIntent,
+  auditEvent?: RestartAuditEvent,
 ) => GatewayRestartEmitResult;
 
 export type GatewayRestartEmitResult =
@@ -630,6 +971,7 @@ async function emitPreparedGatewayRestartUnderAdmission(
   hooks?: RestartEmitHooks,
   reasonOverride?: string,
   intent?: GatewayRestartIntent,
+  auditEvent?: RestartAuditEvent,
   transientGeneration = restartTransientGeneration,
   canEmit: () => boolean = () => true,
 ): Promise<GatewayRestartEmitResult | null> {
@@ -734,8 +1076,8 @@ async function emitPreparedGatewayRestartUnderAdmission(
   const resolvedIntent =
     preferredReason && intent ? { ...intent, reason: preferredReason } : intent;
   const emitResult = emitOwner?.emitRestart
-    ? emitOwner.emitRestart(resolvedReason, resolvedIntent)
-    : requestGatewayRestartWithSignalAdmission(resolvedReason, resolvedIntent);
+    ? emitOwner.emitRestart(resolvedReason, resolvedIntent, auditEvent)
+    : requestGatewayRestartWithSignalAdmission(resolvedReason, resolvedIntent, auditEvent);
   if (emitResult.status !== "emitted") {
     await rejectPreparedRestartHooks(preparedHooksList);
   }
@@ -757,6 +1099,7 @@ async function emitPreparedGatewayRestart(
   intent?: GatewayRestartIntent,
   finalIdleCheck?: () => boolean,
   setFenceRollback?: (rollback: (() => void) | null) => void,
+  auditEvent?: RestartAuditEvent,
 ): Promise<boolean> {
   const transientGeneration = restartTransientGeneration;
   try {
@@ -799,6 +1142,7 @@ async function emitPreparedGatewayRestart(
         hooks,
         reasonOverride,
         intent,
+        auditEvent,
         transientGeneration,
         () => fenceActive,
       );
@@ -827,6 +1171,7 @@ async function emitPreparedGatewayRestart(
  */
 export function deferGatewayRestartUntilIdle(opts: {
   getPendingCount: () => number;
+  auditEvent?: RestartAuditEvent;
   hooks?: RestartDeferralHooks;
   emitHooks?: RestartEmitHooks;
   pollMs?: number;
@@ -878,6 +1223,7 @@ export function deferGatewayRestartUntilIdle(opts: {
       (rollback) => {
         cancelEmissionFence = rollback;
       },
+      opts.auditEvent,
     )
       .then((attempted) => {
         attemptingEmission = false;
@@ -895,7 +1241,14 @@ export function deferGatewayRestartUntilIdle(opts: {
         cancelEmissionFence = null;
         stopPoll();
         opts.hooks?.onCheckError?.(err);
-        void emitPreparedGatewayRestart(opts.emitHooks, opts.reason, params.intent);
+        void emitPreparedGatewayRestart(
+          opts.emitHooks,
+          opts.reason,
+          params.intent,
+          undefined,
+          undefined,
+          opts.auditEvent,
+        );
       });
   };
   const inspectPending = () => {
@@ -908,7 +1261,14 @@ export function deferGatewayRestartUntilIdle(opts: {
     } catch (err) {
       stopPoll();
       opts.hooks?.onCheckError?.(err);
-      void emitPreparedGatewayRestart(opts.emitHooks, opts.reason);
+      void emitPreparedGatewayRestart(
+        opts.emitHooks,
+        opts.reason,
+        undefined,
+        undefined,
+        undefined,
+        opts.auditEvent,
+      );
       return;
     }
     if (current <= 0) {
@@ -935,7 +1295,14 @@ export function deferGatewayRestartUntilIdle(opts: {
     pending = opts.getPendingCount();
   } catch (err) {
     opts.hooks?.onCheckError?.(err);
-    void emitPreparedGatewayRestart(opts.emitHooks, opts.reason);
+    void emitPreparedGatewayRestart(
+      opts.emitHooks,
+      opts.reason,
+      undefined,
+      undefined,
+      undefined,
+      opts.auditEvent,
+    );
     return handle;
   }
   if (pending > 0) {
@@ -1146,6 +1513,19 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   const skipDeferral = opts?.skipDeferral === true;
   let nextPendingEmitHooks = opts?.emitHooks;
   let nextPendingSessionKey = opts?.sessionKey;
+  let nextPendingAudit: RestartAuditEvent | undefined = {
+    eventType: "scheduled",
+    reason,
+    source: opts?.audit?.source,
+    mode,
+    delayMs: Math.max(0, requestedDueAt - nowMs),
+    dueAt: requestedDueAt,
+    cooldownMs: cooldownMsApplied,
+    coalesced: false,
+    sessionKey: opts?.sessionKey,
+    audit: opts?.audit,
+  };
+  let rescheduleAudit: RestartAuditEvent | undefined;
 
   if (hasUnconsumedRestartSignal()) {
     if (shouldPreferRestartReason(reason, emittedRestartReason)) {
@@ -1155,6 +1535,18 @@ export function scheduleGatewaySigusr1Restart(opts?: {
         emittedRestartIntent = { ...emittedRestartIntent, reason };
       }
     }
+    writeGatewayRestartAuditEventSync({
+      eventType: "coalesced",
+      reason,
+      source: opts?.audit?.source,
+      mode,
+      delayMs: 0,
+      dueAt: nowMs,
+      cooldownMs: cooldownMsApplied,
+      coalesced: true,
+      sessionKey: opts?.sessionKey,
+      audit: opts?.audit,
+    });
     restartLog.warn(
       `restart request coalesced (already in-flight) reason=${reason ?? "unspecified"} ${formatRestartAudit(opts?.audit)}`,
     );
@@ -1189,8 +1581,31 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       if (!preservePendingHooks) {
         pendingRestartEmitHooks = opts?.emitHooks;
         pendingRestartSessionKey = opts?.sessionKey;
+        pendingRestartAudit = nextPendingAudit;
       }
-      void emitPreparedGatewayRestart(undefined, reason);
+      void emitPreparedGatewayRestart(
+        undefined,
+        reason,
+        undefined,
+        undefined,
+        undefined,
+        pendingRestartAudit ?? nextPendingAudit,
+      ).then((attempted) => {
+        if (attempted) {
+          writeGatewayRestartAuditEventSync({
+            eventType: "bypassed_deferral",
+            reason,
+            source: opts?.audit?.source,
+            mode,
+            delayMs: 0,
+            dueAt: nowMs,
+            cooldownMs: cooldownMsApplied,
+            coalesced: false,
+            sessionKey: opts?.sessionKey,
+            audit: opts?.audit,
+          });
+        }
+      });
       return {
         ok: true,
         pid: process.pid,
@@ -1217,7 +1632,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
         !canReplacePendingRestartEmitHooks(opts?.emitHooks, opts?.sessionKey)
       ) {
         restartLog.warn(
-          `restart continuation dropped: another session owns the pending restart (callerSessionKey=${opts?.sessionKey ?? "unspecified"} pendingSessionKey=${pendingRestartSessionKey ?? "unspecified"})`,
+          `restart continuation dropped: another session owns the pending restart (callerSessionKey=${formatRestartSessionKeyForLog(opts?.sessionKey)} pendingSessionKey=${formatRestartSessionKeyForLog(pendingRestartSessionKey)})`,
         );
         if (pendingRestartTimer) {
           clearTimeout(pendingRestartTimer);
@@ -1225,8 +1640,21 @@ export function scheduleGatewaySigusr1Restart(opts?: {
         pendingRestartTimer = null;
         pendingRestartDueAt = requestedDueAt;
         pendingRestartReason = reason;
+        pendingRestartAudit = nextPendingAudit;
         pendingRestartSkipDeferral = pendingRestartSkipDeferral || skipDeferral;
         armPendingRestartTimer(requestedDueAt, nowMs);
+        writeGatewayRestartScheduleAuditEvent({
+          eventType: "rescheduled",
+          reason,
+          source: opts?.audit?.source,
+          mode,
+          delayMs: Math.max(0, requestedDueAt - nowMs),
+          dueAt: requestedDueAt,
+          cooldownMs: cooldownMsApplied,
+          coalesced: true,
+          sessionKey: opts?.sessionKey,
+          audit: opts?.audit,
+        });
         return {
           ok: true,
           pid: process.pid,
@@ -1241,6 +1669,19 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       }
       const preservedEmitHooks = preservePendingHooks ? pendingRestartEmitHooks : undefined;
       const preservedSessionKey = preservePendingHooks ? pendingRestartSessionKey : undefined;
+      const preservedAudit = preservePendingHooks ? pendingRestartAudit : undefined;
+      rescheduleAudit = {
+        eventType: "rescheduled",
+        reason,
+        source: opts?.audit?.source,
+        mode,
+        delayMs: Math.max(0, requestedDueAt - nowMs),
+        dueAt: requestedDueAt,
+        cooldownMs: cooldownMsApplied,
+        coalesced: false,
+        sessionKey: opts?.sessionKey,
+        audit: opts?.audit,
+      };
       restartLog.warn(
         `restart request rescheduled earlier reason=${reason ?? "unspecified"} pendingReason=${pendingRestartReason ?? "unspecified"} oldDelayMs=${remainingMs} newDelayMs=${Math.max(0, requestedDueAt - nowMs)} ${formatRestartAudit(opts?.audit)}`,
       );
@@ -1248,19 +1689,33 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       if (preservePendingHooks) {
         nextPendingEmitHooks = preservedEmitHooks;
         nextPendingSessionKey = preservedSessionKey;
+        nextPendingAudit = preservedAudit;
       }
     } else {
       if (shouldPreferRestartReason(reason, pendingRestartReason)) {
         pendingRestartReason = reason;
+        pendingRestartAudit = nextPendingAudit;
       }
       pendingRestartSkipDeferral = pendingRestartSkipDeferral || skipDeferral;
+      writeGatewayRestartScheduleAuditEvent({
+        eventType: "coalesced",
+        reason,
+        source: opts?.audit?.source,
+        mode,
+        delayMs: remainingMs,
+        dueAt: pendingRestartDueAt,
+        cooldownMs: cooldownMsApplied,
+        coalesced: true,
+        sessionKey: opts?.sessionKey,
+        audit: opts?.audit,
+      });
       restartLog.warn(
         `restart request coalesced (already scheduled) reason=${reason ?? "unspecified"} pendingReason=${pendingRestartReason ?? "unspecified"} delayMs=${remainingMs} ${formatRestartAudit(opts?.audit)}`,
       );
       const emitHooksQueued = updatePendingRestartEmitHooks(opts?.emitHooks, opts?.sessionKey);
       if (opts?.emitHooks && !emitHooksQueued) {
         restartLog.warn(
-          `restart continuation dropped: another session owns the pending restart (callerSessionKey=${opts.sessionKey ?? "unspecified"} pendingSessionKey=${pendingRestartSessionKey ?? "unspecified"})`,
+          `restart continuation dropped: another session owns the pending restart (callerSessionKey=${formatRestartSessionKeyForLog(opts.sessionKey)} pendingSessionKey=${formatRestartSessionKeyForLog(pendingRestartSessionKey)})`,
         );
       }
       return {
@@ -1281,8 +1736,25 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   pendingRestartReason = reason;
   pendingRestartEmitHooks = nextPendingEmitHooks;
   pendingRestartSessionKey = nextPendingSessionKey;
+  pendingRestartAudit = nextPendingAudit;
   pendingRestartSkipDeferral = skipDeferral;
   armPendingRestartTimer(requestedDueAt, nowMs);
+
+  if (rescheduleAudit) {
+    writeGatewayRestartScheduleAuditEvent(rescheduleAudit);
+  }
+  writeGatewayRestartScheduleAuditEvent({
+    eventType: "scheduled",
+    reason,
+    source: opts?.audit?.source,
+    mode,
+    delayMs: Math.max(0, requestedDueAt - nowMs),
+    dueAt: requestedDueAt,
+    cooldownMs: cooldownMsApplied,
+    coalesced: false,
+    sessionKey: opts?.sessionKey,
+    audit: opts?.audit,
+  });
   return {
     ok: true,
     pid: process.pid,
@@ -1312,8 +1784,18 @@ function resetSigusr1TransientStateForTest(): void {
 }
 
 export const testing = {
+  gatewayRestartAuditMaxRows: GATEWAY_RESTART_AUDIT_MAX_ROWS,
+  formatRestartSessionKeyForLog,
+  serializeRestartAuditJson,
+  setRestartAuditWriterOverride(writer: ((eventType: string) => void) | null) {
+    restartAuditWriterOverride = writer ? (opts) => writer(opts.eventType) : null;
+  },
+  setRestartAuditEventWriterOverride(writer: ((event: RestartAuditEvent) => void) | null) {
+    restartAuditWriterOverride = writer;
+  },
   resetSigusr1TransientState: resetSigusr1TransientStateForTest,
   resetSigusr1State() {
+    restartAuditWriterOverride = null;
     resetSigusr1TransientStateForTest();
     sigusr1ExternalAllowed = false;
     preRestartCheck = null;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -584,6 +584,23 @@ export interface GatewayBootLifecycle {
   startup_reason: string | null;
 }
 
+export interface GatewayRestartAudit {
+  audit_json: string | null;
+  coalesced: number | null;
+  cooldown_ms: number | null;
+  created_at: number;
+  delay_ms: number | null;
+  due_at: number | null;
+  event_key: string;
+  event_type: string;
+  mode: string | null;
+  pid: number;
+  preflight_json: string | null;
+  reason: string | null;
+  session_key: string | null;
+  source: string | null;
+}
+
 export interface GatewayRestartHandoff {
   created_at: number;
   expires_at: number;
@@ -1231,6 +1248,7 @@ export interface DB {
   fleet_cells: FleetCells;
   flow_runs: FlowRuns;
   gateway_boot_lifecycle: GatewayBootLifecycle;
+  gateway_restart_audit: GatewayRestartAudit;
   gateway_restart_handoff: GatewayRestartHandoff;
   gateway_restart_intent: GatewayRestartIntent;
   gateway_restart_sentinel: GatewayRestartSentinel;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -774,6 +774,26 @@ CREATE TABLE IF NOT EXISTS gateway_restart_intent (
   updated_at_ms INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS gateway_restart_audit (
+  event_key TEXT NOT NULL PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  pid INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  reason TEXT,
+  source TEXT,
+  mode TEXT,
+  delay_ms INTEGER,
+  due_at INTEGER,
+  cooldown_ms INTEGER,
+  coalesced INTEGER,
+  session_key TEXT,
+  audit_json TEXT,
+  preflight_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_gateway_restart_audit_created
+  ON gateway_restart_audit(created_at DESC, event_key);
+
 CREATE TABLE IF NOT EXISTS gateway_restart_handoff (
   handoff_key TEXT NOT NULL PRIMARY KEY,
   kind TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -769,6 +769,26 @@ CREATE TABLE IF NOT EXISTS gateway_restart_intent (
   updated_at_ms INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS gateway_restart_audit (
+  event_key TEXT NOT NULL PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  pid INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  reason TEXT,
+  source TEXT,
+  mode TEXT,
+  delay_ms INTEGER,
+  due_at INTEGER,
+  cooldown_ms INTEGER,
+  coalesced INTEGER,
+  session_key TEXT,
+  audit_json TEXT,
+  preflight_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_gateway_restart_audit_created
+  ON gateway_restart_audit(created_at DESC, event_key);
+
 CREATE TABLE IF NOT EXISTS gateway_restart_handoff (
   handoff_key TEXT NOT NULL PRIMARY KEY,
   kind TEXT NOT NULL,


### PR DESCRIPTION
## Summary

- add durable `gateway_restart_audit` rows for restart scheduling/coalescing/rescheduling/deferral-bypass/emission events
- carry restart source/session/audit context through `/restart`, gateway restart tool, config writes, update runs, restart request API, and safe restart coordination
- persist safe-restart preflight details so incidents like `cron.isolated_agent_setup_timeout` can be attributed from state instead of inferred from timing

## What Problem This Solves

Gateway restart forensics currently loses the initiating reason/source for internal safe restart requests. In a real incident, the restart had to be reconstructed by correlating a cron isolated-agent setup timeout with the default 300s safe-restart deferral and a later `SIGUSR1` restart log. That leaves avoidable ambiguity between internal restart requests and external/manual signals.

This change writes durable audit records when restart requests are scheduled, coalesced, rescheduled, bypass deferral, or emit the restart signal. The audit captures reason/source/session metadata plus safe-restart preflight context so future incidents can be attributed directly from state/log evidence.

## Evidence

Local validation run under guarded `openclaw-heavy-run`:

- `pnpm format:check src/agents/tools/gateway-tool.ts src/auto-reply/reply/commands-session.ts src/gateway/server-methods/config-write-flow.ts src/gateway/server-methods/restart.test.ts src/gateway/server-methods/restart.ts src/gateway/server-methods/update.ts src/infra/restart-coordinator.test.ts src/infra/restart-coordinator.ts src/infra/restart.ts src/state/openclaw-state-db.generated.d.ts src/state/openclaw-state-schema.generated.ts src/state/openclaw-state-schema.sql`
- `pnpm exec oxlint src/agents/tools/gateway-tool.ts src/auto-reply/reply/commands-session.ts src/gateway/server-methods/config-write-flow.ts src/gateway/server-methods/restart.test.ts src/gateway/server-methods/restart.ts src/gateway/server-methods/update.ts src/infra/restart-coordinator.test.ts src/infra/restart-coordinator.ts src/infra/restart.ts`
- `pnpm check:architecture`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/infra-runtime.test.ts --maxWorkers=1` — 36 tests passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/restart.test.ts src/infra/restart-coordinator.test.ts --maxWorkers=1` — 13 tests passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-methods.config.ts src/gateway/server-methods/restart.test.ts --maxWorkers=1` — 6 tests passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-cron.test.ts src/gateway/server-restart-deferral.test.ts --maxWorkers=1` — 28 tests passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/gateway-tool.test.ts src/agents/openclaw-gateway-tool.test.ts --maxWorkers=1` — 14 tests passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/commands-session-restart.test.ts --maxWorkers=1` — 6 tests passed

Additional fix after first CI pass:

- generated Kysely/schema files were regenerated with `pnpm db:kysely:gen`
- changed-file oxlint and `pnpm check:architecture` now pass locally
