### PR TITLE
fix(openrouter): avoid DeepSeek V4 reasoning field conflict

### DIFF
--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -234,6 +234,30 @@ describe("normalizeOpenAICompatibleReasoningPayload", () => {
 });
 
 describe("createDeepSeekV4OpenAICompatibleThinkingWrapper", () => {
+  it("drops nested reasoning when native DeepSeek V4 reasoning_effort is enabled", () => {
+    const payload = {
+      messages: [],
+      reasoning: { effort: "high" },
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload as never, _model as never);
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn,
+      thinkingLevel: "high",
+      shouldPatchModel: () => true,
+    });
+    void wrapped?.({} as never, {} as never, {});
+
+    expect(payload).toEqual({
+      messages: [],
+      thinking: { type: "enabled" },
+      reasoning_effort: "high",
+    });
+  });
+
   it("backfills reasoning_content on every replayed assistant message when thinking is enabled", () => {
     const payload = {
       messages: [

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -551,6 +551,7 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
 
       payload.thinking = { type: "enabled" };
       payload.reasoning_effort = resolveReasoningEffort(params.thinkingLevel);
+      delete payload.reasoning;
       ensureDeepSeekV4AssistantReasoningContent(payload, {
         shouldBackfillAssistantMessage: params.shouldBackfillAssistantReasoningContent,
       });


### PR DESCRIPTION
Fixes #97196

## What Problem This Solves

Fixes an issue where users routing DeepSeek V4 models through OpenRouter could receive HTTP 400 failures because the outgoing Chat Completions payload kept both `reasoning_effort` and nested `reasoning.effort` fields.

## Why This Change Was Made

The shared DeepSeek V4 OpenAI-compatible payload wrapper already clears both reasoning effort shapes when thinking is disabled. This applies the same single-source payload cleanup to the enabled branch: when the wrapper emits native `reasoning_effort`, it removes any nested OpenRouter-style `reasoning` object that an earlier wrapper or transport builder may have added.

The change keeps the DeepSeek V4 replay/backfill wrapper active for OpenRouter-routed DeepSeek V4, so assistant `reasoning_content` compatibility is preserved while avoiding the conflicting effort fields.

## User Impact

OpenRouter-routed DeepSeek V4 requests no longer send two incompatible reasoning effort controls in the same request. Users should be able to use `openrouter/deepseek/deepseek-v4-flash` and `openrouter/deepseek/deepseek-v4-pro` without adding a manual `compat.thinkingFormat` workaround to avoid the duplicate-field rejection.

## Evidence

- Source-level proof against the real helper:
  - `pnpm exec tsx -e "import { createDeepSeekV4OpenAICompatibleThinkingWrapper } from './src/plugin-sdk/provider-stream-shared.ts'; ..."`
  - Output: `{ "messages": [], "thinking": { "type": "enabled" }, "reasoning_effort": "high" }`
  - The probe throws if nested `reasoning` survives or `reasoning_effort` is missing.
- Formatting: `pnpm exec oxfmt --check --threads=1 src/plugin-sdk/provider-stream-shared.ts src/plugin-sdk/provider-stream-shared.test.ts`
- Whitespace: `git diff --check`
- Live OpenRouter attempt reached the intended provider/model path but could not complete because the configured OpenRouter account has no credits:
  - `pnpm openclaw infer model run --local --model openrouter/deepseek/deepseek-v4-flash --thinking high --prompt "Reply exactly: live-ok" --json`
  - Result: `402 Insufficient credits. This account never purchased credits.`
- Targeted Vitest was attempted multiple times on this Windows worktree, but timed out before test execution while repeatedly printing Rolldown plugin timing warnings. The regression test is included in `src/plugin-sdk/provider-stream-shared.test.ts` for CI/Linux to run normally.

Autoreview note: the local autoreview helper was invoked, but the approval reviewer rejected it because it would send the local diff to an external model service. I did a manual scoped diff review instead.
