### PR TITLE
docs: add scripts directory index

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,75 @@
+---
+summary: "Repository script entry points and compatibility notes"
+read_when:
+  - Looking for an existing script before adding a new one
+  - Running repository checks, tests, docs, Docker, release, or GitHub helper scripts
+  - Updating package scripts or CI workflow script references
+title: "Scripts Directory"
+---
+
+# Scripts Directory
+
+The `scripts/` directory contains repository tooling used by local development,
+CI, docs publishing, releases, Docker proof, and maintainer operations. Prefer
+the package-script entry points in `package.json` when one exists, then read the
+underlying script before running it directly.
+
+## Compatibility
+
+Many scripts are stable paths referenced by `package.json`, GitHub Actions,
+docs, and maintainer runbooks. Do not move, rename, or regroup scripts only to
+improve taxonomy. A directory migration needs an explicit maintainer-approved
+compatibility plan for package scripts, workflows, docs snippets, and any raw
+script paths users may have copied.
+
+This index is a discovery aid for the current flat layout. It does not define a
+new directory taxonomy.
+
+## Common Entry Points
+
+| Area            | Prefer                                                                         | Notes                                                                                                              |
+| --------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| Build           | `pnpm build`                                                                   | Runs `scripts/build-all.mjs`; use specific build scripts only when debugging a build stage.                        |
+| Changed checks  | `pnpm changed:lanes --json`, `pnpm check:changed`                              | Lane classification lives in `scripts/changed-lanes.mjs`; changed-file checks live in `scripts/check-changed.mjs`. |
+| Docs            | `pnpm docs:list`, `pnpm docs:check-mdx`, `pnpm docs:check-links`               | Backed by `scripts/docs-list.js`, `scripts/check-docs-mdx.mjs`, and `scripts/docs-link-audit.mjs`.                 |
+| Formatting docs | `pnpm format:docs:check`                                                       | Uses `scripts/format-docs.mjs`; use write mode only when intentionally formatting docs.                            |
+| Lint            | `pnpm lint`, `pnpm lint:core`, `pnpm lint:all`                                 | Wrapper scripts keep oxlint behavior aligned with repo config.                                                     |
+| Targeted tests  | `pnpm test <path-or-filter>` or `node scripts/run-vitest.mjs <path-or-filter>` | Avoid bare `vitest`; it can start watch mode.                                                                      |
+| Changed tests   | `pnpm test:changed`                                                            | Uses the repo's changed-test resolver instead of a broad Vitest run.                                               |
+| Docker proof    | `pnpm test:docker:all`, `pnpm test:docker:rerun`, `pnpm test:docker:timings`   | Use the planner/rerun helpers before launching broad Docker work.                                                  |
+| Live proof      | `pnpm test:live`                                                               | Live checks require the matching environment and credentials.                                                      |
+| Release checks  | `pnpm release:check`, `pnpm release:beta`, `pnpm release:candidate`            | Release scripts are maintainer workflows; read release docs before use.                                            |
+| GitHub reads    | `scripts/gh-read`                                                              | Uses a GitHub App read token when configured, leaving normal `gh` login for writes.                                |
+| Commits         | `scripts/committer "<message>" <files...>`                                     | Preferred scoped commit helper for OpenClaw changes.                                                               |
+| Remote proof    | `node scripts/crabbox-wrapper.mjs ...`                                         | Use for Crabbox/Testbox lanes when local proof would be too broad or environment-sensitive.                        |
+
+## Script Families
+
+- `check-*.mjs` / `check-*.ts`: guardrails for architecture, docs, package
+  contents, boundaries, workflows, and generated artifacts.
+- `run-*.mjs`: wrappers around repo runtimes or tools, such as Node, Vitest,
+  oxlint, tsgo, and environment setup.
+- `test-*.mjs` / `test-*.sh` / `test-*.ts`: test planners, Docker lanes, live
+  checks, and focused validation helpers.
+- `docs-*` and `check-docs-*`: docs listing, link auditing, MDX checks,
+  spellcheck, sync, and i18n glossary checks.
+- `release-*`, `openclaw-npm-*`, and `plugin-*-release-*`: release preparation,
+  package verification, and publishing helpers.
+- `docker-*`, `test-docker-*`, and `test-live-*-docker.sh`: Docker E2E planning,
+  rerun, timing, and live/package lane helpers.
+- `gh-read*`, `label-*`, `sync-labels.ts`, and PR helpers: GitHub read,
+  labeling, and maintainer workflow support.
+- `generate-*`, `write-*`, `copy-*`, and `sync-*`: generated docs, metadata,
+  package surfaces, and build artifact support.
+- `lib/`: shared helpers imported by script entry points.
+
+## Maintenance Rules
+
+- Read `scripts/AGENTS.md` before changing scripts.
+- Keep package scripts, generators, generated-artifact checks, docs references,
+  and workflow references aligned when touching a script path.
+- Prefer existing wrappers instead of introducing a raw tool invocation.
+- Add or update focused tests under `test/scripts/` when changing script
+  behavior.
+
+See also [Scripts](https://docs.openclaw.ai/help/scripts) for public-facing script guidance.


### PR DESCRIPTION
## What Problem This Solves

Fixes the low-risk documentation/index portion of #59728 by adding a discoverable `scripts/README.md` for the current `scripts/` directory.

The issue also proposes a wholesale scripts directory reorganization. This PR intentionally does not move or rename scripts because those paths are referenced by `package.json`, GitHub Actions, docs, and maintainer runbooks. Any relocation still needs a maintainer-approved taxonomy and compatibility plan.

## Why This Change Was Made

The existing `scripts/` directory has many entry points but no local index for contributors or agents to quickly find the right wrapper. This adds a small README that documents:

- what the directory owns
- why script paths should not be moved casually
- common check, lint, test, build, docs, release, GitHub, Docker, and remote-proof entry points
- maintenance pointers to `scripts/AGENTS.md` and the public scripts docs

## User Impact

Contributors can find existing script wrappers faster before adding new tooling or running broad commands. Maintainers get a safer first step toward #59728 without changing any script paths, package scripts, workflows, lockfiles, or generated files.

## Evidence

Claim proved: this PR is docs-only and adds a `scripts/README.md` index for the existing flat `scripts/` layout. It does not move, rename, or regroup scripts, and it does not change `package.json`, GitHub Actions, lockfiles, generated files, or runtime behavior.

Commands / artifacts:

- `pnpm docs:list`
- `git diff --check HEAD~1 HEAD -- scripts/README.md`
- CI `check-docs` passed on this PR: https://github.com/openclaw/openclaw/actions/runs/28290280970/job/83821022006
- PR context gate passed after the no-BOM body refresh: https://github.com/openclaw/openclaw/actions/runs/28290509317

Copied terminal output:

```text
$ pnpm docs:list
$ node scripts/docs-list.js
Listing all markdown files in docs folder:
agent-runtime-architecture.md - How OpenClaw runs the built-in agent runtime, providers, sessions, tools, and extensions.
AGENTS.md - [missing front matter]
announcements\bluebubbles-imessage.md - BlueBubbles support was removed from OpenClaw. Use the bundled iMessage plugin with imsg for new and migrated iMessage setups.
...
web\webchat.md - Loopback WebChat static host and Gateway WS usage for chat UI
  Read when: Debugging or configuring WebChat access

Reminder: keep docs up to date as behavior changes. When your task matches any "Read when" hint above (React hooks, cache directives, database work, tests, etc.), read that doc before coding, and suggest new coverage when it is missing.
Exit code: 0
```

```text
$ git diff --check HEAD~1 HEAD -- scripts/README.md
Exit code: 0
```

```text
$ git diff --name-status HEAD~1 HEAD
A       scripts/README.md

$ git diff --stat HEAD~1 HEAD
 scripts/README.md | 75 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 75 insertions(+)
```

Duplicate PR preflight:

- `gh search prs --repo openclaw/openclaw --state open --match title,body -- 59728` returned no open PRs
- `gh search prs --repo openclaw/openclaw --state open --match title,body -- "scripts README"` returned no open PRs
- `gh issue view 59728 --repo openclaw/openclaw` confirmed #59728 is still open

Result: the docs index renders as Markdown, docs discovery still lists successfully, whitespace checks pass, and scoped CI docs validation is green.

Not tested / proof gaps: no runtime, script execution, script relocation, package-script rewiring, or workflow behavior was tested because this PR intentionally does not change those surfaces. The broader #59728 directory reorganization still needs a maintainer-approved taxonomy and compatibility plan before implementation.