### PR TITLE
fix: expose sessions_send requester return path

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1156,8 +1156,12 @@ describe("sessions tools", () => {
       `Agent 1 (requester) session: ${requesterKey}.`,
     );
     expect(initialAgentParams.extraSystemPrompt).toContain(
-      `Return replies with sessions_send(sessionKey: "${requesterKey}", message: ...).`,
+      'Return visible replies to the requester source conversation with message(action="send", message=...).',
     );
+    expect(initialAgentParams.extraSystemPrompt).toContain(
+      "Do not call sessions_send back to the requester.",
+    );
+    expect(initialAgentParams.extraSystemPrompt).not.toContain("sessions_send(sessionKey:");
     expect(initialAgentParams.extraSystemPrompt).toContain("Agent 1 (requester) channel: discord.");
     expect(initialAgentParams.extraSystemPrompt).toContain(
       "Agent 2 (target) session: <TARGET_SESSION>.",

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1153,13 +1153,15 @@ describe("sessions tools", () => {
     );
     const initialAgentParams = agentParams(initialAgentCall ?? {});
     expect(initialAgentParams.extraSystemPrompt).toContain(
-      "Agent 1 (requester) session: <REQUESTER_SESSION>.",
+      `Agent 1 (requester) session: ${requesterKey}.`,
+    );
+    expect(initialAgentParams.extraSystemPrompt).toContain(
+      `Return replies with sessions_send(sessionKey: "${requesterKey}", message: ...).`,
     );
     expect(initialAgentParams.extraSystemPrompt).toContain("Agent 1 (requester) channel: discord.");
     expect(initialAgentParams.extraSystemPrompt).toContain(
       "Agent 2 (target) session: <TARGET_SESSION>.",
     );
-    expect(initialAgentParams.extraSystemPrompt).not.toContain(requesterKey);
     expect(initialAgentParams.inputProvenance).toMatchObject({
       kind: "inter_session",
       sourceSessionKey: requesterKey,

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -5,6 +5,7 @@ import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
 import {
   buildAgentToAgentMessageContext,
+  buildAgentToAgentAnnounceContext,
   buildAgentToAgentReplyContext,
   resolveAnnounceTargetFromKey,
   resolvePingPongTurns,
@@ -133,7 +134,7 @@ describe("agent-to-agent prompt context", () => {
     expect(context).toContain("Agent 1 (requester) channel: whatsapp.");
   });
 
-  it("preserves optional session line shape with concrete channel values", () => {
+  it("keeps ping-pong session lines placeholdered with concrete channel values", () => {
     const context = buildAgentToAgentReplyContext({
       requesterSessionKey: "agent:requester:main",
       targetSessionKey: "agent:target:main",
@@ -144,11 +145,12 @@ describe("agent-to-agent prompt context", () => {
     });
 
     expect(context).toContain("Current agent: Agent 2 (target).");
-    expect(context).toContain("Agent 1 (requester) session: agent:requester:main.");
+    expect(context).toContain("Agent 1 (requester) session: <REQUESTER_SESSION>.");
     expect(context).not.toContain("Return replies with sessions_send");
     expect(context).not.toContain("Agent 1 (requester) channel:");
     expect(context).toContain("Agent 2 (target) session: <TARGET_SESSION>.");
     expect(context).toContain("Agent 2 (target) channel: telegram.");
+    expect(context).not.toContain("agent:requester:main");
     expect(context).not.toContain("agent:target:main");
   });
 
@@ -163,9 +165,25 @@ describe("agent-to-agent prompt context", () => {
     });
 
     expect(context).toContain("Current agent: Agent 1 (requester).");
-    expect(context).toContain(
-      "Agent 1 (requester) session: agent:koro:whatsapp:group:120363426513385961@g.us.",
-    );
+    expect(context).toContain("Agent 1 (requester) session: <REQUESTER_SESSION>.");
     expect(context).not.toContain("Return replies with sessions_send");
+    expect(context).not.toContain("agent:koro:whatsapp:group:120363426513385961@g.us");
+  });
+
+  it("keeps announce session lines placeholdered", () => {
+    const context = buildAgentToAgentAnnounceContext({
+      requesterSessionKey: "agent:koro:whatsapp:group:120363426513385961@g.us",
+      requesterChannel: "whatsapp",
+      targetSessionKey: "agent:alfred:main",
+      targetChannel: "agent",
+      originalMessage: "Please handle this.",
+      roundOneReply: "Handled.",
+      latestReply: "Handled.",
+    });
+
+    expect(context).toContain("Agent 1 (requester) session: <REQUESTER_SESSION>.");
+    expect(context).not.toContain("Return replies with sessions_send");
+    expect(context).not.toContain("agent:koro:whatsapp:group:120363426513385961@g.us");
+    expect(context).not.toContain("agent:alfred:main");
   });
 });

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -100,7 +100,7 @@ describe("resolvePingPongTurns", () => {
 });
 
 describe("agent-to-agent prompt context", () => {
-  it("includes the concrete requester session as the return path", () => {
+  it("includes the concrete requester session as source-reply context", () => {
     const context = buildAgentToAgentMessageContext({
       requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
       requesterChannel: "slack",
@@ -111,14 +111,16 @@ describe("agent-to-agent prompt context", () => {
       "Agent 1 (requester) session: agent:main:slack:channel:C123:thread:171.222.",
     );
     expect(context).toContain(
-      'Return replies with sessions_send(sessionKey: "agent:main:slack:channel:C123:thread:171.222", message: ...).',
+      'Return visible replies to the requester source conversation with message(action="send", message=...).',
     );
+    expect(context).toContain("Do not call sessions_send back to the requester.");
     expect(context).toContain("Agent 1 (requester) channel: slack.");
     expect(context).toContain("Agent 2 (target) session: <TARGET_SESSION>.");
+    expect(context).not.toContain("sessions_send(sessionKey:");
     expect(context).not.toContain("agent:worker:discord:channel:ops:run:run-123");
   });
 
-  it("keeps WhatsApp group requester keys concrete for return routing", () => {
+  it("keeps WhatsApp group requester keys concrete for source-reply context", () => {
     const context = buildAgentToAgentMessageContext({
       requesterSessionKey: "agent:koro:whatsapp:group:120363426513385961@g.us",
       requesterChannel: "whatsapp",
@@ -129,9 +131,11 @@ describe("agent-to-agent prompt context", () => {
       "Agent 1 (requester) session: agent:koro:whatsapp:group:120363426513385961@g.us.",
     );
     expect(context).toContain(
-      'Return replies with sessions_send(sessionKey: "agent:koro:whatsapp:group:120363426513385961@g.us", message: ...).',
+      'Return visible replies to the requester source conversation with message(action="send", message=...).',
     );
+    expect(context).toContain("Do not call sessions_send back to the requester.");
     expect(context).toContain("Agent 1 (requester) channel: whatsapp.");
+    expect(context).not.toContain("sessions_send(sessionKey:");
   });
 
   it("keeps ping-pong session lines placeholdered with concrete channel values", () => {
@@ -146,7 +150,8 @@ describe("agent-to-agent prompt context", () => {
 
     expect(context).toContain("Current agent: Agent 2 (target).");
     expect(context).toContain("Agent 1 (requester) session: <REQUESTER_SESSION>.");
-    expect(context).not.toContain("Return replies with sessions_send");
+    expect(context).not.toContain("Return visible replies");
+    expect(context).not.toContain("sessions_send(sessionKey:");
     expect(context).not.toContain("Agent 1 (requester) channel:");
     expect(context).toContain("Agent 2 (target) session: <TARGET_SESSION>.");
     expect(context).toContain("Agent 2 (target) channel: telegram.");
@@ -166,7 +171,8 @@ describe("agent-to-agent prompt context", () => {
 
     expect(context).toContain("Current agent: Agent 1 (requester).");
     expect(context).toContain("Agent 1 (requester) session: <REQUESTER_SESSION>.");
-    expect(context).not.toContain("Return replies with sessions_send");
+    expect(context).not.toContain("Return visible replies");
+    expect(context).not.toContain("sessions_send(sessionKey:");
     expect(context).not.toContain("agent:koro:whatsapp:group:120363426513385961@g.us");
   });
 
@@ -182,7 +188,8 @@ describe("agent-to-agent prompt context", () => {
     });
 
     expect(context).toContain("Agent 1 (requester) session: <REQUESTER_SESSION>.");
-    expect(context).not.toContain("Return replies with sessions_send");
+    expect(context).not.toContain("Return visible replies");
+    expect(context).not.toContain("sessions_send(sessionKey:");
     expect(context).not.toContain("agent:koro:whatsapp:group:120363426513385961@g.us");
     expect(context).not.toContain("agent:alfred:main");
   });

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -99,18 +99,38 @@ describe("resolvePingPongTurns", () => {
 });
 
 describe("agent-to-agent prompt context", () => {
-  it("keeps volatile routing identifiers out of system prompt context", () => {
+  it("includes the concrete requester session as the return path", () => {
     const context = buildAgentToAgentMessageContext({
       requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
       requesterChannel: "slack",
       targetSessionKey: "agent:worker:discord:channel:ops:run:run-123",
     });
 
-    expect(context).toContain("Agent 1 (requester) session: <REQUESTER_SESSION>.");
+    expect(context).toContain(
+      "Agent 1 (requester) session: agent:main:slack:channel:C123:thread:171.222.",
+    );
+    expect(context).toContain(
+      'Return replies with sessions_send(sessionKey: "agent:main:slack:channel:C123:thread:171.222", message: ...).',
+    );
     expect(context).toContain("Agent 1 (requester) channel: slack.");
     expect(context).toContain("Agent 2 (target) session: <TARGET_SESSION>.");
-    expect(context).not.toContain("agent:main:slack:channel:C123:thread:171.222");
     expect(context).not.toContain("agent:worker:discord:channel:ops:run:run-123");
+  });
+
+  it("keeps WhatsApp group requester keys concrete for return routing", () => {
+    const context = buildAgentToAgentMessageContext({
+      requesterSessionKey: "agent:koro:whatsapp:group:120363426513385961@g.us",
+      requesterChannel: "whatsapp",
+      targetSessionKey: "agent:alfred:main",
+    });
+
+    expect(context).toContain(
+      "Agent 1 (requester) session: agent:koro:whatsapp:group:120363426513385961@g.us.",
+    );
+    expect(context).toContain(
+      'Return replies with sessions_send(sessionKey: "agent:koro:whatsapp:group:120363426513385961@g.us", message: ...).',
+    );
+    expect(context).toContain("Agent 1 (requester) channel: whatsapp.");
   });
 
   it("preserves optional session line shape with concrete channel values", () => {
@@ -124,11 +144,28 @@ describe("agent-to-agent prompt context", () => {
     });
 
     expect(context).toContain("Current agent: Agent 2 (target).");
-    expect(context).toContain("Agent 1 (requester) session: <REQUESTER_SESSION>.");
+    expect(context).toContain("Agent 1 (requester) session: agent:requester:main.");
+    expect(context).not.toContain("Return replies with sessions_send");
     expect(context).not.toContain("Agent 1 (requester) channel:");
     expect(context).toContain("Agent 2 (target) session: <TARGET_SESSION>.");
     expect(context).toContain("Agent 2 (target) channel: telegram.");
-    expect(context).not.toContain("agent:requester:main");
     expect(context).not.toContain("agent:target:main");
+  });
+
+  it("does not tell requester-side ping-pong turns to send to themselves", () => {
+    const context = buildAgentToAgentReplyContext({
+      requesterSessionKey: "agent:koro:whatsapp:group:120363426513385961@g.us",
+      requesterChannel: "whatsapp",
+      targetSessionKey: "agent:alfred:main",
+      currentRole: "requester",
+      turn: 2,
+      maxTurns: 5,
+    });
+
+    expect(context).toContain("Current agent: Agent 1 (requester).");
+    expect(context).toContain(
+      "Agent 1 (requester) session: agent:koro:whatsapp:group:120363426513385961@g.us.",
+    );
+    expect(context).not.toContain("Return replies with sessions_send");
   });
 });

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -68,7 +68,7 @@ function buildAgentSessionLines(params: {
     : undefined;
   const requesterReturnLine =
     params.requesterSessionKey && params.includeRequesterReturnInstruction
-      ? `Return replies with sessions_send(sessionKey: "${params.requesterSessionKey}", message: ...).`
+      ? `Return visible replies to the requester source conversation with message(action="send", message=...). Do not call sessions_send back to the requester.`
       : undefined;
   return [
     requesterSessionLine,

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -57,12 +57,18 @@ function buildAgentSessionLines(params: {
   requesterChannel?: string;
   targetSessionKey: string;
   targetChannel?: string;
+  includeRequesterReturnInstruction?: boolean;
 }): string[] {
+  const requesterSessionLine = params.requesterSessionKey
+    ? `Agent 1 (requester) session: ${params.requesterSessionKey}.`
+    : undefined;
+  const requesterReturnLine =
+    params.requesterSessionKey && params.includeRequesterReturnInstruction
+      ? `Return replies with sessions_send(sessionKey: "${params.requesterSessionKey}", message: ...).`
+      : undefined;
   return [
-    // Session keys are high-cardinality (thread/run ids), so concrete values churn the
-    // system prompt and break provider prompt-cache reuse across A2A turns. Channels are
-    // low-cardinality and inform reply formatting, so they stay concrete.
-    params.requesterSessionKey ? "Agent 1 (requester) session: <REQUESTER_SESSION>." : undefined,
+    requesterSessionLine,
+    requesterReturnLine,
     params.requesterChannel
       ? `Agent 1 (requester) channel: ${params.requesterChannel}.`
       : undefined,
@@ -77,9 +83,10 @@ export function buildAgentToAgentMessageContext(params: {
   requesterChannel?: string;
   targetSessionKey: string;
 }) {
-  const lines = ["Agent-to-agent message context:", ...buildAgentSessionLines(params)].filter(
-    Boolean,
-  );
+  const lines = [
+    "Agent-to-agent message context:",
+    ...buildAgentSessionLines({ ...params, includeRequesterReturnInstruction: true }),
+  ].filter(Boolean);
   return lines.join("\n");
 }
 

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -60,7 +60,11 @@ function buildAgentSessionLines(params: {
   includeRequesterReturnInstruction?: boolean;
 }): string[] {
   const requesterSessionLine = params.requesterSessionKey
-    ? `Agent 1 (requester) session: ${params.requesterSessionKey}.`
+    ? `Agent 1 (requester) session: ${
+        params.includeRequesterReturnInstruction
+          ? params.requesterSessionKey
+          : "<REQUESTER_SESSION>"
+      }.`
     : undefined;
   const requesterReturnLine =
     params.requesterSessionKey && params.includeRequesterReturnInstruction


### PR DESCRIPTION
## Summary
- expose the concrete requester session key only in the initial `sessions_send` A2A target prompt as source-reply context
- instruct A2A targets to return visible replies through `message(action="send")`, matching `sourceReplyDeliveryMode: "message_tool_only"`
- keep shared ping-pong reply and final announce session lines placeholdered, and explicitly avoid reverse `sessions_send` back to the requester

## Why
A WhatsApp group-originated Koro 2 request to Alfred lost its original return path. Alfred received placeholder context (`<REQUESTER_SESSION>`) and sent the result to `agent:koro:main` / internal UI instead of the originating WhatsApp group session (`agent:koro:whatsapp:group:120363426513385961@g.us`).

## Verification
- RED: `node scripts/test-projects.mjs src/agents/tools/sessions-send-helpers.test.ts` failed on the missing concrete requester session before the fix.
- GREEN: `node scripts/test-projects.mjs src/agents/tools/sessions-send-helpers.test.ts src/agents/openclaw-tools.sessions.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts` passed 3 files / 65 tests after the source-reply follow-up.
- GREEN: `node scripts/test-projects.mjs src/agents/tools/sessions-send-helpers.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/tools/sessions.test.ts src/agents/tools/agent-step.test.ts src/agents/openclaw-tools.sessions.test.ts` passed 5 files / 108 tests after the source-reply follow-up.
- `git diff --check -- src/agents/tools/sessions-send-helpers.ts src/agents/tools/sessions-send-helpers.test.ts src/agents/openclaw-tools.sessions.test.ts` passed.

## Real Behavior Proof
Redacted live relay test on 2026-06-27:
- Source requester session: `agent:koro:whatsapp:group:120363426513385961@g.us`.
- Target session: `agent:alfred:main`.
- Alfred main resent the Sandweiss SAT packet back to the exact requester session during the live mitigation test.
- Koro 2 posted visibly to the originating WhatsApp group exactly once.
- Gateway evidence: WhatsApp group `120363426513385961@g.us`, message id `3EB02408D91490BA94EE86`.
- No self-route to `agent:koro:main` was observed in the relay closeout.

## Review
ClawSweeper first flagged concrete requester keys leaking through shared reply/announce contexts. Commit `962de1b78b` scoped concrete requester context to the initial target prompt only.

ClawSweeper then flagged the reverse `sessions_send` instruction as conflicting with the existing `message_tool_only` source-reply contract and duplicate-delivery guard work. Commit `883e75b0ee` replaces the reverse-send instruction with `message(action="send")` guidance and adds regression expectations that the initial target prompt does not contain `sessions_send(sessionKey:)`.

## Risk
The requester session key is visible to the first A2A target run only as source context. Visible source-channel output stays on the message tool path, while reply and announce contexts remain placeholdered to reduce prompt churn and avoid requester-side self-routing hints.