### PR TITLE
improve(control-ui): expose linear session positions in chat picker

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:32.656Z",
+  "generatedAt": "2026-07-07T18:17:03.591Z",
   "locale": "ar",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:24.981Z",
+  "generatedAt": "2026-07-07T18:16:59.358Z",
   "locale": "de",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:26.317Z",
+  "generatedAt": "2026-07-07T18:17:00.072Z",
   "locale": "es",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:43.221Z",
+  "generatedAt": "2026-07-07T18:17:09.813Z",
   "locale": "fa",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:30.068Z",
+  "generatedAt": "2026-07-07T18:17:02.178Z",
   "locale": "fr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:31.678Z",
+  "generatedAt": "2026-07-07T18:17:02.877Z",
   "locale": "hi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:37.327Z",
+  "generatedAt": "2026-07-07T18:17:06.354Z",
   "locale": "id",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:33.970Z",
+  "generatedAt": "2026-07-07T18:17:04.278Z",
   "locale": "it",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:27.648Z",
+  "generatedAt": "2026-07-07T18:17:00.773Z",
   "locale": "ja-JP",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:29.117Z",
+  "generatedAt": "2026-07-07T18:17:01.462Z",
   "locale": "ko",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:41.995Z",
+  "generatedAt": "2026-07-07T18:17:09.137Z",
   "locale": "nl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:38.593Z",
+  "generatedAt": "2026-07-07T18:17:07.037Z",
   "locale": "pl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:23.799Z",
+  "generatedAt": "2026-07-07T18:16:58.664Z",
   "locale": "pt-BR",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:46.145Z",
+  "generatedAt": "2026-07-07T18:17:10.523Z",
   "locale": "ru",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:39.502Z",
+  "generatedAt": "2026-07-07T18:17:07.736Z",
   "locale": "th",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:34.970Z",
+  "generatedAt": "2026-07-07T18:17:04.973Z",
   "locale": "tr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:35.919Z",
+  "generatedAt": "2026-07-07T18:17:05.666Z",
   "locale": "uk",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:40.747Z",
+  "generatedAt": "2026-07-07T18:17:08.436Z",
   "locale": "vi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:21.379Z",
+  "generatedAt": "2026-07-07T18:16:56.563Z",
   "locale": "zh-CN",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:22.571Z",
+  "generatedAt": "2026-07-07T18:16:57.971Z",
   "locale": "zh-TW",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
-  "translatedKeys": 1669,
+  "sourceHash": "a0ce1e8b37bef2b271ba79e85f6227e9a0fbd51701d8c0f87fcd66cdc61e78ed",
+  "totalKeys": 1671,
+  "translatedKeys": 1671,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1682,6 +1682,8 @@ export const ar: TranslationMap = {
       sessionSearch: "البحث في الجلسات",
       clearSessionSearch: "مسح البحث في الجلسات",
       loadMoreSessions: "تحميل المزيد من الجلسات",
+      currentSession: "الجلسة الحالية",
+      sessionLoadedListPosition: "الجلسة {position} من {total} في القائمة المحملة",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1714,6 +1714,8 @@ export const de: TranslationMap = {
       sessionSearch: "Sitzungen suchen",
       clearSessionSearch: "Sitzungssuche löschen",
       loadMoreSessions: "Weitere Sitzungen laden",
+      currentSession: "aktuelle Sitzung",
+      sessionLoadedListPosition: "Sitzung {position} von {total} in der geladenen Liste",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1688,6 +1688,8 @@ export const en: TranslationMap = {
       sessionSearch: "Search sessions",
       clearSessionSearch: "Clear session search",
       loadMoreSessions: "Load more sessions",
+      currentSession: "current session",
+      sessionLoadedListPosition: "session {position} of {total} in the loaded list",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1713,6 +1713,8 @@ export const es: TranslationMap = {
       sessionSearch: "Buscar sesiones",
       clearSessionSearch: "Borrar búsqueda de sesiones",
       loadMoreSessions: "Cargar más sesiones",
+      currentSession: "sesión actual",
+      sessionLoadedListPosition: "sesión {position} de {total} en la lista cargada",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1700,6 +1700,8 @@ export const fa: TranslationMap = {
       sessionSearch: "جستجوی نشست‌ها",
       clearSessionSearch: "پاک کردن جستجوی نشست",
       loadMoreSessions: "بارگذاری نشست‌های بیشتر",
+      currentSession: "جلسه فعلی",
+      sessionLoadedListPosition: "جلسه {position} از {total} در فهرست بارگذاری‌شده",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1722,6 +1722,8 @@ export const fr: TranslationMap = {
       sessionSearch: "Rechercher des sessions",
       clearSessionSearch: "Effacer la recherche de sessions",
       loadMoreSessions: "Charger plus de sessions",
+      currentSession: "session actuelle",
+      sessionLoadedListPosition: "session {position} sur {total} dans la liste chargée",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -1683,6 +1683,8 @@ export const hi: TranslationMap = {
       sessionSearch: "सत्र खोजें",
       clearSessionSearch: "सत्र खोज साफ़ करें",
       loadMoreSessions: "और सत्र लोड करें",
+      currentSession: "वर्तमान सत्र",
+      sessionLoadedListPosition: "लोड की गई सूची में {total} में से सत्र {position}",
       model: "चैट मॉडल",
       thinkingLevel: "चैट सोच स्तर",
     },

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1701,6 +1701,8 @@ export const id: TranslationMap = {
       sessionSearch: "Cari sesi",
       clearSessionSearch: "Hapus pencarian sesi",
       loadMoreSessions: "Muat sesi lainnya",
+      currentSession: "sesi saat ini",
+      sessionLoadedListPosition: "sesi {position} dari {total} dalam daftar yang dimuat",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1714,6 +1714,8 @@ export const it: TranslationMap = {
       sessionSearch: "Cerca sessioni",
       clearSessionSearch: "Cancella ricerca sessioni",
       loadMoreSessions: "Carica altre sessioni",
+      currentSession: "sessione corrente",
+      sessionLoadedListPosition: "sessione {position} di {total} nell'elenco caricato",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1707,6 +1707,8 @@ export const ja_JP: TranslationMap = {
       sessionSearch: "セッションを検索",
       clearSessionSearch: "セッション検索をクリア",
       loadMoreSessions: "さらにセッションを読み込む",
+      currentSession: "現在のセッション",
+      sessionLoadedListPosition: "読み込まれたリストの{total}件中{position}件目のセッション",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1691,6 +1691,8 @@ export const ko: TranslationMap = {
       sessionSearch: "세션 검색",
       clearSessionSearch: "세션 검색 지우기",
       loadMoreSessions: "세션 더 불러오기",
+      currentSession: "현재 세션",
+      sessionLoadedListPosition: "로드된 목록의 {total}개 중 {position}번째 세션",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1708,6 +1708,8 @@ export const nl: TranslationMap = {
       sessionSearch: "Sessies zoeken",
       clearSessionSearch: "Sessiezoekopdracht wissen",
       loadMoreSessions: "Meer sessies laden",
+      currentSession: "huidige sessie",
+      sessionLoadedListPosition: "sessie {position} van {total} in de geladen lijst",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1705,6 +1705,8 @@ export const pl: TranslationMap = {
       sessionSearch: "Szukaj sesji",
       clearSessionSearch: "Wyczyść wyszukiwanie sesji",
       loadMoreSessions: "Wczytaj więcej sesji",
+      currentSession: "bieżąca sesja",
+      sessionLoadedListPosition: "sesja {position} z {total} na załadowanej liście",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1705,6 +1705,8 @@ export const pt_BR: TranslationMap = {
       sessionSearch: "Pesquisar sessões",
       clearSessionSearch: "Limpar pesquisa de sessões",
       loadMoreSessions: "Carregar mais sessões",
+      currentSession: "sessão atual",
+      sessionLoadedListPosition: "sessão {position} de {total} na lista carregada",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -1714,6 +1714,8 @@ export const ru: TranslationMap = {
       sessionSearch: "Поиск сеансов",
       clearSessionSearch: "Очистить поиск сеансов",
       loadMoreSessions: "Загрузить еще сеансы",
+      currentSession: "текущий сеанс",
+      sessionLoadedListPosition: "сеанс {position} из {total} в загруженном списке",
       model: "Модель чата",
       thinkingLevel: "Уровень мышления чата",
     },

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1664,6 +1664,8 @@ export const th: TranslationMap = {
       sessionSearch: "ค้นหาเซสชัน",
       clearSessionSearch: "ล้างการค้นหาเซสชัน",
       loadMoreSessions: "โหลดเซสชันเพิ่มเติม",
+      currentSession: "เซสชันปัจจุบัน",
+      sessionLoadedListPosition: "เซสชัน {position} จาก {total} ในรายการที่โหลดแล้ว",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1707,6 +1707,8 @@ export const tr: TranslationMap = {
       sessionSearch: "Oturumlarda ara",
       clearSessionSearch: "Oturum aramasını temizle",
       loadMoreSessions: "Daha fazla oturum yükle",
+      currentSession: "geçerli oturum",
+      sessionLoadedListPosition: "yüklenen listedeki {total} oturumdan {position}. oturum",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1703,6 +1703,8 @@ export const uk: TranslationMap = {
       sessionSearch: "Пошук сеансів",
       clearSessionSearch: "Очистити пошук сеансів",
       loadMoreSessions: "Завантажити більше сеансів",
+      currentSession: "поточний сеанс",
+      sessionLoadedListPosition: "сеанс {position} із {total} у завантаженому списку",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1691,6 +1691,8 @@ export const vi: TranslationMap = {
       sessionSearch: "Tìm kiếm phiên",
       clearSessionSearch: "Xóa tìm kiếm phiên",
       loadMoreSessions: "Tải thêm phiên",
+      currentSession: "phiên hiện tại",
+      sessionLoadedListPosition: "phiên {position} trong tổng số {total} trong danh sách đã tải",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1658,6 +1658,8 @@ export const zh_CN: TranslationMap = {
       sessionSearch: "搜索会话",
       clearSessionSearch: "清除会话搜索",
       loadMoreSessions: "加载更多会话",
+      currentSession: "当前会话",
+      sessionLoadedListPosition: "已加载列表中的第 {position} 个会话，共 {total} 个",
       model: "聊天模型",
       thinkingLevel: "聊天思考级别",
     },

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1660,6 +1660,8 @@ export const zh_TW: TranslationMap = {
       sessionSearch: "搜尋工作階段",
       clearSessionSearch: "清除工作階段搜尋",
       loadMoreSessions: "載入更多工作階段",
+      currentSession: "目前工作階段",
+      sessionLoadedListPosition: "已載入清單中的第 {position} 個工作階段，共 {total} 個",
       model: "Chat model",
       thinkingLevel: "Chat thinking level",
     },

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -1,0 +1,61 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import { createPaneSessionSelectOptions } from "./chat-pane.ts";
+
+function createSessionRow(key: string, label: string): GatewaySessionRow {
+  return {
+    key,
+    kind: "direct",
+    label,
+    updatedAt: 1,
+  };
+}
+
+describe("pane session select options", () => {
+  it("labels rows with linear position and current-session state", () => {
+    const options = createPaneSessionSelectOptions({
+      sessionKey: "agent:main:main",
+      sessions: [
+        createSessionRow("agent:main:main", "Main chat"),
+        createSessionRow("agent:main:work", "Main work"),
+      ],
+    });
+
+    expect(options).toEqual([
+      {
+        ariaLabel: "Main chat, current session, session 1 of 2 in the loaded list",
+        key: "agent:main:main",
+        label: "Main chat",
+        position: 1,
+        selected: true,
+        visibleLabel: "1. Main chat",
+      },
+      {
+        ariaLabel: "Main work, session 2 of 2 in the loaded list",
+        key: "agent:main:work",
+        label: "Main work",
+        position: 2,
+        selected: false,
+        visibleLabel: "2. Main work",
+      },
+    ]);
+  });
+
+  it("keeps the selected session addressable when the loaded list omits it", () => {
+    const options = createPaneSessionSelectOptions({
+      sessionKey: "agent:main:missing",
+      sessions: [createSessionRow("agent:main:work", "Main work")],
+    });
+
+    expect(options[0]).toMatchObject({
+      ariaLabel: "agent:main:missing, current session, session 1 of 2 in the loaded list",
+      key: "agent:main:missing",
+      position: 1,
+      selected: true,
+      visibleLabel: "1. agent:main:missing",
+    });
+    expect(options[1]?.position).toBe(2);
+  });
+});

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -84,6 +84,14 @@ import { clearChatMessagesFromCache } from "./session-message-cache.ts";
 
 type ChatPageContext = ApplicationContext;
 type PaneSessionChangeOptions = { replace?: boolean };
+export type PaneSessionSelectOption = {
+  ariaLabel: string;
+  key: string;
+  label: string;
+  position: number;
+  selected: boolean;
+  visibleLabel: string;
+};
 
 const CHAT_OPEN_DETAILS_SELECTOR =
   ".chat-controls__inline-select[open], .context-usage details[open], .agent-chat__talk-select[open], .agent-chat__attach-menu[open]";
@@ -94,6 +102,42 @@ const NEW_SESSION_LIST_LOADING_MESSAGE =
   "Session list is still refreshing. Try New Chat again in a moment.";
 const NEW_SESSION_CREATE_FAILED_MESSAGE =
   "New Chat could not create a new session. Try again in a moment.";
+
+export function createPaneSessionSelectOptions(params: {
+  sessionKey: string;
+  sessions: GatewaySessionRow[];
+}): PaneSessionSelectOption[] {
+  const currentSession = params.sessions.find((row) => row.key === params.sessionKey);
+  const optionKeys = currentSession
+    ? params.sessions.map((row) => row.key)
+    : [params.sessionKey, ...params.sessions.map((row) => row.key)];
+  const total = optionKeys.length;
+  return optionKeys.map((key, index) => {
+    const row = params.sessions.find((session) => session.key === key);
+    const label = resolveSessionDisplayName(key, row);
+    const position = index + 1;
+    const selected = key === params.sessionKey;
+    const loadedListPosition = t("chat.selectors.sessionLoadedListPosition", {
+      position: String(position),
+      total: String(total),
+    });
+    const ariaLabel = [
+      label,
+      selected ? t("chat.selectors.currentSession") : null,
+      loadedListPosition,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    return {
+      ariaLabel,
+      key,
+      label,
+      position,
+      selected,
+      visibleLabel: `${position}. ${label}`,
+    };
+  });
+}
 
 export class ChatPane extends LitElement {
   @consume({ context: applicationContext, subscribe: false })
@@ -679,8 +723,10 @@ export class ChatPane extends LitElement {
       return null;
     }
     const sessions = state.sessionsResult?.sessions ?? [];
-    const currentSession = sessions.find((row) => row.key === state.sessionKey);
-    const options = currentSession ? sessions : [{ key: state.sessionKey }, ...sessions];
+    const options = createPaneSessionSelectOptions({
+      sessionKey: state.sessionKey,
+      sessions,
+    });
     return html`
       <div class="chat-pane__header ${this.active ? "chat-pane--active" : ""}">
         <label class="chat-pane__session-label">
@@ -697,12 +743,14 @@ export class ChatPane extends LitElement {
             }}
           >
             ${options.map(
-              (row) => html`
-                <option value=${row.key}>
-                  ${resolveSessionDisplayName(
-                    row.key,
-                    sessions.find((session) => session.key === row.key),
-                  )}
+              (option) => html`
+                <option
+                  value=${option.key}
+                  aria-label=${option.ariaLabel}
+                  data-chat-session-picker-option="true"
+                  data-chat-session-picker-position=${String(option.position)}
+                >
+                  ${option.visibleLabel}
                 </option>
               `,
             )}


### PR DESCRIPTION
Related: #82450

## What Problem This Solves

Resolves a first slice of the accessibility problem where blind and keyboard users navigating the existing Control UI chat session picker did not get a linear row position or a clear current-session cue from each session option.

This is intentionally related to #82450 rather than closing it: the larger Linear Persistent Workspace Mode still needs product decisions beyond this picker affordance.

## Why This Change Was Made

The chat session picker now gives each loaded option a stable visible ordinal marker and an explicit accessible label that includes current-session state plus its position in the loaded list. This keeps the existing `sessions.list` search, pagination, filtering, and storage behavior unchanged.

ClawSweeper follow-up: the new current-session and loaded-list-position phrases are routed through `chat.selectors.*` i18n keys, and all generated non-English locale outputs now carry translations for those keys with `fallbacks=0` metadata.

## User Impact

Screen-reader users can hear labels such as `Alpha planning, current session, session 1 of 2 in the loaded list` while navigating the picker, and sighted keyboard users get matching linear row numbers in the existing picker UI.

## Evidence

Current head: `ce299a604d74ec08c81fd20391374c9ba87477cf`

- `git diff --check` passed.
- `pnpm changed:lanes --json` reported `core=true`, `coreTests=true`, and no extension/app/docs lanes.
- `pnpm ui:i18n:check` passed locally with all 20 locales clean and `fallbacks=0` after translating the two new selector keys.
- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts --reporter=verbose` passed locally: 1 file, 120 tests.
- Crabbox local-container proof passed on the current head: provider `local-container`, image `mcr.microsoft.com/playwright:v1.60.0-noble`, lease `cbx_b2c64e3b1f32`, slug `crimson-crayfish`, exit `0`.

Current-head Crabbox proof excerpt:

```text
proof_head=ce299a604d74ec08c81fd20391374c9ba87477cf
CRABBOX_PHASE:i18n
zh-CN: clean (fallbacks=0)
zh-TW: clean (fallbacks=0)
pt-BR: clean (fallbacks=0)
de: clean (fallbacks=0)
es: clean (fallbacks=0)
ja-JP: clean (fallbacks=0)
ko: clean (fallbacks=0)
fr: clean (fallbacks=0)
hi: clean (fallbacks=0)
ar: clean (fallbacks=0)
it: clean (fallbacks=0)
tr: clean (fallbacks=0)
uk: clean (fallbacks=0)
id: clean (fallbacks=0)
pl: clean (fallbacks=0)
th: clean (fallbacks=0)
vi: clean (fallbacks=0)
nl: clean (fallbacks=0)
fa: clean (fallbacks=0)
ru: clean (fallbacks=0)
CRABBOX_PHASE:unit
Test Files  1 passed (1)
Tests  120 passed (120)
CRABBOX_PHASE:e2e
ui/src/ui/e2e/chat-picker-pagination.e2e.test.ts (2 tests)
- searches and pages chat sessions through the GUI
- skips hidden subagent-only pages when loading more chat sessions through the GUI
Test Files  1 passed (1)
Tests  2 passed (2)
CRABBOX_PROOF_SUCCESS head=ce299a604d74ec08c81fd20391374c9ba87477cf
```

Inspectable browser proof from the same behavior slice captured before the translation-only follow-up:

```text
Control UI chat session picker after-fix proof
head: 9c1c301aa9fcb4f23dfc4b983856b7fe521282cc
servedUrl: http://127.0.0.1:63121/chat
browser: Chromium via Playwright
sessions.list requests: 1
visibleRowsAndAccessibleNames:
- key=agent:alpha position=1 visibleIndex=1 ariaSelected=true label="Alpha planning" ariaLabel="Alpha planning, current session, session 1 of 2 in the loaded list, openai/gpt-5.5 - 5/22/2026, 9:59:59 AM"
- key=agent:design position=2 visibleIndex=2 ariaSelected=false label="Design review" ariaLabel="Design review, session 2 of 2 in the loaded list, openai/gpt-5.5 - 5/22/2026, 9:59:30 AM"
assertions:
- visible ordinal markers matched positions: true
- current option aria-label includes current-session cue: true
- second option aria-label includes loaded-list position: true
```

State compatibility note: this is a DOM/rendering-only Control UI change. It adds visible ordinal text, `data-chat-session-picker-position`, and i18n-backed `aria-label` text. It does not change persisted session data, serialized state shape, Gateway request/response schemas, migrations, storage keys, or upgrade behavior.
