### PR TITLE
fix(heartbeat): suppress stream-error placeholders

### DIFF
--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import {
   createHeartbeatToolResponsePayload,
   type HeartbeatToolResponse,
@@ -341,6 +342,36 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
         reason: "agent-runner-failure",
         preview: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
         channel: "telegram",
+      });
+    });
+  });
+
+  it("suppresses internal stream-error fallback placeholders before heartbeat delivery", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      replySpy.mockResolvedValue(
+        markReplyPayloadForSourceSuppressionDelivery({
+          text: `${STREAM_ERROR_FALLBACK_TEXT}\n${STREAM_ERROR_FALLBACK_TEXT}`,
+        }),
+      );
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).not.toHaveBeenCalled();
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "ok-token",
+        channel: "telegram",
+        silent: true,
       });
     });
   });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -26,6 +26,7 @@ import { formatReasoningMessage } from "../agents/embedded-agent-utils.js";
 import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { resolveModelRefFromString, type ModelRef } from "../agents/model-selection.js";
 import { resolvePersistedSessionRuntimeId } from "../agents/session-runtime-compat.js";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
@@ -839,11 +840,30 @@ function stripLeadingHeartbeatResponsePrefix(
   return text.replace(prefixPattern, "");
 }
 
+type NormalizedHeartbeatDelivery = {
+  shouldSkip: boolean;
+  text: string;
+  hasMedia: boolean;
+  isInternalPlaceholderOnly: boolean;
+};
+
+function isStreamErrorFallbackPlaceholderOnly(text: string): boolean {
+  let remaining = text.trim();
+  if (!remaining) {
+    return false;
+  }
+
+  while (remaining.startsWith(STREAM_ERROR_FALLBACK_TEXT)) {
+    remaining = remaining.slice(STREAM_ERROR_FALLBACK_TEXT.length).trimStart();
+  }
+  return remaining.length === 0;
+}
+
 function normalizeHeartbeatReply(
   payload: ReplyPayload,
   responsePrefix: string | undefined,
   ackMaxChars: number,
-) {
+): NormalizedHeartbeatDelivery {
   const rawText = typeof payload.text === "string" ? payload.text : "";
   const textForStrip = stripLeadingHeartbeatResponsePrefix(rawText, responsePrefix);
   const stripped = stripHeartbeatToken(textForStrip, {
@@ -851,29 +871,36 @@ function normalizeHeartbeatReply(
     maxAckChars: ackMaxChars,
   });
   const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
-  if (stripped.shouldSkip && !hasMedia) {
+  const isInternalPlaceholderOnly = isStreamErrorFallbackPlaceholderOnly(stripped.text);
+  if ((stripped.shouldSkip || isInternalPlaceholderOnly) && !hasMedia) {
     return {
       shouldSkip: true,
       text: "",
       hasMedia,
+      isInternalPlaceholderOnly,
     };
   }
-  let finalText = stripped.text;
+  let finalText = isInternalPlaceholderOnly ? "" : stripped.text;
   if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
     finalText = `${responsePrefix} ${finalText}`;
   }
-  return { shouldSkip: false, text: finalText, hasMedia };
+  return { shouldSkip: false, text: finalText, hasMedia, isInternalPlaceholderOnly };
 }
 
 function normalizeHeartbeatToolNotification(
   response: HeartbeatToolResponse,
   responsePrefix: string | undefined,
-) {
+): NormalizedHeartbeatDelivery {
   let finalText = getHeartbeatToolNotificationText(response);
   if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
     finalText = `${responsePrefix} ${finalText}`;
   }
-  return { shouldSkip: false, text: finalText, hasMedia: false };
+  return {
+    shouldSkip: false,
+    text: finalText,
+    hasMedia: false,
+    isInternalPlaceholderOnly: false,
+  };
 }
 
 type HeartbeatWakePayloadFlags = {
@@ -1927,7 +1954,12 @@ export async function runHeartbeatOnce(opts: {
       ? normalizeHeartbeatToolNotification(heartbeatToolResponse, responsePrefix)
       : replyPayload
         ? normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars)
-        : { shouldSkip: true, text: "", hasMedia: false };
+        : {
+            shouldSkip: true,
+            text: "",
+            hasMedia: false,
+            isInternalPlaceholderOnly: false,
+          };
     // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
     // The model should be responding with exec results, not ack tokens.
     // Also, if normalized.text is empty due to token stripping but we have exec completion,
@@ -1936,6 +1968,7 @@ export async function runHeartbeatOnce(opts: {
       !heartbeatToolResponse &&
       hasRelayableExecCompletion &&
       !normalized.text.trim() &&
+      !normalized.isInternalPlaceholderOnly &&
       replyPayload?.text?.trim()
         ? replyPayload.text.trim()
         : null;
@@ -1952,7 +1985,9 @@ export async function runHeartbeatOnce(opts: {
       normalized.shouldSkip = false;
     }
     const shouldSkipMain =
-      normalized.shouldSkip && !normalized.hasMedia && !hasRelayableExecCompletion;
+      normalized.shouldSkip &&
+      !normalized.hasMedia &&
+      (!hasRelayableExecCompletion || normalized.isInternalPlaceholderOnly);
     if (shouldSkipMain && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({
         storePath,


### PR DESCRIPTION
Closes #97357.

## What Problem This Solves
Heartbeat fallback replies that echo only the internal stream-error sentinel are non-empty, so current main can normalize and deliver them as visible channel messages. This filters the placeholder-only heartbeat case before durable delivery while leaving the persisted replay sentinel untouched.

## Summary
- Suppress heartbeat replies whose visible text is only the internal stream-error fallback sentinel, including repeated echoes, before durable channel delivery.
- Preserve normal heartbeat delivery behavior, including runner failure copy rewrite and exec-completion fallback for non-placeholder content.

## Evidence
- Added `src/infra/heartbeat-runner.tool-response.test.ts` coverage showing a repeated sentinel heartbeat reply produces no Telegram send and records an ok-token heartbeat event.
- Verified the focused heartbeat runner regression suite, heartbeat token suite, formatter check, and whitespace check locally.
- Redacted local heartbeat/channel proof using the real `runHeartbeatOnce` path and Telegram outbound adapter, with the network send hook recording attempts:

```text
result.status=ran
telegram.send.count=0
heartbeat.event.status=ok-token
heartbeat.event.silent=true
placeholder.delivered=false
```
