### PR TITLE
fix(telegram): bound getChat Bot API response reads

### DIFF
--- a/extensions/telegram/src/api-fetch.test.ts
+++ b/extensions/telegram/src/api-fetch.test.ts
@@ -3,6 +3,35 @@ import { createRequire } from "node:module";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchTelegramChatId } from "./api-fetch.js";
 
+const TELEGRAM_GETCHAT_JSON_CAP_BYTES = 4 * 1024 * 1024;
+
+function getChatOkResponse(id: number | string): Response {
+  return new Response(JSON.stringify({ ok: true, result: { id } }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function oversizedTelegramGetChatJsonResponse(onCancel: () => void): Response {
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(TELEGRAM_GETCHAT_JSON_CAP_BYTES + 1));
+      },
+      cancel() {
+        onCancel();
+      },
+    }),
+    { headers: { "content-type": "application/json" }, status: 200 },
+  );
+  Object.defineProperty(response, "json", {
+    value: async () => {
+      throw new Error("unbounded json reader was used");
+    },
+  });
+  return response;
+}
+
 const require = createRequire(import.meta.url);
 const EnvHttpProxyAgent = require("undici/lib/dispatcher/env-http-proxy-agent.js") as {
   new (opts?: Record<string, unknown>): Record<PropertyKey, unknown>;
@@ -67,18 +96,12 @@ describe("fetchTelegramChatId", () => {
   const cases = [
     {
       name: "returns stringified id when Telegram getChat succeeds",
-      fetchImpl: vi.fn(async () => ({
-        ok: true,
-        json: async () => ({ ok: true, result: { id: 12345 } }),
-      })),
+      fetchImpl: vi.fn(async () => getChatOkResponse(12345)),
       expected: "12345",
     },
     {
       name: "returns null when response is not ok",
-      fetchImpl: vi.fn(async () => ({
-        ok: false,
-        json: async () => ({}),
-      })),
+      fetchImpl: vi.fn(async () => new Response("{}", { status: 404 })),
       expected: null,
     },
     {
@@ -104,10 +127,7 @@ describe("fetchTelegramChatId", () => {
   }
 
   it("calls Telegram getChat endpoint", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ ok: true, result: { id: 12345 } }),
-    }));
+    const fetchMock = vi.fn(async () => getChatOkResponse(12345));
     vi.stubGlobal("fetch", fetchMock);
 
     await fetchTelegramChatId({ token: "abc", chatId: "@user" });
@@ -118,10 +138,7 @@ describe("fetchTelegramChatId", () => {
   });
 
   it("uses caller-provided fetch impl when present", async () => {
-    const customFetch = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ ok: true, result: { id: 12345 } }),
-    }));
+    const customFetch = vi.fn(async () => getChatOkResponse(12345));
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
@@ -139,6 +156,24 @@ describe("fetchTelegramChatId", () => {
       "https://api.telegram.org/botabc/getChat?chat_id=%40user",
       undefined,
     );
+  });
+
+  it("returns null for oversized getChat JSON responses and cancels the stream", async () => {
+    let cancelCount = 0;
+    const fetchImpl = vi.fn(async () =>
+      oversizedTelegramGetChatJsonResponse(() => {
+        cancelCount += 1;
+      }),
+    );
+
+    await expect(
+      fetchTelegramChatId({
+        token: "abc",
+        chatId: "@user",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).resolves.toBeNull();
+    expect(cancelCount).toBe(1);
   });
 });
 

--- a/extensions/telegram/src/api-fetch.ts
+++ b/extensions/telegram/src/api-fetch.ts
@@ -1,7 +1,10 @@
 // Telegram plugin module implements api fetch behavior.
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { resolveTelegramApiBase, resolveTelegramFetch } from "./fetch.js";
 import { makeProxyFetch } from "./proxy.js";
+
+const TELEGRAM_BOT_API_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 
 export function resolveTelegramChatLookupFetch(params?: {
   proxyUrl?: string;
@@ -47,10 +50,14 @@ export async function fetchTelegramChatId(params: {
     if (!res.ok) {
       return null;
     }
-    const data = (await res.json().catch(() => null)) as {
-      ok?: boolean;
-      result?: { id?: number | string };
-    } | null;
+    let data: { ok?: boolean; result?: { id?: number | string } } | null = null;
+    try {
+      data = JSON.parse(
+        (await readResponseWithLimit(res, TELEGRAM_BOT_API_MAX_RESPONSE_BYTES)).toString("utf8"),
+      ) as typeof data;
+    } catch {
+      return null;
+    }
     const id = data?.ok ? data?.result?.id : undefined;
     if (typeof id === "number" || typeof id === "string") {
       return String(id);

--- a/extensions/telegram/src/api-fetch.ts
+++ b/extensions/telegram/src/api-fetch.ts
@@ -6,6 +6,11 @@ import { makeProxyFetch } from "./proxy.js";
 
 const TELEGRAM_BOT_API_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 
+type TelegramGetChatResponse = {
+  ok?: boolean;
+  result?: { id?: number | string };
+};
+
 export function resolveTelegramChatLookupFetch(params?: {
   proxyUrl?: string;
   network?: TelegramNetworkConfig;
@@ -50,11 +55,11 @@ export async function fetchTelegramChatId(params: {
     if (!res.ok) {
       return null;
     }
-    let data: { ok?: boolean; result?: { id?: number | string } } | null = null;
+    let data: TelegramGetChatResponse | null = null;
     try {
       data = JSON.parse(
         (await readResponseWithLimit(res, TELEGRAM_BOT_API_MAX_RESPONSE_BYTES)).toString("utf8"),
-      ) as typeof data;
+      ) as TelegramGetChatResponse;
     } catch {
       return null;
     }

--- a/scripts/proof-telegram-getchat-bound.mjs
+++ b/scripts/proof-telegram-getchat-bound.mjs
@@ -1,0 +1,155 @@
+import { once } from "node:events";
+// Loopback proof: fetchTelegramChatId (getChat) through the production Bot API read path.
+import { createServer } from "node:http";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pkgRoot = resolve(__dirname, "..");
+const TELEGRAM_BOT_API_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+
+const { fetchTelegramChatId } = await import(`${pkgRoot}/extensions/telegram/src/api-fetch.ts`);
+
+const CAP = TELEGRAM_BOT_API_MAX_RESPONSE_BYTES;
+const STREAM_SIZE = 24 * 1024 * 1024;
+
+let allPassed = true;
+function check(label, val) {
+  console.log(`  ${val ? "ok" : "FAIL"}: ${label}`);
+  if (!val) {
+    allPassed = false;
+  }
+}
+
+let serverBytesWritten = 0;
+
+function createStreamingServer() {
+  return createServer((req, res) => {
+    if (req.url === "/huge") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      const chunk = Buffer.alloc(65536, 120);
+      const header = Buffer.from('{"ok":true,"result":{"id":1');
+      res.write(header);
+      serverBytesWritten += header.length;
+      let sent = header.length;
+      const writeNext = () => {
+        if (sent >= STREAM_SIZE) {
+          const tail = Buffer.from("}}");
+          res.write(tail);
+          serverBytesWritten += tail.length;
+          res.end();
+          return;
+        }
+        const ok = res.write(chunk);
+        serverBytesWritten += chunk.length;
+        sent += chunk.length;
+        if (ok) {
+          setImmediate(writeNext);
+        } else {
+          res.once("drain", writeNext);
+        }
+      };
+      writeNext();
+      return;
+    }
+    if (req.url?.includes("/getChat")) {
+      const chatId = new URL(req.url, "http://127.0.0.1").searchParams.get("chat_id");
+      if (chatId === "OVERSIZED") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        const chunk = Buffer.alloc(65536, 120);
+        const header = Buffer.from('{"ok":true,"result":{"id":1');
+        res.write(header);
+        serverBytesWritten += header.length;
+        let sent = header.length;
+        const writeNext = () => {
+          if (sent >= STREAM_SIZE) {
+            const tail = Buffer.from("}}");
+            res.write(tail);
+            serverBytesWritten += tail.length;
+            res.end();
+            return;
+          }
+          const ok = res.write(chunk);
+          serverBytesWritten += chunk.length;
+          sent += chunk.length;
+          if (ok) {
+            setImmediate(writeNext);
+          } else {
+            res.once("drain", writeNext);
+          }
+        };
+        writeNext();
+        return;
+      }
+      const body = JSON.stringify({ ok: true, result: { id: 123456789 } });
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": String(Buffer.byteLength(body)),
+      });
+      res.end(body);
+      serverBytesWritten += Buffer.byteLength(body);
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+}
+
+async function withServer(fn) {
+  serverBytesWritten = 0;
+  const server = createStreamingServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address();
+  try {
+    await fn(port);
+  } finally {
+    await new Promise((resolveDone) => server.close(resolveDone));
+  }
+}
+
+console.log(`\n[proof] fetchTelegramChatId (getChat) production path`);
+console.log(`  cap=${CAP} bytes (4 MiB), would-stream≈${STREAM_SIZE} bytes (24 MiB)\n`);
+
+await withServer(async (port) => {
+  serverBytesWritten = 0;
+  const chatId = await fetchTelegramChatId({
+    token: "proof-token",
+    chatId: "OVERSIZED",
+    apiRoot: `http://127.0.0.1:${port}`,
+  });
+  await new Promise((r) => setTimeout(r, 50));
+  check(
+    "oversized getChat fails closed with null (production fetchTelegramChatId)",
+    chatId === null,
+  );
+  check(
+    `server wrote ${serverBytesWritten} bytes, stopped before full 24 MiB stream`,
+    serverBytesWritten < STREAM_SIZE && serverBytesWritten > CAP,
+  );
+});
+
+await withServer(async (port) => {
+  serverBytesWritten = 0;
+  const res = await fetch(`http://127.0.0.1:${port}/huge`);
+  await res.json().catch(() => undefined);
+  await new Promise((r) => setTimeout(r, 50));
+  check(
+    `negative control: unbounded .json() wrote ${serverBytesWritten} bytes (>> ${CAP})`,
+    serverBytesWritten > CAP,
+  );
+});
+
+await withServer(async (port) => {
+  serverBytesWritten = 0;
+  const chatId = await fetchTelegramChatId({
+    token: "proof-token",
+    chatId: "-100123",
+    apiRoot: `http://127.0.0.1:${port}`,
+  });
+  check(`small getChat parsed through production path (id=${chatId})`, chatId === "123456789");
+});
+
+console.log(allPassed ? "\nALL PROOF ASSERTIONS PASSED" : "\nSOME ASSERTIONS FAILED");
+process.exit(allPassed ? 0 : 1);

--- a/scripts/proof-telegram-getchat-bound.mjs
+++ b/scripts/proof-telegram-getchat-bound.mjs
@@ -4,9 +4,7 @@ import { createServer } from "node:http";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const pkgRoot = resolve(__dirname, "..");
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const TELEGRAM_BOT_API_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 
 const { fetchTelegramChatId } = await import(`${pkgRoot}/extensions/telegram/src/api-fetch.ts`);
@@ -105,7 +103,9 @@ async function withServer(fn) {
   try {
     await fn(port);
   } finally {
-    await new Promise((resolveDone) => server.close(resolveDone));
+    await new Promise((resolveDone) => {
+      server.close(resolveDone);
+    });
   }
 }
 
@@ -119,7 +119,9 @@ await withServer(async (port) => {
     chatId: "OVERSIZED",
     apiRoot: `http://127.0.0.1:${port}`,
   });
-  await new Promise((r) => setTimeout(r, 50));
+  await new Promise((r) => {
+    setTimeout(r, 50);
+  });
   check(
     "oversized getChat fails closed with null (production fetchTelegramChatId)",
     chatId === null,
@@ -134,7 +136,9 @@ await withServer(async (port) => {
   serverBytesWritten = 0;
   const res = await fetch(`http://127.0.0.1:${port}/huge`);
   await res.json().catch(() => undefined);
-  await new Promise((r) => setTimeout(r, 50));
+  await new Promise((r) => {
+    setTimeout(r, 50);
+  });
   check(
     `negative control: unbounded .json() wrote ${serverBytesWritten} bytes (>> ${CAP})`,
     serverBytesWritten > CAP,


### PR DESCRIPTION
## What Problem This Solves

`fetchTelegramChatId()` (`getChat`) on current `main` still parsed successful Telegram Bot API responses with unbounded `res.json()`. On Node, that buffers the full body before parsing, so a misbehaving or hostile Bot API endpoint can stream an oversized success payload during chat-id lookup and push the gateway into memory pressure or OOM.

That matters because this helper is used on operator-facing paths such as onboarding, routing, and chat-id normalization, and it can point at an operator-selected Bot API base URL.

This patch closes the remaining unbounded success read on the shared `getChat` lookup path while preserving the existing fail-closed contract: malformed or oversized responses still resolve to `null`.

## Why This Change Was Made

The success-path `res.json()` in `extensions/telegram/src/api-fetch.ts` now reads through `readResponseWithLimit` with a 4 MiB cap, matching the Telegram Bot API bound-read contract already used elsewhere in this hardening work. The regression test was upgraded to use real `Response` objects plus an oversized `ReadableStream`, and the loopback proof script keeps a reproducible `node:http` bytes-on-wire check for the exact production helper.

## User Impact

Normal `getChat` responses are unchanged. When a Bot API endpoint returns an abnormally large success JSON body, lookup now fails closed with `null` after cancelling near the cap instead of buffering the full response into memory.

## Evidence

Commands run:

```text
git diff --check upstream/main...HEAD -- extensions/telegram/src/api-fetch.ts extensions/telegram/src/api-fetch.test.ts scripts/proof-telegram-getchat-bound.mjs
node scripts/run-vitest.mjs extensions/telegram/src/api-fetch.test.ts
node --import tsx/esm scripts/proof-telegram-getchat-bound.mjs
```

Observed output:

```text
[test] starting test/vitest/vitest.extension-telegram.config.ts
Test Files  1 passed (1)
     Tests  8 passed (8)
[test] passed 1 Vitest shard in 7.78s

[proof] fetchTelegramChatId (getChat) production path
  cap=4194304 bytes (4 MiB), would-stream≈25165824 bytes (24 MiB)

  ok: oversized getChat fails closed with null (production fetchTelegramChatId)
  ok: server wrote 5308443 bytes, stopped before full 24 MiB stream
  ok: negative control: unbounded .json() wrote 25165853 bytes (>> 4194304)
  ok: small getChat parsed through production path (id=123456789)

ALL PROOF ASSERTIONS PASSED
```

Behavior addressed: a successful `getChat` response with no `Content-Length` must not be buffered whole once it exceeds the 4 MiB Bot API cap.

Real environment tested: local checkout on `fix/telegram-bound-getchat-response-reads`, Node `v22.22.0`, `node:http` loopback server on `127.0.0.1`, production `fetchTelegramChatId()` path.

Exact steps or command run after this patch:

```text
1. Run the targeted Telegram Vitest file.
2. Stream ~24 MiB of JSON without Content-Length from a fake Bot API endpoint.
3. Call production `fetchTelegramChatId()` and confirm it returns null before the full body drains.
4. Run the negative control with unbounded `response.json()` against the same stream.
5. Re-run `fetchTelegramChatId()` against a small valid response.
```

Evidence after fix: the bounded path stopped after `5308443` bytes and returned `null`, while the negative control drained `25165853` bytes from the same oversized stream.

Observed result after fix: oversized success bodies now fail closed near the cap, and normal small `getChat` envelopes still parse to the expected chat id.

What was not tested: a live Telegram cloud API call and a broader Telegram extension suite beyond `extensions/telegram/src/api-fetch.test.ts`.
