### PR TITLE
fix(media): make wake-false direct fallback reason-aware

### DIFF
--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -185,6 +185,206 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
     expect(lifecycle.wakeTaskCompletion).toHaveBeenCalledTimes(1);
   });
 
+  it("direct-delivers generated media after a detailed recoverable wake miss", async () => {
+    const scheduled: Array<() => Promise<void>> = [];
+    const onWakeFailure = vi.fn();
+    const lifecycle = {
+      createTaskRun: vi.fn(),
+      recordTaskProgress: vi.fn(),
+      completeTaskRun: vi.fn(),
+      failTaskRun: vi.fn(),
+      wakeTaskCompletion: vi.fn(async () => false),
+      wakeTaskCompletionDetailed: vi.fn(async () => ({
+        delivered: false,
+        delivery: {
+          delivered: false,
+          path: "direct" as const,
+          reason: "generated_media_missing" as const,
+          error: "completion agent did not deliver generated media",
+        },
+      })),
+    };
+    taskRegistryDeliveryRuntimeMocks.sendMessage.mockResolvedValueOnce({});
+
+    scheduleMediaGenerationTaskCompletion({
+      lifecycle,
+      handle: {
+        taskId: "task-image-detailed-direct",
+        runId: "tool:image_generate:detailed-direct",
+        requesterSessionKey: "agent:main:discord:channel:123",
+        requesterOrigin: {
+          channel: "discord",
+          to: "channel:123",
+        },
+        taskLabel: "proof image",
+      },
+      scheduleBackgroundWork: (work) => {
+        scheduled.push(work);
+      },
+      progressSummary: "Generating image",
+      toolName: "Image generation",
+      onWakeFailure,
+      run: async () => ({
+        provider: "openai",
+        model: "gpt-image-1",
+        count: 1,
+        paths: ["/tmp/proof.png"],
+        wakeResult: "generated",
+        mediaUrls: ["/tmp/proof.png"],
+      }),
+    });
+
+    await scheduled[0]?.();
+
+    expect(lifecycle.wakeTaskCompletion).not.toHaveBeenCalled();
+    expect(taskRegistryDeliveryRuntimeMocks.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        to: "channel:123",
+        content: "Image generation completed.",
+        mediaUrls: ["/tmp/proof.png"],
+      }),
+    );
+    expect(onWakeFailure).toHaveBeenCalledWith(
+      "Image generation completion delivery was not confirmed after successful generation",
+      expect.objectContaining({
+        deliveryError: "completion agent did not deliver generated media",
+        deliveryReason: "generated_media_missing",
+        runId: "tool:image_generate:detailed-direct",
+        taskId: "task-image-detailed-direct",
+      }),
+    );
+    expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalResult: undefined,
+      }),
+    );
+    expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
+  });
+
+  it("does not direct-deliver detailed requester-abandoned wake misses", async () => {
+    const scheduled: Array<() => Promise<void>> = [];
+    const lifecycle = {
+      createTaskRun: vi.fn(),
+      recordTaskProgress: vi.fn(),
+      completeTaskRun: vi.fn(),
+      failTaskRun: vi.fn(),
+      wakeTaskCompletion: vi.fn(async () => false),
+      wakeTaskCompletionDetailed: vi.fn(async () => ({
+        delivered: false,
+        delivery: {
+          delivered: false,
+          path: "none" as const,
+          reason: "requester_abandoned" as const,
+          error: "requester session abandoned after timeout",
+        },
+      })),
+    };
+
+    scheduleMediaGenerationTaskCompletion({
+      lifecycle,
+      handle: {
+        taskId: "task-image-detailed-abandoned",
+        runId: "tool:image_generate:detailed-abandoned",
+        requesterSessionKey: "agent:main:discord:channel:123",
+        requesterOrigin: {
+          channel: "discord",
+          to: "channel:123",
+        },
+        taskLabel: "proof image",
+      },
+      scheduleBackgroundWork: (work) => {
+        scheduled.push(work);
+      },
+      progressSummary: "Generating image",
+      toolName: "Image generation",
+      onWakeFailure: vi.fn(),
+      run: async () => ({
+        provider: "openai",
+        model: "gpt-image-1",
+        count: 1,
+        paths: ["/tmp/proof.png"],
+        wakeResult: "generated",
+        mediaUrls: ["/tmp/proof.png"],
+      }),
+    });
+
+    await scheduled[0]?.();
+
+    expect(taskRegistryDeliveryRuntimeMocks.sendMessage).not.toHaveBeenCalled();
+    expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalResult: {
+          terminalOutcome: "blocked",
+          terminalSummary:
+            "Required completion delivery failed before reaching the requester: completion delivery was not confirmed after successful generation.",
+        },
+      }),
+    );
+    expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
+  });
+
+  it("does not direct-deliver detailed generic wake misses", async () => {
+    const scheduled: Array<() => Promise<void>> = [];
+    const lifecycle = {
+      createTaskRun: vi.fn(),
+      recordTaskProgress: vi.fn(),
+      completeTaskRun: vi.fn(),
+      failTaskRun: vi.fn(),
+      wakeTaskCompletion: vi.fn(async () => false),
+      wakeTaskCompletionDetailed: vi.fn(async () => ({
+        delivered: false,
+        delivery: {
+          delivered: false,
+          path: "direct" as const,
+          error: "gateway request timeout for agent",
+        },
+      })),
+    };
+
+    scheduleMediaGenerationTaskCompletion({
+      lifecycle,
+      handle: {
+        taskId: "task-image-detailed-generic",
+        runId: "tool:image_generate:detailed-generic",
+        requesterSessionKey: "agent:main:discord:channel:123",
+        requesterOrigin: {
+          channel: "discord",
+          to: "channel:123",
+        },
+        taskLabel: "proof image",
+      },
+      scheduleBackgroundWork: (work) => {
+        scheduled.push(work);
+      },
+      progressSummary: "Generating image",
+      toolName: "Image generation",
+      onWakeFailure: vi.fn(),
+      run: async () => ({
+        provider: "openai",
+        model: "gpt-image-1",
+        count: 1,
+        paths: ["/tmp/proof.png"],
+        wakeResult: "generated",
+        mediaUrls: ["/tmp/proof.png"],
+      }),
+    });
+
+    await scheduled[0]?.();
+
+    expect(taskRegistryDeliveryRuntimeMocks.sendMessage).not.toHaveBeenCalled();
+    expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalResult: {
+          terminalOutcome: "blocked",
+          terminalSummary:
+            "Required completion delivery failed before reaching the requester: completion delivery was not confirmed after successful generation.",
+        },
+      }),
+    );
+    expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
+  });
+
   it("completes a generated media task when completion wake throws", async () => {
     const scheduled: Array<() => Promise<void>> = [];
     const wakeError = new Error("requester wake failed");

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -39,7 +39,10 @@ import {
   deliverSubagentAnnouncement,
   loadRequesterSessionEntry,
 } from "../subagent-announce-delivery.js";
-import type { SubagentAnnounceDeliveryFailureReason } from "../subagent-announce-dispatch.js";
+import type {
+  SubagentAnnounceDeliveryFailureReason,
+  SubagentAnnounceDeliveryResult,
+} from "../subagent-announce-dispatch.js";
 import { resolveAnnounceOrigin } from "../subagent-announce-origin.js";
 
 const log = createSubsystemLogger("agents/tools/media-generate-background-shared");
@@ -135,12 +138,20 @@ type WakeMediaGenerationTaskCompletionParams = {
   statsLine?: string;
 };
 
+type WakeMediaGenerationTaskCompletionResult = {
+  delivered: boolean;
+  delivery?: SubagentAnnounceDeliveryResult;
+};
+
 type MediaGenerationTaskLifecycle = {
   createTaskRun: (params: CreateMediaGenerationTaskRunParams) => MediaGenerationTaskHandle | null;
   recordTaskProgress: (params: RecordMediaGenerationTaskProgressParams) => void;
   completeTaskRun: (params: CompleteMediaGenerationTaskRunParams) => void;
   failTaskRun: (params: FailMediaGenerationTaskRunParams) => void;
   wakeTaskCompletion: (params: WakeMediaGenerationTaskCompletionParams) => Promise<boolean>;
+  wakeTaskCompletionDetailed?: (
+    params: WakeMediaGenerationTaskCompletionParams,
+  ) => Promise<WakeMediaGenerationTaskCompletionResult>;
 };
 
 function touchMediaGenerationTaskRunContext(handle: MediaGenerationTaskHandle) {
@@ -255,6 +266,33 @@ export async function withMediaGenerationTaskKeepalive<T>(params: {
   } finally {
     clearInterval(interval);
   }
+}
+
+function collectMediaGenerationUrls(params: {
+  attachments?: AgentGeneratedAttachment[];
+  mediaUrls?: string[];
+}): string[] {
+  return Array.from(
+    new Set([
+      ...(params.mediaUrls ?? []),
+      ...mediaUrlsFromGeneratedAttachments(params.attachments),
+    ]),
+  );
+}
+
+function canTryDirectMediaFallbackForDelivery(
+  delivery: SubagentAnnounceDeliveryResult | undefined,
+): boolean {
+  return delivery?.reason != null && MEDIA_DIRECT_FALLBACK_DELIVERY_REASONS.has(delivery.reason);
+}
+
+function buildMediaGenerationDirectSuccessContent(params: {
+  label: string;
+  mediaUrls: string[];
+}): string {
+  return params.mediaUrls.length > 0
+    ? `${params.label} completed.`
+    : `${params.label} completed, but the generated media could not be attached here.`;
 }
 
 function completeMediaGenerationTaskRun(params: {
@@ -459,7 +497,7 @@ export function scheduleMediaGenerationTaskCompletion<
     }
     let terminalResult: RequiredCompletionTerminalResult | undefined;
     try {
-      const completionDelivered = await params.lifecycle.wakeTaskCompletion({
+      const completionParams: WakeMediaGenerationTaskCompletionParams = {
         config: params.config,
         handle: params.handle,
         status: "ok",
@@ -467,17 +505,43 @@ export function scheduleMediaGenerationTaskCompletion<
         result: executed.wakeResult,
         attachments: executed.attachments,
         mediaUrls: executed.mediaUrls,
-      });
-      if (!completionDelivered) {
+      };
+      const completionResult = params.lifecycle.wakeTaskCompletionDetailed
+        ? await params.lifecycle.wakeTaskCompletionDetailed(completionParams)
+        : { delivered: await params.lifecycle.wakeTaskCompletion(completionParams) };
+      if (!completionResult.delivered) {
         // A generated result without confirmed delivery is terminally unsafe for task closeout.
         terminalResult = resolveRequiredCompletionDeliveryFailureTerminalResult(
           "completion delivery was not confirmed after successful generation",
         );
+        if (params.handle && canTryDirectMediaFallbackForDelivery(completionResult.delivery)) {
+          const mediaUrls = collectMediaGenerationUrls(executed);
+          const delivered = await tryDeliverMediaGenerationDirect({
+            config: params.config,
+            handle: params.handle,
+            toolName: params.toolName,
+            content: buildMediaGenerationDirectSuccessContent({
+              label: params.toolName,
+              mediaUrls,
+            }),
+            mediaUrls,
+            idempotencySuffix: "blocked",
+          });
+          if (delivered) {
+            terminalResult = undefined;
+          }
+        }
         params.onWakeFailure(
           `${params.toolName} completion delivery was not confirmed after successful generation`,
           {
             taskId: params.handle?.taskId,
             runId: params.handle?.runId,
+            ...(completionResult.delivery?.reason
+              ? { deliveryReason: completionResult.delivery.reason }
+              : {}),
+            ...(completionResult.delivery?.error
+              ? { deliveryError: completionResult.delivery.error }
+              : {}),
           },
         );
       }
@@ -486,19 +550,13 @@ export function scheduleMediaGenerationTaskCompletion<
         formatErrorMessage(error),
       );
       if (params.handle) {
-        const mediaUrls = Array.from(
-          new Set([
-            ...(executed.mediaUrls ?? []),
-            ...mediaUrlsFromGeneratedAttachments(executed.attachments),
-          ]),
-        );
         // If the wake agent path failed after successful generation, try direct channel delivery.
         const delivered = await tryDeliverMediaGenerationDirect({
           config: params.config,
           handle: params.handle,
           toolName: params.toolName,
           content: `${params.toolName} completed.`,
-          mediaUrls,
+          mediaUrls: collectMediaGenerationUrls(executed),
           idempotencySuffix: "blocked",
         });
         if (delivered) {
@@ -537,7 +595,7 @@ export function scheduleMediaGenerationTaskCompletion<
   });
 }
 
-async function wakeMediaGenerationTaskCompletion(params: {
+async function wakeMediaGenerationTaskCompletionDetailed(params: {
   config?: OpenClawConfig;
   handle: MediaGenerationTaskHandle | null;
   status: "ok" | "error";
@@ -550,17 +608,13 @@ async function wakeMediaGenerationTaskCompletion(params: {
   announceType: string;
   toolName: string;
   completionLabel: string;
-}): Promise<boolean> {
+  attemptDirectFallback?: boolean;
+}): Promise<WakeMediaGenerationTaskCompletionResult> {
   if (!params.handle) {
-    return true;
+    return { delivered: true };
   }
   const announceId = `${params.toolName}:${params.handle.taskId}:${params.status}`;
-  const mediaUrls = Array.from(
-    new Set([
-      ...(params.mediaUrls ?? []),
-      ...mediaUrlsFromGeneratedAttachments(params.attachments),
-    ]),
-  );
+  const mediaUrls = collectMediaGenerationUrls(params);
   const internalEvents: AgentInternalEvent[] = [
     {
       type: "task_completion",
@@ -605,7 +659,7 @@ async function wakeMediaGenerationTaskCompletion(params: {
     directIdempotencyKey: announceId,
   });
   if (delivery.delivered) {
-    return true;
+    return { delivered: true, delivery };
   }
   if (delivery.terminal) {
     log.warn("Media generation completion delivery stopped after terminal fallback", {
@@ -614,29 +668,31 @@ async function wakeMediaGenerationTaskCompletion(params: {
       toolName: params.toolName,
       error: delivery.error,
     });
-    return true;
+    return { delivered: true, delivery };
   }
-  const canTryDirectCompletionFallback =
-    delivery.reason != null && MEDIA_DIRECT_FALLBACK_DELIVERY_REASONS.has(delivery.reason);
-  if (params.status === "ok" && canTryDirectCompletionFallback) {
+  if (
+    params.attemptDirectFallback &&
+    params.status === "ok" &&
+    canTryDirectMediaFallbackForDelivery(delivery)
+  ) {
     // Direct fallback is only for successful media where missing attachments would lose the result.
     const label = `${params.completionLabel[0]?.toUpperCase() ?? "M"}${params.completionLabel.slice(1)}`;
     const delivered = await tryDeliverMediaGenerationDirect({
       config: params.config,
       handle: params.handle,
       toolName: params.toolName,
-      content:
-        mediaUrls.length > 0
-          ? `${label} generation completed.`
-          : `${label} generation completed, but the generated media could not be attached here.`,
+      content: buildMediaGenerationDirectSuccessContent({
+        label: `${label} generation`,
+        mediaUrls,
+      }),
       mediaUrls,
       idempotencySuffix: "ok",
     });
     if (delivered) {
-      return true;
+      return { delivered: true, delivery };
     }
   }
-  if (params.status === "error") {
+  if (params.attemptDirectFallback && params.status === "error") {
     const label = `${params.completionLabel[0]?.toUpperCase() ?? "M"}${params.completionLabel.slice(1)}`;
     const delivered = await tryDeliverMediaGenerationDirect({
       config: params.config,
@@ -646,10 +702,10 @@ async function wakeMediaGenerationTaskCompletion(params: {
       idempotencySuffix: "error",
     });
     if (delivered) {
-      return true;
+      return { delivered: true, delivery };
     }
   }
-  if (delivery.error) {
+  if (params.attemptDirectFallback && delivery.error) {
     log.error("Media generation completion wake failed; requester session was not woken", {
       taskId: params.handle.taskId,
       runId: params.handle.runId,
@@ -657,7 +713,28 @@ async function wakeMediaGenerationTaskCompletion(params: {
       error: delivery.error,
     });
   }
-  return false;
+  return { delivered: false, delivery };
+}
+
+async function wakeMediaGenerationTaskCompletion(params: {
+  config?: OpenClawConfig;
+  handle: MediaGenerationTaskHandle | null;
+  status: "ok" | "error";
+  statusLabel: string;
+  result: string;
+  attachments?: AgentGeneratedAttachment[];
+  mediaUrls?: string[];
+  statsLine?: string;
+  eventSource: AgentInternalEvent["source"];
+  announceType: string;
+  toolName: string;
+  completionLabel: string;
+}): Promise<boolean> {
+  const result = await wakeMediaGenerationTaskCompletionDetailed({
+    ...params,
+    attemptDirectFallback: true,
+  });
+  return result.delivered;
 }
 
 async function tryDeliverMediaGenerationDirect(params: {
@@ -753,6 +830,17 @@ export function createMediaGenerationTaskLifecycle(params: {
         announceType: params.announceType,
         toolName: params.toolName,
         completionLabel: params.completionLabel,
+      });
+    },
+
+    async wakeTaskCompletionDetailed(completionParams: WakeMediaGenerationTaskCompletionParams) {
+      return await wakeMediaGenerationTaskCompletionDetailed({
+        ...completionParams,
+        eventSource: params.eventSource,
+        announceType: params.announceType,
+        toolName: params.toolName,
+        completionLabel: params.completionLabel,
+        attemptDirectFallback: false,
       });
     },
   };


### PR DESCRIPTION
## What Problem This Solves

#95910 tracks a focused follow-up to #86034: after successful media generation, `scheduleMediaGenerationTaskCompletion()` treated a `wakeTaskCompletion()` false return as an unconfirmed completion and closed the detached task as blocked, while the thrown wake path already had direct media recovery.

The unsafe fix would be to direct-send after every boolean `false`. That would recover some media-loss cases, but it also breaks the current no-send contract for `requester_abandoned` and unknown/generic false returns because the scheduler no longer knows why delivery failed.

This PR fixes that boundary by preserving the existing `wakeTaskCompletion(): Promise<boolean>` API and adding a media-internal detailed wake result so successful-generation closeout can still see the structured delivery reason before deciding whether direct fallback is allowed.

Fixes #95910.
Partial follow-up for #86034.
Supersedes the unsafe fallback boundary in #95945.

## Summary

- keeps the existing `wakeTaskCompletion(): Promise<boolean>` API for current media/tool callers
- adds a media-internal detailed wake result for scheduler closeout
- retries direct media delivery only for recoverable media-loss reasons:
  - `generated_media_missing`
  - `message_tool_delivery_missing`
  - `visible_reply_missing`
- keeps `requester_abandoned`, generic/no-reason false returns, and terminal delivery stops as no-send blocked outcomes
- adds scheduler-level regression coverage for the allowed reason, requester-abandoned, generic false, and thrown wake paths

## Behavior Matrix

| wake result | direct fallback? | terminal result |
| --- | --- | --- |
| delivered | no extra fallback | success |
| `generated_media_missing` / `message_tool_delivery_missing` / `visible_reply_missing` | yes, if direct channel origin is deliverable | clears blocked result on success |
| `requester_abandoned` | no | blocked |
| no reason / generic false | no | blocked |
| terminal delivery stop | no | handled as before |
| thrown wake after successful generation | existing direct recovery path remains | clears blocked result on success |

## Evidence

Local validation from this branch:

- Installed dependencies with `pnpm install --frozen-lockfile`; lockfile was unchanged.
- Formatting check passed:
  - `pnpm exec oxfmt --check --threads=1 src/agents/tools/media-generate-background-shared.ts src/agents/tools/media-generate-background-shared.test.ts`
- Relevant Vitest set passed: 5 files, 143 tests.
  - `node scripts/run-vitest.mjs src/agents/tools/media-generate-background-shared.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/tools/image-generate-background.test.ts src/agents/tools/video-generate-background.test.ts src/agents/tools/music-generate-background.test.ts --maxWorkers=1`
- TypeScript core check passed:
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- Narrow lint passed:
  - `node scripts/run-oxlint.mjs src/agents/tools/media-generate-background-shared.ts src/agents/tools/media-generate-background-shared.test.ts`
- Whitespace check passed:
  - `git diff --check`

Regression coverage added in `src/agents/tools/media-generate-background-shared.test.ts`:

- detailed false with `generated_media_missing` and a deliverable origin calls direct fallback and clears `terminalResult`
- detailed false with `requester_abandoned` does not call `sendMessage` and remains blocked
- detailed false with no reason/generic error does not call `sendMessage` and remains blocked
- existing thrown wake direct recovery remains covered
- existing lifecycle-level tests still cover direct fallback through the old boolean wrapper and no-send behavior for requester abandonment/generic handoff failure

Mantis Telegram Desktop proof was attempted in https://github.com/openclaw/openclaw/actions/runs/28294989921. The harness validated the selected refs, but the agentic Telegram proof job failed because the available Telegram setup could not reproduce the required generated-media completion wake-false condition. The uploaded `mantis-evidence.json` reported both baseline and candidate as `skipped`, with no video/artifacts produced.

That Mantis result is not behavioral proof that this PR works, and it is also not evidence that the candidate failed. It shows the current visible Telegram proof harness cannot trigger this internal delivery-result path. Current evidence remains the mocked scheduler and delivery-path coverage for the exact delivery-policy matrix changed by this PR.

Live gateway/channel proof remains open unless maintainers accept the scheduler boundary proof for this internal failure mode or provide/approve a live hook that can inject a recoverable `SubagentAnnounceDeliveryResult` such as `generated_media_missing` against a real channel.
