### PR TITLE
fix(infra): estimate cost when API returns 0 for known-pricing models

### DIFF
--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1165,7 +1165,10 @@ async function scanTranscriptFile(params: {
         // above.
         entry.costTotal = undefined;
         entry.costBreakdown = undefined;
-      } else if (entry.costTotal === undefined) {
+      } else if (
+        entry.costTotal === undefined ||
+        (entry.costTotal === 0 && computeUsageTokenTotals(entry.usage).totalTokens > 0)
+      ) {
         // Fill in missing cost estimates.
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
       }


### PR DESCRIPTION
## Summary

When a model has known pricing (e.g. DeepSeek V4) but its API returns `usage.cost.total = 0`, the `scanTranscriptFile` logic in `session-cost-usage.ts` accepted the 0 as valid instead of estimating from token counts × configured rates. This caused Control UI Spend to show ¥0 for all DeepSeek V4 usage.

## Root Cause

`extractCostBreakdown()` returns `{ total: 0 }` from the API response. Downstream in `scanTranscriptFile()`, the cost aggregation logic checks:

1. **Tiered pricing?** → estimate (branch 1)
2. **Pricing unknown AND cost is 0/missing AND tokens > 0?** → mark as missing (branch 2)
3. **Cost undefined?** → estimate (branch 3)

For DeepSeek V4: pricing IS known (`isModelPricingKnown` returns `true`) so branch 2 is skipped. Cost is `0` (not `undefined`) so branch 3 is also skipped. The 0 is accepted as fact.

## Fix

In the condition for branch 3, also fire when `costTotal === 0` and tokens are non-zero. This causes `estimateUsageCost()` to compute the correct cost from token counts × known pricing rates.

**Changed condition** (src/infra/session-cost-usage.ts):
```
- } else if (entry.costTotal === undefined) {
+ } else if (entry.costTotal === undefined || (entry.costTotal === 0 && computeUsageTokenTotals(entry.usage).totalTokens > 0)) {
```

## Evidence

- ✅ Full monorepo build passes (exit 0, 418s)
- ✅ Change compiles without type errors
- ✅ Existing logic for other cases unchanged (free models, recorded costs, tiered pricing)

## AI-Assisted

This PR was created with AI assistance (Hermes Agent). The issue diagnosis, root cause analysis, and fix implementation were reviewed and validated by the contributor.

Fixes #97047