### PR TITLE
fix: gateway avoids duplicate macOS launchd services

### DIFF
--- a/src/cli/daemon-cli/launchd-recovery.test.ts
+++ b/src/cli/daemon-cli/launchd-recovery.test.ts
@@ -89,4 +89,19 @@ describe("recoverInstalledLaunchAgent", () => {
       "requires a logged-in macOS GUI session",
     );
   });
+
+  it("surfaces system LaunchDaemon conflicts instead of falling back to unmanaged restart", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    launchAgentPlistExists.mockResolvedValue(true);
+    repairLaunchAgentBootstrap.mockResolvedValue({
+      ok: false,
+      status: "system-launchdaemon-conflict",
+      detail:
+        "Refusing to install LaunchAgent ai.openclaw.gateway because launchd already has system/ai.openclaw.gateway.",
+    });
+
+    await expect(recoverInstalledLaunchAgent({ result: "restarted" })).rejects.toThrow(
+      "launchd already has system/ai.openclaw.gateway",
+    );
+  });
 });

--- a/src/cli/daemon-cli/launchd-recovery.ts
+++ b/src/cli/daemon-cli/launchd-recovery.ts
@@ -45,6 +45,9 @@ export async function recoverInstalledLaunchAgent(params: {
         }),
       );
     }
+    if (repaired.status === "system-launchdaemon-conflict") {
+      throw new Error(repaired.detail);
+    }
     return null;
   }
   return {

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -575,6 +575,38 @@ describe("recoverInstalledLaunchAgentAfterUpdate", () => {
         "LaunchAgent was installed but not loaded; automatic bootstrap/kickstart recovery failed.",
     });
   });
+
+  it("preserves LaunchAgent recovery error details after update", async () => {
+    const readState = vi.fn(async () => ({
+      installed: true,
+      loaded: false,
+      running: false,
+      env: { OPENCLAW_PROFILE: "stomme" } as NodeJS.ProcessEnv,
+      command: null,
+      runtime: { status: "unknown", missingSupervision: true },
+    }));
+    const recover = vi.fn(async () => {
+      throw new Error(
+        "Refusing to install LaunchAgent ai.openclaw.gateway because launchd already has system/ai.openclaw.gateway.",
+      );
+    });
+
+    await expect(
+      recoverInstalledLaunchAgentAfterUpdate({
+        service: {} as never,
+        deps: {
+          platform: "darwin",
+          readState: readState as never,
+          recover: recover as never,
+        },
+      }),
+    ).resolves.toEqual({
+      attempted: true,
+      recovered: false,
+      detail:
+        "Refusing to install LaunchAgent ai.openclaw.gateway because launchd already has system/ai.openclaw.gateway.",
+    });
+  });
 });
 
 describe("recoverLaunchAgentAndRecheckGatewayHealth", () => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -767,9 +767,16 @@ export async function recoverInstalledLaunchAgentAfterUpdate(params: {
     return { attempted: false, recovered: false };
   }
 
-  const recovered = await recover({ result: "restarted", env: state?.env ?? params.env }).catch(
-    () => null,
-  );
+  let recovered: Awaited<ReturnType<typeof recover>> | null;
+  try {
+    recovered = await recover({ result: "restarted", env: state?.env ?? params.env });
+  } catch (err) {
+    return {
+      attempted: true,
+      recovered: false,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
   if (!recovered) {
     return {
       attempted: true,

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -45,6 +45,7 @@ const state = vi.hoisted(() => ({
   stopCode: 1,
   bootoutError: "",
   bootoutCode: 1,
+  systemServiceLoaded: false,
   serviceLoaded: true,
   serviceRunning: true,
   stopLeavesRunning: false,
@@ -184,6 +185,12 @@ vi.mock("./exec-file.js", () => ({
       return { stdout: state.listOutput, stderr: "", code: 0 };
     }
     if (call[0] === "print") {
+      if (call[1]?.startsWith("system/")) {
+        if (state.systemServiceLoaded) {
+          return { stdout: ["state = running", "pid = 99"].join("\n"), stderr: "", code: 0 };
+        }
+        return { stdout: "", stderr: "Could not find service", code: 113 };
+      }
       if (state.printNotLoadedRemaining > 0) {
         state.printNotLoadedRemaining -= 1;
         return { stdout: "", stderr: "Could not find service", code: 113 };
@@ -315,6 +322,20 @@ vi.mock("node:fs/promises", async () => {
       }
       throw new Error(`ENOENT: no such file or directory, open '${key}'`);
     }),
+    readdir: vi.fn(async (p: string) => {
+      const prefix = `${p.replace(/\/+$/, "")}/`;
+      const entries = new Set<string>();
+      for (const key of [...state.files.keys(), ...state.dirs]) {
+        if (!key.startsWith(prefix)) {
+          continue;
+        }
+        const entry = key.slice(prefix.length).split("/")[0];
+        if (entry) {
+          entries.add(entry);
+        }
+      }
+      return [...entries];
+    }),
     unlink: vi.fn(async (p: string) => {
       state.files.delete(p);
     }),
@@ -349,6 +370,7 @@ beforeEach(() => {
   state.stopCode = 1;
   state.bootoutError = "";
   state.bootoutCode = 1;
+  state.systemServiceLoaded = false;
   state.serviceLoaded = true;
   state.serviceRunning = true;
   state.stopLeavesRunning = false;
@@ -803,6 +825,21 @@ describe("launchd bootstrap repair", () => {
       detail: "launchctl kickstart failed: permission denied",
     });
   });
+
+  it("does not bootstrap repair a LaunchAgent when the same label is loaded as a system LaunchDaemon", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.systemServiceLoaded = true;
+
+    const repair = await repairLaunchAgentBootstrap({ env });
+
+    expect(repair.ok).toBe(false);
+    if (repair.ok) {
+      throw new Error("expected bootstrap repair to fail");
+    }
+    expect(repair.status).toBe("system-launchdaemon-conflict");
+    expect(repair.detail).toContain("launchd already has system/ai.openclaw.gateway");
+    expect(state.launchctlCalls).toEqual([["print", "system/ai.openclaw.gateway"]]);
+  });
 });
 
 describe("launchd install", () => {
@@ -999,6 +1036,75 @@ describe("launchd install", () => {
 
     expect(state.dirs.has(tmpDir)).toBe(true);
     expect(state.dirModes.get(tmpDir)).toBe(0o700);
+  });
+
+  it("refuses to install a user LaunchAgent when the same label is loaded as a system LaunchDaemon", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.systemServiceLoaded = true;
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow("launchd already has system/ai.openclaw.gateway");
+
+    expect(state.launchctlCalls).toEqual([["print", "system/ai.openclaw.gateway"]]);
+    expect(state.files.has(plistPath)).toBe(false);
+    expect(state.fileWrites.some((write) => write.path === plistPath)).toBe(false);
+  });
+
+  it("refuses to install a user LaunchAgent when a system LaunchDaemon plist already exists", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.files.set("/Library/LaunchDaemons/ai.openclaw.gateway.plist", "<plist/>");
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow(
+      "system-domain LaunchDaemon plist already exists at /Library/LaunchDaemons/ai.openclaw.gateway.plist",
+    );
+
+    expect(state.launchctlCalls).toEqual([["print", "system/ai.openclaw.gateway"]]);
+    expect(state.files.has(plistPath)).toBe(false);
+    expect(state.fileWrites.some((write) => write.path === plistPath)).toBe(false);
+  });
+
+  it("refuses to install when a differently named system LaunchDaemon plist declares the same label", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.files.set(
+      "/Library/LaunchDaemons/com.example.operator-managed.plist",
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<plist version="1.0">',
+        "<dict>",
+        "<key>Label</key>",
+        "<string>ai.openclaw.gateway</string>",
+        "</dict>",
+        "</plist>",
+      ].join("\n"),
+    );
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow(
+      "system-domain LaunchDaemon plist already exists at /Library/LaunchDaemons/com.example.operator-managed.plist",
+    );
+
+    expect(state.launchctlCalls).toEqual([["print", "system/ai.openclaw.gateway"]]);
+    expect(state.files.has(plistPath)).toBe(false);
+    expect(state.fileWrites.some((write) => write.path === plistPath)).toBe(false);
   });
 
   it("writes KeepAlive=true policy with shutdown and throttle limits", async () => {
@@ -1546,6 +1652,7 @@ describe("launchd install", () => {
     expect(result).toEqual({ outcome: "completed" });
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(18789);
     expect(state.launchctlCalls).toEqual([
+      ["print", `system/${label}`],
       ["enable", serviceId],
       ["kickstart", "-k", serviceId],
     ]);
@@ -1588,7 +1695,7 @@ describe("launchd install", () => {
     expect(plist).toContain("<key>StandardInPath</key>");
     expect(plist).toContain("<string>/dev/null</string>");
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
-    expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap"]);
+    expect(launchctlCommandNames()).toEqual(["print", "enable", "bootout", "enable", "bootstrap"]);
     expect(launchctlCommandNames()).not.toContain("kickstart");
   });
 
@@ -1626,7 +1733,14 @@ describe("launchd install", () => {
       stdout: new PassThrough(),
     });
 
-    expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap", "print"]);
+    expect(launchctlCommandNames()).toEqual([
+      "print",
+      "enable",
+      "bootout",
+      "enable",
+      "bootstrap",
+      "print",
+    ]);
     expect(launchctlCommandNames()).not.toContain("kickstart");
   });
 
@@ -1780,6 +1894,24 @@ describe("launchd install", () => {
     expect(launchctlCommandNames()).not.toContain("bootout");
   });
 
+  it("blocks restart before normal kickstart when the same label is loaded as a system LaunchDaemon", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.systemServiceLoaded = true;
+
+    await expect(
+      restartLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+      }),
+    ).rejects.toThrow("launchd already has system/ai.openclaw.gateway");
+
+    expect(launchctlCommandNames()).not.toContain("enable");
+    expect(launchctlCommandNames()).not.toContain("kickstart");
+    expect(launchctlCommandNames()).not.toContain("bootstrap");
+    expect(launchctlCommandNames()).not.toContain("bootout");
+    expect(state.launchctlCalls).toEqual([["print", "system/ai.openclaw.gateway"]]);
+  });
+
   it("surfaces the original kickstart failure when the service is still loaded", async () => {
     const env = createDefaultLaunchdEnv();
     state.kickstartError = "Input/output error";
@@ -1830,7 +1962,24 @@ describe("launchd install", () => {
       mode: "kickstart",
       waitForPid: process.pid,
     });
-    expect(state.launchctlCalls).toStrictEqual([]);
+    expect(state.launchctlCalls).toStrictEqual([["print", "system/ai.openclaw.gateway"]]);
+  });
+
+  it("does not schedule in-band restart handoff when the same label is loaded as a system LaunchDaemon", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.systemServiceLoaded = true;
+
+    await expect(
+      withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
+        restartLaunchAgent({
+          env,
+          stdout: new PassThrough(),
+        }),
+      ),
+    ).rejects.toThrow("launchd already has system/ai.openclaw.gateway");
+
+    expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).not.toHaveBeenCalled();
+    expect(state.launchctlCalls).toStrictEqual([["print", "system/ai.openclaw.gateway"]]);
   });
 
   it("hands plist reload off when current LaunchAgent needs rewritten paths", async () => {
@@ -1870,7 +2019,7 @@ describe("launchd install", () => {
       waitForPid: process.pid,
     });
     expect(state.files.get(plistPath)).toContain("/Users/test/Library/Logs/openclaw/gateway.log");
-    expect(state.launchctlCalls).toStrictEqual([]);
+    expect(state.launchctlCalls).toStrictEqual([["print", "system/ai.openclaw.gateway"]]);
   });
 
   it("surfaces detached handoff failures", async () => {
@@ -1915,7 +2064,7 @@ describe("launchd install", () => {
       mode: "kickstart",
       waitForPid: process.pid,
     });
-    expect(state.launchctlCalls).toStrictEqual([]);
+    expect(state.launchctlCalls).toStrictEqual([["print", "system/ai.openclaw.gateway"]]);
   });
 
   it("does not hand restart off for unrelated inherited XPC service names", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -49,6 +49,7 @@ const LAUNCH_AGENT_ENV_FILE_MODE = 0o600;
 const LAUNCH_AGENT_ENV_WRAPPER_MODE = 0o700;
 const LAUNCH_AGENT_ENV_DIR_NAME = "service-env";
 const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
+const LAUNCH_DAEMON_PLIST_DIR = "/Library/LaunchDaemons";
 const OPENCLAW_UPDATE_LAUNCHD_LABEL_PREFIX = "ai.openclaw.update.";
 const OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN = /^ai\.openclaw\.manual-update\.\d+$/;
 const LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS = LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000;
@@ -130,6 +131,10 @@ function resolveLaunchAgentPlistPathForLabel(
 ): string {
   const home = toPosixPath(resolveHomeDir(env));
   return path.posix.join(home, "Library", "LaunchAgents", `${label}.plist`);
+}
+
+function resolveSystemLaunchDaemonPlistPathForLabel(label: string): string {
+  return path.posix.join(LAUNCH_DAEMON_PLIST_DIR, `${label}.plist`);
 }
 
 function resolveLaunchAgentEnvDir(env: GatewayServiceEnv): string {
@@ -489,10 +494,15 @@ function writeLaunchAgentActionLine(
 
 async function bootstrapLaunchAgentOrThrow(params: {
   domain: string;
+  label: string;
   serviceTarget: string;
   plistPath: string;
   actionHint: string;
+  systemConflictAlreadyChecked?: boolean;
 }) {
+  if (!params.systemConflictAlreadyChecked) {
+    await assertNoSystemLaunchDaemonConflict(params.label);
+  }
   // `disable` state survives bootout and plist rewrites; explicit start/repair
   // paths must clear it before asking launchd to load the job again.
   await execLaunchctl(["enable", params.serviceTarget]);
@@ -635,6 +645,7 @@ type LaunchAgentBootstrapRepairResult =
       status: "bootstrap-failed" | "kickstart-failed";
       detail?: string;
     }
+  | { ok: false; status: "system-launchdaemon-conflict"; detail: string }
   | { ok: false; status: "gui-session-unavailable"; detail: string; domain: string };
 
 function isLaunchctlAlreadyLoaded(res: { stdout: string; stderr: string; code: number }): boolean {
@@ -650,6 +661,14 @@ export async function repairLaunchAgentBootstrap(args: {
   const label = resolveLaunchAgentLabel({ env });
   const plistPath = resolveLaunchAgentPlistPath(env);
   const serviceTarget = `${domain}/${label}`;
+  const conflict = await findSystemLaunchDaemonConflict(label);
+  if (conflict) {
+    return {
+      ok: false,
+      status: "system-launchdaemon-conflict",
+      detail: formatSystemLaunchDaemonConflictError(conflict),
+    };
+  }
   await execLaunchctl(["enable", serviceTarget]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   let repairStatus: "repaired" | "already-loaded" = "repaired";
@@ -1004,15 +1023,101 @@ async function activateLaunchAgent(params: { env: GatewayServiceEnv; plistPath: 
   // launchd can persist "disabled" state even after bootout + plist removal; clear it before bootstrap.
   await bootstrapLaunchAgentOrThrow({
     domain,
+    label,
     serviceTarget: `${domain}/${label}`,
     plistPath: params.plistPath,
     actionHint: "openclaw gateway install --force",
+    systemConflictAlreadyChecked: true,
   });
+}
+
+type SystemLaunchDaemonConflict =
+  | {
+      reason: "loaded";
+      label: string;
+      serviceTarget: string;
+      plistPath: string;
+    }
+  | {
+      reason: "plist";
+      label: string;
+      serviceTarget: string;
+      plistPath: string;
+    };
+
+async function findSystemLaunchDaemonConflict(
+  label: string,
+): Promise<SystemLaunchDaemonConflict | null> {
+  const serviceTarget = `system/${label}`;
+  const plistPath = resolveSystemLaunchDaemonPlistPathForLabel(label);
+  const loaded = await execLaunchctl(["print", serviceTarget]);
+  if (loaded.code === 0) {
+    return { reason: "loaded", label, serviceTarget, plistPath };
+  }
+  try {
+    await fs.access(plistPath);
+    return { reason: "plist", label, serviceTarget, plistPath };
+  } catch {
+    // launchd uses the plist's Label key, not the plist filename, as the job
+    // identity. Operator-owned LaunchDaemons can be stored under arbitrary names.
+  }
+  const matchingPlistPath = await findSystemLaunchDaemonPlistPathByLabel(label);
+  if (matchingPlistPath) {
+    return { reason: "plist", label, serviceTarget, plistPath: matchingPlistPath };
+  }
+  return null;
+}
+
+function extractLaunchDaemonPlistLabel(contents: string): string | null {
+  return (
+    contents.match(/<key>\s*Label\s*<\/key>\s*<string>\s*([^<]+?)\s*<\/string>/i)?.[1]?.trim() ??
+    null
+  );
+}
+
+async function findSystemLaunchDaemonPlistPathByLabel(label: string): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(LAUNCH_DAEMON_PLIST_DIR);
+  } catch {
+    return null;
+  }
+  for (const entry of entries.toSorted()) {
+    if (!entry.endsWith(".plist")) {
+      continue;
+    }
+    const candidatePath = path.posix.join(LAUNCH_DAEMON_PLIST_DIR, entry);
+    const contents = await fs.readFile(candidatePath, "utf8").catch(() => null);
+    if (contents !== null && extractLaunchDaemonPlistLabel(contents) === label) {
+      return candidatePath;
+    }
+  }
+  return null;
+}
+
+function formatSystemLaunchDaemonConflictError(conflict: SystemLaunchDaemonConflict): string {
+  const detected =
+    conflict.reason === "loaded"
+      ? `launchd already has ${conflict.serviceTarget}`
+      : `a system-domain LaunchDaemon plist already exists at ${conflict.plistPath}`;
+  return [
+    `Refusing to install LaunchAgent ${conflict.label} because ${detected}.`,
+    "Installing a GUI LaunchAgent with the same label would create duplicate OpenClaw services in different launchd domains.",
+    `Remove or rename the system LaunchDaemon first, for example with \`sudo launchctl bootout ${conflict.serviceTarget}\` and by removing its plist such as \`${conflict.plistPath}\`, or choose a distinct launchd label for this user service when the calling command supports one.`,
+  ].join("\n");
+}
+
+async function assertNoSystemLaunchDaemonConflict(label: string): Promise<void> {
+  const conflict = await findSystemLaunchDaemonConflict(label);
+  if (conflict) {
+    throw new Error(formatSystemLaunchDaemonConflictError(conflict));
+  }
 }
 
 export async function installLaunchAgent(
   args: GatewayServiceInstallArgs,
 ): Promise<{ plistPath: string }> {
+  await assertNoSystemLaunchDaemonConflict(resolveLaunchAgentLabel({ env: args.env }));
   const { plistPath, stdoutPath } = await writeLaunchAgentPlist(args);
   await activateLaunchAgent({ env: args.env, plistPath });
   // `bootstrap` already loads RunAtLoad agents. Avoid `kickstart -k` here:
@@ -1085,6 +1190,7 @@ async function rewriteLaunchAgentPlistForRestart({
 
 async function ensureLaunchAgentLoadedAfterFailure(params: {
   domain: string;
+  label: string;
   serviceTarget: string;
   plistPath: string;
 }): Promise<void> {
@@ -1095,6 +1201,7 @@ async function ensureLaunchAgentLoadedAfterFailure(params: {
   try {
     await bootstrapLaunchAgentOrThrow({
       domain: params.domain,
+      label: params.label,
       serviceTarget: params.serviceTarget,
       plistPath: params.plistPath,
       actionHint: "openclaw gateway start",
@@ -1119,6 +1226,7 @@ export async function restartLaunchAgent({
   // detached handoff. A direct `kickstart -k` would terminate the caller before
   // it can finish the restart command.
   if (isCurrentProcessLaunchdServiceLabel(label)) {
+    await assertNoSystemLaunchDaemonConflict(label);
     const plistReloadNeeded = await rewriteLaunchAgentPlistForRestart({
       env: serviceEnv,
       label,
@@ -1137,6 +1245,8 @@ export async function restartLaunchAgent({
     writeLaunchAgentActionLine(stdout, "Scheduled LaunchAgent restart", serviceTarget);
     return { outcome: "scheduled" };
   }
+
+  await assertNoSystemLaunchDaemonConflict(label);
 
   const cleanupPort = await resolveLaunchAgentGatewayPort(serviceEnv);
   if (cleanupPort !== null) {
@@ -1170,9 +1280,11 @@ export async function restartLaunchAgent({
     }
     await bootstrapLaunchAgentOrThrow({
       domain,
+      label,
       serviceTarget,
       plistPath,
       actionHint: "openclaw gateway restart",
+      systemConflictAlreadyChecked: true,
     });
     writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);
     return { outcome: "completed" };
@@ -1185,13 +1297,14 @@ export async function restartLaunchAgent({
   }
 
   if (!isLaunchctlNotLoaded(start)) {
-    await ensureLaunchAgentLoadedAfterFailure({ domain, serviceTarget, plistPath });
+    await ensureLaunchAgentLoadedAfterFailure({ domain, label, serviceTarget, plistPath });
     throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
   }
 
   // If the service was previously booted out, re-register the rewritten plist and retry.
   await bootstrapLaunchAgentOrThrow({
     domain,
+    label,
     serviceTarget,
     plistPath,
     actionHint: "openclaw gateway restart",


### PR DESCRIPTION
Closes #97178

## What Problem This Solves

Fixes an issue where macOS users installing or restarting the Gateway as a user LaunchAgent could end up with duplicate OpenClaw services when an operator-managed system LaunchDaemon already uses the same launchd label.

## Why This Change Was Made

The LaunchAgent lifecycle now checks the system launchd domain before installing, repairing, bootstrapping, or restarting the user service, including the normal restart kickstart path. It detects both loaded `system/<label>` services and system LaunchDaemon plist files whose `Label` key matches the user LaunchAgent label, then surfaces the conflict through install, recovery, and update flows instead of silently proceeding.

## User Impact

macOS users get an explicit error that tells them to remove, rename, or choose a different label for the system LaunchDaemon before OpenClaw creates or restarts a user LaunchAgent with the same identity. This prevents duplicate gateway services and restart loops across launchd domains.

## Evidence

- `node scripts/run-vitest.mjs run src/daemon/launchd.test.ts` passed 1 Vitest shard in 13.62s.
- `node scripts/run-vitest.mjs run src/daemon/launchd.test.ts src/cli/daemon-cli/launchd-recovery.test.ts src/cli/update-cli/update-command.test.ts` passed 2 Vitest shards in 23.07s.
- `git diff --check` passed.
- Production-function proof below calls the actual patched `installLaunchAgent` and `restartLaunchAgent` implementations from `src/daemon/launchd.ts`.

## Real behavior proof

**Behavior addressed:** Gateway LaunchAgent install and restart refuse to create or restart a user-domain service when launchd already has `system/ai.openclaw.gateway`.

**Environment tested:** Local source checkout on Linux with Node and a temporary `launchctl` executable on `PATH` that reports `system/ai.openclaw.gateway` as loaded.

**Steps run after the patch:** Called the actual `installLaunchAgent`, `restartLaunchAgent`, and `resolveLaunchAgentPlistPath` exports from `src/daemon/launchd.ts` via `node --import tsx --no-warnings -e`, with a temporary HOME and `launchctl` command log.

**Evidence after fix:**

```text
install blocked: true
install first line: Refusing to install LaunchAgent ai.openclaw.gateway because launchd already has system/ai.openclaw.gateway.
restart blocked: true
restart first line: Refusing to install LaunchAgent ai.openclaw.gateway because launchd already has system/ai.openclaw.gateway.
launchctl calls: print system/ai.openclaw.gateway | print system/ai.openclaw.gateway
kickstart called: false
user plist written: false
```

**Observed result after the fix:** Both install and restart reject the same-label system LaunchDaemon before writing the user plist or running `launchctl kickstart`.

**Not tested:** A live macOS LaunchDaemon removal/rename flow and a real GUI LaunchAgent session were not exercised in this Linux checkout.
