### PR TITLE
perf(memory-wiki): avoid O(n^2) path filtering in import run listing

### DIFF
--- a/extensions/memory-wiki/src/import-runs-state.ts
+++ b/extensions/memory-wiki/src/import-runs-state.ts
@@ -224,12 +224,19 @@ function composeImportRunRecord(
   meta: MemoryWikiImportRunMetaStateRecord,
   pathRows: MemoryWikiImportRunPathStateRecord[],
 ): ChatGptImportRunRecord {
-  const createdPaths = pathRows
-    .filter((row) => row.kind === "created-path")
+  const createdRows: MemoryWikiImportRunPathStateRecord[] = [];
+  const updatedRows: MemoryWikiImportRunPathStateRecord[] = [];
+  for (const row of pathRows) {
+    if (row.kind === "created-path") {
+      createdRows.push(row);
+    } else {
+      updatedRows.push(row);
+    }
+  }
+  const createdPaths = createdRows
     .toSorted((left, right) => left.index - right.index)
     .map((row) => row.path);
-  const updatedPaths = pathRows
-    .filter((row) => row.kind === "updated-path")
+  const updatedPaths = updatedRows
     .toSorted((left, right) => left.index - right.index)
     .map((row) => {
       const entry: ChatGptImportRunEntry = { path: row.path };
@@ -392,7 +399,7 @@ export function createMemoryWikiImportRunStateStore(
     async list(vaultRoot) {
       const vaultRootKey = resolveVaultRootKey(vaultRoot);
       const metaRows = new Map<string, MemoryWikiImportRunMetaStateRecord>();
-      const pathRows: MemoryWikiImportRunPathStateRecord[] = [];
+      const pathRowsByRunId = new Map<string, MemoryWikiImportRunPathStateRecord[]>();
       for (const row of await openStore().entries()) {
         const meta = normalizeMetaRecord(row.value);
         if (meta?.vaultRootKey === vaultRootKey) {
@@ -401,14 +408,13 @@ export function createMemoryWikiImportRunStateStore(
         }
         const pathRecord = normalizePathRecord(row.value);
         if (pathRecord?.vaultRootKey === vaultRootKey) {
+          const pathRows = pathRowsByRunId.get(pathRecord.runId) ?? [];
           pathRows.push(pathRecord);
+          pathRowsByRunId.set(pathRecord.runId, pathRows);
         }
       }
       return [...metaRows.values()].map((meta) =>
-        composeImportRunRecord(
-          meta,
-          pathRows.filter((row) => row.runId === meta.runId),
-        ),
+        composeImportRunRecord(meta, pathRowsByRunId.get(meta.runId) ?? []),
       );
     },
     async rowCount() {


### PR DESCRIPTION
## What Problem This Solves

`listMemoryWikiImportRuns` and its backing store did redundant work when a Memory Wiki vault had many import runs:

- `composeImportRunRecord` scanned `pathRows` twice (once for `created-path`, once for `updated-path`).
- `list()` re-filtered the full path-row list for every meta record, yielding **O(rows × runs)** work.

## Why This Change Was Made

- Single-pass partition into `createdRows` / `updatedRows` removes one full scan inside `composeImportRunRecord`.
- Grouping path rows by `runId` in a `Map` inside `list()` removes the per-meta `pathRows.filter(...)` scan.
- Behavior is identical:
  - `MemoryWikiImportRunPathStateRecord["kind"]` is a closed `"created-path" | "updated-path"` union, so the `else` branch is exhaustive.
  - Within-run ordering by `index` is preserved.
  - Empty / missing path rows collapse to the same empty array.

## User Impact

Vaults that accumulate many import runs (long-lived agents, repeated ChatGPT/Notes imports) get a faster status / insights / UI listing. No behavior change; output of `listMemoryWikiImportRuns` is unchanged.

## Evidence

- `pnpm test extensions/memory-wiki/src/import-runs.test.ts` — `1 passed`.
- Existing assertion covers multi-run listing with both created and updated entries (`chatgpt-old` / `chatgpt-new` runs, including `updatedPaths` with `snapshotPath`).