### PR TITLE
fix(ui): disable session selection outside chat page to prevent confusion

### DIFF
--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -122,7 +122,7 @@ export function renderChatSessionSelect(
         surface,
         selectedSessionLabel,
         pickerOpen,
-        disabled: !state.connected || !state.client,
+        disabled: !state.connected || !state.client || state.tab !== "chat",
         compact,
       })}
       ${modelSelect} ${quotaPill}
@@ -825,7 +825,7 @@ function renderChatAgentSelect(
         aria-label=${t("chat.selectors.agentFilter")}
         title=${selectedLabel}
         .value=${activeAgentId}
-        ?disabled=${!state.connected}
+        ?disabled=${!state.connected || state.tab !== "chat"}
         @change=${(e: Event) => {
           const nextAgentId = normalizeAgentId((e.target as HTMLSelectElement).value);
           if (nextAgentId === activeAgentId) {


### PR DESCRIPTION
## Summary

After commit 2b30951b8090cfea0149c3cd90fe3a43d3044bc1 (landed in [2026.5.31-beta.4](https://github.com/openclaw/openclaw/releases/tag/v2026.5.31-beta.4)), **from a UI interaction perspective**, the chat session selection component was changed from a local control to a global one. While this works fine within the chat page, it causes confusion on other pages – especially the "Sessions" page.

Currently, the session selection component is still visible and interactive on non-chat pages, but its behavior isn't fully consistent with those pages. Some actions on the component affect the Sessions page, while others don't, leading to unexpected UI interactions.

In my test environment, there are two agents: "main" and "opencode". The component currently has the agent set to "main". When I navigate to the Sessions page and select "opencode" in the component, the sessions' store changes from ".*/main/.\*" to "(multiple)" — not to ".\*/opencode/.\*" as I expected. Then, when I click the refresh button on the right side of the Sessions page, the store switches back to ".\*/main/.\*", but still not to ".\*/opencode/.\*". **This is confusing.**

There are two long-term directions we could take:

1. **Keep it local**​ – Only show the session selection component on the chat page. On other pages, either hide it entirely or disable it.
  
2. **Make it truly global**​ – Fully bind the component to every page so that changing the selection updates each page accordingly (e.g., the Sessions page). This would require two-way binding and careful synchronization.
  

For now, I propose we go with a quick fix that aligns with option 1: **disable the session selection component on all non-chat pages**. This prevents users from accidentally interacting with it in places where it doesn't behave correctly. It's a safe, low-risk change that eliminates the immediate confusion.

If the team later decides to adopt option 2 (global component with full two-way binding), I'll submit a follow-up PR to properly integrate it with the Sessions page and other relevant views.

This PR simply disables the component outside the chat context. No behavioral changes inside the chat page itself.

## Real Behavior Proof

### Before Fix

There are two agents: "main" and "opencode".

<img width="435" height="957" alt="2026-06-27-21-02-28-image" src="https://github.com/user-attachments/assets/74264771-ff59-4c0c-9b8d-81919cb6e2f2" />

Navigate to the Sessions page. The store is ".\*/main/.\*".

<img width="1884" height="1014" alt="2026-06-27-21-04-59-image" src="https://github.com/user-attachments/assets/63f668b3-64ab-4bd7-ab48-3621e8e2dc94" />

Select "opencode" in the component, the sessions' store changes from ".\*/main/.\*" to "(multiple)"

<img width="1890" height="897" alt="2026-06-27-21-08-36-image" src="https://github.com/user-attachments/assets/6b6abce0-5da2-4710-90d9-58515aa5b7a8" />

After refreshing, the store switches back to ".\*/main/.*".

<img width="1887" height="873" alt="2026-06-27-21-13-52-image" src="https://github.com/user-attachments/assets/a0f0b3cd-b4bb-40b2-8d62-64dc7933b460" />

### After Fix

Selection is disabled on pages other than the chat page.

<img width="407" height="867" alt="2026-06-27-21-31-36-image" src="https://github.com/user-attachments/assets/48eb5828-d928-4ad5-87c3-29011e534e71" />

Selection is available on the chat page.

<img width="381" height="1119" alt="2026-06-27-21-31-59-image" src="https://github.com/user-attachments/assets/68fb22c0-5f08-4ceb-b596-c399332bc301" />