### PR TITLE
fix(agents): narrow small-context prompt admission

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
@@ -1,6 +1,9 @@
-// Coverage for small run-attempt decision helpers.
 import { describe, expect, it } from "vitest";
+// Coverage for small run-attempt decision helpers.
+import type { OpenClawConfig } from "../../../config/config.js";
 import {
+  countProviderNativeToolsForPrecheck,
+  resolveAttemptPromptModeAndSkillsPrompt,
   resolveAttemptStreamAuthProfileId,
   resolveAttemptToolPolicyMessageProvider,
   resolveEmbeddedAttemptSessionWriteLockOptions,
@@ -45,6 +48,154 @@ describe("resolveAttemptStreamAuthProfileId", () => {
         } as never,
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("countProviderNativeToolsForPrecheck", () => {
+  const codexNativeConfig = {
+    auth: {
+      profiles: {
+        "openai:test": {
+          provider: "openai",
+          mode: "oauth",
+        },
+      },
+    },
+    tools: {
+      web: {
+        search: {
+          enabled: true,
+          openaiCodex: { enabled: true, mode: "cached" },
+        },
+      },
+    },
+  } satisfies OpenClawConfig;
+  const openAIChatGptResponsesModel = {
+    api: "openai-chatgpt-responses",
+    id: "gpt-5.5",
+    provider: "openai",
+  };
+  const openAIResponsesModel = {
+    api: "openai-responses",
+    id: "gpt-5.5",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+  };
+
+  const nativeToolCases: {
+    name: string;
+    config: OpenClawConfig;
+    model: { api?: unknown; id?: unknown; provider?: unknown; baseUrl?: unknown };
+    expectedCount: number;
+  }[] = [
+    {
+      name: "native Codex search active",
+      config: codexNativeConfig,
+      model: openAIChatGptResponsesModel,
+      expectedCount: 1,
+    },
+    { name: "default OpenAI Responses", config: {}, model: openAIResponsesModel, expectedCount: 1 },
+    {
+      name: "disabled OpenAI Responses web search",
+      config: { tools: { web: { search: { enabled: false } } } },
+      model: openAIResponsesModel,
+      expectedCount: 0,
+    },
+    {
+      name: "OpenAI Responses custom base URL",
+      config: {},
+      model: {
+        ...openAIResponsesModel,
+        baseUrl: "https://proxy.example.invalid/v1",
+      },
+      expectedCount: 0,
+    },
+    {
+      name: "OpenAI Responses non-native search provider",
+      config: { tools: { web: { search: { provider: "brave" } } } },
+      model: openAIResponsesModel,
+      expectedCount: 0,
+    },
+    {
+      name: "disabled web search",
+      config: {
+        ...codexNativeConfig,
+        tools: { web: { search: { enabled: false, openaiCodex: { enabled: true } } } },
+      },
+      model: openAIChatGptResponsesModel,
+      expectedCount: 0,
+    },
+    {
+      name: "disabled native Codex search",
+      config: {
+        ...codexNativeConfig,
+        tools: { web: { search: { enabled: true, openaiCodex: { enabled: false } } } },
+      },
+      model: openAIChatGptResponsesModel,
+      expectedCount: 0,
+    },
+    {
+      name: "OpenAI Responses API with Codex native config",
+      config: codexNativeConfig,
+      model: openAIResponsesModel,
+      expectedCount: 1,
+    },
+    {
+      name: "denied Codex web_search policy",
+      config: { ...codexNativeConfig, tools: { ...codexNativeConfig.tools, deny: ["web_search"] } },
+      model: openAIChatGptResponsesModel,
+      expectedCount: 0,
+    },
+    {
+      name: "denied OpenAI Responses web_search policy",
+      config: { tools: { deny: ["web_search"] } },
+      model: openAIResponsesModel,
+      expectedCount: 0,
+    },
+    {
+      name: "OpenAI provider without required auth",
+      config: {
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              openaiCodex: { enabled: true, mode: "cached" },
+            },
+          },
+        },
+      },
+      model: openAIChatGptResponsesModel,
+      expectedCount: 0,
+    },
+  ];
+
+  it.each(nativeToolCases)("$name", ({ config, model, expectedCount }) => {
+    expect(
+      countProviderNativeToolsForPrecheck({
+        config,
+        model,
+        nativeWebSearchPolicyContext: {},
+      }),
+    ).toBe(expectedCount);
+  });
+});
+
+describe("resolveAttemptPromptModeAndSkillsPrompt", () => {
+  it.each([
+    ["no runtime allowlist", undefined, "full", "SKILLS"],
+    ["empty runtime allowlist", [], "minimal", "SKILLS"],
+    ["named runtime allowlist", ["read"], "minimal", undefined],
+  ] as const)("%s", (_name, toolsAllow, expectedPromptMode, expectedSkillsPrompt) => {
+    expect(
+      resolveAttemptPromptModeAndSkillsPrompt({
+        promptMode: "full",
+        skillsPrompt: "SKILLS",
+        toolsAllow,
+      }),
+    ).toEqual({
+      promptMode: expectedPromptMode,
+      ...(expectedSkillsPrompt ? { skillsPrompt: expectedSkillsPrompt } : {}),
+    });
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
@@ -1,13 +1,119 @@
 /**
  * Resolves per-attempt runtime decisions from config and channel context.
  */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../../../config/config.js";
+import {
+  isNativeWebSearchAllowedByToolPolicy,
+  resolveCodexNativeSearchActivation,
+  type NativeWebSearchToolPolicyParams,
+} from "../../codex-native-web-search-core.js";
 import {
   resolveSessionLockMaxHoldFromTimeout,
   resolveSessionWriteLockOptions,
 } from "../../session-write-lock.js";
+import type { PromptMode } from "../../system-prompt.types.js";
 import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type ProviderNativeToolPolicyContext = Omit<
+  NativeWebSearchToolPolicyParams,
+  "agentId" | "config" | "modelId" | "modelProvider"
+>;
+
+function readStringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isOpenAIApiBaseUrlForNativeSearch(baseUrl: unknown): boolean {
+  const trimmed = readStringValue(baseUrl)?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return /^https?:\/\/api\.openai\.com(?:\/v1)?\/?$/i.test(trimmed);
+}
+
+function isOpenAIResponsesNativeSearchEligibleModel(params: {
+  model: { api?: unknown; provider?: unknown; baseUrl?: unknown };
+}): boolean {
+  const provider = readStringValue(params.model.provider);
+  if (
+    params.model.api !== "openai-responses" ||
+    !provider ||
+    normalizeProviderId(provider) !== "openai"
+  ) {
+    return false;
+  }
+  const baseUrl = readStringValue(params.model.baseUrl);
+  return !baseUrl || isOpenAIApiBaseUrlForNativeSearch(baseUrl);
+}
+
+function shouldUseOpenAIResponsesNativeSearchProvider(config: OpenClawConfig | undefined): boolean {
+  const provider = config?.tools?.web?.search?.provider;
+  if (typeof provider !== "string") {
+    return true;
+  }
+  const normalized = normalizeProviderId(provider);
+  return normalized === "" || normalized === "auto" || normalized === "openai";
+}
+
+function isOpenAIResponsesNativeSearchActive(params: {
+  agentId?: string;
+  config?: OpenClawConfig;
+  model: { api?: unknown; id?: unknown; provider?: unknown; baseUrl?: unknown };
+  nativeWebSearchPolicyContext?: ProviderNativeToolPolicyContext;
+}): boolean {
+  const modelProvider = readStringValue(params.model.provider);
+  return (
+    params.config?.tools?.web?.search?.enabled !== false &&
+    shouldUseOpenAIResponsesNativeSearchProvider(params.config) &&
+    isOpenAIResponsesNativeSearchEligibleModel({ model: params.model }) &&
+    isNativeWebSearchAllowedByToolPolicy({
+      config: params.config,
+      modelProvider,
+      modelId: readStringValue(params.model.id),
+      agentId: params.agentId,
+      ...(params.nativeWebSearchPolicyContext ?? {}),
+    })
+  );
+}
+
+export function countProviderNativeToolsForPrecheck(params: {
+  agentId?: string;
+  agentDir?: string;
+  config?: OpenClawConfig;
+  model: { api?: unknown; id?: unknown; provider?: unknown; baseUrl?: unknown };
+  nativeWebSearchPolicyContext?: ProviderNativeToolPolicyContext;
+}): number {
+  const activation = resolveCodexNativeSearchActivation({
+    config: params.config,
+    modelProvider: readStringValue(params.model.provider),
+    modelApi: readStringValue(params.model.api),
+    modelId: readStringValue(params.model.id),
+    agentId: params.agentId,
+    agentDir: params.agentDir,
+    ...(params.nativeWebSearchPolicyContext ?? {}),
+  });
+  return (
+    (activation.state === "native_active" ? 1 : 0) +
+    (isOpenAIResponsesNativeSearchActive(params) ? 1 : 0)
+  );
+}
+
+export function resolveAttemptPromptModeAndSkillsPrompt(params: {
+  promptMode: PromptMode;
+  skillsPrompt?: string;
+  toolsAllow?: readonly string[];
+}): { promptMode: PromptMode; skillsPrompt?: string } {
+  const hasRuntimeToolAllowlist = params.toolsAllow !== undefined;
+  const hasNamedRuntimeToolAllowlist = (params.toolsAllow?.length ?? 0) > 0;
+  return {
+    promptMode: hasRuntimeToolAllowlist ? "minimal" : params.promptMode,
+    ...(!hasNamedRuntimeToolAllowlist && params.skillsPrompt !== undefined
+      ? { skillsPrompt: params.skillsPrompt }
+      : {}),
+  };
+}
 
 /**
  * Builds the session write-lock timing for a live embedded attempt. The lock is

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -411,6 +411,8 @@ import {
 } from "./attempt.prompt-helpers.js";
 import { steerActiveSessionWithOptionalDeliveryWait } from "./attempt.queue-message.js";
 import {
+  countProviderNativeToolsForPrecheck,
+  resolveAttemptPromptModeAndSkillsPrompt,
   resolveAttemptStreamAuthProfileId,
   resolveAttemptToolPolicyMessageProvider,
   resolveEmbeddedAttemptSessionWriteLockOptions,
@@ -1944,9 +1946,12 @@ export async function runEmbeddedAttempt(
       (isRawModelRun ? "none" : resolvePromptModeForSession(params.sessionKey));
     const promptSurface = resolveAgentPromptSurfaceForSessionKey(params.sessionKey);
 
-    // When toolsAllow is set, use minimal prompt and strip skills catalog
-    const effectivePromptMode = params.toolsAllow?.length ? ("minimal" as const) : promptMode;
-    const effectiveSkillsPrompt = params.toolsAllow?.length ? undefined : skillsPrompt;
+    const { promptMode: effectivePromptMode, skillsPrompt: effectiveSkillsPrompt } =
+      resolveAttemptPromptModeAndSkillsPrompt({
+        promptMode,
+        skillsPrompt,
+        toolsAllow: params.toolsAllow,
+      });
     const openClawReferences = await resolveOpenClawReferencePaths({
       workspaceDir: effectiveWorkspace,
       argv1: process.argv[1],
@@ -4609,6 +4614,18 @@ export async function runEmbeddedAttempt(
                   : {}),
                 systemPrompt: systemPromptForHook,
                 prompt: llmBoundaryPromptForPrecheck,
+                contextMode: params.bootstrapContextMode,
+                promptImageCount: imageResult.images.length,
+                toolCount:
+                  effectiveTools.length +
+                  clientToolDefs.length +
+                  countProviderNativeToolsForPrecheck({
+                    config: params.config,
+                    model: params.model,
+                    agentId: sessionAgentId,
+                    agentDir,
+                    nativeWebSearchPolicyContext,
+                  }),
                 contextTokenBudget,
                 reserveTokens,
                 toolResultMaxChars: promptToolResultMaxChars,

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -346,6 +346,27 @@ describe("preemptive-compaction", () => {
     expect(result.route).toBe("fits");
   });
 
+  it("keeps almost the whole window for the prompt when the context window is below the budget floor", () => {
+    // Regression for #96658: a small-context model (e.g. phi3:mini at 4 096
+    // tokens) with the default 20 000 reserve floor previously kept only
+    // ~2 048 tokens for the prompt, so every lightweight cron prompt overflowed
+    // and compact_only had nothing to compact. The budget floor must be
+    // window-bounded so tiny windows still reserve almost all of their space
+    // for the prompt instead of collapsing to the ratio share.
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [makeAssistantHistory("short history")],
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: 4_096,
+      reserveTokens: 20_000,
+    });
+
+    expect(result.promptBudgetBeforeReserve).toBe(4_095);
+    expect(result.effectiveReserveTokens).toBe(1);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.route).toBe("fits");
+  });
+
   it("keeps the requested reserve when it leaves enough prompt budget", () => {
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages: [makeAssistantHistory("short history")],

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -346,26 +346,82 @@ describe("preemptive-compaction", () => {
     expect(result.route).toBe("fits");
   });
 
-  it("keeps almost the whole window for the prompt when the context window is below the budget floor", () => {
-    // Regression for #96658: a small-context model (e.g. phi3:mini at 4 096
-    // tokens) with the default 20 000 reserve floor previously kept only
-    // ~2 048 tokens for the prompt, so every lightweight cron prompt overflowed
-    // and compact_only had nothing to compact. The budget floor must be
-    // window-bounded so tiny windows still reserve almost all of their space
-    // for the prompt instead of collapsing to the ratio share.
-    const result = shouldPreemptivelyCompactBeforePrompt({
-      messages: [makeAssistantHistory("short history")],
-      systemPrompt: "sys",
-      prompt: "hello",
-      contextTokenBudget: 4_096,
-      reserveTokens: 20_000,
-    });
+  it.each([
+    {
+      name: "admits the reported empty-history lightweight cron prompt",
+      contextMode: "lightweight" as const,
+      messages: () => [],
+      promptImageCount: 0,
+      toolCount: 0,
+      expectedPromptBudget: 3_584,
+      expectedRoute: "fits" as const,
+    },
+    {
+      name: "keeps prompt-image lightweight runs on the shared prompt floor",
+      contextMode: "lightweight" as const,
+      messages: () => [],
+      promptImageCount: 1,
+      toolCount: 0,
+      expectedPromptBudget: 2_048,
+      expectedRoute: "compact_only" as const,
+    },
+    {
+      name: "keeps tool-enabled lightweight runs on the shared prompt floor",
+      contextMode: "lightweight" as const,
+      messages: () => [],
+      promptImageCount: 0,
+      toolCount: 1,
+      expectedPromptBudget: 2_048,
+      expectedRoute: "compact_only" as const,
+    },
+    {
+      name: "keeps lightweight shared-history prompts on the shared prompt floor",
+      contextMode: "lightweight" as const,
+      messages: () => [makeAssistantHistory("existing shared heartbeat conversation")],
+      promptImageCount: 0,
+      toolCount: 0,
+      expectedPromptBudget: 2_048,
+      expectedRoute: "compact_only" as const,
+    },
+    {
+      name: "keeps full-context small models on the shared prompt floor",
+      contextMode: "full" as const,
+      messages: () => [],
+      promptImageCount: 0,
+      toolCount: 0,
+      expectedPromptBudget: 2_048,
+      expectedRoute: "compact_only" as const,
+    },
+  ])(
+    "$name",
+    ({
+      contextMode,
+      messages,
+      promptImageCount,
+      toolCount,
+      expectedPromptBudget,
+      expectedRoute,
+    }) => {
+      const result = shouldPreemptivelyCompactBeforePrompt({
+        messages: messages(),
+        systemPrompt: "",
+        prompt: "run scheduled task",
+        contextMode,
+        promptImageCount,
+        toolCount,
+        contextTokenBudget: 4_096,
+        reserveTokens: 20_000,
+        llmBoundaryTokenPressure: {
+          estimatedPromptTokens: 3_544,
+          source: "reported_lightweight_cron",
+        },
+      });
 
-    expect(result.promptBudgetBeforeReserve).toBe(4_095);
-    expect(result.effectiveReserveTokens).toBe(1);
-    expect(result.shouldCompact).toBe(false);
-    expect(result.route).toBe("fits");
-  });
+      expect(result.promptBudgetBeforeReserve).toBe(expectedPromptBudget);
+      expect(result.shouldCompact).toBe(expectedRoute === "compact_only");
+      expect(result.route).toBe(expectedRoute);
+    },
+  );
 
   it("keeps the requested reserve when it leaves enough prompt budget", () => {
     const result = shouldPreemptivelyCompactBeforePrompt({

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -281,9 +281,21 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   }
   const contextTokenBudget = Math.max(1, Math.floor(params.contextTokenBudget));
   const requestedReserveTokens = Math.max(0, Math.floor(params.reserveTokens));
-  const minPromptBudget = Math.min(
+  // The ratio-derived share (half the window) is the default prompt budget, but
+  // for small-context models it can drop below the absolute floor. Treat
+  // MIN_PROMPT_BUDGET_TOKENS as a true floor — but never let it claim more than
+  // the window itself minus one token, so a tiny window still leaves room for a
+  // reserve slot instead of collapsing the budget to zero. Without this floor,
+  // a 4 K-context model keeps only ~2 K for the prompt and every lightweight
+  // cron prompt overflows even when the session history is empty.
+  const ratioPromptBudget = Math.max(1, Math.floor(contextTokenBudget * MIN_PROMPT_BUDGET_RATIO));
+  const windowBoundedFloor = Math.min(
     MIN_PROMPT_BUDGET_TOKENS,
-    Math.max(1, Math.floor(contextTokenBudget * MIN_PROMPT_BUDGET_RATIO)),
+    Math.max(0, contextTokenBudget - 1),
+  );
+  const minPromptBudget = Math.max(
+    Math.min(MIN_PROMPT_BUDGET_TOKENS, ratioPromptBudget),
+    windowBoundedFloor,
   );
   // Keep a minimum prompt budget even when reserveTokens asks for most of the context window.
   const effectiveReserveTokens = Math.min(

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -23,6 +23,7 @@ const MESSAGE_BOUNDARY_OVERHEAD_TOKENS = 12;
 const CONTENT_BLOCK_OVERHEAD_TOKENS = 6;
 const IMAGE_BLOCK_TOKENS = 2_000;
 const TRUNCATION_ROUTE_BUFFER_TOKENS = 512;
+const LIGHTWEIGHT_MIN_PROMPT_BUDGET_RATIO = 0.875;
 
 /** Pre-prompt routing decision plus the budget facts used to explain it in logs and session state. */
 export type PreemptiveCompactionDecision = {
@@ -250,6 +251,9 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   unwindowedMessages?: AgentMessage[];
   systemPrompt?: string;
   prompt: string;
+  contextMode?: "full" | "lightweight";
+  promptImageCount?: number;
+  toolCount?: number;
   contextTokenBudget: number;
   reserveTokens: number;
   toolResultMaxChars?: number;
@@ -281,22 +285,24 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   }
   const contextTokenBudget = Math.max(1, Math.floor(params.contextTokenBudget));
   const requestedReserveTokens = Math.max(0, Math.floor(params.reserveTokens));
-  // The ratio-derived share (half the window) is the default prompt budget, but
-  // for small-context models it can drop below the absolute floor. Treat
-  // MIN_PROMPT_BUDGET_TOKENS as a true floor — but never let it claim more than
-  // the window itself minus one token, so a tiny window still leaves room for a
-  // reserve slot instead of collapsing the budget to zero. Without this floor,
-  // a 4 K-context model keeps only ~2 K for the prompt and every lightweight
-  // cron prompt overflows even when the session history is empty.
-  const ratioPromptBudget = Math.max(1, Math.floor(contextTokenBudget * MIN_PROMPT_BUDGET_RATIO));
-  const windowBoundedFloor = Math.min(
+  const promptImageCount = Math.max(0, Math.floor(params.promptImageCount ?? 0));
+  const toolCount = Math.max(0, Math.floor(params.toolCount ?? 0));
+  const sharedMinPromptBudget = Math.min(
     MIN_PROMPT_BUDGET_TOKENS,
-    Math.max(0, contextTokenBudget - 1),
+    Math.max(1, Math.floor(contextTokenBudget * MIN_PROMPT_BUDGET_RATIO)),
   );
-  const minPromptBudget = Math.max(
-    Math.min(MIN_PROMPT_BUDGET_TOKENS, ratioPromptBudget),
-    windowBoundedFloor,
-  );
+  const lightweightPromptBudgetEligible =
+    params.contextMode === "lightweight" &&
+    promptImageCount === 0 &&
+    toolCount === 0 &&
+    params.messages.length === 0 &&
+    (!params.unwindowedMessages || params.unwindowedMessages.length === 0);
+  const minPromptBudget = lightweightPromptBudgetEligible
+    ? Math.max(
+        sharedMinPromptBudget,
+        Math.max(1, Math.floor(contextTokenBudget * LIGHTWEIGHT_MIN_PROMPT_BUDGET_RATIO)),
+      )
+    : sharedMinPromptBudget;
   // Keep a minimum prompt budget even when reserveTokens asks for most of the context window.
   const effectiveReserveTokens = Math.min(
     requestedReserveTokens,


### PR DESCRIPTION
## What Problem This Solves

Isolated lightweight cron turns on small-context models can false-overflow before model submission. The reported case in #96658 has a 4 096-token window and a normalized prompt around 3 544 tokens; the shared precheck budget leaves only 2 048 prompt tokens after the default reserve, so the run routes to `compact_only` even when there is no history to compact.

The previous version of this PR raised the shared budget behavior too broadly. This update narrows the admission change to history-free lightweight attempts only.

## Why This Change Was Made

- Keep the shared `shouldPreemptivelyCompactBeforePrompt` default budget unchanged for full-context runs, CLI compaction, mid-turn tool-result checks, shared history, prompt images, and any visible/provider-native tools.
- Apply the larger 87.5% prompt budget only when the attempt is `contextMode: "lightweight"`, has no prompt images, no tools, no messages, and no unwindowed messages.
- Count provider-native tools in the precheck, including Codex native search and OpenAI Responses native `web_search`, so native tool payloads do not qualify for the lightweight no-tool budget.
- Treat an explicit empty `toolsAllow: []` as minimal prompt mode while still preserving skills, matching cron behavior where skills remain useful even with no callable tools.

## User Impact

Small-context lightweight cron jobs can submit an empty-history prompt that fits the model window instead of looping through no-op pre-prompt compaction. Tool-enabled, image-enabled, full-context, shared-history, CLI, and mid-turn precheck paths keep the existing shared prompt budget.

## Evidence

**Behavior addressed:** Empty-history lightweight small-context prompts receive enough admission budget, while tool/image/history/full-context paths keep the shared conservative budget.
**Environment tested:** Node v24 on Linux, source imported directly with `node --import tsx` from this branch.
**Steps run after the patch:** Ran targeted tests, core test typecheck, and called the patched production functions directly.

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node --import tsx --no-warnings -e "import { shouldPreemptivelyCompactBeforePrompt } from './src/agents/embedded-agent-runner/run/preemptive-compaction.ts'; import { countProviderNativeToolsForPrecheck } from './src/agents/embedded-agent-runner/run/attempt.run-decisions.ts'; ..."
```

**Evidence after fix:**

```text
lightweight empty history no tools: route=fits promptBudgetBeforeReserve=3584 effectiveReserveTokens=512 overflowTokens=0 shouldCompact=false
full empty history no tools: route=compact_only promptBudgetBeforeReserve=2048 effectiveReserveTokens=2048 overflowTokens=1496 shouldCompact=true
lightweight shared history: route=compact_only promptBudgetBeforeReserve=2048 effectiveReserveTokens=2048 overflowTokens=1496 shouldCompact=true
lightweight prompt image: route=compact_only promptBudgetBeforeReserve=2048 effectiveReserveTokens=2048 overflowTokens=1496 shouldCompact=true
lightweight active tool: route=compact_only promptBudgetBeforeReserve=2048 effectiveReserveTokens=2048 overflowTokens=1496 shouldCompact=true
default openai-responses native toolCount=1
disabled openai-responses native toolCount=0
denied openai-responses native toolCount=0
active openai-chatgpt-responses native toolCount=1
```

Targeted checks:

```text
node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/attempt.run-decisions.ts src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
All matched files use the correct format.

git diff --check
passed

node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
passed 2 Vitest shards

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
passed
```

**Observed result after the fix:** Only the empty-history lightweight/no-tool case routes to `fits`; the full/history/image/tool cases continue to route to `compact_only`, and provider-native web search is counted as a tool for precheck admission.
**Not tested:** A live isolated cron run against a real 4 096-token Ollama model; the production-function probe exercises the exact pre-prompt route decision and provider-native tool counting that gate the failing path.

Closes #96658
