### PR TITLE
fix(plugins): preserve mutable hook context

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2,7 +2,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { applyBootstrapHookOverrides } from "../agents/bootstrap-hooks.js";
 import { listRegisteredAgentHarnesses } from "../agents/harness/registry.js";
+import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import { resolveConfigEnvVars } from "../config/env-substitution.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import {
@@ -2969,6 +2971,163 @@ module.exports = { id: "throws-after-import", register() {} };`,
     await triggerInternalHook(event);
     expect(event.messages).toEqual(["plugin-config-visible"]);
     expect(event.context).toStrictEqual({});
+
+    clearInternalHooks();
+  });
+
+  it("preserves plugin hook context mutations for bootstrap hooks", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "hook-bootstrap-mutation",
+      filename: "hook-bootstrap-mutation.cjs",
+      body: `module.exports = {
+        id: "hook-bootstrap-mutation",
+        register(api) {
+          api.registerHook(
+            "agent:bootstrap",
+            (event) => {
+              event.context.bootstrapFiles = [
+                {
+                  name: "AGENTS.md",
+                  path: "/tmp/override-AGENTS.md",
+                  content: "override bootstrap rules",
+                  missing: false,
+                },
+              ];
+            },
+            { name: "hook-bootstrap-mutation" },
+          );
+        },
+      };`,
+    });
+
+    clearInternalHooks();
+
+    loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["hook-bootstrap-mutation"],
+      },
+      options: {
+        onlyPluginIds: ["hook-bootstrap-mutation"],
+      },
+    });
+
+    const updated = await applyBootstrapHookOverrides({
+      files: [
+        {
+          name: "AGENTS.md",
+          path: "/tmp/base-AGENTS.md",
+          content: "base bootstrap rules",
+          missing: false,
+        } satisfies WorkspaceBootstrapFile,
+      ],
+      workspaceDir: "/tmp",
+      sessionKey: "agent:main:subagent:test-bootstrap",
+    });
+
+    expect(updated).toEqual([
+      {
+        name: "AGENTS.md",
+        path: "/tmp/override-AGENTS.md",
+        content: "override bootstrap rules",
+        missing: false,
+      },
+    ]);
+
+    clearInternalHooks();
+  });
+
+  it("runs consecutive plugin hook handlers with shared mutable context but isolated plugin config", async () => {
+    useNoBundledPlugins();
+    const first = writePlugin({
+      id: "hook-context-first",
+      filename: "hook-context-first.cjs",
+      body: `module.exports = {
+        id: "hook-context-first",
+        register(api) {
+          api.registerHook(
+            "gateway:startup",
+            (event) => {
+              event.messages.push("first-config=" + event.context.pluginConfig?.marker);
+              event.context.note = "mutation-from-first";
+            },
+            { name: "hook-context-first" },
+          );
+        },
+      };`,
+    });
+    const second = writePlugin({
+      id: "hook-context-second",
+      filename: "hook-context-second.cjs",
+      body: `module.exports = {
+        id: "hook-context-second",
+        register(api) {
+          api.registerHook(
+            "gateway:startup",
+            (event) => {
+              event.messages.push(
+                "second-config=" + String(event.context.pluginConfig?.marker ?? "none"),
+              );
+              event.messages.push("note=" + String(event.context.note ?? "missing-note"));
+            },
+            { name: "hook-context-second" },
+          );
+        },
+      };`,
+    });
+    for (const plugin of [first, second]) {
+      fs.writeFileSync(
+        path.join(plugin.dir, "openclaw.plugin.json"),
+        JSON.stringify(
+          {
+            id: plugin.id,
+            configSchema: { type: "object" },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+    }
+
+    clearInternalHooks();
+
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: first.dir,
+      onlyPluginIds: ["hook-context-first", "hook-context-second"],
+      config: {
+        plugins: {
+          load: { paths: [first.file, second.file] },
+          allow: ["hook-context-first", "hook-context-second"],
+          entries: {
+            "hook-context-first": {
+              config: {
+                marker: "visible-to-first",
+              },
+            },
+            "hook-context-second": {
+              config: {
+                marker: "visible-to-second",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const event = createInternalHookEvent("gateway", "startup", "gateway:startup");
+    await triggerInternalHook(event);
+
+    expect(event.messages).toEqual([
+      "first-config=visible-to-first",
+      "second-config=visible-to-second",
+      "note=mutation-from-first",
+    ]);
+    expect(event.context).toEqual({
+      note: "mutation-from-first",
+    });
 
     clearInternalHooks();
   });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -742,7 +742,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     for (const event of normalizedEvents) {
       const wrappedHandler: typeof handler = async (evt) => {
         const context = evt.context;
-        const hadPluginConfig = Object.prototype.hasOwnProperty.call(context, "pluginConfig");
+        const hadPluginConfig = Object.hasOwn(context, "pluginConfig");
         const previousPluginConfig = context.pluginConfig;
         // Internal hooks intentionally share one mutable context object across
         // handlers; only pluginConfig stays per-handler and is restored after.

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -741,9 +741,21 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }> = [];
     for (const event of normalizedEvents) {
       const wrappedHandler: typeof handler = async (evt) => {
-        // Shallow-copy to avoid mutating the shared event object
-        // passed to all handlers sequentially by triggerInternalHook
-        return handler({ ...evt, context: { ...evt.context, pluginConfig } });
+        const context = evt.context;
+        const hadPluginConfig = Object.prototype.hasOwnProperty.call(context, "pluginConfig");
+        const previousPluginConfig = context.pluginConfig;
+        // Internal hooks intentionally share one mutable context object across
+        // handlers; only pluginConfig stays per-handler and is restored after.
+        context.pluginConfig = pluginConfig;
+        try {
+          return await handler({ ...evt, context });
+        } finally {
+          if (hadPluginConfig) {
+            context.pluginConfig = previousPluginConfig;
+          } else {
+            delete context.pluginConfig;
+          }
+        }
       };
       registerInternalHook(event, wrappedHandler);
       nextRegistrations.push({ event, handler: wrappedHandler });


### PR DESCRIPTION
Closes #75245

## What Problem This Solves

Fixes an issue where plugin `registerHook()` handlers could mutate the `event.context` object they received, but core would silently ignore those mutations when the handler ran through the plugin registry wrapper. In practice this broke `agent:bootstrap` plugins that replace `bootstrapFiles`: the plugin logged success, but child runs still received the original bootstrap file set.

## Why This Change Was Made

The plugin registry wrapper now passes the original mutable hook context object to each handler, temporarily injects that handler's `pluginConfig`, and restores/removes `pluginConfig` in a `finally` block after the handler returns. That preserves the documented mutable hook contract while keeping per-handler config isolated so one plugin's config does not leak into later handlers.

AI-assisted: prepared with Codex and verified locally.

## User Impact

Plugins that intentionally mutate hook context now work the way the hook contract and docs imply they should. For `agent:bootstrap`, bootstrap file replacements/removals now survive into the final injected context used by the agent run, while `pluginConfig` remains visible only to the owning handler.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/loader.test.ts -t "injects plugin config into internal hook event context"`
- `node scripts/run-vitest.mjs src/plugins/loader.test.ts -t "preserves plugin hook context mutations for bootstrap hooks"`
- `node scripts/run-vitest.mjs src/plugins/loader.test.ts -t "runs consecutive plugin hook handlers with shared mutable context but isolated plugin config"`
- `node scripts/run-vitest.mjs src/agents/bootstrap-hooks.test.ts`
- `npm run tsgo:test:src`
- `node scripts/run-oxlint.mjs src/plugins/registry.ts`
- `node_modules\.bin\oxfmt.cmd --check --threads=1 src/plugins/registry.ts src/plugins/loader.test.ts`
- `git diff --check`

Real loader proof with temporary local plugins loaded through `loadOpenClawPlugins` and redacted paths:

```text
[proof] loaded plugins via loadOpenClawPlugins: hook-bootstrap-proof, hook-context-first, hook-context-second
[proof] bootstrap before: AGENTS.md, SOUL.md
[proof] bootstrap after: SENTINEL.md
[proof] sentinel content: SENTINEL_BOOTSTRAP_CONTEXT
[proof] startup messages: first-config=visible-to-first | second-config=visible-to-second | note=mutation-from-first
[proof] startup final context keys: note
[proof] PASS registerHook mutable context propagation and pluginConfig cleanup
```

Not run:
- broader `pnpm check` / `pnpm check:changed` lanes were not run in this worktree; focused source tests, lint/format, and `tsgo:test:src` were used instead.
