### PR TITLE
fix: honor Bedrock adaptive max token caps

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -316,6 +316,46 @@ describe("Bedrock Fable contract", () => {
     });
   });
 
+  it("uses model maxTokens for Fable requests through simple options", async () => {
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        { messageStop: { stopReason: "end_turn" } },
+      ]),
+    } as never);
+
+    const stream = streamSimpleBedrock(fableModel(), context());
+    await stream.result();
+
+    const command = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    expect(command.input).toMatchObject({
+      inferenceConfig: { maxTokens: 128_000 },
+      additionalModelRequestFields: {
+        thinking: { type: "adaptive", display: "summarized" },
+        output_config: { effort: "high" },
+      },
+    });
+  });
+
+  it("preserves explicit caller maxTokens for Fable simple options", async () => {
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        { messageStop: { stopReason: "end_turn" } },
+      ]),
+    } as never);
+
+    const stream = streamSimpleBedrock(fableModel(), context(), {
+      maxTokens: 12_000,
+    });
+    await stream.result();
+
+    const command = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    expect(command.input?.inferenceConfig).toEqual({ maxTokens: 12_000 });
+  });
+
   it("preserves explicit tool disabling", async () => {
     const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
       $metadata: { httpStatusCode: 200 },
@@ -477,6 +517,7 @@ describe("Bedrock canonical Claude aliases", () => {
         name: "Production Claude",
         reasoning: false,
         params: { canonicalModelId },
+        maxTokens: 128_000,
         thinkingLevelMap,
       });
 
@@ -492,7 +533,7 @@ describe("Bedrock canonical Claude aliases", () => {
       const command = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
       expect(command.input).toMatchObject({
         modelId: "production-claude",
-        inferenceConfig: {},
+        inferenceConfig: { maxTokens: 128_000 },
         additionalModelRequestFields: {
           thinking: { type: "adaptive", display: "summarized" },
           output_config: { effort: expectedEffort },
@@ -500,4 +541,40 @@ describe("Bedrock canonical Claude aliases", () => {
       });
     },
   );
+
+  it("preserves explicit caller maxTokens for adaptive Claude aliases", async () => {
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        { messageStop: { stopReason: "end_turn" } },
+      ]),
+    } as never);
+    const model = bedrockModel({
+      id: "production-claude",
+      name: "Production Claude",
+      reasoning: false,
+      params: { canonicalModelId: "claude-opus-4-8" },
+      maxTokens: 128_000,
+      thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+    });
+
+    await streamSimpleBedrock(
+      model,
+      { messages: [{ role: "user", content: "Reply briefly.", timestamp: 0 }] } as never,
+      {
+        reasoning: "xhigh",
+        maxTokens: 12_000,
+      },
+    ).result();
+
+    const command = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    expect(command.input).toMatchObject({
+      inferenceConfig: { maxTokens: 12_000 },
+      additionalModelRequestFields: {
+        thinking: { type: "adaptive", display: "summarized" },
+        output_config: { effort: "xhigh" },
+      },
+    });
+  });
 });

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -361,6 +361,7 @@ function resolveSimpleBedrockOptions(
   if (usesClaudeFable5BedrockContract(model)) {
     return {
       ...base,
+      maxTokens: resolveModelBackedMaxTokens(model, base.maxTokens),
       reasoning: options?.reasoning ?? "high",
       thinkingBudgets: options?.thinkingBudgets,
     } satisfies BedrockOptions;
@@ -372,6 +373,10 @@ function resolveSimpleBedrockOptions(
         : undefined;
     return {
       ...base,
+      maxTokens:
+        reasoning !== undefined
+          ? resolveModelBackedMaxTokens(model, base.maxTokens)
+          : base.maxTokens,
       reasoning,
     } satisfies BedrockOptions;
   }
@@ -380,6 +385,7 @@ function resolveSimpleBedrockOptions(
     if (supportsAdaptiveThinking(model)) {
       return {
         ...base,
+        maxTokens: resolveModelBackedMaxTokens(model, base.maxTokens),
         reasoning: options.reasoning,
         thinkingBudgets: options.thinkingBudgets,
       } satisfies BedrockOptions;
@@ -410,6 +416,13 @@ function resolveSimpleBedrockOptions(
     reasoning: options.reasoning,
     thinkingBudgets: options.thinkingBudgets,
   } satisfies BedrockOptions;
+}
+
+function resolveModelBackedMaxTokens(
+  model: Model<"bedrock-converse-stream">,
+  baseMaxTokens: number | undefined,
+): number {
+  return baseMaxTokens ?? model.maxTokens;
 }
 
 function handleContentBlockStart(


### PR DESCRIPTION
Closes #97176

AI-assisted with Codex.

## What Problem This Solves

Fixes an issue where users running Bedrock Claude Fable or adaptive-thinking Claude models could have Converse requests capped at the core default 4096 output tokens when the resolved model metadata had a larger `maxTokens` cap. At higher thinking effort, the thinking block could consume that whole budget and end the turn at `length` before a visible answer or tool call.

## Why This Change Was Made

Bedrock simple-option resolution now carries the model-backed `maxTokens` into Fable, mandatory adaptive, and explicit adaptive-thinking requests when the caller did not set `maxTokens`. Explicit caller `maxTokens` remains the override path, and the existing adaptive thinking payload and temperature behavior are preserved.

## User Impact

Bedrock adaptive-thinking Claude requests can use the configured model/catalog output-token cap instead of silently falling back to 4096, reducing length-truncated turns for long or high-thinking generations.

## Evidence

- Red test first: `node scripts/run-vitest.mjs extensions/amazon-bedrock/stream.runtime.test.ts` failed before the fix with 4 assertions showing `inferenceConfig: {}` instead of model-backed `maxTokens`.
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed -- extensions/amazon-bedrock/stream.runtime.ts extensions/amazon-bedrock/stream.runtime.test.ts`
- `node scripts/run-vitest.mjs extensions/amazon-bedrock/stream.runtime.test.ts extensions/amazon-bedrock/discovery.test.ts` (2 files, 44 tests passed)
- `pnpm test:extension amazon-bedrock` (11 files, 172 tests passed)
- `pnpm format:check -- extensions/amazon-bedrock/stream.runtime.ts extensions/amazon-bedrock/stream.runtime.test.ts`
- `git diff --check`