### PR TITLE
fix(google): rotate Gemini API keys for LLM requests

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -476,6 +476,96 @@ describe("google transport stream", () => {
     expect(result.content[2]).toHaveProperty("thoughtSignature", "Y2FsbF9zaWdfMQ==");
   });
 
+  it("rotates Gemini LLM API keys when a pre-stream request is rate limited", async () => {
+    vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
+    vi.stubEnv("GEMINI_API_KEYS", "gemini-key-2");
+    guardedFetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "quota exceeded",
+              status: "RESOURCE_EXHAUSTED",
+            },
+          }),
+          { status: 429, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "recovered" }] }, finishReason: "STOP" }],
+          },
+        ]),
+      );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        { apiKey: "gemini-key-1" } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
+    expect(guardedFetchMock).toHaveBeenCalledTimes(2);
+    expectHeaders(
+      requireRequestInit(requireMockCall(guardedFetchMock, 0, "guarded fetch"), "guarded fetch"),
+      { "x-goog-api-key": "gemini-key-1" },
+    );
+    expectHeaders(
+      requireRequestInit(requireMockCall(guardedFetchMock, 1, "guarded fetch"), "guarded fetch"),
+      { "x-goog-api-key": "gemini-key-2" },
+    );
+  });
+
+  it("does not rotate OAuth JSON credentials through configured Gemini API keys", async () => {
+    vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
+    vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: "quota exceeded",
+            status: "RESOURCE_EXHAUSTED",
+          },
+        }),
+        { status: 429, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: JSON.stringify({ token: "oauth-token", projectId: "demo" }),
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(guardedFetchMock).toHaveBeenCalledTimes(1);
+    const init = requireRequestInit(
+      requireMockCall(guardedFetchMock, 0, "guarded fetch"),
+      "guarded fetch",
+    );
+    expectHeaders(init, {
+      Authorization: "Bearer oauth-token",
+      "Content-Type": "application/json",
+    });
+    expect(new Headers(init.headers).has("x-goog-api-key")).toBe(false);
+  });
+
   it("preserves MAX_TOKENS when the partial response contains a function call", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildSseResponse([

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -98,6 +98,15 @@ function buildSseResponse(events: unknown[]): Response {
   return buildRawSseResponse(sse);
 }
 
+function buildRateLimitResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: { message: "quota exceeded", status: "RESOURCE_EXHAUSTED" },
+    }),
+    { status: 429, headers: { "content-type": "application/json" } },
+  );
+}
+
 function buildRawSseResponse(sse: string): Response {
   const encoder = new TextEncoder();
   const body = new ReadableStream<Uint8Array>({
@@ -479,25 +488,13 @@ describe("google transport stream", () => {
   it("rotates Gemini LLM API keys when a pre-stream request is rate limited", async () => {
     vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
     vi.stubEnv("GEMINI_API_KEYS", "gemini-key-2");
-    guardedFetchMock
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            error: {
-              message: "quota exceeded",
-              status: "RESOURCE_EXHAUSTED",
-            },
-          }),
-          { status: 429, headers: { "content-type": "application/json" } },
-        ),
-      )
-      .mockResolvedValueOnce(
-        buildSseResponse([
-          {
-            candidates: [{ content: { parts: [{ text: "recovered" }] }, finishReason: "STOP" }],
-          },
-        ]),
-      );
+    guardedFetchMock.mockResolvedValueOnce(buildRateLimitResponse()).mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [{ content: { parts: [{ text: "recovered" }] }, finishReason: "STOP" }],
+        },
+      ]),
+    );
 
     const streamFn = createGoogleGenerativeAiTransportStreamFn();
     const stream = await Promise.resolve(
@@ -527,17 +524,7 @@ describe("google transport stream", () => {
   it("does not rotate OAuth JSON credentials through configured Gemini API keys", async () => {
     vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
     vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
-    guardedFetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          error: {
-            message: "quota exceeded",
-            status: "RESOURCE_EXHAUSTED",
-          },
-        }),
-        { status: 429, headers: { "content-type": "application/json" } },
-      ),
-    );
+    guardedFetchMock.mockResolvedValueOnce(buildRateLimitResponse());
 
     const streamFn = createGoogleGenerativeAiTransportStreamFn();
     const stream = await Promise.resolve(
@@ -566,20 +553,38 @@ describe("google transport stream", () => {
     expect(new Headers(init.headers).has("x-goog-api-key")).toBe(false);
   });
 
+  it("does not rotate when request headers override Gemini authentication", async () => {
+    vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
+    vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
+    guardedFetchMock.mockResolvedValueOnce(buildRateLimitResponse());
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "explicit-option-key",
+          headers: { "x-goog-api-key": "header-key" },
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(guardedFetchMock).toHaveBeenCalledTimes(1);
+    expectHeaders(
+      requireRequestInit(requireMockCall(guardedFetchMock, 0, "guarded fetch"), "guarded fetch"),
+      { "x-goog-api-key": "header-key" },
+    );
+  });
+
   it("does not rotate global Gemini API keys into custom Gemini endpoints", async () => {
     vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
     vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
-    guardedFetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          error: {
-            message: "quota exceeded",
-            status: "RESOURCE_EXHAUSTED",
-          },
-        }),
-        { status: 429, headers: { "content-type": "application/json" } },
-      ),
-    );
+    guardedFetchMock.mockResolvedValueOnce(buildRateLimitResponse());
 
     const streamFn = createGoogleGenerativeAiTransportStreamFn();
     const stream = await Promise.resolve(
@@ -610,17 +615,7 @@ describe("google transport stream", () => {
   it("does not rotate global Gemini API keys into non-TLS Gemini endpoints", async () => {
     vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
     vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
-    guardedFetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          error: {
-            message: "quota exceeded",
-            status: "RESOURCE_EXHAUSTED",
-          },
-        }),
-        { status: 429, headers: { "content-type": "application/json" } },
-      ),
-    );
+    guardedFetchMock.mockResolvedValueOnce(buildRateLimitResponse());
 
     const streamFn = createGoogleGenerativeAiTransportStreamFn();
     const stream = await Promise.resolve(

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -607,6 +607,46 @@ describe("google transport stream", () => {
     });
   });
 
+  it("does not rotate global Gemini API keys into non-TLS Gemini endpoints", async () => {
+    vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
+    vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: "quota exceeded",
+            status: "RESOURCE_EXHAUSTED",
+          },
+        }),
+        { status: 429, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({
+          baseUrl: "http://generativelanguage.googleapis.com/v1beta",
+        }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        { apiKey: "explicit-http-key" } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(guardedFetchMock).toHaveBeenCalledTimes(1);
+    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+    expect(guardedCall[0]).toBe(
+      "http://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse",
+    );
+    expectHeaders(requireRequestInit(guardedCall, "guarded fetch"), {
+      "x-goog-api-key": "explicit-http-key",
+    });
+  });
+
   it("preserves MAX_TOKENS when the partial response contains a function call", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildSseResponse([

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -566,6 +566,47 @@ describe("google transport stream", () => {
     expect(new Headers(init.headers).has("x-goog-api-key")).toBe(false);
   });
 
+  it("does not rotate global Gemini API keys into custom Gemini endpoints", async () => {
+    vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
+    vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: "quota exceeded",
+            status: "RESOURCE_EXHAUSTED",
+          },
+        }),
+        { status: 429, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({
+          provider: "custom-google",
+          baseUrl: "https://proxy.example.com/gemini/v1beta",
+        }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        { apiKey: "explicit-proxy-key" } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(guardedFetchMock).toHaveBeenCalledTimes(1);
+    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+    expect(guardedCall[0]).toBe(
+      "https://proxy.example.com/gemini/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse",
+    );
+    expectHeaders(requireRequestInit(guardedCall, "guarded fetch"), {
+      "x-goog-api-key": "explicit-proxy-key",
+    });
+  });
+
   it("preserves MAX_TOKENS when the partial response contains a function call", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildSseResponse([

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -859,7 +859,8 @@ function isOfficialGoogleGenerativeAiBaseUrl(baseUrl: string | undefined): boole
     return true;
   }
   try {
-    return new URL(baseUrl).hostname === "generativelanguage.googleapis.com";
+    const url = new URL(baseUrl);
+    return url.protocol === "https:" && url.hostname === "generativelanguage.googleapis.com";
   } catch {
     return false;
   }

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -800,21 +800,30 @@ function isGoogleOauthApiKey(apiKey: string | undefined): boolean {
   );
 }
 
+function hasGoogleAuthHeader(headers: Record<string, string> | undefined): boolean {
+  return Object.keys(headers ?? {}).some((name) => {
+    const normalized = name.trim().toLowerCase();
+    return normalized === "authorization" || normalized === "x-goog-api-key";
+  });
+}
+
 function collectGoogleTransportApiKeys(params: {
-  baseUrl: string | undefined;
   kind: CanonicalGoogleTransportApi;
-  provider: string;
+  model: GoogleTransportModel;
+  options: GoogleTransportOptions | undefined;
   primaryApiKey: string | undefined;
 }): string[] {
   if (
     params.kind !== "google-generative-ai" ||
-    !isOfficialGoogleGenerativeAiBaseUrl(params.baseUrl) ||
-    isGoogleOauthApiKey(params.primaryApiKey)
+    !isOfficialGoogleGenerativeAiBaseUrl(params.model.baseUrl) ||
+    isGoogleOauthApiKey(params.primaryApiKey) ||
+    hasGoogleAuthHeader(params.model.headers) ||
+    hasGoogleAuthHeader(params.options?.headers)
   ) {
     return [];
   }
   return collectProviderApiKeysForExecution({
-    provider: params.provider,
+    provider: params.model.provider,
     primaryApiKey: params.primaryApiKey,
   });
 }
@@ -1296,9 +1305,9 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
           });
         };
         const apiKeys = collectGoogleTransportApiKeys({
-          baseUrl: model.baseUrl,
           kind,
-          provider: model.provider,
+          model,
+          options,
           primaryApiKey: apiKey,
         });
         const sse =

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -9,7 +9,14 @@ import {
   type ThinkingLevel,
 } from "openclaw/plugin-sdk/llm";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
-import { createProviderHttpError } from "openclaw/plugin-sdk/provider-http";
+import {
+  collectProviderApiKeysForExecution,
+  executeWithApiKeyRotation,
+} from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  createProviderHttpError,
+  providerOperationRetryConfig,
+} from "openclaw/plugin-sdk/provider-http";
 import {
   buildGuardedModelFetch,
   coerceTransportToolCallArguments,
@@ -787,6 +794,26 @@ function buildGoogleHeaders(
   );
 }
 
+function isGoogleOauthApiKey(apiKey: string | undefined): boolean {
+  return Boolean(
+    apiKey?.trimStart().startsWith("{") && parseGeminiAuth(apiKey).headers.Authorization,
+  );
+}
+
+function collectGoogleTransportApiKeys(params: {
+  kind: CanonicalGoogleTransportApi;
+  provider: string;
+  primaryApiKey: string | undefined;
+}): string[] {
+  if (params.kind !== "google-generative-ai" || isGoogleOauthApiKey(params.primaryApiKey)) {
+    return [];
+  }
+  return collectProviderApiKeysForExecution({
+    provider: params.provider,
+    primaryApiKey: params.primaryApiKey,
+  });
+}
+
 async function buildGoogleVertexHeaders(
   model: GoogleTransportModel,
   apiKey: string | undefined,
@@ -1243,22 +1270,39 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
           params = nextParams as GoogleGenerateContentRequest;
         }
         const requestUrl = buildGoogleTransportRequestUrl(kind, model, options);
-        const requestHeaders = await buildGoogleTransportHeaders({
+        const fetchImpl = (options as { fetch?: typeof fetch } | undefined)?.fetch;
+        const openSse = async (apiKeyForRequest: string | undefined) => {
+          const requestHeaders = await buildGoogleTransportHeaders({
+            kind,
+            model,
+            apiKey: apiKeyForRequest,
+            optionHeaders: options?.headers,
+            fetchImpl,
+          });
+          return await openGoogleSseChunks({
+            kind,
+            model,
+            options,
+            guardedFetch,
+            url: requestUrl,
+            headers: requestHeaders,
+            request: params,
+          });
+        };
+        const apiKeys = collectGoogleTransportApiKeys({
           kind,
-          model,
-          apiKey,
-          optionHeaders: options?.headers,
-          fetchImpl: (options as { fetch?: typeof fetch } | undefined)?.fetch,
+          provider: model.provider,
+          primaryApiKey: apiKey,
         });
-        const sse = await openGoogleSseChunks({
-          kind,
-          model,
-          options,
-          guardedFetch,
-          url: requestUrl,
-          headers: requestHeaders,
-          request: params,
-        });
+        const sse =
+          apiKeys.length > 0
+            ? await executeWithApiKeyRotation({
+                provider: model.provider,
+                apiKeys,
+                transientRetry: providerOperationRetryConfig("read"),
+                execute: openSse,
+              })
+            : await openSse(apiKey);
         stream.push({ type: "start", partial: output as never });
         let currentBlockIndex = -1;
         const toolCallBlocksById = new Map<

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -801,11 +801,16 @@ function isGoogleOauthApiKey(apiKey: string | undefined): boolean {
 }
 
 function collectGoogleTransportApiKeys(params: {
+  baseUrl: string | undefined;
   kind: CanonicalGoogleTransportApi;
   provider: string;
   primaryApiKey: string | undefined;
 }): string[] {
-  if (params.kind !== "google-generative-ai" || isGoogleOauthApiKey(params.primaryApiKey)) {
+  if (
+    params.kind !== "google-generative-ai" ||
+    !isOfficialGoogleGenerativeAiBaseUrl(params.baseUrl) ||
+    isGoogleOauthApiKey(params.primaryApiKey)
+  ) {
     return [];
   }
   return collectProviderApiKeysForExecution({
@@ -1290,6 +1295,7 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
           });
         };
         const apiKeys = collectGoogleTransportApiKeys({
+          baseUrl: model.baseUrl,
           kind,
           provider: model.provider,
           primaryApiKey: apiKey,


### PR DESCRIPTION
Related: #97314

## What Problem This Solves

Fixes an issue where users with multiple Gemini API keys configured would still have Google LLM streaming requests fail immediately when the first key hit a rate limit or quota response. The embedding path already used API-key rotation, but the LLM stream path resolved only one key before sending the provider request.

## Why This Change Was Made

This routes official Google Generative AI stream setup through the existing provider API-key rotation helper before any SSE chunks are emitted. The fix keeps credential boundaries explicit: env-key rotation is allowed only for the HTTPS official Google Generative AI host, while Vertex, OAuth JSON credential requests, custom/proxy Gemini base URLs, and non-TLS Gemini base URLs stay out of global Gemini env-key rotation.

## User Impact

Users can configure multiple Gemini keys and recover from first-key 429/quota responses for official HTTPS Gemini LLM streaming requests instead of manually switching keys or seeing a hard failure. OAuth JSON credential requests continue to use bearer auth without falling back to configured API keys, and custom/proxy or non-TLS Gemini endpoints receive only the caller-provided endpoint credential.

## Evidence

- `pnpm install --frozen-lockfile`
- `pnpm format -- extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts`
- `node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts src/agents/api-key-rotation.test.ts src/agents/embedded-agent-runner/stream-resolution.test.ts`
  - Passed: agents config 2 files / 42 tests; extension-providers config 1 file / 72 tests.
- `git diff --check`
- Redacted runtime proof using `node --import tsx --input-type=module` with the real Google transport stream and guarded-fetch path plus a local fetch stub. The proof keys are fake labels and no secret value was printed:

```text
[provider-transport-fetch] [model-fetch] start provider=google api=google-generative-ai model=gemini-2.5-pro method=POST url=https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=google api=google-generative-ai model=gemini-2.5-pro status=429 elapsedMs=33 contentType=application/json
[provider-transport-fetch] [model-fetch] start provider=google api=google-generative-ai model=gemini-2.5-pro method=POST url=https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=google api=google-generative-ai model=gemini-2.5-pro status=200 elapsedMs=3 contentType=text/event-stream
[provider-transport-fetch] [model-fetch] start provider=custom-google api=google-generative-ai model=gemini-2.5-pro method=POST url=https://proxy.example.com/gemini/v1beta/models/gemini-2.5-pro:streamGenerateContent timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=custom-google api=google-generative-ai model=gemini-2.5-pro status=429 elapsedMs=1 contentType=application/json
[provider-transport-fetch] [model-fetch] start provider=google api=google-generative-ai model=gemini-2.5-pro method=POST url=http://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=google api=google-generative-ai model=gemini-2.5-pro status=429 elapsedMs=1 contentType=application/json
Google Gemini key rotation runtime proof (redacted)
official stopReason=stop
official text=recovered
official request 1: protocol=https: host=generativelanguage.googleapis.com key=proof-key-1(redacted) status=429
official request 2: protocol=https: host=generativelanguage.googleapis.com key=proof-key-2(redacted) status=200
custom stopReason=error
custom request 1: protocol=https: host=proxy.example.com key=explicit-proxy-key(redacted) status=429
custom totalRequests=1
http stopReason=error
http request 1: protocol=http: host=generativelanguage.googleapis.com key=explicit-http-key(redacted) status=429
http totalRequests=1
```

- ClawSweeper findings addressed:
  - Custom/proxy endpoint key sharing fixed in `8f3654c2f3b`: key collection receives `model.baseUrl` and refuses global Gemini env-key rotation unless the endpoint is the official Google host; regression coverage asserts a custom Gemini proxy gets one request with only `explicit-proxy-key`.
  - Non-TLS official-host key sharing fixed in `ef1ec1c3e0f`: the official gate now requires `https://generativelanguage.googleapis.com`, and regression coverage asserts `http://generativelanguage.googleapis.com/v1beta` gets one request with only `explicit-http-key`.

AI-assisted: yes. No agent transcript is included because explicit transcript approval was not given.
