### PR TITLE
improve(talk): count echo token overlap without allocation

### DIFF
--- a/src/talk/session-log-runtime.ts
+++ b/src/talk/session-log-runtime.ts
@@ -107,7 +107,12 @@ function hasMeaningfulEchoOverlap(userTokens: string[], assistantTokens: string[
     return false;
   }
   const assistantTokenSet = new Set(assistantTokens);
-  const overlap = uniqueUserTokens.filter((token) => assistantTokenSet.has(token)).length;
+  let overlap = 0;
+  for (const token of uniqueUserTokens) {
+    if (assistantTokenSet.has(token)) {
+      overlap += 1;
+    }
+  }
   return overlap / uniqueUserTokens.length >= 0.58;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Reduces avoidable allocation while checking echo token overlap in talk session log processing.

## Why This Change Was Made

The change preserves the overlap decision while counting matching tokens directly instead of building intermediate overlap collections.

## User Impact

Talk session log behavior remains unchanged while the overlap check does less memory work.

## Evidence

- node scripts/test-projects.mjs src/talk/session-log-runtime.test.ts: 4 passed
- git diff --check
- autoreview --mode local: clean, no actionable findings