### PR TITLE
fix(ollama): send tool_call arguments as strings on OpenAI-compatible path

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -9,7 +9,11 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
-import { buildAssistantMessage, createOllamaStreamFn } from "./stream.js";
+import {
+  buildAssistantMessage,
+  createOllamaStreamFn,
+  normalizeOllamaCompatMessageToolArgs,
+} from "./stream.js";
 
 function makeOllamaResponse(params: {
   content?: string;
@@ -520,5 +524,119 @@ describe("createOllamaStreamFn thinking events", () => {
       reason: "aborted",
       error: { stopReason: "aborted" },
     });
+  });
+});
+
+describe("normalizeOllamaCompatMessageToolArgs (OpenAI-compatible Ollama Cloud)", () => {
+  // Regression for #96441: Ollama Cloud (*:cloud) proxies through an
+  // OpenAI-compatible Go server that requires tool_calls[].function.arguments
+  // to be a JSON STRING. Replaying assistant tool-call history on the 2nd turn
+  // with object-form arguments produced:
+  //   400 json: cannot unmarshal object into Go struct field
+  //   .messages.tool_calls.function.arguments of type string
+  it("serializes object tool-call arguments to a JSON string", () => {
+    const payload = {
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "config.get", arguments: { key: "gateway.port" } },
+            },
+          ],
+        },
+      ],
+    };
+
+    normalizeOllamaCompatMessageToolArgs(payload);
+
+    const args = (payload.messages[0].tool_calls as Array<Record<string, never>>)[0].function
+      .arguments;
+    expect(typeof args).toBe("string");
+    expect(JSON.parse(args as unknown as string)).toEqual({ key: "gateway.port" });
+  });
+
+  it("leaves already-stringified arguments unchanged (no double-encoding)", () => {
+    const payload = {
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              function: { name: "search", arguments: '{"q":"hello"}' },
+            },
+          ],
+        },
+      ],
+    };
+
+    normalizeOllamaCompatMessageToolArgs(payload);
+
+    const args = (payload.messages[0].tool_calls as Array<Record<string, never>>)[0].function
+      .arguments;
+    expect(args).toBe('{"q":"hello"}');
+    expect(JSON.parse(args as unknown as string)).toEqual({ q: "hello" });
+  });
+
+  it("normalizes the legacy function_call shape to a string", () => {
+    const payload = {
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          function_call: { name: "lookup", arguments: { id: 42 } },
+        },
+      ],
+    };
+
+    normalizeOllamaCompatMessageToolArgs(payload);
+
+    const args = (payload.messages[0].function_call as Record<string, unknown>).arguments;
+    expect(typeof args).toBe("string");
+    expect(JSON.parse(args as string)).toEqual({ id: 42 });
+  });
+
+  it("handles the second-turn replay payload from the bug report", () => {
+    // assistant tool call followed by its tool result, replayed on turn 2
+    const payload = {
+      messages: [
+        { role: "user", content: "What is config.gateway.port?" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call_abc",
+              type: "function",
+              function: { name: "config.get", arguments: { key: "gateway.port" } },
+            },
+          ],
+        },
+        { role: "tool", tool_name: "config.get", content: "8642" },
+      ],
+    };
+
+    normalizeOllamaCompatMessageToolArgs(payload);
+
+    const assistant = payload.messages[1] as {
+      tool_calls: Array<{ function: { arguments: unknown } }>;
+    };
+    expect(typeof assistant.tool_calls[0].function.arguments).toBe("string");
+    // user + tool messages untouched
+    expect(payload.messages[0]).toEqual({ role: "user", content: "What is config.gateway.port?" });
+    expect(payload.messages[2]).toEqual({ role: "tool", tool_name: "config.get", content: "8642" });
+  });
+
+  it("is a no-op when there are no messages or tool calls", () => {
+    const empty = { model: "glm-5.2:cloud" } as Record<string, unknown>;
+    expect(() => normalizeOllamaCompatMessageToolArgs(empty)).not.toThrow();
+
+    const plain = { messages: [{ role: "user", content: "hi" }] };
+    normalizeOllamaCompatMessageToolArgs(plain);
+    expect(plain.messages[0]).toEqual({ role: "user", content: "hi" });
   });
 });

--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -553,10 +553,10 @@ describe("normalizeOllamaCompatMessageToolArgs (OpenAI-compatible Ollama Cloud)"
 
     normalizeOllamaCompatMessageToolArgs(payload);
 
-    const args = (payload.messages[0].tool_calls as Array<Record<string, never>>)[0].function
-      .arguments;
+    const args = (payload.messages[0].tool_calls as Array<{ function: { arguments: unknown } }>)[0]
+      .function.arguments;
     expect(typeof args).toBe("string");
-    expect(JSON.parse(args as unknown as string)).toEqual({ key: "gateway.port" });
+    expect(JSON.parse(args as string)).toEqual({ key: "gateway.port" });
   });
 
   it("leaves already-stringified arguments unchanged (no double-encoding)", () => {
@@ -576,10 +576,10 @@ describe("normalizeOllamaCompatMessageToolArgs (OpenAI-compatible Ollama Cloud)"
 
     normalizeOllamaCompatMessageToolArgs(payload);
 
-    const args = (payload.messages[0].tool_calls as Array<Record<string, never>>)[0].function
-      .arguments;
+    const args = (payload.messages[0].tool_calls as Array<{ function: { arguments: unknown } }>)[0]
+      .function.arguments;
     expect(args).toBe('{"q":"hello"}');
-    expect(JSON.parse(args as unknown as string)).toEqual({ q: "hello" });
+    expect(JSON.parse(args as string)).toEqual({ q: "hello" });
   });
 
   it("normalizes the legacy function_call shape to a string", () => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -737,11 +737,42 @@ function ensureArgsObject(value: unknown): Record<string, unknown> {
   return parseJsonObjectPreservingUnsafeIntegers(value) ?? {};
 }
 
+/**
+ * Serialize tool-call arguments to a JSON string for the OpenAI-compatible
+ * Chat Completions wire format.
+ *
+ * The OpenAI spec (and Ollama Cloud's strict Go server behind
+ * `/v1/chat/completions`) requires `tool_calls[].function.arguments` to be a
+ * STRING. Native Ollama `/api/chat` instead wants an object — see
+ * {@link normalizeOllamaCompatMessageToolArgs} vs the native extraction path.
+ *
+ * Already-serialized strings are passed through unchanged so we don't
+ * double-encode; everything else is normalized through `ensureArgsObject`
+ * first (preserving unsafe integers) and then stringified.
+ */
+function ensureArgsString(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  return JSON.stringify(ensureArgsObject(value));
+}
+
 function normalizeOllamaToolCallArguments(value: unknown): Record<string, unknown> {
   return ensureArgsObject(value);
 }
 
-function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unknown>): void {
+/**
+ * Normalize `tool_calls[].function.arguments` on an OpenAI-compatible
+ * (`/v1/chat/completions`) payload to JSON STRINGS.
+ *
+ * Ollama Cloud (`*:cloud` models) proxies through an OpenAI-compatible Go
+ * server that rejects object-form arguments with
+ * `400 json: cannot unmarshal object into Go struct field
+ * .messages.tool_calls.function.arguments of type string` on the second turn,
+ * when prior assistant tool-call history is replayed. The native `/api/chat`
+ * path keeps object form and is handled separately (see {@link extractToolCalls}).
+ */
+export function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unknown>): void {
   const messages = payloadRecord.messages;
   if (!Array.isArray(messages)) {
     return;
@@ -757,7 +788,7 @@ function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unkn
     if (functionCall && typeof functionCall === "object" && !Array.isArray(functionCall)) {
       const functionCallRecord = functionCall as Record<string, unknown>;
       if (Object.hasOwn(functionCallRecord, "arguments")) {
-        functionCallRecord.arguments = ensureArgsObject(functionCallRecord.arguments);
+        functionCallRecord.arguments = ensureArgsString(functionCallRecord.arguments);
       }
     }
 
@@ -775,7 +806,7 @@ function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unkn
       }
       const functionRecord = functionSpec as Record<string, unknown>;
       if (Object.hasOwn(functionRecord, "arguments")) {
-        functionRecord.arguments = ensureArgsObject(functionRecord.arguments);
+        functionRecord.arguments = ensureArgsString(functionRecord.arguments);
       }
     }
   }


### PR DESCRIPTION
Closes #96441

## What Problem This Solves

Fixes an issue where users on any **Ollama Cloud** model (`*:cloud`, e.g. `ollama/glm-5.2:cloud`, `glm-5.1:cloud`, MiniMax M3 Cloud) would have multi-turn tool use break after the **first** tool call. The first turn succeeds, but the second turn — where prior assistant tool-call history is replayed back to the provider — fails with an HTTP 400 from Ollama's cloud-side Go server:

```
400 json: cannot unmarshal object into Go struct field
.messages.tool_calls.function.arguments of type string
```

This is a regression introduced in 2026.6.9 (2026.6.8 worked). It affects the agent loop for every Ollama Cloud user the moment a conversation contains more than one tool call. Direct (non-Ollama) providers serving the same models — e.g. `zhipu-ai/glm-5.2` straight from the Z.ai API — are unaffected, which isolates the fault to OpenClaw's Ollama OpenAI-compatible request shaping.

## Why This Change Was Made

Ollama exposes two wire contracts and OpenClaw talks to both:

- **Native `/api/chat`** accepts `tool_calls[].function.arguments` as an **object**.
- **OpenAI-compatible `/v1/chat/completions`** (what Ollama Cloud proxies through) requires `arguments` to be a **JSON string**, per the OpenAI spec, and its Go server enforces this strictly.

The OpenAI-compatible `num_ctx` wrapper was reusing the native normalization (`normalizeOllamaCompatMessageToolArgs` → `ensureArgsObject`), coercing string arguments back into objects right before send. This change splits the two contracts, exactly as outlined in the maintainer review on #96441:

- Native `/api/chat` keeps object coercion (`extractToolCalls`, unchanged).
- The OpenAI-compatible payload now serializes `arguments` to JSON strings via a new `ensureArgsString` helper, while still injecting `num_ctx`.

Already-stringified arguments pass through unchanged to avoid double-encoding. Non-tool messages are left untouched. No behavior change for native Ollama.

## User Impact

Ollama Cloud users can now run multi-turn conversations with tool calls without the second turn 400-ing. The fix is provider-payload-shaping only; native Ollama (`/api/chat`) object-form arguments are preserved, so the previously-fixed native replay issues (#46679, #50689) stay fixed.

## Evidence

Targeted tests in `extensions/ollama/src/stream.test.ts` (all 21 pass — 16 existing + 5 new regression):

```
 ✓  extension-providers  extensions/ollama/src/stream.test.ts (21 tests) 29ms
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

New regression coverage:
- object arguments → serialized to a JSON string
- already-stringified arguments → passed through unchanged (no double-encoding)
- legacy `function_call` shape → normalized to a string
- the exact second-turn replay payload from the bug report
- no-op when there are no messages / tool calls

Lint + format clean on the changed files:
```
oxlint:  Found 0 warnings and 0 errors.
oxfmt:   All matched files use the correct format.
```

Type-check: `tsgo -p extensions/ollama/tsconfig.json` reports the **same 7 pre-existing** errors with and without this change (workspace-artifact module-resolution noise in `index.ts` / `embedding-provider.ts` and an untouched `text_delta` event) — **zero new** type errors introduced by this diff.

Note: I did not have live Ollama Cloud credentials to capture an end-to-end 400→200 run; validation is source-level + unit tests against the captured failing payload shape from the issue, matching the maintainer's source-level reproduction.
