### PR TITLE
improve(ui): count mcp summary states in one pass

### DIFF
--- a/ui/src/ui/views/mcp.ts
+++ b/ui/src/ui/views/mcp.ts
@@ -104,9 +104,20 @@ export function renderMcp(props: McpViewProps) {
   const rows = Object.entries(getMcpServers(props.configObject))
     .map(([name, server]) => summarizeServer(name, server))
     .toSorted((a, b) => a.name.localeCompare(b.name));
-  const enabledCount = rows.filter((row) => row.enabled).length;
-  const oauthCount = rows.filter((row) => row.auth === "oauth").length;
-  const filteredCount = rows.filter((row) => row.toolFilter).length;
+  let enabledCount = 0;
+  let oauthCount = 0;
+  let filteredCount = 0;
+  for (const row of rows) {
+    if (row.enabled) {
+      enabledCount += 1;
+    }
+    if (row.auth === "oauth") {
+      oauthCount += 1;
+    }
+    if (row.toolFilter) {
+      filteredCount += 1;
+    }
+  }
   const saveDisabled =
     !props.configDirty || !props.connected || props.configApplying || props.configSaving;
   return html`


### PR DESCRIPTION
## What Problem This Solves

Reduces repeated MCP summary state scans in the UI rendering path.

## Why This Change Was Made

The change keeps the existing MCP summary output while collecting state totals in one traversal of the summary rows.

## User Impact

MCP status summaries render the same information with less repeated counting work.

## Evidence

- node scripts/test-projects.mjs ui/src/ui/views/mcp.test.ts: 7 passed
- git diff --check
- autoreview --mode local: clean, no actionable findings