### PR TITLE
fix(daemon): pin Node heap ceiling via CLI flag for managed services

### DIFF
--- a/src/daemon/program-args.test.ts
+++ b/src/daemon/program-args.test.ts
@@ -38,7 +38,9 @@ vi.mock("node:child_process", async () => {
   };
 });
 
-import { resolveGatewayProgramArguments } from "./program-args.js";
+import { buildLaunchAgentPlist } from "./launchd-plist.js";
+import { resolveGatewayProgramArguments, resolveNodeProgramArguments } from "./program-args.js";
+import { buildSystemdUnit } from "./systemd-unit.js";
 
 const originalArgv = [...process.argv];
 
@@ -61,6 +63,7 @@ describe("resolveGatewayProgramArguments", () => {
 
     expect(result.programArguments).toEqual([
       process.execPath,
+      "--max-old-space-size=8192",
       indexPath,
       "gateway",
       "--port",
@@ -84,6 +87,7 @@ describe("resolveGatewayProgramArguments", () => {
 
     expect(result.programArguments).toEqual([
       process.execPath,
+      "--max-old-space-size=8192",
       entryPath,
       "gateway",
       "--port",
@@ -107,6 +111,7 @@ describe("resolveGatewayProgramArguments", () => {
 
     expect(result.programArguments).toEqual([
       process.execPath,
+      "--max-old-space-size=8192",
       entryPath,
       "gateway",
       "--port",
@@ -130,10 +135,11 @@ describe("resolveGatewayProgramArguments", () => {
     const result = await resolveGatewayProgramArguments({ port: 18789 });
 
     // Should use the symlinked canonical index.js path, not the realpath-resolved versioned path
-    expect(result.programArguments[1]).toBe(
+    // (index [2] now: [node, --max-old-space-size, entrypoint, ...]).
+    expect(result.programArguments[2]).toBe(
       path.resolve("/Users/test/Library/pnpm/global/5/node_modules/openclaw/dist/index.js"),
     );
-    expect(result.programArguments[1]).not.toContain("@2026.1.21-2");
+    expect(result.programArguments[2]).not.toContain("@2026.1.21-2");
   });
 
   it("falls back to node_modules package dist when .bin path is not resolved", async () => {
@@ -152,6 +158,7 @@ describe("resolveGatewayProgramArguments", () => {
 
     expect(result.programArguments).toEqual([
       process.execPath,
+      "--max-old-space-size=8192",
       indexPath,
       "gateway",
       "--port",
@@ -241,5 +248,105 @@ describe("resolveGatewayProgramArguments", () => {
         wrapperPath,
       }),
     ).rejects.toThrow("OPENCLAW_WRAPPER must point to an executable file");
+  });
+
+  it("pins a Node heap ceiling as a CLI flag for the node runtime", async () => {
+    const entryPath = path.resolve("/opt/openclaw/dist/entry.js");
+    const indexPath = path.resolve("/opt/openclaw/dist/index.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const result = await resolveGatewayProgramArguments({
+      port: 18789,
+      runtime: "node",
+      nodePath: "/usr/bin/node",
+    });
+
+    // Heap flag must sit between the node binary and the script so V8 honors it.
+    expect(result.programArguments).toEqual([
+      "/usr/bin/node",
+      "--max-old-space-size=8192",
+      indexPath,
+      "gateway",
+      "--port",
+      "18789",
+    ]);
+  });
+
+  it("does not pass the Node heap flag to the bun runtime", async () => {
+    const entryPath = path.resolve("/opt/openclaw/dist/entry.js");
+    const indexPath = path.resolve("/opt/openclaw/dist/index.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+    childProcessMocks.execFileSync.mockReturnValue("/usr/local/bin/bun\n");
+
+    const result = await resolveGatewayProgramArguments({
+      port: 18789,
+      runtime: "bun",
+    });
+
+    expect(result.programArguments).toEqual([
+      "/usr/local/bin/bun",
+      indexPath,
+      "gateway",
+      "--port",
+      "18789",
+    ]);
+  });
+
+  it("pins a Node heap ceiling for node-service installs too", async () => {
+    const entryPath = path.resolve("/opt/openclaw/dist/entry.js");
+    const indexPath = path.resolve("/opt/openclaw/dist/index.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const result = await resolveNodeProgramArguments({
+      host: "127.0.0.1",
+      port: 18789,
+      runtime: "node",
+      nodePath: "/usr/bin/node",
+    });
+
+    expect(result.programArguments).toEqual([
+      "/usr/bin/node",
+      "--max-old-space-size=8192",
+      indexPath,
+      "node",
+      "run",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "18789",
+    ]);
+  });
+
+  it("carries the heap flag into the rendered systemd unit and launchd plist", async () => {
+    const entryPath = path.resolve("/opt/openclaw/dist/entry.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const { programArguments } = await resolveGatewayProgramArguments({
+      port: 18789,
+      runtime: "node",
+      nodePath: "/usr/bin/node",
+    });
+
+    // The reported OOM crash-loop is on the rendered service artifact, so prove
+    // the flag survives serialization on both managed-service platforms.
+    const unit = buildSystemdUnit({ description: "OpenClaw Gateway", programArguments });
+    expect(unit).toContain("ExecStart=");
+    expect(unit).toContain("--max-old-space-size=8192");
+
+    const plist = buildLaunchAgentPlist({
+      label: "ai.openclaw.gateway",
+      programArguments,
+      stdoutPath: "/tmp/out.log",
+      stderrPath: "/tmp/err.log",
+    });
+    expect(plist).toContain("<string>--max-old-space-size=8192</string>");
   });
 });

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -211,6 +211,15 @@ export async function resolveOpenClawWrapperPath(
   return resolved;
 }
 
+// Managed services run unattended under sustained multi-agent load. Node's
+// default old-space ceiling (~min(host RAM/2, 4 GB)) lets the daemon OOM
+// crash-loop once cron/journal state grows, so pin a heap ceiling. It is a node
+// CLI flag rather than NODE_OPTIONS because NODE_OPTIONS is a host-env-security
+// blocked-everywhere key. Bun ignores --max-old-space-size (its own allocator),
+// so the flag is only injected for the Node runtime.
+const SERVICE_NODE_MAX_OLD_SPACE_MB = 8192;
+const NODE_SERVICE_HEAP_FLAG = `--max-old-space-size=${SERVICE_NODE_MAX_OLD_SPACE_MB}`;
+
 async function resolveCliProgramArguments(params: {
   args: string[];
   dev?: boolean;
@@ -231,7 +240,7 @@ async function resolveCliProgramArguments(params: {
       params.nodePath ?? (isNodeRuntime(execPath) ? execPath : await resolveNodePath());
     const cliEntrypointPath = await resolveCliEntrypointPathForService();
     return {
-      programArguments: [nodePath, cliEntrypointPath, ...params.args],
+      programArguments: [nodePath, NODE_SERVICE_HEAP_FLAG, cliEntrypointPath, ...params.args],
     };
   }
 
@@ -257,9 +266,10 @@ async function resolveCliProgramArguments(params: {
   if (!params.dev) {
     try {
       const cliEntrypointPath = await resolveCliEntrypointPathForService();
-      return {
-        programArguments: [execPath, cliEntrypointPath, ...params.args],
-      };
+      const programArguments = isNodeRuntime(execPath)
+        ? [execPath, NODE_SERVICE_HEAP_FLAG, cliEntrypointPath, ...params.args]
+        : [execPath, cliEntrypointPath, ...params.args];
+      return { programArguments };
     } catch (error) {
       // Non-Node runtimes may execute the CLI wrapper directly; Node needs the
       // built dist entrypoint so service restarts survive package layout.


### PR DESCRIPTION
Closes #96203

> **Relationship to #96250:** that open PR fixes the same issue by setting
> `NODE_OPTIONS=--max-old-space-size` in the service environment. `NODE_OPTIONS`
> is a host-env-security `blockedEverywhere` key, and the builder output is not
> run through that filter, so the value leaks into the generated plist unfiltered
> — the exact key the policy says must never be a managed env var. This PR takes
> the alternative shape requested in the issue title ("set NODE_OPTIONS **or** ...")
> by pinning the heap as a Node CLI argument instead, which sidesteps the policy.
> Offered as a security-aligned alternative; happy to fold the approach into #96250
> if maintainers prefer.

## What Problem This Solves

Fixes an issue where operators running the managed gateway under sustained load
experience repeated OOM crash-loops. `openclaw daemon install` generated launchd/systemd launch commands
that started the gateway under Node's default V8 old-space ceiling
(~`min(host RAM/2, 4 GB)`). Under sustained multi-agent load with accumulated
cron/journal state, the heap overshoots that ceiling and the gateway OOM
crash-loops (reported: **2314 restarts in one day**), blocking all workflow
processing.

## Why This Change Was Made

The naive fix — setting `NODE_OPTIONS=--max-old-space-size=...` in the service
environment — is wrong here: `NODE_OPTIONS` is on the host-env-security
`blockedEverywhere` key list (`src/infra/host-env-security-policy.json`). The
builder output is not run through that filter and `renderEnvDict` does not strip
it, so the value would leak into the generated plist — exactly the key the
security policy says must never be a managed env var.

Instead, this pins `--max-old-space-size=8192` as a **Node CLI argument** in the
launch command (`resolveCliProgramArguments` in `src/daemon/program-args.ts`),
which feeds both launchd `ProgramArguments` and systemd `ExecStart`. This
sidesteps the env-key policy entirely. The flag is injected only for the Node
runtime; bun uses its own allocator and ignores the V8 flag, and an operator
`OPENCLAW_WRAPPER` owns its own runtime flags.

## User Impact

Managed gateway/node services get a stable heap ceiling out of the box. The
ceiling is a cap, not an allocation — steady-state RSS is unaffected (reported
~700 MB). No new config/env surface added. Bun and wrapper installs are
unchanged.

## Evidence

- TDD: new node-runtime tests failed for the right reason (missing flag), pass
  after the fix; bun/wrapper negative tests stay green.
- Artifact-level proof: a test renders the real `buildSystemdUnit` and
  `buildLaunchAgentPlist` from the real builder output and asserts
  `--max-old-space-size=8192` appears in the systemd `ExecStart` and the launchd
  plist `ProgramArguments`.
- `program-args.test.ts`: 13/13. Consumer suites (launchd, systemd, service,
  daemon-install-helpers, node-daemon-install-helpers, doctor-gateway-daemon-flow,
  configure.daemon, service-audit, inspect, schtasks): **397 passed, 0 failed**.
- `oxlint` clean; `tsgo:core` and `tsgo:core:test` clean.

### Proof boundary

Verified at the rendered-artifact level (unit/plist text), **not** live on a
running macOS launchd daemon. Demonstration branch.
