### PR TITLE
Doctor: expose workspace status findings

### DIFF
--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -8,7 +8,10 @@ import {
   createPluginRecord,
   createTypedHook,
 } from "../plugins/status.test-helpers.js";
-import { noteWorkspaceStatus } from "./doctor-workspace-status.js";
+import {
+  collectWorkspaceStatusHealthFindings,
+  noteWorkspaceStatus,
+} from "./doctor-workspace-status.js";
 
 const mocks = vi.hoisted(() => ({
   resolveAgentWorkspaceDir: vi.fn(),
@@ -156,6 +159,110 @@ describe("noteWorkspaceStatus", () => {
     } finally {
       noteSpy.mockRestore();
     }
+  });
+
+  it("collects plugin version drift as structured findings", async () => {
+    mocks.resolveDefaultAgentId.mockReturnValue("default");
+    mocks.resolveAgentWorkspaceDir.mockReturnValue("/workspace");
+    mocks.buildPluginRegistrySnapshotReport.mockReturnValue({
+      workspaceDir: "/workspace",
+      ...createPluginLoadResult({ plugins: [] }),
+    });
+    mocks.buildPluginCompatibilityWarnings.mockReturnValue([]);
+    mocks.listTaskFlowRecords.mockReturnValue([]);
+
+    const findings = collectWorkspaceStatusHealthFindings(
+      {
+        plugins: { entries: { codex: { enabled: true } } },
+      },
+      {
+        pluginVersionDrift: {
+          gatewayVersion: "2026.6.1",
+          drifts: [
+            {
+              pluginId: "codex",
+              installedVersion: "2026.5.30-beta.1",
+              gatewayVersion: "2026.6.1",
+              source: "npm",
+            },
+          ],
+        },
+      },
+    );
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/workspace-status",
+        severity: "warning",
+        path: "plugins.entries.codex",
+        target: "codex",
+        requirement: "plugin-version-drift",
+        message: expect.stringContaining("2026.5.30-beta.1"),
+        fixHint: expect.stringContaining("openclaw plugins update codex"),
+      }),
+    ]);
+  });
+
+  it("collects compatibility warnings, plugin diagnostics, and TaskFlow recovery findings", async () => {
+    mocks.resolveDefaultAgentId.mockReturnValue("default");
+    mocks.resolveAgentWorkspaceDir.mockReturnValue("/workspace");
+    mocks.buildPluginRegistrySnapshotReport.mockReturnValue({
+      workspaceDir: "/workspace",
+      ...createPluginLoadResult({
+        plugins: [],
+        diagnostics: [
+          {
+            level: "error",
+            pluginId: "broken-plugin",
+            message: "channel setup failed",
+            source: "/tmp/plugin.json",
+            code: "channel-setup-failure",
+          },
+        ],
+      }),
+    });
+    mocks.buildPluginCompatibilityWarnings.mockReturnValue([
+      "legacy-plugin still uses legacy before_agent_start",
+    ]);
+    mocks.listTaskFlowRecords.mockReturnValue([
+      {
+        flowId: "flow-123",
+        syncMode: "managed",
+        status: "blocked",
+        blockedTaskId: "task-missing",
+      },
+    ]);
+    mocks.listTasksForFlowId.mockReturnValue([]);
+
+    const findings = collectWorkspaceStatusHealthFindings({});
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/workspace-status",
+        severity: "warning",
+        path: "plugins",
+        requirement: "plugin-compatibility",
+        message: "legacy-plugin still uses legacy before_agent_start",
+      }),
+      expect.objectContaining({
+        checkId: "core/doctor/workspace-status",
+        severity: "error",
+        path: "plugins.entries.broken-plugin",
+        target: "broken-plugin",
+        requirement: "channel-setup-failure",
+        source: "/tmp/plugin.json",
+        message: "channel setup failed",
+      }),
+      expect.objectContaining({
+        checkId: "core/doctor/workspace-status",
+        severity: "warning",
+        path: "tasks.flows",
+        target: "flow-123",
+        requirement: "taskflow-recovery",
+        message: expect.stringContaining("task-missing"),
+        fixHint: expect.stringContaining("openclaw tasks flow show flow-123"),
+      }),
+    ]);
   });
 
   it("surfaces active official managed plugin version drift", async () => {
@@ -372,7 +479,10 @@ describe("noteWorkspaceStatus", () => {
     }
   });
 
-  const makeSkill = (skillKey: string, fields: { eligible: boolean; platformIncompatible: boolean }) =>
+  const makeSkill = (
+    skillKey: string,
+    fields: { eligible: boolean; platformIncompatible: boolean },
+  ) =>
     ({
       skillKey,
       disabled: false,

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -3,6 +3,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HealthFinding } from "../flows/health-checks.js";
 import {
   resolvePluginVersionDriftUpdateCommand,
   type PluginVersionDriftReport,
@@ -19,37 +20,50 @@ type NoteWorkspaceStatusOptions = {
   pluginVersionDrift?: PluginVersionDriftReport;
 };
 
-function noteFlowRecoveryHints() {
-  const suspicious = listTaskFlowRecords().flatMap((flow) => {
+const WORKSPACE_STATUS_CHECK_ID = "core/doctor/workspace-status";
+
+type TaskFlowRecoveryFinding = {
+  flowId: string;
+  message: string;
+};
+
+function collectTaskFlowRecoveryFindings(): TaskFlowRecoveryFinding[] {
+  return listTaskFlowRecords().flatMap((flow) => {
     const tasks = listTasksForFlowId(flow.flowId);
-    const findings: string[] = [];
+    const findings: TaskFlowRecoveryFinding[] = [];
     if (
       flow.syncMode === "managed" &&
       flow.status === "running" &&
       tasks.length === 0 &&
       flow.waitJson === undefined
     ) {
-      findings.push(
-        `${flow.flowId}: running managed TaskFlow has no linked tasks or wait state; inspect or cancel it manually.`,
-      );
+      findings.push({
+        flowId: flow.flowId,
+        message: `${flow.flowId}: running managed TaskFlow has no linked tasks or wait state; inspect or cancel it manually.`,
+      });
     }
     if (
       flow.status === "blocked" &&
       flow.blockedTaskId &&
       !tasks.some((task) => task.taskId === flow.blockedTaskId)
     ) {
-      findings.push(
-        `${flow.flowId}: blocked TaskFlow points at missing task ${flow.blockedTaskId}; inspect before retrying.`,
-      );
+      findings.push({
+        flowId: flow.flowId,
+        message: `${flow.flowId}: blocked TaskFlow points at missing task ${flow.blockedTaskId}; inspect before retrying.`,
+      });
     }
     return findings;
   });
+}
+
+function noteFlowRecoveryHints() {
+  const suspicious = collectTaskFlowRecoveryFindings();
   if (suspicious.length === 0) {
     return;
   }
   note(
     [
-      ...suspicious.slice(0, 5),
+      ...suspicious.slice(0, 5).map((finding) => finding.message),
       suspicious.length > 5 ? `...and ${suspicious.length - 5} more.` : null,
       `Inspect: ${formatCliCommand("openclaw tasks flow show <flow-id>")}`,
       `Cancel: ${formatCliCommand("openclaw tasks flow cancel <flow-id>")}`,
@@ -58,6 +72,89 @@ function noteFlowRecoveryHints() {
       .join("\n"),
     "TaskFlow recovery",
   );
+}
+
+function pluginVersionDriftToHealthFindings(
+  drift: PluginVersionDriftReport | undefined,
+): HealthFinding[] {
+  if (!drift || drift.drifts.length === 0) {
+    return [];
+  }
+  return drift.drifts.map((entry) => {
+    const updateCommand = formatCliCommand(resolvePluginVersionDriftUpdateCommand(entry));
+    return {
+      checkId: WORKSPACE_STATUS_CHECK_ID,
+      severity: "warning",
+      message: `Plugin ${entry.pluginId} is ${entry.installedVersion}, but the Gateway is ${drift.gatewayVersion}.`,
+      path: `plugins.entries.${entry.pluginId}`,
+      target: entry.pluginId,
+      requirement: "plugin-version-drift",
+      fixHint: `${updateCommand} && ${formatCliCommand("openclaw gateway restart")}`,
+    };
+  });
+}
+
+function pluginCompatibilityWarningToHealthFinding(message: string): HealthFinding {
+  return {
+    checkId: WORKSPACE_STATUS_CHECK_ID,
+    severity: "warning",
+    message,
+    path: "plugins",
+    requirement: "plugin-compatibility",
+    fixHint: "Update or replace the plugin so it no longer depends on legacy compatibility paths.",
+  };
+}
+
+function pluginDiagnosticToHealthFinding(
+  diagnostic: ReturnType<typeof buildPluginRegistrySnapshotReport>["diagnostics"][number],
+): HealthFinding {
+  return {
+    checkId: WORKSPACE_STATUS_CHECK_ID,
+    severity: diagnostic.level === "error" ? "error" : "warning",
+    message: diagnostic.message,
+    ...(diagnostic.pluginId ? { path: `plugins.entries.${diagnostic.pluginId}` } : {}),
+    ...(diagnostic.pluginId ? { target: diagnostic.pluginId } : {}),
+    ...(diagnostic.source ? { source: diagnostic.source } : {}),
+    ...(diagnostic.code ? { requirement: diagnostic.code } : { requirement: "plugin-diagnostic" }),
+  };
+}
+
+function taskFlowRecoveryToHealthFinding(finding: TaskFlowRecoveryFinding): HealthFinding {
+  return {
+    checkId: WORKSPACE_STATUS_CHECK_ID,
+    severity: "warning",
+    message: finding.message,
+    path: "tasks.flows",
+    target: finding.flowId,
+    requirement: "taskflow-recovery",
+    fixHint: [
+      formatCliCommand(`openclaw tasks flow show ${finding.flowId}`),
+      formatCliCommand(`openclaw tasks flow cancel ${finding.flowId}`),
+    ].join(" or "),
+  };
+}
+
+export function collectWorkspaceStatusHealthFindings(
+  cfg: OpenClawConfig,
+  options: NoteWorkspaceStatusOptions = {},
+): HealthFinding[] {
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+  const pluginRegistry = buildPluginRegistrySnapshotReport({
+    config: cfg,
+    workspaceDir,
+  });
+  const compatibilityWarnings = buildPluginCompatibilityWarnings({
+    config: cfg,
+    workspaceDir,
+    report: pluginRegistry,
+  });
+
+  return [
+    ...pluginVersionDriftToHealthFindings(options.pluginVersionDrift),
+    ...compatibilityWarnings.map(pluginCompatibilityWarningToHealthFinding),
+    ...pluginRegistry.diagnostics.map(pluginDiagnosticToHealthFinding),
+    ...collectTaskFlowRecoveryFindings().map(taskFlowRecoveryToHealthFinding),
+  ];
 }
 
 function notePluginVersionDrift(drift: PluginVersionDriftReport | undefined) {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -75,6 +75,7 @@ const mocks = vi.hoisted(() => ({
   }),
   gatherDaemonStatus: vi.fn(),
   noteWorkspaceStatus: vi.fn(),
+  collectWorkspaceStatusHealthFindings: vi.fn().mockResolvedValue([]),
   applyWizardMetadata: vi.fn((cfg: unknown) => cfg),
   logConfigUpdated: vi.fn(),
   isRecord: vi.fn(
@@ -268,6 +269,7 @@ vi.mock("../cli/daemon-cli/status.gather.js", () => ({
 
 vi.mock("../commands/doctor-workspace-status.js", () => ({
   noteWorkspaceStatus: mocks.noteWorkspaceStatus,
+  collectWorkspaceStatusHealthFindings: mocks.collectWorkspaceStatusHealthFindings,
 }));
 
 vi.mock("../commands/onboard-helpers.js", () => ({
@@ -440,6 +442,8 @@ describe("doctor health contributions", () => {
     mocks.gatherDaemonStatus.mockReset();
     mocks.gatherDaemonStatus.mockResolvedValue({});
     mocks.noteWorkspaceStatus.mockReset();
+    mocks.collectWorkspaceStatusHealthFindings.mockReset();
+    mocks.collectWorkspaceStatusHealthFindings.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -665,6 +669,42 @@ describe("doctor health contributions", () => {
 
     expect(ids.indexOf("doctor:skills")).toBeGreaterThan(-1);
     expect(ids.indexOf("doctor:skills")).toBeLessThan(ids.indexOf("doctor:write-config"));
+  });
+
+  it("keeps workspace status opt-in for structured lint selection", async () => {
+    const contribution = requireDoctorContribution("doctor:workspace-status");
+    const check = contribution.healthChecks[0] as HealthCheck & { defaultEnabled?: boolean };
+    expect(contribution.healthCheckIds).toEqual(["core/doctor/workspace-status"]);
+    expect(check.defaultEnabled).toBe(false);
+
+    mocks.collectWorkspaceStatusHealthFindings.mockResolvedValueOnce([
+      {
+        checkId: "core/doctor/workspace-status",
+        severity: "warning",
+        message: "Plugin codex is stale.",
+        path: "plugins.entries.codex",
+      },
+    ]);
+    const ctx = {
+      cfg: { plugins: { entries: { codex: { enabled: true } } } },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+
+    await expect(runDoctorLintChecks(ctx, { checks: [check] })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    expect(mocks.collectWorkspaceStatusHealthFindings).not.toHaveBeenCalled();
+
+    await expect(
+      runDoctorLintChecks(ctx, { checks: [check], onlyIds: ["core/doctor/workspace-status"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [expect.objectContaining({ checkId: "core/doctor/workspace-status" })],
+    });
+    expect(mocks.collectWorkspaceStatusHealthFindings).toHaveBeenCalledWith(ctx.cfg);
   });
 
   it("passes daemon-context plugin drift into the workspace status note", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -677,6 +677,21 @@ describe("doctor health contributions", () => {
     expect(contribution.healthCheckIds).toEqual(["core/doctor/workspace-status"]);
     expect(check.defaultEnabled).toBe(false);
 
+    const pluginVersionDrift = {
+      gatewayVersion: "2026.6.1",
+      drifts: [
+        {
+          pluginId: "codex",
+          installedVersion: "2026.5.30-beta.1",
+          gatewayVersion: "2026.6.1",
+          source: "npm" as const,
+        },
+      ],
+    };
+    mocks.gatherDaemonStatus.mockResolvedValueOnce({
+      gateway: { version: "2026.6.1" },
+      pluginVersionDrift,
+    });
     mocks.collectWorkspaceStatusHealthFindings.mockResolvedValueOnce([
       {
         checkId: "core/doctor/workspace-status",
@@ -704,7 +719,9 @@ describe("doctor health contributions", () => {
       checksSkipped: 0,
       findings: [expect.objectContaining({ checkId: "core/doctor/workspace-status" })],
     });
-    expect(mocks.collectWorkspaceStatusHealthFindings).toHaveBeenCalledWith(ctx.cfg);
+    expect(mocks.collectWorkspaceStatusHealthFindings).toHaveBeenCalledWith(ctx.cfg, {
+      pluginVersionDrift,
+    });
   });
 
   it("passes daemon-context plugin drift into the workspace status note", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -703,6 +703,7 @@ describe("doctor health contributions", () => {
     const ctx = {
       cfg: { plugins: { entries: { codex: { enabled: true } } } },
       mode: "lint",
+      allowExecSecretRefs: true,
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
     } as const;
 
@@ -721,6 +722,16 @@ describe("doctor health contributions", () => {
     });
     expect(mocks.collectWorkspaceStatusHealthFindings).toHaveBeenCalledWith(ctx.cfg, {
       pluginVersionDrift,
+    });
+    expect(mocks.gatherDaemonStatus).toHaveBeenCalledWith({
+      rpc: {
+        timeout: "3000",
+        json: true,
+      },
+      probe: true,
+      requireRpc: false,
+      deep: false,
+      allowExecSecretRefs: true,
     });
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1679,6 +1679,16 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:workspace-status",
       label: "Workspace status",
+      healthChecks: {
+        id: "core/doctor/workspace-status",
+        description: "Workspace plugin/status diagnostics are exposed as findings.",
+        defaultEnabled: false,
+        async detect(ctx) {
+          const { collectWorkspaceStatusHealthFindings } =
+            await import("../commands/doctor-workspace-status.js");
+          return collectWorkspaceStatusHealthFindings(ctx.cfg);
+        },
+      },
       run: runWorkspaceStatusHealth,
     }),
     createDoctorHealthContribution({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1698,7 +1698,10 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
             await import("../commands/doctor-workspace-status.js");
           const pluginVersionDrift = await collectWorkspaceStatusPluginVersionDrift({
             cfg: ctx.cfg,
-            options: { nonInteractive: true },
+            options: {
+              nonInteractive: true,
+              allowExec: ctx.allowExecSecretRefs === true,
+            },
           });
           return collectWorkspaceStatusHealthFindings(ctx.cfg, { pluginVersionDrift });
         },

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -16,6 +16,8 @@ import type { HealthCheck, HealthFinding } from "./health-checks.js";
 import type { FlowContribution } from "./types.js";
 
 type DoctorFlowMode = "local" | "remote";
+type PluginVersionDriftReport =
+  import("../plugins/plugin-version-drift.js").PluginVersionDriftReport;
 
 type DoctorConfigResult = {
   cfg: OpenClawConfig;
@@ -917,33 +919,41 @@ async function hasActiveGatewayExecCredential(
   });
 }
 
-async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<void> {
-  let pluginVersionDrift:
-    | import("../plugins/plugin-version-drift.js").PluginVersionDriftReport
-    | undefined;
-  if (ctx.cfg.gateway?.mode !== "remote") {
+async function collectWorkspaceStatusPluginVersionDrift(params: {
+  cfg: OpenClawConfig;
+  options?: Pick<DoctorOptions, "allowExec" | "deep" | "nonInteractive">;
+}): Promise<PluginVersionDriftReport | undefined> {
+  if (params.cfg.gateway?.mode !== "remote") {
     try {
       const { gatherDaemonStatus } = await import("../cli/daemon-cli/status.gather.js");
-      const allowExecSecretRefs = ctx.options.allowExec === true;
+      const allowExecSecretRefs = params.options?.allowExec === true;
       const status = await gatherDaemonStatus({
         rpc: {
-          timeout: ctx.options.nonInteractive === true ? "3000" : "10000",
+          timeout: params.options?.nonInteractive === true ? "3000" : "10000",
           json: true,
         },
         probe: true,
         requireRpc: false,
-        deep: ctx.options.deep === true,
+        deep: params.options?.deep === true,
         allowExecSecretRefs,
       });
       const hasProbedGatewayVersion =
         typeof status.gateway?.version === "string" && status.gateway.version.trim() !== "";
       if (status.pluginVersionDrift && hasProbedGatewayVersion && !status.rpc?.authWarning) {
-        pluginVersionDrift = status.pluginVersionDrift;
+        return status.pluginVersionDrift;
       }
     } catch {
       // Best-effort diagnostic: doctor should keep running if daemon status is unavailable.
     }
   }
+  return undefined;
+}
+
+async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const pluginVersionDrift = await collectWorkspaceStatusPluginVersionDrift({
+    cfg: ctx.cfg,
+    options: ctx.options,
+  });
   const { noteWorkspaceStatus } = await import("../commands/doctor-workspace-status.js");
   noteWorkspaceStatus(ctx.cfg, { pluginVersionDrift });
 }
@@ -1686,7 +1696,11 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
         async detect(ctx) {
           const { collectWorkspaceStatusHealthFindings } =
             await import("../commands/doctor-workspace-status.js");
-          return collectWorkspaceStatusHealthFindings(ctx.cfg);
+          const pluginVersionDrift = await collectWorkspaceStatusPluginVersionDrift({
+            cfg: ctx.cfg,
+            options: { nonInteractive: true },
+          });
+          return collectWorkspaceStatusHealthFindings(ctx.cfg, { pluginVersionDrift });
         },
       },
       run: runWorkspaceStatusHealth,


### PR DESCRIPTION
## Summary
- Adds `core/doctor/workspace-status` as a structured Doctor lint finding source.
- Exposes existing workspace-status diagnostics for plugin version drift, plugin compatibility warnings, plugin diagnostics, and TaskFlow recovery hints.
- Keeps the check opt-in/default-off with `defaultEnabled: false`, so plain `doctor --lint` behavior is unchanged.
- Leaves legacy `openclaw doctor` workspace status notes and all real repair behavior unchanged.
- Wires structured lint to the same gated daemon-context `pluginVersionDrift` source used by legacy Doctor output.

## Contract / Safety
- No plugin SDK/public contract changes.
- No config schema, plugin manifest, or persisted data-model changes.
- No new repair path; this is read-only structured detection only.
- Default `openclaw doctor --lint` does not run `core/doctor/workspace-status`; use `--only core/doctor/workspace-status` or `--all` to include it.

## Real behavior proof

Behavior or issue addressed:
Default-disabled structured Doctor lint for workspace status, including selected-lint plugin/status findings and the daemon-context plugin-version-drift path ClawSweeper flagged.

Real environment tested:
WSL2 Ubuntu 24.04 source checkout at `3221889fa968d8a8a82866d850356d01bd6bc59e`. Positive plugin-version-drift proof used isolated `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH`, a persisted official `brave` npm install record at `2026.5.3`, and a lightweight local Gateway WebSocket hello reporting server version `2026.5.4`. The proof runs the real `runDoctorLintCli` JSON entrypoint for `openclaw doctor --lint --json --only core/doctor/workspace-status` without a full packaged build.

Exact steps or command run after this patch:
1. Rebased branch onto `origin/main` at `816038e97a5df3df52931ffcd40f7d7e3ff0517c`.
2. Ran isolated positive selected-lint proof for `openclaw doctor --lint --json --only core/doctor/workspace-status`.
3. Ran focused tests and changed-file validation listed below.

Evidence after fix:

```json
{"ok":false,"checksRun":1,"checksSkipped":32,"findings":[{"checkId":"core/doctor/workspace-status","severity":"warning","message":"Plugin brave is 2026.5.3, but the Gateway is 2026.5.4.","path":"plugins.entries.brave","target":"brave","requirement":"plugin-version-drift","fixHint":"openclaw plugins update brave && openclaw gateway restart"}]}
```

Redacted proof summary:

```json
{
  "stateDir": "<tmp-state>",
  "configPath": "<tmp-state>/openclaw.json",
  "command": "openclaw doctor --lint --json --only core/doctor/workspace-status",
  "exitCode": 1,
  "checksRun": 1,
  "checksSkipped": 32,
  "finding": {
    "checkId": "core/doctor/workspace-status",
    "severity": "warning",
    "message": "Plugin brave is 2026.5.3, but the Gateway is 2026.5.4.",
    "path": "plugins.entries.brave",
    "target": "brave",
    "requirement": "plugin-version-drift",
    "fixHint": "openclaw plugins update brave && openclaw gateway restart"
  }
}
```

Observed result after fix:
The selected structured lint check emits the daemon-context `pluginVersionDrift` finding when the same gated legacy conditions are met. Default lint still skips `core/doctor/workspace-status`, remote Gateway mode still avoids local daemon drift probes, and auth-warning/fallback-version cases still suppress drift.

What was not tested:
Packaged installer/runtime proof. The proof used the source lint CLI entrypoint because this checkout is an unbuilt source tree.

## Validation
- `node scripts/run-vitest.mjs run src/commands/doctor-workspace-status.test.ts src/flows/doctor-health-contributions.test.ts src/commands/doctor-lint.test.ts src/cli/daemon-cli/status.gather.test.ts --reporter=verbose` (3 Vitest shards, 111 passed, 1 skipped)
- `./node_modules/.bin/oxfmt --check src/commands/doctor-workspace-status.test.ts src/commands/doctor-workspace-status.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-contributions.ts`
- `./node_modules/.bin/oxlint src/commands/doctor-workspace-status.test.ts src/commands/doctor-workspace-status.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-contributions.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm plugin-sdk:check-exports`
- `git diff --check origin/main...HEAD`

## Not Tested
- Packaged installer/runtime proof.
