### PR TITLE
feat(edit): show closest candidate lines on oldText mismatch (#97032)

### DIFF
--- a/src/agents/sessions/tools/edit-diff.closest-lines.test.ts
+++ b/src/agents/sessions/tools/edit-diff.closest-lines.test.ts
@@ -1,0 +1,48 @@
+// Unit tests for the closest-line diagnostics used to explain edit-tool mismatches.
+import { describe, expect, it } from "vitest";
+import { describeClosestLines, findClosestLines } from "./edit-diff.js";
+
+describe("findClosestLines", () => {
+  it("flags a whitespace-only (indentation) difference as the closest line", () => {
+    const content = "function f() {\n        return foo();\n}\n";
+    const [closest] = findClosestLines(content, "    return foo();");
+    expect(closest).toMatchObject({
+      lineNumber: 2,
+      distance: 0,
+      note: "indentation differs: expected 4 spaces, found 8 spaces",
+    });
+  });
+
+  it("surfaces a near-miss content difference (escaped vs literal)", () => {
+    const content = "const re = /\\b/;\nconst other = 1;\n";
+    const [closest] = findClosestLines(content, "const re = /\b/;");
+    expect(closest.lineNumber).toBe(1);
+    expect(closest.distance).toBeGreaterThan(0);
+    expect(closest.note).toBe("content differs");
+  });
+
+  it("returns nothing when no line is reasonably close", () => {
+    expect(findClosestLines("actual current content", "missing")).toEqual([]);
+  });
+
+  it("ignores blank lines and respects the candidate cap", () => {
+    const content = "return x;\n\n\nreturn x;\nreturn x;\nreturn x;\n";
+    const result = findClosestLines(content, "  return x;", 2);
+    expect(result).toHaveLength(2);
+    expect(result.every((c) => c.text.trim().length > 0)).toBe(true);
+  });
+
+  it("describes tab indentation distinctly from spaces", () => {
+    const [closest] = findClosestLines("\t\treturn foo();\n", "    return foo();");
+    expect(closest.note).toBe("indentation differs: expected 4 spaces, found 2 tabs");
+  });
+});
+
+describe("describeClosestLines", () => {
+  it("JSON-escapes candidate text so whitespace is visible, or returns empty", () => {
+    const block = describeClosestLines("        return foo();\n", "    return foo();");
+    expect(block).toContain("Closest line(s) to your oldText");
+    expect(block).toContain('"        return foo();"');
+    expect(describeClosestLines("totally unrelated", "missing")).toBe("");
+  });
+});

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -276,6 +276,154 @@ export function applyEditsToNormalizedContent(
   return { baseContent, newContent };
 }
 
+export interface ClosestLine {
+  /** 1-based line number in the file. */
+  lineNumber: number;
+  /** The raw line text from the file. */
+  text: string;
+  /** Levenshtein distance between the trimmed anchor and trimmed line (0 = whitespace-only difference). */
+  distance: number;
+  /** Human-readable note describing the most likely difference. */
+  note: string;
+}
+
+/** Cap comparison length so a few pathologically long lines can't blow up the O(n*m) distance. */
+const CLOSEST_LINE_MAX_COMPARE = 200;
+/** Lines more than 60% different from the anchor are treated as unrelated noise. */
+const CLOSEST_LINE_MAX_DISSIMILARITY = 0.6;
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  const s = a.length > CLOSEST_LINE_MAX_COMPARE ? a.slice(0, CLOSEST_LINE_MAX_COMPARE) : a;
+  const t = b.length > CLOSEST_LINE_MAX_COMPARE ? b.slice(0, CLOSEST_LINE_MAX_COMPARE) : b;
+  const m = s.length;
+  const n = t.length;
+  if (m === 0) {
+    return n;
+  }
+  if (n === 0) {
+    return m;
+  }
+  let prev = new Array<number>(n + 1);
+  let curr = new Array<number>(n + 1);
+  for (let j = 0; j <= n; j++) {
+    prev[j] = j;
+  }
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = s[i - 1] === t[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n];
+}
+
+function describeIndent(ws: string): string {
+  if (ws.length === 0) {
+    return "no indentation";
+  }
+  const spaces = (ws.match(/ /g) ?? []).length;
+  const tabs = (ws.match(/\t/g) ?? []).length;
+  const parts: string[] = [];
+  if (tabs > 0) {
+    parts.push(`${tabs} tab${tabs === 1 ? "" : "s"}`);
+  }
+  if (spaces > 0) {
+    parts.push(`${spaces} space${spaces === 1 ? "" : "s"}`);
+  }
+  return parts.join(" + ");
+}
+
+function leadingWhitespace(line: string): string {
+  return line.match(/^[ \t]*/)?.[0] ?? "";
+}
+
+function firstNonBlankLine(text: string): string | undefined {
+  for (const line of text.split("\n")) {
+    if (line.trim().length > 0) {
+      return line;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Find the lines in `content` most similar to the first non-blank line of `oldText`.
+ *
+ * Purely diagnostic — it never affects matching. Used to explain *why* an edit's
+ * oldText failed to match (wrong indentation, an escaped vs literal character,
+ * a small typo) instead of returning a bare "not found".
+ */
+export function findClosestLines(
+  content: string,
+  oldText: string,
+  maxCandidates = 3,
+): ClosestLine[] {
+  const anchorLine = firstNonBlankLine(oldText);
+  if (anchorLine === undefined) {
+    return [];
+  }
+  const anchorTrimmed = anchorLine.trim();
+  const anchorIndent = leadingWhitespace(anchorLine);
+  const lines = content.split("\n");
+  const scored: ClosestLine[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineTrimmed = line.trim();
+    if (lineTrimmed.length === 0) {
+      continue;
+    }
+    const distance = levenshtein(lineTrimmed, anchorTrimmed);
+    const longest = Math.max(lineTrimmed.length, anchorTrimmed.length, 1);
+    if (distance > 0 && distance / longest > CLOSEST_LINE_MAX_DISSIMILARITY) {
+      continue;
+    }
+
+    let note: string;
+    if (distance === 0) {
+      const lineIndent = leadingWhitespace(line);
+      note =
+        lineIndent === anchorIndent
+          ? "matches after trimming — check leading/trailing whitespace"
+          : `indentation differs: expected ${describeIndent(anchorIndent)}, found ${describeIndent(lineIndent)}`;
+    } else {
+      note = "content differs";
+    }
+    scored.push({ lineNumber: i + 1, text: line, distance, note });
+  }
+
+  scored.sort((a, b) => a.distance - b.distance || a.lineNumber - b.lineNumber);
+  return scored.slice(0, maxCandidates);
+}
+
+/**
+ * Render up to `maxCandidates` closest lines as a diagnostic block, or "" when
+ * nothing is close enough to be worth showing. Strings are JSON-escaped so that
+ * whitespace and backslash escapes (e.g. `\b` vs `\\b`) are visible.
+ */
+export function describeClosestLines(content: string, oldText: string, maxCandidates = 3): string {
+  const candidates = findClosestLines(content, oldText, maxCandidates);
+  if (candidates.length === 0) {
+    return "";
+  }
+  const anchor = firstNonBlankLine(oldText)?.trim() ?? "";
+  const width = String(Math.max(...candidates.map((c) => c.lineNumber))).length;
+  const rows = candidates.map((c) => {
+    const ln = String(c.lineNumber).padStart(width, " ");
+    return `  L${ln}: ${JSON.stringify(c.text)}  — ${c.note}`;
+  });
+  return [
+    `Closest line(s) to your oldText (anchor: ${JSON.stringify(anchor)}):`,
+    ...rows,
+    "Strings are shown JSON-escaped so whitespace and backslashes are visible.",
+  ].join("\n");
+}
+
 /** Generate a standard unified patch. */
 export function generateUnifiedPatch(
   path: string,

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -308,8 +308,8 @@ function levenshtein(a: string, b: string): number {
   if (n === 0) {
     return m;
   }
-  let prev = new Array<number>(n + 1);
-  let curr = new Array<number>(n + 1);
+  let prev = Array.from<number>({ length: n + 1 });
+  let curr = Array.from<number>({ length: n + 1 });
   for (let j = 0; j <= n; j++) {
     prev[j] = j;
   }

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -291,6 +291,8 @@ export interface ClosestLine {
 const CLOSEST_LINE_MAX_COMPARE = 200;
 /** Lines more than 60% different from the anchor are treated as unrelated noise. */
 const CLOSEST_LINE_MAX_DISSIMILARITY = 0.6;
+/** Skip closest-line scanning on files larger than this to avoid stalling on large/generated files. */
+const CLOSEST_LINE_FILE_SEARCH_CAP = 500;
 
 function levenshtein(a: string, b: string): number {
   if (a === b) {
@@ -367,9 +369,12 @@ export function findClosestLines(
   if (anchorLine === undefined) {
     return [];
   }
+  const lines = content.split("\n");
+  if (lines.length > CLOSEST_LINE_FILE_SEARCH_CAP) {
+    return [];
+  }
   const anchorTrimmed = anchorLine.trim();
   const anchorIndent = leadingWhitespace(anchorLine);
-  const lines = content.split("\n");
   const scored: ClosestLine[] = [];
 
   for (let i = 0; i < lines.length; i++) {

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -46,6 +46,30 @@ describe("edit tool", () => {
     ).rejects.toThrow(/Current file contents:\nactual current content/);
   });
 
+  it("points at the closest line with an indentation note on mismatch", async () => {
+    // File indents the line with 4 spaces; the edit asks for 8, so it cannot match.
+    const filePath = await createTempFile("function f() {\n    return foo();\n}\n");
+    const tool = createEditTool(tmpDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [
+            {
+              oldText: "        return foo();",
+              newText: "        return bar();",
+            },
+          ],
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(
+      /Closest line\(s\)[\s\S]*L2:[\s\S]*indentation differs: expected 8 spaces, found 4 spaces/,
+    );
+  });
+
   it("recovers success after a post-write throw when the edit already applied", async () => {
     // Some backends throw after flushing content; a readback match is the
     // contract that lets the tool report success without duplicating edits.

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -386,6 +386,51 @@ describe("edit tool", () => {
     ).rejects.toThrow(/Current file contents:\nactual content/);
   });
 
+  it("shows closest-line diagnostic for a batched edit miss", async () => {
+    // First edit matches; second edit uses wrong indentation and fails.
+    // The diagnostic must point at the *second* edit, not the first.
+    const filePath = await createTempFile("    return foo();\n    return bar();\n");
+    const tool = createEditTool(tmpDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [
+            { oldText: "    return foo();\n", newText: "    return FOO();\n" },
+            { oldText: "        return bar();\n", newText: "    return BAR();\n" },
+          ],
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(/Closest line\(s\) to your oldText/);
+  });
+
+  it("skips closest-line scan when the file is large", async () => {
+    // Files over 500 lines skip the expensive Levenshtein scan to avoid stalls.
+    const manyLines =
+      Array.from({ length: 501 }, (_, i) => `const line${i} = ${i};`).join("\n") + "\n";
+    const filePath = await createTempFile(manyLines);
+    const tool = createEditTool(tmpDir);
+
+    const err = await tool
+      .execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: "const lineDoesNotExist = 999;", newText: "replacement" }],
+        },
+        undefined,
+      )
+      .catch((e: unknown) => e);
+
+    expect(err instanceof Error ? err.message : String(err)).toContain("Current file contents:");
+    expect(err instanceof Error ? err.message : String(err)).not.toContain(
+      "Closest matching lines",
+    );
+  });
+
   it("does not hide unrelated errors that mention no changes", async () => {
     const filePath = await createTempFile("old content\n");
     const operations: EditOperations = {

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -18,6 +18,7 @@ import type { ToolDefinition } from "../extensions/types.js";
 import {
   applyEditsToNormalizedContent,
   computeEditsDiff,
+  describeClosestLines,
   detectLineEnding,
   EditNoChangeError,
   type Edit,
@@ -173,12 +174,29 @@ function didEditLikelyApply(params: {
   );
 }
 
-function appendMismatchHint(error: Error, currentContent: string): Error {
+/** Pick the oldText that failed to match, so diagnostics target the right edit. */
+function pickUnmatchedOldText(currentContent: string, edits: Edit[]): string {
+  const normalizedCurrent = normalizeToLF(currentContent);
+  for (const edit of edits) {
+    if (!normalizedCurrent.includes(normalizeToLF(edit.oldText))) {
+      return edit.oldText;
+    }
+  }
+  return edits[0]?.oldText ?? "";
+}
+
+function appendMismatchHint(error: Error, currentContent: string, oldText: string): Error {
   const snippet =
     currentContent.length <= EDIT_MISMATCH_HINT_LIMIT
       ? currentContent
       : `${currentContent.slice(0, EDIT_MISMATCH_HINT_LIMIT)}\n... (truncated)`;
-  const enhanced = new Error(`${error.message}\nCurrent file contents:\n${snippet}`, {
+  const closest = describeClosestLines(currentContent, oldText);
+  const sections = [error.message];
+  if (closest) {
+    sections.push(closest);
+  }
+  sections.push(`Current file contents:\n${snippet}`);
+  const enhanced = new Error(sections.join("\n"), {
     cause: error,
   });
   enhanced.stack = error.stack;
@@ -490,7 +508,11 @@ export function createEditToolDefinition(
             };
           }
           if (normalizedError.message.includes(EDIT_MISMATCH_MESSAGE)) {
-            throw appendMismatchHint(normalizedError, currentContent);
+            throw appendMismatchHint(
+              normalizedError,
+              currentContent,
+              pickUnmatchedOldText(currentContent, realEdits),
+            );
           }
           // Terminal no-op: the edit matched but produced identical content.
           if (normalizedError instanceof EditNoChangeError) {

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -78,6 +78,7 @@ type LegacyEditToolInput = Record<string, unknown> & {
 };
 
 const EDIT_MISMATCH_MESSAGE = "Could not find the exact text in";
+const EDIT_MISMATCH_MESSAGE_BATCH = "Could not find edits[";
 const EDIT_MISMATCH_HINT_LIMIT = 800;
 
 /**
@@ -175,13 +176,14 @@ function didEditLikelyApply(params: {
 }
 
 /** Pick the oldText that failed to match, so diagnostics target the right edit. */
-function pickUnmatchedOldText(currentContent: string, edits: Edit[]): string {
-  const normalizedCurrent = normalizeToLF(currentContent);
-  for (const edit of edits) {
-    if (!normalizedCurrent.includes(normalizeToLF(edit.oldText))) {
-      return edit.oldText;
-    }
+function pickUnmatchedOldText(error: Error, edits: Edit[]): string {
+  // Batch errors name the failing edit by index: "Could not find edits[i] in ..."
+  const batchMatch = error.message.match(/Could not find edits\[(\d+)\]/);
+  if (batchMatch) {
+    const idx = parseInt(batchMatch[1], 10);
+    return edits[idx]?.oldText ?? edits[0]?.oldText ?? "";
   }
+  // Single-edit mismatch: only one candidate.
   return edits[0]?.oldText ?? "";
 }
 
@@ -507,11 +509,14 @@ export function createEditToolDefinition(
               details: { diff: "", patch: "" },
             };
           }
-          if (normalizedError.message.includes(EDIT_MISMATCH_MESSAGE)) {
+          if (
+            normalizedError.message.includes(EDIT_MISMATCH_MESSAGE) ||
+            normalizedError.message.includes(EDIT_MISMATCH_MESSAGE_BATCH)
+          ) {
             throw appendMismatchHint(
               normalizedError,
               currentContent,
-              pickUnmatchedOldText(currentContent, realEdits),
+              pickUnmatchedOldText(normalizedError, realEdits),
             );
           }
           // Terminal no-op: the edit matched but produced identical content.

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -180,7 +180,7 @@ function pickUnmatchedOldText(error: Error, edits: Edit[]): string {
   // Batch errors name the failing edit by index: "Could not find edits[i] in ..."
   const batchMatch = error.message.match(/Could not find edits\[(\d+)\]/);
   if (batchMatch) {
-    const idx = parseInt(batchMatch[1], 10);
+    const idx = Number.parseInt(batchMatch[1], 10);
     return edits[idx]?.oldText ?? edits[0]?.oldText ?? "";
   }
   // Single-edit mismatch: only one candidate.


### PR DESCRIPTION
## Problem

When an edit tool call fails because `oldText` doesn't match, the error only showed the raw file contents — no hint about *why* it didn't match. Agents had to re-read the file and guess whether the problem was wrong indentation, an escaped character, or a typo.

## Fix

Adds `findClosestLines` / `describeClosestLines` to `edit-diff.ts`. On a mismatch, the error message now includes the closest matching lines with a diagnostic note (indentation mismatch, content diff, etc.).

## Proof (real terminal output)

Triggering a mismatch where the file uses 4-space indent but the edit requests 8 spaces:

```
Could not find edits[1] in /tmp/openclaw-edit-tool-OLcy0w/demo.txt.
The oldText must match exactly including all whitespace and newlines.
Closest line(s) to your oldText (anchor: "return bar();"):
  L2: "    return bar();"  — indentation differs: expected 8 spaces, found 4 spaces
  L1: "    return foo();"  — content differs
Strings are shown JSON-escaped so whitespace and backslashes are visible.
Current file contents:
    return foo();
    return bar();
```

## Tests

```
Tests  22 passed (22)   (edit.test.ts)
Tests   6 passed (6)    (edit-diff.closest-lines.test.ts)
```

New tests cover:
- Indentation mismatch diagnostic (integration test)  
- Batched edit miss — diagnostic points at the correct (second) edit  
- Large-file (>500 lines) mismatch — scan is skipped, no stall risk

Closes #97032

🤖 Generated with [Claude Code](https://claude.com/claude-code)