### PR TITLE
fix(cron): truncate failure alert error text on UTF-16 boundary

### DIFF
--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -624,8 +624,10 @@ describe("CronService failure alerts", () => {
     expect(typeof alertText).toBe("string");
     if (typeof alertText !== "string") throw new Error("expected failure alert text");
 
-    // Verify no dangling surrogates in the truncated error text
-    for (let i = 0; i < alertText.length - 1; i++) {
+    // Verify no dangling surrogates in the truncated error text.
+    // Must check every character including the last: a dangling high surrogate
+    // at the final position would be missed by stopping at length-1.
+    for (let i = 0; i < alertText.length; i++) {
       const cu = alertText.charCodeAt(i);
       if (cu >= 0xd800 && cu <= 0xdbff) {
         expect(alertText.charCodeAt(i + 1) >= 0xdc00 && alertText.charCodeAt(i + 1) <= 0xdfff).toBe(

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -589,4 +589,60 @@ describe("CronService failure alerts", () => {
     cron.stop();
     await store.cleanup();
   });
+
+  it("truncates failure alert error text on UTF-16 code-point boundary", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    // 209 code units: emoji (surrogate pair) at positions 199-200 straddles the 200-unit boundary
+    const longError = "x".repeat(199) + "🎉" + "trailing";
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: longError,
+    }));
+
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      cronConfig: { failureAlert: { enabled: true, after: 1 } },
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "utf16 boundary job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "ping" },
+      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
+    });
+
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+    const alertText = alertCallArg(sendCronFailureAlert).text;
+    expect(typeof alertText).toBe("string");
+    if (typeof alertText !== "string") throw new Error("expected failure alert text");
+
+    // Verify no dangling surrogates in the truncated error text
+    for (let i = 0; i < alertText.length - 1; i++) {
+      const cu = alertText.charCodeAt(i);
+      if (cu >= 0xd800 && cu <= 0xdbff) {
+        expect(alertText.charCodeAt(i + 1) >= 0xdc00 && alertText.charCodeAt(i + 1) <= 0xdfff).toBe(
+          true,
+        );
+      }
+      if (cu >= 0xdc00 && cu <= 0xdfff) {
+        expect(
+          i > 0 && alertText.charCodeAt(i - 1) >= 0xd800 && alertText.charCodeAt(i - 1) <= 0xdbff,
+        ).toBe(true);
+      }
+    }
+
+    // Verify the emoji was excluded (truncated at the safe boundary before it)
+    expect(alertText).not.toContain("🎉");
+
+    cron.stop();
+    await store.cleanup();
+  });
 });

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -594,7 +594,7 @@ describe("CronService failure alerts", () => {
     const store = await makeStorePath();
     const sendCronFailureAlert = vi.fn(async () => undefined);
     // 209 code units: emoji (surrogate pair) at positions 199-200 straddles the 200-unit boundary
-    const longError = "x".repeat(199) + "🎉" + "trailing";
+    const longError = `${"x".repeat(199)}🎉trailing`;
     const runIsolatedAgentJob = vi.fn(async () => ({
       status: "error" as const,
       error: longError,
@@ -622,7 +622,9 @@ describe("CronService failure alerts", () => {
     expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
     const alertText = alertCallArg(sendCronFailureAlert).text;
     expect(typeof alertText).toBe("string");
-    if (typeof alertText !== "string") throw new Error("expected failure alert text");
+    if (typeof alertText !== "string") {
+      throw new Error("expected failure alert text");
+    }
 
     // Verify no dangling surrogates in the truncated error text.
     // Must check every character including the last: a dangling high surrogate

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -1,6 +1,7 @@
 /** Resolves and emits cron failure-alert notifications. */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
+import { truncateUtf16Safe } from "../../shared/utf16-slice.js";
 import type { CronFailureNotificationDelivery, CronJob, CronMessageChannel } from "../types.js";
 import type { CronServiceState } from "./state.js";
 
@@ -113,7 +114,7 @@ function emitFailureAlert(
   },
 ) {
   const safeJobName = params.job.name || params.job.id;
-  const truncatedError = (params.error?.trim() || "unknown reason").slice(0, 200);
+  const truncatedError = truncateUtf16Safe(params.error?.trim() || "unknown reason", 200);
   const errorReason =
     params.status === "error" && typeof params.error === "string"
       ? (resolveFailoverReasonFromError(params.error, params.provider) ?? undefined)


### PR DESCRIPTION
## Summary
Replace `String.prototype.slice(0, 200)` with `truncateUtf16Safe()` in cron `emitFailureAlert` to prevent broken Unicode from surrogate-pair splitting when error messages contain emoji or non-BMP characters.

## What Problem This Solves
When `emitFailureAlert` in `src/cron/service/failure-alerts.ts:116` truncates an error message for a cron failure notification, it uses `.slice(0, 200)` which can split a UTF-16 surrogate pair in half. The resulting alert text routes through chat channels (as noted by the code comment: "Keep alert bodies compact because they may route through chat channels with notification previews") — where users would see garbled `�` characters.

**Code evidence**: The current code does `(params.error?.trim() || "unknown reason").slice(0, 200)`, operating on UTF-16 code units. Characters outside BMP (emoji, rare CJK, etc.) are encoded as two code units; slicing at an arbitrary index can cut between them.

## Root Cause
- **Introduced by**: commit `9d31cbbd6a` (2026-05-31, refactor: split cron service timer helpers)
- **Violated invariant**: `String.prototype.slice(n)` assumes all characters are single-code-unit BMP characters. Provider error messages can legitimately contain non-BMP characters.
- **Trigger condition**: A cron job failure whose error message contains an emoji at the 200-character truncation boundary. The alert is then delivered to a chat channel with a broken character.

## Why This Fix
- **Chosen approach**: Use the existing `truncateUtf16Safe` utility from `src/shared/utf16-slice.ts` (same utility used by the merged PR #97289 for the same class of bug).
- **Lines changed**: 2 (+import, +call change).

## User Impact
- **Affected**: Cron failure alerts delivered to chat channels (Telegram, Slack, Discord, etc.)
- **Before**: Alert text could end with `�` if the error contained an emoji near the 200-char boundary
- **After**: Alert text is always truncated on a valid code-point boundary

## Evidence

Terminal proof script demonstrating the bug pattern at the 200-code-unit boundary (matching the exact `.slice(0, 200)` in `emitFailureAlert`):

**Before** (`.slice(0, 200)` on a 201-code-unit error with emoji at boundary):
- Truncated length: 200 code units
- **FAIL**: Dangling surrogate detected — the emoji surrogate pair was split in half

**After** (`truncateUtf16Safe` at the same boundary):
- Truncated length: 199 code units (safe boundary)
- **PASS**: No dangling surrogate

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof.mjs
=== PROOF: UTF-16 safe truncation in cron failure alerts ===

Input length: 201 UTF-16 code units
Input ends with emoji: true

=== BEFORE (main, .slice(0, 200)) ===
Truncated length: 200
FAIL: Dangling surrogate detected — truncation split the emoji surrogate pair.
Cron failure alerts sent to chat channels would contain garbled characters.

=== AFTER (fix, truncateUtf16Safe) ===
Truncated length: 199
PASS: No dangling surrogate — truncation is UTF-16 safe.
```

### After (with fix)
```bash
$ node --import tsx proof.mjs
=== PROOF: UTF-16 safe truncation in cron failure alerts ===

Input length: 201 UTF-16 code units
Input ends with emoji: true

=== BEFORE (main, .slice(0, 200)) ===
Truncated length: 200
FAIL: Dangling surrogate detected — truncation split the emoji surrogate pair.

=== AFTER (fix, truncateUtf16Safe) ===
Truncated length: 199
PASS: No dangling surrogate — truncation is UTF-16 safe.
```

## Tests and Validation
- `pnpm check` passed
- TypeScript compilation verified
- Manual proof script confirms the fix prevents surrogate-pair splitting
