### PR TITLE
Fix embedded transcript flush before afterTurn [AI-assisted]

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2285,6 +2285,36 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(runLlmInput).not.toHaveBeenCalled();
   });
 
+  it("flushes the embedded session transcript before afterTurn", async () => {
+    const events: string[] = [];
+    const afterTurn = vi.fn(async () => {
+      events.push("afterTurn");
+    });
+    hoisted.sessionManager.rewriteFile.mockImplementation(() => {
+      events.push("flush");
+    });
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createTestContextEngine({ afterTurn }),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        currentInboundEventKind: "room_event",
+        currentInboundContext: { text: "[OpenClaw room event]" },
+        suppressNextUserMessagePersistence: true,
+        transcriptPrompt: "",
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [...session.messages, doneMessage];
+      },
+    });
+
+    const afterTurnIndex = events.indexOf("afterTurn");
+    expect(afterTurn).toHaveBeenCalledTimes(1);
+    expect(afterTurnIndex).not.toBe(-1);
+    expect(events.slice(0, afterTurnIndex)).toContain("flush");
+  });
+
   it("forwards sessionKey to bootstrap, assemble, and afterTurn", async () => {
     const { bootstrap, assemble } = createContextEngineBootstrapAndAssemble();
     const afterTurn = vi.fn(async (_params: { sessionKey?: string }) => {});

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -57,6 +57,7 @@ type SessionManagerMocks = {
   resetLeaf: UnknownMock;
   buildSessionContext: Mock<() => { messages: AgentMessage[] }>;
   appendCustomEntry: UnknownMock;
+  rewriteFile: UnknownMock;
   flushPendingToolResults: UnknownMock;
   clearPendingToolResults: UnknownMock;
   removeTrailingEntries: UnknownMock;
@@ -207,6 +208,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     resetLeaf: vi.fn(),
     buildSessionContext: vi.fn<() => { messages: AgentMessage[] }>(() => ({ messages: [] })),
     appendCustomEntry: vi.fn(),
+    rewriteFile: vi.fn(),
     flushPendingToolResults: vi.fn(),
     clearPendingToolResults: vi.fn(),
     removeTrailingEntries: vi.fn(() => 0),
@@ -1033,6 +1035,7 @@ export function resetEmbeddedAttemptHarness(
     .mockReset()
     .mockReturnValue({ messages: params.sessionMessages ?? [] });
   hoisted.sessionManager.appendCustomEntry.mockReset();
+  hoisted.sessionManager.rewriteFile.mockReset();
   if (params.subscribeImpl) {
     hoisted.subscribeEmbeddedAgentSessionMock.mockImplementation(params.subscribeImpl);
   }

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5110,6 +5110,12 @@ export async function runEmbeddedAttempt(
               log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
             }
           }
+
+          if (activeContextEngine && !beforeAgentFinalizeRevisionReason) {
+            // Context-engine afterTurn hooks may reconcile against the jsonl, so
+            // materialize the active turn before finalization reads from disk.
+            flushSessionManagerFile(activeSessionManager);
+          }
         });
 
         // Let the active context engine run its post-turn lifecycle. These hooks


### PR DESCRIPTION
## Summary

- Problem: The embedded context-engine host could call `contextEngine.afterTurn` before the current session transcript JSONL had been materialized on disk.
- Solution: Flush the active embedded session manager before context-engine finalization reads the session transcript.
- What changed: The embedded attempt path now flushes the session manager before `finalizeAttemptContextEngineTurn`, and the embedded attempt test harness exposes `rewriteFile` so a regression test can assert the flush happens before `afterTurn`.
- What did NOT change (scope boundary): No context-engine API shape changed, no Codex app-server transcript mirror behavior changed, no room-event suppression policy changed, and no dependencies or lockfiles changed.

## Motivation

Context-engine plugins can reconcile against the on-disk session JSONL during `afterTurn`. For embedded turns, especially room-event turns where durable user-message persistence can be suppressed, the hook could observe a missing or stale transcript and treat a brand-new conversation as never ingested. The embedded host should provide the same durable transcript-before-afterTurn guarantee that the Codex app-server host already has through transcript mirroring.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #97301
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: Embedded context-engine `afterTurn` now runs only after the active turn has been flushed to the session transcript JSONL.
- Real environment tested (affected runtime/layer, not just "unit test"): Local OpenClawUbuntu diagnostic runtime using the real `SessionManager` JSONL persistence path and shared embedded context-engine `afterTurn` finalizer, plus Node/pnpm repo test runtime, embedded agent runner context-engine lifecycle harness, session transcript guard tests, and Codex app-server context-engine afterTurn harness.
- Exact steps or command run after this patch:

```bash
git diff --check
node_modules/.bin/oxfmt --check src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-embedded-agent.config.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts --testNamePattern "flushes the embedded session transcript before afterTurn" --testTimeout 120000 --hookTimeout 120000
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/harness/context-engine-lifecycle.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/session-tool-result-guard.test.ts --testTimeout 120000 --hookTimeout 120000
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/session-tool-result-guard.test.ts --testTimeout 120000 --hookTimeout 120000
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts --testNamePattern "calls afterTurn with the mirrored transcript and runs turn maintenance" --testTimeout 120000 --hookTimeout 120000
node_modules/.bin/tsx --input-type=module -  # temporary local diagnostic: create a real SessionManager JSONL, flush it, then invoke embedded afterTurn and read the JSONL from the hook
```

- Evidence after fix:

```text
real embedded afterTurn diagnostic: PASS
[before-append] fileExists=false jsonlLines=0 containsMarker=false
[after-append-before-flush] fileExists=false jsonlLines=0 containsMarker=false snapshotMessages=1 snapshotContainsMarker=true
[after-flush-before-afterTurn] fileExists=true jsonlLines=2 entryKinds=session,message:user containsMarker=true
[afterTurn] sessionKey=agent:main:embedded-session-real-proof sessionFile=<PROOF_RUN>/attempt-.../sessions/...jsonl fileExists=true jsonlLines=2 entryKinds=session,message:user containsMarker=true snapshotMessages=1 snapshotContainsMarker=true
[result] PASS afterTurn observed flushed JSONL before hook completed; finalJsonlLines=2 containsMarker=true
git diff --check: passed
oxfmt: All matched files use the correct format.
oxlint: Found 0 warnings and 0 errors.
tsgo core: passed
tsgo test-src: passed
focused embedded regression: 1 passed, 62 skipped
agent context-engine run: 2 files passed, 76 tests passed
session-tool-result-guard: 1 file passed, 35 tests passed
focused app-server afterTurn run: 1 passed, 27 skipped
```

- Public artifact URLs, if screenshots/videos/files are referenced:

```text
None. The runtime proof is included as redacted terminal output above; no screenshot, video, or public file artifact is referenced.
```

- Observed result after fix: The diagnostic runtime showed the current turn marker was present in the real session JSONL immediately before and during `afterTurn`; before the explicit flush, the same marker existed only in memory and the JSONL did not exist yet. The embedded regression also records the session-manager flush before `afterTurn`, including the suppressed room-event path where the user message is routed to the model prompt and not persisted as a normal runtime-event row.
- What was not tested: I did not run a live external transport/channel session or a deployed third-party context-engine plugin. A complete local run of the app-server context-engine file had 27/28 tests pass but one unrelated local setup failure for an unregistered `codex-context-test-sandbox` backend; the focused app-server afterTurn test passed.
- Before evidence:

```text
Issue #97301 and the ClawSweeper review documented that current main finalized embedded context-engine turns from an in-memory snapshot before any explicit transcript mirror or flush, while room-event suppression could skip the durable user-message write.
```

- Visual proof:
  - Before screenshot/video: None.
  - After screenshot/video: None.
  - If not applicable, why: This is a runtime/session transcript ordering bug without UI or visual output.
- Remaining proof gap: None for the reported embedded `afterTurn` / session JSONL ordering behavior.

## Root Cause

- Root cause: The embedded attempt path finalized context-engine turns against an in-memory message snapshot without first forcing the active session transcript file to include the current turn.
- Missing detection / guardrail: There was no embedded-runner regression asserting that a suppressed room-event turn flushes the session transcript before `afterTurn`.
- Contributing context (if known): The Codex app-server host mirrors the transcript before finalization, but the embedded host relied on later session event/write processing.

## Regression Test Plan

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- Scenario the test should lock in: With an active context engine and a suppressed room-event turn, the embedded runner flushes the session transcript before `afterTurn` runs.
- Why this is the smallest reliable guardrail: The bug is the embedded runner/context-engine lifecycle ordering, so the existing embedded attempt harness can assert the actual flush and hook sequence without adding a live plugin dependency.
- Existing test that already covers this (if any): The Codex app-server afterTurn tests cover the mirrored app-server host path, but not the embedded host flush contract.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Context-engine plugins that reconcile against session JSONL during embedded `afterTurn` should now see the current turn materialized before reconciliation. There are no UI, config, or command changes.

## Diagram

```text
Before:
embedded turn mutates in-memory session
  -> finalizeAttemptContextEngineTurn
  -> contextEngine.afterTurn reads missing/stale JSONL
  -> later session write/event processing

After:
embedded turn mutates in-memory session
  -> flushSessionManagerFile(activeSessionManager)
  -> finalizeAttemptContextEngineTurn
  -> contextEngine.afterTurn reads materialized current turn
```

## Security Impact

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? No. The same session transcript data is flushed earlier under the existing session manager path.
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: Linux in local OpenClawUbuntu development runtime.
- Runtime/container: Node/pnpm source checkout.
- Model/provider: N/A, mocked embedded runner and app-server harness tests.
- Integration/channel (if any): Embedded context-engine afterTurn diagnostic using real session JSONL persistence; embedded agent runner context-engine lifecycle; Codex app-server context-engine harness for parity check.
- Relevant config (redacted): Default local diagnostic/test harness config; no credentials or private accounts used.

### Steps

1. Run the real embedded afterTurn diagnostic: create a persisted `SessionManager`, append the current-turn marker, show the JSONL is absent before flush, flush the session, then invoke the embedded `afterTurn` finalizer and read the same JSONL from inside `afterTurn`.
2. Run the focused embedded regression test for `flushes the embedded session transcript before afterTurn`.
3. Run the related embedded context-engine lifecycle and session transcript guard tests.
4. Run the focused Codex app-server afterTurn parity test.
5. Run format, lint, diff, and TypeScript checks for the changed surface.

### Expected

- The diagnostic `afterTurn` reads a real session JSONL containing the current turn marker after the pre-hook flush.
- The embedded regression observes a transcript flush before `afterTurn`.
- Related context-engine lifecycle and session guard tests pass.
- Static checks and TypeScript checks pass.

### Actual

- Matched expected results for the real embedded afterTurn diagnostic, focused embedded regression, related agent tests, session guard test, focused app-server afterTurn test, format, lint, diff, and TypeScript checks.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
real embedded afterTurn diagnostic:
[before-append] fileExists=false jsonlLines=0 containsMarker=false
[after-append-before-flush] fileExists=false jsonlLines=0 containsMarker=false snapshotMessages=1 snapshotContainsMarker=true
[after-flush-before-afterTurn] fileExists=true jsonlLines=2 entryKinds=session,message:user containsMarker=true
[afterTurn] sessionKey=agent:main:embedded-session-real-proof sessionFile=<PROOF_RUN>/attempt-.../sessions/...jsonl fileExists=true jsonlLines=2 entryKinds=session,message:user containsMarker=true snapshotMessages=1 snapshotContainsMarker=true
[result] PASS afterTurn observed flushed JSONL before hook completed; finalJsonlLines=2 containsMarker=true

focused embedded regression: 1 passed, 62 skipped
agent context-engine run: 2 files passed, 76 tests passed
session-tool-result-guard: 1 file passed, 35 tests passed
focused app-server afterTurn run: 1 passed, 27 skipped
static checks: diff, format, lint, core typecheck, and test-src typecheck passed
```

## Human Verification

- Verified scenarios: Real embedded `afterTurn` reading the flushed session JSONL, the embedded suppressed room-event regression, the broader embedded context-engine lifecycle file, the context-engine lifecycle harness file, the session tool-result guard, and the app-server afterTurn parity test.
- Edge cases checked: Durable user-message suppression for room events, flush ordering before `afterTurn`, real `SessionManager` rewrite materializing a previously absent JSONL, and existing app-server mirrored afterTurn behavior.
- What you did **not** verify: Live external transport/channel behavior, deployed third-party context-engine plugin behavior, and the complete app-server context-engine file because one unrelated local sandbox backend test requires an unavailable backend registration.

## Review Conversations

- [x] ClawSweeper's top-level proof request is addressed by the updated Real behavior proof and Evidence sections.
- [x] No GitHub review-thread cleanup is being left for maintainers.

## Compatibility / Migration

- Backward compatible? Yes.
- Config/env changes? No.
- Migration needed? No.
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: The embedded host now flushes the session file earlier when an active context engine is present.
  - Mitigation: The change is scoped to the pre-finalization path and uses the existing session manager flush helper before the context-engine hook reads from disk.
- Risk: The proof does not include a live external transport/channel session or deployed third-party plugin.
  - Mitigation: The added diagnostic uses the real local `SessionManager` JSONL persistence path and shared embedded `afterTurn` finalizer, and the regression test directly models the reported suppressed room-event ordering and asserts the host-level flush-before-afterTurn contract.
