### PR TITLE
improve(telegram): count open rich tag scopes in one pass

### DIFF
--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -1170,6 +1170,23 @@ function buildTelegramHtmlCloseSuffixLength(tags: TelegramHtmlTag[]): number {
   return tags.reduce((total, tag) => total + tag.closeTag.length, 0);
 }
 
+function countOpenTelegramRichTagScopes(tags: TelegramHtmlTag[]): {
+  blockCount: number;
+  mediaCount: number;
+} {
+  let blockCount = 0;
+  let mediaCount = 0;
+  for (const tag of tags) {
+    if (tag.richBlock) {
+      blockCount += 1;
+    }
+    if (tag.richMedia) {
+      mediaCount += 1;
+    }
+  }
+  return { blockCount, mediaCount };
+}
+
 function isTelegramRichBlockHtmlTag(rawTag: string, tagName: string): boolean {
   return (
     TELEGRAM_RICH_BLOCK_HTML_TAGS.has(tagName) ||
@@ -1295,8 +1312,9 @@ export function splitTelegramHtmlChunks(
 
   const resetCurrent = () => {
     current = buildTelegramHtmlOpenPrefix(openTags);
-    currentBlockCount = openTags.filter((tag) => tag.richBlock).length;
-    currentMediaCount = openTags.filter((tag) => tag.richMedia).length;
+    const openRichScopes = countOpenTelegramRichTagScopes(openTags);
+    currentBlockCount = openRichScopes.blockCount;
+    currentMediaCount = openRichScopes.mediaCount;
     chunkHasPayload = false;
   };
 


### PR DESCRIPTION
## What Problem This Solves

Reduces repeated rich-text tag scope counting in Telegram formatting.

## Why This Change Was Made

The change preserves Telegram formatting behavior while counting open rich tag scopes with a single traversal.

## User Impact

Telegram output remains the same, with less redundant formatting bookkeeping.

## Evidence

- node scripts/test-projects.mjs extensions/telegram/src/format.test.ts extensions/telegram/src/telegram-outbound.test.ts: 71 passed
- git diff --check
- autoreview --mode local: clean, no actionable findings