### PR TITLE
fix(exec): keep framework verb out of backtick-wrapped failure message (#97319)

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -781,7 +781,7 @@ describe("buildEmbeddedRunPayloads", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ `show matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt (workspace)` failed",
+      text: "⚠️ 🛠️ `matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt (workspace)` failed",
       isError: true,
     });
   });

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -41,6 +41,7 @@ import {
   extractAssistantThinking,
   extractAssistantVisibleText,
 } from "../../embedded-agent-utils.js";
+import { stripLeadingExecDisplayVerb } from "../../tool-display-exec.js";
 import { isExecLikeToolName, type ToolErrorSummary } from "../../tool-error-summary.js";
 import { isLikelyMutatingToolName } from "../../tool-mutation.js";
 
@@ -550,9 +551,18 @@ export function buildEmbeddedRunPayloads(params: {
     // Surface mutating failures unless the assistant explicitly acknowledged the failed action.
     // Otherwise, keep the previous behavior and only surface non-recoverable failures when no reply exists.
     if (warningPolicy.showWarning) {
+      // For exec/bash failures, strip the leading framework verb from the meta so the
+      // backtick-wrapped text is exactly what was run, not `run <command>`. Otherwise the
+      // verb adjacent to the command in the rendered warning is indistinguishable from an
+      // agent-typed `run <command>` invocation (issue #97319).
+      const meta = params.lastToolError.meta;
+      const displayMeta =
+        isExecLikeToolName(params.lastToolError.toolName) && meta
+          ? stripLeadingExecDisplayVerb(meta)
+          : meta;
       const toolSummary = formatToolAggregate(
         params.lastToolError.toolName,
-        params.lastToolError.meta ? [params.lastToolError.meta] : undefined,
+        displayMeta ? [displayMeta] : undefined,
         { markdown: useMarkdown },
       );
       const errorSuffix =

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -287,6 +287,55 @@ function summarizeKnownExec(words: string[]): string {
   return /^[A-Za-z0-9._/-]+$/.test(arg) ? `run ${bin} ${arg}` : `run ${bin}`;
 }
 
+// Known display verbs that summarizeKnownExec emits as the first token of an exec label.
+// Used to split the framework action from the literal command subject so progress and
+// failure surfaces do not backtick-wrap the verb together with the command (issue #97319).
+const EXEC_DISPLAY_VERBS: ReadonlySet<string> = new Set([
+  "run",
+  "check",
+  "view",
+  "show",
+  "list",
+  "switch",
+  "create",
+  "pull",
+  "push",
+  "fetch",
+  "merge",
+  "rebase",
+  "stage",
+  "restore",
+  "reset",
+  "stash",
+  "find",
+  "search",
+  "print",
+  "copy",
+  "move",
+  "remove",
+  "install",
+  "start",
+]);
+
+/**
+ * Strips a leading exec display verb (e.g. "run" in "run python3 /path") so the
+ * framework action label is not backtick-wrapped together with the literal command.
+ *
+ * Returns the original meta when no known exec display verb prefix is present, so
+ * raw shell command text passes through unchanged.
+ */
+export function stripLeadingExecDisplayVerb(meta: string): string {
+  const match = meta.match(/^(\S+)\s+(\S.*)$/);
+  if (!match) {
+    return meta;
+  }
+  const verb = match[1];
+  if (!EXEC_DISPLAY_VERBS.has(verb)) {
+    return meta;
+  }
+  return match[2];
+}
+
 function summarizePipeline(stage: string): string {
   const pipeline = splitTopLevelPipes(stage);
   if (pipeline.length > 1) {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { resolveToolSearchCodeDisplayTarget } from "./tool-display-common.js";
-import { resolveExecDetail } from "./tool-display-exec.js";
+import { resolveExecDetail, stripLeadingExecDisplayVerb } from "./tool-display-exec.js";
 import { formatToolDetail, formatToolSummary, resolveToolDisplay } from "./tool-display.js";
 
 describe("tool display details", () => {
@@ -583,6 +583,34 @@ describe("compactRawCommand middle truncation", () => {
     expect(result).toContain("/opt/custom/bin/run");
     expect(result).toContain("…");
     expect(result).toMatch(/b{4}$/);
+  });
+});
+
+describe("stripLeadingExecDisplayVerb", () => {
+  it("strips a known exec display verb so it stays outside backtick-wrapped command text", () => {
+    expect(stripLeadingExecDisplayVerb("run python3 /path/to/script.py")).toBe(
+      "python3 /path/to/script.py",
+    );
+    expect(stripLeadingExecDisplayVerb("check git status")).toBe("git status");
+    expect(stripLeadingExecDisplayVerb("show some-file.txt (workspace)")).toBe(
+      "some-file.txt (workspace)",
+    );
+    expect(stripLeadingExecDisplayVerb('find files named "x" in /path')).toBe(
+      'files named "x" in /path',
+    );
+  });
+
+  it("returns the meta unchanged when the first token is not a known exec display verb", () => {
+    // `cd` is a real shell builtin, not a summary verb, so a raw `cd ~/dir && ls` meta survives.
+    expect(stripLeadingExecDisplayVerb("cd ~/dir && ls")).toBe("cd ~/dir && ls");
+    expect(stripLeadingExecDisplayVerb("git status")).toBe("git status");
+    expect(stripLeadingExecDisplayVerb("npm install")).toBe("npm install");
+  });
+
+  it("returns the meta unchanged for single-token or empty input", () => {
+    expect(stripLeadingExecDisplayVerb("run")).toBe("run");
+    expect(stripLeadingExecDisplayVerb("")).toBe("");
+    expect(stripLeadingExecDisplayVerb("   ")).toBe("   ");
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

When an `exec`/`bash` tool call fails, the chat and cron run history currently render the failure as:

```
⚠️ 🛠️ `run python3 /path/to/script.py` failed
```

The framework display verb `run` sits **inside** the backticks, adjacent to the actual command. Users debugging failures read this as "the agent typed `run python3 /path`" — the bug reporter burned ~45 minutes concluding the agent was prepending `run` to its commands when in fact the cause was an `exec` exit-code failure (issue #97319).

## Why This Change Was Made

`formatToolAggregate` backtick-wraps the entire meta string for exec/bash tools. The meta string is the display label produced by `summarizeKnownExec` (`src/agents/tool-display-exec.ts`), which **always** starts with a known action verb (`run`, `check`, `view`, `show`, `list`, …). The wrapping has no concept of "this leading word is a framework label, not part of the literal command".

This PR adds `stripLeadingExecDisplayVerb` and uses it in the failure-warning builder (`payloads.ts`) so only the **subject** of the action is backtick-wrapped:

| Before                                    | After                                   |
| ----------------------------------------- | --------------------------------------- |
| `⚠️ 🛠️ \`run python3 /path\` failed`        | `⚠️ 🛠️ \`python3 /path\` failed`           |
| `⚠️ 🛠️ \`show some-file (workspace)\` failed` | `⚠️ 🛠️ \`some-file (workspace)\` failed`   |

Scope is the failure-warning path only. Tool progress, streaming, and other `formatToolAggregate` callers are unchanged.

## User Impact

- Chat tool-failure cards and cron `lastError` lines now backtick-wrap exactly what was run. The framework action verb no longer leaks into the literal command.
- Non-exec tools (filesystem, web_search, etc.) are unchanged.
- Raw shell commands whose first token is not in the known exec-display verb set (e.g. `cd ~/dir && ls`, `git status`, `npm install`) pass through unchanged — the strip helper only fires on labels emitted by `summarizeKnownExec`.

## Evidence

- New unit tests: `src/agents/tool-display.test.ts` → `stripLeadingExecDisplayVerb` covers (a) known verbs (`run`, `check`, `show`, `find`), (b) non-verb first tokens (`cd`, `git`, `npm`), (c) single-token / empty input.
- Existing regression test updated: `src/agents/embedded-agent-runner/run/payloads.errors.test.ts` — the markdown mutation-warning case now expects the verb-stripped shape.
- Local: `npx vitest run src/agents/tool-display.test.ts` → 45/45 pass. `npx vitest run src/agents/embedded-agent-runner/run/payloads.errors.test.ts` → 54/54 pass. `npx vitest run src/auto-reply/tool-meta.test.ts src/cron/isolated-agent/` → 406/406 pass.

Closes #97319.