### PR TITLE
fix(telegram): preserve literal reasoning tags

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3608,10 +3608,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await run;
   });
 
-  it("suppresses reasoning-only finals without raw text fallback", async () => {
+  it("suppresses typed reasoning-only finals without raw text fallback", async () => {
     setupDraftStreams({ answerMessageId: 2001, reasoningMessageId: 3001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
-      await dispatcherOptions.deliver({ text: "<think>hidden</think>" }, { kind: "final" });
+      await dispatcherOptions.deliver(
+        { text: "<think>hidden</think>", isReasoning: true },
+        { kind: "final" },
+      );
       return { queuedFinal: true };
     });
 
@@ -3619,6 +3622,25 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(deliverReplies).not.toHaveBeenCalled();
     expect(editMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("keeps unflagged angle-bracket text visible on the answer lane", async () => {
+    const { answerDraftStream } = setupDraftStreams({
+      answerMessageId: 2001,
+      reasoningMessageId: 3001,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "Before <think>literal tag text after" },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Before <think>literal tag text after");
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("does not add silent fallback when source delivery is message-tool-only", async () => {

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -30,6 +30,11 @@ describe("markdownToTelegramHtml", () => {
         "<script>nope</script>",
         "&lt;script&gt;nope&lt;/script&gt;",
       ],
+      [
+        "escapes literal reasoning-looking tags",
+        "Before <think>literal tag text after",
+        "Before &lt;think&gt;literal tag text after",
+      ],
       ["escapes unsafe characters", "a & b < c", "a &amp; b &lt; c"],
       ["renders paragraphs with blank lines", "first\n\nsecond", "first\n\nsecond"],
       ["renders lists without block HTML", "- one\n- two", "• one\n• two"],

--- a/extensions/telegram/src/reasoning-lane-coordinator.test.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.test.ts
@@ -3,10 +3,23 @@ import { describe, expect, it } from "vitest";
 import { splitTelegramReasoningText } from "./reasoning-lane-coordinator.js";
 
 describe("splitTelegramReasoningText", () => {
-  it("splits real tagged reasoning and answer", () => {
-    expect(splitTelegramReasoningText("<think>example</think>Done")).toEqual({
+  it("keeps unflagged angle-bracket reasoning tags in the answer lane", () => {
+    const text = "<think>example</think>Done";
+    expect(splitTelegramReasoningText(text)).toEqual({
+      answerText: text,
+    });
+  });
+
+  it("keeps unclosed unflagged reasoning-looking text in the answer lane", () => {
+    const text = "Before <think>unclosed content after";
+    expect(splitTelegramReasoningText(text)).toEqual({
+      answerText: text,
+    });
+  });
+
+  it("formats tagged text when the payload is explicitly reasoning", () => {
+    expect(splitTelegramReasoningText("<think>example</think>Done", true)).toEqual({
       reasoningText: "Thinking\n\n_example_",
-      answerText: "Done",
     });
   });
 
@@ -25,7 +38,7 @@ describe("splitTelegramReasoningText", () => {
   });
 
   it("does not emit partial reasoning tag prefixes", () => {
-    expect(splitTelegramReasoningText("  <thi")).toStrictEqual({});
+    expect(splitTelegramReasoningText("  <thi", true)).toStrictEqual({});
   });
 
   it("keeps visible Thinking-prefixed answers in the answer lane", () => {

--- a/extensions/telegram/src/reasoning-lane-coordinator.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.ts
@@ -73,6 +73,10 @@ export function splitTelegramReasoningText(
     return {};
   }
 
+  if (isReasoning !== true) {
+    return { answerText: text };
+  }
+
   const trimmed = text.trim();
   if (isPartialReasoningTagPrefix(trimmed)) {
     return {};

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1170,6 +1170,22 @@ describe("sendMessageTelegram", () => {
     expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
+  it("escapes literal reasoning-looking tags on the text path", async () => {
+    botApi.sendMessage.mockResolvedValue({ message_id: 47, chat: { id: "123" } });
+
+    await sendMessageTelegram("123", "Before <think>literal tag text after", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+    });
+
+    expect(botApi.sendMessage).toHaveBeenCalledWith(
+      "123",
+      "Before &lt;think&gt;literal tag text after",
+      { parse_mode: "HTML" },
+    );
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
+  });
+
   it("escapes HTML media tags on the text path", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 48, chat: { id: "123" } });
 

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -71,6 +71,91 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSinglePayloadText(payloads, "Done.");
   });
 
+  it("does not revive signed unphased text when explicit final-answer text is empty", () => {
+    expectNoPayloads({
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "MEDIA:/tmp/old.png",
+            textSignature: JSON.stringify({ v: 1, id: "item_old" }),
+          },
+          {
+            type: "text",
+            text: "   ",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+  });
+
+  it("does not revive signed unphased text when explicit output_text final-answer text is empty", () => {
+    expectNoPayloads({
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "MEDIA:/tmp/old.png",
+            textSignature: JSON.stringify({ v: 1, id: "item_old" }),
+          },
+          {
+            type: "output_text",
+            text: "   ",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+  });
+
+  it("keeps literal mid-answer reasoning-looking tags in final-answer text", () => {
+    const text = "Before <think>literal tag text after";
+    const payloads = buildPayloads({
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text,
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, text);
+  });
+
+  it("keeps strict reasoning-tag stripping for legacy string fallback text", () => {
+    const payloads = buildPayloads({
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: "Visible prefix <think>private reasoning tail",
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, "Visible prefix");
+  });
+
   it("falls back to final-answer assistant text when streamed text only contains blanks", () => {
     const payloads = buildPayloads({
       assistantTexts: ["   "],

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -24,7 +24,14 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { hasReplyPayloadContent } from "../../../interactive/payload.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { isCronSessionKey } from "../../../routing/session-key.js";
-import { extractAssistantTextForPhase } from "../../../shared/chat-message-content.js";
+import {
+  extractAssistantTextForPhase,
+  parseAssistantTextSignature,
+} from "../../../shared/chat-message-content.js";
+import {
+  sanitizeAssistantFinalAnswerText,
+  sanitizeAssistantVisibleText,
+} from "../../../shared/text/assistant-visible-text.js";
 import { parseInlineDirectives } from "../../../utils/directive-tags.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
@@ -112,14 +119,62 @@ function isVerboseToolDetailEnabled(level?: VerboseLevel): boolean {
   return level === "full";
 }
 
+function isAssistantTextContentBlockType(value: unknown): boolean {
+  return value === "text" || value === "input_text" || value === "output_text";
+}
+
 function resolveRawAssistantAnswerText(lastAssistant: AssistantMessage | undefined): string {
   if (!lastAssistant) {
     return "";
   }
+  const finalAnswerText = extractAssistantTextForPhase(lastAssistant, {
+    phase: "final_answer",
+    sanitizeText: sanitizeAssistantFinalAnswerText,
+  });
+  if (finalAnswerText) {
+    return normalizeOptionalString(finalAnswerText) ?? "";
+  }
+  if (Array.isArray(lastAssistant.content)) {
+    const hasExplicitPhasedTextBlock = lastAssistant.content.some((block) => {
+      if (!block || typeof block !== "object") {
+        return false;
+      }
+      const record = block as { type?: unknown; textSignature?: unknown };
+      return (
+        isAssistantTextContentBlockType(record.type) &&
+        Boolean(parseAssistantTextSignature(record.textSignature)?.phase)
+      );
+    });
+    if (!hasExplicitPhasedTextBlock) {
+      const signedUnphasedParts = lastAssistant.content
+        .map((block) => {
+          if (!block || typeof block !== "object") {
+            return null;
+          }
+          const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
+          const signature = parseAssistantTextSignature(record.textSignature);
+          if (
+            !isAssistantTextContentBlockType(record.type) ||
+            typeof record.text !== "string" ||
+            !signature?.id ||
+            signature.phase
+          ) {
+            return null;
+          }
+          const text = sanitizeAssistantFinalAnswerText(record.text);
+          return text.trim() ? text : null;
+        })
+        .filter((value): value is string => typeof value === "string");
+      if (signedUnphasedParts.length) {
+        return normalizeOptionalString(signedUnphasedParts.join("\n")) ?? "";
+      }
+    }
+  }
   return (
     normalizeOptionalString(
-      extractAssistantTextForPhase(lastAssistant, { phase: "final_answer" }) ??
-        extractAssistantTextForPhase(lastAssistant),
+      extractAssistantTextForPhase(lastAssistant, {
+        sanitizeText: sanitizeAssistantVisibleText,
+      }),
     ) ?? ""
   );
 }

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -102,9 +102,11 @@ function createMessageEndContext(
     finalizeAssistantTexts?: ReturnType<typeof vi.fn>;
     flushBlockReplyBuffer?: ReturnType<typeof vi.fn>;
     consumeReplyDirectives?: ReturnType<typeof vi.fn>;
+    stripBlockTags?: ReturnType<typeof vi.fn>;
     warn?: ReturnType<typeof vi.fn>;
     builtinToolNames?: ReadonlySet<string>;
     sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
+    enforceFinalTag?: boolean;
     blockChunker?: { hasBuffered: () => boolean; reset: () => void };
     state?: Record<string, unknown>;
   } = {},
@@ -119,6 +121,7 @@ function createMessageEndContext(
       ...(params.sourceReplyDeliveryMode
         ? { sourceReplyDeliveryMode: params.sourceReplyDeliveryMode }
         : {}),
+      ...(params.enforceFinalTag !== undefined ? { enforceFinalTag: params.enforceFinalTag } : {}),
       ...(params.onAgentEvent ? { onAgentEvent: params.onAgentEvent } : {}),
       ...(params.onBlockReply ? { onBlockReply: params.onBlockReply } : { onBlockReply: vi.fn() }),
     },
@@ -156,7 +159,7 @@ function createMessageEndContext(
     commitAssistantUsage: vi.fn(),
     log: { debug: vi.fn(), info: vi.fn(), warn: params.warn ?? vi.fn() },
     builtinToolNames: params.builtinToolNames,
-    stripBlockTags: (text: string) => text,
+    stripBlockTags: params.stripBlockTags ?? vi.fn((text: string) => text),
     finalizeAssistantTexts: params.finalizeAssistantTexts ?? vi.fn(),
     emitAssistantStreamData: vi.fn(
       (data: Parameters<EmbeddedAgentSubscribeContext["emitAssistantStreamData"]>[0]) => {
@@ -1158,6 +1161,76 @@ describe("handleMessageEnd", () => {
       text: "",
       mediaUrls: ["/tmp/final.png"],
     });
+  });
+
+  it("preserves literal reasoning-looking tags in unphased final visible text", () => {
+    const onAgentEvent = vi.fn();
+    const stripBlockTags = vi.fn(() => "Before");
+    const ctx = createMessageEndContext({
+      onAgentEvent,
+      stripBlockTags,
+      consumeReplyDirectives: vi.fn((text: string) => ({ text })),
+      state: {
+        blockBuffer: "",
+        deltaBuffer: "",
+      },
+    });
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Before <think>literal tag text after",
+            textSignature: JSON.stringify({ v: 1, id: "item_unphased" }),
+          },
+        ],
+        usage: { input: 10, output: 5, total: 15 },
+      },
+    } as never);
+
+    expect(stripBlockTags).not.toHaveBeenCalled();
+    expect(firstMockArg(ctx.emitAssistantStreamData as never, "assistant stream")).toMatchObject({
+      text: "Before <think>literal tag text after",
+      delta: "Before <think>literal tag text after",
+    });
+    expect(ctx.finalizeAssistantTexts).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Before <think>literal tag text after" }),
+    );
+  });
+
+  it("keeps final-tag enforcement in message_end fallback", () => {
+    const onAgentEvent = vi.fn();
+    const stripBlockTags = vi.fn(() => "");
+    const ctx = createMessageEndContext({
+      enforceFinalTag: true,
+      onAgentEvent,
+      stripBlockTags,
+      consumeReplyDirectives: vi.fn((text: string) => ({ text })),
+      state: {
+        blockBuffer: "",
+        deltaBuffer: "",
+      },
+    });
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: "Hello world",
+        usage: { input: 10, output: 5, total: 15 },
+      },
+    } as never);
+
+    expect(stripBlockTags).toHaveBeenCalledWith(
+      "Hello world",
+      { thinking: false, final: false },
+      { final: true },
+    );
+    expect(ctx.emitAssistantStreamData).not.toHaveBeenCalled();
+    expect(ctx.finalizeAssistantTexts).toHaveBeenCalledWith(expect.objectContaining({ text: "" }));
   });
 
   it("emits a replacement final assistant event when final_answer appears only at message_end", () => {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -942,9 +942,12 @@ export function handleMessageEnd(
         ctx.params.sourceReplyDeliveryMode === "message_tool_only" &&
         ctx.builtinToolNames?.has("message") === true,
     }) ?? rawVisibleText;
+  const finalVisibleText = ctx.params.enforceFinalTag
+    ? ctx.stripBlockTags(visibleText, { thinking: false, final: false }, { final: true })
+    : visibleText;
 
   const text = resolveSilentReplyFallbackText({
-    text: ctx.stripBlockTags(visibleText, { thinking: false, final: false }, { final: true }),
+    text: finalVisibleText,
     messagingToolSentTexts: ctx.state.messagingToolSentTexts,
   });
   const rawThinking =

--- a/src/agents/embedded-agent-utils.test.ts
+++ b/src/agents/embedded-agent-utils.test.ts
@@ -790,6 +790,23 @@ describe("extractAssistantVisibleText", () => {
     expect(extractAssistantVisibleText(msg)).toBe("");
   });
 
+  it("does not fall back to unphased legacy text when an empty output_text final_answer block exists", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "text", text: "Legacy answer" },
+        {
+          type: "output_text",
+          text: "   ",
+          textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantVisibleText(msg)).toBe("");
+  });
+
   it("falls back to legacy unphased text when phased text is absent", () => {
     const msg = makeAssistantMessage({
       role: "assistant",
@@ -798,6 +815,32 @@ describe("extractAssistantVisibleText", () => {
     });
 
     expect(extractAssistantVisibleText(msg)).toBe("Legacy answer");
+  });
+
+  it("keeps strict reasoning-tag stripping for legacy string content", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: "Visible prefix <think>private reasoning tail",
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantVisibleText(msg)).toBe("Visible prefix");
+  });
+
+  it("preserves literal reasoning-looking tags in unphased visible text", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Before <think>literal tag text after",
+          textSignature: JSON.stringify({ v: 1, id: "item_unphased" }),
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantVisibleText(msg)).toBe("Before <think>literal tag text after");
   });
 
   it("does not pull unphased legacy text into final_answer extraction when phased blocks are present", () => {

--- a/src/agents/embedded-agent-utils.ts
+++ b/src/agents/embedded-agent-utils.ts
@@ -10,7 +10,10 @@ import {
   parseAssistantTextSignature,
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
-import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
+import {
+  sanitizeAssistantFinalAnswerText,
+  sanitizeAssistantVisibleText,
+} from "../shared/text/assistant-visible-text.js";
 import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
 import { sanitizeUserFacingText } from "./embedded-agent-helpers/sanitize-user-facing-text.js";
 import type { AgentMessage } from "./runtime/index.js";
@@ -36,8 +39,14 @@ export function stripThinkingTagsFromText(text: string): string {
   return stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
 }
 
-function sanitizeAssistantText(text: string): string {
-  return sanitizeAssistantVisibleText(text);
+function sanitizeAssistantText(text: string, phase?: AssistantPhase): string {
+  return phase === "final_answer"
+    ? sanitizeAssistantFinalAnswerText(text)
+    : sanitizeAssistantVisibleText(text);
+}
+
+function isAssistantTextContentBlockType(value: unknown): boolean {
+  return value === "text" || value === "input_text" || value === "output_text";
 }
 
 export function sanitizeAssistantVisibleStreamText(text: string): string {
@@ -57,6 +66,7 @@ type AssistantTextExtractionResult = {
 function extractAssistantTextForPhase(
   msg: AssistantMessage,
   phase?: AssistantPhase,
+  options?: { unphasedSignedFinalAnswer?: boolean },
 ): AssistantTextExtractionResult {
   const messagePhase = normalizeAssistantPhase((msg as { phase?: unknown }).phase);
   const shouldIncludeContent = (resolvedPhase?: AssistantPhase) => {
@@ -70,7 +80,7 @@ function extractAssistantTextForPhase(
     const hadRequestedPhase = phase ? messagePhase === phase : messagePhase === undefined;
     return {
       text: shouldIncludeContent(messagePhase)
-        ? finalizeAssistantExtraction(msg, sanitizeAssistantText(msg.content))
+        ? finalizeAssistantExtraction(msg, sanitizeAssistantText(msg.content, messagePhase))
         : "",
       hadRequestedPhase,
     };
@@ -85,37 +95,37 @@ function extractAssistantTextForPhase(
       return false;
     }
     const record = block as { type?: unknown; textSignature?: unknown };
-    if (record.type !== "text") {
+    if (!isAssistantTextContentBlockType(record.type)) {
       return false;
     }
     return Boolean(parseAssistantTextSignature(record.textSignature)?.phase);
   });
 
   let hadRequestedPhase = false;
-  const extracted =
-    extractTextFromChatContent(
-      msg.content.filter((block) => {
-        if (!block || typeof block !== "object") {
-          return false;
-        }
-        const record = block as { type?: unknown; textSignature?: unknown };
-        if (record.type !== "text") {
-          return false;
-        }
-        const signature = parseAssistantTextSignature(record.textSignature);
-        const resolvedPhase =
-          signature?.phase ?? (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
-        if (phase ? resolvedPhase === phase : resolvedPhase === undefined) {
-          hadRequestedPhase = true;
-        }
-        return shouldIncludeContent(resolvedPhase);
-      }),
-      {
-        sanitizeText: (text) => sanitizeAssistantText(text),
-        joinWith: "\n",
-        normalizeText: (text) => text.trim(),
-      },
-    ) ?? "";
+  const parts = msg.content
+    .map((block) => {
+      if (!block || typeof block !== "object") {
+        return null;
+      }
+      const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
+      if (!isAssistantTextContentBlockType(record.type) || typeof record.text !== "string") {
+        return null;
+      }
+      const signature = parseAssistantTextSignature(record.textSignature);
+      const resolvedPhase =
+        signature?.phase ?? (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
+      if (!shouldIncludeContent(resolvedPhase)) {
+        return null;
+      }
+      hadRequestedPhase = true;
+      const sanitizerPhase =
+        resolvedPhase ??
+        (options?.unphasedSignedFinalAnswer === true && signature?.id ? "final_answer" : undefined);
+      const text = sanitizeAssistantText(record.text, sanitizerPhase);
+      return text.trim() ? text : null;
+    })
+    .filter((value): value is string => typeof value === "string");
+  const extracted = parts.join("\n").trim();
 
   return {
     text: finalizeAssistantExtraction(msg, extracted),
@@ -130,7 +140,7 @@ export function extractAssistantVisibleText(msg: AssistantMessage): string {
     return finalAnswerExtraction.text.trim() ? finalAnswerExtraction.text : "";
   }
 
-  return extractAssistantTextForPhase(msg).text;
+  return extractAssistantTextForPhase(msg, undefined, { unphasedSignedFinalAnswer: true }).text;
 }
 
 /** Extract sanitized assistant text across all text content blocks. */

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -9466,7 +9466,7 @@ describe("openai transport stream", () => {
     expect(output.content.some((block) => block.type === "thinking")).toBe(false);
   });
 
-  it("strips content-only reasoning tags from OpenAI-compatible visible text", async () => {
+  it("strips content-only closed reasoning tags from OpenAI-compatible visible text", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);
 
@@ -9497,6 +9497,41 @@ describe("openai transport stream", () => {
     expect(output.content).toContainEqual({
       type: "text",
       text: "Before  after",
+    });
+    expect(output.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
+  it("keeps content-only unclosed mid-answer reasoning-looking tags visible", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-content-only-unclosed-tags",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "Before <think>literal tag text after",
+              },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toContainEqual({
+      type: "text",
+      text: "Before <think>literal tag text after",
     });
     expect(output.content.some((block) => block.type === "thinking")).toBe(false);
   });

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -1,6 +1,7 @@
 // Assistant visible text tests cover extracting user-visible assistant output.
 import { describe, expect, it } from "vitest";
 import {
+  sanitizeAssistantFinalAnswerText,
   sanitizeAssistantVisibleText,
   sanitizeAssistantVisibleTextWithProfile,
   stripAssistantInternalScaffolding,
@@ -873,9 +874,24 @@ describe("sanitizeAssistantVisibleText", () => {
     );
   });
 
-  it("keeps unclosed trailing reasoning hidden when visible text already exists", () => {
+  it("hides mid-answer unclosed reasoning tags on the raw delivery path", () => {
     expect(sanitizeAssistantVisibleText("Visible prefix <think>private reasoning tail")).toBe(
       "Visible prefix",
+    );
+  });
+
+  it("still hides mid-answer closed reasoning tags", () => {
+    const text = "Visible prefix <think>private reasoning</think> visible suffix";
+
+    expect(sanitizeAssistantVisibleText(text)).toBe("Visible prefix  visible suffix");
+  });
+
+  it("keeps unclosed literal reasoning-looking tags in final-answer prose", () => {
+    expect(
+      sanitizeAssistantFinalAnswerText("<think>hidden</think>Use <think> literally here"),
+    ).toBe("Use <think> literally here");
+    expect(sanitizeAssistantFinalAnswerText("Before <think>literal tag text after")).toBe(
+      "Before <think>literal tag text after",
     );
   });
 });

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -6,6 +6,7 @@ import { stripModelSpecialTokens } from "./model-special-tokens.js";
 import {
   stripReasoningTagsFromText,
   type ReasoningTagMode,
+  type ReasoningTagScope,
   type ReasoningTagTrim,
 } from "./reasoning-tags.js";
 
@@ -801,6 +802,7 @@ export function stripAssistantInternalTraceLines(text: string): string {
 
 export type AssistantVisibleTextSanitizerProfile =
   | "delivery"
+  | "final-answer-delivery"
   | "history"
   | "internal-scaffolding"
   | "tool-progress";
@@ -813,6 +815,7 @@ type AssistantVisibleTextPipelineOptions = {
   stripFunctionResponseAfterPluralToolCalls?: boolean;
   stripInternalTraceLines?: boolean;
   reasoningMode: ReasoningTagMode;
+  reasoningScope?: ReasoningTagScope;
   reasoningTrim: ReasoningTagTrim;
   stageOrder: "reasoning-first" | "reasoning-last";
 };
@@ -825,6 +828,14 @@ const ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS: Record<
     finalTrim: "both",
     stripFunctionResponseAfterPluralToolCalls: true,
     reasoningMode: "strict",
+    reasoningTrim: "both",
+    stageOrder: "reasoning-last",
+  },
+  "final-answer-delivery": {
+    finalTrim: "both",
+    stripFunctionResponseAfterPluralToolCalls: true,
+    reasoningMode: "strict",
+    reasoningScope: "leading",
     reasoningTrim: "both",
     stageOrder: "reasoning-last",
   },
@@ -863,6 +874,7 @@ function applyAssistantVisibleTextStagePipeline(
   const stripReasoning = (value: string) =>
     stripReasoningTagsFromText(value, {
       mode: options.reasoningMode,
+      scope: options.reasoningScope,
       trim: options.reasoningTrim,
     });
   const applyFinalTrim = (value: string) => {
@@ -923,6 +935,11 @@ export function stripAssistantInternalScaffolding(text: string): string {
  */
 export function sanitizeAssistantVisibleText(text: string): string {
   return sanitizeAssistantVisibleTextWithProfile(text, "delivery");
+}
+
+/** Sanitizes text already marked as final-answer prose by the agent runtime. */
+export function sanitizeAssistantFinalAnswerText(text: string): string {
+  return sanitizeAssistantVisibleTextWithProfile(text, "final-answer-delivery");
 }
 
 /**

--- a/src/shared/text/reasoning-tag-text-partitioner.test.ts
+++ b/src/shared/text/reasoning-tag-text-partitioner.test.ts
@@ -183,7 +183,7 @@ describe("createReasoningTagTextPartitioner", () => {
     ]);
   });
 
-  it("recovers unclosed trailing tags as visible prose in visible mode", () => {
+  it("keeps unclosed trailing tags as visible prose in visible mode", () => {
     const partitioner = createReasoningTagTextPartitioner();
 
     expect(partitioner.pushVisible("Use <think> only in this mode")).toEqual([

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -3,6 +3,7 @@ import { findCodeRegions, isInsideCode } from "./code-regions.js";
 import { findFinalTagMatches } from "./final-tags.js";
 export type ReasoningTagMode = "strict" | "preserve";
 export type ReasoningTagTrim = "none" | "start" | "both";
+export type ReasoningTagScope = "all" | "leading";
 
 // Reasoning tags may carry a model-specific namespace prefix (e.g. Anthropic's
 // `antml:`, MiniMax's `mm:`). Accept the known prefixes so namespaced variants
@@ -29,12 +30,31 @@ export function hasOrphanReasoningCloseBoundary(params: {
   return params.before.trim().length > 0 && params.after.trim().length > 0;
 }
 
+function hasReasoningCloseTagAfter(
+  text: string,
+  start: number,
+  codeRegions: ReturnType<typeof findCodeRegions>,
+) {
+  for (const match of text.slice(start).matchAll(THINKING_TAG_RE)) {
+    const idx = start + (match.index ?? 0);
+    if (isInsideCode(idx, codeRegions)) {
+      continue;
+    }
+    if (match[1] === "/") {
+      return true;
+    }
+  }
+  THINKING_TAG_RE.lastIndex = 0;
+  return false;
+}
+
 /** Strips model reasoning/final tags from visible text while preserving literal code examples. */
 export function stripReasoningTagsFromText(
   text: string,
   options?: {
     mode?: ReasoningTagMode;
     trim?: ReasoningTagTrim;
+    scope?: ReasoningTagScope;
   },
 ): string {
   if (!text) {
@@ -46,6 +66,7 @@ export function stripReasoningTagsFromText(
 
   const mode = options?.mode ?? "strict";
   const trimMode = options?.trim ?? "both";
+  const scope = options?.scope ?? "all";
 
   let cleaned = text;
   const matches = findFinalTagMatches(cleaned);
@@ -92,6 +113,14 @@ export function stripReasoningTagsFromText(
     }
 
     if (thinkingDepth === 0) {
+      if (
+        scope === "leading" &&
+        !isClose &&
+        (result + cleaned.slice(lastIndex, idx)).trim().length > 0 &&
+        !hasReasoningCloseTagAfter(cleaned, idx + match[0].length, codeRegions)
+      ) {
+        return applyTrim(result + cleaned.slice(lastIndex), trimMode);
+      }
       if (isClose) {
         const afterIndex = idx + match[0].length;
         const before = cleaned.slice(lastIndex, idx);


### PR DESCRIPTION
## What Problem This Solves

Fixes #49104.

Telegram already renders normal reply text through an HTML-escaped sender path, but the Telegram reasoning-lane coordinator was still guessing that unflagged answer text containing `<think>`/`<thinking>`-style tags was private reasoning. That meant ordinary model text could be removed or moved out of the answer lane before Telegram formatting ever had a chance to escape it as literal user-visible text.

## Why This Change Was Made

This makes Telegram trust the typed delivery contract instead of reparsing answer text for hidden reasoning. Only payloads explicitly marked `isReasoning: true` are routed through the reasoning lane; unflagged text remains answer text and is escaped by the existing Telegram HTML renderer/sender.

The fix keeps the product model simple:

- typed reasoning payloads still render/suppress as reasoning
- ordinary answer text is delivered literally by default
- Telegram HTML escaping remains the transport-level guard for angle brackets
- no parse-mode fallback stack or channel-local guessing layer is added

## User Impact

Telegram replies that include literal angle-bracket text such as `<think>` are no longer dropped as inferred reasoning. The bot should now show that text literally in the normal answer path, while real reasoning payloads remain separated from user-visible answers.

## Evidence

Source-level proof:

- `node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts -t 'escapes literal reasoning-looking tags on the text path'`
- `node scripts/run-vitest.mjs extensions/telegram/src/reasoning-lane-coordinator.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/format.test.ts src/shared/text/reasoning-tags.test.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` -> clean, no accepted/actionable findings

Telegram-visible proof:

- Direct SUT Bot API send with `parse_mode: HTML` and escaped `&lt;think&gt;` was observed by the real Telegram user driver as literal `<think>literal tag text after`.
- Full patched OpenClaw Telegram turn was attempted with a mock model forced to output a literal `<think>` marker; the patched gateway reached `/v1/responses` successfully, but end-to-end observation was blocked by a concurrent local gateway using the same Telegram SUT bot token (`getUpdates conflict`).
