### PR TITLE
docs: fix path to Developer Mode Discord setup guide

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -78,7 +78,7 @@ You will need to create a new application with a bot, add the bot to your server
   <Step title="Enable Developer Mode and collect your IDs">
     Back in the Discord app, you need to enable Developer Mode so you can copy internal IDs.
 
-    1. Click **User Settings** (gear icon next to your avatar) → **Advanced** → toggle on **Developer Mode**
+    1. Click **User Settings** (gear icon next to your avatar) → Scroll down to **Developer** in the side bar → toggle on **Developer Mode**
     2. Right-click your **server icon** in the sidebar → **Copy Server ID**
     3. Right-click your **own avatar** → **Copy User ID**
 


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

## What Problem This Solves

Fixes an issue where users following the Discord setup guide cannot find the Developer Mode toggle because the docs reference a non-existent "Advanced" menu that no longer exists in Discord's UI.

Users spend time searching for "Advanced" in User Settings when the correct section is now called "Developer" at the bottom of the sidebar.

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

The Discord documentation is updated to reflect the current UI structure. Changed "User Settings → Advanced" to "User Settings → scroll to Developer in sidebar" so new users can immediately find the Developer Mode toggle without confusion.

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact


New users setting up Discord integration will now find the Developer Mode toggle immediately instead of searching for 5+ minutes. No functional changes to the application itself.

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

**Before (incorrect path in docs):**
"Click User Settings (gear icon next to your avatar) → Advanced → toggle on Developer Mode"

**After (correct path):**
"Click User Settings (gear icon next to your avatar) → scroll to Developer in sidebar → toggle on Developer Mode"


**Screenshot of actual Discord UI showing correct path:**
<img width="825" height="350" alt="image" src="https://github.com/user-attachments/assets/64b000a8-3611-4b1f-87ee-e72f62772844" />

The screenshot shows Developer Mode is under the "Developer" section at the bottom of the User Settings sidebar, not under "Advanced".

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

**Notes:**
- This is a docs-only change
- No tests required as no code was modified
- This is my first PR—feedback welcome!
