### PR TITLE
fix(agents): serialize structured non-image tool-result blocks in extractToolResultText (fixes #97267)

### DIFF
--- a/src/agents/embedded-agent-subscribe.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.test.ts
@@ -441,4 +441,14 @@ describe("extractToolResultText", () => {
     expect(withoutText).toBeDefined();
     expect(withoutText).toContain("resource");
   });
+
+  it("truncates large structured fallback output to TOOL_RESULT_MAX_CHARS (#97267)", () => {
+    const bigData = "x".repeat(10_000);
+    const text = extractToolResultText({
+      content: [{ type: "resource", resource: { data: bigData } }],
+    });
+    expect(text).toBeDefined();
+    expect(text!.length).toBeLessThanOrEqual(8100);
+    expect(text).toContain("(truncated)");
+  });
 });

--- a/src/agents/embedded-agent-subscribe.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.test.ts
@@ -6,6 +6,7 @@ import {
   buildToolLifecycleErrorResult,
   extractToolErrorCode,
   extractToolErrorMessage,
+  extractToolResultText,
   isToolResultError,
   sanitizeToolArgs,
   sanitizeToolResult,
@@ -386,5 +387,58 @@ describe("sanitizeToolArgs", () => {
       count: 3,
       file_path: "/tmp/x.txt",
     });
+  });
+});
+
+describe("extractToolResultText", () => {
+  it("returns undefined for non-object results", () => {
+    expect(extractToolResultText(null)).toBeUndefined();
+    expect(extractToolResultText(undefined)).toBeUndefined();
+    expect(extractToolResultText("string")).toBeUndefined();
+  });
+
+  it("collects text from explicit text content blocks", () => {
+    expect(
+      extractToolResultText({
+        content: [
+          { type: "text", text: "hello" },
+          { type: "text", text: "world" },
+        ],
+      }),
+    ).toBe("hello\nworld");
+  });
+
+  it("serializes structured non-image blocks as fallback visible text (#97267)", () => {
+    const text = extractToolResultText({
+      content: [{ type: "resource", resource: { uri: "file:///tmp/data.json" } }],
+    });
+    expect(text).toBeDefined();
+    expect(text).toContain("resource");
+    expect(text).toContain("file:///tmp/data.json");
+  });
+
+  it("skips image blocks in the structured fallback (#97267)", () => {
+    const text = extractToolResultText({
+      content: [{ type: "image", data: "base64...", mimeType: "image/png" }],
+    });
+    expect(text).toBeUndefined();
+  });
+
+  it("returns text blocks directly when present, structured fallback only activates without text (#97267)", () => {
+    // When text blocks exist, they are returned directly.
+    const withText = extractToolResultText({
+      content: [
+        { type: "text", text: "visible output" },
+        { type: "resource", resource: { uri: "file:///tmp/data.json" } },
+      ],
+    });
+    expect(withText).toBe("visible output");
+
+    // When only structured non-image blocks exist, the fallback serializes them.
+    const withoutText = extractToolResultText({
+      content: [{ type: "resource", resource: { uri: "file:///tmp/data.json" } }],
+    });
+    expect(withoutText).toBeDefined();
+    expect(withoutText).toContain("resource");
   });
 });

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -278,10 +278,36 @@ export function extractToolResultText(result: unknown): string | undefined {
       return trimmed ? trimmed : undefined;
     })
     .filter((value): value is string => Boolean(value));
-  if (texts.length === 0) {
-    return undefined;
+  if (texts.length > 0) {
+    return texts.join("\n");
   }
-  return texts.join("\n");
+
+  // Fallback: serialize structured non-image blocks so tool results with
+  // JSON/resource content produce visible text instead of collapsing to an
+  // attachment placeholder (#97267).
+  const content = record.content;
+  if (Array.isArray(content)) {
+    const fallbackParts: string[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const b = block as Record<string, unknown>;
+      if (b.type === "text" || b.type === "image") {
+        continue;
+      }
+      try {
+        fallbackParts.push(JSON.stringify(block));
+      } catch {
+        // skip unserializable blocks
+      }
+    }
+    if (fallbackParts.length > 0) {
+      return fallbackParts.join("\n");
+    }
+  }
+
+  return undefined;
 }
 
 function pushUniqueMessagingMediaUrl(urls: string[], seen: Set<string>, value: unknown): void {

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -303,7 +303,8 @@ export function extractToolResultText(result: unknown): string | undefined {
       }
     }
     if (fallbackParts.length > 0) {
-      return fallbackParts.join("\n");
+      const joined = fallbackParts.join("\n");
+      return truncateToolText(joined);
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #97267.

`extractToolResultText` only collected explicit `text` content blocks from tool results. When a tool result contained only structured non-image blocks (JSON, resource, etc.), it returned `undefined` — causing the tool result to collapse to an attachment placeholder in the visible transcript.

## Changes Made

- `src/agents/embedded-agent-subscribe.tools.ts`: Added a structured-block fallback inside `extractToolResultText`. When no text blocks are present, the fallback serializes structured non-image blocks via `JSON.stringify`. `text` and `image` blocks are skipped in the fallback: images remain handled by media delivery, and text blocks already returned directly.
- `src/agents/embedded-agent-subscribe.tools.test.ts`: Added 5 focused tests covering structured fallback, image skip, mixed text+structured separation, and edge cases.

## Evidence

- **Unit tests:** `node scripts/run-vitest.mjs run src/agents/embedded-agent-subscribe.tools.test.ts` — 56/56 passed
- **Lint:** `npx oxlint --tsconfig tsconfig.json src/agents/embedded-agent-subscribe.tools.ts src/agents/embedded-agent-subscribe.tools.test.ts` — clean
- **Lockfile:** unchanged

## Test coverage

| Scenario | Status |
|----------|:---:|
| Non-object result → undefined | ✅ |
| Explicit text blocks → collected | ✅ |
| Structured non-image block → JSON-serialized | ✅ |
| Image-only block → undefined (media delivery) | ✅ |
| Mixed text + structured → text returned, fallback skipped | ✅ |

**What was not tested:** Live end-to-end tool subscription path (fix is in the shared `extractToolResultText` utility, unit-level verification suffices).

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding**: Yes
