### PR TITLE
fix: proxy streams fail fast on oversized or stalled responses

### DIFF
--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -330,7 +330,6 @@ describe("flex cards", () => {
 });
 
 describe("action label/data surrogate-safe truncation", () => {
-  const loneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
   // 19 ASCII chars + 😀 (U+1F600, two UTF-16 code units) = 21 code units; a raw
   // .slice(0, 20) would keep the first 19 chars plus the lone high surrogate.
   const labelWithEmoji = "1234567890123456789😀";

--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -60,35 +60,57 @@ function responseFromReaderText(text: string, releaseLock: () => void): Response
   } as Response;
 }
 
-function streamingProxyErrorResponse(params: { chunkCount: number; chunkSize: number }): {
-  response: Response;
-  getReadCount: () => number;
-} {
-  let reads = 0;
-  const encoder = new TextEncoder();
-  const stream = new ReadableStream<Uint8Array>({
-    pull(controller) {
-      if (reads >= params.chunkCount) {
-        controller.close();
-        return;
+const unresolved = Symbol("unresolved stream result");
+
+function pendingReaderResponse(params: {
+  chunks: Uint8Array[];
+  status?: number;
+  statusText?: string;
+  onCancel?: (reason?: unknown) => void;
+}): Response {
+  const chunks = [...params.chunks];
+  const reader = {
+    read: vi.fn(async () => {
+      const chunk = chunks.shift();
+      if (chunk) {
+        return { done: false, value: chunk };
       }
-      reads += 1;
-      controller.enqueue(encoder.encode("a".repeat(params.chunkSize)));
-    },
-  });
+      return await new Promise<ReadableStreamReadResult<Uint8Array>>(() => {});
+    }),
+    cancel: vi.fn(async (reason?: unknown) => {
+      params.onCancel?.(reason);
+    }),
+    releaseLock: vi.fn(),
+  } as unknown as ReadableStreamDefaultReader<Uint8Array>;
 
   return {
-    response: new Response(stream, {
-      status: 502,
-      statusText: "Bad Gateway",
-      headers: { "Content-Type": "application/json" },
+    ok: (params.status ?? 200) >= 200 && (params.status ?? 200) < 300,
+    status: params.status ?? 200,
+    statusText: params.statusText ?? "OK",
+    body: { getReader: () => reader },
+  } as Response;
+}
+
+async function resultWithinMs(
+  stream: { result(): Promise<unknown> },
+  timeoutMs = 25,
+): Promise<unknown> {
+  return await Promise.race([
+    stream.result(),
+    new Promise<symbol>((resolve) => {
+      setTimeout(() => resolve(unresolved), timeoutMs);
     }),
-    getReadCount: () => reads,
-  };
+  ]);
+}
+
+async function settledResult(stream: { result(): Promise<unknown> }): Promise<unknown> {
+  return await Promise.race([stream.result(), Promise.resolve(unresolved)]);
 }
 
 describe("streamProxy", () => {
   afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -164,6 +186,327 @@ describe("streamProxy", () => {
     });
   });
 
+  it("applies timeoutMs before proxy response headers arrive", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        const signal = init?.signal;
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            reject(
+              signal.reason instanceof Error ? signal.reason : new Error("Request was aborted"),
+            );
+          });
+        });
+      }),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+      timeoutMs: 5,
+    });
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(await settledResult(stream)).toMatchObject({
+      stopReason: "error",
+      errorMessage: "Proxy request timed out after 5ms",
+    });
+  });
+
+  it("bounds non-2xx proxy JSON error reads", async () => {
+    const firstChunk = new TextEncoder().encode(`{"error":"${"x".repeat(17 * 1024 * 1024)}`);
+    let cancelled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        pendingReaderResponse({
+          chunks: [firstChunk],
+          status: 502,
+          statusText: "Bad Gateway",
+          onCancel: () => {
+            cancelled = true;
+          },
+        }),
+      ),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+
+    expect(await resultWithinMs(stream)).toMatchObject({
+      stopReason: "error",
+      errorMessage: "Proxy error body exceeded 16777216 bytes",
+    });
+    expect(cancelled).toBe(true);
+  });
+
+  it("caps unterminated pending SSE bytes before a frame delimiter arrives", async () => {
+    const overLimitFrame = new TextEncoder().encode(`data: ${"x".repeat(17 * 1024 * 1024)}`);
+    let cancelReason: unknown;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        pendingReaderResponse({
+          chunks: [overLimitFrame],
+          onCancel: (reason) => {
+            cancelReason = reason;
+          },
+        }),
+      ),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+
+    expect(await resultWithinMs(stream)).toMatchObject({
+      stopReason: "error",
+      errorMessage: "Proxy SSE stream exceeded 16777216 bytes",
+    });
+    expect(cancelReason).toBeInstanceOf(Error);
+  });
+
+  it("caps delimiter-terminated SSE success body bytes", async () => {
+    const overLimitFrame = new TextEncoder().encode(`data: ${"x".repeat(17 * 1024 * 1024)}\n`);
+    let cancelReason: unknown;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        pendingReaderResponse({
+          chunks: [overLimitFrame],
+          onCancel: (reason) => {
+            cancelReason = reason;
+          },
+        }),
+      ),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+
+    expect(await resultWithinMs(stream)).toMatchObject({
+      stopReason: "error",
+      errorMessage: "Proxy SSE stream exceeded 16777216 bytes",
+    });
+    expect(cancelReason).toBeInstanceOf(Error);
+  });
+
+  it("re-arms the SSE idle timeout after each received chunk", async () => {
+    vi.useFakeTimers();
+    const encoder = new TextEncoder();
+    let secondReadResolve: ((result: ReadableStreamReadResult<Uint8Array>) => void) | undefined;
+    let thirdReadResolve: ((result: ReadableStreamReadResult<Uint8Array>) => void) | undefined;
+    const cancel = vi.fn(async () => undefined);
+    const reader = {
+      read: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: encoder.encode("data: ") })
+        .mockImplementationOnce(
+          () =>
+            new Promise<ReadableStreamReadResult<Uint8Array>>((resolve) => {
+              secondReadResolve = resolve;
+            }),
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise<ReadableStreamReadResult<Uint8Array>>((resolve) => {
+              thirdReadResolve = resolve;
+            }),
+        ),
+      cancel,
+      releaseLock: vi.fn(),
+    } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          ({
+            ok: true,
+            status: 200,
+            body: { getReader: () => reader },
+          }) as Response,
+      ),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+
+    await vi.advanceTimersByTimeAsync(119_000);
+    expect(cancel).not.toHaveBeenCalled();
+    secondReadResolve?.({
+      done: false,
+      value: encoder.encode(
+        `${JSON.stringify({
+          type: "done",
+          reason: "stop",
+          usage,
+        })}\n\n`,
+      ),
+    });
+    await vi.advanceTimersByTimeAsync(119_000);
+    expect(cancel).not.toHaveBeenCalled();
+    thirdReadResolve?.({ done: true, value: undefined });
+
+    await expect(stream.result()).resolves.toMatchObject({
+      stopReason: "stop",
+      usage,
+    });
+  });
+
+  it("does not apply the pre-header timeout as an absolute stream deadline", async () => {
+    vi.useFakeTimers();
+    const encoder = new TextEncoder();
+    let secondReadResolve: ((result: ReadableStreamReadResult<Uint8Array>) => void) | undefined;
+    let thirdReadResolve: ((result: ReadableStreamReadResult<Uint8Array>) => void) | undefined;
+    const cancel = vi.fn(async () => undefined);
+    const reader = {
+      read: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: encoder.encode("data: ") })
+        .mockImplementationOnce(
+          () =>
+            new Promise<ReadableStreamReadResult<Uint8Array>>((resolve) => {
+              secondReadResolve = resolve;
+            }),
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise<ReadableStreamReadResult<Uint8Array>>((resolve) => {
+              thirdReadResolve = resolve;
+            }),
+        ),
+      cancel,
+      releaseLock: vi.fn(),
+    } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          ({
+            ok: true,
+            status: 200,
+            body: { getReader: () => reader },
+          }) as Response,
+      ),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+      timeoutMs: 5,
+    });
+
+    await vi.advanceTimersByTimeAsync(4);
+    expect(cancel).not.toHaveBeenCalled();
+    secondReadResolve?.({
+      done: false,
+      value: encoder.encode(
+        `${JSON.stringify({
+          type: "done",
+          reason: "stop",
+          usage,
+        })}\n\n`,
+      ),
+    });
+    await vi.advanceTimersByTimeAsync(4);
+    expect(cancel).not.toHaveBeenCalled();
+    thirdReadResolve?.({ done: true, value: undefined });
+
+    await expect(stream.result()).resolves.toMatchObject({
+      stopReason: "stop",
+      usage,
+    });
+  });
+
+  it("returns an error result when the SSE read idles", async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn(async () => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          ({
+            ok: true,
+            status: 200,
+            body: {
+              getReader: () =>
+                ({
+                  read: vi.fn(
+                    async () => await new Promise<ReadableStreamReadResult<Uint8Array>>(() => {}),
+                  ),
+                  cancel,
+                  releaseLock: vi.fn(),
+                }) as unknown as ReadableStreamDefaultReader<Uint8Array>,
+            },
+          }) as Response,
+      ),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(await settledResult(stream)).toMatchObject({
+      stopReason: "error",
+      errorMessage: "Proxy SSE stream stalled: no data received for 120000ms",
+    });
+    expect(cancel).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("honors a longer configured SSE read idle timeout", async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn(async () => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          ({
+            ok: true,
+            status: 200,
+            body: {
+              getReader: () =>
+                ({
+                  read: vi.fn(
+                    async () => await new Promise<ReadableStreamReadResult<Uint8Array>>(() => {}),
+                  ),
+                  cancel,
+                  releaseLock: vi.fn(),
+                }) as unknown as ReadableStreamDefaultReader<Uint8Array>,
+            },
+          }) as Response,
+      ),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+      timeoutMs: 180_000,
+    });
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(await settledResult(stream)).toBe(unresolved);
+    expect(cancel).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(await settledResult(stream)).toMatchObject({
+      stopReason: "error",
+      errorMessage: "Proxy SSE stream stalled: no data received for 180000ms",
+    });
+    expect(cancel).toHaveBeenCalledWith(expect.any(Error));
+  });
+
   it("releases the proxy response reader after a terminal stream", async () => {
     let resolveReleased: (() => void) | undefined;
     const released = new Promise<void>((resolve) => {
@@ -193,30 +536,6 @@ describe("streamProxy", () => {
     await released;
 
     expect(releaseLock).toHaveBeenCalledTimes(1);
-  });
-
-  it("stops reading oversized proxy error JSON responses", async () => {
-    const streamed = streamingProxyErrorResponse({ chunkCount: 20, chunkSize: 1024 * 1024 });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => streamed.response),
-    );
-
-    const stream = streamProxy(model, context, {
-      authToken: "token",
-      proxyUrl: "https://proxy.example",
-    });
-    const events = [];
-    for await (const event of stream) {
-      events.push(event);
-    }
-
-    expect(events.at(-1)?.type).toBe("error");
-    await expect(stream.result()).resolves.toMatchObject({
-      stopReason: "error",
-      errorMessage: "Proxy error: 502 Bad Gateway",
-    });
-    expect(streamed.getReadCount()).toBeLessThan(20);
   });
 
   it("returns an error result when EOF arrives without a terminal event", async () => {

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -3,6 +3,8 @@
  * The server manages auth and proxies requests to LLM providers.
  */
 
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
+import { resolvePositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 // Internal import for JSON parsing utility
 import type {
   AssistantMessage,
@@ -15,7 +17,12 @@ import type {
 } from "../../llm/types.js";
 import { EventStream } from "../../llm/utils/event-stream.js";
 import { parseStreamingJson } from "../../llm/utils/json-parse.js";
-import { readProviderJsonResponse } from "../provider-http-errors.js";
+import { createSseByteGuard, type SseByteGuard } from "../streaming-byte-guard.js";
+
+const PROXY_ERROR_BODY_MAX_BYTES = 16 * 1024 * 1024;
+const PROXY_SSE_STREAM_MAX_BYTES = 16 * 1024 * 1024;
+const PROXY_SSE_PENDING_BUFFER_MAX_BYTES = PROXY_SSE_STREAM_MAX_BYTES;
+const PROXY_SSE_READ_IDLE_TIMEOUT_MS = 120_000;
 
 type StreamingToolCall = ToolCall & { partialJson?: string };
 
@@ -75,6 +82,7 @@ type ProxySerializableStreamOptions = Pick<
   | "transport"
   | "thinkingBudgets"
   | "maxRetryDelayMs"
+  | "timeoutMs"
 >;
 
 export interface ProxyStreamOptions extends ProxySerializableStreamOptions {
@@ -117,12 +125,128 @@ function buildProxyRequestOptions(options: ProxyStreamOptions): ProxySerializabl
     transport: options.transport,
     thinkingBudgets: options.thinkingBudgets,
     maxRetryDelayMs: options.maxRetryDelayMs,
+    timeoutMs: options.timeoutMs,
   };
 }
 
 function sanitizeProxyModel(model: Model): Model {
   const { headers: _headers, ...safeModel } = model;
   return safeModel as Model;
+}
+
+function resolveProxyReadIdleTimeoutMs(timeoutMs: ProxyStreamOptions["timeoutMs"]): number {
+  return resolvePositiveTimerTimeoutMs(timeoutMs, PROXY_SSE_READ_IDLE_TIMEOUT_MS);
+}
+
+type ProxyRequestAbort = {
+  signal: AbortSignal;
+  clear: () => void;
+};
+
+function createProxyRequestTimeoutError(timeoutMs: number): Error {
+  const error = new Error(`Proxy request timed out after ${timeoutMs}ms`);
+  error.name = "TimeoutError";
+  return error;
+}
+
+function buildProxyRequestAbort(
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): ProxyRequestAbort {
+  const timeoutController = new AbortController();
+  const timeoutId = setTimeout(() => {
+    timeoutController.abort(createProxyRequestTimeoutError(timeoutMs));
+  }, timeoutMs);
+  return {
+    signal: callerSignal
+      ? AbortSignal.any([callerSignal, timeoutController.signal])
+      : timeoutController.signal,
+    clear: () => {
+      clearTimeout(timeoutId);
+    },
+  };
+}
+
+function isProxyRequestTimeoutError(params: {
+  error: unknown;
+  callerSignal: AbortSignal | undefined;
+  requestSignal: AbortSignal;
+}): boolean {
+  if (params.callerSignal?.aborted || !params.requestSignal.aborted) {
+    return false;
+  }
+  if (!(params.error instanceof Error)) {
+    return false;
+  }
+  return (
+    params.error.name === "AbortError" ||
+    params.error.name === "TimeoutError" ||
+    params.error.message === "Request was aborted"
+  );
+}
+
+async function readProxyErrorData(
+  response: Response,
+  readIdleTimeoutMs: number,
+): Promise<{ error?: string } | undefined> {
+  const bytes = await readResponseWithLimit(response, PROXY_ERROR_BODY_MAX_BYTES, {
+    onOverflow: ({ maxBytes }) => new Error(`Proxy error body exceeded ${maxBytes} bytes`),
+    chunkTimeoutMs: readIdleTimeoutMs,
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`Proxy error body stalled: no data received for ${chunkTimeoutMs}ms`),
+  });
+  return JSON.parse(new TextDecoder().decode(bytes)) as { error?: string };
+}
+
+async function readProxySseChunk(
+  reader: Pick<SseByteGuard, "read" | "cancel">,
+  readIdleTimeoutMs: number,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  return await new Promise((resolve, reject) => {
+    const timeoutError = new Error(
+      `Proxy SSE stream stalled: no data received for ${readIdleTimeoutMs}ms`,
+    );
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      void reader.cancel(timeoutError);
+      reject(timeoutError);
+    }, readIdleTimeoutMs);
+    void reader.read().then(
+      (result) => {
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+        }
+        if (!timedOut) {
+          resolve(result);
+        }
+      },
+      (error: unknown) => {
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+        }
+        if (!timedOut) {
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      },
+    );
+  });
+}
+
+function assertProxySsePendingBufferWithinLimit(
+  buffer: string,
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): void {
+  const size = new TextEncoder().encode(buffer).byteLength;
+  if (size <= PROXY_SSE_PENDING_BUFFER_MAX_BYTES) {
+    return;
+  }
+  const error = new Error(
+    `Proxy SSE pending buffer exceeded ${PROXY_SSE_PENDING_BUFFER_MAX_BYTES} bytes`,
+  );
+  void reader.cancel(error).catch(() => undefined);
+  throw error;
 }
 
 export function streamProxy(
@@ -153,6 +277,7 @@ export function streamProxy(
     };
 
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    const readIdleTimeoutMs = resolveProxyReadIdleTimeoutMs(options.timeoutMs);
 
     const abortHandler = () => {
       if (reader) {
@@ -165,6 +290,7 @@ export function streamProxy(
     }
 
     try {
+      const requestAbort = buildProxyRequestAbort(options.signal, readIdleTimeoutMs);
       const response = await fetch(`${options.proxyUrl}/api/stream`, {
         method: "POST",
         headers: {
@@ -176,24 +302,46 @@ export function streamProxy(
           context,
           options: buildProxyRequestOptions(options),
         }),
-        signal: options.signal,
-      });
+        signal: requestAbort.signal,
+      })
+        .catch((error: unknown) => {
+          if (
+            isProxyRequestTimeoutError({
+              error,
+              callerSignal: options.signal,
+              requestSignal: requestAbort.signal,
+            })
+          ) {
+            throw new Error(`Proxy request timed out after ${readIdleTimeoutMs}ms`, {
+              cause: error instanceof Error ? error : undefined,
+            });
+          }
+          throw error;
+        })
+        .finally(() => {
+          requestAbort.clear();
+        });
 
       if (!response.ok) {
         let errorMessage = `Proxy error: ${response.status} ${response.statusText}`;
         try {
-          const errorData = await readProviderJsonResponse<{ error?: string }>(
-            response,
-            "Proxy error response",
-          );
-          if (errorData.error) {
+          const errorData = await readProxyErrorData(response, readIdleTimeoutMs);
+          if (errorData?.error) {
             errorMessage = `Proxy error: ${errorData.error}`;
           }
-        } catch {}
+        } catch (error) {
+          if (error instanceof Error && error.message.startsWith("Proxy error body")) {
+            throw error;
+          }
+        }
         throw new Error(errorMessage);
       }
 
       reader = response.body!.getReader();
+      const sseReader = createSseByteGuard(reader, {
+        maxBytes: PROXY_SSE_STREAM_MAX_BYTES,
+        onOverflow: ({ maxBytes }) => new Error(`Proxy SSE stream exceeded ${maxBytes} bytes`),
+      });
       const decoder = new TextDecoder();
       let buffer = "";
       let terminalEventSeen = false;
@@ -216,7 +364,7 @@ export function streamProxy(
       };
 
       while (true) {
-        const { done, value } = await reader.read();
+        const { done, value } = await readProxySseChunk(sseReader, readIdleTimeoutMs);
         if (done) {
           break;
         }
@@ -228,6 +376,7 @@ export function streamProxy(
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split("\n");
         buffer = lines.pop() || "";
+        assertProxySsePendingBufferWithinLimit(buffer, reader);
 
         for (const line of lines) {
           processSseLine(line);


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes an issue where proxied model streams could fail too early because the client-side proxy read guard always used a hard-coded 120 second idle window, even when the caller configured a longer model/request timeout.
- Root cause: `streamProxy` introduced a proxy-local idle read guard, but the guard did not consume the existing stream `timeoutMs` option and the proxy request body did not forward `timeoutMs` to the proxy server.
- Fix classification: root-cause compatibility fix for the proxy response read boundary.

Why does this matter now?

- Why it matters / User impact: the original PR intentionally made oversized or silent proxy responses fail closed, but a fixed 120 second idle window could still break legitimate slow proxy deployments that explicitly configure a longer request timeout.
- Honoring the configured timeout removes that compatibility risk without weakening the default fail-fast behavior.

What is the intended outcome?

- Maintainer-ready confidence: high for this scoped follow-up; it changes only proxy option forwarding and timeout resolution, with focused regression coverage and local HTTP proxy-style proof.
- Proxy streams with no explicit positive timeout still fail after the existing 120 second idle window.
- Proxy streams with a longer positive `timeoutMs` use that configured window for SSE chunk reads and bounded non-2xx error-body reads.
- The proxy request body now forwards `timeoutMs` to the proxy server together with the other serializable stream options.

What is intentionally out of scope?

- What did NOT change: this does not change public config, schema, migration behavior, provider routing, auth behavior, SSE event schema, or the `/api/stream` endpoint contract.
- Out of scope: tuning the existing 16 MiB byte caps, removing the fail-closed behavior, changing provider-specific streaming code, or adding new user configuration.

What does success look like?

A configured proxied stream can wait beyond 120 seconds when `timeoutMs` is set higher, while the default path still fails stalled proxy reads after 120 seconds and oversized response bodies remain bounded.

What should reviewers focus on?

- Why this is root-cause fix: the invariant is that proxy-side read idleness should be derived from the same positive stream timeout already used for provider/request timing, not from a second hard-coded constant hidden inside `streamProxy`. The patch fixes that source boundary by forwarding `timeoutMs`, resolving it once with `resolvePositiveTimerTimeoutMs`, and passing the resolved value to both proxy error-body reads and SSE chunk reads.
- Architecture / source-of-truth check: `resolvePositiveTimerTimeoutMs` remains the canonical positive timer normalization helper; `streamProxy` owns only proxy response read behavior and does not introduce a new config source, provider-routing rule, schema field, or endpoint contract.
- Related open PR / same-contract scan: #96768 and #97191 overlap the same `streamProxy` hardening area; this follow-up does not compete on their byte-cap policy and only repairs the configured idle-timeout compatibility boundary in #97235.
- Patch quality notes: the timeout-related code is deliberate root-cause behavior, not a retry or sleep fallback; the catch paths preserve existing proxy error handling while allowing bounded body-read failures to surface; the `unknown as ReadableStreamDefaultReader` casts are confined to test fixtures that emulate browser reader objects for deterministic pending/cancel behavior.

## Linked context

Which issue does this close?

Existing PR update for #97235; no separate linked GitHub issue is resolved by this follow-up.

Which issues, PRs, or discussions are related?

- Related open PR / same-contract scan: #96768 and #97191 are open overlapping proxy hardening PRs touching the same `streamProxy` loop.
- Current PR context: #97235 adds proxy response bounds for non-2xx bodies, total SSE bytes, pending SSE buffers, and idle SSE reads.

Was this requested by a maintainer or owner?

No maintainer directly requested this exact follow-up. It addresses the ClawSweeper compatibility finding that a legitimate proxied stream silent for more than 120 seconds would otherwise fail before later content arrives.

## Real behavior proof

- Behavior or issue addressed: `streamProxy` now honors a positive configured `timeoutMs` for proxy read idleness instead of forcing the 120 second default on every proxied SSE/error-body read.
- Real environment tested: local OpenClaw PR worktree with the production `streamProxy` implementation and a real local HTTP `/api/stream` server that accepts the proxy request and intentionally leaves the SSE response open without bytes.
- Exact steps or command run after this patch: daily-fix bounded live proof ran a TypeScript harness with `corepack pnpm@11.2.2 exec tsx`, plus focused proxy runtime tests and focused agents type checking.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  ```text
  configured-proxy-sse-idle-timeout live proof:
  requestOptionsTimeoutMs: 250
  configuredTimeoutMs: 250
  stopReason: error
  errorMessage: Proxy SSE stream stalled: no data received for 250ms
  durationMs: 329
  ```

  ```text
  Validation `proxy-runtime-test` (pass, exit_code=0, 14321ms):
  $ node scripts/test-projects.mjs -- src/agents/runtime/proxy.test.ts
  [test] starting test/vitest/vitest.agents.config.ts

   RUN  v4.1.8 [local path redacted]

   Test Files  1 passed (1)
        Tests  10 passed (10)
     Start at  15:14:56
     Duration  2.50s (transform 2.13s, setup 1.14s, import 172ms, tests 828ms, environment 0ms)

  [test] passed 1 Vitest shard in 13.13s
  ```

  ```text
  Validation `agents-test-types` (pass, exit_code=0, 28741ms):
  Validation result: pass, exit_code=0, 28741ms
  ```

- Observed result after fix: the proxy request carried the configured 250ms timeout, and the stalled real HTTP SSE response failed with `Proxy SSE stream stalled: no data received for 250ms`, proving the proxy idle guard no longer clamps the read to the old default.
- What was not tested: no hosted proxy, external provider, Control UI, or full chat flow was used; the proof uses a local HTTP server because this change is at the client-side `streamProxy` response boundary and needs deterministic stalled-response control.
- Proof limitations or environment constraints: this follow-up validates the affected proxy boundary directly; maintainer acceptance is still needed for the broader 16 MiB caps and default 120 second fail-closed policy.

## Tests and validation

Which commands did you run?

- Target test file: `src/agents/runtime/proxy.test.ts`.

```text
corepack pnpm@11.2.2 test -- src/agents/runtime/proxy.test.ts
corepack pnpm@11.2.2 exec tsgo -p test/tsconfig/tsconfig.core.test.agents.json --noEmit --pretty false
daily_fix.sh bounded-live-proof -- corepack pnpm@11.2.2 exec tsx proxy-configured-timeout-live-proof.ts
```

What regression coverage was added or updated?

- Scenario locked in: a `streamProxy` call with `timeoutMs: 180000` remains unresolved after 120 seconds, does not cancel the reader early, and then fails at 180 seconds with `Proxy SSE stream stalled: no data received for 180000ms`.
- Existing idle-timeout coverage still proves the default path fails after 120 seconds.
- The local HTTP proof locks the real request/response boundary by showing the proxy request carries `timeoutMs` and the stalled SSE response fails on the configured value.

What failed before this fix, if known?

- Why this is the smallest reliable guardrail: before this follow-up, the new regression test failed at 120 seconds with `Proxy SSE stream stalled: no data received for 120000ms` even though `timeoutMs: 180000` was provided; fixing option forwarding and read-timeout resolution addresses the source of that wrong timer value without adding config or changing byte caps.

If no test was added, why not?

A focused regression test was added in `src/agents/runtime/proxy.test.ts`, and an additional local HTTP proxy-style proof was captured for the configured-timeout behavior.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, but only for proxied streams that set a positive `timeoutMs`: those streams may now wait longer than the previous hard-coded 120 second proxy read idle window.

Did config, environment, or migration behavior change? (`Yes/No`)

No. This uses an existing stream option and does not add config, environment variables, migrations, or new user-facing settings.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No auth, secrets, or tool execution behavior changed. The network read boundary still fails closed for oversized bodies and stalled reads; the idle duration now follows the existing positive timeout option when present.

What is the highest-risk area?

- Risk labels considered: compatibility and message-delivery behavior in the proxied streaming path.
- Risk explanation: the follow-up allows a configured proxy stream to stay open longer than 120 seconds, but only when the caller already supplied a positive `timeoutMs`; the default 120 second behavior and 16 MiB fail-closed caps remain unchanged.

How is that risk mitigated?

- Why acceptable: positive timeout handling uses the existing `resolvePositiveTimerTimeoutMs` helper, so non-positive or invalid values still fall back to 120 seconds.
- The timeout is resolved once per `streamProxy` call and passed to both non-2xx error-body reads and SSE chunk reads, keeping behavior consistent within the proxy response boundary.
- Focused tests cover the default 120 second path and the longer configured timeout path, and local HTTP proof covers the real proxy request/response boundary.

## Current review state

What is the next action?

Submit this follow-up through the daily-fix `submit-pr` flow and let the remote PR checks and labels settle.

What is still waiting on author, maintainer, CI, or external proof?

- Author-side follow-up for RF-002 is addressed by honoring positive configured `timeoutMs` values; maintainer acceptance is still needed for the default 120 second idle policy.
- Maintainer-side decision remains needed for RF-001, RF-003, and RF-004: accept or tune the 16 MiB fail-closed caps, and sequence this broader proxy guard with #96768 and #97191.
- Remote CI and ClawSweeper need to run on the updated head after submission.

Which bot or reviewer comments were addressed?

- RF-001: disclosed as a maintainer policy decision; this follow-up does not change the existing 16 MiB fail-closed cap.
- RF-002: fixed for configured deployments by honoring positive `timeoutMs`; default 120 second behavior remains unchanged and documented above.
- RF-003: disclosed as related overlap with #96768 and #97191 for maintainer sequencing.
- RF-004: disclosed as a maintainer threshold/sequencing decision after the contributor-side compatibility fix.
