### PR TITLE
[codex] fix(feishu): preserve post markdown line breaks

### DIFF
--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -27,6 +27,20 @@ vi.mock("./media.js", () => ({
 vi.mock("./send.js", () => ({
   editMessageFeishu: vi.fn(),
   getMessageFeishu: vi.fn(),
+  normalizeFeishuPostMarkdownLineBreaks: (text: string) => {
+    const lines = text.replace(/\r\n?/g, "\n").split("\n");
+    const parts: string[] = [];
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index] ?? "";
+      parts.push(line);
+      if (index === lines.length - 1) {
+        continue;
+      }
+      const nextLine = lines[index + 1] ?? "";
+      parts.push(line.length === 0 || nextLine.length === 0 ? "\n" : "\n\n");
+    }
+    return parts.join("");
+  },
   sendCardFeishu: sendCardFeishuMock,
   sendMessageFeishu: sendMessageFeishuMock,
   sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
@@ -281,6 +295,24 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     expect(chunker("hello world", 5)).toEqual(["hello", "world"]);
   });
 
+  it("expands Feishu post markdown line breaks before applying the chunk limit", () => {
+    const chunker = feishuOutbound.chunker;
+    if (!chunker) {
+      throw new Error("feishuOutbound.chunker missing");
+    }
+
+    const rawNearLimit = Array.from({ length: 2000 }, () => "x").join("\n");
+    expect(rawNearLimit).toHaveLength(3999);
+
+    const chunks = chunker(rawNearLimit, 4000);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
+    for (const chunk of chunks) {
+      expect(chunk).not.toMatch(/[^\n]\n[^\n]/u);
+    }
+  });
+
   async function createTmpImage(ext = ".png"): Promise<{ dir: string; file: string }> {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-outbound-"));
     const file = path.join(dir, `sample${ext}`);
@@ -395,6 +427,28 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
 describe("feishuOutbound.sendPayload native cards", () => {
   beforeEach(() => {
     resetOutboundMocks();
+  });
+
+  it("sends newline-expanded post chunks within the Feishu text limit", async () => {
+    const rawNearLimit = Array.from({ length: 2000 }, () => "x").join("\n");
+
+    await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: rawNearLimit,
+      accountId: "main",
+      payload: { text: rawNearLimit },
+    });
+
+    const calls = sendMessageFeishuMock.mock.calls as unknown as Array<[Record<string, any>]>;
+    expect(calls.length).toBeGreaterThan(1);
+    for (const [call] of calls) {
+      expect(call.to).toBe("chat_1");
+      expect(call.accountId).toBe("main");
+      expect(call.postMarkdownLineBreaksNormalized).toBe(true);
+      expect(call.text.length).toBeLessThanOrEqual(4000);
+      expect(call.text).not.toMatch(/[^\n]\n[^\n]/u);
+    }
   });
 
   async function createTmpImage(ext = ".png"): Promise<{ dir: string; file: string }> {
@@ -824,6 +878,19 @@ describe("feishuOutbound.sendPayload native cards", () => {
     expect(sendCardFeishuMock).not.toHaveBeenCalled();
     expect(commentThreadParams()?.content).toBe("Review this\n\n- Approve");
     expectFeishuResult(result, "reply_msg");
+  });
+
+  it("does not apply post markdown newline expansion to document comments", async () => {
+    await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "First line\nSecond line",
+      accountId: "main",
+      payload: { text: "First line\nSecond line" },
+    });
+
+    expect(commentThreadParams()?.content).toBe("First line\nSecond line");
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -31,6 +31,7 @@ import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "./outbound-runtime-api.js";
 import { buildFeishuPresentationCardElements } from "./presentation-card.js";
 import {
+  normalizeFeishuPostMarkdownLineBreaks,
   resolveFeishuCardTemplate,
   sendCardFeishu,
   sendMarkdownCardFeishu,
@@ -39,6 +40,10 @@ import {
 } from "./send.js";
 
 const RENDERED_FEISHU_CARD = Symbol("openclaw.renderedFeishuCard");
+
+type FeishuOutboundTextContext = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0] & {
+  postMarkdownLineBreaksNormalized?: boolean;
+};
 
 function normalizePossibleLocalImagePath(text: string | undefined): string | null {
   const raw = text?.trim();
@@ -83,6 +88,10 @@ function normalizePossibleLocalImagePath(text: string | undefined): string | nul
 
 function shouldUseCard(text: string): boolean {
   return /```[\s\S]*?```/.test(text) || /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
+}
+
+function chunkFeishuPostTextForOutbound(text: string, limit: number): string[] {
+  return chunkTextForOutbound(normalizeFeishuPostMarkdownLineBreaks(text), limit);
 }
 
 function markRenderedFeishuCard(card: Record<string, unknown>): Record<string, unknown> {
@@ -432,8 +441,17 @@ async function sendOutboundText(params: {
   replyToMessageId?: string;
   replyInThread?: boolean;
   accountId?: string;
+  postMarkdownLineBreaksNormalized?: boolean;
 }) {
-  const { cfg, to, text, accountId, replyToMessageId, replyInThread } = params;
+  const {
+    cfg,
+    to,
+    text,
+    accountId,
+    replyToMessageId,
+    replyInThread,
+    postMarkdownLineBreaksNormalized,
+  } = params;
   const commentResult = await sendCommentThreadReply({
     cfg,
     to,
@@ -459,12 +477,44 @@ async function sendOutboundText(params: {
     });
   }
 
-  return sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId, replyInThread });
+  return sendMessageFeishu({
+    cfg,
+    to,
+    text,
+    accountId,
+    replyToMessageId,
+    replyInThread,
+    ...(postMarkdownLineBreaksNormalized ? { postMarkdownLineBreaksNormalized: true } : {}),
+  });
+}
+
+function resolveFeishuTextPayloadAdapter(params: { commentTarget: boolean }) {
+  if (params.commentTarget) {
+    return {
+      ...feishuOutbound,
+      chunker: chunkTextForOutbound,
+    };
+  }
+  return {
+    ...feishuOutbound,
+    chunker: chunkFeishuPostTextForOutbound,
+    sendText: async (ctx: Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0]) => {
+      const sendText = feishuOutbound.sendText;
+      if (!sendText) {
+        throw new Error("Feishu outbound text sender unavailable");
+      }
+      const normalizedCtx: FeishuOutboundTextContext = {
+        ...ctx,
+        postMarkdownLineBreaksNormalized: true,
+      };
+      return await sendText(normalizedCtx);
+    },
+  };
 }
 
 export const feishuOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
-  chunker: chunkTextForOutbound,
+  chunker: chunkFeishuPostTextForOutbound,
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   presentationCapabilities: {
@@ -494,11 +544,12 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       text: ctx.text,
       identity: ctx.identity,
     });
+    const commentTarget = parseFeishuCommentTarget(ctx.to);
     if (!card) {
       return await sendTextMediaPayload({
         channel: "feishu",
         ctx,
-        adapter: feishuOutbound,
+        adapter: resolveFeishuTextPayloadAdapter({ commentTarget: Boolean(commentTarget) }),
       });
     }
 
@@ -506,7 +557,6 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       replyToId: ctx.replyToId,
       threadId: ctx.threadId,
     });
-    const commentTarget = parseFeishuCommentTarget(ctx.to);
     if (commentTarget) {
       return await sendTextMediaPayload({
         channel: "feishu",
@@ -528,7 +578,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             channelData: undefined,
           },
         },
-        adapter: feishuOutbound,
+        adapter: resolveFeishuTextPayloadAdapter({ commentTarget: true }),
       });
     }
 
@@ -564,16 +614,18 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   },
   ...createAttachedChannelResultAdapter({
     channel: "feishu",
-    sendText: async ({
-      cfg,
-      to,
-      text,
-      accountId,
-      replyToId,
-      threadId,
-      mediaLocalRoots,
-      identity,
-    }) => {
+    sendText: async (ctx) => {
+      const {
+        cfg,
+        to,
+        text,
+        accountId,
+        replyToId,
+        threadId,
+        mediaLocalRoots,
+        identity,
+        postMarkdownLineBreaksNormalized,
+      } = ctx as FeishuOutboundTextContext;
       const { replyToMessageId, replyInThread } = resolveFeishuMediaReplyMode({
         replyToId,
         threadId,
@@ -639,6 +691,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         accountId: accountId ?? undefined,
         replyToMessageId,
         replyInThread,
+        ...(postMarkdownLineBreaksNormalized ? { postMarkdownLineBreaksNormalized: true } : {}),
       });
     },
     sendMedia: async ({

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -60,6 +60,20 @@ vi.mock("./accounts.js", () => ({
 }));
 vi.mock("./runtime.js", () => ({ getFeishuRuntime: getFeishuRuntimeMock }));
 vi.mock("./send.js", () => ({
+  normalizeFeishuPostMarkdownLineBreaks: (text: string) => {
+    const lines = text.replace(/\r\n?/g, "\n").split("\n");
+    const parts: string[] = [];
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index] ?? "";
+      parts.push(line);
+      if (index === lines.length - 1) {
+        continue;
+      }
+      const nextLine = lines[index + 1] ?? "";
+      parts.push(line.length === 0 || nextLine.length === 0 ? "\n" : "\n\n");
+    }
+    return parts.join("");
+  },
   sendMessageFeishu: sendMessageFeishuMock,
   sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
   sendStructuredCardFeishu: sendStructuredCardFeishuMock,
@@ -454,6 +468,35 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
       1,
     );
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("chunks non-streaming Feishu post replies after newline expansion", async () => {
+    useNonStreamingAutoAccount();
+    const runtime = getFeishuRuntimeMock();
+    runtime.channel.text.resolveTextChunkLimit.mockReturnValue(4000);
+    runtime.channel.text.chunkTextWithMode.mockImplementation((text: string, limit: number) => {
+      const splitAt = text.lastIndexOf("\n", limit);
+      return [text.slice(0, splitAt).trimEnd(), text.slice(splitAt + 1).trimStart()].filter(
+        Boolean,
+      );
+    });
+    const rawNearLimit = Array.from({ length: 2000 }, () => "x").join("\n");
+
+    const { options } = createDispatcherHarness();
+    await options.deliver({ text: rawNearLimit }, { kind: "final" });
+    await options.onIdle?.();
+
+    const chunkSource = runtime.channel.text.chunkTextWithMode.mock.calls[0]?.[0];
+    expect(chunkSource).toHaveLength(5998);
+    expect(chunkSource).not.toMatch(/[^\n]\n[^\n]/u);
+    const calls = sendMessageFeishuMock.mock.calls as unknown as Array<[Record<string, any>]>;
+    expect(calls.length).toBeGreaterThan(1);
+    for (const [call] of calls) {
+      expect(call.postMarkdownLineBreaksNormalized).toBe(true);
+      expect(call.text.length).toBeLessThanOrEqual(4000);
+      expect(call.text).not.toMatch(/[^\n]\n[^\n]/u);
+    }
     expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
   });
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -24,7 +24,12 @@ import {
   type RuntimeEnv,
 } from "./reply-dispatcher-runtime-api.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } from "./send.js";
+import {
+  normalizeFeishuPostMarkdownLineBreaks,
+  sendMessageFeishu,
+  sendStructuredCardFeishu,
+  type CardHeaderConfig,
+} from "./send.js";
 import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
@@ -485,22 +490,30 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     text: string;
     useCard: boolean;
     infoKind?: string;
-    sendChunk: (params: { chunk: string; isFirst: boolean }) => Promise<void>;
+    sendChunk: (params: {
+      chunk: string;
+      isFirst: boolean;
+      postMarkdownLineBreaksNormalized?: boolean;
+    }) => Promise<void>;
   }) => {
     const chunkSource = paramsLocal.useCard
       ? paramsLocal.text
       : core.channel.text.convertMarkdownTables(paramsLocal.text, tableMode);
+    const deliveryText = paramsLocal.useCard
+      ? chunkSource
+      : normalizeFeishuPostMarkdownLineBreaks(chunkSource);
     const chunkText = paramsLocal.useCard
       ? core.channel.text.chunkMarkdownTextWithMode
       : core.channel.text.chunkTextWithMode;
     const chunks = resolveTextChunksWithFallback(
-      chunkSource,
-      chunkText(chunkSource, textChunkLimit, chunkMode),
+      deliveryText,
+      chunkText(deliveryText, textChunkLimit, chunkMode),
     );
     for (const [index, chunk] of chunks.entries()) {
       await paramsLocal.sendChunk({
         chunk,
         isFirst: index === 0,
+        ...(paramsLocal.useCard ? {} : { postMarkdownLineBreaksNormalized: true }),
       });
       markVisibleReplySent();
     }
@@ -532,7 +545,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             text: options.fallbackText,
             useCard: false,
             infoKind: "final",
-            sendChunk: async ({ chunk }) => {
+            sendChunk: async ({ chunk, postMarkdownLineBreaksNormalized }) => {
               await sendMessageFeishu({
                 cfg,
                 to: chatId,
@@ -541,6 +554,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 replyInThread: effectiveReplyInThread,
                 allowTopLevelReplyFallback,
                 accountId,
+                ...(postMarkdownLineBreaksNormalized
+                  ? { postMarkdownLineBreaksNormalized: true }
+                  : {}),
               });
             },
           });
@@ -559,7 +575,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 text: fallbackText,
                 useCard: false,
                 infoKind: "final",
-                sendChunk: async ({ chunk }) => {
+                sendChunk: async ({ chunk, postMarkdownLineBreaksNormalized }) => {
                   await sendMessageFeishu({
                     cfg,
                     to: chatId,
@@ -568,6 +584,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                     replyInThread: effectiveReplyInThread,
                     allowTopLevelReplyFallback,
                     accountId,
+                    ...(postMarkdownLineBreaksNormalized
+                      ? { postMarkdownLineBreaksNormalized: true }
+                      : {}),
                   });
                 },
               });
@@ -776,7 +795,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               text,
               useCard: false,
               infoKind: info?.kind,
-              sendChunk: async ({ chunk, isFirst }) => {
+              sendChunk: async ({ chunk, isFirst, postMarkdownLineBreaksNormalized }) => {
                 await sendMessageFeishu({
                   cfg,
                   to: chatId,
@@ -787,6 +806,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                   accountId,
                   ...(info?.kind === "final" && isFirst && mentionTargets?.length
                     ? { mentions: mentionTargets }
+                    : {}),
+                  ...(postMarkdownLineBreaksNormalized
+                    ? { postMarkdownLineBreaksNormalized: true }
                     : {}),
                 });
               },

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -105,6 +105,48 @@ describe("buildFeishuPostMessagePayload", () => {
       },
     });
   });
+
+  it("expands single markdown newlines outside fenced code blocks", () => {
+    const payload = buildFeishuPostMessagePayload({
+      messageText: [
+        "First line",
+        "Second line",
+        "",
+        "Already separated",
+        "```ts",
+        "const a = 1;",
+        "const b = 2;",
+        "```",
+        "After",
+      ].join("\n"),
+    });
+
+    expect(JSON.parse(payload.content)).toEqual({
+      zh_cn: {
+        content: [
+          [
+            {
+              tag: "md",
+              text: [
+                "First line",
+                "",
+                "Second line",
+                "",
+                "Already separated",
+                "",
+                "```ts",
+                "const a = 1;",
+                "const b = 2;",
+                "```",
+                "",
+                "After",
+              ].join("\n"),
+            },
+          ],
+        ],
+      },
+    });
+  });
 });
 
 describe("getMessageFeishu", () => {

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -366,6 +366,34 @@ describe("getMessageFeishu", () => {
     });
   });
 
+  it("rejects direct post sends that exceed the normalized Feishu text limit", async () => {
+    const create = vi.fn();
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          reply: vi.fn(),
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+    const overLimitText = Array.from({ length: 1335 }, () => "x").join("\n");
+
+    await expect(
+      sendMessageFeishu({
+        cfg: {} as ClawdbotConfig,
+        to: "oc_send",
+        text: overLimitText,
+      }),
+    ).rejects.toThrow(
+      "Feishu send text exceeds 4000 characters after post markdown line break normalization.",
+    );
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it("extracts text content from interactive card elements", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,
@@ -785,6 +813,47 @@ describe("editMessageFeishu", () => {
       },
     });
     expect(result).toEqual({ messageId: "om_edit", contentType: "post" });
+  });
+
+  it("allows post text edits at the normalized Feishu text limit", async () => {
+    mockClientPatch.mockResolvedValueOnce({ code: 0 });
+    const nearLimitText = Array.from({ length: 1334 }, () => "x").join("\n");
+    const normalizedText = normalizeFeishuPostMarkdownLineBreaks(nearLimitText);
+    expect(normalizedText).toHaveLength(4000);
+
+    const result = await editMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_edit_limit",
+      text: nearLimitText,
+    });
+
+    expect(mockClientPatch).toHaveBeenCalledWith({
+      path: { message_id: "om_edit_limit" },
+      data: {
+        content: JSON.stringify({
+          zh_cn: {
+            content: [[{ tag: "md", text: normalizedText }]],
+          },
+        }),
+      },
+    });
+    expect(result).toEqual({ messageId: "om_edit_limit", contentType: "post" });
+  });
+
+  it("rejects post text edits that exceed the normalized Feishu text limit", async () => {
+    const overLimitText = Array.from({ length: 1335 }, () => "x").join("\n");
+
+    await expect(
+      editMessageFeishu({
+        cfg: {} as ClawdbotConfig,
+        messageId: "om_edit_over_limit",
+        text: overLimitText,
+      }),
+    ).rejects.toThrow(
+      "Feishu edit text exceeds 4000 characters after post markdown line break normalization.",
+    );
+
+    expect(mockClientPatch).not.toHaveBeenCalled();
   });
 
   it("patches interactive content for card edits", async () => {

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -1,7 +1,11 @@
 // Feishu tests cover send plugin behavior.
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
-import { buildFeishuPostMessagePayload, buildMarkdownCard } from "./send.js";
+import {
+  buildFeishuPostMessagePayload,
+  buildMarkdownCard,
+  normalizeFeishuPostMarkdownLineBreaks,
+} from "./send.js";
 
 const {
   mockConvertMarkdownTables,
@@ -105,47 +109,40 @@ describe("buildFeishuPostMessagePayload", () => {
       },
     });
   });
+});
 
+describe("normalizeFeishuPostMarkdownLineBreaks", () => {
   it("expands single markdown newlines outside fenced code blocks", () => {
-    const payload = buildFeishuPostMessagePayload({
-      messageText: [
+    expect(
+      normalizeFeishuPostMarkdownLineBreaks(
+        [
+          "First line",
+          "Second line",
+          "",
+          "Already separated",
+          "```ts",
+          "const a = 1;",
+          "const b = 2;",
+          "```",
+          "After",
+        ].join("\n"),
+      ),
+    ).toBe(
+      [
         "First line",
+        "",
         "Second line",
         "",
         "Already separated",
+        "",
         "```ts",
         "const a = 1;",
         "const b = 2;",
         "```",
+        "",
         "After",
       ].join("\n"),
-    });
-
-    expect(JSON.parse(payload.content)).toEqual({
-      zh_cn: {
-        content: [
-          [
-            {
-              tag: "md",
-              text: [
-                "First line",
-                "",
-                "Second line",
-                "",
-                "Already separated",
-                "",
-                "```ts",
-                "const a = 1;",
-                "const b = 2;",
-                "```",
-                "",
-                "After",
-              ].join("\n"),
-            },
-          ],
-        ],
-      },
-    });
+    );
   });
 });
 
@@ -331,6 +328,40 @@ describe("getMessageFeishu", () => {
             conversationId: "oc_send",
           },
         ],
+      },
+    });
+  });
+
+  it("normalizes post markdown line breaks before sending text", async () => {
+    const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_lines" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          reply: vi.fn(),
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+
+    await sendMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_send",
+      text: "First line\nSecond line",
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      params: { receive_id_type: "chat_id" },
+      data: {
+        receive_id: "oc_send",
+        msg_type: "post",
+        content: JSON.stringify({
+          zh_cn: {
+            content: [[{ tag: "md", text: "First line\n\nSecond line" }]],
+          },
+        }),
       },
     });
   });
@@ -733,7 +764,7 @@ describe("editMessageFeishu", () => {
     const result = await editMessageFeishu({
       cfg: {} as ClawdbotConfig,
       messageId: "om_edit",
-      text: "updated body",
+      text: "updated\nbody",
     });
 
     expect(mockClientPatch).toHaveBeenCalledWith({
@@ -745,7 +776,7 @@ describe("editMessageFeishu", () => {
               [
                 {
                   tag: "md",
-                  text: "updated body",
+                  text: "updated\n\nbody",
                 },
               ],
             ],

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -544,6 +544,8 @@ export type SendFeishuMessageParams = {
   mentions?: MentionTarget[];
   /** Account ID (optional, uses default if not specified) */
   accountId?: string;
+  /** Internal: text already expanded before outbound chunking. */
+  postMarkdownLineBreaksNormalized?: boolean;
 };
 
 type FeishuPostMessageElement =
@@ -571,7 +573,7 @@ function buildFeishuPostMentionElements(mentions?: MentionTarget[]): FeishuPostM
   return elements;
 }
 
-function normalizeFeishuPostMarkdownLineBreaks(text: string): string {
+export function normalizeFeishuPostMarkdownLineBreaks(text: string): string {
   const lines = text.replace(/\r\n?/g, "\n").split("\n");
   const parts: string[] = [];
   let inFence = false;
@@ -611,7 +613,7 @@ export function buildFeishuPostMessagePayload(params: {
     ...buildFeishuPostMentionElements(mentions),
     {
       tag: "md",
-      text: normalizeFeishuPostMarkdownLineBreaks(messageText),
+      text: messageText,
     },
   ];
   return {
@@ -636,6 +638,7 @@ export async function sendMessageFeishu(
     allowTopLevelReplyFallback,
     mentions,
     accountId,
+    postMarkdownLineBreaksNormalized,
   } = params;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const tableMode = resolveMarkdownTableMode({
@@ -643,7 +646,10 @@ export async function sendMessageFeishu(
     channel: "feishu",
   });
 
-  const messageText = convertMarkdownTables(text ?? "", tableMode);
+  const convertedText = convertMarkdownTables(text ?? "", tableMode);
+  const messageText = postMarkdownLineBreaksNormalized
+    ? convertedText
+    : normalizeFeishuPostMarkdownLineBreaks(convertedText);
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText, mentions });
 
@@ -729,7 +735,9 @@ export async function editMessageFeishu(params: {
     cfg,
     channel: "feishu",
   });
-  const messageText = convertMarkdownTables(text!, tableMode);
+  const messageText = normalizeFeishuPostMarkdownLineBreaks(
+    convertMarkdownTables(text!, tableMode),
+  );
   const payload = buildFeishuPostMessagePayload({ messageText });
   const response = await client.im.message.patch({
     path: { message_id: messageId },

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -571,6 +571,34 @@ function buildFeishuPostMentionElements(mentions?: MentionTarget[]): FeishuPostM
   return elements;
 }
 
+function normalizeFeishuPostMarkdownLineBreaks(text: string): string {
+  const lines = text.replace(/\r\n?/g, "\n").split("\n");
+  const parts: string[] = [];
+  let inFence = false;
+  let fenceMarker: "`" | "~" | null = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    parts.push(line);
+
+    const fence = /^(```+|~~~+)/u.exec(line.trimStart())?.[1];
+    const marker = fence?.startsWith("`") ? "`" : fence?.startsWith("~") ? "~" : null;
+    if (marker && (!inFence || marker === fenceMarker)) {
+      inFence = !inFence;
+      fenceMarker = inFence ? marker : null;
+    }
+
+    if (index === lines.length - 1) {
+      continue;
+    }
+
+    const nextLine = lines[index + 1] ?? "";
+    parts.push(inFence || line.length === 0 || nextLine.length === 0 ? "\n" : "\n\n");
+  }
+
+  return parts.join("");
+}
+
 export function buildFeishuPostMessagePayload(params: {
   messageText: string;
   mentions?: MentionTarget[];
@@ -583,7 +611,7 @@ export function buildFeishuPostMessagePayload(params: {
     ...buildFeishuPostMentionElements(mentions),
     {
       tag: "md",
-      text: messageText,
+      text: normalizeFeishuPostMarkdownLineBreaks(messageText),
     },
   ];
   return {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -25,6 +25,7 @@ import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./type
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
 const INTERACTIVE_CARD_FALLBACK_TEXT = "[Interactive Card]";
 const POST_FALLBACK_TEXT = "[Rich text message]";
+const FEISHU_POST_TEXT_LIMIT = 4000;
 const FEISHU_CARD_TEMPLATES = new Set([
   "blue",
   "green",
@@ -601,6 +602,18 @@ export function normalizeFeishuPostMarkdownLineBreaks(text: string): string {
   return parts.join("");
 }
 
+function assertFeishuPostMessageTextWithinLimit(
+  messageText: string,
+  action: "send" | "edit",
+): void {
+  if (messageText.length <= FEISHU_POST_TEXT_LIMIT) {
+    return;
+  }
+  throw new Error(
+    `Feishu ${action} text exceeds ${FEISHU_POST_TEXT_LIMIT} characters after post markdown line break normalization.`,
+  );
+}
+
 export function buildFeishuPostMessagePayload(params: {
   messageText: string;
   mentions?: MentionTarget[];
@@ -650,6 +663,7 @@ export async function sendMessageFeishu(
   const messageText = postMarkdownLineBreaksNormalized
     ? convertedText
     : normalizeFeishuPostMarkdownLineBreaks(convertedText);
+  assertFeishuPostMessageTextWithinLimit(messageText, "send");
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText, mentions });
 
@@ -738,6 +752,7 @@ export async function editMessageFeishu(params: {
   const messageText = normalizeFeishuPostMarkdownLineBreaks(
     convertMarkdownTables(text!, tableMode),
   );
+  assertFeishuPostMessageTextWithinLimit(messageText, "edit");
   const payload = buildFeishuPostMessagePayload({ messageText });
   const response = await client.im.message.patch({
     path: { message_id: messageId },


### PR DESCRIPTION
Fixes #97074

## What Problem This Solves

Feishu `post` messages render single markdown newlines as soft breaks, which can collapse normal agent output into cramped one-line paragraphs. Long Feishu replies are harder to read even when the source text has line breaks.

## Why This Change Was Made

The Feishu send path already owns the final `tag: "md"` post payload. This change normalizes single line breaks at the Feishu-local post boundary after table conversion, while preserving existing blank lines and fenced code block line breaks.

After review, the newline expansion now participates in Feishu post text chunking instead of growing chunks after the 4000-character limit check. Normal outbound post sends and reply-dispatcher post replies expand newlines before chunking, then mark the chunks as already normalized before the final `sendMessageFeishu` call. Feishu document-comment targets keep the original chunker because those deliveries are not post+md messages.

A follow-up review noted that text edits still patched the normalized post payload directly. This branch now enforces the same 4000-character post text ceiling after newline normalization for direct post sends and post text edits. Over-limit edits fail before `client.im.message.patch`, while exactly-at-limit normalized edits still patch normally.

## User Impact

Feishu users should see normal paragraph-style breaks for ordinary agent output. Existing structured mentions stay native Feishu `at` elements, code fences keep their original internal line structure, newline-heavy post replies remain bounded by the Feishu text limit after expansion, and over-limit post edits now fail locally before sending an oversized patch request.

## Evidence

- `node scripts/run-vitest.mjs extensions/feishu/src/send.test.ts extensions/feishu/src/outbound.test.ts extensions/feishu/src/reply-dispatcher.test.ts`
- `./node_modules/.bin/oxfmt --write --threads=1 extensions/feishu/src/send.ts extensions/feishu/src/send.test.ts`
- `git diff --check`

Known proof gap:

- I do not have live Feishu client/API proof available from this local environment, so I cannot attach a redacted live rendering screenshot or API artifact. The added regressions cover newline expansion, near-limit chunk safety for outbound post sends and reply-dispatcher post replies, direct-send limit rejection, exactly-at-limit post text edits, and over-limit post edit rejection before patch.

Attempted but not completed:

- `node scripts/run-vitest.mjs extensions/feishu` was started for broader Feishu coverage, but it did not complete after several minutes with no failure output and was interrupted to avoid leaving a long local runner active.

## AI Assistance

AI-assisted: yes. I used Codex to inspect the issue, check for duplicate PRs, implement the focused Feishu payload and chunking fix, address review feedback, and run the validation above.
