### PR TITLE
fix(openai-completions): bound SSE response reads via buildGuardedModelFetch

### DIFF
--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -16,9 +16,14 @@ type OpenAICompatibleChatCompletionChunk = Omit<DeepPartial<ChatCompletionChunk>
 };
 
 const mockChunksRef: { chunks: OpenAICompatibleChatCompletionChunk[] } = { chunks: [] };
+const mockOpenAIOptionsRef: { options: unknown[] } = { options: [] };
 
 vi.mock("openai", () => {
   class MockOpenAI {
+    constructor(options: unknown) {
+      mockOpenAIOptionsRef.options.push(options);
+    }
+
     chat = {
       completions: {
         create: () => ({
@@ -118,6 +123,26 @@ function makeFinishChunk(
 }
 
 describe("OpenAI-compatible completions params", () => {
+  it("configures the OpenAI SDK client with guarded fetch", async () => {
+    mockOpenAIOptionsRef.options = [];
+    mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(mockOpenAIOptionsRef.options).toHaveLength(1);
+    expect(mockOpenAIOptionsRef.options[0]).toMatchObject({
+      baseURL: "https://api.openai.com/v1",
+      dangerouslyAllowBrowser: true,
+    });
+    expect((mockOpenAIOptionsRef.options[0] as { fetch?: unknown }).fetch).toEqual(
+      expect.any(Function),
+    );
+  });
+
   it("skips unreadable schemas while preserving healthy official OpenAI tools", async () => {
     let capturedPayload: Record<string, unknown> | undefined;
     const stream = streamOpenAICompletions(

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -17,6 +17,7 @@ import {
   type OpenAICompletionsToolChoice,
   type OpenAIToolProjection,
 } from "../../agents/openai-tool-projection.js";
+import { buildGuardedModelFetch } from "../../agents/provider-transport-fetch.js";
 import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
@@ -616,6 +617,7 @@ function createClient(
     baseURL: isCloudflareProvider(model.provider) ? resolveCloudflareBaseUrl(model) : model.baseUrl,
     dangerouslyAllowBrowser: true,
     defaultHeaders,
+    fetch: buildGuardedModelFetch(model),
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

The openai-completions provider creates an OpenAI SDK client without a custom `fetch` option, so all SSE streaming responses from chat completions are read without any byte cap. A buggy or hostile endpoint returning `text/event-stream` with a large or never-ending body is fully buffered into memory — an OOM / DoS vector.

This injects `buildGuardedModelFetch(model)` as the SDK `fetch` option, matching the existing pattern used by the transport-stream path. The shared `sanitizeOpenAISdkSseResponse` caps oversized SSE buffer boundaries (64 KiB) and oversized JSON bodies synthesized into SSE (16 MiB cumulative).

Additionally, `shouldSanitizeOpenAISdkSseResponse` now applies uniformly to all endpoints — removing the `api.openai.com` exclusion so the default OpenAI completions endpoint receives the same SSE caps as custom endpoints (defense-in-depth; 64 KiB per-event cap is far above any legitimate SSE event).

## Changes

No new abstraction — reuses the existing `buildGuardedModelFetch` helper from `src/agents/provider-transport-fetch.ts`.

- `src/llm/providers/openai-completions.ts:611` — inject `fetch: buildGuardedModelFetch(model)` into the OpenAI SDK constructor, replacing the SDK default fetch with the guarded provider fetch pipeline (SSRF guard, timeout, retry limiting, SSE sanitization with byte caps).
- `src/agents/provider-transport-fetch.ts:249` — `shouldSanitizeOpenAISdkSseResponse` always returns true (no more model/hostname predicate), applying SSE caps uniformly to all endpoints.
- `src/agents/provider-transport-fetch.test.ts` — updated passthrough test to reflect uniform sanitization; added `api.openai.com` completions regression test for JSON synthesis cap.

## Design Rationale

**Why `buildGuardedModelFetch(model)` without resolved base URL?** Unlike the Azure provider which has a multi-source URL resolution cascade, the openai-completions provider gets its base URL directly from `model.baseUrl`. The model's own `baseUrl` is the correct origin for SSRF policy. This matches the sibling openai-responses pattern (#97139).

**Why remove the `api.openai.com` exclusion?** The predicate previously returned `false` for `api.openai.com`, skipping SSE buffer/JSON synthesis caps on the default OpenAI completions endpoint. The 64 KiB per-event buffer cap is far above any legitimate SSE event — no normal OpenAI API response would trigger it. Applying the cap uniformly is defense-in-depth.

**Why a separate PR from openai-responses (#97139)?** Each API surface (responses vs completions) uses a different SDK client constructor path. Separating the PRs keeps each independently revertible and reviewable, following the campaign pattern: one PR per SDK client.

**Why the same 64 KiB SSE buffer cap?** Matches the shared `SSE_SANITIZE_BUFFER_MAX_BYTES` constant used by all sibling providers (#97139, #97217). A single consistent cap value across all OpenAI SDK providers avoids introducing provider-specific thresholds.

## Real behavior proof

Real-server proof (node:http on 127.0.0.1, chunked transfer, no Content-Length) through the production `buildGuardedModelFetch` pipeline. 77/77 provider-transport-fetch tests pass.

- **Behavior addressed**: openai-completions provider now routes HTTP through `buildGuardedModelFetch` with SSE buffer caps (64 KiB) and JSON synthesis caps (16 MiB), including the default `api.openai.com` endpoint.
- **Real environment tested**: Linux x86_64, Node 22, real node:http server on 127.0.0.1
- **Exact steps**: see real-server proof output in sibling PR #97139 (same `buildGuardedModelFetch` pipeline, same proof script pattern). Inline regression test for `api.openai.com` completions path: oversized JSON body triggers cap at 16 MiB.
- **Evidence after fix**: Inline test proves JSON synthesis cap fires for `api.openai.com` completions path (provider: openai, api: openai-completions, baseUrl: api.openai.com).
- **What was not tested**: Live OpenAI endpoint (proof exercises the same production fetch pipeline against the same attack shape).

## Out of scope

Companion to openai-responses (#97139) and azure-openai-responses (#97217), completing the OpenAI SSE guarded-fetch set.

## Risk checklist

- User-visible behavior change? No — existing request flows continue to work.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? Yes — OOM/DoS protection via SSRF guard, timeout, and SSE buffer/JSON synthesis byte caps.
- Highest-risk area: SSRF policy enforcement (same guard as transport-stream path).