### PR TITLE
fix: scanned PDF pages reach chat vision models

### DIFF
--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -321,7 +321,7 @@ When `mode: "all"`, outputs are labeled `[Image 1/2]`, `[Audio 2/2]`, etc.
     - The injected block uses explicit boundary markers like `<<<EXTERNAL_UNTRUSTED_CONTENT id="...">>>` / `<<<END_EXTERNAL_UNTRUSTED_CONTENT id="...">>>` and includes a `Source: External` metadata line.
     - This attachment-extraction path intentionally omits the long `SECURITY NOTICE:` banner to avoid bloating the media prompt; the boundary markers and metadata still remain.
     - If a file has no extractable text, OpenClaw injects `[No extractable text]`.
-    - If a PDF falls back to rendered page images in this path, the media prompt keeps the placeholder `[PDF content rendered to images; images not forwarded to model]` because this attachment-extraction step forwards text blocks, not the rendered PDF images.
+    - If a PDF falls back to rendered page images in this path, OpenClaw forwards those page images to vision-capable reply models and keeps the placeholder `[PDF content rendered to images]` in the file block.
 
   </Accordion>
 </AccordionGroup>

--- a/src/auto-reply/reply/agent-turn-attachments.ts
+++ b/src/auto-reply/reply/agent-turn-attachments.ts
@@ -50,8 +50,10 @@ export async function resolveAgentTurnAttachments(params: {
   cfg: OpenClawConfig;
   runtime?: AgentTurnAttachmentRuntime;
   includeRecentHistoryImages?: boolean;
+  includeAttachmentIndexes?: boolean;
 }): Promise<{
   attachments: AgentTurnAttachment[];
+  attachmentIndexes?: number[];
   recentHistoryImages: RecentInboundHistoryImage[];
 }> {
   const includeRecentHistoryImages = params.includeRecentHistoryImages ?? true;
@@ -94,6 +96,7 @@ export async function resolveAgentTurnAttachments(params: {
     }),
   });
   const results: AgentTurnAttachment[] = [];
+  const resultIndexes: number[] = [];
   const resolvedHistoryImages: RecentInboundHistoryImage[] = [];
   const resolveImageAttachment = async (attachment: MediaAttachment): Promise<boolean> => {
     const mediaType = attachment.mime ?? "application/octet-stream";
@@ -113,6 +116,7 @@ export async function resolveAgentTurnAttachments(params: {
         mediaType,
         data: buffer.toString("base64"),
       });
+      resultIndexes.push(attachment.index);
       const historyImage = historyAttachmentByIndex.get(attachment.index);
       if (historyImage) {
         resolvedHistoryImages.push(historyImage);
@@ -149,7 +153,11 @@ export async function resolveAgentTurnAttachments(params: {
       await resolveImageAttachment(attachment);
     }
   }
-  return { attachments: results, recentHistoryImages: resolvedHistoryImages };
+  return {
+    attachments: results,
+    ...(params.includeAttachmentIndexes ? { attachmentIndexes: resultIndexes } : {}),
+    recentHistoryImages: resolvedHistoryImages,
+  };
 }
 
 /** Converts inline image content into ACP attachment payloads. */

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -60,4 +60,74 @@ describe("resolveCurrentTurnImages", () => {
       });
     });
   });
+
+  it("appends extracted PDF page images without dropping current image attachments", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-pdf-images-" }, async (base) => {
+      const imagePath = path.join(base, "photo.png");
+      const imageBytes = Buffer.from("current-photo");
+      await fs.writeFile(imagePath, imageBytes);
+
+      const pdfPage = {
+        type: "image" as const,
+        data: Buffer.from("pdf-page").toString("base64"),
+        mimeType: "image/png",
+        attachmentIndex: 1,
+      };
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "caption",
+          MediaPaths: [imagePath, path.join(base, "scan.pdf")],
+          MediaTypes: ["image/png", "application/pdf"],
+          MediaWorkspaceDir: base,
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+        extractedFileImages: [pdfPage],
+      });
+
+      expect(result.images).toEqual([
+        {
+          type: "image",
+          data: imageBytes.toString("base64"),
+          mimeType: "image/png",
+        },
+        {
+          type: "image",
+          data: pdfPage.data,
+          mimeType: "image/png",
+        },
+      ]);
+      expect(result.imageOrder).toEqual(["inline", "inline"]);
+    });
+  });
+
+  it("orders extracted PDF page images before later current image attachments", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-pdf-order-" }, async (base) => {
+      const imagePath = path.join(base, "photo.png");
+      await fs.writeFile(imagePath, "current-photo");
+      const pdfPage = {
+        type: "image" as const,
+        data: Buffer.from("pdf-page").toString("base64"),
+        mimeType: "image/png",
+        attachmentIndex: 0,
+      };
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "caption",
+          MediaPaths: [path.join(base, "scan.pdf"), imagePath],
+          MediaTypes: ["application/pdf", "image/png"],
+          MediaWorkspaceDir: base,
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+        extractedFileImages: [pdfPage],
+      });
+
+      expect(result.images?.map((image) => Buffer.from(image.data, "base64").toString())).toEqual([
+        "pdf-page",
+        "current-photo",
+      ]);
+      expect(result.imageOrder).toEqual(["inline", "inline"]);
+    });
+  });
 });

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -5,6 +5,10 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { ImageContent } from "../../llm/types.js";
+import {
+  stripExtractedFileImageMetadata,
+  type ExtractedFileImage,
+} from "../../media-understanding/extracted-file-images.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { MsgContext } from "../templating.js";
 import { resolveAgentTurnAttachments } from "./agent-turn-attachments.js";
@@ -13,6 +17,13 @@ type CurrentImageAttachment = {
   index: number;
   path: string;
   mediaType: string;
+};
+
+type OrderedTurnImage = {
+  image: ImageContent;
+  imageOrder: PromptImageOrderEntry;
+  sourceIndex?: number;
+  sequence: number;
 };
 
 function isGenericMediaType(mediaType: string | undefined): boolean {
@@ -88,30 +99,82 @@ function createUndescribedImageContext(
   };
 }
 
+function appendOrderedImages(params: {
+  entries: OrderedTurnImage[];
+  images: ImageContent[] | undefined;
+  imageOrder?: PromptImageOrderEntry[];
+  sourceIndex?: number;
+}) {
+  if (!params.images || params.images.length === 0) {
+    return;
+  }
+  for (const [index, image] of params.images.entries()) {
+    params.entries.push({
+      image,
+      imageOrder: params.imageOrder?.[index] ?? "inline",
+      sourceIndex: params.sourceIndex,
+      sequence: params.entries.length,
+    });
+  }
+}
+
+function resolveMergedTurnImages(entries: OrderedTurnImage[]): {
+  images?: ImageContent[];
+  imageOrder?: PromptImageOrderEntry[];
+} {
+  if (entries.length === 0) {
+    return {};
+  }
+  const merged = entries.toSorted((left, right) => {
+    if (left.sourceIndex !== undefined && right.sourceIndex !== undefined) {
+      return left.sourceIndex - right.sourceIndex || left.sequence - right.sequence;
+    }
+    if (left.sourceIndex !== undefined || right.sourceIndex !== undefined) {
+      return left.sequence - right.sequence;
+    }
+    return left.sequence - right.sequence;
+  });
+  return {
+    images: merged.map((entry) => entry.image),
+    imageOrder: merged.map((entry) => entry.imageOrder),
+  };
+}
+
 /** Resolves current-turn image attachments that were not already described by media understanding. */
 export async function resolveCurrentTurnImages(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
+  extractedFileImages?: ExtractedFileImage[];
 }): Promise<{
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
 }> {
-  if (Array.isArray(params.images) && params.images.length > 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
+  const entries: OrderedTurnImage[] = [];
+  appendOrderedImages({
+    entries,
+    images: params.images,
+    imageOrder: params.imageOrder,
+  });
+  for (const image of params.extractedFileImages ?? []) {
+    appendOrderedImages({
+      entries,
+      images: [stripExtractedFileImageMetadata(image)],
+      sourceIndex: image.attachmentIndex,
+    });
   }
 
   const currentImageAttachments = collectCurrentImageAttachments(params.ctx);
   if (currentImageAttachments.length === 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
+    return resolveMergedTurnImages(entries);
   }
   const describedImageIndexes = collectDescribedImageAttachmentIndexes(params.ctx);
   const undescribedImageAttachments = currentImageAttachments.filter(
     (attachment) => !describedImageIndexes.has(attachment.index),
   );
   if (undescribedImageAttachments.length === 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
+    return resolveMergedTurnImages(entries);
   }
 
   try {
@@ -132,15 +195,20 @@ export async function resolveCurrentTurnImages(params: {
       logVerbose(
         `agent-runner: native OpenClaw media resolution produced ${images.length}/${undescribedImageAttachments.length} current image attachment(s); falling back to prompt image refs`,
       );
-      return { images: params.images, imageOrder: params.imageOrder };
+      return resolveMergedTurnImages(entries);
     }
-    return images.length > 0
-      ? { images, imageOrder: images.map(() => "inline" as const) }
-      : { images: params.images, imageOrder: params.imageOrder };
+    for (const [index, image] of images.entries()) {
+      appendOrderedImages({
+        entries,
+        images: [image],
+        sourceIndex: undescribedImageAttachments[index]?.index,
+      });
+    }
+    return resolveMergedTurnImages(entries);
   } catch (error) {
     logVerbose(
       `agent-runner: media attachment image resolution failed, proceeding without native images: ${formatErrorMessage(error)}`,
     );
-    return { images: params.images, imageOrder: params.imageOrder };
+    return resolveMergedTurnImages(entries);
   }
 }

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -8,6 +8,7 @@ import { AcpRuntimeError } from "../../acp/runtime/errors.js";
 import type { AcpSessionStoreEntry } from "../../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
+import type { ApplyMediaUnderstandingResult } from "../../media-understanding/apply.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import {
   resolveAgentTurnAttachments,
@@ -80,7 +81,9 @@ const ttsMocks = vi.hoisted(() => ({
 }));
 
 const mediaUnderstandingMocks = vi.hoisted(() => ({
-  applyMediaUnderstanding: vi.fn(async (_params: unknown) => undefined),
+  applyMediaUnderstanding: vi.fn<
+    (_params: unknown) => Promise<ApplyMediaUnderstandingResult | undefined>
+  >(async () => undefined),
 }));
 
 const acpAttachmentBuffers = vi.hoisted(() => new Map<string, Buffer>());
@@ -1188,6 +1191,47 @@ describe("tryDispatchAcpReply", () => {
       {
         mediaType: "image/png",
         data: image.data,
+      },
+    ]);
+  });
+
+  it("forwards media-understanding PDF page images alongside current image attachments", async () => {
+    setReadyAcpResolution();
+    const currentPath = "/tmp/openclaw-current-image.png";
+    const currentImage = Buffer.from("current-image");
+    const pdfPage = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: Buffer.from("pdf-page").toString("base64"),
+      attachmentIndex: 1,
+    };
+    acpAttachmentBuffers.set(currentPath, currentImage);
+    mediaUnderstandingMocks.applyMediaUnderstanding.mockResolvedValueOnce({
+      outputs: [],
+      decisions: [],
+      extractedFileImages: [pdfPage],
+      appliedImage: false,
+      appliedAudio: false,
+      appliedVideo: false,
+      appliedFile: true,
+    });
+
+    await runDispatch({
+      bodyForAgent: "describe current image and scanned PDF",
+      ctxOverrides: {
+        MediaPath: currentPath,
+        MediaType: "image/png",
+      },
+    });
+
+    expect(runTurnCall().attachments).toEqual([
+      {
+        mediaType: "image/png",
+        data: currentImage.toString("base64"),
+      },
+      {
+        mediaType: "image/png",
+        data: pdfPage.data,
       },
     ]);
   });

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -10,6 +10,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import type { AcpTurnAttachment } from "../../acp/control-plane/manager.types.js";
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../../acp/policy.js";
 import { AcpRuntimeError, toAcpRuntimeError } from "../../acp/runtime/errors.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
@@ -23,6 +24,10 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
 import { markDiagnosticSessionProgress } from "../../logging/diagnostic.js";
+import {
+  stripExtractedFileImageMetadata,
+  type ExtractedFileImage,
+} from "../../media-understanding/extracted-file-images.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveStatusTtsSnapshot } from "../../tts/status-config.js";
@@ -48,6 +53,40 @@ import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.type
 const dispatchAcpManagerRuntimeLoader = createLazyImportLoader(
   () => import("./dispatch-acp-manager.runtime.js"),
 );
+
+type OrderedAcpAttachment = {
+  attachment: AcpTurnAttachment;
+  sourceIndex?: number;
+  sequence: number;
+};
+
+function appendOrderedAcpAttachments(params: {
+  entries: OrderedAcpAttachment[];
+  attachments: AcpTurnAttachment[];
+  sourceIndexes?: number[];
+}) {
+  for (const [index, attachment] of params.attachments.entries()) {
+    params.entries.push({
+      attachment,
+      sourceIndex: params.sourceIndexes?.[index],
+      sequence: params.entries.length,
+    });
+  }
+}
+
+function resolveMergedAcpAttachments(entries: OrderedAcpAttachment[]): AcpTurnAttachment[] {
+  return entries
+    .toSorted((left, right) => {
+      if (left.sourceIndex !== undefined && right.sourceIndex !== undefined) {
+        return left.sourceIndex - right.sourceIndex || left.sequence - right.sequence;
+      }
+      if (left.sourceIndex !== undefined || right.sourceIndex !== undefined) {
+        return left.sequence - right.sequence;
+      }
+      return left.sequence - right.sequence;
+    })
+    .map((entry) => entry.attachment);
+}
 const dispatchAcpSessionRuntimeLoader = createLazyImportLoader(
   () => import("./dispatch-acp-session.runtime.js"),
 );
@@ -371,6 +410,7 @@ export async function tryDispatchAcpReply(params: {
   sessionKey?: string;
   toolsAllow?: string[];
   images?: Array<{ data: string; mimeType: string }>;
+  extractedFileImages?: ExtractedFileImage[];
   abortSignal?: AbortSignal;
   inboundAudio: boolean;
   sessionTtsAuto?: TtsAutoMode;
@@ -540,16 +580,20 @@ export async function tryDispatchAcpReply(params: {
     if (agentPolicyError) {
       throw agentPolicyError;
     }
+    let extractedFileImages = params.extractedFileImages ?? [];
     if (hasInboundMediaForUnderstanding(params.ctx) && !params.ctx.MediaUnderstanding?.length) {
       try {
         const { applyMediaUnderstanding } = await loadAgentTurnMediaRuntime();
-        await applyMediaUnderstanding({
+        const mediaResult = await applyMediaUnderstanding({
           ctx: params.ctx,
           cfg: params.cfg,
           agentId: acpAgentId,
           agentDir: resolveAgentDir(params.cfg, acpAgentId),
           workspaceDir: resolveAgentWorkspaceDir(params.cfg, acpAgentId),
         });
+        if (mediaResult.extractedFileImages.length > 0) {
+          extractedFileImages = [...extractedFileImages, ...mediaResult.extractedFileImages];
+        }
       } catch (err) {
         logVerbose(
           `dispatch-acp: media understanding failed, proceeding with raw content: ${formatErrorMessage(err)}`,
@@ -561,24 +605,47 @@ export async function tryDispatchAcpReply(params: {
     const resolvedTurnAttachments = await resolveAgentTurnAttachments({
       ctx: params.ctx,
       cfg: params.cfg,
+      includeAttachmentIndexes: true,
     });
     const mediaAttachments = resolvedTurnAttachments.attachments;
     const inlineAttachments = resolveInlineAgentImageAttachments(params.images);
+    const extractedAttachments = resolveInlineAgentImageAttachments(
+      extractedFileImages.map(stripExtractedFileImageMetadata),
+    );
     const mediaAttachmentsAreOnlyRecentHistory =
       mediaAttachments.length > 0 &&
       mediaAttachments.length === resolvedTurnAttachments.recentHistoryImages.length;
-    const attachments =
+    const useMediaAttachments =
       mediaAttachments.length > 0 &&
-      !(mediaAttachmentsAreOnlyRecentHistory && inlineAttachments.length > 0)
-        ? mediaAttachments
-        : inlineAttachments;
-    const turnPromptText =
-      attachments === mediaAttachments
-        ? appendRecentHistoryImageContext({
-            promptText,
-            images: resolvedTurnAttachments.recentHistoryImages,
-          })
-        : promptText;
+      !(
+        mediaAttachmentsAreOnlyRecentHistory &&
+        (inlineAttachments.length > 0 || extractedAttachments.length > 0)
+      );
+    const attachmentEntries: OrderedAcpAttachment[] = [];
+    if (useMediaAttachments) {
+      appendOrderedAcpAttachments({
+        entries: attachmentEntries,
+        attachments: mediaAttachments,
+        sourceIndexes: resolvedTurnAttachments.attachmentIndexes,
+      });
+    } else {
+      appendOrderedAcpAttachments({
+        entries: attachmentEntries,
+        attachments: inlineAttachments,
+      });
+    }
+    appendOrderedAcpAttachments({
+      entries: attachmentEntries,
+      attachments: extractedAttachments,
+      sourceIndexes: extractedFileImages.map((image) => image.attachmentIndex),
+    });
+    const attachments = resolveMergedAcpAttachments(attachmentEntries);
+    const turnPromptText = useMediaAttachments
+      ? appendRecentHistoryImageContext({
+          promptText,
+          images: resolvedTurnAttachments.recentHistoryImages,
+        })
+      : promptText;
     if (!turnPromptText && attachments.length === 0) {
       const counts = params.dispatcher.getQueuedCounts();
       delivery.applyRoutedCounts(counts);

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -940,8 +940,7 @@ export async function runPreparedReply(
       resolvedThinkLevel = fallbackThinkLevel;
     }
   }
-  const internalOpts = opts as InternalGetReplyOptions | undefined;
-  const providedReplyOperation = internalOpts?.replyOperation;
+  const providedReplyOperation = opts?.replyOperation;
   if (
     providedReplyOperation !== undefined &&
     providedReplyOperation.result === null &&

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -31,6 +31,7 @@ import { resolveSilentReplySettings } from "../../config/silent-reply.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
+import type { ExtractedFileImage } from "../../media-understanding/extracted-file-images.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import {
   isAcpSessionKey,
@@ -61,7 +62,7 @@ import {
   type VerboseLevel,
 } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { ReplyPayload } from "../types.js";
 import { applySessionHints } from "./body.js";
 import type { buildCommandContext } from "./commands.js";
 import { resolveCurrentTurnImages } from "./current-turn-images.js";
@@ -69,7 +70,10 @@ import type { InlineDirectives } from "./directive-handling.js";
 import { isSystemEventProvider, resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
 import { resolvePreparedReplyQueueState } from "./get-reply-run-queue.js";
-import type { ReplySessionBinding } from "./get-reply.types.js";
+import type {
+  InternalGetReplyOptions as BaseInternalGetReplyOptions,
+  ReplySessionBinding,
+} from "./get-reply.types.js";
 import {
   buildDirectChatContext,
   buildGroupChatContext,
@@ -110,7 +114,7 @@ import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 import type { TypingController } from "./typing.js";
 
-type InternalGetReplyOptions = GetReplyOptions & {
+type InternalGetReplyOptions = BaseInternalGetReplyOptions & {
   /**
    * Dispatch-owned pre-run operation. This is intentionally not part of the
    * public reply API; it lets dispatch prep and hook work share the same
@@ -123,6 +127,7 @@ type InternalGetReplyOptions = GetReplyOptions & {
    */
   queuedFollowupAbortSignal?: AbortSignal;
   onSessionPrepared?: (binding: ReplySessionBinding) => void;
+  extractedFileImages?: ExtractedFileImage[];
 };
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
@@ -438,7 +443,7 @@ type RunPreparedReplyParams = {
     dropPolicy?: InlineDirectives["dropPolicy"];
   };
   typing: TypingController;
-  opts?: GetReplyOptions;
+  opts?: InternalGetReplyOptions;
   defaultModel: string;
   timeoutMs: number;
   isNewSession: boolean;
@@ -969,7 +974,7 @@ export async function runPreparedReply(
           }).existing ?? sessionEntry)
         : sessionEntry;
     const latestSessionId = latestSessionEntry?.sessionId ?? sessionIdFinal;
-    internalOpts?.onSessionPrepared?.({
+    opts?.onSessionPrepared?.({
       sessionKey,
       sessionId: latestSessionId,
       storePath,
@@ -1226,11 +1231,12 @@ export async function runPreparedReply(
       cfg,
       images: opts?.images,
       imageOrder: opts?.imageOrder,
+      extractedFileImages: opts?.extractedFileImages,
     }),
   );
   const queuedFollowupAbortSignal =
     inboundEventKind === "room_event"
-      ? (internalOpts?.queuedFollowupAbortSignal ?? opts?.abortSignal)
+      ? (opts?.queuedFollowupAbortSignal ?? opts?.abortSignal)
       : undefined;
   const userTurnMediaForPersistence = buildPersistedUserTurnMediaInputsFromFields(ctx);
   const inputProvenance = ctx.InputProvenance ?? sessionCtx.InputProvenance;

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -1,6 +1,7 @@
 // Tests get-reply message hooks before and after agent execution.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { logVerbose } from "../../globals.js";
+import type { ApplyMediaUnderstandingResult } from "../../media-understanding/apply.js";
 import type { MsgContext } from "../templating.js";
 import { withFastReplyConfig } from "./get-reply-fast-path.js";
 import {
@@ -13,7 +14,9 @@ import { loadGetReplyModuleForTest } from "./get-reply.test-loader.js";
 import "./get-reply.test-mocks.js";
 
 const mocks = vi.hoisted(() => ({
-  applyMediaUnderstanding: vi.fn(async (..._args: unknown[]) => undefined),
+  applyMediaUnderstanding: vi.fn<
+    (..._args: unknown[]) => Promise<ApplyMediaUnderstandingResult | undefined>
+  >(async (..._args: unknown[]) => undefined),
   applyLinkUnderstanding: vi.fn(async (..._args: unknown[]) => undefined),
   createInternalHookEvent: vi.fn(),
   triggerInternalHook: vi.fn(async (..._args: unknown[]) => undefined),
@@ -196,6 +199,12 @@ describe("getReplyFromConfig message hooks", () => {
 
   it("enriches staged text-only images before reply without switching the reply model", async () => {
     const enrichedBody = "describe image\n\n[Image 1]\na tiny dot image";
+    const extractedPdfPage = {
+      type: "image",
+      data: "pdf-page",
+      mimeType: "image/png",
+      attachmentIndex: 0,
+    } as const;
     vi.mocked(resolveDefaultModelMock).mockReturnValueOnce({
       defaultProvider: "anthropic",
       defaultModel: "claude-opus-4-6",
@@ -226,6 +235,15 @@ describe("getReplyFromConfig message hooks", () => {
       params.ctx.BodyForCommands = enrichedBody;
       params.ctx.CommandBody = enrichedBody;
       params.ctx.RawBody = enrichedBody;
+      return {
+        outputs: params.ctx.MediaUnderstanding,
+        decisions: [],
+        extractedFileImages: [extractedPdfPage],
+        appliedImage: true,
+        appliedAudio: false,
+        appliedVideo: false,
+        appliedFile: true,
+      };
     });
     mocks.resolveReplyDirectives.mockResolvedValueOnce(
       createGetReplyContinueDirectivesResult({
@@ -301,6 +319,11 @@ describe("getReplyFromConfig message hooks", () => {
         text: "a tiny dot image",
       }),
     ]);
+    expect(runParams?.opts).toEqual(
+      expect.objectContaining({
+        extractedFileImages: [extractedPdfPage],
+      }),
+    );
     expect(stageSandboxMediaMock).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -20,6 +20,8 @@ import { logVerbose } from "../../globals.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { ApplyMediaUnderstandingResult } from "../../media-understanding/apply.js";
+import type { ExtractedFileImage } from "../../media-understanding/extracted-file-images.js";
 import {
   buildAgentHookContextChannelFields,
   buildAgentHookContextIdentityFields,
@@ -70,6 +72,7 @@ type ResetCommandAction = "new" | "reset";
 
 type RuntimeInternalGetReplyOptions = BaseInternalGetReplyOptions & {
   onSessionPrepared?: (binding: ReplySessionBinding) => void;
+  extractedFileImages?: ExtractedFileImage[];
 };
 
 function classifyHeartbeatPendingFinalDelivery(text: string, ackMaxChars: number) {
@@ -184,21 +187,33 @@ async function applyMediaUnderstandingIfNeeded(params: {
   agentDir?: string;
   workspaceDir?: string;
   activeModel: { provider: string; model: string };
-}): Promise<boolean> {
+}): Promise<ApplyMediaUnderstandingResult | undefined> {
   if (!hasInboundMediaForUnderstanding(params.ctx)) {
-    return false;
+    return undefined;
   }
   try {
     const { applyMediaUnderstanding } = await loadMediaUnderstandingApplyRuntime();
-    await applyMediaUnderstanding(params);
-    return true;
+    return await applyMediaUnderstanding(params);
   } catch (err) {
     mediaUnderstandingApplyRuntimeLoader.clear();
     logVerbose(
       `media understanding failed, proceeding with raw content: ${formatErrorMessage(err)}`,
     );
-    return false;
+    return undefined;
   }
+}
+
+function withExtractedFileImages(
+  opts: RuntimeInternalGetReplyOptions | undefined,
+  extractedFileImages: ExtractedFileImage[] | undefined,
+): RuntimeInternalGetReplyOptions | undefined {
+  if (!extractedFileImages || extractedFileImages.length === 0) {
+    return opts;
+  }
+  return {
+    ...opts,
+    extractedFileImages: [...(opts?.extractedFileImages ?? []), ...extractedFileImages],
+  };
 }
 
 async function applyLinkUnderstandingIfNeeded(params: {
@@ -303,6 +318,7 @@ export async function getReplyFromConfig(
   const resolvedOpts =
     mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
   const internalResolvedOpts = resolvedOpts as RuntimeInternalGetReplyOptions | undefined;
+  let extractedFileImages: ExtractedFileImage[] | undefined;
   const agentCfg = cfg.agents?.defaults;
   const sessionCfg = cfg.session;
   const { defaultProvider, defaultModel, aliasIndex } = resolverTiming.measureSync(
@@ -420,7 +436,7 @@ export async function getReplyFromConfig(
     );
   }
   if (!isFastTestEnv && hasInboundMediaForUnderstanding(finalized)) {
-    await traceGetReplyPhase("reply.apply_media_understanding", () =>
+    const mediaResult = await traceGetReplyPhase("reply.apply_media_understanding", () =>
       applyMediaUnderstandingIfNeeded({
         ctx: finalized,
         cfg,
@@ -430,6 +446,9 @@ export async function getReplyFromConfig(
         activeModel: { provider, model },
       }),
     );
+    if (mediaResult?.extractedFileImages.length) {
+      extractedFileImages = mediaResult.extractedFileImages;
+    }
   }
   if (!isFastTestEnv && hasLinkCandidate(finalized)) {
     await traceGetReplyPhase("reply.apply_link_understanding", () =>
@@ -709,7 +728,7 @@ export async function getReplyFromConfig(
         perMessageQueueMode: undefined,
         perMessageQueueOptions: undefined,
         typing,
-        opts: resolvedOpts,
+        opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
         defaultModel,
         timeoutMs,
         isNewSession,
@@ -758,7 +777,7 @@ export async function getReplyFromConfig(
       model,
       hasResolvedHeartbeatModelOverride,
       typing,
-      opts: resolvedOpts,
+      opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
       skillFilter: mergedSkillFilter,
     }),
   );
@@ -836,7 +855,7 @@ export async function getReplyFromConfig(
       sessionScope,
       workspaceDir,
       isGroup,
-      opts: resolvedOpts,
+      opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
       typing,
       allowTextCommands,
       inlineStatusRequested,
@@ -1027,7 +1046,7 @@ export async function getReplyFromConfig(
       perMessageQueueMode,
       perMessageQueueOptions,
       typing,
-      opts: resolvedOpts,
+      opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
       defaultModel,
       timeoutMs,
       isNewSession,

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -5,6 +5,12 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import type { ActiveMediaModel } from "../../packages/media-understanding-common/src/active-model.js";
+import {
+  extractMediaUserText,
+  formatAudioTranscripts,
+  formatMediaUnderstandingBody,
+} from "../../packages/media-understanding-common/src/format.js";
 import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -12,15 +18,10 @@ import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { renderFileContextBlock } from "../media/file-context.js";
 import { extractFileContentFromSource, normalizeMimeType } from "../media/input-files.js";
 import { wrapExternalContent } from "../security/external-content.js";
-import type { ActiveMediaModel } from "../../packages/media-understanding-common/src/active-model.js";
-import {
-  extractMediaUserText,
-  formatAudioTranscripts,
-  formatMediaUnderstandingBody,
-} from "../../packages/media-understanding-common/src/format.js";
 import { resolveAttachmentKind } from "./attachments.js";
 import { runWithConcurrency } from "./concurrency.js";
 import { DEFAULT_ECHO_TRANSCRIPT_FORMAT, sendTranscriptEcho } from "./echo-transcript.js";
+import type { ExtractedFileImage } from "./extracted-file-images.js";
 import {
   type FileExtractionLimits,
   resolveFileExtractionLimits,
@@ -40,9 +41,10 @@ import type {
   MediaUnderstandingProvider,
 } from "./types.js";
 
-type ApplyMediaUnderstandingResult = {
+export type ApplyMediaUnderstandingResult = {
   outputs: MediaUnderstandingOutput[];
   decisions: MediaUnderstandingDecision[];
+  extractedFileImages: ExtractedFileImage[];
   appliedImage: boolean;
   appliedAudio: boolean;
   appliedVideo: boolean;
@@ -377,18 +379,24 @@ function isBinaryMediaMime(mime?: string): boolean {
   return false;
 }
 
-async function extractFileBlocks(params: {
+type ExtractedFileContext = {
+  blocks: string[];
+  images: ExtractedFileImage[];
+};
+
+async function extractFileContext(params: {
   attachments: ReturnType<typeof normalizeMediaAttachments>;
   cache: ReturnType<typeof createMediaAttachmentCache>;
   cfg: OpenClawConfig;
   limits: FileExtractionLimits;
   skipAttachmentIndexes?: Set<number>;
-}): Promise<string[]> {
+}): Promise<ExtractedFileContext> {
   const { attachments, cache, cfg, limits, skipAttachmentIndexes } = params;
   if (!attachments || attachments.length === 0) {
-    return [];
+    return { blocks: [], images: [] };
   }
   const blocks: string[] = [];
+  const images: ExtractedFileImage[] = [];
   for (const attachment of attachments) {
     if (!attachment) {
       continue;
@@ -495,9 +503,14 @@ async function extractFileBlocks(params: {
     }
     const text = extracted?.text?.trim() ?? "";
     let blockText = text ? wrapUntrustedAttachmentContent(text) : "";
+    if (extracted?.images && extracted.images.length > 0) {
+      images.push(
+        ...extracted.images.map((image) => ({ ...image, attachmentIndex: attachment.index })),
+      );
+    }
     if (!blockText) {
       if (extracted?.images && extracted.images.length > 0) {
-        blockText = "[PDF content rendered to images; images not forwarded to model]";
+        blockText = "[PDF content rendered to images]";
       } else {
         blockText = "[No extractable text]";
       }
@@ -511,7 +524,7 @@ async function extractFileBlocks(params: {
       }),
     );
   }
-  return blocks;
+  return { blocks, images };
 }
 
 export async function applyMediaUnderstanding(params: {
@@ -670,30 +683,31 @@ export async function applyMediaUnderstanding(params: {
         )
         .map((output) => output.attachmentIndex),
     );
-    const fileBlocks = await extractFileBlocks({
+    const fileContext = await extractFileContext({
       attachments,
       cache,
       cfg,
       limits: resolveFileExtractionLimits(cfg),
       skipAttachmentIndexes: audioAttachmentIndexes.size > 0 ? audioAttachmentIndexes : undefined,
     });
-    if (fileBlocks.length > 0) {
-      ctx.Body = appendFileBlocks(ctx.Body, fileBlocks);
+    if (fileContext.blocks.length > 0) {
+      ctx.Body = appendFileBlocks(ctx.Body, fileContext.blocks);
     }
-    if (outputs.length > 0 || fileBlocks.length > 0) {
+    if (outputs.length > 0 || fileContext.blocks.length > 0) {
       finalizeInboundContext(ctx, {
         forceBodyForAgent: true,
-        forceBodyForCommands: outputs.length > 0 || fileBlocks.length > 0,
+        forceBodyForCommands: outputs.length > 0 || fileContext.blocks.length > 0,
       });
     }
 
     return {
       outputs,
       decisions,
+      extractedFileImages: fileContext.images,
       appliedImage: outputs.some((output) => output.kind === "image.description"),
       appliedAudio: outputs.some((output) => output.kind === "audio.transcription"),
       appliedVideo: outputs.some((output) => output.kind === "video.description"),
-      appliedFile: fileBlocks.length > 0,
+      appliedFile: fileContext.blocks.length > 0,
     };
   } finally {
     await cache.cleanup();

--- a/src/media-understanding/attachments.cache.ts
+++ b/src/media-understanding/attachments.cache.ts
@@ -19,6 +19,7 @@ import {
   MediaFetchError,
 } from "../media/fetch.js";
 import { getDefaultMediaLocalRoots } from "../media/local-roots.js";
+import { resolveInboundMediaReference } from "../media/media-reference.js";
 import { buildRandomTempFilePath } from "../plugin-sdk/temp-path.js";
 import { normalizeAttachmentPath } from "./attachments.normalize.js";
 import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
@@ -327,7 +328,7 @@ export class MediaAttachmentCache {
     const existing = this.entries.get(attachmentIndex);
     if (existing) {
       if (!existing.resolvedPath) {
-        existing.resolvedPath = this.resolveLocalPath(existing.attachment);
+        existing.resolvedPath = await this.resolveLocalPath(existing.attachment);
       }
       return existing;
     }
@@ -336,16 +337,20 @@ export class MediaAttachmentCache {
     };
     const entry: AttachmentCacheEntry = {
       attachment,
-      resolvedPath: this.resolveLocalPath(attachment),
+      resolvedPath: await this.resolveLocalPath(attachment),
     };
     this.entries.set(attachmentIndex, entry);
     return entry;
   }
 
-  private resolveLocalPath(attachment: MediaAttachment): string | undefined {
+  private async resolveLocalPath(attachment: MediaAttachment): Promise<string | undefined> {
     const rawPath = normalizeAttachmentPath(attachment.path);
     if (!rawPath) {
       return undefined;
+    }
+    const inboundReference = await resolveInboundMediaReference(rawPath).catch(() => null);
+    if (inboundReference) {
+      return inboundReference.physicalPath;
     }
     if (this.workspaceDir) {
       return path.resolve(this.workspaceDir, rawPath);
@@ -373,16 +378,19 @@ export class MediaAttachmentCache {
       return undefined;
     }
     if (!isInboundPathAllowed({ filePath: entry.resolvedPath, roots: this.localPathRoots })) {
-      entry.resolvedPath = undefined;
-      if (shouldLogVerbose()) {
-        logVerbose(
-          `Blocked attachment path outside allowed roots: ${entry.attachment.path ?? entry.attachment.url ?? "(unknown)"}`,
+      const canonicalRoots = await this.getCanonicalLocalPathRoots();
+      if (!isInboundPathAllowed({ filePath: entry.resolvedPath, roots: canonicalRoots })) {
+        entry.resolvedPath = undefined;
+        if (shouldLogVerbose()) {
+          logVerbose(
+            `Blocked attachment path outside allowed roots: ${entry.attachment.path ?? entry.attachment.url ?? "(unknown)"}`,
+          );
+        }
+        throw new MediaUnderstandingSkipError(
+          "blocked",
+          `Attachment ${entry.attachment.index + 1} path is outside allowed roots.`,
         );
       }
-      throw new MediaUnderstandingSkipError(
-        "blocked",
-        `Attachment ${entry.attachment.index + 1} path is outside allowed roots.`,
-      );
     }
     if (entry.statSize !== undefined) {
       return entry.statSize;

--- a/src/media-understanding/extracted-file-images.ts
+++ b/src/media-understanding/extracted-file-images.ts
@@ -1,0 +1,14 @@
+// Shared transient image payloads extracted from inbound file attachments.
+import type { ImageContent } from "../llm/types.js";
+
+export type ExtractedFileImage = ImageContent & {
+  attachmentIndex: number;
+};
+
+export function stripExtractedFileImageMetadata(image: ExtractedFileImage): ImageContent {
+  return {
+    type: "image",
+    data: image.data,
+    mimeType: image.mimeType,
+  };
+}

--- a/src/media-understanding/media-understanding-misc.test.ts
+++ b/src/media-understanding/media-understanding-misc.test.ts
@@ -8,6 +8,7 @@ import * as fsSafe from "../infra/fs-safe.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
+import { saveMediaBuffer } from "../media/store.js";
 import { MediaAttachmentCache } from "./attachments.js";
 import { normalizeMediaUnderstandingChatType, resolveMediaUnderstandingScope } from "./scope.js";
 
@@ -182,6 +183,37 @@ describe("media understanding attachments SSRF", () => {
       expect(result.buffer.toString()).toBe("state-media");
       expect(result.fileName).toBe("telegram.jpg");
     });
+  });
+
+  it("resolves managed inbound media URI attachments", async () => {
+    await withTempDir({ prefix: "openclaw-media-cache-managed-inbound-" }, async (stateDir) => {
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      const saved = await saveMediaBuffer(
+        Buffer.from("managed-media"),
+        "text/plain",
+        "inbound",
+      );
+
+      const cache = new MediaAttachmentCache(
+        [{ index: 0, path: `media://inbound/${encodeURIComponent(saved.id)}` }],
+        {
+          localPathRoots: [path.join(stateDir, "media")],
+        },
+      );
+
+      const result = await cache.getBuffer({ attachmentIndex: 0, maxBytes: 1024, timeoutMs: 1000 });
+
+      expect(result.buffer.toString()).toBe("managed-media");
+      expect(result.fileName).toBe(saved.id);
+    });
+  });
+
+  it("blocks nested managed inbound media URI attachments", async () => {
+    const cache = new MediaAttachmentCache([{ index: 0, path: "media://inbound/nested%2Ffile.pdf" }]);
+
+    await expect(
+      cache.getBuffer({ attachmentIndex: 0, maxBytes: 1024, timeoutMs: 1000 }),
+    ).rejects.toThrow(/outside allowed roots/i);
   });
 
   it("keeps cwd-relative fallback when a state-relative candidate does not exist", async () => {

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const fetchWithSsrFGuardMock = vi.fn();
 const convertHeicToJpegMock = vi.fn();
 const detectMimeMock = vi.fn();
+const extractPdfContentMock = vi.fn();
 
 vi.mock("../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
@@ -15,6 +16,10 @@ vi.mock("./media-services.js", () => ({
 
 vi.mock("@openclaw/media-core/mime", () => ({
   detectMime: (...args: unknown[]) => detectMimeMock(...args),
+}));
+
+vi.mock("./pdf-extract.js", () => ({
+  extractPdfContent: (...args: unknown[]) => extractPdfContentMock(...args),
 }));
 
 async function waitForMicrotaskTurn(): Promise<void> {
@@ -34,6 +39,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  extractPdfContentMock.mockResolvedValue({ text: "", images: [] });
 });
 
 function createImageSourceLimits(allowedMimes: string[], allowUrl = false) {
@@ -428,6 +434,31 @@ describe("input file MIME sniffing", () => {
         limits: createFileSourceLimits(["text/plain"]),
       }),
     ).rejects.toThrow("Unsupported file MIME type: application/zip");
+  });
+
+  it("times out local PDF extraction with the input file timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      detectMimeMock.mockResolvedValueOnce("application/pdf");
+      extractPdfContentMock.mockReturnValueOnce(new Promise(() => {}));
+
+      const pending = expect(
+        extractFileContentFromSource({
+          source: {
+            type: "base64",
+            data: Buffer.from("%PDF-1.4\n").toString("base64"),
+            mediaType: "application/pdf",
+            filename: "scan.pdf",
+          },
+          limits: createFileSourceLimits(["application/pdf"]),
+        }),
+      ).rejects.toThrow("PDF extraction timed out after 1ms");
+
+      await vi.advanceTimersByTimeAsync(1);
+      await pending;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { logWarn } from "../logger.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { convertHeicToJpeg } from "./media-services.js";
 import { extractPdfContent, type PdfExtractedImage } from "./pdf-extract.js";
 
@@ -275,6 +276,25 @@ function clampText(text: string, maxChars: number): string {
   return text.slice(0, maxChars);
 }
 
+function withInputFileTimeout<T>(params: {
+  task: Promise<T>;
+  timeoutMs: number;
+  label: string;
+}): Promise<T> {
+  const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
+  let timeout: NodeJS.Timeout | undefined;
+  const timedOut = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(`${params.label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  return Promise.race([params.task, timedOut]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+}
+
 async function normalizeInputImage(params: {
   buffer: Buffer;
   mimeType?: string;
@@ -439,15 +459,19 @@ export async function extractFileContentFromSource(params: {
   }
 
   if (mimeType === "application/pdf") {
-    const extracted = await extractPdfContent({
-      buffer,
-      maxPages: limits.pdf.maxPages,
-      maxPixels: limits.pdf.maxPixels,
-      minTextChars: limits.pdf.minTextChars,
-      ...(params.config ? { config: params.config } : {}),
-      onImageExtractionError: (err) => {
-        logWarn(`media: PDF image extraction skipped, ${String(err)}`);
-      },
+    const extracted = await withInputFileTimeout({
+      label: "PDF extraction",
+      timeoutMs: limits.timeoutMs,
+      task: extractPdfContent({
+        buffer,
+        maxPages: limits.pdf.maxPages,
+        maxPixels: limits.pdf.maxPixels,
+        minTextChars: limits.pdf.minTextChars,
+        ...(params.config ? { config: params.config } : {}),
+        onImageExtractionError: (err) => {
+          logWarn(`media: PDF image extraction skipped, ${String(err)}`);
+        },
+      }),
     });
     const text = extracted.text ? clampText(extracted.text, limits.maxChars) : "";
     return {


### PR DESCRIPTION
Closes #96541

AI-assisted by Codex.

## What Problem This Solves

Fixes an issue where users sending scanned or image-only PDFs through chat channels would have those rendered PDF page images extracted by media understanding but silently dropped before the reply model saw them.

The affected workflow is chat-channel replies with file attachment extraction enabled, especially scanned PDFs that have no extractable text and need vision input.

## Why This Change Was Made

This threads rendered PDF page images from media-understanding file extraction into the normal reply image pipeline instead of treating them as text-only extraction side effects. It preserves attachment ordering across described media, rendered file pages, and native current-turn images, and applies the same behavior to the ACP dispatch path.

The stale placeholder that said rendered PDF images were not forwarded is removed from runtime output and docs. Local PDF extraction also now honors the existing input-file timeout limit so a stalled extraction path does not hang indefinitely.

## User Impact

Users can attach scanned or image-only PDFs in chat channels and expect vision-capable reply models to receive the rendered pages. The model now has access to the actual PDF page images instead of only seeing a placeholder that the PDF was rendered.

## Evidence

- Focused tests passed: `pnpm test src/auto-reply/reply/get-reply.message-hooks.test.ts src/media/input-files.fetch-guard.test.ts src/media/pdf-extract.test.ts extensions/document-extract/document-extractor.test.ts src/media-understanding/apply.test.ts src/media-understanding/media-understanding-misc.test.ts src/auto-reply/reply/current-turn-images.test.ts src/auto-reply/reply/agent-runner.media-paths.test.ts src/auto-reply/reply/dispatch-acp.test.ts -- --reporter=dot` passed 5 Vitest shards / 281 tests.
- `git diff --check` passed.
- `pnpm changed:lanes --json` reported `core`, `coreTests`, and `docs`.
- `pnpm check:changed` passed on Blacksmith Testbox `tbx_01kw3ve1hw53mx08yn0t05egst` (`swift-crayfish`), exit 0. This covered the code/test diff before the final docs-only edit.
- Docs validation after the docs edit passed: `pnpm docs:list` and `pnpm docs:check-mdx`.
- Autoreview passed with no accepted/actionable findings.
- Linux source extraction Crabbox proof passed on Azure Crabbox `cbx_38ab3f65a3e0`, run `run_ee855ee7e830`: rendered PDF fallback produced `imageCount=1`, placeholder `[PDF content rendered to images]`, and no stale `images not forwarded` placeholder.
- Live Telegram post-fix proof passed on Azure Crabbox `cbx_19bc9a4ae812`, run `run_fb1b4f306692`: real Telegram `telegram` credential, sent scanned PDF message `25170`, and observed `LIVE_PROOF_PASS issue=96541 transport=telegram credentialKind=telegram imageInputCount=1`.
