### PR TITLE
fix(models): accept audio and video input modalities in models.json schema

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -591,7 +591,7 @@ export interface Model<TApi extends Api = Api> {
    * Missing keys use provider defaults. null marks a level as unsupported.
    */
   thinkingLevelMap?: ThinkingLevelMap;
-  input: ("text" | "image")[];
+  input: ("text" | "image" | "audio" | "video")[];
   cost: {
     input: number; // $/million tokens
     output: number; // $/million tokens

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -1477,7 +1477,7 @@ export interface ProviderModelConfig {
   /** Maps OpenClaw thinking levels to provider/model-specific values; null marks a level unsupported. */
   thinkingLevelMap?: Model["thinkingLevelMap"];
   /** Supported input types. */
-  input: ("text" | "image")[];
+  input: ("text" | "image" | "audio" | "video")[];
   /** Cost per token (for tracking, can be 0). */
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
   /** Maximum context window size in tokens. */

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -174,6 +174,48 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.find("zai", "glm-5.1")?.name).toBe("GLM 5.1");
   });
 
+  it("accepts audio and video input modalities from generated plugin catalogs", () => {
+    // Catalog fetch can produce input modalities beyond text/image for models
+    // like MiniMax-M3 (video) or phi-4-multimodal (audio). The schema must
+    // accept these so the model entry is not dropped on validation.
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "minimax", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimaxi.com/v1",
+            api: "openai-completions",
+            apiKey: "MINIMAX_API_KEY",
+            models: [
+              { id: "MiniMax-M3", name: "MiniMax M3", input: ["text", "image", "video"] },
+              {
+                id: "phi-4-multimodal-instruct",
+                name: "Phi-4 Multimodal",
+                input: ["text", "image", "audio"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ minimax: { type: "api_key", key: "sk-test" } }),
+      modelsPath,
+      { pluginMetadataSnapshot: pluginOwnerSnapshot("minimax", "minimax") },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("minimax", "MiniMax-M3")?.input).toEqual(["text", "image", "video"]);
+    expect(registry.find("minimax", "phi-4-multimodal-instruct")?.input).toEqual([
+      "text",
+      "image",
+      "audio",
+    ]);
+  });
+
   it("isolates invalid generated plugin catalog shards from valid models", () => {
     const modelsPath = writeModelsJsonWithPluginCatalogs({
       root: {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -162,7 +162,16 @@ const ModelDefinitionSchema = Type.Object({
   baseUrl: Type.Optional(Type.String({ minLength: 1 })),
   reasoning: Type.Optional(Type.Boolean()),
   thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
-  input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]))),
+  input: Type.Optional(
+    Type.Array(
+      Type.Union([
+        Type.Literal("text"),
+        Type.Literal("image"),
+        Type.Literal("audio"),
+        Type.Literal("video"),
+      ]),
+    ),
+  ),
   cost: Type.Optional(
     Type.Object({
       input: Type.Number(),
@@ -926,7 +935,7 @@ export interface ProviderConfigInput {
     baseUrl?: string;
     reasoning: boolean;
     thinkingLevelMap?: Model["thinkingLevelMap"];
-    input: ("text" | "image")[];
+    input: ("text" | "image" | "audio" | "video")[];
     cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
     contextWindow: number;
     maxTokens: number;


### PR DESCRIPTION
## What Problem This Solves

Fixes #97048.

OpenClaw's catalog-fetch path produces per-agent plugin `catalog.json` files whose `input` modality arrays include `audio` (e.g., `microsoft/phi-4-multimodal-instruct`) or `video` (e.g., `MiniMax-M3`) when the upstream provider reports them. But the models.json schema in `src/agents/sessions/model-registry.ts` only permitted `"text"` and `"image"`, so:

- `validateModelsConfig.Check(parsed)` rejected the entire provider shard.
- `loadCustomModels` returned `emptyCustomModelsResult("Invalid models.json schema: ...")`.
- The model entry was silently dropped.
- Any agent whose primary model was one of these silently fell back.

The issue includes the exact journal output:
```
[agents/model-registry] model catalog load issue: Invalid models.json schema:
  - providers.minimax.models.1.input.2: must be equal to constant
  - providers.minimax.models.1.input.2: must match a schema in anyOf
```

## Why This Change Was Made

Extended the closed `input` modality union to include `"audio"` and `"video"` at four sites that previously narrowed to `"text" | "image"`:

- `ModelDefinitionSchema.input` — the typebox schema used by `validateModelsConfig`.
- `Model["input"]` in `packages/llm-core/src/types.ts` — the canonical type used by provider/model runtime.
- The inline provider-config model type in `src/agents/sessions/model-registry.ts`.
- The extension-facing model type in `src/agents/sessions/extensions/types.ts`.

Closed union chosen over `string[]` per repo convention (closed codes over freeform strings). The set is limited to the four concrete modalities OpenClaw currently understands; unknown future values still fail validation rather than passing silently.

Behavior is otherwise unchanged: every existing call site (`src/llm/providers/*.ts`, `src/media-understanding/*.ts`, `src/agents/live-model-turn-probes.ts`, etc.) checks capability via `model.input.includes("image")` and treats any other array element as a no-op. `audio`/`video` are accepted by the schema but do not yet drive runtime behavior — they preserve provider-reported capability data instead of forcing the entry to be dropped.

## User Impact

- Catalog fetch for `minimax` (MiniMax-M3) and `nvidia` (phi-4-multimodal-instruct) no longer drops the model on validation. Agents configured with those primaries will use them instead of silently falling back.
- No regression for existing providers: every existing `input` array (`["text"]`, `["text","image"]`) remains valid.

## Evidence

- `pnpm test src/agents/sessions/model-registry.test.ts` — `9 passed` (8 prior + 1 new).
- New regression test asserts both `["text","image","video"]` (MiniMax-M3) and `["text","image","audio"]` (phi-4-multimodal-instruct) are accepted by `ModelRegistry.create`, that `getError()` is `undefined`, and that the model is found via `registry.find(...)` with its input array preserved.