### PR TITLE
fix(signal): sanitize internal tool-trace lines from outbound text

### DIFF
--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -22,6 +22,7 @@ import {
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { resolveSignalAccount, type ResolvedSignalAccount } from "./accounts.js";
 import {
   shouldSuppressLocalSignalExecApprovalPrompt,
@@ -461,6 +462,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
         chunker: chunkText,
         chunkerMode: "text",
         textChunkLimit: 4000,
+        sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
         shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload, hint }) =>
           shouldSuppressLocalSignalExecApprovalPrompt({
             cfg,

--- a/extensions/signal/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/signal/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,19 @@
+// Signal outbound must strip assistant internal tool-trace scaffolding, matching
+// the sibling channel fixes tracked under #90684 (Telegram #95774 / Google Chat
+// #95084 / IRC #97214). Signal is plaintext-only, so leaked traces are verbatim.
+import { describe, expect, it } from "vitest";
+import { signalPlugin } from "./channel.js";
+
+describe("signal outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(signalPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(signalPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+});


### PR DESCRIPTION
Related: #90684

## What Problem This Solves

Fixes an issue where Signal users would see OpenClaw's internal tool-execution traces leak into delivered messages. When a tool run fails, the runtime injects a status banner such as `` ⚠️ 🛠️ `…(agent)` failed `` into the assistant's outbound text. Signal's outbound adapter defined no `sanitizeText` hook, so the only sanitization that ran was core's central `stripInternalRuntimeScaffoldingFromPayload` — which removes runtime-injected context wrappers (`<system-reminder>`, etc.) but not these tool-trace lines. The banner was therefore delivered verbatim.

## Why This Change Was Made

The merged Telegram (PR #95774), Google Chat (PR #95084), and IRC (PR #97214) changes already wrap their outbound text with `sanitizeAssistantVisibleText` — the existing shared assistant-visible sanitizer that removes tool-trace banners and other internal scaffolding (reasoning tags, tool-call XML) while preserving ordinary prose and formatting. Signal was a missed sibling of that same fix, tracked under #90684. This change adds the same hook to the Signal outbound adapter (one import plus `sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text)`), reusing the existing SDK sanitizer rather than adding a helper. The wrap is plain `sanitizeAssistantVisibleText` (not the IRC-style `sanitizeForPlainText` wrap) so Signal's existing markdown rendering is untouched. The change is limited to the Signal adapter; other channels are tracked separately under #90684.

## User Impact

Signal users no longer see internal tool-trace banners — or the other assistant-internal scaffolding the shared sanitizer already removes (reasoning tags, tool-call XML) — in delivered messages. Ordinary assistant prose is unaffected.

## Evidence

**Focused unit tests** — `extensions/signal/src/outbound-tool-trace-sanitize.test.ts` adds 2 cases (tool-trace banner stripped; ordinary prose preserved):

```
$ node scripts/run-vitest.mjs extensions/signal/src/outbound-tool-trace-sanitize.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**Real-behavior proof** — the patched `signalPlugin.outbound.sanitizeText`, run directly against the real plugin code path. No live Signal roundtrip is included: this PR only wires the existing outbound sanitizer hook, and the command below exercises that changed code path directly:

```
$ node --import tsx -e '
import { signalPlugin } from "./extensions/signal/src/channel.ts";
const trace = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
const f = signalPlugin.outbound.sanitizeText;
console.log("after :", JSON.stringify(f({ text: trace })));
console.log("prose :", JSON.stringify(f({ text: "The pipeline has 3 open deals." })));
'
after : "Done."
prose : "The pipeline has 3 open deals."
```

Before this change Signal defined no `sanitizeText` hook, so the banner reached users verbatim.
