### PR TITLE
test: link Tool Search gateway QA coverage

### DIFF
--- a/qa/scenarios/runtime/tool-search-gateway-e2e.yaml
+++ b/qa/scenarios/runtime/tool-search-gateway-e2e.yaml
@@ -1,0 +1,28 @@
+title: Tool Search gateway E2E
+
+scenario:
+  id: tool-search-gateway-e2e
+  surface: runtime
+  coverage:
+    primary:
+      - runtime.hosted-tool-use
+    secondary:
+      - plugins.plugin-tools
+      - tools.invocation
+  objective: Verify the Tool Search gateway E2E script keeps a large plugin-owned tool catalog behind the compact bridge while still invoking the selected plugin tool.
+  successCriteria:
+    - Direct mode exposes the fake plugin tool schemas and calls the selected plugin tool.
+    - Tool Search code mode exposes only the compact bridge to the provider.
+    - The compact bridge calls the same selected plugin tool and records bridge plus target tool mentions in session logs.
+    - The Tool Search request payload is smaller than direct tool exposure for the large fake catalog.
+  docsRefs:
+    - docs/tools/tool-search.md
+    - docs/gateway/protocol.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - scripts/tool-search-gateway-e2e.ts
+    - test/scripts/tool-search-gateway-e2e.test.ts
+  execution:
+    kind: script
+    path: scripts/tool-search-gateway-e2e.ts
+    summary: Script-backed gateway E2E for compact Tool Search bridge and plugin-owned tool invocation.


### PR DESCRIPTION
## What Problem This Solves

Batch 2 of the QA maturity linking work had an existing Tool Search gateway E2E script, but no QA Lab scenario wrapper. That meant the evidence runner could not count this existing proof in the scenario inventory.

This PR does not change taxonomy and does not add new product behavior.

## Why This Change Was Made

This adds one native QA scenario wrapper for `scripts/tool-search-gateway-e2e.ts`.

Primary coverage claimed:

| Scenario | Existing proof | Primary coverage |
| --- | --- | --- |
| `tool-search-gateway-e2e` | `scripts/tool-search-gateway-e2e.ts` | `runtime.hosted-tool-use` |

Why primary: the script starts the QA mock OpenAI provider and a real Gateway, creates a temporary fake plugin with a large tool catalog, calls `/v1/responses`, and asserts both direct mode and Tool Search code mode invoke the selected plugin tool. It also verifies compact mode exposes only the `tool_search_code` bridge to the provider while still producing the plugin tool result.

Secondary coverage kept:

| Coverage ID | Why secondary only |
| --- | --- |
| `plugins.plugin-tools` | The script stages a fake plugin and invokes its registered tool, but the scenario is about Tool Search gateway behavior rather than broad plugin-tool registration coverage. |
| `tools.invocation` | The selected plugin tool is invoked through OpenClaw, but this scenario does not own the whole generic tool invocation contract. |

Intentionally not claimed: `gateway.tool-and-skill-apis`. I checked it, but this script does not call the `commands.list`, `tools.*`, or `skills.*` Gateway RPC surface described by that taxonomy ID.

## User Impact

The QA scenario inventory can now run and score the existing Tool Search gateway E2E proof through QA Lab. Operators get evidence for existing hosted tool-use behavior without changing runtime code.

Follow-up note: fully deleting `scripts/tool-search-gateway-e2e.ts` is plausible, but not in this PR. Today the QA flow DSL can run gateway calls and assertions, but it does not have a clean first-class primitive for staging a temporary plugin directory before gateway startup. The smallest durable migration would be a reusable QA Lab fixture/helper for temporary plugin tool catalogs, then a flow scenario can replace the standalone script.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/tool-search-gateway-e2e.test.ts extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/scorecard-evidence.test.ts`
  - 1 script helper test file passed, 11 tests
  - 3 QA extension test files passed, 47 tests
- `pnpm openclaw qa suite --provider-mode mock-openai --scenario tool-search-gateway-e2e --output-dir .artifacts/qa-e2e/tool-search-gateway-coverage`
  - 1 scenario passed
  - evidence artifact: `.artifacts/qa-e2e/tool-search-gateway-coverage/qa-evidence.json`
- `git diff --check -- qa/scenarios/runtime/tool-search-gateway-e2e.yaml`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - first run caught an overclaim for `gateway.tool-and-skill-apis`; accepted and removed
  - final run clean: no accepted/actionable findings
