### PR TITLE
docs(feishu): 使用子目录结构存放动态 agent workspace

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -431,8 +431,8 @@ If a named account created an unscoped dynamic agent on an older release, that l
       allowFrom: ["*"],
       dynamicAgentCreation: {
         enabled: true,
-        workspaceTemplate: "~/.openclaw/workspace-{agentId}",
-        agentDirTemplate: "~/.openclaw/agents/{agentId}/agent",
+        workspaceTemplate: "~/.openclaw/workspaces/{agentId}",
+        agentDirTemplate: "{agentId}",
       },
     },
   },
@@ -460,8 +460,8 @@ When a new user sends their first DM:
 | Setting                                                  | Description                                | Default                              |
 | -------------------------------------------------------- | ------------------------------------------ | ------------------------------------ |
 | `channels.feishu.dynamicAgentCreation.enabled`           | Enable automatic per-user agent creation   | `false`                              |
-| `channels.feishu.dynamicAgentCreation.workspaceTemplate` | Path template for dynamic agent workspaces | `~/.openclaw/workspace-{agentId}`    |
-| `channels.feishu.dynamicAgentCreation.agentDirTemplate`  | Agent directory name template              | `~/.openclaw/agents/{agentId}/agent` |
+| `channels.feishu.dynamicAgentCreation.workspaceTemplate` | Path template for dynamic agent workspaces | `~/.openclaw/workspaces/{agentId}`  |
+| `channels.feishu.dynamicAgentCreation.agentDirTemplate`  | Agent directory name template              | `{agentId}`                          |
 | `channels.feishu.dynamicAgentCreation.maxAgents`         | Maximum number of dynamic agents to create | unlimited                            |
 
 Template variables:
@@ -511,8 +511,8 @@ Use `"per-account-channel-peer"` when named Feishu accounts should keep separate
       requireMention: true,
       dynamicAgentCreation: {
         enabled: true,
-        workspaceTemplate: "~/.openclaw/workspace-{agentId}",
-        agentDirTemplate: "~/.openclaw/agents/{agentId}/agent",
+        workspaceTemplate: "~/.openclaw/workspaces/{agentId}",
+        agentDirTemplate: "{agentId}",
       },
     },
   },
@@ -578,8 +578,8 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 | `channels.feishu.groups.<chat_id>.requireMention`        | Per-group @mention override; explicit IDs also admit the group in allowlist mode | inherited                            |
 | `channels.feishu.groups.<chat_id>.enabled`               | Enable/disable a specific group                                                  | `true`                               |
 | `channels.feishu.dynamicAgentCreation.enabled`           | Enable automatic per-user agent creation                                         | `false`                              |
-| `channels.feishu.dynamicAgentCreation.workspaceTemplate` | Path template for dynamic agent workspaces                                       | `~/.openclaw/workspace-{agentId}`    |
-| `channels.feishu.dynamicAgentCreation.agentDirTemplate`  | Agent directory name template                                                    | `~/.openclaw/agents/{agentId}/agent` |
+| `channels.feishu.dynamicAgentCreation.workspaceTemplate` | Path template for dynamic agent workspaces                                       | `~/.openclaw/workspaces/{agentId}`   |
+| `channels.feishu.dynamicAgentCreation.agentDirTemplate`  | Agent directory name template                                                    | `{agentId}`                          |
 | `channels.feishu.dynamicAgentCreation.maxAgents`         | Maximum number of dynamic agents to create                                       | unlimited                            |
 | `channels.feishu.textChunkLimit`                         | Message chunk size                                                               | `2000`                               |
 | `channels.feishu.mediaMaxMb`                             | Media size limit                                                                 | `30`                                 |


### PR DESCRIPTION
## 变更

将 Feishu 动态 agent 创建的示例配置和默认值从同级文件结构改为子目录结构：

| 配置项 | 旧值 | 新值 |
|--------|------|------|
| workspaceTemplate | ~/.openclaw/workspace-{agentId} | ~/.openclaw/workspaces/{agentId} |
| agentDirTemplate | ~/.openclaw/agents/{agentId}/agent | {agentId} |

## 原因

- 主目录整洁：所有动态 agent 收拢在 workspaces/ 子目录下，不会跟 openclaw.json、logs/、plugins/ 等混在一起
- 可扩展：以后加 agents/、backups/ 等目录结构清晰
- 批量操作方便：ls ~/.openclaw/workspaces/ 一眼看全，rm -rf workspaces/ 可整体清理
- 生产验证：该结构已在实际部署中运行（9+ 个 per-user workspace）

## 影响范围

仅修改文档中的示例配置和默认值表格，不影响现有代码行为。