### PR TITLE
improve(workboard): dedupe dependency links in one pass

### DIFF
--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -2181,17 +2181,24 @@ function buildWorkerContext(card: WorkboardCard, cards: readonly WorkboardCard[]
 }
 
 function cardParentIds(card: WorkboardCard): string[] {
-  return (card.metadata?.links ?? [])
-    .filter((link) => link.type === "parent" && link.targetCardId)
-    .map((link) => link.targetCardId!)
-    .filter((id, index, ids) => ids.indexOf(id) === index);
+  return dependencyTargetIds(card, "parent");
 }
 
 function cardChildIds(card: WorkboardCard): string[] {
-  return (card.metadata?.links ?? [])
-    .filter((link) => link.type === "child" && link.targetCardId)
-    .map((link) => link.targetCardId!)
-    .filter((id, index, ids) => ids.indexOf(id) === index);
+  return dependencyTargetIds(card, "child");
+}
+
+function dependencyTargetIds(card: WorkboardCard, type: "parent" | "child"): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const link of card.metadata?.links ?? []) {
+    if (link.type !== type || !link.targetCardId || seen.has(link.targetCardId)) {
+      continue;
+    }
+    seen.add(link.targetCardId);
+    ids.push(link.targetCardId);
+  }
+  return ids;
 }
 
 function latestRunningAttempt(card: WorkboardCard): WorkboardRunAttempt | undefined {


### PR DESCRIPTION
## What Problem This Solves

Resolves repeated dependency-link deduplication work in the Workboard store path when dependency data is normalized for display.

## Why This Change Was Made

The change keeps the existing output contract while deduplicating dependency links in one pass, reducing avoidable intermediate work in the Workboard data flow.

## User Impact

Workboard dependency data keeps the same behavior and ordering while doing less repeated work during store processing.

## Evidence

- node scripts/test-projects.mjs extensions/workboard/src/store.test.ts: 78 passed
- git diff --check
- autoreview --mode local: clean, no actionable findings