### PR TITLE
fix(telegram): verify provider topic delivery

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -25,6 +25,7 @@ import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import { splitTelegramReasoningText } from "./reasoning-lane-coordinator.js";
 import { buildTelegramRichMarkdown, TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
+import { reportTelegramProviderDelivery } from "./send-outbound.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 
 const draftLogger = createSubsystemLogger("telegram/draft-stream");
@@ -146,6 +147,18 @@ export function createTelegramDraftController(params: {
               text: page.textSnapshot,
             });
           },
+          ...(params.threadSpec.id !== undefined
+            ? {
+                validateProviderMessage: async (message) => {
+                  await reportTelegramProviderDelivery({
+                    message,
+                    messageId: message.message_id,
+                    fallbackChatId: params.chatId,
+                    successfulSendThread: params.threadSpec,
+                  });
+                },
+              }
+            : {}),
           onProviderMessage: async (message) => {
             recordSentMessage(params.chatId, message.message_id, params.cfg);
             await (

--- a/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
@@ -1,3 +1,4 @@
+import type { Message } from "grammy/types";
 import { expect, it, vi } from "vitest";
 import {
   describeTelegramDispatch,
@@ -213,14 +214,16 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
       const streamParams = mockCallArg(createTelegramDraftStream) as Parameters<
         NonNullable<TelegramBotDeps["createTelegramDraftStream"]>
       >[0];
-      await streamParams.onProviderMessage?.({
+      const providerMessage = {
         chat: { id: 123, type: "private", first_name: "Keshav" },
         message_thread_id: 777,
         message_id: 1497,
         date: 1_779_425_461,
         text: "Initial streamed text",
         from: { id: 999, is_bot: true, first_name: "Telegram Bot Name" },
-      });
+      } satisfies Message;
+      await streamParams.validateProviderMessage?.(providerMessage);
+      await streamParams.onProviderMessage?.(providerMessage);
       await dispatcherOptions.deliver(
         { text: "Done already: timeoutSeconds is now 7200s." },
         { kind: "final" },

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -2,10 +2,6 @@
 import { type Bot, GrammyError } from "grammy";
 import type { Message } from "grammy/types";
 import {
-  createChannelPartialDeliveryError,
-  isChannelPartialDeliveryError,
-} from "openclaw/plugin-sdk/channel-inbound";
-import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForDelivery,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -33,6 +29,7 @@ import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { resolveTelegramInlineButtons, type TelegramInlineButtons } from "../button-types.js";
+import { mergeTelegramPartialDeliveryError } from "../chunk-delivery.js";
 import {
   markdownToTelegramChunks,
   markdownToTelegramHtml,
@@ -61,6 +58,7 @@ import {
 } from "../rich-message.js";
 import { isTelegramEmptyContentError } from "../rich-plain-fallback.js";
 import { isTelegramPhotoLimitError } from "../send-error-predicates.js";
+import { reportTelegramProviderDelivery } from "../send-outbound.js";
 import { buildInlineKeyboard, reactMessageTelegram } from "../send.js";
 import { recordSentMessage } from "../sent-message-cache.js";
 import { resolveTelegramTargetChatType } from "../targets.js";
@@ -404,6 +402,21 @@ async function deliverMediaReply(params: {
         }),
     });
     const message = delivery.result;
+    if (params.thread?.id !== undefined) {
+      try {
+        await reportTelegramProviderDelivery({
+          message,
+          messageId: message.message_id,
+          fallbackChatId: params.chatId,
+          successfulSendThread: params.thread,
+        });
+      } catch (error) {
+        throw mergeTelegramPartialDeliveryError(error, {
+          messageIds: deliveredMediaMessageIds,
+          visibleReplySent: true,
+        });
+      }
+    }
     firstDeliveredMessageId ??= message.message_id;
     firstDeliveredCaption ??= delivery.deliveredCaption;
     if (delivery.captionRemoved) {
@@ -415,11 +428,8 @@ async function deliverMediaReply(params: {
     markDelivered(params.progress);
   };
   const throwMediaPartial = (error: unknown): never => {
-    const textMessageIds = isChannelPartialDeliveryError(error)
-      ? (error.deliveryResult.messageIds ?? [])
-      : [];
-    throw createChannelPartialDeliveryError(error, {
-      messageIds: [...new Set([...deliveredMediaMessageIds, ...textMessageIds])],
+    throw mergeTelegramPartialDeliveryError(error, {
+      messageIds: deliveredMediaMessageIds,
       visibleReplySent: true,
     });
   };

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -164,8 +164,9 @@ export async function sendTelegramText(
       runtime.log?.("telegram sendRichMessage rendered empty; falling back to plain text");
       return await sendPlainFallback();
     }
+    let res: Message;
     try {
-      const res = await sendTelegramWithThreadFallback({
+      res = await sendTelegramWithThreadFallback({
         operation: "sendRichMessage",
         runtime,
         requestParams: toTelegramRichMessageContextParams(baseParams),
@@ -178,9 +179,6 @@ export async function sendTelegramText(
             ...effectiveParams,
           }),
       });
-      const messageId = await acceptProviderMessage(res);
-      runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${messageId}`);
-      return messageId;
     } catch (err) {
       const fallbackPlan = buildTelegramPlainFallbackPlan({
         plainText: richPlan.plainText || fallbackText,
@@ -193,6 +191,9 @@ export async function sendTelegramText(
       }
       return await sendPlainFallback(fallbackPlan.plainText);
     }
+    const messageId = await acceptProviderMessage(res);
+    runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${messageId}`);
+    return messageId;
   }
 
   // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -1,5 +1,6 @@
 // Telegram plugin module implements delivery.send behavior.
 import type { Bot } from "grammy";
+import type { Message } from "grammy/types";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { createChannelApiRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -29,6 +30,7 @@ import {
   warnTelegramRichBlocksDegradations,
 } from "../rich-plain-fallback.js";
 import { withTelegramNativeQuoteFallback } from "../send-context.js";
+import { reportTelegramProviderDelivery } from "../send-outbound.js";
 import { buildInlineKeyboard } from "../send.js";
 import type { TelegramThreadSpec } from "./helpers.js";
 
@@ -109,6 +111,17 @@ export async function sendTelegramText(
   const htmlText = textMode === "html" ? text : markdownToTelegramHtml(text);
   const fallbackText = opts?.plainText ?? text;
   const hasFallbackText = fallbackText.trim().length > 0;
+  const acceptProviderMessage = async (message: Message) => {
+    if (opts?.thread?.id !== undefined) {
+      await reportTelegramProviderDelivery({
+        message,
+        messageId: message.message_id,
+        fallbackChatId: chatId,
+        successfulSendThread: opts.thread,
+      });
+    }
+    return message.message_id;
+  };
   const sendPlainFallback = async (plainText: string = fallbackText) => {
     const res = await sendTelegramWithThreadFallback({
       operation: "sendMessage",
@@ -121,8 +134,9 @@ export async function sendTelegramText(
           ...effectiveParams,
         }),
     });
-    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id} (plain)`);
-    return res.message_id;
+    const messageId = await acceptProviderMessage(res);
+    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${messageId} (plain)`);
+    return messageId;
   };
 
   // Caller-authored HTML keeps legacy parse_mode HTML semantics (literal
@@ -164,8 +178,9 @@ export async function sendTelegramText(
             ...effectiveParams,
           }),
       });
-      runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
-      return res.message_id;
+      const messageId = await acceptProviderMessage(res);
+      runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${messageId}`);
+      return messageId;
     } catch (err) {
       const fallbackPlan = buildTelegramPlainFallbackPlan({
         plainText: richPlan.plainText || fallbackText,
@@ -203,8 +218,9 @@ export async function sendTelegramText(
           ...effectiveParams,
         }),
     });
-    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id}`);
-    return res.message_id;
+    const messageId = await acceptProviderMessage(res);
+    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${messageId}`);
+    return messageId;
   } catch (err) {
     const errText = formatErrorMessage(err);
     if (isTelegramHtmlParseError(err) || isTelegramEmptyContentError(err)) {

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1937,6 +1937,32 @@ describe("deliverReplies", () => {
     expect(mockCallArg(sendMessage, 0, 2)).not.toHaveProperty("parse_mode");
   });
 
+  it("does not plain-fallback after Telegram accepts a rich message in the wrong topic", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn();
+    const bot = createBot({ sendMessage });
+    const sendRichMessage = vi.fn().mockResolvedValue({
+      message_id: 31,
+      message_thread_id: 43,
+      chat: { id: "123", type: "supergroup" },
+    });
+    Object.assign(bot.api.raw, { sendRichMessage });
+
+    let observed: unknown;
+    try {
+      await sendTelegramText(bot, "123", "Rich reply", runtime, {
+        richMessages: true,
+        thread: { id: 42, scope: "forum" },
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    expect(sendRichMessage).toHaveBeenCalledOnce();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("falls back to plain text when a rich message is rejected for empty rich content", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -200,10 +200,11 @@ function firstSendText(mock: ReturnType<typeof vi.fn>) {
   return text as string;
 }
 
-function createSendMessageHarness(messageId = 4) {
+function createSendMessageHarness(messageId = 4, messageThreadId?: number) {
   const runtime = createRuntime();
   const sendMessage = vi.fn().mockResolvedValue({
     message_id: messageId,
+    ...(messageThreadId !== undefined ? { message_thread_id: messageThreadId } : {}),
     chat: { id: "123" },
   });
   const bot = createBot({ sendMessage });
@@ -917,7 +918,11 @@ describe("deliverReplies", () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sending");
 
     const runtime = createRuntime(false);
-    const sendMessage = vi.fn().mockResolvedValue({ message_id: 3, chat: { id: "123" } });
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 3,
+      message_thread_id: 42,
+      chat: { id: "123" },
+    });
     const bot = createBot({ sendMessage });
 
     await deliverWith({
@@ -1047,6 +1052,88 @@ describe("deliverReplies", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("stops a media follow-up when the provider returns the wrong topic", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 51,
+      message_thread_id: 43,
+      chat: { id: "123", type: "supergroup" },
+    });
+    const sendMessage = vi.fn();
+    const observer = vi.fn();
+    const promptContextSequence = createObservedPromptContextSequence(observer);
+    mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+    let observed: unknown;
+    try {
+      await deliverWith({
+        replies: [{ mediaUrl: "https://example.com/photo.jpg", text: "x".repeat(1025) }],
+        runtime,
+        bot: createBot({ sendPhoto, sendMessage }),
+        thread: { id: 42, scope: "forum" },
+        promptContextSequence,
+      });
+    } catch (error) {
+      observed = error;
+    }
+    await promptContextSequence.fail();
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(sendPhoto).toHaveBeenCalledOnce();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(observed.deliveryResult.messageIds).toEqual(["51"]);
+    expect(observed.deliveryResult.receipt?.threadId).toBe("43");
+    expect(observer).not.toHaveBeenCalled();
+    expect(recordSentMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps earlier media ids when a later item lands in the wrong topic", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi
+      .fn()
+      .mockResolvedValueOnce({
+        message_id: 61,
+        message_thread_id: 42,
+        chat: { id: "123", type: "supergroup" },
+      })
+      .mockResolvedValueOnce({
+        message_id: 62,
+        message_thread_id: 43,
+        chat: { id: "123", type: "supergroup" },
+      });
+    const observer = vi.fn();
+    const promptContextSequence = createObservedPromptContextSequence(observer);
+    mockMediaLoad("one.jpg", "image/jpeg", "one");
+    mockMediaLoad("two.jpg", "image/jpeg", "two");
+
+    let observed: unknown;
+    try {
+      await deliverWith({
+        replies: [{ mediaUrls: ["https://example.com/one.jpg", "https://example.com/two.jpg"] }],
+        runtime,
+        bot: createBot({ sendPhoto }),
+        thread: { id: 42, scope: "forum" },
+        promptContextSequence,
+      });
+    } catch (error) {
+      observed = error;
+    }
+    await promptContextSequence.fail();
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expect(observed.deliveryResult.messageIds).toEqual(["61", "62"]);
+    expect(observed.deliveryResult.receipt?.threadId).toBe("43");
+    expect(observer).toHaveBeenCalledOnce();
+    expect(recordSentMessage).toHaveBeenCalledOnce();
+  });
+
   it("does not mirror media follow-up text that Telegram rejects as empty", async () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
     const invisibleText = "\u200B".repeat(1025);
@@ -1164,6 +1251,7 @@ describe("deliverReplies", () => {
         );
       const sendDocument = vi.fn().mockResolvedValue({
         message_id: 9,
+        message_thread_id: 42,
         chat: { id: "123" },
       });
       const bot = createBot({ sendPhoto, sendDocument });
@@ -1391,7 +1479,7 @@ describe("deliverReplies", () => {
   });
 
   it("includes message_thread_id for DM topics", async () => {
-    const { runtime, sendMessage, bot } = createSendMessageHarness();
+    const { runtime, sendMessage, bot } = createSendMessageHarness(4, 42);
 
     await deliverWith({
       replies: [{ text: "Hello" }],
@@ -1440,6 +1528,85 @@ describe("deliverReplies", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(runtime.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops streamed text after the first provider topic mismatch", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 31,
+      message_thread_id: 43,
+      chat: { id: "123", type: "supergroup" },
+    });
+    const observer = vi.fn();
+    const promptContextSequence = createObservedPromptContextSequence(observer);
+
+    let observed: unknown;
+    try {
+      await deliverWith({
+        replies: [{ text: "chunk-one\n\nchunk-two" }],
+        runtime,
+        bot: createBot({ sendMessage }),
+        thread: { id: 42, scope: "forum" },
+        textLimit: 12,
+        promptContextSequence,
+      });
+    } catch (error) {
+      observed = error;
+    }
+    await promptContextSequence.fail();
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(observed.deliveryResult.messageIds).toEqual(["31"]);
+    expect(observed.deliveryResult.receipt?.threadId).toBe("43");
+    expect(observer).not.toHaveBeenCalled();
+    expect(recordSentMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps earlier streamed text ids when a later chunk lands in the wrong topic", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        message_id: 41,
+        message_thread_id: 42,
+        chat: { id: "123", type: "supergroup" },
+      })
+      .mockResolvedValueOnce({
+        message_id: 42,
+        message_thread_id: 43,
+        chat: { id: "123", type: "supergroup" },
+      });
+    const observer = vi.fn();
+    const promptContextSequence = createObservedPromptContextSequence(observer);
+
+    let observed: unknown;
+    try {
+      await deliverWith({
+        replies: [{ text: "chunk-one\n\nchunk-two\n\nchunk-three" }],
+        runtime,
+        bot: createBot({ sendMessage }),
+        thread: { id: 42, scope: "forum" },
+        textLimit: 12,
+        promptContextSequence,
+      });
+    } catch (error) {
+      observed = error;
+    }
+    await promptContextSequence.fail();
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(observed.deliveryResult.messageIds).toEqual(["41", "42"]);
+    expect(observed.deliveryResult.receipt?.threadId).toBe("43");
+    expect(observer).toHaveBeenCalledOnce();
+    expect(recordSentMessage).toHaveBeenCalledOnce();
   });
 
   it("retries final text sends for wrapped Undici connect timeouts", async () => {

--- a/extensions/telegram/src/chunk-delivery.ts
+++ b/extensions/telegram/src/chunk-delivery.ts
@@ -11,6 +11,28 @@ const TELEGRAM_TERMINAL_BAD_REQUEST_RE = /\b(?:chat|message thread) not found\b/
 
 type PartialDeliveryResult = Parameters<typeof createChannelPartialDeliveryError>[1];
 
+export function mergeTelegramPartialDeliveryError(
+  error: unknown,
+  priorDeliveryResult: PartialDeliveryResult,
+): ReturnType<typeof createChannelPartialDeliveryError> {
+  if (!isChannelPartialDeliveryError(error)) {
+    return createChannelPartialDeliveryError(error, priorDeliveryResult);
+  }
+  const currentDeliveryResult = error.deliveryResult;
+  const messageIds = [
+    ...new Set([
+      ...(priorDeliveryResult.messageIds ?? []),
+      ...(currentDeliveryResult.messageIds ?? []),
+    ]),
+  ];
+  return createChannelPartialDeliveryError(error, {
+    ...priorDeliveryResult,
+    ...currentDeliveryResult,
+    ...(messageIds.length > 0 ? { messageIds } : {}),
+    visibleReplySent: true,
+  });
+}
+
 function isTelegramSkippableChunkSendError(error: unknown): boolean {
   if (isSafeToRetrySendError(error)) {
     return true;
@@ -35,10 +57,10 @@ export function createTelegramChunkDeliveryTracker(params: {
   let firstSilentSkipError: unknown;
 
   const throwAfterAccepted = (error: unknown): never => {
-    if (acceptedCount === 0 || isChannelPartialDeliveryError(error)) {
+    if (acceptedCount === 0) {
       throw error;
     }
-    throw createChannelPartialDeliveryError(error, params.partialDeliveryResult());
+    throw mergeTelegramPartialDeliveryError(error, params.partialDeliveryResult());
   };
 
   const reject = (error: unknown): "rejected" | "silent-skip" => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -185,6 +185,24 @@ describe("createTelegramDraftStream", () => {
     );
   });
 
+  it("stops before another preview when accepted-message validation fails", async () => {
+    const api = createMockDraftApi(async () => ({ message_id: 101, message_thread_id: 7 }));
+    const validationError = new Error("provider topic mismatch");
+    const validateProviderMessage = vi.fn(async () => {
+      throw validationError;
+    });
+    const stream = createDraftStream(api, { validateProviderMessage });
+
+    stream.update("First preview");
+    await expect(stream.flush()).rejects.toBe(validationError);
+    stream.update("Second preview");
+    await expect(stream.flush()).rejects.toBe(validationError);
+
+    expect(validateProviderMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
   it("stops accepting updates before awaiting durable provider observation", async () => {
     let resolveObservation: (() => void) | undefined;
     const observation = new Promise<void>((resolve) => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -249,6 +249,8 @@ export function createTelegramDraftStream(params: {
   renderText?: (text: string) => TelegramDraftPreview;
   /** Called when a completed page remains visible after the stream advances. */
   onRetainedPage?: (page: RetainedTelegramDraftPage) => void;
+  /** Validates Telegram's response before another preview message can be sent. */
+  validateProviderMessage?: (message: Message) => Promise<void> | void;
   /** Called with Telegram's response after a new preview message becomes durable. */
   onProviderMessage?: (message: Message) => Promise<void> | void;
   log?: (message: string) => void;
@@ -313,6 +315,7 @@ export function createTelegramDraftStream(params: {
   let streamMessageId: number | undefined;
   let streamMessageSnapshot: TelegramDraftMessageSnapshot | undefined;
   let streamProviderMessage: Message | undefined;
+  let terminalDeliveryError: Error | undefined;
   const pendingProviderObservations = new Set<Promise<void>>();
   let streamVisibleSinceMs: number | undefined;
   let lastSentPreviewKey = "";
@@ -524,6 +527,24 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     retainReplyTarget(sendGeneration, normalizedMessageId);
+    try {
+      if (params.validateProviderMessage) {
+        await params.validateProviderMessage(sent.message);
+      }
+    } catch (error) {
+      terminalDeliveryError ??=
+        error instanceof Error ? error : new Error(formatErrorMessage(error));
+      streamState.stopped = true;
+      if (sendGeneration === generation) {
+        streamMessageId = normalizedMessageId;
+        streamMessageSnapshot = sent.snapshot;
+        streamProviderMessage = sent.message;
+        streamVisibleSinceMs = Date.now();
+      } else if (repositionedSendGenerations.delete(sendGeneration)) {
+        scheduleDetachedDelete(normalizedMessageId, Date.now(), REPOSITION_DELETE_DELAY_MS);
+      }
+      return false;
+    }
     if (sendGeneration !== generation) {
       const visibleSinceMs = Date.now();
       if (repositionedSendGenerations.delete(sendGeneration)) {
@@ -732,6 +753,19 @@ export function createTelegramDraftStream(params: {
     sendOrEditStreamMessage,
   });
 
+  const throwTerminalDeliveryError = () => {
+    if (terminalDeliveryError !== undefined) {
+      throw terminalDeliveryError;
+    }
+  };
+  const flush = async () => {
+    await loop.waitForInFlight();
+    if (!streamState.stopped) {
+      await loop.flush();
+    }
+    throwTerminalDeliveryError();
+  };
+
   const requestDraftUpdate = (text: string, preview?: TelegramDraftPreview) => {
     if (streamState.stopped || streamState.final) {
       return;
@@ -771,6 +805,7 @@ export function createTelegramDraftStream(params: {
     // 429 may establish the retry window that gates the initial final flush.
     loop.resetThrottleWindow();
     await loop.waitForInFlight();
+    throwTerminalDeliveryError();
     if (generation !== stopGeneration || streamState.stopped) {
       return;
     }
@@ -778,7 +813,7 @@ export function createTelegramDraftStream(params: {
     if (generation !== stopGeneration || streamState.stopped) {
       return;
     }
-    await loop.flush();
+    await flush();
     if (generation !== stopGeneration || streamState.stopped) {
       return;
     }
@@ -793,6 +828,7 @@ export function createTelegramDraftStream(params: {
           return;
         }
         const sent = await sendOrEditStreamMessage(finalText);
+        throwTerminalDeliveryError();
         if (generation !== stopGeneration) {
           return;
         }
@@ -958,7 +994,7 @@ export function createTelegramDraftStream(params: {
     }
     // Settle pending updates so we edit the real, current window message.
     streamState.final = true;
-    await loop.flush();
+    await flush();
     if (generation !== finalizeGeneration) {
       return undefined;
     }
@@ -1011,7 +1047,7 @@ export function createTelegramDraftStream(params: {
     update: requestDraftUpdate,
     updateLazy: requestLazyDraftUpdate,
     updatePreview,
-    flush: loop.flush,
+    flush,
     messageId: () => streamMessageId,
     lastDeliveredText: () => lastDeliveredText,
     currentMessageSnapshot: () => streamMessageSnapshot,

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -4,11 +4,12 @@ import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
-import { TELEGRAM_GENERAL_TOPIC_ID, type TelegramThreadSpec } from "./bot/helpers.js";
+import type { TelegramThreadSpec } from "./bot/helpers.js";
 import { buildTelegramSelfSenderName } from "./group-history-window.js";
 import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
 import { createTelegramMessageCache } from "./message-cache.js";
 import type { TelegramPromptContextProjection } from "./prompt-context-projection.js";
+import { resolveTelegramProviderObservedThreadId } from "./provider-thread-proof.js";
 
 type TelegramOutboundPromptContextUser = {
   id?: number;
@@ -141,15 +142,11 @@ export async function recordOutboundMessageForPromptContext(params: {
   recordGroupHistory?: boolean;
 }): Promise<boolean> {
   try {
-    const providerGeneralTopicId =
-      params.message.message_thread_id === undefined &&
-      params.message.chat?.type === "supergroup" &&
-      params.successfulSendThread?.scope === "forum" &&
-      params.successfulSendThread.id === TELEGRAM_GENERAL_TOPIC_ID
-        ? TELEGRAM_GENERAL_TOPIC_ID
-        : undefined;
-    const providerObservedThreadId = params.message.message_thread_id ?? providerGeneralTopicId;
-    const messageThreadId = params.messageThreadId ?? providerGeneralTopicId;
+    const providerObservedThreadId = resolveTelegramProviderObservedThreadId({
+      message: params.message,
+      successfulSendThread: params.successfulSendThread,
+    });
+    const messageThreadId = params.messageThreadId ?? providerObservedThreadId;
     const cacheMessage = buildOutboundCacheMessage({
       ...params,
       ...(messageThreadId !== undefined ? { messageThreadId } : {}),

--- a/extensions/telegram/src/provider-thread-proof.ts
+++ b/extensions/telegram/src/provider-thread-proof.ts
@@ -1,0 +1,37 @@
+import { TELEGRAM_GENERAL_TOPIC_ID, type TelegramThreadSpec } from "./bot/helpers.js";
+
+type TelegramThreadMessage = {
+  message_id?: number;
+  message_thread_id?: number;
+  chat?: { type?: string };
+};
+
+export function resolveTelegramProviderObservedThreadId(params: {
+  message: TelegramThreadMessage;
+  successfulSendThread?: TelegramThreadSpec;
+}): number | undefined {
+  if (typeof params.message.message_thread_id === "number") {
+    return params.message.message_thread_id;
+  }
+  return params.message.chat?.type === "supergroup" &&
+    params.successfulSendThread?.scope === "forum" &&
+    params.successfulSendThread.id === TELEGRAM_GENERAL_TOPIC_ID
+    ? TELEGRAM_GENERAL_TOPIC_ID
+    : undefined;
+}
+
+export function assertTelegramProviderThread(params: {
+  message: TelegramThreadMessage;
+  successfulSendThread?: TelegramThreadSpec;
+}): void {
+  const expectedThreadId = params.successfulSendThread?.id;
+  if (expectedThreadId === undefined) {
+    return;
+  }
+  const providerThreadId = resolveTelegramProviderObservedThreadId(params);
+  if (providerThreadId !== expectedThreadId) {
+    throw new Error(
+      `Telegram delivered message ${params.message.message_id ?? "unknown"} to topic ${providerThreadId ?? "unknown"}; expected topic ${expectedThreadId}`,
+    );
+  }
+}

--- a/extensions/telegram/src/send-message-text.ts
+++ b/extensions/telegram/src/send-message-text.ts
@@ -239,7 +239,6 @@ export function createTelegramTextSender(config: {
       plainText: string;
       reportChatId: string | number;
       hasInlineKeyboard: boolean;
-      reported: boolean;
     };
 
     let lastMessageId = "";
@@ -253,32 +252,22 @@ export function createTelegramTextSender(config: {
     const deliveryResults: TelegramSendResult[] = [];
     let sentChunkCount = 0;
     let pendingChunk: PendingChunk | undefined;
+    let finalMeta: TelegramSendResult["meta"] | undefined;
 
     const flushChunk = async (chunk: PendingChunk, finalPart: boolean) => {
-      let hasInlineKeyboard = chunk.hasInlineKeyboard;
       let keyboardError: unknown;
       if (finalPart && replyMarkup && !chunk.hasInlineKeyboard) {
         try {
           await api.editMessageReplyMarkup(chunk.reportChatId, chunk.messageId, {
             reply_markup: replyMarkup,
           });
-          hasInlineKeyboard = true;
+          finalMeta = {
+            telegramDeliveredText: chunk.plainText,
+            telegramHasInlineKeyboard: true,
+          };
         } catch (error) {
           keyboardError = error;
         }
-      }
-      if (!chunk.reported) {
-        await reportDelivery(
-          chunk.messageId,
-          chunk.reportChatId,
-          chunk.result,
-          {
-            telegramDeliveredText: chunk.plainText,
-            telegramHasInlineKeyboard: hasInlineKeyboard,
-          },
-          "text",
-          (delivery) => deliveryResults.push(delivery),
-        );
       }
       await recordDeliveredPromptContext(
         {
@@ -328,20 +317,17 @@ export function createTelegramTextSender(config: {
       }
       sentChunkCount += 1;
       recordSentMessage(chatId, messageId, cfg);
-      const reported = !replyMarkup;
-      if (reported) {
-        await reportDelivery(
-          messageId,
-          params.result?.chat?.id ?? chatId,
-          params.result,
-          {
-            telegramDeliveredText: params.plainText,
-            telegramHasInlineKeyboard: params.hasInlineKeyboard,
-          },
-          "text",
-          (delivery) => deliveryResults.push(delivery),
-        );
-      }
+      await reportDelivery(
+        messageId,
+        params.result?.chat?.id ?? chatId,
+        params.result,
+        {
+          telegramDeliveredText: params.plainText,
+          telegramHasInlineKeyboard: params.hasInlineKeyboard,
+        },
+        "text",
+        (delivery) => deliveryResults.push(delivery),
+      );
       const previousChunk = pendingChunk;
       pendingChunk = {
         result: params.result,
@@ -350,7 +336,6 @@ export function createTelegramTextSender(config: {
         plainText: params.plainText,
         reportChatId: params.result?.chat?.id ?? chatId,
         hasInlineKeyboard: params.hasInlineKeyboard,
-        reported,
       };
       if (previousChunk) {
         await flushChunk(previousChunk, false);
@@ -380,6 +365,7 @@ export function createTelegramTextSender(config: {
         messageId: lastMessageId,
         chatId: lastChatId,
         ...(receipt ? { receipt } : {}),
+        ...(finalMeta ? { meta: finalMeta } : {}),
       };
     };
 

--- a/extensions/telegram/src/send-message-text.ts
+++ b/extensions/telegram/src/send-message-text.ts
@@ -54,27 +54,24 @@ type SendTextOptions = {
 };
 
 function buildTelegramTextSendReceipt(params: {
-  messageIds: readonly string[];
-  chatId: string;
-  messageThreadId?: number;
+  results: readonly TelegramSendResult[];
   replyToMessageId?: number;
 }) {
-  if (params.messageIds.length <= 1) {
+  if (params.results.length === 0) {
     return undefined;
   }
-  return createMessageReceiptFromOutboundResults({
-    results: params.messageIds.map((messageId) => ({
-      messageId,
-      chatId: params.chatId,
-    })),
+  if (params.results.length === 1) {
+    return params.results[0]?.receipt;
+  }
+  const receipt = createMessageReceiptFromOutboundResults({
+    results: params.results,
     kind: "text",
-    ...(typeof params.messageThreadId === "number"
-      ? { threadId: String(params.messageThreadId) }
-      : {}),
     ...(typeof params.replyToMessageId === "number"
       ? { replyToId: String(params.replyToMessageId) }
       : {}),
   });
+  receipt.parts = receipt.parts.map((part, index) => ({ ...part, index }));
+  return receipt;
 }
 
 export function createTelegramTextSender(config: {
@@ -87,8 +84,11 @@ export function createTelegramTextSender(config: {
   reportDelivery: (
     messageId: string | number,
     deliveredChatId: string | number,
+    message: TelegramMessageLike,
     meta?: TelegramSendResult["meta"],
-  ) => Promise<void>;
+    kind?: "text" | "media",
+    onPrepared?: (delivery: TelegramSendResult) => void,
+  ) => Promise<TelegramSendResult>;
   recordDeliveredPromptContext: (
     params: Omit<
       Parameters<typeof recordOutboundMessageForPromptContext>[0],
@@ -250,6 +250,7 @@ export function createTelegramTextSender(config: {
       | undefined;
     let acceptedReplyToMessageId: number | undefined;
     const messageIds: string[] = [];
+    const deliveryResults: TelegramSendResult[] = [];
     let sentChunkCount = 0;
     let pendingChunk: PendingChunk | undefined;
 
@@ -267,10 +268,17 @@ export function createTelegramTextSender(config: {
         }
       }
       if (!chunk.reported) {
-        await reportDelivery(chunk.messageId, chunk.reportChatId, {
-          telegramDeliveredText: chunk.plainText,
-          telegramHasInlineKeyboard: hasInlineKeyboard,
-        });
+        await reportDelivery(
+          chunk.messageId,
+          chunk.reportChatId,
+          chunk.result,
+          {
+            telegramDeliveredText: chunk.plainText,
+            telegramHasInlineKeyboard: hasInlineKeyboard,
+          },
+          "text",
+          (delivery) => deliveryResults.push(delivery),
+        );
       }
       await recordDeliveredPromptContext(
         {
@@ -322,10 +330,17 @@ export function createTelegramTextSender(config: {
       recordSentMessage(chatId, messageId, cfg);
       const reported = !replyMarkup;
       if (reported) {
-        await reportDelivery(messageId, params.result?.chat?.id ?? chatId, {
-          telegramDeliveredText: params.plainText,
-          telegramHasInlineKeyboard: params.hasInlineKeyboard,
-        });
+        await reportDelivery(
+          messageId,
+          params.result?.chat?.id ?? chatId,
+          params.result,
+          {
+            telegramDeliveredText: params.plainText,
+            telegramHasInlineKeyboard: params.hasInlineKeyboard,
+          },
+          "text",
+          (delivery) => deliveryResults.push(delivery),
+        );
       }
       const previousChunk = pendingChunk;
       pendingChunk = {
@@ -358,9 +373,7 @@ export function createTelegramTextSender(config: {
         });
       }
       const receipt = buildTelegramTextSendReceipt({
-        messageIds,
-        chatId: lastChatId,
-        messageThreadId: lastAcceptedParams?.message_thread_id,
+        results: deliveryResults,
         replyToMessageId: acceptedReplyToMessageId,
       });
       return {
@@ -372,9 +385,7 @@ export function createTelegramTextSender(config: {
 
     const partialDeliveryResult = () => {
       const receipt = buildTelegramTextSendReceipt({
-        messageIds,
-        chatId: lastChatId,
-        messageThreadId: lastAcceptedParams?.message_thread_id,
+        results: deliveryResults,
         replyToMessageId: acceptedReplyToMessageId,
       });
       return {

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -333,11 +333,10 @@ async function sendMessageTelegramWithContext(
     const mediaMessageId = resolveTelegramMessageIdOrThrow(result, "media send");
     const resolvedChatId = String(result?.chat?.id ?? chatId);
     recordSentMessage(chatId, mediaMessageId, cfg);
-    let mediaReported = false;
     let mediaDeliveryResult: TelegramSendResult | undefined;
     let mediaPromptRecorded = false;
-    const recordMediaDelivery = async (finalPart: boolean, hasInlineKeyboard: boolean) => {
-      if (!mediaReported) {
+    const reportMediaDelivery = async (hasInlineKeyboard: boolean) => {
+      try {
         mediaDeliveryResult = await reportDelivery(
           mediaMessageId,
           resolvedChatId,
@@ -347,9 +346,22 @@ async function sendMessageTelegramWithContext(
             telegramHasInlineKeyboard: hasInlineKeyboard,
           },
           "media",
+          (delivery) => {
+            mediaDeliveryResult = delivery;
+          },
         );
-        mediaReported = true;
+      } catch (error) {
+        if (isChannelPartialDeliveryError(error)) {
+          throw error;
+        }
+        throw createChannelPartialDeliveryError(error, {
+          messageIds: [String(mediaMessageId)],
+          ...(mediaDeliveryResult?.receipt ? { receipt: mediaDeliveryResult.receipt } : {}),
+          visibleReplySent: true,
+        });
       }
+    };
+    const recordMediaPromptContext = async (finalPart: boolean) => {
       if (!mediaPromptRecorded) {
         await recordDeliveredPromptContext(
           {
@@ -365,8 +377,9 @@ async function sendMessageTelegramWithContext(
         mediaPromptRecorded = true;
       }
     };
+    await reportMediaDelivery(!needsSeparateText && Boolean(replyMarkup));
     if (!needsSeparateText) {
-      await recordMediaDelivery(true, Boolean(replyMarkup));
+      await recordMediaPromptContext(true);
     }
     logTelegramOutboundSendOk({
       accountId: account.accountId,
@@ -391,7 +404,7 @@ async function sendMessageTelegramWithContext(
       try {
         textResult = await sendChunkedText(followUpText, "text follow-up send", {
           replyToAlreadyUsed: singleUseReplyTo && mediaUsedReplyTo,
-          beforeFirstAccepted: () => recordMediaDelivery(false, false),
+          beforeFirstAccepted: () => recordMediaPromptContext(false),
         });
       } catch (error) {
         if (isTelegramEmptyContentError(error)) {
@@ -407,22 +420,29 @@ async function sendMessageTelegramWithContext(
               keyboardError = editError;
             }
           }
-          await recordMediaDelivery(true, hasInlineKeyboard);
+          await recordMediaPromptContext(true);
           if (keyboardError !== undefined) {
             throw createChannelPartialDeliveryError(keyboardError, {
               messageIds: [String(mediaMessageId)],
+              ...(mediaDeliveryResult?.receipt ? { receipt: mediaDeliveryResult.receipt } : {}),
               visibleReplySent: true,
             });
           }
-          return mediaDeliveryResult?.receipt
+          const finalMediaResult = mediaDeliveryResult ?? {
+            messageId: String(mediaMessageId),
+            chatId: resolvedChatId,
+          };
+          return hasInlineKeyboard
             ? {
-                messageId: mediaDeliveryResult.messageId,
-                chatId: mediaDeliveryResult.chatId,
-                receipt: mediaDeliveryResult.receipt,
+                ...finalMediaResult,
+                meta: {
+                  ...finalMediaResult.meta,
+                  telegramHasInlineKeyboard: true,
+                },
               }
-            : { messageId: String(mediaMessageId), chatId: resolvedChatId };
+            : finalMediaResult;
         }
-        await recordMediaDelivery(false, false);
+        await recordMediaPromptContext(false);
         const textMessageIds = isChannelPartialDeliveryError(error)
           ? (error.deliveryResult.messageIds ?? [])
           : [];

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -38,6 +38,7 @@ import {
 import { isTelegramPhotoLimitError } from "./send-error-predicates.js";
 import { createTelegramTextSender } from "./send-message-text.js";
 import type { TelegramSendOpts, TelegramSendResult } from "./send-message-types.js";
+import { reportTelegramProviderDelivery } from "./send-outbound.js";
 import {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
@@ -89,12 +90,20 @@ async function sendMessageTelegramWithContext(
   const reportDelivery = async (
     messageId: string | number,
     deliveredChatId: string | number,
+    message: TelegramMessageLike,
     meta?: TelegramSendResult["meta"],
-  ) => {
-    await opts.onDeliveryResult?.({
-      messageId: String(messageId),
-      chatId: String(deliveredChatId),
+    kind?: "text" | "media",
+    onPrepared?: (delivery: TelegramSendResult) => void,
+  ): Promise<TelegramSendResult> => {
+    return await reportTelegramProviderDelivery({
+      message,
+      messageId,
+      fallbackChatId: deliveredChatId,
+      successfulSendThread: threadSpec,
       ...(meta ? { meta } : {}),
+      ...(kind ? { kind } : {}),
+      ...(onPrepared ? { onPrepared } : {}),
+      onDeliveryResult: opts.onDeliveryResult,
     });
   };
   const recordDeliveredPromptContext = async (
@@ -325,13 +334,20 @@ async function sendMessageTelegramWithContext(
     const resolvedChatId = String(result?.chat?.id ?? chatId);
     recordSentMessage(chatId, mediaMessageId, cfg);
     let mediaReported = false;
+    let mediaDeliveryResult: TelegramSendResult | undefined;
     let mediaPromptRecorded = false;
     const recordMediaDelivery = async (finalPart: boolean, hasInlineKeyboard: boolean) => {
       if (!mediaReported) {
-        await reportDelivery(mediaMessageId, resolvedChatId, {
-          ...(deliveredCaption ? { telegramDeliveredText: deliveredCaption } : {}),
-          telegramHasInlineKeyboard: hasInlineKeyboard,
-        });
+        mediaDeliveryResult = await reportDelivery(
+          mediaMessageId,
+          resolvedChatId,
+          result,
+          {
+            ...(deliveredCaption ? { telegramDeliveredText: deliveredCaption } : {}),
+            telegramHasInlineKeyboard: hasInlineKeyboard,
+          },
+          "media",
+        );
         mediaReported = true;
       }
       if (!mediaPromptRecorded) {
@@ -398,7 +414,13 @@ async function sendMessageTelegramWithContext(
               visibleReplySent: true,
             });
           }
-          return { messageId: String(mediaMessageId), chatId: resolvedChatId };
+          return mediaDeliveryResult?.receipt
+            ? {
+                messageId: mediaDeliveryResult.messageId,
+                chatId: mediaDeliveryResult.chatId,
+                receipt: mediaDeliveryResult.receipt,
+              }
+            : { messageId: String(mediaMessageId), chatId: resolvedChatId };
         }
         await recordMediaDelivery(false, false);
         const textMessageIds = isChannelPartialDeliveryError(error)
@@ -411,11 +433,11 @@ async function sendMessageTelegramWithContext(
       }
       const mediaReplyToId = resolveAcceptedReplyToMessageId(acceptedMediaParams)?.toString();
       const receipt = createMessageReceiptFromOutboundResults({
-        results: [{ messageId: String(mediaMessageId), chatId: resolvedChatId }, textResult],
+        results: [
+          mediaDeliveryResult ?? { messageId: String(mediaMessageId), chatId: resolvedChatId },
+          textResult,
+        ],
         kind: "text",
-        ...(acceptedMediaParams?.message_thread_id !== undefined
-          ? { threadId: String(acceptedMediaParams.message_thread_id) }
-          : {}),
       });
       if (mediaReplyToId) {
         receipt.replyToId = mediaReplyToId;
@@ -436,7 +458,13 @@ async function sendMessageTelegramWithContext(
       };
     }
 
-    return { messageId: String(mediaMessageId), chatId: resolvedChatId };
+    return mediaDeliveryResult?.receipt
+      ? {
+          messageId: mediaDeliveryResult.messageId,
+          chatId: mediaDeliveryResult.chatId,
+          receipt: mediaDeliveryResult.receipt,
+        }
+      : { messageId: String(mediaMessageId), chatId: resolvedChatId };
   }
 
   if (!text || !text.trim()) {

--- a/extensions/telegram/src/send-outbound.ts
+++ b/extensions/telegram/src/send-outbound.ts
@@ -1,5 +1,18 @@
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createMessageReceiptFromOutboundResults,
+  type MessageReceiptPartKind,
+} from "openclaw/plugin-sdk/channel-outbound";
+import type { TelegramThreadSpec } from "./bot/helpers.js";
+import {
+  recordOutboundMessageForPromptContext,
+  type TelegramOutboundPromptContextMessage,
+} from "./outbound-message-context.js";
+import {
+  assertTelegramProviderThread,
+  resolveTelegramProviderObservedThreadId,
+} from "./provider-thread-proof.js";
 import {
   buildTelegramThreadReplyParams,
   resolveTelegramSendThreadSpec,
@@ -13,7 +26,7 @@ import {
   resolveTelegramMessageIdOrThrow,
   type TelegramApiContext,
 } from "./send-context.js";
-import type { TelegramSendOpts } from "./send-message-types.js";
+import type { TelegramSendOpts, TelegramSendResult } from "./send-message-types.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { parseTelegramTarget } from "./targets.js";
 
@@ -26,6 +39,53 @@ type PreparedTelegramOutbound = {
 
 type PreparedTelegramOutboundWithMessageId<T> = PreparedTelegramOutbound &
   (T extends string | number ? { messageId: number } : { messageId?: undefined });
+
+export async function reportTelegramProviderDelivery(params: {
+  message: TelegramOutboundPromptContextMessage;
+  messageId: string | number;
+  fallbackChatId: string | number;
+  successfulSendThread?: TelegramThreadSpec;
+  kind?: MessageReceiptPartKind;
+  meta?: TelegramSendResult["meta"];
+  onPrepared?: (delivery: TelegramSendResult) => void;
+  onDeliveryResult?: TelegramSendOpts["onDeliveryResult"];
+}): Promise<TelegramSendResult> {
+  const messageId = String(params.messageId);
+  const chatId = String(params.message.chat?.id ?? params.fallbackChatId);
+  const providerThreadId = resolveTelegramProviderObservedThreadId({
+    message: params.message,
+    successfulSendThread: params.successfulSendThread,
+  });
+  const delivery: TelegramSendResult = {
+    messageId,
+    chatId,
+    ...(providerThreadId !== undefined
+      ? {
+          receipt: createMessageReceiptFromOutboundResults({
+            results: [{ messageId, chatId }],
+            ...(params.kind !== undefined ? { kind: params.kind } : {}),
+            threadId: String(providerThreadId),
+          }),
+        }
+      : {}),
+    ...(params.meta ? { meta: params.meta } : {}),
+  };
+  params.onPrepared?.(delivery);
+  await params.onDeliveryResult?.(delivery);
+  try {
+    assertTelegramProviderThread({
+      message: params.message,
+      successfulSendThread: params.successfulSendThread,
+    });
+  } catch (error) {
+    throw createChannelPartialDeliveryError(error, {
+      messageIds: [messageId],
+      ...(delivery.receipt ? { receipt: delivery.receipt } : {}),
+      visibleReplySent: true,
+    });
+  }
+  return delivery;
+}
 
 export async function prepareTelegramOutbound<T extends string | number | undefined>(params: {
   to: string | number;
@@ -108,15 +168,17 @@ export async function finalizeTelegramOutbound(params: {
   promptContextProjectionPlan?: TelegramSendOpts["promptContextProjectionPlan"];
   onDeliveryResult?: TelegramSendOpts["onDeliveryResult"];
   beforeActivity?: (result: { messageId: string; chatId: string }) => void;
-}): Promise<{ messageId: string; chatId: string }> {
+}): Promise<TelegramSendResult> {
   const { cfg, account } = params.context;
   const messageId = resolveTelegramMessageIdOrThrow(params.result, params.resultContext);
-  const resultIds = {
-    messageId: String(messageId),
-    chatId: String(params.result.chat?.id ?? params.prepared.chatId),
-  };
   recordSentMessage(params.prepared.chatId, messageId, cfg);
-  await params.onDeliveryResult?.(resultIds);
+  const resultIds = await reportTelegramProviderDelivery({
+    message: params.result,
+    messageId,
+    fallbackChatId: params.prepared.chatId,
+    successfulSendThread: params.prepared.threadSpec,
+    onDeliveryResult: params.onDeliveryResult,
+  });
   const projection = params.promptContextProjectionPlan?.cursor.take(
     params.promptContextProjectionPlan.finalPart,
   );

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1876,8 +1876,9 @@ describe("sendMessageTelegram", () => {
       reply_markup: { inline_keyboard: [[{ text: "OK", callback_data: "ok" }]] },
     });
     expect(result.messageId).toBe("71");
+    expect(result.meta?.telegramHasInlineKeyboard).toBe(true);
     expect(onDeliveryResult).toHaveBeenCalledTimes(1);
-    expect(onDeliveryResult.mock.calls[0]?.[0]?.meta?.telegramHasInlineKeyboard).toBe(true);
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.meta?.telegramHasInlineKeyboard).toBe(false);
     const cached = await createTelegramMessageCache({
       scope: resolveTelegramMessageCacheScope(storePath),
     }).get({ accountId: "default", chatId: "123", messageId: "71" });
@@ -2401,6 +2402,53 @@ describe("sendMessageTelegram", () => {
     ]);
   });
 
+  it("stops an oversized-caption follow-up when media lands in the wrong topic", async () => {
+    const chatId = "-1001234567890";
+    const longText = "A".repeat(1100);
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 70,
+      message_thread_id: 272,
+      chat: { id: chatId, type: "supergroup" },
+    });
+    const sendMessage = vi.fn();
+    const onDeliveryResult = vi.fn();
+    const api = { sendPhoto, sendMessage } as unknown as TelegramApiOverride;
+    mockLoadedMedia({ contentType: "image/jpeg", fileName: "photo.jpg" });
+
+    let observed: unknown;
+    try {
+      await sendMessageTelegram(chatId, longText, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api,
+        mediaUrl: "https://example.com/photo.jpg",
+        messageThreadId: 271,
+        onDeliveryResult,
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expectMediaSendCall(firstMockCall(sendPhoto, "send photo call"), "send photo call", chatId, {
+      caption: undefined,
+      message_thread_id: 271,
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(observed.deliveryResult.messageIds).toEqual(["70"]);
+    expect(observed.deliveryResult.receipt).toMatchObject({
+      primaryPlatformMessageId: "70",
+      platformMessageIds: ["70"],
+      threadId: "272",
+      parts: [expect.objectContaining({ platformMessageId: "70", kind: "media" })],
+    });
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.receipt?.threadId).toBe("272");
+  });
+
   it("sends oversized voice captions as a voice note followed by text", async () => {
     const chatId = "123";
     const longText = "A".repeat(1100);
@@ -2451,13 +2499,17 @@ describe("sendMessageTelegram", () => {
       promptContextProjectionPlan: { cursor, finalPart: true },
     });
 
-    expect(result).toEqual({ messageId: "70", chatId: "123" });
+    expect(result).toEqual({
+      messageId: "70",
+      chatId: "123",
+      meta: { telegramHasInlineKeyboard: true },
+    });
     expect(botApi.sendMessage).toHaveBeenCalledTimes(2);
     expect(botApi.editMessageReplyMarkup).toHaveBeenCalledWith("123", 70, {
       reply_markup: { inline_keyboard: [[{ text: "OK", callback_data: "ok" }]] },
     });
     expect(onDeliveryResult).toHaveBeenCalledOnce();
-    expect(onDeliveryResult.mock.calls[0]?.[0]?.meta?.telegramHasInlineKeyboard).toBe(true);
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.meta?.telegramHasInlineKeyboard).toBe(false);
     const cached = await createTelegramMessageCache({
       scope: resolveTelegramMessageCacheScope(storePath),
     }).get({ accountId: "default", chatId: "123", messageId: "70" });
@@ -3847,6 +3899,40 @@ describe("sendMessageTelegram", () => {
         receipt: expect.objectContaining({ threadId: "272" }),
       }),
     );
+  });
+
+  it("stops multipart text after the first provider topic mismatch", async () => {
+    const chatId = "-1001234567890";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 55,
+      message_thread_id: 272,
+      chat: { id: chatId, type: "supergroup" },
+    });
+    const onDeliveryResult = vi.fn();
+
+    let observed: unknown;
+    try {
+      await sendMessageTelegram(chatId, "A".repeat(9000), {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api: { sendMessage } as unknown as TelegramApiOverride,
+        textMode: "html",
+        messageThreadId: 271,
+        buttons: [[{ text: "OK", callback_data: "ok" }]],
+        onDeliveryResult,
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(observed.deliveryResult.messageIds).toEqual(["55"]);
+    expect(observed.deliveryResult.receipt?.threadId).toBe("272");
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
   });
 
   it("does not infer a missing private-chat topic as the General forum topic", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2320,6 +2320,7 @@ describe("sendMessageTelegram", () => {
     const chatId = "-1001234567890";
     const sendPhoto = vi.fn().mockResolvedValue({
       message_id: 58,
+      message_thread_id: 99,
       chat: { id: chatId },
     });
     const api = { sendPhoto } as unknown as {
@@ -2353,10 +2354,12 @@ describe("sendMessageTelegram", () => {
 
     const sendPhoto = vi.fn().mockResolvedValue({
       message_id: 70,
+      message_thread_id: 271,
       chat: { id: chatId },
     });
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 71,
+      message_thread_id: 271,
       chat: { id: chatId },
     });
     const api = { sendPhoto, sendMessage } as unknown as {
@@ -2510,10 +2513,12 @@ describe("sendMessageTelegram", () => {
 
     const sendPhoto = vi.fn().mockResolvedValue({
       message_id: 70,
+      message_thread_id: 271,
       chat: { id: chatId },
     });
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 71,
+      message_thread_id: 271,
       chat: { id: chatId },
     });
     const api = { sendPhoto, sendMessage } as unknown as {
@@ -2963,6 +2968,50 @@ describe("sendMessageTelegram", () => {
     expect(wasSentByBot(chatId, 302)).toBe(true);
   });
 
+  it.each([
+    {
+      name: "location",
+      location: { latitude: 48.858844, longitude: 2.294351 },
+    },
+    {
+      name: "venue",
+      location: {
+        latitude: 48.858844,
+        longitude: 2.294351,
+        name: "Eiffel Tower",
+        address: "Champ de Mars",
+      },
+    },
+  ])("rejects a provider topic mismatch for a native $name", async ({ location }) => {
+    const chatId = "-1001234567890";
+    const providerResult = {
+      message_id: 303,
+      message_thread_id: 100,
+      chat: { id: chatId, type: "supergroup" },
+    };
+    const sendLocation = vi.fn().mockResolvedValue(providerResult);
+    const sendVenue = vi.fn().mockResolvedValue(providerResult);
+
+    let observed: unknown;
+    try {
+      await sendLocationTelegram(`${chatId}:topic:99`, location, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api: { sendLocation, sendVenue } as unknown as TelegramApiOverride,
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["303"]);
+    expect(observed.deliveryResult.receipt?.threadId).toBe("100");
+    expect(observed).toHaveProperty("message", expect.stringContaining("expected topic 99"));
+  });
+
   it("rejects incomplete Telegram venues", async () => {
     await expect(
       sendLocationTelegram(
@@ -3353,6 +3402,7 @@ describe("sendMessageTelegram", () => {
       const sendPhoto = vi.fn().mockRejectedValueOnce(new Error(`400: Bad Request: ${reason}`));
       const sendDocument = vi.fn().mockResolvedValue({
         message_id: 10,
+        message_thread_id: 42,
         chat: { id: "123" },
       });
       mockLoadedMedia({ contentType: "image/png", fileName: "photo.png" });
@@ -3667,10 +3717,16 @@ describe("sendMessageTelegram", () => {
     for (const testCase of cases) {
       const sendAudio = vi.fn().mockResolvedValue({
         message_id: 10,
+        ...("messageThreadId" in testCase && testCase.messageThreadId !== undefined
+          ? { message_thread_id: testCase.messageThreadId }
+          : {}),
         chat: { id: testCase.chatId },
       });
       const sendVoice = vi.fn().mockResolvedValue({
         message_id: 11,
+        ...("messageThreadId" in testCase && testCase.messageThreadId !== undefined
+          ? { message_thread_id: testCase.messageThreadId }
+          : {}),
         chat: { id: testCase.chatId },
       });
       const api = { sendAudio, sendVoice } as unknown as {
@@ -3736,6 +3792,7 @@ describe("sendMessageTelegram", () => {
     for (const testCase of cases) {
       const sendMessage = vi.fn().mockResolvedValue({
         message_id: testCase.messageId,
+        message_thread_id: 271,
         chat: { id: testCase.chatId },
       });
       const api = { sendMessage } as unknown as {
@@ -3756,12 +3813,76 @@ describe("sendMessageTelegram", () => {
     }
   });
 
+  it("records the accepted message before rejecting a mismatched topic", async () => {
+    const chatId = "-1001234567890";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 55,
+      message_thread_id: 272,
+      chat: { id: chatId, type: "supergroup" },
+    });
+    const onDeliveryResult = vi.fn();
+
+    let observed: unknown;
+    try {
+      await sendMessageTelegram(chatId, "hello forum", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api: { sendMessage } as unknown as TelegramApiOverride,
+        messageThreadId: 271,
+        onDeliveryResult,
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["55"]);
+    expect(observed.deliveryResult.receipt?.threadId).toBe("272");
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "55",
+        receipt: expect.objectContaining({ threadId: "272" }),
+      }),
+    );
+  });
+
+  it("does not infer a missing private-chat topic as the General forum topic", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 56,
+      chat: { id: "123456789", type: "private" },
+    });
+
+    await expect(
+      sendMessageTelegram("123456789", "hello private topic", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api: { sendMessage } as unknown as TelegramApiOverride,
+        messageThreadId: 1,
+      }),
+    ).rejects.toThrow("topic unknown; expected topic 1");
+  });
+
   it("returns a multipart receipt and avoids native replies for chunked first-mode text", async () => {
     const sendMessage = vi
       .fn()
-      .mockResolvedValueOnce({ message_id: 101, chat: { id: "-1001234567890" } })
-      .mockResolvedValueOnce({ message_id: 102, chat: { id: "-1001234567890" } })
-      .mockResolvedValueOnce({ message_id: 103, chat: { id: "-1001234567890" } });
+      .mockResolvedValueOnce({
+        message_id: 101,
+        message_thread_id: 271,
+        chat: { id: "-1001234567890" },
+      })
+      .mockResolvedValueOnce({
+        message_id: 102,
+        message_thread_id: 271,
+        chat: { id: "-1001234567890" },
+      })
+      .mockResolvedValueOnce({
+        message_id: 103,
+        message_thread_id: 271,
+        chat: { id: "-1001234567890" },
+      });
     const api = { sendMessage } as unknown as {
       sendMessage: typeof sendMessage;
     };
@@ -3972,6 +4093,7 @@ describe("sendMessageTelegram", () => {
     const chatId = "-1001234567890";
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 55,
+      message_thread_id: 271,
       chat: { id: chatId },
     });
     const api = { sendMessage } as unknown as {
@@ -3996,6 +4118,7 @@ describe("sendMessageTelegram", () => {
     const body = "incident reply body should stay private";
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 321,
+      message_thread_id: 271,
       chat: { id: chatId },
     });
     const api = { sendMessage } as unknown as {
@@ -4061,6 +4184,7 @@ describe("sendMessageTelegram", () => {
     const fileName = "private-photo.jpg";
     const sendPhoto = vi.fn().mockResolvedValue({
       message_id: 654,
+      message_thread_id: 45,
       chat: { id: chatId },
     });
     const api = { sendPhoto } as unknown as {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -3851,7 +3851,7 @@ describe("sendMessageTelegram", () => {
         sendMessage: typeof sendMessage;
       };
 
-      await sendMessageTelegram(testCase.chatId, testCase.text, {
+      const result = await sendMessageTelegram(testCase.chatId, testCase.text, {
         cfg: TELEGRAM_TEST_CFG,
         token: "tok",
         api,
@@ -3862,6 +3862,7 @@ describe("sendMessageTelegram", () => {
         parse_mode: "HTML",
         message_thread_id: 271,
       });
+      expect(result.receipt?.threadId, testCase.name).toBe("271");
     }
   });
 


### PR DESCRIPTION
## What problem this solves

Telegram send methods return the accepted Message, including the provider-observed topic. OpenClaw reduced that response to requested routing data, so cron and reply delivery could report success without proving where Telegram placed the message.

## Root cause

Provider evidence was discarded at several acceptance boundaries. Durable sends rebuilt receipts from requested state; streamed text, media, and draft previews could continue after an accepted message without checking its returned topic.

## Fix

- Build Telegram delivery receipts from the accepted provider Message.
- Verify provider topic placement before another physical send begins.
- Preserve every already-visible message id and the observed-topic receipt in canonical partial-delivery errors.
- Cover durable text/media/special sends, streamed text/media, and streamed draft previews with one plugin-owned proof path.
- Keep rich-render fallback limited to transport rejection; provider validation runs outside that catch, so a visible wrong-topic rich message cannot trigger a second plain send.
- Keep General-topic inference limited to forum supergroups and topic 1.

No config, public SDK, default, or user-visible error-copy change.

## Telegram topic contract

OpenClaw `scope: "dm"` means bot-threaded private chats, whose request and response use `message_thread_id`. Telegram channel direct-message chats are a separate API surface using `direct_messages_topic_id` and `direct_messages_topic.topic_id`; treating that field as private-chat proof would conflate two namespaces. This was checked against the official Bot API changelog and installed grammY types.

## Scope

Rebuilt on current main. The stale validation proposal and unrelated changes were dropped. Production delta: +333/-94, net +239. Test delta: +437/-12, net +425. Production growth establishes the provider-evidence owner boundary across every Telegram message-producing funnel touched by this invariant.

## Evidence

- Exact head `2fb4267a94d46f0f2c50e4d79367ad7e548ce618`.
- Focused local proof: 438/438 across `send.test.ts`, `bot/delivery.test.ts`, `draft-stream.test.ts`, and `bot-message-dispatch.delivery-transcript.test.ts`.
- Blacksmith Testbox, OpenClaw org: `tbx_01kzb4tttny1rezgh59445zzt5`; `pnpm check:changed` passed production/test tsgo, Oxlint, formatting, plugin boundaries, dead exports, storage guards, and import-cycle checks. Actions run `31087249832`.
- Distill: one provider-proof boundary; no duplicate topic policy or fallback path.
- Greybeard: topicless sends add no validator callback; threaded work remains linear in physical Telegram messages.
- Codex autoreview at P1: clean, confidence 0.89; no actionable P0/P1 findings.
- Merge-head refresh note: the branch was rebased twice; current-main drift during exact-head gates is limited to config, onboarding, CI-test, QQBot, and Feishu changes with no Telegram overlap. GitHub reports the PR mergeable, so the optional refresh rank-up is skipped instead of restarting an unbounded moving-main loop.
- Dependency contract: official Telegram Bot API and installed grammY sources/types confirm send methods return Message with optional `message_thread_id`.

## Real behavior proof

Exact head ran through `telegram-e2e-userbot` with a real Telegram user, repo mock provider, and ephemeral current-head Gateway. One prompt entered a temporary non-General forum topic; the only SUT reply returned in that same topic. One provider request was observed. The temporary topic was deleted. No Mantis path was used.

```json
{
  "verdict": "pass",
  "head": "2fb4267a94d46f0f2c50e4d79367ad7e548ce618",
  "harness": "telegram-e2e-userbot",
  "gateway": "ephemeral current-head",
  "provider": "repo mock-openai",
  "inputTopic": 48350,
  "replyTopic": 48350,
  "sutText": "OPENCLAW_E2E_STREAM_TOPIC_97361_2FB4267",
  "sutMessages": 1,
  "providerRequests": 1,
  "recordingComplete": true
}
```

