### PR TITLE
fix: preserve allow-always unavailable reasons across approval surfaces

### DIFF
--- a/packages/gateway-protocol/src/exec-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/exec-approvals-validators.test.ts
@@ -129,4 +129,21 @@ describe("exec approvals protocol validators", () => {
       ).toBe(false);
     }
   });
+
+  it("accepts only typed allow-always unavailable reasons", () => {
+    expect(
+      validateExecApprovalRequestParams({
+        command: "echo hi",
+        unavailableDecisions: ["allow-always"],
+        allowAlwaysUnavailableReason: "no-reusable-pattern",
+      }),
+    ).toBe(true);
+
+    expect(
+      validateExecApprovalRequestParams({
+        command: "echo hi",
+        allowAlwaysUnavailableReason: "made-up-reason",
+      }),
+    ).toBe(false);
+  });
 });

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -157,6 +157,17 @@ export const ExecApprovalRequestParamsSchema = Type.Object(
         maxItems: 1,
       }),
     ),
+    allowAlwaysUnavailableReason: Type.Optional(
+      Type.String({
+        enum: [
+          "approval-policy-always",
+          "no-reusable-pattern",
+          "prompt-only",
+          "runtime-payload",
+          "unplanned",
+        ],
+      }),
+    ),
     commandSpans: Type.Optional(
       Type.Array(
         Type.Object(

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -12,6 +12,7 @@ import {
   normalizeOptionalString as parseString,
 } from "@openclaw/normalization-core/string-coerce";
 import type {
+  ExecApprovalAllowAlwaysUnavailableReason,
   ExecApprovalCommandSpan,
   ExecApprovalUnavailableDecision,
   ExecAsk,
@@ -57,6 +58,7 @@ type RequestExecApprovalDecisionParams = {
   warningText?: string;
   commandSpans?: ExecApprovalCommandSpan[];
   unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
   agentId?: string;
   resolvedPath?: string;
   sessionKey?: string;
@@ -92,6 +94,9 @@ function buildExecApprovalRequestToolParams(
     commandSpans: params.commandSpans,
     ...(params.unavailableDecisions?.length
       ? { unavailableDecisions: params.unavailableDecisions }
+      : {}),
+    ...(params.allowAlwaysUnavailableReason
+      ? { allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason }
       : {}),
     agentId: params.agentId,
     resolvedPath: params.resolvedPath,
@@ -199,6 +204,7 @@ type HostExecApprovalParams = {
   warningText?: string;
   commandSpans?: ExecApprovalCommandSpan[];
   unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason;
   commandHighlighting?: boolean;
   agentId?: string;
   resolvedPath?: string;
@@ -309,6 +315,7 @@ async function buildHostApprovalDecisionParams(
     warningText: params.warningText,
     commandSpans,
     unavailableDecisions: params.unavailableDecisions,
+    allowAlwaysUnavailableReason: params.allowAlwaysUnavailableReason,
     ...buildExecApprovalRequesterContext({
       agentId: params.agentId,
       sessionKey: params.sessionKey,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -23,6 +23,7 @@ import {
   persistAllowAlwaysDecision,
   recordAllowlistMatchesUse,
   resolveApprovalAuditTrustPath,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   resolveAllowAlwaysPersistenceDecision,
   resolveExecApprovalUnavailableDecisions,
   requiresExecApproval,
@@ -597,9 +598,16 @@ export async function processGatewayAllowlist(
     ask: hostAsk,
     allowAlwaysPersistence: effectiveAllowAlwaysPersistence,
   });
+  const allowAlwaysUnavailableReason = resolveExecApprovalAllowAlwaysUnavailableReason({
+    ask: hostAsk,
+    allowAlwaysPersistence: effectiveAllowAlwaysPersistence,
+  });
   const unavailableDecisionRequestParams =
     approvalUnavailableDecisions.length > 0
-      ? { unavailableDecisions: approvalUnavailableDecisions }
+      ? {
+          unavailableDecisions: approvalUnavailableDecisions,
+          ...(allowAlwaysUnavailableReason ? { allowAlwaysUnavailableReason } : {}),
+        }
       : {};
   if (requiresSecurityAuditSuppressionApproval) {
     params.warnings.push(

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -164,6 +164,19 @@ const resolveExecApprovalUnavailableDecisionsMock = vi.hoisted(() =>
         : [],
   ),
 );
+const resolveExecApprovalAllowAlwaysUnavailableReasonMock = vi.hoisted(() =>
+  vi.fn(
+    (params?: {
+      ask?: string | null;
+      allowAlwaysPersistence?: { kind: string; reasons?: string[] | null } | null;
+    }): string | null =>
+      params?.ask === "always"
+        ? "approval-policy-always"
+        : params?.allowAlwaysPersistence?.kind === "one-shot"
+          ? (params.allowAlwaysPersistence.reasons?.[0] ?? "unplanned")
+          : null,
+  ),
+);
 const resolveExecHostApprovalContextMock = vi.hoisted(() =>
   vi.fn(() => ({
     approvals: { allowlist: [] as ExecAllowlistEntry[], file: { version: 1, agents: {} } },
@@ -221,6 +234,8 @@ vi.mock("../infra/exec-approvals.js", () => ({
   requiresExecApproval: requiresExecApprovalMock,
   resolveAllowAlwaysPersistenceDecision: resolveAllowAlwaysPersistenceDecisionMock,
   resolveAllowAlwaysPatternCoverage: resolveAllowAlwaysPatternCoverageMock,
+  resolveExecApprovalAllowAlwaysUnavailableReason:
+    resolveExecApprovalAllowAlwaysUnavailableReasonMock,
   resolveExecApprovalAllowedDecisions: resolveExecApprovalAllowedDecisionsMock,
   resolveExecApprovalUnavailableDecisions: resolveExecApprovalUnavailableDecisionsMock,
   resolveExecApprovalsFromFile: resolveExecApprovalsFromFileMock,
@@ -533,6 +548,7 @@ describe("executeNodeHostCommand", () => {
       kind: "patterns",
       patterns: [{ pattern: "/trusted/bin/tool" }],
     });
+    resolveExecApprovalAllowAlwaysUnavailableReasonMock.mockClear();
     resolveExecApprovalAllowedDecisionsMock.mockClear();
     resolveExecApprovalUnavailableDecisionsMock.mockClear();
     resolveExecHostApprovalContextMock.mockReset();
@@ -1791,6 +1807,9 @@ describe("executeNodeHostCommand", () => {
       },
     });
     expect(requireRegisteredApprovalRequest().unavailableDecisions).toEqual(["allow-always"]);
+    expect(requireRegisteredApprovalRequest().allowAlwaysUnavailableReason).toBe(
+      "approval-policy-always",
+    );
     expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
       expect.objectContaining({
         allowedDecisions: ["allow-once", "deny"],
@@ -1840,6 +1859,9 @@ describe("executeNodeHostCommand", () => {
       },
     });
     expect(requireRegisteredApprovalRequest().unavailableDecisions).toEqual(["allow-always"]);
+    expect(requireRegisteredApprovalRequest().allowAlwaysUnavailableReason).toBe(
+      "approval-policy-always",
+    );
   });
 
   it("offers allow-always for prepared node commands with complete node coverage", async () => {
@@ -2247,6 +2269,7 @@ describe("executeNodeHostCommand", () => {
       allowAlwaysPersistence: { kind: "one-shot", reasons: ["unplanned"] },
     });
     expect(requireRegisteredApprovalRequest().unavailableDecisions).toEqual(["allow-always"]);
+    expect(requireRegisteredApprovalRequest().allowAlwaysUnavailableReason).toBe("unplanned");
     expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
       expect.objectContaining({
         allowedDecisions: ["allow-once", "deny"],

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -11,6 +11,7 @@ import {
   maxAsk,
   requiresExecApproval,
   resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   resolveExecApprovalUnavailableDecisions,
 } from "../infra/exec-approvals.js";
 import { defaultExecAutoReviewer, type ExecAutoReviewInput } from "../infra/exec-auto-review.js";
@@ -142,8 +143,17 @@ export async function executeNodeHostCommand(
     ask: approvalDecisionAsk,
     allowAlwaysPersistence,
   });
+  const allowAlwaysUnavailableReason = resolveExecApprovalAllowAlwaysUnavailableReason({
+    ask: approvalDecisionAsk,
+    allowAlwaysPersistence,
+  });
   const unavailableDecisionRequestParams =
-    unavailableDecisions.length > 0 ? { unavailableDecisions } : {};
+    unavailableDecisions.length > 0
+      ? {
+          unavailableDecisions,
+          ...(allowAlwaysUnavailableReason ? { allowAlwaysUnavailableReason } : {}),
+        }
+      : {};
   const requiresAsk =
     requiresExecApproval({
       ask: hostAsk,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -21,7 +21,9 @@ import {
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  formatExecApprovalAllowAlwaysUnavailableReason,
   normalizeExecApprovalUnavailableDecisions,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
@@ -171,6 +173,7 @@ export function createExecApprovalHandlers(
         ask?: string;
         warningText?: string | null;
         unavailableDecisions?: string[];
+        allowAlwaysUnavailableReason?: string;
         commandSpans?: {
           startIndex: number;
           endIndex: number;
@@ -324,6 +327,10 @@ export function createExecApprovalHandlers(
         commandAnalysis,
         commandSpans,
         unavailableDecisions: unavailableDecisions.length > 0 ? unavailableDecisions : undefined,
+        allowAlwaysUnavailableReason:
+          typeof p.allowAlwaysUnavailableReason === "string"
+            ? p.allowAlwaysUnavailableReason
+            : null,
         allowedDecisions: resolveExecApprovalRequestAllowedDecisions({
           ask: p.ask ?? null,
           unavailableDecisions,
@@ -458,8 +465,10 @@ export function createExecApprovalHandlers(
           return allowedDecisions.includes(decision)
             ? null
             : {
-                message:
-                  "allow-always is unavailable because the effective policy requires approval every time",
+                message: formatExecApprovalAllowAlwaysUnavailableReason(
+                  snapshot.request.allowAlwaysUnavailableReason ??
+                    resolveExecApprovalAllowAlwaysUnavailableReason(snapshot.request),
+                ),
                 details: APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS,
               };
         },

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3345,7 +3345,7 @@ describe("exec approval handlers", () => {
     expect(mockCallArg(resolveRespond, 0, 1)).toBeUndefined();
     expectRecordFields(mockCallArg(resolveRespond, 0, 2), {
       message:
-        "allow-always is unavailable because the effective policy requires approval every time",
+        "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     });
 
     const denyRespond = vi.fn();
@@ -3387,8 +3387,7 @@ describe("exec approval handlers", () => {
     expect(mockCallArg(resolveRespond)).toBe(false);
     expect(mockCallArg(resolveRespond, 0, 1)).toBeUndefined();
     expectRecordFields(mockCallArg(resolveRespond, 0, 2), {
-      message:
-        "allow-always is unavailable because the effective policy requires approval every time",
+      message: "Allow Always is unavailable.",
     });
 
     const allowOnceRespond = vi.fn();
@@ -3402,6 +3401,48 @@ describe("exec approval handlers", () => {
 
     await requestPromise;
     expect(allowOnceRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it("uses the request reason when rejecting unavailable allow-always", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        twoPhase: true,
+        unavailableDecisions: ["allow-always"],
+        allowAlwaysUnavailableReason: "no-reusable-pattern",
+      },
+    });
+    const { id } = await waitForRequestedExecApprovalPayload(broadcasts);
+
+    const resolveRespond = vi.fn();
+    await resolveExecApproval({
+      handlers,
+      id,
+      decision: "allow-always",
+      respond: resolveRespond,
+      context,
+    });
+
+    expectRecordFields(mockCallArg(resolveRespond, 0, 2), {
+      message:
+        "Allow Always is unavailable because OpenClaw could not derive a safe reusable approval pattern for this command.",
+    });
+
+    const denyRespond = vi.fn();
+    await resolveExecApproval({
+      handlers,
+      id,
+      decision: "deny",
+      respond: denyRespond,
+      context,
+    });
+
+    await requestPromise;
+    expect(denyRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
   });
 
   it("keeps baseline decisions available when allow-always is unavailable", async () => {

--- a/src/infra/approval-view-model.ts
+++ b/src/infra/approval-view-model.ts
@@ -72,6 +72,7 @@ function buildExecViewBase<TPhase extends ApprovalPhase>(
     metadata: buildExecMetadata(request),
     ask: request.request.ask ?? null,
     agentId: request.request.agentId ?? null,
+    allowAlwaysUnavailableReason: request.request.allowAlwaysUnavailableReason ?? null,
     warningText: request.request.warningText ?? null,
     commandAnalysis: request.request.commandAnalysis ?? null,
     commandText,

--- a/src/infra/approval-view-model.types.ts
+++ b/src/infra/approval-view-model.types.ts
@@ -3,6 +3,7 @@ import type { InteractiveReplyButton } from "../interactive/payload.js";
 import type { ChannelApprovalKind } from "./approval-types.js";
 import type { CommandExplanationSummary } from "./command-analysis/explain.js";
 import type {
+  ExecApprovalAllowAlwaysUnavailableReason,
   ExecApprovalDecision,
   ExecApprovalRequest,
   ExecApprovalResolved,
@@ -40,6 +41,7 @@ export type ExecApprovalViewBase = ApprovalViewBase & {
   approvalKind: "exec";
   ask?: string | null;
   agentId?: string | null;
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason | null;
   warningText?: string | null;
   commandAnalysis?: CommandExplanationSummary | null;
   commandText: string;

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -645,6 +645,27 @@ describe("exec approval forwarder", () => {
     expect(text).toContain("Allow Always is unavailable");
   });
 
+  it("renders one-shot allow-always copy in forwarded fallback text", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+    await expect(
+      forwarder.handleRequested({
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          unavailableDecisions: ["allow-always"],
+          allowAlwaysUnavailableReason: "no-reusable-pattern",
+          allowedDecisions: ["allow-once", "deny"],
+        },
+      }),
+    ).resolves.toBe(true);
+    await Promise.resolve();
+    const text = getFirstDeliveryText(deliver);
+    expect(text).toContain(
+      "Allow Always is unavailable because OpenClaw could not derive a safe reusable approval pattern for this command.",
+    );
+  });
+
   it.each([
     {
       command: "bash safe\u200B.sh",

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -32,6 +32,8 @@ import {
 } from "./exec-approval-command-display.js";
 import { formatExecApprovalExpiresIn } from "./exec-approval-reply.js";
 import {
+  formatExecApprovalAllowAlwaysUnavailableReason,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
@@ -294,7 +296,10 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
   lines.push(`Reply with: /approve ${request.id} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
     lines.push(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
+      formatExecApprovalAllowAlwaysUnavailableReason(
+        request.request.allowAlwaysUnavailableReason ??
+          resolveExecApprovalAllowAlwaysUnavailableReason(request.request),
+      ),
     );
   }
   return lines.join("\n");

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -368,6 +368,21 @@ describe("exec approval reply helpers", () => {
     expect(payload.interactive).toBeUndefined();
   });
 
+  it("renders reason-specific copy when allow-always is one-shot only", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-one-shot",
+      approvalSlug: "slug-one",
+      allowAlwaysUnavailableReason: "no-reusable-pattern",
+      allowedDecisions: ["allow-once", "deny"],
+      command: "bash -lc 'echo hi 2>&1'",
+      host: "gateway",
+    });
+
+    expect(payload.text).toContain(
+      "Allow Always is unavailable because OpenClaw could not derive a safe reusable approval pattern for this command.",
+    );
+  });
+
   it("stores agent and session metadata for downstream suppression checks", () => {
     const payload = buildExecApprovalPendingReplyPayload({
       approvalId: "req-meta",

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -18,6 +18,8 @@ import {
   supportsNativeExecApprovalClient,
 } from "./exec-approval-surface.js";
 import {
+  formatExecApprovalAllowAlwaysUnavailableReason,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   resolveExecApprovalAllowedDecisions,
   type ExecApprovalDecision,
   type ExecHost,
@@ -51,6 +53,9 @@ export type ExecApprovalPendingReplyParams = {
   approvalSlug: string;
   approvalCommandId?: string;
   ask?: string | null;
+  allowAlwaysUnavailableReason?:
+    | import("./exec-approvals.js").ExecApprovalAllowAlwaysUnavailableReason
+    | null;
   agentId?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
   command: string;
@@ -377,7 +382,10 @@ export function buildExecApprovalPendingReplyPayload(
   }
   if (!allowedDecisions.includes("allow-always")) {
     lines.push(
-      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+      formatExecApprovalAllowAlwaysUnavailableReason(
+        params.allowAlwaysUnavailableReason ??
+          resolveExecApprovalAllowAlwaysUnavailableReason({ ask: params.ask ?? null }),
+      ),
     );
   }
   const info: string[] = [];

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -27,6 +27,7 @@ let normalizeExecSecurity: typeof import("./exec-approvals.js").normalizeExecSec
 let requiresExecApproval: typeof import("./exec-approvals.js").requiresExecApproval;
 let normalizeExecApprovalUnavailableDecisions: typeof import("./exec-approvals.js").normalizeExecApprovalUnavailableDecisions;
 let resolveExecApprovalUnavailableDecisions: typeof import("./exec-approvals.js").resolveExecApprovalUnavailableDecisions;
+let resolveExecApprovalAllowAlwaysUnavailableReason: typeof import("./exec-approvals.js").resolveExecApprovalAllowAlwaysUnavailableReason;
 let resolveExecApprovalRequestAllowedDecisions: typeof import("./exec-approvals.js").resolveExecApprovalRequestAllowedDecisions;
 let resolveExecModeFromPolicy: typeof import("./exec-approvals.js").resolveExecModeFromPolicy;
 let resolveExecModePolicy: typeof import("./exec-approvals.js").resolveExecModePolicy;
@@ -55,6 +56,8 @@ async function loadActualExecApprovalModules(): Promise<void> {
   normalizeExecApprovalUnavailableDecisions =
     execApprovals.normalizeExecApprovalUnavailableDecisions;
   resolveExecApprovalUnavailableDecisions = execApprovals.resolveExecApprovalUnavailableDecisions;
+  resolveExecApprovalAllowAlwaysUnavailableReason =
+    execApprovals.resolveExecApprovalAllowAlwaysUnavailableReason;
   resolveExecApprovalRequestAllowedDecisions =
     execApprovals.resolveExecApprovalRequestAllowedDecisions;
   resolveExecModeFromPolicy = execApprovals.resolveExecModeFromPolicy;
@@ -263,6 +266,18 @@ describe("exec approvals policy helpers", () => {
         allowAlwaysPersistence: { kind: "one-shot", reasons: ["no-reusable-pattern"] },
       }),
     ).toEqual(["allow-always"]);
+  });
+
+  it("derives reason-specific allow-always unavailability", () => {
+    expect(resolveExecApprovalAllowAlwaysUnavailableReason({ ask: "always" })).toBe(
+      "approval-policy-always",
+    );
+    expect(
+      resolveExecApprovalAllowAlwaysUnavailableReason({
+        ask: "on-miss",
+        allowAlwaysPersistence: { kind: "one-shot", reasons: ["no-reusable-pattern"] },
+      }),
+    ).toBe("no-reusable-pattern");
   });
 
   it.each([

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -221,6 +221,7 @@ export type ExecApprovalRequestPayload = {
   commandAnalysis?: CommandExplanationSummary | null;
   commandSpans?: ExecApprovalCommandSpan[];
   unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  allowAlwaysUnavailableReason?: ExecApprovalAllowAlwaysUnavailableReason | null;
   allowedDecisions?: readonly ExecApprovalDecision[];
   agentId?: string | null;
   resolvedPath?: string | null;
@@ -1626,6 +1627,10 @@ export type AllowAlwaysPersistenceDecision =
   | { kind: "exact-command"; commandText: string }
   | { kind: "one-shot"; reasons: AllowAlwaysPersistenceReason[] };
 
+export type ExecApprovalAllowAlwaysUnavailableReason =
+  | "approval-policy-always"
+  | AllowAlwaysPersistenceReason;
+
 function hasRuntimeShellPayload(argv: readonly string[]): boolean {
   const inlineCommand = extractBindableShellWrapperInlineCommand([...argv]);
   return Boolean(
@@ -1833,6 +1838,53 @@ export function resolveExecApprovalUnavailableDecisions(params?: {
 }): readonly ExecApprovalUnavailableDecision[] {
   const allowed = new Set(resolveExecApprovalAllowedDecisions(params));
   return OPTIONAL_EXEC_APPROVAL_DECISIONS.filter((decision) => !allowed.has(decision));
+}
+
+const EXEC_APPROVAL_ALLOW_ALWAYS_REASON_PRIORITY = [
+  "runtime-payload",
+  "prompt-only",
+  "unplanned",
+  "no-reusable-pattern",
+] as const satisfies readonly AllowAlwaysPersistenceReason[];
+
+export function resolveExecApprovalAllowAlwaysUnavailableReason(params?: {
+  ask?: string | null;
+  allowAlwaysPersistence?: AllowAlwaysPersistenceDecision | null;
+}): ExecApprovalAllowAlwaysUnavailableReason | undefined {
+  const ask = normalizeExecAsk(params?.ask);
+  if (ask === "always") {
+    return "approval-policy-always";
+  }
+  const reasons =
+    params?.allowAlwaysPersistence?.kind === "one-shot"
+      ? params.allowAlwaysPersistence.reasons
+      : undefined;
+  if (!reasons?.length) {
+    return undefined;
+  }
+  const reasonSet = new Set(reasons);
+  return (
+    EXEC_APPROVAL_ALLOW_ALWAYS_REASON_PRIORITY.find((reason) => reasonSet.has(reason)) ?? reasons[0]
+  );
+}
+
+export function formatExecApprovalAllowAlwaysUnavailableReason(
+  reason?: ExecApprovalAllowAlwaysUnavailableReason | null,
+): string {
+  switch (reason) {
+    case "approval-policy-always":
+      return "The effective approval policy requires approval every time, so Allow Always is unavailable.";
+    case "runtime-payload":
+      return "Allow Always is unavailable because this command includes runtime-evaluated shell payload that cannot be safely persisted.";
+    case "prompt-only":
+      return "Allow Always is unavailable because this command depends on prompt-only authorization context that cannot be safely persisted.";
+    case "unplanned":
+      return "Allow Always is unavailable because OpenClaw could not derive a complete reusable approval plan for this command.";
+    case "no-reusable-pattern":
+      return "Allow Always is unavailable because OpenClaw could not derive a safe reusable approval pattern for this command.";
+    default:
+      return "Allow Always is unavailable.";
+  }
 }
 
 export function resolveExecApprovalRequestAllowedDecisions(params?: {

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -173,9 +173,7 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
     expect(payload.text).not.toContain("♾️ Allow Always");
     expect(payload.text).toContain("Allow Once: /approve plugin:approval-123 allow-once");
     expect(payload.text).toContain("Deny: /approve plugin:approval-123 deny");
-    expect(payload.text).toContain(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
-    );
+    expect(payload.text).toContain("Allow Always is unavailable.");
     expect(
       payload.text?.trim().endsWith("Reply with: /approve plugin:approval-123 allow-once|deny"),
     ).toBe(true);
@@ -185,6 +183,24 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
       approvalKind: "plugin",
       allowedDecisions: ["allow-once", "deny"],
     });
+  });
+
+  it("renders reason-specific exec reaction prompts when allow-always is one-shot", () => {
+    const payload = buildApprovalReactionPromptPayloadForRequest({
+      request: {
+        ...execRequest,
+        request: {
+          ...execRequest.request,
+          unavailableDecisions: ["allow-always"],
+          allowAlwaysUnavailableReason: "no-reusable-pattern",
+        },
+      },
+      nowMs: 1_000,
+    });
+
+    expect(payload.text).toContain(
+      "Allow Always is unavailable because OpenClaw could not derive a safe reusable approval pattern for this command.",
+    );
   });
 
   it("keeps plugin command actions visible for custom prompt views", () => {

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -12,6 +12,7 @@ import {
   type ExecApprovalPendingReplyParams,
   type ExecApprovalReplyDecision,
 } from "../infra/exec-approval-reply.js";
+import { formatExecApprovalAllowAlwaysUnavailableReason } from "../infra/exec-approvals.js";
 import type { PluginApprovalRequest } from "../infra/plugin-approvals.js";
 import {
   buildApprovalPendingReplyPayload,
@@ -208,12 +209,11 @@ function buildDecisionText(allowedDecisions: readonly ExecApprovalReplyDecision[
 function buildManualInstructionSection(params: {
   approvalId: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
+  allowAlwaysUnavailableText?: string | null;
 }): string[] {
   const lines: string[] = [];
   if (!params.allowedDecisions.includes("allow-always")) {
-    lines.push(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
-    );
+    lines.push(params.allowAlwaysUnavailableText ?? "Allow Always is unavailable.");
   }
   if (params.allowedDecisions.length > 0) {
     lines.push(
@@ -307,6 +307,12 @@ function buildApprovalReactionPromptText(params: {
   const manualInstructions = buildManualInstructionSection({
     approvalId: view.approvalId,
     allowedDecisions,
+    allowAlwaysUnavailableText:
+      view.approvalKind === "exec"
+        ? formatExecApprovalAllowAlwaysUnavailableReason(view.allowAlwaysUnavailableReason)
+        : allowedDecisions.includes("allow-always")
+          ? null
+          : "Allow Always is unavailable.",
   });
   if (manualInstructions.length > 0) {
     sections.push(manualInstructions.join("\n"));
@@ -410,6 +416,7 @@ export function buildApprovalReactionPendingContent(params: {
             approvalCommandId: params.request.id,
             warningText: params.view.warningText ?? undefined,
             ask: params.view.ask ?? null,
+            allowAlwaysUnavailableReason: params.view.allowAlwaysUnavailableReason ?? null,
             agentId: params.view.agentId ?? null,
             allowedDecisions: reactionPayload.allowedDecisions,
             command: params.view.commandText,

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -14,6 +14,7 @@ export type ExecApprovalRequestPayload = {
     startIndex: number;
     endIndex: number;
   }[];
+  allowAlwaysUnavailableReason?: string | null;
   allowedDecisions?: readonly ExecApprovalDecision[];
 };
 
@@ -134,6 +135,10 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
       resolvedPath: typeof request.resolvedPath === "string" ? request.resolvedPath : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
       commandSpans: parseCommandSpans(request.commandSpans, command.length),
+      allowAlwaysUnavailableReason:
+        typeof request.allowAlwaysUnavailableReason === "string"
+          ? request.allowAlwaysUnavailableReason
+          : null,
       allowedDecisions: parseAllowedDecisions(request.allowedDecisions),
     },
     createdAtMs,

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -158,6 +158,20 @@ describe("approval and confirmation modals", () => {
     );
   });
 
+  it("renders reason-specific allow-always warning text", async () => {
+    const request = createExecRequest();
+    request.request.allowedDecisions = ["allow-once", "deny"];
+    request.request.allowAlwaysUnavailableReason = "no-reusable-pattern";
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
+
+    await getRenderedDialog();
+
+    expect(container.querySelector(".exec-approval-warning")?.textContent?.trim()).toBe(
+      "Allow Always is unavailable because OpenClaw could not derive a safe reusable approval pattern for this command.",
+    );
+  });
+
   it("falls back to ask when exec approval decisions are omitted", async () => {
     const request = createExecRequest();
     request.request.ask = "always";

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -1,6 +1,10 @@
 // Control UI view renders exec approval screen content.
 import { html, nothing } from "lit";
 import { formatApprovalDisplayPath } from "../../../../src/infra/approval-display-paths.ts";
+import {
+  formatExecApprovalAllowAlwaysUnavailableReason,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
+} from "../../../../src/infra/exec-approvals.ts";
 import { t } from "../../i18n/index.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import "../components/modal-dialog.ts";
@@ -155,7 +159,15 @@ function renderUnavailableDecisionWarning(
 ) {
   return active.kind !== "exec" || decisions.includes("allow-always")
     ? nothing
-    : html`<div class="exec-approval-warning">${t("execApproval.allowAlwaysUnavailable")}</div>`;
+    : html`<div class="exec-approval-warning">
+        ${active.request.allowAlwaysUnavailableReason
+          ? formatExecApprovalAllowAlwaysUnavailableReason(
+              active.request.allowAlwaysUnavailableReason,
+            )
+          : formatExecApprovalAllowAlwaysUnavailableReason(
+              resolveExecApprovalAllowAlwaysUnavailableReason({ ask: active.request.ask ?? null }),
+            )}
+      </div>`;
 }
 
 export function renderExecApprovalPrompt(state: AppViewState) {


### PR DESCRIPTION
## Summary
- carry a typed `allowAlwaysUnavailableReason` through exec approval requests, gateway transport, Control UI parsing, and approval view models
- render reason-specific Allow Always unavailability copy in forwarded replies, reaction prompts, manual approval fallback text, and the Control UI
- add focused coverage for policy derivation, gateway validation, node-host request plumbing, and the affected approval UI/runtime surfaces

## Testing
- node scripts/run-vitest.mjs src/plugin-sdk/approval-reaction-runtime.test.ts packages/gateway-protocol/src/exec-approvals-validators.test.ts src/gateway/server-methods/server-methods.test.ts src/infra/exec-approvals-policy.test.ts src/infra/exec-approval-forwarder.test.ts src/infra/exec-approval-reply.test.ts src/agents/bash-tools.exec-host-node.test.ts ui/src/ui/views/exec-approval.test.ts

Closes #97069
