### PR TITLE
Add Codex native hook relay memory guard

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -105,6 +105,7 @@ Supported `appServer` fields:
 | `defaultWorkspaceDir`                         | current process directory                              | Workspace used by `/codex bind` when `--cwd` is omitted.                                                                                                                                                                                                                                                                                                                                        |
 | `serviceTier`                                 | unset                                                  | Optional Codex app-server service tier. `"priority"` enables fast-mode routing, `"flex"` requests flex processing, and `null` clears the override. Legacy `"fast"` is accepted as `"priority"`.                                                                                                                                                                                                 |
 | `networkProxy`                                | disabled                                               | Opt into Codex permissions-profile networking for app-server commands. OpenClaw defines the selected `permissions.<profile>.network` config and selects it with `default_permissions` instead of sending `sandbox`.                                                                                                                                                                             |
+| `nativeHookRelay.memoryGuard`                 | disabled                                               | Admission control for Codex native hook relay commands. When enabled, OpenClaw can clear native hook relay config for a turn under memory pressure or when too many guarded relays are already active.                                                                                                                                                                                          |
 | `experimental.sandboxExecServer`              | `false`                                                | Preview opt-in that registers an OpenClaw sandbox-backed Codex environment with Codex app-server 0.132.0 or newer so native Codex execution can run inside the active OpenClaw sandbox.                                                                                                                                                                                                         |
 
 `appServer.networkProxy` is explicit because it changes the Codex sandbox
@@ -143,6 +144,43 @@ If the normal app-server runtime would be `danger-full-access`, enabling
 `networkProxy` uses workspace-style filesystem access for the generated
 permission profile. Codex managed network enforcement is sandboxed networking,
 so a full-access profile would not protect outbound traffic.
+
+`appServer.nativeHookRelay.memoryGuard` is an opt-in pressure valve for hosts
+where Codex native hook helper processes can create unacceptable memory
+pressure. When enabled, OpenClaw checks cgroup memory when available, falls
+back to `/proc/meminfo` `MemAvailable`, checks Gateway process RSS, and applies
+an in-process active relay cap before installing Codex native hook commands. If
+any configured threshold is exceeded, OpenClaw sends a clearing hook config for
+that turn instead of registering the relay.
+
+```json5
+{
+  plugins: {
+    entries: {
+      codex: {
+        config: {
+          appServer: {
+            nativeHookRelay: {
+              memoryGuard: {
+                enabled: true,
+                minAvailableMemoryMb: 1024,
+                maxProcessRssMb: 1536,
+                maxActiveRelays: 1,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+When the guard disables relay config, Codex model calls can still run, but
+OpenClaw native hook behavior for Codex-owned native tools and finalization is
+not installed for that turn. Use this only as bounded admission control on
+memory-constrained hosts, and keep native tool policy requirements in mind when
+choosing thresholds.
 
 The plugin blocks older or unversioned app-server handshakes. Codex app-server
 must report stable version `0.125.0` or newer.

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -237,6 +237,34 @@
               "dangerouslyAllowAllUnixSockets": { "type": "boolean" }
             }
           },
+          "nativeHookRelay": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "memoryGuard": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "minAvailableMemoryMb": {
+                    "type": "number",
+                    "minimum": 1
+                  },
+                  "maxProcessRssMb": {
+                    "type": "number",
+                    "minimum": 1
+                  },
+                  "maxActiveRelays": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          },
           "defaultWorkspaceDir": {
             "type": "string"
           },
@@ -516,6 +544,36 @@
     "appServer.networkProxy.dangerouslyAllowAllUnixSockets": {
       "label": "Allow All Unix Sockets",
       "help": "Bypass Codex's Unix socket allowlist for tightly controlled environments.",
+      "advanced": true
+    },
+    "appServer.nativeHookRelay": {
+      "label": "Native Hook Relay",
+      "help": "Controls Codex native hook relay admission for native tool policy and finalization hooks.",
+      "advanced": true
+    },
+    "appServer.nativeHookRelay.memoryGuard": {
+      "label": "Memory Guard",
+      "help": "Disable Codex native hook relay for a turn when configured memory or active-relay thresholds are exceeded.",
+      "advanced": true
+    },
+    "appServer.nativeHookRelay.memoryGuard.enabled": {
+      "label": "Enable Memory Guard",
+      "help": "When true, OpenClaw checks memory pressure and active relay count before installing Codex native hook relay commands.",
+      "advanced": true
+    },
+    "appServer.nativeHookRelay.memoryGuard.minAvailableMemoryMb": {
+      "label": "Minimum Available Memory",
+      "help": "Do not install Codex native hook relay commands when available memory is below this MiB floor.",
+      "advanced": true
+    },
+    "appServer.nativeHookRelay.memoryGuard.maxProcessRssMb": {
+      "label": "Maximum Process RSS",
+      "help": "Do not install Codex native hook relay commands when Gateway process RSS is above this MiB ceiling.",
+      "advanced": true
+    },
+    "appServer.nativeHookRelay.memoryGuard.maxActiveRelays": {
+      "label": "Maximum Active Relays",
+      "help": "Do not install another Codex native hook relay when this many guarded relays are already active.",
       "advanced": true
     },
     "appServer.defaultWorkspaceDir": {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -259,6 +259,28 @@ describe("Codex app-server config", () => {
     });
   });
 
+  it("parses native hook relay memory guard config", () => {
+    const config = readCodexPluginConfig({
+      appServer: {
+        nativeHookRelay: {
+          memoryGuard: {
+            enabled: true,
+            minAvailableMemoryMb: 1024,
+            maxProcessRssMb: 1536,
+            maxActiveRelays: 1,
+          },
+        },
+      },
+    });
+
+    expect(config.appServer?.nativeHookRelay?.memoryGuard).toEqual({
+      enabled: true,
+      minAvailableMemoryMb: 1024,
+      maxProcessRssMb: 1536,
+      maxActiveRelays: 1,
+    });
+  });
+
   it("falls back for non-positive app-server timer config", () => {
     const runtime = resolveRuntimeForTest({
       pluginConfig: {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -118,6 +118,17 @@ export type CodexAppServerExperimentalConfig = {
   sandboxExecServer?: boolean;
 };
 
+export type CodexNativeHookRelayMemoryGuardConfig = {
+  enabled?: boolean;
+  minAvailableMemoryMb?: number;
+  maxProcessRssMb?: number;
+  maxActiveRelays?: number;
+};
+
+export type CodexNativeHookRelayConfig = {
+  memoryGuard?: CodexNativeHookRelayMemoryGuardConfig;
+};
+
 export type CodexAppServerNetworkProxyDomainPermission = "allow" | "deny";
 export type CodexAppServerNetworkProxyUnixSocketPermission = "allow" | "none";
 export type CodexAppServerNetworkProxyBaseProfile = "read-only" | "workspace";
@@ -230,6 +241,7 @@ export type CodexPluginConfig = {
     approvalsReviewer?: CodexAppServerApprovalsReviewer;
     serviceTier?: CodexServiceTier | null;
     networkProxy?: CodexAppServerNetworkProxyConfig;
+    nativeHookRelay?: CodexNativeHookRelayConfig;
     defaultWorkspaceDir?: string;
     experimental?: CodexAppServerExperimentalConfig;
   };
@@ -264,6 +276,7 @@ export const CODEX_APP_SERVER_CONFIG_KEYS = [
   "approvalsReviewer",
   "serviceTier",
   "networkProxy",
+  "nativeHookRelay",
   "defaultWorkspaceDir",
   "experimental",
 ] as const;
@@ -351,6 +364,21 @@ const codexAppServerNetworkProxySchema = z
   })
   .strict();
 
+const codexNativeHookRelayMemoryGuardSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    minAvailableMemoryMb: z.number().positive().optional(),
+    maxProcessRssMb: z.number().positive().optional(),
+    maxActiveRelays: z.number().int().positive().optional(),
+  })
+  .strict();
+
+const codexNativeHookRelaySchema = z
+  .object({
+    memoryGuard: codexNativeHookRelayMemoryGuardSchema.optional(),
+  })
+  .strict();
+
 const codexPluginEntryConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -413,6 +441,7 @@ const codexPluginConfigSchema = z
         approvalsReviewer: codexAppServerApprovalsReviewerSchema.optional(),
         serviceTier: codexAppServerServiceTierSchema,
         networkProxy: codexAppServerNetworkProxySchema.optional(),
+        nativeHookRelay: codexNativeHookRelaySchema.optional(),
         defaultWorkspaceDir: z.string().optional(),
         experimental: codexAppServerExperimentalSchema.optional(),
       })

--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -3,8 +3,11 @@ import type { NativeHookRelayRegistrationHandle } from "openclaw/plugin-sdk/agen
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it } from "vitest";
 import {
+  acquireCodexNativeHookRelayAdmission,
+  attachCodexNativeHookRelayAdmissionRelease,
   buildCodexNativeHookRelayConfig,
   buildCodexNativeHookRelayDisabledConfig,
+  resetCodexNativeHookRelayAdmissionsForTests,
   resolveCodexNativeHookRelayCommandTimeoutMs,
   resolveCodexNativeHookRelayUnregisterGraceMs,
 } from "./native-hook-relay.js";
@@ -301,6 +304,89 @@ describe("Codex native hook relay config", () => {
     expect(resolveCodexNativeHookRelayUnregisterGraceMs(Number.MAX_SAFE_INTEGER)).toBe(
       MAX_TIMER_TIMEOUT_MS,
     );
+  });
+
+  it("denies relay admission when available memory is below the configured floor", () => {
+    const admission = acquireCodexNativeHookRelayAdmission({
+      enabled: true,
+      minAvailableMemoryMb: 1024,
+      getAvailableMemoryBytesForTests: () => 512 * 1024 * 1024,
+      memoryUsageForTests: () => ({ rss: 128 * 1024 * 1024 }),
+    });
+
+    expect(admission).toMatchObject({
+      allowed: false,
+      reason: "available_memory",
+      availableMemoryBytes: 512 * 1024 * 1024,
+      thresholdBytes: 1024 * 1024 * 1024,
+    });
+  });
+
+  it("denies relay admission when process rss exceeds the configured ceiling", () => {
+    const admission = acquireCodexNativeHookRelayAdmission({
+      enabled: true,
+      maxProcessRssMb: 512,
+      getAvailableMemoryBytesForTests: () => 4096 * 1024 * 1024,
+      memoryUsageForTests: () => ({ rss: 768 * 1024 * 1024 }),
+    });
+
+    expect(admission).toMatchObject({
+      allowed: false,
+      reason: "process_rss",
+      processRssBytes: 768 * 1024 * 1024,
+      thresholdBytes: 512 * 1024 * 1024,
+    });
+  });
+
+  it("caps concurrent admitted native hook relays", () => {
+    resetCodexNativeHookRelayAdmissionsForTests();
+    const config = {
+      enabled: true,
+      maxActiveRelays: 1,
+      getAvailableMemoryBytesForTests: () => 4096 * 1024 * 1024,
+      memoryUsageForTests: () => ({ rss: 128 * 1024 * 1024 }),
+    };
+    const first = acquireCodexNativeHookRelayAdmission(config);
+    const second = acquireCodexNativeHookRelayAdmission(config);
+
+    expect(first.allowed).toBe(true);
+    expect(second).toMatchObject({
+      allowed: false,
+      reason: "max_active_relays",
+      activeRelays: 1,
+      thresholdRelays: 1,
+    });
+    if (first.allowed) {
+      first.release?.();
+    }
+    const afterRelease = acquireCodexNativeHookRelayAdmission(config);
+    expect(afterRelease.allowed).toBe(true);
+    if (afterRelease.allowed) {
+      afterRelease.release?.();
+    }
+  });
+
+  it("releases an admission cap when the wrapped relay unregisters", () => {
+    resetCodexNativeHookRelayAdmissionsForTests();
+    const config = {
+      enabled: true,
+      maxActiveRelays: 1,
+      getAvailableMemoryBytesForTests: () => 4096 * 1024 * 1024,
+      memoryUsageForTests: () => ({ rss: 128 * 1024 * 1024 }),
+    };
+    const admission = acquireCodexNativeHookRelayAdmission(config);
+    if (!admission.allowed) {
+      throw new Error("Expected relay admission");
+    }
+    const relay = attachCodexNativeHookRelayAdmissionRelease(createRelay(), admission.release);
+
+    relay.unregister();
+
+    const afterRelease = acquireCodexNativeHookRelayAdmission(config);
+    expect(afterRelease.allowed).toBe(true);
+    if (afterRelease.allowed) {
+      afterRelease.release?.();
+    }
   });
 });
 

--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -7,10 +7,12 @@ import {
   attachCodexNativeHookRelayAdmissionRelease,
   buildCodexNativeHookRelayConfig,
   buildCodexNativeHookRelayDisabledConfig,
+  buildCodexNativeHookRelaySuppressedConfig,
   resetCodexNativeHookRelayAdmissionsForTests,
   resolveCodexNativeHookRelayCommandTimeoutMs,
   resolveCodexNativeHookRelayUnregisterGraceMs,
 } from "./native-hook-relay.js";
+import { mergeCodexThreadConfigs } from "./plugin-thread-config.js";
 
 describe("Codex native hook relay config", () => {
   it("builds deterministic Codex config overrides with command hooks", () => {
@@ -297,6 +299,59 @@ describe("Codex native hook relay config", () => {
       "hooks.PostToolUse": [],
       "hooks.PermissionRequest": [],
       "hooks.Stop": [],
+    });
+  });
+
+  it("builds scoped suppression config without disabling unrelated hooks", () => {
+    expect(buildCodexNativeHookRelaySuppressedConfig()).toEqual({
+      "hooks.state": {
+        "/<session-flags>/config.toml:pre_tool_use:0:0": { enabled: false },
+        "<session-flags>/config.toml:pre_tool_use:0:0": { enabled: false },
+        "/<session-flags>/config.toml:post_tool_use:0:0": { enabled: false },
+        "<session-flags>/config.toml:post_tool_use:0:0": { enabled: false },
+        "/<session-flags>/config.toml:permission_request:0:0": { enabled: false },
+        "<session-flags>/config.toml:permission_request:0:0": { enabled: false },
+        "/<session-flags>/config.toml:stop:0:0": { enabled: false },
+        "<session-flags>/config.toml:stop:0:0": { enabled: false },
+      },
+    });
+  });
+
+  it("preserves existing Codex hooks when suppression config is merged last", () => {
+    expect(
+      mergeCodexThreadConfigs(
+        {
+          "features.hooks": true,
+          "hooks.PreToolUse": [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: "echo user-pre-tool-use",
+                  timeout: 5,
+                },
+              ],
+            },
+          ],
+        },
+        buildCodexNativeHookRelaySuppressedConfig(),
+      ),
+    ).toMatchObject({
+      "features.hooks": true,
+      "hooks.PreToolUse": [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: "echo user-pre-tool-use",
+              timeout: 5,
+            },
+          ],
+        },
+      ],
+      "hooks.state": {
+        "/<session-flags>/config.toml:pre_tool_use:0:0": { enabled: false },
+      },
     });
   });
 

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -3,6 +3,7 @@
  * app-server tool events can still run OpenClaw policy and diagnostics.
  */
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import {
   registerNativeHookRelay,
   type EmbeddedRunAttemptParams,
@@ -33,6 +34,37 @@ const CODEX_NATIVE_HOOK_RELAY_COMMAND_MIN_PARENT_MARGIN_MS = 250;
 const CODEX_NATIVE_HOOK_RELAY_COMMAND_MAX_PARENT_MARGIN_MS = 1_000;
 const CODEX_NATIVE_HOOK_RELAY_UNREGISTER_GRACE_MS = 10_000;
 const CODEX_NATIVE_HOOK_RELAY_UNREGISTER_EXTRA_GRACE_MS = 5_000;
+const MB = 1024 * 1024;
+const CGROUP_MEMORY_CURRENT_PATH = "/sys/fs/cgroup/memory.current";
+const CGROUP_MEMORY_MAX_PATH = "/sys/fs/cgroup/memory.max";
+const PROC_MEMINFO_PATH = "/proc/meminfo";
+
+export type CodexNativeHookRelayMemoryGuardConfig = {
+  enabled?: boolean;
+  minAvailableMemoryMb?: number;
+  maxProcessRssMb?: number;
+  maxActiveRelays?: number;
+  getAvailableMemoryBytesForTests?: () => number | undefined;
+  memoryUsageForTests?: () => Pick<NodeJS.MemoryUsage, "rss">;
+};
+
+export type CodexNativeHookRelayAdmission =
+  | {
+      allowed: true;
+      activeRelays: number;
+      availableMemoryBytes?: number;
+      processRssBytes?: number;
+      release?: () => void;
+    }
+  | {
+      allowed: false;
+      reason: "available_memory" | "process_rss" | "max_active_relays";
+      activeRelays: number;
+      availableMemoryBytes?: number;
+      processRssBytes?: number;
+      thresholdBytes?: number;
+      thresholdRelays?: number;
+    };
 
 type CodexHookEventName = "PreToolUse" | "PostToolUse" | "PermissionRequest" | "Stop";
 
@@ -42,6 +74,7 @@ type PendingCodexNativeHookRelayUnregister = {
 };
 
 const pendingCodexNativeHookRelayUnregisters = new Set<PendingCodexNativeHookRelayUnregister>();
+let activeCodexNativeHookRelayAdmissions = 0;
 
 /** Defers relay unregister so late native hook subprocesses can still resolve. */
 export function scheduleCodexNativeHookRelayUnregister(params: {
@@ -101,6 +134,107 @@ export function clearPendingCodexNativeHookRelayUnregistersForTests(): void {
     clearTimeout(pending.timeout);
   }
   pendingCodexNativeHookRelayUnregisters.clear();
+}
+
+export function acquireCodexNativeHookRelayAdmission(
+  config: CodexNativeHookRelayMemoryGuardConfig | undefined,
+): CodexNativeHookRelayAdmission {
+  if (config?.enabled !== true) {
+    return { allowed: true, activeRelays: activeCodexNativeHookRelayAdmissions };
+  }
+  const activeRelays = activeCodexNativeHookRelayAdmissions;
+  const availableMemoryBytes =
+    config.getAvailableMemoryBytesForTests?.() ?? readAvailableMemoryBytes();
+  const minAvailableMemoryBytes = mbToBytes(config.minAvailableMemoryMb);
+  if (
+    minAvailableMemoryBytes !== undefined &&
+    availableMemoryBytes !== undefined &&
+    availableMemoryBytes < minAvailableMemoryBytes
+  ) {
+    return {
+      allowed: false,
+      reason: "available_memory",
+      activeRelays,
+      availableMemoryBytes,
+      thresholdBytes: minAvailableMemoryBytes,
+    };
+  }
+  const processRssBytes = (config.memoryUsageForTests?.() ?? process.memoryUsage()).rss;
+  const maxProcessRssBytes = mbToBytes(config.maxProcessRssMb);
+  if (
+    maxProcessRssBytes !== undefined &&
+    Number.isFinite(processRssBytes) &&
+    processRssBytes > maxProcessRssBytes
+  ) {
+    return {
+      allowed: false,
+      reason: "process_rss",
+      activeRelays,
+      availableMemoryBytes,
+      processRssBytes,
+      thresholdBytes: maxProcessRssBytes,
+    };
+  }
+  const maxActiveRelays = normalizePositiveInteger(config.maxActiveRelays);
+  if (maxActiveRelays !== undefined && activeRelays >= maxActiveRelays) {
+    return {
+      allowed: false,
+      reason: "max_active_relays",
+      activeRelays,
+      availableMemoryBytes,
+      processRssBytes,
+      thresholdRelays: maxActiveRelays,
+    };
+  }
+  if (maxActiveRelays === undefined) {
+    return { allowed: true, activeRelays, availableMemoryBytes, processRssBytes };
+  }
+  activeCodexNativeHookRelayAdmissions += 1;
+  let released = false;
+  return {
+    allowed: true,
+    activeRelays,
+    availableMemoryBytes,
+    processRssBytes,
+    release: () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      activeCodexNativeHookRelayAdmissions = Math.max(0, activeCodexNativeHookRelayAdmissions - 1);
+    },
+  };
+}
+
+export function attachCodexNativeHookRelayAdmissionRelease(
+  relay: NativeHookRelayRegistrationHandle,
+  release: (() => void) | undefined,
+): NativeHookRelayRegistrationHandle {
+  if (!release) {
+    return relay;
+  }
+  let released = false;
+  const releaseOnce = () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    release();
+  };
+  return {
+    ...relay,
+    unregister: () => {
+      try {
+        relay.unregister();
+      } finally {
+        releaseOnce();
+      }
+    },
+  };
+}
+
+export function resetCodexNativeHookRelayAdmissionsForTests(): void {
+  activeCodexNativeHookRelayAdmissions = 0;
 }
 
 /** Registers an OpenClaw native hook relay for a Codex app-server turn. */
@@ -313,6 +447,69 @@ export function buildCodexNativeHookRelayDisabledConfig(): JsonObject {
 
 function normalizeHookTimeoutSec(value: number | undefined): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.ceil(value) : 5;
+}
+
+function normalizePositiveInteger(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function mbToBytes(value: number | undefined): number | undefined {
+  const normalized = normalizePositiveInteger(value);
+  return normalized === undefined ? undefined : normalized * MB;
+}
+
+function readAvailableMemoryBytes(): number | undefined {
+  return readCgroupAvailableMemoryBytes() ?? readProcMemAvailableBytes();
+}
+
+function readCgroupAvailableMemoryBytes(): number | undefined {
+  const current = readUnsignedIntegerFile(CGROUP_MEMORY_CURRENT_PATH);
+  const max = readCgroupMaxFile(CGROUP_MEMORY_MAX_PATH);
+  if (current === undefined || max === undefined || max <= 0 || current < 0) {
+    return undefined;
+  }
+  return Math.max(0, max - current);
+}
+
+function readProcMemAvailableBytes(): number | undefined {
+  const content = readTextFile(PROC_MEMINFO_PATH);
+  if (!content) {
+    return undefined;
+  }
+  const match = /^MemAvailable:\s+(\d+)\s+kB$/imu.exec(content);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  const kib = Number(match[1]);
+  return Number.isFinite(kib) && kib >= 0 ? kib * 1024 : undefined;
+}
+
+function readCgroupMaxFile(filePath: string): number | undefined {
+  const value = readTextFile(filePath)?.trim();
+  if (!value || value === "max") {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function readUnsignedIntegerFile(filePath: string): number | undefined {
+  const value = readTextFile(filePath)?.trim();
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function readTextFile(filePath: string): string | undefined {
+  try {
+    return readFileSync(filePath, "utf8");
+  } catch {
+    return undefined;
+  }
 }
 
 export function resolveCodexNativeHookRelayCommandTimeoutMs(

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -445,6 +445,21 @@ export function buildCodexNativeHookRelayDisabledConfig(): JsonObject {
   };
 }
 
+/** Builds a scoped overlay for automatic relay suppression without disabling other hooks. */
+export function buildCodexNativeHookRelaySuppressedConfig(): JsonObject {
+  const hookState: JsonObject = {};
+  for (const event of CODEX_NATIVE_HOOK_RELAY_EVENTS) {
+    for (const sourcePath of CODEX_SESSION_FLAGS_HOOK_SOURCE_PATHS) {
+      hookState[`${sourcePath}:${CODEX_HOOK_KEY_LABEL_BY_NATIVE_EVENT[event]}:0:0`] = {
+        enabled: false,
+      } satisfies JsonValue;
+    }
+  }
+  return {
+    "hooks.state": hookState,
+  };
+}
+
 function normalizeHookTimeoutSec(value: number | undefined): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.ceil(value) : 5;
 }

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -30,9 +30,7 @@ const DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
   web_search: "disabled",
 });
 
-function writeCodexAppServerBinding(
-  ...args: Parameters<typeof writeRawCodexAppServerBinding>
-) {
+function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppServerBinding>) {
   const [sessionFile, binding, lookup] = args;
   return writeRawCodexAppServerBinding(
     sessionFile,
@@ -703,6 +701,36 @@ describe("runCodexAppServerAttempt native hook relay", () => {
 
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
       nativeHookRelay: { enabled: false },
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
+      ?.config;
+    expect(startConfig?.["features.hooks"]).toBe(false);
+    expect(startConfig?.["hooks.PreToolUse"]).toEqual([]);
+    expect(startConfig?.["hooks.PostToolUse"]).toEqual([]);
+    expect(startConfig?.["hooks.PermissionRequest"]).toEqual([]);
+    expect(startConfig?.["hooks.Stop"]).toEqual([]);
+  });
+
+  it("sends clearing Codex native hook config when memory guard denies relay admission", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        memoryGuard: {
+          enabled: true,
+          minAvailableMemoryMb: 1024,
+          getAvailableMemoryBytesForTests: () => 512 * 1024 * 1024,
+          memoryUsageForTests: () => ({ rss: 128 * 1024 * 1024 }),
+        },
+      },
     });
     await harness.waitForMethod("turn/start");
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -716,7 +716,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect(startConfig?.["hooks.Stop"]).toEqual([]);
   });
 
-  it("sends clearing Codex native hook config when memory guard denies relay admission", async () => {
+  it("suppresses only OpenClaw relay hook state when memory guard denies relay admission", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const harness = createStartedThreadHarness();
@@ -739,11 +739,17 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startRequest = harness.requests.find((request) => request.method === "thread/start");
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
-    expect(startConfig?.["features.hooks"]).toBe(false);
-    expect(startConfig?.["hooks.PreToolUse"]).toEqual([]);
-    expect(startConfig?.["hooks.PostToolUse"]).toEqual([]);
-    expect(startConfig?.["hooks.PermissionRequest"]).toEqual([]);
-    expect(startConfig?.["hooks.Stop"]).toEqual([]);
+    expect(startConfig?.["features.hooks"]).not.toBe(false);
+    expect(startConfig).not.toHaveProperty("hooks.PreToolUse");
+    expect(startConfig).not.toHaveProperty("hooks.PostToolUse");
+    expect(startConfig).not.toHaveProperty("hooks.PermissionRequest");
+    expect(startConfig).not.toHaveProperty("hooks.Stop");
+    expect(startConfig?.["hooks.state"]).toMatchObject({
+      "/<session-flags>/config.toml:pre_tool_use:0:0": { enabled: false },
+      "/<session-flags>/config.toml:post_tool_use:0:0": { enabled: false },
+      "/<session-flags>/config.toml:permission_request:0:0": { enabled: false },
+      "/<session-flags>/config.toml:stop:0:0": { enabled: false },
+    });
   });
 
   it("cleans up native hook relay state when turn/start fails", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -195,6 +195,8 @@ import {
   shouldEmitTranscriptToolProgress,
 } from "./event-projector.js";
 import {
+  acquireCodexNativeHookRelayAdmission,
+  attachCodexNativeHookRelayAdmissionRelease,
   buildCodexNativeHookRelayDisabledConfig,
   buildCodexNativeHookRelayConfig,
   buildCodexNativeHookRelayId,
@@ -205,7 +207,10 @@ import {
   resolveCodexNativeHookRelayEvents,
   resolveCodexNativeHookRelayTtlMs,
   resolveCodexNativeHookRelayUnregisterGraceMs,
+  resetCodexNativeHookRelayAdmissionsForTests,
   scheduleCodexNativeHookRelayUnregister,
+  type CodexNativeHookRelayAdmission,
+  type CodexNativeHookRelayMemoryGuardConfig,
 } from "./native-hook-relay.js";
 import { registerCodexNativeSubagentMonitor } from "./native-subagent-monitor.js";
 import { describeCodexNotificationCorrelation } from "./notification-correlation.js";
@@ -419,6 +424,7 @@ export async function runCodexAppServerAttempt(
       ttlMs?: number;
       gatewayTimeoutMs?: number;
       hookTimeoutSec?: number;
+      memoryGuard?: CodexNativeHookRelayMemoryGuardConfig;
     };
     turnCompletionIdleTimeoutMs?: number;
     turnAssistantCompletionIdleTimeoutMs?: number;
@@ -449,6 +455,8 @@ export async function runCodexAppServerAttempt(
   });
   const attemptClientFactory = options.clientFactory ?? defaultLeasedCodexAppServerClientFactory;
   const pluginConfig = readCodexPluginConfig(options.pluginConfig);
+  const nativeHookRelayMemoryGuard =
+    options.nativeHookRelay?.memoryGuard ?? pluginConfig.appServer?.nativeHookRelay?.memoryGuard;
   const computerUseConfig = resolveCodexComputerUseConfig({ pluginConfig });
   const { sessionAgentId } = resolveSessionAgentIds({
     sessionKey: params.sessionKey,
@@ -1429,26 +1437,50 @@ export async function runCodexAppServerAttempt(
     decision: { action: "resume"; binding: CodexAppServerThreadBinding } | { action: "start" },
   ) => {
     nativeHookRelay?.unregister();
-    nativeHookRelay = createCodexNativeHookRelay({
-      options: options.nativeHookRelay,
-      generation:
-        decision.action === "resume" ? decision.binding.nativeHookRelayGeneration : undefined,
-      generationMismatchGraceMs:
-        decision.action === "resume" && !decision.binding.nativeHookRelayGeneration
-          ? CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS
-          : undefined,
-      events: nativeHookRelayEvents,
-      agentId: sessionAgentId,
-      sessionId: params.sessionId,
-      sessionKey: sandboxSessionKey,
-      config: params.config,
-      runId: params.runId,
-      channelId: hookChannelId,
-      attemptTimeoutMs: params.timeoutMs,
-      startupTimeoutMs,
-      turnStartTimeoutMs: params.timeoutMs,
-      signal: runAbortController.signal,
-    });
+    const admission = acquireCodexNativeHookRelayAdmission(nativeHookRelayMemoryGuard);
+    let nativeHookRelayDisabledByMemoryGuard = false;
+    if (admission.allowed) {
+      try {
+        nativeHookRelay = createCodexNativeHookRelay({
+          options: options.nativeHookRelay,
+          generation:
+            decision.action === "resume" ? decision.binding.nativeHookRelayGeneration : undefined,
+          generationMismatchGraceMs:
+            decision.action === "resume" && !decision.binding.nativeHookRelayGeneration
+              ? CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS
+              : undefined,
+          events: nativeHookRelayEvents,
+          agentId: sessionAgentId,
+          sessionId: params.sessionId,
+          sessionKey: sandboxSessionKey,
+          config: params.config,
+          runId: params.runId,
+          channelId: hookChannelId,
+          attemptTimeoutMs: params.timeoutMs,
+          startupTimeoutMs,
+          turnStartTimeoutMs: params.timeoutMs,
+          signal: runAbortController.signal,
+        });
+      } catch (error) {
+        admission.release?.();
+        throw error;
+      }
+      if (nativeHookRelay) {
+        nativeHookRelay = attachCodexNativeHookRelayAdmissionRelease(
+          nativeHookRelay,
+          admission.release,
+        );
+      } else {
+        admission.release?.();
+      }
+    } else {
+      nativeHookRelayDisabledByMemoryGuard = true;
+      logCodexNativeHookRelayMemoryGuardDecision({
+        params,
+        admission,
+        memoryGuard: nativeHookRelayMemoryGuard,
+      });
+    }
     return {
       configPatch: nativeHookRelay
         ? buildCodexNativeHookRelayConfig({
@@ -1456,7 +1488,7 @@ export async function runCodexAppServerAttempt(
             events: nativeHookRelayEvents,
             hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
           })
-        : options.nativeHookRelay?.enabled === false
+        : options.nativeHookRelay?.enabled === false || nativeHookRelayDisabledByMemoryGuard
           ? buildCodexNativeHookRelayDisabledConfig()
           : undefined,
       nativeHookRelayGeneration: nativeHookRelay?.generation,
@@ -3457,6 +3489,27 @@ function handleApprovalRequest(params: {
   });
 }
 
+function logCodexNativeHookRelayMemoryGuardDecision(params: {
+  params: EmbeddedRunAttemptParams;
+  admission: Exclude<CodexNativeHookRelayAdmission, { allowed: true }>;
+  memoryGuard: CodexNativeHookRelayMemoryGuardConfig | undefined;
+}): void {
+  embeddedAgentLog.warn("codex native hook relay disabled by memory guard", {
+    runId: params.params.runId,
+    sessionId: params.params.sessionId,
+    sessionKey: params.params.sessionKey,
+    reason: params.admission.reason,
+    activeRelays: params.admission.activeRelays,
+    thresholdRelays: params.admission.thresholdRelays,
+    availableMemoryBytes: params.admission.availableMemoryBytes,
+    processRssBytes: params.admission.processRssBytes,
+    thresholdBytes: params.admission.thresholdBytes,
+    minAvailableMemoryMb: params.memoryGuard?.minAvailableMemoryMb,
+    maxProcessRssMb: params.memoryGuard?.maxProcessRssMb,
+    maxActiveRelays: params.memoryGuard?.maxActiveRelays,
+  });
+}
+
 function resolveCodexDynamicToolDirectNames(params: EmbeddedRunAttemptParams): string[] {
   if (params.sourceReplyDeliveryMode !== "message_tool_only") {
     return [];
@@ -3492,5 +3545,6 @@ export const testing = {
   flushPendingCodexNativeHookRelayUnregistersForTests,
   clearPendingCodexNativeHookRelayUnregistersForTests,
   resolveCodexNativeHookRelayUnregisterGraceMs,
+  resetCodexNativeHookRelayAdmissionsForTests,
 } as const;
 export { testing as __testing };

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -200,6 +200,7 @@ import {
   buildCodexNativeHookRelayDisabledConfig,
   buildCodexNativeHookRelayConfig,
   buildCodexNativeHookRelayId,
+  buildCodexNativeHookRelaySuppressedConfig,
   clearPendingCodexNativeHookRelayUnregistersForTests,
   CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS,
   createCodexNativeHookRelay,
@@ -1488,9 +1489,11 @@ export async function runCodexAppServerAttempt(
             events: nativeHookRelayEvents,
             hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
           })
-        : options.nativeHookRelay?.enabled === false || nativeHookRelayDisabledByMemoryGuard
-          ? buildCodexNativeHookRelayDisabledConfig()
-          : undefined,
+        : nativeHookRelayDisabledByMemoryGuard
+          ? buildCodexNativeHookRelaySuppressedConfig()
+          : options.nativeHookRelay?.enabled === false
+            ? buildCodexNativeHookRelayDisabledConfig()
+            : undefined,
       nativeHookRelayGeneration: nativeHookRelay?.generation,
     };
   };

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1135,6 +1135,44 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(config).not.toHaveProperty("hooks.state");
   });
 
+  it("suppresses only OpenClaw relay hook state when side-thread memory guard denies relay admission", async () => {
+    const client = createFakeClient();
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await expect(
+      runCodexAppServerSideQuestion(sideParams(), {
+        nativeHookRelay: {
+          enabled: true,
+          memoryGuard: {
+            enabled: true,
+            minAvailableMemoryMb: 1024,
+            getAvailableMemoryBytesForTests: () => 512 * 1024 * 1024,
+            memoryUsageForTests: () => ({ rss: 128 * 1024 * 1024 }),
+          },
+        },
+      }),
+    ).resolves.toEqual({ text: "Side answer." });
+
+    const forkParams = mockCall(client.request)[1] as Record<string, unknown> | undefined;
+    const config = forkParams?.config as Record<string, unknown> | undefined;
+    expect(config).toMatchObject({
+      "features.code_mode": true,
+      "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
+    });
+    expect(config?.["features.hooks"]).not.toBe(false);
+    expect(config).not.toHaveProperty("hooks.PreToolUse");
+    expect(config).not.toHaveProperty("hooks.PostToolUse");
+    expect(config).not.toHaveProperty("hooks.PermissionRequest");
+    expect(config).not.toHaveProperty("hooks.Stop");
+    expect(config?.["hooks.state"]).toMatchObject({
+      "/<session-flags>/config.toml:pre_tool_use:0:0": { enabled: false },
+      "/<session-flags>/config.toml:post_tool_use:0:0": { enabled: false },
+      "/<session-flags>/config.toml:permission_request:0:0": { enabled: false },
+      "/<session-flags>/config.toml:stop:0:0": { enabled: false },
+    });
+  });
+
   it("passes Codex code-mode-only opt-in to side-thread forks", async () => {
     const client = createFakeClient();
     getSharedCodexAppServerClientMock.mockResolvedValue(client);

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -51,6 +51,7 @@ import {
   attachCodexNativeHookRelayAdmissionRelease,
   buildCodexNativeHookRelayConfig,
   buildCodexNativeHookRelayDisabledConfig,
+  buildCodexNativeHookRelaySuppressedConfig,
   CODEX_NATIVE_HOOK_RELAY_EVENTS,
   type CodexNativeHookRelayAdmission,
   type CodexNativeHookRelayMemoryGuardConfig,
@@ -443,9 +444,11 @@ export async function runCodexAppServerSideQuestion(
           hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
           clearOmittedEvents: true,
         })
-      : options.nativeHookRelay?.enabled === false || nativeHookRelayDisabledByMemoryGuard
-        ? buildCodexNativeHookRelayDisabledConfig()
-        : undefined;
+      : nativeHookRelayDisabledByMemoryGuard
+        ? buildCodexNativeHookRelaySuppressedConfig()
+        : options.nativeHookRelay?.enabled === false
+          ? buildCodexNativeHookRelayDisabledConfig()
+          : undefined;
     const runtimeThreadConfig = buildCodexRuntimeThreadConfig(webSearchPlan.threadConfig, {
       nativeCodeModeEnabled: nativeToolSurfaceEnabled,
       nativeCodeModeOnlyEnabled: appServer.codeModeOnly,

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -47,9 +47,13 @@ import {
 import { createCodexDynamicToolBridge, type CodexDynamicToolBridge } from "./dynamic-tools.js";
 import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
 import {
+  acquireCodexNativeHookRelayAdmission,
+  attachCodexNativeHookRelayAdmissionRelease,
   buildCodexNativeHookRelayConfig,
   buildCodexNativeHookRelayDisabledConfig,
   CODEX_NATIVE_HOOK_RELAY_EVENTS,
+  type CodexNativeHookRelayAdmission,
+  type CodexNativeHookRelayMemoryGuardConfig,
 } from "./native-hook-relay.js";
 import {
   readCodexNotificationThreadId,
@@ -141,6 +145,7 @@ export async function runCodexAppServerSideQuestion(
       ttlMs?: number;
       gatewayTimeoutMs?: number;
       hookTimeoutSec?: number;
+      memoryGuard?: CodexNativeHookRelayMemoryGuardConfig;
     };
   } = {},
 ): Promise<AgentHarnessSideQuestionResult> {
@@ -154,6 +159,8 @@ export async function runCodexAppServerSideQuestion(
     );
   }
   const pluginConfig = readCodexPluginConfig(options.pluginConfig);
+  const nativeHookRelayMemoryGuard =
+    options.nativeHookRelay?.memoryGuard ?? pluginConfig.appServer?.nativeHookRelay?.memoryGuard;
   const { sessionAgentId } = resolveSessionAgentIds({
     sessionKey: params.sessionKey,
     config: params.cfg,
@@ -322,16 +329,16 @@ export async function runCodexAppServerSideQuestion(
           threadId: childThreadId,
           turnId,
           nativeHookRelay,
-	          execPolicy,
-	          execReviewerAgentId: sessionAgentId,
-	          internalExecAutoReview: modelScopedAppServer.approvalsReviewer === "user",
-	          autoApprove: shouldAutoApproveCodexAppServerApprovals({
-	            approvalPolicy,
-	            networkProxy: modelScopedAppServer.networkProxy,
-	            sandbox,
-	          }),
-	          signal: runAbortController.signal,
-	        });
+          execPolicy,
+          execReviewerAgentId: sessionAgentId,
+          internalExecAutoReview: modelScopedAppServer.approvalsReviewer === "user",
+          autoApprove: shouldAutoApproveCodexAppServerApprovals({
+            approvalPolicy,
+            networkProxy: modelScopedAppServer.networkProxy,
+            sandbox,
+          }),
+          signal: runAbortController.signal,
+        });
       }
       if (request.method !== "item/tool/call") {
         return undefined;
@@ -382,8 +389,13 @@ export async function runCodexAppServerSideQuestion(
       configuredEvents: options.nativeHookRelay?.events,
       approvalPolicy,
     });
-    nativeHookRelay = options.nativeHookRelay
-      ? registerCodexSideNativeHookRelay({
+    const admission = options.nativeHookRelay
+      ? acquireCodexNativeHookRelayAdmission(nativeHookRelayMemoryGuard)
+      : ({ allowed: true, activeRelays: 0 } satisfies CodexNativeHookRelayAdmission);
+    let nativeHookRelayDisabledByMemoryGuard = false;
+    if (options.nativeHookRelay && admission.allowed) {
+      try {
+        nativeHookRelay = registerCodexSideNativeHookRelay({
           options: options.nativeHookRelay,
           events: nativeHookRelayEvents,
           agentId: sessionAgentId,
@@ -403,8 +415,27 @@ export async function runCodexAppServerSideQuestion(
             SIDE_QUESTION_COMPLETION_TIMEOUT_MS,
           ),
           signal: runAbortController.signal,
-        })
-      : undefined;
+        });
+      } catch (error) {
+        admission.release?.();
+        throw error;
+      }
+      if (nativeHookRelay) {
+        nativeHookRelay = attachCodexNativeHookRelayAdmissionRelease(
+          nativeHookRelay,
+          admission.release,
+        );
+      } else {
+        admission.release?.();
+      }
+    } else if (!admission.allowed) {
+      nativeHookRelayDisabledByMemoryGuard = true;
+      logCodexSideNativeHookRelayMemoryGuardDecision({
+        params,
+        admission,
+        memoryGuard: nativeHookRelayMemoryGuard,
+      });
+    }
     const nativeHookRelayConfig = nativeHookRelay
       ? buildCodexNativeHookRelayConfig({
           relay: nativeHookRelay,
@@ -412,19 +443,19 @@ export async function runCodexAppServerSideQuestion(
           hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
           clearOmittedEvents: true,
         })
-      : options.nativeHookRelay?.enabled === false
+      : options.nativeHookRelay?.enabled === false || nativeHookRelayDisabledByMemoryGuard
         ? buildCodexNativeHookRelayDisabledConfig()
         : undefined;
     const runtimeThreadConfig = buildCodexRuntimeThreadConfig(webSearchPlan.threadConfig, {
       nativeCodeModeEnabled: nativeToolSurfaceEnabled,
       nativeCodeModeOnlyEnabled: appServer.codeModeOnly,
     });
-	    const threadConfig =
-	      mergeCodexThreadConfigs(
-	        nativeHookRelayConfig,
-	        runtimeThreadConfig,
-	        modelScopedAppServer.networkProxy?.configPatch,
-	      ) ?? runtimeThreadConfig;
+    const threadConfig =
+      mergeCodexThreadConfigs(
+        nativeHookRelayConfig,
+        runtimeThreadConfig,
+        modelScopedAppServer.networkProxy?.configPatch,
+      ) ?? runtimeThreadConfig;
     const forkResponse = assertCodexThreadForkResponse(
       await forkCodexSideThread(
         client,
@@ -436,7 +467,7 @@ export async function runCodexAppServerSideQuestion(
           cwd,
           approvalPolicy,
           approvalsReviewer: modelScopedAppServer.approvalsReviewer,
-	          ...(modelScopedAppServer.networkProxy ? {} : { sandbox }),
+          ...(modelScopedAppServer.networkProxy ? {} : { sandbox }),
           ...(serviceTier ? { serviceTier } : {}),
           config: threadConfig,
           developerInstructions: SIDE_DEVELOPER_INSTRUCTIONS,
@@ -567,6 +598,26 @@ function registerCodexSideNativeHookRelay(params: {
     command: {
       timeoutMs: params.options.gatewayTimeoutMs,
     },
+  });
+}
+
+function logCodexSideNativeHookRelayMemoryGuardDecision(params: {
+  params: AgentHarnessSideQuestionParams;
+  admission: Exclude<CodexNativeHookRelayAdmission, { allowed: true }>;
+  memoryGuard: CodexNativeHookRelayMemoryGuardConfig | undefined;
+}): void {
+  embeddedAgentLog.warn("codex side-question native hook relay disabled by memory guard", {
+    sessionId: params.params.sessionId,
+    sessionKey: params.params.sessionKey,
+    reason: params.admission.reason,
+    activeRelays: params.admission.activeRelays,
+    thresholdRelays: params.admission.thresholdRelays,
+    availableMemoryBytes: params.admission.availableMemoryBytes,
+    processRssBytes: params.admission.processRssBytes,
+    thresholdBytes: params.admission.thresholdBytes,
+    minAvailableMemoryMb: params.memoryGuard?.minAvailableMemoryMb,
+    maxProcessRssMb: params.memoryGuard?.maxProcessRssMb,
+    maxActiveRelays: params.memoryGuard?.maxActiveRelays,
   });
 }
 


### PR DESCRIPTION
### Summary

- Add opt-in `plugins.entries.codex.config.appServer.nativeHookRelay.memoryGuard`
- Gate Codex native hook relay registration on available memory, process RSS, and active guarded relay count
- Clear native hook config for guarded turns under pressure instead of registering hook commands
- Apply the guard to both main Codex app-server turns and `/btw` side-question turns
- Document the config and add manifest schema/UI hints

### What Problem This Solves

On memory-constrained Gateway hosts, multiple Codex native hook relay helper processes can exist concurrently and each can consume hundreds of MiB. OpenClaw already has a disabled native hook relay config path; this patch makes relay installation conditional so low-memory hosts can degrade per turn instead of compounding pressure.

The guard is opt-in, so default behavior is unchanged.

### Behavior

When `memoryGuard.enabled` is true, OpenClaw checks:

- cgroup memory (`memory.current`/`memory.max`) when bounded
- `/proc/meminfo` `MemAvailable` fallback
- Gateway process RSS
- guarded active relay count

If a configured threshold is exceeded, OpenClaw sends `features.hooks=false` plus empty native hook arrays for that turn. The model call can continue, but Codex-native hook relay behavior is not installed for that turn.

Example:

```json5
{
  plugins: {
    entries: {
      codex: {
        config: {
          appServer: {
            nativeHookRelay: {
              memoryGuard: {
                enabled: true,
                minAvailableMemoryMb: 1024,
                maxProcessRssMb: 1536,
                maxActiveRelays: 1,
              },
            },
          },
        },
      },
    },
  },
}
```

### Tests

- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/native-hook-relay.test.ts --maxWorkers=1`
- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/config.test.ts --maxWorkers=1`
- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts --maxWorkers=1`
- `git diff --check HEAD~1 HEAD`

### Evidence

Local focused validation on the source branch:

- `native-hook-relay.test.ts`: 13 tests passed
- `config.test.ts`: 109 tests passed
- `run-attempt.native-hook-relay.test.ts`: 19 tests passed
- `git diff --check HEAD~1 HEAD`: clean

The implementation uses the existing disabled relay overlay (`features.hooks=false`, empty hook arrays), so guarded degradation reuses the already-supported clearing path instead of introducing a new Codex config shape.

### Notes

Raw `pnpm exec vitest` was not used for final validation because it spent several minutes in bundler startup on this host. The repository test wrapper was used instead.
