### PR TITLE
Add generated media wake proof harness

### DIFF
--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -105,11 +105,14 @@ than Telegram-visible behavior`. Use this manifest shape and do not create
    send a Telegram message asking the agent to generate an image and include
    `OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF` in the message. The trusted
    mock model will first call `image_generate`, then after the tool result will
-   return a text completion that still expects the generated media to be attached
-   through the normal visible-reply contract. Use the same stimulus for baseline
+   return a marker-preserving completion. The local Telegram SUT sets
+   `OPENCLAW_E2E_FORCE_GENERATED_MEDIA_WAKE_FALSE=1`, so a generated image task
+   whose prompt carries the marker forces a recoverable scheduler-level
+   `generated_media_missing` delivery miss. Use the same stimulus for baseline
    and candidate. Expected baseline behavior for the wake-false regression is a
    missing or blocked generated media delivery after the tool completes; expected
-   fixed behavior is exactly one generated image visible in Telegram Desktop.
+   fixed behavior, when the candidate includes the reason-aware scheduler
+   fallback, is exactly one generated image visible in Telegram Desktop.
 5. Create detached worktrees under
    `.artifacts/qa-e2e/mantis/telegram-desktop-proof-worktrees/baseline` and
    `.artifacts/qa-e2e/mantis/telegram-desktop-proof-worktrees/candidate`, then

--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -101,6 +101,15 @@ than Telegram-visible behavior`. Use this manifest shape and do not create
 4. Decide what Telegram message, mock model response, command, callback, button,
    media, or sequence best proves the PR. Use `MANTIS_INSTRUCTIONS` as extra
    maintainer guidance, not as a replacement for reading the PR.
+   For generated-media wake-false proof requests, use this dedicated stimulus:
+   send a Telegram message asking the agent to generate an image and include
+   `OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF` in the message. The trusted
+   mock model will first call `image_generate`, then after the tool result will
+   return a text completion that still expects the generated media to be attached
+   through the normal visible-reply contract. Use the same stimulus for baseline
+   and candidate. Expected baseline behavior for the wake-false regression is a
+   missing or blocked generated media delivery after the tool completes; expected
+   fixed behavior is exactly one generated image visible in Telegram Desktop.
 5. Create detached worktrees under
    `.artifacts/qa-e2e/mantis/telegram-desktop-proof-worktrees/baseline` and
    `.artifacts/qa-e2e/mantis/telegram-desktop-proof-worktrees/candidate`, then

--- a/scripts/e2e/mock-openai-server.mjs
+++ b/scripts/e2e/mock-openai-server.mjs
@@ -17,6 +17,7 @@ const port =
     : readTcpPortEnv("OPENCLAW_MOCK_OPENAI_PORT");
 const successMarker = process.env.SUCCESS_MARKER ?? "OPENCLAW_E2E_OK";
 const requestLog = process.env.MOCK_REQUEST_LOG;
+const generatedMediaWakeFalseProofMarker = "OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF";
 
 function responseEvents(text) {
   const itemId = "msg_e2e_1";
@@ -290,6 +291,32 @@ function mcpCodeModeApiFileEvents(body, bodyText) {
   );
 }
 
+function generatedMediaWakeFalseProofEvents(body, bodyText) {
+  if (!bodyText.includes(generatedMediaWakeFalseProofMarker)) {
+    return null;
+  }
+  const toolOutput = collectFunctionCallOutputText(body);
+  if (toolOutput) {
+    return responseEvents(
+      [
+        "Generated media completion acknowledged.",
+        generatedMediaWakeFalseProofMarker,
+        "The image is ready; attach the generated media in the visible reply.",
+      ].join(" "),
+    );
+  }
+  if (!hasDeclaredTool(bodyText, "image_generate")) {
+    return null;
+  }
+  return toolCallEvents("image_generate", {
+    action: "generate",
+    prompt: `Generate a tiny Telegram proof image for ${generatedMediaWakeFalseProofMarker}.`,
+    model: "openai/gpt-image-1",
+    size: "1024x1024",
+    outputFormat: "png",
+  });
+}
+
 const server = http.createServer((req, res) => {
   void (async () => {
     const url = new URL(req.url ?? "/", "http://127.0.0.1");
@@ -338,6 +365,11 @@ const server = http.createServer((req, res) => {
       const codeModeEvents = mcpCodeModeApiFileEvents(body, bodyText);
       if (codeModeEvents) {
         writeResponsesEvents(res, body.stream, codeModeEvents);
+        return;
+      }
+      const generatedMediaEvents = generatedMediaWakeFalseProofEvents(body, bodyText);
+      if (generatedMediaEvents) {
+        writeResponsesEvents(res, body.stream, generatedMediaEvents);
         return;
       }
       const responseText = resolveResponseText(bodyText);

--- a/scripts/e2e/mock-openai-server.mjs
+++ b/scripts/e2e/mock-openai-server.mjs
@@ -299,9 +299,9 @@ function generatedMediaWakeFalseProofEvents(body, bodyText) {
   if (toolOutput) {
     return responseEvents(
       [
-        "Generated media completion acknowledged.",
+        "Generated media wake-false proof hook armed.",
         generatedMediaWakeFalseProofMarker,
-        "The image is ready; attach the generated media in the visible reply.",
+        "The generated image task prompt carries the marker so the trusted SUT can force a recoverable scheduler-level delivery miss.",
       ].join(" "),
     );
   }

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -530,6 +530,7 @@ function gatewayEnv(params: { configPath: string; stateDir: string; sutToken: st
   return {
     ...childProcessBaseEnv(),
     OPENAI_API_KEY: "sk-openclaw-e2e-mock",
+    OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER: "1",
     OPENCLAW_CONFIG_PATH: params.configPath,
     OPENCLAW_STATE_DIR: params.stateDir,
     TELEGRAM_BOT_TOKEN: params.sutToken,
@@ -1118,6 +1119,7 @@ function writeSutConfig(params: {
   const config = {
     agents: {
       defaults: {
+        imageGenerationModel: { primary: "openai/gpt-image-1", timeoutMs: 30_000 },
         model: { primary: "openai/gpt-5.5" },
         models: { "openai/gpt-5.5": { params: { openaiWsWarmup: false, transport: "sse" } } },
       },

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -530,6 +530,7 @@ function gatewayEnv(params: { configPath: string; stateDir: string; sutToken: st
   return {
     ...childProcessBaseEnv(),
     OPENAI_API_KEY: "sk-openclaw-e2e-mock",
+    OPENCLAW_E2E_FORCE_GENERATED_MEDIA_WAKE_FALSE: "1",
     OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER: "1",
     OPENCLAW_CONFIG_PATH: params.configPath,
     OPENCLAW_STATE_DIR: params.stateDir,

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -1,6 +1,6 @@
 // Background media generation tests cover detached task completion, requester
 // wake delivery, and direct media fallback behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions/types.js";
 
 const subagentAnnounceDeliveryMocks = vi.hoisted(() => ({
@@ -35,6 +35,10 @@ beforeEach(() => {
   subagentAnnounceDeliveryMocks.loadRequesterSessionEntry.mockReturnValue({ entry: undefined });
   detachedTaskRuntimeMocks.createRunningTaskRun.mockClear();
   taskRegistryDeliveryRuntimeMocks.sendMessage.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 function createImageMediaLifecycle() {
@@ -557,6 +561,62 @@ describe("createMediaGenerationTaskLifecycle", () => {
         result: "generated",
       }),
     ).resolves.toBe(true);
+  });
+
+  it("forces generated-media wake-false proof misses only for the dedicated marker", async () => {
+    vi.stubEnv("OPENCLAW_E2E_FORCE_GENERATED_MEDIA_WAKE_FALSE", "1");
+    const lifecycle = createImageMediaLifecycle();
+    const marker = "OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF";
+
+    await expect(
+      lifecycle.wakeTaskCompletion({
+        handle: {
+          taskId: "task-image-wake-false-proof",
+          runId: "tool:image_generate:wake-false-proof",
+          requesterSessionKey: "agent:main:telegram:proof-room",
+          taskLabel: `Generate proof image ${marker}`,
+          requesterOrigin: {
+            channel: "telegram",
+            to: "proof-room",
+          },
+        },
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "Generated 1 image.",
+        mediaUrls: ["/tmp/openclaw-proof.png"],
+      }),
+    ).resolves.toBe(false);
+
+    expect(subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement).not.toHaveBeenCalled();
+  });
+
+  it("keeps normal generated-media wake delivery when the proof marker is absent", async () => {
+    vi.stubEnv("OPENCLAW_E2E_FORCE_GENERATED_MEDIA_WAKE_FALSE", "1");
+    subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValueOnce({
+      delivered: true,
+    });
+    const lifecycle = createImageMediaLifecycle();
+
+    await expect(
+      lifecycle.wakeTaskCompletion({
+        handle: {
+          taskId: "task-image-normal-proof-env",
+          runId: "tool:image_generate:normal-proof-env",
+          requesterSessionKey: "agent:main:telegram:proof-room",
+          taskLabel: "Generate ordinary proof image",
+          requesterOrigin: {
+            channel: "telegram",
+            to: "proof-room",
+          },
+        },
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "Generated 1 image.",
+        mediaUrls: ["/tmp/openclaw-proof.png"],
+      }),
+    ).resolves.toBe(true);
+
+    expect(subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement).toHaveBeenCalledTimes(1);
   });
 
   it("treats terminal generated-media fallback failure as handled", async () => {

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -39,11 +39,16 @@ import {
   deliverSubagentAnnouncement,
   loadRequesterSessionEntry,
 } from "../subagent-announce-delivery.js";
-import type { SubagentAnnounceDeliveryFailureReason } from "../subagent-announce-dispatch.js";
+import type {
+  SubagentAnnounceDeliveryFailureReason,
+  SubagentAnnounceDeliveryResult,
+} from "../subagent-announce-dispatch.js";
 import { resolveAnnounceOrigin } from "../subagent-announce-origin.js";
 
 const log = createSubsystemLogger("agents/tools/media-generate-background-shared");
 const MEDIA_GENERATION_TASK_KEEPALIVE_INTERVAL_MS = 60_000;
+const GENERATED_MEDIA_WAKE_FALSE_PROOF_ENV = "OPENCLAW_E2E_FORCE_GENERATED_MEDIA_WAKE_FALSE";
+const GENERATED_MEDIA_WAKE_FALSE_PROOF_MARKER = "OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF";
 const MEDIA_DIRECT_FALLBACK_DELIVERY_REASONS = new Set<SubagentAnnounceDeliveryFailureReason>([
   "generated_media_missing",
   "message_tool_delivery_missing",
@@ -148,6 +153,43 @@ function touchMediaGenerationTaskRunContext(handle: MediaGenerationTaskHandle) {
     sessionKey: handle.requesterSessionKey,
     lastActiveAt: Date.now(),
   });
+}
+
+function resolveGeneratedMediaWakeFalseProofDelivery(params: {
+  handle: MediaGenerationTaskHandle;
+  status: "ok" | "error";
+  result: string;
+  attachments?: AgentGeneratedAttachment[];
+  mediaUrls?: string[];
+  toolName: string;
+}): SubagentAnnounceDeliveryResult | undefined {
+  if (process.env[GENERATED_MEDIA_WAKE_FALSE_PROOF_ENV] !== "1") {
+    return undefined;
+  }
+  if (params.status !== "ok" || params.toolName !== "image_generate") {
+    return undefined;
+  }
+  const markerSources = [
+    params.handle.taskLabel,
+    params.result,
+    ...(params.mediaUrls ?? []),
+    ...(params.attachments ?? []).flatMap((attachment) => [
+      attachment.path,
+      attachment.name,
+      attachment.url,
+      attachment.mediaUrl,
+      attachment.filePath,
+    ]),
+  ].filter((value): value is string => typeof value === "string");
+  if (!markerSources.some((value) => value.includes(GENERATED_MEDIA_WAKE_FALSE_PROOF_MARKER))) {
+    return undefined;
+  }
+  return {
+    delivered: false,
+    path: "direct",
+    reason: "generated_media_missing",
+    error: "E2E generated-media wake-false proof forced a recoverable delivery miss",
+  };
 }
 
 function createMediaGenerationTaskRun(params: {
@@ -553,6 +595,24 @@ async function wakeMediaGenerationTaskCompletion(params: {
 }): Promise<boolean> {
   if (!params.handle) {
     return true;
+  }
+  const forcedProofDelivery = resolveGeneratedMediaWakeFalseProofDelivery({
+    handle: params.handle,
+    status: params.status,
+    result: params.result,
+    attachments: params.attachments,
+    mediaUrls: params.mediaUrls,
+    toolName: params.toolName,
+  });
+  if (forcedProofDelivery) {
+    log.warn("Media generation completion wake false proof forced a delivery miss", {
+      taskId: params.handle.taskId,
+      runId: params.handle.runId,
+      toolName: params.toolName,
+      reason: forcedProofDelivery.reason,
+      error: forcedProofDelivery.error,
+    });
+    return false;
   }
   const announceId = `${params.toolName}:${params.handle.taskId}:${params.status}`;
   const mediaUrls = Array.from(

--- a/test/scripts/e2e-mock-config-limits.test.ts
+++ b/test/scripts/e2e-mock-config-limits.test.ts
@@ -245,6 +245,70 @@ describe("e2e mock and config helper numeric limits", () => {
     }
   });
 
+  it("drives generated-media wake-false proof through image_generate then text completion", async () => {
+    const marker = "OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF";
+    await withMockServer(mockOpenAiPath, {}, async (baseUrl) => {
+      const firstResponse = await fetch(`${baseUrl}/v1/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          input: `Please generate an image for ${marker}.`,
+          stream: false,
+          tools: [{ type: "function", name: "image_generate" }],
+        }),
+      });
+      const firstBody = await firstResponse.json();
+      const functionCall = firstBody.output?.[0];
+
+      expect(firstResponse.status).toBe(200);
+      expect(functionCall).toMatchObject({
+        type: "function_call",
+        name: "image_generate",
+      });
+      const args = JSON.parse(functionCall.arguments);
+      expect(args).toMatchObject({
+        action: "generate",
+        model: "openai/gpt-image-1",
+        outputFormat: "png",
+        size: "1024x1024",
+      });
+      expect(args.prompt).toContain(marker);
+
+      const secondResponse = await fetch(`${baseUrl}/v1/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          input: [
+            { type: "message", role: "user", content: `Generate ${marker}` },
+            functionCall,
+            {
+              type: "function_call_output",
+              call_id: functionCall.call_id,
+              output: {
+                text: `Generated 1 image for ${marker}.`,
+                media: [{ mimeType: "image/png", path: "/tmp/openclaw-proof.png" }],
+              },
+            },
+          ],
+          stream: false,
+          tools: [{ type: "function", name: "image_generate" }],
+        }),
+      });
+      const secondBody = await secondResponse.json();
+
+      expect(secondResponse.status).toBe(200);
+      expect(secondBody.output?.[0]).toMatchObject({
+        type: "message",
+        content: [
+          expect.objectContaining({
+            text: expect.stringContaining(marker),
+          }),
+        ],
+      });
+      expect(JSON.stringify(secondBody.output)).not.toContain('"type":"function_call"');
+    });
+  });
+
   it("returns a clear error when web-search mock cannot append request logs", async () => {
     const requestLogDirectory = await mkdtemp(join(tmpdir(), "openclaw-web-search-log-"));
     try {

--- a/test/scripts/e2e-mock-config-limits.test.ts
+++ b/test/scripts/e2e-mock-config-limits.test.ts
@@ -245,7 +245,7 @@ describe("e2e mock and config helper numeric limits", () => {
     }
   });
 
-  it("drives generated-media wake-false proof through image_generate then text completion", async () => {
+  it("drives generated-media wake-false proof through image_generate then marker-preserving completion", async () => {
     const marker = "OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF";
     await withMockServer(mockOpenAiPath, {}, async (baseUrl) => {
       const firstResponse = await fetch(`${baseUrl}/v1/responses`, {
@@ -305,6 +305,12 @@ describe("e2e mock and config helper numeric limits", () => {
           }),
         ],
       });
+      expect(JSON.stringify(secondBody.output)).toContain(
+        "Generated media wake-false proof hook armed.",
+      );
+      expect(JSON.stringify(secondBody.output)).toContain(
+        "trusted SUT can force a recoverable scheduler-level delivery miss",
+      );
       expect(JSON.stringify(secondBody.output)).not.toContain('"type":"function_call"');
     });
   });

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -465,12 +465,13 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     const proofScript = readFileSync(PROOF_SCRIPT, "utf8");
     expect(proofScript).toContain("function childProcessBaseEnv()");
     expect(proofScript).toContain("...childProcessBaseEnv()");
+    expect(proofScript).toContain('OPENCLAW_E2E_FORCE_GENERATED_MEDIA_WAKE_FALSE: "1"');
     expect(proofScript).toContain('OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER: "1"');
     expect(proofScript).not.toContain("...process.env,\n    OPENAI_API_KEY");
     expect(proofScript).not.toContain("...process.env,\n    MOCK_PORT");
   });
 
-  it("enables generated-media wake-false Telegram proof through the mock image provider", () => {
+  it("enables generated-media wake-false Telegram proof through a trusted SUT hook", () => {
     const proofScript = readFileSync(PROOF_SCRIPT, "utf8");
     const prompt = readFileSync(PROMPT, "utf8");
     const marker = "OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF";
@@ -478,8 +479,11 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(proofScript).toContain(
       'imageGenerationModel: { primary: "openai/gpt-image-1", timeoutMs: 30_000 }',
     );
+    expect(proofScript).toContain('OPENCLAW_E2E_FORCE_GENERATED_MEDIA_WAKE_FALSE: "1"');
     expect(prompt).toContain(marker);
     expect(prompt).toContain("first call `image_generate`");
+    expect(prompt).toContain("forces a recoverable scheduler-level");
+    expect(prompt).toContain("`generated_media_missing` delivery miss");
     expect(prompt).toContain("missing or blocked generated media delivery");
     expect(prompt).toContain("exactly one generated image visible in Telegram Desktop");
   });

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -465,7 +465,22 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     const proofScript = readFileSync(PROOF_SCRIPT, "utf8");
     expect(proofScript).toContain("function childProcessBaseEnv()");
     expect(proofScript).toContain("...childProcessBaseEnv()");
+    expect(proofScript).toContain('OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER: "1"');
     expect(proofScript).not.toContain("...process.env,\n    OPENAI_API_KEY");
     expect(proofScript).not.toContain("...process.env,\n    MOCK_PORT");
+  });
+
+  it("enables generated-media wake-false Telegram proof through the mock image provider", () => {
+    const proofScript = readFileSync(PROOF_SCRIPT, "utf8");
+    const prompt = readFileSync(PROMPT, "utf8");
+    const marker = "OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF";
+
+    expect(proofScript).toContain(
+      'imageGenerationModel: { primary: "openai/gpt-image-1", timeoutMs: 30_000 }',
+    );
+    expect(prompt).toContain(marker);
+    expect(prompt).toContain("first call `image_generate`");
+    expect(prompt).toContain("missing or blocked generated media delivery");
+    expect(prompt).toContain("exactly one generated image visible in Telegram Desktop");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

This is a proof-harness follow-up for #97275, #95910, and #86034. The previous Telegram Desktop Mantis harness could not produce live proof for the internal generated-media wake-false path because the local Telegram SUT did not expose `image_generate`, and the mock OpenAI path did not drive a generated-image task into the scheduler-level false-return condition.

## Why This Change Was Made

#97275 is intentionally scoped to the production fix. This PR keeps the proof infrastructure separate so Mantis can later run the same generated-media scenario on baseline and candidate, with the expected visible delta in native Telegram Desktop.

After ClawSweeper review, the proof stimulus now forces the correct layer: the trusted Telegram SUT sets `OPENCLAW_E2E_FORCE_GENERATED_MEDIA_WAKE_FALSE=1`, and only generated image tasks whose prompt/result carries `OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF` are converted into a recoverable scheduler-level `generated_media_missing` wake miss. This avoids relying on a normal text completion path that current main can already recover internally.

## User Impact

No normal media delivery behavior changes. The new hook is constrained by both a Mantis-only env var and a dedicated marker:

- enables a mock image-generation model in the Telegram proof SUT
- allows the QA harness to call the loopback mock image endpoint
- adds a dedicated `OPENCLAW_E2E_GENERATED_MEDIA_WAKE_FALSE_PROOF` marker path in the mock OpenAI server
- adds the trusted `OPENCLAW_E2E_FORCE_GENERATED_MEDIA_WAKE_FALSE=1` SUT hook for scheduler-level wake-false proof
- documents the Mantis stimulus and baseline/candidate expectations
- adds tests covering the marker path, proof hook, and prompt/SUT constraints

## Evidence

- `node scripts/run-vitest.mjs src/agents/tools/media-generate-background-shared.test.ts test/scripts/e2e-mock-config-limits.test.ts test/scripts/mantis-telegram-desktop-proof-workflow.test.ts test/scripts/telegram-user-crabbox-proof.test.ts --maxWorkers=1`
  - passed: 76 tests across 4 files
- `node scripts/run-oxlint.mjs src/agents/tools/media-generate-background-shared.ts src/agents/tools/media-generate-background-shared.test.ts scripts/e2e/mock-openai-server.mjs scripts/e2e/telegram-user-crabbox-proof.ts test/scripts/e2e-mock-config-limits.test.ts test/scripts/mantis-telegram-desktop-proof-workflow.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/tools/media-generate-background-shared.ts src/agents/tools/media-generate-background-shared.test.ts scripts/e2e/mock-openai-server.mjs scripts/e2e/telegram-user-crabbox-proof.ts test/scripts/e2e-mock-config-limits.test.ts test/scripts/mantis-telegram-desktop-proof-workflow.test.ts .github/codex/prompts/mantis-telegram-desktop-proof.md`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `git diff --check`

Note: this PR now supplies a targeted live-proof hook. It still does not claim a completed Telegram Desktop visual proof artifact until Mantis runs successfully with the corrected stimulus.
