### PR TITLE
fix(telegram): preserve long streamed reply chunks

### DIFF
--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -364,7 +364,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     };
 
     const candidateTexts = [stream.lastDeliveredText?.(), lane.lastPartialText];
-    if (useFinalTextRecovery && remainingChunks.length === 0 && isPotentialTruncatedFinal(activeFullText)) {
+    if (
+      useFinalTextRecovery &&
+      remainingChunks.length === 0 &&
+      isPotentialTruncatedFinal(activeFullText)
+    ) {
       const resolvedFullCandidate = await params.resolveFinalTextCandidate?.({
         finalText: text,
         laneName,
@@ -379,7 +383,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
 
     const retainedPreview =
-      useFinalTextRecovery && remainingChunks.length === 0 && isPotentialTruncatedFinal(activeFullText)
+      useFinalTextRecovery &&
+      remainingChunks.length === 0 &&
+      isPotentialTruncatedFinal(activeFullText)
         ? selectLongerFinalText({
             finalText: activeFullText,
             candidateTexts,
@@ -443,9 +449,20 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     } else {
       await params.flushDraftLane(lane);
     }
-    const activeChunkIndexAfterStop = useFinalTextRecovery ? clampActiveChunkIndex() : activeChunkIndex;
-    const activeChunkAfterStop = chunks[activeChunkIndexAfterStop] ?? activeChunk;
-    const remainingChunksAfterStop = chunks.slice(activeChunkIndexAfterStop + 1);
+    const activeChunkIndexAfterStop = useFinalTextRecovery
+      ? clampActiveChunkIndex()
+      : activeChunkIndex;
+    const deliveredStreamTextAfterStop = stream.lastDeliveredText?.();
+    const retainedOriginalActiveChunkAfterStop =
+      activeChunkIndexAfterStop > activeChunkIndex &&
+      deliveredStreamTextAfterStop === activeChunk.trimEnd();
+    // `activeChunkIndex` is advanced by retained preview callbacks. If callbacks
+    // outrun the stream's delivered text, trust the delivered text and replay the gap.
+    const effectiveActiveChunkIndexAfterStop = retainedOriginalActiveChunkAfterStop
+      ? activeChunkIndex
+      : activeChunkIndexAfterStop;
+    const activeChunkAfterStop = chunks[effectiveActiveChunkIndexAfterStop] ?? activeChunk;
+    const remainingChunksAfterStop = chunks.slice(effectiveActiveChunkIndexAfterStop + 1);
 
     const messageId = stream.messageId();
     if (typeof messageId !== "number") {
@@ -460,16 +477,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       return undefined;
     }
 
-    const deliveredStreamTextAfterStop = stream.lastDeliveredText?.();
     const activeChunkTextAfterStop = activeChunkAfterStop.trimEnd();
-    const retainedActiveChunkAfterStop =
-      activeChunkIndexAfterStop !== activeChunkIndex &&
-      deliveredStreamTextAfterStop === activeChunk.trimEnd();
     if (
       finalizePreview &&
       deliveredStreamTextAfterStop !== undefined &&
       deliveredStreamTextAfterStop !== activeChunkTextAfterStop &&
-      !retainedActiveChunkAfterStop
+      !retainedOriginalActiveChunkAfterStop
     ) {
       if (
         useFinalTextRecovery &&

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -228,10 +228,7 @@ describe("createLaneTextDeliverer", () => {
     expect(answer.update).toHaveBeenCalledWith(previousBlock);
     expect(answer.update).not.toHaveBeenCalledWith(nextAssistantBlock);
     expect(harness.clearDraftLane).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).toHaveBeenCalledWith(
-      { text: previousBlock },
-      { durable: false },
-    );
+    expect(harness.sendPayload).toHaveBeenCalledWith({ text: previousBlock }, { durable: false });
     expect(harness.sendPayload).not.toHaveBeenCalledWith(
       { text: nextAssistantBlock },
       expect.anything(),
@@ -924,7 +921,7 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
   });
 
-  it("does not resend chunks retained while stopping a long streamed final", async () => {
+  it("sends chunks after the reported delivered text when stop advances the retained index", async () => {
     const answer = createTestDraftStream({ messageId: 999 });
     const harness = createHarness({
       answerStream: answer,
@@ -940,9 +937,33 @@ describe("createLaneTextDeliverer", () => {
 
     const delivery = expectPreviewFinalized(result);
     expect(delivery.content).toBe("Hello world again");
-    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).toHaveBeenCalledWith({ text: " again" });
+    expect(delivery.promptContextContent).toBe("Hello");
+    expect(harness.sendPayload).toHaveBeenCalledTimes(2);
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(1, { text: " world" });
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(2, { text: " again" });
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not skip middle chunks when stop advances past the reported delivered chunk", async () => {
+    const answer = createTestDraftStream({ messageId: 999 });
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 6,
+      splitFinalTextForStream: () => ["chunk0", "chunk1", "chunk2", "chunk3"],
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+    answer.stop.mockImplementation(async () => {
+      harness.lanes.answer.activeChunkIndex = 2;
+    });
+
+    const result = await deliverFinalAnswer(harness, "chunk0chunk1chunk2chunk3");
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.promptContextContent).toBe("chunk0");
+    expect(harness.sendPayload).toHaveBeenCalledTimes(3);
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(1, { text: "chunk1" });
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(2, { text: "chunk2" });
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(3, { text: "chunk3" });
   });
 
   it("compares retained delivered prefixes against the full final text", async () => {
@@ -995,11 +1016,15 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.editStreamMessage).toHaveBeenCalledWith({
       laneName: "answer",
       messageId: 999,
-      text: " world",
+      text: "Hello",
       buttons,
     });
-    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).toHaveBeenCalledWith({
+    expect(harness.sendPayload).toHaveBeenCalledTimes(2);
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(1, {
+      text: " world",
+      channelData: { telegram: { buttons } },
+    });
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(2, {
       text: " again",
       channelData: { telegram: { buttons } },
     });


### PR DESCRIPTION
What Problem This Solves

Fixes #95878.

Default Telegram replies with `richMessages` unset could drop a middle span of a long streamed final response. In the reproduced fixture, OpenClaw delivered the first and final Telegram messages and all chunks stayed under Telegram's 4096-character limit, but sections 16-29 disappeared. That made the failure look like truncation from the user's side even though Telegram accepted every send OpenClaw attempted.

Why This Change Was Made

The streamed final delivery path used `activeChunkIndex` after stopping the draft stream to decide which chunks had already reached Telegram. Retained-preview callbacks can advance that index ahead of the stream's reported delivered text. When that happened, final delivery resumed after the advanced index and skipped the chunk between the visible preview and the follow-up chunks.

This change makes the finalizer trust the stream's reported delivered text when retained callbacks outrun it. If the stream still reports the original active chunk, OpenClaw replays the gap instead of assuming the advanced index was delivered.

User Impact

Long Telegram replies now preserve middle chunks under the default Telegram config. This keeps streamed final replies complete without requiring `richMessages`, `textChunkLimit`, or `chunkMode` workarounds.

Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/lane-delivery.test.ts` passed: 42 tests.
- `pnpm exec oxfmt --check extensions/telegram/src/lane-delivery-text-deliverer.ts extensions/telegram/src/lane-delivery.test.ts` passed.
- `git diff --check` passed.
- Live Telegram E2E before fix on current `origin/main` reproduced the drop: payload sections 1-44, start/end visible, but sections 16-29 missing.
- Live Telegram E2E after fix on this branch passed with real Telegram-visible proof: prompt message 40191, 7 bot replies, sections 1-44 present, start/end markers present, all replies under 4096 chars. Summary artifact: `/var/folders/tr/ttb4qpdj3v12wvzr05hsdfv40000gn/T/openclaw-tg-fix-93gxnG/summary-after-fix.json`.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local --prompt ...` returned clean: no accepted/actionable findings.
