### PR TITLE
fix(model-resolver): use numeric-aware localeCompare for alias version sort (#96588)

### DIFF
--- a/scripts/proof-issue-96588.ts
+++ b/scripts/proof-issue-96588.ts
@@ -1,0 +1,80 @@
+/**
+ * Proof script for issue #96588 fix.
+ *
+ * Demonstrates that model alias resolution uses numeric-aware
+ * localeCompare so that "opus-4-10" sorts above "opus-4-9".
+ *
+ * Usage: npx tsx scripts/proof-issue-96588.ts
+ */
+import { parseModelPattern } from "../src/agents/sessions/model-resolver.js";
+import type { Model } from "../src/llm/types.js";
+
+const divider = "=".repeat(64);
+
+function model(provider: string, id: string): Model {
+  return {
+    id,
+    name: id,
+    api: "openai-responses" as const,
+    provider,
+    baseUrl: `https://${provider}.example.test`,
+    reasoning: false,
+    input: ["text"] as const,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+  };
+}
+
+console.log(divider);
+console.log("PROOF: Numeric-aware model alias resolution — issue #96588");
+console.log(divider);
+
+const models = [model("anthropic", "claude-opus-4-9"), model("anthropic", "claude-opus-4-10")];
+
+console.log("\nAvailable models:");
+for (const m of models) {
+  console.log(`  ${m.provider}/${m.id}`);
+}
+
+// ── Core test ─────────────────────────────────────────────────────
+console.log(`\nAlias requested: "opus"`);
+
+const result = parseModelPattern("opus", models);
+
+console.log(`Resolver picked: ${result.model?.id}`);
+
+const correct = result.model?.id === "claude-opus-4-10";
+console.log(`Expected (numerically newest): claude-opus-4-10`);
+console.log(`Correct? ${correct ? "YES" : "NO — older version selected"}`);
+
+// ── Before/After comparison ───────────────────────────────────────
+console.log("\n" + divider);
+console.log("BEFORE/AFTER");
+console.log(divider);
+
+console.log(`
+BEFORE FIX (plain localeCompare, no numeric option):
+  Sort order: "claude-opus-4-9" > "claude-opus-4-10" (lexicographic)
+  Resolver picks: claude-opus-4-9  ← WRONG (older version)
+  Why: '9' > '1' in character code order
+
+AFTER FIX (localeCompare with { numeric: true }):
+  Sort order: "claude-opus-4-10" > "claude-opus-4-9" (numeric)
+  Resolver picks: claude-opus-4-10 ← CORRECT (newest version)
+  Why: 10 > 9 in numeric order
+`);
+
+// ── Summary ────────────────────────────────────────────────────────
+console.log(divider);
+console.log("RESULT");
+console.log(divider);
+console.log();
+console.log(`  Picked:   ${result.model?.id}`);
+console.log(`  Expected: claude-opus-4-10`);
+console.log(`  Status:   ${correct ? "✓ PASS" : "✗ FAIL"}`);
+console.log();
+console.log("Fix: added { numeric: true } to localeCompare sort comparators");
+console.log("File: src/agents/sessions/model-resolver.ts lines 119, 123");
+console.log("Verified on: " + new Date().toISOString());
+console.log(divider);

--- a/src/agents/sessions/model-resolver.test.ts
+++ b/src/agents/sessions/model-resolver.test.ts
@@ -1,10 +1,10 @@
 // Model resolver tests pin the startup fallback order for fresh and restored
-// agent sessions.
+// agent sessions, and verify numeric-aware alias version resolution.
 import { describe, expect, it } from "vitest";
 import type { Model } from "../../llm/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
-import { findInitialModel, restoreModelFromSession } from "./model-resolver.js";
+import { findInitialModel, parseModelPattern, restoreModelFromSession } from "./model-resolver.js";
 
 function model(provider: string, id: string): Model {
   return {
@@ -55,5 +55,34 @@ describe("model resolver fallback selection", () => {
     );
 
     expect(result.model).toBe(firstAvailable);
+  });
+});
+
+describe("parseModelPattern alias resolution", () => {
+  it("selects numerically newest version when aliases span double-digit minor versions (#96588)", () => {
+    // Simulate the scenario where a model family crosses into double-digit
+    // minor versions: opus-4-9 vs opus-4-10. Plain localeCompare without
+    // { numeric: true } sorts "opus-4-9" higher than "opus-4-10", picking
+    // the OLDER model. With numeric collation, "4-10" > "4-9".
+    const v9 = model("anthropic", "claude-opus-4-9");
+    const v10 = model("anthropic", "claude-opus-4-10");
+    const models = [v9, v10];
+
+    const result = parseModelPattern("opus", models);
+
+    expect(result.model).toBe(v10);
+  });
+
+  it("sorts multi-version aliases correctly when minor versions span single and double digits", () => {
+    // When a family has versions opus-4-2, opus-4-9, opus-4-10, the resolver
+    // must pick the numerically newest (4-10), not the lexicographically highest.
+    const v2 = model("anthropic", "claude-opus-4-2");
+    const v9 = model("anthropic", "claude-opus-4-9");
+    const v10 = model("anthropic", "claude-opus-4-10");
+    const models = [v2, v9, v10];
+
+    const result = parseModelPattern("opus", models);
+
+    expect(result.model).toBe(v10);
   });
 });

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -115,12 +115,12 @@ function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | 
   const datedVersions = matches.filter((m) => !isAlias(m.id));
 
   if (aliases.length > 0) {
-    // Prefer alias - if multiple aliases, pick the one that sorts highest
-    aliases.sort((a, b) => b.id.localeCompare(a.id));
+    // Prefer alias - if multiple aliases, pick the numerically newest
+    aliases.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
     return aliases[0];
   }
   // No alias found, pick latest dated version
-  datedVersions.sort((a, b) => b.id.localeCompare(a.id));
+  datedVersions.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
   return datedVersions[0];
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes P2 issue #96588: when a model family alias (e.g. `opus`) matches multiple versioned model IDs that span double-digit minor versions (e.g. `claude-opus-4-9` and `claude-opus-4-10`), model resolution orders the candidates with plain `String.localeCompare` (lexicographic). This picks the lexicographically highest id rather than the **numerically newest** version — `"4-9"` sorts above `"4-10"` because `'9' > '1'` in character code order. The resolver silently selects the older model.

## Why This Change Was Made

`tryMatchModel` in `src/agents/sessions/model-resolver.ts` uses `localeCompare` without `{ numeric: true }` on two sort comparators (alias bucket and dated-version bucket). Adding `{ numeric: true }` (standard `localeCompare` option, supported in all modern JS engines) makes the comparison numeric-aware so `10 > 9` as expected.

## User Impact

When model families grow into double-digit minor versions, alias resolution (`/model opus`, scope config) correctly picks the newest version. Existing single-digit-version behavior is preserved (numeric collation is consistent with lexicographic for single-digit numbers).

## Evidence

### Real behavior proof (`npx tsx scripts/proof-issue-96588.ts`)

```
================================================================
PROOF: Numeric-aware model alias resolution — issue #96588
================================================================

Available models:
  anthropic/claude-opus-4-9
  anthropic/claude-opus-4-10

Alias requested: "opus"
Resolver picked: claude-opus-4-10
Expected (numerically newest): claude-opus-4-10
Correct? YES

================================================================
BEFORE/AFTER
================================================================

BEFORE FIX (plain localeCompare, no numeric option):
  Sort order: "claude-opus-4-9" > "claude-opus-4-10" (lexicographic)
  Resolver picks: claude-opus-4-9  ← WRONG (older version)
  Why: '9' > '1' in character code order

AFTER FIX (localeCompare with { numeric: true }):
  Sort order: "claude-opus-4-10" > "claude-opus-4-9" (numeric)
  Resolver picks: claude-opus-4-10 ← CORRECT (newest version)
  Why: 10 > 9 in numeric order

================================================================
RESULT
================================================================

  Picked:   claude-opus-4-10
  Expected: claude-opus-4-10
  Status:   ✓ PASS

Fix: added { numeric: true } to localeCompare sort comparators
File: src/agents/sessions/model-resolver.ts lines 119, 123
================================================================
```

### Unit test results — 4/4 passing (including 2 new alias resolution tests)

```
 ✓ model-resolver.test.ts (4 tests)
   ✓ prefers the product default when no configured or scoped model is selected
   ✓ falls back to available model when session model is missing
   ✓ selects numerically newest version when aliases span double-digit minor versions (#96588)  ← NEW
   ✓ sorts multi-version aliases correctly when minor versions span single and double digits  ← NEW

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

### Static checks

- `git diff --check` — passed
- Change: 2 lines in `model-resolver.ts`, both adding `, undefined, { numeric: true }` to existing `localeCompare` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)