### PR TITLE
fix(irc): sanitize internal tool-trace lines from outbound text

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -316,6 +316,11 @@ conversation bindings, or any non-Codex harness.
   plugin/app support for the Codex harness. Default: `false`.
 - `plugins.entries.codex.config.codexPlugins.allow_destructive_actions`:
   default destructive-action policy for migrated plugin app elicitations.
+  Use `true` to accept safe Codex approval schemas without prompting, `false`
+  to decline them, `"auto"` to route Codex-required approvals through OpenClaw
+  plugin approvals, or `"always"` to ask for every plugin write/destructive
+  action without durable approval. The `"always"` mode clears durable Codex
+  per-tool approval overrides for the affected app before starting the thread.
   Default: `true`.
 - `plugins.entries.codex.config.codexPlugins.plugins.<key>.enabled`: enables a
   migrated plugin entry when global `codexPlugins.enabled` is also true.
@@ -326,7 +331,8 @@ conversation bindings, or any non-Codex harness.
   Codex plugin identity from migration, for example `"google-calendar"`.
 - `plugins.entries.codex.config.codexPlugins.plugins.<key>.allow_destructive_actions`:
   per-plugin destructive-action override. When omitted, the global
-  `allow_destructive_actions` value is used.
+  `allow_destructive_actions` value is used. The per-plugin value accepts the
+  same `true`, `false`, `"auto"`, or `"always"` policies.
 
 `codexPlugins.enabled` is the global enablement directive. Explicit plugin
 entries written by migration are the durable install and repair eligibility set.

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -200,11 +200,11 @@ enabled.
 
 OpenClaw sets app-level `destructive_enabled` from the effective global or
 per-plugin `allow_destructive_actions` policy and lets Codex enforce
-destructive tool metadata from its native app tool annotations. `true` and
-`"auto"` both set `destructive_enabled: true`; `false` sets it false. The
-`_default` app config is disabled with `open_world_enabled: false`. Enabled
-plugin apps are emitted with `open_world_enabled: true`; OpenClaw does not
-expose a separate plugin open-world policy knob and does not maintain
+destructive tool metadata from its native app tool annotations. `true`,
+`"auto"`, and `"always"` set `destructive_enabled: true`; `false` sets it
+false. The `_default` app config is disabled with `open_world_enabled: false`.
+Enabled plugin apps are emitted with `open_world_enabled: true`; OpenClaw does
+not expose a separate plugin open-world policy knob and does not maintain
 per-plugin destructive tool-name deny lists.
 
 Tool approval mode is automatic by default for plugin apps so non-destructive
@@ -225,6 +225,10 @@ plugins, while unsafe schemas and ambiguous ownership still fail closed:
 - When policy is `"auto"`, OpenClaw exposes destructive plugin actions to
   Codex but turns ownership-proven MCP approval elicitations into OpenClaw
   plugin approvals before returning the Codex approval response.
+- When policy is `"always"`, OpenClaw uses the same Codex write/destructive
+  gating as `"auto"`, clears durable Codex per-tool approval overrides for the
+  app before the thread starts, and only offers one-shot approval or denial so
+  durable approvals cannot suppress later write-action prompts.
 - Missing plugin identity, ambiguous ownership, a missing turn id, a wrong turn
   id, or an unsafe elicitation schema declines instead of prompting.
 
@@ -272,8 +276,9 @@ Codex thread bindings keep the app config they started with until OpenClaw
 establishes a new harness session or replaces a stale binding.
 
 **Destructive action is declined:** check the global and per-plugin
-`allow_destructive_actions` values. Even when policy is true or `"auto"`,
-unsafe elicitation schemas and ambiguous plugin identity still fail closed.
+`allow_destructive_actions` values. Even when policy is true, `"auto"`, or
+`"always"`, unsafe elicitation schemas and ambiguous plugin identity still fail
+closed.
 
 ## Related
 

--- a/extensions/clickclack/src/http-client.test.ts
+++ b/extensions/clickclack/src/http-client.test.ts
@@ -1,5 +1,80 @@
+import { createServer, type Server } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import { createClickClackClient } from "./http-client.js";
+
+const LOOPBACK_RESPONSE_BYTES = 18 * 1024 * 1024;
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function createOversizedJsonServer(): { server: Server; closed: Promise<number> } {
+  let resolveClosed: (sentBytes: number) => void = () => {};
+  const closed = new Promise<number>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const server = createServer((req, res) => {
+    let sentBytes = 0;
+    let stopped = false;
+    let prefixSent = false;
+    const prefixChunk = Buffer.from('{"user":{"id":"');
+    const bodyChunk = Buffer.alloc(64 * 1024, 0x61);
+    const suffixChunk = Buffer.from('"}}');
+    const writeBuffer = (buffer: Buffer) => {
+      sentBytes += buffer.length;
+      if (!res.write(buffer)) {
+        res.once("drain", writeChunks);
+        return false;
+      }
+      return true;
+    };
+    const writeChunks = () => {
+      if (!prefixSent) {
+        prefixSent = true;
+        if (!writeBuffer(prefixChunk)) {
+          return;
+        }
+      }
+      while (true) {
+        if (stopped) {
+          return;
+        }
+        if (sentBytes + bodyChunk.length + suffixChunk.length >= LOOPBACK_RESPONSE_BYTES) {
+          break;
+        }
+        if (!writeBuffer(bodyChunk)) {
+          return;
+        }
+      }
+      if (!stopped) {
+        sentBytes += suffixChunk.length;
+        res.end(suffixChunk);
+      }
+    };
+    res.writeHead(200, { connection: "close", "content-type": "application/json" });
+    res.on("close", () => {
+      stopped = true;
+      resolveClosed(sentBytes);
+    });
+    req.on("aborted", () => {
+      stopped = true;
+      res.destroy();
+    });
+    writeChunks();
+  });
+  return { server, closed };
+}
 
 function streamedErrorResponse(body: string, limit: number) {
   const encoded = new TextEncoder().encode(body);
@@ -39,6 +114,25 @@ function streamedErrorResponse(body: string, limit: number) {
 }
 
 describe("ClickClack HTTP client", () => {
+  it("bounds oversized success JSON responses and closes the stream early", async () => {
+    const { server, closed } = createOversizedJsonServer();
+    const port = await listenLoopbackServer(server);
+    const client = createClickClackClient({
+      baseUrl: `http://127.0.0.1:${port}`,
+      token: "test-token",
+    });
+
+    try {
+      await expect(client.me()).rejects.toThrow(
+        "ClickClack response: JSON response exceeds 16777216 bytes",
+      );
+      const sentBytes = await closed;
+      expect(sentBytes).toBeLessThan(LOOPBACK_RESPONSE_BYTES);
+    } finally {
+      server.close();
+    }
+  });
+
   it("bounds error response bodies without using raw response.text()", async () => {
     const streamed = streamedErrorResponse("x".repeat(9000), 8 * 1024);
     const fetchMock = vi.fn(async () => streamed.response);

--- a/extensions/clickclack/src/http-client.ts
+++ b/extensions/clickclack/src/http-client.ts
@@ -2,7 +2,10 @@
  * Thin ClickClack REST/websocket client used by gateway, resolver, and outbound
  * delivery code.
  */
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { WebSocket } from "ws";
 import type {
   ClickClackChannel,
@@ -44,7 +47,7 @@ export function createClickClackClient(options: ClientOptions) {
       const detail = await readResponseTextLimited(response, CLICKCLACK_ERROR_BODY_LIMIT_BYTES);
       throw new Error(`ClickClack ${response.status}: ${detail}`);
     }
-    return (await response.json()) as T;
+    return await readProviderJsonResponse<T>(response, "ClickClack response");
   }
 
   return {

--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -36,6 +36,14 @@ describe("codex doctor contract", () => {
         },
       }),
     ).toBe(false);
+    expect(
+      legacyConfigRules[1]?.match({
+        allow_destructive_actions: "always",
+        plugins: {
+          "google-calendar": { allow_destructive_actions: "always" },
+        },
+      }),
+    ).toBe(false);
   });
 
   it("removes the retired dynamic tools profile without dropping other Codex config", () => {

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -101,7 +101,7 @@
             "default": false
           },
           "allow_destructive_actions": {
-            "oneOf": [{ "type": "boolean" }, { "const": "auto" }],
+            "oneOf": [{ "type": "boolean" }, { "const": "auto" }, { "const": "always" }],
             "default": true
           },
           "plugins": {
@@ -121,7 +121,7 @@
                   "type": "string"
                 },
                 "allow_destructive_actions": {
-                  "oneOf": [{ "type": "boolean" }, { "const": "auto" }]
+                  "oneOf": [{ "type": "boolean" }, { "const": "auto" }, { "const": "always" }]
                 }
               }
             }
@@ -343,7 +343,7 @@
     },
     "codexPlugins.allow_destructive_actions": {
       "label": "Allow Destructive Plugin Actions",
-      "help": "Default policy for plugin app write or destructive action elicitations. Use true to accept safe schemas without prompting, false to decline, or auto to ask through plugin approvals.",
+      "help": "Default policy for plugin app write or destructive action elicitations. Use true to accept safe schemas without prompting, false to decline, auto to ask through plugin approvals when Codex requires approval, or always to ask for every write/destructive action without durable approval.",
       "advanced": true
     },
     "codexPlugins.plugins": {

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -346,6 +346,7 @@ export async function startCodexAttemptThread(params: {
                               timeoutMs: params.appServer.requestTimeoutMs,
                               signal,
                             }),
+                          configCwd: startupExecutionCwd,
                           appCache: defaultCodexAppInventoryCache,
                           appCacheKey: pluginAppCacheKey,
                         }),

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -1192,6 +1192,52 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     });
   });
 
+  it("parses always native Codex plugin destructive policy", () => {
+    const config = readCodexPluginConfig({
+      codexPlugins: {
+        enabled: true,
+        allow_destructive_actions: "always",
+        plugins: {
+          "google-calendar": {
+            marketplaceName: "openai-curated",
+            pluginName: "google-calendar",
+          },
+          slack: {
+            marketplaceName: "openai-curated",
+            pluginName: "slack",
+            allow_destructive_actions: "auto",
+          },
+        },
+      },
+    });
+
+    expect(config.codexPlugins?.allow_destructive_actions).toBe("always");
+    expect(resolveCodexPluginsPolicy(config)).toEqual({
+      configured: true,
+      enabled: true,
+      allowDestructiveActions: true,
+      destructiveApprovalMode: "always",
+      pluginPolicies: [
+        {
+          configKey: "google-calendar",
+          marketplaceName: "openai-curated",
+          pluginName: "google-calendar",
+          enabled: true,
+          allowDestructiveActions: true,
+          destructiveApprovalMode: "always",
+        },
+        {
+          configKey: "slack",
+          marketplaceName: "openai-curated",
+          pluginName: "slack",
+          enabled: true,
+          allowDestructiveActions: true,
+          destructiveApprovalMode: "auto",
+        },
+      ],
+    });
+  });
+
   it("rejects unsupported native Codex plugin destructive policy strings", () => {
     const config = readCodexPluginConfig({
       codexPlugins: {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -74,8 +74,8 @@ export type CodexAppServerSandboxMode = "read-only" | "workspace-write" | "dange
 type CodexAppServerApprovalsReviewer = "user" | "auto_review" | "guardian_subagent";
 type CodexAppServerCommandSource = "managed" | "resolved-managed" | "config" | "env";
 export type CodexDynamicToolsLoading = "searchable" | "direct";
-export type CodexPluginDestructivePolicy = boolean | "auto";
-export type CodexPluginDestructiveApprovalMode = "allow" | "deny" | "auto";
+export type CodexPluginDestructivePolicy = boolean | "auto" | "always";
+export type CodexPluginDestructiveApprovalMode = "allow" | "deny" | "auto" | "always";
 
 export const CODEX_PLUGINS_MARKETPLACE_NAME = "openai-curated";
 
@@ -311,7 +311,11 @@ const codexAppServerApprovalPolicySchema = z.enum([
 const codexAppServerSandboxSchema = z.enum(["read-only", "workspace-write", "danger-full-access"]);
 const codexAppServerApprovalsReviewerSchema = z.enum(["user", "auto_review", "guardian_subagent"]);
 const codexDynamicToolsLoadingSchema = z.enum(["searchable", "direct"]);
-const codexPluginDestructivePolicySchema = z.union([z.boolean(), z.literal("auto")]);
+const codexPluginDestructivePolicySchema = z.union([
+  z.boolean(),
+  z.literal("auto"),
+  z.literal("always"),
+]);
 const codexAppServerServiceTierSchema = z
   .preprocess(
     (value) => (value === null ? null : normalizeCodexServiceTier(value)),
@@ -495,8 +499,8 @@ function resolveCodexPluginDestructivePolicy(policy: CodexPluginDestructivePolic
   allowDestructiveActions: boolean;
   destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
 } {
-  if (policy === "auto") {
-    return { allowDestructiveActions: true, destructiveApprovalMode: "auto" };
+  if (policy === "auto" || policy === "always") {
+    return { allowDestructiveActions: true, destructiveApprovalMode: policy };
   }
   return {
     allowDestructiveActions: policy,

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -157,7 +157,7 @@ function buildConnectorPluginApprovalElicitation(overrides: Record<string, unkno
 function createPluginAppPolicyContext(
   params: {
     allowDestructiveActions?: boolean;
-    destructiveApprovalMode?: "allow" | "deny" | "auto";
+    destructiveApprovalMode?: "allow" | "deny" | "auto" | "always";
     apps?: Array<{ appId: string; pluginName: string; mcpServerNames: string[] }>;
   } = {},
 ) {
@@ -1014,6 +1014,96 @@ describe("Codex app-server elicitation bridge", () => {
     });
     expect(gatewayToolArg(0, 2)).toMatchObject({
       allowedDecisions: ["allow-once", "deny"],
+    });
+  });
+
+  it("does not expose allow-always for always plugin policy", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-calendar-always-policy", status: "accepted" })
+      .mockResolvedValueOnce({
+        id: "plugin:approval-calendar-always-policy",
+        decision: "allow-once",
+      });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildConnectorPluginApprovalElicitation({
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          source: "connector",
+          connector_id: "connector_google_calendar",
+          connector_name: "Google Calendar",
+          persist: ["session", "always"],
+          tool_title: "create_event",
+        },
+      }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({
+        allowDestructiveActions: true,
+        destructiveApprovalMode: "always",
+        apps: [
+          {
+            appId: "connector_google_calendar",
+            pluginName: "google-calendar",
+            mcpServerNames: [],
+          },
+        ],
+      }),
+    });
+
+    expect(result).toEqual({
+      action: "accept",
+      content: null,
+      _meta: null,
+    });
+    expect(gatewayToolArg(0, 2)).toMatchObject({
+      allowedDecisions: ["allow-once", "deny"],
+    });
+  });
+
+  it("maps unexpected allow-always decisions to one-shot for always plugin policy", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({
+        id: "plugin:approval-calendar-unexpected-always",
+        status: "accepted",
+      })
+      .mockResolvedValueOnce({
+        id: "plugin:approval-calendar-unexpected-always",
+        decision: "allow-always",
+      });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildConnectorPluginApprovalElicitation({
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          source: "connector",
+          connector_id: "connector_google_calendar",
+          connector_name: "Google Calendar",
+          persist: ["session", "always"],
+          tool_title: "create_event",
+        },
+      }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({
+        allowDestructiveActions: true,
+        destructiveApprovalMode: "always",
+        apps: [
+          {
+            appId: "connector_google_calendar",
+            pluginName: "google-calendar",
+            mcpServerNames: [],
+          },
+        ],
+      }),
+    });
+
+    expect(result).toEqual({
+      action: "accept",
+      content: null,
+      _meta: null,
     });
   });
 

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -318,10 +318,13 @@ async function buildPluginPolicyElicitationResponse(params: {
       paramsForRun: params.paramsForRun,
       title: approvalPrompt.title,
       description: approvalPrompt.description,
-      allowedDecisions: approvalPrompt.allowedDecisions,
+      allowedDecisions: allowedPluginPolicyApprovalDecisions(mode, approvalPrompt),
       signal: params.signal,
     });
-    return buildElicitationResponse(approvalPrompt, outcome);
+    return buildElicitationResponse(
+      approvalPrompt,
+      oneShotPluginPolicyApprovalOutcome(mode, outcome),
+    );
   }
   logPluginElicitationDecline("unmappable_schema", params.requestParams);
   return declineElicitationResponse();
@@ -329,8 +332,26 @@ async function buildPluginPolicyElicitationResponse(params: {
 
 function resolvePluginDestructiveApprovalMode(
   entry: PluginAppPolicyContextEntry,
-): "allow" | "deny" | "auto" {
+): "allow" | "deny" | "auto" | "always" {
   return entry.destructiveApprovalMode ?? (entry.allowDestructiveActions ? "allow" : "deny");
+}
+
+function allowedPluginPolicyApprovalDecisions(
+  mode: "allow" | "deny" | "auto" | "always",
+  approvalPrompt: BridgeableApprovalElicitation,
+): ExecApprovalDecision[] {
+  const allowedDecisions = approvalPrompt.allowedDecisions ?? ["allow-once", "deny"];
+  if (mode !== "always") {
+    return allowedDecisions;
+  }
+  return allowedDecisions.filter((decision) => decision !== "allow-always");
+}
+
+function oneShotPluginPolicyApprovalOutcome(
+  mode: "allow" | "deny" | "auto" | "always",
+  outcome: AppServerApprovalOutcome,
+): AppServerApprovalOutcome {
+  return mode === "always" && outcome === "approved-session" ? "approved-once" : outcome;
 }
 
 function readPluginApprovalElicitation(

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -170,6 +170,379 @@ describe("Codex plugin thread config", () => {
     });
   });
 
+  it("exposes destructive app access while clearing only durable approval overrides for always mode", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async () => ({
+        data: [appInfo("google-calendar-app", true)],
+        nextCursor: null,
+      }),
+    });
+    let configReadCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginDetail(
+          "google-calendar",
+          [appSummary("google-calendar-app")],
+          ["google-calendar"],
+        );
+      }
+      if (method === "config/read") {
+        configReadCount += 1;
+        if (configReadCount > 1) {
+          return {
+            config: {
+              apps: {
+                "google-calendar-app": {
+                  tools: {
+                    "calendar/read": {
+                      enabled: false,
+                    },
+                  },
+                },
+              },
+            },
+          };
+        }
+        return {
+          config: {
+            apps: {
+              "google-calendar-app": {
+                tools: {
+                  "calendar/create": {
+                    approval_mode: "approve",
+                    enabled: false,
+                  },
+                  "calendar/read": {
+                    enabled: false,
+                  },
+                  "calendar/update": {
+                    approvalMode: "approve",
+                  },
+                },
+              },
+            },
+          },
+        };
+      }
+      if (method === "config/value/write") {
+        return {};
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          allow_destructive_actions: "always",
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request,
+    });
+
+    const apps = config.configPatch?.apps as Record<string, unknown> | undefined;
+    expect(apps?.["google-calendar-app"]).toEqual({
+      enabled: true,
+      destructive_enabled: true,
+      open_world_enabled: true,
+      default_tools_approval_mode: "auto",
+    });
+    expect(config.policyContext.apps["google-calendar-app"]).toMatchObject({
+      allowDestructiveActions: true,
+      destructiveApprovalMode: "always",
+    });
+    expect(request).toHaveBeenCalledWith("config/read", { includeLayers: false });
+    expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(2);
+    expect(request).toHaveBeenCalledWith("config/value/write", {
+      keyPath: 'apps."google-calendar-app".tools."calendar/create".approval_mode',
+      value: null,
+      mergeStrategy: "replace",
+    });
+    expect(request).toHaveBeenCalledWith("config/value/write", {
+      keyPath: 'apps."google-calendar-app".tools."calendar/update".approval_mode',
+      value: null,
+      mergeStrategy: "replace",
+    });
+    expect(request).not.toHaveBeenCalledWith("config/value/write", {
+      keyPath: 'apps."google-calendar-app".tools',
+      value: null,
+      mergeStrategy: "replace",
+    });
+  });
+
+  it("omits always policy apps when cwd effective approval overrides remain after cleanup", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async () => ({
+        data: [appInfo("google-calendar-app", true)],
+        nextCursor: null,
+      }),
+    });
+    let configReadCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginDetail(
+          "google-calendar",
+          [appSummary("google-calendar-app")],
+          ["google-calendar"],
+        );
+      }
+      if (method === "config/read") {
+        configReadCount += 1;
+        return {
+          config: {
+            apps: {
+              "google-calendar-app": {
+                tools: {
+                  "calendar/create": {
+                    approval_mode: "approve",
+                    source: configReadCount === 1 ? "user" : "project",
+                  },
+                },
+              },
+            },
+          },
+        };
+      }
+      if (method === "config/value/write") {
+        return { status: "ok" };
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          allow_destructive_actions: "always",
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      configCwd: "/repo/project",
+      nowMs: 1,
+      request,
+    });
+
+    expect(config.configPatch).toEqual({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+      },
+    });
+    expect(config.policyContext.apps).toStrictEqual({});
+    expect(request).toHaveBeenCalledWith("config/read", {
+      includeLayers: false,
+      cwd: "/repo/project",
+    });
+    expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(2);
+    expect(config.diagnostics).toStrictEqual([
+      {
+        code: "approval_overrides_clear_failed",
+        plugin: {
+          configKey: "google-calendar",
+          marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+          pluginName: "google-calendar",
+          enabled: true,
+          allowDestructiveActions: true,
+          destructiveApprovalMode: "always",
+        },
+        message:
+          "Could not clear durable Codex app approval overrides for google-calendar-app: effective approval overrides remain for calendar/create",
+      },
+    ]);
+  });
+
+  it("omits always policy apps when approval override writes are overridden", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async () => ({
+        data: [appInfo("google-calendar-app", true)],
+        nextCursor: null,
+      }),
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginDetail(
+          "google-calendar",
+          [appSummary("google-calendar-app")],
+          ["google-calendar"],
+        );
+      }
+      if (method === "config/read") {
+        return {
+          config: {
+            apps: {
+              "google-calendar-app": {
+                tools: {
+                  "calendar/create": {
+                    approval_mode: "approve",
+                  },
+                },
+              },
+            },
+          },
+        };
+      }
+      if (method === "config/value/write") {
+        return { status: "okOverridden" };
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          allow_destructive_actions: "always",
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      configCwd: "/repo/project",
+      nowMs: 1,
+      request,
+    });
+
+    expect(config.configPatch).toEqual({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+      },
+    });
+    expect(config.policyContext.apps).toStrictEqual({});
+    expect(config.diagnostics).toStrictEqual([
+      {
+        code: "approval_overrides_clear_failed",
+        plugin: {
+          configKey: "google-calendar",
+          marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+          pluginName: "google-calendar",
+          enabled: true,
+          allowDestructiveActions: true,
+          destructiveApprovalMode: "always",
+        },
+        message:
+          "Could not clear durable Codex app approval overrides for google-calendar-app: approval override for calendar/create is controlled by another config layer",
+      },
+    ]);
+  });
+
+  it("omits always policy apps when durable approval override cleanup fails", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async () => ({
+        data: [appInfo("google-calendar-app", true)],
+        nextCursor: null,
+      }),
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          allow_destructive_actions: "always",
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request: async (method) => {
+        if (method === "plugin/list") {
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read") {
+          return pluginDetail(
+            "google-calendar",
+            [appSummary("google-calendar-app")],
+            ["google-calendar"],
+          );
+        }
+        if (method === "config/read") {
+          throw new Error("readonly config");
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    expect(config.configPatch).toEqual({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+      },
+    });
+    expect(config.policyContext.apps).toStrictEqual({});
+    expect(config.diagnostics).toStrictEqual([
+      {
+        code: "approval_overrides_clear_failed",
+        plugin: {
+          configKey: "google-calendar",
+          marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+          pluginName: "google-calendar",
+          enabled: true,
+          allowDestructiveActions: true,
+          destructiveApprovalMode: "always",
+        },
+        message:
+          "Could not clear durable Codex app approval overrides for google-calendar-app: readonly config",
+      },
+    ]);
+  });
+
   it("builds a restrictive app config when native plugin support is disabled", async () => {
     expect(
       shouldBuildCodexPluginThreadConfig({

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -29,7 +29,7 @@ import {
   type CodexPluginOwnedApp,
   type CodexPluginRuntimeRequest,
 } from "./plugin-inventory.js";
-import type { JsonObject, JsonValue } from "./protocol.js";
+import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
 
 /** Policy context for one app id exposed by a configured Codex plugin. */
 export type PluginAppPolicyContextEntry = {
@@ -52,7 +52,7 @@ export type PluginAppPolicyContext = {
 export type CodexPluginThreadConfigDiagnostic =
   | CodexPluginInventoryDiagnostic
   | {
-      code: "plugin_activation_failed" | "app_not_ready";
+      code: "plugin_activation_failed" | "app_not_ready" | "approval_overrides_clear_failed";
       plugin?: ResolvedCodexPluginPolicy;
       message: string;
     };
@@ -72,6 +72,7 @@ export type CodexPluginThreadConfig = {
 export type BuildCodexPluginThreadConfigParams = {
   pluginConfig?: unknown;
   request: CodexPluginRuntimeRequest;
+  configCwd?: string;
   appCache?: CodexAppInventoryCache;
   appCacheKey: string;
   nowMs?: number;
@@ -250,6 +251,18 @@ export async function buildCodexPluginThreadConfig(
         });
         continue;
       }
+      if (
+        record.policy.destructiveApprovalMode === "always" &&
+        !(await clearPersistedAppToolApprovalOverrides({
+          request: params.request,
+          configCwd: params.configCwd,
+          plugin: record.policy,
+          app,
+          diagnostics,
+        }))
+      ) {
+        continue;
+      }
       const appConfig: JsonObject = {
         enabled: true,
         destructive_enabled: record.policy.allowDestructiveActions,
@@ -365,6 +378,86 @@ function buildPluginAppPolicyContext(
     apps,
     pluginAppIds,
   };
+}
+
+async function clearPersistedAppToolApprovalOverrides(params: {
+  request: CodexPluginRuntimeRequest;
+  configCwd?: string;
+  plugin: ResolvedCodexPluginPolicy;
+  app: CodexPluginOwnedApp;
+  diagnostics: CodexPluginThreadConfigDiagnostic[];
+}): Promise<boolean> {
+  try {
+    const overrideNames = await readPersistedAppToolApprovalOverrideNames(params);
+    for (const toolName of overrideNames) {
+      const response = await params.request("config/value/write", {
+        keyPath: `apps.${quoteConfigKeyPathSegment(params.app.id)}.tools.${quoteConfigKeyPathSegment(
+          toolName,
+        )}.approval_mode`,
+        value: null,
+        mergeStrategy: "replace",
+      });
+      if (isOverriddenConfigWriteResponse(response)) {
+        throw new Error(`approval override for ${toolName} is controlled by another config layer`);
+      }
+    }
+    const remainingOverrideNames = await readPersistedAppToolApprovalOverrideNames(params);
+    if (remainingOverrideNames.length > 0) {
+      throw new Error(
+        `effective approval overrides remain for ${remainingOverrideNames.join(", ")}`,
+      );
+    }
+    return true;
+  } catch (error) {
+    params.diagnostics.push({
+      code: "approval_overrides_clear_failed",
+      plugin: params.plugin,
+      message: `Could not clear durable Codex app approval overrides for ${params.app.id}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    });
+    return false;
+  }
+}
+
+async function readPersistedAppToolApprovalOverrideNames(params: {
+  request: CodexPluginRuntimeRequest;
+  configCwd?: string;
+  app: CodexPluginOwnedApp;
+}): Promise<string[]> {
+  const response = await params.request("config/read", {
+    includeLayers: false,
+    ...(params.configCwd ? { cwd: params.configCwd } : {}),
+  });
+  const config = isJsonObject(response) ? response.config : undefined;
+  const appsRoot = isJsonObject(config) ? config.apps : undefined;
+  const nestedApps = isJsonObject(appsRoot) ? appsRoot.apps : undefined;
+  const appConfig = isJsonObject(appsRoot)
+    ? (appsRoot[params.app.id] ??
+      (isJsonObject(nestedApps) ? nestedApps[params.app.id] : undefined))
+    : undefined;
+  const tools = isJsonObject(appConfig) ? appConfig.tools : undefined;
+  if (!isJsonObject(tools)) {
+    return [];
+  }
+  return Object.entries(tools)
+    .filter(([, value]) => hasPersistedToolApprovalOverride(value))
+    .map(([toolName]) => toolName)
+    .toSorted();
+}
+
+function hasPersistedToolApprovalOverride(value: JsonValue): boolean {
+  return (
+    isJsonObject(value) && (value.approval_mode !== undefined || value.approvalMode !== undefined)
+  );
+}
+
+function isOverriddenConfigWriteResponse(response: unknown): boolean {
+  return isJsonObject(response) && response.status === "okOverridden";
+}
+
+function quoteConfigKeyPathSegment(segment: string): string {
+  return `"${segment.replace(/["\\]/g, (char) => `\\${char}`)}"`;
 }
 
 function shouldWaitForInitialAppInventory(

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -575,6 +575,8 @@ type CodexAppServerRequestResultMap = {
   "account/read": CodexGetAccountResponse;
   "app/list": CodexAppsListResponse;
   "config/mcpServer/reload": JsonValue;
+  "config/read": JsonValue;
+  "config/value/write": JsonValue;
   "environment/add": JsonValue;
   "experimentalFeature/enablement/set": JsonValue;
   "feedback/upload": JsonValue;

--- a/extensions/codex/src/app-server/request.test.ts
+++ b/extensions/codex/src/app-server/request.test.ts
@@ -112,6 +112,44 @@ describe("requestCodexAppServerJson sandbox guard", () => {
     expect(request).toHaveBeenCalledWith("thread/list", { limit: 10 }, { timeoutMs: 60_000 });
   });
 
+  it("allows config value writes in sandboxed sessions", async () => {
+    const request = vi.fn(async () => ({ ok: true }));
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });
+    const params = {
+      keyPath: 'apps."google-calendar-app".tools',
+      value: null,
+      mergeStrategy: "replace",
+    };
+
+    await expect(
+      requestCodexAppServerJson({
+        method: "config/value/write",
+        requestParams: params,
+        config: { agents: { defaults: { sandbox: { mode: "all" } } } },
+        sessionKey: "sandboxed-session",
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(request).toHaveBeenCalledWith("config/value/write", params, { timeoutMs: 60_000 });
+  });
+
+  it("allows config reads in sandboxed sessions", async () => {
+    const request = vi.fn(async () => ({ config: { apps: { apps: {} } } }));
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });
+    const params = { includeLayers: false };
+
+    await expect(
+      requestCodexAppServerJson({
+        method: "config/read",
+        requestParams: params,
+        config: { agents: { defaults: { sandbox: { mode: "all" } } } },
+        sessionKey: "sandboxed-session",
+      }),
+    ).resolves.toEqual({ config: { apps: { apps: {} } } });
+
+    expect(request).toHaveBeenCalledWith("config/read", params, { timeoutMs: 60_000 });
+  });
+
   it("allows sandbox-pinned thread starts in sandboxed sessions", async () => {
     const request = vi.fn(async () => ({ thread: { id: "thread-1" }, model: "gpt-5.5" }));
     sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });

--- a/extensions/codex/src/app-server/sandbox-guard.ts
+++ b/extensions/codex/src/app-server/sandbox-guard.ts
@@ -19,6 +19,8 @@ const DIRECT_METHOD_POLICIES = new Map<string, DirectMethodPolicy>([
   ["account/read", "allowed-control-plane"],
   ["app/list", "allowed-control-plane"],
   ["config/mcpServer/reload", "allowed-control-plane"],
+  ["config/read", "allowed-control-plane"],
+  ["config/value/write", "allowed-control-plane"],
   ["environment/add", "allowed-control-plane"],
   ["experimentalFeature/enablement/set", "allowed-control-plane"],
   ["feedback/upload", "allowed-control-plane"],

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -145,6 +145,35 @@ describe("codex app-server session binding", () => {
     expect(binding?.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
   });
 
+  it("round-trips always plugin app policy context destructive approval mode", async () => {
+    const sessionFile = path.join(tempDir, "session.json");
+    const pluginAppPolicyContext = {
+      fingerprint: "plugin-policy-always",
+      apps: {
+        "google-calendar-app": {
+          configKey: "google-calendar",
+          marketplaceName: "openai-curated" as const,
+          pluginName: "google-calendar",
+          allowDestructiveActions: true,
+          destructiveApprovalMode: "always" as const,
+          mcpServerNames: ["google-calendar"],
+        },
+      },
+      pluginAppIds: {
+        "google-calendar": ["google-calendar-app"],
+      },
+    };
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-123",
+      cwd: tempDir,
+      pluginAppPolicyContext,
+    });
+
+    const binding = await readCodexAppServerBinding(sessionFile);
+
+    expect(binding?.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
+  });
+
   it("normalizes v1 plugin app policy context destructive approval modes", async () => {
     const sessionFile = path.join(tempDir, "session.json");
     await fs.writeFile(

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -421,6 +421,9 @@ function readDestructiveApprovalMode(
   if (value === "auto") {
     return bindingSchemaVersion === 1 ? "allow" : "auto";
   }
+  if (value === "always" && bindingSchemaVersion === 2) {
+    return "always";
+  }
   if (value === "on-request" && bindingSchemaVersion === 1) {
     return "auto";
   }

--- a/extensions/codex/src/command-plugins-management.ts
+++ b/extensions/codex/src/command-plugins-management.ts
@@ -23,7 +23,7 @@ export type CodexPluginConfigEntry = {
   enabled?: boolean;
   marketplaceName?: string;
   pluginName?: string;
-  allow_destructive_actions?: boolean | "auto";
+  allow_destructive_actions?: boolean | "auto" | "always";
 };
 
 export type CodexPluginsConfigBlock = {

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -43,7 +43,7 @@ export type CodexPluginMigrationConfigEntry = {
   configKey: string;
   pluginName: string;
   enabled: boolean;
-  allowDestructiveActions?: "auto";
+  allowDestructiveActions?: "auto" | "always";
 };
 
 type CodexPluginMigrationBlockSkipDetails = {
@@ -168,15 +168,18 @@ function isLegacyDestructivePolicyRepair(
   );
 }
 
-function isLegacyDestructivePolicyConfigEntryRepair(
+function readExistingPluginAllowDestructiveActions(
   existing: unknown,
   pluginName: string,
-): boolean {
+): "auto" | "always" | undefined {
   const existingEntry = isRecord(existing) ? existing : undefined;
-  return (
-    existingEntry?.allow_destructive_actions === "on-request" &&
-    existingEntry.pluginName === pluginName
+  if (existingEntry?.pluginName !== pluginName) {
+    return undefined;
+  }
+  const normalized = normalizeExistingAllowDestructiveActions(
+    existingEntry.allow_destructive_actions,
   );
+  return normalized === "auto" || normalized === "always" ? normalized : undefined;
 }
 
 function buildPluginItems(
@@ -203,12 +206,15 @@ function buildPluginItems(
         enabled: true,
         marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
         pluginName: plugin.pluginName,
-        ...(isLegacyDestructivePolicyConfigEntryRepair(
-          existingPluginEntries[configKey],
-          plugin.pluginName,
-        )
-          ? { allow_destructive_actions: "auto" }
-          : {}),
+        ...(() => {
+          const allowDestructiveActions = readExistingPluginAllowDestructiveActions(
+            existingPluginEntries[configKey],
+            plugin.pluginName,
+          );
+          return allowDestructiveActions
+            ? { allow_destructive_actions: allowDestructiveActions }
+            : {};
+        })(),
       };
       const conflict =
         !ctx.overwrite &&
@@ -234,8 +240,9 @@ function buildPluginItems(
             pluginName: plugin.pluginName,
             sourceInstalled: plugin.installed === true,
             sourceEnabled: plugin.enabled === true,
-            ...(plannedEntry.allow_destructive_actions === "auto"
-              ? { allowDestructiveActions: "auto" }
+            ...(plannedEntry.allow_destructive_actions === "auto" ||
+            plannedEntry.allow_destructive_actions === "always"
+              ? { allowDestructiveActions: plannedEntry.allow_destructive_actions }
               : {}),
             ...(plugin.apps && plugin.apps.length > 0 && !shouldVerifyPluginApps(ctx)
               ? { sourceAppVerification: CODEX_PLUGIN_SOURCE_APP_VERIFICATION_UNVERIFIED }
@@ -310,13 +317,15 @@ export function readCodexPluginMigrationConfigEntry(
     configKey,
     pluginName,
     enabled,
-    ...(allowDestructiveActions === "auto" ? { allowDestructiveActions: "auto" } : {}),
+    ...(allowDestructiveActions === "auto" || allowDestructiveActions === "always"
+      ? { allowDestructiveActions }
+      : {}),
   };
 }
 
 function readExistingAllowDestructiveActions(
   config: MigrationProviderContext["config"],
-): boolean | "auto" | undefined {
+): boolean | "auto" | "always" | undefined {
   const value = readMigrationConfigPath(config as Record<string, unknown>, [
     ...CODEX_PLUGIN_NATIVE_CONFIG_PATH,
     "allow_destructive_actions",
@@ -324,8 +333,16 @@ function readExistingAllowDestructiveActions(
   return normalizeExistingAllowDestructiveActions(value);
 }
 
-function normalizeExistingAllowDestructiveActions(value: unknown): boolean | "auto" | undefined {
-  return value === "auto" || value === "on-request" ? "auto" : asBoolean(value);
+function normalizeExistingAllowDestructiveActions(
+  value: unknown,
+): boolean | "auto" | "always" | undefined {
+  if (value === "auto" || value === "on-request") {
+    return "auto";
+  }
+  if (value === "always") {
+    return "always";
+  }
+  return asBoolean(value);
 }
 
 function readExistingPluginPolicyRepairs(

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -2108,6 +2108,76 @@ describe("buildCodexMigrationProvider", () => {
     });
   });
 
+  it("preserves global always destructive plugin policy during migration", async () => {
+    const fixture = await createCodexFixture();
+    const configState: MigrationProviderContext["config"] = {
+      plugins: {
+        entries: {
+          codex: {
+            enabled: true,
+            config: {
+              codexPlugins: {
+                enabled: true,
+                allow_destructive_actions: "always",
+                plugins: {},
+              },
+            },
+          },
+        },
+      },
+      agents: { defaults: { workspace: fixture.workspaceDir } },
+    } as MigrationProviderContext["config"];
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("google-calendar");
+      }
+      if (method === "plugin/install") {
+        return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
+      }
+      if (method === "skills/list") {
+        return { data: [] } satisfies v2.SkillsListResponse;
+      }
+      if (method === "hooks/list") {
+        return { data: [] } satisfies v2.HooksListResponse;
+      }
+      if (method === "config/mcpServer/reload") {
+        return {};
+      }
+      if (method === "app/list") {
+        return appsList([]);
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider({
+      runtime: createConfigRuntime(configState),
+    });
+
+    const result = await provider.apply(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+        config: configState,
+      }),
+    );
+
+    expectRecordFields(findItem(result.items, "config:codex-plugins"), { status: "migrated" });
+    expect(configState.plugins?.entries?.codex?.config?.codexPlugins).toEqual({
+      enabled: true,
+      allow_destructive_actions: "always",
+      plugins: {
+        "google-calendar": {
+          enabled: true,
+          marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+          pluginName: "google-calendar",
+        },
+      },
+    });
+  });
+
   it("records auth-required plugin installs as disabled explicit config entries", async () => {
     const fixture = await createCodexFixture();
     const configState: MigrationProviderContext["config"] = {

--- a/extensions/google/media-understanding-provider.ts
+++ b/extensions/google/media-understanding-provider.ts
@@ -11,6 +11,7 @@ import {
 import {
   assertOkOrThrowProviderError,
   postJsonRequest,
+  readProviderJsonResponse,
   type ProviderRequestTransportOverrides,
 } from "openclaw/plugin-sdk/provider-http";
 import {
@@ -97,11 +98,11 @@ async function generateGeminiInlineDataText(params: {
   try {
     await assertOkOrThrowProviderError(res, params.httpErrorLabel);
 
-    const payload = (await res.json()) as {
+    const payload = await readProviderJsonResponse<{
       candidates?: Array<{
         content?: { parts?: Array<{ text?: string }> };
       }>;
-    };
+    }>(res, params.httpErrorLabel);
     const parts = payload.candidates?.[0]?.content?.parts ?? [];
     const text = parts
       .map((part) => part?.text?.trim())

--- a/extensions/google/media-understanding-provider.video.test.ts
+++ b/extensions/google/media-understanding-provider.video.test.ts
@@ -1,4 +1,5 @@
 // Google tests cover media understanding provider.video plugin behavior.
+import { createServer, type Server } from "node:http";
 import {
   createRequestCaptureJsonFetch,
   installPinnedHostnameTestHooks,
@@ -9,6 +10,49 @@ import { describeGeminiVideo, transcribeGeminiAudio } from "./media-understandin
 import { resolveGoogleGenerativeAiHttpRequestConfig } from "./runtime-api.js";
 
 installPinnedHostnameTestHooks();
+
+const LOOPBACK_RESPONSE_BYTES = 18 * 1024 * 1024;
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function createOversizedJsonServer(): { server: Server; closed: Promise<number> } {
+  let resolveClosed: (sentBytes: number) => void = () => {};
+  const closed = new Promise<number>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const server = createServer((_req, res) => {
+    let sentBytes = 0;
+    const chunk = Buffer.alloc(64 * 1024, 0x20);
+    res.writeHead(200, { "content-type": "application/json" });
+    const timer = setInterval(() => {
+      if (sentBytes >= LOOPBACK_RESPONSE_BYTES) {
+        clearInterval(timer);
+        res.end();
+        return;
+      }
+      sentBytes += chunk.length;
+      res.write(chunk);
+    }, 1);
+    res.on("close", () => {
+      clearInterval(timer);
+      resolveClosed(sentBytes);
+    });
+  });
+  return { server, closed };
+}
 
 describe("describeGeminiVideo", () => {
   it("respects case-insensitive x-goog-api-key overrides", async () => {
@@ -112,6 +156,29 @@ describe("describeGeminiVideo", () => {
     expect(body.contents?.[0]?.parts?.[1]?.inline_data?.data).toBe(
       Buffer.from("video-bytes").toString("base64"),
     );
+  });
+
+  it("bounds oversized video JSON responses and closes the stream early", async () => {
+    const { server, closed } = createOversizedJsonServer();
+    const port = await listenLoopbackServer(server);
+    const fetchFn = withFetchPreconnect(async () =>
+      fetch(`http://127.0.0.1:${port}/google-video-json`),
+    );
+
+    try {
+      await expect(
+        describeGeminiVideo({
+          buffer: Buffer.from("video-bytes"),
+          fileName: "clip.mp4",
+          apiKey: "test-key",
+          timeoutMs: 1500,
+          fetchFn,
+        }),
+      ).rejects.toThrow(/JSON response exceeds 16777216 bytes/u);
+      await expect(closed).resolves.toBeLessThan(LOOPBACK_RESPONSE_BYTES);
+    } finally {
+      server.close();
+    }
   });
 
   it("rejects non-Google video base URLs before sending authenticated requests", async () => {

--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -20,6 +20,8 @@ const {
 let buildGoogleSpeechProvider: typeof import("./speech-provider.js").buildGoogleSpeechProvider;
 let testing: typeof import("./speech-provider.js").testing;
 
+const GOOGLE_TTS_JSON_CAP_BYTES = 16 * 1024 * 1024;
+
 beforeAll(async () => {
   ({ buildGoogleSpeechProvider, testing } = await import("./speech-provider.js"));
 });
@@ -54,6 +56,26 @@ function installGoogleTtsRequestMock(pcm = Buffer.from([1, 0, 2, 0])) {
     release: vi.fn(async () => {}),
   });
   return postJsonRequestMock;
+}
+
+function oversizedGoogleTtsJsonResponse(onCancel: () => void): Response {
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(GOOGLE_TTS_JSON_CAP_BYTES + 1));
+      },
+      cancel() {
+        onCancel();
+      },
+    }),
+    { headers: { "content-type": "application/json" }, status: 200 },
+  );
+  Object.defineProperty(response, "json", {
+    value: async () => {
+      throw new Error("unbounded json reader was used");
+    },
+  });
+  return response;
 }
 
 function expectRecordFields(value: unknown, expected: Record<string, unknown>) {
@@ -147,6 +169,39 @@ describe("Google speech provider", () => {
     expect(result.audioBuffer.readUInt32LE(24)).toBe(testing.GOOGLE_TTS_SAMPLE_RATE);
     expect(result.audioBuffer.subarray(44)).toEqual(Buffer.from([1, 0, 2, 0]));
     expect(transcodeAudioBufferToOpusMock).not.toHaveBeenCalled();
+  });
+
+  it("bounds oversized Gemini TTS success JSON responses and cancels the stream", async () => {
+    let cancelCount = 0;
+    const release = vi.fn(async () => {});
+    postJsonRequestMock
+      .mockResolvedValueOnce({
+        response: oversizedGoogleTtsJsonResponse(() => {
+          cancelCount += 1;
+        }),
+        release,
+      })
+      .mockResolvedValueOnce({
+        response: oversizedGoogleTtsJsonResponse(() => {
+          cancelCount += 1;
+        }),
+        release,
+      });
+    const provider = buildGoogleSpeechProvider();
+
+    await expect(
+      provider.synthesize({
+        text: "oversized tts response",
+        cfg: {},
+        providerConfig: {
+          apiKey: "google-test-key",
+        },
+        target: "audio-file",
+        timeoutMs: 12_000,
+      }),
+    ).rejects.toThrow("Google TTS response: JSON response exceeds 16777216 bytes");
+    expect(cancelCount).toBe(2);
+    expect(release).toHaveBeenCalledTimes(2);
   });
 
   it("transcodes Gemini PCM to Opus for voice-note targets", async () => {

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -3,6 +3,7 @@ import { transcodeAudioBufferToOpus } from "openclaw/plugin-sdk/media-runtime";
 import {
   assertOkOrThrowProviderError,
   postJsonRequest,
+  readProviderJsonResponse,
   sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
@@ -503,7 +504,11 @@ async function synthesizeGoogleTtsPcmOnce(params: {
       }
     }
     try {
-      return extractGoogleSpeechPcm((await res.json()) as GoogleGenerateSpeechResponse);
+      const payload = await readProviderJsonResponse<GoogleGenerateSpeechResponse>(
+        res,
+        "Google TTS response",
+      );
+      return extractGoogleSpeechPcm(payload);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new GoogleTtsRetryableError(message);

--- a/extensions/irc/src/channel.test.ts
+++ b/extensions/irc/src/channel.test.ts
@@ -15,3 +15,21 @@ describe("irc outbound chunking", () => {
     expect(ircOutboundBaseAdapter.textChunkLimit).toBe(350);
   });
 });
+
+describe("irc outbound sanitizeText", () => {
+  afterEach(() => {
+    clearIrcRuntime();
+  });
+
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(ircOutboundBaseAdapter.sanitizeText({ text })).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(ircOutboundBaseAdapter.sanitizeText({ text })).toBe(text);
+  });
+});

--- a/extensions/irc/src/outbound-base.ts
+++ b/extensions/irc/src/outbound-base.ts
@@ -1,5 +1,6 @@
 // Irc plugin module implements outbound base behavior.
 import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { chunkTextForOutbound } from "./channel-api.js";
 
 export const ircOutboundBaseAdapter = {
@@ -7,5 +8,9 @@ export const ircOutboundBaseAdapter = {
   chunker: chunkTextForOutbound,
   chunkerMode: "markdown" as const,
   textChunkLimit: 350,
-  sanitizeText: ({ text }: { text: string }) => sanitizeForPlainText(text),
+  // IRC's plain-text pass does not remove assistant scaffolding. Run the
+  // canonical delivery sanitizer first so internal tool traces are dropped
+  // before channel formatting.
+  sanitizeText: ({ text }: { text: string }) =>
+    sanitizeForPlainText(sanitizeAssistantVisibleText(text)),
 };

--- a/extensions/nostr/src/nostr-bus.integration.test.ts
+++ b/extensions/nostr/src/nostr-bus.integration.test.ts
@@ -232,6 +232,55 @@ describe("SeenTracker", () => {
       tracker.stop();
       vi.useRealTimers();
     });
+
+    it.each([-1, 0])("falls back to default TTL for non-positive ttlMs %s", (ttlMs) => {
+      vi.useFakeTimers();
+      const tracker = createTracker({ ttlMs, pruneIntervalMs: 10 * 60 * 1000 });
+
+      try {
+        tracker.add("id1");
+        vi.advanceTimersByTime(1);
+        expect(tracker.peek("id1")).toBe(true);
+      } finally {
+        tracker.stop();
+        vi.useRealTimers();
+      }
+    });
+
+    it("falls back to default TTL for infinite ttlMs", () => {
+      vi.useFakeTimers();
+      const tracker = createTracker({
+        ttlMs: Number.POSITIVE_INFINITY,
+        pruneIntervalMs: 10 * 60 * 1000,
+      });
+
+      try {
+        tracker.add("id1");
+        vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+        expect(tracker.peek("id1")).toBe(false);
+      } finally {
+        tracker.stop();
+        vi.useRealTimers();
+      }
+    });
+
+    it.each([-1, 0, Number.POSITIVE_INFINITY])(
+      "uses the default prune interval for unsafe pruneIntervalMs %s",
+      (pruneIntervalMs) => {
+        vi.useFakeTimers();
+        const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+        const tracker = createTracker({ pruneIntervalMs });
+
+        try {
+          expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+          expect(setIntervalSpy.mock.calls[0]?.[1]).toBe(10 * 60 * 1000);
+        } finally {
+          tracker.stop();
+          setIntervalSpy.mockRestore();
+          vi.useRealTimers();
+        }
+      },
+    );
   });
 });
 

--- a/extensions/nostr/src/seen-tracker.ts
+++ b/extensions/nostr/src/seen-tracker.ts
@@ -3,7 +3,10 @@
  * Prevents unbounded memory growth under high load or abuse.
  */
 
-import { resolveIntegerOption } from "openclaw/plugin-sdk/number-runtime";
+import {
+  resolveIntegerOption,
+  resolvePositiveTimerTimeoutMs,
+} from "openclaw/plugin-sdk/number-runtime";
 
 interface SeenTrackerOptions {
   /** Maximum number of entries to track (default: 100,000) */
@@ -45,8 +48,8 @@ interface Entry {
  */
 export function createSeenTracker(options?: SeenTrackerOptions): SeenTracker {
   const maxEntries = resolveIntegerOption(options?.maxEntries, 100_000, { min: 1 });
-  const ttlMs = options?.ttlMs ?? 60 * 60 * 1000; // 1 hour
-  const pruneIntervalMs = options?.pruneIntervalMs ?? 10 * 60 * 1000; // 10 minutes
+  const ttlMs = resolvePositiveTimerTimeoutMs(options?.ttlMs, 60 * 60 * 1000);
+  const pruneIntervalMs = resolvePositiveTimerTimeoutMs(options?.pruneIntervalMs, 10 * 60 * 1000);
 
   // Main storage
   const entries = new Map<string, Entry>();

--- a/extensions/qqbot/src/engine/utils/stt.test.ts
+++ b/extensions/qqbot/src/engine/utils/stt.test.ts
@@ -1,8 +1,8 @@
 // Qqbot tests cover stt plugin behavior.
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ssrfRuntimeMocks = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn(),
@@ -38,6 +38,36 @@ function cancelTrackedResponse(
   return {
     response: new Response(stream, init),
     wasCanceled: () => canceled,
+  };
+}
+
+function largeTranscriptionJsonResponse(params: { chunkCount: number; chunkSize: number }): {
+  response: Response;
+  getReadCount: () => number;
+} {
+  let chunkIndex = 0;
+  const encoder = new TextEncoder();
+  const chunks = [
+    '{"text":"',
+    ...Array.from({ length: params.chunkCount }, () => "a".repeat(params.chunkSize)),
+    '"}',
+  ];
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (chunkIndex >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(encoder.encode(chunks[chunkIndex]));
+      chunkIndex += 1;
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    getReadCount: () => chunkIndex,
   };
 }
 
@@ -173,6 +203,44 @@ describe("engine/utils/stt", () => {
       expect(new Uint8Array(await (file as File).arrayBuffer())).toEqual(
         new Uint8Array([1, 2, 3, 4]),
       );
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("bounds successful STT JSON responses before parsing", async () => {
+    await withTempDir("openclaw-qqbot-stt-success-limit-", async (tmpDir) => {
+      const audioPath = path.join(tmpDir, "voice.wav");
+      fs.writeFileSync(audioPath, Buffer.from([1, 2, 3, 4]));
+
+      const release = vi.fn(async () => {});
+      const streamed = largeTranscriptionJsonResponse({
+        chunkCount: 18,
+        chunkSize: 1024 * 1024,
+      });
+      ssrfRuntimeMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: streamed.response,
+        release,
+      });
+
+      let error: unknown;
+      try {
+        await transcribeAudio(audioPath, {
+          channels: {
+            qqbot: {
+              stt: {
+                baseUrl: "https://api.example.test/v1/",
+                apiKey: "secret",
+                model: "whisper-1",
+              },
+            },
+          },
+        });
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(String(error)).toContain("qqbot.stt: JSON response exceeds 16777216 bytes");
+      expect(streamed.getReadCount()).toBeLessThan(20);
       expect(release).toHaveBeenCalledTimes(1);
     });
   });

--- a/extensions/qqbot/src/engine/utils/stt.ts
+++ b/extensions/qqbot/src/engine/utils/stt.ts
@@ -8,7 +8,10 @@
 import * as fs from "node:fs";
 import path from "node:path";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeOptionalString,
@@ -100,7 +103,7 @@ export async function transcribeAudio(
       throw new Error(`STT failed (HTTP ${resp.status}): ${detail.slice(0, 300)}`);
     }
 
-    const result = (await resp.json()) as { text?: string };
+    const result = await readProviderJsonResponse<{ text?: string }>(resp, "qqbot.stt");
     return normalizeOptionalString(result.text) ?? null;
   } finally {
     await release();

--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
+
+const telegramChatWindowContext: TelegramPromptContextEntry = {
+  label: "Conversation context",
+  source: "telegram",
+  type: "chat_window",
+  payload: {
+    order: "chronological",
+    relation: "selected_for_current_message",
+    messages: [
+      {
+        message_id: "10",
+        sender: "Pat",
+        timestamp_ms: 1_700_000_000_000,
+        body: "Earlier DM turn already in the transcript",
+      },
+    ],
+  },
+};
+
+describe("buildTelegramMessageContext prompt context", () => {
+  it("omits Telegram chat-window context for existing unthreaded private DM sessions", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 1234, type: "private", first_name: "Pat" },
+        from: { id: 1234, first_name: "Pat" },
+        text: "continue",
+      },
+      promptContext: [telegramChatWindowContext],
+      sessionRuntime: {
+        readSessionUpdatedAt: ({ sessionKey }) =>
+          sessionKey === "agent:main:main" ? 1_700_000_000_000 : undefined,
+      },
+    });
+
+    expect(ctx?.ctxPayload.SessionKey).toBe("agent:main:main");
+    expect(ctx?.ctxPayload.UntrustedStructuredContext).toBeUndefined();
+  });
+
+  it("keeps Telegram chat-window context for fresh private DM sessions", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 1234, type: "private", first_name: "Pat" },
+        from: { id: 1234, first_name: "Pat" },
+        text: "start",
+      },
+      promptContext: [telegramChatWindowContext],
+    });
+
+    expect(ctx?.ctxPayload.UntrustedStructuredContext).toEqual([telegramChatWindowContext]);
+  });
+
+  it("keeps Telegram chat-window context for existing private DM replies", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 1234, type: "private", first_name: "Pat" },
+        from: { id: 1234, first_name: "Pat" },
+        text: "replying with context",
+        reply_to_message: {
+          chat: { id: 1234, type: "private", first_name: "Pat" },
+          from: { id: 1234, first_name: "Pat" },
+          text: "older referenced turn",
+          date: 1_700_000_000,
+          message_id: 10,
+        },
+      },
+      promptContext: [telegramChatWindowContext],
+      sessionRuntime: {
+        readSessionUpdatedAt: ({ sessionKey }) =>
+          sessionKey === "agent:main:main" ? 1_700_000_000_000 : undefined,
+      },
+    });
+
+    expect(ctx?.ctxPayload.UntrustedStructuredContext).toEqual([telegramChatWindowContext]);
+  });
+});

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -113,6 +113,10 @@ export async function resolveTelegramMessageContextStorePath(params: {
   });
 }
 
+function isTelegramChatWindowPromptContext(entry: TelegramPromptContextEntry): boolean {
+  return entry.source === "telegram" && entry.type === "chat_window";
+}
+
 function replyTargetToChainEntry(replyTarget: TelegramReplyTarget): TelegramReplyChainEntry {
   return {
     ...(replyTarget.id ? { messageId: replyTarget.id } : {}),
@@ -378,6 +382,17 @@ export async function buildTelegramInboundContextPayload(params: {
     storePath,
     sessionKey: route.sessionKey,
   });
+  const shouldSuppressPersistedDmChatWindowContext =
+    !isGroup &&
+    previousTimestamp !== undefined &&
+    dmThreadId == null &&
+    visibleReplyChain.length === 0 &&
+    !visibleReplyTarget;
+  // Existing plain DMs already carry their history through the persistent
+  // transcript. Keep chat windows for fresh DMs, topics, replies, and groups.
+  const visiblePromptContext = shouldSuppressPersistedDmChatWindowContext
+    ? promptContext.filter((entry) => !isTelegramChatWindowPromptContext(entry))
+    : promptContext;
   const body = formatInboundEnvelope({
     channel: "Telegram",
     from: conversationLabel,
@@ -559,7 +574,7 @@ export async function buildTelegramInboundContextPayload(params: {
           }
         : undefined,
       groupSystemPrompt: isGroup || (!isGroup && groupConfig) ? groupSystemPrompt : undefined,
-      untrustedContext: promptContext.length > 0 ? promptContext : undefined,
+      untrustedContext: visiblePromptContext.length > 0 ? visiblePromptContext : undefined,
     },
     contextVisibility: contextVisibilityMode,
     extra: {

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -23,6 +23,7 @@ type BuildTelegramMessageContextForTestParams = {
   message: Record<string, unknown>;
   me?: Record<string, unknown>;
   allMedia?: TelegramMediaRef[];
+  promptContext?: BuildTelegramMessageContextParams["promptContext"];
   options?: BuildTelegramMessageContextParams["options"];
   cfg?: Record<string, unknown>;
   accountId?: string;
@@ -112,6 +113,7 @@ export async function buildTelegramMessageContextForTest(
       me: { id: 7, username: "bot", ...params.me },
     } as never,
     allMedia: params.allMedia ?? [],
+    promptContext: params.promptContext ?? [],
     storeAllowFrom: [],
     options: params.options ?? {},
     bot: {

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -10,6 +10,19 @@ import * as ts from "typescript";
 import { formatErrorMessage } from "../src/infra/errors.ts";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 
+const { formatGeneratedModule } = (await import(
+  new URL("./lib/format-generated-module.mjs", import.meta.url).href
+)) as {
+  formatGeneratedModule: (
+    source: string,
+    options: {
+      errorLabel: string;
+      outputPath: string;
+      repoRoot: string;
+    },
+  ) => string;
+};
+
 interface TranslationMap {
   [key: string]: string | TranslationMap;
 }
@@ -1228,18 +1241,12 @@ export async function runProcess(
 }
 
 async function formatGeneratedTypeScript(filePath: string, source: string): Promise<string> {
-  const directFormatterPath = path.join(ROOT, "node_modules", ".bin", "oxfmt");
-  const formatterCommand =
-    process.platform !== "win32" && existsSync(directFormatterPath) ? directFormatterPath : "pnpm";
-  const formatterArgs =
-    formatterCommand === directFormatterPath
-      ? ["--stdin-filepath", path.relative(ROOT, filePath)]
-      : ["exec", "oxfmt", "--stdin-filepath", path.relative(ROOT, filePath)];
-  const result = await runProcess(formatterCommand, formatterArgs, {
-    input: source,
-    rejectOnFailure: true,
+  const formatted = formatGeneratedModule(source, {
+    errorLabel: "control ui locale",
+    outputPath: filePath,
+    repoRoot: ROOT,
   });
-  return restoreReplacementCorruptedStringLiterals(source, result.stdout);
+  return restoreReplacementCorruptedStringLiterals(source, formatted);
 }
 
 function restoreReplacementCorruptedStringLiterals(source: string, formatted: string): string {

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -1,4 +1,9 @@
 {
+  "schemaVersion": 1,
+  "id": "openclaw-official-external-plugins",
+  "generatedAt": "2026-06-22T00:00:00.000Z",
+  "sequence": 1,
+  "description": "Bundled fallback feed for official external OpenClaw plugins.",
   "entries": [
     {
       "name": "@openclaw/acpx",

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -233,6 +233,50 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   pollProviderOperationJson: providerHttpMocks.pollProviderOperationJsonMock,
   postJsonRequest: providerHttpMocks.postJsonRequestMock,
   postMultipartRequest: providerHttpMocks.postMultipartRequestMock,
+  readProviderJsonResponse: async <T>(
+    response: Response,
+    label: string,
+    opts?: { maxBytes?: number },
+  ): Promise<T> => {
+    const maxBytes = opts?.maxBytes ?? 16 * 1024 * 1024;
+    if (!response.body) {
+      try {
+        return (await response.json()) as T;
+      } catch (cause) {
+        throw new Error(`${label}: malformed JSON response`, { cause });
+      }
+    }
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+          await reader.cancel();
+          throw new Error(`${label}: JSON response exceeds ${maxBytes} bytes`);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    const body = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    try {
+      return JSON.parse(new TextDecoder().decode(body)) as T;
+    } catch (cause) {
+      throw new Error(`${label}: malformed JSON response`, { cause });
+    }
+  },
   providerOperationRetryConfig: (_stage: string) => true,
   resolveProviderOperationTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
     defaultTimeoutMs,

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
+import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import {
   type OfficialExternalPluginCatalogEntry,
   getOfficialExternalPluginCatalogEntry,
+  isOfficialExternalPluginCatalogFeed,
   listOfficialExternalPluginCatalogEntries,
+  parseOfficialExternalPluginCatalogEntries,
   resolveOfficialExternalProviderContractPluginIds,
   resolveOfficialExternalProviderPluginIds,
   resolveOfficialExternalProviderPluginIdsForEnv,
@@ -20,6 +23,54 @@ function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
 }
 
 describe("official external plugin catalog", () => {
+  it("ships the official plugin catalog as a feed-shaped bundled fallback", () => {
+    expect(isOfficialExternalPluginCatalogFeed(officialExternalPluginCatalog)).toBe(true);
+    expect(officialExternalPluginCatalog).toMatchObject({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      sequence: 1,
+    });
+    expect(officialExternalPluginCatalog.entries.length).toBeGreaterThan(0);
+  });
+
+  it("does not allow malformed feed wrappers to count as feed documents", () => {
+    expect(
+      isOfficialExternalPluginCatalogFeed({
+        schemaVersion: 1,
+        id: " ",
+        generatedAt: "2026-06-22T00:00:00.000Z",
+        sequence: 1,
+        entries: [],
+      }),
+    ).toBe(false);
+    expect(
+      isOfficialExternalPluginCatalogFeed({
+        schemaVersion: 2,
+        id: "openclaw-official-external-plugins",
+        generatedAt: "2026-06-22T00:00:00.000Z",
+        sequence: 1,
+        entries: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps unsupported versioned feed wrappers out of legacy catalog parsing", () => {
+    expect(
+      parseOfficialExternalPluginCatalogEntries({
+        schemaVersion: 2,
+        id: "future-feed",
+        generatedAt: "2026-06-22T00:00:00.000Z",
+        sequence: 1,
+        entries: [{ name: "should-not-load" }],
+      }),
+    ).toEqual([]);
+    expect(
+      parseOfficialExternalPluginCatalogEntries({
+        entries: [{ name: "legacy-catalog-entry" }],
+      }),
+    ).toEqual([{ name: "legacy-catalog-entry" }]);
+  });
+
   it("lists the externalized provider and capability plugins with install metadata", () => {
     const providers = [
       ["arcee", "@openclaw/arcee-provider"],

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -84,6 +84,16 @@ export type OfficialExternalPluginCatalogEntry = {
   kind?: string;
 } & Partial<Record<ManifestKey, OfficialExternalPluginCatalogManifest>>;
 
+/** Feed-shaped wrapper used by the bundled external plugin catalog fallback. */
+export type OfficialExternalPluginCatalogFeed = {
+  schemaVersion: number;
+  id: string;
+  generatedAt: string;
+  sequence: number;
+  description?: string;
+  entries: readonly OfficialExternalPluginCatalogEntry[];
+};
+
 type OfficialExternalProviderContract =
   | "embeddingProviders"
   | "mediaUnderstandingProviders"
@@ -97,11 +107,43 @@ const OFFICIAL_CATALOG_SOURCES = [
   officialExternalPluginCatalog,
 ] as const;
 
-function parseCatalogEntries(raw: unknown): OfficialExternalPluginCatalogEntry[] {
+const OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSION = 1;
+
+export function isOfficialExternalPluginCatalogFeed(
+  raw: unknown,
+): raw is OfficialExternalPluginCatalogFeed {
+  if (!isRecord(raw)) {
+    return false;
+  }
+  const sequence = raw.sequence;
+  return (
+    raw.schemaVersion === OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSION &&
+    typeof raw.id === "string" &&
+    raw.id.trim().length > 0 &&
+    typeof raw.generatedAt === "string" &&
+    raw.generatedAt.trim().length > 0 &&
+    typeof sequence === "number" &&
+    Number.isInteger(sequence) &&
+    sequence >= 0 &&
+    Array.isArray(raw.entries)
+  );
+}
+
+export function parseOfficialExternalPluginCatalogEntries(
+  raw: unknown,
+): OfficialExternalPluginCatalogEntry[] {
   if (Array.isArray(raw)) {
     return raw.filter((entry): entry is OfficialExternalPluginCatalogEntry => isRecord(entry));
   }
+  if (isOfficialExternalPluginCatalogFeed(raw)) {
+    return raw.entries.filter((entry): entry is OfficialExternalPluginCatalogEntry =>
+      isRecord(entry),
+    );
+  }
   if (!isRecord(raw)) {
+    return [];
+  }
+  if ("schemaVersion" in raw) {
     return [];
   }
   const list = raw.entries ?? raw.packages ?? raw.plugins;
@@ -191,7 +233,9 @@ export function resolveOfficialExternalPluginInstall(
 }
 
 export function listOfficialExternalPluginCatalogEntries(): OfficialExternalPluginCatalogEntry[] {
-  const entries = OFFICIAL_CATALOG_SOURCES.flatMap((source) => parseCatalogEntries(source));
+  const entries = OFFICIAL_CATALOG_SOURCES.flatMap((source) =>
+    parseOfficialExternalPluginCatalogEntries(source),
+  );
   const resolved = new Map<string, OfficialExternalPluginCatalogEntry>();
   for (const entry of entries) {
     const pluginId = resolveOfficialExternalPluginId(entry);


### PR DESCRIPTION
Related: #90684

## What Problem This Solves

Fixes an issue where IRC users would see OpenClaw's internal tool-execution traces leak into channel messages. When a tool run fails, the runtime injects a status banner such as `` ⚠️ 🛠️ `…(agent)` failed `` into the assistant's outbound text. On IRC — a plaintext-only transport — that banner was delivered verbatim instead of being stripped.

## Why This Change Was Made

The IRC outbound adapter's `sanitizeText` ran only `sanitizeForPlainText(text)`, which does not strip assistant-visible scaffolding. The Telegram (#95774) and Google Chat (#95084) outbound adapters already wrap the same call with `sanitizeAssistantVisibleText` — the canonical assistant-visible sanitizer that removes tool-trace banners and other internal scaffolding (reasoning tags, tool-call XML). This change applies that same wrap to IRC: one import plus `sanitizeForPlainText(sanitizeAssistantVisibleText(text))`, reusing the existing SDK sanitizer rather than adding a helper. The change is limited to the IRC adapter; other channels are tracked separately under #90684.

## User Impact

IRC users no longer see internal tool-trace banners — or other assistant-internal scaffolding handled by the shared sanitizer — in delivered messages. Ordinary assistant prose is unaffected.

## Evidence

**Focused unit tests** — `extensions/irc/src/channel.test.ts` adds 2 cases (tool-trace banner stripped; ordinary prose preserved):

```
$ node scripts/run-vitest.mjs extensions/irc/src/channel.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

**Real-behavior proof** — the patched IRC outbound adapter's `ircOutboundBaseAdapter.sanitizeText`, run directly against the real code path. No live IRC proof is included because the change is isolated to the outbound sanitizer; the command below exercises that adapter directly (the banner is runtime-injected, not model-produced, so a channel roundtrip adds no signal):

```
$ node --import tsx -e '
import { ircOutboundBaseAdapter } from "./extensions/irc/src/outbound-base.ts";
import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
const trace = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
const prose = "The pipeline has 3 open deals.";
console.log("before (sanitizeForPlainText only):", JSON.stringify(sanitizeForPlainText(trace)));
console.log("after  (ircOutboundBaseAdapter):   ", JSON.stringify(ircOutboundBaseAdapter.sanitizeText({ text: trace })));
console.log("prose  (ircOutboundBaseAdapter):   ", JSON.stringify(ircOutboundBaseAdapter.sanitizeText({ text: prose })));
'
before (sanitizeForPlainText only): "Done.\n⚠️ 🛠️ `search repos (agent)` failed"
after  (ircOutboundBaseAdapter):    "Done."
prose  (ircOutboundBaseAdapter):    "The pipeline has 3 open deals."
```

Before the fix, `sanitizeForPlainText(text)` alone leaks the banner verbatim; after the fix it is stripped to `Done.`, and ordinary prose passes through unchanged.
