### PR TITLE
test: promote OpenAI HTTP QA coverage

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -235,6 +235,7 @@ describe("qa scenario catalog", () => {
   it("loads folded HTTP API script scenarios with primary taxonomy coverage", () => {
     expect(readQaScenarioById("openai-compatible-chat-tools").coverage?.primary).toStrictEqual([
       "gateway.openai-compatible-apis",
+      "runtime.hosted-tool-use",
     ]);
     expect(readQaScenarioById("openai-web-search-minimal").coverage?.primary).toStrictEqual([
       "runtime.reasoning-and-cache-controls",
@@ -244,6 +245,7 @@ describe("qa scenario catalog", () => {
     ).toStrictEqual(["web-search.openai-native-web-search", "plugins.web-search-and-fetch"]);
     expect(readQaScenarioById("openwebui-openai-compatible").coverage?.primary).toStrictEqual([
       "gateway.openai-compatible-apis",
+      "runtime.hosted-provider-turns",
     ]);
   });
 

--- a/qa/scenarios/runtime/openai-compatible-chat-tools.yaml
+++ b/qa/scenarios/runtime/openai-compatible-chat-tools.yaml
@@ -6,7 +6,6 @@ scenario:
   coverage:
     primary:
       - gateway.openai-compatible-apis
-    secondary:
       - runtime.hosted-tool-use
   objective: Verify the OpenAI-compatible chat-completions client and Docker lane preserve strict tool-call API behavior.
   successCriteria:

--- a/qa/scenarios/runtime/openwebui-openai-compatible.yaml
+++ b/qa/scenarios/runtime/openwebui-openai-compatible.yaml
@@ -6,8 +6,8 @@ scenario:
   coverage:
     primary:
       - gateway.openai-compatible-apis
-    secondary:
       - runtime.hosted-provider-turns
+    secondary:
       - runtime.provider-specific-model-options
   objective: Verify the OpenWebUI E2E probe exercises OpenClaw through OpenWebUI's OpenAI-compatible model and chat APIs.
   successCriteria:


### PR DESCRIPTION
## What Problem This Solves

Batch 1 of the QA maturity linking work has existing native E2E wrappers for the OpenAI-compatible HTTP/API scripts, but two IDs were still recorded as secondary metadata even though the tests are direct primary proof for those behaviors. That leaves release-score primary coverage understated for the existing scenario inventory.

This PR does not change taxonomy and does not mint any new coverage IDs.

## Why This Change Was Made

This promotes only the existing coverage IDs that the current tests directly prove:

| Scenario | Native test | Primary coverage now represented |
| --- | --- | --- |
| `openai-compatible-chat-tools` | `test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts` | `gateway.openai-compatible-apis`; `runtime.hosted-tool-use` |
| `openwebui-openai-compatible` | `test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts` | `gateway.openai-compatible-apis`; `runtime.hosted-provider-turns` |
| `openai-web-search-minimal` | `test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts` | `runtime.reasoning-and-cache-controls` |
| `openai-web-search-native-assertions` | `test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts` | `plugins.web-search-and-fetch`; `web-search.openai-native-web-search` |

The only newly promoted primary IDs in this PR are `runtime.hosted-tool-use` and `runtime.hosted-provider-turns`. `gateway.openai-compatible-apis`, `runtime.reasoning-and-cache-controls`, `plugins.web-search-and-fetch`, and `web-search.openai-native-web-search` were already primary in the batch-1 wrappers.

I am intentionally not claiming `gateway.tool-invocation-api` here: the existing chat-tools test proves OpenAI-compatible `/v1/chat/completions` tool-call behavior, not the direct gateway `/tools/invoke` HTTP path.

## User Impact

The QA coverage inventory and evidence scorecard now count the existing OpenAI-compatible chat-tools and OpenWebUI probe tests as primary proof for the hosted-provider behaviors they already exercise. No runtime behavior, taxonomy, or scenario execution path changes.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/scorecard-evidence.test.ts test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts`
  - 4 E2E files passed, 48 tests
  - 3 QA extension files passed, 47 tests
- `pnpm openclaw qa suite --provider-mode mock-openai --scenario openai-compatible-chat-tools --scenario openwebui-openai-compatible --scenario openai-web-search-minimal --scenario openai-web-search-native-assertions --output-dir .artifacts/qa-e2e/openai-http-api-coverage`
  - 4 scenarios passed
  - evidence artifact: `.artifacts/qa-e2e/openai-http-api-coverage/qa-evidence.json`
- `git diff --check -- qa/scenarios/runtime/openai-compatible-chat-tools.yaml qa/scenarios/runtime/openwebui-openai-compatible.yaml extensions/qa-lab/src/scenario-catalog.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - first run caught an overclaim for `gateway.tool-invocation-api`; accepted and removed
  - final run clean: no accepted/actionable findings
