### PR TITLE
fix(auto-reply): truncate user-facing text on UTF-16 boundary

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -87,6 +87,7 @@ import { CommandLaneClearedError, GatewayDrainingError } from "../../process/com
 import { CommandLane } from "../../process/lanes.js";
 import { defaultRuntime } from "../../runtime.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
+import { truncateUtf16Safe } from "../../shared/utf16-slice.js";
 import {
   isMarkdownCapableMessageChannel,
   resolveMessageChannel,
@@ -753,7 +754,7 @@ function extractCodexUsageLimitMessage(text: string): string | undefined {
   if (!message) {
     return undefined;
   }
-  return message.length > 500 ? `${message.slice(0, 497)}...` : message;
+  return message.length > 500 ? `${truncateUtf16Safe(message, 497)}...` : message;
 }
 
 function isPureTransientRateLimitSummary(err: unknown): boolean {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -95,6 +95,7 @@ import { isAcpSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveSilentReplyPolicyFromPolicies } from "../../shared/silent-reply-policy.js";
+import { truncateUtf16Safe } from "../../shared/utf16-slice.js";
 import { createTtsDirectiveTextStreamCleaner } from "../../tts/directives.js";
 import {
   normalizeTtsAutoMode,
@@ -2565,7 +2566,7 @@ export async function dispatchReplyFromConfig(
       if (collapsed.length <= 80) {
         return collapsed;
       }
-      return `${collapsed.slice(0, 77).trimEnd()}...`;
+      return `${truncateUtf16Safe(collapsed, 77).trimEnd()}...`;
     };
     const formatPlanUpdateText = (payload: { explanation?: string; steps?: string[] }) => {
       const explanation = payload.explanation?.replace(/\s+/g, " ").trim();


### PR DESCRIPTION
## Summary
Replace `String.prototype.slice(0, N)` with `truncateUtf16Safe()` in two auto-reply text truncation paths — agent-runner message preview (497 chars) and plan working label (77 chars) — to prevent broken Unicode when non-BMP characters straddle the truncation boundary.

## What Problem This Solves
Two user-facing text truncation paths in `src/auto-reply/reply/` use raw `.slice(0, N)` which can split UTF-16 surrogate pairs:

1. **agent-runner-execution.ts:756** — Agent message preview truncated to 497 chars: `message.slice(0, 497)`
2. **dispatch-from-config.ts:2568** — Plan "working label" truncated to 77 chars: `collapsed.slice(0, 77)`

Both produce dangling surrogates when an emoji or non-BMP CJK character falls at the truncation boundary, displaying garbled `�` to users in chat channels.

## Root Cause
- `String.prototype.slice()` operates on UTF-16 code units, not Unicode code points
- Non-BMP characters (emoji, rare CJK, etc.) use 2 code units (surrogate pairs)
- Slicing at an arbitrary index can cut between the high and low surrogate

## Why This Fix
- **Chosen approach**: Use the existing `truncateUtf16Safe` utility from `src/shared/utf16-slice.ts` (same utility used by sibling PRs #97289 and #97298)
- **Lines changed**: +4 −2 across 2 files

## User Impact
- **Affected**: Agent-runner message previews and plan status labels displayed in chat channels (Telegram, Slack, Discord, etc.)
- **Before**: Text could end with `�` when containing emoji near the truncation boundary
- **After**: Text always truncated on valid code-point boundaries

## Evidence

Terminal proof testing both boundaries (497-char and 77-char) with emoji straddling the cutoff:

**Before** (`.slice(0, N)`): Both boundaries produce dangling surrogates — FAIL
**After** (`truncateUtf16Safe`): Both boundaries truncate safely — PASS

## Real Behavior Proof

```bash
$ node --import tsx proof.mjs
=== Test 1: 497-char boundary (agent-runner message) ===
Input length: 498

BEFORE .slice(0, 497): length = 497 | dangling = FAIL
AFTER  truncateUtf16Safe:  length = 496 | dangling = PASS

=== Test 2: 77-char boundary (plan working label) ===
Input length: 78

BEFORE .slice(0, 77): length = 77 | dangling = FAIL
AFTER  truncateUtf16Safe:  length = 76 | dangling = PASS

=== SUMMARY ===
Before (main): FAIL — dangling surrogates detected
After (fix):   PASS — all truncations UTF-16 safe
```

## Tests and Validation
- `pnpm check` passed
- TypeScript compilation verified
- Manual proof script confirms both boundaries are fixed
