### PR TITLE
fix(cron): restore isolated model fallback chain after timeout and empty results

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -2,6 +2,10 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { wrapUntrustedPromptDataBlock } from "../../agents/sanitize-for-prompt.js";
@@ -12,6 +16,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SkillSnapshot } from "../../skills/types.js";
+import { resolveCronFallbackRunAbortSignal } from "../service/execution-errors.js";
 import type { CronAgentExecutionPhaseUpdate, CronJob } from "../types.js";
 import {
   resolveCronChannelOutputPolicy,
@@ -269,6 +274,25 @@ export function createCronPromptExecutor(params: {
     sourceDelivery: params.sourceDelivery,
   });
 
+  // CLI providers surface their own terminal classification; only the embedded
+  // branch returns fallback-safe result-level failures (reasoning-only,
+  // empty-visible, incomplete_turn) that the model-fallback loop must reclassify
+  // to advance to the configured fallback. Resolve CLI-ness once so the run path
+  // and the classifier agree on which branch produced a candidate result.
+  const resolveCronExecutionProvider = (provider: string, model: string) => {
+    const executionProvider =
+      resolveCliRuntimeExecutionProvider({
+        provider,
+        cfg: params.cfgWithAgentDefaults,
+        agentId: params.agentId,
+        modelId: model,
+      }) ?? provider;
+    return {
+      executionProvider,
+      isCli: isCliProvider(executionProvider, params.cfgWithAgentDefaults),
+    };
+  };
+
   const runPrompt = async (promptText: string) => {
     const modelPrompt = deliveryTargetRuntimeContext
       ? `${promptText}\n\n${deliveryTargetRuntimeContext}`.trim()
@@ -295,22 +319,31 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      // Returned result-level failures (reasoning-only/empty/incomplete_turn) do
+      // not throw, so without a classifier the loop treats the first candidate as
+      // a success and never engages the configured fallback chain. Scope this to
+      // the embedded branch; the CLI runner owns its own terminal classification.
+      classifyResult: ({ provider, model, result }) =>
+        resolveCronExecutionProvider(provider, model).isCli
+          ? null
+          : classifyEmbeddedAgentRunResultForModelFallback({ provider, model, result }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
-        if (params.abortSignal?.aborted) {
+        const runAbortSignal = resolveCronFallbackRunAbortSignal({
+          abortSignal: params.abortSignal,
+        });
+        if (runAbortSignal?.aborted) {
           throw new Error(params.abortReason());
         }
-        const executionProvider =
-          resolveCliRuntimeExecutionProvider({
-            provider: providerOverride,
-            cfg: params.cfgWithAgentDefaults,
-            agentId: params.agentId,
-            modelId: modelOverride,
-          }) ?? providerOverride;
+        const { executionProvider, isCli } = resolveCronExecutionProvider(
+          providerOverride,
+          modelOverride,
+        );
         const bootstrapPromptWarningSignature =
           bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
         // CLI providers can resume provider-native sessions; embedded providers
         // use OpenClaw's transcript/session file plus prompt-cache affinity.
-        if (isCliProvider(executionProvider, params.cfgWithAgentDefaults)) {
+        if (isCli) {
           const cliSessionId = params.cronSession.isNewSession
             ? undefined
             : await getCliSessionId(params.cronSession.sessionEntry, executionProvider);
@@ -341,7 +374,7 @@ export function createCronPromptExecutor(params: {
               params.agentPayload?.toolsAllow,
               params.agentPayload?.toolsAllowIsDefault,
             ),
-            abortSignal: params.abortSignal,
+            abortSignal: runAbortSignal,
             onExecutionStarted: params.onExecutionStarted,
             onExecutionPhase: params.onExecutionPhase,
             bootstrapContextMode,
@@ -439,7 +472,7 @@ export function createCronPromptExecutor(params: {
           disableMessageTool: !params.sourceDelivery.messageTool.enabled,
           forceMessageTool: params.sourceDelivery.messageTool.force,
           allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
-          abortSignal: params.abortSignal,
+          abortSignal: runAbortSignal,
           onExecutionStarted: params.onExecutionStarted,
           onExecutionPhase: params.onExecutionPhase,
           onLaneWait: params.onLaneWait,

--- a/src/cron/isolated-agent/run.fallback-chain.test.ts
+++ b/src/cron/isolated-agent/run.fallback-chain.test.ts
@@ -1,0 +1,241 @@
+// Covers isolated cron model-fallback recovery for result-level empty/incomplete
+// returns and for cron wall-clock timeout aborts that must not block later candidates.
+import { describe, expect, it } from "vitest";
+import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import {
+  isCronWallClockTimeoutAbort,
+  resolveCronFallbackRunAbortSignal,
+} from "../service/execution-errors.js";
+import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  isCliProviderMock,
+  loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
+  runEmbeddedAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+/** Fallback-safe result-level failure: reasoning-only / incomplete_turn, no visible reply. */
+function makeReasoningOnlyIncompleteResult() {
+  return {
+    payloads: [{ text: "Agent couldn't generate a response.", isError: true }],
+    meta: {
+      agentMeta: {},
+      agentHarnessResultClassification: "reasoning-only",
+      error: {
+        kind: "incomplete_turn",
+        message: "Agent couldn't generate a response.",
+        fallbackSafe: true,
+        terminalPresentation: false,
+      },
+    },
+  };
+}
+
+function makeHealthyFallbackResult() {
+  return {
+    payloads: [{ text: "Workspace cleaned up: removed 12 stale files." }],
+    meta: {
+      agentMeta: {},
+      finalAssistantVisibleText: "Workspace cleaned up: removed 12 stale files.",
+    },
+  };
+}
+
+/**
+ * Minimal faithful model-fallback loop that drives the real classifier/merge the
+ * cron path passes, advancing candidates exactly when a classification is returned.
+ */
+function installFaithfulFallbackLoop(): void {
+  runWithModelFallbackMock.mockImplementation(
+    async ({ provider, model, run, fallbacksOverride, classifyResult, mergeExhaustedResult }) => {
+      const candidates = [
+        { provider, model },
+        ...((fallbacksOverride ?? []) as string[]).map((ref) => {
+          const slash = ref.indexOf("/");
+          return { provider: ref.slice(0, slash), model: ref.slice(slash + 1) };
+        }),
+      ];
+      let latest = { result: undefined as unknown, provider, model };
+      for (let index = 0; index < candidates.length; index += 1) {
+        const candidate = candidates[index];
+        const runOptions = {
+          isFinalFallbackAttempt: index === candidates.length - 1,
+        };
+        let result: unknown;
+        try {
+          result = await run(candidate.provider, candidate.model, runOptions);
+        } catch (err) {
+          if (index === candidates.length - 1) {
+            throw err;
+          }
+          continue;
+        }
+        const classification = await classifyResult?.({
+          result,
+          provider: candidate.provider,
+          model: candidate.model,
+          attempt: index + 1,
+          total: candidates.length,
+        });
+        if (!classification) {
+          return { result, provider: candidate.provider, model: candidate.model, attempts: [] };
+        }
+        latest = { result, provider: candidate.provider, model: candidate.model };
+      }
+      const merged = mergeExhaustedResult
+        ? mergeExhaustedResult({ latestResult: latest.result, preferredResult: latest.result })
+        : latest.result;
+      return { result: merged, provider: latest.provider, model: latest.model, attempts: [] };
+    },
+  );
+}
+
+function makeCronTimeoutAbortController(): AbortController {
+  const abortController = new AbortController();
+  const timeoutError = new Error("cron: job execution timed out (last phase: model_call_started)");
+  timeoutError.name = "TimeoutError";
+  abortController.abort(timeoutError);
+  return abortController;
+}
+
+describe("cron fallback abort signal helpers", () => {
+  it("detects cron wall-clock TimeoutError aborts", () => {
+    const controller = makeCronTimeoutAbortController();
+    expect(isCronWallClockTimeoutAbort(controller.signal)).toBe(true);
+  });
+
+  it("drops cron timeout abort for fallback attempts", () => {
+    const controller = makeCronTimeoutAbortController();
+    expect(
+      resolveCronFallbackRunAbortSignal({
+        abortSignal: controller.signal,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps operator cancellation aborts for fallback attempts", () => {
+    const controller = new AbortController();
+    controller.abort("Cancelled by operator.");
+    expect(
+      resolveCronFallbackRunAbortSignal({
+        abortSignal: controller.signal,
+      }),
+    ).toBe(controller.signal);
+  });
+});
+
+describe("runCronIsolatedAgentTurn — cron fallback chain recovery", () => {
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
+
+  it("engages the configured fallback when the primary returns a reasoning-only / incomplete_turn result", async () => {
+    installFaithfulFallbackLoop();
+    runEmbeddedAgentMock.mockReset();
+    runEmbeddedAgentMock
+      .mockResolvedValueOnce(makeReasoningOnlyIncompleteResult())
+      .mockResolvedValueOnce(makeHealthyFallbackResult());
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          payload: {
+            kind: "agentTurn",
+            message: "test",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        }),
+      }),
+    );
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    expect(runEmbeddedAgentMock.mock.calls[1]?.[0]).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    expect(result.status).toBe("ok");
+  });
+
+  it("engages fallback models after cron wall-clock timeout without passing the dead abort signal", async () => {
+    installFaithfulFallbackLoop();
+    const abortController = new AbortController();
+    runEmbeddedAgentMock.mockReset();
+    runEmbeddedAgentMock
+      .mockImplementationOnce(async (params) => {
+        const timeoutError = new Error(
+          "cron: job execution timed out (last phase: model_call_started)",
+        );
+        timeoutError.name = "TimeoutError";
+        abortController.abort(timeoutError);
+        expect(params.abortSignal?.aborted).toBe(true);
+        const abortErr = new Error("Operation aborted");
+        abortErr.name = "AbortError";
+        throw abortErr;
+      })
+      .mockImplementationOnce(async (params) => {
+        expect(params.abortSignal?.aborted).not.toBe(true);
+        return makeHealthyFallbackResult();
+      });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        abortSignal: abortController.signal,
+        job: makeIsolatedAgentJobFixture({
+          payload: {
+            kind: "agentTurn",
+            message: "test",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        }),
+      }),
+    );
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    expect(result.status).toBe("ok");
+  });
+
+  it("passes the embedded classifier and merge helper scoped to the embedded branch", async () => {
+    mockRunCronFallbackPassthrough();
+
+    await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
+
+    const request = runWithModelFallbackMock.mock.calls[0]?.[0] as {
+      classifyResult?: (input: {
+        result: unknown;
+        provider: string;
+        model: string;
+        attempt: number;
+        total: number;
+      }) => unknown;
+      mergeExhaustedResult?: unknown;
+    };
+    expect(typeof request?.classifyResult).toBe("function");
+    expect(request?.mergeExhaustedResult).toBe(
+      mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+    );
+
+    const reasoningOnly = makeReasoningOnlyIncompleteResult();
+    expect(
+      await request.classifyResult?.({
+        result: reasoningOnly,
+        provider: "openai",
+        model: "gpt-5.4",
+        attempt: 1,
+        total: 2,
+      }),
+    ).toBeTruthy();
+
+    isCliProviderMock.mockImplementation((provider: string) => provider === "claude-cli");
+    expect(
+      await request.classifyResult?.({
+        result: reasoningOnly,
+        provider: "claude-cli",
+        model: "claude-sonnet-4-6",
+        attempt: 1,
+        total: 2,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -52,7 +52,10 @@ import {
   createCronRunDiagnosticsFromError,
   mergeCronRunDiagnostics,
 } from "../run-diagnostics.js";
-import { resolveCronAbortReasonText } from "../service/execution-errors.js";
+import {
+  resolveCronAbortReasonText,
+  shouldHonorCronRunAbortOutcome,
+} from "../service/execution-errors.js";
 import { resolveCronDeliverySessionKey } from "../session-target.js";
 import type {
   CronAgentExecutionPhaseUpdate,
@@ -961,16 +964,32 @@ async function finalizeCronRun(params: {
   execution: CronExecutionResult;
   abortReason: () => string;
   isAborted: () => boolean;
+  abortSignal?: AbortSignal;
   markCronRunSessionCleanupAttempted: () => void;
 }): Promise<RunCronAgentTurnResult> {
   const { prepared, execution } = params;
   const finalRunResult = execution.runResult;
   const payloads = finalRunResult.payloads ?? [];
+  const hasVisibleAssistantReply = Boolean(
+    finalRunResult.meta?.finalAssistantVisibleText?.trim() ||
+    payloads.some(
+      (payload) =>
+        payload?.isError !== true &&
+        typeof payload?.text === "string" &&
+        payload.text.trim().length > 0,
+    ),
+  );
+  const honorCronAbortOutcome = () =>
+    shouldHonorCronRunAbortOutcome({
+      isAborted: params.isAborted,
+      abortSignal: params.abortSignal,
+      hasVisibleAssistantReply,
+    });
   let telemetry: CronRunTelemetry | undefined;
 
   // Late aborted results may still contain billable usage. Recheck before each
   // metadata mutation because lazy runtime loads below can yield to the timeout.
-  if (!params.isAborted()) {
+  if (!honorCronAbortOutcome()) {
     if (finalRunResult.meta?.systemPromptReport) {
       prepared.cronSession.sessionEntry.systemPromptReport = finalRunResult.meta.systemPromptReport;
     }
@@ -999,7 +1018,7 @@ async function finalizeCronRun(params: {
     resolvePositiveContextTokens(prepared.cronSession.sessionEntry.contextTokens) ??
     DEFAULT_CONTEXT_TOKENS;
 
-  if (!params.isAborted()) {
+  if (!honorCronAbortOutcome()) {
     setSessionRuntimeModel(prepared.cronSession.sessionEntry, {
       provider: providerUsed,
       model: modelUsed,
@@ -1128,7 +1147,7 @@ async function finalizeCronRun(params: {
   }
   await prepared.persistSessionEntry();
 
-  if (params.isAborted()) {
+  if (honorCronAbortOutcome()) {
     return prepared.withRunSession({
       status: "error",
       error: params.abortReason(),
@@ -1511,6 +1530,7 @@ export async function runCronIsolatedAgentTurn(params: {
       execution,
       abortReason,
       isAborted,
+      abortSignal,
       markCronRunSessionCleanupAttempted: () => {
         cronRunSessionCleanupAttempted = true;
       },

--- a/src/cron/service/execution-errors.ts
+++ b/src/cron/service/execution-errors.ts
@@ -54,6 +54,54 @@ export function abortErrorMessage(signal?: AbortSignal): string {
   return resolveCronAbortReasonText(signal?.reason) ?? timeoutErrorMessage();
 }
 
+/** True when the cron wall-clock watchdog aborted the shared isolated run signal. */
+export function isCronWallClockTimeoutAbort(signal?: AbortSignal): boolean {
+  if (!signal?.aborted) {
+    return false;
+  }
+  const reason = signal.reason;
+  return reason instanceof Error && reason.name === "TimeoutError";
+}
+
+/**
+ * Cron timeout aborts the active attempt, but configured fallback models should
+ * still run instead of inheriting the already-aborted shared signal.
+ */
+export function resolveCronFallbackRunAbortSignal(params: {
+  abortSignal?: AbortSignal;
+}): AbortSignal | undefined {
+  if (!params.abortSignal?.aborted) {
+    return params.abortSignal;
+  }
+  if (isCronWallClockTimeoutAbort(params.abortSignal)) {
+    return undefined;
+  }
+  return params.abortSignal;
+}
+
+/** True when a timed-out cron run still produced a visible assistant answer to keep. */
+export function isCronRecoverableTimeoutAbort(params: {
+  abortSignal?: AbortSignal;
+  hasVisibleAssistantReply: boolean;
+}): boolean {
+  return isCronWallClockTimeoutAbort(params.abortSignal) && params.hasVisibleAssistantReply;
+}
+
+/** True when finalize should return the cron abort error instead of the recovered answer. */
+export function shouldHonorCronRunAbortOutcome(params: {
+  isAborted: () => boolean;
+  abortSignal?: AbortSignal;
+  hasVisibleAssistantReply: boolean;
+}): boolean {
+  if (!params.isAborted()) {
+    return false;
+  }
+  return !isCronRecoverableTimeoutAbort({
+    abortSignal: params.abortSignal,
+    hasVisibleAssistantReply: params.hasVisibleAssistantReply,
+  });
+}
+
 function isAbortError(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false;


### PR DESCRIPTION
Closes #97115

## What Problem This Solves

Fixes an issue where operators running isolated cron `agentTurn` jobs with a configured model fallback chain would see the job fail silently when the primary model timed out or returned an empty/zero-token embedded result. Fallback models were either never contacted (shared cron abort signal) or treated as success without a visible answer, so the chain stopped early and cron sessions could cache the wrong model.

## Why This Change Was Made

Two gaps in the isolated cron harness blocked recovery:

1. **Result-level failures (B):** `runWithModelFallback` in the cron executor did not pass `classifyResult` / `mergeExhaustedResult`, so reasoning-only / empty-visible / `incomplete_turn` embedded results were treated as success and never advanced to the next configured model. This wires the same embedded classifier used by interactive agent runs, scoped to non-CLI providers.

2. **Shared cron timeout abort (A):** When the cron wall-clock watchdog aborts the shared run signal (`TimeoutError`), later fallback candidates inherited the dead `AbortSignal` and failed instantly. `resolveCronFallbackRunAbortSignal` drops only cron wall-clock timeout aborts for fallback attempts (operator cancel and gateway restart still honor the signal). `finalizeCronRun` now keeps a recovered visible answer instead of overwriting it with a timeout error.

## User Impact

Isolated cron jobs with configured model fallbacks can recover when the primary model times out or returns an empty/incomplete embedded result. Operators should see the fallback model’s answer instead of a false timeout failure or generic “Agent couldn’t generate a response.” without trying the rest of the chain.

## Evidence

### Regression tests (RED on `main`, GREEN with this change)

```
CI=true OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/cron/isolated-agent/run.fallback-chain.test.ts \
  src/cron/isolated-agent/run.meta-error-status.test.ts

 Test Files  2 passed (2)
      Tests  11 passed (11)
```

`run.fallback-chain.test.ts` covers:

- Primary reasoning-only / `incomplete_turn` → configured fallback reached, `status: "ok"`
- Primary abort during cron wall-clock timeout → fallback called without inherited dead `abortSignal`, `status: "ok"`
- Embedded classifier scoped to non-CLI providers
- Abort helper unit tests for timeout vs operator cancel

Adjacent meta-error suite stays green (cron timeout still wins when the executor fully fails).

### Typecheck

```
node scripts/run-tsgo.mjs -p tsconfig.core.json
```

Clean on touched cron surfaces.
