### PR TITLE
fix(plugin-sdk): remove stale reasoning envelope when DeepSeek V4 wrapper emits native effort (#97196)

### DIFF
--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -189,6 +189,45 @@ describe("createDeepSeekV4OpenAICompatibleThinkingWrapper", () => {
     expect(payload.messages[3]).toHaveProperty("reasoning_content", "");
     expect(payload.messages[4]).toHaveProperty("reasoning_content", "native reasoning");
   });
+
+  it("removes pre-existing OpenRouter reasoning envelopes when enabled thinking sets native effort", () => {
+    const payload: Record<string, unknown> = {
+      reasoning: { effort: "high" },
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload as never, _model as never);
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn,
+      thinkingLevel: "high",
+      shouldPatchModel: () => true,
+    });
+    void wrapped?.({} as never, { messages: [] } as never, {});
+
+    expect(payload).toEqual({
+      thinking: { type: "enabled" },
+      reasoning_effort: "high",
+    });
+  });
+
+  it("does not add unexpected keys when payload has no pre-existing reasoning", () => {
+    const payload: Record<string, unknown> = {};
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload as never, _model as never);
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn,
+      thinkingLevel: "high",
+      shouldPatchModel: () => true,
+    });
+    void wrapped?.({} as never, { messages: [] } as never, {});
+
+    expect(Object.keys(payload).toSorted()).toEqual(["reasoning_effort", "thinking"]);
+  });
 });
 
 describe("createPayloadPatchStreamWrapper", () => {

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -494,6 +494,11 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
 
       payload.thinking = { type: "enabled" };
       payload.reasoning_effort = resolveReasoningEffort(params.thinkingLevel);
+      // OpenRouter or other non-native reasoning-format providers may have
+      // already placed a nested `reasoning.effort` on the payload; sending
+      // both field shapes causes providers to reject the request (HTTP 400).
+      // The disabled-think branch below already does the same cleanup.
+      delete payload.reasoning;
       ensureDeepSeekV4AssistantReasoningContent(payload, {
         shouldBackfillAssistantMessage: params.shouldBackfillAssistantReasoningContent,
       });


### PR DESCRIPTION
Related to #97196.

## What Problem This Solves

OpenRouter-routed DeepSeek V4 requests fail with HTTP 400 because the
chat-completions builder emits `reasoning: { effort }` (OpenRouter format)
and the shared DeepSeek V4 wrapper also emits `reasoning_effort` (native
format). DeepSeek rejects requests containing both field shapes.

## Why This Change Was Made

The `createDeepSeekV4OpenAICompatibleThinkingWrapper` disabled-thinking
branch already performs the same cleanup (deletes `payload.reasoning` at
L489-490), so this is a symmetry fix: the enabled branch now clears the
stale envelope just like the disabled branch already does.

We avoid a broader gate change because:

- The OpenRouter plugin path (`extensions/openrouter/stream.ts`) calls this
  wrapper directly with its own gate (`shouldPatchDeepSeekV4OpenRouterPayload`),
  bypassing `extra-params.ts`'s `deepSeekV4NativeThinkingAllowedByCompat`.
- A gate-only fix in `extra-params.ts` would not cover the OpenRouter plugin
  path, which is the primary route for this bug.
- The wrapper is the shared code path for *all* callers (OpenRouter plugin,
  DeepSeek plugin, Xiaomi plugin, OpenCode-Go, extra-params fallback), so a
  payload-level cleanup here covers every entry point.

## Root Cause

Two code paths use different sources of truth for the thinking format
decision:

1. **Chat-completions builder** (`openai-transport-stream.ts:4321`): reads
   `getCompat(model)` which merges user config over auto-detected defaults.
   Auto-detection (`openai-completions-compat.ts:122`) sets
   `thinkingFormat: "openrouter"` for `provider === "openrouter"`, so it
   emits `params.reasoning = { effort }`.

2. **DeepSeek V4 wrapper gate** (`extra-params.ts:960`):
   `deepSeekV4NativeThinkingAllowedByCompat` reads `model.compat.thinkingFormat`
   (user-config only, **not** the merged compat). For OpenRouter-routed
   models the user config has no `thinkingFormat`, returning `undefined`
   → `true` → wrapper fires and emits `reasoning_effort`.

Both fields → HTTP 400. Confidence: **clear**.

Introduced by `1ee2733b2f` (Vincent Koc, 2026-06-17) — provider stream SDK
seam refactor; adjacent fix `ec1bc41cf2` (tenequm) addressed generic
OpenRouter `reasoning_effort` conflict but not the DeepSeek V4 wrapper
interaction.

## User Impact

OpenRouter-routed DeepSeek V4 Flash/Pro models receive HTTP 400 on every
request with thinking enabled. Config workaround: pin
`compat.thinkingFormat = "openrouter"`.

## Evidence

**Behavior addressed**: Dual `reasoning.effort` / `reasoning_effort` in
OpenRouter DeepSeek V4 requests causes HTTP 400.

**Real environment tested**: Linux, Node 22.11, branch
`fix/deepseek-openrouter-reasoning-97196`, base commit `68ead4dd80`.

**Integration proof — real OpenRouter plugin + DeepSeek V4 wrapper chain**:

The proof test registers the real OpenRouter provider plugin, runs the full
`wrapStreamFn` composition (OpenRouter generic hook → DeepSeek V4 wrapper
→ our fix), and captures the final outgoing payload via `onPayload`.

| Input payload (simulating chat-completions builder) | thinkingLevel | Final payload keys | reasoning | reasoning_effort | Result |
|---|---|---|---|---|---|
| `{ reasoning: { effort: "xhigh" }, messages: [...] }` | `"xhigh"` | `["messages", "thinking", "reasoning_effort"]` | ❌ deleted | ✅ `"xhigh"` | No conflict |
| `{ reasoning: { effort: "none" }, messages: [] }` | `"off"` | `["messages", "thinking"]` | ❌ deleted | ❌ deleted | Clean disabled |

```console
$ npx vitest run extensions/openrouter/payload-proof.test.ts --reporter=verbose
stdout | produces exactly one reasoning-effort representation after wrapper chain
=== Proof: payload keys after OpenRouter DeepSeek V4 wrapper chain ===
Keys: ["messages","thinking","reasoning_effort"]
Has reasoning (OpenRouter nested format): false
Has reasoning_effort (DeepSeek native format): true
Has thinking: true
Full payload: {
  "messages": [{"role": "user", "content": "hello"}],
  "thinking": {"type": "enabled"},
  "reasoning_effort": "xhigh"
}
✅ VERDICT: Only one reasoning-effort representation → no HTTP 400 conflict

stdout | disabled thinking also cleans up duplicate fields (regression check)
=== Disabled thinking: payload keys ===
Keys: ["messages","thinking"]
 ✓ produces exactly one reasoning-effort representation after wrapper chain
 ✓ disabled thinking also cleans up duplicate fields (regression check)
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**Unit test evidence**:

```console
$ npx vitest run src/plugin-sdk/provider-stream-shared.test.ts --run
 Test Files  1 passed (1)
      Tests  63 passed (63)
```

```console
$ npx vitest run extensions/openrouter/index.test.ts --run
 Test Files  1 passed (1)
      Tests  42 passed (42)
```

**Observed result after fix**: The OpenRouter DeepSeek V4 wrapper chain
produces exactly one reasoning-effort representation (`reasoning_effort`
in the native DeepSeek format). The stale `reasoning` envelope placed by
the chat-completions builder is deleted before the request leaves OpenClaw.

**What was not tested**: End-to-end HTTP round-trip through the OpenRouter
API (requires external API key). The integration test exercises the exact
production code path and captures the final outgoing payload object.

## Regression Test Plan

```console
$ node scripts/run-vitest.mjs src/plugin-sdk/provider-stream-shared.test.ts
# 63 passed — includes 2 new regression tests for the fix

$ pnpm exec oxfmt --check --threads=1 src/plugin-sdk/provider-stream-shared.ts src/plugin-sdk/provider-stream-shared.test.ts
# All matched files use the correct format.
```

## Changes

- `src/plugin-sdk/provider-stream-shared.ts`: +5 — add `delete payload.reasoning` in the enabled-thinking branch (symmetry with existing disabled branch cleanup)
- `src/plugin-sdk/provider-stream-shared.test.ts`: +39 — two new regression tests covering payloads with and without pre-existing `reasoning`
