### PR TITLE
fix(github-copilot): seed idle timeout fallbacks

### DIFF
--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -600,6 +600,7 @@ describe("github-copilot plugin", () => {
     });
     expect(result?.agents?.defaults?.model).toEqual({
       primary: "github-copilot/claude-opus-4.7",
+      fallbacks: ["github-copilot/gpt-5.5"],
     });
     expect(result?.agents?.defaults?.models?.["github-copilot/claude-opus-4.7"]).toStrictEqual({});
 
@@ -748,6 +749,77 @@ describe("github-copilot plugin", () => {
     });
     expect(result?.agents?.defaults?.models).toEqual({
       "github-copilot/gpt-5.4": { label: "Existing" },
+    });
+  });
+
+  it("adds Copilot fallbacks when an existing Copilot primary has no fallback list", async () => {
+    const provider = registerProviderWithPluginConfig({});
+    const method = provider.auth[0];
+    const agentDir = await createAgentDir();
+    const runtime = { error: vi.fn(), exit: vi.fn() };
+
+    const result = await method.runNonInteractive({
+      authChoice: "github-copilot",
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "github-copilot/gpt-5.5",
+            },
+          },
+        },
+      },
+      baseConfig: {},
+      opts: { githubCopilotToken: "ghu_test" },
+      runtime,
+      agentDir,
+      resolveApiKey: vi.fn(async () => ({
+        key: "ghu_test",
+        source: "flag" as const,
+      })),
+      toApiKeyCredential: vi.fn(),
+    });
+
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(result?.agents?.defaults?.model).toEqual({
+      primary: "github-copilot/gpt-5.5",
+      fallbacks: ["github-copilot/claude-opus-4.7"],
+    });
+  });
+
+  it("preserves an explicit empty Copilot fallback list during non-interactive onboarding", async () => {
+    const provider = registerProviderWithPluginConfig({});
+    const method = provider.auth[0];
+    const agentDir = await createAgentDir();
+    const runtime = { error: vi.fn(), exit: vi.fn() };
+
+    const result = await method.runNonInteractive({
+      authChoice: "github-copilot",
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "github-copilot/gpt-5.5",
+              fallbacks: [],
+            },
+          },
+        },
+      },
+      baseConfig: {},
+      opts: { githubCopilotToken: "ghu_test" },
+      runtime,
+      agentDir,
+      resolveApiKey: vi.fn(async () => ({
+        key: "ghu_test",
+        source: "flag" as const,
+      })),
+      toApiKeyCredential: vi.fn(),
+    });
+
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(result?.agents?.defaults?.model).toEqual({
+      primary: "github-copilot/gpt-5.5",
+      fallbacks: [],
     });
   });
 

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -37,6 +37,7 @@ import { wrapCopilotProviderStream } from "./stream.js";
 
 const COPILOT_ENV_VARS = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
 const DEFAULT_COPILOT_MODEL = "github-copilot/claude-opus-4.7";
+const DEFAULT_COPILOT_MODEL_CHAIN = [DEFAULT_COPILOT_MODEL, "github-copilot/gpt-5.5"];
 const DEFAULT_COPILOT_PROFILE_ID = "github-copilot:github";
 
 type GithubCopilotPluginConfig = {
@@ -49,9 +50,17 @@ async function loadGithubCopilotRuntime() {
   return await import("./register.runtime.js");
 }
 
+function resolveDefaultCopilotModelFallbacks(primary: string): string[] {
+  return DEFAULT_COPILOT_MODEL_CHAIN.filter((candidate) => candidate !== primary);
+}
+
 function applyCopilotDefaultModel(cfg: OpenClawConfig): OpenClawConfig {
   const defaults = cfg.agents?.defaults;
   const existingModel = defaults?.model;
+  const existingFallbacks =
+    typeof existingModel === "object" && existingModel !== null && "fallbacks" in existingModel
+      ? (existingModel as { fallbacks?: string[] }).fallbacks
+      : undefined;
   const existingPrimary =
     typeof existingModel === "string"
       ? existingModel.trim()
@@ -59,12 +68,26 @@ function applyCopilotDefaultModel(cfg: OpenClawConfig): OpenClawConfig {
         ? existingModel.primary.trim()
         : "";
   if (existingPrimary) {
-    return cfg;
+    if (
+      !existingPrimary.toLowerCase().startsWith(`${PROVIDER_ID}/`) ||
+      existingFallbacks !== undefined
+    ) {
+      return cfg;
+    }
+    return {
+      ...cfg,
+      agents: {
+        ...cfg.agents,
+        defaults: {
+          ...defaults,
+          model: {
+            primary: existingPrimary,
+            fallbacks: resolveDefaultCopilotModelFallbacks(existingPrimary),
+          },
+        },
+      },
+    };
   }
-  const fallbacks =
-    typeof existingModel === "object" && existingModel !== null && "fallbacks" in existingModel
-      ? (existingModel as { fallbacks?: string[] }).fallbacks
-      : undefined;
   return {
     ...cfg,
     agents: {
@@ -72,8 +95,9 @@ function applyCopilotDefaultModel(cfg: OpenClawConfig): OpenClawConfig {
       defaults: {
         ...defaults,
         model: {
-          ...(fallbacks ? { fallbacks } : undefined),
           primary: DEFAULT_COPILOT_MODEL,
+          fallbacks:
+            existingFallbacks ?? resolveDefaultCopilotModelFallbacks(DEFAULT_COPILOT_MODEL),
         },
         models: {
           ...defaults?.models,


### PR DESCRIPTION
Closes #97290
Related: #87692

## What Problem This Solves

Fixes an issue where users who authenticate GitHub Copilot without configuring model fallbacks can hit an LLM idle timeout and immediately surface an error because the failover path has no fallback candidate.

## Why This Change Was Made

The GitHub Copilot provider now seeds a provider-owned fallback chain during onboarding: the default `claude-opus-4.7` primary gets `gpt-5.5` as a fallback, and an existing Copilot primary without a fallback list gets the other default Copilot model as its fallback. Explicit fallback lists, including an empty list, remain authoritative.

## User Impact

New or refreshed GitHub Copilot setups have a same-provider fallback candidate available when a Copilot model goes silent and the idle watchdog classifies the failure as retryable. Users who intentionally set `fallbacks: []` keep that no-fallback behavior.

## Evidence

Before evidence from retained gateway logs:

```shell
RAW: timeout model/kind breakdown from retained embedded_run_failover_decision logs:
58 github-copilot/gpt-5.5 timeout/unclassified; 44 github-copilot/gpt-5.5 timeout/null; 5 github-copilot/gpt-5.5 timeout/timeout; 4 github-copilot/claude-opus-4.7 timeout/timeout.

RAW: gateway-dev.log:2822 {"event":"embedded_run_failover_decision","runId":"[redacted run id]","stage":"assistant","decision":"surface_error","failoverReason":"timeout","profileFailureReason":"timeout","provider":"github-copilot","model":"claude-opus-4.7","fallbackConfigured":false,"timedOut":true,"aborted":true,"rawErrorPreview":"LLM idle timeout (120s): no response from model","providerRuntimeFailureKind":"timeout"} time="2026-06-27T17:09:12.875+00:00"
```

Commands run:

```shell
pnpm install --frozen-lockfile
pnpm format -- extensions/github-copilot/index.ts extensions/github-copilot/index.test.ts
node scripts/run-vitest.mjs extensions/github-copilot/index.test.ts src/agents/embedded-agent-runner/run/fallbacks.test.ts --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Results:

```text
[test] passed 2 Vitest shards in 33.87s
git diff --check: pass
autoreview clean: no accepted/actionable findings reported
```

## Real behavior proof

**Behavior addressed:** GitHub Copilot onboarding now writes a concrete same-provider model fallback when no fallback list is present, so later Copilot idle-timeout failover decisions are not doomed by a default `fallbackConfigured=false` setup.

**Real environment tested:** Local OpenClaw source worktree on branch `bug-048-copilot-idle-fallback`, commit `f4be01332962`, with workspace dependencies installed by `pnpm install --frozen-lockfile`.

**Exact steps or command run after this patch:**

```shell
node scripts/run-vitest.mjs extensions/github-copilot/index.test.ts src/agents/embedded-agent-runner/run/fallbacks.test.ts --reporter=verbose
```

**Evidence after fix:**

```text
✓ |extension-providers| extensions/github-copilot/index.test.ts > github-copilot plugin > stores GitHub Copilot token from non-interactive onboarding
✓ |extension-providers| extensions/github-copilot/index.test.ts > github-copilot plugin > adds Copilot fallbacks when an existing Copilot primary has no fallback list
✓ |extension-providers| extensions/github-copilot/index.test.ts > github-copilot plugin > preserves an explicit empty Copilot fallback list during non-interactive onboarding
✓ |unit-fast| src/agents/embedded-agent-runner/run/fallbacks.test.ts > hasEmbeddedRunConfiguredModelFallbacks > falls back to normal agent/default model fallback config when no override is provided
[test] passed 2 Vitest shards in 33.87s
```

**Observed result after fix:** Non-interactive GitHub Copilot onboarding now produces `agents.defaults.model` with `primary: "github-copilot/claude-opus-4.7"` and `fallbacks: ["github-copilot/gpt-5.5"]`. An existing `github-copilot/gpt-5.5` primary without fallback config gets `fallbacks: ["github-copilot/claude-opus-4.7"]`, while an explicit empty fallback list remains empty.

**What was not tested:** No live GitHub Copilot request was forced into a real model-silence timeout after this patch. The proof covers the config written by Copilot onboarding and the embedded-run fallback detection seam that decides whether a fallback path is configured.
