### PR TITLE
fix(slack): sanitize internal tool-trace lines from outbound text

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -30,6 +30,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import {
   resolveDefaultSlackAccountId,
   resolveSlackAccount,
@@ -423,6 +424,7 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: SLACK_TEXT_LIMIT,
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   normalizePayload: ({ payload, cfg, accountId }) =>
     isSlackInteractiveRepliesEnabled({ cfg, accountId })
       ? compileSlackInteractiveReplies(payload)

--- a/extensions/slack/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/slack/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,19 @@
+// Slack outbound must strip assistant internal tool-trace scaffolding, matching
+// the sibling channel fixes tracked under #90684 (Telegram #95774 / Google Chat
+// #95084 / IRC #97214). sanitizeAssistantVisibleText keeps mrkdwn formatting.
+import { describe, expect, it } from "vitest";
+import { slackPlugin } from "./channel.js";
+
+describe("slack outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(slackPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(slackPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+});


### PR DESCRIPTION
Related: #90684

## What Problem This Solves

Fixes an issue where OpenClaw's internal tool-execution traces could leak into Slack outbound messages. When a tool run fails, the runtime injects a status banner such as `` ⚠️ 🛠️ `…(agent)` failed `` into the assistant's outbound text. Slack's outbound adapter defined no `sanitizeText` hook, so the only sanitization that ran was core's central `stripInternalRuntimeScaffoldingFromPayload` — which removes runtime-injected context wrappers (`<system-reminder>`, etc.) but not these tool-trace lines. The banner was therefore delivered verbatim.

## Why This Change Was Made

The merged Telegram (PR #95774), Google Chat (PR #95084), and IRC (PR #97214) changes already wrap their outbound text with `sanitizeAssistantVisibleText` — the existing shared assistant-visible sanitizer that removes tool-trace banners and other internal scaffolding (reasoning tags, tool-call XML) while preserving ordinary prose and formatting. Slack was a missed sibling of that same fix, tracked under #90684. This change adds the same hook to the Slack outbound adapter (one import plus `sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text)`), reusing the existing SDK sanitizer rather than adding a helper. It applies `sanitizeAssistantVisibleText` directly (not the IRC-style `sanitizeForPlainText` wrap) so Slack's mrkdwn rendering is untouched. The hook sanitizes the assistant reply text (`payload.text`), which is the leak surface. The change touches only `extensions/slack/src/channel.ts` (the outbound adapter) plus a focused test; other channels are tracked separately under #90684.

## User Impact

Slack outbound messages no longer include internal tool-trace banners; the shared sanitizer also strips its other inherited internal scaffolding (reasoning tags, tool-call XML). Ordinary assistant prose is unaffected.

## Evidence

**Focused unit tests** — `extensions/slack/src/outbound-tool-trace-sanitize.test.ts` adds 2 cases (tool-trace banner stripped; ordinary prose preserved):

```
$ node scripts/run-vitest.mjs extensions/slack/src/outbound-tool-trace-sanitize.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**Real-behavior proof** — the patched `slackPlugin.outbound.sanitizeText`, run directly against the real plugin code path. No live Slack roundtrip is included: this PR only wires the existing outbound sanitizer hook, and the command below exercises that changed code path directly:

```
$ node --import tsx -e '
import { slackPlugin } from "./extensions/slack/src/channel.ts";
const f = slackPlugin.outbound.sanitizeText;
console.log("after :", JSON.stringify(f({ text: "Done.\n⚠️ 🛠️ `search repos (agent)` failed" })));
console.log("prose :", JSON.stringify(f({ text: "The pipeline has 3 open deals." })));
'
after : "Done."
prose : "The pipeline has 3 open deals."
```

Before this change Slack defined no `sanitizeText` hook, so the banner reached users verbatim.
