### PR TITLE
fix(ui): show cron job model selection in quick-create and job list/detail

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1248,11 +1248,13 @@ function resolveQuickSettingsSessionRow(state: AppViewState) {
 function renderCronQuickCreateForTab(
   state: AppViewState,
   requestHostUpdate: (() => void) | undefined,
+  modelSuggestions: readonly string[],
 ) {
   return renderCronQuickCreate({
     open: state.cronQuickCreateOpen,
     step: state.cronQuickCreateStep,
     draft: state.cronQuickCreateDraft ?? createDefaultDraft(),
+    modelSuggestions,
     onDraftChange: (patch) => {
       state.cronQuickCreateDraft = {
         ...(state.cronQuickCreateDraft ?? createDefaultDraft()),
@@ -3040,7 +3042,9 @@ export function renderApp(state: AppViewState) {
             })
           : nothing}
         ${renderUsageTab(state, lazyUsage)}
-        ${state.tab === "cron" ? renderCronQuickCreateForTab(state, requestHostUpdate) : nothing}
+        ${state.tab === "cron"
+          ? renderCronQuickCreateForTab(state, requestHostUpdate, cronModelSuggestions)
+          : nothing}
         ${state.tab === "cron"
           ? renderLazyView(lazyCron, (m) =>
               m.renderCron({

--- a/ui/src/ui/views/cron-quick-create.node.test.ts
+++ b/ui/src/ui/views/cron-quick-create.node.test.ts
@@ -6,6 +6,7 @@ function createDraft(overrides: Partial<CronQuickCreateDraft> = {}): CronQuickCr
   return {
     prompt: "Check inbox",
     name: "Inbox check",
+    model: "",
     schedulePreset: "every-morning",
     deliveryPreset: "notify",
     ...overrides,
@@ -46,5 +47,20 @@ describe("cron quick create", () => {
     expect(patch.payloadKind).toBe("systemEvent");
     expect(patch.deliveryMode).toBe("none");
     expect(patch.wakeMode).toBe("now");
+  });
+
+  it("maps a selected model into the cron payload model override", () => {
+    const patch = draftToCronFormPatch(createDraft({ model: " openai/gpt-5.2 " }));
+
+    expect(patch.payloadModel).toBe("openai/gpt-5.2");
+  });
+
+  it("does not map a model for silent systemEvent presets", () => {
+    const patch = draftToCronFormPatch(
+      createDraft({ deliveryPreset: "silent", model: "openai/gpt-5.2" }),
+    );
+
+    expect(patch.payloadKind).toBe("systemEvent");
+    expect(patch.payloadModel).toBeUndefined();
   });
 });

--- a/ui/src/ui/views/cron-quick-create.ts
+++ b/ui/src/ui/views/cron-quick-create.ts
@@ -17,6 +17,7 @@ export type CronQuickCreateProps = {
   open: boolean;
   step: CronQuickCreateStep;
   draft: CronQuickCreateDraft;
+  modelSuggestions?: readonly string[];
   onDraftChange: (patch: Partial<CronQuickCreateDraft>) => void;
   onStepChange: (step: CronQuickCreateStep) => void;
   onCreate: () => void;
@@ -29,6 +30,7 @@ export type CronQuickCreateStep = "what" | "when" | "how";
 export type CronQuickCreateDraft = {
   prompt: string;
   name: string;
+  model: string;
   schedulePreset: SchedulePresetId | "custom";
   deliveryPreset: DeliveryPresetId;
 };
@@ -121,6 +123,7 @@ export function createDefaultDraft(): CronQuickCreateDraft {
   return {
     prompt: "",
     name: "",
+    model: "",
     schedulePreset: "every-morning",
     deliveryPreset: "notify",
   };
@@ -199,6 +202,11 @@ export function draftToCronFormPatch(draft: CronQuickCreateDraft): Partial<CronF
       patch.deliveryMode = "none";
       patch.wakeMode = "now";
       break;
+  }
+
+  const model = draft.model.trim();
+  if (patch.payloadKind === "agentTurn" && model) {
+    patch.payloadModel = model;
   }
 
   return patch;
@@ -322,10 +330,12 @@ function renderWhenStep(props: CronQuickCreateProps) {
 }
 
 function renderHowStep(props: CronQuickCreateProps) {
+  const supportsModelOverride = draftSupportsModelOverride(props.draft);
   return html`
     <div class="cqc-body">
       <h3 class="cqc-body__heading">${t("cron.quickCreate.howHeading")}</h3>
       <p class="cqc-body__hint muted">${t("cron.quickCreate.howHint")}</p>
+      ${supportsModelOverride ? renderQuickCreateModelField(props) : nothing}
       <div class="cqc-delivery-options">
         ${DELIVERY_PRESETS.map(
           (preset) => html`
@@ -360,6 +370,30 @@ function renderHowStep(props: CronQuickCreateProps) {
 }
 
 // ── Main render ──
+
+function draftSupportsModelOverride(draft: CronQuickCreateDraft) {
+  return draft.deliveryPreset !== "silent";
+}
+
+function renderQuickCreateModelField(props: CronQuickCreateProps) {
+  return html`
+    <div class="cqc-field">
+      <label class="cqc-field__label" for="cron-quick-create-model">
+        ${t("cron.form.model")}
+      </label>
+      <input
+        id="cron-quick-create-model"
+        class="cqc-input"
+        type="text"
+        list="cron-quick-create-model-suggestions"
+        placeholder=${t("cron.form.modelPlaceholder")}
+        .value=${props.draft.model}
+        @input=${(e: Event) => props.onDraftChange({ model: (e.target as HTMLInputElement).value })}
+      />
+      <div class="cron-help">${t("cron.form.modelHelp")}</div>
+    </div>
+  `;
+}
 
 export function renderCronQuickCreate(props: CronQuickCreateProps) {
   if (!props.open) {
@@ -396,6 +430,17 @@ export function renderCronQuickCreate(props: CronQuickCreateProps) {
             ? renderWhenStep(props)
             : renderHowStep(props)}
       </section>
+      ${renderQuickCreateModelSuggestions(props.modelSuggestions)}
     </div>
   `;
+}
+
+function renderQuickCreateModelSuggestions(options: readonly string[] | undefined) {
+  const clean = Array.from(new Set((options ?? []).map((value) => value.trim()).filter(Boolean)));
+  if (clean.length === 0) {
+    return nothing;
+  }
+  return html`<datalist id="cron-quick-create-model-suggestions">
+    ${clean.map((value) => html`<option value=${value}></option>`)}
+  </datalist>`;
 }

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -413,6 +413,63 @@ describe("cron view", () => {
     expect(onCancelEdit).toHaveBeenCalledTimes(1);
   });
 
+  it("wires quick-create model selection into the draft", () => {
+    const container = document.createElement("div");
+    const onDraftChange = vi.fn();
+
+    render(
+      renderCronQuickCreate({
+        open: true,
+        step: "how",
+        draft: { ...createDefaultDraft(), model: "openai/gpt-5.2" },
+        modelSuggestions: ["openai/gpt-5.2", "anthropic/claude-sonnet-4.6"],
+        onDraftChange,
+        onStepChange: () => undefined,
+        onCreate: () => undefined,
+        onCancel: () => undefined,
+      }),
+      container,
+    );
+
+    const model = getElement(container, "#cron-quick-create-model", HTMLInputElement);
+    expect(model.value).toBe("openai/gpt-5.2");
+    expect(model.getAttribute("list")).toBe("cron-quick-create-model-suggestions");
+    expect(
+      Array.from(container.querySelectorAll("#cron-quick-create-model-suggestions option")).map(
+        (option) => option.getAttribute("value"),
+      ),
+    ).toEqual(["openai/gpt-5.2", "anthropic/claude-sonnet-4.6"]);
+
+    model.value = "openai/gpt-5.5";
+    model.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(onDraftChange).toHaveBeenCalledWith({ model: "openai/gpt-5.5" });
+  });
+
+  it("hides quick-create model selection for silent systemEvent presets", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderCronQuickCreate({
+        open: true,
+        step: "how",
+        draft: {
+          ...createDefaultDraft(),
+          deliveryPreset: "silent",
+          model: "openai/gpt-5.2",
+        },
+        modelSuggestions: ["openai/gpt-5.2"],
+        onDraftChange: () => undefined,
+        onStepChange: () => undefined,
+        onCreate: () => undefined,
+        onCancel: () => undefined,
+      }),
+      container,
+    );
+
+    expect(container.querySelector("#cron-quick-create-model")).toBeNull();
+  });
+
   it("shows webhook delivery details for jobs", () => {
     const container = document.createElement("div");
     const job = {
@@ -438,8 +495,38 @@ describe("cron view", () => {
     );
     expect(details).toEqual([
       { label: "Prompt", value: "do it" },
+      { label: "Model", value: "Default" },
       { label: "Delivery", value: "webhook (https://example.invalid/cron)" },
     ]);
+    expect(
+      Array.from(container.querySelectorAll(".cron-job-chips .chip")).map((chip) =>
+        chip.textContent?.trim(),
+      ),
+    ).toContain("Model: Default");
+  });
+
+  it("shows configured cron job models in job details", () => {
+    const container = document.createElement("div");
+    const job = {
+      ...createJob("job-model"),
+      sessionTarget: "isolated" as const,
+      payload: { kind: "agentTurn" as const, message: "do it", model: "openai/gpt-5.2" },
+    };
+
+    render(renderCron(createProps({ jobs: [job] })), container);
+
+    const details = Array.from(container.querySelectorAll(".cron-job-detail-section")).map(
+      (section) => ({
+        label: section.querySelector(".cron-job-detail-label")?.textContent?.trim(),
+        value: section.querySelector(".cron-job-detail-value")?.textContent?.trim(),
+      }),
+    );
+    expect(details).toContainEqual({ label: "Model", value: "openai/gpt-5.2" });
+    expect(
+      Array.from(container.querySelectorAll(".cron-job-chips .chip")).map((chip) =>
+        chip.textContent?.trim(),
+      ),
+    ).toContain("Model: openai/gpt-5.2");
   });
 
   it("renders a stale cron job with no payload", () => {

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -1607,6 +1607,7 @@ function renderFieldError(message?: string, id?: string) {
 function renderJob(job: CronJob, props: CronProps) {
   const isSelected = props.runsJobId === job.id;
   const itemClass = `list-item list-item-clickable cron-job${isSelected ? " list-item-selected" : ""}`;
+  const modelLabel = getCronJobModelLabel(job);
   const selectAnd = (action: () => void) => {
     props.onLoadRuns(job.id);
     action();
@@ -1633,6 +1634,9 @@ function renderJob(job: CronJob, props: CronProps) {
           </span>
           <span class="chip">${job.sessionTarget}</span>
           <span class="chip">${job.wakeMode}</span>
+          ${modelLabel
+            ? html`<span class="chip">${t("cron.form.model")}: ${modelLabel}</span>`
+            : nothing}
         </div>
         <div class="row cron-job-actions">
           <button
@@ -1711,6 +1715,14 @@ function renderJob(job: CronJob, props: CronProps) {
   `;
 }
 
+function getCronJobModelLabel(job: CronJob) {
+  const payload = getCronJobPayload(job);
+  if (payload?.kind !== "agentTurn") {
+    return null;
+  }
+  return payload.model?.trim() || t("agents.default");
+}
+
 function renderJobPayload(job: CronJob) {
   const payload = getCronJobPayload(job);
   if (!payload) {
@@ -1763,6 +1775,10 @@ function renderJobPayload(job: CronJob) {
         <div class="muted cron-job-detail-value chat-text" @click=${stopPropagationForInteractive}>
           ${unsafeHTML(toSanitizedMarkdownHtml(payload.message))}
         </div>
+      </div>
+      <div class="cron-job-detail-section">
+        <span class="cron-job-detail-label">${t("cron.form.model")}</span>
+        <span class="muted cron-job-detail-value">${getCronJobModelLabel(job)}</span>
       </div>
       ${delivery
         ? html`<div class="cron-job-detail-section">


### PR DESCRIPTION
Supersedes #95341
Fixes #93507

## What Problem This Solves
Fixes an issue where users creating cron jobs from the Web UI quick-create flow could not choose a model, and existing cron jobs did not make their configured/default model visible in the job list or detail view.

## Why This Change Was Made
This reuses the existing cron `payload.model` / Control UI `payloadModel` contract instead of adding runtime or schema behavior. The quick-create wizard now accepts the same model suggestions already loaded for the advanced cron form, maps the selected value into the cron form patch for agentTurn cron jobs, and scheduled agent jobs show either the configured model or an explicit default label in both the row chips and job detail section.

Silent quick-create jobs save a `systemEvent` payload, so the model selector is hidden for that preset and the patch conversion does not emit `payloadModel` for silent jobs.

## User Impact
Users can choose a model while creating a cron job from the guided Web UI flow, and can inspect scheduled agent jobs at a glance to see which model they will use. Jobs that use the default model now say so explicitly. Silent jobs no longer present a model choice that would be ignored during save.

## Evidence
- `node scripts/run-vitest.mjs ui/src/ui/views/cron-quick-create.node.test.ts ui/src/ui/views/cron.test.ts ui/src/ui/controllers/cron.test.ts` passed: 3 files, 63 tests.
- `npx oxfmt --check ui/src/ui/views/cron-quick-create.ts ui/src/ui/views/cron-quick-create.node.test.ts ui/src/ui/views/cron.ts ui/src/ui/views/cron.test.ts ui/src/ui/app-render.ts` passed.
- `git diff --check` passed.
- Added regression coverage that silent/systemEvent quick-create presets do not map `payloadModel` and do not render the quick-create model input.
- Added regression coverage that configured job models appear in both the row chips and detail sections.

## Proof Tier
L2: real vitest passes verify component wiring; controller tests verify payload persistence. Additional non-mocked Gateway/Control UI proof pending per ClawSweeper requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)