### PR TITLE
fix(telegram): bound Bot API response reads to prevent OOM

### DIFF
--- a/extensions/telegram/src/audit-membership-runtime.ts
+++ b/extensions/telegram/src/audit-membership-runtime.ts
@@ -1,5 +1,6 @@
 // Telegram plugin module implements audit membership runtime behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { fetchWithTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import type {
@@ -13,6 +14,8 @@ import { makeProxyFetch } from "./proxy.js";
 type TelegramApiOk<T> = { ok: true; result: T };
 type TelegramApiErr = { ok: false; description?: string };
 type TelegramGroupMembershipAuditData = Omit<TelegramGroupMembershipAudit, "elapsedMs">;
+// Telegram getChatMember responses are tiny (< 1 KiB). 4 MiB guards against hostile endpoints.
+const TELEGRAM_BOT_API_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 type TelegramChatMemberResult = { status?: string };
 
 export async function auditTelegramGroupMembershipImpl(
@@ -30,7 +33,9 @@ export async function auditTelegramGroupMembershipImpl(
     try {
       const url = `${base}/getChatMember?chat_id=${encodeURIComponent(chatId)}&user_id=${encodeURIComponent(String(params.botId))}`;
       const res = await fetchWithTimeout(url, {}, params.timeoutMs, fetcher);
-      const json = (await res.json()) as TelegramApiOk<TelegramChatMemberResult> | TelegramApiErr;
+      const json = JSON.parse(
+        (await readResponseWithLimit(res, TELEGRAM_BOT_API_MAX_RESPONSE_BYTES)).toString("utf8"),
+      ) as TelegramApiOk<TelegramChatMemberResult> | TelegramApiErr;
       if (!res.ok || !isRecord(json) || !json.ok) {
         const desc =
           isRecord(json) && !json.ok && typeof json.description === "string"

--- a/extensions/telegram/src/probe.test.ts
+++ b/extensions/telegram/src/probe.test.ts
@@ -16,6 +16,20 @@ vi.mock("./proxy.js", () => ({
   makeProxyFetch,
 }));
 
+// readResponseWithLimit requires a real Response body; pass-through so existing plain-object
+// fetch mocks continue to work. The size-cap behavior is verified by the proof script.
+vi.mock("openclaw/plugin-sdk/response-limit-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/response-limit-runtime")>();
+  return {
+    ...actual,
+    readResponseWithLimit: async (response: Response) => {
+      const data = await response.json();
+      return Buffer.from(JSON.stringify(data));
+    },
+  };
+});
+
 describe("probeTelegram retry logic", () => {
   const token = "test-token";
   const timeoutMs = 5000;

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -2,6 +2,7 @@
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeTelegramBotInfo, type TelegramBotInfo } from "./bot-info.js";
 import {
@@ -42,6 +43,9 @@ export type TelegramProbeOptions = {
 
 const probeTransportCache = new Map<string, TelegramTransport>();
 const MAX_PROBE_TRANSPORT_CACHE_SIZE = 64;
+// Generous cap: Telegram Bot API responses for getMe/getWebhookInfo are always < 1 KiB.
+// 4 MiB guards against a misbehaving or hostile API endpoint streaming an oversized payload.
+const TELEGRAM_BOT_API_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 
 export function resetTelegramProbeFetcherCacheForTests(): void {
   probeTransportCache.clear();
@@ -185,7 +189,9 @@ export async function probeTelegram(
       );
     }
 
-    const meJson = (await meRes.json()) as {
+    const meJson = JSON.parse(
+      (await readResponseWithLimit(meRes, TELEGRAM_BOT_API_MAX_RESPONSE_BYTES)).toString("utf8"),
+    ) as {
       ok?: boolean;
       description?: string;
       result?: unknown;
@@ -228,7 +234,11 @@ export async function probeTelegram(
             Math.max(1, Math.min(timeoutBudgetMs, webhookRemainingBudgetMs)),
             fetcher,
           );
-          const webhookJson = (await webhookRes.json()) as {
+          const webhookJson = JSON.parse(
+            (await readResponseWithLimit(webhookRes, TELEGRAM_BOT_API_MAX_RESPONSE_BYTES)).toString(
+              "utf8",
+            ),
+          ) as {
             ok?: boolean;
             result?: { url?: string; has_custom_certificate?: boolean };
           };

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.ts
@@ -1,5 +1,6 @@
 // Telegram plugin module implements telegram ingress worker behavior.
 import { parentPort, workerData } from "node:worker_threads";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
 import { resolveTelegramTransport } from "./fetch.js";
@@ -17,6 +18,9 @@ import type {
 
 const options = workerData as TelegramIngressWorkerOptions;
 const pollLimit = 100;
+// getUpdates can return up to 100 updates; 4 MiB is a generous bound that no legitimate
+// Telegram Bot API response will reach, guarding against misbehaving/hostile endpoints.
+const TELEGRAM_GET_UPDATES_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 const retryInitialMs = 1000;
 const retryMaxMs = 30_000;
 let stopped = false;
@@ -140,7 +144,11 @@ async function fetchJson(params: {
       body: JSON.stringify(params.body),
       signal: controller.signal,
     });
-    const json = (await response.json()) as {
+    const json = JSON.parse(
+      (await readResponseWithLimit(response, TELEGRAM_GET_UPDATES_MAX_RESPONSE_BYTES)).toString(
+        "utf8",
+      ),
+    ) as {
       ok?: unknown;
       error_code?: unknown;
       result?: unknown;

--- a/scripts/proof-telegram-bound.mjs
+++ b/scripts/proof-telegram-bound.mjs
@@ -1,0 +1,137 @@
+import { once } from "node:events";
+// Proof script: verifies readResponseWithLimit stops Telegram Bot API response reads at the cap.
+import { createServer } from "node:http";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pkgRoot = resolve(__dirname, "..");
+
+const { readResponseWithLimit } = await import(
+  `${pkgRoot}/packages/media-core/src/read-response-with-limit.ts`
+).catch(() => import("@openclaw/media-core/read-response-with-limit"));
+
+const CAP = 1 * 1024 * 1024; // 1 MiB proof cap
+const STREAM_SIZE = 24 * 1024 * 1024; // 24 MiB – simulates hostile oversized Bot API response
+
+let allPassed = true;
+function check(label, val) {
+  console.log(`  ${val ? "ok" : "FAIL"}: ${label}`);
+  if (!val) allPassed = false;
+}
+
+// Server-side byte counter: track how many response bytes were actually written to the socket.
+let serverBytesWritten = 0;
+
+async function withServer(fn) {
+  serverBytesWritten = 0;
+  const server = createServer((req, res) => {
+    if (req.url === "/huge") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      const chunk = Buffer.alloc(65536, 120); // 64 KiB of 'x'
+      const header = Buffer.from('{"ok":true,"result":[');
+      res.write(header);
+      serverBytesWritten += header.length;
+
+      let sent = header.length;
+      const writeNext = () => {
+        if (sent >= STREAM_SIZE) {
+          const tail = Buffer.from("]}");
+          res.write(tail);
+          serverBytesWritten += tail.length;
+          res.end();
+          return;
+        }
+        const ok = res.write(chunk);
+        serverBytesWritten += chunk.length;
+        sent += chunk.length;
+        if (ok) {
+          setImmediate(writeNext);
+        } else {
+          res.once("drain", writeNext);
+        }
+      };
+      writeNext();
+    } else {
+      const body = JSON.stringify({
+        ok: true,
+        result: {
+          id: 123456789,
+          is_bot: true,
+          username: "my_test_bot",
+          first_name: "TestBot",
+        },
+      });
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": String(Buffer.byteLength(body)),
+      });
+      res.end(body);
+      serverBytesWritten += Buffer.byteLength(body);
+    }
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address();
+  try {
+    await fn(port, server);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+console.log(`\n[proof] Telegram Bot API response-limit`);
+console.log(`  cap=${CAP} bytes (1 MiB), would-stream≈${STREAM_SIZE} bytes (24 MiB)\n`);
+
+// ── Case 1: readResponseWithLimit rejects oversized body ─────────────────────
+await withServer(async (port) => {
+  serverBytesWritten = 0;
+  const res = await fetch(`http://127.0.0.1:${port}/huge`);
+  let err;
+  try {
+    await readResponseWithLimit(res, CAP);
+  } catch (e) {
+    err = e;
+  }
+  // Give server a tick to flush its internal counter before checking
+  await new Promise((r) => setTimeout(r, 50));
+  const sent = serverBytesWritten;
+  check(`oversized body rejected (threw=${!!err})`, !!err);
+  check(
+    `error message contains limit info: "${err?.message?.slice(0, 80)}"`,
+    !!err?.message?.includes("limit"),
+  );
+  check(
+    `server wrote ≈${sent} bytes, well below 24 MiB (stream was cancelled early)`,
+    sent < STREAM_SIZE * 0.1,
+  );
+});
+
+// ── Negative control: unbounded .json() reads the FULL 24 MiB ────────────────
+await withServer(async (port) => {
+  serverBytesWritten = 0;
+  const res2 = await fetch(`http://127.0.0.1:${port}/huge`);
+  await res2.json().catch(() => {});
+  await new Promise((r) => setTimeout(r, 50));
+  const sent2 = serverBytesWritten;
+  check(
+    `negative control: unbounded .json() caused server to write ≈${sent2} bytes (>> ${CAP})`,
+    sent2 > CAP,
+  );
+});
+
+// ── Case 3: small happy-path response (like real getMe / getUpdates OK) ───────
+await withServer(async (port) => {
+  const res3 = await fetch(`http://127.0.0.1:${port}/small`);
+  const buf = await readResponseWithLimit(res3, CAP);
+  const parsed = JSON.parse(buf.toString("utf8"));
+  check(
+    `small response parsed correctly (ok=${parsed?.ok} id=${parsed?.result?.id})`,
+    parsed?.ok === true && parsed?.result?.id === 123456789,
+  );
+  check(`result bytes within cap (${buf.length} < ${CAP})`, buf.length > 0 && buf.length < CAP);
+});
+
+console.log(allPassed ? "\nALL PROOF ASSERTIONS PASSED" : "\nSOME ASSERTIONS FAILED");
+process.exit(allPassed ? 0 : 1);

--- a/scripts/proof-telegram-bound.mjs
+++ b/scripts/proof-telegram-bound.mjs
@@ -1,12 +1,9 @@
 import { once } from "node:events";
 // Proof script: verifies readResponseWithLimit stops Telegram Bot API response reads at the cap.
 import { createServer } from "node:http";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const pkgRoot = resolve(__dirname, "..");
+const pkgRoot = resolve(import.meta.dirname, "..");
 
 const { readResponseWithLimit } = await import(
   `${pkgRoot}/packages/media-core/src/read-response-with-limit.ts`
@@ -18,7 +15,9 @@ const STREAM_SIZE = 24 * 1024 * 1024; // 24 MiB – simulates hostile oversized 
 let allPassed = true;
 function check(label, val) {
   console.log(`  ${val ? "ok" : "FAIL"}: ${label}`);
-  if (!val) allPassed = false;
+  if (!val) {
+    allPassed = false;
+  }
 }
 
 // Server-side byte counter: track how many response bytes were actually written to the socket.
@@ -77,7 +76,9 @@ async function withServer(fn) {
   try {
     await fn(port, server);
   } finally {
-    await new Promise((resolve) => server.close(resolve));
+    await new Promise((resolveDone) => {
+      server.close(resolveDone);
+    });
   }
 }
 
@@ -95,12 +96,14 @@ await withServer(async (port) => {
     err = e;
   }
   // Give server a tick to flush its internal counter before checking
-  await new Promise((r) => setTimeout(r, 50));
+  await new Promise((done) => {
+    setTimeout(done, 50);
+  });
   const sent = serverBytesWritten;
-  check(`oversized body rejected (threw=${!!err})`, !!err);
+  check(`oversized body rejected (threw=${err != null})`, err != null);
   check(
     `error message contains limit info: "${err?.message?.slice(0, 80)}"`,
-    !!err?.message?.includes("limit"),
+    err?.message?.includes("limit") === true,
   );
   check(
     `server wrote ≈${sent} bytes, well below 24 MiB (stream was cancelled early)`,
@@ -112,8 +115,10 @@ await withServer(async (port) => {
 await withServer(async (port) => {
   serverBytesWritten = 0;
   const res2 = await fetch(`http://127.0.0.1:${port}/huge`);
-  await res2.json().catch(() => {});
-  await new Promise((r) => setTimeout(r, 50));
+  await res2.json().catch(() => undefined);
+  await new Promise((done) => {
+    setTimeout(done, 50);
+  });
   const sent2 = serverBytesWritten;
   check(
     `negative control: unbounded .json() caused server to write ≈${sent2} bytes (>> ${CAP})`,


### PR DESCRIPTION
## What Problem This Solves

Three Telegram Bot API response paths use unbounded `await response.json()` on the **success** path, leaving the gateway exposed to OOM if a misbehaving or hostile endpoint streams an oversized response body:

| File | Endpoint | Risk |
|---|---|---|
| `extensions/telegram/src/probe.ts` | `getMe`, `getWebhookInfo` | Called on every probe / health-check |
| `extensions/telegram/src/audit-membership-runtime.ts` | `getChatMember` | Called during group-membership audit |
| `extensions/telegram/src/telegram-ingress-worker.runtime.ts` | `getUpdates` | **Hot path** — called every polling cycle in the ingress worker |

Legitimate Telegram Bot API responses for these endpoints are tiny (< 1 KiB for `getMe`/`getChatMember`, < 500 KiB for 100 `getUpdates`). An unbounded read allows any interceptor or rogue endpoint to force the gateway to buffer an arbitrarily large body before returning control.

This continues the response-limit campaign already merged for Discord, xAI, fal, MiniMax, OpenRouter, embeddings, speech, and other surfaces.

## Changes

* `extensions/telegram/src/probe.ts`
  - Imports `readResponseWithLimit` from `openclaw/plugin-sdk/response-limit-runtime`
  - Adds `TELEGRAM_BOT_API_MAX_RESPONSE_BYTES = 4 MiB` constant
  - Replaces `await meRes.json()` (`getMe`) with `readResponseWithLimit` + `JSON.parse`
  - Replaces `await webhookRes.json()` (`getWebhookInfo`) with `readResponseWithLimit` + `JSON.parse`

* `extensions/telegram/src/audit-membership-runtime.ts`
  - Imports `readResponseWithLimit` from `openclaw/plugin-sdk/response-limit-runtime`
  - Adds `TELEGRAM_BOT_API_MAX_RESPONSE_BYTES = 4 MiB` constant
  - Replaces `await res.json()` (`getChatMember`) with `readResponseWithLimit` + `JSON.parse`

* `extensions/telegram/src/telegram-ingress-worker.runtime.ts`
  - Imports `readResponseWithLimit` from `openclaw/plugin-sdk/response-limit-runtime`
  - Adds `TELEGRAM_GET_UPDATES_MAX_RESPONSE_BYTES = 4 MiB` constant
  - Replaces `await response.json()` (`getUpdates`) with `readResponseWithLimit` + `JSON.parse`

* `extensions/telegram/src/probe.test.ts`
  - Adds a `vi.mock` pass-through for `openclaw/plugin-sdk/response-limit-runtime` so existing
    plain-object fetch mocks continue to work without requiring real `Response` body streams

* `scripts/proof-telegram-bound.mjs` — local proof script (see Evidence below)

## Real behavior proof

- **Behavior addressed:** Unbounded `response.json()` on Telegram Bot API success paths — a misbehaving endpoint can stream an arbitrarily large body, exhausting gateway heap before the read returns
- **Real environment tested:** `node:http` `createServer` on `127.0.0.1:0`, Node v22+, macOS
- **Exact steps run after this patch:**
  ```
  node --import tsx/esm scripts/proof-telegram-bound.mjs
  ```
- **Evidence after fix:** see Evidence section below
- **Observed result:** `readResponseWithLimit` cancelled the stream after reading ~1.1 MiB (server wrote ~1.4 MiB total including HTTP framing); the unbounded `.json()` negative-control read the full 25 MiB; a normal 99-byte happy-path response parsed correctly
- **What was not tested:** live Telegram Bot API calls; the `api-fetch.ts` `getChat` path (already guarded by `.catch(() => null)`, lower risk)
- **Proof limitations:** Byte tracking is server-side write counters. TCP framing adds overhead so server-written bytes are slightly above the 1 MiB cap; the reader itself stops at the cap.

shen@192 openclaw % node --import tsx/esm scripts/proof-telegram-bound.mjs


[proof] Telegram Bot API response-limit
  cap=1048576 bytes (1 MiB), would-stream≈25165824 bytes (24 MiB)

  ok: oversized body rejected (threw=true)
  ok: error message contains limit info: "Content too large: 1072391 bytes (limit: 1048576 bytes)"
  ok: server wrote ≈1572885 bytes, well below 24 MiB (stream was cancelled early)
  ok: negative control: unbounded .json() caused server to write ≈25165847 bytes (>> 1048576)
  ok: small response parsed correctly (ok=true id=123456789)
  ok: result bytes within cap (99 < 1048576)

ALL PROOF ASSERTIONS PASSED
shen@192 openclaw % pnpm test extensions/telegram/src/probe.test.ts

$ node scripts/test-projects.mjs extensions/telegram/src/probe.test.ts
[test] starting test/vitest/vitest.extension-telegram.config.ts

 RUN  v4.1.8 /Users/shen/Documents/GitHub/openclaw

 ✓  extension-telegram  extensions/telegram/src/probe.test.ts (12 tests) 19ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  21:56:43
   Duration  2.09s (transform 1.17s, setup 253ms, import 1.74s, tests 19ms, environment 0ms)

[test] passed 1 Vitest shard in 5.36s


## Evidence

```
node --import tsx/esm scripts/proof-telegram-bound.mjs

[proof] Telegram Bot API response-limit
  cap=1048576 bytes (1 MiB), would-stream≈25165824 bytes (24 MiB)

  ok: oversized body rejected (threw=true)
  ok: error message contains limit info: "Content too large: 1072391 bytes (limit: 1048576 bytes)"
  ok: server wrote ≈1441813 bytes, well below 24 MiB (stream was cancelled early)
  ok: negative control: unbounded .json() caused server to write ≈25165847 bytes (>> 1048576)
  ok: small response parsed correctly (ok=true id=123456789)
  ok: result bytes within cap (99 < 1048576)

ALL PROOF ASSERTIONS PASSED
```

```
pnpm test extensions/telegram/src/probe.test.ts

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

## Tests and validation

- `pnpm test extensions/telegram/src/probe.test.ts` — 12/12 pass
- `pnpm test extensions/telegram` — 2214/2218 pass (4 pre-existing failures in `bot.create-telegram-bot.channel-post-media.test.ts`, confirmed on `main` before this change)
- `scripts/proof-telegram-bound.mjs` — ALL PROOF ASSERTIONS PASSED
- Regression test added: N/A — size-cap behavior covered by the proof script; existing probe tests verify the happy-path JSON round-trip through the mock

## Risk checklist

- Did user-visible behavior change? **No** — only affects what happens when a Bot API endpoint returns an abnormally oversized response body; all normal responses are well under 4 MiB
- Did config, environment, or migration behavior change? **No**
- Did security, auth, secrets, network, or tool execution behavior change? **No** — defense-in-depth addition only
- Highest-risk area: `telegram-ingress-worker.runtime.ts` (`getUpdates` hot path); new import from `openclaw/plugin-sdk/response-limit-runtime` in the worker thread
- Mitigation: `readResponseWithLimit` uses only standard Web Streams + `Buffer` APIs available in Node.js worker threads; the 4 MiB cap is far above the largest realistic Bot API response

## Current review state

- Next action: awaiting maintainer review
- Bot comments addressed: none yet
- AI-assisted (Claude / Cursor Agent); human-run proof script on macOS
