### PR TITLE
fix(workspace): prevent false Missing labels on existing files and fix panel layout overlap

### DIFF
--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -1,4 +1,5 @@
 // Gateway methods expose files referenced by one session transcript.
+import fs from "node:fs";
 import path from "node:path";
 import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -405,12 +406,49 @@ async function toSessionFileEntry(
     name: displayNameForPath(touched.path),
     kind: touched.kind,
   } satisfies Pick<SessionFileEntry, "path" | "name" | "kind">;
+
+  // Best-effort direct stat when the workspace sandbox cannot resolve the
+  // path — still-existing files outside the workspace root (e.g. /tmp/foo)
+  // should not be reported as missing.
+  const directStat = (absolutePath: string): SessionFileEntry | undefined => {
+    if (!fs.existsSync(absolutePath)) {
+      return undefined;
+    }
+    try {
+      const stat = fs.statSync(absolutePath);
+      if (!stat.isFile()) {
+        return undefined;
+      }
+      return {
+        ...base,
+        missing: false,
+        size: stat.size,
+        updatedAtMs: Math.floor(stat.mtimeMs),
+      };
+    } catch {
+      return undefined;
+    }
+  };
+
   if (!resolved) {
+    // Files outside the workspace root may still exist — try the original
+    // path directly (handles Unix-style /tmp/foo on Windows too).
+    const entry = directStat(touched.path);
+    if (entry) {
+      return entry;
+    }
     return { ...base, missing: true };
   }
   const browserPath = toDisplayPath(root!, resolved);
   const stat = await statWorkspacePath(root!, browserPath);
   if (!stat || workspaceStatKind(stat) !== "file") {
+    // Workspace sandbox could not resolve the path; try the original path
+    // and the resolved path directly before declaring missing.
+    const entry =
+      directStat(touched.path) ?? (resolved !== touched.path ? directStat(resolved) : undefined);
+    if (entry) {
+      return entry;
+    }
     return { ...base, missing: true };
   }
   const entry: SessionFileEntry = {

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -433,6 +433,12 @@ async function toSessionFileEntry(
   if (!resolved) {
     // Files outside the workspace root may still exist — try the original
     // path directly (handles Unix-style /tmp/foo on Windows too).
+    // When content is requested, we can never serve it for paths outside the
+    // workspace sandbox: return missing so the caller produces
+    // session_file_not_found rather than session_file_too_large.
+    if (opts.includeContent) {
+      return { ...base, missing: true };
+    }
     const entry = directStat(touched.path);
     if (entry) {
       return entry;
@@ -444,10 +450,15 @@ async function toSessionFileEntry(
   if (!stat || workspaceStatKind(stat) !== "file") {
     // Workspace sandbox could not resolve the path; try the original path
     // and the resolved path directly before declaring missing.
-    const entry =
-      directStat(touched.path) ?? (resolved !== touched.path ? directStat(resolved) : undefined);
-    if (entry) {
-      return entry;
+    // When content is requested, directStat cannot provide it (we rely on
+    // the sandbox for safe reads); return missing so the caller produces
+    // session_file_not_found rather than session_file_too_large.
+    if (!opts.includeContent) {
+      const entry =
+        directStat(touched.path) ?? (resolved !== touched.path ? directStat(resolved) : undefined);
+      if (entry) {
+        return entry;
+      }
     }
     return { ...base, missing: true };
   }

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -184,6 +184,7 @@
   flex-direction: column;
   min-height: 0;
   padding-top: 8px;
+  flex-shrink: 0;
 }
 
 .chat-workspace-rail__section-title {
@@ -192,6 +193,7 @@
   line-height: 1.1;
   padding: 0 12px 6px;
   text-transform: uppercase;
+  flex-shrink: 0;
 }
 
 .chat-workspace-rail__summary {


### PR DESCRIPTION
Fixes two bugs in the session workspace side panel where files referenced by tool calls outside the workspace root were incorrectly shown as "Missing",and the panel layout would visually overlap when many files were present.

Note: the root-path leading-dot issue reported in the same issue (#96660) was already resolved separately. The remaining two bugs were reproduced with screenshots attached below.
<img width="557" height="954" alt="CimNG2o_nGSAIIDuAAE0V8ci1H0848" src="https://github.com/user-attachments/assets/8c2cf543-5ca6-4873-95a0-9b1f58b0ffef" />

Fixes #96660

## What Problem This Solves
- False "Missing" badge on existing files
Fixes an issue where the "Expand Session Workspace" side panel would show a red "Missing" badge on files that actually exist on disk (e.g. /tmp/foo.txt). Any tool-call path outside the workspace root was unconditionally flagged as missing because resolveTouchedFilePath returns undefined for external paths, and statWorkspacePath can fail to reach them through the workspace sandbox.

- Side panel layout overlap
Fixes a layout bug where the section headers, search input, and file rows in the side panel would visually overlap when the file list grew large, making the panel unreadable.

- Regression in sessions.files.get error type
The directStat fallback (item 1) introduced a regression: when sessions.files.get requested content for a file outside the workspace, directStat returned { missing: false } without content, causing the handler to emit session_file_too_large instead of the correct session_file_not_found. Fixed by skipping directStat when includeContent is requested, since we can never safely serve file content for paths outside the workspace sandbox.

## Why This Change Was Made
A directStat helper was added that uses fs.existsSync + fs.statSync as a best-effort fallback before marking a file as missing. This runs in two places: (1) when the resolved path is outside the workspace root, and (2) when the workspace sandbox fails to stat the path. The fallback is only used for the list view (sessions.files.list), where content is not needed — stat metadata alone is sufficient. When content is requested (sessions.files.get), paths that can't be reached through the sandbox are treated as not found, preserving the original error semantics.

The CSS fix adds flex-shrink: 0 to .chat-workspace-rail__section and its title so flex containers cannot compress sections below their content height, which was causing the overlapping layers.

## User Impact

Users opening the session workspace side panel will no longer see false "Missing" badges on files that exist on disk but are outside the workspace root. The panel layout remains stable and readable even with many files, artifacts, and browser entries.

## Evidence

Verified locally by creating files at `/tmp/a.txt` ... via tool calls, then confirming the workspace panel shows them without the red "Missing" badge in both Changed and Read sections. The panel layout no longer overlaps after refreshing with many files present. the screenshots attached below.
<img width="460" height="1058" alt="CimNG2o_zFiANdpwAAEDeQbJJ_Y765-1" src="https://github.com/user-attachments/assets/03b9c0cb-a869-4d12-a38d-e3d5e7bc8d58" />
