### PR TITLE
fix(matrix): sanitize internal tool-trace lines from outbound text

### DIFF
--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -32,7 +32,10 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
+import {
+  chunkTextForOutbound,
+  sanitizeAssistantVisibleText,
+} from "openclaw/plugin-sdk/text-chunking";
 import { matrixMessageActions } from "./actions.js";
 import { matrixApprovalCapability } from "./approval-native.js";
 import { createMatrixPairingText, createMatrixProbeAccount } from "./channel-account-paths.js";
@@ -336,6 +339,7 @@ const matrixChannelOutbound: ChannelOutboundAdapter = {
   chunker: chunkTextForOutbound,
   chunkerMode: "markdown",
   textChunkLimit: 4000,
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   deliveryCapabilities: {
     durableFinal: {
       text: true,

--- a/extensions/matrix/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/matrix/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,20 @@
+// Matrix outbound must strip assistant internal tool-trace scaffolding, matching
+// the sibling channel fixes tracked under #90684 (Telegram #95774 / Google Chat
+// #95084 / IRC #97214). The hook runs before the markdown->HTML render, so a
+// single sanitize cleans both the plain body and the formatted_body.
+import { describe, expect, it } from "vitest";
+import { matrixPlugin } from "./channel.js";
+
+describe("matrix outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(matrixPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(matrixPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+});


### PR DESCRIPTION
Related: #90684

## What Problem This Solves

Fixes an issue where OpenClaw's internal tool-execution traces could leak into Matrix outbound messages. When a tool run fails, the runtime injects a status banner such as `` ⚠️ 🛠️ `…(agent)` failed `` into the assistant's outbound text. Matrix's outbound adapter defined no `sanitizeText` hook, so the only sanitization that ran was core's central `stripInternalRuntimeScaffoldingFromPayload` — which removes runtime-injected context wrappers (`<system-reminder>`, etc.) but not these tool-trace lines. The banner was therefore delivered verbatim.

## Why This Change Was Made

The merged Telegram (PR #95774), Google Chat (PR #95084), and IRC (PR #97214) changes already wrap their outbound text with `sanitizeAssistantVisibleText` — the existing shared assistant-visible sanitizer that removes tool-trace banners and other internal scaffolding (reasoning tags, tool-call XML) while preserving ordinary prose and formatting. Matrix was a missed sibling of that same fix, tracked under #90684. This change adds the same hook to the Matrix outbound adapter (one import plus `sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text)`), reusing the existing SDK sanitizer rather than adding a helper. It applies `sanitizeAssistantVisibleText` directly (not the IRC-style `sanitizeForPlainText` wrap) because Matrix text is markdown destined for the markdown→HTML renderer; the hook runs before that render, so the outgoing message is built from already-sanitized text. The change touches only `extensions/matrix/src/channel.ts` (the outbound adapter) plus a focused test; other channels are tracked separately under #90684.

## User Impact

Matrix outbound messages no longer include internal tool-trace banners; the shared sanitizer also strips its other inherited internal scaffolding (reasoning tags, tool-call XML). Ordinary assistant prose is unaffected.

## Evidence

**Focused unit tests** — `extensions/matrix/src/outbound-tool-trace-sanitize.test.ts` adds 2 cases (tool-trace banner stripped; ordinary prose preserved):

```
$ node scripts/run-vitest.mjs extensions/matrix/src/outbound-tool-trace-sanitize.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**Real-behavior proof** — the patched `matrixPlugin.outbound.sanitizeText`, run directly against the real plugin code path. No live Matrix roundtrip is included: this PR only wires the existing outbound sanitizer hook, and the command below exercises that changed code path directly:

```
$ node --import tsx -e '
import { matrixPlugin } from "./extensions/matrix/src/channel.ts";
const f = matrixPlugin.outbound.sanitizeText;
console.log("after :", JSON.stringify(f({ text: "Done.\n⚠️ 🛠️ `search repos (agent)` failed" })));
console.log("prose :", JSON.stringify(f({ text: "The pipeline has 3 open deals." })));
'
after : "Done."
prose : "The pipeline has 3 open deals."
```

Matrix previously had no `sanitizeText` hook in `extensions/matrix/src/channel.ts`, so the banner reached users verbatim.
