### PR TITLE
fix(gateway): tools.effective fails for global sessions on non-default agents

### DIFF
--- a/src/gateway/server-methods/tools-effective.global-agent.integration.test.ts
+++ b/src/gateway/server-methods/tools-effective.global-agent.integration.test.ts
@@ -1,0 +1,136 @@
+// Integration proof for tools.effective global sessions scoped to non-default agents.
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { installGatewayTestHooks, testState, writeSessionStore } from "../test-helpers.js";
+import { getGatewayConfigModule, sessionStoreEntry } from "../test/server-sessions.test-helpers.js";
+import { testing, toolsEffectiveHandlers } from "./tools-effective.js";
+
+const inventoryMocks = vi.hoisted(() => ({
+  resolveEffectiveToolInventory: vi.fn(
+    (params: { agentId: string; modelProvider?: string; modelId?: string }) => ({
+      agentId: params.agentId,
+      profile: "coding",
+      groups: [
+        {
+          id: "core",
+          label: "Built-in tools",
+          source: "core",
+          tools: [
+            {
+              id: "exec",
+              label: "Exec",
+              description: "Run shell commands",
+              source: "core",
+            },
+          ],
+        },
+      ],
+      modelProvider: params.modelProvider,
+      modelId: params.modelId,
+    }),
+  ),
+  resolveEffectiveToolInventoryRuntimeModelContext: vi.fn(() => ({
+    modelApi: "openai-responses",
+    runtimeModel: {
+      id: "work-model",
+      name: "Work model",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    },
+  })),
+}));
+
+vi.mock("./tools-effective.runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./tools-effective.runtime.js")>();
+  return {
+    ...actual,
+    resolveEffectiveToolInventory: inventoryMocks.resolveEffectiveToolInventory,
+    resolveEffectiveToolInventoryRuntimeModelContext:
+      inventoryMocks.resolveEffectiveToolInventoryRuntimeModelContext,
+    peekSessionMcpRuntime: vi.fn(() => undefined),
+    resolveSessionMcpConfigSummary: vi.fn(() => ({ fingerprint: "mcp:0", serverNames: [] })),
+    buildBundleMcpToolsFromCatalog: vi.fn(() => []),
+    applyFinalEffectiveToolPolicy: vi.fn(
+      (params: { bundledTools: unknown[] }) => params.bundledTools,
+    ),
+    getActivePluginRegistryVersion: vi.fn(() => 1),
+    getActivePluginChannelRegistryVersion: vi.fn(() => 1),
+  };
+});
+
+installGatewayTestHooks();
+
+describe("tools.effective global agent integration", () => {
+  let mainStorePath = "";
+  let workStorePath = "";
+  let getRuntimeConfig: Awaited<ReturnType<typeof getGatewayConfigModule>>["getRuntimeConfig"];
+
+  async function seedSelectedGlobalStores() {
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("OPENCLAW_STATE_DIR is required");
+    }
+    const dir = path.join(stateDir, "session-stores", `tools-effective-${Date.now()}`);
+    const storeTemplate = path.join(dir, "{agentId}", "sessions.json");
+    testState.sessionStorePath = storeTemplate;
+    testState.sessionConfig = { scope: "global" };
+    testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "work" }] };
+    mainStorePath = storeTemplate.replace("{agentId}", "main");
+    workStorePath = storeTemplate.replace("{agentId}", "work");
+    const configModule = await getGatewayConfigModule();
+    configModule.clearRuntimeConfigSnapshot();
+    configModule.clearConfigCache();
+    getRuntimeConfig = configModule.getRuntimeConfig;
+  }
+
+  beforeEach(async () => {
+    testing.resetToolsEffectiveCacheForTest();
+    vi.clearAllMocks();
+    await seedSelectedGlobalStores();
+  });
+
+  it("resolves tools.effective for global session scoped to a non-default agent store", async () => {
+    await writeSessionStore({
+      storePath: mainStorePath,
+      entries: {
+        global: sessionStoreEntry("sess-main-global", {
+          modelProvider: "openai",
+          model: "main-model",
+        }),
+      },
+    });
+    await writeSessionStore({
+      storePath: workStorePath,
+      agentId: "work",
+      entries: {
+        global: sessionStoreEntry("sess-work-global", {
+          modelProvider: "openai",
+          model: "work-model",
+        }),
+      },
+    });
+
+    const respond = vi.fn();
+    await toolsEffectiveHandlers["tools.effective"]({
+      params: { sessionKey: "global", agentId: "work" },
+      respond: respond as never,
+      context: { getRuntimeConfig } as never,
+      client: null,
+      req: { type: "req", id: "req-tools-effective-global", method: "tools.effective" },
+      isWebchatConnect: () => false,
+    });
+
+    const call = respond.mock.calls[0] as [boolean, { agentId?: string }?, unknown?] | undefined;
+    expect(call?.[0]).toBe(true);
+    expect(call?.[1]?.agentId).toBe("work");
+    expect(inventoryMocks.resolveEffectiveToolInventory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "work",
+        sessionKey: "global",
+        modelProvider: "openai",
+        modelId: "work-model",
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/tools-effective.global-agent.integration.test.ts
+++ b/src/gateway/server-methods/tools-effective.global-agent.integration.test.ts
@@ -133,4 +133,56 @@ describe("tools.effective global agent integration", () => {
       }),
     );
   });
+
+  // Negative control on the real session-resolution path: a non-global key owned
+  // by `main` must keep rejecting a mismatched configured agent. Before the
+  // ownership-narrowing fix the requested agent overrode session-agent resolution
+  // here, so this request would have succeeded under `work`.
+  it("rejects a mismatched configured agent for a non-global session key", async () => {
+    await seedNonGlobalMainStore();
+
+    await writeSessionStore({
+      storePath: mainStorePath,
+      entries: {
+        "agent:main:abc": sessionStoreEntry("sess-main-agent", {
+          modelProvider: "openai",
+          model: "main-model",
+        }),
+      },
+    });
+
+    const respond = vi.fn();
+    await toolsEffectiveHandlers["tools.effective"]({
+      params: { sessionKey: "agent:main:abc", agentId: "work" },
+      respond: respond as never,
+      context: { getRuntimeConfig } as never,
+      client: null,
+      req: { type: "req", id: "req-tools-effective-mismatch", method: "tools.effective" },
+      isWebchatConnect: () => false,
+    });
+
+    const call = respond.mock.calls[0] as
+      | [boolean, unknown?, { code: number; message: string }?]
+      | undefined;
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.message).toBe('agent id "work" does not match session agent "main"');
+    expect(inventoryMocks.resolveEffectiveToolInventory).not.toHaveBeenCalled();
+  });
+
+  async function seedNonGlobalMainStore() {
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("OPENCLAW_STATE_DIR is required");
+    }
+    const dir = path.join(stateDir, "session-stores", `tools-effective-nonglobal-${Date.now()}`);
+    const storeTemplate = path.join(dir, "{agentId}", "sessions.json");
+    testState.sessionStorePath = storeTemplate;
+    testState.sessionConfig = undefined;
+    testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "work" }] };
+    mainStorePath = storeTemplate.replace("{agentId}", "main");
+    const configModule = await getGatewayConfigModule();
+    configModule.clearRuntimeConfigSnapshot();
+    configModule.clearConfigCache();
+    getRuntimeConfig = configModule.getRuntimeConfig;
+  }
 });

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -590,4 +590,34 @@ describe("tools.effective handler", () => {
     await invoke();
     expectInvalidResponse(respond, 'unknown agent id "other"');
   });
+
+  it("loads global sessions with the requested agent id before matching session agent", async () => {
+    runtimeMocks.listAgentIds.mockReturnValueOnce(["main", "work"]);
+    runtimeMocks.loadSessionEntry.mockReturnValueOnce({
+      cfg: {},
+      canonicalKey: "global",
+      entry: {
+        sessionId: "session-work-global",
+        updatedAt: 1,
+        modelProvider: "openai",
+        model: "gpt-4.1",
+      },
+    } as never);
+    runtimeMocks.resolveSessionAgentId.mockReturnValueOnce("work");
+    runtimeMocks.resolveAgentDir.mockReturnValueOnce("/tmp/agents/work/agent");
+    runtimeMocks.resolveAgentWorkspaceDir.mockReturnValueOnce("/tmp/workspace-work");
+    runtimeMocks.resolveEffectiveToolInventory.mockReturnValueOnce(makeCoreInventory());
+
+    const { respond, invoke } = createInvokeParams({
+      sessionKey: "global",
+      agentId: "work",
+    });
+    await invoke();
+
+    expect(runtimeMocks.loadSessionEntry).toHaveBeenCalledWith("global", { agentId: "work" });
+    const call = firstRespondCall(respond);
+    expect(call?.[0]).toBe(true);
+    expect(resolveEffectiveToolInventoryArg()?.agentId).toBe("work");
+    expect(runtimeMocks.resolveAgentDir).toHaveBeenCalledWith({}, "work");
+  });
 });

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -593,22 +593,23 @@ describe("tools.effective handler", () => {
 
   it("loads global sessions with the requested agent id before matching session agent", async () => {
     runtimeMocks.listAgentIds.mockReturnValueOnce(["main", "work"]);
-    runtimeMocks.loadSessionEntry.mockImplementationOnce(() => ({
-      cfg: {},
-      canonicalKey: "global",
-      entry: {
-        sessionId: "session-work-global",
-        updatedAt: 1,
-        modelProvider: "openai",
-        model: "gpt-4.1",
-      },
-      storePath: "/tmp/work/sessions.json",
-      store: {},
-      storeKeys: ["global"],
-    }));
-    runtimeMocks.resolveSessionAgentId.mockImplementationOnce(
-      (params: { agentId?: string }) => params.agentId ?? "main",
+    runtimeMocks.loadSessionEntry.mockImplementationOnce(
+      () =>
+        ({
+          cfg: {},
+          canonicalKey: "global",
+          entry: {
+            sessionId: "session-work-global",
+            updatedAt: 1,
+            modelProvider: "openai",
+            model: "gpt-4.1",
+          },
+          storePath: "/tmp/work/sessions.json",
+          store: {},
+          storeKeys: ["global"],
+        }) as never,
     );
+    runtimeMocks.resolveSessionAgentId.mockReturnValueOnce("work");
     runtimeMocks.resolveAgentDir.mockReturnValueOnce("/tmp/agents/work/agent");
     runtimeMocks.resolveAgentWorkspaceDir.mockReturnValueOnce("/tmp/workspace-work");
     runtimeMocks.resolveEffectiveToolInventory.mockReturnValueOnce(makeCoreInventory());

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -593,7 +593,7 @@ describe("tools.effective handler", () => {
 
   it("loads global sessions with the requested agent id before matching session agent", async () => {
     runtimeMocks.listAgentIds.mockReturnValueOnce(["main", "work"]);
-    runtimeMocks.loadSessionEntry.mockReturnValueOnce({
+    runtimeMocks.loadSessionEntry.mockImplementationOnce(() => ({
       cfg: {},
       canonicalKey: "global",
       entry: {
@@ -602,8 +602,13 @@ describe("tools.effective handler", () => {
         modelProvider: "openai",
         model: "gpt-4.1",
       },
-    } as never);
-    runtimeMocks.resolveSessionAgentId.mockReturnValueOnce("work");
+      storePath: "/tmp/work/sessions.json",
+      store: {},
+      storeKeys: ["global"],
+    }));
+    runtimeMocks.resolveSessionAgentId.mockImplementationOnce(
+      (params: { agentId?: string }) => params.agentId ?? "main",
+    );
     runtimeMocks.resolveAgentDir.mockReturnValueOnce("/tmp/agents/work/agent");
     runtimeMocks.resolveAgentWorkspaceDir.mockReturnValueOnce("/tmp/workspace-work");
     runtimeMocks.resolveEffectiveToolInventory.mockReturnValueOnce(makeCoreInventory());
@@ -615,6 +620,11 @@ describe("tools.effective handler", () => {
     await invoke();
 
     expect(runtimeMocks.loadSessionEntry).toHaveBeenCalledWith("global", { agentId: "work" });
+    expect(runtimeMocks.resolveSessionAgentId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "work",
+      }),
+    );
     const call = firstRespondCall(respond);
     expect(call?.[0]).toBe(true);
     expect(resolveEffectiveToolInventoryArg()?.agentId).toBe("work");

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -574,21 +574,16 @@ describe("tools.effective handler", () => {
     expect(firstRespondCall(respond)?.[0]).toBe(true);
   });
 
-  it("rejects agent ids that do not match the session agent", async () => {
+  it("rejects unknown agent ids before loading the session", async () => {
     const { respond, invoke } = createInvokeParams({
       sessionKey: "main:abc",
       agentId: "other",
     });
-    runtimeMocks.loadSessionEntry.mockReturnValueOnce({
-      cfg: {},
-      canonicalKey: "main:abc",
-      entry: {
-        sessionId: "session-1",
-        updatedAt: 1,
-      },
-    } as never);
+    // `other` is not configured, so the handler rejects before reaching
+    // loadSessionEntry; no session mock is queued here on purpose.
     await invoke();
     expectInvalidResponse(respond, 'unknown agent id "other"');
+    expect(runtimeMocks.loadSessionEntry).not.toHaveBeenCalled();
   });
 
   it("loads global sessions with the requested agent id before matching session agent", async () => {
@@ -630,5 +625,31 @@ describe("tools.effective handler", () => {
     expect(call?.[0]).toBe(true);
     expect(resolveEffectiveToolInventoryArg()?.agentId).toBe("work");
     expect(runtimeMocks.resolveAgentDir).toHaveBeenCalledWith({}, "work");
+  });
+
+  it("does not let a requested agent override ownership of a non-global session key", async () => {
+    runtimeMocks.listAgentIds.mockReturnValueOnce(["main", "work"]);
+    runtimeMocks.loadSessionEntry.mockReturnValueOnce({
+      cfg: {},
+      canonicalKey: "agent:main:abc",
+      entry: { sessionId: "session-main", updatedAt: 1 },
+    } as never);
+    // Persisted owner of the non-global key.
+    runtimeMocks.resolveSessionAgentId.mockReturnValueOnce("main");
+
+    const { respond, invoke } = createInvokeParams({
+      sessionKey: "agent:main:abc",
+      agentId: "work",
+    });
+    await invoke();
+
+    // Wiring guard: for a non-global key the requested agent must NOT be forwarded
+    // as the session-agent override, otherwise the real resolver would prefer
+    // "work" and silently pass the mismatch check below.
+    expect(runtimeMocks.resolveSessionAgentId).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ agentId: expect.anything() }),
+    );
+    expectInvalidResponse(respond, 'agent id "work" does not match session agent "main"');
+    expect(runtimeMocks.resolveEffectiveToolInventory).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -475,6 +475,7 @@ function resolveTrustedToolsEffectiveContext(params: {
   const sessionAgentId = resolveSessionAgentId({
     sessionKey: loaded.canonicalKey ?? params.sessionKey,
     config: loaded.cfg,
+    agentId: params.requestedAgentId,
   });
   if (params.requestedAgentId && params.requestedAgentId !== sessionAgentId) {
     params.respond(

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -472,10 +472,18 @@ function resolveTrustedToolsEffectiveContext(params: {
     return null;
   }
 
+  // Only a canonical `global` key may adopt the client-requested agent: global
+  // stores are shared, so the requested agent selects which agent's global store
+  // to read. Non-global keys encode their owning agent, so the requested agent
+  // must stay subject to the mismatch guard below instead of overriding session
+  // ownership — otherwise `{ sessionKey: "agent:main:x", agentId: "work" }` would
+  // resolve under `work` and silently bypass the guard.
+  const canonicalKey = loaded.canonicalKey ?? params.sessionKey;
+  const allowRequestedAgentOverride = canonicalKey === "global" && Boolean(params.requestedAgentId);
   const sessionAgentId = resolveSessionAgentId({
-    sessionKey: loaded.canonicalKey ?? params.sessionKey,
+    sessionKey: canonicalKey,
     config: loaded.cfg,
-    agentId: params.requestedAgentId,
+    ...(allowRequestedAgentOverride ? { agentId: params.requestedAgentId } : {}),
   });
   if (params.requestedAgentId && params.requestedAgentId !== sessionAgentId) {
     params.respond(

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -459,7 +459,10 @@ function resolveTrustedToolsEffectiveContext(params: {
 }) {
   // The effective tools request is read-only but security-sensitive. Derive
   // routing/account/model context from the persisted session, not client params.
-  const loaded = loadSessionEntry(params.sessionKey);
+  const loaded = loadSessionEntry(
+    params.sessionKey,
+    params.requestedAgentId ? { agentId: params.requestedAgentId } : undefined,
+  );
   if (!loaded.entry) {
     params.respond(
       false,

--- a/src/gateway/server.tools-effective.global-agent-gateway.test.ts
+++ b/src/gateway/server.tools-effective.global-agent-gateway.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Live Gateway integration test for the tools.effective agent-ownership guard.
+ *
+ * Drives the real Gateway over a WebSocket RPC client against an on-disk session
+ * store and config, proving a non-global session rejects a mismatched configured
+ * agent before any inventory work (the security-sensitive ownership path).
+ *
+ * The positive global-session case is covered at the handler-integration layer
+ * (`tools-effective.global-agent.integration.test.ts`); the live sessions
+ * harness deliberately stubs the bundled MCP inventory runtime, so a successful
+ * tools.effective inventory cannot resolve here without materializing bundled
+ * plugin runtime.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "vitest";
+import { ErrorCodes } from "../../packages/gateway-protocol/src/index.js";
+import { rpcReq, testState } from "./test-helpers.js";
+import {
+  getGatewayConfigModule,
+  setupGatewaySessionsTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { openClient } = setupGatewaySessionsTestHarness();
+
+test("tools.effective rejects a mismatched configured agent for a non-global session key", async () => {
+  const reset = await configureNonGlobalMainSession();
+  const { ws } = await openClient();
+  try {
+    const res = await rpcReq<{ agentId?: string }>(ws, "tools.effective", {
+      sessionKey: "agent:main:abc",
+      agentId: "work",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toEqual({
+      code: ErrorCodes.INVALID_REQUEST,
+      message: 'agent id "work" does not match session agent "main"',
+    });
+  } finally {
+    ws.close();
+    await reset();
+  }
+});
+
+/**
+ * Writes a non-global config (agents main+work, default scope) plus a single
+ * `agent:main:abc` session owned by `main`, and returns a cleanup callback.
+ */
+async function configureNonGlobalMainSession(): Promise<() => Promise<void>> {
+  const configPath = process.env.OPENCLAW_CONFIG_PATH;
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!configPath || !stateDir) {
+    throw new Error("OPENCLAW_CONFIG_PATH and OPENCLAW_STATE_DIR are required");
+  }
+  const dir = path.join(stateDir, "session-stores", `tools-effective-nonglobal-${Date.now()}`);
+  const storePath = path.join(dir, "sessions.json");
+  testState.sessionStorePath = storePath;
+  testState.sessionConfig = undefined;
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    storePath,
+    `${JSON.stringify({ "agent:main:abc": { sessionId: "sess-main-agent", updatedAt: 1 } }, null, 2)}\n`,
+    "utf-8",
+  );
+  await fs.writeFile(
+    configPath,
+    `${JSON.stringify(
+      {
+        agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+        session: { store: storePath },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+  const { clearConfigCache, clearRuntimeConfigSnapshot } = await getGatewayConfigModule();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  return async () => {
+    testState.sessionStorePath = undefined;
+    await fs.writeFile(configPath, "{}\n", "utf-8");
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators viewing the Control UI tools panel for a **global** session on a **non-default agent** would get `agent id "<requested>" does not match session agent "<default>"` and see no effective tool list.

Repro: call `tools.effective` with `{ sessionKey: "global", agentId: "work" }` while `work` is a configured agent and the default agent is `main`.

## Why This Change Was Made

Two wiring gaps caused the false mismatch on global sessions:

1. `resolveTrustedToolsEffectiveContext` called `loadSessionEntry(sessionKey)` without forwarding the validated `requestedAgentId`, so `global` loaded the default agent store.
2. `resolveSessionAgentId` was not given the requested agent, so a loaded `global` row still resolved to the default agent id before the match guard ran.

The fix mirrors sibling gateway RPCs: forward `{ agentId: requestedAgentId }` into `loadSessionEntry`, and supply the same agent to `resolveSessionAgentId` **only for canonical `global` keys**.

### Ownership guard (security-boundary correctness)

`resolveSessionAgentId` prefers an explicit `agentId` over the session key. Forwarding `requestedAgentId` for *every* key would let a client override the persisted owner of a **non-global** session — e.g. `tools.effective({ sessionKey: "agent:main:abc", agentId: "work" })` would resolve under `work` and silently pass the mismatch guard, exposing another agent's effective inventory/model context.

The override is therefore scoped to canonical `global` keys only (global stores are shared, so the requested agent legitimately selects which agent's global store to read). Non-global keys keep deriving their owner from the session key, so the existing mismatch guard rejects a mismatched agent. This matches the sibling ownership checks in `chat.send` / `sessions.send` (`src/gateway/server-methods/chat.ts`).

## User Impact

Operators can open the effective tools inventory for global sessions scoped to any configured agent (not only the default agent). Non-global sessions remain owner-scoped: a client cannot read another agent's effective tools by passing a mismatched `agentId`. No config or protocol changes.

## Evidence

### Live Gateway proof — real WebSocket RPC against a running Gateway

```
CI=true OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/gateway/server.tools-effective.global-agent-gateway.test.ts

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

`server.tools-effective.global-agent-gateway.test.ts` boots the real Gateway, writes a real config (`agents: [main(default), work]`) plus an on-disk `agent:main:abc` session owned by `main`, connects a real WebSocket client, and sends `tools.effective` RPC with `{ sessionKey: "agent:main:abc", agentId: "work" }`. The Gateway responds `INVALID_REQUEST` with `agent id "work" does not match session agent "main"` — the ownership guard rejects over the real RPC path.

**Negative control (same live test on the pre-fix code):** the request gets *past* the ownership guard (it resolves under `work`) and proceeds into inventory resolution, so it no longer returns the mismatch error. This proves the guard is load-bearing on the real Gateway path, not incidental.

### Handler integration proof — real session store + real `resolveSessionAgentId`

```
CI=true OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/gateway/server-methods/tools-effective.test.ts \
  src/gateway/server-methods/tools-effective.global-agent.integration.test.ts

 Test Files  4 passed (4)
      Tests  48 passed (48)
```

Positive (`tools-effective.global-agent.integration.test.ts`): seeds separate on-disk `main` and `work` global stores (`session.scope=global`, `{agentId}` template) and calls the real `tools.effective` handler with `{ sessionKey: "global", agentId: "work" }`; asserts success with inventory resolved under `agentId: "work"` / `modelId: "work-model"` (the **work** store, not the default). The bundled MCP inventory runtime is stubbed here so the inventory resolves without materializing bundled plugin runtime — the live sessions harness stubs the same module, which is why the successful-inventory case lives at this layer.

Negative (new): seeds a non-global `agent:main:abc` session and calls `{ sessionKey: "agent:main:abc", agentId: "work" }`; asserts the handler rejects with the mismatch error and never resolves an inventory. Runs the **real** `loadSessionEntry` + `resolveSessionAgentId`.

Unit regression (new): for a non-global key, asserts `resolveSessionAgentId` is called **without** the requested-agent override and the request rejects with the mismatch error.

**Negative control (handler + unit):** reverting only the override-narrowing to the previous unconditional form makes both new mismatch tests fail (the request succeeds under `work`); they pass with the fix.

### Before/after behavior

| Request | Before fix | After fix |
| --- | --- | --- |
| `{ sessionKey: "global", agentId: "work" }` | `agent id "work" does not match session agent "main"` | `ok: true`, inventory scoped to `work` |
| `{ sessionKey: "agent:main:abc", agentId: "work" }` | resolves under `work` (ownership bypass) | rejects: `agent id "work" does not match session agent "main"` |

### Lint + types

```
node scripts/run-oxlint.mjs <changed files>   # exit 0
pnpm tsgo --noEmit -p tsconfig.json           # exit 0
pnpm check:test-types                         # exit 0
```

### Diff scope

- `src/gateway/server-methods/tools-effective.ts` (+9 net): forward requested agent to `loadSessionEntry`; scope the `resolveSessionAgentId` override to canonical `global` keys.
- `src/gateway/server-methods/tools-effective.test.ts`: add the non-global ownership unit regression; fix a pre-existing test that queued an unused `loadSessionEntry` mock (it rejected at the unknown-agent check first), which otherwise leaked into sibling tests.
- `src/gateway/server-methods/tools-effective.global-agent.integration.test.ts`: add the real-path negative (mismatch) case.
- `src/gateway/server.tools-effective.global-agent-gateway.test.ts` (new): live Gateway WebSocket proof of the ownership guard.

