### PR TITLE
feat(xai): route OAuth login through the device-code flow

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -29,10 +29,11 @@ Use the path that matches your OpenClaw install state:
     openclaw onboard --install-daemon
     ```
 
-    On a VPS or over SSH, use device-code during onboarding:
+    On a VPS or over SSH, select xAI OAuth directly; OpenClaw uses device-code
+    verification and does not require a localhost callback:
 
     ```bash
-    openclaw onboard --install-daemon --auth-choice xai-device-code
+    openclaw onboard --install-daemon --auth-choice xai-oauth
     ```
 
     OAuth does not require an xAI API key. OpenClaw does not require the Grok
@@ -46,13 +47,6 @@ Use the path that matches your OpenClaw install state:
 
     ```bash
     openclaw models auth login --provider xai --method oauth
-    ```
-
-    Use the device-code flow instead when the Gateway runs over SSH, Docker, or
-    a VPS and a localhost browser callback is awkward:
-
-    ```bash
-    openclaw models auth login --provider xai --device-code
     ```
 
     To make Grok the default model after signing in, apply it separately:
@@ -86,8 +80,7 @@ Use the path that matches your OpenClaw install state:
 
 <Note>
 OpenClaw uses the xAI Responses API as the bundled xAI transport. The same
-credential from `openclaw models auth login --provider xai --method oauth`,
-`openclaw models auth login --provider xai --device-code`, or
+credential from `openclaw models auth login --provider xai --method oauth` or
 `openclaw models auth login --provider xai --method api-key` can also power first-class
 `web_search`, `x_search`, remote `code_execution`, and xAI image/video generation.
 Speech and transcription currently require `XAI_API_KEY` or provider config.
@@ -102,8 +95,9 @@ and, by default, `x_search` through an operator xAI Responses proxy.
 
 ## OAuth troubleshooting
 
-- If browser OAuth cannot reach `127.0.0.1:56121`, use
-  `openclaw models auth login --provider xai --device-code`.
+- For SSH, Docker, VPS, or other remote setups, use
+  `openclaw models auth login --provider xai --method oauth`; xAI OAuth uses
+  device-code verification instead of a localhost callback.
 - If sign-in succeeds but Grok is not the default model, run
   `openclaw models set xai/grok-4.3`.
 - To inspect saved xAI auth profiles, run:
@@ -117,9 +111,9 @@ and, by default, `x_search` through an operator xAI Responses proxy.
   eligible, try the API-key path or check the subscription on xAI's side.
 
 <Tip>
-Use `xai-device-code` when signing in from SSH, Docker, or a VPS. OpenClaw
-prints an xAI URL and short code; finish sign-in in any local browser while the
-remote process polls xAI for the completed token exchange.
+Use `xai-oauth` when signing in from SSH, Docker, or a VPS. OpenClaw prints an
+xAI URL and short code; finish sign-in in any local browser while the remote
+process polls xAI for the completed token exchange.
 </Tip>
 
 ## Built-in catalog
@@ -498,12 +492,10 @@ Legacy aliases still normalize to the canonical bundled ids:
 
   <Accordion title="Known limits">
     - xAI auth can use an API key, environment variable, plugin config fallback,
-      browser OAuth, or device-code OAuth with an eligible xAI account. Browser
-      OAuth uses a local callback on `127.0.0.1:56121`; for remote hosts, use
-      `xai-device-code` unless you want to forward that port before opening the
-      sign-in URL. xAI decides which accounts can receive OAuth API tokens, and
-      the consent page may show Grok Build even though OpenClaw does not require
-      the Grok Build app.
+      or OAuth with an eligible xAI account. OAuth uses device-code verification
+      without a localhost callback. xAI decides which accounts can receive OAuth
+      API tokens, and the consent page may show Grok Build even though OpenClaw
+      does not require the Grok Build app.
     - OpenClaw does not currently expose the xAI multi-agent model family. xAI
       serves these models through the Responses API, but they do not accept the
       client-side or custom tools used by OpenClaw's shared agent loop. See the

--- a/docs/tools/code-execution.md
+++ b/docs/tools/code-execution.md
@@ -38,13 +38,13 @@ Do **not** use it when you need local files, your shell, your repo, or paired de
 <Steps>
   <Step title="Provide xAI credentials">
     Sign in with Grok OAuth using an eligible SuperGrok or X Premium subscription,
-    use the remote-friendly device-code flow, or store an API key. OAuth works
-    for `code_execution` and `x_search`; `XAI_API_KEY` or plugin web-search
-    config can also power Grok `web_search`.
+    or store an API key. xAI OAuth uses device-code verification, so it works
+    from remote hosts without a localhost callback. OAuth works for
+    `code_execution` and `x_search`; `XAI_API_KEY` or plugin web-search config
+    can also power Grok `web_search`.
 
     ```bash
     openclaw models auth login --provider xai --method oauth
-    openclaw models auth login --provider xai --device-code
     ```
 
     During a fresh install, the same auth choices are available inside
@@ -52,7 +52,7 @@ Do **not** use it when you need local files, your shell, your repo, or paired de
 
     ```bash
     openclaw onboard --install-daemon
-    openclaw onboard --install-daemon --auth-choice xai-device-code
+    openclaw onboard --install-daemon --auth-choice xai-oauth
     ```
 
     Or use an API key:

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -92,7 +92,8 @@ describe("xai provider plugin", () => {
     expect(oauth?.wizard?.choiceId).toBe("xai-oauth");
     const deviceCode = provider.auth?.find((method) => method.id === "device-code");
     expect(deviceCode?.kind).toBe("device_code");
-    expect(deviceCode?.wizard).toBeUndefined();
+    expect(deviceCode?.wizard?.choiceId).toBe("xai-device-code");
+    expect(deviceCode?.wizard?.assistantVisibility).toBe("manual-only");
     expect(manifest.providerAuthChoices).toContainEqual(
       expect.objectContaining({
         assistantVisibility: "manual-only",

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -18,6 +18,7 @@ const providerAuthRuntimeMocks = vi.hoisted(() => ({
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => providerAuthRuntimeMocks);
 
 import plugin from "./index.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { buildLiveXaiProvider } from "./provider-catalog.js";
 import setupPlugin from "./setup-api.js";
 import {
@@ -82,13 +83,23 @@ describe("xai provider plugin", () => {
     vi.unstubAllGlobals();
   });
 
-  it("exposes xAI OAuth as the browser auth choice", async () => {
+  it("exposes xAI OAuth and preserves the explicit device-code alias", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 
-    expect(provider.auth?.map((method) => method.id)).toEqual(["api-key", "oauth"]);
+    expect(provider.auth?.map((method) => method.id)).toEqual(["api-key", "oauth", "device-code"]);
     const oauth = provider.auth?.find((method) => method.id === "oauth");
     expect(oauth?.kind).toBe("oauth");
     expect(oauth?.wizard?.choiceId).toBe("xai-oauth");
+    const deviceCode = provider.auth?.find((method) => method.id === "device-code");
+    expect(deviceCode?.kind).toBe("device_code");
+    expect(deviceCode?.wizard).toBeUndefined();
+    expect(manifest.providerAuthChoices).toContainEqual(
+      expect.objectContaining({
+        choiceId: "xai-oauth",
+        method: "oauth",
+        deprecatedChoiceIds: ["xai-device-code"],
+      }),
+    );
   });
 
   it("filters the xAI API-key catalog against live model ids", async () => {

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -82,13 +82,13 @@ describe("xai provider plugin", () => {
     vi.unstubAllGlobals();
   });
 
-  it("exposes OAuth and device-code auth choices", async () => {
+  it("exposes xAI OAuth as the browser auth choice", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 
-    expect(provider.auth?.map((method) => method.id)).toEqual(["api-key", "oauth", "device-code"]);
-    const deviceCode = provider.auth?.find((method) => method.id === "device-code");
-    expect(deviceCode?.kind).toBe("device_code");
-    expect(deviceCode?.wizard?.choiceId).toBe("xai-device-code");
+    expect(provider.auth?.map((method) => method.id)).toEqual(["api-key", "oauth"]);
+    const oauth = provider.auth?.find((method) => method.id === "oauth");
+    expect(oauth?.kind).toBe("oauth");
+    expect(oauth?.wizard?.choiceId).toBe("xai-oauth");
   });
 
   it("filters the xAI API-key catalog against live model ids", async () => {

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -95,9 +95,9 @@ describe("xai provider plugin", () => {
     expect(deviceCode?.wizard).toBeUndefined();
     expect(manifest.providerAuthChoices).toContainEqual(
       expect.objectContaining({
-        choiceId: "xai-oauth",
-        method: "oauth",
-        deprecatedChoiceIds: ["xai-device-code"],
+        assistantVisibility: "manual-only",
+        choiceId: "xai-device-code",
+        method: "device-code",
       }),
     );
   });

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -41,11 +41,7 @@ import {
   buildMissingXSearchApiKeyPayload,
   createXSearchToolDefinition,
 } from "./x-search-tool-shared.js";
-import {
-  createXaiDeviceCodeAuthMethod,
-  createXaiOAuthAuthMethod,
-  refreshXaiOAuthCredential,
-} from "./xai-oauth.js";
+import { createXaiOAuthAuthMethod, refreshXaiOAuthCredential } from "./xai-oauth.js";
 
 const PROVIDER_ID = "xai";
 type CodeExecutionModule = typeof import("./code-execution.js");
@@ -178,7 +174,7 @@ export default defineSingleProviderPluginEntry({
         },
       },
     ],
-    extraAuth: [createXaiOAuthAuthMethod(), createXaiDeviceCodeAuthMethod()],
+    extraAuth: [createXaiOAuthAuthMethod()],
     catalog: {
       order: "simple",
       run: async (ctx) => {

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -41,7 +41,11 @@ import {
   buildMissingXSearchApiKeyPayload,
   createXSearchToolDefinition,
 } from "./x-search-tool-shared.js";
-import { createXaiOAuthAuthMethod, refreshXaiOAuthCredential } from "./xai-oauth.js";
+import {
+  createXaiDeviceCodeAuthMethod,
+  createXaiOAuthAuthMethod,
+  refreshXaiOAuthCredential,
+} from "./xai-oauth.js";
 
 const PROVIDER_ID = "xai";
 type CodeExecutionModule = typeof import("./code-execution.js");
@@ -174,7 +178,7 @@ export default defineSingleProviderPluginEntry({
         },
       },
     ],
-    extraAuth: [createXaiOAuthAuthMethod()],
+    extraAuth: [createXaiOAuthAuthMethod(), createXaiDeviceCodeAuthMethod()],
     catalog: {
       order: "simple",
       run: async (ctx) => {

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -100,6 +100,7 @@
       "choiceId": "xai-oauth",
       "choiceLabel": "xAI OAuth",
       "choiceHint": "Remote-friendly browser sign-in without a localhost callback",
+      "deprecatedChoiceIds": ["xai-device-code"],
       "groupId": "xai",
       "groupLabel": "xAI (Grok)",
       "groupHint": "API key or OAuth",

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -100,11 +100,21 @@
       "choiceId": "xai-oauth",
       "choiceLabel": "xAI OAuth",
       "choiceHint": "Remote-friendly browser sign-in without a localhost callback",
-      "deprecatedChoiceIds": ["xai-device-code"],
       "groupId": "xai",
       "groupLabel": "xAI (Grok)",
       "groupHint": "API key or OAuth",
       "onboardingFeatured": true
+    },
+    {
+      "provider": "xai",
+      "method": "device-code",
+      "choiceId": "xai-device-code",
+      "choiceLabel": "xAI device code",
+      "choiceHint": "Compatibility alias for xAI OAuth device-code sign-in",
+      "assistantVisibility": "manual-only",
+      "groupId": "xai",
+      "groupLabel": "xAI (Grok)",
+      "groupHint": "API key or OAuth"
     }
   ],
   "uiHints": {

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -87,7 +87,7 @@
       "choiceLabel": "xAI API key",
       "groupId": "xai",
       "groupLabel": "xAI (Grok)",
-      "groupHint": "API key or browser OAuth",
+      "groupHint": "API key or OAuth",
       "onboardingFeatured": true,
       "optionKey": "xaiApiKey",
       "cliFlag": "--xai-api-key",
@@ -99,21 +99,10 @@
       "method": "oauth",
       "choiceId": "xai-oauth",
       "choiceLabel": "xAI OAuth",
-      "choiceHint": "Browser sign-in for eligible xAI accounts",
-      "groupId": "xai",
-      "groupLabel": "xAI (Grok)",
-      "groupHint": "API key or browser OAuth",
-      "onboardingFeatured": true
-    },
-    {
-      "provider": "xai",
-      "method": "device-code",
-      "choiceId": "xai-device-code",
-      "choiceLabel": "xAI device code",
       "choiceHint": "Remote-friendly browser sign-in without a localhost callback",
       "groupId": "xai",
       "groupLabel": "xAI (Grok)",
-      "groupHint": "API key or browser OAuth",
+      "groupHint": "API key or OAuth",
       "onboardingFeatured": true
     }
   ],

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -78,7 +78,9 @@ describe("xAI OAuth", () => {
 
     expect(method.id).toBe("device-code");
     expect(method.kind).toBe("device_code");
-    expect(method.wizard).toBeUndefined();
+    expect(method.wizard?.choiceId).toBe("xai-device-code");
+    expect(method.wizard?.methodId).toBe("device-code");
+    expect(method.wizard?.assistantVisibility).toBe("manual-only");
   });
 
   it("validates discovered endpoints before using them", async () => {

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -7,6 +7,7 @@ import {
 import type { OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createXaiDeviceCodeAuthMethod,
   createXaiOAuthAuthMethod,
   fetchXaiOAuthDiscovery,
   isTrustedXaiOAuthEndpoint,
@@ -70,6 +71,14 @@ describe("xAI OAuth", () => {
     expect(method.kind).toBe("oauth");
     expect(method.wizard?.choiceId).toBe("xai-oauth");
     expect(method.wizard?.methodId).toBe("oauth");
+  });
+
+  it("preserves device-code as an explicit auth method alias", () => {
+    const method = createXaiDeviceCodeAuthMethod();
+
+    expect(method.id).toBe("device-code");
+    expect(method.kind).toBe("device_code");
+    expect(method.wizard).toBeUndefined();
   });
 
   it("validates discovered endpoints before using them", async () => {

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -302,6 +302,25 @@ describe("xAI OAuth", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry refresh on transport errors so a rotated refresh token is never resent", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      throw new Error("socket hang up");
+    });
+    const credential = {
+      type: "oauth",
+      provider: "xai",
+      access: "access-1",
+      refresh: "refresh-1",
+      expires: 100,
+      tokenEndpoint: "https://auth.x.ai/oauth2/token",
+    } satisfies OAuthCredential & { tokenEndpoint: string };
+
+    await expect(refreshXaiOAuthCredential(credential, { fetchImpl })).rejects.toThrow(
+      "socket hang up",
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("does not coerce partial xAI expires_in values", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async () =>
       jsonResponse({

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -5,28 +5,15 @@ import {
   createTestWizardPrompter,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const waitForLocalOAuthCallbackMock = vi.hoisted(() => vi.fn());
-
-vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
-  waitForLocalOAuthCallback: waitForLocalOAuthCallbackMock,
-}));
-
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  buildXaiOAuthAuthorizationCodeTokenBody,
-  buildXaiOAuthAuthorizeUrl,
+  createXaiOAuthAuthMethod,
   fetchXaiOAuthDiscovery,
   isTrustedXaiOAuthEndpoint,
   loginXaiDeviceCode,
-  loginXaiOAuth,
   refreshXaiOAuthCredential,
-  XAI_OAUTH_CALLBACK_CORS_ORIGIN_ALLOWLIST,
-  XAI_OAUTH_CALLBACK_HOST,
-  XAI_OAUTH_CALLBACK_PORT,
   XAI_OAUTH_CLIENT_ID,
   XAI_OAUTH_DISCOVERY_URL,
-  XAI_OAUTH_REDIRECT_URI,
   XAI_OAUTH_SCOPE,
 } from "./xai-oauth.js";
 
@@ -61,32 +48,7 @@ function requestUrl(input: RequestInfo | URL): string {
   return input.url;
 }
 
-function stubSuccessfulXaiOAuthNetwork(): void {
-  const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
-    if (requestUrl(url) === XAI_OAUTH_DISCOVERY_URL) {
-      return jsonResponse({
-        authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
-        token_endpoint: "https://auth.x.ai/oauth2/token",
-      });
-    }
-
-    expect(requestUrl(url)).toBe("https://auth.x.ai/oauth2/token");
-    expect(init?.method).toBe("POST");
-    expect(requireStringBody(init)).toContain("code=AUTHCODE");
-    return jsonResponse({
-      access_token: "access-token",
-      refresh_token: "refresh-token",
-      expires_in: 3600,
-    });
-  });
-  vi.stubGlobal("fetch", fetchImpl);
-}
-
 describe("xAI OAuth", () => {
-  beforeEach(() => {
-    waitForLocalOAuthCallbackMock.mockReset();
-  });
-
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
@@ -101,50 +63,13 @@ describe("xAI OAuth", () => {
     expect(isTrustedXaiOAuthEndpoint("not a url")).toBe(false);
   });
 
-  it("exposes the loopback CORS origin allowlist that loginXaiOAuth threads to the SDK helper", () => {
-    expect([...XAI_OAUTH_CALLBACK_CORS_ORIGIN_ALLOWLIST]).toEqual(["auth.x.ai", "accounts.x.ai"]);
-  });
+  it("keeps the public auth method named OAuth while using device code", () => {
+    const method = createXaiOAuthAuthMethod();
 
-  it("builds the xAI authorize URL for OpenClaw", () => {
-    const url = new URL(
-      buildXaiOAuthAuthorizeUrl({
-        authorizationEndpoint: "https://auth.x.ai/oauth2/authorize",
-        state: "state-1",
-        nonce: "nonce-1",
-        challenge: "challenge-1",
-      }),
-    );
-
-    expect(url.origin + url.pathname).toBe("https://auth.x.ai/oauth2/authorize");
-    expect(url.searchParams.get("response_type")).toBe("code");
-    expect(url.searchParams.get("client_id")).toBe(XAI_OAUTH_CLIENT_ID);
-    expect(url.searchParams.get("redirect_uri")).toBe(XAI_OAUTH_REDIRECT_URI);
-    expect(url.searchParams.get("scope")).toBe(XAI_OAUTH_SCOPE);
-    expect(url.searchParams.get("code_challenge")).toBe("challenge-1");
-    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
-    expect(url.searchParams.get("state")).toBe("state-1");
-    expect(url.searchParams.get("nonce")).toBe("nonce-1");
-    expect(url.searchParams.get("plan")).toBe("generic");
-    expect(url.searchParams.get("referrer")).toBe("openclaw");
-    expect(XAI_OAUTH_REDIRECT_URI).toContain(`:${XAI_OAUTH_CALLBACK_PORT}/`);
-  });
-
-  it("echoes PKCE challenge fields when exchanging authorization codes with xAI", () => {
-    expect(
-      buildXaiOAuthAuthorizationCodeTokenBody({
-        code: "AUTHCODE",
-        codeVerifier: "verifier-1",
-        codeChallenge: "challenge-1",
-      }),
-    ).toEqual({
-      grant_type: "authorization_code",
-      code: "AUTHCODE",
-      redirect_uri: XAI_OAUTH_REDIRECT_URI,
-      client_id: XAI_OAUTH_CLIENT_ID,
-      code_verifier: "verifier-1",
-      code_challenge: "challenge-1",
-      code_challenge_method: "S256",
-    });
+    expect(method.id).toBe("oauth");
+    expect(method.kind).toBe("oauth");
+    expect(method.wizard?.choiceId).toBe("xai-oauth");
+    expect(method.wizard?.methodId).toBe("oauth");
   });
 
   it("validates discovered endpoints before using them", async () => {
@@ -157,7 +82,6 @@ describe("xAI OAuth", () => {
     );
 
     await expect(fetchXaiOAuthDiscovery({ fetchImpl })).resolves.toEqual({
-      authorizationEndpoint: "https://auth.x.ai/oauth2/authorize",
       tokenEndpoint: "https://auth.x.ai/oauth2/token",
     });
 
@@ -272,6 +196,112 @@ describe("xAI OAuth", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("retries transient HTML refresh failures before succeeding", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response("<!DOCTYPE html><html><body>Attention Required! Cloudflare</body></html>", {
+          status: 403,
+          headers: {
+            "Content-Type": "text/html",
+            "cf-mitigated": "challenge",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response("<!DOCTYPE html><html><body>Just a moment...</body></html>", {
+          status: 403,
+          headers: {
+            "Content-Type": "text/html",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "access-2",
+          expires_in: 120,
+        }),
+      );
+    const credential = {
+      type: "oauth",
+      provider: "xai",
+      access: "access-1",
+      refresh: "refresh-1",
+      expires: 100,
+      tokenEndpoint: "https://auth.x.ai/oauth2/token",
+    } satisfies OAuthCredential & { tokenEndpoint: string };
+
+    const refresh = refreshXaiOAuthCredential(credential, { fetchImpl, now: () => 1_000 });
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(250);
+    const refreshed = await refresh;
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(refreshed.access).toBe("access-2");
+    expect(refreshed.refresh).toBe("refresh-1");
+  });
+
+  it("surfaces xAI Cloudflare refresh failures after retry exhaustion", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          "<!DOCTYPE html><html><head><title>Attention Required! | Cloudflare</title></head><body>You are unable to access x.ai</body></html>",
+          {
+            status: 403,
+            headers: {
+              "Content-Type": "text/html",
+              "cf-mitigated": "challenge",
+            },
+          },
+        ),
+    );
+    const credential = {
+      type: "oauth",
+      provider: "xai",
+      access: "access-1",
+      refresh: "refresh-1",
+      expires: 100,
+      tokenEndpoint: "https://auth.x.ai/oauth2/token",
+    } satisfies OAuthCredential & { tokenEndpoint: string };
+
+    const refresh = refreshXaiOAuthCredential(credential, { fetchImpl, now: () => 1_000 });
+    const expectation = expect(refresh).rejects.toThrow(
+      "xAI returned an HTML/Cloudflare challenge",
+    );
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expectation;
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry terminal xAI OAuth refresh errors", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      jsonResponse(
+        {
+          error: "invalid_grant",
+          error_description: "Invalid or unknown refresh token",
+        },
+        { status: 400 },
+      ),
+    );
+    const credential = {
+      type: "oauth",
+      provider: "xai",
+      access: "access-1",
+      refresh: "refresh-1",
+      expires: 100,
+      tokenEndpoint: "https://auth.x.ai/oauth2/token",
+    } satisfies OAuthCredential & { tokenEndpoint: string };
+
+    await expect(refreshXaiOAuthCredential(credential, { fetchImpl })).rejects.toThrow(
+      "invalid_grant (Invalid or unknown refresh token)",
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("does not coerce partial xAI expires_in values", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async () =>
       jsonResponse({
@@ -332,85 +362,6 @@ describe("xAI OAuth", () => {
     const refreshed = await refreshXaiOAuthCredential(credential, { fetchImpl, now: () => 1_000 });
 
     expect(refreshed.expires).toBe(100);
-  });
-
-  it("prints the authorize URL through plain prompter output so terminal link detection keeps it whole", async () => {
-    waitForLocalOAuthCallbackMock.mockResolvedValue({ code: "AUTHCODE", state: "state-1" });
-    stubSuccessfulXaiOAuthNetwork();
-
-    const progress = { update: vi.fn(), stop: vi.fn() };
-    const note = vi.fn<(message: string, title?: string) => Promise<void>>(async () => undefined);
-    const plain = vi.fn<(message: string) => Promise<void>>(async () => undefined);
-    const openUrl = vi.fn<(url: string) => Promise<void>>(async () => undefined);
-    const runtimeLog = vi.fn<(message: string) => void>();
-    const ctx = {
-      config: {},
-      isRemote: true,
-      openUrl,
-      prompter: {
-        note,
-        plain,
-        progress: vi.fn(() => progress),
-      },
-      runtime: {
-        log: runtimeLog,
-        error: vi.fn(),
-        exit: vi.fn(),
-      },
-      oauth: { createVpsAwareHandlers: vi.fn() },
-    } as unknown as ProviderAuthContext;
-
-    await loginXaiOAuth(ctx);
-
-    expect(openUrl).not.toHaveBeenCalled();
-    const noteMessage = note.mock.calls[0]?.[0] ?? "";
-    expect(noteMessage).toContain("Open this xAI OAuth URL in your browser:");
-    expect(noteMessage).toContain(
-      `ssh -N -L ${XAI_OAUTH_CALLBACK_PORT}:${XAI_OAUTH_CALLBACK_HOST}:${XAI_OAUTH_CALLBACK_PORT} <host>`,
-    );
-    expect(noteMessage).not.toContain("https://auth.x.ai/oauth2/authorize");
-
-    const plainOutput = plain.mock.calls[0]?.[0] ?? "";
-    expect(plainOutput.trim()).toMatch(/^https:\/\/auth\.x\.ai\/oauth2\/authorize\?/);
-    expect(plainOutput).toContain(`client_id=${encodeURIComponent(XAI_OAUTH_CLIENT_ID)}`);
-    expect(plainOutput).toContain("code_challenge=");
-    expect(runtimeLog).not.toHaveBeenCalled();
-    expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
-  });
-
-  it("keeps the authorize URL visible for prompters without plain output", async () => {
-    waitForLocalOAuthCallbackMock.mockResolvedValue({ code: "AUTHCODE", state: "state-1" });
-    stubSuccessfulXaiOAuthNetwork();
-
-    const progress = { update: vi.fn(), stop: vi.fn() };
-    const note = vi.fn<(message: string, title?: string) => Promise<void>>(async () => undefined);
-    const openUrl = vi.fn<(url: string) => Promise<void>>(async () => undefined);
-    const runtimeLog = vi.fn<(message: string) => void>();
-    const ctx = {
-      config: {},
-      isRemote: false,
-      openUrl,
-      prompter: {
-        note,
-        progress: vi.fn(() => progress),
-      },
-      runtime: {
-        log: runtimeLog,
-        error: vi.fn(),
-        exit: vi.fn(),
-      },
-      oauth: { createVpsAwareHandlers: vi.fn() },
-    } as unknown as ProviderAuthContext;
-
-    await loginXaiOAuth(ctx);
-
-    const authorizeUrl = openUrl.mock.calls[0]?.[0] ?? "";
-    const noteMessage = note.mock.calls[0]?.[0] ?? "";
-    expect(authorizeUrl).toContain("https://auth.x.ai/oauth2/authorize?");
-    expect(noteMessage).toContain("Open this xAI OAuth URL in your browser:");
-    expect(noteMessage).not.toContain(authorizeUrl);
-    expect(runtimeLog.mock.calls[0]?.[0] ?? "").toContain(authorizeUrl);
-    expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
   });
 
   it("logs in with xAI device code without a localhost callback", async () => {
@@ -474,7 +425,7 @@ describe("xAI OAuth", () => {
     const result = await loginXaiDeviceCode(ctx);
 
     expect(openUrl).not.toHaveBeenCalled();
-    expect(note).toHaveBeenCalledWith(expect.stringContaining("ABCD-1234"), "xAI device code");
+    expect(note).toHaveBeenCalledWith(expect.stringContaining("ABCD-1234"), "xAI OAuth");
     const remoteLog = log.mock.calls[0]?.[0];
     expect(remoteLog).toContain("https://accounts.x.ai/oauth2/device");
     expect(remoteLog).not.toContain("ABCD-1234");
@@ -506,7 +457,7 @@ describe("xAI OAuth", () => {
       access: expect.any(String),
     });
     expect(progress.update).toHaveBeenCalledWith("Waiting for xAI device authorization...");
-    expect(progress.stop).toHaveBeenCalledWith("xAI device code complete");
+    expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
   });
 
   it("falls back for unsafe xAI device-code lifetime fields", async () => {
@@ -561,8 +512,8 @@ describe("xAI OAuth", () => {
 
     expect(note).toHaveBeenCalledWith(
       expect.stringContaining("Code expires in 5 minutes."),
-      "xAI device code",
+      "xAI OAuth",
     );
-    expect(progress.stop).toHaveBeenCalledWith("xAI device code complete");
+    expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
   });
 });

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -311,6 +311,31 @@ describe("xAI OAuth", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry refresh-token service failures", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      jsonResponse(
+        {
+          error: "server_error",
+          error_description: "try again later",
+        },
+        { status: 503 },
+      ),
+    );
+    const credential = {
+      type: "oauth",
+      provider: "xai",
+      access: "access-1",
+      refresh: "refresh-1",
+      expires: 100,
+      tokenEndpoint: "https://auth.x.ai/oauth2/token",
+    } satisfies OAuthCredential & { tokenEndpoint: string };
+
+    await expect(refreshXaiOAuthCredential(credential, { fetchImpl })).rejects.toThrow(
+      "server_error (try again later)",
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("does not retry refresh on transport errors so a rotated refresh token is never resent", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async () => {
       throw new Error("socket hang up");

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -1,5 +1,4 @@
 // Xai plugin module implements xai oauth behavior.
-import { randomBytes } from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   positiveSecondsToSafeMilliseconds,
@@ -9,42 +8,32 @@ import {
 import type { ProviderAuthContext, ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
 import {
   buildOauthProviderAuthResult,
-  generateHexPkceVerifierChallenge,
   toFormUrlEncoded,
   type OAuthCredential,
   type ProviderAuthResult,
 } from "openclaw/plugin-sdk/provider-auth";
-import { waitForLocalOAuthCallback } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { applyXaiConfig, XAI_DEFAULT_MODEL_REF } from "./onboard.js";
 import { xaiUserAgent } from "./src/xai-user-agent.js";
 
 const PROVIDER_ID = "xai";
 export const XAI_OAUTH_METHOD_ID = "oauth";
 export const XAI_OAUTH_CHOICE_ID = "xai-oauth";
-export const XAI_DEVICE_CODE_METHOD_ID = "device-code";
-export const XAI_DEVICE_CODE_CHOICE_ID = "xai-device-code";
 export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
 export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
 export const XAI_OAUTH_ISSUER = "https://auth.x.ai";
 export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
 const XAI_LEGACY_OAUTH_TOKEN_ENDPOINT = `${XAI_OAUTH_ISSUER}/oauth/token`;
-export const XAI_OAUTH_CALLBACK_HOST = "127.0.0.1";
-export const XAI_OAUTH_CALLBACK_PORT = 56121;
-export const XAI_OAUTH_CALLBACK_PATH = "/callback";
-export const XAI_OAUTH_REDIRECT_URI = `http://${XAI_OAUTH_CALLBACK_HOST}:${XAI_OAUTH_CALLBACK_PORT}${XAI_OAUTH_CALLBACK_PATH}`;
-// Hosts whose CORS preflight against the loopback redirect URI should be
-// echoed; everything else gets a 204 with no `Access-Control-Allow-*`.
-export const XAI_OAUTH_CALLBACK_CORS_ORIGIN_ALLOWLIST = ["auth.x.ai", "accounts.x.ai"] as const;
 
 const XAI_OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const XAI_OAUTH_FETCH_TIMEOUT_MS = 30 * 1000;
+const XAI_OAUTH_REFRESH_MAX_ATTEMPTS = 3;
+const XAI_OAUTH_REFRESH_RETRY_DELAY_MS = 250;
 const XAI_DEVICE_CODE_DEFAULT_INTERVAL_MS = 5 * 1000;
 const XAI_DEVICE_CODE_MIN_INTERVAL_MS = 1 * 1000;
 const XAI_DEVICE_CODE_SLOW_DOWN_INCREMENT_MS = 5 * 1000;
 const XAI_DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 
 type XaiOAuthDiscovery = {
-  authorizationEndpoint: string;
   tokenEndpoint: string;
 };
 
@@ -85,6 +74,11 @@ type XaiOAuthErrorResponse = {
   errorDescription?: string;
 };
 
+type XaiOAuthResponseBody = {
+  json: unknown;
+  text: string;
+};
+
 function getFetchImpl(fetchImpl?: typeof fetch): typeof fetch {
   return fetchImpl ?? fetch;
 }
@@ -114,20 +108,27 @@ function readStringRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
-async function readJsonResponse(response: Response, context: string): Promise<unknown> {
-  let body: unknown;
+async function readResponseBody(response: Response): Promise<XaiOAuthResponseBody> {
+  const text = await response.text();
+  let json: unknown;
   try {
-    body = await response.json();
+    json = JSON.parse(text);
   } catch {
-    body = null;
+    json = null;
   }
+  return { json, text };
+}
+
+async function readJsonResponse(response: Response, context: string): Promise<unknown> {
+  const body = await readResponseBody(response);
   if (!response.ok) {
-    const errorText = readStringRecord(body).error_description ?? readStringRecord(body).error;
+    const errorText =
+      readStringRecord(body.json).error_description ?? readStringRecord(body.json).error;
     throw new Error(
       `${context} failed (${response.status})${typeof errorText === "string" ? `: ${errorText}` : ""}`,
     );
   }
-  return body;
+  return body.json;
 }
 
 async function fetchXaiOAuthDiscoveryDocument(
@@ -147,16 +148,11 @@ export async function fetchXaiOAuthDiscovery(
   options: XaiOAuthFetchOptions = {},
 ): Promise<XaiOAuthDiscovery> {
   const json = await fetchXaiOAuthDiscoveryDocument(options);
-  const authorizationEndpoint = json.authorization_endpoint;
   const tokenEndpoint = json.token_endpoint;
-  if (typeof authorizationEndpoint !== "string" || typeof tokenEndpoint !== "string") {
-    throw new Error("xAI OAuth discovery response is missing endpoints");
+  if (typeof tokenEndpoint !== "string") {
+    throw new Error("xAI OAuth discovery response is missing the token endpoint");
   }
   return {
-    authorizationEndpoint: requireTrustedXaiOAuthEndpoint(
-      authorizationEndpoint,
-      "authorization endpoint",
-    ),
     tokenEndpoint: requireTrustedXaiOAuthEndpoint(tokenEndpoint, "token endpoint"),
   };
 }
@@ -176,45 +172,6 @@ async function fetchXaiDeviceCodeDiscovery(
       "device authorization endpoint",
     ),
     tokenEndpoint: requireTrustedXaiOAuthEndpoint(tokenEndpoint, "token endpoint"),
-  };
-}
-
-export function buildXaiOAuthAuthorizeUrl(params: {
-  authorizationEndpoint: string;
-  state: string;
-  nonce: string;
-  challenge: string;
-}): string {
-  const url = new URL(
-    requireTrustedXaiOAuthEndpoint(params.authorizationEndpoint, "authorization endpoint"),
-  );
-  url.searchParams.set("response_type", "code");
-  url.searchParams.set("client_id", XAI_OAUTH_CLIENT_ID);
-  url.searchParams.set("redirect_uri", XAI_OAUTH_REDIRECT_URI);
-  url.searchParams.set("scope", XAI_OAUTH_SCOPE);
-  url.searchParams.set("state", params.state);
-  url.searchParams.set("nonce", params.nonce);
-  url.searchParams.set("code_challenge", params.challenge);
-  url.searchParams.set("code_challenge_method", "S256");
-  url.searchParams.set("plan", "generic");
-  url.searchParams.set("referrer", "openclaw");
-  return url.toString();
-}
-
-export function buildXaiOAuthAuthorizationCodeTokenBody(params: {
-  code: string;
-  codeVerifier: string;
-  codeChallenge: string;
-}): Record<string, string> {
-  return {
-    grant_type: "authorization_code",
-    code: params.code,
-    redirect_uri: XAI_OAUTH_REDIRECT_URI,
-    client_id: XAI_OAUTH_CLIENT_ID,
-    code_verifier: params.codeVerifier,
-    // xAI validates these PKCE fields again at token exchange for this client.
-    code_challenge: params.codeChallenge,
-    code_challenge_method: "S256",
   };
 }
 
@@ -288,6 +245,60 @@ function formatXaiOAuthError(params: { context: string; status: number; body: un
   return `${params.context} failed (${params.status})`;
 }
 
+function isLikelyXaiCloudflareChallenge(params: { response: Response; bodyText: string }): boolean {
+  const contentType = params.response.headers.get("content-type") ?? "";
+  return (
+    params.response.headers.get("cf-mitigated") === "challenge" ||
+    /text\/html/i.test(contentType) ||
+    /<!doctype html|<html\b/i.test(params.bodyText) ||
+    /\b(?:cloudflare|attention required|just a moment|enable javascript and cookies|challenge-platform)\b/i.test(
+      params.bodyText,
+    )
+  );
+}
+
+function formatXaiOAuthCloudflareChallengeError(params: {
+  context: string;
+  status: number;
+}): string {
+  return (
+    `${params.context} failed (${params.status}): xAI returned an HTML/Cloudflare challenge ` +
+    "instead of OAuth JSON. xAI may be blocking the automated token refresh; try again later " +
+    "or re-run xAI OAuth login."
+  );
+}
+
+/**
+ * Single source of truth for how a non-OK token response is reported and whether
+ * it is worth retrying. Detection runs once so the message and the retry decision
+ * never disagree: a structured OAuth error (e.g. invalid_grant) is authoritative
+ * and final, transient transport failures (5xx/429) and Cloudflare HTML
+ * challenges are retryable.
+ */
+function describeXaiOAuthTokenFailure(params: {
+  context: string;
+  response: Response;
+  body: XaiOAuthResponseBody;
+}): { message: string; retryable: boolean } {
+  const { context, response, body } = params;
+  const status = response.status;
+  const hasStructuredError = Boolean(parseXaiOAuthErrorResponse(body.json).error);
+  const isCloudflareChallenge =
+    !hasStructuredError && isLikelyXaiCloudflareChallenge({ response, bodyText: body.text });
+  return {
+    message: isCloudflareChallenge
+      ? formatXaiOAuthCloudflareChallengeError({ context, status })
+      : formatXaiOAuthError({ context, status, body: body.json }),
+    retryable: status >= 500 || status === 429 || isCloudflareChallenge,
+  };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 async function exchangeXaiOAuthToken(
   params: {
     tokenEndpoint: string;
@@ -296,24 +307,48 @@ async function exchangeXaiOAuthToken(
     requireRefreshToken?: boolean;
   } & XaiOAuthFetchOptions,
 ): Promise<XaiOAuthTokenResponse> {
-  const response = await getFetchImpl(params.fetchImpl)(
-    requireTrustedXaiOAuthEndpoint(params.tokenEndpoint, "token endpoint"),
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Accept: "application/json",
-        "User-Agent": xaiUserAgent(),
-      },
-      body: toFormUrlEncoded(params.body),
-      signal: AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
-    },
-  );
-  return parseXaiOAuthTokenResponse(
-    await readJsonResponse(response, params.context),
-    params.now ?? Date.now,
-    { requireRefreshToken: params.requireRefreshToken },
-  );
+  const endpoint = requireTrustedXaiOAuthEndpoint(params.tokenEndpoint, "token endpoint");
+  const maxAttempts =
+    params.body.grant_type === "refresh_token" ? XAI_OAUTH_REFRESH_MAX_ATTEMPTS : 1;
+  let lastMessage = `${params.context} failed`;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let response: Response;
+    try {
+      response = await getFetchImpl(params.fetchImpl)(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+          "User-Agent": xaiUserAgent(),
+        },
+        body: toFormUrlEncoded(params.body),
+        signal: AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
+      });
+    } catch (err) {
+      lastMessage = `${params.context} failed: ${formatErrorMessage(err)}`;
+      if (attempt >= maxAttempts) {
+        throw new Error(lastMessage, { cause: err });
+      }
+      await sleep(XAI_OAUTH_REFRESH_RETRY_DELAY_MS);
+      continue;
+    }
+    const body = await readResponseBody(response);
+    if (response.ok) {
+      return parseXaiOAuthTokenResponse(body.json, params.now ?? Date.now, {
+        requireRefreshToken: params.requireRefreshToken,
+      });
+    }
+
+    const failure = describeXaiOAuthTokenFailure({ context: params.context, response, body });
+    lastMessage = failure.message;
+    if (attempt >= maxAttempts || !failure.retryable) {
+      throw new Error(lastMessage);
+    }
+    await sleep(XAI_OAUTH_REFRESH_RETRY_DELAY_MS);
+  }
+
+  throw new Error(lastMessage);
 }
 
 async function requestXaiDeviceCode(
@@ -493,113 +528,27 @@ function readCredentialString<TKey extends string>(
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
+function isLegacyXaiOAuthTokenEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint);
+    return `${url.origin}${url.pathname}` === XAI_LEGACY_OAUTH_TOKEN_ENDPOINT;
+  } catch {
+    return false;
+  }
+}
+
 async function resolveXaiOAuthRefreshTokenEndpoint(
   credential: OAuthCredential,
   options: XaiOAuthFetchOptions,
 ): Promise<string> {
   const cachedEndpoint = readCredentialString(credential, "tokenEndpoint");
-  if (!cachedEndpoint) {
+  // Rediscover when there is no cached endpoint, or when an older persisted
+  // credential still points at the retired endpoint, so refresh writes back the
+  // current OAuth token endpoint.
+  if (!cachedEndpoint || isLegacyXaiOAuthTokenEndpoint(cachedEndpoint)) {
     return (await fetchXaiOAuthDiscovery(options)).tokenEndpoint;
   }
-  let endpoint: URL;
-  try {
-    endpoint = new URL(cachedEndpoint);
-  } catch {
-    return cachedEndpoint;
-  }
-  if (`${endpoint.origin}${endpoint.pathname}` !== XAI_LEGACY_OAUTH_TOKEN_ENDPOINT) {
-    return cachedEndpoint;
-  }
-  // Older persisted xAI OAuth credentials can point at the retired endpoint;
-  // rediscover once so refresh writes back the current OAuth token endpoint.
-  return (await fetchXaiOAuthDiscovery(options)).tokenEndpoint;
-}
-
-async function noteXaiOAuthUrl(ctx: ProviderAuthContext, authorizeUrl: string): Promise<void> {
-  const lines = ["Open this xAI OAuth URL in your browser:"];
-  if (ctx.isRemote) {
-    lines.push(
-      "",
-      "Remote host: forward the callback before signing in:",
-      `ssh -N -L ${XAI_OAUTH_CALLBACK_PORT}:${XAI_OAUTH_CALLBACK_HOST}:${XAI_OAUTH_CALLBACK_PORT} <host>`,
-    );
-  }
-  await ctx.prompter.note(lines.join("\n"), "xAI OAuth");
-  if (ctx.prompter.plain) {
-    await ctx.prompter.plain(`\n${authorizeUrl}\n`);
-    return;
-  }
-  ctx.runtime.log(`\n${authorizeUrl}\n`);
-}
-
-export async function loginXaiOAuth(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
-  const progress = ctx.prompter.progress("Starting xAI OAuth...");
-  try {
-    const discovery = await fetchXaiOAuthDiscovery();
-    const pkce = generateHexPkceVerifierChallenge();
-    const state = randomBytes(32).toString("hex");
-    const nonce = randomBytes(16).toString("hex");
-    const authorizeUrl = buildXaiOAuthAuthorizeUrl({
-      authorizationEndpoint: discovery.authorizationEndpoint,
-      state,
-      nonce,
-      challenge: pkce.challenge,
-    });
-    progress.update(`Waiting for xAI OAuth callback on ${XAI_OAUTH_REDIRECT_URI}...`);
-    const callbackPromise = waitForLocalOAuthCallback({
-      expectedState: state,
-      timeoutMs: XAI_OAUTH_TIMEOUT_MS,
-      port: XAI_OAUTH_CALLBACK_PORT,
-      callbackPath: XAI_OAUTH_CALLBACK_PATH,
-      redirectUri: XAI_OAUTH_REDIRECT_URI,
-      hostname: XAI_OAUTH_CALLBACK_HOST,
-      successTitle: "xAI OAuth complete",
-      onProgress: (message) => progress.update(message),
-      corsOriginAllowlist: XAI_OAUTH_CALLBACK_CORS_ORIGIN_ALLOWLIST,
-    });
-    void callbackPromise.catch(() => undefined);
-    await noteXaiOAuthUrl(ctx, authorizeUrl);
-    if (!ctx.isRemote) {
-      await ctx.openUrl(authorizeUrl);
-    }
-    const callback = await callbackPromise;
-    const tokens = await exchangeXaiOAuthToken({
-      tokenEndpoint: discovery.tokenEndpoint,
-      context: "xAI OAuth token exchange",
-      requireRefreshToken: true,
-      body: buildXaiOAuthAuthorizationCodeTokenBody({
-        code: callback.code,
-        codeVerifier: pkce.verifier,
-        codeChallenge: pkce.challenge,
-      }),
-    });
-    const identity = resolveXaiOAuthIdentity(tokens);
-    progress.stop("xAI OAuth complete");
-    return buildOauthProviderAuthResult({
-      providerId: PROVIDER_ID,
-      defaultModel: XAI_DEFAULT_MODEL_REF,
-      access: tokens.accessToken,
-      refresh: tokens.refreshToken,
-      expires: tokens.expires,
-      email: identity.email,
-      displayName: identity.displayName,
-      profileName: identity.email ?? identity.accountId,
-      configPatch: applyXaiConfig(ctx.config),
-      credentialExtra: {
-        tokenEndpoint: discovery.tokenEndpoint,
-        issuer: XAI_OAUTH_ISSUER,
-        ...(tokens.idToken ? { idToken: tokens.idToken } : {}),
-        ...(identity.accountId ? { accountId: identity.accountId } : {}),
-      },
-      notes: [
-        "xAI OAuth uses your xAI account entitlement; xAI API keys still work.",
-        "xAI may label the consent app as Grok Build because OpenClaw uses xAI's shared OAuth client.",
-      ],
-    });
-  } catch (err) {
-    progress.stop("xAI OAuth failed");
-    throw new Error(`xAI OAuth failed: ${formatErrorMessage(err)}`, { cause: err });
-  }
+  return cachedEndpoint;
 }
 
 async function noteXaiDeviceCode(
@@ -616,15 +565,15 @@ async function noteXaiDeviceCode(
       `Code: ${deviceCode.userCode}`,
       `Code expires in ${expiresInMinutes} minutes. Never share it.`,
     ].join("\n"),
-    "xAI device code",
+    "xAI OAuth",
   );
 }
 
 export async function loginXaiDeviceCode(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
-  const progress = ctx.prompter.progress("Starting xAI device code flow...");
+  const progress = ctx.prompter.progress("Starting xAI OAuth...");
   try {
     const discovery = await fetchXaiDeviceCodeDiscovery();
-    progress.update("Requesting xAI device code...");
+    progress.update("Requesting xAI OAuth device code...");
     const deviceCode = await requestXaiDeviceCode({
       deviceAuthorizationEndpoint: discovery.deviceAuthorizationEndpoint,
     });
@@ -650,7 +599,7 @@ export async function loginXaiDeviceCode(ctx: ProviderAuthContext): Promise<Prov
       intervalMs: deviceCode.intervalMs,
     });
     const identity = resolveXaiOAuthIdentity(tokens);
-    progress.stop("xAI device code complete");
+    progress.stop("xAI OAuth complete");
     return buildOauthProviderAuthResult({
       providerId: PROVIDER_ID,
       defaultModel: XAI_DEFAULT_MODEL_REF,
@@ -670,13 +619,13 @@ export async function loginXaiDeviceCode(ctx: ProviderAuthContext): Promise<Prov
         ...(identity.accountId ? { accountId: identity.accountId } : {}),
       },
       notes: [
-        "xAI device code login uses your xAI account entitlement without requiring a localhost callback.",
+        "xAI OAuth uses device-code verification without requiring a localhost callback.",
         "xAI may label the consent app as Grok Build because OpenClaw uses xAI's shared OAuth client.",
       ],
     });
   } catch (err) {
-    progress.stop("xAI device code failed");
-    throw new Error(`xAI device code failed: ${formatErrorMessage(err)}`, { cause: err });
+    progress.stop("xAI OAuth failed");
+    throw new Error(`xAI OAuth failed: ${formatErrorMessage(err)}`, { cause: err });
   }
 }
 
@@ -720,35 +669,16 @@ export function createXaiOAuthAuthMethod(): ProviderAuthMethod {
   return {
     id: XAI_OAUTH_METHOD_ID,
     label: "xAI OAuth",
-    hint: "Browser sign-in for eligible xAI accounts",
+    hint: "Remote-friendly browser sign-in without a localhost callback",
     kind: "oauth",
     wizard: {
       choiceId: XAI_OAUTH_CHOICE_ID,
       choiceLabel: "xAI OAuth",
-      choiceHint: "Browser sign-in for eligible xAI accounts",
-      groupId: PROVIDER_ID,
-      groupLabel: "xAI (Grok)",
-      groupHint: "API key or browser OAuth",
-      methodId: XAI_OAUTH_METHOD_ID,
-    },
-    run: async (ctx) => loginXaiOAuth(ctx),
-  };
-}
-
-export function createXaiDeviceCodeAuthMethod(): ProviderAuthMethod {
-  return {
-    id: XAI_DEVICE_CODE_METHOD_ID,
-    label: "xAI device code",
-    hint: "Remote-friendly browser sign-in without a localhost callback",
-    kind: "device_code",
-    wizard: {
-      choiceId: XAI_DEVICE_CODE_CHOICE_ID,
-      choiceLabel: "xAI device code",
       choiceHint: "Remote-friendly browser sign-in without a localhost callback",
       groupId: PROVIDER_ID,
       groupLabel: "xAI (Grok)",
-      groupHint: "API key or browser OAuth",
-      methodId: XAI_DEVICE_CODE_METHOD_ID,
+      groupHint: "API key or OAuth",
+      methodId: XAI_OAUTH_METHOD_ID,
     },
     run: async (ctx) => loginXaiDeviceCode(ctx),
   };

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -19,6 +19,7 @@ const PROVIDER_ID = "xai";
 export const XAI_OAUTH_METHOD_ID = "oauth";
 export const XAI_OAUTH_CHOICE_ID = "xai-oauth";
 export const XAI_DEVICE_CODE_METHOD_ID = "device-code";
+export const XAI_DEVICE_CODE_CHOICE_ID = "xai-device-code";
 export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
 export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
 export const XAI_OAUTH_ISSUER = "https://auth.x.ai";
@@ -688,6 +689,16 @@ export function createXaiDeviceCodeAuthMethod(): ProviderAuthMethod {
     label: "xAI device code",
     hint: "Deprecated alias for xAI OAuth device-code login",
     kind: "device_code",
+    wizard: {
+      choiceId: XAI_DEVICE_CODE_CHOICE_ID,
+      choiceLabel: "xAI device code",
+      choiceHint: "Compatibility alias for xAI OAuth device-code sign-in",
+      assistantVisibility: "manual-only",
+      groupId: PROVIDER_ID,
+      groupLabel: "xAI (Grok)",
+      groupHint: "API key or OAuth",
+      methodId: XAI_DEVICE_CODE_METHOD_ID,
+    },
     run: async (ctx) => loginXaiDeviceCode(ctx),
   };
 }

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -326,12 +326,11 @@ async function exchangeXaiOAuthToken(
         signal: AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
       });
     } catch (err) {
-      lastMessage = `${params.context} failed: ${formatErrorMessage(err)}`;
-      if (attempt >= maxAttempts) {
-        throw new Error(lastMessage, { cause: err });
-      }
-      await sleep(XAI_OAUTH_REFRESH_RETRY_DELAY_MS);
-      continue;
+      // Transport failures are not safe to retry for refresh grants: xAI rotates
+      // refresh tokens, so a response lost after xAI consumed the token would burn
+      // it on resend. Retryable Cloudflare/5xx/429 cases are handled on the response
+      // branch below, where the request provably did not consume the refresh token.
+      throw new Error(`${params.context} failed: ${formatErrorMessage(err)}`, { cause: err });
     }
     const body = await readResponseBody(response);
     if (response.ok) {

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -18,6 +18,7 @@ import { xaiUserAgent } from "./src/xai-user-agent.js";
 const PROVIDER_ID = "xai";
 export const XAI_OAUTH_METHOD_ID = "oauth";
 export const XAI_OAUTH_CHOICE_ID = "xai-oauth";
+export const XAI_DEVICE_CODE_METHOD_ID = "device-code";
 export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
 export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
 export const XAI_OAUTH_ISSUER = "https://auth.x.ai";
@@ -679,6 +680,16 @@ export function createXaiOAuthAuthMethod(): ProviderAuthMethod {
       groupHint: "API key or OAuth",
       methodId: XAI_OAUTH_METHOD_ID,
     },
+    run: async (ctx) => loginXaiDeviceCode(ctx),
+  };
+}
+
+export function createXaiDeviceCodeAuthMethod(): ProviderAuthMethod {
+  return {
+    id: XAI_DEVICE_CODE_METHOD_ID,
+    label: "xAI device code",
+    hint: "Deprecated alias for xAI OAuth device-code login",
+    kind: "device_code",
     run: async (ctx) => loginXaiDeviceCode(ctx),
   };
 }

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -273,8 +273,7 @@ function formatXaiOAuthCloudflareChallengeError(params: {
  * Single source of truth for how a non-OK token response is reported and whether
  * it is worth retrying. Detection runs once so the message and the retry decision
  * never disagree: a structured OAuth error (e.g. invalid_grant) is authoritative
- * and final, transient transport failures (5xx/429) and Cloudflare HTML
- * challenges are retryable.
+ * and final, while intermediary Cloudflare HTML challenges are retryable.
  */
 function describeXaiOAuthTokenFailure(params: {
   context: string;
@@ -290,7 +289,7 @@ function describeXaiOAuthTokenFailure(params: {
     message: isCloudflareChallenge
       ? formatXaiOAuthCloudflareChallengeError({ context, status })
       : formatXaiOAuthError({ context, status, body: body.json }),
-    retryable: status >= 500 || status === 429 || isCloudflareChallenge,
+    retryable: isCloudflareChallenge,
   };
 }
 
@@ -329,8 +328,7 @@ async function exchangeXaiOAuthToken(
     } catch (err) {
       // Transport failures are not safe to retry for refresh grants: xAI rotates
       // refresh tokens, so a response lost after xAI consumed the token would burn
-      // it on resend. Retryable Cloudflare/5xx/429 cases are handled on the response
-      // branch below, where the request provably did not consume the refresh token.
+      // it on resend. Only Cloudflare challenge responses are retried below.
       throw new Error(`${params.context} failed: ${formatErrorMessage(err)}`, { cause: err });
     }
     const body = await readResponseBody(response);


### PR DESCRIPTION
## What Problem This Solves

We had a lot of users reporting problems with the xAI OAuth callback. Sign-in relied on a localhost callback (`127.0.0.1:56121`), which fails on VPS, SSH, Docker, and other remote or headless setups, and also when Cloudflare sits in front of the callback. Affected users could not complete xAI/Grok OAuth at all.

## Why This Change Was Made

The single xAI OAuth method (`xai-oauth`, method `oauth`) now runs the device-code flow: OpenClaw prints a verification URL plus a short code, the user approves in any browser, and the CLI polls for the token, with no localhost callback. The legacy callback implementation and the separate `xai-device-code` choice/method are removed so there is one OAuth path, still named "oauth". Token refresh also migrates credentials that still point at the retired `/oauth/token` endpoint, retries transient `5xx`/`429` and Cloudflare HTML-challenge responses, and fails fast on transport errors so a rotated refresh token is never resent.

## User Impact

xAI/Grok OAuth now works from remote hosts (SSH, Docker, VPS) without a localhost callback. The choice is still presented as "xAI OAuth", and existing `--method oauth` / `--auth-choice xai-oauth` flows are unchanged. Credentials still pointing at the retired `/oauth/token` endpoint self-heal on the next refresh.

## Evidence

- `pnpm test extensions/xai/xai-oauth.test.ts`: 15 tests pass, covering device-code login without a localhost callback, stale-endpoint rediscovery, discovery-failure handling (no stale reuse), Cloudflare retry-then-succeed and retry-exhaustion, terminal-error no-retry, and refresh not being retried on transport errors.
- `pnpm tsgo:extensions` clean; `oxfmt --check` clean.
- Rebased onto latest `openclaw/main` (single commit).
- Live: a real device-code sign-in against `auth.x.ai` completes with no localhost callback, access and refresh tokens are issued, and the account identity resolves. Note: the interactive `openclaw models auth login` command requires a TTY by design, so it is exercised manually rather than in automation.

