### PR TITLE
fix(plugin-sdk): drop OpenRouter reasoning for DeepSeek V4

### DIFF
--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -262,6 +262,28 @@ describe("createDeepSeekV4OpenAICompatibleThinkingWrapper", () => {
     expect(payload.messages[3]).toHaveProperty("reasoning_content", "");
     expect(payload.messages[4]).toHaveProperty("reasoning_content", "native reasoning");
   });
+
+  it("removes OpenRouter reasoning envelopes when sending DeepSeek native effort", () => {
+    const payload: Record<string, unknown> = {
+      reasoning: { effort: "high" },
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload as never, _model as never);
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn,
+      thinkingLevel: "high",
+      shouldPatchModel: () => true,
+    });
+    void wrapped?.({} as never, { messages: [] } as never, {});
+
+    expect(payload).toEqual({
+      thinking: { type: "enabled" },
+      reasoning_effort: "high",
+    });
+  });
 });
 
 describe("createPayloadPatchStreamWrapper", () => {

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -551,6 +551,7 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
 
       payload.thinking = { type: "enabled" };
       payload.reasoning_effort = resolveReasoningEffort(params.thinkingLevel);
+      delete payload.reasoning;
       ensureDeepSeekV4AssistantReasoningContent(payload, {
         shouldBackfillAssistantMessage: params.shouldBackfillAssistantReasoningContent,
       });


### PR DESCRIPTION
## Summary
- Remove OpenRouter-style nested `reasoning` envelopes when the DeepSeek V4 OpenAI-compatible wrapper emits native DeepSeek thinking controls.
- Keep the native `thinking` and top-level `reasoning_effort` fields intact.
- Add a regression test for payloads that already contain `reasoning: { effort }`.

## What Problem This Solves
Fixes #97196.

OpenRouter-routed DeepSeek V4 requests can pass through the shared OpenAI-compatible reasoning normalizer before the DeepSeek V4 wrapper runs. That first pass can leave an OpenRouter-style nested `reasoning.effort` object in the outgoing payload. The DeepSeek V4 wrapper then adds native top-level `thinking` and `reasoning_effort` controls on the same request object, producing a mixed payload with two reasoning-control shapes. This PR makes the DeepSeek V4 wrapper emit one consistent wire shape by deleting the stale nested `reasoning` envelope after setting native `reasoning_effort`.

## Changes
- Delete `payload.reasoning` in the enabled DeepSeek V4 wrapper path after setting `reasoning_effort`.
- Cover the mixed OpenRouter/native payload shape in `provider-stream-shared.test.ts`.

## Testing
- `node scripts/run-vitest.mjs src/plugin-sdk/provider-stream-shared.test.ts extensions/openrouter/index.test.ts` — passed (`src/plugin-sdk/provider-stream-shared.test.ts`: 66 tests; `extensions/openrouter/index.test.ts`: 42 tests)
- `pnpm oxfmt --check src/plugin-sdk/provider-stream-shared.ts src/plugin-sdk/provider-stream-shared.test.ts extensions/openrouter/stream.ts extensions/openrouter/index.test.ts` — passed
- `git diff --check` — passed
- Secret scan over added PR diff lines — no potential secrets found

## Live OpenRouter proof (redacted)
Ran a direct OpenRouter Chat Completions request with the same post-fix DeepSeek V4 wire shape this PR preserves: top-level `thinking` + top-level `reasoning_effort`, with no nested `reasoning` request field. The API key was supplied from the environment and is not printed.

Command shape used:

```bash
python3 - <<'PY'
# POST https://openrouter.ai/api/v1/chat/completions
# Authorization: Bearer ***  # redacted, not printed
payload = {
  "model": "deepseek/deepseek-v4-flash",
  "messages": [{"role": "user", "content": "Reply with exactly one word: ok"}],
  "max_tokens": 128,
  "temperature": 0,
  "stream": False,
  "thinking": {"type": "enabled"},
  "reasoning_effort": "minimal",
}
PY
```

Redacted terminal output:

```text
request_shape= {"max_tokens": 128, "model": "deepseek/deepseek-v4-flash", "reasoning_effort": "minimal", "stream": false, "temperature": 0, "thinking": {"type": "enabled"}}
status= 200
id_prefix= gen-1782584796-2yR
model= deepseek/deepseek-v4-flash-20260423
finish_reason= stop
message_keys= ['content', 'reasoning', 'reasoning_details', 'refusal', 'role']
content_preview= 'ok'
has_reasoning= True
usage_total_tokens= 35
```

This confirms the patched request shape (no nested `reasoning` envelope) is accepted by live OpenRouter for DeepSeek V4 and returns a successful completion plus reasoning metadata.

## Evidence
This is AI-assisted. I verified the issue was open/unassigned and re-ran duplicate searches for #97196, title/field keywords, the shared wrapper name, and touched files immediately before opening this PR.
