### PR TITLE
Add SNES Studio PCC real local model execution

### DIFF
--- a/.agents/skills/snes-game-creator/SKILL.md
+++ b/.agents/skills/snes-game-creator/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: snes-game-creator
+description: Use for SNES Studio worker-agent tasks that create, repair, or review SNES, Super Nintendo-style, 16-bit side-scrolling platformer games, including game blueprints, local OpenClaw/GLM structured patch JSON, executable playtest QA, visual-quality gates, and remote playable-link handoff.
+---
+
+# SNES Game Creator
+
+Use for SNES Studio worker-agent tasks that create, repair, or review a side-scrolling Super Nintendo platformer. For Metro Bomberman, this skill is the parent orchestrator for all game modifications, builds, patches, emulator QA, FXPAK readiness checks, and milestone status updates.
+
+## Required Output
+
+Every response must include:
+
+- `surface`: exact game surface changed, such as story, level, gameplay, art, audio, hardware, QA, or publish-link.
+- `content`: concrete playable content, not broad mood text.
+- `constraints`: SNES/FXPAK constraints preserved.
+- `playtestHypothesis`: what should be true when the level is tested.
+- `riskOrBlocker`: the highest-risk issue, or `none`.
+- `patchReceipt`: what JSON patch or structured receipt should be reviewed before apply.
+
+## Role Contracts
+
+- Game Director: define premise, core loop, stakes, fun hook, target player emotion, ending, art-quality rubric, and build receipt.
+- Level Designer: define finishable route, reachable jumps, fair enemy placement, reward pacing, secrets, midpoint/checkpoint, and visible goal.
+- Gameplay Designer: define movement constants, enemy behavior, item effects, hazards, lives/death behavior, crouch/projectile origins, and repair instructions.
+- Art/Audio: define concrete 16x16 tile ids, sprite frames, palette indexes, animation beats, landmark/background layers, music patterns, and SFX events.
+- Hardware QA: verify ROM, SRAM, VRAM, CGRAM, ARAM, FXPAK PRO FAT32, SuperFX, checksum, and export blockers.
+- QA Gate: executable proof only. Text checklists can critique but cannot approve.
+
+## Quality Bar
+
+Do not approve vague output. A good game draft must be finishable, understandable in the first screen, fair to a beginner, rewarding within the first 30 seconds, and export-safe for the configured SNES hardware profile.
+
+Visual quality is a gate, not a preference:
+
+- Draft visual quality must be at least `50/100`.
+- Requested high-quality drafts must meet the requested score, such as `70/100`.
+- Production visual quality needs deterministic metrics plus GPT 5.5 or human visual approval.
+- Art output must include non-rectangle sprite silhouettes, multiple animation frames, palette ramps, foreground/background separation, and concrete landmark/tile/sprite data.
+
+## Legal SNES Reference Corpus
+
+When the user asks to download SNES games/code for inspiration, improve Codex/OpenClaw SNES coding skill, or build FXPAK Pro-compatible reference material, read `references/legal-snes-reference-corpus.md` before acting. The safe local root is `.artifacts/snes-game-builder-reference/`. Commercial ROMs, commercial source leaks, reverse-engineered commercial disassemblies, and copied commercial art/audio/code are blocked even for personal-use requests. Use permissive SDK examples, hardware docs, and clean-room katas instead.
+
+## Revision Workflow
+
+Use this loop for game creation and repairs:
+
+1. GPT 5.5 high-reasoning writes the initial blueprint, art rubric, mechanics contract, and QA requirements.
+2. Local OpenClaw/GLM workers produce structured patch JSON only.
+3. Deterministic code applies patches; workers must not emit raw runtime HTML/JS.
+4. Executable browser QA runs controls, replay, mechanics, visual metrics, route/link proof, and export blockers.
+5. If QA fails, GPT 5.5 diagnoses the evidence and writes a minimal repair brief.
+6. Local OpenClaw/GLM workers apply the repair as structured patch JSON.
+7. GPT 5.5 gives final approval only after machine proof passes.
+8. Dashboard or chat links are delivered only after live route proof passes.
+
+## Producer Orchestrator And GPT 5.5 Token Policy
+
+The Producer Orchestrator owns the project manifest, milestone order, token policy, pass/fail decisions, and role receipts. Agents do not remember the project; the manifest and memory cards do.
+
+Use GPT 5.5 only when it clearly improves quality:
+
+- high reasoning: initial blueprint, repeated blocker diagnosis, major design conflict, production visual approval, final shipping approval;
+- low reasoning: concise QA summary or obvious repair brief;
+- never for routine local milestone patch generation.
+
+Routine local milestones should record `gpt55Used: false`, `reasoningLevel: none`, why local OpenClaw/GLM was used, and what GPT 5.5 cost was avoided. Local OpenClaw/GLM workers implement scoped patches from compact packets.
+
+Every agent handoff must include:
+
+- surface changed;
+- patch path or hash;
+- assumptions;
+- risks;
+- playtest hypothesis;
+- QA evidence required;
+- next role;
+- blocker, or `none`;
+- GPT 5.5 use and reasoning level;
+- local model used, or `none`.
+
+## Art Director / Visual QA
+
+General QA cannot approve production graphics. The Art Director / Visual QA gate must reject rectangle/placeholder art, spec-only graphics, missing real sprite sheets, too few tile variants, missing palette ramps, missing background/parallax layers, and missing screenshot proof.
+
+Human visual grade overrides synthetic scoring. If the human grade is below target, production remains blocked even if the model or machine score claims the visuals are good.
+
+## Durable GLM Production Loop
+
+For long game upgrades, do not ask GLM to remember the whole project. Use the Stanski/SNES production-loop pattern:
+
+1. OpenClaw owns the backlog, `state.json`, `memory-cards.json`, `decision-log.json`, and latest summary.
+2. GLM receives exactly one compact milestone packet: current milestone, current grade, relevant memory cards, allowed schema, and do-not-break constraints.
+3. GLM returns strict JSON only with `localGlmOnly: true`, `hostedGlmUsed: false`, the exact `milestoneId`, and the expected patch type.
+4. Deterministic code validates, applies, rebuilds, runs executable QA, writes a receipt, creates a memory card, and then selects the next milestone.
+5. Use `pnpm stanski:produce -- --mode status --json`, `pnpm stanski:produce -- --mode continue --max-milestones 1 --json`, or `pnpm stanski:produce -- --mode retry-blocked --json` for Stanski's World.
+6. Routine milestone execution should not call GPT 5.5. Use low-reasoning GPT 5.5 only for concise QA summaries or obvious repair briefs, and high reasoning only for repeated blockers, architecture changes, major design conflicts, or final production visual approval.
+
+Core rule: GLM is stateless; OpenClaw persists progress and chooses the next milestone.
+
+## Project Command Center Workflow
+
+For long-running SNES game creation, use the Project Command Center (PCC) as the durable orchestrator. Read these references when the task needs the full production workflow:
+
+- `references/production-orchestration.md` for PCC state, completion runner, and repair loop.
+- `references/agent-routing.md` for agent roles, model defaults, and parallelism rules.
+- `references/proof-gates.md` for milestone judging and proof separation.
+- `references/art-quality-rubric.md` for legal classic-SNES visual quality criteria.
+- `references/prompt-to-rom-workflow.md` for the end-to-end prompt-to-ROM process.
+
+Use `pnpm snes:team -- --mode status --project <id> --json` to inspect PCC state, `--mode next` to pick the next safe milestone, and `--mode validate` before claiming completion. PCC v2 adds deterministic overnight runner scaffolding, approval queues, pause/resume/cancel, and worker-packet export. It still does not automatically spend hosted model calls or run live worker agents without approval.
+
+## SNES Studio Heavy-Lifting Contract
+
+For every nontrivial SNES Studio project, make OpenClaw own the repeatable work. Prefer project-local scripts and receipts over agent memory, broad prompts, or manual checklists.
+
+Each active project should maintain these surfaces when applicable:
+
+- milestone ledger with complete, incomplete, blocked, and superseded work;
+- next-milestone router that returns the first incomplete milestone and required skill routing;
+- source/reference preservation receipts for user-provided images;
+- sprite/package validator for file existence, dimensions, palette/index mode, blank frames, duplicate frames when available, and deliberate negative fixtures;
+- contact-sheet generator for changed sprites, backgrounds, title surfaces, and UI assets;
+- visual-surface validator for title overlap, crop/nonblank checks, runtime screenshot visibility, and before/after comparisons;
+- emulator regression gate for build, patch, header, FXPAK dry-run, scripted gameplay, screenshots, and WRAM checks when available;
+- patch-only handoff gate that scans ZIP contents for `.sfc`, `.smc`, `.swc`, `.fig`, and `.rom`;
+- QA dashboard that separates `available checks passed` from `production complete`.
+
+Completion rules:
+
+- Do not claim completion from a plan, prompt, contact sheet, static image, or runtime screenshot alone.
+- Treat source preservation, contact-sheet proof, runtime visibility, gameplay behavior, full playthrough, and hardware proof as separate gates.
+- If a required source image, mounted FXPAK volume, human approval, local model, emulator, or runtime route is unavailable, write a blocked receipt with the exact blocker.
+- Routine milestones should use deterministic local scripts first. Use GPT 5.5 for initial blueprints, repeated blocker diagnosis, subjective visual approval summaries, or final production approval.
+
+## Image Asset Delegation
+
+When a user provides or requests an image for an SNES/16-bit game, use the `snes-16bit-image-assets` skill. This includes title portraits, character sprites, enemy sprites, item sprites, background layers, tilesets, and UI icons. Preserve the source image, convert it into a deterministic SNES-safe asset, request only local GLM-5.2 structured JSON patches, and require executable visual QA before claiming the asset is used.
+
+For Metro Bomberman character repair work, also use the specialized character skills when they apply:
+
+- `metro-tim-misney-boss-sprite` for the World 1 Tim Misney Bigaron boss surface.
+- `metro-drew-carey-enemy-sprite` for Drew Carey as a normal World 1 enemy target.
+
+The routing order is mandatory:
+
+1. Start with `snes-game-creator` to identify the game milestone, gameplay constraints, build commands, patch policy, and QA gate.
+2. Delegate source-image preservation and SNES-safe conversion to `snes-16bit-image-assets`.
+3. Delegate Metro-specific Tim/Drew frame mapping and sprite package rules to the matching character skill.
+4. Return to `snes-game-creator` for integration, `make CONFIG=us`, patch regeneration, emulator proof, FXPAK dry-run, and milestone status updates.
+5. Do not mark any Metro sprite milestone complete from an image/contact sheet alone; completion requires a rebuilt ROM and executable runtime proof unless the milestone is explicitly documentation-only.
+
+## Remote Play Link Handoff
+
+When publishing a playable preview for another device, including a MacBook on a different network:
+
+- Use the canonical Tailscale/remote dashboard route, not a loopback-only link.
+- Verify the route with `curl` or an equivalent HTTP probe before sending it.
+- Verify `/game`, `/game/`, and `/game/index.html` variants when a static directory is served.
+- Include links to the playable game, executable QA receipt, and model patch receipt.
+- Never send the playable link until executable QA and remote route proof both pass.
+
+## Local-Only Media And Model Policy
+
+- Hosted GLM is forbidden for SNES Studio local-game content unless the user explicitly changes scope.
+- Local GLM-5.2 may create creative patch JSON; deterministic code applies it.
+- Local image/video generation must fail closed. If local ComfyUI or a local video workflow is unavailable, report `blocked` with the exact blocker instead of using a hosted provider.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.
+
+## PCC Real Local Model Execution
+
+For approved PCC live work, use `--local-only --invoke-local-models` to call installed Ollama/OpenClaw models. A real worker receipt must show `modelInvoked: true`, local model metadata, strict JSON validation, `hostedGlmUsed: false`, and `gpt55Used: false`. Do not apply model output until the PCC patch gate and milestone judge pass.

--- a/.agents/skills/snes-game-creator/references/agent-routing.md
+++ b/.agents/skills/snes-game-creator/references/agent-routing.md
@@ -1,0 +1,40 @@
+# SNES Studio Agent Routing
+
+## Default model policy
+
+- Producer Orchestrator: deterministic script, no model.
+- Initial blueprint and final high-level review: GPT 5.5 high-reasoning, approval-gated.
+- Routine workers: `ollama/openclaw-control-qwen3-30b-q6-chatfix:latest`.
+- Quality fallback: `ollama/openclaw-control-qwen36-27b:latest`.
+- Speed fallback: `ollama/openclaw-control-qwen25-32b:latest`.
+- Hosted GLM: disabled unless explicitly approved.
+
+## Parallel-safe workers
+
+These can run together when write surfaces do not overlap:
+
+- `snes-level-designer`
+- `snes-game-feel-tuner`
+- `snes-pixel-art-director`
+- `snes-audio-spc700`
+- `snes-engine-architect`
+
+## Sequential gates
+
+Run these sequentially:
+
+- initial blueprint;
+- integration;
+- ROM build;
+- milestone judging;
+- final release decision.
+
+The worker who produced a milestone must not approve it.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.
+
+## Real local worker routing
+
+Dry-run dispatch creates packets only. Real worker dispatch requires `--local-only --invoke-local-models`, uses installed Ollama/OpenClaw models, records model health and response hashes, and falls back only to other healthy local models. Hosted GPT/GLM routing remains approval-gated.

--- a/.agents/skills/snes-game-creator/references/art-quality-rubric.md
+++ b/.agents/skills/snes-game-creator/references/art-quality-rubric.md
@@ -1,0 +1,24 @@
+# SNES Studio Art Quality Rubric
+
+Use a legal clean-room classic SNES polish rubric. Do not copy commercial ROMs, source, sprites, tiles, maps, palettes, music, or SFX.
+
+## Production art criteria
+
+- readable silhouette;
+- non-rectangle character shape;
+- animation frames with visible motion beats;
+- foreground/background separation;
+- palette ramps within SNES limits;
+- item and enemy readability at runtime size;
+- background landmarks or motifs specified by prompt;
+- runtime screenshot proof, not just contact sheets.
+
+## Asset Intent Contract
+
+Every production asset should state `assetId`, `kind`, `dimensions`, `frames`, `paletteLimit`, `mustShow`, `mustNotShow`, `animationBeats`, `runtimeProofRequired`, and `humanVisualTarget`.
+
+Human visual grade overrides model scoring.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.

--- a/.agents/skills/snes-game-creator/references/production-orchestration.md
+++ b/.agents/skills/snes-game-creator/references/production-orchestration.md
@@ -1,0 +1,59 @@
+# SNES Studio Production Orchestration
+
+Use the Project Command Center (PCC) for long-running SNES game work. The PCC owns state; agents are replaceable workers.
+
+## PCC responsibilities
+
+- Persist project intent, milestone ledger, dependency DAG, worker locks, decisions, memory cards, repairs, model use, and build history.
+- Select the next milestone from receipts, not chat memory.
+- Assign only one owner per write surface.
+- Keep source, conversion, runtime, ROM, emulator, FXPAK, hardware, and human approval proof separate.
+- Stop at external blockers instead of pretending completion.
+
+## Completion runner
+
+Use:
+
+```bash
+pnpm snes:team -- --mode init --project <id> --prompt <prompt-file> --json
+pnpm snes:team -- --mode status --project <id> --json
+pnpm snes:team -- --mode next --project <id> --json
+pnpm snes:team -- --mode validate --project <id> --json
+pnpm snes:team -- --mode repair-plan --project <id> --milestone <id> --json
+pnpm snes:team -- --mode approvals --project <id> --json
+pnpm snes:team -- --mode run --project <id> --max-milestones 10 --max-minutes 480 --json
+pnpm snes:team -- --mode pause --project <id> --json
+pnpm snes:team -- --mode resume --project <id> --json
+pnpm snes:team -- --mode cancel --project <id> --json
+pnpm snes:team -- --mode worker-packet --project <id> --milestone <id> --json
+```
+
+PCC v2 adds deterministic overnight runner scaffolding, approval queues, pause/resume/cancel, run history, summaries, and worker packets. It still does not automatically spend model calls.
+
+## Repair loop
+
+On failure, classify the blocker as `invalid-patch`, `build-failure`, `runtime-failure`, `visual-failure`, `budget-failure`, or `external-blocker`. Retry once with the same role, once with a fallback local model, then require GPT 5.5 high-reasoning diagnosis. On the fourth failure, block unless the user approves deeper work.
+
+## Approval queue
+
+PCC queues approvals for hosted GLM, paid tools or assets, FXPAK/removable writes, push/PR, original hardware proof, human production visual approval, and live model-spending automation. The runner stops instead of assuming approval.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.
+
+PCC v3 commands:
+
+```bash
+pnpm snes:team -- --mode dispatch-worker --project <id> --milestone <id> --dry-run --json
+pnpm snes:team -- --mode dispatch-worker --project <id> --milestone <id> --local-only --json
+pnpm snes:team -- --mode apply-worker-output --project <id> --worker-output <file> --json
+pnpm snes:team -- --mode telemetry --project <id> --json
+pnpm snes:team -- --mode dashboard-snapshot --project <id> --json
+pnpm snes:team -- --mode regression-benchmark --project <id> --json
+pnpm snes:team -- --mode run-live --project <id> --local-only --max-workers 4 --max-minutes 480 --json
+```
+
+## Live local model run commands
+
+Preflight with `pnpm snes:team -- --mode model-health --project <id> --json`. Execute bounded live work with `pnpm snes:team -- --mode run-live --project <id> --local-only --invoke-local-models --max-minutes 480 --max-workers 4 --json`. Resume with `--mode resume-live` using the same local-only flags.

--- a/.agents/skills/snes-game-creator/references/prompt-to-rom-workflow.md
+++ b/.agents/skills/snes-game-creator/references/prompt-to-rom-workflow.md
@@ -1,0 +1,18 @@
+# Prompt To ROM Workflow
+
+1. User prompt becomes PCC project intent.
+2. GPT 5.5 high-reasoning writes the blueprint and quality rubric.
+3. PCC validates legal and hardware constraints.
+4. Local workers propose bounded JSON patches for level, gameplay, art, audio, and hardware planning.
+5. Deterministic scripts validate and integrate accepted patches.
+6. Engine and asset compilers build SNES-safe source data.
+7. The ROM build runs, then SuperFamicheck and budget checks run.
+8. Emulator screenshot/replay and runtime asset truth prove the ROM contains the intended content.
+9. Human visual approval gates production art.
+10. Package/export runs only after required receipts pass.
+
+If a step fails, PCC creates a repair task and preserves the exact blocker.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.

--- a/.agents/skills/snes-game-creator/references/proof-gates.md
+++ b/.agents/skills/snes-game-creator/references/proof-gates.md
@@ -1,0 +1,35 @@
+# SNES Studio Proof Gates
+
+A milestone is complete only when its Definition of Done and required receipts pass.
+
+## Required separation
+
+Do not collapse these proof surfaces:
+
+- source preservation;
+- asset conversion;
+- browser preview;
+- ROM build;
+- runtime asset truth;
+- emulator screenshot/replay;
+- FXPAK package dry-run;
+- removable-media copy;
+- original hardware proof;
+- human visual approval.
+
+## Judge order
+
+1. Deterministic validator.
+2. Domain QA validator.
+3. GPT 5.5 for repeated blockers or final review only.
+4. Human approval for production visuals.
+
+If required proof is missing, write a blocked or failed receipt. Do not substitute prose, contact sheets, or screenshots for unrelated proof surfaces.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.
+
+## Real worker output gate
+
+PCC must reject malformed model JSON, wrong project or milestone ids, missing proof receipts, hosted-provider flags, commercial SNES indicators, FXPAK/removable writes, secret-looking paths, and unsupported file writes before applying any receipt.

--- a/docs/reference/snes-studio-agent-routing.md
+++ b/docs/reference/snes-studio-agent-routing.md
@@ -1,0 +1,53 @@
+---
+summary: "SNES Studio PCC agent roles, model routing, and parallel work policy"
+read_when:
+  - You are assigning SNES Studio PCC work to agents
+  - You are changing local model defaults for SNES worker roles
+  - You need to know which SNES tasks may run in parallel
+title: "SNES Studio Agent Routing"
+---
+
+SNES Studio uses deterministic orchestration first. Model calls are explicit, receipt-backed, and avoided for routine state checks.
+
+## Default Model Routing
+
+| Role                   | Default                                                                                  |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| Producer Orchestrator  | deterministic script                                                                     |
+| Initial blueprint      | GPT 5.5 high reasoning, approval-gated                                                   |
+| Routine worker patches | `ollama/openclaw-control-qwen3-30b-q6-chatfix:latest`                                    |
+| Quality fallback       | `ollama/openclaw-control-qwen36-27b:latest`                                              |
+| Speed fallback         | `ollama/openclaw-control-qwen25-32b:latest`                                              |
+| Final approval         | deterministic receipts, GPT 5.5 high reasoning, and human visual approval where required |
+
+## Parallel Work
+
+The PCC may run these worker plans in parallel when write surfaces do not overlap:
+
+- level design;
+- gameplay feel;
+- art intent contracts;
+- audio and SPC700 planning;
+- hardware budget planning.
+
+Run these sequentially:
+
+- initial blueprint;
+- integration;
+- ROM build;
+- milestone judging;
+- final release approval.
+
+Max default parallelism is four workers. A worker must not judge its own milestone.
+
+## PCC v2 worker packets
+
+Use `pnpm snes:team -- --mode worker-packet --project <id> --milestone <id> --json` to export a bounded task packet. The packet lists owner role, allowed write surfaces, proof requirements, pass/fail criteria, forbidden actions, model policy, and the next validation command. Routine packets default to `gpt55Used: false` and `hostedGlmUsed: false`.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.
+
+## PCC real local model execution
+
+PCC can now distinguish dry-run worker dispatch from real local-only Ollama dispatch. Dry runs keep `modelInvoked: false`; `--local-only --invoke-local-models` must call a local Ollama/OpenClaw model, validate strict JSON worker output, and record model, prompt SHA, response SHA, latency, and validation status. Hosted GPT/GLM remains approval-gated and is not used by routine PCC workers.

--- a/docs/reference/snes-studio-art-pipeline.md
+++ b/docs/reference/snes-studio-art-pipeline.md
@@ -1,0 +1,43 @@
+---
+summary: "SNES Studio production art pipeline and asset intent contract"
+read_when:
+  - You are creating sprites, tilesets, backgrounds, UI, or title art for SNES Studio
+  - You need to judge whether art matches the prompt
+  - You need to prove improved art is actually in the ROM
+title: "SNES Studio Art Pipeline"
+---
+
+Production art uses an Asset Intent Contract before generation or conversion. The contract makes prompt accuracy measurable.
+
+## Asset Intent Contract
+
+Required fields:
+
+- `assetId`
+- `kind`
+- `dimensions`
+- `frames`
+- `paletteLimit`
+- `mustShow`
+- `mustNotShow`
+- `animationBeats`
+- `runtimeProofRequired`
+- `humanVisualTarget`
+
+Production assets must require runtime proof and human visual approval.
+
+## Proof Chain
+
+1. Preserve source files and hashes.
+2. Convert to SNES-safe indexed assets.
+3. Validate dimensions, frame count, palette limit, blank frames, and duplicate frames.
+4. Generate contact sheets and animation previews.
+5. Integrate into the ROM.
+6. Capture runtime screenshots.
+7. Ask for human visual grade when production quality is required.
+
+Human grade overrides synthetic or model scoring.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.

--- a/docs/reference/snes-studio-model-benchmarking.md
+++ b/docs/reference/snes-studio-model-benchmarking.md
@@ -1,0 +1,43 @@
+---
+summary: "SNES Studio local model benchmark and promotion policy"
+read_when:
+  - You are comparing local models for SNES Studio worker roles
+  - You are changing SNES Studio model routing defaults
+  - You need to know when GLM or another local model can be promoted
+title: "SNES Studio Model Benchmarking"
+---
+
+SNES Studio promotes models only from local benchmark receipts. Installed models are not automatically trusted.
+
+## Current Default Policy
+
+Routine worker model:
+
+```text
+ollama/openclaw-control-qwen3-30b-q6-chatfix:latest
+```
+
+Fallbacks:
+
+```text
+ollama/openclaw-control-qwen36-27b:latest
+ollama/openclaw-control-qwen25-32b:latest
+```
+
+Use GPT 5.5 for blueprint, repeated blocker diagnosis, and final review. Do not use it for routine patch generation when deterministic scripts or local workers can do the work.
+
+## Benchmark Command
+
+```bash
+pnpm snes:benchmark:models -- --mode output --rounds 3 --judge none --no-download --timeout 180 --json
+```
+
+Hosted GLM and model downloads are disabled unless explicitly approved. Promotion requires valid JSON, safe patches, SNES specificity, verification awareness, reliability, and no blocked or unsafe runs.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.
+
+## PCC model health versus benchmark scores
+
+Model benchmarks compare quality, but PCC `model-health` is the executable readiness check for live worker use. A model is eligible only when it is installed locally, returns valid JSON within timeout, and keeps `hostedGlmUsed: false` and `gpt55Used: false`.

--- a/docs/reference/snes-studio-proof-gates.md
+++ b/docs/reference/snes-studio-proof-gates.md
@@ -1,0 +1,50 @@
+---
+summary: "SNES Studio PCC proof surfaces and milestone judging rules"
+read_when:
+  - You are marking a SNES Studio milestone complete
+  - You are debugging why PCC blocked or failed a milestone
+  - You need to preserve source, runtime, emulator, FXPAK, hardware, and human approval separately
+title: "SNES Studio Proof Gates"
+---
+
+SNES Studio completion is receipt-based. A milestone cannot pass because prose sounds right or a contact sheet looks better.
+
+## Separate Proof Surfaces
+
+Keep these surfaces separate:
+
+- source preservation;
+- asset conversion;
+- browser preview;
+- ROM build;
+- runtime asset truth;
+- emulator screenshot and replay;
+- FXPAK package dry-run;
+- removable-media copy;
+- original hardware proof;
+- human visual approval.
+
+## Judge Order
+
+1. Deterministic validator.
+2. Domain QA validator.
+3. GPT 5.5 for repeated blockers or final review only.
+4. Human approval for production visuals.
+
+If proof is unavailable, write a blocked receipt with the exact blocker. Do not use available checks to claim full production completion.
+
+## Repair Policy
+
+Failures are classified as `invalid-patch`, `build-failure`, `runtime-failure`, `visual-failure`, `budget-failure`, or `external-blocker`. External blockers do not loop endlessly; they wait for user, hardware, or approval action.
+
+## Approval queue and overnight stops
+
+PCC v2 records approval-gated work in `approval-queue.json`. A runner may continue deterministic validation and repair planning, but it must stop for human production visual approval, live model-spending automation, hosted GLM, paid tools/assets, FXPAK/removable writes, push/PR, or original hardware proof.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.
+
+## Real worker output proof gate
+
+Real PCC worker output must validate as `openclaw-snes-pcc-worker-output-v1` before any receipt or patch is applied. The gate rejects malformed JSON, hosted-provider flags, paid/commercial/FXPAK claims, secret-looking paths, unsupported file writes, wrong project or milestone ids, and missing required proof receipts. The milestone judge still runs after apply.

--- a/docs/reference/snes-studio-workflow.md
+++ b/docs/reference/snes-studio-workflow.md
@@ -1,0 +1,54 @@
+---
+summary: "SNES Studio Project Command Center prompt-to-ROM workflow"
+read_when:
+  - You are implementing or operating the SNES Studio PCC workflow
+  - You need to understand how one prompt becomes a verified SNES project
+  - You are separating PCC scaffolding from finished game proof
+title: "SNES Studio Workflow"
+---
+
+SNES Studio uses a Project Command Center (PCC) to keep long-running game work durable. The PCC owns state, milestones, locks, receipts, repairs, and pass/fail decisions. Agents produce bounded proposals; deterministic scripts validate, apply, build, test, and record receipts.
+
+## Prompt To PCC
+
+1. The user prompt is saved as project intent.
+2. The PCC creates a milestone ledger and dependency DAG.
+3. Legal and hardware constraints are recorded before creative work starts.
+4. The next safe milestone is selected with `pnpm snes:team -- --mode next --project <id> --json`.
+
+## PCC Commands
+
+```bash
+pnpm snes:team -- --mode init --project <id> --prompt <prompt-file> --json
+pnpm snes:team -- --mode status --project <id> --json
+pnpm snes:team -- --mode next --project <id> --json
+pnpm snes:team -- --mode validate --project <id> --json
+pnpm snes:team -- --mode repair-plan --project <id> --milestone <id> --json
+pnpm snes:team -- --mode approvals --project <id> --json
+pnpm snes:team -- --mode request-approval --project <id> --approval-type <type> --milestone <id> --json
+pnpm snes:team -- --mode run --project <id> --max-milestones 10 --max-minutes 480 --json
+pnpm snes:team -- --mode pause --project <id> --json
+pnpm snes:team -- --mode resume --project <id> --json
+pnpm snes:team -- --mode cancel --project <id> --json
+pnpm snes:team -- --mode worker-packet --project <id> --milestone <id> --json
+```
+
+PCC v2 adds an overnight runner, approval queue, pause/resume/cancel, durable run summaries, and worker-packet export. It still does not automatically spend model calls or run live worker agents.
+
+## Completion Rule
+
+A game is complete only when all required project milestones pass and no required proof surface is blocked. A complete generic PCC state does not prove a specific game has production art, emulator proof, FXPAK copy proof, or hardware proof.
+
+See also [agent routing](/reference/snes-studio-agent-routing), [proof gates](/reference/snes-studio-proof-gates), and [art pipeline](/reference/snes-studio-art-pipeline).
+
+## Overnight Operation
+
+The runner stops at completion, validation failure, retry blocker, pause/cancel, time limit, or a pending approval. Approval-gated actions include hosted GLM, paid tools/assets, FXPAK/removable writes, push/PR, original hardware proof, human production visual approval, and live model-spending automation.
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.
+
+## Running local model workers
+
+Use `pnpm snes:team -- --mode model-health --project <id> --json` before live work. Then use `pnpm snes:team -- --mode run-live --project <id> --local-only --invoke-local-models --max-minutes 480 --max-workers 4 --json` for bounded local model execution. PCC stops at approval gates, malformed outputs, repeated failures, human visual approval requirements, or unsafe write attempts.

--- a/docs/web/snes-studio.md
+++ b/docs/web/snes-studio.md
@@ -1,0 +1,927 @@
+---
+summary: "SNES Studio dashboard for AI-first side-scrolling platformer projects"
+read_when:
+  - You want to use or change the SNES Studio dashboard
+  - You are working on AI-first creation, playable simulation, or hardware-aware export planning
+title: "SNES Studio"
+---
+
+SNES Studio is a local-first Control UI dashboard for making Super Nintendo game
+projects with a GPT 5.5-directed OpenClaw Game Team.
+
+The default experience is now SNES Studio's one-prompt flow for one beginner-friendly
+game type first: story-driven side-scrolling platformers.
+
+1. Describe the game.
+2. GPT 5.5 creates the blueprint, quality rubric, risk list, playtest metrics, and OpenClaw role
+   tasks.
+3. OpenClaw fills the game plan, level chapters, cast, items, rules, save plan,
+   and first playable level.
+4. Deterministic validation and playtest metrics run, then GPT 5.5 approves or disapproves playtest/export.
+5. Play it in the emulator-like canvas.
+6. Click a thing or drag-select an area on the game screen.
+7. Prompt OpenClaw to add, remove, or change what was selected.
+8. Drag/drop tune the level where useful.
+9. Export a SNES game file.
+
+Dense professional tools are still available, but they live behind **Expert
+Studio** so the beginner path stays clear.
+
+## Project Command Center
+
+SNES Studio now uses a Project Command Center (PCC) for long-running production work. The PCC keeps project intent, milestones, worker locks, receipts, repairs, model routing, and build history durable so agents can continue until a game is complete, blocked, paused, or escalated.
+
+Reference docs:
+
+- [SNES Studio Workflow](/reference/snes-studio-workflow)
+- [SNES Studio Agent Routing](/reference/snes-studio-agent-routing)
+- [SNES Studio Proof Gates](/reference/snes-studio-proof-gates)
+- [SNES Studio Art Pipeline](/reference/snes-studio-art-pipeline)
+- [SNES Studio Model Benchmarking](/reference/snes-studio-model-benchmarking)
+
+PCC v1 is deterministic orchestration and QA scaffolding. It does not automatically spend model calls or prove a finished game without the required project receipts.
+
+## Guided Builder
+
+The first screen shows one obvious action:
+
+- One game prompt.
+- AI production team status: **GPT 5.5 Game Director**, **OpenClaw Game Team**, deterministic validation, and
+  **GPT 5.5 Quality Gate**.
+- **Make My Game**.
+- Starter prompt chips.
+- Nothing else from the professional workbench unless **Expert Studio** is opened.
+
+After AI makes the draft, the guided steps are **Idea**, **Game Plan**, **Build
+Levels**, **Make Things**, **Play & Change**, and **Create Game File**.
+
+## Game Plan And Gap Filling
+
+The production loop now creates a full game draft rather than only a first level:
+
+1. **GPT 5.5 Game Director** writes the game blueprint, quality rubric, risks, playtest metrics, and
+   role-agent task briefs.
+2. **OpenClaw Game Team** fills the editable text boxes and game parts.
+3. **Deterministic Validation** checks schema, patch safety, first-level playability, rewards,
+   SNES constraints, and export readiness.
+4. **GPT 5.5 Quality Gate** approves or disapproves the draft with exact OpenClaw repair instructions.
+5. **OpenClaw Game Team** applies required GPT 5.5 repairs, then GPT 5.5 performs the final approval gate.
+
+The Game Plan contains the premise, world, hero goal, villain, conflict, ending,
+tone, items, music mood, save plan, and plain gameplay rules. **Build Levels**
+shows levels as chapters with a purpose, setting, challenge, reward, and goal.
+
+Cost control is part of the contract. The **Producer Orchestrator** owns the
+project manifest, milestone order, token policy, pass/fail decisions, and role
+receipts. OpenClaw local workers handle normal creative generation, text boxes,
+level edits, selected-object changes, and gap filling. GPT 5.5 is reserved for
+high-leverage gates only: initial blueprint/rubric, concise QA summaries, repair
+briefs, repeated blocker diagnosis, major design conflicts, approved visual
+review, and final shipping approval. Routine milestone patch generation records
+`gpt55Used: false`, `reasoningLevel: none`, and the local-worker cost avoided.
+Generic agent task helpers default to OpenClaw so new prompt surfaces do not
+accidentally spend Codex calls.
+SNES Studio also ships a local model benchmark ladder for the worker roles. It
+does not promote a model just because it is installed; candidates must beat the
+current worker default on JSON validity, asset specificity, fair enemy tuning,
+hardware QA correctness, and deterministic playtest quality before they become a
+default route.
+
+## Production SNES Studio
+
+The reusable production builder is generic. Stanski's World is now treated as a
+canary sample, not as a special runtime path. Every game can be represented as an
+`openclaw-snes-project-package` that contains:
+
+- a versioned game manifest;
+- asset registry records and conversion receipts;
+- browser-preview, QA, ROM, emulator, FXPAK, and hardware proof receipts;
+- production readiness gates that keep browser preview, real assets, visual
+  approval, `.sfc` ROM build, emulator proof, FXPAK package, and original-SNES
+  hardware proof separate.
+
+The dashboard groups the builder into five modes:
+
+1. **Create** for the prompt-first MVP.
+2. **Edit** for object, level, mechanic, and selected-area changes.
+3. **Art Lab** for sprites, tilesets, palettes, backgrounds, music, SFX, and
+   visual approval.
+4. **Playtest** for deterministic browser replay, quality gates, and human
+   visual grading.
+5. **Ship** for ROM build status, emulator proof, FXPAK package planning, and
+   hardware proof checklist.
+
+Production cannot be marked complete from prose, procedural previews, or
+converted placeholder PNGs. Real graphics require source paths, hashes,
+provenance, palette/frame/tile metadata, visual maturity, and review proof
+artifacts. Source PNGs do not count as screenshot proof. Human visual grade
+overrides synthetic visual scores. Browser preview never counts as ROM proof;
+ROM proof never counts as emulator or FXPAK proof; hardware proof remains
+manual.
+
+The **100/100 Visual Board** separates graphics into production-approved art,
+editable Pixelorama/Tiled source art, imported/converted source art, and
+spec-only/procedural placeholder art. Stanski Level 1 currently carries a human
+visual rejection receipt at **3/100** for in-game screenshots, with sprite sheets
+at 72/100, the tileset at 20/100, and the background layer at 8/100. SNES Studio
+must block production and FXPAK production export until a human 100/100 approval
+receipt exists. Art Lab
+shows asset cards for sprites, enemies, items, tilesets, backgrounds, UI, music,
+and SFX with source path/hash, provenance, conversion metadata, maturity state,
+in-game usage, review proof, and any visual blocker. Local OpenClaw/GLM may
+create structured art manifests, but procedural blobs/grids are placeholder-only
+and cannot pass production visuals.
+
+The visual recovery command sequence is
+`pnpm snes:toolchain -- visual-reject --project-id stanskis-world --level-id w1-1-cleveland-skyline-scramble --human-score 3 --json`,
+`pnpm snes:toolchain -- project-art-bible --project-id stanskis-world --level-id w1-1-cleveland-skyline-scramble --json`,
+`pnpm snes:toolchain -- project-art-source-pack --project-id stanskis-world --level-id w1-1-cleveland-skyline-scramble --json`,
+`pnpm snes:toolchain -- project-art-compile --project-id stanskis-world --json`,
+`pnpm snes:toolchain -- project-conversion --project-id stanskis-world --json`,
+`pnpm snes:toolchain -- project-visual-proof --project-id stanskis-world --json`,
+`pnpm snes:toolchain -- project-visual-proof --project-id stanskis-world --proof-source runtime-capture --json`,
+`pnpm snes:toolchain -- project-runtime-asset-truth --project-id stanskis-world --json`,
+and `pnpm snes:toolchain -- project-visual-quality-audit --project-id stanskis-world --json`. The runtime asset-truth receipt proves whether compiled source assets are actually listed in the ROM/runtime receipt, bound to converted SuperFamiconv pixel output, and backed by runtime or emulator screenshot proof. Synthetic composite screenshots are diagnostic only and cannot satisfy production visual proof. The quality audit records the current human category grades: in-game screenshots 3/100, all sprite sheets 72/100, tileset 20/100, and background layer 8/100. It also blocks when runtime asset truth is not proven, meaning screenshots exist but do not prove the improved sprite/tile/background source pixels are actually rendered in the ROM. Only after actual human review may the operator run `pnpm snes:toolchain -- project-visual-approval --project-id stanskis-world --human-score 100 --confirm-human-reviewed-visuals --approver human-operator --review-note "reviewed contact sheets, atlases, composites, and in-game screenshots" --json`. Without the confirmation flag and review note, a 100/100 approval command blocks instead of promoting the assets.
+The Visual Board buttons call the same local Gateway-backed commands: **Reject
+3/100 Visuals**, **Build Art Bible**, **Create Source Pack**, **Create Art
+Manifest**, **Compile Art**, **Capture Visual Proof**, **Prove Runtime Assets**, **Audit Visual Quality**, and **Approve Visuals**.
+These actions write receipts; they do not use hosted GLM, hosted image/video
+providers, or GPT 5.5 visual judging.
+
+The internal generic production runner stores the project package plus backlog,
+current milestone, completed milestones, blockers, memory cards, QA receipts, and
+latest summary under `.artifacts/snes-projects/<projectId>/`. The project
+manifest is the source of truth; agents receive compact packets plus relevant
+memory cards, not the full transcript. Every role handoff must include the
+surface changed, patch path/hash, assumptions, risks, playtest hypothesis, QA
+evidence required, next role, blocker, GPT 5.5 use, reasoning level, and local
+model used. The dashboard calls
+the generic Gateway methods `snes.production.status`, `snes.production.continue`,
+`snes.production.auto`, `snes.production.pause`, `snes.production.resume`,
+`snes.production.cancel`, `snes.production.splitNext`, and
+`snes.production.retryBlocked`. Local GLM/OpenClaw workers receive one compact
+milestone packet at a time and must return strict JSON with `localGlmOnly: true`
+and `hostedGlmUsed: false`. Routine milestone execution records
+`gpt55Used: false`; GPT 5.5 is reserved for initial blueprint, repeated blocker
+diagnosis, major architecture decisions, or final visual approval when explicitly
+used.
+
+The Toolchain Doctor is read-only unless the user explicitly approves installs.
+The live Gateway method `snes.toolchain.status` detects or reports blockers for
+PVSnesLib, SuperFamiconv, Pixelorama, LDtk, Tiled, Mesen/MesenCE, bsnes,
+SuperFamicheck, BRRtools, optional Aseprite, and FXPAK/SD2SNES-style FAT32 media.
+The dashboard also shows fixture-backed adapter receipts, a PVSnesLib ROM
+scaffold dry-run, emulator proof plan, and FXPAK copy dry-run. Browser preview,
+real asset conversion, real `.sfc` builds, emulator launch, and FXPAK writes are
+separate proof surfaces.
+
+After explicit approval for free/accountless local tool setup, use the local
+toolchain runner:
+
+```bash
+pnpm snes:toolchain -- probe --json
+pnpm snes:toolchain -- install --json
+pnpm snes:toolchain -- conversion-smoke --json
+pnpm snes:toolchain -- rom-smoke --json
+pnpm snes:toolchain -- emulator-smoke --json
+```
+
+The runner installs or registers tools under
+`~/.openclaw/snes-toolchain`, writes the manifest at
+`~/.openclaw/snes-toolchain/toolchain-manifest.json`, and stores receipts under
+`.artifacts/snes-toolchain/`. It does not use hosted GLM, does not use GPT 5.5 as
+a visual judge, does not bypass Gatekeeper, and does not write to FXPAK,
+SD2SNES, or other removable media. The real conversion smoke creates an
+original PNG fixture and converts it with SuperFamiconv into SNES tile, map, and
+palette outputs. The real ROM smoke builds a PVSnesLib `.sfc` and records the
+SuperFamicheck header/checksum receipt when available. The emulator smoke
+launches the built ROM with the detected local emulator and records either a
+screenshot proof or a launch receipt if screen capture is unavailable.
+
+After the smoke lane is green, project-level proof uses the same local toolchain
+against a persisted SNES project package:
+
+```bash
+pnpm snes:toolchain -- project-conversion --project-id comet-fox-mvp --json
+pnpm snes:toolchain -- project-rom --project-id comet-fox-mvp --json
+pnpm snes:toolchain -- project-engine-rom --project-id comet-fox-mvp --json
+pnpm snes:toolchain -- project-emulator --project-id comet-fox-mvp --json
+pnpm snes:toolchain -- project-engine-emulator --project-id comet-fox-mvp --json
+pnpm snes:toolchain -- fxpak-dry-run --project-id comet-fox-mvp --json
+```
+
+Project conversion materializes deterministic local PNG source assets for
+spec-only required graphics, converts them with SuperFamiconv, and writes
+input/output hashes under `.artifacts/snes-projects/<projectId>/toolchain/`.
+It proves only the asset pipeline; it does not claim human visual approval. The
+project ROM command generates a PVSnesLib project from the project package,
+embeds project id/title and the asset conversion hash in the generated source,
+builds a real scaffold `.sfc`, and runs SuperFamicheck. The project engine ROM
+command builds the first reusable PVSnesLib platformer runtime proof with
+controller movement, jump/gravity, collision floor, enemy marker, collectible,
+goal, and engine feature receipt. The project emulator commands launch the
+latest passing scaffold or engine ROM in MesenCE, bsnes, or SNES9x and record
+launch proof plus screenshot proof when macOS capture allows it. Scaffold ROM
+proof is not production gameplay proof; production readiness requires the
+separate engine runtime proof gate.
+
+SNES Studio now fails closed on text-mode engine scaffolds. A ROM generated from
+`hello_world.c`, `consoleDrawText` gameplay, `"@"` player markers, or without
+real BG tilemap, metasprite/OAM, gameplay, and audio runtime evidence is marked
+`rejected-scaffold`. Rejected scaffold ROMs may remain as diagnostic artifacts,
+but they cannot satisfy gameplay proof and cannot be exported to FXPAK.
+
+Runtime maturity is tracked separately from ROM build success. A ROM can pass
+SuperFamicheck and still be only a `scaffold` or `single-screen-runtime`.
+Stanski's World Level 1 export requires at least `production-candidate-level`,
+which means the receipt proves a scrolling level, camera bounds, real collision,
+metasprite objects, a finishable ending state machine, and runtime-integrated
+audio. The dashboard shows this maturity state so "ROM builds" is never confused
+with "the level is production grade."
+
+FXPAK or SD2SNES writes require an exact volume and an explicit write flag:
+
+```bash
+pnpm snes:toolchain -- fxpak-transfer-package --project-id stanskis-world --json
+pnpm snes:toolchain -- fxpak-dry-run --project-id comet-fox-mvp --fxpak-volume /Volumes/FXPAK --json
+pnpm snes:toolchain -- fxpak-copy --project-id comet-fox-mvp --fxpak-volume /Volumes/FXPAK --confirm-fxpak-volume /Volumes/FXPAK --allow-fxpak-write --json
+```
+
+When the FXPAK Pro SD card is mounted on another machine, use
+`fxpak-transfer-package`. It creates a local export folder containing the
+verified `.sfc`, SHA-256 receipt, SuperFamicheck context, and MacBook handoff
+instructions for copying only that ROM to `FXPAK/Games`. It does not write to
+`/Volumes`, does not create SD-card directories, and does not modify `.srm` save
+files.
+
+The copy command refuses auto-detected-only writes, non-`/Volumes` paths,
+non-FAT32 media, missing destination roots, existing destination ROMs, SRAM
+writes, and mismatched confirmation paths. It copies only the approved `.sfc`
+file and verifies the copied SHA-256 before writing a pass receipt.
+
+## Stanski's World Batch 1
+
+`stanskis-world` is the first full production project to use the generic SNES
+Studio package path. The full 8-world plan remains preserved for later, but the
+active production target is now **Level 1 only: Cleveland: Skyline Scramble**.
+The package still keeps the full canon, references, Secret World 9, The Auditor,
+true ending, later worlds, and release-candidate proof as planned backlog items;
+they are not treated as failed or complete.
+
+The Stanski package stores its durable data under
+`.artifacts/snes-projects/stanskis-world/`:
+
+- `project.json` for the generic SNES Studio project package;
+- `references/` for copied prompt files, source-image receipts, and canon
+  summaries;
+- `production/backlog.json`, `state.json`, `memory-cards.json`,
+  `decision-log.json`, and `latest-summary.md`;
+- `qa/` and `toolchain/` receipts from project conversion, ROM, emulator, and
+  FXPAK dry-run commands.
+
+The locked Batch 1 canon keeps the target platform as original SNES via FXPAK
+Pro, with optional enhancements disabled by default. FXPAK writes remain blocked
+until the operator provides a real exact mounted FAT32 volume path. Visual
+quality remains human-gated at 100/100.
+
+World 1 data includes Cleveland: Skyline Scramble, Detroit: Motor City Mayhem,
+Lakewood: Warren Road Roof Run, Edgewater Ticket Cache, Turnpike Toll Trouble,
+and the Fare Snatcher boss. Fare Snatcher grants Golden Transfer Pass #1.
+Lakewood/Warren Road house requirements, toilet endings, Secret World 9, Receipt
+Reality, Back of the Map, The Auditor, the true ending, the Todd drawing
+reference, and the man-and-boy photo inclusion requirement are preserved as
+canon/reference data before implementation.
+
+The Level 1 active slice records its own definition of done: `World: Cleveland`
+and `Level: 1` opening overlay, five starting lives, walk/run/jump, 1.5× run
+speed, 1.5× falling gas boost, crouch/projectile origins, cheeseburger onboarding
+in the first 30 seconds, a fair first enemy, early burrito block, pizza before a
+projectile-required enemy, one checkpoint, one reachable secret route, and a
+toilet ending with Todd sitting, newspaper, exactly two poop drops, and fireworks.
+The deterministic Level 1 package includes sections, gameplay objects, SNES
+budget, and a replay script that ends at the toilet. Browser playtest proof, ROM
+proof, visual approval, emulator proof, FXPAK copy, and original hardware proof
+remain separate gates.
+
+Batch 2 closes the man-and-boy reference gap only when the source photo is
+readable locally. The reference id is `man-boy-snes-photo-reference`. Its planned
+use is the **Family Memory Card** secret room cameo in World 1, with an optional
+ending or credits memory-card reuse after visual QA. The source photo is
+reference media first: a preserved hash and dimensions prove provenance, not
+production in-game art. SNES Studio must not claim the cameo appears in-game
+until a converted SNES-safe asset and executable visual proof show it in the
+runtime. If the Photos temp path is stale or the attachment is unavailable, the
+project must keep the reference blocked with `source image unavailable`.
+
+Batch 3 converts that preserved source into what the SNES can actually show. For
+`backgroundLayer` image assets, the local image converter crops the source into a
+96×64, 8×8-tile-aligned **Family Memory Card** panel, maps it to one 16-color
+SNES-safe palette with ordered dithering, writes a contact/review sheet, and
+records the asset as `draft-generated`. The converted PNG can feed
+SuperFamiconv/project conversion, but it still does not count as
+production-approved art until in-game visual proof and human visual approval pass.
+
+Level 1 proof commands:
+
+```bash
+pnpm snes:toolchain -- reconcile-production-state --project-id stanskis-world --json
+pnpm snes:toolchain -- project-conversion --project-id stanskis-world --json
+pnpm snes:toolchain -- project-visual-proof --project-id stanskis-world --json
+pnpm snes:toolchain -- project-browser-playtest --project-id stanskis-world --level-id w1-1-cleveland-skyline-scramble --json
+pnpm snes:toolchain -- project-visual-review-pack --project-id stanskis-world --level-id w1-1-cleveland-skyline-scramble --json
+pnpm snes:toolchain -- project-engine-rom --project-id stanskis-world --json
+pnpm snes:toolchain -- project-engine-emulator --project-id stanskis-world --json
+pnpm snes:toolchain -- fxpak-transfer-package --project-id stanskis-world --json
+pnpm snes:toolchain -- fxpak-dry-run --project-id stanskis-world --json
+```
+
+Those commands produce receipt-backed state or exact blockers. Conversion may
+use reference/source assets with non-production maturity. The browser playtest
+checks Stanski-specific Level 1 mechanics and toilet-ending assertions from the
+deterministic project data. The visual review pack is for human approval and
+does not claim 100/100 by itself. Engine ROM proof is a scaffold/runtime proof,
+not full-game proof. FXPAK copy proof remains blocked until a real volume path
+is approved.
+
+SNES Studio now separates the fast synthetic benchmark from the real output
+benchmark. The synthetic ladder checks local availability and expected role fit.
+The real output benchmark asks each installed local candidate model to return
+strict SNES Studio role JSON, saves raw outputs under
+`.artifacts/snes-real-output-model-benchmark/`, scores JSON validity, patch
+safety, role-signal coverage, asset/hardware specificity, latency, and optional
+GPT 5.5 judge feedback. Local GLM-5.2 must pass both `/v1/models` discovery and
+a minimal decode probe before it is benchmarkable; a server that only lists GLM
+but returns `Compute error` is reported as decode-blocked and is not promoted.
+Hosted GLM is never used. GPT 5.5 judging is allowed only when
+`OPENCLAW_SNES_BENCHMARK_GPT_JUDGE=1` is set, and it judges saved outputs rather
+than generating the game content. Run it with:
+
+```bash
+OPENCLAW_LOCAL_GLM52_BASE_URL=http://127.0.0.1:28080 \
+pnpm snes:benchmark:models -- --mode output \
+  --roles snes-game-director \
+  --models ollama/openclaw-control-qwen25-32b:latest,ollama/openclaw-control-qwen36-27b:latest,local-glm-5.2-2bit \
+  --rounds 3 --judge none --no-download --timeout 240 --max-output-tokens 900 --json
+
+# Optional hosted judge add-on, only after explicit approval to send benchmark outputs to GPT 5.5:
+OPENCLAW_SNES_BENCHMARK_GPT_JUDGE=1 pnpm snes:benchmark:models -- --mode output \
+  --judge gpt-5.5 --no-download --timeout 900 --json
+```
+
+A model is not recommended unless it beats the current role default by at least
+five mean points across all rounds with no blocked, invalid JSON, or fail runs.
+The real benchmark also writes
+`.artifacts/snes-real-output-model-benchmark/latest-summary.md` for a compact
+side-by-side report. To diagnose GLM itself without running the full benchmark,
+use:
+
+```bash
+pnpm glm52:runtime -- probe --json
+```
+
+That writes `.artifacts/glm52-local-runtime/latest.json` with the llama.cpp
+endpoint, model id, decode blocker, request hash, memory snapshot, and repair
+context. To restart GLM safely and try bounded local launch profiles, run:
+
+```bash
+pnpm glm52:runtime -- repair --json
+```
+
+The repair command only stops a process on the GLM port when the port owner is
+`llama-server`; it refuses to kill unrelated processes. It then tries
+`metal-low`, `metal-no-mmap`, and `cpu-safe` profiles in order, stopping after
+the first successful decode probe. Metal profiles keep Flash Attention enabled
+when using q8 KV cache because llama.cpp rejects quantized V cache without it.
+Use the successful low-memory repair profile for SNES benchmark work. Treat
+`metal-agent-8k` and `metal-agent-4k` as experimental profiles only: they may
+decode on an idle machine, but can fail with Metal out-of-memory and a
+`Compute error` under benchmark conditions.
+
+When a local GLM-5.2 run wins a role, make it a real OpenClaw model route before
+expecting SNES Studio agents to use it:
+
+```bash
+pnpm glm52:runtime -- register-provider --context 8192 --max-output-tokens 256 --json
+pnpm glm52:runtime -- promote-winners --agent snes-hardware-qa --json
+pnpm openclaw gateway restart
+pnpm glm52:runtime -- agent-proof --agent snes-hardware-qa --timeout 600 --json
+pnpm glm52:runtime -- status --agent snes-hardware-qa --json
+```
+
+`register-provider` adds a local-only OpenAI-compatible provider named
+`local-glm52` pointed at the loopback llama.cpp server. `promote-winners` reads
+the latest real output benchmark and updates only roles where
+`local-glm-5.2-2bit` is a clean benchmark winner; the promoted agent keeps the
+previous local worker as fallback. `agent-proof` runs an actual OpenClaw agent
+turn through `local-glm52/...` and fails closed unless the reply contains strict
+SNES Studio hardware QA JSON with safe patch paths. `status` checks runtime
+decode, provider registration, benchmark recommendation, agent promotion, and
+agent proof in one receipt.
+
+### Durable GLM Production Loop
+
+For long Stanski's World production work, SNES Studio does not send GLM one giant
+prompt. OpenClaw owns the production memory and asks local GLM-5.2 to complete
+one milestone at a time. The loop persists progress in
+`.artifacts/stanskis-world/production/`:
+
+- `backlog.json` lists the graphics and gameplay milestones.
+- `state.json` records the current milestone, completed milestones, blocked
+  milestone, human visual grade, last good build, and last executable QA receipt.
+- `memory-cards.json` keeps compact locked decisions and QA proof from passed
+  milestones.
+- `decision-log.json` records every status, patch, pass, fail, and blocker.
+- `latest-summary.md` is the dashboard-readable handoff.
+- `production-policy.json` records the local-only policy: local GLM required,
+  hosted GLM disabled, routine GPT 5.5 disabled, executable QA required, and
+  remote proof required before publishing.
+- `control.json` and `worker.lock` provide pause/resume/cancel and double-run
+  protection.
+- `latest-worker-receipt.md` summarizes the most recent stop reason, blocker,
+  next action, model use, and QA receipt.
+
+Run the loop one milestone at a time by default:
+
+```bash
+pnpm stanski:produce -- --mode status --json
+pnpm stanski:produce -- --mode split-next --json
+pnpm stanski:produce -- --mode continue --max-milestones 1 --json
+pnpm stanski:produce -- --mode retry-blocked --json
+pnpm stanski:produce -- --mode auto --until blocked --max-runtime-minutes 30 --json
+pnpm stanski:produce -- --mode pause --json
+pnpm stanski:produce -- --mode resume --json
+pnpm stanski:produce -- --mode cancel --json
+```
+
+Each milestone call builds a compact packet containing only the next milestone,
+the current visual grade, relevant memory cards, the allowed patch schema, and
+things that must not break. GLM must return strict JSON with `localGlmOnly: true`
+and `hostedGlmUsed: false`. Markdown, raw HTML, raw JavaScript, wrong milestone
+ids, wrong patch types, or hosted-provider flags fail closed. OpenClaw applies
+the accepted patch deterministically, rebuilds the playable artifact, runs the
+executable smoke gate, writes a milestone receipt, creates a memory card, and
+then selects the next milestone.
+
+Large asset milestones are split before GLM is asked for a giant response. For
+example, `G07 Cleveland master tileset` becomes `G07a` through `G07e`, each with
+10-25 concrete tile or integration requirements. The bounded `auto` mode holds a
+recoverable worker lock, checks pause/cancel between milestones, retries GLM once
+for invalid JSON or timeouts, and stops cleanly on blockers instead of running as
+a persistent daemon.
+
+The dashboard exposes the same loop with **Load Production Status**, **Start
+Bounded Auto**, **Run One Milestone**, **Split Next**, **Retry Blocked
+Milestone**, **Pause**, **Resume**, and **Cancel**. It also surfaces the current
+milestone, completed count, GLM/GPT policy, worker lock heartbeat, last GLM patch
+path, and last QA receipt path. Routine milestone execution does not call GPT
+5.5. GPT 5.5 is reserved for low-reasoning QA summaries or repair briefs after
+failures, and high-reasoning use is reserved for repeated blockers, architecture
+changes, major design conflicts, or final production visual approval.
+
+The dashboard also exposes a **Run Live Production Check** route. It sends three
+staged Gateway `agent` jobs: GPT 5.5 Game Director, OpenClaw Game Team, deterministic validation, and GPT 5.5
+Quality Gate. The GPT 5.5 stages request the configured `openai/gpt-5.5` model, OpenClaw
+worker stages use the local OpenClaw agent lane, and SNES Studio waits with
+`agent.wait` before reading the final `chat.history` response. The route is only
+marked verified when every stage returns approval-gated JSON through Gateway. A
+local deterministic draft is still available when live agents are not connected,
+but it is labeled as fallback work rather than live GPT 5.5/OpenClaw proof.
+
+Dashboard live checks do **not** require FXPAK hardware or the
+`OPENCLAW_SNES_STUDIO_LIVE_AGENT_E2E` flag. They require a connected,
+authenticated Dashboard Gateway session that can call `agent`, `agent.wait`, and
+`chat.history`. The env flag is only for automated smoke/E2E runs so test lanes
+do not accidentally spend GPT 5.5/OpenClaw model time. If the dashboard shows a
+401 or disconnected Gateway, fix Dashboard auth or reconnect the Gateway first;
+mounting a flash cart will not fix live AI.
+
+For the safest authenticated launch, run:
+
+```bash
+openclaw dashboard --no-open --path /snes-studio
+```
+
+Open the copied URL. The SNES Studio **Connection Doctor** then reports whether
+the page loaded, the Gateway WebSocket connected, the browser is authenticated,
+and live agents can be checked. If it says `AUTH_TOKEN_MISSING`,
+`AUTH_TOKEN_MISMATCH`, or "Dashboard auth missing or expired", reopen the copied
+URL or paste the gateway token in Control UI settings before testing live agents.
+
+SNES Studio checks the live AI team setup automatically when the Dashboard
+Gateway is ready, but the automatic check does **not** spend model calls. The
+GPT 5.5-Directed Team Status card reports **Live proof pending**, **Live OpenClaw
+ready**, **Checking live OpenClaw**, or **Live OpenClaw unavailable**. Before
+sending role work, the dashboard inspects `agents.list`, checks
+`agents.runtime.status`, and safely creates missing SNES Studio OpenClaw worker
+agents with `agents.create` when Gateway permissions allow it. **Check Again**
+reruns the same fast setup check.
+
+The status check covers role-specific Gateway sessions for GPT 5.5 Game Director,
+OpenClaw Game Director, OpenClaw Level Designer, OpenClaw Gameplay Designer,
+OpenClaw Art and Audio, OpenClaw Hardware QA, and GPT 5.5 Quality Gate. GPT 5.5 roles
+request `openai/gpt-5.5`; OpenClaw worker roles target explicit worker agents
+such as `snes-game-director` and `snes-level-designer`, and are the only roles
+that fill creative text boxes. The expensive model-backed proof runs only when
+the user chooses **Run Live Production Check** or explicitly starts a live build.
+That proof runs stages sequentially with a longer timeout so cold-started local
+models do not cause seven simultaneous 30-second failures. If live proof is
+pending or unavailable, **Make My Game** uses the local deterministic
+fallback and shows that receipt instead of pretending live agents were used.
+
+## Classic Platformer Graphics
+
+The default visual preset is **Classic Colorful SNES Platformer**: bright
+original grassland tiles, chunky readable platforms, expressive enemies,
+sparkling rewards, simple parallax-style skies, and 2-4 frame sprite recipes.
+The preset is data-first: it carries concrete 16x16 tile specs, sprite frame
+specs, palette indexes, music pattern specs, and sound-effect event mappings so
+OpenClaw workers produce usable assets instead of vague mood-only notes.
+
+When a prompt asks for "Super Mario World graphics," SNES Studio maps that to
+the original preset and shows that it is using original SNES-safe art inspired by
+classic platformer readability. It does not copy Nintendo tiles, sprites, music,
+names, logos, or characters. Licensed assets are only used when the user imports
+their own authorized files.
+
+For Stanski Level 1, the clean-room Cleveland recovery target specifically
+requires Terminal Tower, Key Tower, 200 Public Square, a Cuyahoga bridge truss,
+and Lake Erie to be recognizable in the background. Downloading or copying Super
+Mario World code, ROM data, sprites, tiles, maps, palettes, music, or assembly is
+not allowed, even for personal-use builds.
+
+The playtest canvas uses the active graphics preset immediately, and the preview
+SNES game-file manifest records the preset, provenance, palette budget, tile
+budget, sprite budget, and style warnings. Expert Studio exposes the exact
+palette, level-square, moving-thing, memory, and checksum proof while the guided
+builder keeps the beginner language simple.
+
+The **AI Gap Filler** watches for missing pieces:
+
+- Missing hero, goal, enemies, rewards, music, save memory, or ending.
+- Empty or incomplete levels.
+- Playability and export readiness blockers.
+
+**Fill Missing Pieces** applies deterministic local fixes with undo, and locked
+parts are preserved when the user marks story, levels, cast, rules, music, or
+export settings as locked.
+
+## Prompt-First Creation
+
+There is one main game prompt, plus contextual prompts where they are useful.
+
+- No selection: the prompt creates or changes the whole game or current level.
+- Selected hero: the prompt changes hero movement or placement.
+- Selected enemy: the prompt changes speed, patrol, behavior, or placement.
+- Selected item: the prompt changes the pickup purpose or placement.
+- Selected emulator area: the prompt can add coins, paint danger, add a door,
+  remove things, or make a jump easier only inside that selected screen region.
+- **Make Things**: prompts create custom heroes, enemies, items, powerups,
+  blocks, doors, goals, hazards, music ideas, and new levels.
+
+Every AI action records what changed, who did the work, what stayed safe, what
+gaps remain, and what to test next. OpenClaw is the visible creative filler for
+text boxes and game parts. GPT 5.5 appears as game director, critic, problem solver, and approval gate,
+not as the normal text-box filler. Content changes can apply instantly with undo.
+Code, runtime, and export changes still require approval through the agent patch
+flow.
+
+When a live Gateway agent session is unavailable, **Run Local Agent Proof** uses
+the same OpenClaw/Codex approval-gated patch contract with the deterministic
+local runner. That proves prompts can still create an editable review patch
+instead of appearing inert. **Run Live Agent Proof** checks one connected
+preview task. **Run Live Production Check** checks the full staged
+GPT 5.5/OpenClaw/validation/GPT 5.5 loop and is not marked passed until each stage returns
+editable patch JSON.
+
+## Playtest
+
+The browser playtest is the beginner proof surface. It now runs through the
+shared platformer runtime contract used by the dashboard and export manifest.
+The live loop targets the SNES NTSC cadence of 60.0988 frames per second with a
+fixed-step runtime, then draws the scene to a 256x224 pixel canvas using
+nearest-neighbor scaling and simple pixel-style hero, enemy, item, door, and
+goal sprites.
+
+It supports:
+
+- A 60 Hz runtime playtest canvas with readable pixel-style hero, enemy, item,
+  door, and goal sprites plus compact editable handles.
+- Continuous live play: press **Start Test**, then hold keyboard keys or
+  controller buttons to move and jump until pausing or restarting.
+- Drag-select an empty area of the game screen, type a prompt, and apply the
+  change to that part of the level.
+- Click visible ground, danger, water, or empty space to snap the highlighted
+  area to that part of the level before prompting AI.
+- Highlighted-area prompts understand common add, remove, and change intents,
+  such as "add coins here," "remove enemies in this area," "make this safe
+  ground," "make this a gap," "add a secret door," and "paint this as danger."
+- When the highlight came from clicking an existing ground, danger, or water
+  chunk, dragging the highlighted chunk moves that level piece itself; prompts
+  like "move this ground down" also move the actual level piece.
+- The same terrain chunks can be resized directly with the corner handle or with
+  prompts such as "make this platform longer" or "make this ground shorter."
+- Drag the highlighted selection itself to move it, or drag its corner handle to
+  resize it before asking AI to add, remove, or change content there.
+- Click and hold any visible hero, enemy, item, door, or goal handle to move it
+  directly on the play surface; releasing hot-reloads the runtime so the new
+  position is immediately testable.
+- In **Play & Change**, the **Ask AI** bar appears before the emulator canvas so
+  prompt-based editing stays the first obvious action.
+- Once an area is selected, quick actions can immediately add coins, add an
+  enemy, add a key, make the jump easier, make safe ground, make danger, or
+  remove things inside that rectangle.
+- The selected-area prompt bar also shows plain "Try asking" examples, such as
+  "Make this jump easier," "Add a hidden key here," and "Remove only enemies
+  here," so users can learn the prompt loop by playing with the controls.
+- Use **Preview Area Change** when you want to check an AI edit before it changes
+  the game. The preview card shows what will change, offers **Apply Preview**,
+  and lets you cancel without touching the playtest.
+- The play surface keeps game objects as compact glowing edit handles by
+  default, with labels revealed on hover, focus, or selection so the game stays
+  readable while editing remains discoverable.
+- Obvious **Run Right**, **Jump**, and **Show It Working** actions that explain
+  what changed after each test input.
+- Left/right movement.
+- Jump and gravity.
+- Ground, gaps, and hazard behavior.
+- Enemy patrol/contact.
+- Item pickup.
+- Score, health, lives, win/loss state.
+- Goal reach.
+- Restart and test controls.
+- A deterministic game-quality report that hard-gates AI approval on finishable
+  levels, reachable jumps, first-screen fairness, reachable rewards, visible
+  goal/path, reasonable enemy density, first-30-seconds pacing, and export
+  constraints.
+
+Every prompt or drag/drop edit recompiles the runtime contract and hot-reloads
+the playtest. When state can be preserved safely, the hero stays in the current
+test. Otherwise the level restarts with a visible message.
+The production card shows the actual planner route, worker route, QA route,
+quality score, playtest status, and whether live GPT 5.5/Codex cost was used. The
+**Improve Game Quality** action repairs deterministic quality blockers before
+the dashboard suggests export.
+
+Expert Details show the runtime hash, target frame cadence, drawn FPS, slow-frame
+counter, deterministic browser replay proof, and emulator replay parity status.
+The replay parity report ties together the exported game-file runtime manifest,
+the browser input replay, the expected emulator state hash, the selected emulator
+boot command, screenshot proof, and an emulator state dump when one exists. The
+downloadable proof package includes the exact replay input frames and operator
+instructions needed to reproduce the browser run in an emulator. When an
+emulator is selected in Expert Studio, SNES Studio also prepares a downloadable
+run script that boots the exported game file with the same runtime hash, replay
+frame count, and expected final state hash. Real ROM/emulator parity is only
+claimed after the emulator state hash matches the browser replay hash; otherwise
+SNES Studio keeps the exact blocker visible.
+
+Keyboard controls work from the playtest card: hold arrow keys or WASD to move,
+Space jumps, Enter starts running, Escape pauses, and R restarts.
+
+## Drag And Drop
+
+Drag/drop is secondary to prompting and used where it helps:
+
+- The **Things Shelf** can add hero, enemy, item, powerup, platform, hazard,
+  door, goal, and coin-trail pieces.
+- Existing visible game things can be dragged on the playtest stage.
+- Direct pointer dragging works inside the emulator-like canvas, so users do not
+  need to understand browser drag/drop mechanics before moving a game thing.
+- The selected thing panel exposes direct controls for simple movement and
+  behavior tuning.
+- The highlighted screen-area tool supports both prompts and one-click quick
+  edits, so add/change/remove actions are available without searching panels.
+- The highlighted screen-area tool can also be moved and resized directly on the
+  play surface before applying AI changes.
+- Terrain selected with one click acts like a movable level piece: drag it or
+  prompt AI to move it, then the 60 Hz playtest hot-reloads immediately.
+- Terrain selected with one click can also be stretched or shrunk directly, so
+  platforms can be tuned without opening the advanced level editor.
+- Selected-area removal can target matching game things, such as enemies or
+  rewards, without wiping out the whole level unless the prompt asks for a gap,
+  empty space, or clearing everything.
+- A simple click on existing ground, danger, water, or empty space selects that
+  part of the level, keeping changes discoverable without manual rectangle drawing.
+
+## Beginner Language
+
+Beginner-facing UI avoids expert wording where possible:
+
+- **SNES game file** instead of ROM.
+- **Save memory** instead of SRAM.
+- **Flash cart** instead of FXPAK PRO.
+- **Level square** instead of tile.
+- **Where the player bumps** instead of collision.
+
+Unavoidable expert terms use question-mark help with plain definitions,
+why the term matters, and whether the user needs to care now.
+
+## Expert Studio
+
+Expert Studio preserves professional SNES control without crowding the guided
+flow. It includes:
+
+- Full project safety and recovery.
+- Advanced AI stage and patch review.
+- Hardware budgets.
+- Build console.
+- Asset pipeline.
+- Emulator proof.
+- Flash cart export plan.
+- Generated object audit.
+
+Hardware constraints remain enforced:
+
+- LoROM profile.
+- Save memory/SRAM plan.
+- Flash cart/FXPAK PRO package path.
+- 128 GB FAT32 microSD target.
+- SuperFX profile state.
+- VRAM, CGRAM, OAM, ARAM/SPC700, banks, and checksum proof.
+
+## Verification
+
+The guided surface is covered by `ui/src/ui/views/snes-studio.test.ts`.
+The live smoke flow is `scripts/dev/control-ui-snes-studio-smoke.ts`.
+
+The covered flow verifies:
+
+- The default route renders the story-first guided builder, not the dense tool rail.
+- One prompt creates a GPT 5.5 blueprint when the live route is approved, or a local
+  fallback blueprint, then OpenClaw fills the story map, level chapters, cast,
+  rules, and playable platformer draft.
+- GPT 5.5 Quality Gate can fail weak output, request OpenClaw corrections, and
+  approve only after checks pass when that approved route runs.
+- The AI Gap Filler reports and fills missing game parts without hiding the result.
+- The playtest stage shows hero, enemies, items, score, health, and state.
+- Prompt-created things appear in the Things Shelf and playtest.
+- Clicking a visible thing opens direct editing.
+- Selected-thing prompts only change the selected object.
+- Selected-area prompts can add, remove matching things, and change highlighted
+  terrain with natural language.
+- Beginner export uses plain language.
+- Expert Studio still exposes the hardware proof path.
+- Local OpenClaw proof returns an approval-gated editable patch even when
+  live Gateway proof is not configured.
+- Emulator replay parity is surfaced in the playtest HUD, export proof panel, and
+  downloadable proof report instead of being hidden behind logs.
+
+## Visual Quality And Revision Gates
+
+SNES Studio treats graphics quality as a build gate. Drafts must score at least
+`50/100`, requested high-quality drafts must meet the requested target, and
+production art needs deterministic metrics plus human visual approval unless GPT
+5.5 visual review is separately approved.
+The **Art Director / Visual QA** gate is separate from general QA: it blocks
+rectangle/placeholder art, spec-only graphics, missing sprite sheets, too few
+tile variants, missing palette ramps, missing background/parallax layers, and
+missing review proof. Human visual grade overrides synthetic scoring; if the
+human grade is below target, production remains blocked even when machine scores
+look good. For a `100/100` target, the gate requires production-approved assets,
+40 approved hero animation frames, at least 96 production tileset variants,
+background depth proof, review artifacts, in-game screenshot proof, and human
+approval. Draft-generated compiler output is reviewable evidence, not approval. The executable
+quality receipt should prove non-rectangle hero sprites, multiple animation
+frames, palette ramps, foreground/background separation, concrete landmark
+layers, and visible item/enemy/goal silhouettes.
+
+For revisions, GPT 5.5 writes the diagnosis and minimal repair brief, local
+OpenClaw or local GLM workers return structured patch JSON only, deterministic
+code applies the patch, browser QA runs, and GPT 5.5 approves only after machine
+proof passes. Text checklists and model self-reviews are advisory; they cannot
+approve a game.
+
+Playable preview links follow the same proof chain. Publish the canonical remote
+Control UI or Tailscale route only after loopback and remote HTTP probes prove
+the game route serves the playable artifact instead of the Control UI shell. The
+handoff should include the playable link, executable QA receipt, and patch/model
+receipt.
+
+Local media generation is fail-closed. If a local ComfyUI image workflow or a
+local video workflow is unavailable, the title image or title animation status is
+`blocked` with the exact local blocker. Hosted media providers are not used for
+local-only SNES game assets unless the operator explicitly changes scope.
+
+## Production SNES Studio Gates
+
+SNES Studio now treats the browser game as a fast preview, not production proof.
+The reusable Production SNES Studio cockpit separates five beginner modes:
+**Create**, **Edit**, **Art Lab**, **Playtest**, and **Ship**.
+
+Production completion is blocked until all required proof surfaces pass:
+
+- Browser preview and deterministic playtest.
+- Real asset pipeline with traced sprite, item, tileset, and background assets.
+- Human or approved GPT 5.5 visual approval for the requested target score.
+- `.sfc` ROM build receipt.
+- Emulator boot proof receipt.
+- FXPAK PRO package dry-run.
+- Manual original-SNES hardware proof.
+
+SNES Studio proof tiers are intentionally separate. A DOM/static dashboard check
+can prove that the built bundle contains the SNES Mastery card and blocker
+language, but it is labeled `dom-static` and `productionBrowserEquivalent:
+false`. It cannot close browser-visible proof. Browser-visible proof requires a
+verified Playwright Chromium launch, route load, and smoke receipt. Emulator
+launch proof also stays separate from emulator screenshot proof and runtime
+signature proof; a launch-only receipt cannot close screenshot, timing, or
+runtime-asset milestones.
+
+The **Toolchain Doctor** is read-only. It reports missing or available SNES tools
+without installing anything: PVSnesLib, SuperFamiconv, Pixelorama, optional
+Aseprite CLI, LDtk, optional Tiled, Mesen or bsnes, SuperFamicheck, BRRtools, and
+FXPAK/SD2SNES-style FAT32 media. Missing tools are shown as actionable blockers,
+not hidden behind a green dashboard state.
+
+Stanski's World remains the canary project. Generic SNES Game Builder code must
+load Stanski through the same manifest, asset registry, toolchain, visual, ROM,
+emulator, and FXPAK gates used by every future game.
+
+## Local Model Benchmark And Live Proof Gates
+
+Run the local-only SNES model benchmark without downloads:
+
+```bash
+pnpm snes:benchmark:models -- --no-download --timeout 180
+```
+
+The benchmark writes `.artifacts/snes-local-model-benchmark/latest.json` and a
+timestamped `report.json`. It must not download models or use hosted providers.
+Unavailable models, including GLM-5.2 unless already installed locally, are
+reported as skipped blockers.
+For real output comparison, run the output benchmark with `--rounds 3`. SNES
+Studio keeps `promotionApplied: false`; the report provides role-specific
+recommendations for review instead of changing worker defaults automatically.
+
+Full live GPT 5.5 proof is intentionally manual unless automated E2E is enabled.
+To complete it from the authenticated dashboard session:
+
+1. Run `openclaw dashboard --no-open --path /snes-studio`.
+2. Open the copied URL.
+3. Confirm the Connection Doctor says the page loaded, Gateway is connected, and
+   auth is OK.
+4. Click **Check Again**.
+5. Click **Run Live Production Check**.
+6. Confirm GPT 5.5 approval appears only if the live route actually ran.
+7. Build a game.
+8. Run **Improve Game Quality**.
+9. Export the `.sfc` preview and emulator proof bundle.
+
+Do not claim full live completion if the dashboard is using local fallback or if
+the automated smoke only reports `OPENCLAW_SNES_STUDIO_LIVE_AGENT_E2E=1`.
+Full automated live proof must click **Run Live Production Check** and see the
+dashboard success receipt that GPT 5.5 planning, OpenClaw building, and GPT 5.5
+approval stages returned approval-gated JSON through Gateway.
+
+Local GLM-5.2 remains a local-only experimental lane. SNES Studio may benchmark
+`local-glm-5.2-2bit` only when a local llama.cpp OpenAI-compatible server reports
+a GLM-5.2 model and a minimal `/v1/chat/completions` decode probe succeeds. Do
+not use hosted GLM for SNES Studio, and do not promote GLM to a worker default
+unless the local benchmark report shows it wins that role with no blockers.
+
+Maintainers can run the same authenticated browser proof without printing the
+tokenized URL:
+
+```bash
+pnpm openclaw dashboard --no-open --path /snes-studio
+pnpm ui:smoke:snes-studio --from-clipboard
+```
+
+The smoke reads the copied URL from the macOS clipboard and redacts token
+fragments in `summary.json`, `latest.json`, and terminal output.
+
+## Generic SNES Mastery Proof Chain
+
+The reusable SNES Studio capability ledger is separate from any one game. The current generic mastery gate is verified with:
+
+```bash
+pnpm snes:mastery status --json
+pnpm snes:mastery next --json
+pnpm snes:mastery:receipts
+node .artifacts/snes-game-builder-reference/scripts/validate-reference-corpus.mjs
+node .artifacts/snes-game-builder-reference/scripts/validate-generic-scope.mjs
+```
+
+A complete generic ledger means the reusable proof system is green; it does not mean a specific game has production art, full route design, FXPAK copy proof, or original SNES hardware proof. SNES Studio keeps these proof surfaces separate: browser-visible dashboard proof, emulator screenshot/runtime proof, budget enforcement, runtime asset truth, FXPAK package dry-run, removable-media copy proof, and original hardware proof.
+
+Expert Studio exposes local proof actions for the generic chain: mastery refresh, browser proof, emulator proof, budget proof, runtime asset truth, FXPAK dry-run validation, and the generic project generator gate. These actions run local scripts, write local receipts, and never write to FXPAK/removable media. Browser proof may require a working Playwright Chromium install; emulator proof may require a working local emulator adapter or a disposable local container. If local container infrastructure is broken, the blocker must be recorded separately instead of downgrading generic proof status.
+
+The default artifact policy is local-first: keep bulky `.artifacts/**` proof outputs local unless a release process explicitly requires committing a small reproducible receipt or script. Commit source, tests, and docs needed to reproduce the proof; do not commit commercial SNES ROMs, copied commercial code/assets, screenshots from commercial games, FXPAK media contents, or secret/key files.
+
+For a new game, use **Create Blank SNES Project** to create a clean generic `openclaw-snes-project-package`. Project creation is only a package-creation receipt. The project still must pass ROM build, SuperFamicheck, budget, runtime asset truth, emulator screenshot, FXPAK dry-run, and any game-specific human approval gates before production claims are allowed.
+
+Stanski's World remains a separate canary project with its own blockers. Generic SNES mastery can be 100% while Stanski production remains blocked by visual grade, missing human 100/100 approval, missing source-photo preservation, missing FXPAK copy proof, and missing original SNES hardware proof.
+
+## Project Command Center v2
+
+SNES Studio PCC includes deterministic overnight runner scaffolding, approval queues, run control, run summaries, and worker-packet export. It keeps long-running work moving until it reaches completion, a validation failure, a retry blocker, pause/cancel, time limit, or an approval gate.
+
+See [workflow](/reference/snes-studio-workflow), [agent routing](/reference/snes-studio-agent-routing), and [proof gates](/reference/snes-studio-proof-gates).
+
+## PCC v3 Multi-Agent Coordination
+
+PCC v3 adds dispatch dry-runs, worker sandbox contracts, write-surface guards, patch application gates, local-only live worker dispatch, parallel scheduling metadata, model health routing, artifact cache metadata, reviewer receipts, conflict detection, compact memory cards, telemetry, dashboard snapshots, and legal clean-room prompt-to-ROM benchmark scaffolding. Hosted GLM, paid tools, commercial SNES material, FXPAK writes, push/PR, and human production visual approval remain approval-gated.
+
+## PCC local model execution
+
+SNES Studio PCC supports local-only worker execution through installed Ollama/OpenClaw models. Browser, hardware, FXPAK, and human visual proof remain separate gates; local worker execution alone does not make a game production complete.

--- a/scripts/lib/snes-team-orchestrator.mjs
+++ b/scripts/lib/snes-team-orchestrator.mjs
@@ -1,0 +1,2869 @@
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export const PCC_FORMAT = "openclaw-snes-team-pcc-v1";
+export const PCC_STATE_FILES = [
+  "project.intent.json",
+  "milestone-ledger.json",
+  "dependency-dag.json",
+  "active-worker-locks.json",
+  "decision-log.json",
+  "memory-cards.json",
+  "repair-queue.json",
+  "approval-queue.json",
+  "run-control.json",
+  "run-history.json",
+  "model-usage.json",
+  "build-history.json",
+  "latest-run-summary.md",
+  "latest-summary.md",
+  "worker-dispatch-log.json",
+  "worker-sandboxes.json",
+  "patch-ledger.json",
+  "artifact-cache.json",
+  "reviewer-receipts.json",
+  "conflict-receipts.json",
+  "telemetry.json",
+  "dashboard-snapshot.json",
+  "regression-benchmarks.json",
+];
+
+export const PCC_STATUSES = new Set([
+  "pending",
+  "ready",
+  "in_progress",
+  "pass",
+  "fail",
+  "blocked",
+  "rejected",
+  "superseded",
+]);
+
+export const PCC_FAILURE_CLASSES = new Set([
+  "invalid-patch",
+  "build-failure",
+  "runtime-failure",
+  "visual-failure",
+  "budget-failure",
+  "external-blocker",
+]);
+
+export const PCC_APPROVAL_TYPES = new Set([
+  "hosted-glm",
+  "paid-tool-or-asset",
+  "fxpak-removable-write",
+  "push-or-pr",
+  "original-hardware-proof",
+  "human-production-visual-approval",
+  "live-model-spending-automation",
+]);
+
+export const DEFAULT_ROUTING_POLICY = Object.freeze({
+  format: "openclaw-snes-team-routing-policy-v1",
+  producerOrchestrator: {
+    role: "deterministic-script",
+    model: "none",
+  },
+  initialBlueprint: {
+    role: "gpt-game-director",
+    model: "openai/gpt-5.5",
+    reasoning: "high",
+    approvalGated: true,
+  },
+  routineWorkers: {
+    model: "ollama/openclaw-control-qwen3-30b-q6-chatfix:latest",
+    fallbacks: [
+      "ollama/openclaw-control-qwen36-27b:latest",
+      "ollama/openclaw-control-qwen25-32b:latest",
+    ],
+  },
+  finalApproval: {
+    role: "deterministic-receipts-gpt55-human-when-required",
+    model: "openai/gpt-5.5",
+    reasoning: "high",
+    approvalGated: true,
+  },
+  hostedGlmUsed: false,
+  gpt55UsedByDeterministicCommands: false,
+});
+
+export const DEFAULT_RETRY_POLICY = Object.freeze({
+  maxAttempts: 4,
+  attempts: [
+    { attempt: 1, action: "same-role-repair" },
+    { attempt: 2, action: "fallback-local-model-repair" },
+    { attempt: 3, action: "gpt55-high-diagnosis-required" },
+    { attempt: 4, action: "block-unless-user-approves-deeper-work" },
+  ],
+});
+
+const nowIso = () => new Date().toISOString();
+
+function sha256Text(text) {
+  return crypto.createHash("sha256").update(text).digest("hex");
+}
+
+function jsonStable(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, jsonStable(value));
+}
+
+function spawnText(result, stream) {
+  return typeof result?.[stream] === "string" ? result[stream] : "";
+}
+
+function extractJsonObject(text) {
+  const raw = String(text ?? "");
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start < 0 || end < start) return null;
+  try {
+    return JSON.parse(raw.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+}
+
+function ollamaModelId(modelRef) {
+  return String(modelRef ?? "").startsWith("ollama/")
+    ? String(modelRef).slice("ollama/".length)
+    : String(modelRef ?? "");
+}
+
+function parseOllamaList(stdout) {
+  return String(stdout ?? "")
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => !/^name\s+/iu.test(line))
+    .map((line) => line.split(/\s+/u)[0])
+    .filter(Boolean)
+    .map((name) => (name.startsWith("ollama/") ? name : `ollama/${name}`));
+}
+
+function configuredLocalWorkerModels() {
+  return [
+    DEFAULT_ROUTING_POLICY.routineWorkers.model,
+    ...DEFAULT_ROUTING_POLICY.routineWorkers.fallbacks,
+  ];
+}
+
+function safeProjectId(projectId) {
+  if (!projectId || !/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,80}$/.test(projectId)) {
+    throw new Error("project id must use letters, numbers, dot, underscore, or dash");
+  }
+  if (projectId.includes("..")) {
+    throw new Error("project id must not contain '..'");
+  }
+  return projectId;
+}
+
+export function pccProjectDir({ project, root = ".artifacts/snes-projects" }) {
+  return path.join(root, safeProjectId(project), "pcc");
+}
+
+function pccFile(projectDir, name) {
+  return path.join(projectDir, name);
+}
+
+function defaultRequiredProof(names) {
+  return names.map((name) => ({ name, required: true }));
+}
+
+export function createDefaultMilestones() {
+  const common = {
+    retryPolicy: DEFAULT_RETRY_POLICY,
+    modelPolicy: DEFAULT_ROUTING_POLICY.routineWorkers,
+    completionPercent: 0,
+    proof: {},
+    failCriteria: ["missing-required-proof", "unsafe-patch", "commercial-material", "hosted-glm"],
+  };
+  return [
+    {
+      ...common,
+      milestoneId: "PCC-001-blueprint",
+      title: "Initial game blueprint and rubric",
+      ownerRole: "gpt-game-director",
+      workerRole: "gpt-game-director",
+      judgeRole: "deterministic-validator",
+      dependsOn: [],
+      parallelGroup: "sequential-blueprint",
+      sequentialOnly: true,
+      allowedWriteSurfaces: ["blueprint"],
+      requiredProof: defaultRequiredProof(["blueprintReceipt", "legalBoundaryReceipt"]),
+      passCriteria: ["blueprint-complete", "legal-clean-room", "quality-rubric-present"],
+      status: "ready",
+      humanApprovalRequired: false,
+      modelPolicy: DEFAULT_ROUTING_POLICY.initialBlueprint,
+    },
+    {
+      ...common,
+      milestoneId: "PCC-010-level-plan",
+      title: "Finishable level route plan",
+      ownerRole: "snes-level-designer",
+      workerRole: "snes-level-designer",
+      judgeRole: "deterministic-validator",
+      dependsOn: ["PCC-001-blueprint"],
+      parallelGroup: "parallel-design",
+      allowedWriteSurfaces: ["level-plan"],
+      requiredProof: defaultRequiredProof(["levelRouteReceipt", "reachabilityReceipt"]),
+      passCriteria: [
+        "spawn-to-goal-route",
+        "first-screen-teaches",
+        "checkpoint-and-reward-specified",
+      ],
+      status: "pending",
+      humanApprovalRequired: false,
+    },
+    {
+      ...common,
+      milestoneId: "PCC-011-gameplay-plan",
+      title: "Gameplay feel and mechanics plan",
+      ownerRole: "snes-game-feel-tuner",
+      workerRole: "snes-game-feel-tuner",
+      judgeRole: "deterministic-validator",
+      dependsOn: ["PCC-001-blueprint"],
+      parallelGroup: "parallel-design",
+      allowedWriteSurfaces: ["gameplay-constants"],
+      requiredProof: defaultRequiredProof(["gameplayReceipt", "replayHypothesisReceipt"]),
+      passCriteria: ["movement-constants", "enemy-rules", "playtest-hypothesis"],
+      status: "pending",
+      humanApprovalRequired: false,
+    },
+    {
+      ...common,
+      milestoneId: "PCC-012-asset-intents",
+      title: "Production asset intent contracts",
+      ownerRole: "snes-pixel-art-director",
+      workerRole: "snes-pixel-art-director",
+      judgeRole: "deterministic-validator",
+      dependsOn: ["PCC-001-blueprint"],
+      parallelGroup: "parallel-design",
+      allowedWriteSurfaces: ["asset-intents"],
+      requiredProof: defaultRequiredProof(["assetIntentReceipt", "promptMatchReceipt"]),
+      passCriteria: [
+        "must-show-and-must-not-show",
+        "palette-and-frame-bounds",
+        "runtime-proof-required",
+      ],
+      status: "pending",
+      humanApprovalRequired: true,
+    },
+    {
+      ...common,
+      milestoneId: "PCC-013-audio-plan",
+      title: "Audio and SPC700 event plan",
+      ownerRole: "snes-audio-spc700",
+      workerRole: "snes-audio-spc700",
+      judgeRole: "deterministic-validator",
+      dependsOn: ["PCC-001-blueprint"],
+      parallelGroup: "parallel-design",
+      allowedWriteSurfaces: ["audio-plan"],
+      requiredProof: defaultRequiredProof(["audioEventReceipt", "aramBudgetReceipt"]),
+      passCriteria: ["music-loop-intent", "sfx-event-map", "aram-budget"],
+      status: "pending",
+      humanApprovalRequired: false,
+    },
+    {
+      ...common,
+      milestoneId: "PCC-014-hardware-plan",
+      title: "SNES hardware and FXPAK constraint plan",
+      ownerRole: "snes-engine-architect",
+      workerRole: "snes-engine-architect",
+      judgeRole: "deterministic-validator",
+      dependsOn: ["PCC-001-blueprint"],
+      parallelGroup: "parallel-design",
+      allowedWriteSurfaces: ["hardware-budget"],
+      requiredProof: defaultRequiredProof(["budgetReceipt", "fxpakConstraintReceipt"]),
+      passCriteria: ["vram-oam-cgram-aram-budget", "lorom-default", "no-removable-write"],
+      status: "pending",
+      humanApprovalRequired: false,
+    },
+    {
+      ...common,
+      milestoneId: "PCC-020-integration",
+      title: "Deterministic integration plan",
+      ownerRole: "producer-orchestrator",
+      workerRole: "deterministic-script",
+      judgeRole: "deterministic-validator",
+      dependsOn: [
+        "PCC-010-level-plan",
+        "PCC-011-gameplay-plan",
+        "PCC-012-asset-intents",
+        "PCC-013-audio-plan",
+        "PCC-014-hardware-plan",
+      ],
+      parallelGroup: "sequential-integration",
+      sequentialOnly: true,
+      allowedWriteSurfaces: ["integration"],
+      requiredProof: defaultRequiredProof(["integrationReceipt", "conflictScanReceipt"]),
+      passCriteria: ["no-write-conflicts", "accepted-patches-only"],
+      status: "pending",
+      humanApprovalRequired: false,
+      modelPolicy: DEFAULT_ROUTING_POLICY.producerOrchestrator,
+    },
+    {
+      ...common,
+      milestoneId: "PCC-030-rom-build-proof",
+      title: "ROM build and SNES budget proof",
+      ownerRole: "snes-engine-architect",
+      workerRole: "deterministic-script",
+      judgeRole: "deterministic-validator",
+      dependsOn: ["PCC-020-integration"],
+      parallelGroup: "sequential-build",
+      sequentialOnly: true,
+      allowedWriteSurfaces: ["rom-build"],
+      requiredProof: defaultRequiredProof(["romReceipt", "superfamicheckReceipt", "budgetReceipt"]),
+      passCriteria: ["sfc-builds", "superfamicheck-pass", "budgets-pass"],
+      status: "pending",
+      humanApprovalRequired: false,
+      modelPolicy: DEFAULT_ROUTING_POLICY.producerOrchestrator,
+    },
+    {
+      ...common,
+      milestoneId: "PCC-040-runtime-proof",
+      title: "Emulator and runtime asset proof",
+      ownerRole: "snes-emulator-regression-qa",
+      workerRole: "deterministic-script",
+      judgeRole: "deterministic-validator",
+      dependsOn: ["PCC-030-rom-build-proof"],
+      parallelGroup: "sequential-runtime-proof",
+      sequentialOnly: true,
+      allowedWriteSurfaces: ["runtime-proof"],
+      requiredProof: defaultRequiredProof([
+        "emulatorScreenshotReceipt",
+        "runtimeAssetTruthReceipt",
+      ]),
+      passCriteria: ["fresh-nonblank-screenshot", "runtime-assets-visible"],
+      status: "pending",
+      humanApprovalRequired: false,
+      modelPolicy: DEFAULT_ROUTING_POLICY.producerOrchestrator,
+    },
+    {
+      ...common,
+      milestoneId: "PCC-050-human-visual-approval",
+      title: "Human production visual approval",
+      ownerRole: "snes-pixel-art-director",
+      workerRole: "human-review-required",
+      judgeRole: "human-visual-judge",
+      dependsOn: ["PCC-040-runtime-proof"],
+      parallelGroup: "sequential-human-review",
+      sequentialOnly: true,
+      allowedWriteSurfaces: ["visual-approval"],
+      requiredProof: defaultRequiredProof(["humanVisualApproval"]),
+      passCriteria: ["human-score-meets-target", "runtime-screenshot-reviewed"],
+      status: "pending",
+      humanApprovalRequired: true,
+      modelPolicy: { role: "human", model: "none" },
+    },
+    {
+      ...common,
+      milestoneId: "PCC-060-package-readiness",
+      title: "Package and handoff readiness",
+      ownerRole: "snes-rom-patch-handoff",
+      workerRole: "deterministic-script",
+      judgeRole: "deterministic-validator",
+      dependsOn: ["PCC-050-human-visual-approval"],
+      parallelGroup: "sequential-package",
+      sequentialOnly: true,
+      allowedWriteSurfaces: ["package"],
+      requiredProof: defaultRequiredProof(["packageReceipt", "noRomLeakReceipt"]),
+      passCriteria: ["package-hashes", "no-disallowed-rom-handoff", "fxpak-write-not-performed"],
+      status: "pending",
+      humanApprovalRequired: false,
+      modelPolicy: DEFAULT_ROUTING_POLICY.producerOrchestrator,
+    },
+  ];
+}
+
+export function createDependencyDag(milestones) {
+  return {
+    format: "openclaw-snes-pcc-dependency-dag-v1",
+    generatedAt: nowIso(),
+    maxParallelWorkers: 4,
+    nodes: milestones.map((milestone) => ({
+      milestoneId: milestone.milestoneId,
+      dependsOn: milestone.dependsOn,
+      parallelGroup: milestone.parallelGroup,
+      sequentialOnly: Boolean(milestone.sequentialOnly),
+      allowedWriteSurfaces: milestone.allowedWriteSurfaces,
+    })),
+  };
+}
+
+export function createProjectIntent({ project, promptText }) {
+  return {
+    format: "openclaw-snes-pcc-project-intent-v1",
+    generatedAt: nowIso(),
+    projectId: project,
+    prompt: promptText,
+    promptSha256: sha256Text(promptText),
+    target: "production-snes-platformer",
+    constraints: {
+      noCommercialSnesMaterial: true,
+      hostedGlmUsed: false,
+      fxpakWritePerformed: false,
+      liveAgentExecution: false,
+      localFirst: true,
+    },
+    qualityTarget: {
+      draftMinimumVisualScore: 50,
+      productionCandidateMinimumVisualScore: 80,
+      finalHumanApprovalRequired: true,
+      styleTarget: "legal-clean-room-classic-snes-platformer-polish",
+    },
+  };
+}
+
+function projectSummary({ project, promptText, milestones }) {
+  const total = milestones.length;
+  const passed = milestones.filter((m) => m.status === "pass").length;
+  const blocked = milestones.filter((m) => m.status === "blocked").length;
+  const failed = milestones.filter((m) => m.status === "fail").length;
+  return [
+    `# SNES PCC Project: ${project}`,
+    "",
+    `Prompt SHA-256: ${sha256Text(promptText)}`,
+    `Milestones passed: ${passed}/${total}`,
+    `Blocked: ${blocked}`,
+    `Failed: ${failed}`,
+    "",
+    "This PCC state is deterministic scaffolding only. It does not prove a finished game until the milestone ledger and required receipts pass.",
+    "",
+  ].join("\n");
+}
+
+export function initPccProject({ project, promptPath, promptText, root }) {
+  const projectDir = pccProjectDir({ project, root });
+  if (fs.existsSync(projectDir)) {
+    return pccStatus({ project, root, initialized: false, note: "existing-project-preserved" });
+  }
+  const actualPromptText = promptText ?? fs.readFileSync(promptPath, "utf8");
+  const milestones = createDefaultMilestones();
+  fs.mkdirSync(projectDir, { recursive: true });
+  writeJson(
+    pccFile(projectDir, "project.intent.json"),
+    createProjectIntent({ project, promptText: actualPromptText }),
+  );
+  writeJson(pccFile(projectDir, "milestone-ledger.json"), {
+    format: "openclaw-snes-pcc-milestone-ledger-v1",
+    generatedAt: nowIso(),
+    projectId: project,
+    statuses: [...PCC_STATUSES],
+    milestones,
+    futureMilestonesPreserved: futureMilestonesPreserved(),
+  });
+  writeJson(pccFile(projectDir, "dependency-dag.json"), createDependencyDag(milestones));
+  writeJson(pccFile(projectDir, "active-worker-locks.json"), {
+    format: "openclaw-snes-pcc-worker-locks-v1",
+    generatedAt: nowIso(),
+    locks: [],
+  });
+  writeJson(pccFile(projectDir, "decision-log.json"), {
+    format: "openclaw-snes-pcc-decision-log-v1",
+    generatedAt: nowIso(),
+    decisions: [
+      {
+        at: nowIso(),
+        event: "init",
+        status: "pass",
+        hostedGlmUsed: false,
+        gpt55Used: false,
+      },
+    ],
+  });
+  writeJson(pccFile(projectDir, "memory-cards.json"), {
+    format: "openclaw-snes-pcc-memory-cards-v1",
+    generatedAt: nowIso(),
+    cards: [
+      {
+        id: "legal-clean-room-only",
+        text: "Do not use commercial SNES ROMs, source leaks, disassemblies, copied art, maps, palettes, music, or SFX.",
+      },
+      {
+        id: "proof-surfaces-separate",
+        text: "Do not collapse source, conversion, runtime, ROM, emulator, FXPAK, hardware, or human approval proof.",
+      },
+    ],
+  });
+  writeJson(pccFile(projectDir, "repair-queue.json"), {
+    format: "openclaw-snes-pcc-repair-queue-v1",
+    generatedAt: nowIso(),
+    repairs: [],
+  });
+  writeJson(pccFile(projectDir, "approval-queue.json"), {
+    format: "openclaw-snes-pcc-approval-queue-v1",
+    generatedAt: nowIso(),
+    approvals: [],
+  });
+  writeJson(pccFile(projectDir, "run-control.json"), {
+    format: "openclaw-snes-pcc-run-control-v1",
+    generatedAt: nowIso(),
+    state: "running",
+    reason: null,
+  });
+  writeJson(pccFile(projectDir, "run-history.json"), {
+    format: "openclaw-snes-pcc-run-history-v1",
+    generatedAt: nowIso(),
+    runs: [],
+  });
+  writeJson(pccFile(projectDir, "worker-dispatch-log.json"), {
+    format: "openclaw-snes-pcc-worker-dispatch-log-v1",
+    generatedAt: nowIso(),
+    dispatches: [],
+  });
+  writeJson(pccFile(projectDir, "worker-sandboxes.json"), {
+    format: "openclaw-snes-pcc-worker-sandboxes-v1",
+    generatedAt: nowIso(),
+    sandboxes: [],
+  });
+  writeJson(pccFile(projectDir, "patch-ledger.json"), {
+    format: "openclaw-snes-pcc-patch-ledger-v1",
+    generatedAt: nowIso(),
+    patches: [],
+  });
+  writeJson(pccFile(projectDir, "artifact-cache.json"), {
+    format: "openclaw-snes-pcc-artifact-cache-v1",
+    generatedAt: nowIso(),
+    entries: [],
+  });
+  writeJson(pccFile(projectDir, "reviewer-receipts.json"), {
+    format: "openclaw-snes-pcc-reviewer-receipts-v1",
+    generatedAt: nowIso(),
+    receipts: [],
+  });
+  writeJson(pccFile(projectDir, "conflict-receipts.json"), {
+    format: "openclaw-snes-pcc-conflict-receipts-v1",
+    generatedAt: nowIso(),
+    conflicts: [],
+  });
+  writeJson(pccFile(projectDir, "telemetry.json"), {
+    format: "openclaw-snes-pcc-telemetry-v1",
+    generatedAt: nowIso(),
+    events: [],
+  });
+  writeJson(pccFile(projectDir, "dashboard-snapshot.json"), {
+    format: "openclaw-snes-pcc-dashboard-snapshot-v1",
+    generatedAt: nowIso(),
+    projectId: project,
+    activeRun: null,
+    pendingApprovals: [],
+    blockedMilestones: [],
+    nextSafeAction: "inspect-status",
+    completionPercent: 0,
+  });
+  writeJson(pccFile(projectDir, "regression-benchmarks.json"), {
+    format: "openclaw-snes-pcc-regression-benchmarks-v1",
+    generatedAt: nowIso(),
+    prompts: [
+      { id: "clean-room-runner", prompt: "Create a tiny legal clean-room SNES runner kata." },
+      {
+        id: "clean-room-collectathon",
+        prompt: "Create a tiny legal clean-room SNES item collection kata.",
+      },
+      {
+        id: "clean-room-checkpoint",
+        prompt: "Create a tiny legal clean-room SNES checkpoint kata.",
+      },
+    ],
+    runs: [],
+  });
+  writeJson(pccFile(projectDir, "model-usage.json"), {
+    format: "openclaw-snes-pcc-model-usage-v1",
+    generatedAt: nowIso(),
+    routingPolicy: DEFAULT_ROUTING_POLICY,
+    usage: [],
+  });
+  writeJson(pccFile(projectDir, "build-history.json"), {
+    format: "openclaw-snes-pcc-build-history-v1",
+    generatedAt: nowIso(),
+    lastKnownGood: null,
+    builds: [],
+  });
+  fs.writeFileSync(
+    pccFile(projectDir, "latest-summary.md"),
+    projectSummary({ project, promptText: actualPromptText, milestones }),
+  );
+  fs.writeFileSync(
+    pccFile(projectDir, "latest-run-summary.md"),
+    `# SNES PCC Run Summary: ${project}\n\nNo run has been executed yet.\n`,
+  );
+  return pccStatus({ project, root, initialized: true });
+}
+
+export function futureMilestonesPreserved() {
+  return [
+    "Live multi-agent execution that actually calls OpenClaw worker agents.",
+    "Real prompt-to-ROM game generation through PCC.",
+    "Level editor/compiler pipeline.",
+    "Runtime asset integration compiler.",
+    "Full production art generator.",
+    "Human visual approval station in dashboard.",
+    "PCC dashboard UI.",
+    "Prompt-to-ROM regression benchmark.",
+    "Original SNES hardware proof.",
+    "FXPAK copy proof.",
+    "Stanski-specific visual fixes, source photo preservation, Cleveland background, and full Stanski content.",
+  ];
+}
+
+function ensurePccV3State(projectDir, project) {
+  const defaults = {
+    "worker-dispatch-log.json": {
+      format: "openclaw-snes-pcc-worker-dispatch-log-v1",
+      generatedAt: nowIso(),
+      dispatches: [],
+    },
+    "worker-sandboxes.json": {
+      format: "openclaw-snes-pcc-worker-sandboxes-v1",
+      generatedAt: nowIso(),
+      sandboxes: [],
+    },
+    "patch-ledger.json": {
+      format: "openclaw-snes-pcc-patch-ledger-v1",
+      generatedAt: nowIso(),
+      patches: [],
+    },
+    "artifact-cache.json": {
+      format: "openclaw-snes-pcc-artifact-cache-v1",
+      generatedAt: nowIso(),
+      entries: [],
+    },
+    "reviewer-receipts.json": {
+      format: "openclaw-snes-pcc-reviewer-receipts-v1",
+      generatedAt: nowIso(),
+      receipts: [],
+    },
+    "conflict-receipts.json": {
+      format: "openclaw-snes-pcc-conflict-receipts-v1",
+      generatedAt: nowIso(),
+      conflicts: [],
+    },
+    "telemetry.json": {
+      format: "openclaw-snes-pcc-telemetry-v1",
+      generatedAt: nowIso(),
+      events: [],
+    },
+    "dashboard-snapshot.json": {
+      format: "openclaw-snes-pcc-dashboard-snapshot-v1",
+      generatedAt: nowIso(),
+      projectId: project,
+      activeRun: null,
+      pendingApprovals: [],
+      blockedMilestones: [],
+      nextSafeAction: "inspect-status",
+      completionPercent: 0,
+    },
+    "regression-benchmarks.json": {
+      format: "openclaw-snes-pcc-regression-benchmarks-v1",
+      generatedAt: nowIso(),
+      prompts: [
+        { id: "clean-room-runner", prompt: "Create a tiny legal clean-room SNES runner kata." },
+        {
+          id: "clean-room-collectathon",
+          prompt: "Create a tiny legal clean-room SNES item collection kata.",
+        },
+        {
+          id: "clean-room-checkpoint",
+          prompt: "Create a tiny legal clean-room SNES checkpoint kata.",
+        },
+      ],
+      runs: [],
+    },
+  };
+  for (const [fileName, defaultValue] of Object.entries(defaults)) {
+    const filePath = pccFile(projectDir, fileName);
+    if (!fs.existsSync(filePath)) writeJson(filePath, defaultValue);
+  }
+}
+
+export function loadPccProject({ project, root }) {
+  const projectDir = pccProjectDir({ project, root });
+  if (!fs.existsSync(projectDir)) {
+    return { ok: false, projectDir, missingProject: true };
+  }
+  ensurePccV3State(projectDir, project);
+  const files = Object.fromEntries(
+    PCC_STATE_FILES.map((name) => [name, pccFile(projectDir, name)]),
+  );
+  const missingFiles = PCC_STATE_FILES.filter((name) => !fs.existsSync(files[name]));
+  const loaded = { ok: missingFiles.length === 0, projectDir, files, missingFiles };
+  if (fs.existsSync(files["project.intent.json"]))
+    loaded.intent = readJson(files["project.intent.json"]);
+  if (fs.existsSync(files["milestone-ledger.json"]))
+    loaded.ledger = readJson(files["milestone-ledger.json"]);
+  if (fs.existsSync(files["dependency-dag.json"]))
+    loaded.dag = readJson(files["dependency-dag.json"]);
+  if (fs.existsSync(files["repair-queue.json"]))
+    loaded.repairQueue = readJson(files["repair-queue.json"]);
+  if (fs.existsSync(files["approval-queue.json"]))
+    loaded.approvalQueue = readJson(files["approval-queue.json"]);
+  if (fs.existsSync(files["run-control.json"]))
+    loaded.runControl = readJson(files["run-control.json"]);
+  if (fs.existsSync(files["run-history.json"]))
+    loaded.runHistory = readJson(files["run-history.json"]);
+  if (fs.existsSync(files["build-history.json"]))
+    loaded.buildHistory = readJson(files["build-history.json"]);
+  if (fs.existsSync(files["worker-dispatch-log.json"]))
+    loaded.workerDispatchLog = readJson(files["worker-dispatch-log.json"]);
+  if (fs.existsSync(files["worker-sandboxes.json"]))
+    loaded.workerSandboxes = readJson(files["worker-sandboxes.json"]);
+  if (fs.existsSync(files["patch-ledger.json"]))
+    loaded.patchLedger = readJson(files["patch-ledger.json"]);
+  if (fs.existsSync(files["artifact-cache.json"]))
+    loaded.artifactCache = readJson(files["artifact-cache.json"]);
+  if (fs.existsSync(files["reviewer-receipts.json"]))
+    loaded.reviewerReceipts = readJson(files["reviewer-receipts.json"]);
+  if (fs.existsSync(files["conflict-receipts.json"]))
+    loaded.conflictReceipts = readJson(files["conflict-receipts.json"]);
+  if (fs.existsSync(files["telemetry.json"])) loaded.telemetry = readJson(files["telemetry.json"]);
+  if (fs.existsSync(files["dashboard-snapshot.json"]))
+    loaded.dashboardSnapshot = readJson(files["dashboard-snapshot.json"]);
+  if (fs.existsSync(files["regression-benchmarks.json"]))
+    loaded.regressionBenchmarks = readJson(files["regression-benchmarks.json"]);
+  return loaded;
+}
+
+export function validateAssetIntentContract(intent) {
+  const errors = [];
+  const requiredStrings = ["assetId", "kind", "dimensions"];
+  for (const field of requiredStrings) {
+    if (typeof intent?.[field] !== "string" || intent[field].trim() === "") {
+      errors.push(`missing-${field}`);
+    }
+  }
+  if (!Number.isInteger(intent?.frames) || intent.frames < 1) errors.push("invalid-frames");
+  if (
+    !Number.isInteger(intent?.paletteLimit) ||
+    intent.paletteLimit < 1 ||
+    intent.paletteLimit > 16
+  ) {
+    errors.push("invalid-paletteLimit");
+  }
+  if (!Array.isArray(intent?.mustShow) || intent.mustShow.length === 0)
+    errors.push("missing-mustShow");
+  if (!Array.isArray(intent?.mustNotShow)) errors.push("missing-mustNotShow");
+  if (!Array.isArray(intent?.animationBeats)) errors.push("missing-animationBeats");
+  if (intent?.production === true && intent.runtimeProofRequired !== true) {
+    errors.push("production-runtimeProofRequired-missing");
+  }
+  if (
+    intent?.production === true &&
+    (!Number.isInteger(intent.humanVisualTarget) || intent.humanVisualTarget < 1)
+  ) {
+    errors.push("production-humanVisualTarget-missing");
+  }
+  return {
+    format: "openclaw-snes-pcc-asset-intent-validation-v1",
+    status: errors.length ? "fail" : "pass",
+    ok: errors.length === 0,
+    errors,
+  };
+}
+
+export function validateMilestoneShape(milestone) {
+  const errors = [];
+  const required = [
+    "milestoneId",
+    "title",
+    "ownerRole",
+    "dependsOn",
+    "parallelGroup",
+    "allowedWriteSurfaces",
+    "requiredProof",
+    "passCriteria",
+    "failCriteria",
+    "retryPolicy",
+    "humanApprovalRequired",
+    "modelPolicy",
+    "completionPercent",
+  ];
+  for (const field of required) {
+    if (!(field in milestone)) errors.push(`missing-${field}`);
+  }
+  if (!PCC_STATUSES.has(milestone.status)) errors.push("invalid-status");
+  if (!Array.isArray(milestone.dependsOn)) errors.push("dependsOn-not-array");
+  if (
+    !Array.isArray(milestone.allowedWriteSurfaces) ||
+    milestone.allowedWriteSurfaces.length === 0
+  ) {
+    errors.push("allowedWriteSurfaces-empty");
+  }
+  if (!Array.isArray(milestone.requiredProof)) errors.push("requiredProof-not-array");
+  if (typeof milestone.completionPercent !== "number") errors.push("completionPercent-not-number");
+  if (
+    milestone.status === "pass" &&
+    milestone.workerRole &&
+    milestone.judgeRole &&
+    milestone.workerRole === milestone.judgeRole
+  ) {
+    errors.push("worker-self-approval-rejected");
+  }
+  return errors;
+}
+
+export function missingProofForMilestone(milestone, projectDir) {
+  if (milestone.status !== "pass") return [];
+  const proof = milestone.proof ?? {};
+  const missing = [];
+  for (const entry of milestone.requiredProof ?? []) {
+    const name = typeof entry === "string" ? entry : entry.name;
+    if (!name) continue;
+    const proofPath = proof[name];
+    if (!proofPath) {
+      missing.push(name);
+      continue;
+    }
+    const resolved = path.isAbsolute(proofPath) ? proofPath : path.join(projectDir, proofPath);
+    if (!fs.existsSync(resolved)) missing.push(name);
+  }
+  if (
+    milestone.humanApprovalRequired &&
+    !proof.humanVisualApproval &&
+    milestone.status === "pass"
+  ) {
+    missing.push("humanVisualApproval");
+  }
+  return [...new Set(missing)];
+}
+
+export function validatePccProject({ project, root }) {
+  const loaded = loadPccProject({ project, root });
+  const errors = [];
+  if (loaded.missingProject) {
+    return {
+      format: "openclaw-snes-pcc-validation-v1",
+      status: "blocked",
+      ok: false,
+      project,
+      errors: ["project-not-found"],
+      missingFiles: PCC_STATE_FILES,
+      gpt55Used: false,
+      hostedGlmUsed: false,
+      commercialMaterialUsed: false,
+      fxpakWritePerformed: false,
+    };
+  }
+  for (const missing of loaded.missingFiles ?? []) errors.push(`missing-state-file:${missing}`);
+  const ledger = loaded.ledger;
+  if (!ledger || !Array.isArray(ledger.milestones)) {
+    errors.push("missing-or-invalid-ledger");
+  } else {
+    const ids = new Set();
+    for (const milestone of ledger.milestones) {
+      for (const error of validateMilestoneShape(milestone)) {
+        errors.push(`${milestone.milestoneId ?? "unknown"}:${error}`);
+      }
+      if (ids.has(milestone.milestoneId)) errors.push(`${milestone.milestoneId}:duplicate-id`);
+      ids.add(milestone.milestoneId);
+      for (const dep of milestone.dependsOn ?? []) {
+        if (!ledger.milestones.some((entry) => entry.milestoneId === dep)) {
+          errors.push(`${milestone.milestoneId}:unknown-dependency:${dep}`);
+        }
+      }
+      for (const missing of missingProofForMilestone(milestone, loaded.projectDir)) {
+        errors.push(`${milestone.milestoneId}:missing-proof:${missing}`);
+      }
+    }
+  }
+  return {
+    format: "openclaw-snes-pcc-validation-v1",
+    generatedAt: nowIso(),
+    status: errors.length ? "fail" : "pass",
+    ok: errors.length === 0,
+    project,
+    errors,
+    missingFiles: loaded.missingFiles ?? [],
+    gpt55Used: false,
+    hostedGlmUsed: false,
+    commercialMaterialUsed: false,
+    fxpakWritePerformed: false,
+  };
+}
+
+function milestonePassMap(milestones) {
+  return new Map(
+    milestones.map((milestone) => [milestone.milestoneId, milestone.status === "pass"]),
+  );
+}
+
+export function planParallelMilestones({ milestones, maxParallel = 4 }) {
+  const passed = milestonePassMap(milestones);
+  const candidates = milestones.filter(
+    (milestone) =>
+      ["pending", "ready"].includes(milestone.status) &&
+      (milestone.dependsOn ?? []).every((dep) => passed.get(dep) === true),
+  );
+  const sequential = candidates.find((milestone) => milestone.sequentialOnly);
+  if (sequential) {
+    return {
+      format: "openclaw-snes-pcc-parallel-plan-v1",
+      maxParallel,
+      readyMilestones: [sequential.milestoneId],
+      parallelBatches: [[sequential.milestoneId]],
+      serializedMilestones: candidates
+        .filter((m) => m.milestoneId !== sequential.milestoneId)
+        .map((m) => m.milestoneId),
+    };
+  }
+  const batch = [];
+  const surfaces = new Set();
+  const serialized = [];
+  for (const milestone of candidates) {
+    const conflicts = (milestone.allowedWriteSurfaces ?? []).some((surface) =>
+      surfaces.has(surface),
+    );
+    if (!conflicts && batch.length < maxParallel) {
+      batch.push(milestone.milestoneId);
+      for (const surface of milestone.allowedWriteSurfaces ?? []) surfaces.add(surface);
+    } else {
+      serialized.push(milestone.milestoneId);
+    }
+  }
+  return {
+    format: "openclaw-snes-pcc-parallel-plan-v1",
+    maxParallel,
+    readyMilestones: candidates.map((milestone) => milestone.milestoneId),
+    parallelBatches: batch.length ? [batch] : [],
+    serializedMilestones: serialized,
+  };
+}
+
+export function pccNext({ project, root, maxParallel = 4 }) {
+  const loaded = loadPccProject({ project, root });
+  if (loaded.missingProject) {
+    return {
+      format: "openclaw-snes-pcc-next-v1",
+      status: "blocked",
+      ok: false,
+      project,
+      blocker: "project-not-found",
+    };
+  }
+  const milestones = loaded.ledger?.milestones ?? [];
+  const plan = planParallelMilestones({ milestones, maxParallel });
+  return {
+    format: "openclaw-snes-pcc-next-v1",
+    generatedAt: nowIso(),
+    status: plan.readyMilestones.length ? "pass" : "blocked",
+    ok: plan.readyMilestones.length > 0,
+    project,
+    ...plan,
+    nextMilestone: plan.parallelBatches[0]?.[0] ?? null,
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+export function judgeMilestone({ project, root, milestoneId }) {
+  const loaded = loadPccProject({ project, root });
+  if (loaded.missingProject) {
+    return {
+      format: "openclaw-snes-pcc-milestone-judge-v1",
+      status: "blocked",
+      ok: false,
+      project,
+      milestoneId,
+      failReasons: ["project-not-found"],
+    };
+  }
+  const milestone = loaded.ledger?.milestones?.find((entry) => entry.milestoneId === milestoneId);
+  if (!milestone) {
+    return {
+      format: "openclaw-snes-pcc-milestone-judge-v1",
+      status: "blocked",
+      ok: false,
+      project,
+      milestoneId,
+      failReasons: ["milestone-not-found"],
+    };
+  }
+  const shapeErrors = validateMilestoneShape(milestone);
+  const missingProof = missingProofForMilestone(
+    { ...milestone, status: "pass" },
+    loaded.projectDir,
+  );
+  const selfApproval =
+    milestone.workerRole && milestone.judgeRole && milestone.workerRole === milestone.judgeRole;
+  const failReasons = [
+    ...shapeErrors,
+    ...missingProof.map((name) => `missing-proof:${name}`),
+    ...(selfApproval ? ["worker-self-approval-rejected"] : []),
+  ];
+  const requiresHuman = Boolean(
+    milestone.humanApprovalRequired && missingProof.includes("humanVisualApproval"),
+  );
+  return {
+    format: "openclaw-snes-pcc-milestone-judge-v1",
+    generatedAt: nowIso(),
+    status: failReasons.length ? (requiresHuman ? "blocked" : "fail") : "pass",
+    ok: failReasons.length === 0,
+    project,
+    milestoneId,
+    proofChecked: (milestone.requiredProof ?? []).map((entry) =>
+      typeof entry === "string" ? entry : entry.name,
+    ),
+    missingProof,
+    failReasons,
+    repairRecommendation: failReasons.length
+      ? "create-repair-plan-for-missing-proof-or-invalid-milestone"
+      : "none",
+    canRetry: failReasons.length > 0 && !requiresHuman,
+    requiresHuman,
+    completionPercent: failReasons.length ? Math.min(milestone.completionPercent ?? 0, 99) : 100,
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+export function createRepairPlan({ project, root, milestoneId, failureClass = "invalid-patch" }) {
+  const loaded = loadPccProject({ project, root });
+  if (loaded.missingProject) {
+    return {
+      format: "openclaw-snes-pcc-repair-plan-v1",
+      status: "blocked",
+      ok: false,
+      project,
+      milestoneId,
+      blocker: "project-not-found",
+    };
+  }
+  if (!PCC_FAILURE_CLASSES.has(failureClass)) {
+    return {
+      format: "openclaw-snes-pcc-repair-plan-v1",
+      status: "fail",
+      ok: false,
+      project,
+      milestoneId,
+      blocker: `invalid-failure-class:${failureClass}`,
+    };
+  }
+  const milestone = loaded.ledger?.milestones?.find((entry) => entry.milestoneId === milestoneId);
+  if (!milestone) {
+    return {
+      format: "openclaw-snes-pcc-repair-plan-v1",
+      status: "blocked",
+      ok: false,
+      project,
+      milestoneId,
+      blocker: "milestone-not-found",
+    };
+  }
+  const queue = loaded.repairQueue ?? { format: "openclaw-snes-pcc-repair-queue-v1", repairs: [] };
+  const priorCount = (queue.repairs ?? []).filter(
+    (entry) => entry.failedMilestoneId === milestoneId,
+  ).length;
+  const retryCount = priorCount + 1;
+  const externalBlocker = failureClass === "external-blocker";
+  const exceeded = retryCount >= DEFAULT_RETRY_POLICY.maxAttempts;
+  const nextModel =
+    retryCount === 1
+      ? DEFAULT_ROUTING_POLICY.routineWorkers.model
+      : retryCount === 2
+        ? DEFAULT_ROUTING_POLICY.routineWorkers.fallbacks[0]
+        : retryCount === 3
+          ? "openai/gpt-5.5-high-diagnosis-required"
+          : "none";
+  const repair = {
+    id: `${milestoneId}-repair-${retryCount}`,
+    createdAt: nowIso(),
+    failedMilestoneId: milestoneId,
+    failureClass,
+    failingReceipt: milestone.latestReceipt ?? null,
+    ownerRole: milestone.ownerRole,
+    allowedWriteSurface: milestone.allowedWriteSurfaces?.[0] ?? "unknown",
+    retryCount,
+    nextModel: externalBlocker || exceeded ? "none" : nextModel,
+    stopCondition: externalBlocker
+      ? "external-blocker-requires-user-or-hardware-action"
+      : exceeded
+        ? "retry-limit-reached-block-unless-user-approves-deeper-work"
+        : "rerun-milestone-judge-after-repair",
+  };
+  queue.repairs = [...(queue.repairs ?? []), repair];
+  queue.generatedAt = nowIso();
+  writeJson(pccFile(loaded.projectDir, "repair-queue.json"), queue);
+  if (externalBlocker || exceeded) {
+    milestone.status = "blocked";
+    milestone.blocker = repair.stopCondition;
+    writeJson(pccFile(loaded.projectDir, "milestone-ledger.json"), loaded.ledger);
+  }
+  return {
+    format: "openclaw-snes-pcc-repair-plan-v1",
+    generatedAt: nowIso(),
+    status: externalBlocker || exceeded ? "blocked" : "pass",
+    ok: !(externalBlocker || exceeded),
+    project,
+    milestoneId,
+    repair,
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+function writeLedger(projectDir, ledger) {
+  writeJson(pccFile(projectDir, "milestone-ledger.json"), ledger);
+}
+
+function loadedOrBlocked({ project, root, format }) {
+  const loaded = loadPccProject({ project, root });
+  if (loaded.missingProject) {
+    return {
+      loaded,
+      blocked: {
+        format,
+        generatedAt: nowIso(),
+        status: "blocked",
+        ok: false,
+        project,
+        blocker: "project-not-found",
+        gpt55Used: false,
+        hostedGlmUsed: false,
+      },
+    };
+  }
+  return { loaded, blocked: null };
+}
+
+export function listApprovals({ project, root }) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-approvals-v1",
+  });
+  if (blocked) return blocked;
+  const approvals = loaded.approvalQueue?.approvals ?? [];
+  return {
+    format: "openclaw-snes-pcc-approvals-v1",
+    generatedAt: nowIso(),
+    status: "pass",
+    ok: true,
+    project,
+    approvals,
+    pendingApprovals: approvals.filter((approval) => approval.status === "pending"),
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+export function requestApproval({
+  project,
+  root,
+  approvalType,
+  milestoneId,
+  reason = "approval-required",
+  risk = "approval-gated-action",
+  requestedAction = "manual-approval-required",
+}) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-approval-request-v1",
+  });
+  if (blocked) return blocked;
+  if (!PCC_APPROVAL_TYPES.has(approvalType)) {
+    return {
+      format: "openclaw-snes-pcc-approval-request-v1",
+      generatedAt: nowIso(),
+      status: "blocked",
+      ok: false,
+      project,
+      milestoneId,
+      blocker: `invalid-approval-type:${approvalType}`,
+      validApprovalTypes: [...PCC_APPROVAL_TYPES],
+      gpt55Used: false,
+      hostedGlmUsed: false,
+    };
+  }
+  const queue = loaded.approvalQueue ?? {
+    format: "openclaw-snes-pcc-approval-queue-v1",
+    approvals: [],
+  };
+  const existing = (queue.approvals ?? []).find(
+    (approval) =>
+      approval.status === "pending" &&
+      approval.approvalType === approvalType &&
+      approval.milestoneId === milestoneId,
+  );
+  if (existing) {
+    return {
+      format: "openclaw-snes-pcc-approval-request-v1",
+      generatedAt: nowIso(),
+      status: "pass",
+      ok: true,
+      project,
+      approval: existing,
+      duplicateSuppressed: true,
+      gpt55Used: false,
+      hostedGlmUsed: false,
+    };
+  }
+  const approval = {
+    id: `${milestoneId}-${approvalType}-${sha256Text(`${milestoneId}:${approvalType}`).slice(0, 12)}`,
+    createdAt: nowIso(),
+    milestoneId,
+    approvalType,
+    reason,
+    risk,
+    requestedAction,
+    status: "pending",
+  };
+  queue.approvals = [...(queue.approvals ?? []), approval];
+  queue.generatedAt = nowIso();
+  writeJson(pccFile(loaded.projectDir, "approval-queue.json"), queue);
+  return {
+    format: "openclaw-snes-pcc-approval-request-v1",
+    generatedAt: nowIso(),
+    status: "pass",
+    ok: true,
+    project,
+    approval,
+    duplicateSuppressed: false,
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+export function setRunControl({ project, root, action }) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-run-control-update-v1",
+  });
+  if (blocked) return blocked;
+  const stateByAction = { pause: "paused", resume: "running", cancel: "cancelled" };
+  const nextState = stateByAction[action];
+  if (!nextState) {
+    return {
+      format: "openclaw-snes-pcc-run-control-update-v1",
+      generatedAt: nowIso(),
+      status: "blocked",
+      ok: false,
+      project,
+      blocker: `invalid-run-control-action:${action}`,
+      gpt55Used: false,
+      hostedGlmUsed: false,
+    };
+  }
+  const runControl = {
+    format: "openclaw-snes-pcc-run-control-v1",
+    generatedAt: nowIso(),
+    state: nextState,
+    reason: action === "pause" ? "user-paused" : action === "cancel" ? "run-cancelled" : null,
+  };
+  writeJson(pccFile(loaded.projectDir, "run-control.json"), runControl);
+  return {
+    format: "openclaw-snes-pcc-run-control-update-v1",
+    generatedAt: nowIso(),
+    status: "pass",
+    ok: true,
+    project,
+    action,
+    runControl,
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+function writeRunSummary(projectDir, project, runRecord) {
+  const lines = [
+    `# SNES PCC Run Summary: ${project}`,
+    "",
+    `Status: ${runRecord.status}`,
+    `Stop reason: ${runRecord.stopReason}`,
+    `Started: ${runRecord.startedAt}`,
+    `Ended: ${runRecord.endedAt}`,
+    `Completed milestones: ${runRecord.completedMilestones.join(", ") || "none"}`,
+    `Blocked milestones: ${runRecord.blockedMilestones.join(", ") || "none"}`,
+    `Approvals requested: ${runRecord.approvalsRequested.join(", ") || "none"}`,
+    `Receipts checked: ${runRecord.receiptsChecked.join(", ") || "none"}`,
+    `Next action: ${runRecord.nextAction}`,
+    "",
+  ].join("\n");
+  fs.writeFileSync(pccFile(projectDir, "latest-run-summary.md"), lines);
+}
+
+function appendRunHistory(loaded, project, runRecord) {
+  const history = loaded.runHistory ?? { format: "openclaw-snes-pcc-run-history-v1", runs: [] };
+  history.generatedAt = nowIso();
+  history.runs = [...(history.runs ?? []), runRecord];
+  writeJson(pccFile(loaded.projectDir, "run-history.json"), history);
+  writeRunSummary(loaded.projectDir, project, runRecord);
+}
+
+export function exportWorkerPacket({ project, root, milestoneId, allowPassed = false }) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-worker-packet-v1",
+  });
+  if (blocked) return blocked;
+  const milestone = loaded.ledger?.milestones?.find((entry) => entry.milestoneId === milestoneId);
+  if (!milestone) {
+    return {
+      format: "openclaw-snes-pcc-worker-packet-v1",
+      generatedAt: nowIso(),
+      status: "blocked",
+      ok: false,
+      project,
+      milestoneId,
+      blocker: "milestone-not-found",
+      gpt55Used: false,
+      hostedGlmUsed: false,
+    };
+  }
+  const passed = milestonePassMap(loaded.ledger?.milestones ?? []);
+  const ready =
+    (["pending", "ready"].includes(milestone.status) ||
+      (allowPassed && milestone.status === "pass")) &&
+    (milestone.dependsOn ?? []).every((dep) => passed.get(dep) === true);
+  if (!ready) {
+    return {
+      format: "openclaw-snes-pcc-worker-packet-v1",
+      generatedAt: nowIso(),
+      status: "blocked",
+      ok: false,
+      project,
+      milestoneId,
+      blocker: "milestone-not-ready",
+      currentStatus: milestone.status,
+      gpt55Used: false,
+      hostedGlmUsed: false,
+    };
+  }
+  return {
+    format: "openclaw-snes-pcc-worker-packet-v1",
+    generatedAt: nowIso(),
+    status: "pass",
+    ok: true,
+    project,
+    milestoneId,
+    ownerRole: milestone.ownerRole,
+    allowedWriteSurfaces: milestone.allowedWriteSurfaces,
+    requiredProof: milestone.requiredProof,
+    passCriteria: milestone.passCriteria,
+    failCriteria: milestone.failCriteria,
+    forbiddenActions: [
+      "hosted-glm-without-approval",
+      "commercial-snes-material",
+      "fxpak-removable-write",
+      "paid-tools-without-approval",
+      "unrelated-file-edits",
+    ],
+    modelPolicy: milestone.modelPolicy,
+    receiptPath: `receipts/${milestoneId}.json`,
+    nextValidationCommand: `pnpm snes:team -- --mode judge --project ${project} --milestone ${milestoneId} --json`,
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+function markMilestoneBlocked(loaded, milestone, blocker) {
+  milestone.status = "blocked";
+  milestone.blocker = blocker;
+  milestone.completionPercent = Math.min(milestone.completionPercent ?? 0, 99);
+  writeLedger(loaded.projectDir, loaded.ledger);
+}
+
+export function runPccUntilBlocked({ project, root, maxMilestones = 10, maxMinutes = 480 }) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-run-v1",
+  });
+  if (blocked) return blocked;
+  const startedAt = nowIso();
+  const completedMilestones = [];
+  const blockedMilestones = [];
+  const approvalsRequested = [];
+  const receiptsChecked = [];
+  let stopReason = "max-milestones-reached";
+  let status = "blocked";
+  const startedMs = Date.now();
+  for (let count = 0; count < maxMilestones; count += 1) {
+    const fresh = loadPccProject({ project, root });
+    const runState = fresh.runControl?.state ?? "running";
+    if (runState === "paused") {
+      stopReason = "run-paused";
+      break;
+    }
+    if (runState === "cancelled") {
+      stopReason = "run-cancelled";
+      break;
+    }
+    if ((Date.now() - startedMs) / 60000 > maxMinutes) {
+      stopReason = "max-minutes-reached";
+      break;
+    }
+    const validation = validatePccProject({ project, root });
+    receiptsChecked.push("project-validation");
+    if (validation.status !== "pass") {
+      stopReason = "validation-failed";
+      break;
+    }
+    const next = pccNext({ project, root });
+    if (!next.nextMilestone) {
+      stopReason = "all-milestones-complete-or-none-ready";
+      status = "pass";
+      break;
+    }
+    const active = loadPccProject({ project, root });
+    const milestone = active.ledger?.milestones?.find(
+      (entry) => entry.milestoneId === next.nextMilestone,
+    );
+    if (!milestone) {
+      stopReason = "milestone-not-found";
+      break;
+    }
+    if (milestone.humanApprovalRequired) {
+      const approval = requestApproval({
+        project,
+        root,
+        approvalType: "human-production-visual-approval",
+        milestoneId: milestone.milestoneId,
+        reason: "humanApprovalRequired",
+        risk: "subjective-production-quality-gate",
+        requestedAction: "human-review-and-approve-before-pass",
+      });
+      if (approval.approval?.id) approvalsRequested.push(approval.approval.id);
+      markMilestoneBlocked(active, milestone, "approval-required:human-production-visual-approval");
+      blockedMilestones.push(milestone.milestoneId);
+      stopReason = "approval-required";
+      break;
+    }
+    const judge = judgeMilestone({ project, root, milestoneId: milestone.milestoneId });
+    receiptsChecked.push(`judge:${milestone.milestoneId}`);
+    if (judge.status === "pass") {
+      milestone.status = "pass";
+      milestone.completionPercent = 100;
+      writeLedger(active.projectDir, active.ledger);
+      completedMilestones.push(milestone.milestoneId);
+      continue;
+    }
+    const repair = createRepairPlan({
+      project,
+      root,
+      milestoneId: milestone.milestoneId,
+      failureClass: judge.requiresHuman ? "external-blocker" : "runtime-failure",
+    });
+    if (repair.status === "blocked") {
+      blockedMilestones.push(milestone.milestoneId);
+      stopReason = repair.repair?.stopCondition ?? repair.blocker ?? "repair-blocked";
+      break;
+    }
+    stopReason = "repair-created";
+    break;
+  }
+  const endedAt = nowIso();
+  const after = loadPccProject({ project, root });
+  const remaining = planParallelMilestones({ milestones: after.ledger?.milestones ?? [] });
+  const runRecord = {
+    id: `run-${sha256Text(`${project}:${startedAt}`).slice(0, 12)}`,
+    startedAt,
+    endedAt,
+    status,
+    stopReason,
+    completedMilestones,
+    blockedMilestones,
+    approvalsRequested,
+    receiptsChecked,
+    nextAction:
+      approvalsRequested.length > 0
+        ? "review-pending-approvals"
+        : remaining.parallelBatches[0]?.[0]
+          ? `continue-with:${remaining.parallelBatches[0][0]}`
+          : "none",
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+  appendRunHistory(after, project, runRecord);
+  return {
+    format: "openclaw-snes-pcc-run-v1",
+    generatedAt: endedAt,
+    ok: status === "pass",
+    project,
+    ...runRecord,
+  };
+}
+
+function safeRelativePccPath(relativePath) {
+  if (!relativePath || typeof relativePath !== "string") return null;
+  if (path.isAbsolute(relativePath) || relativePath.includes("..")) return null;
+  return relativePath.replace(/^\/+/, "");
+}
+
+function commercialMaterialIndicator(value) {
+  const text = String(value ?? "");
+  return /\b(super\s+mario\s+world|commercial\s+snes|source\s+leak|disassembl(?:y|ies)|\.sfc\b|\.smc\b|\.swc\b|\.fig\b|\.rom\b)\b/iu.test(
+    text,
+  );
+}
+
+function fxpakWriteIndicator(value) {
+  return /(?:\/Volumes\/|\bFXPAK\b|\bSD2SNES\b|removable-media|flashcart)/iu.test(
+    String(value ?? ""),
+  );
+}
+
+function validateWorkerOutputObject({
+  output,
+  project,
+  milestoneId,
+  dispatchId,
+  allowedWriteSurfaces = [],
+  requiredProof = [],
+}) {
+  const errors = [];
+  if (!output || typeof output !== "object" || Array.isArray(output))
+    errors.push("output-not-object");
+  if (output?.format !== "openclaw-snes-pcc-worker-output-v1") errors.push("invalid-format");
+  if (output?.status !== "pass") errors.push("status-not-pass");
+  if (output?.project !== project) errors.push("wrong-project");
+  if (output?.milestoneId !== milestoneId) errors.push("wrong-milestone");
+  if (dispatchId && output?.dispatchId !== dispatchId) errors.push("wrong-dispatch-id");
+  if (output?.patchType !== "receipt-only") errors.push("unsupported-patch-type");
+  if (output?.hostedGlmUsed !== false) errors.push("hosted-glm-rejected");
+  if (output?.gpt55Used !== false) errors.push("gpt55-rejected-for-routine-worker");
+  if (output?.commercialMaterialUsed === true) errors.push("commercial-material-rejected");
+  if (output?.fxpakWritePerformed === true) errors.push("fxpak-write-rejected");
+  if (output?.paidToolsUsed === true || output?.paidToolUsed === true)
+    errors.push("paid-tool-rejected");
+  if (!Array.isArray(output?.writes)) errors.push("writes-not-array");
+  if (!Array.isArray(output?.receipts)) errors.push("receipts-not-array");
+  if (!Array.isArray(output?.assumptions)) errors.push("assumptions-not-array");
+  if (!Array.isArray(output?.risks)) errors.push("risks-not-array");
+  if (typeof output?.playtestHypothesis !== "string" || !output.playtestHypothesis.trim())
+    errors.push("missing-playtest-hypothesis");
+
+  for (const write of Array.isArray(output?.writes) ? output.writes : []) {
+    const writePath = write?.path ?? "";
+    if (pathLooksSecret(writePath)) errors.push(`secret-like-write:${writePath}`);
+    if (commercialMaterialIndicator(writePath))
+      errors.push(`commercial-material-write:${writePath}`);
+    if (fxpakWriteIndicator(writePath)) errors.push(`fxpak-removable-write:${writePath}`);
+    if (!writeSurfaceMatches(writePath, allowedWriteSurfaces))
+      errors.push(`write-surface-rejected:${writePath}`);
+  }
+  if ((output?.writes ?? []).length > 0)
+    errors.push("file-writes-not-supported-in-pcc-real-model-v1");
+
+  const requiredProofNames = (requiredProof ?? [])
+    .map((entry) => (typeof entry === "string" ? entry : entry?.name))
+    .filter(Boolean);
+  const proofNames = new Set();
+  for (const receipt of Array.isArray(output?.receipts) ? output.receipts : []) {
+    if (!receipt?.proofName) errors.push("receipt-missing-proofName");
+    else proofNames.add(receipt.proofName);
+    const receiptPath = safeRelativePccPath(receipt?.path);
+    if (!receiptPath) errors.push(`unsafe-receipt-path:${receipt?.path ?? "missing"}`);
+    if (receiptPath && !receiptPath.startsWith("receipts/"))
+      errors.push(`receipt-outside-receipts-dir:${receipt.path}`);
+    if (pathLooksSecret(receipt?.path ?? "")) errors.push(`secret-like-receipt:${receipt.path}`);
+    if (!receipt?.content || typeof receipt.content !== "object")
+      errors.push("receipt-missing-content");
+    if (receipt?.content?.hostedGlmUsed !== false) errors.push("receipt-hosted-glm-rejected");
+    if (receipt?.content?.gpt55Used !== false) errors.push("receipt-gpt55-rejected");
+  }
+  for (const proofName of requiredProofNames) {
+    if (!proofNames.has(proofName)) errors.push(`missing-required-proof:${proofName}`);
+  }
+  return {
+    format: "openclaw-snes-pcc-worker-output-validation-v1",
+    generatedAt: nowIso(),
+    status: errors.length ? "fail" : "pass",
+    ok: errors.length === 0,
+    errors,
+    hostedGlmUsed: false,
+    gpt55Used: false,
+  };
+}
+
+export function validateWorkerOutput({
+  output,
+  project,
+  milestoneId,
+  dispatchId,
+  allowedWriteSurfaces = [],
+  requiredProof = [],
+}) {
+  return validateWorkerOutputObject({
+    output,
+    project,
+    milestoneId,
+    dispatchId,
+    allowedWriteSurfaces,
+    requiredProof,
+  });
+}
+
+export function parseAndValidateWorkerOutputText({
+  text,
+  project,
+  milestoneId,
+  dispatchId,
+  allowedWriteSurfaces = [],
+  requiredProof = [],
+}) {
+  const output = extractJsonObject(text);
+  if (!output) {
+    return {
+      format: "openclaw-snes-pcc-worker-output-validation-v1",
+      generatedAt: nowIso(),
+      status: "fail",
+      ok: false,
+      errors: ["invalid-json"],
+      hostedGlmUsed: false,
+      gpt55Used: false,
+    };
+  }
+  return validateWorkerOutputObject({
+    output,
+    project,
+    milestoneId,
+    dispatchId,
+    allowedWriteSurfaces,
+    requiredProof,
+  });
+}
+
+function createAdapterWorkerOutput({ packet, dispatch, generator = "local-pcc-worker-adapter" }) {
+  const proofReceipts = (packet.requiredProof ?? []).map((entry) => {
+    const proofName = typeof entry === "string" ? entry : entry.name;
+    return {
+      proofName,
+      path: `receipts/${packet.milestoneId}-${proofName}.json`,
+      content: {
+        format: "openclaw-snes-pcc-worker-proof-receipt-v1",
+        status: "pass",
+        milestoneId: packet.milestoneId,
+        proofName,
+        generatedBy: generator,
+        localOnly: true,
+        hostedGlmUsed: false,
+        gpt55Used: false,
+      },
+    };
+  });
+  return {
+    format: "openclaw-snes-pcc-worker-output-v1",
+    status: "pass",
+    project: packet.project,
+    milestoneId: packet.milestoneId,
+    dispatchId: dispatch.id,
+    patchType: "receipt-only",
+    writes: [],
+    receipts: proofReceipts,
+    assumptions: ["local-only PCC worker output", "legal clean-room SNES constraints preserved"],
+    risks: ["receipt-only output does not replace later runtime proof"],
+    playtestHypothesis: `${packet.milestoneId} proof receipts should allow deterministic PCC judging to pass for this milestone only.`,
+    commercialMaterialUsed: false,
+    fxpakWritePerformed: false,
+    hostedGlmUsed: false,
+    gpt55Used: false,
+  };
+}
+
+function buildWorkerPrompt({ packet, dispatch, previousErrors = [] }) {
+  const template = createAdapterWorkerOutput({
+    packet,
+    dispatch,
+    generator: "local-ollama-worker",
+  });
+  return [
+    "You are a local-only SNES Studio PCC worker.",
+    "Return JSON only. No markdown. No comments. No code fences.",
+    "Do not use hosted GLM, paid tools, commercial SNES ROMs/code/assets, or FXPAK/removable writes.",
+    "Your output must exactly match the openclaw-snes-pcc-worker-output-v1 schema.",
+    previousErrors.length
+      ? `Repair these prior validation errors: ${previousErrors.join(", ")}`
+      : "No prior validation errors.",
+    "Worker packet:",
+    JSON.stringify(packet),
+    "Return this JSON shape with the same project, milestoneId, dispatchId, required proof receipts, and false hosted/gpt flags:",
+    JSON.stringify(template),
+  ].join("\n");
+}
+
+function callOllamaJson({
+  modelRef,
+  prompt,
+  timeoutSeconds = 120,
+  maxOutputTokens = 900,
+  spawn = spawnSync,
+}) {
+  const payload = JSON.stringify({
+    format: "json",
+    model: ollamaModelId(modelRef),
+    options: { num_ctx: 4096, num_predict: maxOutputTokens, temperature: 0 },
+    prompt,
+    stream: false,
+  });
+  const started = Date.now();
+  const result = spawn(
+    "curl",
+    [
+      "--silent",
+      "--show-error",
+      "--max-time",
+      String(timeoutSeconds),
+      "http://127.0.0.1:11434/api/generate",
+      "-H",
+      "Content-Type: application/json",
+      "-d",
+      payload,
+    ],
+    { encoding: "utf8", maxBuffer: 8 * 1024 * 1024, timeout: timeoutSeconds * 1000 },
+  );
+  const stdout = spawnText(result, "stdout");
+  const stderr = spawnText(result, "stderr");
+  const api = extractJsonObject(stdout);
+  const raw = typeof api?.response === "string" ? api.response : stdout;
+  const parsed = extractJsonObject(raw);
+  const error = result.error
+    ? String(result.error.message ?? result.error)
+    : api?.error
+      ? String(api.error)
+      : result.status === 0
+        ? null
+        : stderr || `ollama-curl-exit-${result.status}`;
+  return {
+    status: error ? "blocked" : "pass",
+    ok: !error,
+    modelRef,
+    latencyMs: Date.now() - started,
+    promptSha256: sha256Text(prompt),
+    responseSha256: sha256Text(raw),
+    raw,
+    parsed,
+    error,
+    exitStatus: result.status ?? null,
+  };
+}
+
+export function modelHealth({ project, root, spawn = spawnSync, timeoutSeconds = 45 }) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-model-health-v1",
+  });
+  if (blocked) return blocked;
+  const listResult = spawn("ollama", ["list"], {
+    encoding: "utf8",
+    timeout: timeoutSeconds * 1000,
+  });
+  if (listResult.error || listResult.status !== 0) {
+    return {
+      format: "openclaw-snes-pcc-model-health-v1",
+      generatedAt: nowIso(),
+      status: "blocked",
+      ok: false,
+      project,
+      blocker: listResult.error
+        ? String(listResult.error.message ?? listResult.error)
+        : spawnText(listResult, "stderr") || `ollama-list-exit-${listResult.status}`,
+      downloadsAttempted: false,
+      hostedGlmUsed: false,
+      gpt55Used: false,
+    };
+  }
+  const installedModels = parseOllamaList(spawnText(listResult, "stdout"));
+  const installed = new Set(installedModels);
+  const probes = [];
+  for (const modelRef of configuredLocalWorkerModels()) {
+    if (!installed.has(modelRef)) {
+      probes.push({ modelRef, status: "blocked", ok: false, blocker: "model-not-installed" });
+      continue;
+    }
+    const prompt = 'Return exactly this JSON object: {"status":"pass","ok":true}';
+    const call = callOllamaJson({ modelRef, prompt, timeoutSeconds, maxOutputTokens: 64, spawn });
+    probes.push({
+      modelRef,
+      status: call.parsed?.status === "pass" ? "pass" : "blocked",
+      ok: call.parsed?.status === "pass",
+      blocker: call.error ?? (call.parsed?.status === "pass" ? null : "invalid-json-probe-output"),
+      latencyMs: call.latencyMs,
+      promptSha256: call.promptSha256,
+      responseSha256: call.responseSha256,
+    });
+  }
+  const usage = loaded.modelUsage ?? { format: "openclaw-snes-pcc-model-usage-v1", usage: [] };
+  usage.generatedAt = nowIso();
+  usage.health = { generatedAt: usage.generatedAt, installedModels, probes };
+  writeJson(pccFile(loaded.projectDir, "model-usage.json"), usage);
+  appendTelemetry(loaded, {
+    type: "model-health",
+    status: probes.some((probe) => probe.status === "pass") ? "pass" : "blocked",
+    healthyModels: probes.filter((probe) => probe.status === "pass").map((probe) => probe.modelRef),
+  });
+  return {
+    format: "openclaw-snes-pcc-model-health-v1",
+    generatedAt: nowIso(),
+    status: probes.some((probe) => probe.status === "pass") ? "pass" : "blocked",
+    ok: probes.some((probe) => probe.status === "pass"),
+    project,
+    installedModels,
+    probes,
+    downloadsAttempted: false,
+    hostedGlmUsed: false,
+    gpt55Used: false,
+  };
+}
+
+export function runLocalModelWorker({
+  loaded,
+  packet,
+  dispatch,
+  route,
+  spawn = spawnSync,
+  timeoutSeconds = 120,
+}) {
+  const outputDir = path.join(loaded.projectDir, "worker-outputs");
+  fs.mkdirSync(outputDir, { recursive: true });
+  const outputPath = path.join(outputDir, `${dispatch.id}.json`);
+  const attempts = [];
+  const models = route?.candidates?.map((candidate) => candidate.model) ?? [route.selectedModel];
+  let previousErrors = [];
+  for (const modelRef of models) {
+    for (let repairAttempt = 0; repairAttempt < 2; repairAttempt += 1) {
+      const prompt = buildWorkerPrompt({ packet, dispatch, previousErrors });
+      const call = callOllamaJson({ modelRef, prompt, timeoutSeconds, spawn });
+      const validation = call.parsed
+        ? validateWorkerOutputObject({
+            output: call.parsed,
+            project: packet.project,
+            milestoneId: packet.milestoneId,
+            dispatchId: dispatch.id,
+            allowedWriteSurfaces: packet.allowedWriteSurfaces,
+            requiredProof: packet.requiredProof,
+          })
+        : {
+            format: "openclaw-snes-pcc-worker-output-validation-v1",
+            status: "fail",
+            ok: false,
+            errors: [call.error ?? "invalid-json"],
+          };
+      const attempt = {
+        modelRef,
+        repairAttempt,
+        status: validation.status,
+        errors: validation.errors ?? [],
+        latencyMs: call.latencyMs,
+        promptSha256: call.promptSha256,
+        responseSha256: call.responseSha256,
+        exitStatus: call.exitStatus,
+      };
+      attempts.push(attempt);
+      if (validation.ok) {
+        const output = {
+          ...call.parsed,
+          modelInvocation: {
+            modelRef,
+            modelInvoked: true,
+            latencyMs: call.latencyMs,
+            promptSha256: call.promptSha256,
+            responseSha256: call.responseSha256,
+            timeoutSeconds,
+            validationStatus: "pass",
+          },
+        };
+        writeJson(outputPath, output);
+        return {
+          format: "openclaw-snes-pcc-local-model-worker-v1",
+          generatedAt: nowIso(),
+          status: "pass",
+          ok: true,
+          modelInvoked: true,
+          modelRef,
+          workerOutputPath: path.relative(loaded.projectDir, outputPath),
+          attempts,
+          hostedGlmUsed: false,
+          gpt55Used: false,
+        };
+      }
+      previousErrors = validation.errors ?? ["invalid-json"];
+    }
+  }
+  const failedPath = path.join(outputDir, `${dispatch.id}.failed.json`);
+  writeJson(failedPath, {
+    format: "openclaw-snes-pcc-worker-output-failure-v1",
+    status: "blocked",
+    project: packet.project,
+    milestoneId: packet.milestoneId,
+    dispatchId: dispatch.id,
+    attempts,
+    hostedGlmUsed: false,
+    gpt55Used: false,
+  });
+  return {
+    format: "openclaw-snes-pcc-local-model-worker-v1",
+    generatedAt: nowIso(),
+    status: "blocked",
+    ok: false,
+    modelInvoked: attempts.length > 0,
+    blocker: attempts.at(-1)?.errors?.join(",") || "local-model-worker-output-invalid",
+    failedOutputPath: path.relative(loaded.projectDir, failedPath),
+    attempts,
+    hostedGlmUsed: false,
+    gpt55Used: false,
+  };
+}
+
+function appendTelemetry(loaded, event) {
+  const telemetry = loaded.telemetry ?? { format: "openclaw-snes-pcc-telemetry-v1", events: [] };
+  telemetry.generatedAt = nowIso();
+  telemetry.events = [...(telemetry.events ?? []), { at: nowIso(), ...event }];
+  writeJson(pccFile(loaded.projectDir, "telemetry.json"), telemetry);
+}
+
+function selectLocalModelForRole(loaded, role) {
+  const events = loaded.telemetry?.events ?? [];
+  const models = [
+    DEFAULT_ROUTING_POLICY.routineWorkers.model,
+    ...DEFAULT_ROUTING_POLICY.routineWorkers.fallbacks,
+  ];
+  const candidates = models
+    .map((model) => {
+      const relevant = events.filter(
+        (event) => event.model === model && (!role || event.role === role),
+      );
+      const failures = relevant.filter(
+        (event) => event.status === "fail" || event.status === "blocked",
+      ).length;
+      const passes = relevant.filter((event) => event.status === "pass").length;
+      return { model, score: 100 + passes * 5 - failures * 25, passes, failures };
+    })
+    .sort((a, b) => b.score - a.score || a.model.localeCompare(b.model));
+  return {
+    format: "openclaw-snes-pcc-model-route-v1",
+    role,
+    selectedModel: candidates[0].model,
+    candidates,
+    hostedGlmUsed: false,
+  };
+}
+
+function pathLooksSecret(filePath) {
+  return /(?:secret|token|key|credential|\.pem$|ed25519|id_rsa|id_dsa)/i.test(filePath);
+}
+
+function writeSurfaceMatches(filePath, surfaces) {
+  return surfaces.some(
+    (surface) => filePath.includes(surface) || filePath.includes(surface.replaceAll("-", "_")),
+  );
+}
+
+export function guardWriteSurfaces({
+  beforeFiles = [],
+  afterFiles = [],
+  allowedWriteSurfaces = [],
+}) {
+  const before = new Set(beforeFiles);
+  const changedFiles = afterFiles.filter((filePath) => !before.has(filePath));
+  const secretChanges = changedFiles.filter(pathLooksSecret);
+  const unexpectedChanges = changedFiles.filter(
+    (filePath) => !writeSurfaceMatches(filePath, allowedWriteSurfaces),
+  );
+  return {
+    format: "openclaw-snes-pcc-write-surface-guard-v1",
+    status: secretChanges.length || unexpectedChanges.length ? "blocked" : "pass",
+    ok: secretChanges.length === 0 && unexpectedChanges.length === 0,
+    changedFiles,
+    secretChanges,
+    unexpectedChanges,
+  };
+}
+
+export function dispatchWorker({
+  project,
+  root,
+  milestoneId,
+  dryRun = true,
+  localOnly = false,
+  invokeLocalModels = false,
+  spawn = spawnSync,
+  timeoutSeconds = 120,
+}) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-worker-dispatch-v1",
+  });
+  if (blocked) return blocked;
+  const packet = exportWorkerPacket({ project, root, milestoneId, allowPassed: invokeLocalModels });
+  if (packet.status !== "pass")
+    return { ...packet, format: "openclaw-snes-pcc-worker-dispatch-v1" };
+  if (invokeLocalModels && (!localOnly || dryRun)) {
+    return {
+      format: "openclaw-snes-pcc-worker-dispatch-v1",
+      generatedAt: nowIso(),
+      status: "blocked",
+      ok: false,
+      project,
+      milestoneId,
+      blocker: "real-model-dispatch-requires-local-only-non-dry-run",
+      gpt55Used: false,
+      hostedGlmUsed: false,
+    };
+  }
+  const route = selectLocalModelForRole(loaded, packet.ownerRole);
+  const sandbox = {
+    sandboxId: `${milestoneId}-${sha256Text(`${project}:${milestoneId}`).slice(0, 10)}`,
+    project,
+    milestoneId,
+    allowedWriteSurfaces: packet.allowedWriteSurfaces,
+    forbiddenPaths: [
+      "music-creator-v1/",
+      "trading-lab/",
+      "local-video-lab/",
+      ".git/",
+      "**/*.pem",
+      "**/*ed25519*",
+    ],
+    expectedReceiptPath: packet.receiptPath,
+    stopConditions: [
+      "unexpected-file-change",
+      "secret-like-path-change",
+      "validation-failure",
+      "approval-required",
+    ],
+  };
+  const dispatch = {
+    id: `${sandbox.sandboxId}-${dryRun ? "dry" : invokeLocalModels ? "ollama" : "local"}`,
+    createdAt: nowIso(),
+    project,
+    milestoneId,
+    dryRun,
+    localOnly,
+    invokeLocalModels,
+    role: packet.ownerRole,
+    model: route.selectedModel,
+    modelInvoked: false,
+    dispatchPlan: packet,
+    sandbox,
+    status: "pass",
+  };
+  const log = loaded.workerDispatchLog ?? {
+    format: "openclaw-snes-pcc-worker-dispatch-log-v1",
+    dispatches: [],
+  };
+  log.generatedAt = nowIso();
+  log.dispatches = [...(log.dispatches ?? []), dispatch];
+  writeJson(pccFile(loaded.projectDir, "worker-dispatch-log.json"), log);
+  const sandboxes = loaded.workerSandboxes ?? {
+    format: "openclaw-snes-pcc-worker-sandboxes-v1",
+    sandboxes: [],
+  };
+  sandboxes.generatedAt = nowIso();
+  sandboxes.sandboxes = [...(sandboxes.sandboxes ?? []), sandbox];
+  writeJson(pccFile(loaded.projectDir, "worker-sandboxes.json"), sandboxes);
+  appendTelemetry(loaded, {
+    type: "worker-dispatch",
+    status: "pass",
+    role: packet.ownerRole,
+    model: route.selectedModel,
+    milestoneId,
+    dryRun,
+    localOnly,
+    invokeLocalModels,
+  });
+  if (!dryRun && localOnly) {
+    if (invokeLocalModels) {
+      const worker = runLocalModelWorker({
+        loaded,
+        packet,
+        dispatch,
+        route,
+        spawn,
+        timeoutSeconds,
+      });
+      dispatch.modelInvoked = worker.modelInvoked === true;
+      dispatch.modelInvocation = worker;
+      if (worker.status !== "pass") {
+        dispatch.status = "blocked";
+        log.dispatches[log.dispatches.length - 1] = dispatch;
+        writeJson(pccFile(loaded.projectDir, "worker-dispatch-log.json"), log);
+        appendTelemetry(loaded, {
+          type: "worker-dispatch-model-result",
+          status: "blocked",
+          milestoneId,
+          model: route.selectedModel,
+          blocker: worker.blocker,
+        });
+        return {
+          format: "openclaw-snes-pcc-worker-dispatch-v1",
+          generatedAt: nowIso(),
+          status: "blocked",
+          ok: false,
+          project,
+          milestoneId,
+          dispatch,
+          route,
+          sandbox,
+          worker,
+          blocker: worker.blocker,
+          gpt55Used: false,
+          hostedGlmUsed: false,
+        };
+      }
+      dispatch.workerOutputPath = worker.workerOutputPath;
+      log.dispatches[log.dispatches.length - 1] = dispatch;
+      writeJson(pccFile(loaded.projectDir, "worker-dispatch-log.json"), log);
+      appendTelemetry(loaded, {
+        type: "worker-dispatch-model-result",
+        status: "pass",
+        milestoneId,
+        model: worker.modelRef,
+        modelInvoked: true,
+      });
+    } else {
+      const outputDir = path.join(loaded.projectDir, "worker-outputs");
+      fs.mkdirSync(outputDir, { recursive: true });
+      const outputPath = path.join(outputDir, `${dispatch.id}.json`);
+      writeJson(outputPath, createAdapterWorkerOutput({ packet, dispatch }));
+      dispatch.workerOutputPath = path.relative(loaded.projectDir, outputPath);
+      log.dispatches[log.dispatches.length - 1] = dispatch;
+      writeJson(pccFile(loaded.projectDir, "worker-dispatch-log.json"), log);
+    }
+  }
+  return {
+    format: "openclaw-snes-pcc-worker-dispatch-v1",
+    generatedAt: nowIso(),
+    status: "pass",
+    ok: true,
+    project,
+    milestoneId,
+    dispatch,
+    route,
+    sandbox,
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+export function applyWorkerOutput({ project, root, workerOutputPath }) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-apply-worker-output-v1",
+  });
+  if (blocked) return blocked;
+  const resolved = path.isAbsolute(workerOutputPath)
+    ? workerOutputPath
+    : path.join(loaded.projectDir, workerOutputPath);
+  if (!fs.existsSync(resolved))
+    return {
+      format: "openclaw-snes-pcc-apply-worker-output-v1",
+      status: "blocked",
+      ok: false,
+      project,
+      blocker: "worker-output-not-found",
+    };
+  let output;
+  try {
+    output = readJson(resolved);
+  } catch (error) {
+    return {
+      format: "openclaw-snes-pcc-apply-worker-output-v1",
+      status: "blocked",
+      ok: false,
+      project,
+      blocker: `invalid-worker-output-json:${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  const milestone = loaded.ledger?.milestones?.find(
+    (entry) => entry.milestoneId === output?.milestoneId,
+  );
+  const validation = validateWorkerOutputObject({
+    output,
+    project,
+    milestoneId: output?.milestoneId,
+    allowedWriteSurfaces: milestone?.allowedWriteSurfaces ?? [],
+    requiredProof: milestone?.requiredProof ?? [],
+  });
+  if (!milestone) validation.errors.push("milestone-not-found");
+  if (!validation.ok || !milestone) {
+    validation.status = "fail";
+    validation.ok = false;
+    return {
+      format: "openclaw-snes-pcc-apply-worker-output-v1",
+      status: "blocked",
+      ok: false,
+      project,
+      blocker: "worker-output-validation-failed",
+      validation,
+      gpt55Used: false,
+      hostedGlmUsed: false,
+    };
+  }
+
+  for (const receipt of output.receipts ?? []) {
+    const receiptPath = safeRelativePccPath(receipt.path);
+    if (!receiptPath)
+      return {
+        format: "openclaw-snes-pcc-apply-worker-output-v1",
+        status: "blocked",
+        ok: false,
+        project,
+        blocker: "unsafe-receipt-path",
+      };
+    writeJson(path.join(loaded.projectDir, receiptPath), receipt.content ?? { status: "pass" });
+  }
+  const ledgerDoc = loaded.ledger;
+  milestone.proof = { ...(milestone.proof ?? {}) };
+  for (const receipt of output.receipts ?? []) {
+    if (receipt.proofName) milestone.proof[receipt.proofName] = receipt.path;
+  }
+  milestone.status = "pass";
+  milestone.completionPercent = 100;
+  milestone.latestReceipt = output.receipts?.[0]?.path ?? milestone.latestReceipt ?? null;
+  writeJson(pccFile(loaded.projectDir, "milestone-ledger.json"), ledgerDoc);
+
+  const judge = judgeMilestone({ project, root, milestoneId: output.milestoneId });
+  const patch = {
+    id: sha256Text(fs.readFileSync(resolved, "utf8")).slice(0, 16),
+    appliedAt: nowIso(),
+    workerOutputPath: path.relative(loaded.projectDir, resolved),
+    milestoneId: output.milestoneId,
+    patchType: output.patchType,
+    status: judge.status,
+    modelInvoked: output.modelInvocation?.modelInvoked === true,
+  };
+  const ledger = loaded.patchLedger ?? { format: "openclaw-snes-pcc-patch-ledger-v1", patches: [] };
+  ledger.generatedAt = nowIso();
+  ledger.patches = [...(ledger.patches ?? []), patch];
+  writeJson(pccFile(loaded.projectDir, "patch-ledger.json"), ledger);
+  appendTelemetry(loaded, {
+    type: "apply-worker-output",
+    status: judge.status,
+    milestoneId: output.milestoneId,
+    modelInvoked: output.modelInvocation?.modelInvoked === true,
+  });
+  return {
+    format: "openclaw-snes-pcc-apply-worker-output-v1",
+    generatedAt: nowIso(),
+    status: judge.status === "pass" ? "pass" : "blocked",
+    ok: judge.status === "pass",
+    project,
+    patch,
+    judge,
+    validation,
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+export function resolvePccConflicts({ patches = [] }) {
+  const seenFiles = new Set();
+  const conflicts = [];
+  for (const patch of patches)
+    for (const filePath of patch.files ?? []) {
+      if (seenFiles.has(filePath)) conflicts.push({ type: "same-file-conflict", filePath });
+      seenFiles.add(filePath);
+    }
+  return {
+    format: "openclaw-snes-pcc-conflict-resolution-v1",
+    status: conflicts.length ? "blocked" : "pass",
+    ok: conflicts.length === 0,
+    conflicts,
+  };
+}
+
+export function updateArtifactCache({
+  project,
+  root,
+  cacheKey,
+  inputSha,
+  outputPath,
+  toolVersion = "unknown",
+}) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-artifact-cache-update-v1",
+  });
+  if (blocked) return blocked;
+  const cache = loaded.artifactCache ?? {
+    format: "openclaw-snes-pcc-artifact-cache-v1",
+    entries: [],
+  };
+  const entry = {
+    cacheKey,
+    inputSha,
+    outputPath,
+    toolVersion,
+    updatedAt: nowIso(),
+    status: "pass",
+  };
+  cache.entries = [...(cache.entries ?? []).filter((item) => item.cacheKey !== cacheKey), entry];
+  cache.generatedAt = nowIso();
+  writeJson(pccFile(loaded.projectDir, "artifact-cache.json"), cache);
+  return {
+    format: "openclaw-snes-pcc-artifact-cache-update-v1",
+    status: "pass",
+    ok: true,
+    project,
+    entry,
+  };
+}
+
+export function createReviewerReceipt({
+  project,
+  root,
+  milestoneId,
+  reviewerRole = "domain-reviewer",
+  status = "pass",
+  reasons = [],
+}) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-reviewer-receipt-v1",
+  });
+  if (blocked) return blocked;
+  const milestone = loaded.ledger?.milestones?.find((m) => m.milestoneId === milestoneId);
+  const receipt = {
+    id: `${milestoneId}-${reviewerRole}-${sha256Text(reasons.join("|")).slice(0, 8)}`,
+    createdAt: nowIso(),
+    milestoneId,
+    reviewerRole,
+    status,
+    reasons,
+    workerSelfApprovalRejected: reviewerRole === milestone?.workerRole,
+  };
+  const receipts = loaded.reviewerReceipts ?? {
+    format: "openclaw-snes-pcc-reviewer-receipts-v1",
+    receipts: [],
+  };
+  receipts.generatedAt = nowIso();
+  receipts.receipts = [...(receipts.receipts ?? []), receipt];
+  writeJson(pccFile(loaded.projectDir, "reviewer-receipts.json"), receipts);
+  return {
+    format: "openclaw-snes-pcc-reviewer-receipt-v1",
+    status: receipt.workerSelfApprovalRejected ? "blocked" : status,
+    ok: !receipt.workerSelfApprovalRejected && status === "pass",
+    project,
+    receipt,
+  };
+}
+
+export function compactMemoryCards({ project, root }) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-memory-compact-v1",
+  });
+  if (blocked) return blocked;
+  const cards =
+    loaded.ledger?.milestones?.map((milestone) => ({
+      id: `milestone-${milestone.milestoneId}`,
+      status: milestone.status,
+      text: `${milestone.milestoneId}: ${milestone.title} is ${milestone.status}.`,
+      sha256: sha256Text(JSON.stringify(milestone)),
+    })) ?? [];
+  writeJson(pccFile(loaded.projectDir, "memory-cards.json"), {
+    format: "openclaw-snes-pcc-memory-cards-v1",
+    generatedAt: nowIso(),
+    cards,
+  });
+  return {
+    format: "openclaw-snes-pcc-memory-compact-v1",
+    status: "pass",
+    ok: true,
+    project,
+    cardCount: cards.length,
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+export function pccTelemetry({ project, root }) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-telemetry-report-v1",
+  });
+  if (blocked) return blocked;
+  const events = loaded.telemetry?.events ?? [];
+  return {
+    format: "openclaw-snes-pcc-telemetry-report-v1",
+    generatedAt: nowIso(),
+    status: "pass",
+    ok: true,
+    project,
+    eventCount: events.length,
+    events,
+    gpt55Used: false,
+    hostedGlmUsed: false,
+  };
+}
+
+export function pccDashboardSnapshot({ project, root }) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-dashboard-snapshot-v1",
+  });
+  if (blocked) return blocked;
+  const status = pccStatus({ project, root });
+  const approvals = listApprovals({ project, root });
+  const snapshot = {
+    format: "openclaw-snes-pcc-dashboard-snapshot-v1",
+    generatedAt: nowIso(),
+    status: "pass",
+    ok: true,
+    projectId: project,
+    activeRun: loaded.runHistory?.runs?.at?.(-1) ?? null,
+    pendingApprovals: approvals.pendingApprovals ?? [],
+    blockedMilestones: (loaded.ledger?.milestones ?? [])
+      .filter((m) => m.status === "blocked")
+      .map((m) => m.milestoneId),
+    nextSafeAction: status.nextMilestone ? `continue-with:${status.nextMilestone}` : "none",
+    completionPercent: status.completionPercentByMilestoneCount,
+  };
+  writeJson(pccFile(loaded.projectDir, "dashboard-snapshot.json"), snapshot);
+  return snapshot;
+}
+
+export function runRegressionBenchmark({ project, root }) {
+  const { loaded, blocked } = loadedOrBlocked({
+    project,
+    root,
+    format: "openclaw-snes-pcc-regression-benchmark-v1",
+  });
+  if (blocked) return blocked;
+  const bench = loaded.regressionBenchmarks ?? {
+    format: "openclaw-snes-pcc-regression-benchmarks-v1",
+    prompts: [],
+    runs: [],
+  };
+  const run = {
+    id: `benchmark-${sha256Text(`${project}:${nowIso()}`).slice(0, 10)}`,
+    createdAt: nowIso(),
+    promptCount: bench.prompts?.length ?? 0,
+    status: (bench.prompts?.length ?? 0) >= 3 ? "pass" : "blocked",
+    legalCleanRoom: true,
+    hostedGlmUsed: false,
+  };
+  bench.runs = [...(bench.runs ?? []), run];
+  writeJson(pccFile(loaded.projectDir, "regression-benchmarks.json"), bench);
+  return {
+    format: "openclaw-snes-pcc-regression-benchmark-v1",
+    status: run.status,
+    ok: run.status === "pass",
+    project,
+    run,
+  };
+}
+
+export function runLivePcc({
+  project,
+  root,
+  maxMilestones = 10,
+  maxMinutes = 480,
+  maxParallel = 4,
+  localOnly = true,
+  invokeLocalModels = false,
+  spawn = spawnSync,
+  timeoutSeconds = 120,
+}) {
+  if (!localOnly)
+    return {
+      format: "openclaw-snes-pcc-live-run-v1",
+      status: "blocked",
+      ok: false,
+      project,
+      blocker: "only-local-live-worker-execution-approved",
+    };
+  const startedAt = Date.now();
+  const completedMilestones = [];
+  const dispatches = [];
+  const applications = [];
+  for (let index = 0; index < maxMilestones; index += 1) {
+    if ((Date.now() - startedAt) / 60000 > maxMinutes) {
+      return {
+        format: "openclaw-snes-pcc-live-run-v1",
+        generatedAt: nowIso(),
+        status: "blocked",
+        ok: false,
+        project,
+        stopReason: "time-limit-reached",
+        completedMilestones,
+        dispatches,
+        applications,
+        localOnly: true,
+        invokeLocalModels,
+        maxParallel,
+        hostedGlmUsed: false,
+        gpt55Used: false,
+      };
+    }
+    const loaded = loadPccProject({ project, root });
+    if (loaded.missingProject)
+      return {
+        format: "openclaw-snes-pcc-live-run-v1",
+        status: "blocked",
+        ok: false,
+        project,
+        blocker: "project-not-found",
+      };
+    const next = pccNext({ project, root, maxParallel });
+    const candidateMilestones = next.parallelBatches?.[0] ?? [];
+    const targetMilestone =
+      candidateMilestones.find((id) => {
+        const entry = loaded.ledger?.milestones?.find((milestone) => milestone.milestoneId === id);
+        return entry && !entry.humanApprovalRequired;
+      }) ?? next.nextMilestone;
+    if (!targetMilestone) {
+      return {
+        format: "openclaw-snes-pcc-live-run-v1",
+        generatedAt: nowIso(),
+        status: "pass",
+        ok: true,
+        project,
+        stopReason: "no-ready-milestone",
+        completedMilestones,
+        dispatches,
+        applications,
+        localOnly: true,
+        invokeLocalModels,
+        maxParallel,
+        hostedGlmUsed: false,
+        gpt55Used: false,
+      };
+    }
+    const milestone = loaded.ledger?.milestones?.find(
+      (entry) => entry.milestoneId === targetMilestone,
+    );
+    if (milestone?.humanApprovalRequired) {
+      const approval = requestApproval({
+        project,
+        root,
+        approvalType: "human-production-visual-approval",
+        milestoneId: milestone.milestoneId,
+        reason: "Live local worker execution cannot self-approve human visual quality.",
+        risk: "production-visual-approval-required",
+        requestedAction: "Provide explicit human visual approval receipt.",
+      });
+      return {
+        format: "openclaw-snes-pcc-live-run-v1",
+        generatedAt: nowIso(),
+        status: "blocked",
+        ok: false,
+        project,
+        stopReason: "human-approval-required",
+        approval,
+        completedMilestones,
+        dispatches,
+        applications,
+        localOnly: true,
+        invokeLocalModels,
+        maxParallel,
+        hostedGlmUsed: false,
+        gpt55Used: false,
+      };
+    }
+    const dispatch = dispatchWorker({
+      project,
+      root,
+      milestoneId: targetMilestone,
+      dryRun: false,
+      localOnly: true,
+      invokeLocalModels,
+      spawn,
+      timeoutSeconds,
+    });
+    dispatches.push(dispatch);
+    if (dispatch.status !== "pass")
+      return {
+        ...dispatch,
+        format: "openclaw-snes-pcc-live-run-v1",
+        completedMilestones,
+        dispatches,
+        applications,
+      };
+    const apply = applyWorkerOutput({
+      project,
+      root,
+      workerOutputPath: dispatch.dispatch.workerOutputPath,
+    });
+    applications.push(apply);
+    if (apply.status !== "pass")
+      return {
+        format: "openclaw-snes-pcc-live-run-v1",
+        generatedAt: nowIso(),
+        status: "blocked",
+        ok: false,
+        project,
+        stopReason: "apply-or-judge-failed",
+        completedMilestones,
+        dispatches,
+        applications,
+        localOnly: true,
+        invokeLocalModels,
+        maxParallel,
+        hostedGlmUsed: false,
+        gpt55Used: false,
+      };
+    completedMilestones.push(targetMilestone);
+  }
+  return {
+    format: "openclaw-snes-pcc-live-run-v1",
+    generatedAt: nowIso(),
+    status: "pass",
+    ok: true,
+    project,
+    stopReason: "max-milestones-reached",
+    completedMilestones,
+    dispatches,
+    applications,
+    localOnly: true,
+    invokeLocalModels,
+    maxParallel,
+    hostedGlmUsed: false,
+    gpt55Used: false,
+  };
+}
+
+export function recordLastKnownGood({ project, root, milestoneId, receipt }) {
+  const loaded = loadPccProject({ project, root });
+  if (loaded.missingProject) throw new Error("project not found");
+  const buildHistory = loaded.buildHistory ?? { builds: [] };
+  const record = {
+    milestoneId,
+    recordedAt: nowIso(),
+    sourceHash: receipt.sourceHash ?? null,
+    romHash: receipt.romHash ?? null,
+    assetHashes: receipt.assetHashes ?? [],
+    emulatorScreenshotHash: receipt.emulatorScreenshotHash ?? null,
+    passReceipts: receipt.passReceipts ?? [],
+    buildTimestamp: receipt.buildTimestamp ?? nowIso(),
+  };
+  buildHistory.lastKnownGood = record;
+  buildHistory.builds = [...(buildHistory.builds ?? []), record];
+  writeJson(pccFile(loaded.projectDir, "build-history.json"), buildHistory);
+  return record;
+}
+
+export function pccStatus({ project, root, initialized, note } = {}) {
+  const loaded = loadPccProject({ project, root });
+  if (loaded.missingProject) {
+    return {
+      format: "openclaw-snes-pcc-status-v1",
+      generatedAt: nowIso(),
+      status: "blocked",
+      ok: false,
+      project,
+      blocker: "project-not-found",
+      gpt55Used: false,
+      hostedGlmUsed: false,
+    };
+  }
+  const milestones = loaded.ledger?.milestones ?? [];
+  const total = milestones.length;
+  const counts = Object.fromEntries([...PCC_STATUSES].map((status) => [status, 0]));
+  for (const milestone of milestones)
+    counts[milestone.status] = (counts[milestone.status] ?? 0) + 1;
+  const next = planParallelMilestones({
+    milestones,
+    maxParallel: loaded.dag?.maxParallelWorkers ?? 4,
+  });
+  return {
+    format: "openclaw-snes-pcc-status-v1",
+    generatedAt: nowIso(),
+    status: "pass",
+    ok: true,
+    project,
+    initialized: Boolean(initialized),
+    note,
+    projectDir: loaded.projectDir,
+    totalMilestones: total,
+    statusCounts: counts,
+    completionPercentByMilestoneCount: total ? Math.round((counts.pass / total) * 1000) / 10 : 0,
+    nextMilestone: next.parallelBatches[0]?.[0] ?? null,
+    parallelPlan: next,
+    futureMilestonesPreserved:
+      loaded.ledger?.futureMilestonesPreserved ?? futureMilestonesPreserved(),
+    gpt55Used: false,
+    hostedGlmUsed: false,
+    commercialMaterialUsed: false,
+    fxpakWritePerformed: false,
+  };
+}
+
+export function parseSnesTeamArgs(argv) {
+  const args = { mode: "status", json: false, maxParallel: 4, maxMilestones: 10, maxMinutes: 480 };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") continue;
+    if (arg === "--help" || arg === "-h") args.help = true;
+    else if (arg === "--json") args.json = true;
+    else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--local-only") args.localOnly = true;
+    else if (arg === "--invoke-local-models") args.invokeLocalModels = true;
+    else if (arg === "--mode") args.mode = argv[++index];
+    else if (arg === "--project") args.project = argv[++index];
+    else if (arg === "--prompt") args.promptPath = argv[++index];
+    else if (arg === "--milestone") args.milestoneId = argv[++index];
+    else if (arg === "--failure-class") args.failureClass = argv[++index];
+    else if (arg === "--approval-type") args.approvalType = argv[++index];
+    else if (arg === "--reason") args.reason = argv[++index];
+    else if (arg === "--risk") args.risk = argv[++index];
+    else if (arg === "--requested-action") args.requestedAction = argv[++index];
+    else if (arg === "--root") args.root = argv[++index];
+    else if (arg === "--max-parallel") args.maxParallel = Number(argv[++index]);
+    else if (arg === "--max-workers") args.maxParallel = Number(argv[++index]);
+    else if (arg === "--max-milestones") args.maxMilestones = Number(argv[++index]);
+    else if (arg === "--max-minutes") args.maxMinutes = Number(argv[++index]);
+    else if (arg === "--model-timeout-seconds") args.modelTimeoutSeconds = Number(argv[++index]);
+    else if (arg === "--asset-intent") args.assetIntentPath = argv[++index];
+    else if (arg === "--worker-output") args.workerOutputPath = argv[++index];
+    else if (arg === "--cache-key") args.cacheKey = argv[++index];
+    else if (arg === "--input-sha") args.inputSha = argv[++index];
+    else if (arg === "--output-path") args.outputPath = argv[++index];
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+export function snesTeamHelp() {
+  return [
+    "Usage: pnpm snes:team -- --mode <init|status|next|validate|judge|repair-plan|approvals|request-approval|run|run-live|resume-live|model-health|pause|resume|cancel|worker-packet|dispatch-worker|apply-worker-output|asset-intent-validate> --project <id> [--json]",
+    "       pnpm snes:team -- --mode init --project demo --prompt fixtures/snes-demo-prompt.txt --json",
+    "       pnpm snes:team -- --mode repair-plan --project demo --milestone PCC-010-level-plan --failure-class runtime-failure --json",
+    "       pnpm snes:team -- --mode asset-intent-validate --asset-intent asset-intent.json --json",
+  ].join("\n");
+}
+
+export function runSnesTeam(args) {
+  if (args.help) return { status: "pass", ok: true, help: snesTeamHelp() };
+  const mode = args.mode ?? "status";
+  if (mode !== "asset-intent-validate" && !args.project) {
+    return { format: PCC_FORMAT, status: "blocked", ok: false, blocker: "missing-project" };
+  }
+  try {
+    if (mode === "init")
+      return initPccProject({
+        project: args.project,
+        promptPath: args.promptPath,
+        root: args.root,
+      });
+    if (mode === "status") return pccStatus({ project: args.project, root: args.root });
+    if (mode === "next")
+      return pccNext({ project: args.project, root: args.root, maxParallel: args.maxParallel });
+    if (mode === "validate") return validatePccProject({ project: args.project, root: args.root });
+    if (mode === "judge")
+      return judgeMilestone({
+        project: args.project,
+        root: args.root,
+        milestoneId: args.milestoneId,
+      });
+    if (mode === "repair-plan")
+      return createRepairPlan({
+        project: args.project,
+        root: args.root,
+        milestoneId: args.milestoneId,
+        failureClass: args.failureClass ?? "invalid-patch",
+      });
+    if (mode === "approvals") return listApprovals({ project: args.project, root: args.root });
+    if (mode === "request-approval")
+      return requestApproval({
+        project: args.project,
+        root: args.root,
+        approvalType: args.approvalType,
+        milestoneId: args.milestoneId,
+        reason: args.reason,
+        risk: args.risk,
+        requestedAction: args.requestedAction,
+      });
+    if (["pause", "resume", "cancel"].includes(mode))
+      return setRunControl({ project: args.project, root: args.root, action: mode });
+    if (mode === "run")
+      return runPccUntilBlocked({
+        project: args.project,
+        root: args.root,
+        maxMilestones: args.maxMilestones,
+        maxMinutes: args.maxMinutes,
+      });
+    if (mode === "worker-packet")
+      return exportWorkerPacket({
+        project: args.project,
+        root: args.root,
+        milestoneId: args.milestoneId,
+      });
+    if (mode === "model-health")
+      return modelHealth({
+        project: args.project,
+        root: args.root,
+        timeoutSeconds: args.modelTimeoutSeconds ?? 45,
+      });
+    if (mode === "dispatch-worker")
+      return dispatchWorker({
+        project: args.project,
+        root: args.root,
+        milestoneId: args.milestoneId,
+        dryRun: args.dryRun || !args.localOnly,
+        localOnly: args.localOnly,
+        invokeLocalModels: args.invokeLocalModels,
+        timeoutSeconds: args.modelTimeoutSeconds ?? 120,
+      });
+    if (mode === "apply-worker-output")
+      return applyWorkerOutput({
+        project: args.project,
+        root: args.root,
+        workerOutputPath: args.workerOutputPath,
+      });
+    if (mode === "telemetry") return pccTelemetry({ project: args.project, root: args.root });
+    if (mode === "dashboard-snapshot")
+      return pccDashboardSnapshot({ project: args.project, root: args.root });
+    if (mode === "regression-benchmark")
+      return runRegressionBenchmark({ project: args.project, root: args.root });
+    if (mode === "run-live" || mode === "resume-live")
+      return runLivePcc({
+        project: args.project,
+        root: args.root,
+        maxMilestones: args.maxMilestones,
+        maxMinutes: args.maxMinutes,
+        maxParallel: args.maxParallel,
+        localOnly: args.localOnly,
+        invokeLocalModels: args.invokeLocalModels,
+        timeoutSeconds: args.modelTimeoutSeconds ?? 120,
+      });
+    if (mode === "artifact-cache-update")
+      return updateArtifactCache({
+        project: args.project,
+        root: args.root,
+        cacheKey: args.cacheKey,
+        inputSha: args.inputSha,
+        outputPath: args.outputPath,
+      });
+    if (mode === "memory-compact")
+      return compactMemoryCards({ project: args.project, root: args.root });
+    if (mode === "asset-intent-validate")
+      return validateAssetIntentContract(readJson(args.assetIntentPath));
+    return { format: PCC_FORMAT, status: "blocked", ok: false, blocker: `unknown-mode:${mode}` };
+  } catch (error) {
+    return {
+      format: PCC_FORMAT,
+      generatedAt: nowIso(),
+      status: "blocked",
+      ok: false,
+      blocker: error instanceof Error ? error.message : String(error),
+      gpt55Used: false,
+      hostedGlmUsed: false,
+    };
+  }
+}
+
+export function snesTeamSucceeded(report) {
+  return report?.ok !== false && !["fail", "blocked", "rejected"].includes(report?.status);
+}

--- a/test/scripts/snes-team-orchestrator.test.ts
+++ b/test/scripts/snes-team-orchestrator.test.ts
@@ -1,0 +1,885 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  applyWorkerOutput,
+  compactMemoryCards,
+  createReviewerReceipt,
+  createRepairPlan,
+  dispatchWorker,
+  exportWorkerPacket,
+  initPccProject,
+  judgeMilestone,
+  listApprovals,
+  modelHealth,
+  parseAndValidateWorkerOutputText,
+  pccNext,
+  pccProjectDir,
+  pccStatus,
+  recordLastKnownGood,
+  guardWriteSurfaces,
+  pccDashboardSnapshot,
+  pccTelemetry,
+  requestApproval,
+  resolvePccConflicts,
+  runLivePcc,
+  runPccUntilBlocked,
+  runRegressionBenchmark,
+  runSnesTeam,
+  setRunControl,
+  updateArtifactCache,
+  validateAssetIntentContract,
+  validateWorkerOutput,
+  validatePccProject,
+} from "../../scripts/lib/snes-team-orchestrator.mjs";
+
+function tempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snes-pcc-"));
+}
+
+function writePrompt(root: string, text = "Make a legal clean-room SNES platformer.") {
+  const promptPath = path.join(root, "prompt.txt");
+  fs.writeFileSync(promptPath, text);
+  return promptPath;
+}
+
+type TestMilestone = {
+  milestoneId: string;
+  status: string;
+  completionPercent: number;
+  requiredProof: Array<string | { name: string }>;
+  proof: Record<string, string>;
+  humanApprovalRequired?: boolean;
+  workerRole?: string;
+  judgeRole?: string;
+  allowedWriteSurfaces: string[];
+};
+
+type TestLedger = { milestones: TestMilestone[] };
+
+function readJson<T = unknown>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function writeJson(filePath: string, value: unknown) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function apiResponse(payload: unknown) {
+  return JSON.stringify({ response: JSON.stringify(payload) });
+}
+
+function dispatchIdFromCurlArgs(args: string[]) {
+  const payloadIndex = args.indexOf("-d");
+  const payload = payloadIndex >= 0 ? args[payloadIndex + 1] : args.join(" ");
+  const match = payload.match(/\\"dispatchId\\":\\"([^\\"]+)/);
+  return match?.[1] ?? "unknown";
+}
+
+function validWorkerOutput(project: string, milestoneId: string, dispatchId: string) {
+  return {
+    format: "openclaw-snes-pcc-worker-output-v1",
+    status: "pass",
+    project,
+    milestoneId,
+    dispatchId,
+    patchType: "receipt-only",
+    writes: [],
+    receipts: [
+      {
+        proofName: "blueprintReceipt",
+        path: `receipts/${milestoneId}-blueprintReceipt.json`,
+        content: {
+          status: "pass",
+          proofName: "blueprintReceipt",
+          hostedGlmUsed: false,
+          gpt55Used: false,
+        },
+      },
+      {
+        proofName: "legalBoundaryReceipt",
+        path: `receipts/${milestoneId}-legalBoundaryReceipt.json`,
+        content: {
+          status: "pass",
+          proofName: "legalBoundaryReceipt",
+          hostedGlmUsed: false,
+          gpt55Used: false,
+        },
+      },
+    ],
+    assumptions: ["clean-room local model output"],
+    risks: ["runtime proof remains separate"],
+    playtestHypothesis: "PCC judge should pass this receipt-only milestone.",
+    commercialMaterialUsed: false,
+    fxpakWritePerformed: false,
+    hostedGlmUsed: false,
+    gpt55Used: false,
+  };
+}
+
+function initDemo(project = "demo") {
+  const root = tempRoot();
+  const promptPath = writePrompt(root);
+  const report = initPccProject({ project, promptPath, root });
+  expect(report.status).toBe("pass");
+  return { root, project, pccDir: pccProjectDir({ project, root }) };
+}
+
+function passMilestone(root: string, project: string, milestoneId: string) {
+  const pccDir = pccProjectDir({ project, root });
+  const ledgerPath = path.join(pccDir, "milestone-ledger.json");
+  const ledger = readJson<TestLedger>(ledgerPath);
+  const milestone = ledger.milestones.find((entry) => entry.milestoneId === milestoneId);
+  expect(milestone).toBeTruthy();
+  milestone.status = "pass";
+  milestone.completionPercent = 100;
+  milestone.proof = {};
+  for (const entry of milestone.requiredProof) {
+    const name = typeof entry === "string" ? entry : entry.name;
+    const proofPath = `pass-receipts/${milestoneId}-${name}.json`;
+    fs.mkdirSync(path.join(pccDir, "pass-receipts"), { recursive: true });
+    fs.writeFileSync(path.join(pccDir, proofPath), JSON.stringify({ status: "pass", name }));
+    milestone.proof[name] = proofPath;
+  }
+  if (milestone.humanApprovalRequired) {
+    const proofPath = `pass-receipts/${milestoneId}-humanVisualApproval.json`;
+    fs.writeFileSync(path.join(pccDir, proofPath), JSON.stringify({ status: "pass", score: 100 }));
+    milestone.proof.humanVisualApproval = proofPath;
+  }
+  writeJson(ledgerPath, ledger);
+}
+
+describe("SNES PCC team orchestrator", () => {
+  it("initializes durable PCC state and preserves it on rerun", () => {
+    const root = tempRoot();
+    const project = "demo-pcc";
+    const promptPath = writePrompt(root, "Make a colorful clean-room SNES game.");
+    const first = initPccProject({ project, promptPath, root });
+    expect(first).toMatchObject({ status: "pass", ok: true, initialized: true });
+
+    const pccDir = pccProjectDir({ project, root });
+    for (const name of [
+      "project.intent.json",
+      "milestone-ledger.json",
+      "dependency-dag.json",
+      "active-worker-locks.json",
+      "decision-log.json",
+      "memory-cards.json",
+      "repair-queue.json",
+      "approval-queue.json",
+      "run-control.json",
+      "run-history.json",
+      "model-usage.json",
+      "build-history.json",
+      "latest-run-summary.md",
+      "latest-summary.md",
+      "worker-dispatch-log.json",
+      "worker-sandboxes.json",
+      "patch-ledger.json",
+      "artifact-cache.json",
+      "reviewer-receipts.json",
+      "conflict-receipts.json",
+      "telemetry.json",
+      "dashboard-snapshot.json",
+      "regression-benchmarks.json",
+    ]) {
+      expect(fs.existsSync(path.join(pccDir, name))).toBe(true);
+    }
+
+    const before = fs.readFileSync(path.join(pccDir, "milestone-ledger.json"), "utf8");
+    const second = initPccProject({ project, promptPath, root });
+    expect(second).toMatchObject({ status: "pass", ok: true, initialized: false });
+    expect(fs.readFileSync(path.join(pccDir, "milestone-ledger.json"), "utf8")).toBe(before);
+  });
+
+  it("reports status, next milestone, and valid state", () => {
+    const { root, project } = initDemo();
+    expect(pccStatus({ project, root })).toMatchObject({
+      status: "pass",
+      nextMilestone: "PCC-001-blueprint",
+    });
+    expect(pccNext({ project, root })).toMatchObject({
+      status: "pass",
+      nextMilestone: "PCC-001-blueprint",
+    });
+    expect(validatePccProject({ project, root })).toMatchObject({
+      status: "pass",
+      ok: true,
+      errors: [],
+    });
+  });
+
+  it("returns blocked JSON instead of crashing for a missing project", () => {
+    const root = tempRoot();
+    const report = runSnesTeam({ mode: "status", project: "missing", root, json: true });
+    expect(report).toMatchObject({ status: "blocked", ok: false, blocker: "project-not-found" });
+  });
+
+  it("validates milestone Definition of Done and rejects missing proof", () => {
+    const { root, project, pccDir } = initDemo();
+    const ledgerPath = path.join(pccDir, "milestone-ledger.json");
+    const ledger = readJson<TestLedger>(ledgerPath);
+    const milestone = ledger.milestones.find((entry) => entry.milestoneId === "PCC-001-blueprint");
+    milestone.status = "pass";
+    milestone.completionPercent = 100;
+    milestone.proof = {};
+    writeJson(ledgerPath, ledger);
+
+    const validation = validatePccProject({ project, root });
+    expect(validation.status).toBe("fail");
+    expect(validation.errors).toContain("PCC-001-blueprint:missing-proof:blueprintReceipt");
+  });
+
+  it("judges pass, missing runtime proof, human approval blockers, and self-approval", () => {
+    const { root, project, pccDir } = initDemo();
+    passMilestone(root, project, "PCC-001-blueprint");
+    expect(judgeMilestone({ project, root, milestoneId: "PCC-001-blueprint" })).toMatchObject({
+      status: "pass",
+      ok: true,
+    });
+
+    const ledgerPath = path.join(pccDir, "milestone-ledger.json");
+    const ledger = readJson<TestLedger>(ledgerPath);
+    const runtime = ledger.milestones.find(
+      (entry) => entry.milestoneId === "PCC-040-runtime-proof",
+    );
+    runtime.status = "pass";
+    runtime.completionPercent = 100;
+    runtime.proof = {};
+    const visual = ledger.milestones.find(
+      (entry) => entry.milestoneId === "PCC-050-human-visual-approval",
+    );
+    visual.status = "pass";
+    visual.completionPercent = 100;
+    visual.proof = {};
+    const self = ledger.milestones.find((entry) => entry.milestoneId === "PCC-010-level-plan");
+    self.status = "pass";
+    self.workerRole = "same-agent";
+    self.judgeRole = "same-agent";
+    self.proof = {};
+    writeJson(ledgerPath, ledger);
+
+    expect(
+      judgeMilestone({ project, root, milestoneId: "PCC-040-runtime-proof" }).failReasons,
+    ).toContain("missing-proof:emulatorScreenshotReceipt");
+    expect(
+      judgeMilestone({ project, root, milestoneId: "PCC-050-human-visual-approval" }),
+    ).toMatchObject({
+      status: "blocked",
+      requiresHuman: true,
+    });
+    expect(
+      judgeMilestone({ project, root, milestoneId: "PCC-010-level-plan" }).failReasons,
+    ).toContain("worker-self-approval-rejected");
+  });
+
+  it("plans parallel workers after blueprint and serializes conflicting surfaces", () => {
+    const { root, project, pccDir } = initDemo();
+    passMilestone(root, project, "PCC-001-blueprint");
+    const next = pccNext({ project, root, maxParallel: 4 });
+    expect(next.parallelBatches[0]).toHaveLength(4);
+    expect(next.serializedMilestones).toContain("PCC-014-hardware-plan");
+
+    const ledgerPath = path.join(pccDir, "milestone-ledger.json");
+    const ledger = readJson<TestLedger>(ledgerPath);
+    const level = ledger.milestones.find((entry) => entry.milestoneId === "PCC-010-level-plan");
+    const gameplay = ledger.milestones.find(
+      (entry) => entry.milestoneId === "PCC-011-gameplay-plan",
+    );
+    gameplay.allowedWriteSurfaces = [...level.allowedWriteSurfaces];
+    writeJson(ledgerPath, ledger);
+    const conflicted = pccNext({ project, root, maxParallel: 4 });
+    expect(conflicted.parallelBatches[0]).toContain("PCC-010-level-plan");
+    expect(conflicted.serializedMilestones).toContain("PCC-011-gameplay-plan");
+  });
+
+  it("creates repair tasks, blocks external blockers, and blocks on the fourth retry", () => {
+    const { root, project } = initDemo();
+    const first = createRepairPlan({
+      project,
+      root,
+      milestoneId: "PCC-010-level-plan",
+      failureClass: "runtime-failure",
+    });
+    expect(first).toMatchObject({ status: "pass", ok: true });
+    expect(first.repair.nextModel).toBe("ollama/openclaw-control-qwen3-30b-q6-chatfix:latest");
+
+    const external = createRepairPlan({
+      project,
+      root,
+      milestoneId: "PCC-011-gameplay-plan",
+      failureClass: "external-blocker",
+    });
+    expect(external).toMatchObject({ status: "blocked", ok: false });
+
+    createRepairPlan({
+      project,
+      root,
+      milestoneId: "PCC-010-level-plan",
+      failureClass: "runtime-failure",
+    });
+    createRepairPlan({
+      project,
+      root,
+      milestoneId: "PCC-010-level-plan",
+      failureClass: "runtime-failure",
+    });
+    const fourth = createRepairPlan({
+      project,
+      root,
+      milestoneId: "PCC-010-level-plan",
+      failureClass: "runtime-failure",
+    });
+    expect(fourth).toMatchObject({ status: "blocked", ok: false });
+  });
+
+  it("records last known good without overwriting it on failure", () => {
+    const { root, project } = initDemo();
+    const good = recordLastKnownGood({
+      project,
+      root,
+      milestoneId: "PCC-030-rom-build-proof",
+      receipt: {
+        sourceHash: "source-sha",
+        romHash: "rom-sha",
+        assetHashes: ["asset-sha"],
+        emulatorScreenshotHash: "shot-sha",
+        passReceipts: ["pass.json"],
+      },
+    });
+    createRepairPlan({
+      project,
+      root,
+      milestoneId: "PCC-030-rom-build-proof",
+      failureClass: "build-failure",
+    });
+    const buildHistory = readJson<{ lastKnownGood: unknown }>(
+      path.join(pccProjectDir({ project, root }), "build-history.json"),
+    );
+    expect(buildHistory.lastKnownGood).toEqual(good);
+  });
+
+  it("creates approval requests, suppresses duplicates, and rejects invalid approval types", () => {
+    const { root, project } = initDemo();
+    const approval = requestApproval({
+      project,
+      root,
+      milestoneId: "PCC-050-human-visual-approval",
+      approvalType: "human-production-visual-approval",
+      reason: "human visual gate",
+      risk: "subjective production approval",
+      requestedAction: "review screenshots",
+    });
+    expect(approval).toMatchObject({ status: "pass", ok: true, duplicateSuppressed: false });
+    expect(approval.approval.status).toBe("pending");
+
+    const duplicate = requestApproval({
+      project,
+      root,
+      milestoneId: "PCC-050-human-visual-approval",
+      approvalType: "human-production-visual-approval",
+    });
+    expect(duplicate).toMatchObject({ status: "pass", ok: true, duplicateSuppressed: true });
+
+    const approvals = listApprovals({ project, root });
+    expect(approvals.pendingApprovals).toHaveLength(1);
+
+    const invalid = requestApproval({
+      project,
+      root,
+      milestoneId: "PCC-001-blueprint",
+      approvalType: "bad-approval-type",
+    });
+    expect(invalid).toMatchObject({ status: "blocked", ok: false });
+    expect(invalid.blocker).toBe("invalid-approval-type:bad-approval-type");
+  });
+
+  it("exports bounded worker packets only for ready milestones", () => {
+    const { root, project } = initDemo();
+    const ready = exportWorkerPacket({ project, root, milestoneId: "PCC-001-blueprint" });
+    expect(ready).toMatchObject({ status: "pass", ok: true, milestoneId: "PCC-001-blueprint" });
+    expect(ready.forbiddenActions).toContain("hosted-glm-without-approval");
+    expect(ready.nextValidationCommand).toContain("--mode judge");
+
+    const blocked = exportWorkerPacket({ project, root, milestoneId: "PCC-010-level-plan" });
+    expect(blocked).toMatchObject({ status: "blocked", ok: false, blocker: "milestone-not-ready" });
+  });
+
+  it("pauses, resumes, and cancels PCC runs", () => {
+    const { root, project } = initDemo();
+    expect(setRunControl({ project, root, action: "pause" })).toMatchObject({ status: "pass" });
+    expect(runPccUntilBlocked({ project, root, maxMilestones: 1, maxMinutes: 10 })).toMatchObject({
+      status: "blocked",
+      stopReason: "run-paused",
+    });
+
+    expect(setRunControl({ project, root, action: "resume" })).toMatchObject({ status: "pass" });
+    expect(setRunControl({ project, root, action: "cancel" })).toMatchObject({ status: "pass" });
+    expect(runPccUntilBlocked({ project, root, maxMilestones: 1, maxMinutes: 10 })).toMatchObject({
+      status: "blocked",
+      stopReason: "run-cancelled",
+    });
+  });
+
+  it("runs until repair, approval, or completion and writes run summaries", () => {
+    const { root, project, pccDir } = initDemo();
+    const first = runPccUntilBlocked({ project, root, maxMilestones: 1, maxMinutes: 10 });
+    expect(first.status).toBe("blocked");
+    expect(first.stopReason).toBe("repair-created");
+    expect(fs.existsSync(path.join(pccDir, "latest-run-summary.md"))).toBe(true);
+    const history = readJson<{ runs: Array<{ stopReason: string }> }>(
+      path.join(pccDir, "run-history.json"),
+    );
+    expect(history.runs.at(-1)?.stopReason).toBe("repair-created");
+
+    passMilestone(root, project, "PCC-001-blueprint");
+    passMilestone(root, project, "PCC-010-level-plan");
+    passMilestone(root, project, "PCC-011-gameplay-plan");
+    const approvalStop = runPccUntilBlocked({ project, root, maxMilestones: 10, maxMinutes: 10 });
+    expect(approvalStop.status).toBe("blocked");
+    expect(approvalStop.stopReason).toBe("approval-required");
+    expect(approvalStop.approvalsRequested).toHaveLength(1);
+
+    const complete = initDemo("complete-demo");
+    for (const id of [
+      "PCC-001-blueprint",
+      "PCC-010-level-plan",
+      "PCC-011-gameplay-plan",
+      "PCC-012-asset-intents",
+      "PCC-013-audio-plan",
+      "PCC-014-hardware-plan",
+      "PCC-020-integration",
+      "PCC-030-rom-build-proof",
+      "PCC-040-runtime-proof",
+      "PCC-050-human-visual-approval",
+      "PCC-060-package-readiness",
+    ]) {
+      passMilestone(complete.root, complete.project, id);
+    }
+    const done = runPccUntilBlocked({
+      project: complete.project,
+      root: complete.root,
+      maxMilestones: 10,
+      maxMinutes: 10,
+    });
+    expect(done).toMatchObject({
+      status: "pass",
+      stopReason: "all-milestones-complete-or-none-ready",
+    });
+  });
+
+  it("dispatches workers with sandbox contracts and guards write surfaces", () => {
+    const { root, project } = initDemo();
+    const dry = dispatchWorker({ project, root, milestoneId: "PCC-001-blueprint", dryRun: true });
+    expect(dry).toMatchObject({ status: "pass", ok: true });
+    expect(dry.dispatch.modelInvoked).toBe(false);
+    expect(dry.sandbox.allowedWriteSurfaces).toContain("blueprint");
+
+    const guardPass = guardWriteSurfaces({
+      beforeFiles: ["docs/reference/snes-studio-workflow.md"],
+      afterFiles: ["docs/reference/snes-studio-workflow.md", "blueprint/receipt.json"],
+      allowedWriteSurfaces: ["blueprint"],
+    });
+    expect(guardPass.status).toBe("pass");
+
+    const guardBlocked = guardWriteSurfaces({
+      beforeFiles: [],
+      afterFiles: ["music-creator-v1/state/private-key.pem"],
+      allowedWriteSurfaces: ["blueprint"],
+    });
+    expect(guardBlocked.status).toBe("blocked");
+    expect(guardBlocked.secretChanges).toHaveLength(1);
+  });
+
+  it("runs local worker adapter, applies schema-valid output, and records telemetry", () => {
+    const { root, project, pccDir } = initDemo();
+    const dispatch = dispatchWorker({
+      project,
+      root,
+      milestoneId: "PCC-001-blueprint",
+      dryRun: false,
+      localOnly: true,
+    });
+    expect(dispatch.status).toBe("pass");
+    expect(dispatch.dispatch.workerOutputPath).toBeTruthy();
+
+    const applied = applyWorkerOutput({
+      project,
+      root,
+      workerOutputPath: dispatch.dispatch.workerOutputPath,
+    });
+    expect(applied.status).toBe("pass");
+    expect(applied.judge.failReasons).toEqual([]);
+    expect(
+      fs.existsSync(path.join(pccDir, "receipts/PCC-001-blueprint-blueprintReceipt.json")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(pccDir, "receipts/PCC-001-blueprint-legalBoundaryReceipt.json")),
+    ).toBe(true);
+
+    const telemetry = pccTelemetry({ project, root });
+    expect(telemetry.status).toBe("pass");
+    expect(telemetry.eventCount).toBeGreaterThan(0);
+  });
+
+  it("updates cache, reviewer receipts, conflicts, memory cards, dashboard, and benchmark", () => {
+    const { root, project } = initDemo();
+    expect(
+      updateArtifactCache({
+        project,
+        root,
+        cacheKey: "asset-check:hero",
+        inputSha: "input-sha",
+        outputPath: "artifacts/hero.json",
+      }),
+    ).toMatchObject({ status: "pass" });
+
+    expect(
+      createReviewerReceipt({
+        project,
+        root,
+        milestoneId: "PCC-001-blueprint",
+        reviewerRole: "domain-reviewer",
+      }),
+    ).toMatchObject({ status: "pass", ok: true });
+
+    expect(
+      resolvePccConflicts({ patches: [{ files: ["a.json"] }, { files: ["b.json"] }] }),
+    ).toMatchObject({ status: "pass" });
+    expect(
+      resolvePccConflicts({ patches: [{ files: ["a.json"] }, { files: ["a.json"] }] }),
+    ).toMatchObject({ status: "blocked" });
+
+    expect(compactMemoryCards({ project, root })).toMatchObject({ status: "pass" });
+    expect(pccDashboardSnapshot({ project, root })).toMatchObject({ status: "pass", ok: true });
+    expect(runRegressionBenchmark({ project, root })).toMatchObject({ status: "pass", ok: true });
+  });
+
+  it("runs live local PCC path through bounded worker dispatch", () => {
+    const { root, project } = initDemo();
+    const live = runLivePcc({
+      project,
+      root,
+      maxMilestones: 1,
+      maxMinutes: 10,
+      maxParallel: 4,
+      localOnly: true,
+    });
+    expect(live.format).toBe("openclaw-snes-pcc-live-run-v1");
+    expect(live.localOnly).toBe(true);
+    expect(live.hostedGlmUsed).toBe(false);
+    expect(live.dispatches[0].status).toBe("pass");
+    expect(live.applications[0].status).toBe("pass");
+    expect(live.completedMilestones).toEqual(["PCC-001-blueprint"]);
+  });
+
+  it("probes local model health with an injected Ollama runner", () => {
+    const { root, project } = initDemo();
+    const fakeSpawn = (command: string) => {
+      if (command === "ollama") {
+        return {
+          status: 0,
+          stdout:
+            "NAME ID SIZE MODIFIED\nopenclaw-control-qwen3-30b-q6-chatfix:latest abc 1GB now\n",
+          stderr: "",
+        } as ReturnType<typeof spawnSync>;
+      }
+      return {
+        status: 0,
+        stdout: apiResponse({ status: "pass", ok: true }),
+        stderr: "",
+      } as ReturnType<typeof spawnSync>;
+    };
+    const health = modelHealth({ project, root, spawn: fakeSpawn, timeoutSeconds: 1 });
+    expect(health.status).toBe("pass");
+    expect(health.downloadsAttempted).toBe(false);
+    expect(health.hostedGlmUsed).toBe(false);
+    expect(health.probes.some((probe) => probe.status === "pass")).toBe(true);
+  });
+
+  it("validates strict worker output and rejects unsafe variants", () => {
+    const valid = validWorkerOutput("demo", "PCC-001-blueprint", "dispatch-1");
+    expect(
+      validateWorkerOutput({
+        output: valid,
+        project: "demo",
+        milestoneId: "PCC-001-blueprint",
+        dispatchId: "dispatch-1",
+        allowedWriteSurfaces: ["blueprint"],
+        requiredProof: [{ name: "blueprintReceipt" }, { name: "legalBoundaryReceipt" }],
+      }),
+    ).toMatchObject({ status: "pass", ok: true });
+
+    expect(
+      parseAndValidateWorkerOutputText({
+        text: "not json",
+        project: "demo",
+        milestoneId: "PCC-001-blueprint",
+      }).errors,
+    ).toContain("invalid-json");
+
+    expect(
+      validateWorkerOutput({
+        output: { ...valid, hostedGlmUsed: true },
+        project: "demo",
+        milestoneId: "PCC-001-blueprint",
+        dispatchId: "dispatch-1",
+        allowedWriteSurfaces: ["blueprint"],
+        requiredProof: [{ name: "blueprintReceipt" }, { name: "legalBoundaryReceipt" }],
+      }).errors,
+    ).toContain("hosted-glm-rejected");
+
+    expect(
+      validateWorkerOutput({
+        output: { ...valid, writes: [{ path: "music-creator-v1/state/private-key.pem" }] },
+        project: "demo",
+        milestoneId: "PCC-001-blueprint",
+        dispatchId: "dispatch-1",
+        allowedWriteSurfaces: ["blueprint"],
+        requiredProof: [{ name: "blueprintReceipt" }, { name: "legalBoundaryReceipt" }],
+      }).errors,
+    ).toContain("secret-like-write:music-creator-v1/state/private-key.pem");
+  });
+
+  it("invokes a real-model path through an injected local Ollama runner", () => {
+    const { root, project, pccDir } = initDemo();
+    let capturedPayload = "";
+    const fakeSpawn = (command: string, args: string[]) => {
+      if (command === "curl") {
+        const dispatchId = dispatchIdFromCurlArgs(args);
+        capturedPayload = args.join(" ");
+        return {
+          status: 0,
+          stdout: apiResponse(validWorkerOutput(project, "PCC-001-blueprint", dispatchId)),
+          stderr: "",
+        } as ReturnType<typeof spawnSync>;
+      }
+      return { status: 1, stdout: "", stderr: "unexpected command" } as ReturnType<
+        typeof spawnSync
+      >;
+    };
+    const dispatch = dispatchWorker({
+      project,
+      root,
+      milestoneId: "PCC-001-blueprint",
+      dryRun: false,
+      localOnly: true,
+      invokeLocalModels: true,
+      spawn: fakeSpawn,
+      timeoutSeconds: 1,
+    });
+    expect(dispatch.status).toBe("pass");
+    expect(dispatch.dispatch.modelInvoked).toBe(true);
+    expect(capturedPayload).toContain("api/generate");
+
+    const applied = applyWorkerOutput({
+      project,
+      root,
+      workerOutputPath: dispatch.dispatch.workerOutputPath,
+    });
+    expect(applied.status).toBe("pass");
+    expect(applied.patch.modelInvoked).toBe(true);
+    expect(
+      fs.existsSync(path.join(pccDir, "receipts/PCC-001-blueprint-blueprintReceipt.json")),
+    ).toBe(true);
+  });
+
+  it("repairs malformed local model output before applying it", () => {
+    const { root, project } = initDemo();
+    let callCount = 0;
+    const fakeSpawn = (_command: string, args: string[]) => {
+      callCount += 1;
+      if (callCount === 1) {
+        return {
+          status: 0,
+          stdout: JSON.stringify({ response: "not json" }),
+          stderr: "",
+        } as ReturnType<typeof spawnSync>;
+      }
+      return {
+        status: 0,
+        stdout: apiResponse(
+          validWorkerOutput(project, "PCC-001-blueprint", dispatchIdFromCurlArgs(args)),
+        ),
+        stderr: "",
+      } as ReturnType<typeof spawnSync>;
+    };
+    const dispatch = dispatchWorker({
+      project,
+      root,
+      milestoneId: "PCC-001-blueprint",
+      dryRun: false,
+      localOnly: true,
+      invokeLocalModels: true,
+      spawn: fakeSpawn,
+      timeoutSeconds: 1,
+    });
+    expect(dispatch.status).toBe("pass");
+    expect(dispatch.dispatch.modelInvocation.attempts).toHaveLength(2);
+    expect(dispatch.dispatch.modelInvocation.attempts[0].status).toBe("fail");
+  });
+
+  it("runs live PCC with real-model flag through injected local model output", () => {
+    const { root, project } = initDemo();
+    const fakeSpawn = (_command: string, args: string[]) =>
+      ({
+        status: 0,
+        stdout: apiResponse(
+          validWorkerOutput(project, "PCC-001-blueprint", dispatchIdFromCurlArgs(args)),
+        ),
+        stderr: "",
+      }) as ReturnType<typeof spawnSync>;
+    const live = runLivePcc({
+      project,
+      root,
+      maxMilestones: 1,
+      maxMinutes: 10,
+      maxParallel: 4,
+      localOnly: true,
+      invokeLocalModels: true,
+      spawn: fakeSpawn,
+      timeoutSeconds: 1,
+    });
+    expect(live.status).toBe("pass");
+    expect(live.invokeLocalModels).toBe(true);
+    expect(live.dispatches[0].dispatch.modelInvoked).toBe(true);
+    expect(live.completedMilestones).toEqual(["PCC-001-blueprint"]);
+  });
+
+  it("validates production asset intent contracts", () => {
+    expect(
+      validateAssetIntentContract({
+        assetId: "hero_walk",
+        kind: "sprite",
+        dimensions: "32x32",
+        frames: 6,
+        paletteLimit: 16,
+        mustShow: ["readable face"],
+        mustNotShow: ["placeholder box"],
+        animationBeats: ["left foot", "right foot"],
+        production: true,
+        runtimeProofRequired: true,
+        humanVisualTarget: 90,
+      }),
+    ).toMatchObject({ status: "pass", ok: true });
+
+    const invalid = validateAssetIntentContract({
+      assetId: "hero_walk",
+      kind: "sprite",
+      frames: 1,
+      paletteLimit: 17,
+      mustShow: [],
+      mustNotShow: [],
+      animationBeats: [],
+      production: true,
+    });
+    expect(invalid.status).toBe("fail");
+    expect(invalid.errors).toContain("missing-dimensions");
+    expect(invalid.errors).toContain("production-runtimeProofRequired-missing");
+  });
+
+  it("exposes CLI JSON modes", () => {
+    const root = tempRoot();
+    const project = "cli-demo";
+    const promptPath = writePrompt(root);
+    const script = path.join(process.cwd(), "scripts/snes-team-orchestrator.mjs");
+    const init = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          script,
+          "--mode",
+          "init",
+          "--project",
+          project,
+          "--prompt",
+          promptPath,
+          "--root",
+          root,
+          "--json",
+        ],
+        {
+          encoding: "utf8",
+        },
+      ),
+    );
+    expect(init.status).toBe("pass");
+    for (const mode of [
+      "status",
+      "next",
+      "validate",
+      "approvals",
+      "telemetry",
+      "dashboard-snapshot",
+      "regression-benchmark",
+    ]) {
+      const report = JSON.parse(
+        execFileSync(
+          process.execPath,
+          [script, "--mode", mode, "--project", project, "--root", root, "--json"],
+          {
+            encoding: "utf8",
+          },
+        ),
+      );
+      expect(report.status).toBe("pass");
+    }
+
+    const runProcess = spawnSync(
+      process.execPath,
+      [
+        script,
+        "--mode",
+        "run",
+        "--project",
+        project,
+        "--root",
+        root,
+        "--max-milestones",
+        "1",
+        "--max-minutes",
+        "10",
+        "--json",
+      ],
+      { encoding: "utf8" },
+    );
+    expect(runProcess.status).toBe(1);
+    const run = JSON.parse(runProcess.stdout);
+    expect(run.status).toBe("blocked");
+
+    const dispatch = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          script,
+          "--mode",
+          "dispatch-worker",
+          "--project",
+          project,
+          "--milestone",
+          "PCC-001-blueprint",
+          "--root",
+          root,
+          "--dry-run",
+          "--json",
+        ],
+        { encoding: "utf8" },
+      ),
+    );
+    expect(dispatch.status).toBe("pass");
+  });
+
+  it("keeps SNES skill orchestration references discoverable", () => {
+    for (const file of [
+      ".agents/skills/snes-game-creator/references/production-orchestration.md",
+      ".agents/skills/snes-game-creator/references/agent-routing.md",
+      ".agents/skills/snes-game-creator/references/proof-gates.md",
+      ".agents/skills/snes-game-creator/references/art-quality-rubric.md",
+      ".agents/skills/snes-game-creator/references/prompt-to-rom-workflow.md",
+    ]) {
+      expect(fs.existsSync(file)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

SNES Studio needed the Project Command Center to move beyond deterministic orchestration scaffolding into safe, local-only real worker execution. Before this PR, PCC could dispatch dry-run worker packets and validate receipts, but it did not prove a real installed local model could be health-checked, invoked, schema-validated, repaired/fallen back, and routed through the patch gate without hosted GLM, commercial SNES material, FXPAK writes, or unrelated repo mutations.

This PR adds the local-only model execution layer for SNES Studio PCC while keeping the existing proof gates intact: strict worker-output schemas, local model health metadata, real invocation receipts, JSON repair/fallback handling, live/resume execution flags, write-surface guards, and updated docs/skill references for the prompt-to-ROM workflow.

## Evidence

Original scoped checkout before clean-branch cherry-pick:
- `pnpm docs:list`
- `pnpm test test/scripts/snes-team-orchestrator.test.ts` (24/24 passed)
- `pnpm snes:team -- --mode model-health --project demo-pcc-v2 --json`
- `pnpm snes:team -- --mode dispatch-worker --project demo-pcc-v2 --milestone PCC-010-level-plan --local-only --invoke-local-models --json`
- `pnpm snes:team -- --mode run-live --project demo-pcc-v2 --local-only --invoke-local-models --max-milestones 1 --max-minutes 480 --max-workers 4 --json`
- `pnpm snes:team -- --mode validate --project demo-pcc-v2 --json`
- `pnpm snes:mastery status --json` (15/15 katas, 17/17 milestones)
- `git diff --check -- scripts package.json test docs .agents/skills/snes-game-creator fixtures`

Clean PR branch proof:
- `git diff --check origin/main..HEAD`
- `git diff --name-only origin/main..HEAD` contains only the 14 SNES/PCC files in this PR

Current follow-up verification:
- PR file scope inspected live: exactly the intended 14 SNES/PCC files
- Original checkout cleaned after PR creation; no unrelated dirty-tree files are included
- Dirty-tree backup was deleted only after explicit approval

Note: dependency-backed `pnpm docs:list` in the isolated clean worktree attempted `pnpm install` and was stopped after npm registry DNS failures (`ENOTFOUND`).

## Summary

- add SNES Studio PCC real local-model execution via local-only Ollama worker dispatch
- add strict worker-output validation, local model health checks, repair/fallback handling, and live/resume execution flags
- document PCC real local model routing and proof gates
