### PR TITLE
fix(feishu): render single newlines as line breaks in post+md messages (#97074)

### DIFF
--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -88,6 +88,30 @@ describe("buildFeishuPostMessagePayload", () => {
     });
   });
 
+  it("upgrades single newlines to paragraph breaks so Feishu renders separate lines", () => {
+    const payload = buildFeishuPostMessagePayload({
+      messageText: "first paragraph\nsecond paragraph\n- item one\n- item two",
+    });
+
+    const parsed = JSON.parse(payload.content) as {
+      zh_cn: { content: Array<Array<{ tag: string; text?: string }>> };
+    };
+    const md = parsed.zh_cn.content[0].find((el) => el.tag === "md");
+    expect(md?.text).toBe("first paragraph\n\nsecond paragraph\n\n- item one\n\n- item two");
+  });
+
+  it("preserves newlines inside fenced code blocks and collapses oversized gaps", () => {
+    const payload = buildFeishuPostMessagePayload({
+      messageText: "intro\n\n\n\n```\nline1\nline2\n```\noutro",
+    });
+
+    const parsed = JSON.parse(payload.content) as {
+      zh_cn: { content: Array<Array<{ tag: string; text?: string }>> };
+    };
+    const md = parsed.zh_cn.content[0].find((el) => el.tag === "md");
+    expect(md?.text).toBe("intro\n\n```\nline1\nline2\n```\n\noutro");
+  });
+
   it("leaves body-supplied at tags literal in the markdown element", () => {
     const payload = buildFeishuPostMessagePayload({
       messageText: 'please keep <at user_id="ou_body">Body User</at> literal',
@@ -99,7 +123,10 @@ describe("buildFeishuPostMessagePayload", () => {
         content: [
           [
             { tag: "at", user_id: "ou_target", user_name: "Target User" },
-            { tag: "md", text: 'please keep <at user_id="ou_body">Body User</at> literal' },
+            {
+              tag: "md",
+              text: 'please keep <at user_id="ou_body">Body User</at> literal',
+            },
           ],
         ],
       },
@@ -251,7 +278,10 @@ describe("getMessageFeishu", () => {
             content: [
               [
                 { tag: "at", user_id: "ou_target", user_name: "Target User" },
-                { tag: "md", text: 'body <at user_id="ou_body">Body User</at>' },
+                {
+                  tag: "md",
+                  text: 'body <at user_id="ou_body">Body User</at>',
+                },
               ],
             ],
           },
@@ -729,7 +759,10 @@ describe("editMessageFeishu", () => {
         content: JSON.stringify({ schema: "2.0" }),
       },
     });
-    expect(result).toEqual({ messageId: "om_card", contentType: "interactive" });
+    expect(result).toEqual({
+      messageId: "om_card",
+      contentType: "interactive",
+    });
   });
 });
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -81,11 +81,21 @@ type FeishuCreateMessageClient = {
       reply: (opts: {
         path: { message_id: string };
         data: { content: string; msg_type: string; reply_in_thread?: true };
-      }) => Promise<{ code?: number; msg?: string; data?: { message_id?: string } }>;
+      }) => Promise<{
+        code?: number;
+        msg?: string;
+        data?: { message_id?: string };
+      }>;
       create: (opts: {
-        params: { receive_id_type: "chat_id" | "email" | "open_id" | "union_id" | "user_id" };
+        params: {
+          receive_id_type: "chat_id" | "email" | "open_id" | "union_id" | "user_id";
+        };
         data: { receive_id: string; content: string; msg_type: string };
-      }) => Promise<{ code?: number; msg?: string; data?: { message_id?: string } }>;
+      }) => Promise<{
+        code?: number;
+        msg?: string;
+        data?: { message_id?: string };
+      }>;
     };
   };
 };
@@ -571,6 +581,31 @@ function buildFeishuPostMentionElements(mentions?: MentionTarget[]): FeishuPostM
   return elements;
 }
 
+/**
+ * Feishu's `post` + `tag: "md"` renderer treats a single `\n` as a soft break
+ * (rendered as a space), so paragraphs and list items get mashed onto one line.
+ * Only `\n\n` produces a real line break. This upgrades single newlines to double
+ * newlines outside fenced code blocks, leaving code blocks (where `\n` is
+ * significant) untouched and collapsing 3+ newlines so gaps don't balloon.
+ */
+export function upgradeFeishuPostNewlines(text: string): string {
+  const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  // Split on fenced code blocks; odd indices are the (preserved) code blocks.
+  const segments = normalized.split(/(```[\s\S]*?```)/g);
+  const upgraded = segments
+    .map((segment, index) => {
+      if (index % 2 === 1) {
+        return segment; // fenced code block — keep newlines verbatim
+      }
+      return segment
+        .replace(/\n{3,}/g, "\n\n") // collapse oversized gaps
+        .replace(/(?<!\n)\n(?!\n)/g, "\n\n"); // single \n -> paragraph break
+    })
+    .join("");
+  // Trim leading/trailing blank lines introduced by the upgrade.
+  return upgraded.replace(/^\n+/, "").replace(/\n+$/, "");
+}
+
 export function buildFeishuPostMessagePayload(params: {
   messageText: string;
   mentions?: MentionTarget[];
@@ -583,7 +618,7 @@ export function buildFeishuPostMessagePayload(params: {
     ...buildFeishuPostMentionElements(mentions),
     {
       tag: "md",
-      text: messageText,
+      text: upgradeFeishuPostNewlines(messageText),
     },
   ];
   return {
@@ -609,7 +644,11 @@ export async function sendMessageFeishu(
     mentions,
     accountId,
   } = params;
-  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
+  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
+    cfg,
+    to,
+    accountId,
+  });
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "feishu",
@@ -617,7 +656,10 @@ export async function sendMessageFeishu(
 
   const messageText = convertMarkdownTables(text ?? "", tableMode);
 
-  const { content, msgType } = buildFeishuPostMessagePayload({ messageText, mentions });
+  const { content, msgType } = buildFeishuPostMessagePayload({
+    messageText,
+    mentions,
+  });
 
   const directParams = { receiveId, receiveIdType, content, msgType };
   return sendReplyOrFallbackDirect(client, {
@@ -646,10 +688,19 @@ export type SendFeishuCardParams = {
 export async function sendCardFeishu(params: SendFeishuCardParams): Promise<FeishuSendResult> {
   const { cfg, to, card, replyToMessageId, replyInThread, allowTopLevelReplyFallback, accountId } =
     params;
-  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
+  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
+    cfg,
+    to,
+    accountId,
+  });
   const content = JSON.stringify(card);
 
-  const directParams = { receiveId, receiveIdType, content, msgType: "interactive" };
+  const directParams = {
+    receiveId,
+    receiveIdType,
+    content,
+    msgType: "interactive",
+  };
   return sendReplyOrFallbackDirect(client, {
     replyToMessageId,
     replyInThread,
@@ -767,7 +818,10 @@ export function buildStructuredCard(
   const elements: Record<string, unknown>[] = [{ tag: "markdown", content: text }];
   if (options?.note) {
     elements.push({ tag: "hr" });
-    elements.push({ tag: "markdown", content: `<font color='grey'>${options.note}</font>` });
+    elements.push({
+      tag: "markdown",
+      content: `<font color='grey'>${options.note}</font>`,
+    });
   }
   const card: Record<string, unknown> = {
     schema: "2.0",


### PR DESCRIPTION
Closes #97074.

## What Problem This Solves

Feishu's `post` payload with `tag: "md"` treats a single `\n` as a soft break, so standard markdown output with single-newline paragraph or list breaks renders mashed together on one line. Only blank-line-separated markdown creates a visible break. That makes multiline agent responses hard to read for users on the Feishu channel.

## Fix

`buildFeishuPostMessagePayload`, the builder for the `post` + `md` payload, now runs text through `upgradeFeishuPostNewlines()` before wrapping it as `{ tag: "md", text }`.

The helper:

- upgrades single `\n` to `\n\n` outside fenced code blocks
- leaves newlines inside fenced code blocks unchanged
- collapses 3+ newlines to 2 so gaps do not balloon
- trims leading and trailing blank lines introduced by the upgrade

The issue referenced `@larksuite/openclaw-lark` / `optimizeMarkdownStyle()`; in this repo the outbound `post` + `md` text is assembled in `extensions/feishu/src/send.ts`, so the upgrade lives there.

## Evidence

Focused tests were added for:

- multi-paragraph and list input gaining paragraph breaks
- code-block newlines being preserved
- oversized gaps being collapsed
- existing single-line payload behavior remaining unchanged

Validation:

```text
extensions/feishu/src/send.test.ts green (21 passing)
```
