### PR TITLE
fix(tasks): harden ACP task cancellation

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -241,6 +241,80 @@ describe("tasks commands", () => {
     });
   });
 
+  it("routes ACP task cancellation through the live gateway before local fallback", async () => {
+    await withTaskCommandStateDir(async () => {
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:jarvis:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-acp-cancel",
+        task: "Cancel ACP child",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+      });
+      mocks.callGateway.mockResolvedValueOnce({
+        found: true,
+        cancelled: true,
+        task: {
+          taskId: task.taskId,
+          runtime: "acp",
+          runId: task.runId,
+        },
+      });
+      const runtime = createRuntime();
+
+      await tasksCancelCommand({ lookup: task.taskId }, runtime);
+
+      expect(mocks.callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "tasks.cancel",
+          params: { taskId: task.taskId },
+          timeoutMs: 5_000,
+        }),
+      );
+      expect(runtime.log).toHaveBeenCalledWith(
+        `Cancelled ${task.taskId} (acp) run run-acp-cancel.`,
+      );
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.exit).not.toHaveBeenCalled();
+    });
+  });
+
+  it("fails ACP task cancellation loudly when the live gateway is unavailable", async () => {
+    await withTaskCommandStateDir(async () => {
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:jarvis:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-acp-cancel-gateway-down",
+        task: "Cancel ACP child",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+      });
+      mocks.callGateway.mockRejectedValueOnce(new Error("gateway unavailable"));
+      const runtime = createRuntime();
+
+      await tasksCancelCommand({ lookup: task.taskId }, runtime);
+
+      expect(mocks.callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "tasks.cancel",
+          params: { taskId: task.taskId },
+          timeoutMs: 5_000,
+        }),
+      );
+      expect(runtime.error).toHaveBeenCalledWith(
+        "ACP task cancellation requires the live Gateway tasks.cancel path: gateway unavailable",
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.log).not.toHaveBeenCalled();
+    });
+  });
+
   it("explains stale running tasks retained by backing sessions in maintenance JSON", async () => {
     await withTaskCommandStateDir(async (state) => {
       const now = Date.now();

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -88,10 +88,10 @@ type GatewayTaskCancelResult = {
   task?: GatewayTaskCancelSummary;
 };
 
-async function tryCancelCronTaskViaGateway(
+async function tryCancelGatewayOwnedTaskViaGateway(
   task: TaskRecord,
 ): Promise<GatewayTaskCancelResult | null> {
-  if (task.runtime !== "cron") {
+  if (task.runtime !== "cron" && task.runtime !== "acp") {
     return null;
   }
   try {
@@ -101,7 +101,16 @@ async function tryCancelCronTaskViaGateway(
       params: { taskId: task.taskId },
       timeoutMs: 5_000,
     });
-  } catch {
+  } catch (error) {
+    if (task.runtime === "acp") {
+      const detail = error instanceof Error ? error.message : String(error);
+      return {
+        found: true,
+        cancelled: false,
+        reason: `ACP task cancellation requires the live Gateway tasks.cancel path: ${detail}`,
+        task,
+      };
+    }
     return null;
   }
 }
@@ -468,7 +477,7 @@ export async function tasksCancelCommand(opts: { lookup: string }, runtime: Runt
     runtime.exit(1);
     return;
   }
-  const gatewayResult = await tryCancelCronTaskViaGateway(task);
+  const gatewayResult = await tryCancelGatewayOwnedTaskViaGateway(task);
   if (gatewayResult) {
     if (!gatewayResult.found) {
       runtime.error(gatewayResult.reason ?? formatTaskLookupMiss(opts.lookup));

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -4,19 +4,26 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTaskRecord as createTaskRecordOrNull,
+  getTaskById,
   markTaskTerminalById,
   recordTaskProgressByRunId,
+  reloadTaskRegistryFromStore,
+  resetTaskRegistryControlRuntimeForTests,
   resetTaskRegistryForTests,
+  setTaskRegistryControlRuntimeForTests,
 } from "../../tasks/runtime-internal.js";
+import { saveTaskRegistryStateToSqlite } from "../../tasks/task-registry.store.sqlite.js";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import { tasksHandlers } from "./tasks.js";
 import type { RespondFn } from "./types.js";
 
 const stateDirEnvSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+const cancelSessionMock = vi.fn();
+const killSubagentRunAdminMock = vi.fn();
 type TaskResponsePayload = {
   tasks?: Array<Record<string, unknown>>;
   task?: Record<string, unknown>;
@@ -38,9 +45,18 @@ beforeEach(async () => {
   stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-tasks-"));
   setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
   resetTaskRegistryForTests();
+  cancelSessionMock.mockReset();
+  killSubagentRunAdminMock.mockReset();
+  setTaskRegistryControlRuntimeForTests({
+    getAcpSessionManager: () => ({
+      cancelSession: cancelSessionMock,
+    }),
+    killSubagentRunAdmin: async (params) => killSubagentRunAdminMock(params),
+  });
 });
 
 afterEach(async () => {
+  resetTaskRegistryControlRuntimeForTests();
   resetTaskRegistryForTests();
   stateDirEnvSnapshot.restore();
   await fs.rm(stateDir, { recursive: true, force: true });
@@ -58,6 +74,25 @@ function createContext() {
   return {
     getRuntimeConfig: () => ({}),
   } as never;
+}
+
+function createSnapshotTask(overrides: Partial<TaskRecord>): TaskRecord {
+  return {
+    taskId: "task-snapshot",
+    runtime: "cli",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    runId: "run-snapshot",
+    task: "Snapshot task",
+    status: "running",
+    deliveryStatus: "pending",
+    notifyPolicy: "done_only",
+    createdAt: 1_000,
+    startedAt: 1_010,
+    lastEventAt: 1_010,
+    ...overrides,
+  };
 }
 
 async function runTaskHandler(
@@ -234,5 +269,55 @@ describe("tasks gateway handlers", () => {
     expect(payload?.task?.id).toBe(task.taskId);
     expect(payload?.task?.status).toBe("cancelled");
     expect(payload?.task?.error).toBe("user stopped task");
+  });
+
+  it("cancels ACP tasks through the live Gateway handler and control runtime", async () => {
+    const task = createSnapshotTask({
+      taskId: "task-acp-primary",
+      runtime: "acp",
+      childSessionKey: "agent:codex:acp:child",
+      agentId: "codex",
+      runId: "run-cancel-acp-gateway",
+      task: "Primary ACP task",
+    });
+    const siblingTask = createSnapshotTask({
+      taskId: "task-acp-sibling",
+      runtime: "acp",
+      childSessionKey: "agent:codex:acp:child",
+      agentId: "codex",
+      runId: "run-cancel-acp-gateway",
+      task: "Sibling ACP task",
+      createdAt: 1_001,
+      startedAt: 1_011,
+      lastEventAt: 1_011,
+    });
+    saveTaskRegistryStateToSqlite({
+      tasks: new Map([
+        [task.taskId, task],
+        [siblingTask.taskId, siblingTask],
+      ]),
+      deliveryStates: new Map(),
+    });
+    reloadTaskRegistryFromStore();
+    cancelSessionMock.mockResolvedValue(undefined);
+
+    const { calls, payload } = await runTaskHandler("tasks.cancel", {
+      taskId: task.taskId,
+      reason: "operator requested stop",
+    });
+
+    expect(calls[0]?.[0]).toBe(true);
+    expect(cancelSessionMock).toHaveBeenCalledWith({
+      cfg: {},
+      sessionKey: "agent:codex:acp:child",
+      reason: "operator requested stop",
+    });
+    expect(payload?.found).toBe(true);
+    expect(payload?.cancelled).toBe(true);
+    expect(payload?.task?.id).toBe(task.taskId);
+    expect(payload?.task?.status).toBe("cancelled");
+    expect(getTaskById(task.taskId)?.status).toBe("cancelled");
+    expect(getTaskById(siblingTask.taskId)?.status).toBe("cancelled");
+    expect(getTaskById(siblingTask.taskId)?.error).toBe("operator requested stop");
   });
 });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -524,6 +524,49 @@ describe("task-registry", () => {
     });
   });
 
+  it("reuses an ACP run task when a derived flow id is linked before a duplicate create", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      configureInMemoryTaskStoresForLinkValidationTests();
+
+      const first = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:jarvis:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-acp-derived-flow-dedupe",
+        label: "original ACP task",
+        task: "Run ACP child",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+      });
+      const flow = createTaskFlowForTask({ task: first });
+      const linked = linkTaskToFlowById({
+        taskId: first.taskId,
+        flowId: flow.flowId,
+      });
+      expect(linked?.parentFlowId).toBe(flow.flowId);
+
+      const duplicateCreate = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:jarvis:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-acp-derived-flow-dedupe",
+        label: "late ACP mirror",
+        task: "Late mirror of the same ACP child",
+        status: "running",
+        deliveryStatus: "pending",
+        notifyPolicy: "silent",
+      });
+
+      expect(duplicateCreate.taskId).toBe(first.taskId);
+      expect(listTaskRecords().filter((task) => task.runId === first.runId)).toHaveLength(1);
+    });
+  });
+
   it("ignores late agent events for operator-cancelled tasks", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -812,17 +812,27 @@ function findExistingTaskForCreate(params: {
 }): TaskRecord | undefined {
   const runId = params.runId?.trim();
   const runScopeMatches = runId
-    ? getTasksByRunId(runId).filter(
-        (task) =>
-          task.runtime === params.runtime &&
-          task.scopeKind === params.scopeKind &&
-          (normalizeOptionalString(task.ownerKey) ?? "") ===
-            (normalizeOptionalString(params.ownerKey) ?? "") &&
-          (normalizeOptionalString(task.childSessionKey) ?? "") ===
-            (normalizeOptionalString(params.childSessionKey) ?? "") &&
+    ? getTasksByRunId(runId).filter((task) => {
+        if (
+          task.runtime !== params.runtime ||
+          task.scopeKind !== params.scopeKind ||
+          (normalizeOptionalString(task.ownerKey) ?? "") !==
+            (normalizeOptionalString(params.ownerKey) ?? "") ||
+          (normalizeOptionalString(task.childSessionKey) ?? "") !==
+            (normalizeOptionalString(params.childSessionKey) ?? "")
+        ) {
+          return false;
+        }
+        if (params.runtime === "acp") {
+          // ACP one-task flow ids can be derived after creation; they must not
+          // split one logical ACP run into duplicate task rows.
+          return true;
+        }
+        return (
           (normalizeOptionalString(task.parentFlowId) ?? "") ===
-            (normalizeOptionalString(params.parentFlowId) ?? ""),
-      )
+          (normalizeOptionalString(params.parentFlowId) ?? "")
+        );
+      })
     : [];
   const exact = runId
     ? runScopeMatches.find(
@@ -2138,12 +2148,25 @@ export async function cancelTaskById(params: {
         };
       }
     }
-    const updated = updateTask(task.taskId, {
-      status: "cancelled",
-      endedAt: Date.now(),
-      lastEventAt: Date.now(),
-      error: params.reason?.trim() || "Cancelled by operator.",
-    });
+    const endedAt = Date.now();
+    const error = params.reason?.trim() || "Cancelled by operator.";
+    const updated =
+      task.runtime === "acp" && task.runId?.trim()
+        ? (updateTaskStateByRunId({
+            runId: task.runId,
+            runtime: "acp",
+            sessionKey: childSessionKey,
+            status: "cancelled",
+            endedAt,
+            lastEventAt: endedAt,
+            error,
+          }).find((record) => record.taskId === task.taskId) ?? null)
+        : updateTask(task.taskId, {
+            status: "cancelled",
+            endedAt,
+            lastEventAt: endedAt,
+            error,
+          });
     if (!updated) {
       return {
         found: true,


### PR DESCRIPTION
## What Problem This Solves
ACP task cancellation had two production-facing lifecycle gaps from the v8 cancel proof. First, one logical ACP run could produce duplicate task rows when a task-mirrored parentFlowId was derived after the first row was created. Second, operator CLI cancellation could fall through to standalone local cancellation, which does not have the ACP runtime backend loaded; Gateway tasks.cancel is the live owner of ACP cancellation. The team review also flagged silent Gateway fallback as unsafe because it can make a failed cancel look successful.

## Summary
- route ACP task cancellation through live Gateway tasks.cancel before local cancellation
- fail ACP cancellation loudly with a nonzero error when Gateway cancellation is unavailable
- prevent derived task-mirrored parentFlowId values from splitting one logical ACP run into duplicate task records
- propagate ACP cancellation across active rows in the same run/session

## Evidence
- Base: origin/main 830467bc93065f6ef5a1302b3c86bf14c930c3df
- Commit: cb779612239a3fb8489892302915ee6eed189c73
- Team review: jarvis:team-review:codex-acp-local-hardening-delta-review-20260628
- Failure scan: jarvis:persona-review-failure-scan:codex-acp-local-hardening-delta-review-20260628
- Local proof: v8 ACP abort proof accepted under jarvis:codex-acp-abort-proof:codex-acp-abort-20260628:v8

## Tests
- pnpm test src/commands/tasks.test.ts (13 passed)
- pnpm test src/tasks/task-registry.test.ts (85 passed)
- pnpm build
- git diff --check -- changed OpenClaw files

## Remaining Rollout Gates
- PR review/CI/merge
- production deploy/readback with real ACP spawn/cancel/list/process proof
- stale-correlation ACP spawn fence
- Watch-Tower native ACP smoke
- Jarvis timeout alerting and Gateway-down runbook/canary policy
