### PR TITLE
fix: prevent empty Anthropic error tool results

### DIFF
--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -49,6 +49,27 @@ function makeAnthropicModel(overrides: Partial<Model<"anthropic-messages">> = {}
   } satisfies Model<"anthropic-messages">;
 }
 
+function emptyUsage() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function firstToolResultFromPayload(payload: unknown): Record<string, unknown> {
+  const messages = (payload as { messages?: Array<{ role: string; content: unknown }> }).messages;
+  const userMessage = messages?.find((message) => message.role === "user");
+  const [toolResult] = userMessage?.content as Array<Record<string, unknown>>;
+  if (!toolResult) {
+    throw new Error("expected Anthropic tool_result payload");
+  }
+  return toolResult;
+}
+
 describe("Anthropic provider", () => {
   beforeEach(() => {
     anthropicMockState.configs = [];
@@ -602,6 +623,118 @@ describe("Anthropic provider", () => {
     const assistantMessage = payload.messages.find((message) => message.role === "assistant");
     expect(assistantMessage?.content).toEqual([{ type: "text", text: "visible answer" }]);
     expect(JSON.stringify(assistantMessage)).not.toContain("sig_model_bound");
+  });
+
+  it.each([
+    ["empty string", ""],
+    ["whitespace-only", " \n\t "],
+    ["invalid-surrogate-only", String.fromCharCode(0xd83d)],
+  ])("replaces %s error tool results with a non-empty payload", async (_label, text) => {
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(
+      makeAnthropicModel({ provider: "github-copilot", id: "claude-opus-4.7" }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "github-copilot",
+            api: "anthropic-messages",
+            model: "claude-opus-4.7",
+            stopReason: "toolUse",
+            timestamp: 0,
+            usage: emptyUsage(),
+            content: [{ type: "toolCall", id: "tool_1", name: "quiet", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            toolName: "quiet",
+            content: [{ type: "text", text }],
+            isError: true,
+            timestamp: 0,
+          },
+        ],
+      },
+      {
+        apiKey: "copilot-token",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+    const toolResult = firstToolResultFromPayload(capturedPayload);
+
+    expect(result.stopReason).toBe("error");
+    expect(toolResult).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "tool_1",
+      content: "[tool error with no output]",
+      is_error: true,
+    });
+  });
+
+  it("drops empty text blocks from image tool results before Anthropic payloads", async () => {
+    let capturedPayload: unknown;
+    const imageData = Buffer.from("image").toString("base64");
+    const stream = streamAnthropic(
+      makeAnthropicModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            usage: emptyUsage(),
+            content: [{ type: "toolCall", id: "tool_1", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            toolName: "screenshot",
+            content: [
+              { type: "text", text: "" },
+              { type: "image", data: imageData, mimeType: "image/png" },
+            ],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      },
+      {
+        apiKey: "sk-ant-provider",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+    const toolResult = firstToolResultFromPayload(capturedPayload);
+
+    expect(result.stopReason).toBe("error");
+    expect(toolResult).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "tool_1",
+      is_error: false,
+    });
+    expect(toolResult.content).toEqual([
+      { type: "text", text: "(see attached image)" },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: imageData,
+        },
+      },
+    ]);
   });
 
   it.each([

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -119,11 +119,16 @@ const ccToolLookup = new Map(claudeCodeTools.map((t) => [t.toLowerCase(), t]));
 
 // Convert tool name to CC canonical casing if it matches (case-insensitive)
 const toClaudeCodeName = (name: string) => ccToolLookup.get(name.toLowerCase()) ?? name;
+const EMPTY_TOOL_RESULT_TEXT = "(no output)";
+const EMPTY_ERROR_TOOL_RESULT_TEXT = "[tool error with no output]";
 
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(content: (TextContent | ImageContent)[]):
+function convertContentBlocks(
+  content: (TextContent | ImageContent)[],
+  isError: boolean,
+):
   | string
   | Array<
       | { type: "text"; text: string }
@@ -139,15 +144,23 @@ function convertContentBlocks(content: (TextContent | ImageContent)[]):
   // If only text blocks, return as concatenated string for simplicity
   const hasImages = content.some((c) => c.type === "image");
   if (!hasImages) {
-    return sanitizeSurrogates(content.map((c) => (c as TextContent).text).join("\n"));
+    const text = sanitizeSurrogates(content.map((c) => (c as TextContent).text).join("\n"));
+    if (text.trim().length > 0) {
+      return text;
+    }
+    return isError ? EMPTY_ERROR_TOOL_RESULT_TEXT : EMPTY_TOOL_RESULT_TEXT;
   }
 
   // If we have images, convert to content block array
-  const blocks = content.map((block) => {
+  const blocks = content.flatMap((block) => {
     if (block.type === "text") {
+      const text = sanitizeSurrogates(block.text);
+      if (text.trim().length === 0) {
+        return [];
+      }
       return {
         type: "text" as const,
-        text: sanitizeSurrogates(block.text),
+        text,
       };
     }
     return {
@@ -1275,7 +1288,7 @@ function convertMessages(
       toolResults.push({
         type: "tool_result",
         tool_use_id: msg.toolCallId,
-        content: convertContentBlocks(msg.content),
+        content: convertContentBlocks(msg.content, msg.isError),
         is_error: msg.isError,
       });
 
@@ -1285,7 +1298,7 @@ function convertMessages(
         toolResults.push({
           type: "tool_result",
           tool_use_id: nextMsg.toolCallId,
-          content: convertContentBlocks(nextMsg.content),
+          content: convertContentBlocks(nextMsg.content, nextMsg.isError),
           is_error: nextMsg.isError,
         });
         j++;


### PR DESCRIPTION
Closes #97292

## What Problem This Solves

Fixes an issue where users running GitHub Copilot Claude models would see agent runs fail before the assistant could reply when replay included an Anthropic error `tool_result` whose content became empty.

## Why This Change Was Made

The legacy Anthropic provider path now treats empty text-only tool results as invalid at the provider boundary. Empty error results are replaced with `[tool error with no output]`, empty non-error results keep the existing `(no output)` placeholder, and empty text blocks are removed from image tool results before the outbound payload is sent.

## User Impact

Affected GitHub Copilot Claude runs can continue past empty error tool-result replay instead of surfacing a provider schema failure. Meaningful non-empty tool output is preserved.

## Evidence

Before evidence, from redacted retained Gateway logs:

```shell
{"event":"embedded_run_agent_end","runId":"[redacted run id]","isError":true,"error":"LLM request failed: provider rejected the request schema or tool payload.","failoverReason":"format","model":"claude-opus-4.7","provider":"github-copilot","rawErrorPreview":"400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"messages.12.content.0.tool_result: content cannot be empty if `is_error` is true\"},\"request_id\":\"sha256:572439d01edf\"}","httpCode":"400","providerRuntimeFailureKind":"schema","providerErrorType":"invalid_request_error","providerErrorMessagePreview":"messages.12.content.0.tool_result: content cannot be empty if `is_error` is true","requestIdHash":"sha256:572439d01edf"} time="2026-06-26T17:35:22.414+00:00" traceId="[redacted trace id]"
{"event":"embedded_run_failover_decision","runId":"[redacted run id]","stage":"assistant","decision":"surface_error","failoverReason":"format","provider":"github-copilot","model":"claude-opus-4.7","fallbackConfigured":false,"timedOut":false,"aborted":false,"httpCode":"400","providerRuntimeFailureKind":"schema","providerErrorType":"invalid_request_error","providerErrorMessagePreview":"messages.12.content.0.tool_result: content cannot be empty if `is_error` is true","requestIdHash":"sha256:572439d01edf"} time="2026-06-26T17:35:22.488+00:00" traceId="[redacted trace id]"
```

Dependency contract checked: `node_modules/@anthropic-ai/sdk/src/resources/messages/messages.ts` defines `ToolResultBlockParam` with `content?: string | Array<...>` and `is_error?: boolean`; the observed provider response proves empty content is invalid when `is_error=true`.

Validation run after the patch:

```shell
$ node scripts/run-vitest.mjs src/llm/providers/anthropic.test.ts -- --reporter=verbose
[test] starting test/vitest/vitest.unit.config.ts
...
✓ |unit| src/llm/providers/anthropic.test.ts > Anthropic provider > replaces empty string error tool results with a non-empty payload
✓ |unit| src/llm/providers/anthropic.test.ts > Anthropic provider > replaces whitespace-only error tool results with a non-empty payload
✓ |unit| src/llm/providers/anthropic.test.ts > Anthropic provider > replaces invalid-surrogate-only error tool results with a non-empty payload
✓ |unit| src/llm/providers/anthropic.test.ts > Anthropic provider > drops empty text blocks from image tool results before Anthropic payloads

Test Files  1 passed (1)
Tests  40 passed (40)
[test] passed 1 Vitest shard in 209.51s

$ pnpm tsgo:test:src
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo
# exited 0

$ pnpm exec oxfmt --check src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 192ms on 2 files using 16 threads.

$ git diff --check
# exited 0

$ .agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.86)
```

### Crabbox evidence attempt

Requested Azure Crabbox proof could not acquire a lease in this shell because provider authentication is unavailable. No Crabbox lease id was created, so there is no remote workdir or remote test output to cite.

```shell
$ crabbox doctor --provider azure
failed  azure    DefaultAzureCredential: failed to acquire a token.
AzureCLICredential: ERROR: User [redacted] does not exist in MSAL token cache. Run `az login`.

$ az account get-access-token --resource https://management.azure.com/ --output json
ERROR: User [redacted] does not exist in MSAL token cache. Run `az login`.

$ crabbox doctor --provider aws
failed  aws      operation error EC2: DescribeInstances, get identity: get credentials: failed to refresh cached credentials, no EC2 IMDS role found

$ blacksmith testbox list --all
not authenticated -- run 'blacksmith auth login' first
```

Crabbox proof gap: the focused Anthropic regression test was not rerun on a remote Crabbox lease because all available remote backends require interactive/cloud authentication from this shell. The after-fix provider-boundary evidence remains the local targeted test/type/format/autoreview proof above plus the passing GitHub PR checks, including `check-test-types` and `build-artifacts`.

## Real behavior proof

Behavior addressed: Anthropic-compatible GitHub Copilot Claude requests no longer include `is_error=true` tool results with empty content after provider-boundary conversion.

Real environment tested: Local OpenClaw source worktree on Node v26.3.0 and pnpm 11.2.2, using the real legacy Anthropic payload builder seam with mocked network dispatch stopped after payload capture.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/llm/providers/anthropic.test.ts -- --reporter=verbose`; `pnpm tsgo:test:src`; `pnpm exec oxfmt --check src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`.

Evidence after fix: The terminal capture above shows the new regression cases passing, including empty string, whitespace-only, and invalid-surrogate-only error tool results being converted to non-empty content before outbound dispatch. The same capture shows the full targeted Anthropic provider test file passing with 40 tests.

Observed result after fix: The captured outbound Anthropic payload contains `content: "[tool error with no output]"` with `is_error: true` for empty error tool results, so it no longer matches the provider-rejected empty-content shape from the logs.

What was not tested: I did not run a live GitHub Copilot Claude request because that requires private Copilot credentials and replaying the affected private session state. The provider request-build/schema boundary that produced the logged 400 was covered locally.
