### PR TITLE
fix(memory-wiki): truncate import insights safely

### DIFF
--- a/extensions/memory-wiki/src/import-insights.test.ts
+++ b/extensions/memory-wiki/src/import-insights.test.ts
@@ -8,6 +8,24 @@ import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const { createVault } = createMemoryWikiTestHarness();
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("listMemoryWikiImportInsights", () => {
   it("clusters ChatGPT import pages by topic and extracts digest fields", async () => {
     const { rootDir, config } = await createVault({
@@ -138,5 +156,58 @@ describe("listMemoryWikiImportInsights", () => {
     expect(healthItem?.firstUserLine).toBeUndefined();
     expect(healthItem?.lastUserLine).toBeUndefined();
     expect(healthItem?.assistantOpener).toBeUndefined();
+  });
+
+  it("truncates import insight summaries without leaving lone surrogates", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-import-insights-surrogate-",
+      initialize: true,
+    });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
+    const assistantOpener = `${"a".repeat(178)}😀${"b".repeat(20)}`;
+    await fs.writeFile(
+      path.join(rootDir, "sources", "chatgpt-emoji.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.chatgpt.emoji",
+          title: "ChatGPT Export: Emoji truncation",
+          sourceType: "chatgpt-export",
+          riskLevel: "low",
+          riskReasons: [],
+          labels: ["domain/work", "area/memory", "topic/memory"],
+          updatedAt: "2026-02-01T12:00:00.000Z",
+        },
+        body: [
+          "# ChatGPT Export: Emoji truncation",
+          "",
+          "## Auto Digest",
+          "- User messages: 1",
+          "- Assistant messages: 1",
+          "- First user line: summarize this",
+          "- Last user line: summarize this",
+          "- Preference signals:",
+          "  - prefers emoji-safe summaries",
+          "",
+          "## Active Branch Transcript",
+          "### User",
+          "",
+          "summarize this",
+          "",
+          "### Assistant",
+          "",
+          assistantOpener,
+          "",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+
+    const result = await listMemoryWikiImportInsights(config);
+
+    const item = result.clusters[0]?.items[0];
+    expect(item?.summary).toBe(`${"a".repeat(178)}…`);
+    expect(hasLoneSurrogate(item?.summary ?? "")).toBe(false);
+    expect(item?.summary).not.toContain("�");
   });
 });

--- a/extensions/memory-wiki/src/import-insights.ts
+++ b/extensions/memory-wiki/src/import-insights.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 // Memory Wiki plugin module implements import insights behavior.
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { parseWikiMarkdown } from "./markdown.js";
@@ -208,7 +209,7 @@ function shortenSentence(value: string, maxLength = 180): string {
   if (compact.length <= maxLength) {
     return compact;
   }
-  return `${compact.slice(0, maxLength - 1).trimEnd()}…`;
+  return `${truncateUtf16Safe(compact, maxLength - 1).trimEnd()}…`;
 }
 
 function extractCorrectionSignals(turns: TranscriptTurn[]): string[] {


### PR DESCRIPTION
## Summary

- Fix Memory Wiki import insight snippet truncation so summaries do not split UTF-16 surrogate pairs.
- Add regression coverage through `listMemoryWikiImportInsights` for a ChatGPT export assistant opener with an astral emoji at the truncation boundary.

## What Problem This Solves

Memory Wiki import insights shorten assistant opener and user/correction snippets before showing them in the import review data. That shortening used raw UTF-16 `slice()`, so an astral emoji crossing the summary limit could leave a dangling surrogate and render as `�` in the user-visible import insight summary.

## Why This Change Was Made

The existing shared text helper already preserves UTF-16 surrogate pairs for truncation. Memory Wiki import insights should use that same boundary-safe truncation rather than keeping a one-off raw slice in `shortenSentence`.

## User Impact

Users reviewing ChatGPT import insights in Memory Wiki no longer see broken replacement glyphs when imported conversation text contains emoji or other astral Unicode characters exactly at the snippet truncation boundary.

- **Why it matters / User impact:** ChatGPT import review data is meant to help users decide what memory/wiki facts are safe to extract; broken `�` summaries make imported snippets look corrupted and reduce trust in that review path.

## Origin / follow-up

- Follows/completes: #96958 fixed the same UTF-16 truncation class in tool-display detail rendering.
- Related consistency: #96963 applied the same code-point-boundary truncation model to exec command detail rendering.
- Gap this fills: `extensions/memory-wiki/src/import-insights.ts` still shortened import insight snippets with `compact.slice(0, maxLength - 1)`, which could cut surrogate pairs before appending `…`.
- Consistency: this patch reuses `truncateUtf16Safe` through the plugin SDK text utility runtime, matching the existing extension boundary instead of importing core internals directly.

## Competition / linked PR analysis

No linked issue is attached because this is a follow-up to the merged UTF-16 truncation fixes. Prework did not identify an existing open PR covering the Memory Wiki import-insights `shortenSentence` path.

## Evidence

See `## Real behavior proof` for the executed local behavior path and regression output.

## Real behavior proof

- **Behavior or issue addressed:** Memory Wiki ChatGPT import insight summaries produced by `listMemoryWikiImportInsights` must truncate snippets without leaving lone UTF-16 surrogate halves or rendering `�`.
- **Real environment tested:** Linux local OpenClaw worktree, Memory Wiki plugin code on current branch, Node with repo dependencies installed; the exercised path is local file parsing plus import-insight generation.
- **Exact steps or command run after this patch:**

```bash
node --import tsx --input-type=module <<'NODE'
# inline script creates a temporary wiki vault, writes a ChatGPT export source page,
# calls listMemoryWikiImportInsights, and asserts the truncated summary has no
# lone surrogate or replacement glyph.
NODE
node scripts/run-vitest.mjs extensions/memory-wiki/src/import-insights.test.ts
git diff --check
```

- **Evidence after fix:**

```text
HEAD b2d27f24341a
entrypoint listMemoryWikiImportInsights
items 1; clusters 1
summaryLength 179
loneSurrogate false
replacementGlyph false
```

```text
[test] starting test/vitest/vitest.extension-memory.config.ts

 RUN  v4.1.8 /media/vdb/code/ai/aispace/openclaw-worktrees/followup-96958


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  12:35:03
   Duration  5.14s (transform 2.46s, setup 361ms, import 4.46s, tests 107ms, environment 0ms)

[test] passed 1 Vitest shard in 15.82s
```

```text
git diff --check
# no output
```

- **Observed result after fix:** The public import insights entry point returns a truncated 179-code-unit summary ending with `…`, with `loneSurrogate false` and `replacementGlyph false`; the targeted Memory Wiki test file passes.
- **What was not tested:** Full OpenClaw gateway/UI rendering was not started because the changed path is a deterministic local Memory Wiki import-insights function; no network boundary is involved.
- **Fix classification:** Root cause fix

## Review findings addressed

N/A — new follow-up PR, no existing review findings.

## Regression Test Plan

- **Target test file:** `extensions/memory-wiki/src/import-insights.test.ts`
- **Scenario locked in:** A ChatGPT export assistant opener places an astral emoji across the 180-character summary truncation boundary; `listMemoryWikiImportInsights` must return a summary ending in `…` without a lone surrogate or replacement glyph.
- **Why this is the smallest reliable guardrail:** The test uses the public import insights entry point and a real temporary wiki source page, so it catches the raw-slice regression without reaching into the private `shortenSentence` helper.
- Pre-fix RED: `node scripts/run-vitest.mjs extensions/memory-wiki/src/import-insights.test.ts` failed because the new public-entry regression test received a summary containing `�…`.
- Post-fix GREEN: `node scripts/run-vitest.mjs extensions/memory-wiki/src/import-insights.test.ts` passed with 2 tests.
- Diff hygiene: `git diff --check` produced no output.

## Merge risk

- **Risk labels considered:** `merge-risk:session-state` heuristic considered because this is under Memory Wiki; no compatibility, message-delivery, security-boundary, auth-provider, availability, or automation risk applies.
- **Risk explanation:** The patch touches snippet formatting for import insight output only. It does not change Memory Wiki persisted state, session visibility, storage paths, config, schema, or any runtime state transition.
- **Why acceptable:** The diff is two files, the production change replaces one raw slice with an existing SDK helper, and both the public function proof and regression test cover the exact truncation boundary.

## Risk / Compatibility

Low risk. The change stays inside Memory Wiki import insight snippet formatting, keeps the same length budget and ellipsis behavior, does not change config/schema/storage, and uses an existing plugin SDK runtime helper already consumed by other extensions.

## What was not changed

- **What did NOT change:** Public API, schema, protocol, defaults, storage, clustering, topic resolution, risk withholding, and preference/correction signal extraction are unchanged.
- No change to the stored `assistantOpener` source text; only shortened display snippets use the safe truncation helper.
- No dependency or lockfile changes.

## Root Cause

- **Root cause:** The Memory Wiki import insight source-of-truth for shortened snippets is `shortenSentence`, and it compacted text before using raw UTF-16 `slice(0, maxLength - 1)` and appending `…`; when an astral Unicode character's high surrogate landed at that slice boundary, the returned summary contained a dangling surrogate half.
- **Why this is root-cause fix:** The fix changes that source truncation operation to `truncateUtf16Safe`, so every summary/correction snippet generated through `shortenSentence` is boundary-adjusted before downstream import insight data receives it, preventing the broken replacement glyph at generation time rather than masking it later.
- **Maintainer-ready confidence:** High; the defect is a single raw UTF-16 truncation point, the production diff is one helper substitution through the plugin SDK boundary, and the public entry point proof exercises the same source page flow that returns import insights.
- **Patch quality notes:** Patch-quality warnings are heuristics from the test-only `hasLoneSurrogate` boolean helper and Memory Wiki file-family risk detection. They are not production defaults, catches, fallbacks, or symptom masking; production code replaces raw `slice()` with the existing surrogate-safe helper.
- **Architecture / source-of-truth check:** The owner and source-of-truth boundary is Memory Wiki import insight snippet generation in `extensions/memory-wiki/src/import-insights.ts`. This changes text formatting before the `summary` and correction/candidate signals are returned, with no downstream UI-only projection, persisted transcript, config, schema, or storage contract change.
