### PR TITLE
fix(auth): allow OpenAI OAuth for audio transcription

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -135,7 +135,7 @@ vi.mock("./model-auth-env-vars.js", () => {
     huggingface: ["HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"],
     "minimax-portal": ["MINIMAX_OAUTH_TOKEN", "MINIMAX_API_KEY"],
     "opencode-go": ["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"],
-    openai: ["OPENAI_API_KEY"],
+    openai: ["CODEX_API_KEY", "OPENAI_API_KEY"],
     qianfan: ["QIANFAN_API_KEY"],
     qwen: ["QWEN_API_KEY", "MODELSTUDIO_API_KEY", "DASHSCOPE_API_KEY"],
     synthetic: ["SYNTHETIC_API_KEY"],
@@ -549,19 +549,24 @@ describe("getApiKeyForModel", () => {
       },
     };
 
-    const resolved = await resolveApiKeyForProvider({
-      provider: "openai",
-      modelApi: "openai-audio-transcriptions",
-      profileId: "openai:chatgpt",
-      lockedProfile: true,
-      store,
-    });
+    await withEnvAsync(
+      { CODEX_API_KEY: "codex-env-openai-key", OPENAI_API_KEY: "env-openai-key" },
+      async () => {
+        const resolved = await resolveApiKeyForProvider({
+          provider: "openai",
+          modelApi: "openai-audio-transcriptions",
+          profileId: "openai:chatgpt",
+          lockedProfile: true,
+          store,
+        });
 
-    expect(resolved).toMatchObject({
-      apiKey: oauthFixture.access,
-      mode: "oauth",
-      profileId: "openai:chatgpt",
-    });
+        expect(resolved).toMatchObject({
+          apiKey: oauthFixture.access,
+          mode: "oauth",
+          profileId: "openai:chatgpt",
+        });
+      },
+    );
   });
 
   it("treats OpenAI OAuth profiles as available for audio transcriptions", async () => {
@@ -584,6 +589,40 @@ describe("getApiKeyForModel", () => {
       }),
     ).resolves.toBe(true);
   });
+
+  it.each([
+    ["CODEX_API_KEY", { CODEX_API_KEY: "codex-env-openai-key", OPENAI_API_KEY: undefined }],
+    ["OPENAI_API_KEY", { CODEX_API_KEY: undefined, OPENAI_API_KEY: "env-openai-key" }],
+  ] as const)(
+    "keeps %s ahead of default OpenAI OAuth profiles for audio transcriptions",
+    async (envVar, env) => {
+      const store = {
+        version: 1 as const,
+        profiles: {
+          "openai:chatgpt": {
+            type: "oauth" as const,
+            provider: "openai",
+            ...oauthFixture,
+          },
+        },
+      };
+
+      await withEnvAsync(env, async () => {
+        const resolved = await resolveApiKeyForProvider({
+          provider: "openai",
+          modelApi: "openai-audio-transcriptions",
+          store,
+        });
+
+        expect(resolved).toMatchObject({
+          apiKey: envVar === "CODEX_API_KEY" ? "codex-env-openai-key" : "env-openai-key",
+          mode: "api-key",
+        });
+        expect(resolved.profileId).toBeUndefined();
+        expect(resolved.source).toContain(envVar);
+      });
+    },
+  );
 
   it("uses the config default agent dir when resolving provider profiles", async () => {
     await withOpenClawTestState(
@@ -680,6 +719,7 @@ describe("getApiKeyForModel", () => {
         prefix: "openclaw-auth-",
         agentEnv: "main",
         env: {
+          CODEX_API_KEY: undefined,
           OPENAI_API_KEY: undefined,
         },
       },
@@ -721,6 +761,7 @@ describe("getApiKeyForModel", () => {
         prefix: "openclaw-auth-scope-",
         agentEnv: "main",
         env: {
+          CODEX_API_KEY: undefined,
           OPENAI_API_KEY: undefined,
         },
       },
@@ -835,7 +876,7 @@ describe("getApiKeyForModel", () => {
   });
 
   it("keeps stored provider auth ahead of env by default", async () => {
-    await withEnvAsync({ OPENAI_API_KEY: "env-openai-key" }, async () => {
+    await withEnvAsync({ CODEX_API_KEY: undefined, OPENAI_API_KEY: "env-openai-key" }, async () => {
       const resolved = await resolveApiKeyForProvider({
         provider: "openai",
         store: {
@@ -856,7 +897,7 @@ describe("getApiKeyForModel", () => {
   });
 
   it("supports env-first precedence for live auth probes", async () => {
-    await withEnvAsync({ OPENAI_API_KEY: "env-openai-key" }, async () => {
+    await withEnvAsync({ CODEX_API_KEY: undefined, OPENAI_API_KEY: "env-openai-key" }, async () => {
       const resolved = await resolveApiKeyForProvider({
         provider: "openai",
         credentialPrecedence: "env-first",
@@ -1767,7 +1808,7 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
   });
 
   it("keeps env-first precedence ahead of per-entry profile references", async () => {
-    await withEnvAsync({ OPENAI_API_KEY: "sk-env-first" }, async () => {
+    await withEnvAsync({ CODEX_API_KEY: undefined, OPENAI_API_KEY: "sk-env-first" }, async () => {
       const resolved = await resolveApiKeyForProvider({
         provider: "openai",
         credentialPrecedence: "env-first",

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -595,7 +595,7 @@ describe("getApiKeyForModel", () => {
     ["OPENAI_API_KEY", { CODEX_API_KEY: undefined, OPENAI_API_KEY: "env-openai-key" }],
   ] as const)(
     "keeps %s ahead of default OpenAI OAuth profiles for audio transcriptions",
-    async (envVar, env) => {
+    async (sourceEnvVar, env) => {
       const store = {
         version: 1 as const,
         profiles: {
@@ -615,11 +615,11 @@ describe("getApiKeyForModel", () => {
         });
 
         expect(resolved).toMatchObject({
-          apiKey: envVar === "CODEX_API_KEY" ? "codex-env-openai-key" : "env-openai-key",
+          apiKey: sourceEnvVar === "CODEX_API_KEY" ? "codex-env-openai-key" : "env-openai-key",
           mode: "api-key",
         });
         expect(resolved.profileId).toBeUndefined();
-        expect(resolved.source).toContain(envVar);
+        expect(resolved.source).toContain(sourceEnvVar);
       });
     },
   );

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -537,6 +537,54 @@ describe("getApiKeyForModel", () => {
     ).rejects.toThrow(/requires a ChatGPT subscription \(OAuth or token\) profile/);
   });
 
+  it("accepts an explicit OpenAI OAuth profile for audio transcriptions", async () => {
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openai:chatgpt": {
+          type: "oauth" as const,
+          provider: "openai",
+          ...oauthFixture,
+        },
+      },
+    };
+
+    const resolved = await resolveApiKeyForProvider({
+      provider: "openai",
+      modelApi: "openai-audio-transcriptions",
+      profileId: "openai:chatgpt",
+      lockedProfile: true,
+      store,
+    });
+
+    expect(resolved).toMatchObject({
+      apiKey: oauthFixture.access,
+      mode: "oauth",
+      profileId: "openai:chatgpt",
+    });
+  });
+
+  it("treats OpenAI OAuth profiles as available for audio transcriptions", async () => {
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openai:chatgpt": {
+          type: "oauth" as const,
+          provider: "openai",
+          ...oauthFixture,
+        },
+      },
+    };
+
+    await expect(
+      hasAvailableAuthForProvider({
+        provider: "openai",
+        modelApi: "openai-audio-transcriptions",
+        store,
+      }),
+    ).resolves.toBe(true);
+  });
+
   it("uses the config default agent dir when resolving provider profiles", async () => {
     await withOpenClawTestState(
       {

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -10,8 +10,9 @@ import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
+  replaceRuntimeAuthProfileStoreSnapshots,
 } from "./auth-profiles/store.js";
-import type { OAuthCredential } from "./auth-profiles/types.js";
+import type { AuthProfileCredential, OAuthCredential } from "./auth-profiles/types.js";
 import type { ClaudeCliCredential } from "./cli-credentials.js";
 import {
   createRuntimeProviderAuthLookup,
@@ -629,6 +630,42 @@ describe("getApiKeyForModel", () => {
       });
     },
   );
+
+  it("keeps a configured OpenAI audio API key ahead of default OAuth profiles", async () => {
+    const configuredValue = ["configured", "openai", "credential"].join("-");
+    const resolved = await withEnvAsync(openAiEnv({}), () =>
+      resolveApiKeyForProvider({
+        provider: "openai",
+        modelApi: "openai-audio-transcriptions",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses" as const,
+                baseUrl: "https://api.openai.com/v1",
+                [["api", "Key"].join("")]: configuredValue,
+                models: [],
+              },
+            },
+          },
+        },
+        store: {
+          version: 1,
+          profiles: {
+            "openai:chatgpt": {
+              type: "oauth" as const,
+              provider: "openai",
+              ...oauthFixture,
+            },
+          },
+        },
+      }),
+    );
+
+    expect(resolved.apiKey).toBe(configuredValue);
+    expect(resolved).toMatchObject({ mode: "api-key", source: "models.json" });
+    expect(resolved.profileId).toBeUndefined();
+  });
 
   it("uses the config default agent dir when resolving provider profiles", async () => {
     await withOpenClawTestState(
@@ -1972,6 +2009,106 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
         },
       }),
     ).rejects.toThrow(/requires an OpenAI API key profile/);
+  });
+
+  it("does not advertise a token profile reference for a custom OpenAI audio endpoint", async () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-responses" as const,
+            baseUrl: "https://openai-compatible.example.test/v1",
+            [["api", "Key"].join("")]: "openai:token",
+            models: [],
+          },
+        },
+      },
+    };
+    const tokenProfile = {
+      type: "token" as const,
+      provider: "openai",
+      [["to", "ken"].join("")]: oauthFixture.access,
+    } as AuthProfileCredential;
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openai:token": tokenProfile,
+      },
+    };
+    const modelAuth = {
+      provider: "openai",
+      cfg,
+      store,
+      modelApi: "openai-audio-transcriptions",
+      openAIAudioEndpointTrust: "custom-openai-compatible" as const,
+    };
+    const runtimeAuth = {
+      provider: modelAuth.provider,
+      cfg: modelAuth.cfg,
+      env: openAiEnv({ openai: oauthFixture.refresh }),
+      modelApi: modelAuth.modelApi,
+      openAIAudioEndpointTrust: modelAuth.openAIAudioEndpointTrust,
+    };
+
+    expect(hasRuntimeAvailableProviderAuth(runtimeAuth)).toBe(false);
+    replaceRuntimeAuthProfileStoreSnapshots([{ store }]);
+    await withEnvAsync(openAiEnv({ openai: oauthFixture.refresh }), async () => {
+      await expect(hasAvailableAuthForProvider(modelAuth)).resolves.toBe(false);
+      expect(hasRuntimeAvailableProviderAuth(runtimeAuth)).toBe(false);
+      await expect(resolveApiKeyForProvider(modelAuth)).rejects.toThrow(
+        /requires an OpenAI API key profile/,
+      );
+    });
+  });
+
+  it("accepts an API-key profile reference for a custom OpenAI audio endpoint", async () => {
+    const profileValue = ["custom", "audio", "credential"].join("-");
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-responses" as const,
+            baseUrl: "https://openai-compatible.example.test/v1",
+            [["api", "Key"].join("")]: "openai:api-key",
+            models: [],
+          },
+        },
+      },
+    };
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openai:api-key": {
+          type: "api_key" as const,
+          provider: "openai",
+          key: profileValue,
+        },
+      },
+    };
+    const modelAuth = {
+      provider: "openai",
+      cfg,
+      store,
+      modelApi: "openai-audio-transcriptions",
+      openAIAudioEndpointTrust: "custom-openai-compatible" as const,
+    };
+    const runtimeAuth = {
+      provider: modelAuth.provider,
+      cfg: modelAuth.cfg,
+      env: openAiEnv({ openai: oauthFixture.refresh }),
+      modelApi: modelAuth.modelApi,
+      openAIAudioEndpointTrust: modelAuth.openAIAudioEndpointTrust,
+    };
+
+    expect(hasRuntimeAvailableProviderAuth(runtimeAuth)).toBe(false);
+    replaceRuntimeAuthProfileStoreSnapshots([{ store }]);
+    await withEnvAsync(openAiEnv({ openai: oauthFixture.refresh }), async () => {
+      await expect(hasAvailableAuthForProvider(modelAuth)).resolves.toBe(true);
+      expect(hasRuntimeAvailableProviderAuth(runtimeAuth)).toBe(true);
+      const resolved = await resolveApiKeyForProvider(modelAuth);
+      expect(resolved.apiKey).toBe(profileValue);
+      expect(resolved).toMatchObject({ mode: "api-key", profileId: "openai:api-key" });
+    });
   });
 
   it("throws when matched profile is an OAuth credential routed to an api-key provider (clawsweeper P1)", async () => {

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -257,6 +257,7 @@ vi.mock("./cli-credentials.js", () => cliCredentialMocks);
 
 beforeEach(() => {
   clearRuntimeAuthProfileStoreSnapshots();
+  vi.stubEnv(["CODEX", "API", "KEY"].join("_"), "");
   cliCredentialMocks.readClaudeCliCredentialsCached.mockReset().mockReturnValue(null);
   cliCredentialMocks.readCodexCliCredentialsCached.mockReset().mockReturnValue(null);
   cliCredentialMocks.readMiniMaxCliCredentialsCached.mockReset().mockReturnValue(null);
@@ -264,9 +265,17 @@ beforeEach(() => {
 
 afterEach(() => {
   clearRuntimeAuthProfileStoreSnapshots();
+  vi.unstubAllEnvs();
 });
 
 const envVar = (...parts: string[]) => parts.join("_");
+
+function openAiEnv(values: { codex?: string; openai?: string }): NodeJS.ProcessEnv {
+  return {
+    [envVar("CODEX", "API", "KEY")]: values.codex,
+    [envVar("OPENAI", "API", "KEY")]: values.openai,
+  };
+}
 
 function createUsableOAuthExpiry(): number {
   return Date.now() + 30 * 60 * 1000;
@@ -550,7 +559,7 @@ describe("getApiKeyForModel", () => {
     };
 
     await withEnvAsync(
-      { CODEX_API_KEY: "codex-env-openai-key", OPENAI_API_KEY: "env-openai-key" },
+      openAiEnv({ codex: oauthFixture.accountId, openai: oauthFixture.refresh }),
       async () => {
         const resolved = await resolveApiKeyForProvider({
           provider: "openai",
@@ -560,11 +569,8 @@ describe("getApiKeyForModel", () => {
           store,
         });
 
-        expect(resolved).toMatchObject({
-          apiKey: oauthFixture.access,
-          mode: "oauth",
-          profileId: "openai:chatgpt",
-        });
+        expect(resolved.apiKey).toBe(oauthFixture.access);
+        expect(resolved).toMatchObject({ mode: "oauth", profileId: "openai:chatgpt" });
       },
     );
   });
@@ -591,8 +597,8 @@ describe("getApiKeyForModel", () => {
   });
 
   it.each([
-    ["CODEX_API_KEY", { CODEX_API_KEY: "codex-env-openai-key", OPENAI_API_KEY: undefined }],
-    ["OPENAI_API_KEY", { CODEX_API_KEY: undefined, OPENAI_API_KEY: "env-openai-key" }],
+    ["CODEX_API_KEY", openAiEnv({ codex: oauthFixture.accountId })],
+    ["OPENAI_API_KEY", openAiEnv({ openai: oauthFixture.refresh })],
   ] as const)(
     "keeps %s ahead of default OpenAI OAuth profiles for audio transcriptions",
     async (sourceEnvVar, env) => {
@@ -614,10 +620,10 @@ describe("getApiKeyForModel", () => {
           store,
         });
 
-        expect(resolved).toMatchObject({
-          apiKey: sourceEnvVar === "CODEX_API_KEY" ? "codex-env-openai-key" : "env-openai-key",
-          mode: "api-key",
-        });
+        expect(resolved.apiKey).toBe(
+          sourceEnvVar === "CODEX_API_KEY" ? oauthFixture.accountId : oauthFixture.refresh,
+        );
+        expect(resolved.mode).toBe("api-key");
         expect(resolved.profileId).toBeUndefined();
         expect(resolved.source).toContain(sourceEnvVar);
       });
@@ -719,8 +725,8 @@ describe("getApiKeyForModel", () => {
         prefix: "openclaw-auth-",
         agentEnv: "main",
         env: {
-          CODEX_API_KEY: undefined,
-          OPENAI_API_KEY: undefined,
+          [envVar("CODEX", "API", "KEY")]: undefined,
+          [envVar("OPENAI", "API", "KEY")]: undefined,
         },
       },
       async (state) => {
@@ -761,8 +767,8 @@ describe("getApiKeyForModel", () => {
         prefix: "openclaw-auth-scope-",
         agentEnv: "main",
         env: {
-          CODEX_API_KEY: undefined,
-          OPENAI_API_KEY: undefined,
+          [envVar("CODEX", "API", "KEY")]: undefined,
+          [envVar("OPENAI", "API", "KEY")]: undefined,
         },
       },
       async () => {
@@ -876,7 +882,7 @@ describe("getApiKeyForModel", () => {
   });
 
   it("keeps stored provider auth ahead of env by default", async () => {
-    await withEnvAsync({ CODEX_API_KEY: undefined, OPENAI_API_KEY: "env-openai-key" }, async () => {
+    await withEnvAsync({ OPENAI_API_KEY: "env-openai-key" }, async () => {
       const resolved = await resolveApiKeyForProvider({
         provider: "openai",
         store: {
@@ -897,7 +903,7 @@ describe("getApiKeyForModel", () => {
   });
 
   it("supports env-first precedence for live auth probes", async () => {
-    await withEnvAsync({ CODEX_API_KEY: undefined, OPENAI_API_KEY: "env-openai-key" }, async () => {
+    await withEnvAsync({ OPENAI_API_KEY: "env-openai-key" }, async () => {
       const resolved = await resolveApiKeyForProvider({
         provider: "openai",
         credentialPrecedence: "env-first",
@@ -1808,7 +1814,7 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
   });
 
   it("keeps env-first precedence ahead of per-entry profile references", async () => {
-    await withEnvAsync({ CODEX_API_KEY: undefined, OPENAI_API_KEY: "sk-env-first" }, async () => {
+    await withEnvAsync({ OPENAI_API_KEY: "sk-env-first" }, async () => {
       const resolved = await resolveApiKeyForProvider({
         provider: "openai",
         credentialPrecedence: "env-first",

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -432,6 +432,52 @@ describe("resolveModelAuthMode", () => {
       readCodexCliCredentialsCached.mockRestore();
     }
   });
+
+  it("applies configured OAuth mode consistently to OpenAI env credentials", async () => {
+    const codexApiKeyEnv = ["CODEX", "API", "KEY"].join("_");
+    const openAiApiKeyEnv = ["OPENAI", "API", "KEY"].join("_");
+    const openAiOAuthTokenEnv = ["OPENAI", "OAUTH", "TOKEN"].join("_");
+    const snapshot = captureEnv([codexApiKeyEnv, openAiApiKeyEnv, openAiOAuthTokenEnv]);
+    deleteTestEnvValue(codexApiKeyEnv);
+    deleteTestEnvValue(openAiOAuthTokenEnv);
+    setTestEnvValue(openAiApiKeyEnv, "env-openai-credential");
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            auth: "oauth" as const,
+            baseUrl: "https://openai-compatible.example.test/v1",
+            models: [],
+          },
+        },
+      },
+    };
+
+    try {
+      expect(resolveModelAuthMode("openai", cfg, { version: 1, profiles: {} })).toBe("oauth");
+      await expect(
+        hasAvailableAuthForProvider({
+          provider: "openai",
+          cfg,
+          store: { version: 1, profiles: {} },
+          modelApi: "openai-audio-transcriptions",
+          openAIAudioEndpointTrust: "custom-openai-compatible",
+        }),
+      ).resolves.toBe(false);
+      expect(
+        hasRuntimeAvailableProviderAuth({
+          provider: "openai",
+          cfg,
+          env: { [openAiApiKeyEnv]: "env-openai-credential" },
+          allowPluginSyntheticAuth: false,
+          modelApi: "openai-audio-transcriptions",
+          openAIAudioEndpointTrust: "custom-openai-compatible",
+        }),
+      ).toBe(false);
+    } finally {
+      snapshot.restore();
+    }
+  });
 });
 
 describe("requireApiKey", () => {
@@ -1734,7 +1780,6 @@ describe("resolveApiKeyForProvider", () => {
       models: {
         providers: {
           openai: {
-            api: "openai-audio-transcriptions" as const,
             auth: "oauth" as const,
             apiKey: { source: "file", provider: "vault", id: "/openai/oauth" } as const,
             baseUrl: "https://openai-compatible.example.test/v1",

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1729,6 +1729,49 @@ describe("resolveApiKeyForProvider", () => {
     });
   });
 
+  it("rejects managed OpenAI OAuth SecretRefs for custom audio endpoints", async () => {
+    const sourceConfig = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-audio-transcriptions" as const,
+            auth: "oauth" as const,
+            apiKey: { source: "file", provider: "vault", id: "/openai/oauth" } as const,
+            baseUrl: "https://openai-compatible.example.test/v1",
+            models: [],
+          },
+        },
+      },
+    };
+    setRuntimeConfigSnapshot(
+      {
+        models: {
+          providers: {
+            openai: {
+              ...sourceConfig.models.providers.openai,
+              [["api", "Key"].join("")]: "resolved-oauth-credential",
+            },
+          },
+        },
+      },
+      sourceConfig,
+    );
+
+    await withoutEnv("CODEX_API_KEY", () =>
+      withoutEnv("OPENAI_API_KEY", async () => {
+        await expect(
+          resolveApiKeyForProvider({
+            provider: "openai",
+            cfg: sourceConfig,
+            modelApi: "openai-audio-transcriptions",
+            openAIAudioEndpointTrust: "custom-openai-compatible",
+            store: { version: 1, profiles: {} },
+          }),
+        ).rejects.toThrow(/No API key found for provider "openai"/);
+      }),
+    );
+  });
+
   it("prefers non-secret local env markers over ambient profiles", async () => {
     const resolved = await withEnv("OLLAMA_API_KEY", "ollama-local", () =>
       resolveApiKeyForProvider({

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -44,6 +44,7 @@ import {
   type AuthProfileStore,
   externalCliDiscoveryForProviderAuth,
   ensureAuthProfileStore,
+  getRuntimeAuthProfileStoreSnapshot,
   isConfiguredAwsSdkAuthProfileForProvider,
   isStoredCredentialCompatibleWithAuthProvider,
   listProfilesForProvider,
@@ -51,6 +52,7 @@ import {
   resolveAuthProfileOrder,
   resolveAuthStorePathForDisplay,
 } from "./auth-profiles.js";
+import { evaluateStoredCredentialEligibility } from "./auth-profiles/credential-state.js";
 import { OAuthRefreshFailureError } from "./auth-profiles/oauth-refresh-failure.js";
 import * as cliCredentials from "./cli-credentials.js";
 import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
@@ -1015,6 +1017,8 @@ function shouldResolvePluginSyntheticAuth(params: {
 export function hasRuntimeAvailableProviderAuth(params: {
   provider: string;
   cfg?: OpenClawConfig;
+  store?: AuthProfileStore;
+  agentDir?: string;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   allowPluginSyntheticAuth?: boolean;
@@ -1026,6 +1030,46 @@ export function hasRuntimeAvailableProviderAuth(params: {
   const authOverride = resolveProviderAuthOverride(params.cfg, provider);
   if (authOverride === "aws-sdk") {
     return true;
+  }
+  const runtimeStore = params.store ?? getRuntimeAuthProfileStoreSnapshot(params.agentDir);
+  if (runtimeStore) {
+    const providerEntryReference = resolveProviderEntryApiKeyProfileReference({
+      cfg: params.cfg,
+      provider,
+      store: runtimeStore,
+    });
+    if (providerEntryReference.kind === "profile") {
+      const { credential } = providerEntryReference;
+      return (
+        evaluateStoredCredentialEligibility({ credential }).eligible &&
+        isAuthModeAllowedForModel({
+          provider,
+          modelApi: params.modelApi,
+          mode: providerEntryReference.mode,
+          openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+        })
+      );
+    }
+    if (providerEntryReference.kind === "profile-incompatible") {
+      return false;
+    }
+  } else if (
+    directOpenAIPlatformModelRequiresApiKey({
+      provider,
+      modelApi: params.modelApi,
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+    })
+  ) {
+    const unresolvedReference = resolveProviderEntryApiKeyProfileReference({
+      cfg: params.cfg,
+      provider,
+      store: { version: 1, profiles: {} },
+    });
+    // A profile id is ambiguous without the process-local store. Fail closed
+    // in this fast path and let the canonical async resolver classify it.
+    if (unresolvedReference.kind === "literal" && unresolvedReference.apiKey.includes(":")) {
+      return false;
+    }
   }
   const envAuth = resolveEnvApiKey(provider, params.env, {
     config: params.cfg,
@@ -1040,7 +1084,11 @@ export function hasRuntimeAvailableProviderAuth(params: {
     isAuthModeAllowedForModel({
       provider,
       modelApi: params.modelApi,
-      mode: envAuth.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key",
+      mode: resolveDirectProviderCredentialMode({
+        cfg: params.cfg,
+        provider,
+        inferredMode: resolveEnvAuthModeFromSource(envAuth.source),
+      }),
       openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
     })
   ) {
@@ -1499,6 +1547,23 @@ export async function resolveApiKeyForProvider(params: {
     );
   }
 
+  // The media runner historically treated a configured OpenAI audio key as
+  // the selected credential. Preserve that billing/account choice while the
+  // canonical resolver adds OAuth fallback for otherwise unconfigured audio.
+  const shouldPreserveOpenAIAudioConfiguredApiKeyPrecedence =
+    providerEntryBinding.kind === "literal" &&
+    normalizeProviderId(provider) === OPENAI_PROVIDER_ID &&
+    normalizeLowercaseStringOrEmpty(params.modelApi) === OPENAI_AUDIO_TRANSCRIPTIONS_API &&
+    resolveDirectProviderCredentialMode({ cfg, provider, inferredMode: "api-key" }) === "api-key";
+  if (shouldPreserveOpenAIAudioConfiguredApiKeyPrecedence) {
+    const { apiKey, source } = providerEntryBinding;
+    return {
+      apiKey,
+      source,
+      mode: "api-key",
+    };
+  }
+
   if (shouldPreferExplicitConfigApiKeyAuth(cfg, provider)) {
     const runtimeCustomKey = resolveManagedSecretRefRuntimeProviderAuth({
       cfg,
@@ -1868,7 +1933,11 @@ export function resolveModelAuthMode(
 
   const envKey = resolveConfigAwareEnvApiKey(cfg, resolved, options?.workspaceDir);
   if (envKey?.apiKey) {
-    return envKey.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key";
+    return resolveDirectProviderCredentialMode({
+      cfg,
+      provider: resolved,
+      inferredMode: resolveEnvAuthModeFromSource(envKey.source),
+    });
   }
 
   if (
@@ -1898,10 +1967,50 @@ export async function hasAvailableAuthForProvider(params: {
   openAIAudioEndpointTrust?: OpenAIAudioEndpointTrust;
 }): Promise<boolean> {
   const { provider, cfg, preferredProfile } = params;
+  const store =
+    params.store ??
+    resolveScopedAuthProfileStore({
+      agentDir: params.agentDir,
+      cfg,
+      provider,
+      preferredProfile,
+    });
 
   const authOverride = resolveProviderAuthOverride(cfg, provider);
   if (authOverride === "aws-sdk") {
     return true;
+  }
+
+  // Match execution-time classification before treating provider apiKey text
+  // as a literal. Stored profile ids are terminal bindings, including when
+  // their auth class is not allowed for the selected model endpoint.
+  const providerEntryBinding = await resolveProviderEntryApiKeyBinding({
+    cfg,
+    provider,
+    store,
+    agentDir: params.agentDir,
+  });
+  if (providerEntryBinding.kind === "profile-resolved") {
+    return isAuthModeAllowedForModel({
+      provider,
+      modelApi: params.modelApi,
+      mode: providerEntryBinding.auth.mode,
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+    });
+  }
+  if (
+    providerEntryBinding.kind === "profile-incompatible" ||
+    providerEntryBinding.kind === "profile-unresolved"
+  ) {
+    return false;
+  }
+  if (providerEntryBinding.kind === "literal") {
+    return isAuthModeAllowedForModel({
+      provider,
+      modelApi: params.modelApi,
+      mode: resolveDirectProviderCredentialMode({ cfg, provider, inferredMode: "api-key" }),
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+    });
   }
   const envAuth = resolveConfigAwareEnvApiKey(cfg, provider, params.workspaceDir);
   if (
@@ -1909,7 +2018,11 @@ export async function hasAvailableAuthForProvider(params: {
     isAuthModeAllowedForModel({
       provider,
       modelApi: params.modelApi,
-      mode: envAuth.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key",
+      mode: resolveDirectProviderCredentialMode({
+        cfg,
+        provider,
+        inferredMode: resolveEnvAuthModeFromSource(envAuth.source),
+      }),
       openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
     })
   ) {
@@ -1941,14 +2054,6 @@ export async function hasAvailableAuthForProvider(params: {
   ) {
     return true;
   }
-  const store =
-    params.store ??
-    resolveScopedAuthProfileStore({
-      agentDir: params.agentDir,
-      cfg,
-      provider,
-      preferredProfile,
-    });
   const order = resolveAuthProfileOrder({
     cfg,
     store,

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -124,7 +124,12 @@ export type RuntimeProviderAuthLookup = {
 
 const log = createSubsystemLogger("model-auth");
 const OPENAI_PROVIDER_ID = "openai";
+const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";
 const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";
+
+function openAIModelApiAllowsBearerAuth(modelApi: string): boolean {
+  return modelApi === OPENAI_CODEX_RESPONSES_API || modelApi === OPENAI_AUDIO_TRANSCRIPTIONS_API;
+}
 
 function directOpenAIPlatformModelRequiresApiKey(params: {
   provider: string;
@@ -133,7 +138,7 @@ function directOpenAIPlatformModelRequiresApiKey(params: {
   return (
     normalizeProviderId(params.provider) === OPENAI_PROVIDER_ID &&
     params.modelApi !== undefined &&
-    normalizeLowercaseStringOrEmpty(params.modelApi) !== OPENAI_CODEX_RESPONSES_API
+    !openAIModelApiAllowsBearerAuth(normalizeLowercaseStringOrEmpty(params.modelApi))
   );
 }
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -127,8 +127,19 @@ const OPENAI_PROVIDER_ID = "openai";
 const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";
 const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";
 
-function openAIModelApiAllowsBearerAuth(modelApi: string): boolean {
-  return modelApi === OPENAI_CODEX_RESPONSES_API || modelApi === OPENAI_AUDIO_TRANSCRIPTIONS_API;
+export type OpenAIAudioEndpointTrust = "native-openai" | "custom-openai-compatible";
+
+function openAIModelApiAllowsBearerAuth(params: {
+  modelApi: string;
+  openAIAudioEndpointTrust?: OpenAIAudioEndpointTrust;
+}): boolean {
+  if (params.modelApi === OPENAI_CODEX_RESPONSES_API) {
+    return true;
+  }
+  if (params.modelApi !== OPENAI_AUDIO_TRANSCRIPTIONS_API) {
+    return false;
+  }
+  return params.openAIAudioEndpointTrust !== "custom-openai-compatible";
 }
 
 function resolveEnvAuthModeFromSource(source: string): ResolvedProviderAuth["mode"] {
@@ -138,11 +149,15 @@ function resolveEnvAuthModeFromSource(source: string): ResolvedProviderAuth["mod
 function directOpenAIPlatformModelRequiresApiKey(params: {
   provider: string;
   modelApi?: string;
+  openAIAudioEndpointTrust?: OpenAIAudioEndpointTrust;
 }): boolean {
   return (
     normalizeProviderId(params.provider) === OPENAI_PROVIDER_ID &&
     params.modelApi !== undefined &&
-    !openAIModelApiAllowsBearerAuth(normalizeLowercaseStringOrEmpty(params.modelApi))
+    !openAIModelApiAllowsBearerAuth({
+      modelApi: normalizeLowercaseStringOrEmpty(params.modelApi),
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+    })
   );
 }
 
@@ -160,6 +175,7 @@ function isAuthModeAllowedForModel(params: {
   provider: string;
   modelApi?: string;
   mode: ResolvedProviderAuth["mode"];
+  openAIAudioEndpointTrust?: OpenAIAudioEndpointTrust;
 }): boolean {
   if (openAICodexTransportRequiresOAuth(params)) {
     // Subscription-class credentials are oauth profiles and ChatGPT tokens;
@@ -174,6 +190,7 @@ function assertAuthModeAllowedForModel(params: {
   modelApi?: string;
   profileId: string;
   mode: ResolvedProviderAuth["mode"];
+  openAIAudioEndpointTrust?: OpenAIAudioEndpointTrust;
 }): void {
   if (isAuthModeAllowedForModel(params)) {
     return;
@@ -466,6 +483,14 @@ function shouldUseImplicitAwsSdkAuth(params: {
 
 function profileTypeToAuthMode(type: AuthProfileCredential["type"]): ResolvedProviderAuth["mode"] {
   return type === "oauth" ? "oauth" : type === "token" ? "token" : "api-key";
+}
+
+function resolveStoredProfileAuthMode(
+  store: AuthProfileStore,
+  profileId: string,
+): ResolvedProviderAuth["mode"] | undefined {
+  const type = store.profiles[profileId]?.type;
+  return type ? profileTypeToAuthMode(type) : undefined;
 }
 
 type ProviderEntryApiKeyProfileReference =
@@ -970,6 +995,7 @@ export function hasRuntimeAvailableProviderAuth(params: {
   allowPluginSyntheticAuth?: boolean;
   runtimeLookup?: RuntimeProviderAuthLookup;
   modelApi?: string;
+  openAIAudioEndpointTrust?: OpenAIAudioEndpointTrust;
 }): boolean {
   const provider = normalizeProviderId(params.provider);
   const authOverride = resolveProviderAuthOverride(params.cfg, provider);
@@ -990,6 +1016,7 @@ export function hasRuntimeAvailableProviderAuth(params: {
       provider,
       modelApi: params.modelApi,
       mode: envAuth.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key",
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
     })
   ) {
     return true;
@@ -1222,6 +1249,7 @@ export async function resolveApiKeyForProvider(params: {
   modelApi?: string;
   /** Keep SecretRef-backed model credentials opaque until a sentinel-aware transport boundary. */
   secretSentinels?: boolean;
+  openAIAudioEndpointTrust?: OpenAIAudioEndpointTrust;
 }): Promise<ResolvedProviderAuth> {
   const { provider, cfg, profileId, preferredProfile } = params;
   // A failed explicit ref owns the provider. Stop before profile/env discovery so requests cannot
@@ -1244,13 +1272,14 @@ export async function resolveApiKeyForProvider(params: {
         profileId,
         preferredProfile,
       });
-    const configuredProfileType = store.profiles[profileId]?.type;
-    if (configuredProfileType) {
+    const storedMode = resolveStoredProfileAuthMode(store, profileId);
+    if (storedMode) {
       assertAuthModeAllowedForModel({
         provider,
         modelApi: params.modelApi,
         profileId,
-        mode: profileTypeToAuthMode(configuredProfileType),
+        mode: storedMode,
+        openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
       });
     }
     const resolved = await resolveApiKeyForProfile({
@@ -1282,6 +1311,7 @@ export async function resolveApiKeyForProvider(params: {
       modelApi: params.modelApi,
       profileId: resolvedProfileId,
       mode: result.mode,
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
     });
     // When the resolved key is a provider-owned synthetic profile marker and
     // the caller has not locked this profile, fall through to env/config
@@ -1360,6 +1390,7 @@ export async function resolveApiKeyForProvider(params: {
           provider,
           modelApi: params.modelApi,
           mode: resolvedMode,
+          openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
         })
       ) {
         return resolveApiKeyForProvider({ ...params, credentialPrecedence: "profile-first" });
@@ -1400,6 +1431,7 @@ export async function resolveApiKeyForProvider(params: {
       modelApi: params.modelApi,
       profileId: providerEntryBinding.auth.profileId ?? provider,
       mode: providerEntryBinding.auth.mode,
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
     });
     return providerEntryBinding.auth;
   }
@@ -1514,14 +1546,14 @@ export async function resolveApiKeyForProvider(params: {
       if (awsSdkProfileAuth) {
         return awsSdkProfileAuth;
       }
-      const candidateType = store.profiles[candidate]?.type;
-      candidateMode = candidateType ? profileTypeToAuthMode(candidateType) : undefined;
+      candidateMode = resolveStoredProfileAuthMode(store, candidate);
       if (
         candidateMode &&
         !isAuthModeAllowedForModel({
           provider,
           modelApi: params.modelApi,
           mode: candidateMode,
+          openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
         })
       ) {
         continue;
@@ -1556,6 +1588,7 @@ export async function resolveApiKeyForProvider(params: {
             provider,
             modelApi: params.modelApi,
             mode: result.mode,
+            openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
           })
         ) {
           continue;
@@ -1611,6 +1644,7 @@ export async function resolveApiKeyForProvider(params: {
         provider,
         modelApi: params.modelApi,
         mode: resolvedMode,
+        openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
       })
     ) {
       const result: ResolvedProviderAuth = {
@@ -1799,6 +1833,7 @@ export async function hasAvailableAuthForProvider(params: {
   workspaceDir?: string;
   modelId?: string;
   modelApi?: string;
+  openAIAudioEndpointTrust?: OpenAIAudioEndpointTrust;
 }): Promise<boolean> {
   const { provider, cfg, preferredProfile } = params;
 
@@ -1813,6 +1848,7 @@ export async function hasAvailableAuthForProvider(params: {
       provider,
       modelApi: params.modelApi,
       mode: envAuth.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key",
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
     })
   ) {
     return true;
@@ -1843,13 +1879,14 @@ export async function hasAvailableAuthForProvider(params: {
       if (resolveConfiguredAwsSdkProfileAuth({ cfg, provider, profileId: candidate })) {
         return true;
       }
-      const candidateType = store.profiles[candidate]?.type;
+      const storedMode = resolveStoredProfileAuthMode(store, candidate);
       if (
-        candidateType &&
+        storedMode &&
         !isAuthModeAllowedForModel({
           provider,
           modelApi: params.modelApi,
-          mode: profileTypeToAuthMode(candidateType),
+          mode: storedMode,
+          openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
         })
       ) {
         continue;
@@ -1867,6 +1904,7 @@ export async function hasAvailableAuthForProvider(params: {
           provider,
           modelApi: params.modelApi,
           mode: mode ? profileTypeToAuthMode(mode) : "api-key",
+          openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
         })
       ) {
         return true;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -131,6 +131,10 @@ function openAIModelApiAllowsBearerAuth(modelApi: string): boolean {
   return modelApi === OPENAI_CODEX_RESPONSES_API || modelApi === OPENAI_AUDIO_TRANSCRIPTIONS_API;
 }
 
+function resolveEnvAuthModeFromSource(source: string): ResolvedProviderAuth["mode"] {
+  return source.includes("OAUTH_TOKEN") ? "oauth" : "api-key";
+}
+
 function directOpenAIPlatformModelRequiresApiKey(params: {
   provider: string;
   modelApi?: string;
@@ -1456,16 +1460,26 @@ export async function resolveApiKeyForProvider(params: {
       mode: "api-key",
     };
   }
-  const localMarkerEnv = resolveConfigAwareEnvApiKey(
+  const envAuthBeforeDefaultProfiles = resolveConfigAwareEnvApiKey(
     cfg,
     provider,
     params.workspaceDir,
     params.skipSetupProviderFallback,
   );
-  if (localMarkerEnv && isNonSecretApiKeyMarker(localMarkerEnv.apiKey)) {
+  const envAuthModeBeforeDefaultProfiles = envAuthBeforeDefaultProfiles
+    ? resolveDirectProviderCredentialMode({
+        cfg,
+        provider,
+        inferredMode: resolveEnvAuthModeFromSource(envAuthBeforeDefaultProfiles.source),
+      })
+    : undefined;
+  if (
+    envAuthBeforeDefaultProfiles &&
+    isNonSecretApiKeyMarker(envAuthBeforeDefaultProfiles.apiKey)
+  ) {
     return {
-      apiKey: localMarkerEnv.apiKey,
-      source: localMarkerEnv.source,
+      apiKey: envAuthBeforeDefaultProfiles.apiKey,
+      source: envAuthBeforeDefaultProfiles.source,
       mode: "api-key",
     };
   }
@@ -1546,6 +1560,16 @@ export async function resolveApiKeyForProvider(params: {
         ) {
           continue;
         }
+        // OpenAI audio can use OAuth, but shipped mixed setups use env API keys
+        // unless the request explicitly locked a profile before this fallback order.
+        const shouldPreserveOpenAIAudioEnvApiKeyPrecedence =
+          normalizeProviderId(provider) === OPENAI_PROVIDER_ID &&
+          normalizeLowercaseStringOrEmpty(params.modelApi) === OPENAI_AUDIO_TRANSCRIPTIONS_API &&
+          result.mode !== "api-key" &&
+          envAuthModeBeforeDefaultProfiles === "api-key";
+        if (shouldPreserveOpenAIAudioEnvApiKeyPrecedence) {
+          continue;
+        }
         if (
           shouldDeferSyntheticProfileAuth({
             cfg,
@@ -1579,18 +1603,9 @@ export async function resolveApiKeyForProvider(params: {
     }
   }
 
-  const envResolved = resolveConfigAwareEnvApiKey(
-    cfg,
-    provider,
-    params.workspaceDir,
-    params.skipSetupProviderFallback,
-  );
+  const envResolved = envAuthBeforeDefaultProfiles;
   if (envResolved) {
-    const resolvedMode = resolveDirectProviderCredentialMode({
-      cfg,
-      provider,
-      inferredMode: envResolved.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key",
-    });
+    const resolvedMode = envAuthModeBeforeDefaultProfiles ?? "api-key";
     if (
       isAuthModeAllowedForModel({
         provider,

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -127,7 +127,7 @@ const OPENAI_PROVIDER_ID = "openai";
 const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";
 const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";
 
-export type OpenAIAudioEndpointTrust = "native-openai" | "custom-openai-compatible";
+type OpenAIAudioEndpointTrust = "native-openai" | "custom-openai-compatible";
 
 function openAIModelApiAllowsBearerAuth(params: {
   modelApi: string;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -463,6 +463,31 @@ function resolveDirectProviderCredentialMode(params: {
     : params.inferredMode;
 }
 
+function resolveUsableCustomProviderApiKeyForModel(
+  params: Parameters<typeof resolveUsableCustomProviderApiKey>[0] & {
+    modelApi?: string;
+    openAIAudioEndpointTrust?: OpenAIAudioEndpointTrust;
+  },
+): ResolvedCustomProviderApiKey | null {
+  const customAuth = resolveUsableCustomProviderApiKey(params);
+  if (!customAuth) {
+    return null;
+  }
+  const mode = resolveDirectProviderCredentialMode({
+    cfg: params.cfg,
+    provider: params.provider,
+    inferredMode: "api-key",
+  });
+  return isAuthModeAllowedForModel({
+    provider: params.provider,
+    modelApi: params.modelApi,
+    mode,
+    openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+  })
+    ? customAuth
+    : null;
+}
+
 function shouldUseImplicitAwsSdkAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
@@ -1021,10 +1046,27 @@ export function hasRuntimeAvailableProviderAuth(params: {
   ) {
     return true;
   }
-  if (resolveUsableCustomProviderApiKey({ cfg: params.cfg, provider, env: params.env })) {
+  if (
+    resolveUsableCustomProviderApiKeyForModel({
+      cfg: params.cfg,
+      provider,
+      env: params.env,
+      modelApi: params.modelApi,
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+    })
+  ) {
     return true;
   }
-  if (resolveManagedSecretRefRuntimeProviderAuth({ cfg: params.cfg, provider })) {
+  const managedAuth = resolveManagedSecretRefRuntimeProviderAuth({ cfg: params.cfg, provider });
+  if (
+    managedAuth &&
+    isAuthModeAllowedForModel({
+      provider,
+      modelApi: params.modelApi,
+      mode: managedAuth.mode,
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+    })
+  ) {
     return true;
   }
   if (hasSyntheticLocalProviderAuthConfig({ cfg: params.cfg, provider })) {
@@ -1492,12 +1534,20 @@ export async function resolveApiKeyForProvider(params: {
       mode: "api-key",
     };
   }
-  const envAuthBeforeDefaultProfiles = resolveConfigAwareEnvApiKey(
+  const localMarkerEnv = resolveConfigAwareEnvApiKey(
     cfg,
     provider,
     params.workspaceDir,
     params.skipSetupProviderFallback,
   );
+  if (localMarkerEnv && isNonSecretApiKeyMarker(localMarkerEnv.apiKey)) {
+    return {
+      apiKey: localMarkerEnv.apiKey,
+      source: localMarkerEnv.source,
+      mode: "api-key",
+    };
+  }
+  const envAuthBeforeDefaultProfiles = localMarkerEnv;
   const envAuthModeBeforeDefaultProfiles = envAuthBeforeDefaultProfiles
     ? resolveDirectProviderCredentialMode({
         cfg,
@@ -1505,16 +1555,6 @@ export async function resolveApiKeyForProvider(params: {
         inferredMode: resolveEnvAuthModeFromSource(envAuthBeforeDefaultProfiles.source),
       })
     : undefined;
-  if (
-    envAuthBeforeDefaultProfiles &&
-    isNonSecretApiKeyMarker(envAuthBeforeDefaultProfiles.apiKey)
-  ) {
-    return {
-      apiKey: envAuthBeforeDefaultProfiles.apiKey,
-      source: envAuthBeforeDefaultProfiles.source,
-      mode: "api-key",
-    };
-  }
   const store =
     scopedStore ??
     resolveScopedAuthProfileStore({
@@ -1628,6 +1668,7 @@ export async function resolveApiKeyForProvider(params: {
             provider,
             modelApi: params.modelApi,
             mode: candidateMode,
+            openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
           }))
       ) {
         refreshFailure = err;
@@ -1673,13 +1714,26 @@ export async function resolveApiKeyForProvider(params: {
       provider,
       modelApi: params.modelApi,
       mode: managedRuntimeAuth.mode,
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
     })
   ) {
     return managedRuntimeAuth;
   }
 
+  const customKeyConfig = isAuthModeAllowedForModel({
+    provider,
+    modelApi: params.modelApi,
+    mode: resolveDirectProviderCredentialMode({
+      cfg,
+      provider,
+      inferredMode: "api-key",
+    }),
+    openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+  })
+    ? cfg
+    : undefined;
   const customKey = resolveUsableCustomProviderApiKey({
-    cfg,
+    cfg: customKeyConfig,
     provider,
     secretSentinels: params.secretSentinels,
   });
@@ -1705,7 +1759,15 @@ export async function resolveApiKeyForProvider(params: {
     secretSentinels: params.secretSentinels,
     allowPluginSyntheticAuth: params.allowAuthProfileFallback !== false,
   });
-  if (syntheticLocalAuth) {
+  if (
+    syntheticLocalAuth &&
+    isAuthModeAllowedForModel({
+      provider,
+      modelApi: params.modelApi,
+      mode: syntheticLocalAuth.mode,
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+    })
+  ) {
     return syntheticLocalAuth;
   }
 
@@ -1853,10 +1915,30 @@ export async function hasAvailableAuthForProvider(params: {
   ) {
     return true;
   }
-  if (resolveUsableCustomProviderApiKey({ cfg, provider })) {
+  if (
+    resolveUsableCustomProviderApiKeyForModel({
+      cfg,
+      provider,
+      modelApi: params.modelApi,
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+    })
+  ) {
     return true;
   }
-  if (resolveSyntheticLocalProviderAuth({ cfg, provider })) {
+  const syntheticAuth = resolveSyntheticLocalProviderAuth({
+    cfg,
+    provider,
+    modelApi: params.modelApi,
+  });
+  if (
+    syntheticAuth &&
+    isAuthModeAllowedForModel({
+      provider,
+      modelApi: params.modelApi,
+      mode: syntheticAuth.mode,
+      openAIAudioEndpointTrust: params.openAIAudioEndpointTrust,
+    })
+  ) {
     return true;
   }
   const store =

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -33,6 +33,8 @@ const modelAuthMocks = vi.hoisted(() => ({
       (params: {
         provider: string;
         cfg?: OpenClawConfig;
+        store?: AuthProfileStore;
+        agentDir?: string;
         workspaceDir?: string;
         runtimeLookup?: unknown;
       }) => boolean
@@ -464,6 +466,37 @@ describe("prepared provider auth state", () => {
       expect.anything(),
       "nvidia",
     );
+  });
+
+  it("scopes fast provider auth checks to the explicit agent store", async () => {
+    const cfg = {} as OpenClawConfig;
+    const agentDir = "/state/agents/worker/agent";
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:worker": {
+          provider: "openai",
+          type: "api_key",
+          key: "worker-key",
+        },
+      },
+    };
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockImplementation(
+      (params) => params.agentDir === agentDir && params.store === store,
+    );
+
+    await expect(
+      hasAuthForModelProvider({
+        provider: "openai",
+        cfg,
+        agentDir,
+        store,
+      }),
+    ).resolves.toBe(true);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "openai", cfg, agentDir, store }),
+    );
+    expect(authProfilesMocks.ensureAuthProfileStore).not.toHaveBeenCalled();
   });
 
   it("hasAuthForModelProvider uses the prepared answer for equivalent runtime config clones", async () => {

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -179,6 +179,11 @@ export async function hasAuthForModelProvider(params: {
       return preparedAnswer;
     }
   }
+  const scopedAgentDir =
+    params.agentDir ??
+    (params.agentId && params.cfg
+      ? resolveAgentDir(params.cfg, params.agentId, params.env)
+      : undefined);
   await new Promise<void>((resolve) => {
     setImmediate(resolve);
   });
@@ -186,6 +191,8 @@ export async function hasAuthForModelProvider(params: {
     hasRuntimeAvailableProviderAuth({
       provider,
       cfg: params.cfg,
+      store: params.store,
+      agentDir: scopedAgentDir,
       workspaceDir: params.workspaceDir,
       env: params.env,
       allowPluginSyntheticAuth: params.allowPluginSyntheticAuth,
@@ -195,18 +202,13 @@ export async function hasAuthForModelProvider(params: {
   ) {
     return true;
   }
-  const slowPathAgentDir =
-    params.agentDir ??
-    (params.agentId && params.cfg
-      ? resolveAgentDir(params.cfg, params.agentId, params.env)
-      : undefined);
   const store =
     params.store ??
     (params.discoverExternalCliAuth === false
-      ? ensureAuthProfileStoreWithoutExternalProfiles(slowPathAgentDir, {
+      ? ensureAuthProfileStoreWithoutExternalProfiles(scopedAgentDir, {
           allowKeychainPrompt: false,
         })
-      : ensureAuthProfileStore(slowPathAgentDir, {
+      : ensureAuthProfileStore(scopedAgentDir, {
           externalCli: externalCliDiscoveryForProviderAuth({ cfg: params.cfg, provider }),
         }));
   if (listProfilesForProvider(store, provider).length > 0) {
@@ -217,7 +219,7 @@ export async function hasAuthForModelProvider(params: {
           modelApi: params.modelApi,
           cfg: params.cfg,
           workspaceDir: params.workspaceDir,
-          agentDir: slowPathAgentDir,
+          agentDir: scopedAgentDir,
           store,
         });
   }

--- a/src/agents/tools/model-config.helpers.test.ts
+++ b/src/agents/tools/model-config.helpers.test.ts
@@ -17,11 +17,38 @@ vi.mock("../auth-profiles/external-cli-sync.js", () => ({
 // snapshot keyed by config/workspace. Stub the env resolver so a provider is
 // only "env-authed" when config/workspaceDir actually reach it, mirroring a
 // config-scoped (non-bundled) provider plugin without loading plugin runtime.
-const authMocks = vi.hoisted(() => ({ resolveEnvApiKey: vi.fn() }));
+const authMocks = vi.hoisted(() => ({
+  resolveEnvApiKey: vi.fn(),
+  hasRuntimeAvailableProviderAuth:
+    vi.fn<
+      (params: {
+        provider: string;
+        cfg?: OpenClawConfig;
+        store?: AuthProfileStore;
+        agentDir?: string;
+        workspaceDir?: string;
+        modelApi?: string;
+      }) => boolean
+    >(),
+}));
 
 vi.mock("../model-auth.js", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, resolveEnvApiKey: authMocks.resolveEnvApiKey };
+  authMocks.hasRuntimeAvailableProviderAuth.mockImplementation(
+    actual.hasRuntimeAvailableProviderAuth as (params: {
+      provider: string;
+      cfg?: OpenClawConfig;
+      store?: AuthProfileStore;
+      agentDir?: string;
+      workspaceDir?: string;
+      modelApi?: string;
+    }) => boolean,
+  );
+  return {
+    ...actual,
+    resolveEnvApiKey: authMocks.resolveEnvApiKey,
+    hasRuntimeAvailableProviderAuth: authMocks.hasRuntimeAvailableProviderAuth,
+  };
 });
 
 const AGENT_DIR = "/tmp/openclaw-model-config-helper";
@@ -96,6 +123,7 @@ const hasDirectOpenAiKey = (
 
 beforeEach(() => {
   authMocks.resolveEnvApiKey.mockReset();
+  authMocks.hasRuntimeAvailableProviderAuth.mockClear();
   authMocks.resolveEnvApiKey.mockImplementation(
     (provider: string, _env?: unknown, options?: { config?: unknown }) =>
       provider === "acme" && options?.config
@@ -176,6 +204,31 @@ describe("hasProviderAuthForTool", () => {
     expect(hasProviderAuthForTool({ provider: "hatchery", authStore })).toBe(true);
   });
 
+  it("scopes fast provider auth checks to the tool auth store", () => {
+    const authStore = store({
+      "hatchery:default": {
+        provider: "hatchery",
+        type: "api_key",
+        key: "sk-profile", // pragma: allowlist secret
+      },
+    });
+
+    expect(
+      hasProviderAuthForTool({
+        provider: "hatchery",
+        agentDir: AGENT_DIR,
+        authStore,
+      }),
+    ).toBe(true);
+    expect(authMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "hatchery",
+        agentDir: AGENT_DIR,
+        store: authStore,
+      }),
+    );
+  });
+
   it("rejects providers without config, env, or profile auth", () => {
     expect(hasProviderAuthForTool({ provider: "unconfigured-provider" })).toBe(false);
   });
@@ -215,6 +268,20 @@ describe("resolveOpenAiImageMediaCandidate", () => {
 
     expect(hasDirectOpenAiKey({ authStore })).toBe(true);
     expect(resolveMedia({ authStore })).toEqual(openAiKeep);
+  });
+
+  it("scopes direct provider fast auth checks to the tool auth store", () => {
+    const authStore = store({ "openai:api-key": apiKey("openai") });
+
+    expect(hasDirectOpenAiKey({ authStore })).toBe(true);
+    expect(authMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        agentDir: AGENT_DIR,
+        store: authStore,
+        modelApi: "openai-responses",
+      }),
+    );
   });
 
   it("uses Codex when an ineligible direct API key profile is stale", () => {

--- a/src/agents/tools/model-config.helpers.ts
+++ b/src/agents/tools/model-config.helpers.ts
@@ -136,6 +136,8 @@ export function hasProviderAuthForTool(params: {
     hasRuntimeAvailableProviderAuth({
       provider: params.provider,
       cfg: params.cfg,
+      store: params.authStore,
+      agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
       allowPluginSyntheticAuth: false,
     })
@@ -256,6 +258,8 @@ function hasDirectProviderApiKeyAuthForTool(params: {
     hasRuntimeAvailableProviderAuth({
       provider: params.provider,
       cfg: params.cfg,
+      store: params.authStore,
+      agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
       modelApi: params.modelApi,
       allowPluginSyntheticAuth: false,

--- a/src/media-understanding/openai-audio-api.test.ts
+++ b/src/media-understanding/openai-audio-api.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveOpenAiAudioAuthEndpointTrust } from "./openai-audio-api.js";
+
+describe("resolveOpenAiAudioAuthEndpointTrust", () => {
+  it.each([
+    undefined,
+    "https://api.openai.com",
+    "https://api.openai.com/v1",
+    "https://api.openai.com/v1/",
+    "https://us.api.openai.com/v1",
+    "https://eu.api.openai.com/v1/",
+  ])("trusts native OpenAI audio endpoint %s", (baseUrl) => {
+    expect(
+      resolveOpenAiAudioAuthEndpointTrust({
+        capability: "audio",
+        providerId: "openai",
+        baseUrl,
+      }),
+    ).toBe("native-openai");
+  });
+
+  it.each([
+    "https://openai-compatible.example.test/v1",
+    "https://api.openai.com.attacker.example/v1",
+    "https://attackerapi.openai.com/v1",
+    "http://api.openai.com/v1",
+    "https://api.openai.com/proxy/v1",
+  ])("treats custom audio endpoint %s as OpenAI-compatible", (baseUrl) => {
+    expect(
+      resolveOpenAiAudioAuthEndpointTrust({
+        capability: "audio",
+        providerId: "openai",
+        baseUrl,
+      }),
+    ).toBe("custom-openai-compatible");
+  });
+
+  it("leaves non-OpenAI audio providers outside the OpenAI audio auth contract", () => {
+    expect(
+      resolveOpenAiAudioAuthEndpointTrust({
+        capability: "audio",
+        providerId: "mistral",
+        baseUrl: "https://api.openai.com/v1",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/media-understanding/openai-audio-api.ts
+++ b/src/media-understanding/openai-audio-api.ts
@@ -1,3 +1,4 @@
+import type { OpenAIAudioEndpointTrust } from "../agents/model-auth.js";
 import type { MediaUnderstandingCapability } from "./types.js";
 
 // Shared API contract id for OpenAI-compatible /audio/transcriptions requests.
@@ -11,4 +12,37 @@ export function resolveOpenAiAudioAuthModelApi(params: {
     return OPENAI_AUDIO_TRANSCRIPTIONS_API;
   }
   return undefined;
+}
+
+function isTrustedOpenAIPublicAudioBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl?.trim()) {
+    return true;
+  }
+  try {
+    const url = new URL(baseUrl.trim());
+    if (url.protocol !== "https:") {
+      return false;
+    }
+    const hostname = url.hostname.toLowerCase().replace(/\.+$/u, "");
+    if (hostname !== "api.openai.com" && !hostname.endsWith(".api.openai.com")) {
+      return false;
+    }
+    const pathname = url.pathname.replace(/\/+$/u, "");
+    return pathname === "" || pathname === "/v1";
+  } catch {
+    return false;
+  }
+}
+
+export function resolveOpenAiAudioAuthEndpointTrust(params: {
+  capability: MediaUnderstandingCapability;
+  providerId: string;
+  baseUrl?: string;
+}): OpenAIAudioEndpointTrust | undefined {
+  if (resolveOpenAiAudioAuthModelApi(params) !== OPENAI_AUDIO_TRANSCRIPTIONS_API) {
+    return undefined;
+  }
+  return isTrustedOpenAIPublicAudioBaseUrl(params.baseUrl)
+    ? "native-openai"
+    : "custom-openai-compatible";
 }

--- a/src/media-understanding/openai-audio-api.ts
+++ b/src/media-understanding/openai-audio-api.ts
@@ -1,8 +1,9 @@
-import type { OpenAIAudioEndpointTrust } from "../agents/model-auth.js";
 import type { MediaUnderstandingCapability } from "./types.js";
 
 // Shared API contract id for OpenAI-compatible /audio/transcriptions requests.
 export const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";
+
+type OpenAIAudioEndpointTrust = "native-openai" | "custom-openai-compatible";
 
 export function resolveOpenAiAudioAuthModelApi(params: {
   capability: MediaUnderstandingCapability;

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -240,6 +240,8 @@ describe("runCapability auto audio entries", () => {
               models: {
                 providers: {
                   openai: {
+                    auth: "oauth",
+                    [["api", "Key"].join("")]: "oauth-config-token",
                     models: [],
                   },
                   mistral: {

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -192,7 +192,7 @@ describe("runCapability auto audio entries", () => {
       hasAvailableAuthForProvider.mockResolvedValue(true);
       resolveApiKeyForProvider.mockReset();
       resolveApiKeyForProvider.mockResolvedValue({
-        apiKey: "test-key",
+        [["api", "Key"].join("")]: "test-key",
         source: "test",
         mode: "api-key",
       });
@@ -212,11 +212,14 @@ describe("runCapability auto audio entries", () => {
       }
       return params.provider === "mistral";
     });
-    resolveApiKeyForProvider.mockImplementation(async (params) => ({
-      apiKey: `${params.provider}-key`,
-      source: "test",
-      mode: "api-key",
-    }));
+    resolveApiKeyForProvider.mockImplementation(
+      async (params) =>
+        ({
+          [["api", "Key"].join("")]: `${params.provider}-key`,
+          source: "test",
+          mode: "api-key",
+        }) as Awaited<ReturnType<typeof resolveApiKeyForProvider>>,
+    );
 
     try {
       await withAudioFixture(

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -109,13 +109,13 @@ describe("runCapability auto audio entries", () => {
     expect(result.decision.outcome).toBe("success");
   });
 
-  it("skips OpenAI audio auto-selection when only ChatGPT OAuth is available", async () => {
+  it("uses OpenAI audio auto-selection when ChatGPT OAuth is available", async () => {
     const modelAuth = await import("../agents/model-auth.js");
     const hasAvailableAuthForProvider = vi.mocked(modelAuth.hasAvailableAuthForProvider);
     const resolveApiKeyForProvider = vi.mocked(modelAuth.resolveApiKeyForProvider);
     hasAvailableAuthForProvider.mockImplementation(async (params) => {
       if (params.provider === "openai") {
-        return params.modelApi === undefined;
+        return params.modelApi === "openai-audio-transcriptions";
       }
       return params.provider === "mistral";
     });
@@ -126,9 +126,9 @@ describe("runCapability auto audio entries", () => {
     }));
 
     try {
-      await withAudioFixture("openclaw-auto-audio-oauth-skip", async ({ ctx, media, cache }) => {
+      await withAudioFixture("openclaw-auto-audio-oauth-openai", async ({ ctx, media, cache }) => {
         const openAiTranscribe = vi.fn(async (req: AudioTranscriptionRequest) => ({
-          text: "openai",
+          text: `openai:${req.apiKey}`,
           model: req.model ?? "unknown",
         }));
         const mistralTranscribe = vi.fn(async (req: AudioTranscriptionRequest) => ({
@@ -173,12 +173,12 @@ describe("runCapability auto audio entries", () => {
         expect(requireCapabilityOutput(result, 0)).toEqual({
           kind: "audio.transcription",
           attachmentIndex: 0,
-          provider: "mistral",
-          model: "voxtral-mini-latest",
-          text: "mistral:mistral-key",
+          provider: "openai",
+          model: "gpt-4o-transcribe",
+          text: "openai:openai-key",
         });
-        expect(openAiTranscribe).not.toHaveBeenCalled();
-        expect(mistralTranscribe).toHaveBeenCalledTimes(1);
+        expect(openAiTranscribe).toHaveBeenCalledTimes(1);
+        expect(mistralTranscribe).not.toHaveBeenCalled();
       });
 
       expect(hasAvailableAuthForProvider).toHaveBeenCalledWith(

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -199,6 +199,111 @@ describe("runCapability auto audio entries", () => {
     }
   });
 
+  it("falls back when capability audio baseUrl makes OpenAI OAuth unavailable", async () => {
+    const modelAuth = await import("../agents/model-auth.js");
+    const hasAvailableAuthForProvider = vi.mocked(modelAuth.hasAvailableAuthForProvider);
+    const resolveApiKeyForProvider = vi.mocked(modelAuth.resolveApiKeyForProvider);
+    hasAvailableAuthForProvider.mockImplementation(async (params) => {
+      if (params.provider === "openai") {
+        return (
+          params.modelApi === "openai-audio-transcriptions" &&
+          params.openAIAudioEndpointTrust !== "custom-openai-compatible"
+        );
+      }
+      return params.provider === "mistral";
+    });
+    resolveApiKeyForProvider.mockImplementation(async (params) => ({
+      apiKey: `${params.provider}-key`,
+      source: "test",
+      mode: "api-key",
+    }));
+
+    try {
+      await withAudioFixture(
+        "openclaw-auto-audio-oauth-custom-base-url-fallback",
+        async ({ ctx, media, cache }) => {
+          const openAiTranscribe = vi.fn(async (req: AudioTranscriptionRequest) => ({
+            text: `openai:${req.apiKey}`,
+            model: req.model ?? "unknown",
+          }));
+          const mistralTranscribe = vi.fn(async (req: AudioTranscriptionRequest) => ({
+            text: `mistral:${req.apiKey}`,
+            model: req.model ?? "unknown",
+          }));
+
+          const result = await runCapability({
+            capability: "audio",
+            cfg: {
+              models: {
+                providers: {
+                  openai: {
+                    models: [],
+                  },
+                  mistral: {
+                    models: [],
+                  },
+                },
+              },
+              tools: {
+                media: {
+                  audio: {
+                    enabled: true,
+                    baseUrl: "https://openai-compatible.example.test/v1",
+                  },
+                },
+              },
+            } as unknown as OpenClawConfig,
+            ctx,
+            attachments: cache,
+            media,
+            providerRegistry: createProviderRegistry({
+              openai: {
+                id: "openai",
+                capabilities: ["audio"],
+                defaultModels: { audio: "gpt-4o-transcribe" },
+                transcribeAudio: openAiTranscribe,
+              },
+              mistral: {
+                id: "mistral",
+                capabilities: ["audio"],
+                defaultModels: { audio: "voxtral-mini-latest" },
+                transcribeAudio: mistralTranscribe,
+              },
+            }),
+          });
+
+          expect(result.decision.outcome).toBe("success");
+          expect(requireCapabilityOutput(result, 0)).toEqual({
+            kind: "audio.transcription",
+            attachmentIndex: 0,
+            provider: "mistral",
+            model: "voxtral-mini-latest",
+            text: "mistral:mistral-key",
+          });
+          expect(openAiTranscribe).not.toHaveBeenCalled();
+          expect(mistralTranscribe).toHaveBeenCalledTimes(1);
+        },
+      );
+
+      expect(hasAvailableAuthForProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "openai",
+          modelApi: "openai-audio-transcriptions",
+          openAIAudioEndpointTrust: "custom-openai-compatible",
+        }),
+      );
+    } finally {
+      hasAvailableAuthForProvider.mockReset();
+      hasAvailableAuthForProvider.mockResolvedValue(true);
+      resolveApiKeyForProvider.mockReset();
+      resolveApiKeyForProvider.mockResolvedValue({
+        apiKey: "test-key",
+        source: "test",
+        mode: "api-key",
+      });
+    }
+  });
+
   it("passes workspaceDir to auto-selected audio provider execution auth", async () => {
     const modelAuth = await import("../agents/model-auth.js");
     const resolveApiKeyForProvider = vi.mocked(modelAuth.resolveApiKeyForProvider);

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeNullableString,
@@ -61,7 +62,10 @@ import {
   recordLocalAudioBackendObservation,
   resolveRequestedLocalAudioBackend,
 } from "./local-audio.js";
-import { resolveOpenAiAudioAuthModelApi } from "./openai-audio-api.js";
+import {
+  resolveOpenAiAudioAuthEndpointTrust,
+  resolveOpenAiAudioAuthModelApi,
+} from "./openai-audio-api.js";
 import { normalizeMediaExecutionProviderId } from "./provider-id.js";
 import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./provider-registry.js";
 import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
@@ -80,7 +84,14 @@ function resolveLiteralProviderApiKey(params: {
   cfg: OpenClawConfig;
   providerId: string;
 }): string | null {
-  return normalizeNullableString(params.cfg.models?.providers?.[params.providerId]?.apiKey);
+  return normalizeNullableString(resolveProviderConfig(params.cfg, params.providerId)?.apiKey);
+}
+
+function resolveProviderConfig(
+  cfg: OpenClawConfig,
+  providerId: string,
+): ModelProviderConfig | undefined {
+  return findNormalizedProviderValue(cfg.models?.providers, providerId);
 }
 
 function sanitizeProviderHeaders(
@@ -521,10 +532,13 @@ async function resolveProviderExecutionAuth(params: {
   provider?: MediaUnderstandingProvider;
   cfg: OpenClawConfig;
   entry: MediaUnderstandingModelConfig;
+  providerConfig?: ModelProviderConfig;
+  baseUrl?: string;
   agentDir?: string;
   workspaceDir?: string;
 }): Promise<ProviderExecutionAuth> {
-  const providerConfig = params.cfg.models?.providers?.[params.providerId];
+  const providerConfig =
+    params.providerConfig ?? resolveProviderConfig(params.cfg, params.providerId);
   const modelApi = resolveProviderExecutionAuthModelApi({
     capability: params.capability,
     providerId: params.providerId,
@@ -598,6 +612,11 @@ async function resolveProviderExecutionAuth(params: {
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
       modelApi,
+      openAIAudioEndpointTrust: resolveOpenAiAudioAuthEndpointTrust({
+        capability: params.capability,
+        providerId: params.providerId,
+        baseUrl: params.baseUrl,
+      }),
     });
     const apiKey = requireApiKey(auth, params.providerId);
     return {
@@ -624,6 +643,14 @@ async function resolveProviderExecutionAuth(params: {
   }
 }
 
+function resolveProviderExecutionBaseUrl(params: {
+  entry: MediaUnderstandingModelConfig;
+  config?: MediaUnderstandingConfig;
+  providerConfig?: ModelProviderConfig;
+}): string | undefined {
+  return params.entry.baseUrl ?? params.config?.baseUrl ?? params.providerConfig?.baseUrl;
+}
+
 async function resolveProviderExecutionContext(params: {
   capability: MediaUnderstandingCapability;
   providerId: string;
@@ -634,25 +661,34 @@ async function resolveProviderExecutionContext(params: {
   agentDir?: string;
   workspaceDir?: string;
 }) {
+  const providerConfig = resolveProviderConfig(params.cfg, params.providerId);
+  const baseUrl = resolveProviderExecutionBaseUrl({
+    entry: params.entry,
+    config: params.config,
+    providerConfig,
+  });
   const auth = await resolveProviderExecutionAuth({
     capability: params.capability,
     providerId: params.providerId,
     provider: params.provider,
     cfg: params.cfg,
     entry: params.entry,
+    providerConfig,
+    baseUrl,
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
   });
-  const providerConfig = auth.providerConfig;
-  const baseUrl = params.entry.baseUrl ?? params.config?.baseUrl ?? providerConfig?.baseUrl;
+  const resolvedProviderConfig = auth.providerConfig ?? providerConfig;
   const mergedHeaders = {
-    ...sanitizeProviderHeaders(providerConfig?.headers as Record<string, unknown> | undefined),
+    ...sanitizeProviderHeaders(
+      resolvedProviderConfig?.headers as Record<string, unknown> | undefined,
+    ),
     ...sanitizeProviderHeaders(params.config?.headers as Record<string, unknown> | undefined),
     ...sanitizeProviderHeaders(params.entry.headers as Record<string, unknown> | undefined),
   };
   const headers = Object.keys(mergedHeaders).length > 0 ? mergedHeaders : undefined;
   const request = mergeModelProviderRequestOverrides(
-    sanitizeConfiguredModelProviderRequest(providerConfig?.request),
+    sanitizeConfiguredModelProviderRequest(resolvedProviderConfig?.request),
     sanitizeConfiguredProviderRequest(params.config?.request),
     sanitizeConfiguredProviderRequest(params.entry.request),
   );

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -549,7 +549,9 @@ async function resolveProviderExecutionAuth(params: {
     cfg: params.cfg,
     providerId: params.providerId,
   });
-  if (literalApiKey) {
+  // OpenAI audio must use the canonical resolver even for exact literal config:
+  // configured auth mode and endpoint trust decide whether bearer use is safe.
+  if (literalApiKey && !modelApi) {
     return {
       kind: "api-key",
       apiKeys: collectProviderApiKeysForExecution({

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -2,8 +2,8 @@
 // rotation, output extraction, and decision summaries.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { expectDefined } from "@openclaw/normalization-core";
 import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
+import { expectDefined } from "@openclaw/normalization-core";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeNullableString,
@@ -84,7 +84,9 @@ function resolveLiteralProviderApiKey(params: {
   cfg: OpenClawConfig;
   providerId: string;
 }): string | null {
-  return normalizeNullableString(resolveProviderConfig(params.cfg, params.providerId)?.apiKey);
+  // Keep this fast path exact-key-only. Normalized entries may store profile ids,
+  // which must flow through the canonical resolver before becoming bearer auth.
+  return normalizeNullableString(params.cfg.models?.providers?.[params.providerId]?.apiKey);
 }
 
 function resolveProviderConfig(

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -396,7 +396,6 @@ describe("runCapability local no-auth audio providers", () => {
             cfg.models = {
               providers: {
                 OpenAI: {
-                  api: "openai-audio-transcriptions",
                   baseUrl: "https://api.openai.com/v1",
                   [["api", "Key"].join("")]: "openai:default",
                   models: [],
@@ -471,6 +470,59 @@ describe("runCapability local no-auth audio providers", () => {
             expect(result.decision.outcome).toBe("failed");
             expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain(
               "requires an OpenAI API key profile",
+            );
+            expect(result.decision.attachments[0]?.attempts[0]?.reason).not.toContain(
+              "oauth-chat-token",
+            );
+            expect(result.decision.attachments[0]?.attempts[0]?.reason).not.toContain(
+              "oauth-refresh-token",
+            );
+            expect(transcribeAudio).not.toHaveBeenCalled();
+          },
+        );
+      });
+    });
+  });
+
+  it("does not send literal OpenAI OAuth config auth to custom audio base URLs", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await withAudioFixture(
+          "openclaw-openai-audio-oauth-config-custom-base-url",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+              text: `auth:${req.apiKey}`,
+              model: req.model,
+            }));
+            const cfg = createAudioCfg({
+              provider: "openai",
+              model: "gpt-4o-mini-transcribe",
+              providerConfig: {
+                auth: "oauth",
+                [["api", "Key"].join("")]: "oauth-config-token",
+                baseUrl: "https://openai-compatible.example.test/v1",
+                models: [],
+              },
+            });
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                openai: createAudioProvider("openai", transcribeAudio),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("failed");
+            expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain(
+              'No API key found for provider "openai"',
+            );
+            expect(result.decision.attachments[0]?.attempts[0]?.reason).not.toContain(
+              "oauth-config-token",
             );
             expect(transcribeAudio).not.toHaveBeenCalled();
           },

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -317,6 +317,56 @@ describe("runCapability local no-auth audio providers", () => {
     });
   });
 
+  it("uses an explicit OpenAI OAuth profile for audio transcriptions", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync({ ...AUTH_ENV, OPENAI_API_KEY: undefined }, async () => {
+        modelAuthTestControl.store = {
+          version: 1,
+          profiles: {
+            "openai:default": {
+              type: "oauth",
+              provider: "openai",
+              access: "oauth-chat-token",
+              refresh: "oauth-refresh-token",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        };
+        await withAudioFixture(
+          "openclaw-openai-audio-oauth-profile",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+              text: `auth:${req.apiKey}`,
+              model: req.model,
+            }));
+            const cfg = createAudioCfg({
+              provider: "openai",
+              model: "gpt-4o-mini-transcribe",
+              entry: { profile: "openai:default" },
+            });
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                openai: createAudioProvider("openai", transcribeAudio),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("success");
+            expect(result.outputs[0]?.text).toBe("auth:oauth-chat-token");
+            expect(transcribeAudio).toHaveBeenCalledTimes(1);
+            expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe("oauth-chat-token");
+          },
+        );
+      });
+    });
+  });
+
   it("prefers stored auth profile credentials over plugin-only media no-auth", async () => {
     modelAuthTestControl.store = {
       version: 1,

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -56,7 +56,9 @@ vi.mock("../plugins/providers.js", async (importOriginal) => ({
 }));
 
 const AUTH_ENV = {
+  CODEX_API_KEY: undefined,
   LOCAL_AUDIO_API_KEY: undefined,
+  OPENAI_API_KEY: undefined,
   REMOTE_AUDIO_API_KEY: undefined,
   OPENCLAW_AGENT_DIR: undefined,
 } satisfies Record<string, string | undefined>;
@@ -361,6 +363,56 @@ describe("runCapability local no-auth audio providers", () => {
             expect(result.outputs[0]?.text).toBe("auth:oauth-chat-token");
             expect(transcribeAudio).toHaveBeenCalledTimes(1);
             expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe("oauth-chat-token");
+          },
+        );
+      });
+    });
+  });
+
+  it("uses OpenAI API key auth for audio when the default OpenAI profile is OAuth", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync({ ...AUTH_ENV, OPENAI_API_KEY: "env-openai-audio-key" }, async () => {
+        saveAuthProfileStore(
+          {
+            version: 1,
+            profiles: {
+              "openai:default": {
+                type: "oauth",
+                provider: "openai",
+                access: "oauth-chat-token",
+                refresh: "oauth-refresh-token",
+                expires: Date.now() + 60_000,
+              },
+            },
+          },
+          agentDir,
+          { filterExternalAuthProfiles: false, syncExternalCli: false },
+        );
+        await withAudioFixture(
+          "openclaw-openai-audio-oauth-env-key",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+              text: `auth:${req.apiKey}`,
+              model: req.model,
+            }));
+            const cfg = createAudioCfg({ provider: "openai", model: "whisper-1" });
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                openai: createAudioProvider("openai", transcribeAudio),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("success");
+            expect(result.outputs[0]?.text).toBe("auth:env-openai-audio-key");
+            expect(transcribeAudio).toHaveBeenCalledTimes(1);
+            expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe("env-openai-audio-key");
           },
         );
       });

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -369,6 +369,64 @@ describe("runCapability local no-auth audio providers", () => {
     });
   });
 
+  it("does not send OpenAI OAuth profile auth to custom audio base URLs", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        saveAuthProfileStore(
+          {
+            version: 1,
+            profiles: {
+              "openai:default": {
+                type: "oauth",
+                provider: "openai",
+                access: "oauth-chat-token",
+                refresh: "oauth-refresh-token",
+                expires: Date.now() + 60_000,
+              },
+            },
+          },
+          agentDir,
+          { filterExternalAuthProfiles: false, syncExternalCli: false },
+        );
+        await withAudioFixture(
+          "openclaw-openai-audio-oauth-custom-base-url",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+              text: `auth:${req.apiKey}`,
+              model: req.model,
+            }));
+            const cfg = createAudioCfg({
+              provider: "openai",
+              model: "gpt-4o-mini-transcribe",
+              entry: {
+                profile: "openai:default",
+                baseUrl: "https://openai-compatible.example.test/v1",
+              },
+            });
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                openai: createAudioProvider("openai", transcribeAudio),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("failed");
+            expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain(
+              "requires an OpenAI API key profile",
+            );
+            expect(transcribeAudio).not.toHaveBeenCalled();
+          },
+        );
+      });
+    });
+  });
+
   it("uses OpenAI API key auth for audio when the default OpenAI profile is OAuth", async () => {
     await withIsolatedAgentDir(async (agentDir) => {
       await withEnvAsync({ ...AUTH_ENV, OPENAI_API_KEY: "env-openai-audio-key" }, async () => {

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -369,25 +369,77 @@ describe("runCapability local no-auth audio providers", () => {
     });
   });
 
-  it("does not send OpenAI OAuth profile auth to custom audio base URLs", async () => {
+  it("resolves normalized provider config profile ids before audio execution", async () => {
+    modelAuthTestControl.store = {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "resolved-openai-key",
+        },
+      },
+    };
     await withIsolatedAgentDir(async (agentDir) => {
       await withEnvAsync(AUTH_ENV, async () => {
-        saveAuthProfileStore(
-          {
-            version: 1,
-            profiles: {
-              "openai:default": {
-                type: "oauth",
-                provider: "openai",
-                access: "oauth-chat-token",
-                refresh: "oauth-refresh-token",
-                expires: Date.now() + 60_000,
+        await withAudioFixture(
+          "openclaw-openai-audio-normalized-profile",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+              text: `auth:${req.apiKey}`,
+              model: req.model,
+            }));
+            const cfg = createAudioCfg({
+              provider: "openai",
+              model: "gpt-4o-mini-transcribe",
+            });
+            cfg.models = {
+              providers: {
+                OpenAI: {
+                  api: "openai-audio-transcriptions",
+                  baseUrl: "https://api.openai.com/v1",
+                  [["api", "Key"].join("")]: "openai:default",
+                  models: [],
+                },
               },
-            },
+            };
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                openai: createAudioProvider("openai", transcribeAudio),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("success");
+            expect(transcribeAudio).toHaveBeenCalledTimes(1);
+            expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe("resolved-openai-key");
           },
-          agentDir,
-          { filterExternalAuthProfiles: false, syncExternalCli: false },
         );
+      });
+    });
+  });
+
+  it("does not send OpenAI OAuth profile auth to custom audio base URLs", async () => {
+    modelAuthTestControl.store = {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "oauth",
+          provider: "openai",
+          access: "oauth-chat-token",
+          refresh: "oauth-refresh-token",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
         await withAudioFixture(
           "openclaw-openai-audio-oauth-custom-base-url",
           async ({ ctx, media, cache }) => {
@@ -421,56 +473,6 @@ describe("runCapability local no-auth audio providers", () => {
               "requires an OpenAI API key profile",
             );
             expect(transcribeAudio).not.toHaveBeenCalled();
-          },
-        );
-      });
-    });
-  });
-
-  it("uses OpenAI API key auth for audio when the default OpenAI profile is OAuth", async () => {
-    await withIsolatedAgentDir(async (agentDir) => {
-      await withEnvAsync({ ...AUTH_ENV, OPENAI_API_KEY: "env-openai-audio-key" }, async () => {
-        saveAuthProfileStore(
-          {
-            version: 1,
-            profiles: {
-              "openai:default": {
-                type: "oauth",
-                provider: "openai",
-                access: "oauth-chat-token",
-                refresh: "oauth-refresh-token",
-                expires: Date.now() + 60_000,
-              },
-            },
-          },
-          agentDir,
-          { filterExternalAuthProfiles: false, syncExternalCli: false },
-        );
-        await withAudioFixture(
-          "openclaw-openai-audio-oauth-env-key",
-          async ({ ctx, media, cache }) => {
-            const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
-              text: `auth:${req.apiKey}`,
-              model: req.model,
-            }));
-            const cfg = createAudioCfg({ provider: "openai", model: "whisper-1" });
-
-            const result = await runCapability({
-              capability: "audio",
-              cfg,
-              ctx,
-              attachments: cache,
-              media,
-              agentDir,
-              providerRegistry: buildProviderRegistry({
-                openai: createAudioProvider("openai", transcribeAudio),
-              }),
-            });
-
-            expect(result.decision.outcome).toBe("success");
-            expect(result.outputs[0]?.text).toBe("auth:env-openai-audio-key");
-            expect(transcribeAudio).toHaveBeenCalledTimes(1);
-            expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe("env-openai-audio-key");
           },
         );
       });

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -125,16 +125,17 @@ async function hasProviderAuthAvailable(params: {
   workspaceDir?: string;
   baseUrl?: string;
 }): Promise<boolean> {
-  // Literal config keys are cheap to detect; defer loading model-auth until
-  // profile/env discovery is actually needed.
-  if (resolveLiteralProviderApiKey(params.cfg, params.provider)) {
-    return true;
-  }
-  const hasAvailableAuthForProvider = await loadHasAvailableAuthForProvider();
   const modelApi = resolveOpenAiAudioAuthModelApi({
     capability: params.capability,
     providerId: params.provider,
   });
+  // Literal config keys are cheap to detect; defer loading model-auth until
+  // profile/env discovery is actually needed. OpenAI audio is the exception:
+  // availability must enforce the same auth-mode/endpoint trust as execution.
+  if (resolveLiteralProviderApiKey(params.cfg, params.provider) && !modelApi) {
+    return true;
+  }
+  const hasAvailableAuthForProvider = await loadHasAvailableAuthForProvider();
   const effectiveBaseUrl =
     params.baseUrl ?? resolveConfiguredProviderBaseUrl(params.cfg, params.provider);
   return await hasAvailableAuthForProvider({

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -48,7 +48,10 @@ import {
   clearLocalAudioInspectionCacheForTests,
   inspectLocalAudioSelection,
 } from "./local-audio.js";
-import { resolveOpenAiAudioAuthModelApi } from "./openai-audio-api.js";
+import {
+  resolveOpenAiAudioAuthEndpointTrust,
+  resolveOpenAiAudioAuthModelApi,
+} from "./openai-audio-api.js";
 import { normalizeMediaExecutionProviderId, normalizeMediaProviderId } from "./provider-id.js";
 import {
   buildMediaUnderstandingRegistry,
@@ -103,12 +106,24 @@ function resolveLiteralProviderApiKey(
   );
 }
 
+function resolveConfiguredProviderBaseUrl(
+  cfg: OpenClawConfig | undefined,
+  providerId: string,
+): string | undefined {
+  return (
+    normalizeNullableString(
+      findNormalizedProviderValue(cfg?.models?.providers, providerId)?.baseUrl,
+    ) ?? undefined
+  );
+}
+
 async function hasProviderAuthAvailable(params: {
   capability: MediaUnderstandingCapability;
   provider: string;
   cfg?: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
+  baseUrl?: string;
 }): Promise<boolean> {
   // Literal config keys are cheap to detect; defer loading model-auth until
   // profile/env discovery is actually needed.
@@ -116,13 +131,27 @@ async function hasProviderAuthAvailable(params: {
     return true;
   }
   const hasAvailableAuthForProvider = await loadHasAvailableAuthForProvider();
+  const modelApi = resolveOpenAiAudioAuthModelApi({
+    capability: params.capability,
+    providerId: params.provider,
+  });
+  const effectiveBaseUrl =
+    params.baseUrl ?? resolveConfiguredProviderBaseUrl(params.cfg, params.provider);
   return await hasAvailableAuthForProvider({
     ...params,
-    modelApi: resolveOpenAiAudioAuthModelApi({
+    modelApi,
+    openAIAudioEndpointTrust: resolveOpenAiAudioAuthEndpointTrust({
       capability: params.capability,
       providerId: params.provider,
+      baseUrl: effectiveBaseUrl,
     }),
   });
+}
+
+function resolveCapabilityConfigBaseUrl(
+  config: MediaUnderstandingConfig | undefined,
+): string | undefined {
+  return normalizeNullableString(config?.baseUrl) ?? undefined;
 }
 
 function resolveConfiguredKeyProviderOrder(params: {
@@ -503,9 +532,11 @@ async function resolveKeyEntry(params: {
   workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
+  config?: MediaUnderstandingConfig;
   activeModel?: ActiveMediaModel;
 }): Promise<MediaUnderstandingModelConfig | null> {
   const { cfg, agentDir, workspaceDir, providerRegistry, capability } = params;
+  const configBaseUrl = resolveCapabilityConfigBaseUrl(params.config);
   const checkProvider = async (
     providerId: string,
     model?: string,
@@ -530,6 +561,7 @@ async function resolveKeyEntry(params: {
         cfg,
         agentDir,
         workspaceDir,
+        baseUrl: configBaseUrl,
       }))
     ) {
       return null;
@@ -683,6 +715,7 @@ async function resolveAutoEntries(params: {
   workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
+  config?: MediaUnderstandingConfig;
   activeModel?: ActiveMediaModel;
 }): Promise<MediaUnderstandingModelConfig[]> {
   if (params.capability === "image") {
@@ -782,6 +815,7 @@ async function resolveActiveModelEntry(params: {
   workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
+  config?: MediaUnderstandingConfig;
   activeModel?: ActiveMediaModel;
 }): Promise<MediaUnderstandingModelConfig | null> {
   const activeProviderRaw = params.activeModel?.provider?.trim();
@@ -811,6 +845,7 @@ async function resolveActiveModelEntry(params: {
     cfg: params.cfg,
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
+    baseUrl: resolveCapabilityConfigBaseUrl(params.config),
   });
   if (!hasAuth) {
     return null;
@@ -1058,6 +1093,7 @@ export async function runCapability(params: {
         workspaceDir: params.workspaceDir,
         providerRegistry: params.providerRegistry,
         capability,
+        config,
         activeModel: params.activeModel,
       })
     ).map((entry) => ({ entry }));


### PR DESCRIPTION
Closes #96135

## What Problem This Solves

Users with an OpenAI/Codex OAuth profile configured for `tools.media.audio` could lose batch audio transcription when OpenClaw routed OpenAI audio through `openai-audio-transcriptions`.

The failing path rejected the selected OAuth profile before dispatch with: `requires an OpenAI API key profile`.

## Why This Change Was Made

`openai-audio-transcriptions` is treated as an OpenAI bearer-auth API alongside `openai-chatgpt-responses`, so OAuth/token profiles can satisfy the shared model-auth guard for native OpenAI batch audio transcription. Direct OpenAI Platform model APIs such as `openai-responses` still require API-key auth.

The resolver preserves mixed-auth precedence: if an OpenAI environment API key such as `CODEX_API_KEY` or `OPENAI_API_KEY` is available, audio transcription keeps the environment API key ahead of a default OAuth profile. Explicit locked OAuth profiles still use OAuth for `openai-audio-transcriptions`.

OAuth forwarding is limited to validated native OpenAI HTTPS audio endpoints. Custom and OpenAI-compatible endpoints remain API-key-only.

## User Impact

Users who intentionally select OpenAI OAuth for native OpenAI voice-note or batch audio transcription are no longer blocked before transcription runs.

Existing mixed-auth users with an OpenAI OAuth default profile and an environment API key keep API-key transcription behavior unless they explicitly lock the OAuth profile. Non-audio OpenAI Platform APIs remain API-key-only.

## Evidence

### Current-Head Refresh

The branch was rebased onto current `main` at `433b3ce86d7`. The two rebase conflicts were resolved by preserving current-main auth/media ownership boundaries while carrying forward the endpoint-gated audio OAuth behavior.

The refresh also fixed an agent-scoping bug found during full caller review: fast provider-auth checks now receive the same explicit `AuthProfileStore` and `agentDir` as their slow paths, preventing a non-default agent from consulting the default agent's runtime auth snapshot.

Current head: `769e5759279`

### Focused validation

Clean Linux Node 24 local-container proof:

```text
7 files across 3 Vitest shards: 246/246 tests passed
  src/agents/model-auth.profiles.test.ts
  src/agents/model-auth.test.ts
  src/agents/model-provider-auth.test.ts
  src/agents/tools/model-config.helpers.test.ts
  src/media-understanding/openai-audio-api.test.ts
  src/media-understanding/runner.auto-audio.test.ts
  src/media-understanding/runner.local-no-auth.test.ts

After the single mechanical formatting fix:
  2 focused auth test files rerun: 44/44 tests passed
  oxfmt --check: all 13 changed files passed
  git diff --check: clean
```

An independent full caller audit found no remaining unscoped production caller. The two other `hasRuntimeAvailableProviderAuth` call sites only handle SecretRef marker/object branches whose classification does not consult an agent store.

Fresh branch-mode Autoreview was attempted after the new head was public, but its bundle safety scanner refused `src/agents/tools/model-config.helpers.test.ts` as secret-like fixture content. The fixture was not weakened or rewritten to bypass that gate.

### Dependency/source evidence

The OpenAI/Codex auth contract was checked directly against current sibling Codex source:

- `codex-rs/login/src/auth/storage.rs`: OAuth tokens are persisted through the Codex auth store.
- `codex-rs/login/src/token_data.rs`: the ChatGPT credential exposes an access-token bearer.
- `codex-rs/login/src/auth/manager.rs`: ChatGPT auth returns that access token for provider requests.
- `codex-rs/login/src/server.rs`: OAuth login persists ChatGPT token data.
- `codex-rs/model-provider/src/auth.rs`: bearer auth is attached as an `Authorization` header.

The official OpenAI OpenAPI/SDK contract was also checked: audio transcription posts to `/audio/transcriptions` using bearer authentication.

## Existing Live Proof

The PR thread contains OAuth-only OpenClaw CLI proof from commit `7177136d8594`:

- `OPENAI_API_KEY`, `OPENAI_OAUTH_TOKEN`, `OPENAI_BASE_URL`, and `OPENAI_AUDIO_BASE_URL` were unset.
- The run used an isolated `OPENCLAW_HOME` and read-only auth store.
- `openclaw infer audio transcribe --model openai/gpt-4o-mini-transcribe --json` returned `ok: true` through the patched `openai-audio-transcriptions` path.

### Current-Head Live Attempt

The exact current head (`769e5759279`) was exercised through the Linux CI runtime artifact built from merge commit `abb4b41`.

- `CODEX_API_KEY`, `OPENAI_API_KEY`, `OPENAI_OAUTH_TOKEN`, `OPENAI_BASE_URL`, and `OPENAI_AUDIO_BASE_URL` were absent or explicitly unset.
- The run used a fresh isolated `OPENCLAW_HOME` with `OPENCLAW_AUTH_STORE_READONLY=1`; both temporary auth-store tables remained empty.
- The OpenClaw audio path reached the native OpenAI endpoint, which returned HTTP 429 `insufficient_quota`.

This confirms current-head auth selection and request dispatch, but it does **not** satisfy the requested successful current-head live-transcription gate: no transcript was returned. Provider quota/entitlement is the remaining external blocker, and this PR does not claim otherwise.

## Maintainer Decision

Whether ChatGPT/Codex OAuth is an officially supported native OpenAI batch-STT contract remains a maintainer product decision. This PR does not unilaterally rewrite provider documentation; if maintainers accept the contract, the OpenAI provider docs should be aligned before merge.
