### PR TITLE
fix(gateway): reject agent RPC runs for deleted-agent sessions

### DIFF
--- a/src/gateway/server-methods/agent.deleted-agent.test.ts
+++ b/src/gateway/server-methods/agent.deleted-agent.test.ts
@@ -134,4 +134,36 @@ describe("agent RPC deleted-agent guard", () => {
       expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
     },
   );
+
+  it("rejects deleted-agent sessions before stale exec followup dedupe", async () => {
+    const orphanKey = mockDeletedAgentSession();
+
+    const respond = vi.fn() as unknown as RespondFn;
+    const dedupe = new Map();
+
+    await agentHandlers.agent({
+      req: { id: "req-followup" } as never,
+      params: {
+        sessionKey: orphanKey,
+        message: "approval followup",
+        idempotencyKey: "exec-approval-followup:req-followup",
+        execApprovalFollowupExpectedSessionId: "old-session",
+      },
+      respond,
+      context: {
+        dedupe,
+        chatAbortControllers: new Map(),
+        getRuntimeConfig: () => ({}),
+      } as never,
+      client: { connect: { client: { mode: "backend" } } } as never,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(false, undefined, {
+      code: ErrorCodes.INVALID_REQUEST,
+      message: 'Agent "deleted-agent" no longer exists in configuration',
+    });
+    expect(dedupe.size).toBe(0);
+    expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/gateway/server-methods/agent.deleted-agent.test.ts
+++ b/src/gateway/server-methods/agent.deleted-agent.test.ts
@@ -11,15 +11,23 @@ import {
 import type { RespondFn } from "./types.js";
 
 const agentCommandFromIngressMock = vi.hoisted(() => vi.fn());
+const performGatewaySessionResetMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../commands/agent.js", () => ({
   agentCommandFromIngress: agentCommandFromIngressMock,
+}));
+
+vi.mock("../session-reset-service.js", () => ({
+  performGatewaySessionReset: performGatewaySessionResetMock,
+  emitGatewaySessionEndPluginHook: vi.fn(),
+  emitGatewaySessionStartPluginHook: vi.fn(),
 }));
 
 describe("agent RPC deleted-agent guard", () => {
   beforeEach(() => {
     resetDeletedAgentSessionMocks();
     agentCommandFromIngressMock.mockReset();
+    performGatewaySessionResetMock.mockReset();
   });
 
   it("rejects keys belonging to a deleted agent", async () => {
@@ -50,4 +58,37 @@ describe("agent RPC deleted-agent guard", () => {
     });
     expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
   });
+
+  it.each(["/reset", "/reset follow up"])(
+    "rejects deleted-agent session keys before %s handling",
+    async (message) => {
+      const orphanKey = mockDeletedAgentSession();
+
+      const respond = vi.fn() as unknown as RespondFn;
+
+      await agentHandlers.agent({
+        req: { id: "req-reset" } as never,
+        params: {
+          sessionKey: orphanKey,
+          message,
+          idempotencyKey: `run-reset-${message}`,
+        },
+        respond,
+        context: {
+          dedupe: new Map(),
+          chatAbortControllers: new Map(),
+          getRuntimeConfig: () => ({}),
+        } as never,
+        client: { connect: { scopes: ["operator.admin"] } } as never,
+        isWebchatConnect: () => false,
+      });
+
+      expect(respond).toHaveBeenCalledWith(false, undefined, {
+        code: ErrorCodes.INVALID_REQUEST,
+        message: 'Agent "deleted-agent" no longer exists in configuration',
+      });
+      expect(performGatewaySessionResetMock).not.toHaveBeenCalled();
+      expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/gateway/server-methods/agent.deleted-agent.test.ts
+++ b/src/gateway/server-methods/agent.deleted-agent.test.ts
@@ -1,6 +1,3 @@
-/**
- * Tests that the agent RPC rejects deleted-agent sessions before dispatch.
- */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { agentHandlers } from "./agent.js";
@@ -100,8 +97,6 @@ describe("agent RPC deleted-agent guard", () => {
       code: ErrorCodes.INVALID_REQUEST,
       message: 'Agent "deleted-agent" no longer exists in configuration',
     });
-    // Guard runs before attachment parsing (inbound media offload), the
-    // pre-accept dedupe reservation, and run dispatch.
     expect(parseMessageWithAttachmentsMock).not.toHaveBeenCalled();
     expect(dedupe.size).toBe(0);
     expect(agentCommandFromIngressMock).not.toHaveBeenCalled();

--- a/src/gateway/server-methods/agent.deleted-agent.test.ts
+++ b/src/gateway/server-methods/agent.deleted-agent.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests that the agent RPC rejects deleted-agent sessions before dispatch.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { agentHandlers } from "./agent.js";
+import {
+  mockDeletedAgentSession,
+  resetDeletedAgentSessionMocks,
+} from "./deleted-agent-guard.test-helpers.js";
+import type { RespondFn } from "./types.js";
+
+const agentCommandFromIngressMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../commands/agent.js", () => ({
+  agentCommandFromIngress: agentCommandFromIngressMock,
+}));
+
+describe("agent RPC deleted-agent guard", () => {
+  beforeEach(() => {
+    resetDeletedAgentSessionMocks();
+    agentCommandFromIngressMock.mockReset();
+  });
+
+  it("rejects keys belonging to a deleted agent", async () => {
+    const orphanKey = mockDeletedAgentSession();
+
+    const respond = vi.fn() as unknown as RespondFn;
+
+    await agentHandlers.agent({
+      req: { id: "req-1" } as never,
+      params: {
+        sessionKey: orphanKey,
+        message: "hi",
+        idempotencyKey: "run-1",
+      },
+      respond,
+      context: {
+        dedupe: new Map(),
+        chatAbortControllers: new Map(),
+        getRuntimeConfig: () => ({}),
+      } as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(false, undefined, {
+      code: ErrorCodes.INVALID_REQUEST,
+      message: 'Agent "deleted-agent" no longer exists in configuration',
+    });
+    expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/agent.deleted-agent.test.ts
+++ b/src/gateway/server-methods/agent.deleted-agent.test.ts
@@ -12,6 +12,7 @@ import type { RespondFn } from "./types.js";
 
 const agentCommandFromIngressMock = vi.hoisted(() => vi.fn());
 const performGatewaySessionResetMock = vi.hoisted(() => vi.fn());
+const parseMessageWithAttachmentsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../commands/agent.js", () => ({
   agentCommandFromIngress: agentCommandFromIngressMock,
@@ -23,11 +24,21 @@ vi.mock("../session-reset-service.js", () => ({
   emitGatewaySessionStartPluginHook: vi.fn(),
 }));
 
+vi.mock("../chat-attachments.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../chat-attachments.js")>("../chat-attachments.js");
+  return {
+    ...actual,
+    parseMessageWithAttachments: parseMessageWithAttachmentsMock,
+  };
+});
+
 describe("agent RPC deleted-agent guard", () => {
   beforeEach(() => {
     resetDeletedAgentSessionMocks();
     agentCommandFromIngressMock.mockReset();
     performGatewaySessionResetMock.mockReset();
+    parseMessageWithAttachmentsMock.mockReset();
   });
 
   it("rejects keys belonging to a deleted agent", async () => {
@@ -56,6 +67,43 @@ describe("agent RPC deleted-agent guard", () => {
       code: ErrorCodes.INVALID_REQUEST,
       message: 'Agent "deleted-agent" no longer exists in configuration',
     });
+    expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects deleted-agent sessions before media offload or dedupe reservation", async () => {
+    const orphanKey = mockDeletedAgentSession();
+
+    const respond = vi.fn() as unknown as RespondFn;
+    const dedupe = new Map();
+
+    await agentHandlers.agent({
+      req: { id: "req-attach" } as never,
+      params: {
+        sessionKey: orphanKey,
+        message: "see attachment",
+        idempotencyKey: "run-attach",
+        attachments: [
+          { type: "file", mimeType: "application/pdf", fileName: "doc.pdf", content: "aGVsbG8=" },
+        ],
+      },
+      respond,
+      context: {
+        dedupe,
+        chatAbortControllers: new Map(),
+        getRuntimeConfig: () => ({}),
+      } as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(false, undefined, {
+      code: ErrorCodes.INVALID_REQUEST,
+      message: 'Agent "deleted-agent" no longer exists in configuration',
+    });
+    // Guard runs before attachment parsing (inbound media offload), the
+    // pre-accept dedupe reservation, and run dispatch.
+    expect(parseMessageWithAttachmentsMock).not.toHaveBeenCalled();
+    expect(dedupe.size).toBe(0);
     expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -5316,6 +5316,8 @@ describe("gateway agent handler", () => {
   });
 
   it("does not auto-route voice wake requests with another agent's explicit main session", async () => {
+    const opsAgentCfg = { agents: { list: [{ id: "main" }, { id: "ops" }] } };
+    mocks.listAgentIds.mockReturnValue(["main", "ops"]);
     mocks.loadVoiceWakeRoutingConfig.mockResolvedValue({
       version: 1,
       defaultTarget: { sessionKey: "agent:main:voice" },
@@ -5325,7 +5327,7 @@ describe("gateway agent handler", () => {
     mocks.resolveVoiceWakeRouteByTrigger.mockReturnValue({ sessionKey: "agent:main:voice" });
 
     mocks.loadSessionEntry.mockImplementation((sessionKey: string) => ({
-      cfg: {},
+      cfg: opsAgentCfg,
       storePath: "/tmp/sessions.json",
       entry: {
         sessionId: "voice-session-id",
@@ -5340,6 +5342,7 @@ describe("gateway agent handler", () => {
     });
     mocks.loadVoiceWakeRoutingConfig.mockClear();
     mocks.resolveVoiceWakeRouteByTrigger.mockClear();
+    mocks.agentCommand.mockClear();
 
     const respond = vi.fn();
     await invokeAgent(

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1453,44 +1453,6 @@ export const agentHandlers: GatewayRequestHandlers = {
         agentId = inferredAgentId;
       }
     }
-    // Drop an exec-approval followup whose session key was rebound by /new or
-    // /reset while the approval was pending, before the handler touches the
-    // rebound session (store write, run registration, dedupe, accepted ack).
-    if (execApprovalFollowupApprovalId && requestedSessionKeyRaw) {
-      const expectedSessionId = normalizeOptionalString(
-        request.execApprovalFollowupExpectedSessionId,
-      );
-      let currentSessionId: string | undefined;
-      try {
-        currentSessionId = normalizeOptionalString(
-          loadSessionEntry(requestedSessionKeyRaw).entry?.sessionId,
-        );
-      } catch {
-        currentSessionId = undefined;
-      }
-      if (
-        isExecApprovalFollowupSessionRebound({
-          expectedSessionId,
-          resolvedSessionId: currentSessionId,
-        })
-      ) {
-        context.logGateway.info(
-          `Dropping stale exec approval followup ${execApprovalFollowupApprovalId}: session ${requestedSessionKeyRaw} rebound (expected ${expectedSessionId}, current ${currentSessionId}) before the approval resolved`,
-        );
-        const droppedPayload = {
-          runId,
-          status: "ok" as const,
-          summary: "exec approval followup dropped: session was reset before the approval resolved",
-        };
-        setGatewayDedupeEntries({
-          dedupe: context.dedupe,
-          keys: agentDedupeKeys,
-          entry: { ts: Date.now(), ok: true, payload: droppedPayload },
-        });
-        respond(true, droppedPayload, undefined, { runId });
-        return;
-      }
-    }
     let requestedSessionKey =
       requestedSessionKeyRaw ??
       (!requestedSessionId
@@ -1529,6 +1491,44 @@ export const agentHandlers: GatewayRequestHandlers = {
       respondDeletedAgentSessionForKey({ sessionKey: requestedSessionKey, agentId, respond })
     ) {
       return;
+    }
+    // Drop an exec-approval followup whose session key was rebound by /new or
+    // /reset while the approval was pending, before the handler touches the
+    // rebound session (store write, run registration, dedupe, accepted ack).
+    if (execApprovalFollowupApprovalId && requestedSessionKeyRaw) {
+      const expectedSessionId = normalizeOptionalString(
+        request.execApprovalFollowupExpectedSessionId,
+      );
+      let currentSessionId: string | undefined;
+      try {
+        currentSessionId = normalizeOptionalString(
+          loadSessionEntry(requestedSessionKeyRaw).entry?.sessionId,
+        );
+      } catch {
+        currentSessionId = undefined;
+      }
+      if (
+        isExecApprovalFollowupSessionRebound({
+          expectedSessionId,
+          resolvedSessionId: currentSessionId,
+        })
+      ) {
+        context.logGateway.info(
+          `Dropping stale exec approval followup ${execApprovalFollowupApprovalId}: session ${requestedSessionKeyRaw} rebound (expected ${expectedSessionId}, current ${currentSessionId}) before the approval resolved`,
+        );
+        const droppedPayload = {
+          runId,
+          status: "ok" as const,
+          summary: "exec approval followup dropped: session was reset before the approval resolved",
+        };
+        setGatewayDedupeEntries({
+          dedupe: context.dedupe,
+          keys: agentDedupeKeys,
+          entry: { ts: Date.now(), ok: true, payload: droppedPayload },
+        });
+        respond(true, droppedPayload, undefined, { runId });
+        return;
+      }
     }
     // Reserve the run before awaited attachment/session/delivery work so duplicate calls dedupe and
     // pre-registration chat.abort can be made durable by idempotency key.

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -221,6 +221,36 @@ function clientHasAdminScope(client: GatewayRequestHandlerOptions["client"]): bo
   return scopes.includes(ADMIN_SCOPE);
 }
 
+function respondDeletedAgentSessionForKey(params: {
+  sessionKey: string;
+  agentId?: string;
+  respond: GatewayRequestHandlerOptions["respond"];
+}): boolean {
+  const sessionLoadOptions = {
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    clone: false,
+  };
+  const { cfg, entry, canonicalKey, legacyKey } = loadSessionEntry(
+    params.sessionKey,
+    sessionLoadOptions,
+  );
+  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, canonicalKey, entry, {
+    acpMetadataSessionKey: legacyKey ?? canonicalKey,
+  });
+  if (deletedAgentId === null) {
+    return false;
+  }
+  params.respond(
+    false,
+    undefined,
+    errorShape(
+      ErrorCodes.INVALID_REQUEST,
+      `Agent "${deletedAgentId}" no longer exists in configuration`,
+    ),
+  );
+  return true;
+}
+
 function resolveAllowModelOverrideFromClient(
   client: GatewayRequestHandlerOptions["client"],
 ): boolean {
@@ -1660,6 +1690,13 @@ export const agentHandlers: GatewayRequestHandlers = {
       let isNewSession = false;
       let skipAgentInitialSessionTouch = false;
       let pendingChatRun: { sessionKey: string; agentId?: string } | undefined;
+
+      if (
+        requestedSessionKey &&
+        respondDeletedAgentSessionForKey({ sessionKey: requestedSessionKey, agentId, respond })
+      ) {
+        return;
+      }
 
       const resetCommandMatch = message.match(RESET_COMMAND_RE);
       if (resetCommandMatch && requestedSessionKey) {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -221,22 +221,21 @@ function clientHasAdminScope(client: GatewayRequestHandlerOptions["client"]): bo
   return scopes.includes(ADMIN_SCOPE);
 }
 
-function respondDeletedAgentSessionForKey(params: {
-  sessionKey: string;
-  agentId?: string;
+function respondDeletedAgentSession(params: {
+  cfg: OpenClawConfig;
+  canonicalKey: string;
+  entry?: SessionEntry | null;
+  acpMetadataSessionKey?: string;
   respond: GatewayRequestHandlerOptions["respond"];
 }): boolean {
-  const sessionLoadOptions = {
-    ...(params.agentId ? { agentId: params.agentId } : {}),
-    clone: false,
-  };
-  const { cfg, entry, canonicalKey, legacyKey } = loadSessionEntry(
-    params.sessionKey,
-    sessionLoadOptions,
+  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(
+    params.cfg,
+    params.canonicalKey,
+    params.entry,
+    {
+      acpMetadataSessionKey: params.acpMetadataSessionKey ?? params.canonicalKey,
+    },
   );
-  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, canonicalKey, entry, {
-    acpMetadataSessionKey: legacyKey ?? canonicalKey,
-  });
   if (deletedAgentId === null) {
     return false;
   }
@@ -249,6 +248,24 @@ function respondDeletedAgentSessionForKey(params: {
     ),
   );
   return true;
+}
+
+function respondDeletedAgentSessionForKey(params: {
+  sessionKey: string;
+  agentId?: string;
+  respond: GatewayRequestHandlerOptions["respond"];
+}): boolean {
+  const { cfg, entry, canonicalKey, legacyKey } = loadSessionEntry(params.sessionKey, {
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    clone: false,
+  });
+  return respondDeletedAgentSession({
+    cfg,
+    canonicalKey,
+    entry,
+    acpMetadataSessionKey: legacyKey,
+    respond: params.respond,
+  });
 }
 
 function resolveAllowModelOverrideFromClient(
@@ -1505,11 +1522,8 @@ export const agentHandlers: GatewayRequestHandlers = {
         return;
       }
     }
-    // Reject orphaned deleted-agent session keys before any side effect (dedupe
-    // reservation, attachment media offload, reset, dispatch), matching the
-    // chat.send / sessions.send invariant. Voice-wake auto-routing below only
-    // retargets to knownAgents, so a post-routing key is never deleted; guarding
-    // the original requestedSessionKey here covers every dispatch path.
+    // Keep deleted-agent rejection ahead of dedupe, media offload, reset, and
+    // dispatch so agent RPC shares the chat.send / sessions.send boundary.
     if (
       requestedSessionKey &&
       respondDeletedAgentSessionForKey({ sessionKey: requestedSessionKey, agentId, respond })
@@ -1834,18 +1848,15 @@ export const agentHandlers: GatewayRequestHandlers = {
           legacyKey,
         } = loadSessionEntry(requestedSessionKey, sessionLoadOptions);
         cfgForAgent = cfgLocal;
-        const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfgLocal, canonicalKey, entry, {
-          acpMetadataSessionKey: legacyKey ?? canonicalKey,
-        });
-        if (deletedAgentId !== null) {
-          respond(
-            false,
-            undefined,
-            errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              `Agent "${deletedAgentId}" no longer exists in configuration`,
-            ),
-          );
+        if (
+          respondDeletedAgentSession({
+            cfg: cfgLocal,
+            canonicalKey,
+            entry,
+            acpMetadataSessionKey: legacyKey,
+            respond,
+          })
+        ) {
           return;
         }
         const sessionMaintenanceConfig = resolveMaintenanceConfigFromInput(

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1505,6 +1505,17 @@ export const agentHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+    // Reject orphaned deleted-agent session keys before any side effect (dedupe
+    // reservation, attachment media offload, reset, dispatch), matching the
+    // chat.send / sessions.send invariant. Voice-wake auto-routing below only
+    // retargets to knownAgents, so a post-routing key is never deleted; guarding
+    // the original requestedSessionKey here covers every dispatch path.
+    if (
+      requestedSessionKey &&
+      respondDeletedAgentSessionForKey({ sessionKey: requestedSessionKey, agentId, respond })
+    ) {
+      return;
+    }
     // Reserve the run before awaited attachment/session/delivery work so duplicate calls dedupe and
     // pre-registration chat.abort can be made durable by idempotency key.
     const preAcceptedReservedSessionKey =
@@ -1690,13 +1701,6 @@ export const agentHandlers: GatewayRequestHandlers = {
       let isNewSession = false;
       let skipAgentInitialSessionTouch = false;
       let pendingChatRun: { sessionKey: string; agentId?: string } | undefined;
-
-      if (
-        requestedSessionKey &&
-        respondDeletedAgentSessionForKey({ sessionKey: requestedSessionKey, agentId, respond })
-      ) {
-        return;
-      }
 
       const resetCommandMatch = message.match(RESET_COMMAND_RE);
       if (resetCommandMatch && requestedSessionKey) {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -152,6 +152,7 @@ import {
   canonicalizeSpawnedByForAgent,
   loadSessionEntry,
   migrateAndPruneGatewaySessionStoreKey,
+  resolveDeletedAgentIdFromSessionKey,
   resolveGatewaySessionStoreTarget,
   resolveGatewayModelSupportsImages,
   resolveSessionStoreKey,
@@ -1789,8 +1790,23 @@ export const agentHandlers: GatewayRequestHandlers = {
           storePath,
           entry,
           canonicalKey,
+          legacyKey,
         } = loadSessionEntry(requestedSessionKey, sessionLoadOptions);
         cfgForAgent = cfgLocal;
+        const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfgLocal, canonicalKey, entry, {
+          acpMetadataSessionKey: legacyKey ?? canonicalKey,
+        });
+        if (deletedAgentId !== null) {
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              `Agent "${deletedAgentId}" no longer exists in configuration`,
+            ),
+          );
+          return;
+        }
         const sessionMaintenanceConfig = resolveMaintenanceConfigFromInput(
           cfgLocal.session?.maintenance,
         );

--- a/src/gateway/server.agent.deleted-agent-gateway.test.ts
+++ b/src/gateway/server.agent.deleted-agent-gateway.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Live Gateway integration tests for deleted-agent guard on agent RPC.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, test, vi } from "vitest";
+import { ErrorCodes } from "../../packages/gateway-protocol/src/index.js";
+import { agentCommand, rpcReq, testState } from "./test-helpers.js";
+import {
+  sessionStoreEntry,
+  setupGatewaySessionsTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
+
+async function configurePerAgentSessionStore(dir: string) {
+  const storeTemplate = path.join(dir, "{agentId}", "sessions.json");
+  testState.sessionStorePath = storeTemplate;
+  testState.agentsConfig = { list: [{ id: "main", default: true }] };
+  return storeTemplate;
+}
+
+function resetSessionStoreFixture() {
+  testState.agentsConfig = undefined;
+  testState.sessionStorePath = undefined;
+}
+
+test("agent RPC rejects deleted-agent session keys before dispatch", async () => {
+  const { dir } = await createSessionStoreDir();
+  const storeTemplate = await configurePerAgentSessionStore(dir);
+  const deletedStorePath = storeTemplate.replace("{agentId}", "deleted-agent");
+  const orphanKey = "agent:deleted-agent:main";
+
+  await fs.mkdir(path.dirname(deletedStorePath), { recursive: true });
+  await fs.writeFile(
+    deletedStorePath,
+    JSON.stringify(
+      {
+        [orphanKey]: sessionStoreEntry("sess-orphan"),
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+
+  vi.mocked(agentCommand).mockClear();
+  const { ws } = await openClient();
+  try {
+    const blocked = await rpcReq(ws, "agent", {
+      sessionKey: orphanKey,
+      message: "hi",
+      idempotencyKey: "proof-deleted-agent",
+    });
+    expect(blocked.ok).toBe(false);
+    expect(blocked.error).toEqual({
+      code: ErrorCodes.INVALID_REQUEST,
+      message: 'Agent "deleted-agent" no longer exists in configuration',
+    });
+    expect(agentCommand).not.toHaveBeenCalled();
+  } finally {
+    ws.close();
+    resetSessionStoreFixture();
+  }
+});
+
+test("agent RPC still dispatches for configured-agent session keys", async () => {
+  const { dir } = await createSessionStoreDir();
+  const storeTemplate = await configurePerAgentSessionStore(dir);
+  const mainStorePath = storeTemplate.replace("{agentId}", "main");
+
+  await fs.mkdir(path.dirname(mainStorePath), { recursive: true });
+  await fs.writeFile(
+    mainStorePath,
+    JSON.stringify(
+      {
+        main: sessionStoreEntry("sess-main"),
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+
+  vi.mocked(agentCommand).mockClear();
+  const { ws } = await openClient();
+  try {
+    const accepted = await rpcReq(ws, "agent", {
+      sessionKey: "main",
+      message: "ping",
+      idempotencyKey: "proof-main-agent",
+    });
+    expect(accepted.ok).toBe(true);
+    expect(accepted.payload?.status).toBe("accepted");
+    expect(accepted.payload?.runId).toBe("proof-main-agent");
+    await vi.waitFor(() => expect(agentCommand).toHaveBeenCalled());
+  } finally {
+    ws.close();
+    resetSessionStoreFixture();
+  }
+});

--- a/src/gateway/server.agent.deleted-agent-gateway.test.ts
+++ b/src/gateway/server.agent.deleted-agent-gateway.test.ts
@@ -1,6 +1,3 @@
-/**
- * Live Gateway integration tests for deleted-agent guard on agent RPC.
- */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, test, vi } from "vitest";


### PR DESCRIPTION
Related #65524

## What Problem This Solves

Fixes an issue where operators who removed an agent from `agents.list` could still start model runs against orphaned session keys through the Gateway `agent` RPC. `chat.send` and `sessions.send` / `sessions.steer` already reject these sessions, but `agent` skipped the same deleted-agent guard and could continue into run dispatch.

## Why This Change Was Made

#65524 added `resolveDeletedAgentIdFromSessionKey` to message/send paths. The `agent` handler never called the helper before dispatch. This wires the same guard used by `chat.send` and `sessions.send`, and places it **before any request side effect** — immediately after session-key / agent-id validation and before the pre-accept dedupe reservation, attachment media offload, `/reset` handling, and run dispatch.

Sibling `chat.send` (`src/gateway/server-methods/chat.ts`) and `sessions.send` reject deleted-agent sessions before attachment preparation; this matches that invariant so a rejected `agent` RPC cannot reserve a dedupe entry or persist offloaded inbound media before failing closed. Voice-wake auto-routing only retargets to agents in `agents.list`, so a post-routing session key is never deleted — guarding the original `requestedSessionKey` here covers every dispatch path, and the previous post-routing guard was removed as redundant (one canonical path).

This is an intentional fail-closed compatibility change: orphaned session keys for removed agents now return `INVALID_REQUEST` on `agent` RPC, matching the existing `chat.send` / `sessions.send` behavior from #65986.

## User Impact

Deleting an agent from configuration now consistently blocks all common Gateway entry points from reusing its orphaned session keys. Operators no longer get silent agent runs, transcript writes, dedupe reservations, persisted inbound media, or delivery attempts against sessions whose owning agent was removed.

## Evidence

### Unit regression — guard runs before side effects (dedupe / media / reset / dispatch)

```
CI=true OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/gateway/server-methods/agent.deleted-agent.test.ts \
  src/gateway/server-methods/chat.send-deleted-agent.test.ts \
  src/gateway/server-methods/sessions.send-deleted-agent.test.ts \
  src/gateway/server.agent.deleted-agent-gateway.test.ts

 Test Files  8 passed (8)
      Tests  18 passed (18)
```

New case `rejects deleted-agent sessions before media offload or dedupe reservation` sends an `agent` RPC with an offloadable attachment on `agent:deleted-agent:main` and asserts the handler returns `INVALID_REQUEST` while `parseMessageWithAttachments` (inbound media offload) is **not** called, the dedupe map stays empty (no pre-accept reservation), and `agentCommandFromIngress` (dispatch) is **not** called. The existing `/reset` and `/reset follow up` cases prove the guard also precedes reset handling.

**Before fix (`main`):** the `agent` handler proceeds into pre-accept dedupe reservation, attachment parsing, and run registration before any deleted-agent check.

### Live Gateway integration proof (real WebSocket RPC against running Gateway)

```
CI=true OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/gateway/server.agent.deleted-agent-gateway.test.ts

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**Deleted-agent rejection:** `server.agent.deleted-agent-gateway.test.ts` seeds a per-agent session store for `deleted-agent` (not in `agents.list`), connects a real Gateway client, and calls `agent` RPC with `sessionKey: agent:deleted-agent:main`. The handler returns `INVALID_REQUEST` with `Agent "deleted-agent" no longer exists in configuration` and `agentCommand` is not invoked.

**Configured-agent dispatch:** same harness calls `agent` RPC with `sessionKey: main` for the default configured agent; response is `accepted` with the requested `runId`, and `agentCommand` is invoked.

### No regression in the full agent handler suite (voice-wake invariants)

```
CI=true OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/gateway/server-methods/agent.test.ts

 Test Files  2 passed (2)
      Tests  330 passed (330)
```

Confirms the earlier guard placement does not change voice-wake auto-routing for configured agents (the `does not auto-route voice wake requests with another agent's explicit main session` invariant still holds).

### Lint + types (changed files)

```
node scripts/run-oxlint.mjs src/gateway/server-methods/agent.ts \
  src/gateway/server-methods/agent.deleted-agent.test.ts   # exit 0
pnpm tsgo --noEmit -p tsconfig.json                        # exit 0, 0 errors
```

### Diff scope

- `src/gateway/server-methods/agent.ts` (+4 net): move the deleted-agent guard ahead of dedupe / attachment / reset / dispatch; delete the redundant post-routing guard.
- `src/gateway/server-methods/agent.deleted-agent.test.ts` (new case): offloadable-attachment regression proving no media save, dedupe reservation, or dispatch on rejection.
- `src/gateway/server.agent.deleted-agent-gateway.test.ts` (new): live Gateway WebSocket integration proof.

No protocol/schema changes. No competing open PR for this surface (verified before opening).

🤖 AI-assisted (Claude Code).
