### PR TITLE
fix(agents): keep multimodal models when generated catalogs include audio/video inputs

### DIFF
--- a/extensions/openai/openai-chatgpt-provider.ts
+++ b/extensions/openai/openai-chatgpt-provider.ts
@@ -399,7 +399,10 @@ function withDefaultCodexContextMetadata(params: {
         : params.contextTokens;
   const input = params.model.input?.includes("image")
     ? params.model.input
-    : uniqueValues<"text" | "image">([...(params.model.input ?? ["text"]), "image"]);
+    : uniqueValues<ProviderRuntimeModel["input"][number]>([
+        ...(params.model.input ?? ["text"]),
+        "image",
+      ]);
   return {
     ...params.model,
     input,

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -606,7 +606,7 @@ export interface Model<TApi extends Api = Api> {
    * Missing keys use provider defaults. null marks a level as unsupported.
    */
   thinkingLevelMap?: ThinkingLevelMap;
-  input: ("text" | "image")[];
+  input: ("text" | "image" | "video" | "audio")[];
   cost: {
     input: number; // $/million tokens
     output: number; // $/million tokens

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -1479,7 +1479,7 @@ export interface ProviderModelConfig {
   /** Maps OpenClaw thinking levels to provider/model-specific values; null marks a level unsupported. */
   thinkingLevelMap?: Model["thinkingLevelMap"];
   /** Supported input types. */
-  input: ("text" | "image")[];
+  input: Model["input"];
   /** Cost per token (for tracking, can be 0). */
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
   /** Maximum context window size in tokens. */

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -174,6 +174,76 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.find("zai", "glm-5.1")?.name).toBe("GLM 5.1");
   });
 
+  it("accepts audio and video input modalities from generated plugin catalog shards", () => {
+    const modelsPath = writeModelsJsonWithPluginCatalogs({
+      root: { providers: {} },
+      pluginCatalogs: [
+        {
+          pluginRelativePath: join("plugins", "minimax", PLUGIN_MODEL_CATALOG_FILE),
+          pluginCatalog: {
+            generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+            providers: {
+              minimax: {
+                baseUrl: "https://api.minimax.io/v1",
+                api: "openai-completions",
+                apiKey: "MINIMAX_API_KEY",
+                models: [
+                  {
+                    id: "MiniMax-M3",
+                    name: "MiniMax M3",
+                    input: ["text", "image", "video"],
+                  },
+                ],
+              },
+            },
+          },
+        },
+        {
+          pluginRelativePath: join("plugins", "nvidia", PLUGIN_MODEL_CATALOG_FILE),
+          pluginCatalog: {
+            generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+            providers: {
+              nvidia: {
+                baseUrl: "https://integrate.api.nvidia.com/v1",
+                api: "openai-completions",
+                apiKey: "NVIDIA_API_KEY",
+                models: [
+                  {
+                    id: "microsoft/phi-4-multimodal-instruct",
+                    name: "Phi-4 Multimodal Instruct",
+                    input: ["text", "image", "audio"],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({
+        minimax: { type: "api_key", key: "sk-minimax" },
+        nvidia: { type: "api_key", key: "sk-nvidia" },
+      }),
+      modelsPath,
+      {
+        pluginMetadataSnapshot: pluginOwnerSnapshotEntries([
+          { providerId: "minimax", pluginId: "minimax" },
+          { providerId: "nvidia", pluginId: "nvidia" },
+        ]),
+      },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("minimax", "MiniMax-M3")?.input).toEqual(["text", "image", "video"]);
+    expect(registry.find("nvidia", "microsoft/phi-4-multimodal-instruct")?.input).toEqual([
+      "text",
+      "image",
+      "audio",
+    ]);
+  });
+
   it("isolates invalid generated plugin catalog shards from valid models", () => {
     const modelsPath = writeModelsJsonWithPluginCatalogs({
       root: {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -162,7 +162,16 @@ const ModelDefinitionSchema = Type.Object({
   baseUrl: Type.Optional(Type.String({ minLength: 1 })),
   reasoning: Type.Optional(Type.Boolean()),
   thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
-  input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]))),
+  input: Type.Optional(
+    Type.Array(
+      Type.Union([
+        Type.Literal("text"),
+        Type.Literal("image"),
+        Type.Literal("video"),
+        Type.Literal("audio"),
+      ]),
+    ),
+  ),
   cost: Type.Optional(
     Type.Object({
       input: Type.Number(),
@@ -926,7 +935,7 @@ export interface ProviderConfigInput {
     baseUrl?: string;
     reasoning: boolean;
     thinkingLevelMap?: Model["thinkingLevelMap"];
-    input: ("text" | "image")[];
+    input: Model["input"];
     cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
     contextWindow: number;
     maxTokens: number;

--- a/src/commands/models/list.model-row.ts
+++ b/src/commands/models/list.model-row.ts
@@ -1,5 +1,6 @@
-/** Converts registry/catalog models into printable model-list rows. */
 import { modelKey } from "../../agents/model-ref-shared.js";
+import type { Model } from "../../llm/types.js";
+/** Converts registry/catalog models into printable model-list rows. */
 import { isLocalBaseUrl } from "./list.local-url.js";
 import type { ModelRow } from "./list.types.js";
 
@@ -8,7 +9,8 @@ export type ListRowModel = {
   id: string;
   name: string;
   provider: string;
-  input: Array<"text" | "image" | "document">;
+  // Derive from the registry Model contract plus config-catalog-only "document".
+  input: Array<Model["input"][number] | "document">;
   baseUrl?: string;
   contextWindow?: number | null;
   contextTokens?: number | null;

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -241,4 +241,45 @@ describe("appendConfiguredProviderRows", () => {
     expect(mocks.normalizeProviderResolvedModelWithPlugin).toHaveBeenCalledOnce();
     expect(requireOnlyRow(rows).input).toBe("text+image");
   });
+
+  it("preserves audio and video inputs for configured provider models", async () => {
+    const rows: ModelRow[] = [];
+
+    await appendConfiguredProviderRows({
+      rows,
+      seenKeys: new Set(),
+      context: {
+        cfg: {
+          models: {
+            providers: {
+              minimax: {
+                api: "openai-completions",
+                baseUrl: "https://api.minimax.io/v1",
+                apiKey: "MINIMAX_API_KEY",
+                models: [
+                  {
+                    id: "MiniMax-M3",
+                    name: "MiniMax M3",
+                    reasoning: false,
+                    input: ["text", "image", "video"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 1_000_000,
+                    maxTokens: 131_072,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-agent",
+        authIndex,
+        configuredByKey: new Map(),
+        discoveredKeys: new Set(),
+        filter: { provider: "minimax", local: false },
+        skipRuntimeModelSuppression: true,
+      },
+    });
+
+    expect(requireOnlyRow(rows).input).toBe("text+image+video");
+  });
 });

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -211,10 +211,11 @@ async function appendVisibleRow(params: {
 
 function resolveConfiguredModelInput(params: {
   model: Partial<ModelDefinitionConfig>;
-}): Array<"text" | "image"> {
+}): ListRowModel["input"] {
   const input = Array.isArray(params.model.input)
     ? params.model.input.filter(
-        (item): item is "text" | "image" => item === "text" || item === "image",
+        (item): item is Exclude<ListRowModel["input"][number], "document"> =>
+          item === "text" || item === "image" || item === "audio" || item === "video",
       )
     : [];
   return input.length > 0 ? input : ["text"];
@@ -239,7 +240,11 @@ function toConfiguredProviderListModel(params: {
 function toListRowInput(input: readonly string[] | undefined): ListRowModel["input"] {
   const parsed = input?.filter(
     (item): item is ListRowModel["input"][number] =>
-      item === "text" || item === "image" || item === "document",
+      item === "text" ||
+      item === "image" ||
+      item === "audio" ||
+      item === "video" ||
+      item === "document",
   );
   return parsed?.length ? parsed : ["text"];
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configure MiniMax or NVIDIA providers with generated plugin catalog shards would see `Invalid models.json schema` on gateway start when those catalogs advertise `video` or `audio` input modalities (for example `MiniMax-M3`, `microsoft/phi-4-multimodal-instruct`). The session model registry rejected otherwise-valid generated catalogs, dropped those models, and an agent whose primary matched one of them silently fell back to an older model.

Fixes #97048

## Why This Change Was Made

This aligns the session model registry and sibling type surfaces with the catalog contract OpenClaw already accepts elsewhere (`src/config/types.models.ts`, `src/config/zod-schema.core.ts`, `src/plugin-sdk/provider-catalog-shared.ts`):

1. **Registry validator** — `ModelDefinitionSchema.input` now accepts `text` / `image` / `video` / `audio`.
2. **Type-contract alignment** — widened public `Model.input`, derived `ProviderConfigInput.models[].input` and session-extension `ProviderModelConfig.input` from `Model["input"]`, updated the OpenAI ChatGPT provider helper to preserve the widened union, and derived `ListRowModel.input` from `Model["input"]` plus config-catalog-only `document` so list rendering cannot drift.

No config migration; the change is additive and backward-compatible.

AI-assisted: Cursor agent prepared the patch; human reviewed and validated locally.

## User Impact

Affected provider catalog refreshes no longer drop multimodal primaries solely because generated `input` lists include `audio` or `video`. `openclaw models list` preserves those modalities in row output. No operator action required beyond upgrading.

## Evidence

### Real-behavior proof — production `ModelRegistry.create` path

Drove the production registry loader against on-disk `models.json` + `plugins/{minimax,nvidia}/catalog.json` files using the issue's offending data (`MiniMax-M3` = `["text","image","video"]`, `microsoft/phi-4-multimodal-instruct` = `["text","image","audio"]`).

**Before (current `main` schema — `text`/`image` only):**
```
model catalog load error: Invalid models.json schema:
  - providers.minimax.models.0.input.2: must be equal to constant
  - providers.minimax.models.0.input.2: must match a schema in anyOf
File: .../plugins/minimax/catalog.json
Invalid models.json schema:
  - providers.nvidia.models.0.input.2: must be equal to constant
  - providers.nvidia.models.0.input.2: must match a schema in anyOf
File: .../plugins/nvidia/catalog.json
minimax/MiniMax-M3: DROPPED
nvidia/microsoft/phi-4-multimodal-instruct: DROPPED
RESULT: FAIL — catalog rejected
```

**After (this PR):**
```
model catalog load error: (none)
minimax/MiniMax-M3: loaded input=["text","image","video"]
nvidia/microsoft/phi-4-multimodal-instruct: loaded input=["text","image","audio"]
RESULT: PASS — both multimodal primaries loaded
```

Regression test `accepts audio and video input modalities from generated plugin catalog shards` fails on pre-fix schema with the same `must be equal to constant` validation error and passes with this branch.

### Tests / checks (local)

```bash
CI=true OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/sessions/model-registry.test.ts \
  src/commands/models/list.rows.test.ts \
  src/commands/models/list.model-row.test.ts
# => passed 3 Vitest shards (17 tests)

node scripts/run-tsgo.mjs -p tsconfig.core.json
# => clean
```

Diff: Source +26, Tests +111. Total +140 across 8 files (schema, types, OpenAI helper, list rows, regression tests).
