### PR TITLE
fix: avoid DeepSeek-native thinking on OpenRouter V4

### DIFF
--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -380,8 +380,8 @@ does **not** inject those OpenRouter-specific headers or Anthropic cache markers
     `openrouter/deepseek/deepseek-v4-pro` fill missing `reasoning_content` on
     replayed assistant turns so thinking/tool conversations keep DeepSeek V4's
     required follow-up shape. OpenClaw sends OpenRouter-supported
-    `reasoning_effort` values for these routes; `xhigh` is the highest advertised
-    level, and stale `max` overrides are mapped to `xhigh`.
+    `reasoning.effort` values for these routes; lower non-off levels map to
+    `high`, and stale `max` overrides are mapped to `xhigh`.
   </Accordion>
 
   <Accordion title="OpenAI-only request shaping">

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -27,7 +27,7 @@ title: "Thinking levels"
   - Anthropic Claude Opus 4.7+ maps `/think xhigh` to adaptive thinking plus `output_config.effort: "xhigh"`, because `/think` is a thinking directive and `xhigh` is the Opus effort setting.
   - Anthropic Claude Opus 4.7+ also exposes `/think max`; it maps to the same provider-owned max effort path.
   - Direct DeepSeek V4 models expose `/think xhigh|max`; both map to DeepSeek `reasoning_effort: "max"` while lower non-off levels map to `high`.
-  - OpenRouter-routed DeepSeek V4 models expose `/think xhigh` and send OpenRouter-supported `reasoning_effort` values. Stored `max` overrides fall back to `xhigh`.
+  - OpenRouter-routed DeepSeek V4 models expose `/think xhigh` and send OpenRouter-supported `reasoning.effort` values instead of DeepSeek-native top-level `reasoning_effort`. Lower non-off levels map to `high`, and stored `max` overrides fall back to `xhigh`.
   - Ollama thinking-capable models expose `/think low|medium|high|max`; `max` maps to native `think: "high"` because Ollama's native API accepts `low`, `medium`, and `high` effort strings.
   - OpenAI GPT models map `/think` through model-specific Responses API effort support. `/think off` sends `reasoning.effort: "none"` only when the target model supports it; otherwise OpenClaw omits the disabled reasoning payload instead of sending an unsupported value.
   - Custom OpenAI-compatible catalog entries can opt into `/think xhigh` by setting `models.providers.<provider>.models[].compat.supportedReasoningEfforts` to include `"xhigh"`. This uses the same compat metadata that maps outbound OpenAI reasoning effort payloads, so menus, session validation, agent CLI, and `llm-task` agree with transport behavior.

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -1060,7 +1060,7 @@ describe("openrouter provider hooks", () => {
     expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
-  it("skips DeepSeek V4 reasoning_content on OpenRouter tool-call replay turns", async () => {
+  it("uses OpenRouter reasoning for DeepSeek V4 replay turns", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
     let capturedPayload: Record<string, unknown> | undefined;
     const baseStreamFn = vi.fn(
@@ -1100,8 +1100,9 @@ describe("openrouter provider hooks", () => {
       {},
     );
 
-    expect(capturedPayload?.thinking).toEqual({ type: "enabled" });
-    expect(capturedPayload?.reasoning_effort).toBe("xhigh");
+    expect(capturedPayload?.reasoning).toEqual({ effort: "xhigh" });
+    expect(capturedPayload).not.toHaveProperty("thinking");
+    expect(capturedPayload).not.toHaveProperty("reasoning_effort");
     expect(capturedPayload?.messages).toEqual([
       { role: "user", content: "read file" },
       {
@@ -1114,14 +1115,14 @@ describe("openrouter provider hooks", () => {
     expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
-  it("keeps OpenRouter DeepSeek V4 reasoning_effort within OpenRouter values", async () => {
+  it("clamps OpenRouter DeepSeek V4 reasoning.effort to supported OpenRouter values", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
     const payloads: Array<Record<string, unknown>> = [];
     const baseStreamFn = vi.fn(
       (
         ...args: Parameters<import("openclaw/plugin-sdk/agent-core").StreamFn>
       ): ReturnType<import("openclaw/plugin-sdk/agent-core").StreamFn> => {
-        const payload = { messages: [] };
+        const payload = { reasoning: { effort: "high" }, messages: [] };
         void args[2]?.onPayload?.(payload, args[0]);
         payloads.push(payload);
         return { async *[Symbol.asyncIterator]() {} } as never;
@@ -1148,14 +1149,60 @@ describe("openrouter provider hooks", () => {
       );
     }
 
-    expect(payloads.map((payload) => payload.reasoning_effort)).toEqual([
-      "minimal",
-      "low",
-      "medium",
+    expect(payloads.map((payload) => (payload.reasoning as { effort?: unknown }).effort)).toEqual([
+      "high",
+      "high",
+      "high",
       "high",
       "xhigh",
       "xhigh",
     ]);
+    for (const payload of payloads) {
+      expect(payload).not.toHaveProperty("thinking");
+      expect(payload).not.toHaveProperty("reasoning_effort");
+    }
+  });
+
+  it("strips disabled OpenRouter DeepSeek V4 reasoning replay fields", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn(
+      (
+        ...args: Parameters<import("openclaw/plugin-sdk/agent-core").StreamFn>
+      ): ReturnType<import("openclaw/plugin-sdk/agent-core").StreamFn> => {
+        const payload = {
+          reasoning: { effort: "high" },
+          messages: [{ role: "assistant", content: "done", reasoning_content: "" }],
+        };
+        void args[2]?.onPayload?.(payload, args[0]);
+        capturedPayload = payload;
+        return { async *[Symbol.asyncIterator]() {} } as never;
+      },
+    );
+
+    const wrapped = provider.wrapStreamFn?.({
+      provider: "openrouter",
+      modelId: "openrouter/deepseek/deepseek-v4-pro",
+      streamFn: baseStreamFn,
+      thinkingLevel: "off",
+    } as never);
+    void wrapped?.(
+      {
+        provider: "openrouter",
+        api: "openai-completions",
+        id: "openrouter/deepseek/deepseek-v4-pro",
+        baseUrl: "https://openrouter.ai/api/v1",
+        compat: {},
+      } as never,
+      { messages: [] } as never,
+      {},
+    );
+
+    expect(capturedPayload).not.toHaveProperty("reasoning");
+    expect(capturedPayload).not.toHaveProperty("thinking");
+    expect(capturedPayload).not.toHaveProperty("reasoning_effort");
+    expect(capturedPayload?.messages).toEqual([{ role: "assistant", content: "done" }]);
+    expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
   it("recognizes full OpenRouter DeepSeek V4 refs but skips custom proxy routes", async () => {

--- a/extensions/openrouter/stream.ts
+++ b/extensions/openrouter/stream.ts
@@ -12,12 +12,7 @@ import {
   readProviderJsonResponse,
 } from "openclaw/plugin-sdk/provider-http";
 import { OPENROUTER_THINKING_STREAM_HOOKS } from "openclaw/plugin-sdk/provider-stream-family";
-import {
-  createDeepSeekV4OpenAICompatibleThinkingWrapper,
-  type DeepSeekV4ReasoningEffort,
-  type DeepSeekV4ThinkingLevel,
-  createPayloadPatchStreamWrapper,
-} from "openclaw/plugin-sdk/provider-stream-shared";
+import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { isOpenRouterDeepSeekV4ModelId } from "./models.js";
 import {
@@ -289,27 +284,6 @@ function stripTrailingOpenRouterAssistantPrefillMessages(payload: Record<string,
   return stripped;
 }
 
-function resolveOpenRouterDeepSeekV4ReasoningEffort(
-  thinkingLevel: DeepSeekV4ThinkingLevel,
-): DeepSeekV4ReasoningEffort {
-  switch (thinkingLevel) {
-    case "minimal":
-    case "low":
-    case "medium":
-    case "high":
-    case "xhigh":
-      return thinkingLevel;
-    case "max":
-      return "xhigh";
-    case "adaptive":
-      return "medium";
-    case "off":
-    case undefined:
-      return "high";
-  }
-  return "high";
-}
-
 function isEnabledReasoningValue(value: unknown): boolean {
   if (value === undefined || value === null || value === false) {
     return false;
@@ -318,6 +292,13 @@ function isEnabledReasoningValue(value: unknown): boolean {
     const normalized = value.trim().toLowerCase();
     return normalized !== "" && normalized !== "off" && normalized !== "none";
   }
+  if (typeof value === "object" && !Array.isArray(value)) {
+    const effort = (value as Record<string, unknown>).effort;
+    if (typeof effort === "string") {
+      const normalized = effort.trim().toLowerCase();
+      return normalized !== "" && normalized !== "off" && normalized !== "none";
+    }
+  }
   return true;
 }
 
@@ -325,6 +306,37 @@ function isOpenRouterReasoningPayloadEnabled(payload: Record<string, unknown>): 
   return (
     isEnabledReasoningValue(payload.reasoning) || isEnabledReasoningValue(payload.reasoning_effort)
   );
+}
+
+function stripOpenRouterDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void {
+  if (!Array.isArray(payload.messages)) {
+    return;
+  }
+  for (const message of payload.messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    delete (message as Record<string, unknown>).reasoning_content;
+  }
+}
+
+function backfillOpenRouterDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void {
+  if (!Array.isArray(payload.messages)) {
+    return;
+  }
+  for (const message of payload.messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    if (
+      record.role === "assistant" &&
+      !assistantMessageHasOpenAIToolCalls(record) &&
+      !("reasoning_content" in record)
+    ) {
+      record.reasoning_content = "";
+    }
+  }
 }
 
 function injectOpenRouterRouting(
@@ -383,18 +395,55 @@ function createOpenRouterAnthropicPrefillWrapper(baseStreamFn: StreamFn | undefi
   );
 }
 
-function createOpenRouterDeepSeekV4ThinkingWrapper(
+function resolveOpenRouterDeepSeekV4ReasoningEffort(
+  thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
+): "high" | "xhigh" | undefined {
+  if (thinkingLevel === "off") {
+    return undefined;
+  }
+  if (thinkingLevel === "xhigh" || thinkingLevel === "max") {
+    return "xhigh";
+  }
+  return "high";
+}
+
+function applyOpenRouterDeepSeekV4ReasoningEffort(
+  payload: Record<string, unknown>,
+  thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
+): boolean {
+  const effort = resolveOpenRouterDeepSeekV4ReasoningEffort(thinkingLevel);
+  if (!effort) {
+    delete payload.reasoning;
+    return false;
+  }
+  const reasoning =
+    payload.reasoning && typeof payload.reasoning === "object" && !Array.isArray(payload.reasoning)
+      ? (payload.reasoning as Record<string, unknown>)
+      : {};
+  reasoning.effort = effort;
+  payload.reasoning = reasoning;
+  return true;
+}
+
+function createOpenRouterDeepSeekV4ReplayWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
-): StreamFn | undefined {
-  return createDeepSeekV4OpenAICompatibleThinkingWrapper({
+): StreamFn {
+  return createPayloadPatchStreamWrapper(
     baseStreamFn,
-    thinkingLevel,
-    shouldPatchModel: shouldPatchDeepSeekV4OpenRouterPayload,
-    resolveReasoningEffort: resolveOpenRouterDeepSeekV4ReasoningEffort,
-    shouldBackfillAssistantReasoningContent: (message) =>
-      !assistantMessageHasOpenAIToolCalls(message),
-  });
+    ({ payload }) => {
+      delete payload.thinking;
+      delete payload.reasoning_effort;
+      if (!applyOpenRouterDeepSeekV4ReasoningEffort(payload, thinkingLevel)) {
+        stripOpenRouterDeepSeekV4ReasoningContent(payload);
+        return;
+      }
+      backfillOpenRouterDeepSeekV4ReasoningContent(payload);
+    },
+    {
+      shouldPatch: ({ model }) => shouldPatchDeepSeekV4OpenRouterPayload(model),
+    },
+  );
 }
 
 export function wrapOpenRouterProviderStream(
@@ -412,7 +461,7 @@ export function wrapOpenRouterProviderStream(
     return createOpenRouterBilledCostWrapper(
       createOpenRouterAnthropicPrefillWrapper(
         createOpenRouterAuthHeaderWrapper(
-          createOpenRouterDeepSeekV4ThinkingWrapper(routedStreamFn, ctx.thinkingLevel),
+          createOpenRouterDeepSeekV4ReplayWrapper(routedStreamFn, ctx.thinkingLevel),
         ),
       ),
     );
@@ -428,7 +477,7 @@ export function wrapOpenRouterProviderStream(
   return createOpenRouterBilledCostWrapper(
     createOpenRouterAnthropicPrefillWrapper(
       createOpenRouterAuthHeaderWrapper(
-        createOpenRouterDeepSeekV4ThinkingWrapper(wrappedStreamFn, ctx.thinkingLevel),
+        createOpenRouterDeepSeekV4ReplayWrapper(wrappedStreamFn, ctx.thinkingLevel),
       ),
     ),
   );

--- a/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
@@ -107,6 +107,17 @@ describe("extra-params: DeepSeek V4 OpenAI-compatible thinking fallback", () => 
     );
   });
 
+  it("does not inject DeepSeek-native thinking on OpenRouter auto-detected compat", () => {
+    const payload = runDeepSeekV4Case({
+      payloadExtras: { reasoning: { effort: "xhigh" } },
+      provider: "openrouter",
+      thinkingLevel: "high",
+    });
+    expect(payload.reasoning).toEqual({ effort: "xhigh" });
+    expect(payload).not.toHaveProperty("thinking");
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
   it("does not inject thinking:disabled when thinkingFormat is openai and thinking is off", () => {
     // Even `thinking: { type: "disabled" }` is rejected by Azure Foundry, so the
     // override must suppress the parameter entirely, not just disable it.

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -36,6 +36,7 @@ import {
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { canonicalizeMaxTokensParam, resolveMaxTokensParam } from "../model-max-tokens-params.js";
 import { legacyModelKey, modelKey } from "../model-selection-normalize.js";
+import { detectOpenAICompletionsCompat } from "../openai-completions-compat.js";
 import { supportsGptParallelToolCallsPayload } from "../provider-api-families.js";
 import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
 import type { AgentRuntimeTransport } from "../runtime-plan/types.js";
@@ -960,14 +961,29 @@ function isMicrosoftFoundryProviderId(provider: unknown): boolean {
  * format (plus `reasoning_effort`). Honor an explicit `compat.thinkingFormat`
  * override that selects a different reasoning format: some OpenAI-compatible
  * deployments — notably Azure AI Foundry DeepSeek V4 — reject the `thinking`
- * parameter outright, even `thinking: { type: "disabled" }`. When the format is
- * unset we keep id-based auto-detection so genuine DeepSeek V4 endpoints still
- * receive the native thinking payload; an explicit `"deepseek"` also keeps it.
+ * parameter outright, even `thinking: { type: "disabled" }`. When no override
+ * exists, honor provider-level detection for non-native formats such as
+ * OpenRouter while keeping id-based fallback for unknown DeepSeek-compatible
+ * proxy routes.
  */
 function deepSeekV4NativeThinkingAllowedByCompat(model: Parameters<StreamFn>[0]): boolean {
-  const compat = (model as ProviderRuntimeModel).compat;
-  const thinkingFormat = compat && typeof compat === "object" ? compat.thinkingFormat : undefined;
+  const thinkingFormat = resolveDeepSeekV4ThinkingFormatOverride(model);
   return thinkingFormat === undefined || thinkingFormat === "deepseek";
+}
+
+function resolveDeepSeekV4ThinkingFormatOverride(
+  model: Parameters<StreamFn>[0],
+): string | undefined {
+  const compat = (model as ProviderRuntimeModel).compat;
+  const configured = compat && typeof compat === "object" ? compat.thinkingFormat : undefined;
+  if (typeof configured === "string") {
+    return configured;
+  }
+  const detected = detectOpenAICompletionsCompat(model as ProviderRuntimeModel).defaults
+    .thinkingFormat;
+  return detected === "openrouter" || detected === "together" || detected === "zai"
+    ? detected
+    : undefined;
 }
 
 function createDeepSeekV4NonNativeCompatSanitizerWrapper(


### PR DESCRIPTION
Fixes #97196

## What Problem This Solves

Fixes an issue where users running OpenRouter-routed DeepSeek V4 models could hit a 400 response because OpenClaw sent both OpenRouter reasoning controls and DeepSeek-native thinking controls in the same request.

## Why This Change Was Made

OpenRouter DeepSeek V4 requests now stay on the OpenRouter reasoning payload shape (`reasoning.effort`) instead of adding DeepSeek-native `thinking` / `reasoning_effort` fields after the provider wrapper runs. The DeepSeek V4 replay repair still backfills `reasoning_content` only when OpenRouter reasoning remains enabled, and the core fallback now respects detected non-native thinking formats so unowned DeepSeek-compatible proxy routes keep their native fallback without breaking OpenRouter.

## User Impact

Users can use `openrouter/deepseek/deepseek-v4-flash` and `openrouter/deepseek/deepseek-v4-pro` without the request being rejected for conflicting reasoning fields. `/think max` and stale max overrides still map to OpenRouter's supported `xhigh` effort.

## Evidence

- `node scripts/run-vitest.mjs extensions/openrouter/index.test.ts src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts`
  - `extensions/openrouter/index.test.ts`: 43 passed
  - `src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts`: 9 passed
  - Covers both `openrouter/deepseek/deepseek-v4-flash` and `openrouter/deepseek/deepseek-v4-pro` payload wrapping.
- `pnpm docs:list`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - clean: no accepted/actionable findings reported

Live OpenRouter DeepSeek V4 Flash proof:

- Command shape, with the API key kept in the environment and not printed: `OPENCLAW_DEBUG_PROXY_ENABLED=1 OPENCLAW_DEBUG_PROXY_SESSION_ID=openrouter-v4-payload-proof-1782549892 OPENCLAW_DEBUG_MODEL_TRANSPORT=1 OPENCLAW_DEBUG_MODEL_PAYLOAD=full-redacted pnpm openclaw --no-color agent --local --agent main --session-key agent:main:openrouter-v4-payload-proof-direct --model openrouter/deepseek/deepseek-v4-flash --thinking xhigh --message "Reply with exactly: openrouter deepseek v4 proof"`
- Terminal result:

```text
[provider-transport-fetch] [model-fetch] start provider=openrouter api=openai-completions model=deepseek/deepseek-v4-flash method=POST url=https://openrouter.ai/api/v1/chat/completions timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=openrouter api=openai-completions model=deepseek/deepseek-v4-flash status=200 elapsedMs=7360 contentType=text/event-stream
openrouter deepseek v4 proof
[agent] run 596eee2d-d90b-4227-a46c-974b90d8f6e8 ended with stopReason=stop
```

- Captured guarded-fetch request event from the same run:

```json
{
  "direction": "outbound",
  "kind": "request",
  "method": "POST",
  "host": "openrouter.ai",
  "path": "/api/v1/chat/completions",
  "content_type": "application/json",
  "data_sha256": "d8d51a60386add5ba607082eda654829b0333e46113f8317b292369ab165ab1e",
  "meta": {
    "captureOrigin": "guarded-fetch",
    "provider": "openrouter",
    "api": "openai-completions",
    "model": "deepseek/deepseek-v4-flash"
  }
}
```

- Redacted final outbound payload summary from that captured request body:

```json
{
  "model": "deepseek/deepseek-v4-flash",
  "topLevelFields": [
    "max_completion_tokens",
    "messages",
    "model",
    "reasoning",
    "stream",
    "tool_choice",
    "tools"
  ],
  "reasoning": {
    "effort": "high"
  },
  "hasReasoningEffort": false,
  "hasThinking": false,
  "messageCount": 2,
  "stream": true
}
```

The captured body proves the final wire payload keeps nested `reasoning.effort` and omits both top-level `reasoning_effort` and `thinking`.

Live OpenRouter DeepSeek V4 proof screenshot: the request reached OpenRouter for `deepseek/deepseek-v4-flash`, returned status=200, and produced the expected reply without the previous conflicting reasoning-fields error.

**Screenshot**
<img width="796" height="480" alt="Live OpenRouter DeepSeek V4 Flash request succeeded with status 200 and returned the expected proof reply" src="https://github.com/user-attachments/assets/be54d75d-a455-4b55-93e8-805d83fdf4e2" />

