### PR TITLE
fix(sessions): fail fast on non-serializable JSONL root values

### DIFF
--- a/src/config/sessions/transcript-jsonl.test.ts
+++ b/src/config/sessions/transcript-jsonl.test.ts
@@ -1,0 +1,60 @@
+// Covers JSONL serialization behavior, including fail-fast on non-serializable
+// root values that JSON.stringify would otherwise coerce to the literal string
+// "undefined" (a silent transcript-data-loss path).
+import { describe, expect, it } from "vitest";
+import {
+  serializeJsonlEntry,
+  serializeJsonlLine,
+  serializeJsonlLines,
+} from "./transcript-jsonl.js";
+
+describe("serializeJsonlLine", () => {
+  it("throws TypeError when the root value is undefined", () => {
+    expect(() => serializeJsonlLine(undefined)).toThrow(TypeError);
+    expect(() => serializeJsonlLine(undefined)).toThrow(/not JSON-serializable/);
+  });
+
+  it("throws TypeError when the root value is a function", () => {
+    expect(() => serializeJsonlLine(() => 42)).toThrow(TypeError);
+  });
+
+  it("throws TypeError when the root value is a symbol", () => {
+    expect(() => serializeJsonlLine(Symbol("x"))).toThrow(TypeError);
+  });
+
+  it("serializes null as the JSON literal 'null'", () => {
+    expect(serializeJsonlLine(null)).toBe("null");
+  });
+
+  it("serializes primitives as their JSON representation", () => {
+    expect(serializeJsonlLine("hello")).toBe('"hello"');
+    expect(serializeJsonlLine(42)).toBe("42");
+    expect(serializeJsonlLine(true)).toBe("true");
+  });
+
+  it("serializes plain objects and arrays (regression guard)", () => {
+    expect(serializeJsonlLine({ msg: "hello" })).toBe('{"msg":"hello"}');
+    expect(serializeJsonlLine([1, 2, 3])).toBe("[1,2,3]");
+  });
+});
+
+describe("serializeJsonlEntry", () => {
+  it("appends a newline terminator for serializable values", () => {
+    expect(serializeJsonlEntry({ msg: "ok" })).toBe('{"msg":"ok"}\n');
+  });
+
+  it("throws for a non-serializable root value (does not emit 'undefined\\n')", () => {
+    // Regression guard: the literal string "undefined" must never reach the file.
+    expect(() => serializeJsonlEntry(undefined)).toThrow(TypeError);
+  });
+});
+
+describe("serializeJsonlLines", () => {
+  it("joins serialized lines and terminates the batch with a newline", () => {
+    expect(serializeJsonlLines(['{"a":1}', '{"b":2}'])).toBe('{"a":1}\n{"b":2}\n');
+  });
+
+  it("returns an empty string for an empty batch", () => {
+    expect(serializeJsonlLines([])).toBe("");
+  });
+});

--- a/src/config/sessions/transcript-jsonl.ts
+++ b/src/config/sessions/transcript-jsonl.ts
@@ -14,7 +14,18 @@ export function serializeJsonlEntry(entry: unknown): string {
 }
 
 export function serializeJsonlLine(entry: unknown): string {
-  return JSON.stringify(entry);
+  const serialized = JSON.stringify(entry);
+  // JSON.stringify returns undefined when the root value is undefined, a
+  // function, or a symbol. Without this guard the template literal in
+  // serializeJsonlEntry coerces it to the literal string "undefined", which is
+  // not valid JSON and is silently skipped by readers — a fail-silent loss of a
+  // transcript entry. Fail fast instead so the caller fixes the bad value.
+  if (serialized === undefined) {
+    throw new TypeError(
+      `serializeJsonlLine: entry of type ${typeof entry} is not JSON-serializable (JSON.stringify returned undefined)`,
+    );
+  }
+  return serialized;
 }
 
 export function serializeJsonlEntries(entries: readonly unknown[]): string {


### PR DESCRIPTION
## What Problem This Solves

`serializeJsonlLine` (src/config/sessions/transcript-jsonl.ts) returned `JSON.stringify(entry)` without guarding the `undefined` return case. When the root value is `undefined`, a `function`, or a `Symbol`, `JSON.stringify` returns `undefined` (ECMA-262), which `serializeJsonlEntry`'s template literal coerced to the literal string `"undefined"` and wrote to the transcript file. That is not valid JSON, so `parseJsonlEntries` silently caught the `JSON.parse` SyntaxError and skipped the line — a fail-silent loss of a transcript entry with no error log.

## Why This Change Was Made

The transcript write path is on the hot session-persistence path for every channel, and the team already tracks serialization edge cases here (`session-manager.ts:2109` notes serialization can run extension/provider code via toJSON/getters). All root non-serializable paths funnel through this one helper, so a single guard fixes every caller (`serializeJsonlEntry`, `serializeJsonlEntries`, and direct `serializeJsonlLine` callers). Circular-reference and BigInt inputs already throw via `JSON.stringify` and are not fail-silent, so they are out of scope.

## User Impact

Transcript entries with a non-serializable root no longer silently vanish on restart. Callers that previously produced `"undefined"` lines (a latent bug — entry data was already lost) now get a visible `TypeError` at write time so the bad value can be fixed. Legitimate entries (objects, primitives, null) are unchanged.

## Real behavior proof

- **Behavior addressed:** `serializeJsonlLine` coerced a non-serializable root to the literal string `"undefined"`, which readers silently skipped — fail-silent transcript data loss.
- **Real environment tested:** Linux x86_64, Node 22, commit `d60515ef91` on branch `fix/serialize-jsonl-non-serializable-throw`.
- **Exact steps or command run after this patch:** `node --import tsx /tmp/verify-serialize-jsonl.mjs` — imports the real `serializeJsonlLine`/`serializeJsonlEntry` and exercises non-serializable roots plus legitimate values.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```text
  Terminal capture of node runtime verification (live stdout):
    fix: root non-serializable values must throw, not coerce to literal 'undefined'

    undefined : threw  TypeError: ...entry of type undefined is not JSON-serializable (JSON.stringify returned undefined)
    function  : threw  TypeError: ...entry of type function is not JSON-serializable ...
    symbol    : threw  TypeError: ...entry of type symbol is not JSON-serializable ...

    null      : PASS  -> null
    "hello"   : PASS  -> "hello"
    42        : PASS  -> 42
    object    : PASS  -> {"msg":"ok"}
    entry+nl   : PASS  -> newline terminator preserved

  Verdict: PASS
  ```

- **Observed result after fix:** `undefined`/`function`/`symbol` roots now throw a `TypeError` instead of emitting the literal `"undefined"`; `null`, primitives, objects, and the entry newline terminator are unchanged.
- **What was not tested:** Live end-to-end session write under an injected non-serializable root (function-level proof covers the predicate directly); circular-reference/BigInt behavior is unchanged and not re-tested here.

## Tests and validation

```text
$ pnpm test src/config/sessions/transcript-jsonl.test.ts
Test Files  1 passed (1)
Tests       10 passed (10)

$ pnpm test src/config/sessions/transcript-append-redact.test.ts src/config/sessions/transcript.test.ts src/agents/sessions/session-manager.test.ts
Test Files  3 passed (3)
Tests       112 passed (112)

$ pnpm tsgo:core:test
EXIT=0 (type check passed)
```

Added `src/config/sessions/transcript-jsonl.test.ts` (the module previously had no tests) covering the throw cases, null/primitive/object regression, and the newline terminator. Ran the three closest caller test suites (112 tests) to confirm no regression on the legitimate-object path.

## Risk checklist

- User-visible behavior: Yes, intentionally - a latent fail-silent data-loss path now throws. Callers that already triggered it (lost data silently) will see a visible write error; callers passing legitimate objects are unaffected.
- Config/env/migration behavior: No - no config or env surface touched.
- Security/auth/secrets/network/tool execution: No - only the serialization predicate changes; no new command execution, credential, or network path.
- Plugins/providers/channels/SDK: No - internal to `src/config/sessions`; `serializeJsonlLine` keeps its `(entry: unknown) => string` signature (it throws rather than widening the return type).
- Highest-risk area: the behavior change is fail-fast - a caller passing a non-serializable root will now get a write-time TypeError instead of a corrupted file. This is the intended fix; all known callers pass typed object entries (e.g. `persist(entry: SessionEntry)`), so the throw is only reachable via a type-unsafe or runtime-undefined value.
- Mitigation: 10 new unit tests plus 112 existing caller tests pass; `tsgo:core:test` is green; `TypeError` is the same error class `JSON.stringify` already raises for circular/BigInt, so existing catch handlers remain compatible.

Closes: N/A (no existing issue)
