### PR TITLE
feat(docker): support OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS env var

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -148,25 +148,26 @@ and setup-time config writes through `openclaw-gateway` with
 
 The setup script accepts these optional environment variables:
 
-| Variable                                   | Purpose                                                               |
-| ------------------------------------------ | --------------------------------------------------------------------- |
-| `OPENCLAW_IMAGE`                           | Use a remote image instead of building locally                        |
-| `OPENCLAW_IMAGE_APT_PACKAGES`              | Install extra apt packages during build (space-separated)             |
-| `OPENCLAW_IMAGE_PIP_PACKAGES`              | Install extra Python packages during build (space-separated)          |
-| `OPENCLAW_EXTENSIONS`                      | Pre-install plugin dependencies at build time (space-separated names) |
-| `OPENCLAW_EXTRA_MOUNTS`                    | Extra host bind mounts (comma-separated `source:target[:opts]`)       |
-| `OPENCLAW_HOME_VOLUME`                     | Persist `/home/node` in a named Docker volume                         |
-| `OPENCLAW_SANDBOX`                         | Opt in to sandbox bootstrap (`1`, `true`, `yes`, `on`)                |
-| `OPENCLAW_SKIP_ONBOARDING`                 | Skip the interactive onboarding step (`1`, `true`, `yes`, `on`)       |
-| `OPENCLAW_DOCKER_SOCKET`                   | Override Docker socket path                                           |
-| `OPENCLAW_DISABLE_BONJOUR`                 | Disable Bonjour/mDNS advertising (defaults to `1` for Docker)         |
-| `OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS` | Disable bundled plugin source bind-mount overlays                     |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`              | Shared OTLP/HTTP collector endpoint for OpenTelemetry export          |
-| `OTEL_EXPORTER_OTLP_*_ENDPOINT`            | Signal-specific OTLP endpoints for traces, metrics, or logs           |
-| `OTEL_EXPORTER_OTLP_PROTOCOL`              | OTLP protocol override. Only `http/protobuf` is supported today       |
-| `OTEL_SERVICE_NAME`                        | Service name used for OpenTelemetry resources                         |
-| `OTEL_SEMCONV_STABILITY_OPT_IN`            | Opt in to latest experimental GenAI semantic attributes               |
-| `OPENCLAW_OTEL_PRELOADED`                  | Skip starting a second OpenTelemetry SDK when one is preloaded        |
+| Variable                                      | Purpose                                                                                                                                                                                                          |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OPENCLAW_IMAGE`                              | Use a remote image instead of building locally                                                                                                                                                                   |
+| `OPENCLAW_IMAGE_APT_PACKAGES`                 | Install extra apt packages during build (space-separated)                                                                                                                                                        |
+| `OPENCLAW_IMAGE_PIP_PACKAGES`                 | Install extra Python packages during build (space-separated)                                                                                                                                                     |
+| `OPENCLAW_EXTENSIONS`                         | Pre-install plugin dependencies at build time (space-separated names)                                                                                                                                            |
+| `OPENCLAW_EXTRA_MOUNTS`                       | Extra host bind mounts (comma-separated `source:target[:opts]`)                                                                                                                                                  |
+| `OPENCLAW_HOME_VOLUME`                        | Persist `/home/node` in a named Docker volume                                                                                                                                                                    |
+| `OPENCLAW_SANDBOX`                            | Opt in to sandbox bootstrap (`1`, `true`, `yes`, `on`)                                                                                                                                                           |
+| `OPENCLAW_SKIP_ONBOARDING`                    | Skip the interactive onboarding step (`1`, `true`, `yes`, `on`)                                                                                                                                                  |
+| `OPENCLAW_DOCKER_SOCKET`                      | Override Docker socket path                                                                                                                                                                                      |
+| `OPENCLAW_DISABLE_BONJOUR`                    | Disable Bonjour/mDNS advertising (defaults to `1` for Docker)                                                                                                                                                    |
+| `OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS`    | Disable bundled plugin source bind-mount overlays                                                                                                                                                                |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`                 | Shared OTLP/HTTP collector endpoint for OpenTelemetry export                                                                                                                                                     |
+| `OTEL_EXPORTER_OTLP_*_ENDPOINT`               | Signal-specific OTLP endpoints for traces, metrics, or logs                                                                                                                                                      |
+| `OTEL_EXPORTER_OTLP_PROTOCOL`                 | OTLP protocol override. Only `http/protobuf` is supported today                                                                                                                                                  |
+| `OTEL_SERVICE_NAME`                           | Service name used for OpenTelemetry resources                                                                                                                                                                    |
+| `OTEL_SEMCONV_STABILITY_OPT_IN`               | Opt in to latest experimental GenAI semantic attributes                                                                                                                                                          |
+| `OPENCLAW_OTEL_PRELOADED`                     | Skip starting a second OpenTelemetry SDK when one is preloaded                                                                                                                                                   |
+| `OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS` | Control UI browser origin allowlist (JSON array, e.g. `["https://example.com"]`). Read during Docker setup and written to config; overrides the default allowlist. Avoid `["*"]` — it allows any browser origin. |
 
 The official Docker image does not ship Homebrew. During onboarding, OpenClaw
 hides brew-only skill dependency installers when it is running in a Linux

--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -144,7 +144,10 @@ sync_gateway_config() {
   local current_allowed_origins=""
   local batch_json=""
 
-  if [[ "${OPENCLAW_GATEWAY_BIND}" != "loopback" ]]; then
+  if [[ -n "${OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS:-}" ]]; then
+    validate_allowed_origins_value "$OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS"
+    allowed_origin_json="$OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS"
+  elif [[ "${OPENCLAW_GATEWAY_BIND}" != "loopback" ]]; then
     allowed_origin_json="$(printf '["http://localhost:%s","http://127.0.0.1:%s"]' "$OPENCLAW_GATEWAY_PORT" "$OPENCLAW_GATEWAY_PORT")"
     current_allowed_origins="$(
       run_prestart_cli config get gateway.controlUi.allowedOrigins 2>/dev/null || true
@@ -441,6 +444,28 @@ validate_mount_spec() {
   if [[ ! "$mount" =~ ^[^,:]+:[^,:]+(:[^,:]+)?$ ]]; then
     fail "Invalid mount format '$mount'. Expected source:target[:options] without commas or control characters."
   fi
+}
+
+validate_allowed_origins_value() {
+  local value="$1"
+  if contains_disallowed_chars "$value"; then
+    fail "OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS contains unsupported control characters."
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c "
+import json, sys
+try:
+    parsed = json.loads(sys.argv[1])
+except json.JSONDecodeError:
+    sys.exit(1)
+if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+    sys.exit(1)
+" "$value" 2>/dev/null || fail "OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS must be a valid JSON array of strings"
+    return
+  fi
+
+  fail "OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS requires python3 for strict validation"
 }
 
 quote_yaml_string() {

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -1163,6 +1163,46 @@ describe("scripts/docker/setup.sh", () => {
     ).toHaveLength(2);
   });
 
+  it("honors OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS env var override", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+    await resetDockerLog(activeSandbox);
+
+    const customOrigins = '["https://openclaw.example.com","https://my-tailnet-host.ts.net"]';
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS: customOrigins,
+    });
+
+    expect(result.status).toBe(0);
+    const log = await readDockerLog(activeSandbox);
+    expect(log).toContain(`{"path":"gateway.controlUi.allowedOrigins","value":${customOrigins}}`);
+    expect(result.stdout).toContain("Set gateway.controlUi.allowedOrigins to");
+    expect(result.stdout).toContain(customOrigins);
+  });
+
+  it("rejects OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS with non-array value", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+    await resetDockerLog(activeSandbox);
+
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS: "not-a-json-array",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS");
+  });
+
+  it("rejects OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS with non-string array elements", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+    await resetDockerLog(activeSandbox);
+
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS: "[42]",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS");
+  });
+
   it("Dockerfile ARG OPENCLAW_IMAGE_APT_PACKAGES must not have a default value", async () => {
     // If the ARG has a default (e.g. ARG OPENCLAW_IMAGE_APT_PACKAGES=""), Docker treats it as
     // "set" even when no --build-arg is passed. That breaks the RUN fallback expression


### PR DESCRIPTION

Closes #93142

## What Problem This Solves

Fixes an issue where operators deploying OpenClaw via Portainer or other GUI-managed Compose stacks could not configure `gateway.controlUi.allowedOrigins` without running an extra shell command. The Docker setup script already auto-seeds localhost loopback origins for non-loopback binds, but did not accept user-provided non-localhost origins, forcing operators to run `docker compose run ... config set --batch-json` manually after every deployment.

## Why This Change Was Made

Adds `OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS` environment variable to `scripts/docker/setup.sh`. When set, the env var value (a JSON array of origin strings) is validated and passed to `config set --batch-json` in `sync_gateway_config`, persisting it into `openclaw.json` — the same mechanism already used for `gateway.bind` and the default localhost origins.

Design decisions:

✅ Portainer users running `setup.sh` can now configure non-localhost origins via env var — the primary target use case
✅ Persisted to `openclaw.json` via existing `config set` pipeline, keeping origin allowlist in durable config storage
✅ Security: env var consumed only at setup time, not at runtime; resulting allowlist is file-auditable in `openclaw.json`
✅ Follows the same script-layer propagation pattern as `OPENCLAW_GATEWAY_BIND`
✅ Validation (validate_allowed_origins_value) rejects malformed env values at setup time via strict JSON string array checking (python3); fails closed when python3 is unavailable — preventing both batch JSON corruption and non-string allowlist values
❌ Does not cover users who skip `setup.sh` entirely — the existing manual flow (`docs/install/docker.md:128`) already documents `config set --batch-json` for that path and can be updated separately with the env var

No TS core changes needed.

## User Impact

Portainer and Docker Compose users can now set `OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS='["https://openclaw.example.com"]'` in their environment and have it automatically applied on setup, without needing shell access for `config set` commands.

## Evidence

### Unit / E2E tests (43 passed)

```
Test Files  1 passed (1)
Tests  43 passed (43)
```

All 43 tests pass, including 3 new tests:
- `honors OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS env var override` — valid custom origin is written to config
- `rejects OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS with non-array value` — malformed value is rejected at setup time
- `rejects OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS with non-string array elements` — non-string array value (`[42]`) is rejected at setup time

### Real Docker proof

Test results from an offline Docker deployment (pre-loaded `ghcr.io/openclaw/openclaw:latest`, `setup.sh --offline`):

- Custom origin (`http://my-vm-host:18789`) is written to config and persisted
- Control UI health endpoint is reachable
- WebSocket `connect` with matched origin → origin allowed (proceeds to device identity check)
- WebSocket `connect` with unlisted origin (`https://evil.com`) → `ORIGIN_NOT_ALLOWED` error
- WebSocket `connect` without origin → `ORIGIN_NOT_ALLOWED` (`origin missing or invalid`)
- Default fallback (`localhost` + `127.0.0.1`) when env var is unset
- Malformed value (`not-a-json-array`) is rejected with a clear error; gateway does not start
- Non-string array value ([42, "http://my-vm-host:18789"]) is rejected via python3 strict validation with a clear error; gateway does not start

<details>
<summary>Initial proof: setup persistence, health check, default fallback, malformed value rejection</summary>

```

Step 1: Custom origin setup

[root@host-10-54-156-59 openclaw]# export OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS='["http://my-vm-host:18789"]'
[root@host-10-54-156-59 openclaw]# export OPENCLAW_SKIP_ONBOARDING=1
[root@host-10-54-156-59 openclaw]# ./scripts/docker/setup.sh --offline
Reusing gateway token from /data/openclaw/.env
==> Using preloaded Docker image: ghcr.io/openclaw/openclaw:latest

==> Fixing data-directory permissions
[+] Creating 1/1
 ✔ Network openclaw_default  Created                                                                                                                                      0.1s 

==> Skipping onboarding (OPENCLAW_SKIP_ONBOARDING is set)

==> Docker gateway defaults
Pinned gateway.mode=local and gateway.bind=lan for Docker setup.
Set gateway.controlUi.allowedOrigins to ["http://my-vm-host:18789"] for non-loopback bind.

==> Provider setup (optional)
WhatsApp (QR):
  docker compose -f /data/openclaw/docker-compose.yml run --rm openclaw-cli channels login
Telegram (bot token):
  docker compose -f /data/openclaw/docker-compose.yml run --rm openclaw-cli channels add --channel telegram --token <token>
Discord (bot token):
  docker compose -f /data/openclaw/docker-compose.yml run --rm openclaw-cli channels add --channel discord --token <token>
Docs: https://docs.openclaw.ai/channels

==> Starting gateway
[+] Running 1/1
 ✔ Container openclaw-openclaw-gateway-1  Started                                                                                                                         0.4s 
[+] Creating 1/1
 ✔ Container openclaw-openclaw-gateway-1  Running0.0s 

Gateway running with host port mapping.
Access from tailnet devices via the host's tailnet IP.
Config: /root/.openclaw
Workspace: /root/.openclaw/workspace
Token: stored in Docker environment/config (not printed).

Commands:
  docker compose -f /data/openclaw/docker-compose.yml logs -f openclaw-gateway
  docker compose -f /data/openclaw/docker-compose.yml exec openclaw-gateway sh -lc 'node dist/index.js health --token "$OPENCLAW_GATEWAY_TOKEN"'


Step 2: Persisted in config

[root@host-10-54-156-59 openclaw]# docker compose run --rm openclaw-cli config get gateway.controlUi.allowedOrigins
[+] Creating 1/1
 ✔ Container openclaw-openclaw-gateway-1  Running                                                                                                                           0.0s 

OpenClaw 2026.6.10 (unknown) — I'm the assistant your terminal demanded, not the one your sleep schedule requested.

[
  "http://my-vm-host:18789"
]

Step 3: Control UI reachable

[root@host-10-54-156-59 openclaw]# curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:18789/healthz
HTTP 200
[root@host-10-54-156-59 openclaw]# curl -s -o /dev/null -w "HTTP %{http_code}\n" http://my-vm-host:18789/healthz
HTTP 200
[root@host-10-54-156-59 openclaw]# curl -s -H "Origin: http://my-vm-host:18789" -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:18789/healthz
HTTP 200
[root@host-10-54-156-59 openclaw]# curl -s -H "Origin: https://evil.com" -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:18789/healthz
HTTP 200


Step 4: Default fallback (unset env var)

[root@host-10-54-156-59 openclaw]# docker compose down
[+] Running 2/2
 ✔ Container openclaw-openclaw-gateway-1  Removed                                                                                                                         0.9s 
 ✔ Network openclaw_default               Removed                                                                                                                         0.1s 

[root@host-10-54-156-59 openclaw]# docker compose run --rm openclaw-cli config set gateway.controlUi.allowedOrigins "[]"
[+] Creating 2/2
 ✔ Network openclaw_default               Created                                                                                                                         0.1s 
 ✔ Container openclaw-openclaw-gateway-1  Created                                                                                                                         0.1s 
[+] Running 1/1
 ✔ Container openclaw-openclaw-gateway-1  Started                                                                                                                         0.3s 
│
◇  

OpenClaw 2026.6.10 (unknown) — Your task has been queued; your dignity has been deprecated.

Updated gateway.controlUi.allowedOrigins. Restart the gateway to apply.


[root@host-10-54-156-59 openclaw]# export OPENCLAW_IMAGE="ghcr.io/openclaw/openclaw:latest"
[root@host-10-54-156-59 openclaw]# export OPENCLAW_SKIP_ONBOARDING=1
[root@host-10-54-156-59 openclaw]# unset OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS
[root@host-10-54-156-59 openclaw]# ./scripts/docker/setup.sh --offline
Reusing gateway token from /data/openclaw/.env
==> Using preloaded Docker image: ghcr.io/openclaw/openclaw:latest

==> Fixing data-directory permissions

==> Skipping onboarding (OPENCLAW_SKIP_ONBOARDING is set)

==> Docker gateway defaults
Pinned gateway.mode=local and gateway.bind=lan for Docker setup.
Set gateway.controlUi.allowedOrigins to ["http://localhost:18789","http://127.0.0.1:18789"] for non-loopback bind.

==> Provider setup (optional)
WhatsApp (QR):
  docker compose -f /data/openclaw/docker-compose.yml run --rm openclaw-cli channels login
Telegram (bot token):
  docker compose -f /data/openclaw/docker-compose.yml run --rm openclaw-cli channels add --channel telegram --token <token>
Discord (bot token):
  docker compose -f /data/openclaw/docker-compose.yml run --rm openclaw-cli channels add --channel discord --token <token>
Docs: https://docs.openclaw.ai/channels

==> Starting gateway
[+] Running 1/1
 ✔ Container openclaw-openclaw-gateway-1  Running                                                                                                                         0.0s 
[+] Creating 1/1
 ✔ Container openclaw-openclaw-gateway-1  Running0.0s 

Gateway running with host port mapping.
Access from tailnet devices via the host's tailnet IP.
Config: /root/.openclaw
Workspace: /root/.openclaw/workspace
Token: stored in Docker environment/config (not printed).

Commands:
  docker compose -f /data/openclaw/docker-compose.yml logs -f openclaw-gateway
  docker compose -f /data/openclaw/docker-compose.yml exec openclaw-gateway sh -lc 'node dist/index.js health --token "$OPENCLAW_GATEWAY_TOKEN"'


Step 5: Malformed value rejected
[root@host-10-54-156-59 openclaw]# docker compose down
[+] Running 2/2
 ✔ Container openclaw-openclaw-gateway-1  Removed                                                                                                                         0.5s 
 ✔ Network openclaw_default               Removed                                                                                                                         0.1s 

[root@host-10-54-156-59 openclaw]# export OPENCLAW_IMAGE="ghcr.io/openclaw/openclaw:latest"
[root@host-10-54-156-59 openclaw]# export OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS="not-a-json-array"
[root@host-10-54-156-59 openclaw]# export OPENCLAW_SKIP_ONBOARDING=1
[root@host-10-54-156-59 openclaw]# ./scripts/docker/setup.sh --offline
Reusing gateway token from /data/openclaw/.env
==> Using preloaded Docker image: ghcr.io/openclaw/openclaw:latest

==> Fixing data-directory permissions

==> Skipping onboarding (OPENCLAW_SKIP_ONBOARDING is set)

==> Docker gateway defaults
ERROR: OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS must be a valid JSON array of strings


Step 6: Validate non-string array elements rejected
[root@host-10-54-156-59 openclaw]# docker compose down
[+] Running 2/2
 ✔ Container openclaw-openclaw-gateway-1  Removed                                                                                                           0.8s 
 ✔ Network openclaw_default               Removed                                                                                                           0.1s 

[root@host-10-54-156-59 openclaw]# export OPENCLAW_IMAGE="ghcr.io/openclaw/openclaw:latest"
[root@host-10-54-156-59 openclaw]# export OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS='[42, "http://my-vm-host:18789"]'
[root@host-10-54-156-59 openclaw]# export OPENCLAW_SKIP_ONBOARDING=1
[root@host-10-54-156-59 openclaw]# ./scripts/docker/setup.sh --offline
Reusing gateway token from /data/openclaw/.env
==> Using preloaded Docker image: ghcr.io/openclaw/openclaw:latest

==> Fixing data-directory permissions
[+] Creating 1/1
 ✔ Network openclaw_default  Created                                                                                                                        0.1s 

==> Skipping onboarding (OPENCLAW_SKIP_ONBOARDING is set)

==> Docker gateway defaults
ERROR: OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS must be a valid JSON array of strings


```
</details>

<details>
<summary>WebSocket origin validation: allowlisted vs unlisted origin</summary>

```
Step 1: Start Gateway with custom origin

[root@host-10-54-156-59 openclaw]# export OPENCLAW_IMAGE="ghcr.io/openclaw/openclaw:latest"
[root@host-10-54-156-59 openclaw]# export OPENCLAW_GATEWAY_CONTROL_UI_ALLOWED_ORIGINS='["http://my-vm-host:18789"]'
[root@host-10-54-156-59 openclaw]# export OPENCLAW_SKIP_ONBOARDING=1
[root@host-10-54-156-59 openclaw]# ./scripts/docker/setup.sh --offline
Reusing gateway token from /data/openclaw/.env
==> Using preloaded Docker image: ghcr.io/openclaw/openclaw:latest

==> Fixing data-directory permissions
[+] Creating 1/1
 ✔ Network openclaw_default  Created                                                                                                                        0.1s 

==> Skipping onboarding (OPENCLAW_SKIP_ONBOARDING is set)

==> Docker gateway defaults
Pinned gateway.mode=local and gateway.bind=lan for Docker setup.
Set gateway.controlUi.allowedOrigins to ["http://my-vm-host:18789"] for non-loopback bind.

==> Provider setup (optional)
WhatsApp (QR):
  docker compose -f /data/openclaw/docker-compose.yml run --rm openclaw-cli channels login
Telegram (bot token):
  docker compose -f /data/openclaw/docker-compose.yml run --rm openclaw-cli channels add --channel telegram --token <token>
Discord (bot token):
  docker compose -f /data/openclaw/docker-compose.yml run --rm openclaw-cli channels add --channel discord --token <token>
Docs: https://docs.openclaw.ai/channels

==> Starting gateway
[+] Running 1/1
 ✔ Container openclaw-openclaw-gateway-1  Started                                                                                                           0.3s 
[+] Creating 1/1
 ✔ Container openclaw-openclaw-gateway-1  Running0.0s 

Gateway running with host port mapping.
Access from tailnet devices via the host's tailnet IP.
Config: /root/.openclaw
Workspace: /root/.openclaw/workspace
Token: stored in Docker environment/config (not printed).

Commands:
  docker compose -f /data/openclaw/docker-compose.yml logs -f openclaw-gateway
  docker compose -f /data/openclaw/docker-compose.yml exec openclaw-gateway sh -lc 'node dist/index.js health --token "$OPENCLAW_GATEWAY_TOKEN"'

Step 2: Verify persistence

[root@host-10-54-156-59 openclaw]# docker compose run --rm openclaw-cli config get gateway.controlUi.allowedOrigins
[+] Creating 1/1
 ✔ Container openclaw-openclaw-gateway-1  Running                                                                                                           0.0s 

OpenClaw 2026.6.10 (unknown) — We ship features faster than Apple ships calculator updates.

[
  "http://my-vm-host:18789"
]

Step 3: Health check

[root@host-10-54-156-59 openclaw]# curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:18789/healthz
HTTP 200

Step 4: WebSocket — allowlisted origin

[root@host-10-54-156-59 openclaw]# websocat --origin "http://my-vm-host:18789" ws://127.0.0.1:18789/
{"type":"event","event":"connect.challenge","payload":{"nonce":"8c004d64-4473-4045-b5c7-1fbe3698f704","ts":1782718670128}}
{"type":"req","id":"1","method":"connect","params":{"minProtocol":4,"maxProtocol":4,"client":{"id":"openclaw-control-ui","version":"control-ui","platform":"Linux x86_64","mode":"webchat","instanceId":"test"},"role":"operator","scopes":["operator.admin","operator.read","operator.write","operator.approvals","operator.pairing"],"caps":["tool-events"],"auth":{"token":"bc7c20e021ed1882c68986269fa3cf4fc731dfa42da39de6f2f70d85f99f02c4"}}}
{"type":"res","id":"1","ok":false,"error":{"code":"INVALID_REQUEST","message":"control ui requires device identity (use HTTPS or localhost secure context)","details":{"code":"CONTROL_UI_DEVICE_IDENTITY_REQUIRED"}}}
^C

Step 5: WebSocket — unlisted origin
[root@host-10-54-156-59 openclaw]# websocat --origin "https://evil.com" ws://127.0.0.1:18789/
{"type":"event","event":"connect.challenge","payload":{"nonce":"df94b0ab-00fd-4ee0-9a42-e783923056c9","ts":1782718705177}}
{"type":"req","id":"1","method":"connect","params":{"minProtocol":4,"maxProtocol":4,"client":{"id":"openclaw-control-ui","version":"control-ui","platform":"Linux x86_64","mode":"webchat","instanceId":"test"},"role":"operator","scopes":["operator.admin","operator.read","operator.write","operator.approvals","operator.pairing"],"caps":["tool-events"],"auth":{"token":"bc7c20e021ed1882c68986269fa3cf4fc731dfa42da39de6f2f70d85f99f02c4"}}}
{"type":"res","id":"1","ok":false,"error":{"code":"INVALID_REQUEST","message":"origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)","details":{"code":"CONTROL_UI_ORIGIN_NOT_ALLOWED","reason":"origin not allowed"}}}
^C

Step 6: WebSocket — no origin
[root@host-10-54-156-59 openclaw]# websocat ws://127.0.0.1:18789/
{"type":"event","event":"connect.challenge","payload":{"nonce":"56c17a29-7c1c-4fe2-aae6-7706c8d1fff4","ts":1782718741695}}
{"type":"req","id":"1","method":"connect","params":{"minProtocol":4,"maxProtocol":4,"client":{"id":"openclaw-control-ui","version":"control-ui","platform":"Linux x86_64","mode":"webchat","instanceId":"test"},"role":"operator","scopes":["operator.admin","operator.read","operator.write","operator.approvals","operator.pairing"],"caps":["tool-events"],"auth":{"token":"bc7c20e021ed1882c68986269fa3cf4fc731dfa42da39de6f2f70d85f99f02c4"}}}
{"type":"res","id":"1","ok":false,"error":{"code":"INVALID_REQUEST","message":"origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)","details":{"code":"CONTROL_UI_ORIGIN_NOT_ALLOWED","reason":"origin missing or invalid"}}}
^C


```

</details>


`git diff --numstat`: +86/−20 across 3 files

The gateway token shown in proof output is a disposable test token generated during setup and is no longer valid.

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using opencode with review by the author.