### PR TITLE
fix: explain non-persistable exec approvals correctly

### DIFF
--- a/packages/gateway-protocol/src/exec-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/exec-approvals-validators.test.ts
@@ -112,6 +112,7 @@ describe("exec approvals protocol validators", () => {
       validateExecApprovalRequestParams({
         command: "echo hi",
         unavailableDecisions: ["allow-always"],
+        allowAlwaysUnavailableReason: "one-shot",
       }),
     ).toBe(true);
 
@@ -128,5 +129,25 @@ describe("exec approvals protocol validators", () => {
         }),
       ).toBe(false);
     }
+  });
+
+  it("accepts only known allow-always unavailable reasons", () => {
+    for (const allowAlwaysUnavailableReason of ["policy-always", "one-shot"]) {
+      expect(
+        validateExecApprovalRequestParams({
+          command: "echo hi",
+          unavailableDecisions: ["allow-always"],
+          allowAlwaysUnavailableReason,
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      validateExecApprovalRequestParams({
+        command: "echo hi",
+        unavailableDecisions: ["allow-always"],
+        allowAlwaysUnavailableReason: "unknown",
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -157,6 +157,9 @@ export const ExecApprovalRequestParamsSchema = Type.Object(
         maxItems: 1,
       }),
     ),
+    allowAlwaysUnavailableReason: Type.Optional(
+      Type.Union([Type.Literal("policy-always"), Type.Literal("one-shot")]),
+    ),
     commandSpans: Type.Optional(
       Type.Array(
         Type.Object(

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -58,8 +58,10 @@ function restoreProcessPlatformForTest(): void {
 }
 
 type ApprovalRequestPayload = {
+  allowAlwaysUnavailableReason?: string;
   approvalReviewerDeviceIds?: string[];
   commandSpans?: Array<{ startIndex: number; endIndex: number }>;
+  unavailableDecisions?: string[];
 };
 
 function requireApprovalRequestPayload(callIndex: number): ApprovalRequestPayload {
@@ -175,6 +177,25 @@ describe("exec approval requests", () => {
 
     const payload = requireApprovalRequestPayload(0);
     expect(payload?.approvalReviewerDeviceIds).toEqual(["device-ios-reviewer"]);
+  });
+
+  it("passes allow-always unavailable reasons into host approval registration payloads", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
+
+    await registerExecApprovalRequestForHost({
+      approvalId: "approval-id",
+      command: "ls *.ts",
+      unavailableDecisions: ["allow-always"],
+      allowAlwaysUnavailableReason: "one-shot",
+      workdir: "/tmp/project",
+      host: "node",
+      security: "allowlist",
+      ask: "on-miss",
+    });
+
+    const payload = requireApprovalRequestPayload(0);
+    expect(payload?.unavailableDecisions).toEqual(["allow-always"]);
+    expect(payload?.allowAlwaysUnavailableReason).toBe("one-shot");
   });
 
   it("does not generate command spans by default", async () => {

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -13,6 +13,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type {
   ExecApprovalCommandSpan,
+  ExecApprovalAllowAlwaysUnavailableReason,
   ExecApprovalUnavailableDecision,
   ExecAsk,
   ExecSecurity,
@@ -57,6 +58,7 @@ type RequestExecApprovalDecisionParams = {
   warningText?: string;
   commandSpans?: ExecApprovalCommandSpan[];
   unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
   agentId?: string;
   resolvedPath?: string;
   sessionKey?: string;
@@ -93,6 +95,7 @@ function buildExecApprovalRequestToolParams(
     ...(params.unavailableDecisions?.length
       ? { unavailableDecisions: params.unavailableDecisions }
       : {}),
+    allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason,
     agentId: params.agentId,
     resolvedPath: params.resolvedPath,
     sessionKey: params.sessionKey,
@@ -199,6 +202,7 @@ type HostExecApprovalParams = {
   warningText?: string;
   commandSpans?: ExecApprovalCommandSpan[];
   unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
   commandHighlighting?: boolean;
   agentId?: string;
   resolvedPath?: string;
@@ -309,6 +313,7 @@ async function buildHostApprovalDecisionParams(
     warningText: params.warningText,
     commandSpans,
     unavailableDecisions: params.unavailableDecisions,
+    allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason,
     ...buildExecApprovalRequesterContext({
       agentId: params.agentId,
       sessionKey: params.sessionKey,

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -102,6 +102,22 @@ const resolveExecApprovalUnavailableDecisionsMock = vi.hoisted(() =>
         : [],
   ),
 );
+const resolveExecApprovalAllowAlwaysUnavailableReasonMock = vi.hoisted(() =>
+  vi.fn(
+    (params?: {
+      ask?: string | null;
+      allowAlwaysPersistence?: { kind: string } | null;
+    }): "policy-always" | "one-shot" | undefined => {
+      if (params?.ask === "always") {
+        return "policy-always";
+      }
+      if (params?.allowAlwaysPersistence?.kind === "one-shot") {
+        return "one-shot";
+      }
+      return undefined;
+    },
+  ),
+);
 const buildEnforcedShellCommandMock = vi.hoisted(() =>
   vi.fn((): { ok: boolean; reason?: string; command?: string } => ({
     ok: false,
@@ -162,6 +178,8 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => ({
   resolveAllowAlwaysPatterns: vi.fn(() => []),
   resolveExecApprovalAllowedDecisions: resolveExecApprovalAllowedDecisionsMock,
   resolveExecApprovalUnavailableDecisions: resolveExecApprovalUnavailableDecisionsMock,
+  resolveExecApprovalAllowAlwaysUnavailableReason:
+    resolveExecApprovalAllowAlwaysUnavailableReasonMock,
   addAllowlistEntry: vi.fn(),
   addDurableCommandApproval: vi.fn(),
 }));
@@ -326,6 +344,7 @@ describe("processGatewayAllowlist", () => {
     detectInterpreterInlineEvalArgvMock.mockReset();
     detectInterpreterInlineEvalArgvMock.mockReturnValue(null);
     resolveExecApprovalUnavailableDecisionsMock.mockClear();
+    resolveExecApprovalAllowAlwaysUnavailableReasonMock.mockClear();
     buildExecApprovalPendingToolResultMock.mockReturnValue({
       details: { status: "approval-pending" },
       content: [],
@@ -811,6 +830,7 @@ describe("processGatewayAllowlist", () => {
     expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
       expect.objectContaining({
         allowedDecisions: ["allow-once", "deny"],
+        allowAlwaysUnavailableReason: "one-shot",
       }),
     );
   });

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -13,6 +13,7 @@ import {
   commandRequiresSecurityAuditSuppressionApproval,
   type ExecAsk,
   resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   type ExecCommandSegment,
   type ExecSecurity,
   type ExecSegmentSatisfiedBy,
@@ -597,9 +598,18 @@ export async function processGatewayAllowlist(
     ask: hostAsk,
     allowAlwaysPersistence: effectiveAllowAlwaysPersistence,
   });
+  const approvalAllowAlwaysUnavailableReason = resolveExecApprovalAllowAlwaysUnavailableReason({
+    ask: hostAsk,
+    allowAlwaysPersistence: effectiveAllowAlwaysPersistence,
+  });
   const unavailableDecisionRequestParams =
     approvalUnavailableDecisions.length > 0
-      ? { unavailableDecisions: approvalUnavailableDecisions }
+      ? {
+          unavailableDecisions: approvalUnavailableDecisions,
+          ...(approvalAllowAlwaysUnavailableReason
+            ? { allowAlwaysUnavailableReason: approvalAllowAlwaysUnavailableReason }
+            : {}),
+        }
       : {};
   if (requiresSecurityAuditSuppressionApproval) {
     params.warnings.push(
@@ -1015,6 +1025,7 @@ export async function processGatewayAllowlist(
         sentApproverDms,
         unavailableReason,
         allowedDecisions: approvalAllowedDecisions,
+        allowAlwaysUnavailableReason: approvalAllowAlwaysUnavailableReason,
       }),
     };
   }

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -164,6 +164,22 @@ const resolveExecApprovalUnavailableDecisionsMock = vi.hoisted(() =>
         : [],
   ),
 );
+const resolveExecApprovalAllowAlwaysUnavailableReasonMock = vi.hoisted(() =>
+  vi.fn(
+    (params?: {
+      ask?: string | null;
+      allowAlwaysPersistence?: { kind: string } | null;
+    }): "policy-always" | "one-shot" | undefined => {
+      if (params?.ask === "always") {
+        return "policy-always";
+      }
+      if (params?.allowAlwaysPersistence?.kind === "one-shot") {
+        return "one-shot";
+      }
+      return undefined;
+    },
+  ),
+);
 const resolveExecHostApprovalContextMock = vi.hoisted(() =>
   vi.fn(() => ({
     approvals: { allowlist: [] as ExecAllowlistEntry[], file: { version: 1, agents: {} } },
@@ -223,6 +239,8 @@ vi.mock("../infra/exec-approvals.js", () => ({
   resolveAllowAlwaysPatternCoverage: resolveAllowAlwaysPatternCoverageMock,
   resolveExecApprovalAllowedDecisions: resolveExecApprovalAllowedDecisionsMock,
   resolveExecApprovalUnavailableDecisions: resolveExecApprovalUnavailableDecisionsMock,
+  resolveExecApprovalAllowAlwaysUnavailableReason:
+    resolveExecApprovalAllowAlwaysUnavailableReasonMock,
   resolveExecApprovalsFromFile: resolveExecApprovalsFromFileMock,
   maxAsk: (a: ExecAsk, b: ExecAsk): ExecAsk => {
     const order: Record<ExecAsk, number> = { off: 0, "on-miss": 1, always: 2 };
@@ -535,6 +553,7 @@ describe("executeNodeHostCommand", () => {
     });
     resolveExecApprovalAllowedDecisionsMock.mockClear();
     resolveExecApprovalUnavailableDecisionsMock.mockClear();
+    resolveExecApprovalAllowAlwaysUnavailableReasonMock.mockClear();
     resolveExecHostApprovalContextMock.mockReset();
     resolveExecHostApprovalContextMock.mockReturnValue({
       approvals: { allowlist: [], file: { version: 1, agents: {} } },
@@ -1794,6 +1813,7 @@ describe("executeNodeHostCommand", () => {
     expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
       expect.objectContaining({
         allowedDecisions: ["allow-once", "deny"],
+        allowAlwaysUnavailableReason: "policy-always",
       }),
     );
   });
@@ -2247,9 +2267,11 @@ describe("executeNodeHostCommand", () => {
       allowAlwaysPersistence: { kind: "one-shot", reasons: ["unplanned"] },
     });
     expect(requireRegisteredApprovalRequest().unavailableDecisions).toEqual(["allow-always"]);
+    expect(requireRegisteredApprovalRequest().allowAlwaysUnavailableReason).toBe("one-shot");
     expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
       expect.objectContaining({
         allowedDecisions: ["allow-once", "deny"],
+        allowAlwaysUnavailableReason: "one-shot",
       }),
     );
   });

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -11,6 +11,7 @@ import {
   maxAsk,
   requiresExecApproval,
   resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   resolveExecApprovalUnavailableDecisions,
 } from "../infra/exec-approvals.js";
 import { defaultExecAutoReviewer, type ExecAutoReviewInput } from "../infra/exec-auto-review.js";
@@ -142,8 +143,17 @@ export async function executeNodeHostCommand(
     ask: approvalDecisionAsk,
     allowAlwaysPersistence,
   });
+  const allowAlwaysUnavailableReason = resolveExecApprovalAllowAlwaysUnavailableReason({
+    ask: approvalDecisionAsk,
+    allowAlwaysPersistence,
+  });
   const unavailableDecisionRequestParams =
-    unavailableDecisions.length > 0 ? { unavailableDecisions } : {};
+    unavailableDecisions.length > 0
+      ? {
+          unavailableDecisions,
+          ...(allowAlwaysUnavailableReason ? { allowAlwaysUnavailableReason } : {}),
+        }
+      : {};
   const requiresAsk =
     requiresExecApproval({
       ask: hostAsk,
@@ -456,6 +466,7 @@ export async function executeNodeHostCommand(
           sentApproverDms,
           unavailableReason,
           allowedDecisions,
+          allowAlwaysUnavailableReason,
           nodeId: target.nodeId,
         });
       }

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -554,6 +554,36 @@ describe("buildExecApprovalPendingToolResult", () => {
     expect(text).not.toContain("native chat exec approvals are not configured on Discord");
   });
 
+  it("explains one-shot allow-always unavailability in local approval prompts", () => {
+    const result = buildExecApprovalPendingToolResult({
+      host: "gateway",
+      command: "openclaw --version 2>&1",
+      cwd: process.cwd(),
+      warningText: "",
+      approvalId: "approval-id",
+      approvalSlug: "approval-slug",
+      expiresAtMs: Date.now() + 60_000,
+      initiatingSurface: {
+        kind: "disabled",
+        channel: "discord",
+        channelLabel: "Discord",
+        accountId: "default",
+      },
+      sentApproverDms: false,
+      unavailableReason: null,
+      allowedDecisions: ["allow-once", "deny"],
+      allowAlwaysUnavailableReason: "one-shot",
+    });
+
+    const text = result.content.find((part) => part.type === "text")?.text ?? "";
+    expect(result.details.status).toBe("approval-pending");
+    expect(result.details.allowAlwaysUnavailableReason).toBe("one-shot");
+    expect(text).toContain(
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
+    );
+    expect(text).not.toContain("effective approval policy requires approval every time");
+  });
+
   it("returns an unavailable reply when Discord exec approvals are disabled", () => {
     const result = buildDisabledSurfaceApprovalResult({
       channel: "discord",

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -18,6 +18,7 @@ import {
   resolveExecApprovals,
   resolveExecApprovalsTranscriptPath,
   type ExecAsk,
+  type ExecApprovalAllowAlwaysUnavailableReason,
   type ExecApprovalDecision,
   type ExecSecurity,
 } from "../infra/exec-approvals.js";
@@ -503,6 +504,7 @@ export function buildExecApprovalPendingToolResult(params: {
   sentApproverDms: boolean;
   unavailableReason: ExecApprovalUnavailableReason | null;
   allowedDecisions?: readonly ExecApprovalDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
   nodeId?: string;
 }): AgentToolResult<ExecToolDetails> {
   const allowedDecisions = params.allowedDecisions ?? resolveExecApprovalAllowedDecisions();
@@ -525,6 +527,7 @@ export function buildExecApprovalPendingToolResult(params: {
                 approvalSlug: params.approvalSlug,
                 approvalId: params.approvalId,
                 allowedDecisions,
+                allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason,
                 command: params.command,
                 cwd: params.cwd,
                 host: params.host,
@@ -553,6 +556,7 @@ export function buildExecApprovalPendingToolResult(params: {
             approvalSlug: params.approvalSlug,
             expiresAtMs: params.expiresAtMs,
             allowedDecisions,
+            allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason,
             host: params.host,
             command: params.command,
             cwd: params.cwd,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -11,9 +11,11 @@ import {
   resolveEventSessionKeyForPolicy,
   scopedHeartbeatWakeOptionsForPolicy,
 } from "../infra/event-session-routing.js";
+import { formatExecApprovalAllowAlwaysUnavailableText } from "../infra/exec-approval-unavailable-reason.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
   resolveExecApprovalAllowedDecisions,
+  type ExecApprovalAllowAlwaysUnavailableReason,
   type ExecHost,
   type ExecApprovalDecision,
   type ExecTarget,
@@ -368,6 +370,7 @@ export function buildApprovalPendingMessage(params: {
   approvalSlug: string;
   approvalId: string;
   allowedDecisions?: readonly ExecApprovalDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
   command: string;
   cwd: string | undefined;
   host: "gateway" | "node";
@@ -401,9 +404,7 @@ export function buildApprovalPendingMessage(params: {
   );
   lines.push(`Reply with: /approve ${params.approvalSlug} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push(
-      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
-    );
+    lines.push(formatExecApprovalAllowAlwaysUnavailableText(params.allowAlwaysUnavailableReason));
   }
   lines.push("If the short code is ambiguous, use the full id in /approve.");
   return lines.join("\n");

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -5,8 +5,9 @@
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { EventSessionRoutingPolicy } from "../infra/event-session-routing.js";
-import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
 import type {
+  ExecApprovalAllowAlwaysUnavailableReason,
+  ExecApprovalDecision,
   ExecAsk,
   ExecHost,
   ExecMode,
@@ -135,6 +136,7 @@ export type ExecToolDetails =
       approvalSlug: string;
       expiresAtMs: number;
       allowedDecisions?: readonly ExecApprovalDecision[];
+      allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
       host: ExecHost;
       command: string;
       cwd?: string;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1547,6 +1547,42 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
     ]);
   });
 
+  it("preserves allow-always unavailable reasons from tool details", async () => {
+    const { ctx } = createTestContext();
+    const onToolResult = vi.fn();
+    ctx.params.onToolResult = onToolResult;
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-approval-one-shot",
+        isError: false,
+        result: {
+          details: {
+            status: "approval-pending",
+            approvalId: "12345678-1234-1234-1234-123456789012",
+            approvalSlug: "12345678",
+            expiresAtMs: 1_800_000_000_000,
+            allowedDecisions: ["allow-once", "deny"],
+            allowAlwaysUnavailableReason: "one-shot",
+            host: "gateway",
+            command: "npm view diver name version description",
+          },
+        },
+      } as never,
+    );
+
+    const result = requireMockCallArg(onToolResult, 0, "tool result");
+    expect(requireString(result.text, "tool result text")).toContain(
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
+    );
+    expect(requireString(result.text, "tool result text")).not.toContain(
+      "effective approval policy requires approval every time",
+    );
+  });
+
   it("emits a deterministic unavailable payload when the initiating surface cannot approve", async () => {
     const { ctx } = createTestContext();
     const onToolResult = vi.fn();

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -29,7 +29,11 @@ import {
   emitAgentItemEvent,
   emitAgentPatchSummaryEvent,
 } from "../infra/agent-events.js";
-import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
+import {
+  normalizeExecApprovalAllowAlwaysUnavailableReason,
+  type ExecApprovalAllowAlwaysUnavailableReason,
+  type ExecApprovalDecision,
+} from "../infra/exec-approvals.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { truncateUtf16Safe } from "../utils.js";
@@ -579,6 +583,7 @@ function readExecApprovalPendingDetails(result: unknown): {
   approvalSlug: string;
   expiresAtMs?: number;
   allowedDecisions?: readonly ExecApprovalDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
   host: "gateway" | "node";
   command: string;
   cwd?: string;
@@ -613,6 +618,9 @@ function readExecApprovalPendingDetails(result: unknown): {
             decision === "allow-once" || decision === "allow-always" || decision === "deny",
         )
       : undefined,
+    allowAlwaysUnavailableReason: normalizeExecApprovalAllowAlwaysUnavailableReason(
+      readStringValue(details.allowAlwaysUnavailableReason),
+    ),
     host,
     command,
     cwd: readStringValue(details.cwd),
@@ -692,6 +700,7 @@ async function emitToolResultOutput(params: {
           approvalId: approvalPending.approvalId,
           approvalSlug: approvalPending.approvalSlug,
           allowedDecisions: approvalPending.allowedDecisions,
+          allowAlwaysUnavailableReason: approvalPending.allowAlwaysUnavailableReason,
           command: approvalPending.command,
           cwd: approvalPending.cwd,
           host: approvalPending.host,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -19,9 +19,12 @@ import {
   sanitizeExecApprovalWarningText,
 } from "../../infra/exec-approval-command-display.js";
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
+import { formatExecApprovalAllowAlwaysUnavailableErrorMessage } from "../../infra/exec-approval-unavailable-reason.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  normalizeExecApprovalAllowAlwaysUnavailableReason,
   normalizeExecApprovalUnavailableDecisions,
+  resolveExecApprovalRequestAllowAlwaysUnavailableReason,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
@@ -171,6 +174,7 @@ export function createExecApprovalHandlers(
         ask?: string;
         warningText?: string | null;
         unavailableDecisions?: string[];
+        allowAlwaysUnavailableReason?: string;
         commandSpans?: {
           startIndex: number;
           endIndex: number;
@@ -305,6 +309,9 @@ export function createExecApprovalHandlers(
       const unavailableDecisions = normalizeExecApprovalUnavailableDecisions(
         p.unavailableDecisions,
       );
+      const allowAlwaysUnavailableReason = normalizeExecApprovalAllowAlwaysUnavailableReason(
+        p.allowAlwaysUnavailableReason,
+      );
       const request = {
         command: sanitizedCommandText,
         commandPreview:
@@ -324,6 +331,7 @@ export function createExecApprovalHandlers(
         commandAnalysis,
         commandSpans,
         unavailableDecisions: unavailableDecisions.length > 0 ? unavailableDecisions : undefined,
+        allowAlwaysUnavailableReason,
         allowedDecisions: resolveExecApprovalRequestAllowedDecisions({
           ask: p.ask ?? null,
           unavailableDecisions,
@@ -457,11 +465,19 @@ export function createExecApprovalHandlers(
           const allowedDecisions = resolveExecApprovalRequestAllowedDecisions(snapshot.request);
           return allowedDecisions.includes(decision)
             ? null
-            : {
-                message:
-                  "allow-always is unavailable because the effective policy requires approval every time",
-                details: APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS,
-              };
+            : (() => {
+                const allowAlwaysUnavailableReason =
+                  resolveExecApprovalRequestAllowAlwaysUnavailableReason(snapshot.request);
+                return {
+                  message: formatExecApprovalAllowAlwaysUnavailableErrorMessage(
+                    allowAlwaysUnavailableReason,
+                  ),
+                  details: {
+                    ...APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS,
+                    allowAlwaysUnavailableReason,
+                  },
+                };
+              })();
         },
         resolvedEventName: "exec.approval.resolved",
         buildResolvedEvent: ({

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -2646,6 +2646,7 @@ describe("exec approval handlers", () => {
         validateExecApprovalRequestParams({
           ...baseParams,
           unavailableDecisions: ["allow-always"],
+          allowAlwaysUnavailableReason: "one-shot",
         }),
       ).toBe(true);
     });
@@ -3402,6 +3403,55 @@ describe("exec approval handlers", () => {
 
     await requestPromise;
     expect(allowOnceRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it("rejects allow-always with a one-shot unavailable reason", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        twoPhase: true,
+        unavailableDecisions: ["allow-always"],
+        allowAlwaysUnavailableReason: "one-shot",
+      },
+    });
+    const { id, request } = await waitForRequestedExecApprovalPayload(broadcasts);
+
+    expect(request.allowAlwaysUnavailableReason).toBe("one-shot");
+
+    const resolveRespond = vi.fn();
+    await resolveExecApproval({
+      handlers,
+      id,
+      decision: "allow-always",
+      respond: resolveRespond,
+      context,
+    });
+
+    expect(mockCallArg(resolveRespond)).toBe(false);
+    expect(mockCallArg(resolveRespond, 0, 1)).toBeUndefined();
+    expectRecordFields(mockCallArg(resolveRespond, 0, 2), {
+      message:
+        "allow-always is unavailable because this command cannot be safely saved as a reusable approval",
+    });
+    expectRecordFields((mockCallArg(resolveRespond, 0, 2) as Record<string, unknown>).details, {
+      allowAlwaysUnavailableReason: "one-shot",
+    });
+
+    const denyRespond = vi.fn();
+    await resolveExecApproval({
+      handlers,
+      id,
+      decision: "deny",
+      respond: denyRespond,
+      context,
+    });
+
+    await requestPromise;
+    expect(denyRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
   });
 
   it("keeps baseline decisions available when allow-always is unavailable", async () => {

--- a/src/infra/approval-view-model.ts
+++ b/src/infra/approval-view-model.ts
@@ -12,6 +12,7 @@ import type {
 import { resolveExecApprovalCommandDisplay } from "./exec-approval-command-display.js";
 import { buildExecApprovalActionDescriptors } from "./exec-approval-reply.js";
 import {
+  resolveExecApprovalRequestAllowAlwaysUnavailableReason,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
 } from "./exec-approvals.js";
@@ -71,6 +72,8 @@ function buildExecViewBase<TPhase extends ApprovalPhase>(
     description: phase === "pending" ? "A command needs your approval." : null,
     metadata: buildExecMetadata(request),
     ask: request.request.ask ?? null,
+    allowAlwaysUnavailableReason:
+      resolveExecApprovalRequestAllowAlwaysUnavailableReason(request.request) ?? null,
     agentId: request.request.agentId ?? null,
     warningText: request.request.warningText ?? null,
     commandAnalysis: request.request.commandAnalysis ?? null,

--- a/src/infra/approval-view-model.types.ts
+++ b/src/infra/approval-view-model.types.ts
@@ -4,6 +4,7 @@ import type { ChannelApprovalKind } from "./approval-types.js";
 import type { CommandExplanationSummary } from "./command-analysis/explain.js";
 import type {
   ExecApprovalDecision,
+  ExecApprovalAllowAlwaysUnavailableReason,
   ExecApprovalRequest,
   ExecApprovalResolved,
 } from "./exec-approvals.js";
@@ -39,6 +40,7 @@ type ApprovalViewBase = {
 export type ExecApprovalViewBase = ApprovalViewBase & {
   approvalKind: "exec";
   ask?: string | null;
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason | null;
   agentId?: string | null;
   warningText?: string | null;
   commandAnalysis?: CommandExplanationSummary | null;

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -645,6 +645,28 @@ describe("exec approval forwarder", () => {
     expect(text).toContain("Allow Always is unavailable");
   });
 
+  it("explains one-shot allow-always unavailability in forwarded fallback text", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+    await expect(
+      forwarder.handleRequested({
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          unavailableDecisions: ["allow-always"],
+          allowAlwaysUnavailableReason: "one-shot",
+        },
+      }),
+    ).resolves.toBe(true);
+    await Promise.resolve();
+    const text = getFirstDeliveryText(deliver);
+    expect(text).toContain("Reply with: /approve req-1 allow-once|deny");
+    expect(text).toContain(
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
+    );
+    expect(text).not.toContain("effective policy requires approval every time");
+  });
+
   it.each([
     {
       command: "bash safe\u200B.sh",

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -31,7 +31,9 @@ import {
   sanitizeExecApprovalWarningText,
 } from "./exec-approval-command-display.js";
 import { formatExecApprovalExpiresIn } from "./exec-approval-reply.js";
+import { formatExecApprovalAllowAlwaysUnavailableText } from "./exec-approval-unavailable-reason.js";
 import {
+  resolveExecApprovalRequestAllowAlwaysUnavailableReason,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
@@ -239,6 +241,9 @@ function formatApprovalCommand(command: string): { inline: boolean; text: string
 
 export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, nowMs: number) {
   const allowedDecisions = resolveExecApprovalRequestAllowedDecisions(request.request);
+  const allowAlwaysUnavailableReason = resolveExecApprovalRequestAllowAlwaysUnavailableReason(
+    request.request,
+  );
   const decisionText = allowedDecisions.join("|");
   const lines: string[] = ["🔒 Exec approval required", `ID: ${request.id}`];
   const warningText = request.request.warningText?.trim();
@@ -293,9 +298,7 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
   );
   lines.push(`Reply with: /approve ${request.id} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
-    );
+    lines.push(formatExecApprovalAllowAlwaysUnavailableText(allowAlwaysUnavailableReason));
   }
   return lines.join("\n");
 }

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -368,6 +368,22 @@ describe("exec approval reply helpers", () => {
     expect(payload.interactive).toBeUndefined();
   });
 
+  it("explains one-shot allow-always unavailability without blaming policy", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-one-shot",
+      approvalSlug: "slug-one-shot",
+      allowedDecisions: ["allow-once", "deny"],
+      allowAlwaysUnavailableReason: "one-shot",
+      command: "openclaw --version 2>&1",
+      host: "gateway",
+    });
+
+    expect(payload.text).toContain(
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
+    );
+    expect(payload.text).not.toContain("effective approval policy requires approval every time");
+  });
+
   it("stores agent and session metadata for downstream suppression checks", () => {
     const payload = buildExecApprovalPendingReplyPayload({
       approvalId: "req-meta",

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -17,9 +17,11 @@ import {
   listNativeExecApprovalClientLabels,
   supportsNativeExecApprovalClient,
 } from "./exec-approval-surface.js";
+import { formatExecApprovalAllowAlwaysUnavailableText } from "./exec-approval-unavailable-reason.js";
 import {
   resolveExecApprovalAllowedDecisions,
   type ExecApprovalDecision,
+  type ExecApprovalRequestPayload,
   type ExecHost,
 } from "./exec-approvals.js";
 
@@ -53,6 +55,7 @@ export type ExecApprovalPendingReplyParams = {
   ask?: string | null;
   agentId?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalRequestPayload["allowAlwaysUnavailableReason"];
   command: string;
   cwd?: string;
   host: ExecHost;
@@ -376,9 +379,7 @@ export function buildExecApprovalPendingReplyPayload(
     lines.push(secondaryFence);
   }
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push(
-      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
-    );
+    lines.push(formatExecApprovalAllowAlwaysUnavailableText(params.allowAlwaysUnavailableReason));
   }
   const info: string[] = [];
   info.push(`Host: ${params.host}`);

--- a/src/infra/exec-approval-unavailable-reason.ts
+++ b/src/infra/exec-approval-unavailable-reason.ts
@@ -1,0 +1,24 @@
+// User-facing copy for optional exec approval decisions that cannot be offered.
+import type { ExecApprovalAllowAlwaysUnavailableReason } from "./exec-approvals.js";
+
+export const EXEC_APPROVAL_ALLOW_ALWAYS_POLICY_UNAVAILABLE_TEXT =
+  "The effective approval policy requires approval every time, so Allow Always is unavailable.";
+
+export const EXEC_APPROVAL_ALLOW_ALWAYS_ONE_SHOT_UNAVAILABLE_TEXT =
+  "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.";
+
+export function formatExecApprovalAllowAlwaysUnavailableText(
+  reason?: ExecApprovalAllowAlwaysUnavailableReason | null,
+): string {
+  return reason === "one-shot"
+    ? EXEC_APPROVAL_ALLOW_ALWAYS_ONE_SHOT_UNAVAILABLE_TEXT
+    : EXEC_APPROVAL_ALLOW_ALWAYS_POLICY_UNAVAILABLE_TEXT;
+}
+
+export function formatExecApprovalAllowAlwaysUnavailableErrorMessage(
+  reason?: ExecApprovalAllowAlwaysUnavailableReason | null,
+): string {
+  return reason === "one-shot"
+    ? "allow-always is unavailable because this command cannot be safely saved as a reusable approval"
+    : "allow-always is unavailable because the effective policy requires approval every time";
+}

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -221,6 +221,7 @@ export type ExecApprovalRequestPayload = {
   commandAnalysis?: CommandExplanationSummary | null;
   commandSpans?: ExecApprovalCommandSpan[];
   unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
   allowedDecisions?: readonly ExecApprovalDecision[];
   agentId?: string | null;
   resolvedPath?: string | null;
@@ -1783,9 +1784,18 @@ export const OPTIONAL_EXEC_APPROVAL_DECISIONS = [
   "allow-always",
 ] as const satisfies readonly ExecApprovalDecision[];
 export type ExecApprovalUnavailableDecision = (typeof OPTIONAL_EXEC_APPROVAL_DECISIONS)[number];
+export const EXEC_APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_REASONS = [
+  "policy-always",
+  "one-shot",
+] as const;
+export type ExecApprovalAllowAlwaysUnavailableReason =
+  (typeof EXEC_APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_REASONS)[number];
 
 const OPTIONAL_EXEC_APPROVAL_DECISION_SET: ReadonlySet<string> = new Set(
   OPTIONAL_EXEC_APPROVAL_DECISIONS,
+);
+const EXEC_APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_REASON_SET: ReadonlySet<string> = new Set(
+  EXEC_APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_REASONS,
 );
 
 function isOptionalExecApprovalDecision(
@@ -1816,6 +1826,14 @@ export function normalizeExecApprovalUnavailableDecisions(
   return OPTIONAL_EXEC_APPROVAL_DECISIONS.filter((decision) => unavailable.has(decision));
 }
 
+export function normalizeExecApprovalAllowAlwaysUnavailableReason(
+  reason?: string | null,
+): ExecApprovalAllowAlwaysUnavailableReason | undefined {
+  return reason && EXEC_APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_REASON_SET.has(reason)
+    ? (reason as ExecApprovalAllowAlwaysUnavailableReason)
+    : undefined;
+}
+
 export function resolveExecApprovalAllowedDecisions(params?: {
   ask?: string | null;
   allowAlwaysPersistence?: AllowAlwaysPersistenceDecision | null;
@@ -1833,6 +1851,40 @@ export function resolveExecApprovalUnavailableDecisions(params?: {
 }): readonly ExecApprovalUnavailableDecision[] {
   const allowed = new Set(resolveExecApprovalAllowedDecisions(params));
   return OPTIONAL_EXEC_APPROVAL_DECISIONS.filter((decision) => !allowed.has(decision));
+}
+
+export function resolveExecApprovalAllowAlwaysUnavailableReason(params?: {
+  ask?: string | null;
+  allowAlwaysPersistence?: AllowAlwaysPersistenceDecision | null;
+}): ExecApprovalAllowAlwaysUnavailableReason | undefined {
+  const ask = normalizeExecAsk(params?.ask);
+  if (ask === "always") {
+    return "policy-always";
+  }
+  if (params?.allowAlwaysPersistence?.kind === "one-shot") {
+    return "one-shot";
+  }
+  return undefined;
+}
+
+export function resolveExecApprovalRequestAllowAlwaysUnavailableReason(params?: {
+  ask?: string | null;
+  unavailableDecisions?: readonly ExecApprovalUnavailableDecision[] | readonly string[] | null;
+  allowAlwaysUnavailableReason?: string | null;
+}): ExecApprovalAllowAlwaysUnavailableReason | undefined {
+  const normalizedReason = normalizeExecApprovalAllowAlwaysUnavailableReason(
+    params?.allowAlwaysUnavailableReason,
+  );
+  if (normalizedReason) {
+    return normalizedReason;
+  }
+  if (normalizeExecAsk(params?.ask) === "always") {
+    return "policy-always";
+  }
+  const unavailableDecisions = collectExecApprovalUnavailableDecisionSet(
+    params?.unavailableDecisions,
+  );
+  return unavailableDecisions.has("allow-always") ? "policy-always" : undefined;
 }
 
 export function resolveExecApprovalRequestAllowedDecisions(params?: {

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -187,6 +187,26 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
     });
   });
 
+  it("explains one-shot exec reaction prompts without blaming policy", () => {
+    const payload = buildApprovalReactionPromptPayloadForRequest({
+      request: {
+        ...execRequest,
+        request: {
+          ...execRequest.request,
+          unavailableDecisions: ["allow-always"],
+          allowAlwaysUnavailableReason: "one-shot",
+        },
+      },
+      nowMs: 1_000,
+    });
+
+    expect(payload.text).toContain(
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
+    );
+    expect(payload.text).not.toContain("effective policy requires approval every time");
+    expect(payload.text).toContain("Reply with: /approve exec-approval-123 allow-once|deny");
+  });
+
   it("keeps plugin command actions visible for custom prompt views", () => {
     const payload = buildApprovalPendingPromptPayload({
       request: {

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -12,6 +12,8 @@ import {
   type ExecApprovalPendingReplyParams,
   type ExecApprovalReplyDecision,
 } from "../infra/exec-approval-reply.js";
+import { formatExecApprovalAllowAlwaysUnavailableText } from "../infra/exec-approval-unavailable-reason.js";
+import type { ExecApprovalAllowAlwaysUnavailableReason } from "../infra/exec-approvals.js";
 import type { PluginApprovalRequest } from "../infra/plugin-approvals.js";
 import {
   buildApprovalPendingReplyPayload,
@@ -21,6 +23,9 @@ export { shouldSuppressLocalNativeExecApprovalPrompt } from "./approval-native-h
 import type { ReplyPayload } from "./reply-payload.js";
 
 type ApprovalKind = "exec" | "plugin";
+const APPROVAL_REACTION_ALLOW_ALWAYS_POLICY_UNAVAILABLE_TEXT =
+  "Allow Always is unavailable because the effective policy requires approval every time.";
+
 type KeyedStore<TValue> = {
   register(key: string, value: TValue, opts?: { ttlMs?: number }): Promise<void>;
   lookup(key: string): Promise<TValue | undefined>;
@@ -208,11 +213,14 @@ function buildDecisionText(allowedDecisions: readonly ExecApprovalReplyDecision[
 function buildManualInstructionSection(params: {
   approvalId: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason | null;
 }): string[] {
   const lines: string[] = [];
   if (!params.allowedDecisions.includes("allow-always")) {
     lines.push(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
+      params.allowAlwaysUnavailableReason === "one-shot"
+        ? formatExecApprovalAllowAlwaysUnavailableText(params.allowAlwaysUnavailableReason)
+        : APPROVAL_REACTION_ALLOW_ALWAYS_POLICY_UNAVAILABLE_TEXT,
     );
   }
   if (params.allowedDecisions.length > 0) {
@@ -307,6 +315,8 @@ function buildApprovalReactionPromptText(params: {
   const manualInstructions = buildManualInstructionSection({
     approvalId: view.approvalId,
     allowedDecisions,
+    allowAlwaysUnavailableReason:
+      view.approvalKind === "exec" ? view.allowAlwaysUnavailableReason : undefined,
   });
   if (manualInstructions.length > 0) {
     sections.push(manualInstructions.join("\n"));
@@ -412,6 +422,10 @@ export function buildApprovalReactionPendingContent(params: {
             ask: params.view.ask ?? null,
             agentId: params.view.agentId ?? null,
             allowedDecisions: reactionPayload.allowedDecisions,
+            allowAlwaysUnavailableReason:
+              params.view.approvalKind === "exec"
+                ? params.view.allowAlwaysUnavailableReason
+                : undefined,
             command: params.view.commandText,
             cwd: params.view.cwd ?? undefined,
             host: params.view.host === "node" ? "node" : "gateway",

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.496Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:14.942Z",
   "locale": "ar",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:19.968Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:13.205Z",
   "locale": "de",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.073Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:13.563Z",
   "locale": "es",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:21.449Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:17.876Z",
   "locale": "fa",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.388Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:14.610Z",
   "locale": "fr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.917Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:16.205Z",
   "locale": "id",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.601Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:15.260Z",
   "locale": "it",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.179Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:13.922Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.285Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:14.276Z",
   "locale": "ko",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:21.341Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:17.488Z",
   "locale": "nl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:21.022Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:16.529Z",
   "locale": "pl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:19.858Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:12.848Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:21.129Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:16.842Z",
   "locale": "th",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.705Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:15.576Z",
   "locale": "tr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:20.812Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:15.896Z",
   "locale": "uk",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:21.236Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:17.140Z",
   "locale": "vi",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:18.876Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:12.075Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-22T18:58:19.747Z",
+  "fallbackKeys": [
+    "execApproval.allowAlwaysUnavailableOneShot"
+  ],
+  "generatedAt": "2026-06-27T16:28:12.484Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "46876bf110ad1feefe2b6b4cb652ffa002d7968b4351a24e589e62be6b08a9f2",
-  "totalKeys": 1414,
+  "sourceHash": "7b851245dc63d9aef21628492a289a4f680b387a28ecfa28b6711b0f06e829e4",
+  "totalKeys": 1415,
   "translatedKeys": 1414,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -370,6 +370,8 @@ export const ar: TranslationMap = {
     alwaysAllow: "السماح دائمًا",
     allowAlwaysUnavailable:
       "تتطلب سياسة الموافقة السارية الحصول على الموافقة في كل مرة، لذا فإن خيار السماح دائمًا غير متاح.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "رفض",
     labels: {
       host: "المضيف",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -374,6 +374,8 @@ export const de: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "Die wirksame Genehmigungsrichtlinie erfordert jedes Mal eine Genehmigung, daher ist Immer erlauben nicht verfügbar.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -369,6 +369,8 @@ export const en: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -371,6 +371,8 @@ export const es: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "La política de aprobación efectiva requiere aprobación cada vez, por lo que Permitir siempre no está disponible.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -372,6 +372,8 @@ export const fa: TranslationMap = {
     alwaysAllow: "همیشه مجاز کن",
     allowAlwaysUnavailable:
       "سیاست تأیید مؤثر هر بار به تأیید نیاز دارد، بنابراین «همیشه مجاز باشد» در دسترس نیست.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "رد کردن",
     labels: {
       host: "میزبان",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -373,6 +373,8 @@ export const fr: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "La politique d’approbation effective exige une approbation à chaque fois, donc Autoriser toujours n’est pas disponible.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -371,6 +371,8 @@ export const id: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "Kebijakan persetujuan yang berlaku mengharuskan persetujuan setiap kali, sehingga Izinkan Selalu tidak tersedia.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -373,6 +373,8 @@ export const it: TranslationMap = {
     alwaysAllow: "Consenti sempre",
     allowAlwaysUnavailable:
       "Il criterio di approvazione effettivo richiede l’approvazione ogni volta, quindi Consenti sempre non è disponibile.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Nega",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -374,6 +374,8 @@ export const ja_JP: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "有効な承認ポリシーでは毎回承認が必要なため、Allow Always は利用できません。",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -370,6 +370,8 @@ export const ko: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "유효한 승인 정책이 매번 승인을 요구하므로, 항상 허용을 사용할 수 없습니다.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -373,6 +373,8 @@ export const nl: TranslationMap = {
     alwaysAllow: "Altijd toestaan",
     allowAlwaysUnavailable:
       "Het effectieve goedkeuringsbeleid vereist elke keer goedkeuring, dus Altijd toestaan is niet beschikbaar.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Weigeren",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -372,6 +372,8 @@ export const pl: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "Obowiązująca zasada zatwierdzania wymaga zatwierdzenia za każdym razem, więc opcja Zawsze zezwalaj jest niedostępna.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -371,6 +371,8 @@ export const pt_BR: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "A política de aprovação efetiva exige aprovação todas as vezes, portanto Permitir sempre não está disponível.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -369,6 +369,8 @@ export const th: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "นโยบายการอนุมัติที่มีผลบังคับใช้กำหนดให้ต้องอนุมัติทุกครั้ง ดังนั้น Allow Always จึงไม่พร้อมใช้งาน",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -373,6 +373,8 @@ export const tr: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "Geçerli onay ilkesi her seferinde onay gerektiriyor, bu nedenle Her Zaman İzin Ver kullanılamıyor.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -372,6 +372,8 @@ export const uk: TranslationMap = {
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable:
       "Чинна політика схвалення вимагає схвалення щоразу, тому «Дозволяти завжди» недоступно.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -371,6 +371,8 @@ export const vi: TranslationMap = {
     alwaysAllow: "Luôn cho phép",
     allowAlwaysUnavailable:
       "Chính sách phê duyệt có hiệu lực yêu cầu phê duyệt mọi lần, vì vậy Không cho phép Luôn cho phép.",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Từ chối",
     labels: {
       host: "Máy chủ",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -368,6 +368,8 @@ export const zh_CN: TranslationMap = {
     allowOnce: "允许一次",
     alwaysAllow: "始终允许",
     allowAlwaysUnavailable: "有效的批准策略要求每次都批准，因此“始终允许”不可用。",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "拒绝",
     labels: {
       host: "主机",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -368,6 +368,8 @@ export const zh_TW: TranslationMap = {
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
     allowAlwaysUnavailable: "有效的核准政策要求每次都需核准，因此「一律允許」無法使用。",
+    allowAlwaysUnavailableOneShot:
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -15,9 +15,11 @@ export type ExecApprovalRequestPayload = {
     endIndex: number;
   }[];
   allowedDecisions?: readonly ExecApprovalDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
 };
 
 export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
+export type ExecApprovalAllowAlwaysUnavailableReason = "policy-always" | "one-shot";
 
 export type ExecApprovalRequest = {
   id: string;
@@ -103,6 +105,12 @@ function parseAllowedDecisions(value: unknown): ExecApprovalDecision[] | undefin
   return decisions.length > 0 ? decisions : undefined;
 }
 
+function parseAllowAlwaysUnavailableReason(
+  value: unknown,
+): ExecApprovalAllowAlwaysUnavailableReason | undefined {
+  return value === "policy-always" || value === "one-shot" ? value : undefined;
+}
+
 export function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | null {
   if (!isRecord(payload)) {
     return null;
@@ -135,6 +143,9 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
       commandSpans: parseCommandSpans(request.commandSpans, command.length),
       allowedDecisions: parseAllowedDecisions(request.allowedDecisions),
+      allowAlwaysUnavailableReason: parseAllowAlwaysUnavailableReason(
+        request.allowAlwaysUnavailableReason,
+      ),
     },
     createdAtMs,
     expiresAtMs,

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -158,6 +158,25 @@ describe("approval and confirmation modals", () => {
     );
   });
 
+  it("explains one-shot unavailable exec approval decisions", async () => {
+    const request = createExecRequest();
+    request.request.allowedDecisions = ["allow-once", "deny"];
+    request.request.allowAlwaysUnavailableReason = "one-shot";
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
+
+    await getRenderedDialog();
+
+    expect(
+      Array.from(container.querySelectorAll(".exec-approval-actions button")).map((button) =>
+        button.textContent?.trim(),
+      ),
+    ).toEqual(["Allow once", "Deny"]);
+    expect(container.querySelector(".exec-approval-warning")?.textContent?.trim()).toBe(
+      "Allow Always is unavailable because this command cannot be safely saved as a reusable approval.",
+    );
+  });
+
   it("falls back to ask when exec approval decisions are omitted", async () => {
     const request = createExecRequest();
     request.request.ask = "always";

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -155,7 +155,13 @@ function renderUnavailableDecisionWarning(
 ) {
   return active.kind !== "exec" || decisions.includes("allow-always")
     ? nothing
-    : html`<div class="exec-approval-warning">${t("execApproval.allowAlwaysUnavailable")}</div>`;
+    : html`<div class="exec-approval-warning">
+        ${t(
+          active.request.allowAlwaysUnavailableReason === "one-shot"
+            ? "execApproval.allowAlwaysUnavailableOneShot"
+            : "execApproval.allowAlwaysUnavailable",
+        )}
+      </div>`;
 }
 
 export function renderExecApprovalPrompt(state: AppViewState) {


### PR DESCRIPTION
﻿Closes #97069

## What Problem This Solves

Fixes an issue where users approving redirected or otherwise non-persistable exec commands would see Allow Always hidden with text that incorrectly said the effective approval policy requires approval every time.

## Why This Change Was Made

The approval request now carries a typed reason when Allow Always is unavailable, distinguishing policy-driven `ask=always` from one-shot commands that cannot be safely saved as reusable approvals. The existing one-shot safety behavior is preserved, and gateway, native/chat fallback, embedded prompt reconstruction, and Control UI renderers use the reason-specific copy.

## User Impact

Users now see the correct explanation when Allow Always is unavailable for a non-persistable command: the command cannot be safely saved as a reusable approval. Policy-driven prompts continue to use the existing approval-policy explanation.

## Evidence

- `node scripts/run-vitest.mjs packages/gateway-protocol/src/exec-approvals-validators.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts`
- `node scripts/run-vitest.mjs src/infra/exec-approval-reply.test.ts src/infra/exec-approval-forwarder.test.ts src/plugin-sdk/approval-reaction-runtime.test.ts`
- `node scripts/run-vitest.mjs ui/src/ui/views/exec-approval.test.ts`
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-approval-request.test.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-host-shared.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts`
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-gateway.test.ts -- -t "omits allow-always when allowlist execution cannot persist reusable patterns"`
- `git diff --check`
- `node --import tsx scripts/control-ui-i18n.ts check` with translation provider env cleared and a temporary local formatter workaround for this Windows worktree; generated locale output checked clean and the workaround was not committed.
- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 LC_ALL=C.UTF-8 python .agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings.

Known unrelated local baseline: `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-gateway.test.ts` has 3 Windows-only failures on clean `origin/main` at `f65aca64fc` for existing enforced-command expectations. The new gateway-host regression test above passes.
