### PR TITLE
fix(feishu): recover bot identity after abort races

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -487,8 +487,13 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   const { botOpenId } = applyBotIdentityState(accountId, botIdentity);
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
 
-  if (!botOpenId && !abortSignal?.aborted) {
-    startBotIdentityRecovery({ account, accountId, runtime, abortSignal });
+  if (!botOpenId) {
+    startBotIdentityRecovery({
+      account,
+      accountId,
+      runtime,
+      abortSignal: abortSignal?.aborted ? undefined : abortSignal,
+    });
   }
 
   const connectionMode = account.config.connectionMode ?? "websocket";

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -19,7 +19,7 @@ import { createFeishuDriveCommentNoticeHandler } from "./monitor.comment-notice-
 import type { FeishuStatusSink } from "./monitor.js";
 import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
-import { botNames, botOpenIds } from "./monitor.state.js";
+import { botNames, botOpenIds, readFeishuBotIdentityRevision } from "./monitor.state.js";
 import { FeishuRetryableSyntheticEventError } from "./monitor.synthetic-error.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { createFeishuVcMeetingInvitedHandler } from "./monitor.vc-meeting-invited-handler.js";
@@ -485,6 +485,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
       ? { botOpenId: botOpenIdSource.botOpenId, botName: botOpenIdSource.botName }
       : await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
   const { botOpenId } = applyBotIdentityState(accountId, botIdentity);
+  const botIdentityRevision = readFeishuBotIdentityRevision(accountId);
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
 
   if (!botOpenId) {
@@ -493,6 +494,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
       accountId,
       runtime,
       abortSignal: abortSignal?.aborted ? undefined : abortSignal,
+      staleRevision: abortSignal?.aborted ? botIdentityRevision : undefined,
     });
   }
 

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -13,13 +13,16 @@ import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-actio
 import { createEventDispatcher } from "./client.js";
 import { isRecord, readString } from "./comment-shared.js";
 import { hasProcessedFeishuMessage, warmupDedupFromPluginState } from "./dedup.js";
-import { applyBotIdentityState, startBotIdentityRecovery } from "./monitor.bot-identity.js";
+import {
+  applyBotIdentityState,
+  startBotIdentityRecoveryAfterProbe,
+} from "./monitor.bot-identity.js";
 import { createFeishuBotMenuHandler } from "./monitor.bot-menu-handler.js";
 import { createFeishuDriveCommentNoticeHandler } from "./monitor.comment-notice-handler.js";
 import type { FeishuStatusSink } from "./monitor.js";
 import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
-import { botNames, botOpenIds, readFeishuBotIdentityRevision } from "./monitor.state.js";
+import { botNames, botOpenIds } from "./monitor.state.js";
 import { FeishuRetryableSyntheticEventError } from "./monitor.synthetic-error.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { createFeishuVcMeetingInvitedHandler } from "./monitor.vc-meeting-invited-handler.js";
@@ -485,18 +488,8 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
       ? { botOpenId: botOpenIdSource.botOpenId, botName: botOpenIdSource.botName }
       : await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
   const { botOpenId } = applyBotIdentityState(accountId, botIdentity);
-  const botIdentityRevision = readFeishuBotIdentityRevision(accountId);
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
-
-  if (!botOpenId) {
-    startBotIdentityRecovery({
-      account,
-      accountId,
-      runtime,
-      abortSignal: abortSignal?.aborted ? undefined : abortSignal,
-      staleRevision: abortSignal?.aborted ? botIdentityRevision : undefined,
-    });
-  }
+  startBotIdentityRecoveryAfterProbe({ account, accountId, runtime, abortSignal, botOpenId });
 
   const connectionMode = account.config.connectionMode ?? "websocket";
   if (connectionMode === "webhook" && !account.verificationToken?.trim()) {

--- a/extensions/feishu/src/monitor.bot-identity.test.ts
+++ b/extensions/feishu/src/monitor.bot-identity.test.ts
@@ -1,0 +1,85 @@
+// Feishu tests cover monitor.bot identity recovery behavior.
+import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startBotIdentityRecovery } from "./monitor.bot-identity.js";
+import {
+  botOpenIds,
+  readFeishuBotIdentityRevision,
+  setFeishuBotIdentityState,
+} from "./monitor.state.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const probeFeishuMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./probe.js", () => ({
+  probeFeishu: probeFeishuMock,
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  probeFeishuMock.mockReset();
+  botOpenIds.delete("default");
+});
+
+function buildAccount(): ResolvedFeishuAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    appId: "cli_test",
+    appSecret: "secret_test", // pragma: allowlist secret
+    domain: "feishu",
+    config: {
+      enabled: true,
+      connectionMode: "websocket",
+    },
+  } as ResolvedFeishuAccount;
+}
+
+describe("startBotIdentityRecovery", () => {
+  it("does not let stale aborted-lifecycle recovery overwrite replacement bot identity", async () => {
+    vi.useFakeTimers();
+    const runtime = createNonExitingRuntimeEnv();
+    setFeishuBotIdentityState("default", { botOpenId: "", botName: undefined });
+    const staleRevision = readFeishuBotIdentityRevision("default");
+    probeFeishuMock.mockResolvedValueOnce({ ok: true, botOpenId: "ou_stale", botName: "Stale" });
+
+    startBotIdentityRecovery({
+      account: buildAccount(),
+      accountId: "default",
+      runtime,
+      staleRevision,
+    });
+    setFeishuBotIdentityState("default", { botOpenId: "ou_replacement", botName: "Replacement" });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(probeFeishuMock).toHaveBeenCalledTimes(1);
+    expect(botOpenIds.get("default")).toBe("ou_replacement");
+  });
+
+  it("recovers bot identity when no replacement lifecycle changes the revision", async () => {
+    vi.useFakeTimers();
+    const runtime = createNonExitingRuntimeEnv();
+    setFeishuBotIdentityState("default", { botOpenId: "", botName: undefined });
+    const staleRevision = readFeishuBotIdentityRevision("default");
+    probeFeishuMock.mockResolvedValueOnce({
+      ok: true,
+      botOpenId: "ou_recovered",
+      botName: "Recovered",
+    });
+
+    startBotIdentityRecovery({
+      account: buildAccount(),
+      accountId: "default",
+      runtime,
+      staleRevision,
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(probeFeishuMock).toHaveBeenCalledTimes(1);
+    expect(botOpenIds.get("default")).toBe("ou_recovered");
+  });
+});

--- a/extensions/feishu/src/monitor.bot-identity.test.ts
+++ b/extensions/feishu/src/monitor.bot-identity.test.ts
@@ -1,12 +1,8 @@
 // Feishu tests cover monitor.bot identity recovery behavior.
 import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { startBotIdentityRecovery } from "./monitor.bot-identity.js";
-import {
-  botOpenIds,
-  readFeishuBotIdentityRevision,
-  setFeishuBotIdentityState,
-} from "./monitor.state.js";
+import { startBotIdentityRecoveryAfterProbe } from "./monitor.bot-identity.js";
+import { botOpenIds, setFeishuBotIdentityState } from "./monitor.state.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
@@ -37,20 +33,25 @@ function buildAccount(): ResolvedFeishuAccount {
   } as ResolvedFeishuAccount;
 }
 
-describe("startBotIdentityRecovery", () => {
+function startAbortedProbeRecovery(runtime: ReturnType<typeof createNonExitingRuntimeEnv>): void {
+  const controller = new AbortController();
+  controller.abort();
+  startBotIdentityRecoveryAfterProbe({
+    account: buildAccount(),
+    accountId: "default",
+    runtime,
+    abortSignal: controller.signal,
+  });
+}
+
+describe("startBotIdentityRecoveryAfterProbe", () => {
   it("does not let stale aborted-lifecycle recovery overwrite replacement bot identity", async () => {
     vi.useFakeTimers();
     const runtime = createNonExitingRuntimeEnv();
     setFeishuBotIdentityState("default", { botOpenId: "", botName: undefined });
-    const staleRevision = readFeishuBotIdentityRevision("default");
     probeFeishuMock.mockResolvedValueOnce({ ok: true, botOpenId: "ou_stale", botName: "Stale" });
 
-    startBotIdentityRecovery({
-      account: buildAccount(),
-      accountId: "default",
-      runtime,
-      staleRevision,
-    });
+    startAbortedProbeRecovery(runtime);
     setFeishuBotIdentityState("default", { botOpenId: "ou_replacement", botName: "Replacement" });
 
     await vi.advanceTimersByTimeAsync(60_000);
@@ -63,19 +64,13 @@ describe("startBotIdentityRecovery", () => {
     vi.useFakeTimers();
     const runtime = createNonExitingRuntimeEnv();
     setFeishuBotIdentityState("default", { botOpenId: "", botName: undefined });
-    const staleRevision = readFeishuBotIdentityRevision("default");
     probeFeishuMock.mockResolvedValueOnce({
       ok: true,
       botOpenId: "ou_recovered",
       botName: "Recovered",
     });
 
-    startBotIdentityRecovery({
-      account: buildAccount(),
-      accountId: "default",
-      runtime,
-      staleRevision,
-    });
+    startAbortedProbeRecovery(runtime);
 
     await vi.advanceTimersByTimeAsync(60_000);
 
@@ -87,17 +82,11 @@ describe("startBotIdentityRecovery", () => {
     vi.useFakeTimers();
     const runtime = createNonExitingRuntimeEnv();
     setFeishuBotIdentityState("default", { botOpenId: "", botName: undefined });
-    const staleRevision = readFeishuBotIdentityRevision("default");
     probeFeishuMock
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({ ok: true, botOpenId: "ou_recovered", botName: "Recovered" });
 
-    startBotIdentityRecovery({
-      account: buildAccount(),
-      accountId: "default",
-      runtime,
-      staleRevision,
-    });
+    startAbortedProbeRecovery(runtime);
 
     await vi.advanceTimersByTimeAsync(180_000);
 

--- a/extensions/feishu/src/monitor.bot-identity.test.ts
+++ b/extensions/feishu/src/monitor.bot-identity.test.ts
@@ -82,4 +82,26 @@ describe("startBotIdentityRecovery", () => {
     expect(probeFeishuMock).toHaveBeenCalledTimes(1);
     expect(botOpenIds.get("default")).toBe("ou_recovered");
   });
+
+  it("keeps retrying after its own unknown identity update", async () => {
+    vi.useFakeTimers();
+    const runtime = createNonExitingRuntimeEnv();
+    setFeishuBotIdentityState("default", { botOpenId: "", botName: undefined });
+    const staleRevision = readFeishuBotIdentityRevision("default");
+    probeFeishuMock
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true, botOpenId: "ou_recovered", botName: "Recovered" });
+
+    startBotIdentityRecovery({
+      account: buildAccount(),
+      accountId: "default",
+      runtime,
+      staleRevision,
+    });
+
+    await vi.advanceTimersByTimeAsync(180_000);
+
+    expect(probeFeishuMock).toHaveBeenCalledTimes(2);
+    expect(botOpenIds.get("default")).toBe("ou_recovered");
+  });
 });

--- a/extensions/feishu/src/monitor.bot-identity.ts
+++ b/extensions/feishu/src/monitor.bot-identity.ts
@@ -33,6 +33,7 @@ async function retryBotIdentityProbe(
   const error = runtime?.error ?? console.error;
 
   const nextDelays = BOT_IDENTITY_RETRY_DELAYS_MS.slice(1)[Symbol.iterator]();
+  let expectedRevision = staleRevision;
   for (const [i, delayMs] of BOT_IDENTITY_RETRY_DELAYS_MS.entries()) {
     if (abortSignal?.aborted) {
       return;
@@ -44,13 +45,19 @@ async function retryBotIdentityProbe(
     }
 
     const identity = await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
-    if (staleRevision !== undefined && readFeishuBotIdentityRevision(accountId) !== staleRevision) {
+    if (
+      expectedRevision !== undefined &&
+      readFeishuBotIdentityRevision(accountId) !== expectedRevision
+    ) {
       log(
         `feishu[${accountId}]: bot identity background retry stopped because a newer lifecycle updated identity`,
       );
       return;
     }
     const resolved = applyBotIdentityState(accountId, identity);
+    if (expectedRevision !== undefined) {
+      expectedRevision = readFeishuBotIdentityRevision(accountId);
+    }
     if (resolved.botOpenId) {
       log(
         `feishu[${accountId}]: bot open_id recovered via background retry: ${resolved.botOpenId}`,

--- a/extensions/feishu/src/monitor.bot-identity.ts
+++ b/extensions/feishu/src/monitor.bot-identity.ts
@@ -91,3 +91,23 @@ export function startBotIdentityRecovery(params: {
 
   void retryBotIdentityProbe(account, accountId, runtime, abortSignal, staleRevision);
 }
+
+export function startBotIdentityRecoveryAfterProbe(params: {
+  account: ResolvedFeishuAccount;
+  accountId: string;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  botOpenId?: string;
+}): void {
+  if (params.botOpenId) {
+    return;
+  }
+  const aborted = params.abortSignal?.aborted === true;
+  startBotIdentityRecovery({
+    account: params.account,
+    accountId: params.accountId,
+    runtime: params.runtime,
+    abortSignal: aborted ? undefined : params.abortSignal,
+    staleRevision: aborted ? readFeishuBotIdentityRevision(params.accountId) : undefined,
+  });
+}

--- a/extensions/feishu/src/monitor.bot-identity.ts
+++ b/extensions/feishu/src/monitor.bot-identity.ts
@@ -78,7 +78,7 @@ async function retryBotIdentityProbe(
   );
 }
 
-export function startBotIdentityRecovery(params: {
+function startBotIdentityRecovery(params: {
   account: ResolvedFeishuAccount;
   accountId: string;
   runtime?: RuntimeEnv;

--- a/extensions/feishu/src/monitor.bot-identity.ts
+++ b/extensions/feishu/src/monitor.bot-identity.ts
@@ -3,7 +3,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import type { RuntimeEnv } from "../runtime-api.js";
 import { waitForAbortableDelay } from "./async.js";
 import { fetchBotIdentityForMonitor, type FeishuMonitorBotIdentity } from "./monitor.startup.js";
-import { setFeishuBotIdentityState } from "./monitor.state.js";
+import { readFeishuBotIdentityRevision, setFeishuBotIdentityState } from "./monitor.state.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 // Delays must be >= PROBE_ERROR_TTL_MS (60s) so each retry makes a real network request
@@ -27,6 +27,7 @@ async function retryBotIdentityProbe(
   accountId: string,
   runtime: RuntimeEnv | undefined,
   abortSignal: AbortSignal | undefined,
+  staleRevision: number | undefined,
 ): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
@@ -43,6 +44,12 @@ async function retryBotIdentityProbe(
     }
 
     const identity = await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
+    if (staleRevision !== undefined && readFeishuBotIdentityRevision(accountId) !== staleRevision) {
+      log(
+        `feishu[${accountId}]: bot identity background retry stopped because a newer lifecycle updated identity`,
+      );
+      return;
+    }
     const resolved = applyBotIdentityState(accountId, identity);
     if (resolved.botOpenId) {
       log(
@@ -69,9 +76,11 @@ export function startBotIdentityRecovery(params: {
   accountId: string;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
+  staleRevision?: number;
 }): void {
   const { account, accountId, runtime, abortSignal } = params;
   const log = runtime?.log ?? console.log;
+  const staleRevision = params.staleRevision;
 
   log(
     `feishu[${accountId}]: bot open_id unknown; starting background retry (delays: ${BOT_IDENTITY_RETRY_DELAYS_MS.map((delay) => `${delay / 1000}s`).join(", ")})`,
@@ -80,5 +89,5 @@ export function startBotIdentityRecovery(params: {
     `feishu[${accountId}]: requireMention group messages stay gated until bot identity recovery succeeds`,
   );
 
-  void retryBotIdentityProbe(account, accountId, runtime, abortSignal);
+  void retryBotIdentityProbe(account, accountId, runtime, abortSignal, staleRevision);
 }

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -23,7 +23,7 @@ const createEventDispatcherMock = vi.hoisted(() => vi.fn());
 const monitorWebSocketMock = vi.hoisted(() => vi.fn(async () => {}));
 const monitorWebhookMock = vi.hoisted(() => vi.fn(async () => {}));
 const createFeishuThreadBindingManagerMock = vi.hoisted(() => vi.fn(() => ({ stop: vi.fn() })));
-const startBotIdentityRecoveryMock = vi.hoisted(() => vi.fn());
+const startBotIdentityRecoveryAfterProbeMock = vi.hoisted(() => vi.fn());
 
 let handlers: Record<string, (data: unknown) => Promise<void>> = {};
 
@@ -52,7 +52,7 @@ vi.mock("./monitor.bot-identity.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./monitor.bot-identity.js")>();
   return {
     ...actual,
-    startBotIdentityRecovery: startBotIdentityRecoveryMock,
+    startBotIdentityRecoveryAfterProbe: startBotIdentityRecoveryAfterProbeMock,
   };
 });
 
@@ -497,7 +497,7 @@ describe("resolveReactionSyntheticEvent", () => {
 
 describe("monitorSingleAccount lifecycle", () => {
   beforeEach(() => {
-    startBotIdentityRecoveryMock.mockReset();
+    startBotIdentityRecoveryAfterProbeMock.mockReset();
     createFeishuThreadBindingManagerMock.mockReset().mockImplementation(() => ({
       stop: vi.fn(),
     }));
@@ -567,12 +567,12 @@ describe("monitorSingleAccount lifecycle", () => {
       },
     });
 
-    expect(startBotIdentityRecoveryMock).toHaveBeenCalledTimes(1);
-    expect(startBotIdentityRecoveryMock).toHaveBeenCalledWith(
+    expect(startBotIdentityRecoveryAfterProbeMock).toHaveBeenCalledTimes(1);
+    expect(startBotIdentityRecoveryAfterProbeMock).toHaveBeenCalledWith(
       expect.objectContaining({
         accountId: "default",
-        abortSignal: undefined,
-        staleRevision: readFeishuBotIdentityRevision("default"),
+        abortSignal: controller.signal,
+        botOpenId: undefined,
       }),
     );
   });
@@ -590,11 +590,11 @@ describe("monitorSingleAccount lifecycle", () => {
       },
     });
 
-    expect(startBotIdentityRecoveryMock).toHaveBeenCalledWith(
+    expect(startBotIdentityRecoveryAfterProbeMock).toHaveBeenCalledWith(
       expect.objectContaining({
         accountId: "default",
         abortSignal: undefined,
-        staleRevision: undefined,
+        botOpenId: undefined,
       }),
     );
   });

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -22,6 +22,7 @@ const createEventDispatcherMock = vi.hoisted(() => vi.fn());
 const monitorWebSocketMock = vi.hoisted(() => vi.fn(async () => {}));
 const monitorWebhookMock = vi.hoisted(() => vi.fn(async () => {}));
 const createFeishuThreadBindingManagerMock = vi.hoisted(() => vi.fn(() => ({ stop: vi.fn() })));
+const startBotIdentityRecoveryMock = vi.hoisted(() => vi.fn());
 
 let handlers: Record<string, (data: unknown) => Promise<void>> = {};
 
@@ -46,11 +47,20 @@ vi.mock("./thread-bindings.js", () => ({
   createFeishuThreadBindingManager: createFeishuThreadBindingManagerMock,
 }));
 
+vi.mock("./monitor.bot-identity.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./monitor.bot-identity.js")>();
+  return {
+    ...actual,
+    startBotIdentityRecovery: startBotIdentityRecoveryMock,
+  };
+});
+
 afterAll(() => {
   vi.doUnmock("./client.js");
   vi.doUnmock("./bot.js");
   vi.doUnmock("./monitor.transport.js");
   vi.doUnmock("./thread-bindings.js");
+  vi.doUnmock("./monitor.bot-identity.js");
   vi.resetModules();
 });
 
@@ -486,6 +496,7 @@ describe("resolveReactionSyntheticEvent", () => {
 
 describe("monitorSingleAccount lifecycle", () => {
   beforeEach(() => {
+    startBotIdentityRecoveryMock.mockReset();
     createFeishuThreadBindingManagerMock.mockReset().mockImplementation(() => ({
       stop: vi.fn(),
     }));
@@ -537,6 +548,31 @@ describe("monitorSingleAccount lifecycle", () => {
       | { stop: ReturnType<typeof vi.fn> }
       | undefined;
     expect(manager?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts bot identity recovery even when startup aborts after identity is unknown", async () => {
+    setFeishuRuntime(createFeishuMonitorRuntime());
+    const controller = new AbortController();
+    controller.abort();
+
+    await monitorSingleAccount({
+      cfg: buildDebounceConfig(),
+      account: buildDebounceAccount(),
+      runtime: createNonExitingRuntimeEnv(),
+      abortSignal: controller.signal,
+      botOpenIdSource: {
+        kind: "prefetched",
+        botOpenId: undefined,
+      },
+    });
+
+    expect(startBotIdentityRecoveryMock).toHaveBeenCalledTimes(1);
+    expect(startBotIdentityRecoveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        abortSignal: undefined,
+      }),
+    );
   });
 });
 

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -14,6 +14,7 @@ import {
   resolveReactionSyntheticEvent,
   type FeishuReactionCreatedEvent,
 } from "./monitor.account.js";
+import { readFeishuBotIdentityRevision, setFeishuBotIdentityState } from "./monitor.state.js";
 import { setFeishuRuntime } from "./runtime.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -571,8 +572,40 @@ describe("monitorSingleAccount lifecycle", () => {
       expect.objectContaining({
         accountId: "default",
         abortSignal: undefined,
+        staleRevision: readFeishuBotIdentityRevision("default"),
       }),
     );
+  });
+
+  it("passes no stale revision for active lifecycle bot identity recovery", async () => {
+    setFeishuRuntime(createFeishuMonitorRuntime());
+
+    await monitorSingleAccount({
+      cfg: buildDebounceConfig(),
+      account: buildDebounceAccount(),
+      runtime: createNonExitingRuntimeEnv(),
+      botOpenIdSource: {
+        kind: "prefetched",
+        botOpenId: undefined,
+      },
+    });
+
+    expect(startBotIdentityRecoveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        abortSignal: undefined,
+        staleRevision: undefined,
+      }),
+    );
+  });
+
+  it("records a changed identity revision after a replacement lifecycle restores the bot", async () => {
+    setFeishuBotIdentityState("default", { botOpenId: "", botName: undefined });
+    const staleRevision = readFeishuBotIdentityRevision("default");
+
+    setFeishuBotIdentityState("default", { botOpenId: "ou_replacement", botName: "Bot" });
+
+    expect(readFeishuBotIdentityRevision("default")).toBeGreaterThan(staleRevision);
   });
 });
 

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -49,23 +49,23 @@ const feishuWebhookAnomalyTracker = createWebhookAnomalyTracker({
   logEvery: feishuWebhookAnomalyDefaults.logEvery,
 });
 
-function readBotIdentityRevision(accountId: string): number {
+export function readFeishuBotIdentityRevision(accountId: string): number {
   return botIdentityRevisions.get(accountId) ?? 0;
 }
 
 function bumpBotIdentityRevision(accountId: string): void {
-  botIdentityRevisions.set(accountId, readBotIdentityRevision(accountId) + 1);
+  botIdentityRevisions.set(accountId, readFeishuBotIdentityRevision(accountId) + 1);
 }
 
 function captureBotIdentitySnapshot(accountId: string): BotIdentitySnapshot {
-  return { revision: readBotIdentityRevision(accountId) };
+  return { revision: readFeishuBotIdentityRevision(accountId) };
 }
 
 function clearFeishuBotIdentityStateIfUnchanged(
   accountId: string,
   snapshot: BotIdentitySnapshot,
 ): void {
-  if (readBotIdentityRevision(accountId) !== snapshot.revision) {
+  if (readFeishuBotIdentityRevision(accountId) !== snapshot.revision) {
     return;
   }
   botOpenIds.delete(accountId);


### PR DESCRIPTION
## What Problem This Solves

Feishu monitor startup can briefly know neither the bot open_id nor the bot name. The original fix kept requireMention groups gated while a background retry recovered bot identity after an abort race, but an aborted old lifecycle could still complete its detached retry after a replacement lifecycle had already restored identity. That stale retry could overwrite the replacement lifecycle's bot identity and re-open the mention-gating race.

This follow-up keeps the detached recovery path but records the bot identity revision when it starts from an aborted lifecycle. Before writing recovered identity, the retry checks that no newer lifecycle has changed the account identity revision; if a replacement lifecycle already updated identity, the stale retry exits without overwriting it.

## Validation Evidence

- Added deterministic regression coverage for stale aborted-lifecycle recovery not overwriting replacement bot identity.
- Verified normal recovery still writes identity when no newer lifecycle updates the revision.
- `pnpm test:extension feishu extensions/feishu/src/monitor.bot-identity.test.ts extensions/feishu/src/monitor.reaction.test.ts extensions/feishu/src/monitor.startup.test.ts extensions/feishu/src/monitor.cleanup.test.ts` — 4 files passed, 47 tests passed.
- `pnpm oxfmt --check extensions/feishu/src/monitor.account.ts extensions/feishu/src/monitor.bot-identity.ts extensions/feishu/src/monitor.bot-identity.test.ts extensions/feishu/src/monitor.reaction.test.ts extensions/feishu/src/monitor.state.ts` — passed.
- `git diff --check` / `git diff --cached --check` — passed.
- Added-line secret scan — clean, with only an explicit allowlisted test placeholder `secret_test`.

I did not run or claim live Feishu tenant reload proof; this is deterministic local proof for the lifecycle race ClawSweeper flagged.

## Summary
- Start Feishu bot identity recovery whenever startup leaves an account with an unknown bot open_id.
- Avoid passing an already-aborted startup signal into the recovery task, so a replacement lifecycle can still recover the identity.
- Add a regression test for the aborted-startup/unknown-identity path.

## Issue / Motivation
Fixes #77717.

Feishu accounts can remain disconnected after restart/reload if startup resolves the bot identity as unknown after the lifecycle signal is already aborted. The previous guard skipped background identity recovery in that state, leaving require-mention/group routing gated indefinitely.

## Changes
- Keep the unknown-identity recovery path active even when the startup signal has already been aborted.
- Pass `undefined` instead of an already-aborted signal to the recovery task to avoid immediate cancellation.
- Mock and assert `startBotIdentityRecovery` in the Feishu lifecycle regression test.

## Testing
- `pnpm test:extension feishu extensions/feishu/src/monitor.startup.test.ts extensions/feishu/src/monitor.cleanup.test.ts extensions/feishu/src/monitor.reaction.test.ts` — 3 files passed, 43 tests passed
- `pnpm oxfmt --check extensions/feishu/src/monitor.account.ts extensions/feishu/src/monitor.reaction.test.ts` — passed
- `git diff --check` — passed
- Secret scan over added diff lines — no potential secrets found

## Evidence
This is AI-assisted. I verified the issue was open/unassigned and re-ran duplicate searches for #77717, the issue title/keywords, and the touched Feishu monitor files immediately before opening this PR.

Latest repair (a09cde2333eb): the detached recovery now advances its owned expected revision after an unresolved retry, so that retry cannot self-stale its later successful attempt. Added a fake-timer regression covering unknown first retry followed by successful second retry. Local executable test/oxfmt could not be rerun because dependency hydration stalled on this low-disk host; `git diff --check` and a no-tabs/trailing-whitespace scan passed, and fresh exact-head CI is running.