### PR TITLE
fix(azure-openai-responses): bound SSE response reads via buildGuardedModelFetch

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1465,6 +1465,90 @@ describe("buildGuardedModelFetch", () => {
     expect(String(caught)).toMatch(/exceeded.*bytes while synthesizing SSE/i);
   });
 
+  it("caps non-OK response body lazily so SDK can still cancel retryable responses", async () => {
+    // Regression: a 429/5xx non-OK body used to be returned unchanged by the
+    // shared sanitizer, so a hostile endpoint could OOM the SDK when it called
+    // response.text(). The cap is applied lazily via TransformStream so the SDK
+    // can still cancel the response before reading any body.
+    const OVER_LIMIT = 100 * 1024;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(OVER_LIMIT));
+            controller.close();
+          },
+        }),
+        { status: 429, statusText: "Too Many Requests" },
+      ),
+      finalUrl: "https://custom-azure.openai.azure.com/openai/v1/responses",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "gpt-5.5",
+      provider: "azure",
+      api: "azure-openai-responses",
+      baseUrl: "https://custom-azure.openai.azure.com/openai/v1",
+    } as unknown as Model<"azure-openai-responses">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://custom-azure.openai.azure.com/openai/v1/responses",
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.ok).toBe(false);
+
+    const text = await response.text();
+    expect(text.length).toBeLessThanOrEqual(64 * 1024);
+    expect(text.length).toBeLessThan(OVER_LIMIT);
+  });
+
+  it("preserves SDK ability to cancel retryable non-OK responses before reading body", async () => {
+    // Regression: a non-OK body wrapper must be lazy. The OpenAI SDK may decide
+    // to cancel a 429/5xx response and retry before reading the body. If the
+    // wrapper eagerly reads the body, the SDK loses that capability.
+    const TOTAL_BYTES = 80 * 1024;
+    let bytesPulled = 0;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream({
+          pull(controller) {
+            if (bytesPulled < TOTAL_BYTES) {
+              const chunk = new Uint8Array(8 * 1024);
+              bytesPulled += chunk.byteLength;
+              controller.enqueue(chunk);
+            } else {
+              controller.close();
+            }
+          },
+        }),
+        { status: 503, statusText: "Service Unavailable" },
+      ),
+      finalUrl: "https://custom-azure.openai.azure.com/openai/v1/responses",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "gpt-5.5",
+      provider: "azure",
+      api: "azure-openai-responses",
+      baseUrl: "https://custom-azure.openai.azure.com/openai/v1",
+    } as unknown as Model<"azure-openai-responses">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://custom-azure.openai.azure.com/openai/v1/responses",
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(503);
+    // SDK cancels the response body before reading anything. The lazy cap must
+    // not pull the full body from the source — a small pre-buffered chunk is
+    // allowed (ReadableStream default high-water-mark), but the full payload
+    // must remain unconsumed so the SDK can still retry.
+    await response.body?.cancel();
+    expect(bytesPulled).toBeLessThan(TOTAL_BYTES);
+  });
+
   describe("long retry-after handling", () => {
     const anthropicModel = {
       id: "sonnet-4.6",

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -96,13 +96,43 @@ function findSseEventBoundary(buffer: string): { index: number; length: number }
   return best;
 }
 
+function capNonOkResponseBodyLazily(response: Response, maxBytes: number): Response {
+  const source = response.body;
+  if (!source) {
+    return response;
+  }
+  let total = 0;
+  const capped = source.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        const nextTotal = total + chunk.byteLength;
+        if (nextTotal > maxBytes) {
+          const remaining = maxBytes - total;
+          if (remaining > 0) {
+            controller.enqueue(chunk.subarray(0, remaining));
+          }
+          total = maxBytes;
+          controller.terminate();
+          return;
+        }
+        total = nextTotal;
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+  return new Response(capped, response);
+}
+
 function sanitizeOpenAISdkSseResponse(
   response: Response,
   options?: { synthesizeJsonAsSse?: boolean },
 ): Response {
   const contentType = response.headers.get("content-type") ?? "";
-  if (!response.ok || !response.body) {
+  if (!response.body) {
     return response;
+  }
+  if (!response.ok) {
+    return capNonOkResponseBodyLazily(response, SSE_SANITIZE_BUFFER_MAX_BYTES);
   }
   if (
     options?.synthesizeJsonAsSse === true &&

--- a/src/llm/providers/azure-openai-responses.ts
+++ b/src/llm/providers/azure-openai-responses.ts
@@ -1,6 +1,7 @@
 // Azure OpenAI Responses provider adapts Azure deployments to Responses API streams.
 import OpenAI, { AzureOpenAI } from "openai";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
+import { buildGuardedModelFetch } from "../../agents/provider-transport-fetch.js";
 import { isOpenAICompatibleAzureResponsesBaseUrl } from "../../shared/azure-openai-responses-client-compat.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import type {
@@ -198,6 +199,7 @@ function createClient(
   }
 
   const { baseUrl, apiVersion } = resolveAzureConfig(model, options);
+  const guardedFetch = buildGuardedModelFetch({ ...model, baseUrl });
 
   if (isOpenAICompatibleAzureResponsesBaseUrl(baseUrl)) {
     return new OpenAI({
@@ -205,6 +207,7 @@ function createClient(
       dangerouslyAllowBrowser: true,
       defaultHeaders: headers,
       baseURL: baseUrl,
+      fetch: guardedFetch,
     });
   }
 
@@ -214,6 +217,7 @@ function createClient(
     dangerouslyAllowBrowser: true,
     defaultHeaders: headers,
     baseURL: baseUrl,
+    fetch: guardedFetch,
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

The azure-openai-responses provider creates OpenAI/AzureOpenAI SDK clients without a custom `fetch` option, so all SSE streaming responses are read without any byte cap. A buggy or hostile endpoint returning `text/event-stream` with a large or never-ending body is fully buffered into memory by the SDK's internal HTTP layer — an OOM / DoS vector.

This injects `buildGuardedModelFetch` as the SDK `fetch` option in both the OpenAI-compatible and native AzureOpenAI client constructors, using the **resolved** Azure base URL (from options, env, resource name, or `model.baseUrl`) so SSRF policy and exact-origin trust evaluate the actual request origin. The shared `sanitizeOpenAISdkSseResponse` caps oversized SSE buffer boundaries (64 KiB per unterminated event, from #96989) and oversized JSON bodies synthesized into SSE (16 MiB cumulative).

The non-OK body cap (4xx/5xx) is applied **lazily** inside the shared `sanitizeOpenAISdkSseResponse` guard via `TransformStream`. The previous per-provider eager wrapper in #97217 read the entire non-OK body before the SDK saw the response, breaking the OpenAI SDK's retry/cancel semantics for retryable 4xx/5xx. This PR uses the lazy shared-guard pattern that closed that defect.

## Changes

No new abstraction — reuses the existing `buildGuardedModelFetch` and `SSE_SANITIZE_BUFFER_MAX_BYTES` from `provider-transport-fetch.ts`. The new `capNonOkResponseBodyLazily` helper is a small inline `TransformStream` that fires the cap on pull, not eager.

- `src/llm/providers/azure-openai-responses.ts:4` — import `buildGuardedModelFetch` from `provider-transport-fetch.js`.
- `src/llm/providers/azure-openai-responses.ts:202,206,217` — after resolving `baseUrl` via `resolveAzureConfig`, create `buildGuardedModelFetch({ ...model, baseUrl })` with the resolved URL. Inject the result as `fetch:` into both SDK constructor branches (OpenAI path and AzureOpenAI path). No per-provider wrapper.
- `src/agents/provider-transport-fetch.ts:99` — new `capNonOkResponseBodyLazily(response, maxBytes)` helper: wraps `response.body` in a `pipeThrough(TransformStream)` that caps at `maxBytes` and `controller.terminate()`s the source once the cap is reached.
- `src/agents/provider-transport-fetch.ts:138` — `sanitizeOpenAISdkSseResponse` now applies `capNonOkResponseBodyLazily` when `!response.ok` and `response.body` is present, closing the shared-guard gap for all SDK providers (not just Azure).
- `src/agents/provider-transport-fetch.test.ts` — 2 inline tests at the `buildGuardedModelFetch` describe block:
  - `"caps non-OK response body lazily so SDK can still cancel retryable responses"` — 100 KiB 429 body → `text.length ≤ 64 KiB` after `await response.text()`.
  - `"preserves SDK ability to cancel retryable non-OK responses before reading body"` — 80 KiB 503 body, `await response.body?.cancel()` does not pull the full payload from the source.

## Design Rationale

**Why fetch injection with resolved baseUrl?** `buildGuardedModelFetch` uses `model.baseUrl` for SSRF origin trust and policy resolution. The Azure provider resolves the final base URL from a cascade (option → env → resource name → `model.baseUrl`). Spreading the resolved URL into the model ensures SSRF and exact-origin trust evaluate the actual request origin.

**Why apply the cap in the shared guard instead of per-provider?** Closes the gap for every SDK provider in one place with the same `SSE_SANITIZE_BUFFER_MAX_BYTES` boundary. Per-provider wrappers risk behavioral drift and complicate the fix for sibling providers (OpenAI Responses, OpenAI Completions, etc.).

**Why lazy via TransformStream?** The OpenAI SDK may want to cancel a retryable 4xx/5xx response and retry before reading the body. An eager wrapper that pre-reads the body in `fetch` would destroy that capability. A `TransformStream` only pulls when the consumer pulls, and `controller.terminate()` is the cap's stop signal — the source is never drained if the consumer cancels.

**Why preserve the existing "non-OK small body for error parsing" test path?** The lazy cap terminates the source only once accumulated bytes exceed the cap. A small non-OK body (e.g. 4xx JSON error) is unaffected — the consumer reads the full body via `response.json()` and gets the error message unchanged. The existing `"preserves non-OK SSE bodies for provider HTTP error parsing"` test continues to pass against the new shared-guard path.

## Real behavior proof

Real local HTTP-server proof (local-only proof script, not committed — per checklist #23): a real `node:http` server on 127.0.0.1 streams a non-OK body through a 3-step vitest proof. The proof script runs the production `buildGuardedModelFetch` pipeline (with `fetchWithSsrFGuard` re-pointed at the real `fetch()` so the network roundtrip is real), and the lazy cap fires inside the production `sanitizeOpenAISdkSseResponse`.

```
=== Real local HTTP-server proof: lazy non-OK body cap ===

  PASS  1/3 server bytesSent=73728 → response.text() length=65536 ≤ 64 KiB
            100 KiB 429 body streamed over real HTTP; cap fires at 64 KiB; source not drained

  PASS  2/3 server bytesSent=16384 < 163840 (160 KiB) after cancel
            160 KiB 503 body; SDK cancels body before reading; server only sent 16 KiB (10% of full payload)

  PASS  3/3 small 400 body preserved for error parsing — message="API key expired"
            4xx JSON body of <1 KiB round-trips intact through the lazy cap wrapper
```

**Mock-based regression coverage** (committed `provider-transport-fetch.test.ts`): 78/78 vitest tests pass, including 2 inline tests for the new non-OK cap and SDK cancel behavior, plus the existing `"preserves non-OK SSE bodies for provider HTTP error parsing"` test which proves small error bodies are not affected by the cap.

Test suite totals (after this patch):
- `provider-transport-fetch.test.ts`: 78/78 passed
- `azure-openai-responses.test.ts`: 4/4 passed

- **Behavior addressed**: Non-OK response bodies (4xx/5xx) are now lazily capped at 64 KiB by the shared `sanitizeOpenAISdkSseResponse` guard, closing the unbounded `response.text()` OOM path while preserving the OpenAI SDK's ability to cancel and retry. All Azure Responses requests route through `buildGuardedModelFetch` with the resolved base URL.
- **Real environment tested**: Linux x86_64, Node 22, real `node:http` server on 127.0.0.1 streaming chunked transfer responses.
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs src/agents/provider-transport-fetch.test.ts --run
  node scripts/run-vitest.mjs src/llm/providers/azure-openai-responses.test.ts --run
  ```
- **Evidence after fix**: 82/82 vitest tests passed across the 2 committed test files. The real-server proof shows the cap truncating a 100 KiB body to exactly 64 KiB (73728 → 65536, byte-for-byte). The cancel test shows the server only sent 16384 bytes (10% of the 160 KiB total) when the SDK cancelled the body before reading, proving the lazy semantics.
- **Observed result after fix**: All Azure Responses requests now go through guarded transport (SSRF, timeout, SSE/JSON synthesis caps, plus the new 64 KiB non-OK cap). SDK can still call `body.cancel()` on a 429/5xx response before reading — verified by the cancel test, which confirms the source stream is not drained on cancel.
- **What was not tested**: Live Azure endpoint (proof exercises the same production fetch pipeline against the same attack shapes; real credentials not required). End-to-end test through the Azure SDK constructor requires a real Azure endpoint — the proof exercises the exact `sanitizeOpenAISdkSseResponse` codepath that `buildGuardedModelFetch` invokes.

## Out of scope

Closes the loop on #97217 (closed as superseded by this PR — see comment thread). Companion to openai-responses (#97139) and openai-completions (#97228) guarded-fetch rollout. The non-OK body cap now lives in the shared guard rather than per-provider.

## Diff stats

```
3 files changed, 119 insertions(+), 1 deletion(-)
  src/agents/provider-transport-fetch.ts        +31/-1   (capNonOkResponseBodyLazily helper + sanitize cap path)
  src/llm/providers/azure-openai-responses.ts  +4/-0    (buildGuardedModelFetch import + fetch injection)
  src/agents/provider-transport-fetch.test.ts  +84/-0   (2 new inline tests: cap + cancel)
```

Net change: +31 lines production code (the `capNonOkResponseBodyLazily` helper + fetch injection), +84 lines committed test code, +0 real-server proof in repo. The real local HTTP-server proof was captured locally and lives in the PR body only — not committed, per the proof-script-not-committed checklist rule (#23).

## Risk checklist

- User-visible behavior change? Yes — existing Azure Responses requests now go through guarded transport (SSRF, timeout, SSE/JSON synthesis caps, plus the new 64 KiB non-OK cap). Non-OK error bodies are capped at 64 KiB.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? Yes — closes OOM/DoS vector via lazy cap on non-OK bodies. No new auth or secrets surface.
- Highest-risk area: Guarded fetch may fail existing Azure, APIM, private endpoint, or proxy requests that SDK/default fetch previously allowed. Same risk as the transport-stream path's existing guarded fetch rollout. Non-OK body cap could truncate unusually large error responses from custom endpoints at 64 KiB.
