### PR TITLE
fix(gateway): recover channel wedged after timed-out recovery stop

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -599,6 +599,45 @@ describe("server-channels auto restart", () => {
     expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
   });
 
+  it("force-restarts when a timed-out recovery stop task never settles", async () => {
+    // Models the production wedge: a poller stuck on a network call that ignores
+    // its abort signal, so the recovery stop times out and the task never
+    // settles. The completion tail that would normally reboot never runs, so a
+    // repeated start (e.g. the next health-monitor cycle) must orphan the wedged
+    // task and boot a fresh provider instead of deferring forever.
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      abortSignal.addEventListener("abort", () => {}, { once: true });
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+    expect(startAccount).toHaveBeenCalledTimes(1);
+
+    // First post-timeout start defers to the (wedged) task's reboot tail.
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]?.restartPending,
+    ).toBe(true);
+
+    // Second start: the task is still wedged, so escape-hatch into a fresh boot.
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await waitForMicrotaskCondition(
+      () => startAccount.mock.calls.length === 2,
+      "expected a wedged recovery task to be force-restarted",
+    );
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(account?.running).toBe(true);
+    expect(account?.restartPending).toBe(false);
+  });
+
   it("consumes startup failures during immediate recovery restart", async () => {
     const unhandledRejection = vi.fn();
     process.on("unhandledRejection", unhandledRejection);

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -421,6 +421,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       store.runtimes.delete(id);
       restartAttempts.delete(restartKey(channelId, id));
       manuallyStopped.delete(restartKey(channelId, id));
+      // Clear both recovery flags together: evicting a stale account must not
+      // leave a dangling timed-out-recovery marker that would mis-route a later
+      // fresh boot of the same id into the recovery branch.
+      recoveryStopTimedOut.delete(restartKey(channelId, id));
       recoveryStartRequested.delete(restartKey(channelId, id));
     }
   };
@@ -456,17 +460,35 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       tasks: accountIds.map((id) => async () => {
         const rKey = restartKey(channelId, id);
         if (store.tasks.has(id)) {
-          if (recoveryStopTimedOut.has(rKey)) {
-            if (!preserveManualStop) {
-              manuallyStopped.delete(rKey);
-            }
-            if (manuallyStopped.has(rKey)) {
-              return;
-            }
+          if (!recoveryStopTimedOut.has(rKey)) {
+            // A live or cleanly-stopping task still owns this account; its own
+            // lifecycle will boot/replace it, so never double-start here.
+            return;
+          }
+          if (!preserveManualStop) {
+            manuallyStopped.delete(rKey);
+          }
+          if (manuallyStopped.has(rKey)) {
+            return;
+          }
+          if (!recoveryStartRequested.has(rKey)) {
+            // First start after a recovery stop timed out: the previous task was
+            // aborted and its provider lease force-released, but the task promise
+            // has not settled yet. Defer once so its completion tail can reboot.
             recoveryStartRequested.add(rKey);
             setRuntime(channelId, id, { accountId: id, restartPending: true });
+            return;
           }
-          return;
+          // A reboot was already requested and the aborted task still has not
+          // settled, so its completion tail will never run to honor it. Without
+          // this escape hatch the channel stays "stopped" forever: the health
+          // monitor keeps logging restarts while this guard short-circuits every
+          // attempt. Orphan the wedged task and fall through to a fresh start;
+          // its settle handlers below no-op once a replacement owns the slot.
+          recoveryStopTimedOut.delete(rKey);
+          recoveryStartRequested.delete(rKey);
+          store.tasks.delete(id);
+          store.aborts.delete(id);
         }
         const existingStart = store.starting.get(id);
         if (existingStart) {
@@ -629,7 +651,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           });
           const trackedPromise = task
             .then(() => {
-              if (abort.signal.aborted || manuallyStopped.has(rKey)) {
+              // Skip shared-runtime writes if a forced recovery restart already
+              // orphaned this task and a replacement owns the account slot.
+              if (
+                store.tasks.get(id) !== trackedPromise ||
+                abort.signal.aborted ||
+                manuallyStopped.has(rKey)
+              ) {
                 return;
               }
               const message = "channel exited without an error";
@@ -637,17 +665,30 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               log.error?.(`[${id}] ${message}`);
             })
             .catch((err: unknown) => {
+              if (store.tasks.get(id) !== trackedPromise) {
+                return;
+              }
               const message = formatErrorMessage(err);
               setRuntime(channelId, id, { accountId: id, lastError: message });
               log.error?.(`[${id}] channel exited: ${message}`);
             })
             .then(async () => {
+              // Always release this task's own scoped runtime, but only mark the
+              // account stopped while this task still owns the slot.
               await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
+              if (store.tasks.get(id) !== trackedPromise) {
+                return;
+              }
               setStoppedRuntime(channelId, id, {
                 lastStopAt: Date.now(),
               });
             })
             .then(async () => {
+              if (store.tasks.get(id) !== trackedPromise) {
+                // Orphaned by a forced recovery restart; the replacement task
+                // owns recovery/restart state, so do nothing here.
+                return;
+              }
               if (manuallyStopped.has(rKey)) {
                 recoveryStopTimedOut.delete(rKey);
                 recoveryStartRequested.delete(rKey);


### PR DESCRIPTION
## Summary

A channel can get permanently wedged in a "stopped" state after a transient provider/network outage, and the in-process health monitor cannot recover it — only a full gateway process restart does.

### Root cause

When a channel's recovery stop (`manual: false`) times out, `stopChannel` intentionally leaves the still-running poll task in `store.tasks` and sets `recoveryStopTimedOut`, deferring the reboot to that task's completion tail (`src/gateway/server-channels.ts`). `startChannelInternal` then short-circuits on `store.tasks.has(id)`, only re-flagging `recoveryStartRequested` and returning.

If the underlying task **never settles** (e.g. a poller stuck on a network call that ignores its abort signal), the completion tail that would honor the requested restart never runs. `store.tasks` is never cleared, so every subsequent `startChannel` keeps hitting the guard and returning. The health monitor logs `restarting (reason: stopped)` every cycle with no recovery, indefinitely, until the process is restarted.

Observed in production (Telegram channel) after a Telegram API blip (`Too Many Requests` / `502 Bad Gateway` / DNS timeouts): 27 health-monitor restart log lines over ~5 hours with zero actual recovery and zero errors; a full `systemctl restart` recovered in ~3s.

### Fix

Add a bounded escape hatch in `startChannelInternal`:

- **First** start after a timed-out recovery stop still defers once (unchanged behavior — gives a slow-but-settling task a chance to reboot itself).
- **Second** start while the task is *still* wedged orphans the stale task (`store.tasks.delete` / `store.aborts.delete`, clear recovery flags) and falls through to boot a fresh provider. The task was already aborted and (for Telegram) its polling lease was already force-released during the timed-out stop, so the replacement starts cleanly.

To keep this safe, the orphaned task's settle handlers are guarded by slot ownership (`store.tasks.get(id) === trackedPromise`): a zombie that eventually settles no longer writes shared runtime/restart state once a replacement owns the account. Its own scoped runtime is still disposed.

This is a generic gateway-lifecycle fix — any channel whose task hangs would otherwise trigger the same permanent wedge.

## Verification

- `pnpm test src/gateway/server-channels.test.ts` → **82 passed** (all existing recovery tests + 1 new).
- New test `force-restarts when a timed-out recovery stop task never settles` reproduces the wedge (a poll task that never settles even after abort) and asserts a fresh provider boots on the repeated start. **Negative control:** the new test fails (times out, channel never restarts) against unpatched `main` and passes with the fix.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` clean; `oxfmt --check` clean on changed files; `run-oxlint.mjs` clean.

### Real behavior proof

- **Behavior addressed:** Channel stuck "stopped" after a timed-out recovery stop whose poll task never settles; health monitor cannot recover it.
- **Real environment tested:** Reproduced via the gateway channel-manager test harness (deterministic never-settling task); root cause confirmed against a live production incident (Telegram on a self-hosted always-on gateway).
- **Exact steps or command run after this patch:** `pnpm test src/gateway/server-channels.test.ts`; negative control by shelving the prod change and re-running the new test.
- **Evidence after fix:** 82/82 tests pass; new test passes with fix, fails without.
- **Observed result after fix:** A repeated start after a wedged recovery stop orphans the dead task and boots a fresh provider (`running: true`, `restartPending: false`).
- **What was not tested:** No live re-trigger of the original upstream Telegram API outage (transient/external); the fix is at the gateway lifecycle layer and is provider-agnostic.

### Follow-up (not in this PR)

Telegram-side hardening so the poller honors its abort signal within the stop timeout would let the task settle cleanly and avoid relying on the escape hatch; complementary, not required.
