### PR TITLE
fix(deepseek): exclude OpenRouter from native V4 thinking wrapper

### DIFF
--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -981,6 +981,31 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("thinking");
   });
 
+  it("does not add DeepSeek V4 native thinking params on the OpenRouter route", () => {
+    // OpenRouter already emits the broker's nested `reasoning.effort` wire format
+    // (auto-detected as `thinkingFormat: "openrouter"` in openai-completions).
+    // The native DeepSeek wrapper must not additionally inject `thinking` or
+    // top-level `reasoning_effort` — that combination raises HTTP 400 — see #97196.
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openrouter",
+      applyModelId: "deepseek-v4-pro",
+      thinkingLevel: "high",
+      model: {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "deepseek-v4-pro",
+      } as Model<"openai-completions">,
+      payload: {
+        reasoning: { effort: "high" },
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    expect(payload.reasoning).toEqual({ effort: "high" });
+    expect(payload).not.toHaveProperty("reasoning_effort");
+    expect(payload).not.toHaveProperty("thinking");
+  });
+
   it("fills MiMo V2.6 reasoning_content for unowned OpenAI-compatible proxy models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "opencode",

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -933,7 +933,11 @@ function normalizeDeepSeekV4CandidateId(modelId: unknown): string | undefined {
 }
 
 function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
-  return isDeepSeekV4OpenAICompletionsModel(model) && !isMicrosoftFoundryProviderId(model.provider);
+  return (
+    isDeepSeekV4OpenAICompletionsModel(model) &&
+    !isMicrosoftFoundryProviderId(model.provider) &&
+    !isOpenRouterProviderId(model.provider)
+  );
 }
 
 function isDeepSeekV4OpenAICompletionsModel(model: Parameters<StreamFn>[0]): boolean {
@@ -953,6 +957,18 @@ function isMicrosoftFoundryProviderId(provider: unknown): boolean {
     normalizedProvider === "microsoft-foundry" ||
     normalizedProvider.startsWith("microsoft-foundry-")
   );
+}
+
+// OpenRouter-routed DeepSeek V4 uses the broker's nested `reasoning.effort` wire format
+// (auto-detected as `thinkingFormat: "openrouter"` in openai-completions). The native
+// DeepSeek wrapper would additionally inject `thinking` + top-level `reasoning_effort`,
+// causing HTTP 400 ("reasoning_effort" and "reasoning.effort" both provided) — see #97196.
+function isOpenRouterProviderId(provider: unknown): boolean {
+  if (typeof provider !== "string") {
+    return false;
+  }
+  const normalizedProvider = provider.trim().toLowerCase();
+  return normalizedProvider === "openrouter";
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Closes #97196.

DeepSeek V4 models routed through OpenRouter (`openrouter/deepseek/deepseek-v4-flash`, `openrouter/deepseek/deepseek-v4-pro`) failed every request with:

```
400 "reasoning_effort" and "reasoning.effort" are both provided with conflicting values
```

The request never reached the model.

## Why This Change Was Made

Two code paths emit reasoning control fields, but they read different sources of truth:

- **Path 1 — chat-completions builder** (`src/llm/providers/openai-completions.ts:731`) reads the **merged** compat from `getCompat(model)`. Auto-detection sets `thinkingFormat: "openrouter"` for any `provider === "openrouter"`, so this path emits the broker-native `reasoning: { effort }` nested field.
- **Path 2 — DeepSeek V4 native wrapper** (`src/agents/embedded-agent-runner/extra-params.ts`) gates via `isDeepSeekV4OpenAICompatibleModel` + `deepSeekV4NativeThinkingAllowedByCompat`. The latter reads `model.compat.thinkingFormat` (user-config only), which is `undefined` for OpenRouter-routed models, so the wrapper fires and injects `thinking` + top-level `reasoning_effort`.

Both fields in the same request body → DeepSeek rejects with HTTP 400.

The existing `microsoft-foundry` exclusion on `isDeepSeekV4OpenAICompatibleModel` establishes the pattern: a DeepSeek V4 model sitting on a non-DeepSeek-native broker provider should not be touched by the native wrapper. OpenRouter is in the same category — the broker already speaks its own wire format. This PR extends the provider exclusion to also skip `openrouter`.

The issue also offers a deeper alternative (have `deepSeekV4NativeThinkingAllowedByCompat` read merged compat via `getCompat`). I went with the provider-exclusion approach because:

1. It matches the existing `microsoft-foundry` precedent one-to-one.
2. It avoids importing `getCompat` into `extra-params.ts`, which keeps the wrapper gate free of the openai-completions compat-resolution dependency (and avoids cycle risk).
3. The set of broker providers that auto-detect a non-`deepseek` `thinkingFormat` is small and enumerable (`openrouter`, `microsoft-foundry`, possibly `azure`/`together` later). A provider allow-list is the right shape.

## User Impact

- `openrouter/deepseek/deepseek-v4-flash` and `openrouter/deepseek/deepseek-v4-pro` work out of the box — no user-config `compat.thinkingFormat: "openrouter"` workaround needed.
- Native DeepSeek provider (`deepseek/*`) and Microsoft Foundry routes are unchanged.
- OpenRouter doc at `docs/providers/openrouter.md` already advertises these routes as supported, so this aligns runtime behavior with docs.

## Evidence

- New unit test `does not add DeepSeek V4 native thinking params on the OpenRouter route` in `src/agents/embedded-agent-runner-extraparams.test.ts:984`. Mirrors the existing Foundry-fallback test at line 964. Feeds a payload with `reasoning: { effort: "high" }` (what Path 1 emits) and asserts the wrapper does NOT add top-level `reasoning_effort` or `thinking`.
- Full extraparams suite: 280 passed (0 regressions).

```
PATH="/Users/ywwl/.nvm/versions/node/v22.22.1/bin:$PATH" npx vitest run src/agents/embedded-agent-runner-extraparams.test.ts
Test Files  2 passed (2)
     Tests  280 passed (280)
```

- `pnpm tsgo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
