### PR TITLE
fix(bedrock): honor adaptive model max tokens

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -179,15 +179,68 @@ describe("Bedrock thinking effort mapping", () => {
     expect(testing.buildAdditionalModelRequestFields(model, options)).toBeUndefined();
   });
 
+  it("uses the model maxTokens cap for adaptive Claude thinking requests", () => {
+    const model = bedrockModel({
+      id: "us.anthropic.claude-opus-4-8",
+      name: "Claude Opus 4.8",
+      reasoning: true,
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    });
+    const options = testing.resolveSimpleBedrockOptions(model, { reasoning: "high" });
+
+    expect(options.maxTokens).toBe(128_000);
+    expect(options.reasoning).toBe("high");
+    expect(testing.buildAdditionalModelRequestFields(model, options)).toEqual({
+      thinking: { type: "adaptive", display: "summarized" },
+      output_config: { effort: "high" },
+    });
+  });
+
+  it.each([4096, 8192, 16_384])(
+    "does not turn fallback maxTokens %s into an adaptive cap",
+    (maxTokens) => {
+      const model = bedrockModel({
+        id: "us.anthropic.claude-opus-4-8",
+        name: "Claude Opus 4.8",
+        reasoning: true,
+        maxTokens,
+      });
+      const options = testing.resolveSimpleBedrockOptions(model, { reasoning: "high" });
+
+      expect(options.maxTokens).toBeUndefined();
+      expect(options.reasoning).toBe("high");
+    },
+  );
+
+  it("preserves explicit maxTokens caps for adaptive Claude thinking requests", () => {
+    const model = bedrockModel({
+      id: "us.anthropic.claude-opus-4-8",
+      name: "Claude Opus 4.8",
+      reasoning: true,
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    });
+    const options = testing.resolveSimpleBedrockOptions(model, {
+      reasoning: "high",
+      maxTokens: 32_000,
+    });
+
+    expect(options.maxTokens).toBe(32_000);
+  });
+
   it("forces adaptive thinking for Bedrock Mythos Preview when callers omit reasoning", () => {
     const model = bedrockModel({
       id: "us.anthropic.claude-mythos-preview",
       name: "US Claude Mythos Preview",
       reasoning: true,
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
     });
     const options = testing.resolveSimpleBedrockOptions(model, {});
 
     expect(options.reasoning).toBe("high");
+    expect(options.maxTokens).toBe(128_000);
     expect(testing.buildAdditionalModelRequestFields(model, options)).toEqual({
       thinking: { type: "adaptive", display: "summarized" },
       output_config: { effort: "high" },
@@ -280,6 +333,15 @@ describe("Bedrock Fable contract", () => {
       ],
     } as never;
   }
+
+  it("uses the model maxTokens cap for simple Fable options", () => {
+    const options = testing.resolveSimpleBedrockOptions(fableModel(), {});
+
+    expect(options).toMatchObject({
+      maxTokens: 128_000,
+      reasoning: "high",
+    });
+  });
 
   it("sends always-adaptive high effort without unsupported request controls", async () => {
     const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -90,6 +90,20 @@ function normalizeFableToolChoice(
   return toolChoice;
 }
 
+// OpenClaw synthesizes these caps when the provider's real output limit is unknown.
+// Keep them out of Bedrock adaptive requests so Bedrock can use its native default.
+const OPENCLAW_FALLBACK_MODEL_MAX_TOKENS = new Set([4096, 8192, 16_384]);
+
+function resolveAdaptiveBedrockMaxTokens(
+  model: Model<"bedrock-converse-stream">,
+  baseMaxTokens: number | undefined,
+): number | undefined {
+  if (baseMaxTokens !== undefined) {
+    return baseMaxTokens;
+  }
+  return OPENCLAW_FALLBACK_MODEL_MAX_TOKENS.has(model.maxTokens) ? undefined : model.maxTokens;
+}
+
 /** Stream a Bedrock Converse request using Bedrock-specific options. */
 export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> = (
   model: Model<"bedrock-converse-stream">,
@@ -361,6 +375,7 @@ function resolveSimpleBedrockOptions(
   if (usesClaudeFable5BedrockContract(model)) {
     return {
       ...base,
+      maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens),
       reasoning: options?.reasoning ?? "high",
       thinkingBudgets: options?.thinkingBudgets,
     } satisfies BedrockOptions;
@@ -372,6 +387,9 @@ function resolveSimpleBedrockOptions(
         : undefined;
     return {
       ...base,
+      ...(reasoning !== undefined
+        ? { maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens) }
+        : {}),
       reasoning,
     } satisfies BedrockOptions;
   }
@@ -380,6 +398,7 @@ function resolveSimpleBedrockOptions(
     if (supportsAdaptiveThinking(model)) {
       return {
         ...base,
+        maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens),
         reasoning: options.reasoning,
         thinkingBudgets: options.thinkingBudgets,
       } satisfies BedrockOptions;


### PR DESCRIPTION
## Summary

- Bedrock adaptive-thinking request shaping now uses the configured model `maxTokens` when no per-request cap is supplied.
- Explicit request `maxTokens` still wins over the model-level value.
- Known OpenClaw fallback caps stay omitted for adaptive requests so Bedrock native defaults remain available.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security
- [ ] Chore

## Scope

- [ ] Gateway
- [ ] Skills
- [ ] Auth
- [ ] Memory
- [x] Integrations
- [ ] API
- [ ] UI/UX
- [ ] CI

## Verification

- `node scripts/run-vitest.mjs extensions/amazon-bedrock/stream.runtime.test.ts` -> passed 1 Vitest shard in 12.80s.
- `node scripts/run-vitest.mjs extensions/amazon-bedrock/discovery.test.ts` -> passed 1 Vitest shard in 22.64s.
- `git diff --check` -> passed.

## Real behavior proof

**Behavior addressed:** Bedrock adaptive-thinking options now carry configured high output-token caps while leaving fallback caps unset.

**Environment tested:** Node runtime on Linux in the local `fix/97176-bedrock-adaptive-max-tokens` branch.

**Steps run after the patch:** Ran a `node --import tsx --no-warnings -e` command that imports `testing` from `./extensions/amazon-bedrock/stream.runtime.ts` and calls `resolveSimpleBedrockOptions` plus `buildAdditionalModelRequestFields` with configured, explicit, and fallback max-token cases.

**Evidence after fix:**

```text
{
  "configuredAdaptiveMaxTokens": 128000,
  "configuredAdaptiveReasoning": "high",
  "explicitMaxTokens": 32000,
  "discoveryFallback4096MaxTokensValue": null,
  "normalizedFallback8192MaxTokensValue": null,
  "registryFallback16384MaxTokensValue": null,
  "additionalFields": {
    "thinking": {
      "type": "adaptive",
      "display": "summarized"
    },
    "output_config": {
      "effort": "high"
    }
  }
}
```

**Observed result:** The configured model cap resolves to `128000`, the explicit request cap remains `32000`, fallback caps `4096`, `8192`, and `16384` remain unset, and adaptive request fields are still produced.

**Not tested:** Live AWS Bedrock request with real credentials was not run.

## Impact Assessment

- Scope: Bedrock stream runtime option resolution and its regression tests only.
- Downstream: The shared simple Bedrock options helper feeds Fable, mandatory adaptive, and adaptive request branches; non-adaptive request paths are unchanged.
- Edge cases: absent request cap, explicit request cap, configured high model cap, and fallback model caps were covered.
- Hard-coded values: the fix uses configured/runtime caps and preserves caller caps; only existing OpenClaw fallback cap values are excluded from becoming explicit Bedrock request caps.
- Existing fixes: no competing open PR was found for `#97176` before implementation.
- Import paths: no new imports were added.

## Root Cause

- Root cause: Bedrock adaptive request options relied on request-level `maxTokens`, so configured model-level output caps were not forwarded when callers omitted a per-request cap.
- Missing guardrail: Regression coverage did not cover configured adaptive output caps or fallback caps.

## Regression Test Plan

- Added focused stream runtime tests for configured adaptive caps, explicit request caps, fallback caps, mandatory adaptive behavior, and Fable defaults.
- Re-ran the Bedrock discovery tests to verify discovery fallback behavior stayed unchanged.

## User-visible / Behavior Changes

Users with Bedrock adaptive-thinking models and configured high `maxTokens` values can receive the intended response budget without adding a per-request override. OpenClaw fallback caps are still left to Bedrock defaults instead of reducing native capacity.

## Security Impact

- New permissions? No
- Secrets handling changed? No
- New network calls? No

Closes #97176
