### PR TITLE
fix(openrouter): avoid dual DeepSeek V4 reasoning fields

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -993,8 +993,9 @@ describe("openrouter provider hooks", () => {
       {},
     );
 
-    expect(capturedPayload?.thinking).toEqual({ type: "enabled" });
-    expect(capturedPayload?.reasoning_effort).toBe("xhigh");
+    expect(capturedPayload).not.toHaveProperty("thinking");
+    expect(capturedPayload).not.toHaveProperty("reasoning_effort");
+    expect(capturedPayload?.reasoning).toEqual({ effort: "xhigh" });
     expect(capturedPayload?.messages).toEqual([
       { role: "user", content: "read file" },
       {
@@ -1007,7 +1008,7 @@ describe("openrouter provider hooks", () => {
     expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
-  it("keeps OpenRouter DeepSeek V4 reasoning_effort within OpenRouter values", async () => {
+  it("keeps OpenRouter DeepSeek V4 reasoning effort within OpenRouter values", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
     const payloads: Array<Record<string, unknown>> = [];
     const baseStreamFn = vi.fn(
@@ -1041,7 +1042,9 @@ describe("openrouter provider hooks", () => {
       );
     }
 
-    expect(payloads.map((payload) => payload.reasoning_effort)).toEqual([
+    expect(payloads.every((payload) => !Object.hasOwn(payload, "thinking"))).toBe(true);
+    expect(payloads.every((payload) => !Object.hasOwn(payload, "reasoning_effort"))).toBe(true);
+    expect(payloads.map((payload) => (payload.reasoning as { effort?: unknown }).effort)).toEqual([
       "minimal",
       "low",
       "medium",

--- a/extensions/openrouter/stream.ts
+++ b/extensions/openrouter/stream.ts
@@ -346,7 +346,7 @@ function createOpenRouterDeepSeekV4ThinkingWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
 ): StreamFn | undefined {
-  return createDeepSeekV4OpenAICompatibleThinkingWrapper({
+  const deepSeekV4StreamFn = createDeepSeekV4OpenAICompatibleThinkingWrapper({
     baseStreamFn,
     thinkingLevel,
     shouldPatchModel: shouldPatchDeepSeekV4OpenRouterPayload,
@@ -354,6 +354,22 @@ function createOpenRouterDeepSeekV4ThinkingWrapper(
     shouldBackfillAssistantReasoningContent: (message) =>
       !assistantMessageHasOpenAIToolCalls(message),
   });
+  if (!deepSeekV4StreamFn) {
+    return undefined;
+  }
+  return createPayloadPatchStreamWrapper(
+    deepSeekV4StreamFn,
+    ({ payload }) => {
+      if (!isEnabledReasoningValue(payload.reasoning)) {
+        return;
+      }
+      // OpenRouter proxy reasoning runs first; keep its nested effort while
+      // preserving the DeepSeek V4 replay backfill from the wrapper above.
+      delete payload.thinking;
+      delete payload.reasoning_effort;
+    },
+    { shouldPatch: ({ model }) => shouldPatchDeepSeekV4OpenRouterPayload(model) },
+  );
 }
 
 export function wrapOpenRouterProviderStream(


### PR DESCRIPTION
## What Problem This Solves

OpenRouter-routed DeepSeek V4 requests could end up with both nested `reasoning.effort` and top-level DeepSeek-native effort controls after wrapper composition. OpenRouter rejects that shape with a 400 because two effort controls are present on the same request.

Closes #97196

## Why This Change Was Made

- Keep the existing DeepSeek V4 replay wrapper for verified OpenRouter routes so replayed assistant turns still receive the required `reasoning_content` backfill.
- Add an OpenRouter-only payload cleanup after that replay wrapper so the final request keeps OpenRouter's nested `reasoning.effort` and drops `thinking` / `reasoning_effort`.
- Update the OpenRouter DeepSeek V4 tests to assert the final composed payload shape, including the `max` to `xhigh` mapping and replay backfill.

## User Impact

Users can route `openrouter/deepseek/deepseek-v4-flash` and `openrouter/deepseek/deepseek-v4-pro` without hitting the dual effort-field 400. Existing DeepSeek V4 replay handling for tool conversations remains in place.

## Evidence

- `node scripts/run-vitest.mjs run extensions/openrouter/index.test.ts` passed.
- `node scripts/run-vitest.mjs run src/plugin-sdk/provider-stream-shared.test.ts src/llm/providers/stream-wrappers/proxy.test.ts` passed.
- `git diff --check` passed.

## Real behavior proof

**Behavior addressed:** OpenRouter DeepSeek V4 payloads keep one effort representation after wrapper composition.

**Environment tested:** Local Linux checkout with Node source execution via `node --import tsx`.

**Steps run after the patch:** Ran a source-level payload proof against `wrapOpenRouterProviderStream` for an OpenRouter DeepSeek V4 model with nested `reasoning.effort` active.

**Evidence after fix:**

```text
{
  "reasoning": {
    "effort": "high"
  },
  "hasThinking": false,
  "hasReasoningEffort": false,
  "model": "deepseek/deepseek-v4-flash"
}
```

**Observed result:** The final request payload keeps `reasoning.effort` and does not include `thinking` or `reasoning_effort`, so the conflicting dual-field shape is gone.

**Not tested:** A live OpenRouter request with a real API key was not run.
