### PR TITLE
fix: align talk settings native select rows

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1108,14 +1108,6 @@
   box-shadow: var(--focus-ring);
 }
 
-.agent-chat__talk-select-label {
-  min-width: 0;
-  overflow: hidden;
-  line-height: 1.35;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .agent-chat__talk-select-icon,
 .agent-chat__talk-select-check {
   display: inline-flex;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1476,11 +1476,11 @@ describe("chat voice controls", () => {
     const model = container.querySelector<HTMLInputElement>(
       '.agent-chat__talk-options-primary input[placeholder="Auto"]',
     );
-    const sensitivityLabel = requireElement(
+    const sensitivitySelect = requireElement(
       container,
-      '[data-talk-select="sensitivity"] .agent-chat__talk-select-label',
-      "Talk sensitivity selected label",
-    );
+      '[data-talk-select="sensitivity"] select',
+      "Talk sensitivity select",
+    ) as HTMLSelectElement;
 
     expect(getTalkSelectOptionValues(container, "voice")).toEqual([
       "",
@@ -1495,7 +1495,7 @@ describe("chat voice controls", () => {
       "marin",
       "cedar",
     ]);
-    expect(sensitivityLabel.textContent).toBe("Custom");
+    expect(sensitivitySelect.value).toBe("__custom");
     expect(getTalkSelectOptionValues(container, "sensitivity")).toEqual([
       "",
       "0.65",
@@ -1542,12 +1542,12 @@ describe("chat voice controls", () => {
       },
       onRealtimeTalkOptionsChange,
     });
-    const defaultSensitivityLabel = requireElement(
+    const defaultSensitivitySelect = requireElement(
       defaultContainer,
-      '[data-talk-select="sensitivity"] .agent-chat__talk-select-label',
-      "default Talk sensitivity selected label",
-    );
-    expect(defaultSensitivityLabel.textContent).toBe("Default");
+      '[data-talk-select="sensitivity"] select',
+      "default Talk sensitivity select",
+    ) as HTMLSelectElement;
+    expect(defaultSensitivitySelect.value).toBe("");
     expect(getTalkSelectOptionValues(defaultContainer, "sensitivity")).toEqual([
       "",
       "0.65",

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -292,14 +292,9 @@ function renderNativeTalkSelect(params: {
   onSelect: (value: string) => void;
   selectedLabel?: string;
 }) {
-  const selectedLabel =
-    params.selectedLabel ?? params.options.find((entry) => entry.value === params.value)?.label;
   return html`
     <label class="agent-chat__talk-field" data-talk-select=${params.label.toLowerCase()}>
       <span>${params.label}</span>
-      ${selectedLabel
-        ? html`<span class="agent-chat__talk-select-label">${selectedLabel}</span>`
-        : nothing}
       <select
         .value=${params.value}
         @change=${(event: Event) =>


### PR DESCRIPTION
## Summary\n- remove the extra native select value label rendered inside Talk settings rows\n- keep the select itself as the single visible value source so Voice and Sensitivity align with the Model row\n- update the Talk settings test to validate native select values/options instead of the removed duplicate label span\n\n## Testing\n- node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts\n\nCloses #96915