### PR TITLE
improve(codex-supervisor): share endpoint health summary counting

### DIFF
--- a/extensions/codex-supervisor/src/mcp-tools.ts
+++ b/extensions/codex-supervisor/src/mcp-tools.ts
@@ -36,6 +36,18 @@ function errorResult(message: string) {
   };
 }
 
+export function formatCodexSupervisorEndpointHealthSummary(
+  health: readonly { ok: boolean }[],
+): string {
+  let okCount = 0;
+  for (const entry of health) {
+    if (entry.ok) {
+      okCount += 1;
+    }
+  }
+  return `codex endpoints: ${okCount}/${health.length} ok`;
+}
+
 function redactString(value: string): string {
   return value
     .replace(/\b(?:sk|glpat|xox[baprs])-[-_a-zA-Z0-9]{12,}\b/g, "[redacted]")
@@ -164,13 +176,10 @@ export function registerCodexSupervisorMcpTools(
         endpointId,
         ok,
       }));
-      return textResult(
-        `codex endpoints: ${health.filter((entry) => entry.ok).length}/${health.length} ok`,
-        {
-          endpoints,
-          health,
-        },
-      );
+      return textResult(formatCodexSupervisorEndpointHealthSummary(health), {
+        endpoints,
+        health,
+      });
     },
   );
 

--- a/extensions/codex-supervisor/src/plugin-tools.ts
+++ b/extensions/codex-supervisor/src/plugin-tools.ts
@@ -5,6 +5,7 @@
 import { jsonResult, readStringParam, type AnyAgentTool } from "openclaw/plugin-sdk/core";
 import { Type } from "typebox";
 import {
+  formatCodexSupervisorEndpointHealthSummary,
   redactCodexSupervisorEndpoint,
   redactCodexSupervisorValue,
   sanitizeCodexSupervisorSessionListResult,
@@ -132,7 +133,7 @@ export function createCodexSupervisorTools({
           ok,
         }));
         return jsonResult({
-          summary: `codex endpoints: ${health.filter((entry) => entry.ok).length}/${health.length} ok`,
+          summary: formatCodexSupervisorEndpointHealthSummary(health),
           endpoints,
           health,
         });


### PR DESCRIPTION
## What Problem This Solves

Reduces duplicated endpoint health summary counting across codex-supervisor tool surfaces.

## Why This Change Was Made

The change keeps the existing endpoint health output while sharing one summary-counting path between the related codex-supervisor tools.

## User Impact

codex-supervisor health reporting remains unchanged for users while avoiding duplicate aggregation logic.

## Evidence

- node scripts/test-projects.mjs extensions/codex-supervisor/src/plugin-tools.test.ts extensions/codex-supervisor/src/mcp-tools.test.ts: 8 passed
- git diff --check
- autoreview --mode local: clean, no actionable findings