### PR TITLE
fix(media): restore readable path for inbound binary documents

### DIFF
--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -48,6 +48,57 @@ describe("buildInboundMediaNote", () => {
     );
   });
 
+  it("renders inbound BINARY documents as a readable absolute path, not an opaque URI", () => {
+    // Regression: binary documents (application/pdf aside) have no inliner and
+    // no claim-check tool, so the opaque media://inbound/<id> URI left
+    // shell-capable agents unable to open the file. The guarded absolute path
+    // (proven inside the inbound dir) must be prompt-visible. Restores prior
+    // behavior where agents could open inbound PDFs/zips directly.
+    const inboundPath = path.join(getMediaDir(), "inbound", "report---abc123.zip");
+    const note = buildInboundMediaNote({
+      MediaPath: inboundPath,
+      MediaType: "application/zip",
+      MediaUrl: inboundPath,
+    });
+    expect(note).toBe(`[media attached: ${inboundPath} (application/zip)]`);
+    // The agent-visible reference is a real, readable path - not the opaque URI.
+    expect(note).not.toContain("media://inbound/");
+    expect(note).toContain(inboundPath);
+  });
+
+  it("renders inbound octet-stream documents as a readable absolute path", () => {
+    const inboundPath = path.join(getMediaDir(), "inbound", "blob---def456.bin");
+    const note = buildInboundMediaNote({
+      MediaPath: inboundPath,
+      MediaType: "application/octet-stream",
+      MediaUrl: inboundPath,
+    });
+    expect(note).toBe(`[media attached: ${inboundPath} (application/octet-stream)]`);
+    expect(note).not.toContain("media://inbound/");
+  });
+
+  it("keeps the stable URI for inbound PDFs (handled by the dedicated PDF claim-check tool)", () => {
+    // PDFs resolve media://inbound/<id> via the PDF tool, so the URI form is
+    // still correct and the host path stays hidden.
+    const inboundPath = path.join(getMediaDir(), "inbound", "doc---abc123.pdf");
+    const note = buildInboundMediaNote({
+      MediaPath: inboundPath,
+      MediaType: "application/pdf",
+      MediaUrl: inboundPath,
+    });
+    expect(note).toBe("[media attached: media://inbound/doc---abc123.pdf (application/pdf)]");
+  });
+
+  it("keeps the stable URI for inbound images (native injection + workspace-only safety)", () => {
+    const inboundPath = path.join(getMediaDir(), "inbound", "photo---abc123.png");
+    const note = buildInboundMediaNote({
+      MediaPath: inboundPath,
+      MediaType: "image/png",
+      MediaUrl: inboundPath,
+    });
+    expect(note).toBe("[media attached: media://inbound/photo---abc123.png (image/png)]");
+  });
+
   it("formats multiple MediaPaths as numbered media notes (collapses duplicate URLs, #47587)", () => {
     const note = buildInboundMediaNote({
       MediaPaths: ["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"],

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -89,6 +89,37 @@ describe("buildInboundMediaNote", () => {
     expect(note).toBe("[media attached: media://inbound/doc---abc123.pdf (application/pdf)]");
   });
 
+  it("keeps the stable URI for text-like inbound documents (generic media:// resolver decodes them)", () => {
+    for (const mediaType of [
+      "text/plain",
+      "text/csv",
+      "application/json",
+      "application/ld+json",
+      "application/xml",
+    ]) {
+      const inboundPath = path.join(getMediaDir(), "inbound", "doc---abc123.txt");
+      const note = buildInboundMediaNote({
+        MediaPath: inboundPath,
+        MediaType: mediaType,
+        MediaUrl: inboundPath,
+      });
+      expect(note).toBe(`[media attached: media://inbound/doc---abc123.txt (${mediaType})]`);
+      expect(note).not.toContain(inboundPath);
+    }
+  });
+
+  it("renders office documents (xlsx) as a readable absolute path (no binary-aware consumer)", () => {
+    const inboundPath = path.join(getMediaDir(), "inbound", "workbook---abc123.xlsx");
+    const mediaType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    const note = buildInboundMediaNote({
+      MediaPath: inboundPath,
+      MediaType: mediaType,
+      MediaUrl: inboundPath,
+    });
+    expect(note).toBe(`[media attached: ${inboundPath} (${mediaType})]`);
+    expect(note).not.toContain("media://inbound/");
+  });
+
   it("keeps the stable URI for inbound images (native injection + workspace-only safety)", () => {
     const inboundPath = path.join(getMediaDir(), "inbound", "photo---abc123.png");
     const note = buildInboundMediaNote({

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -36,13 +36,15 @@ function inboundTypeHasManagedConsumer(type: string | undefined): boolean {
  * `media://inbound/<basename>` URI so prompts do not leak host-specific temp
  * paths and the downstream claim-check resolvers keep working.
  *
- * Binary documents with no inliner and no claim-check tool (PDF aside) -- e.g.
- * application/zip, application/octet-stream, arbitrary file types -- previously
- * received only the opaque `media://inbound/<id>` URI plus a bare
- * `<media:document>` placeholder, with no readable path. A shell-capable agent
- * could not open the file. Restoring prior behavior, those types render the
- * guarded absolute path (already proven to live inside the inbound dir) so the
- * agent can read the file directly. See issue: inbound documents unreadable.
+ * Binary documents (application/pdf aside) have no binary-aware inliner or tool
+ * consumer -- e.g. application/zip, application/octet-stream, arbitrary file
+ * types. The generic `media://` resolver decodes bytes as text/image, so it
+ * cannot make these usable. They previously received only the opaque
+ * `media://inbound/<id>` URI plus a bare `<media:document>` placeholder, leaving
+ * a shell-capable agent unable to pass the file to OS tools. Restoring prior
+ * behavior, those types render the guarded absolute path (already proven to live
+ * inside the inbound dir) so the agent can read the file directly. Restores
+ * direct access for zips and other non-PDF documents.
  */
 function normalizeManagedInboundMediaRef(value: string, type?: string): string {
   if (!path.isAbsolute(value)) {
@@ -61,8 +63,8 @@ function normalizeManagedInboundMediaRef(value: string, type?: string): string {
   ) {
     return value;
   }
-  // Binary documents have no inliner/claim-check consumer: hand the agent the
-  // real, readable absolute path (guarded to be inside the inbound dir above).
+  // Binary documents have no binary-aware inliner/tool consumer: hand the agent
+  // the real, readable absolute path (guarded to be inside the inbound dir above).
   if (!inboundTypeHasManagedConsumer(type)) {
     return candidate;
   }

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -8,7 +8,43 @@ function stripDarwinPrivatePrefix(value: string): string {
   return value.startsWith("/private/var/") ? value.slice("/private".length) : value;
 }
 
-function normalizeManagedInboundMediaRef(value: string): string {
+/**
+ * MIME types (or prefixes) whose inbound attachments the runtime either inlines
+ * (image -> vision, audio -> transcript) or resolves through a dedicated
+ * claim-check tool that understands `media://inbound/<id>` (e.g. the PDF tool,
+ * native image injection). For these, the stable `media://inbound/` URI is the
+ * correct prompt-visible reference and the raw host path is intentionally hidden.
+ */
+function inboundTypeHasManagedConsumer(type: string | undefined): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(type);
+  if (!normalized) {
+    // Unknown type: fall back to the safe legacy URI form rather than leaking a path.
+    return true;
+  }
+  return (
+    normalized.startsWith("image/") ||
+    normalized.startsWith("audio/") ||
+    normalized.startsWith("video/") ||
+    normalized === "application/pdf"
+  );
+}
+
+/**
+ * Resolves an inbound attachment reference for prompt rendering.
+ *
+ * Inlined / tool-backed media (image, audio, video, PDF) keeps the stable
+ * `media://inbound/<basename>` URI so prompts do not leak host-specific temp
+ * paths and the downstream claim-check resolvers keep working.
+ *
+ * Binary documents with no inliner and no claim-check tool (PDF aside) -- e.g.
+ * application/zip, application/octet-stream, arbitrary file types -- previously
+ * received only the opaque `media://inbound/<id>` URI plus a bare
+ * `<media:document>` placeholder, with no readable path. A shell-capable agent
+ * could not open the file. Restoring prior behavior, those types render the
+ * guarded absolute path (already proven to live inside the inbound dir) so the
+ * agent can read the file directly. See issue: inbound documents unreadable.
+ */
+function normalizeManagedInboundMediaRef(value: string, type?: string): string {
   if (!path.isAbsolute(value)) {
     return value;
   }
@@ -16,7 +52,8 @@ function normalizeManagedInboundMediaRef(value: string): string {
   const candidate = stripDarwinPrivatePrefix(path.resolve(value));
   const inboundDir = path.join(mediaDir, "inbound");
   const relativeToInbound = path.relative(inboundDir, candidate);
-  // Managed inbound media gets a stable URI so prompts do not leak host-specific temp paths.
+  // Only managed inbound media (path resolves inside the inbound dir) is eligible
+  // for rewriting; anything else is returned untouched.
   if (
     !relativeToInbound ||
     relativeToInbound.startsWith("..") ||
@@ -24,15 +61,22 @@ function normalizeManagedInboundMediaRef(value: string): string {
   ) {
     return value;
   }
+  // Binary documents have no inliner/claim-check consumer: hand the agent the
+  // real, readable absolute path (guarded to be inside the inbound dir above).
+  if (!inboundTypeHasManagedConsumer(type)) {
+    return candidate;
+  }
+  // Inlined / tool-backed media gets a stable URI so prompts do not leak
+  // host-specific temp paths and claim-check resolvers keep matching.
   return `media://inbound/${path.basename(candidate)}`;
 }
 
-function sanitizeInlineMediaNoteValue(value: string | undefined): string {
+function sanitizeInlineMediaNoteValue(value: string | undefined, type?: string): string {
   const trimmed = value?.trim();
   if (!trimmed) {
     return "";
   }
-  return normalizeManagedInboundMediaRef(trimmed)
+  return normalizeManagedInboundMediaRef(trimmed, type)
     .replace(/[\p{Cc}\]]+/gu, " ")
     .replace(/\s+/g, " ")
     .trim();
@@ -49,10 +93,12 @@ function formatMediaAttachedLine(params: {
     typeof params.index === "number" && typeof params.total === "number"
       ? `[media attached ${params.index}/${params.total}: `
       : "[media attached: ";
-  const pathValue = sanitizeInlineMediaNoteValue(params.path);
+  const pathValue = sanitizeInlineMediaNoteValue(params.path, params.type);
   const typeRaw = sanitizeInlineMediaNoteValue(params.type);
   const typePart = typeRaw ? ` (${typeRaw})` : "";
-  const urlRaw = sanitizeInlineMediaNoteValue(params.url);
+  // Normalize the URL with the same type so a mirrored inbound path (Telegram
+  // album media) still collapses against the rendered path form (#47587).
+  const urlRaw = sanitizeInlineMediaNoteValue(params.url, params.type);
   // When the channel mirrors the local path into MediaUrl (Telegram album
   // media is the canonical case), rendering ` | ${url}` adds no information
   // and clutters the prompt with `path | path` duplication (issue #47587).

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -10,10 +10,11 @@ function stripDarwinPrivatePrefix(value: string): string {
 
 /**
  * MIME types (or prefixes) whose inbound attachments the runtime either inlines
- * (image -> vision, audio -> transcript) or resolves through a dedicated
- * claim-check tool that understands `media://inbound/<id>` (e.g. the PDF tool,
- * native image injection). For these, the stable `media://inbound/` URI is the
- * correct prompt-visible reference and the raw host path is intentionally hidden.
+ * (image -> vision, audio -> transcript) or resolves through a consumer that
+ * understands `media://inbound/<id>` — a dedicated claim-check tool (PDF tool,
+ * native image injection) or the generic media resolver, which decodes
+ * text-like payloads as text. For these, the stable `media://inbound/` URI is
+ * the correct prompt-visible reference and the raw host path stays hidden.
  */
 function inboundTypeHasManagedConsumer(type: string | undefined): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(type);
@@ -25,7 +26,15 @@ function inboundTypeHasManagedConsumer(type: string | undefined): boolean {
     normalized.startsWith("image/") ||
     normalized.startsWith("audio/") ||
     normalized.startsWith("video/") ||
-    normalized === "application/pdf"
+    normalized === "application/pdf" ||
+    // Text-like documents decode fine through the generic media:// resolver,
+    // so they keep the URI form; only binary types with no binary-aware
+    // consumer (zip, octet-stream, office docs, ...) fall through to a path.
+    normalized.startsWith("text/") ||
+    normalized === "application/json" ||
+    normalized === "application/xml" ||
+    normalized.endsWith("+json") ||
+    normalized.endsWith("+xml")
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Inbound chat attachments are downloaded into the managed media store and then
referenced in the agent prompt. For **binary documents with no binary-aware
inliner or tool consumer** — `application/zip`, `application/octet-stream`,
arbitrary file types — the renderer emits only an opaque `media://inbound/<id>`
URI plus a bare `<media:document>` placeholder.

A shell-capable agent then has no way to open the file: there is no readable
filesystem path in the prompt, and the generic `media://` resolver decodes bytes
as text/image, so it cannot make a zip (or other arbitrary binary) usable. The
agent is left guessing at paths or asking the user where the file is.

(Images, audio, video and PDFs are unaffected — they have inliners / a dedicated
tool that resolves the `media://` URI.)

## Root Cause

`normalizeManagedInboundMediaRef` rewrote **every** managed inbound path to a
`media://inbound/<basename>` URI, regardless of whether any consumer could
resolve that type back to a file.

## Fix

Make the rewrite MIME-type aware via `inboundTypeHasManagedConsumer(type)`:

- `image/*`, `audio/*`, `video/*`, `application/pdf` → keep the
  `media://inbound/<id>` URI (host paths stay hidden; their resolvers keep
  working).
- Binary documents with no resolver → return the **guarded absolute path**
  (already proven to live inside the inbound dir) so the agent can read the file
  directly.
- Unknown / empty type → URI (safe fallback).

The in-dir path guard is preserved, and the sibling id-based helper is untouched.

## Evidence

- **Regression tests added** in `src/auto-reply/media-note.test.ts`: zip and
  `application/octet-stream` assert a readable absolute path (and explicitly
  `not.toContain("media://inbound/")`); `application/pdf` and image assert URI
  retention. The full `media-note` suite passes **24/24**, adjacent
  `reply.media-note` + image-detection suites **88/88**.
- **Typecheck/lint:** `tsc --noEmit` reports 0 errors; oxlint clean on the
  touched file.
- **Before/after behavior:** before, an inbound `.zip` rendered in the prompt as
  `[media attached: media://inbound/<id>.zip (application/zip)]` + `<media:document>`
  with no path, and a shell agent could not open it. After, the same attachment
  renders with the guarded absolute path under the inbound media dir, which the
  agent can read directly; image/audio/video/PDF rendering is byte-for-byte
  unchanged (covered by the URI-retention tests).

## Risk / Back-Compat

Image native-injection, workspace-only safety, the PDF tool path, and the
host-path-privacy default are all preserved because those types still render the
URI. Only previously-unopenable binary documents change behavior.

---

### Real behavior proof

This fix has been running as a local dist patch on a private OpenClaw deployment since late June 2026. Below is a redacted trace of a real inbound binary document from July 2026.

**1. Inbound event:**
```text
[timestamp redacted] [chat] Inbound message [redacted-chat] -> [redacted-bot] (application/vnd.openxmlformats-officedocument.spreadsheetml.sheet)
```

**2. Prompt render (`prompt.submitted`):** the attachment renders as a readable absolute path, not the opaque URI:
```text
[media attached: /[absolute-managed-inbound-dir]/[redacted-document].xlsx (application/vnd.openxmlformats-officedocument.spreadsheetml.sheet)]
```

**3. Agent opens and uses the file (`model.completed`, next turn):**
```text
"Read the spreadsheet and summarized workbook-only values [domain-specific values redacted]."
```

The summarized values existed only inside the spreadsheet. Pre-patch, the same attachment class rendered only `media://inbound/<id>` plus a `<media:document>` placeholder, which a shell-capable agent cannot open. After the patch, binary documents with no binary-aware managed consumer render as guarded absolute paths; image/audio/video/PDF/text-like rendering remains URI-based and is covered by tests.

Redactions: chat IDs, topic IDs, bot name, operator identifiers, local path components, filename, attachment ID, and domain-specific workbook values. A further redacted trace can be shared privately with maintainers if needed.

### Scope narrowing (addresses the P1)

`inboundTypeHasManagedConsumer` now also treats `text/*`, `application/json`, `application/xml`, and `+json`/`+xml` structured-syntax suffixes as managed — the generic `media://` resolver decodes those as text, so they keep the stable URI. The absolute-path fallback is now scoped to genuinely binary documents. Unknown/missing MIME still defaults to the URI form (no path leak). Tests cover both sides of the gate.
