### PR TITLE
fix(memory-core): recover primary embedding provider after fallback latch (#96534)

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2075,10 +2075,12 @@ describe("memory index", () => {
     // 30s, but first attempt always allowed), reloads the primary, pings it,
     // and restores it. Manager state must reflect primary restored.
     const callsBeforeRecoverySearch = providerCalls.length;
-    await manager.search("alpha");
+    const recoveredResults = await manager.search("alpha");
 
     // Recovery restored the primary: provider id flipped back to "mock" and
     // fallbackFrom cleared.
+    expect(recoveredResults.length).toBeGreaterThan(0);
+    expect(recoveredResults[0]?.path).toContain("memory/2026-01-12.md");
     expect(fields.provider.id).toBe("mock");
     expect(fields.fallbackFrom).toBeUndefined();
     // Recovery reloaded the primary via loadProviderResult, which registered

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -370,6 +370,7 @@ describe("memory index", () => {
     minScore?: number;
     onSearch?: boolean;
     hybrid?: { enabled: boolean; vectorWeight?: number; textWeight?: number };
+    embeddingBatchTimeoutSeconds?: number;
   }): TestCfg {
     return {
       agents: {
@@ -383,7 +384,14 @@ describe("memory index", () => {
             store: { vector: { enabled: params.vectorEnabled ?? false } },
             // Perf: keep test indexes to a single chunk to reduce sqlite work.
             chunking: { tokens: 4000, overlap: 0 },
-            sync: { watch: false, onSessionStart: false, onSearch: params.onSearch ?? true },
+            sync: {
+              watch: false,
+              onSessionStart: false,
+              onSearch: params.onSearch ?? true,
+              ...(params.embeddingBatchTimeoutSeconds !== undefined
+                ? { embeddingBatchTimeoutSeconds: params.embeddingBatchTimeoutSeconds }
+                : {}),
+            },
             remote: params.batchEnabled
               ? {
                   nonBatchConcurrency: 1,

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2001,17 +2001,14 @@ describe("memory index", () => {
 
     const results = await manager.search("alpha");
 
-    expect(results).toStrictEqual([]);
+    // Fallback must be activated during the search flow (probe-time
+    // degradation triggers fallback). Search itself either returns []
+    // when the index identity is still mismatched, or returns results
+    // after primary-provider recovery restores the originally-indexed
+    // provider (see issue #96534); both are acceptable post-fix outcomes.
     expect(providerCalls.slice(callsBeforeSearch).map((call) => call.provider)).toContain(
       "fallback-provider",
     );
-    expect(
-      (
-        manager as unknown as {
-          provider: { id: string } | null;
-        }
-      ).provider?.id,
-    ).toBe("fallback-provider");
   });
 
   it("clears identity dirty after status resolves the indexed fallback provider", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1999,7 +1999,7 @@ describe("memory index", () => {
       error: expect.stringContaining("Local embedding worker exited"),
     });
 
-    const results = await manager.search("alpha");
+    await manager.search("alpha");
 
     // Fallback must be activated during the search flow (probe-time
     // degradation triggers fallback). Search itself either returns []

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2019,6 +2019,73 @@ describe("memory index", () => {
     );
   });
 
+  it("recovers primary provider on next search after fallback activation (issue #96534)", async () => {
+    // End-to-end regression proof for the recovery flow:
+    //   1. Working primary indexes content
+    //   2. Primary fails -> search activates fallback (latch bug pre-fix)
+    //   3. Primary recovers -> next search auto-restores primary
+    // The test infrastructure's createEmbeddingProvider mock returns a working
+    // primary on every call, so the recovery ping always succeeds here.
+    const cfg = createCfg({
+      fallback: "fallback-provider",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+
+    // Step 1: index content with the primary provider.
+    await manager.sync({ reason: "test" });
+    const initialStatus = manager.status();
+    expect(initialStatus.provider).toBe("mock");
+    expect(initialStatus.dirty).toBe(false);
+
+    // Step 2: simulate primary failure by replacing the live provider with
+    // a failing one, then trigger search to activate fallback.
+    const fields = manager as unknown as {
+      fallbackFrom: string | undefined;
+      provider: {
+        id: string;
+        model: string;
+        embedQuery: (text: string) => Promise<number[]>;
+        embedBatch: (texts: string[]) => Promise<number[][]>;
+        close: () => Promise<void>;
+      };
+    };
+    fields.provider = {
+      id: "mock",
+      model: "mock-embed",
+      embedQuery: async () => {
+        throw createLocalWorkerExitError();
+      },
+      embedBatch: async () => {
+        throw createLocalWorkerExitError();
+      },
+      close: async () => {},
+    };
+    const callsBeforeFallbackSearch = providerCalls.length;
+    await manager.search("alpha");
+
+    // Fallback activated: provider id flipped to fallback-provider, fallbackFrom set.
+    expect(fields.provider.id).toBe("fallback-provider");
+    expect(fields.fallbackFrom).toBeTruthy();
+    expect(providerCalls.slice(callsBeforeFallbackSearch).map((c) => c.provider)).toContain(
+      "fallback-provider",
+    );
+
+    // Step 3: trigger another search. The recovery probe runs (throttled to
+    // 30s, but first attempt always allowed), reloads the primary, pings it,
+    // and restores it. Manager state must reflect primary restored.
+    const callsBeforeRecoverySearch = providerCalls.length;
+    await manager.search("alpha");
+
+    // Recovery restored the primary: provider id flipped back to "mock" and
+    // fallbackFrom cleared.
+    expect(fields.provider.id).toBe("mock");
+    expect(fields.fallbackFrom).toBeUndefined();
+    // Recovery reloaded the primary via loadProviderResult, which registered
+    // a fresh createEmbeddingProvider call beyond the fallback activation.
+    expect(providerCalls.length).toBeGreaterThan(callsBeforeRecoverySearch);
+  });
+
   it("clears identity dirty after status resolves the indexed fallback provider", async () => {
     const indexedCfg = createCfg({
       provider: "fallback-provider",

--- a/extensions/memory-core/src/memory/manager-provider-state.ts
+++ b/extensions/memory-core/src/memory/manager-provider-state.ts
@@ -106,6 +106,33 @@ export function resolveFallbackCurrentProviderId(params: {
   return null;
 }
 
+/**
+ * Decides whether to attempt restoring the primary embedding provider given
+ * that fallback is currently active. Throttles attempts so a latched fallback
+ * does not produce a network probe on every search call. See issue #96534.
+ *
+ * `lastAttemptMs: 0` is treated as "never attempted", so the first recovery
+ * check after fallback activation is always allowed.
+ */
+export function shouldAttemptPrimaryProviderRecovery(params: {
+  fallbackFrom: string | undefined;
+  lastAttemptMs: number;
+  nowMs: number;
+  throttleMs: number;
+  force?: boolean;
+}): boolean {
+  if (!params.fallbackFrom) {
+    return false;
+  }
+  if (params.force) {
+    return true;
+  }
+  if (params.lastAttemptMs === 0) {
+    return true;
+  }
+  return params.nowMs - params.lastAttemptMs >= params.throttleMs;
+}
+
 export function resolveMemoryPrimaryProviderRequest(params: {
   settings: ResolvedMemorySearchConfig;
 }): {

--- a/extensions/memory-core/src/memory/manager.mistral-provider.test.ts
+++ b/extensions/memory-core/src/memory/manager.mistral-provider.test.ts
@@ -9,6 +9,7 @@ import {
   resolveMemoryFallbackProviderRequest,
   resolveMemoryPrimaryProviderRequest,
   resolveMemoryProviderState,
+  shouldAttemptPrimaryProviderRecovery,
 } from "./manager-provider-state.js";
 
 const DEFAULT_OLLAMA_EMBEDDING_MODEL = "nomic-embed-text";
@@ -206,5 +207,60 @@ describe("memory manager mistral provider wiring", () => {
     expect(fallbackRequest.provider).toBe("lmstudio");
     expect(fallbackRequest.model).toBe(DEFAULT_LMSTUDIO_EMBEDDING_MODEL);
     expect(fallbackRequest.fallback).toBe("none");
+  });
+});
+
+describe("memory manager primary provider recovery throttle", () => {
+  it("skips recovery when no fallback is active", () => {
+    expect(
+      shouldAttemptPrimaryProviderRecovery({
+        fallbackFrom: undefined,
+        lastAttemptMs: 0,
+        nowMs: 60_000,
+        throttleMs: 30_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows recovery on the first attempt after fallback activates", () => {
+    expect(
+      shouldAttemptPrimaryProviderRecovery({
+        fallbackFrom: "ollama",
+        lastAttemptMs: 0,
+        nowMs: 1_000,
+        throttleMs: 30_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("throttles repeated recovery attempts within the probe window", () => {
+    expect(
+      shouldAttemptPrimaryProviderRecovery({
+        fallbackFrom: "ollama",
+        lastAttemptMs: 10_000,
+        nowMs: 40_001,
+        throttleMs: 30_000,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAttemptPrimaryProviderRecovery({
+        fallbackFrom: "ollama",
+        lastAttemptMs: 10_000,
+        nowMs: 39_999,
+        throttleMs: 30_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("forces recovery regardless of throttle when force is set", () => {
+    expect(
+      shouldAttemptPrimaryProviderRecovery({
+        fallbackFrom: "ollama",
+        lastAttemptMs: 10_000,
+        nowMs: 10_001,
+        throttleMs: 30_000,
+        force: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -53,6 +53,7 @@ import {
   createPendingMemoryProviderLifecycle,
   resolveMemoryPrimaryProviderRequest,
   resolveMemoryProviderState,
+  shouldAttemptPrimaryProviderRecovery,
   type MemoryProviderLifecycleState,
 } from "./manager-provider-state.js";
 import type { MemoryIndexIdentityState } from "./manager-reindex-state.js";
@@ -241,6 +242,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private providerInitialized = false;
   protected override fallbackFrom?: EmbeddingProviderId;
   protected override fallbackReason?: string;
+  // Throttles primary-provider recovery attempts so a latched fallback does
+  // not bring the network path back online every search call. Without this,
+  // a transient remote outage permanently downgrades the in-gateway tool even
+  // after the primary is reachable again (only a full process restart clears
+  // the latch). See issue #96534.
+  private lastPrimaryRecoveryAttemptMs = 0;
   protected providerUnavailableReason?: string;
   protected override providerLifecycle: MemoryProviderLifecycleState;
   protected override providerRuntime?: EmbeddingProviderRuntime;
@@ -500,6 +507,70 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.providerLifecycle = createPendingMemoryProviderLifecycle(this.requestedProvider);
   }
 
+  /**
+   * Attempts to restore the configured primary embedding provider after a
+   * fallback was activated. Returns true when the primary is reachable again
+   * and the manager has switched back.
+   *
+   * Without this, a single transient outage permanently latches the in-gateway
+   * memory tool onto the fallback provider (see issue #96534): the index is
+   * keyed by the original model identity, so subsequent searches fail with
+   * "index was built for model X, expected Y" until the gateway process is
+   * fully restarted. SIGUSR1 in-process restarts and config soft-reloads do
+   * not clear the latch because the singleton manager instance is reused.
+   */
+  private async attemptPrimaryProviderRecovery(params: { force?: boolean }): Promise<boolean> {
+    const nowMs = Date.now();
+    if (
+      !shouldAttemptPrimaryProviderRecovery({
+        fallbackFrom: this.fallbackFrom,
+        lastAttemptMs: this.lastPrimaryRecoveryAttemptMs,
+        nowMs,
+        throttleMs: EMBEDDING_PROBE_CACHE_TTL_MS,
+        force: params.force,
+      })
+    ) {
+      return false;
+    }
+    this.lastPrimaryRecoveryAttemptMs = nowMs;
+    try {
+      const primaryResult = await MemoryIndexManager.loadProviderResult({
+        cfg: this.cfg,
+        agentId: this.agentId,
+        settings: this.settings,
+      });
+      if (!primaryResult.provider || primaryResult.fallbackFrom) {
+        return false;
+      }
+      // Probe the freshly-built primary with a ping before adopting it so a
+      // provider that resolved but cannot reach its backend does not evict a
+      // working fallback.
+      await primaryResult.provider.embedBatch(["ping"]);
+      const previousProvider = this.provider;
+      this.applyProviderResult(primaryResult);
+      this.providerKey = this.computeProviderKey();
+      this.batch = this.resolveBatchConfig();
+      this.lastPrimaryRecoveryAttemptMs = 0;
+      if (previousProvider && previousProvider !== this.provider) {
+        void Promise.resolve(previousProvider.close?.()).catch((err: unknown) => {
+          log.debug(
+            `memory embeddings: failed to close fallback provider during recovery: ${String(err)}`,
+          );
+        });
+      }
+      EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
+      log.info(
+        `memory embeddings: recovered primary provider (${primaryResult.provider.id}) from fallback`,
+      );
+      return true;
+    } catch (err) {
+      log.debug(
+        `memory embeddings: primary recovery attempted but failed: ${formatErrorMessage(err)}`,
+      );
+      return false;
+    }
+  }
+
   protected markLocalEmbeddingProviderDegraded(err: unknown): void {
     if (this.provider?.id !== "local") {
       return;
@@ -664,9 +735,25 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         });
       }
     }
-    const indexIdentity = this.refreshIndexIdentityDirty({
+    let indexIdentity = this.refreshIndexIdentityDirty({
       providerKeyKnown: this.providerInitialized,
     });
+    // If we latched onto the fallback and the on-disk index no longer matches
+    // the active provider, try restoring the primary before giving up. This
+    // clears the "transient remote outage permanently pins the tool to a
+    // fallback" state from issue #96534. Skipped when the index is already
+    // valid for the fallback (e.g. an explicit identity repair rebuilt it).
+    if (this.fallbackFrom && indexIdentity.status !== "valid" && !opts?.signal?.aborted) {
+      const recovered = await this.attemptPrimaryProviderRecovery({}).catch((err: unknown) => {
+        log.debug(`memory search: primary provider recovery failed: ${formatErrorMessage(err)}`);
+        return false;
+      });
+      if (recovered) {
+        indexIdentity = this.refreshIndexIdentityDirty({
+          providerKeyKnown: this.providerInitialized,
+        });
+      }
+    }
     if (indexIdentity.status !== "valid") {
       return [];
     }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -46,7 +46,11 @@ import {
   resolveSingletonManagedCache,
 } from "./manager-cache.js";
 import { closeMemoryDatabase } from "./manager-db.js";
-import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
+import {
+  MemoryManagerEmbeddingOps,
+  resolveEmbeddingTimeoutMs,
+  runEmbeddingOperationWithTimeout,
+} from "./manager-embedding-ops.js";
 import { isLocalEmbeddingWorkerFailure } from "./manager-local-worker-errors.js";
 import {
   createDegradedMemoryProviderLifecycle,
@@ -519,7 +523,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
    * fully restarted. SIGUSR1 in-process restarts and config soft-reloads do
    * not clear the latch because the singleton manager instance is reused.
    */
-  private async attemptPrimaryProviderRecovery(params: { force?: boolean }): Promise<boolean> {
+  private async attemptPrimaryProviderRecovery(params: {
+    force?: boolean;
+    signal?: AbortSignal;
+  }): Promise<boolean> {
     const nowMs = Date.now();
     if (
       !shouldAttemptPrimaryProviderRecovery({
@@ -563,8 +570,28 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       pendingProvider = primaryResult.provider;
       // Probe the freshly-built primary with a ping before adopting it so a
       // provider that resolved but cannot reach its backend does not evict a
-      // working fallback.
-      await primaryResult.provider.embedBatch(["ping"]);
+      // working fallback. Bound the probe with the same batch timeout the
+      // index path uses and the caller's cancellation signal so a slow or
+      // hung recovered primary cannot stall the user search that triggered
+      // recovery.
+      const pingProvider = primaryResult.provider;
+      const pingRuntime = primaryResult.runtime;
+      const pingTimeoutMs = resolveEmbeddingTimeoutMs({
+        kind: "batch",
+        providerId: pingProvider.id,
+        providerRuntime: pingRuntime
+          ? {
+              inlineQueryTimeoutMs: pingRuntime.inlineQueryTimeoutMs,
+              inlineBatchTimeoutMs: pingRuntime.inlineBatchTimeoutMs,
+            }
+          : undefined,
+      });
+      await runEmbeddingOperationWithTimeout({
+        timeoutMs: pingTimeoutMs,
+        message: `memory embeddings recovery ping timed out after ${Math.round(pingTimeoutMs / 1000)}s`,
+        signal: params.signal,
+        run: async (signal) => await pingProvider.embedBatch(["ping"], { signal }),
+      });
       const previousProvider = this.provider;
       this.applyProviderResult(primaryResult);
       this.providerKey = this.computeProviderKey();
@@ -766,7 +793,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     // fallback" state from issue #96534. Skipped when the index is already
     // valid for the fallback (e.g. an explicit identity repair rebuilt it).
     if (this.fallbackFrom && indexIdentity.status !== "valid" && !opts?.signal?.aborted) {
-      const recovered = await this.attemptPrimaryProviderRecovery({}).catch((err: unknown) => {
+      const recovered = await this.attemptPrimaryProviderRecovery({
+        signal: opts?.signal,
+      }).catch((err: unknown) => {
         log.debug(`memory search: primary provider recovery failed: ${formatErrorMessage(err)}`);
         return false;
       });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -585,6 +585,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
               inlineBatchTimeoutMs: pingRuntime.inlineBatchTimeoutMs,
             }
           : undefined,
+        // Honor the operator-configured inline batch timeout for the recovery
+        // probe, matching the normal batch embedding path. Otherwise operators
+        // who shortened `sync.embeddingBatchTimeoutSeconds` to bound user-facing
+        // search latency would see recovery wait on provider/runtime defaults.
+        configuredBatchTimeoutSeconds: this.settings.sync.embeddingBatchTimeoutSeconds,
       });
       await runEmbeddingOperationWithTimeout({
         timeoutMs: pingTimeoutMs,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -533,6 +533,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return false;
     }
     this.lastPrimaryRecoveryAttemptMs = nowMs;
+    // Track a freshly-loaded provider that this attempt has not yet adopted
+    // into manager state. Closed on any failure path so a sustained primary
+    // outage does not leak a fresh worker each throttle window.
+    let pendingProvider: EmbeddingProvider | null = null;
+    const discardPending = (label: string): void => {
+      const provider = pendingProvider;
+      pendingProvider = null;
+      if (provider && provider !== this.provider) {
+        void Promise.resolve(provider.close?.()).catch((err: unknown) => {
+          log.debug(`memory embeddings: failed to close ${label}: ${String(err)}`);
+        });
+      }
+    };
     try {
       const primaryResult = await MemoryIndexManager.loadProviderResult({
         cfg: this.cfg,
@@ -540,21 +553,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         settings: this.settings,
       });
       if (!primaryResult.provider || primaryResult.fallbackFrom) {
-        // Primary is still unavailable and loadProviderResult may have
-        // instantiated the configured fallback to probe it. Close that
-        // discarded provider so a sustained outage does not leak a fresh
-        // fallback worker on every throttle window. Skip when the returned
-        // provider is the one this manager already holds.
-        const discarded = primaryResult.provider;
-        if (discarded && discarded !== this.provider) {
-          void Promise.resolve(discarded.close?.()).catch((err: unknown) => {
-            log.debug(
-              `memory embeddings: failed to close discarded recovery probe: ${String(err)}`,
-            );
-          });
-        }
+        // Primary still unavailable; loadProviderResult may have instantiated
+        // the configured fallback to probe it. Close the discarded provider
+        // unless it is the one this manager already holds.
+        pendingProvider = primaryResult.provider;
+        discardPending("discarded recovery probe");
         return false;
       }
+      pendingProvider = primaryResult.provider;
       // Probe the freshly-built primary with a ping before adopting it so a
       // provider that resolved but cannot reach its backend does not evict a
       // working fallback.
@@ -564,6 +570,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.providerKey = this.computeProviderKey();
       this.batch = this.resolveBatchConfig();
       this.lastPrimaryRecoveryAttemptMs = 0;
+      // Ownership of pendingProvider transferred to this.provider.
+      pendingProvider = null;
       if (previousProvider && previousProvider !== this.provider) {
         void Promise.resolve(previousProvider.close?.()).catch((err: unknown) => {
           log.debug(
@@ -577,6 +585,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       );
       return true;
     } catch (err) {
+      discardPending("failed recovery probe");
       log.debug(
         `memory embeddings: primary recovery attempted but failed: ${formatErrorMessage(err)}`,
       );

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -540,6 +540,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         settings: this.settings,
       });
       if (!primaryResult.provider || primaryResult.fallbackFrom) {
+        // Primary is still unavailable and loadProviderResult may have
+        // instantiated the configured fallback to probe it. Close that
+        // discarded provider so a sustained outage does not leak a fresh
+        // fallback worker on every throttle window. Skip when the returned
+        // provider is the one this manager already holds.
+        const discarded = primaryResult.provider;
+        if (discarded && discarded !== this.provider) {
+          void Promise.resolve(discarded.close?.()).catch((err: unknown) => {
+            log.debug(
+              `memory embeddings: failed to close discarded recovery probe: ${String(err)}`,
+            );
+          });
+        }
         return false;
       }
       // Probe the freshly-built primary with a ping before adopting it so a


### PR DESCRIPTION
## What Problem This Solves

Closes #96534.

When `agents.defaults.memorySearch` runs a remote primary embedding provider with `fallback: "local"`, a transient remote outage activates the fallback — and the in-gateway `memory_search` tool then **permanently latches** onto that fallback. Because the on-disk vector index is keyed by the original primary model identity, every subsequent search fails with `index was built for model <remote>, expected <local>` until the gateway process is fully restarted. SIGUSR1 in-process restarts and config soft-reloads do not clear the latch, because the singleton manager instance is reused.

## Why This Change Was Made

The latch is the actual user-visible bug, not the fallback activation itself. Today the recovery story is "restart the whole gateway", which is exactly what #96534 reports.

This change adds a throttled primary-provider recovery probe on the search path:

- A new pure helper `shouldAttemptPrimaryProviderRecovery` decides whether to probe, gated by `EMBEDDING_PROBE_CACHE_TTL_MS` (30s) so the network path runs at most once per window — not on every search call.
- `MemoryIndexManager.attemptPrimaryProviderRecovery` reloads the configured primary, pings it with `embedBatch(["ping"])`, and only swaps it back in when the ping succeeds. On success it closes the previous fallback provider and clears the embedding-probe cache so the next sync reuses the restored primary.
- The search path runs recovery **only when** `fallbackFrom` is set **and** the current index identity is mismatched (`status !== "valid"`). An explicit identity repair that already rebuilt the index for the fallback is left alone, so we don't trade one bad state for another.

Recovery is best-effort: any probe failure is swallowed at debug log level and search continues against the fallback (which is the same behavior as before, just no longer permanent).

## User Impact

Operators running `memorySearch` with a remote primary + `fallback: "local"` recover automatically once the remote embedding provider is reachable again. No gateway restart needed. The change is internal to memory-core; no config, CLI, or persisted-state shape changes.

## Evidence

- `pnpm tsgo:extensions` — green.
- `pnpm test extensions/memory-core/src/memory/manager.mistral-provider.test.ts` — 11 passed (4 new throttle-helper cases: skip when no fallback, allow first attempt, respect throttle window, force bypass).
- `pnpm test extensions/memory-core/src/memory/index.test.ts` — 54 passed. The `rebuilds with fallback provider during explicit identity repair` test guards against over-eager recovery (index already valid for fallback → no recovery); the `activates configured fallback after probe-time local degradation` test was relaxed because its old assertions (`results = []`, `provider.id = "fallback-provider"`) were asserting the latch this PR removes.
