### PR TITLE
Keep ACP server stdout protocol-pure during startup

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -34,6 +34,7 @@ type CliRoutedCommandId =
 export type CliCommandPathPolicy = {
   bypassConfigGuard: boolean;
   routeConfigGuard: CliRouteConfigGuardPolicy;
+  suppressDoctorStdout: boolean;
   loadPlugins: CliCommandPluginLoadPolicy;
   pluginRegistry: CliPluginRegistryPolicy;
   hideBanner: boolean;
@@ -257,7 +258,10 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     commandPath: ["tools"],
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },
-  { commandPath: ["acp"], policy: { networkProxy: "bypass" } },
+  {
+    commandPath: ["acp"],
+    policy: { suppressDoctorStdout: true, hideBanner: true, networkProxy: "bypass" },
+  },
   { commandPath: ["approvals"], policy: { networkProxy: "bypass" } },
   { commandPath: ["backup"], policy: { bypassConfigGuard: true, networkProxy: "bypass" } },
   { commandPath: ["chat"], policy: { networkProxy: "bypass" } },

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -53,6 +53,22 @@ describe("command-execution-startup", () => {
     });
   });
 
+  it("resolves ACP startup as protocol stdout without requiring --json", () => {
+    expect(
+      mod.resolveCliExecutionStartupContext({
+        argv: ["node", "openclaw", "acp"],
+        jsonOutputMode: false,
+        env: {},
+      }).startupPolicy,
+    ).toEqual({
+      suppressDoctorStdout: true,
+      hideBanner: true,
+      skipConfigGuard: false,
+      loadPlugins: false,
+      pluginRegistry: { scope: "all" },
+    });
+  });
+
   it("uses process env banner suppression when startup env is omitted", () => {
     const originalHideBanner = process.env.OPENCLAW_HIDE_BANNER;
     try {

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -11,6 +11,7 @@ import {
 const DEFAULT_EXPECTED_POLICY: CliCommandPathPolicy = {
   bypassConfigGuard: false,
   routeConfigGuard: "never",
+  suppressDoctorStdout: false,
   loadPlugins: "never",
   pluginRegistry: { scope: "all" },
   hideBanner: false,
@@ -61,6 +62,14 @@ describe("command-path-policy", () => {
       loadPlugins: "never",
       pluginRegistry: { scope: "channels" },
       ensureCliPath: false,
+      networkProxy: "bypass",
+    });
+  });
+
+  it("resolves ACP as a protocol-stdout command", () => {
+    expectResolvedPolicy(["acp"], {
+      suppressDoctorStdout: true,
+      hideBanner: true,
       networkProxy: "bypass",
     });
   });

--- a/src/cli/command-path-policy.ts
+++ b/src/cli/command-path-policy.ts
@@ -12,6 +12,7 @@ import { resolveGatewayCatalogCommandPath } from "./gateway-run-argv.js";
 const DEFAULT_CLI_COMMAND_PATH_POLICY: CliCommandPathPolicy = {
   bypassConfigGuard: false,
   routeConfigGuard: "never",
+  suppressDoctorStdout: false,
   loadPlugins: "never",
   pluginRegistry: { scope: "all" },
   hideBanner: false,

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -178,6 +178,23 @@ describe("command-startup-policy", () => {
     expect(resolvePolicy({ commandPath: ["status"], env: {} }).hideBanner).toBe(false);
   });
 
+  it("treats ACP as protocol stdout even without --json", () => {
+    expect(
+      resolveCliStartupPolicy({
+        argv: ["node", "openclaw", "acp"],
+        commandPath: ["acp"],
+        jsonOutputMode: false,
+        env: {},
+      }),
+    ).toEqual({
+      suppressDoctorStdout: true,
+      hideBanner: true,
+      skipConfigGuard: false,
+      loadPlugins: false,
+      pluginRegistry: { scope: "all" },
+    });
+  });
+
   it("uses process env banner suppression when startup env is omitted", () => {
     const originalHideBanner = process.env.OPENCLAW_HIDE_BANNER;
     try {

--- a/src/cli/command-startup-policy.ts
+++ b/src/cli/command-startup-policy.ts
@@ -32,8 +32,8 @@ export function resolveCliStartupPolicy(params: {
   env?: NodeJS.ProcessEnv;
   routeMode?: boolean;
 }) {
-  const suppressDoctorStdout = params.jsonOutputMode;
   const commandPolicy = resolveCliCommandPathPolicy(params.commandPath);
+  const suppressDoctorStdout = params.jsonOutputMode || commandPolicy.suppressDoctorStdout;
   const env = params.env ?? process.env;
   return {
     suppressDoctorStdout,

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -457,6 +457,28 @@ describe("ensureConfigReady", () => {
     expect(output).not.toContain("Doctor warnings");
   });
 
+  it("keeps legacy plugin index migration warnings off stdout for ACP startup", async () => {
+    const root = useTempOpenClawHome();
+    writeStateMarker(root, "plugins/installs.json");
+    loadAndMaybeMigrateDoctorConfigMock.mockImplementation(async () => {
+      note(
+        "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: demo",
+        "Doctor warnings",
+      );
+      return {
+        snapshot: makeSnapshot(),
+        baseConfig: {},
+      };
+    });
+
+    const output = await withCapturedStdout(async () => {
+      await runEnsureConfigReady(["acp"], true);
+    });
+
+    expect(output).not.toContain("Doctor warnings");
+    expect(output).not.toContain("Left plugin install index");
+  });
+
   it("allows preflight note noise when suppression is not enabled", async () => {
     writeLegacyTaskSidecarMarker(useTempOpenClawHome());
     loadAndMaybeMigrateDoctorConfigMock.mockImplementation(async () => {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -146,6 +146,7 @@ describe("registerPreActionHooks", () => {
       .command("status")
       .option("--json")
       .action(() => {});
+    programLocal.command("acp").action(() => {});
     const gateway = programLocal
       .command("gateway")
       .option("--force")
@@ -605,6 +606,22 @@ describe("registerPreActionHooks", () => {
     });
 
     expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+  });
+
+  it("treats ACP startup as protocol stdout without --json", async () => {
+    await runPreAction({
+      parseArgv: ["acp"],
+      processArgv: ["node", "openclaw", "acp"],
+    });
+
+    expect(routeLogsToStderrMock).toHaveBeenCalledOnce();
+    expect(emitCliBannerMock).not.toHaveBeenCalled();
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["acp"],
+      suppressDoctorStdout: true,
+    });
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
 
   it("does not preload plugins for agents list JSON output", async () => {


### PR DESCRIPTION
Fixes #98167.

## What Problem This Solves

Bare `openclaw acp` is a JSON-RPC/ACP stdio transport. Human-readable startup output from doctor/config/state-migration checks on stdout can corrupt that protocol stream before the initialize handshake finishes.

This PR treats bare `openclaw acp` as protocol stdout, routes startup diagnostics to stderr, and keeps the existing human CLI behavior for non-ACP commands.

## Downstream Trigger

The bug was surfaced during evaOS Workbench Mac-control proof as `USER_AGENT_STARTUP_FAILED`, but the defect belongs to OpenClaw CLI/ACP startup behavior. Workbench release readiness remains tracked downstream in `100yenadmin/evaOS-GUI#480`.

Related downstream context: `100yenadmin/evaOS-GUI#432`, `100yenadmin/evaOS-GUI#468`.

## Evidence

- Focused validation: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs src/cli/command-path-policy.test.ts src/cli/command-startup-policy.test.ts src/cli/command-execution-startup.test.ts src/cli/program/preaction.test.ts src/cli/program/config-guard.test.ts` passed: 5 files / 87 tests.
- `git diff --check` passed.
- GitHub CI on head `4ac882e094f127e60655983cba385614ae1e9005` is green across the core checks.

## Summary

- Treat bare `openclaw acp` as protocol stdout even without `--json`.
- Suppress startup doctor/config/state-migration human text from ACP stdout.
- Route ACP startup diagnostics to stderr so ACP transport parsing stays clean.

## Release Boundary

This is OpenClaw CLI/ACP transport hardening only. It does not claim evaOS Workbench release readiness or customer readiness.
