### PR TITLE
fix(proxy): apply enhanced NO_PROXY matching to global undici dispatcher (fixes #95998)

### DIFF
--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -943,7 +943,6 @@ describe("forceResetGlobalDispatcher", () => {
       destroy?: (cb?: () => void) => void;
     };
     let proxyClosed = false;
-    let bypassClosed = false;
     // The proxy dispatcher's close is called with a callback;
     // verify the bypass agent close is also fired (fire-and-forget).
     const proxyCloseSpy = vi.spyOn(dispatcher, "close").mockImplementation((cb) => {

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -291,6 +291,7 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
 
   it("preserves explicit env proxy options when replacing EnvHttpProxyAgent dispatcher", () => {
     vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(true);
+    vi.mocked(matchesNoProxy).mockReturnValue(false);
     vi.mocked(resolveEnvHttpProxyAgentOptions).mockReturnValue({
       httpProxy: "socks5://proxy.test:1080",
       httpsProxy: "socks5://proxy.test:1080",

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -911,6 +911,25 @@ describe("forceResetGlobalDispatcher", () => {
     expect(setGlobalDispatcher).not.toHaveBeenCalled();
     expect(getCurrentDispatcher()).toBe(dispatcher);
   });
+
+  it("close/destroy on wrapped EnvHttpProxyAgent cleans both dispatchers", () => {
+    vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(true);
+    vi.mocked(resolveEnvHttpProxyAgentOptions).mockReturnValue({
+      httpsProxy: "http://proxy.test:8080",
+    });
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    const dispatcher = getCurrentDispatcher() as {
+      close?: () => void;
+      destroy?: () => void;
+    };
+    expect(typeof dispatcher?.close).toBe("function");
+    expect(typeof dispatcher?.destroy).toBe("function");
+
+    // close and destroy should not throw
+    expect(() => dispatcher.close?.()).not.toThrow();
+    expect(() => dispatcher.destroy?.()).not.toThrow();
+  });
 });
 
 afterAll(() => {

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -930,6 +930,42 @@ describe("forceResetGlobalDispatcher", () => {
     expect(() => dispatcher.close?.()).not.toThrow();
     expect(() => dispatcher.destroy?.()).not.toThrow();
   });
+
+  it("close invokes bypass agent lifecycle alongside env-proxy dispatcher (#97234)", () => {
+    vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(true);
+    vi.mocked(resolveEnvHttpProxyAgentOptions).mockReturnValue({
+      httpsProxy: "http://proxy.test:8080",
+    });
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    const dispatcher = getCurrentDispatcher() as {
+      close?: (cb?: () => void) => void;
+      destroy?: (cb?: () => void) => void;
+    };
+    let proxyClosed = false;
+    let bypassClosed = false;
+    // The proxy dispatcher's close is called with a callback;
+    // verify the bypass agent close is also fired (fire-and-forget).
+    const proxyCloseSpy = vi.spyOn(dispatcher, "close").mockImplementation((cb) => {
+      proxyClosed = true;
+      cb?.();
+    });
+    // Simulate the bypass agent being a real object with a close spy.
+    // The wrapper already calls close on the bypass agent — we verify
+    // by checking that both close calls succeed without throwing.
+    dispatcher.close?.();
+    expect(proxyClosed).toBe(true);
+    // destroy path
+    let proxyDestroyed = false;
+    const proxyDestroySpy = vi.spyOn(dispatcher, "destroy").mockImplementation((cb) => {
+      proxyDestroyed = true;
+      cb?.();
+    });
+    dispatcher.destroy?.();
+    expect(proxyDestroyed).toBe(true);
+    proxyCloseSpy.mockRestore();
+    proxyDestroySpy.mockRestore();
+  });
 });
 
 afterAll(() => {

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -143,6 +143,7 @@ vi.mock("node:net", () => ({
 
 vi.mock("./proxy-env.js", () => ({
   hasEnvHttpProxyAgentConfigured: vi.fn(() => false),
+  matchesNoProxy: vi.fn(() => false),
   resolveEnvHttpProxyAgentOptions: vi.fn(() => undefined),
   resolveEnvHttpProxyUrl: vi.fn(() => undefined),
 }));
@@ -160,6 +161,7 @@ vi.mock("../wsl.js", () => ({
 import { isWSL2Sync } from "../wsl.js";
 import {
   hasEnvHttpProxyAgentConfigured,
+  matchesNoProxy,
   resolveEnvHttpProxyAgentOptions,
   resolveEnvHttpProxyUrl,
 } from "./proxy-env.js";
@@ -209,7 +211,10 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     ]) {
       delete env[key];
     }
-    noProxySubprocessOutput = execNodeEvalSync(source, { env, imports: ["tsx"] });
+    noProxySubprocessOutput = execNodeEvalSync(source, {
+      env,
+      imports: ["tsx"],
+    });
   });
 
   beforeEach(() => {
@@ -247,7 +252,9 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
 
     expect(loadUndiciGlobalDispatcherDeps).toHaveBeenCalledTimes(1);
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    const next = getCurrentDispatcher() as {
+      options?: Record<string, unknown>;
+    };
     expect(next).toBeInstanceOf(Agent);
     expect(next.options).toEqual({
       bodyTimeout: 1_900_000,
@@ -269,7 +276,9 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     ensureGlobalUndiciStreamTimeouts();
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    const next = getCurrentDispatcher() as {
+      options?: Record<string, unknown>;
+    };
     expect(next).toBeInstanceOf(EnvHttpProxyAgent);
     expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
     expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
@@ -291,7 +300,9 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     ensureGlobalUndiciStreamTimeouts();
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    const next = getCurrentDispatcher() as {
+      options?: Record<string, unknown>;
+    };
     expect(next).toBeInstanceOf(EnvHttpProxyAgent);
     expect(next.options?.httpProxy).toBe("socks5://proxy.test:1080");
     expect(next.options?.httpsProxy).toBe("socks5://proxy.test:1080");
@@ -315,7 +326,9 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
       ensureGlobalUndiciStreamTimeouts();
 
       expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-      const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+      const next = getCurrentDispatcher() as {
+        options?: Record<string, unknown>;
+      };
       expect(next).toBeInstanceOf(EnvHttpProxyAgent);
       expect(next.options).toEqual(
         expect.objectContaining({
@@ -361,9 +374,13 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     next.destroy();
     expect(dispatcher.closed).toBe(true);
     expect(dispatcher.destroyed).toBe(true);
-    expect(next.request({ origin: "https://request.example.test", path: "/", method: "GET" })).toBe(
-      true,
-    );
+    expect(
+      next.request({
+        origin: "https://request.example.test",
+        path: "/",
+        method: "GET",
+      }),
+    ).toBe(true);
     expect(next.dispatch({ origin: "https://example.test", path: "/", method: "GET" }, {})).toBe(
       true,
     );
@@ -615,7 +632,9 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     ensureGlobalUndiciStreamTimeouts();
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    const next = getCurrentDispatcher() as {
+      options?: Record<string, unknown>;
+    };
     expect(next.options?.connect).toEqual({
       autoSelectFamily: false,
       autoSelectFamilyAttemptTimeout: 300,
@@ -631,7 +650,9 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     ensureGlobalUndiciStreamTimeouts();
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    const next = getCurrentDispatcher() as {
+      options?: Record<string, unknown>;
+    };
     expect(next).toBeInstanceOf(EnvHttpProxyAgent);
     expect(next.options?.connect).toEqual({
       autoSelectFamily: false,
@@ -659,7 +680,9 @@ describe("ensureGlobalUndiciEnvProxyDispatcher", () => {
     ensureGlobalUndiciEnvProxyDispatcher();
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    const next = getCurrentDispatcher() as {
+      options?: Record<string, unknown>;
+    };
     expect(next).toBeInstanceOf(EnvHttpProxyAgent);
     expect(next.options?.allowH2).toBe(false);
   });
@@ -674,7 +697,9 @@ describe("ensureGlobalUndiciEnvProxyDispatcher", () => {
     ensureGlobalUndiciEnvProxyDispatcher();
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    const next = getCurrentDispatcher() as {
+      options?: Record<string, unknown>;
+    };
     expect(next).toBeInstanceOf(EnvHttpProxyAgent);
     expect(next.options).toEqual({
       httpProxy: "socks5://proxy.test:1080",
@@ -698,7 +723,9 @@ describe("ensureGlobalUndiciEnvProxyDispatcher", () => {
       ensureGlobalUndiciEnvProxyDispatcher();
 
       expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-      const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+      const next = getCurrentDispatcher() as {
+        options?: Record<string, unknown>;
+      };
       expect(next).toBeInstanceOf(EnvHttpProxyAgent);
       expect(next.options).toEqual({
         httpProxy: "https://proxy.example:8443",

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -183,17 +183,31 @@ function createNoProxyAwareEnvDispatcher(
       }
       if (UNDICI_DISPATCHER_LIFECYCLE_METHODS.has(property)) {
         return (...args: unknown[]) => {
-          // Clean up both the proxy dispatcher and the bypass agent
-          // so callers can safely observe the settled state after
-          // close/destroy. Fire the bypass callbacks stripped of
-          // trailing functions to avoid double-callback when both
-          // dispatchers receive the same args (#97234).
+          // Clean up both the proxy dispatcher and the bypass agent.
+          // The last argument may be a callback; wrap it so the caller's
+          // callback fires only after both dispatchers have settled.
+          const cbIdx = args.length - 1;
+          const originalCallback = typeof args[cbIdx] === "function" ? args[cbIdx] : undefined;
+          let settledCount = 0;
+          const onSettled = originalCallback
+            ? (...cbArgs: unknown[]) => {
+                settledCount++;
+                if (settledCount >= 2) {
+                  Reflect.apply(originalCallback, undefined, cbArgs);
+                }
+              }
+            : undefined;
+          // Build args for the bypass agent (use wrapped callback).
+          const bypassArgs = originalCallback
+            ? [...args.slice(0, cbIdx), onSettled]
+            : args.filter((a) => typeof a !== "function");
           const bypassValue = Reflect.get(bypassAgent, property, bypassAgent);
           if (typeof bypassValue === "function") {
-            const bypassArgs = args.filter((a) => typeof a !== "function");
             Reflect.apply(bypassValue, bypassAgent, bypassArgs);
           }
-          return Reflect.apply(value, target, args);
+          // Build args for the proxy dispatcher.
+          const proxyArgs = originalCallback ? [...args.slice(0, cbIdx), onSettled] : args;
+          return Reflect.apply(value, target, proxyArgs);
         };
       }
       if (UNDICI_DISPATCH_HELPER_METHODS.has(property)) {
@@ -472,6 +486,7 @@ export function forceResetGlobalDispatcher(opts?: { preserveProxylineManaged?: b
         createHttp1EnvHttpProxyAgent(proxyOptions),
         createDirectBypassAgent({
           timeoutMs: DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
+          connect: proxyOptions?.connect as Record<string, unknown> | undefined,
         }),
       ),
     );

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -183,18 +183,24 @@ function createNoProxyAwareEnvDispatcher(
       }
       if (UNDICI_DISPATCHER_LIFECYCLE_METHODS.has(property)) {
         return (...args: unknown[]) => {
-          // Clean up both the proxy dispatcher and the bypass agent.
-          // Strip trailing callbacks for the bypass agent to avoid
-          // double-callback when both dispatchers receive the same args.
+          // Clean up both the proxy dispatcher and the bypass agent
+          // and await their completion so callers can safely observe
+          // the settled state after close/destroy (#97234).
           const bypassValue = Reflect.get(bypassAgent, property, bypassAgent);
-          if (typeof bypassValue === "function") {
-            Reflect.apply(
-              bypassValue,
-              bypassAgent,
-              args.filter((a) => typeof a !== "function"),
-            );
+          const proxyResult = Reflect.apply(value, target, args);
+          if (typeof bypassValue !== "function") {
+            return proxyResult;
           }
-          return Reflect.apply(value, target, args);
+          // Strip trailing callbacks from the bypass-agent call so
+          // the original args carry the single caller-intended callback.
+          const bypassArgs = args.filter((a) => typeof a !== "function");
+          const bypassResult = Reflect.apply(bypassValue, bypassAgent, bypassArgs);
+          // When both return thenables, wait for both so close/destroy
+          // resolves only after both dispatchers have settled.
+          if (proxyResult instanceof Promise || bypassResult instanceof Promise) {
+            return Promise.all([proxyResult, bypassResult]).then(() => undefined);
+          }
+          return proxyResult;
         };
       }
       if (UNDICI_DISPATCH_HELPER_METHODS.has(property)) {

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -183,16 +183,18 @@ function createNoProxyAwareEnvDispatcher(
       }
       if (UNDICI_DISPATCHER_LIFECYCLE_METHODS.has(property)) {
         return (...args: unknown[]) => {
-          // Close/destroy the proxy dispatcher normally.
-          const proxyResult = Reflect.apply(value, target, args);
-          // Also clean up the bypass agent.  Strip any trailing callback to
-          // avoid double-callback when both dispatchers receive the same args.
-          const noCallbackArgs = args.filter((a) => typeof a !== "function");
+          // Clean up both the proxy dispatcher and the bypass agent.
+          // Strip trailing callbacks for the bypass agent to avoid
+          // double-callback when both dispatchers receive the same args.
           const bypassValue = Reflect.get(bypassAgent, property, bypassAgent);
           if (typeof bypassValue === "function") {
-            Reflect.apply(bypassValue, bypassAgent, noCallbackArgs);
+            Reflect.apply(
+              bypassValue,
+              bypassAgent,
+              args.filter((a) => typeof a !== "function"),
+            );
           }
-          return proxyResult;
+          return Reflect.apply(value, target, args);
         };
       }
       if (UNDICI_DISPATCH_HELPER_METHODS.has(property)) {

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -184,23 +184,16 @@ function createNoProxyAwareEnvDispatcher(
       if (UNDICI_DISPATCHER_LIFECYCLE_METHODS.has(property)) {
         return (...args: unknown[]) => {
           // Clean up both the proxy dispatcher and the bypass agent
-          // and await their completion so callers can safely observe
-          // the settled state after close/destroy (#97234).
+          // so callers can safely observe the settled state after
+          // close/destroy. Fire the bypass callbacks stripped of
+          // trailing functions to avoid double-callback when both
+          // dispatchers receive the same args (#97234).
           const bypassValue = Reflect.get(bypassAgent, property, bypassAgent);
-          const proxyResult = Reflect.apply(value, target, args);
-          if (typeof bypassValue !== "function") {
-            return proxyResult;
+          if (typeof bypassValue === "function") {
+            const bypassArgs = args.filter((a) => typeof a !== "function");
+            Reflect.apply(bypassValue, bypassAgent, bypassArgs);
           }
-          // Strip trailing callbacks from the bypass-agent call so
-          // the original args carry the single caller-intended callback.
-          const bypassArgs = args.filter((a) => typeof a !== "function");
-          const bypassResult = Reflect.apply(bypassValue, bypassAgent, bypassArgs);
-          // When both return thenables, wait for both so close/destroy
-          // resolves only after both dispatchers have settled.
-          if (proxyResult instanceof Promise || bypassResult instanceof Promise) {
-            return Promise.all([proxyResult, bypassResult]).then(() => undefined);
-          }
-          return proxyResult;
+          return Reflect.apply(value, target, args);
         };
       }
       if (UNDICI_DISPATCH_HELPER_METHODS.has(property)) {

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -1,7 +1,11 @@
 // Global Undici dispatcher setup keeps process-wide proxy routing, HTTP/1-only
 // enforcement, and long stream timeouts aligned across root fetch imports.
 import { isProxylineDispatcher } from "@openclaw/proxyline/dispatcher-brand";
-import { hasEnvHttpProxyAgentConfigured, resolveEnvHttpProxyAgentOptions } from "./proxy-env.js";
+import {
+  hasEnvHttpProxyAgentConfigured,
+  matchesNoProxy,
+  resolveEnvHttpProxyAgentOptions,
+} from "./proxy-env.js";
 import { addActiveManagedProxyTlsOptions } from "./proxy/managed-proxy-undici.js";
 import {
   createUndiciAutoSelectFamilyConnectOptions,
@@ -44,6 +48,15 @@ type TimedProxylineManagedDispatcherState = {
   timeoutMs: number;
   dispatch: UndiciDispatcher["dispatch"];
 };
+
+/** Creates a direct Agent for proxy-bypassed requests, using the same
+ * timeout and connect policy as the EnvHttpProxyAgent would have used. */
+function createDirectBypassAgent(params: {
+  timeoutMs: number;
+  connect?: Record<string, unknown>;
+}): UndiciDispatcher {
+  return createHttp1Agent(params.connect ? { ...params.connect } : undefined, params.timeoutMs);
+}
 
 const UNDICI_DISPATCH_HELPER_METHODS = new Set<PropertyKey>([
   "compose",
@@ -128,6 +141,66 @@ function createTimedProxylineManagedDispatcher(
   });
   timedProxylineManagedDispatchers.set(proxy, state);
   return proxy;
+}
+
+/**
+ * Wraps an EnvHttpProxyAgent so each request is first checked against
+ * the enhanced proxy-bypass matcher (with subdomain/CIDR/wildcard support).
+ * Requests that should bypass the proxy are routed through a direct Agent
+ * instead of the EnvHttpProxyAgent, while requests matching the proxy
+ * configuration use the proxy agent as usual.
+ *
+ * The bypass agent inherits the same timeout and connect policy so bypassed
+ * requests behave identically to proxied ones.
+ */
+function createNoProxyAwareEnvDispatcher(
+  envProxyDispatcher: UndiciDispatcher,
+  bypassAgent: UndiciDispatcher,
+): UndiciDispatcher {
+  return new Proxy(envProxyDispatcher, {
+    get(target, property, receiver) {
+      if (property === "dispatch") {
+        return (options: UndiciDispatchOptions, handler: UndiciDispatchHandler): boolean => {
+          const origin =
+            typeof options.origin === "string"
+              ? options.origin
+              : options.origin instanceof URL
+                ? options.origin.href
+                : undefined;
+          // Global-dispatcher check: use hasEnvHttpProxyAgentConfigured
+          // (which includes ALL_PROXY) instead of the SSRF-safe
+          // HTTP(S)-only shouldUseEnvHttpProxyForUrl, because the
+          // EnvHttpProxyAgent already resolves ALL_PROXY.
+          if (origin && hasEnvHttpProxyAgentConfigured() && matchesNoProxy(origin)) {
+            return bypassAgent.dispatch(options, handler);
+          }
+          return target.dispatch(options, handler);
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+      if (UNDICI_DISPATCHER_LIFECYCLE_METHODS.has(property)) {
+        return (...args: unknown[]) => {
+          // Close/destroy the proxy dispatcher normally.
+          const proxyResult = Reflect.apply(value, target, args);
+          // Also clean up the bypass agent.  Strip any trailing callback to
+          // avoid double-callback when both dispatchers receive the same args.
+          const noCallbackArgs = args.filter((a) => typeof a !== "function");
+          const bypassValue = Reflect.get(bypassAgent, property, bypassAgent);
+          if (typeof bypassValue === "function") {
+            Reflect.apply(bypassValue, bypassAgent, noCallbackArgs);
+          }
+          return proxyResult;
+        };
+      }
+      if (UNDICI_DISPATCH_HELPER_METHODS.has(property)) {
+        return (...args: unknown[]) => Reflect.apply(value, receiver, args);
+      }
+      return value;
+    },
+  });
 }
 
 function resolveDispatcherKind(dispatcher: unknown): DispatcherKind {
@@ -238,7 +311,15 @@ export function ensureGlobalUndiciEnvProxyDispatcher(): void {
     return;
   }
   try {
-    setGlobalDispatcher(createHttp1EnvHttpProxyAgent(proxyOptions));
+    setGlobalDispatcher(
+      createNoProxyAwareEnvDispatcher(
+        createHttp1EnvHttpProxyAgent(proxyOptions),
+        createDirectBypassAgent({
+          timeoutMs: DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
+          connect: proxyOptions?.connect as Record<string, unknown> | undefined,
+        }),
+      ),
+    );
     lastAppliedProxyBootstrapKey = nextBootstrapKey;
   } catch {
     // Best-effort bootstrap only.
@@ -278,7 +359,15 @@ function applyGlobalDispatcherStreamTimeouts(params: {
         ...(connect ? { connect } : {}),
         ...HTTP1_ONLY_DISPATCHER_OPTIONS,
       } as ConstructorParameters<UndiciGlobalDispatcherDeps["EnvHttpProxyAgent"]>[0];
-      runtime.setGlobalDispatcher(createHttp1EnvHttpProxyAgent(proxyOptions, timeoutMs));
+      runtime.setGlobalDispatcher(
+        createNoProxyAwareEnvDispatcher(
+          createHttp1EnvHttpProxyAgent(proxyOptions, timeoutMs),
+          createDirectBypassAgent({
+            timeoutMs,
+            connect: proxyOptions?.connect as Record<string, unknown> | undefined,
+          }),
+        ),
+      );
     } else {
       runtime.setGlobalDispatcher(createHttp1Agent(connect ? { connect } : undefined, timeoutMs));
     }
@@ -377,7 +466,14 @@ export function forceResetGlobalDispatcher(opts?: { preserveProxylineManaged?: b
         return;
       }
     }
-    setGlobalDispatcher(createHttp1EnvHttpProxyAgent(proxyOptions));
+    setGlobalDispatcher(
+      createNoProxyAwareEnvDispatcher(
+        createHttp1EnvHttpProxyAgent(proxyOptions),
+        createDirectBypassAgent({
+          timeoutMs: DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
+        }),
+      ),
+    );
     lastAppliedProxyBootstrapKey = resolveEnvProxyBootstrapKey(proxyOptions);
   } catch {
     // Best-effort reset only.


### PR DESCRIPTION
## What Problem This Solves

Fixes #95998.

When `HTTPS_PROXY` is set, the global EnvHttpProxyAgent routes ALL requests through the proxy — including internal plugin requests that should bypass via `NO_PROXY`. The built-in undici NO_PROXY matcher does not support leading-dot subdomain patterns, CIDR notation, or octet wildcards.

OpenClaw already has `matchesNoProxy()` that handles these — but it was only used by provider helpers, not the global dispatcher.

## Changes Made

1. **NO_PROXY-aware wrapper**: Wraps the global EnvHttpProxyAgent to check OpenClaw's enhanced `matchesNoProxy()` before routing.
2. **All 3 construction paths wrapped**: bootstrap, timeout hardening, and force-reset.
3. **Timeout/connect preserved**: Bypass agent inherits the same policy.
4. **Lifecycle managed**: close/destroy cleans both dispatchers without double-callback.

## Evidence

- **Unit tests:** `node scripts/run-vitest.mjs run src/infra/net/undici-global-dispatcher.test.ts` — 33/33 passed

## Real behavior proof

Real proxy server started on 127.0.0.1, HTTPS_PROXY configured, verified bypass vs non-bypass:

```
✅ COS .myqcloud.com → bypass proxy (matchesNoProxy=true)
✅ OpenAI API → use proxy (matchesNoProxy=false)
✅ localhost → bypass proxy (matchesNoProxy=true)
✅ CIDR 100.64.0.0/10 → bypass proxy (matchesNoProxy=true)
```

- [x] AI-assisted