### PR TITLE
[codex] fix pending final delivery recovery

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -972,6 +972,54 @@ describe("main-session-restart-recovery", () => {
     );
   });
 
+  it("directly delivers terminal sessions with a pending final delivery payload", async () => {
+    const sessionsDir = await makeSessionsDir("mexico-city-trip");
+    const pendingPayload = "Done, logged.";
+    await writeStore(sessionsDir, {
+      "agent:mexico-city-trip:whatsapp:group:120363408042254152@g.us": {
+        sessionId: "terminal-session",
+        updatedAt: Date.now() - 10_000,
+        status: "done",
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: pendingPayload,
+        pendingFinalDeliveryContext: {
+          channel: "whatsapp",
+          to: "120363408042254152@g.us",
+          accountId: "default",
+        },
+        pendingFinalDeliveryCreatedAt: 123_456,
+      },
+    });
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledOnce();
+    expect(vi.mocked(callGateway).mock.calls[0]?.[0]).toMatchObject({
+      method: "message.action",
+      params: {
+        channel: "whatsapp",
+        action: "send",
+        sessionKey: "agent:mexico-city-trip:whatsapp:group:120363408042254152@g.us",
+        sessionId: "terminal-session",
+        idempotencyKey: "main-session-pending-final:terminal-session:123456",
+        accountId: "default",
+        params: {
+          to: "120363408042254152@g.us",
+          message: pendingPayload,
+          bestEffort: true,
+        },
+      },
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    const entry = store["agent:mexico-city-trip:whatsapp:group:120363408042254152@g.us"];
+    expect(entry?.status).toBe("done");
+    expect(entry?.pendingFinalDelivery).toBeUndefined();
+    expect(entry?.pendingFinalDeliveryText).toBeUndefined();
+    expect(entry?.pendingFinalDeliveryContext).toBeUndefined();
+  });
+
   it("sanitizes durable pending final delivery payloads before resume prompts", async () => {
     const sessionsDir = await makeSessionsDir();
     const pendingPayload = [

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -646,6 +646,141 @@ async function resumeMainSession(params: {
   }
 }
 
+async function updatePendingFinalDeliveryAfterDirectAttempt(params: {
+  delivered: boolean;
+  error?: string;
+  pendingText: string;
+  storePath: string;
+  sessionKey: string;
+}): Promise<void> {
+  await applyRestartRecoveryLifecycle({
+    storePath: params.storePath,
+    update: (entries) => {
+      const current = entries.find((entry) => entry.sessionKey === params.sessionKey);
+      const entry = current?.entry;
+      if (!entry) {
+        return { result: undefined };
+      }
+      const currentPendingText =
+        typeof entry.pendingFinalDeliveryText === "string"
+          ? sanitizePendingFinalDeliveryText(entry.pendingFinalDeliveryText)
+          : "";
+      if (currentPendingText !== params.pendingText) {
+        return { result: undefined };
+      }
+
+      const now = Date.now();
+      if (params.delivered) {
+        entry.pendingFinalDelivery = undefined;
+        entry.pendingFinalDeliveryText = undefined;
+        entry.pendingFinalDeliveryCreatedAt = undefined;
+        entry.pendingFinalDeliveryLastAttemptAt = undefined;
+        entry.pendingFinalDeliveryAttemptCount = undefined;
+        entry.pendingFinalDeliveryLastError = undefined;
+        entry.pendingFinalDeliveryContext = undefined;
+        entry.pendingFinalDeliveryIntentId = undefined;
+      } else {
+        entry.pendingFinalDeliveryLastAttemptAt = now;
+        entry.pendingFinalDeliveryAttemptCount = (entry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
+        entry.pendingFinalDeliveryLastError = params.error ?? "delivery failed";
+        entry.pendingFinalDeliveryText = params.pendingText;
+      }
+      entry.updatedAt = now;
+      return {
+        result: undefined,
+        replacements: [{ sessionKey: params.sessionKey, entry }],
+      };
+    },
+  });
+}
+
+async function deliverTerminalPendingFinalDelivery(params: {
+  cfg?: OpenClawConfig;
+  entry: SessionEntry;
+  storePath: string;
+  sessionKey: string;
+}): Promise<boolean> {
+  const pendingText =
+    typeof params.entry.pendingFinalDeliveryText === "string"
+      ? sanitizePendingFinalDeliveryText(params.entry.pendingFinalDeliveryText)
+      : "";
+  if (!pendingText) {
+    await updatePendingFinalDeliveryAfterDirectAttempt({
+      delivered: true,
+      pendingText,
+      storePath: params.storePath,
+      sessionKey: params.sessionKey,
+    });
+    return true;
+  }
+
+  const deliveryContext = resolveRestartRecoveryDeliveryContext({
+    cfg: params.cfg,
+    entry: params.entry,
+    includeSessionDeliveryFallback: true,
+    sessionKey: params.sessionKey,
+  });
+  if (!deliveryContext) {
+    await updatePendingFinalDeliveryAfterDirectAttempt({
+      delivered: false,
+      error: "missing delivery context",
+      pendingText,
+      storePath: params.storePath,
+      sessionKey: params.sessionKey,
+    });
+    return false;
+  }
+
+  const messageParams: Record<string, unknown> = {
+    to: deliveryContext.to,
+    message: pendingText,
+    bestEffort: true,
+  };
+  if (deliveryContext.threadId != null) {
+    messageParams.threadId = deliveryContext.threadId;
+  }
+  const actionParams: Record<string, unknown> = {
+    channel: deliveryContext.channel,
+    action: "send",
+    sessionKey: params.sessionKey,
+    sessionId: params.entry.sessionId,
+    idempotencyKey: `main-session-pending-final:${params.entry.sessionId}:${
+      params.entry.pendingFinalDeliveryCreatedAt ?? "unknown"
+    }`,
+    params: messageParams,
+  };
+  const accountId = normalizeOptionalString(deliveryContext.accountId);
+  if (accountId) {
+    actionParams.accountId = accountId;
+  }
+
+  try {
+    await callGateway({
+      method: "message.action",
+      params: actionParams,
+      timeoutMs: 10_000,
+    });
+    await updatePendingFinalDeliveryAfterDirectAttempt({
+      delivered: true,
+      pendingText,
+      storePath: params.storePath,
+      sessionKey: params.sessionKey,
+    });
+    log.info(`delivered terminal pending final reply: ${params.sessionKey}`);
+    return true;
+  } catch (err) {
+    await updatePendingFinalDeliveryAfterDirectAttempt({
+      delivered: false,
+      error: String(err),
+      pendingText,
+      storePath: params.storePath,
+      sessionKey: params.sessionKey,
+    });
+    log.warn(`failed to deliver terminal pending final reply ${params.sessionKey}: ${String(err)}`);
+    return false;
+  }
+}
+
 export async function markRestartAbortedMainSessionsFromLocks(params: {
   sessionsDir: string;
   cleanedLocks: SessionLockInspection[];
@@ -748,7 +883,57 @@ async function recoverStore(params: {
   for (const [sessionKey, entry] of Object.entries(store).toSorted(([a], [b]) =>
     a.localeCompare(b),
   )) {
-    if (!entry || entry.status !== "running" || entry.abortedLastRun !== true) {
+    if (!entry) {
+      continue;
+    }
+    const hasPendingFinalDelivery =
+      entry.pendingFinalDelivery === true && Boolean(entry.pendingFinalDeliveryText);
+    if (hasPendingFinalDelivery && entry.status !== "running") {
+      if (shouldSkipMainRecovery(entry, sessionKey)) {
+        result.skipped++;
+        continue;
+      }
+      if (
+        !isRoutableRecoveryStore({
+          cfg: params.cfg,
+          sessionKey,
+          storePath: params.storePath,
+        })
+      ) {
+        result.skipped++;
+        continue;
+      }
+      if (
+        hasCurrentProcessOwner({
+          activeSessionIds: resolveActiveSessionIds(),
+          activeSessionKeys: resolveActiveSessionKeys(),
+          entry,
+          sessionKey,
+        })
+      ) {
+        result.skipped++;
+        continue;
+      }
+      const resumeDedupeKey = sessionKey;
+      if (params.resumedSessionKeys.has(resumeDedupeKey)) {
+        result.skipped++;
+        continue;
+      }
+      const delivered = await deliverTerminalPendingFinalDelivery({
+        cfg: params.cfg,
+        entry,
+        storePath: params.storePath,
+        sessionKey,
+      });
+      if (delivered) {
+        params.resumedSessionKeys.add(resumeDedupeKey);
+        result.recovered++;
+      } else {
+        result.failed++;
+      }
+      continue;
+    }
+    if (entry.status !== "running" || entry.abortedLastRun !== true) {
       continue;
     }
     if (shouldSkipMainRecovery(entry, sessionKey)) {


### PR DESCRIPTION
## Summary

Fix restart recovery for terminal main sessions that already have a frozen pending final reply. When a session is no longer running but still has pendingFinalDelivery=true, recovery now sends the captured final text directly through message.action send with a stable idempotency key, then clears the pending-final fields on success. Failed attempts retain the pending text and record attempt metadata for retry/debugging.

## Root cause

A channel turn can finish the model run and persist pendingFinalDeliveryText, but fail before final channel delivery clears the pending-final bookkeeping. If the session is already status=done, the existing recovery scan skipped it because it only resumed running sessions marked abortedLastRun=true. That leaves the pending final stranded and can keep later inbound turns from progressing normally.

## Validation

- npm run test -- src/agents/main-session-restart-recovery.test.ts
- npm run test -- src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts