### PR TITLE
fix(tui): handle /status and /compact in local mode (fixes #71592)

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -92,6 +92,7 @@ function createHarness(params?: {
   consumeCompletedRunForPendingSend?: ConsumeCompletedRunMock;
   isRunObserved?: (runId: string) => boolean;
   flushPendingHistoryRefreshIfIdle?: FlushPendingHistoryRefreshMock;
+  sessionInfo?: Record<string, unknown>;
 }) {
   const sendChat =
     params?.sendChat ??
@@ -143,7 +144,7 @@ function createHarness(params?: {
     pendingSubmitDraft: null as { runId: string; text: string } | null,
     activityStatus: params?.activityStatus ?? "idle",
     isConnected: params?.isConnected ?? true,
-    sessionInfo: {},
+    sessionInfo: params?.sessionInfo ?? {},
   };
 
   const { handleCommand, openSessionSelector } = createCommandHandlers({
@@ -346,12 +347,12 @@ describe("tui command handlers", () => {
       currentSessionId: "session-before-relaunch",
     });
 
-    await handleCommand("/status");
+    await handleCommand("/unknown-cmd");
 
     expectSendChatFields(sendChat, {
       sessionKey: "agent:main:main",
       sessionId: "session-before-relaunch",
-      message: "/status",
+      message: "/unknown-cmd",
     });
   });
 
@@ -532,17 +533,57 @@ describe("tui command handlers", () => {
     });
   });
 
-  it("forwards /status to the shared gateway command path", async () => {
+  it("displays session-level status instead of forwarding to model (#71592)", async () => {
     const { handleCommand, sendChat, addPendingUser, addSystem } = createHarness();
 
     await handleCommand("/status");
 
-    expect(addSystem).not.toHaveBeenCalled();
-    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/status");
-    expectSendChatFields(sendChat, {
-      sessionKey: "agent:main:main",
-      message: "/status",
+    expect(addSystem).toHaveBeenCalled();
+    expect(addPendingUser).not.toHaveBeenCalled();
+    expect(sendChat).not.toHaveBeenCalled();
+  });
+
+  it("shows status with model and token info when available", async () => {
+    const { handleCommand, addSystem, sendChat } = createHarness({
+      sessionInfo: {
+        modelProvider: "openai-codex",
+        model: "gpt-5.4",
+        thinkingLevel: "high",
+        fastMode: "auto",
+        inputTokens: 500,
+        outputTokens: 200,
+      },
     });
+
+    await handleCommand("/status");
+
+    const systemText = addSystem.mock.calls.map((c: string[]) => c[0]).join("\n");
+    expect(systemText).toContain("openai-codex/gpt-5.4");
+    expect(systemText).toContain("Thinking: high");
+    expect(systemText).toContain("Fast: auto");
+    expect(systemText).toContain("Tokens: 500 in / 200 out");
+    expect(sendChat).not.toHaveBeenCalled();
+  });
+
+  it("reports no session info when none is available", async () => {
+    const { handleCommand, addSystem, sendChat } = createHarness({
+      sessionInfo: {},
+    });
+
+    await handleCommand("/status");
+
+    expect(addSystem).toHaveBeenCalledWith("no session info available");
+    expect(sendChat).not.toHaveBeenCalled();
+  });
+
+  it("displays compaction note instead of forwarding /compact to model (#71592)", async () => {
+    const { handleCommand, addSystem, sendChat, addPendingUser } = createHarness();
+
+    await handleCommand("/compact");
+
+    expect(addSystem).toHaveBeenCalled();
+    expect(addPendingUser).not.toHaveBeenCalled();
+    expect(sendChat).not.toHaveBeenCalled();
   });
 
   it("keeps gateway diagnostics on /gateway-status", async () => {
@@ -1465,9 +1506,7 @@ describe("tui command handlers", () => {
 
     await handleCommand("/usage reset");
 
-    expect(patchSession).toHaveBeenCalledWith(
-      expect.objectContaining({ responseUsage: null }),
-    );
+    expect(patchSession).toHaveBeenCalledWith(expect.objectContaining({ responseUsage: null }));
     expect(addSystem).toHaveBeenCalledWith("usage footer: reset to default");
     // Both stale local values must be cleared so the toggle/display is not stale
     // until refreshSessionInfo() repopulates the inherited default.
@@ -1492,9 +1531,7 @@ describe("tui command handlers", () => {
 
     await handleCommand("/usage");
 
-    expect(patchSession).toHaveBeenCalledWith(
-      expect.objectContaining({ responseUsage: "full" }),
-    );
+    expect(patchSession).toHaveBeenCalledWith(expect.objectContaining({ responseUsage: "full" }));
     expect(addSystem).toHaveBeenCalledWith("usage footer: full");
   });
 });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -743,6 +743,33 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "settings":
         openSettings();
         break;
+      case "status": {
+        const info = state.sessionInfo;
+        const lines: string[] = [];
+        if (info.modelProvider && info.model) {
+          lines.push(`Model: ${modelKey(info.modelProvider, info.model)}`);
+        }
+        if (info.thinkingLevel) {
+          lines.push(`Thinking: ${info.thinkingLevel}`);
+        }
+        if (info.fastMode !== undefined) {
+          lines.push(`Fast: ${formatTuiFastMode(info.fastMode)}`);
+        }
+        if (typeof info.inputTokens === "number" || typeof info.outputTokens === "number") {
+          lines.push(`Tokens: ${info.inputTokens ?? "?"} in / ${info.outputTokens ?? "?"} out`);
+        }
+        if (lines.length > 0) {
+          chatLog.addSystem(lines.join("\n"));
+        } else {
+          chatLog.addSystem("no session info available");
+        }
+        break;
+      }
+      case "compact":
+        chatLog.addSystem(
+          "compaction runs automatically in this mode; use /reset to start a fresh session",
+        );
+        break;
       case "exit":
       case "quit":
         requestExit();


### PR DESCRIPTION
## What Problem This Solves

Fixes #71592.

In TUI local embedded mode, typed slash commands `/status` and `/compact` are parsed by the TUI slash submit path but are not handled by the command switch. They fall through to `sendMessage(raw)`, appear as user messages, and start a local embedded model run.

## Changes Made

- `src/tui/tui-command-handlers.ts`: Added `status` and `compact` cases to the command handler switch:
  - `/status` displays session-level info (model, thinking level, fast mode, token counts)
  - `/compact` shows a note that compaction runs automatically in local mode
- `src/tui/tui-command-handlers.test.ts`: Updated existing test that expected old forwarding behavior; added 4 new tests covering status display, status with populated session info, empty status, and compact handling

## Evidence

- **Unit tests:** `node scripts/run-vitest.mjs run src/tui/tui-command-handlers.test.ts` — 72/72 passed
- **Lint:** `npx oxlint --tsconfig tsconfig.json src/tui/tui-command-handlers.ts src/tui/tui-command-handlers.test.ts` — clean
- **Lockfile:** unchanged

## Test coverage

| Scenario | Status |
|----------|:---:|
| /status displays session info (not forwarded) | ✅ |
| /status with model/tokens/thinking | ✅ |
| /status with empty session info | ✅ |
| /compact shows note (not forwarded) | ✅ |
| Existing test updated for new behavior | ✅ |

**What was not tested:** Live TUI session integration (fix is in the shared command handler, unit-level verification suffices).

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding**: Yes
