### PR TITLE
fix: clarify pinned plugin dry-run updates

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -434,6 +434,8 @@ Updates apply to tracked plugin installs in the managed plugin index and tracked
   <Accordion title="Resolving plugin id vs npm spec">
     When you pass a plugin id, OpenClaw reuses the recorded install spec for that plugin. That means previously stored dist-tags such as `@beta` and exact pinned versions continue to be used on later `update <id>` runs.
 
+    During `update <id> --dry-run`, exact pinned npm installs stay pinned. If OpenClaw can also resolve the package's registry default line and that default line is newer than the installed pinned version, the dry run reports the pin and prints the explicit `@latest` package update command to follow the registry default line.
+
     That targeted-update rule is different from the bulk `openclaw plugins update --all` maintenance path. Bulk updates still respect ordinary tracked install specs, but trusted official OpenClaw plugin records can sync to the current official catalog target instead of staying on a stale exact official package. Use targeted `update <id>` when you intentionally want to keep an exact or tagged official spec untouched.
 
     For npm installs, you can also pass an explicit npm package spec with a dist-tag or exact version. OpenClaw resolves that package name back to the tracked plugin record, updates that installed plugin, and records the new npm spec for future id-based updates.

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2460,6 +2460,60 @@ describe("updateNpmInstalledPlugins", () => {
     });
   });
 
+  it("reports newer registry default releases for exact pinned npm dry-runs", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@acme/demo",
+      version: "1.2.3",
+    });
+    mockNpmViewMetadata({
+      name: "@acme/demo",
+      version: "1.2.4",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: true,
+      pluginId: "demo",
+      targetDir: installPath,
+      version: "1.2.3",
+      extensions: ["index.ts"],
+      npmResolution: {
+        name: "@acme/demo",
+        version: "1.2.3",
+        resolvedSpec: "@acme/demo@1.2.3",
+      },
+    });
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "demo",
+        spec: "@acme/demo@1.2.3",
+        installPath,
+      }),
+      pluginIds: ["demo"],
+      dryRun: true,
+    });
+
+    expect(npmInstallCall()?.spec).toBe("@acme/demo@1.2.3");
+    expect(npmViewCall()?.[0]).toEqual([
+      "npm",
+      "view",
+      "@acme/demo",
+      "name",
+      "version",
+      "dist.integrity",
+      "dist.shasum",
+      "openclaw",
+      "--json",
+    ]);
+    expectRecordFields(result.outcomes[0], {
+      pluginId: "demo",
+      status: "unchanged",
+      currentVersion: "1.2.3",
+      nextVersion: "1.2.3",
+      message:
+        "demo is pinned to @acme/demo@1.2.3 (installed 1.2.3); registry default resolves to 1.2.4. Pass `openclaw plugins update @acme/demo@latest` to follow the registry default line.",
+    });
+  });
+
   it("updates disabled trusted official ClawHub installs through the catalog spec", async () => {
     installPluginFromClawHubMock.mockResolvedValue(
       createSuccessfulClawHubUpdateResult({

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2460,59 +2460,61 @@ describe("updateNpmInstalledPlugins", () => {
     });
   });
 
-  it("reports newer registry default releases for exact pinned npm dry-runs", async () => {
-    const installPath = createInstalledPackageDir({
-      name: "@acme/demo",
-      version: "1.2.3",
-    });
-    mockNpmViewMetadata({
-      name: "@acme/demo",
-      version: "1.2.4",
-    });
-    installPluginFromNpmSpecMock.mockResolvedValue({
-      ok: true,
-      pluginId: "demo",
-      targetDir: installPath,
-      version: "1.2.3",
-      extensions: ["index.ts"],
-      npmResolution: {
+  it.each(["@acme/demo@1.2.3", "@acme/demo@v1.2.3"])(
+    "reports newer registry default releases for exact pinned npm dry-runs from %s",
+    async (spec) => {
+      const installPath = createInstalledPackageDir({
         name: "@acme/demo",
         version: "1.2.3",
-        resolvedSpec: "@acme/demo@1.2.3",
-      },
-    });
-
-    const result = await updateNpmInstalledPlugins({
-      config: createNpmInstallConfig({
+      });
+      mockNpmViewMetadata({
+        name: "@acme/demo",
+        version: "1.2.4",
+      });
+      installPluginFromNpmSpecMock.mockResolvedValue({
+        ok: true,
         pluginId: "demo",
-        spec: "@acme/demo@1.2.3",
-        installPath,
-      }),
-      pluginIds: ["demo"],
-      dryRun: true,
-    });
+        targetDir: installPath,
+        version: "1.2.3",
+        extensions: ["index.ts"],
+        npmResolution: {
+          name: "@acme/demo",
+          version: "1.2.3",
+          resolvedSpec: spec,
+        },
+      });
 
-    expect(npmInstallCall()?.spec).toBe("@acme/demo@1.2.3");
-    expect(npmViewCall()?.[0]).toEqual([
-      "npm",
-      "view",
-      "@acme/demo",
-      "name",
-      "version",
-      "dist.integrity",
-      "dist.shasum",
-      "openclaw",
-      "--json",
-    ]);
-    expectRecordFields(result.outcomes[0], {
-      pluginId: "demo",
-      status: "unchanged",
-      currentVersion: "1.2.3",
-      nextVersion: "1.2.3",
-      message:
-        "demo is pinned to @acme/demo@1.2.3 (installed 1.2.3); registry default resolves to 1.2.4. Pass `openclaw plugins update @acme/demo@latest` to follow the registry default line.",
-    });
-  });
+      const result = await updateNpmInstalledPlugins({
+        config: createNpmInstallConfig({
+          pluginId: "demo",
+          spec,
+          installPath,
+        }),
+        pluginIds: ["demo"],
+        dryRun: true,
+      });
+
+      expect(npmInstallCall()?.spec).toBe(spec);
+      expect(npmViewCall()?.[0]).toEqual([
+        "npm",
+        "view",
+        "@acme/demo",
+        "name",
+        "version",
+        "dist.integrity",
+        "dist.shasum",
+        "openclaw",
+        "--json",
+      ]);
+      expectRecordFields(result.outcomes[0], {
+        pluginId: "demo",
+        status: "unchanged",
+        currentVersion: "1.2.3",
+        nextVersion: "1.2.3",
+        message: `demo is pinned to ${spec} (installed 1.2.3); registry default resolves to 1.2.4. Pass \`openclaw plugins update @acme/demo@latest\` to follow the registry default line.`,
+      });
+    },
+  );
 
   it("updates disabled trusted official ClawHub installs through the catalog spec", async () => {
     installPluginFromClawHubMock.mockResolvedValue(

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -400,6 +400,37 @@ function compareNpmSemverForUpdate(left: string, right: string): number {
   return compareComparableSemver(parseComparableSemver(left), parseComparableSemver(right)) ?? 0;
 }
 
+async function resolveNewerExactPinnedNpmDefaultLine(params: {
+  currentVersion: string | undefined;
+  effectiveSpec: string | undefined;
+  probeNpmVersion: string | undefined;
+  timeoutMs?: number;
+}): Promise<{ packageName: string; version: string } | undefined> {
+  if (!params.currentVersion || !params.probeNpmVersion || !params.effectiveSpec) {
+    return undefined;
+  }
+  const packageName = resolveNpmSpecPackageName(params.effectiveSpec);
+  const exactVersion = resolveExactNpmSpecVersion(params.effectiveSpec);
+  if (!packageName || !exactVersion || params.probeNpmVersion !== exactVersion) {
+    return undefined;
+  }
+
+  const metadataResult = await resolveNpmSpecMetadata({
+    spec: packageName,
+    timeoutMs: params.timeoutMs,
+  }).catch(() => undefined);
+  if (
+    !metadataResult?.ok ||
+    metadataResult.metadata.name !== packageName ||
+    !metadataResult.metadata.version
+  ) {
+    return undefined;
+  }
+  return compareNpmSemverForUpdate(metadataResult.metadata.version, params.currentVersion) > 0
+    ? { packageName, version: metadataResult.metadata.version }
+    : undefined;
+}
+
 async function loadNpmPackageVersionsForUpdate(params: {
   packageName: string;
   timeoutMs?: number;
@@ -1950,13 +1981,32 @@ export async function updateNpmInstalledPlugins(params: {
           : Boolean(
               currentVersion && resolvedProbeVersion && currentVersion === resolvedProbeVersion,
             );
+      const newerExactPinnedDefaultLine =
+        unchanged &&
+        record.source === "npm" &&
+        !params.specOverrides?.[pluginId] &&
+        !officialNpmSpec
+          ? await resolveNewerExactPinnedNpmDefaultLine({
+              currentVersion,
+              effectiveSpec,
+              probeNpmVersion: npmProbeVersion,
+              timeoutMs: params.timeoutMs,
+            })
+          : undefined;
       if (unchanged) {
+        const message =
+          newerExactPinnedDefaultLine && effectiveSpec
+            ? `${pluginId} is pinned to ${effectiveSpec} (installed ${currentLabel}); ` +
+              `registry default resolves to ${newerExactPinnedDefaultLine.version}. ` +
+              `Pass \`openclaw plugins update ${newerExactPinnedDefaultLine.packageName}@latest\` to follow the registry default line.` +
+              channelFallbackSuffix
+            : `${pluginId} is up to date (${currentLabel}).${channelFallbackSuffix}`;
         outcomes.push({
           pluginId,
           status: "unchanged",
           currentVersion: currentVersion ?? undefined,
           nextVersion: resolvedProbeVersion,
-          message: `${pluginId} is up to date (${currentLabel}).${channelFallbackSuffix}`,
+          message,
           ...(npmChannelFallback ? { channelFallback: npmChannelFallback } : {}),
         });
       } else {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -411,7 +411,8 @@ async function resolveNewerExactPinnedNpmDefaultLine(params: {
   }
   const packageName = resolveNpmSpecPackageName(params.effectiveSpec);
   const exactVersion = resolveExactNpmSpecVersion(params.effectiveSpec);
-  if (!packageName || !exactVersion || params.probeNpmVersion !== exactVersion) {
+  const probeNpmVersion = normalizeExactNpmVersion(params.probeNpmVersion);
+  if (!packageName || !exactVersion || probeNpmVersion !== exactVersion) {
     return undefined;
   }
 
@@ -907,7 +908,20 @@ function resolveNpmSpecPackageName(spec: string | undefined): string | undefined
 
 function resolveExactNpmSpecVersion(spec: string | undefined): string | undefined {
   const parsed = spec ? parseRegistryNpmSpec(spec) : null;
-  return parsed?.selectorKind === "exact-version" ? parsed.selector : undefined;
+  return parsed?.selectorKind === "exact-version"
+    ? normalizeExactNpmVersion(parsed.selector)
+    : undefined;
+}
+
+function normalizeExactNpmVersion(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!isExactSemverVersion(trimmed)) {
+    return undefined;
+  }
+  return trimmed.startsWith("v") ? trimmed.slice(1) : trimmed;
 }
 
 function resolveNpmResultVersion(result: {


### PR DESCRIPTION
Closes #92183

## What Problem This Solves

Fixes an issue where users running `openclaw plugins update <id> --dry-run` on an exact pinned npm plugin would only see an `up to date` result, even when the registry default line had a newer release available.

## Why This Change Was Made

Exact pinned plugin-id updates still stay pinned, preserving the existing sticky-pin contract. The dry-run path now adds a best-effort registry default-line check for exact pinned npm installs and, when a newer default is resolvable, reports the pin plus an explicit `@latest` package update command instead of silently implying there is no newer registry default.

The exact-version comparison now normalizes accepted leading-`v` exact selectors such as `@pkg@v1.2.3`, so those supported pins receive the same default-line advisory as `@pkg@1.2.3`.

## User Impact

Operators can keep reproducible exact pins while still seeing when a newer registry default release exists during dry-run planning. Users who want to leave the pin get clear confirmation that the install is pinned; users who want to follow the default line get a command that avoids plugin-id/package-name ambiguity.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/update.test.ts --testNamePattern "reports newer registry default releases"` (1 file passed; 2 tests passed, covering `@acme/demo@1.2.3` and `@acme/demo@v1.2.3`)
- `node_modules/.bin/oxfmt --check src/plugins/update.ts src/plugins/update.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean: no accepted/actionable findings; overall patch correct)

Live after-fix CLI proof:

- Installed `npm:@openclaw/voice-call@v2026.6.9` into an isolated redacted proof state.
- Ran `node scripts/run-node.mjs plugins update voice-call --dry-run` against that installed exact pin.
- Dry-run output reported: `voice-call is pinned to @openclaw/voice-call@v2026.6.9 (installed 2026.6.9); registry default resolves to 2026.6.10. Pass \`openclaw plugins update @openclaw/voice-call@latest\` to follow the registry default line.`
- Post dry-run SQLite record check showed the tracked install remained pinned to `@openclaw/voice-call@v2026.6.9`, with resolved version `2026.6.9`.
